### PR TITLE
feat(layout): equalize pane sizes via Cmd+= and context menus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { StatusBar } from "./components/StatusBar";
 import { RemoveSessionDialog } from "./components/RemoveSessionDialog";
 import { RemoveProjectDialog } from "./components/RemoveProjectDialog";
 import { LayoutRenderer } from "./components/LayoutRenderer";
+import { EQUALIZE_PANES_EVENT } from "./lib/layoutEvents";
 import { RightPanel } from "./components/RightPanel";
 import { ResizeHandle } from "./components/ResizeHandle";
 import { CommandPalette } from "./components/CommandPalette";
@@ -125,6 +126,10 @@ function App() {
       [Hotkeys.splitHorizontal]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().splitFocusedPane("vertical");
+      },
+      [Hotkeys.equalizePanes]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
       },
       [Hotkeys.closeTab]: (e: KeyboardEvent) => {
         e.preventDefault();

--- a/src/components/LayoutRenderer.tsx
+++ b/src/components/LayoutRenderer.tsx
@@ -1,7 +1,34 @@
-import { Panel, PanelGroup } from "react-resizable-panels";
-import type { LayoutNode } from "../lib/layout";
+import { useEffect, useMemo, useRef } from "react";
+import {
+  Panel,
+  PanelGroup,
+  type ImperativePanelGroupHandle,
+} from "react-resizable-panels";
+import type { Direction, LayoutNode } from "../lib/layout";
+import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import { Pane } from "./Pane";
 import { ResizeHandle } from "./ResizeHandle";
+
+/**
+ * Count leaves that share the parent's split axis. When a child is a leaf
+ * pane, or a split running perpendicular to `axis`, it contributes 1 — the
+ * whole sub-tree reads as a single cell on this axis. When the child is a
+ * split running along `axis`, recurse so chained same-direction splits
+ * (like `B | C | D` rendered as nested horizontals) collapse into one
+ * counter and the equalize call divides them evenly.
+ *
+ * Without this perpendicular-aware counting, a layout like
+ *   vertical(A, horizontal(B, horizontal(C, D)))
+ * would equalize to A=25% / B=25% / C=25% / D=25% along the vertical axis,
+ * even though A is a single row and B/C/D share one row underneath. This
+ * helper makes the vertical split count rows (1:1 → 50/50) and the
+ * horizontal row count columns (1:2 → 33/67 → B=33%, C=33.5%, D=33.5%).
+ */
+function coAxialLeafCount(node: LayoutNode, axis: Direction): number {
+  if (node.kind === "pane") return 1;
+  if (node.direction !== axis) return 1;
+  return coAxialLeafCount(node.a, axis) + coAxialLeafCount(node.b, axis);
+}
 
 interface LayoutRendererProps {
   node: LayoutNode;
@@ -21,15 +48,66 @@ export function LayoutRenderer({ node }: LayoutRendererProps) {
   // `direction="vertical"` stacks them and the handle is horizontal.
   const handleDirection =
     node.direction === "horizontal" ? "horizontal" : "vertical";
+  // Weight by co-axial leaves so each row/column is divided evenly along
+  // its own axis without inflating cross-axis subtrees.
+  const leftLeaves = coAxialLeafCount(node.a, node.direction);
+  const rightLeaves = coAxialLeafCount(node.b, node.direction);
+  const total = leftLeaves + rightLeaves;
+  const leftPct = (leftLeaves / total) * 100;
+  const rightPct = 100 - leftPct;
   return (
-    <PanelGroup direction={node.direction} id={node.id}>
-      <Panel id={`${node.id}:a`} order={1} defaultSize={50} minSize={10}>
+    <EqualizablePanelGroup
+      direction={node.direction}
+      id={node.id}
+      leftPct={leftPct}
+      rightPct={rightPct}
+    >
+      <Panel id={`${node.id}:a`} order={1} defaultSize={leftPct} minSize={10}>
         <LayoutRenderer node={node.a} />
       </Panel>
       <ResizeHandle direction={handleDirection} />
-      <Panel id={`${node.id}:b`} order={2} defaultSize={50} minSize={10}>
+      <Panel id={`${node.id}:b`} order={2} defaultSize={rightPct} minSize={10}>
         <LayoutRenderer node={node.b} />
       </Panel>
+    </EqualizablePanelGroup>
+  );
+}
+
+interface EqualizablePanelGroupProps {
+  id: string;
+  direction: "horizontal" | "vertical";
+  leftPct: number;
+  rightPct: number;
+  children: React.ReactNode;
+}
+
+/** PanelGroup wrapper that listens for the equalize event and resets its own
+ * children to leaf-count-weighted sizes. We attach per-group rather than
+ * enumerating all groups from a parent because react-resizable-panels does
+ * not expose a registry; the event-bus pattern keeps the recursion local. */
+function EqualizablePanelGroup({
+  id,
+  direction,
+  leftPct,
+  rightPct,
+  children,
+}: EqualizablePanelGroupProps) {
+  const ref = useRef<ImperativePanelGroupHandle | null>(null);
+  const target = useMemo(() => [leftPct, rightPct], [leftPct, rightPct]);
+
+  useEffect(() => {
+    const onEqualize = () => {
+      ref.current?.setLayout(target);
+    };
+    window.addEventListener(EQUALIZE_PANES_EVENT, onEqualize);
+    return () => {
+      window.removeEventListener(EQUALIZE_PANES_EVENT, onEqualize);
+    };
+  }, [target]);
+
+  return (
+    <PanelGroup ref={ref} direction={direction} id={id}>
+      {children}
     </PanelGroup>
   );
 }

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -1,4 +1,5 @@
 import {
+  Columns2,
   Copy,
   Files,
   FolderOpen,
@@ -24,6 +25,7 @@ import {
   hasConfiguredEditor,
   openInConfiguredEditor,
 } from "../lib/editor";
+import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import { useSettings } from "../lib/settings";
 import type { Direction, PaneId } from "../lib/layout";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
@@ -433,6 +435,13 @@ function TabItem({
       onClick: () => onSplitTab("vertical"),
       disabled: siblingCount <= 1,
     },
+    {
+      label: "Equalize Pane Sizes",
+      icon: <Columns2 size={12} />,
+      onClick: () => {
+        window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
+      },
+    },
     { type: "separator" },
     {
       label: "Open Worktree in Editor",
@@ -714,6 +723,14 @@ function buildPaneMenuItems({
       label: "Split Down",
       icon: <SplitSquareVertical size={12} />,
       onClick: () => onSplit("vertical"),
+    },
+    {
+      label: "Equalize Pane Sizes",
+      icon: <Columns2 size={12} />,
+      onClick: () => {
+        window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
+      },
+      disabled: totalPanes <= 1,
     },
     ...worktreeItems,
     { type: "separator" },

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -32,6 +32,10 @@ export const Hotkeys = {
   toggleStaged: "$mod+Shift+s",
   splitVertical: "$mod+d",
   splitHorizontal: "$mod+Shift+d",
+  // Cmd+= mirrors VS Code's "Workbench: Toggle Centered Layout" pattern of
+  // using = for equal/centered actions. Avoid Cmd+Alt+0 which collides with
+  // browser zoom-reset behavior in some webviews.
+  equalizePanes: "$mod+=",
   closeTab: "$mod+w",
   closeEmptyPane: "Escape",
   openSettings: "$mod+Comma",

--- a/src/lib/layoutEvents.ts
+++ b/src/lib/layoutEvents.ts
@@ -1,0 +1,9 @@
+/**
+ * Window-level events used to coordinate workspace layout actions across
+ * components without prop-drilling. Kept in a dependency-free module so
+ * `Pane` and `LayoutRenderer` can both import from it without forming a
+ * circular import.
+ */
+
+/** Reset every nested PanelGroup in the active workspace to an even split. */
+export const EQUALIZE_PANES_EVENT = "acorn:equalize-panes";


### PR DESCRIPTION
## Summary
- New "Equalize Pane Sizes" action: resets every workspace PanelGroup back to even per-axis sizes.
- Triggered by Cmd+= or the new entries in the tab and pane-body right-click menus.
- Sizing weights each binary split by *co-axial* leaf count, so a layout like `vertical(A, horizontal(B, horizontal(C, D)))` snaps to A=50% h / B=33% w / C=33% w / D=33% w (rather than naive 50/50 leaving A at 25% h or B at 50% w).
- Adds `lib/layoutEvents.ts` to host the window event constant and break a Pane <-> LayoutRenderer import cycle.

## Test plan
- [x] `bunx tsc --noEmit` clean (verified)
- [x] HMR applies without runtime errors (dev log clean)
- [x] Console logs (during dev) confirmed `setLayout` fires per group with correct targets, e.g. `[A | (B|C|D)]` produced `target: [50,50]`, `[33.33, 66.67]`, `[50,50]`
- [x] Layouts manually walked-through with the user for shapes `[A][B|C|D]`, `[A|B][C|D|E]`, `[A|B][C][D|E|F]` — all match expected per-axis equalization
- [ ] CI / required status check passes