### PR TITLE
feat(right-panel): PRs tab + scrollable tab strip + conditional Todos

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 use crate::error::{AppError, AppResult};
 use crate::git_ops::{self, CommitInfo, DiffPayload, StagedFile};
 use crate::persistence;
+use crate::pull_requests::{self, PrStateFilter, PullRequestListing};
 use crate::scrollback;
 use crate::session::{Project, Session, SessionStatus};
 use crate::session_status;
@@ -553,6 +554,19 @@ pub fn open_in_editor(
 #[tauri::command]
 pub fn staged_diff(repo_path: String) -> AppResult<DiffPayload> {
     git_ops::diff_staged(&PathBuf::from(repo_path))
+}
+
+#[tauri::command]
+pub fn list_pull_requests(
+    repo_path: String,
+    state: Option<PrStateFilter>,
+    limit: Option<u32>,
+) -> AppResult<PullRequestListing> {
+    pull_requests::list_pull_requests(
+        &PathBuf::from(repo_path),
+        state.unwrap_or(PrStateFilter::Open),
+        limit.unwrap_or(50),
+    )
 }
 
 fn create_unique_worktree(

--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -42,6 +42,19 @@ pub struct DiffFile {
 /// given commit. Returns `None` when there is no `origin` remote, the URL
 /// cannot be parsed, or the host is not recognised as GitHub.
 pub fn web_url_for_commit(repo_path: &Path, sha: &str) -> AppResult<Option<String>> {
+    let Some(owner_repo) = github_owner_repo(repo_path)? else {
+        return Ok(None);
+    };
+    Ok(Some(format!(
+        "https://github.com/{owner_repo}/commit/{sha}"
+    )))
+}
+
+/// Return the GitHub `owner/repo` slug derived from the repo's `origin`
+/// remote, or `None` when there's no origin, the URL is unparseable, or the
+/// host isn't GitHub. Reused by features that talk to the GitHub web/API
+/// layer (commit URLs, PR listing).
+pub fn github_owner_repo(repo_path: &Path) -> AppResult<Option<String>> {
     let repo = ensure_repo(repo_path)?;
     let remote = match repo.find_remote("origin") {
         Ok(r) => r,
@@ -50,10 +63,10 @@ pub fn web_url_for_commit(repo_path: &Path, sha: &str) -> AppResult<Option<Strin
     let Some(url) = remote.url() else {
         return Ok(None);
     };
-    Ok(parse_github_commit_url(url, sha))
+    Ok(parse_github_owner_repo(url))
 }
 
-fn parse_github_commit_url(remote: &str, sha: &str) -> Option<String> {
+fn parse_github_owner_repo(remote: &str) -> Option<String> {
     let trimmed = remote.trim();
     // Pull "host" + "owner/repo[.git]" out of any of the three common URL
     // shapes git uses.
@@ -83,7 +96,7 @@ fn parse_github_commit_url(remote: &str, sha: &str) -> Option<String> {
     if owner_repo.is_empty() || !owner_repo.contains('/') {
         return None;
     }
-    Some(format!("https://github.com/{owner_repo}/commit/{sha}"))
+    Some(owner_repo.to_string())
 }
 
 pub fn list_commits(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod error;
 mod git_ops;
 mod persistence;
 mod pty;
+mod pull_requests;
 mod scrollback;
 mod session;
 mod session_status;
@@ -144,6 +145,7 @@ pub fn run() {
             commands::claude_session_exists,
             commands::open_in_editor,
             commands::staged_diff,
+            commands::list_pull_requests,
             commands::pty_spawn,
             commands::pty_write,
             commands::pty_resize,

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -1,0 +1,152 @@
+//! GitHub pull request listing via the `gh` CLI.
+//!
+//! We shell out to `gh pr list --json ...` rather than calling GitHub's REST
+//! API directly so that the user's existing `gh` auth (keychain, OAuth
+//! device flow, enterprise hosts) is reused with zero in-app token storage.
+//! When `gh` is missing or unauthenticated we surface a typed error so the
+//! frontend can show actionable guidance.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, AppResult};
+use crate::git_ops::github_owner_repo;
+
+/// PR state filter accepted from the frontend. Mirrors the values gh
+/// understands so we can pass it straight through.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PrStateFilter {
+    Open,
+    Closed,
+    Merged,
+    All,
+}
+
+impl PrStateFilter {
+    fn as_gh_arg(self) -> &'static str {
+        match self {
+            PrStateFilter::Open => "open",
+            PrStateFilter::Closed => "closed",
+            PrStateFilter::Merged => "merged",
+            PrStateFilter::All => "all",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PullRequestInfo {
+    pub number: u64,
+    pub title: String,
+    /// Lifecycle state from gh: "OPEN" / "CLOSED" / "MERGED".
+    pub state: String,
+    pub author: String,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub url: String,
+    /// ISO-8601 timestamp from gh; the frontend formats it for display.
+    pub updated_at: String,
+    pub is_draft: bool,
+}
+
+/// Raw shape of a single PR entry returned by `gh pr list --json ...`.
+/// Field names match gh's JSON output, which uses camelCase.
+#[derive(Debug, Deserialize)]
+struct GhPullRequest {
+    number: u64,
+    title: String,
+    state: String,
+    #[serde(default)]
+    author: GhAuthor,
+    #[serde(rename = "headRefName")]
+    head_ref_name: String,
+    #[serde(rename = "baseRefName")]
+    base_ref_name: String,
+    url: String,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+    #[serde(rename = "isDraft", default)]
+    is_draft: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GhAuthor {
+    #[serde(default)]
+    login: Option<String>,
+}
+
+/// Outcome of the listing call. `NotGithub` lets the frontend show an
+/// "origin is not a GitHub remote" empty state without surfacing an error
+/// banner; everything else flows through `AppError`.
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PullRequestListing {
+    Ok { items: Vec<PullRequestInfo> },
+    NotGithub,
+}
+
+pub fn list_pull_requests(
+    repo_path: &Path,
+    state: PrStateFilter,
+    limit: u32,
+) -> AppResult<PullRequestListing> {
+    let Some(slug) = github_owner_repo(repo_path)? else {
+        return Ok(PullRequestListing::NotGithub);
+    };
+
+    let limit = limit.clamp(1, 200);
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--repo",
+            &slug,
+            "--state",
+            state.as_gh_arg(),
+            "--limit",
+            &limit.to_string(),
+            "--json",
+            "number,title,state,author,headRefName,baseRefName,url,updatedAt,isDraft",
+        ])
+        .output()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                AppError::Other(
+                    "`gh` CLI not found. Install it from https://cli.github.com and run `gh auth login`.".to_string(),
+                )
+            } else {
+                AppError::Other(format!("failed to invoke gh: {e}"))
+            }
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("gh exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+
+    let raw: Vec<GhPullRequest> = serde_json::from_slice(&output.stdout)
+        .map_err(|e| AppError::Other(format!("failed to parse gh output: {e}")))?;
+
+    let items = raw
+        .into_iter()
+        .map(|pr| PullRequestInfo {
+            number: pr.number,
+            title: pr.title,
+            state: pr.state,
+            author: pr.author.login.unwrap_or_else(|| "unknown".to_string()),
+            head_branch: pr.head_ref_name,
+            base_branch: pr.base_ref_name,
+            url: pr.url,
+            updated_at: pr.updated_at,
+            is_draft: pr.is_draft,
+        })
+        .collect();
+    Ok(PullRequestListing::Ok { items })
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,6 +119,10 @@ function App() {
         e.preventDefault();
         useAppStore.getState().setRightTab("staged");
       },
+      [Hotkeys.togglePrs]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        useAppStore.getState().setRightTab("prs");
+      },
       [Hotkeys.splitVertical]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().splitFocusedPane("horizontal");

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -3,6 +3,7 @@ import { Command } from "cmdk";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import {
   GitCommit,
+  GitPullRequest,
   ListChecks,
   ListPlus,
   Plus,
@@ -69,7 +70,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     }
   }
 
-  function handleSetTab(tab: "todos" | "commits" | "staged") {
+  function handleSetTab(tab: "todos" | "commits" | "staged" | "prs") {
     useAppStore.getState().setRightTab(tab);
     close();
   }
@@ -169,6 +170,14 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           >
             <ListPlus size={14} className="text-fg-muted" />
             <span>View Staged</span>
+          </Command.Item>
+          <Command.Item
+            value="view-prs"
+            onSelect={() => handleSetTab("prs")}
+            keywords={["pull requests", "pr", "github"]}
+          >
+            <GitPullRequest size={14} className="text-fg-muted" />
+            <span>View Pull Requests</span>
           </Command.Item>
         </Command.Group>
 

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -4,9 +4,11 @@ import {
   ExternalLink,
   FileDiff,
   GitCommit,
+  GitPullRequest,
   Globe,
   ListTodo,
   Maximize2,
+  RefreshCw,
 } from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Panel, PanelGroup } from "react-resizable-panels";
@@ -19,6 +21,9 @@ import { useAppStore } from "../store";
 import type {
   CommitInfo,
   DiffPayload,
+  PrStateFilter,
+  PullRequestInfo,
+  PullRequestListing,
   StagedFile,
   TodoItem,
 } from "../lib/types";
@@ -43,15 +48,41 @@ export function RightPanel() {
   const repoPath = active?.worktree_path ?? activeProject ?? null;
   const [expanded, setExpanded] = useState<ExpandedDiff | null>(null);
 
+  // Polling lives at the panel level (not inside TodosTab) so we can hide the
+  // Todos tab when the active session has none — without requiring the tab to
+  // be mounted first to discover that.
+  const todosState = useSessionTodos(
+    active?.id ?? null,
+    active?.worktree_path ?? null,
+  );
+  const showTodos = todosState.todos.length > 0;
+
+  // If the user is sitting on Todos but the underlying list emptied (e.g.
+  // session ended, switched to a session with no todos), fall back rather
+  // than render an empty hidden tab.
+  useEffect(() => {
+    if (rightTab === "todos" && !showTodos && todosState.loaded) {
+      setRightTab("commits");
+    }
+  }, [rightTab, showTodos, todosState.loaded, setRightTab]);
+
   return (
     <aside className="flex h-full w-full flex-col bg-bg-sidebar">
-      <nav className="flex shrink-0 border-b border-border">
-        <TabButton
-          icon={<ListTodo size={14} />}
-          label="Todos"
-          active={rightTab === "todos"}
-          onClick={() => setRightTab("todos")}
-        />
+      <nav
+        className={cn(
+          "flex shrink-0 overflow-x-auto whitespace-nowrap border-b border-border",
+          "[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+        )}
+      >
+        {showTodos ? (
+          <TabButton
+            icon={<ListTodo size={14} />}
+            label="Todos"
+            badge={todosState.todos.length}
+            active={rightTab === "todos"}
+            onClick={() => setRightTab("todos")}
+          />
+        ) : null}
         <TabButton
           icon={<GitCommit size={14} />}
           label="Commits"
@@ -64,13 +95,19 @@ export function RightPanel() {
           active={rightTab === "staged"}
           onClick={() => setRightTab("staged")}
         />
+        <TabButton
+          icon={<GitPullRequest size={14} />}
+          label="PRs"
+          active={rightTab === "prs"}
+          onClick={() => setRightTab("prs")}
+        />
       </nav>
       <div className="flex-1 overflow-hidden">
         {rightTab === "todos" ? (
-          active ? (
-            <TodosTab sessionId={active.id} cwd={active.worktree_path} />
+          active && showTodos ? (
+            <TodosTab todos={todosState.todos} />
           ) : (
-            <Empty msg="No session selected" />
+            <Empty msg="No todos in this session" />
           )
         ) : rightTab === "commits" ? (
           repoPath ? (
@@ -78,8 +115,14 @@ export function RightPanel() {
           ) : (
             <Empty msg="No project selected" />
           )
+        ) : rightTab === "staged" ? (
+          repoPath ? (
+            <StagedTab repoPath={repoPath} onExpand={setExpanded} />
+          ) : (
+            <Empty msg="No project selected" />
+          )
         ) : repoPath ? (
-          <StagedTab repoPath={repoPath} onExpand={setExpanded} />
+          <PullRequestsTab repoPath={repoPath} />
         ) : (
           <Empty msg="No project selected" />
         )}
@@ -100,15 +143,16 @@ interface TabButtonProps {
   label: string;
   active: boolean;
   onClick: () => void;
+  badge?: number;
 }
 
-function TabButton({ icon, label, active, onClick }: TabButtonProps) {
+function TabButton({ icon, label, active, onClick, badge }: TabButtonProps) {
   return (
     <button
       type="button"
       onClick={onClick}
       className={cn(
-        "relative flex flex-1 items-center justify-center gap-1.5 px-2 py-2 text-xs transition",
+        "relative flex shrink-0 items-center justify-center gap-1.5 px-3 py-2 text-xs transition",
         active
           ? "text-fg after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-accent/30"
           : "text-fg-muted hover:text-fg",
@@ -116,6 +160,18 @@ function TabButton({ icon, label, active, onClick }: TabButtonProps) {
     >
       {icon}
       {label}
+      {typeof badge === "number" && badge > 0 ? (
+        <span
+          className={cn(
+            "rounded-full px-1.5 py-px text-[9px] font-medium tabular-nums",
+            active
+              ? "bg-accent/20 text-fg"
+              : "bg-fg-muted/15 text-fg-muted",
+          )}
+        >
+          {badge}
+        </span>
+      ) : null}
     </button>
   );
 }
@@ -130,32 +186,42 @@ function Empty({ msg }: { msg: string }) {
 
 const TODOS_POLL_INTERVAL_MS = 1500;
 
-function TodosTab({ sessionId, cwd }: { sessionId: string; cwd: string }) {
-  const [todos, setTodos] = useState<TodoItem[]>([]);
-  const [loaded, setLoaded] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+interface SessionTodosState {
+  todos: TodoItem[];
+  loaded: boolean;
+  error: string | null;
+}
+
+function useSessionTodos(
+  sessionId: string | null,
+  cwd: string | null,
+): SessionTodosState {
+  const [state, setState] = useState<SessionTodosState>({
+    todos: [],
+    loaded: false,
+    error: null,
+  });
 
   useEffect(() => {
+    if (!sessionId || !cwd) {
+      setState({ todos: [], loaded: true, error: null });
+      return;
+    }
     let cancelled = false;
-    setLoaded(false);
-    setError(null);
-    setTodos([]);
+    setState({ todos: [], loaded: false, error: null });
 
     const poll = async () => {
       try {
         const result = await api.readSessionTodos(sessionId, cwd);
         if (cancelled) return;
-        setTodos(result);
-        setError(null);
+        setState({ todos: result, loaded: true, error: null });
       } catch (e) {
         if (cancelled) return;
-        setError(String(e));
-      } finally {
-        if (!cancelled) setLoaded(true);
+        setState((prev) => ({ ...prev, loaded: true, error: String(e) }));
       }
     };
 
-    poll();
+    void poll();
     const handle = setInterval(poll, TODOS_POLL_INTERVAL_MS);
     return () => {
       cancelled = true;
@@ -163,24 +229,10 @@ function TodosTab({ sessionId, cwd }: { sessionId: string; cwd: string }) {
     };
   }, [sessionId, cwd]);
 
-  if (error) {
-    return <div className="p-3 text-xs text-danger">{error}</div>;
-  }
-  if (!loaded) {
-    return <Empty msg="Loading todos..." />;
-  }
-  if (todos.length === 0) {
-    return (
-      <div className="p-3 text-xs text-fg-muted">
-        <p>No todos yet.</p>
-        <p className="mt-1 opacity-60">
-          Todos appear once Claude calls `TodoWrite` or `TaskCreate` in this
-          session.
-        </p>
-      </div>
-    );
-  }
+  return state;
+}
 
+function TodosTab({ todos }: { todos: TodoItem[] }) {
   const counts = countByStatus(todos);
 
   return (
@@ -722,4 +774,213 @@ function StagedTab({
       />
     </PanelGroup>
   );
+}
+
+const PR_STATE_OPTIONS: { value: PrStateFilter; label: string }[] = [
+  { value: "open", label: "Open" },
+  { value: "closed", label: "Closed" },
+  { value: "merged", label: "Merged" },
+  { value: "all", label: "All" },
+];
+
+const PR_REFRESH_INTERVAL_MS = 60_000;
+
+function PullRequestsTab({ repoPath }: { repoPath: string }) {
+  const [stateFilter, setStateFilter] = useState<PrStateFilter>("open");
+  const [listing, setListing] = useState<PullRequestListing | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [menu, setMenu] = useState<{
+    x: number;
+    y: number;
+    pr: PullRequestInfo;
+  } | null>(null);
+
+  const fetchPrs = useCallback(
+    async (signal?: { cancelled: boolean }) => {
+      setLoading(true);
+      try {
+        const result = await api.listPullRequests(repoPath, stateFilter);
+        if (signal?.cancelled) return;
+        setListing(result);
+        setError(null);
+      } catch (e) {
+        if (signal?.cancelled) return;
+        setError(String(e));
+      } finally {
+        if (!signal?.cancelled) setLoading(false);
+      }
+    },
+    [repoPath, stateFilter],
+  );
+
+  useEffect(() => {
+    const signal = { cancelled: false };
+    void fetchPrs(signal);
+    const handle = setInterval(() => {
+      void fetchPrs(signal);
+    }, PR_REFRESH_INTERVAL_MS);
+    return () => {
+      signal.cancelled = true;
+      clearInterval(handle);
+    };
+  }, [fetchPrs]);
+
+  async function copyText(text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function openPr(pr: PullRequestInfo) {
+    try {
+      await openUrl(pr.url);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1.5">
+        {PR_STATE_OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => setStateFilter(opt.value)}
+            className={cn(
+              "rounded px-2 py-0.5 text-[11px] transition",
+              stateFilter === opt.value
+                ? "bg-bg-elevated text-fg"
+                : "text-fg-muted hover:text-fg",
+            )}
+          >
+            {opt.label}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => void fetchPrs()}
+          className="ml-auto rounded p-1 text-fg-muted transition hover:text-fg"
+          title="Refresh"
+          disabled={loading}
+        >
+          <RefreshCw
+            size={12}
+            className={cn(loading && "animate-spin")}
+          />
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {error ? (
+          <div className="p-3 text-xs text-danger">{error}</div>
+        ) : !listing ? (
+          <Empty msg="Loading pull requests..." />
+        ) : listing.kind === "not_github" ? (
+          <Empty msg="Origin remote is not a GitHub repository." />
+        ) : listing.items.length === 0 ? (
+          <Empty msg={`No ${stateFilter} pull requests.`} />
+        ) : (
+          <ul className="text-xs">
+            {listing.items.map((pr) => (
+              <li key={pr.number}>
+                <button
+                  type="button"
+                  onClick={() => void openPr(pr)}
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    setMenu({ x: e.clientX, y: e.clientY, pr });
+                  }}
+                  className="flex w-full flex-col items-start gap-0.5 border-b border-border/40 px-3 py-2 text-left transition hover:bg-bg-elevated/50"
+                  title={absoluteTime(toUnixSeconds(pr.updated_at))}
+                >
+                  <span className="flex w-full min-w-0 items-center gap-2">
+                    <span className="shrink-0 font-mono text-fg-muted">
+                      #{pr.number}
+                    </span>
+                    <PrStateBadge state={pr.state} isDraft={pr.is_draft} />
+                    <span className="truncate text-fg">{pr.title}</span>
+                  </span>
+                  <span className="flex w-full min-w-0 items-center gap-2 text-[10px] text-fg-muted">
+                    <span className="truncate">{pr.author}</span>
+                    <span className="opacity-50">·</span>
+                    <span className="truncate font-mono">
+                      {pr.head_branch} → {pr.base_branch}
+                    </span>
+                    <span className="opacity-50">·</span>
+                    <span className="font-mono">
+                      {relativeTime(toUnixSeconds(pr.updated_at))}
+                    </span>
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <ContextMenu
+        open={menu !== null}
+        x={menu?.x ?? 0}
+        y={menu?.y ?? 0}
+        items={
+          menu
+            ? ([
+                {
+                  label: "Open in browser",
+                  icon: <ExternalLink size={12} />,
+                  onClick: () => {
+                    void openPr(menu.pr);
+                  },
+                },
+                {
+                  label: "Copy URL",
+                  icon: <Copy size={12} />,
+                  onClick: () => {
+                    void copyText(menu.pr.url);
+                  },
+                },
+                {
+                  label: `Copy branch (${menu.pr.head_branch})`,
+                  icon: <Copy size={12} />,
+                  onClick: () => {
+                    void copyText(menu.pr.head_branch);
+                  },
+                },
+              ] satisfies ContextMenuItem[])
+            : []
+        }
+        onClose={() => setMenu(null)}
+      />
+    </div>
+  );
+}
+
+function PrStateBadge({ state, isDraft }: { state: string; isDraft: boolean }) {
+  const upper = state.toUpperCase();
+  const label = isDraft ? "DRAFT" : upper;
+  const tone = isDraft
+    ? "bg-fg-muted/15 text-fg-muted"
+    : upper === "OPEN"
+      ? "bg-emerald-500/15 text-emerald-400"
+      : upper === "MERGED"
+        ? "bg-purple-500/15 text-purple-400"
+        : "bg-rose-500/15 text-rose-400";
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide",
+        tone,
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function toUnixSeconds(iso: string): number {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return Math.floor(Date.now() / 1000);
+  return Math.floor(ms / 1000);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,6 +4,8 @@ import type {
   DiffPayload,
   MemoryUsage,
   Project,
+  PrStateFilter,
+  PullRequestListing,
   Session,
   SessionStatus,
   StagedFile,
@@ -70,6 +72,17 @@ export const api = {
   },
   stagedDiff(repoPath: string): Promise<DiffPayload> {
     return invoke<DiffPayload>("staged_diff", { repoPath });
+  },
+  listPullRequests(
+    repoPath: string,
+    state: PrStateFilter = "open",
+    limit = 50,
+  ): Promise<PullRequestListing> {
+    return invoke<PullRequestListing>("list_pull_requests", {
+      repoPath,
+      state,
+      limit,
+    });
   },
   getMemoryUsage(): Promise<MemoryUsage> {
     return invoke<MemoryUsage>("get_memory_usage");

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -30,6 +30,7 @@ export const Hotkeys = {
   toggleTodos: "$mod+Shift+t",
   toggleCommits: "$mod+Shift+c",
   toggleStaged: "$mod+Shift+s",
+  togglePrs: "$mod+Shift+p",
   splitVertical: "$mod+d",
   splitHorizontal: "$mod+Shift+d",
   // Cmd+= mirrors VS Code's "Workbench: Toggle Centered Layout" pattern of

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -74,3 +74,21 @@ export interface TodoItem {
   status: TodoStatus | string;
   activeForm?: string | null;
 }
+
+export type PrStateFilter = "open" | "closed" | "merged" | "all";
+
+export interface PullRequestInfo {
+  number: number;
+  title: string;
+  state: string;
+  author: string;
+  head_branch: string;
+  base_branch: string;
+  url: string;
+  updated_at: string;
+  is_draft: boolean;
+}
+
+export type PullRequestListing =
+  | { kind: "ok"; items: PullRequestInfo[] }
+  | { kind: "not_github" };

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,7 +13,7 @@ import {
   splitPaneInLayout,
 } from "./lib/layout";
 
-type RightTab = "todos" | "commits" | "staged";
+type RightTab = "todos" | "commits" | "staged" | "prs";
 
 const ROOT_PANE_ID: PaneId = "root";
 


### PR DESCRIPTION
## Summary
- New **PRs** tab in the right panel — lists pull requests for the active project's GitHub origin via `gh pr list --json ...`. State filter (open/closed/merged/all), manual refresh, periodic poll, context menu (open in browser, copy URL, copy branch).
- Tab strip is now horizontally **scrollable** (`overflow-x-auto`, hidden scrollbar) so adding tabs doesn't squish the row.
- **Todos tab now appears only when the active session actually has todos.** Polling lifted to `RightPanel` via `useSessionTodos`. Auto-falls back to Commits when the list empties. Active count appears as a tab badge.

## Implementation notes
- Added `pull_requests.rs` Rust module that shells `gh` and parses JSON. Returns a typed `PullRequestListing::Ok { items }` or `NotGithub` so the UI can show a clean empty state for non-GitHub remotes (vs surfacing an error banner).
- Extracted `github_owner_repo()` from the existing commit-URL parser in `git_ops.rs` so the same parsing path serves both features.
- Auth and rate-limiting delegated to the user's existing `gh` install — no in-app token storage. Missing-binary case returns an actionable message.
- Hotkey: `Cmd+Shift+P` toggles the PRs tab; command palette gains a **View Pull Requests** entry.

## Test plan
- [ ] GitHub-hosted project: PRs tab loads with badges (OPEN/MERGED/CLOSED/DRAFT) and metadata.
- [ ] State filter (open/closed/merged/all) changes the list.
- [ ] Click row → opens in browser.
- [ ] Right-click row → Open / Copy URL / Copy branch all work.
- [ ] Manual refresh shows spinner and refetches.
- [ ] Non-GitHub remote → "Origin remote is not a GitHub repository."
- [ ] Missing/unauth gh → actionable error.
- [ ] Tab strip horizontal scroll when panel narrow.
- [ ] Todos tab appears only when active session has todos; badge updates; auto-redirect to Commits when list empties.
- [ ] `Cmd+Shift+P` and palette "View Pull Requests" both switch tabs.