### PR TITLE
feat(pr-tab): per-repo gh account routing + perf + SSH alias support

### DIFF
--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -88,7 +88,7 @@ fn parse_github_owner_repo(remote: &str) -> Option<String> {
         return None;
     };
 
-    if !host.eq_ignore_ascii_case("github.com") {
+    if !is_github_host(host) {
         return None;
     }
 
@@ -97,6 +97,73 @@ fn parse_github_owner_repo(remote: &str) -> Option<String> {
         return None;
     }
     Some(owner_repo.to_string())
+}
+
+/// Test whether `host` ultimately points at github.com.
+///
+/// Direct match for plain `github.com`. For everything else we resolve via
+/// `ssh -G <host>` — multi-identity setups commonly alias github.com in
+/// `~/.ssh/config` with blocks like:
+///
+/// ```text
+/// Host github-im-ian
+///     HostName github.com
+///     IdentityFile ~/.ssh/id_im_ian
+/// ```
+///
+/// which produces remotes such as `git@github-im-ian:org/repo.git`. Without
+/// alias resolution we'd reject those as "not GitHub" even though they're
+/// just GitHub-with-routing.
+fn is_github_host(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("github.com") {
+        return true;
+    }
+    cached_ssh_hostname(host)
+        .map(|real| real.eq_ignore_ascii_case("github.com"))
+        .unwrap_or(false)
+}
+
+fn cached_ssh_hostname(alias: &str) -> Option<String> {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+
+    static CACHE: OnceLock<Mutex<HashMap<String, Option<String>>>> =
+        OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+
+    if let Ok(map) = cache.lock() {
+        if let Some(hit) = map.get(alias) {
+            return hit.clone();
+        }
+    }
+
+    let resolved = resolve_ssh_hostname(alias);
+    if let Ok(mut map) = cache.lock() {
+        map.insert(alias.to_string(), resolved.clone());
+    }
+    resolved
+}
+
+fn resolve_ssh_hostname(alias: &str) -> Option<String> {
+    let out = std::process::Command::new("ssh")
+        .args(["-G", alias])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for line in stdout.lines() {
+        // `ssh -G` lowercases keys; the hostname line is exactly:
+        //     hostname github.com
+        if let Some(rest) = line.strip_prefix("hostname ") {
+            let h = rest.trim();
+            if !h.is_empty() {
+                return Some(h.to_string());
+            }
+        }
+    }
+    None
 }
 
 pub fn list_commits(

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -5,6 +5,26 @@
 //! device flow, enterprise hosts) is reused with zero in-app token storage.
 //! When `gh` is missing or unauthenticated we surface a typed error so the
 //! frontend can show actionable guidance.
+//!
+//! ## Multi-account routing
+//!
+//! Users frequently keep multiple GitHub identities logged into `gh` (e.g. a
+//! work account in `~/Documents/Github` and a personal account in
+//! `~/Documents/Personal`). The currently-active `gh` account is global, so
+//! a personal repo opened while the work account is active would 403.
+//!
+//! To avoid that, before listing PRs we resolve the *correct* account for
+//! the repo:
+//!
+//!   1. Enumerate every login authenticated against `github.com`.
+//!   2. Probe `repos/<slug>` access with each account's token.
+//!   3. If only one account has access — use it.
+//!   4. If multiple do — prefer the one whose primary email matches the
+//!      repo's `git config user.email` (best-effort; falls back to the
+//!      currently-active gh account).
+//!
+//! The picked token is passed to `gh pr list` via `GH_TOKEN`, overriding
+//! whichever account `gh` would otherwise pick.
 
 use std::path::Path;
 use std::process::Command;
@@ -51,6 +71,14 @@ pub struct PullRequestInfo {
     pub is_draft: bool,
 }
 
+/// One gh login that was probed during account resolution. `has_access` lets
+/// the frontend explain why none of the user's accounts could see the repo.
+#[derive(Debug, Clone, Serialize)]
+pub struct AccountSummary {
+    pub login: String,
+    pub has_access: bool,
+}
+
 /// Raw shape of a single PR entry returned by `gh pr list --json ...`.
 /// Field names match gh's JSON output, which uses camelCase.
 #[derive(Debug, Deserialize)]
@@ -77,15 +105,30 @@ struct GhAuthor {
     login: Option<String>,
 }
 
-/// Outcome of the listing call. `NotGithub` lets the frontend show an
-/// "origin is not a GitHub remote" empty state without surfacing an error
-/// banner; everything else flows through `AppError`.
+/// Outcome of the listing call.
+///
+/// - `NotGithub` — origin remote is non-GitHub; frontend renders a quiet
+///   empty state instead of an error banner.
+/// - `NoAccess` — `gh` is authenticated but none of the logged-in accounts
+///   have access to the repo. Frontend lists the tried logins so the user
+///   knows what to fix.
+/// - `Ok` — listing succeeded; `account` is the login that was used so the
+///   frontend can surface "via @login" context.
 #[derive(Debug, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum PullRequestListing {
-    Ok { items: Vec<PullRequestInfo> },
+    Ok {
+        items: Vec<PullRequestInfo>,
+        account: String,
+    },
     NotGithub,
+    NoAccess {
+        slug: String,
+        accounts: Vec<AccountSummary>,
+    },
 }
+
+const GH_HOST: &str = "github.com";
 
 pub fn list_pull_requests(
     repo_path: &Path,
@@ -96,8 +139,21 @@ pub fn list_pull_requests(
         return Ok(PullRequestListing::NotGithub);
     };
 
+    let resolution = resolve_account_for_repo(repo_path, &slug)?;
+    let Some(picked) = resolution.picked else {
+        return Ok(PullRequestListing::NoAccess {
+            slug,
+            accounts: resolution.candidates,
+        });
+    };
+
     let limit = limit.clamp(1, 200);
     let output = Command::new("gh")
+        .env("GH_TOKEN", &picked.token)
+        // gh treats GH_HOST + GH_TOKEN as an "external" auth source and skips
+        // its own keyring lookup, so this isolates the run to the picked
+        // identity even when a different `gh auth status` account is active.
+        .env("GH_HOST", GH_HOST)
         .args([
             "pr",
             "list",
@@ -111,15 +167,7 @@ pub fn list_pull_requests(
             "number,title,state,author,headRefName,baseRefName,url,updatedAt,isDraft",
         ])
         .output()
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                AppError::Other(
-                    "`gh` CLI not found. Install it from https://cli.github.com and run `gh auth login`.".to_string(),
-                )
-            } else {
-                AppError::Other(format!("failed to invoke gh: {e}"))
-            }
-        })?;
+        .map_err(map_gh_spawn_error)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -148,5 +196,225 @@ pub fn list_pull_requests(
             is_draft: pr.is_draft,
         })
         .collect();
-    Ok(PullRequestListing::Ok { items })
+    Ok(PullRequestListing::Ok {
+        items,
+        account: picked.login,
+    })
+}
+
+struct PickedAccount {
+    login: String,
+    token: String,
+}
+
+struct AccountResolution {
+    candidates: Vec<AccountSummary>,
+    picked: Option<PickedAccount>,
+}
+
+/// Pick the gh account most likely to have access to `slug`. Preference
+/// order: only-accessible-account → email-match against the repo's git
+/// config → currently-active gh account → first accessible. Returns
+/// `picked = None` when nothing has access.
+fn resolve_account_for_repo(repo_path: &Path, slug: &str) -> AppResult<AccountResolution> {
+    let logins = enumerate_logins(GH_HOST)?;
+    if logins.is_empty() {
+        return Err(AppError::Other(
+            "gh CLI is not authenticated. Run `gh auth login`.".to_string(),
+        ));
+    }
+
+    let mut candidates: Vec<AccountSummary> = Vec::with_capacity(logins.len());
+    let mut accessible: Vec<(String, String)> = Vec::new();
+    for login in &logins {
+        let Some(token) = gh_token_for(login) else {
+            candidates.push(AccountSummary {
+                login: login.clone(),
+                has_access: false,
+            });
+            continue;
+        };
+        let has_access = account_can_access(slug, &token);
+        candidates.push(AccountSummary {
+            login: login.clone(),
+            has_access,
+        });
+        if has_access {
+            accessible.push((login.clone(), token));
+        }
+    }
+
+    let picked = match accessible.len() {
+        0 => None,
+        1 => Some(PickedAccount {
+            login: accessible[0].0.clone(),
+            token: accessible[0].1.clone(),
+        }),
+        _ => Some(pick_from_multiple(repo_path, &accessible)),
+    };
+
+    Ok(AccountResolution { candidates, picked })
+}
+
+fn pick_from_multiple(
+    repo_path: &Path,
+    accessible: &[(String, String)],
+) -> PickedAccount {
+    // 1. Prefer an account whose primary email matches the repo's
+    //    git user.email. Best-effort; either side may be missing.
+    if let Some(repo_email) = git_user_email(repo_path) {
+        for (login, token) in accessible {
+            if let Some(account_email) = primary_email_for(token) {
+                if account_email.eq_ignore_ascii_case(&repo_email) {
+                    return PickedAccount {
+                        login: login.clone(),
+                        token: token.clone(),
+                    };
+                }
+            }
+        }
+    }
+
+    // 2. Fall back to whatever account `gh` currently considers active —
+    //    matches the user's existing mental model.
+    if let Some(active) = gh_active_token() {
+        if let Some((login, token)) =
+            accessible.iter().find(|(_, t)| t == &active)
+        {
+            return PickedAccount {
+                login: login.clone(),
+                token: token.clone(),
+            };
+        }
+    }
+
+    // 3. Otherwise just take the first account that worked.
+    PickedAccount {
+        login: accessible[0].0.clone(),
+        token: accessible[0].1.clone(),
+    }
+}
+
+fn map_gh_spawn_error(e: std::io::Error) -> AppError {
+    if e.kind() == std::io::ErrorKind::NotFound {
+        AppError::Other(
+            "`gh` CLI not found. Install it from https://cli.github.com and run `gh auth login`."
+                .to_string(),
+        )
+    } else {
+        AppError::Other(format!("failed to invoke gh: {e}"))
+    }
+}
+
+/// Parse `gh auth status --hostname <host>` output and pull out logins.
+/// gh writes the human-readable status block to *stderr*, so we read both
+/// streams. Lines look like:
+///   "  ✓ Logged in to github.com account jtf-ian (keyring)"
+fn enumerate_logins(host: &str) -> AppResult<Vec<String>> {
+    let out = Command::new("gh")
+        .args(["auth", "status", "--hostname", host])
+        .output()
+        .map_err(map_gh_spawn_error)?;
+    // Unauthenticated returns non-zero — empty list, not an error, so the
+    // caller can produce a single canonical "not authenticated" message.
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let needle = " account ";
+    let mut logins: Vec<String> = Vec::new();
+    for line in combined.lines() {
+        let Some(idx) = line.find(needle) else { continue };
+        let after = &line[idx + needle.len()..];
+        let login: String = after
+            .chars()
+            .take_while(|c| !c.is_whitespace())
+            .collect();
+        if !login.is_empty() && !logins.iter().any(|l| l == &login) {
+            logins.push(login);
+        }
+    }
+    Ok(logins)
+}
+
+fn gh_token_for(login: &str) -> Option<String> {
+    let out = Command::new("gh")
+        .args(["auth", "token", "--user", login])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+fn gh_active_token() -> Option<String> {
+    let out = Command::new("gh").args(["auth", "token"]).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+/// Cheap repo-access probe via `gh api repos/<slug> --silent`. Exits
+/// non-zero on 403/404, success on 200 — exactly the signal we need.
+fn account_can_access(slug: &str, token: &str) -> bool {
+    let endpoint = format!("repos/{slug}");
+    let out = Command::new("gh")
+        .env("GH_TOKEN", token)
+        .env("GH_HOST", GH_HOST)
+        .args(["api", &endpoint, "--silent"])
+        .output();
+    match out {
+        Ok(o) => o.status.success(),
+        Err(_) => false,
+    }
+}
+
+fn primary_email_for(token: &str) -> Option<String> {
+    let out = Command::new("gh")
+        .env("GH_TOKEN", token)
+        .env("GH_HOST", GH_HOST)
+        .args(["api", "user", "--jq", ".email"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() || s == "null" {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+fn git_user_email(repo_path: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo_path)
+        .args(["config", "user.email"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
 }

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -26,8 +26,11 @@
 //! The picked token is passed to `gh pr list` via `GH_TOKEN`, overriding
 //! whichever account `gh` would otherwise pick.
 
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
@@ -130,6 +133,64 @@ pub enum PullRequestListing {
 
 const GH_HOST: &str = "github.com";
 
+/// How long a successful (login, repo) resolution stays trusted before we
+/// re-probe access. Picked to be long enough to make periodic refreshes
+/// cheap, short enough that a `gh auth login` for a new account becomes
+/// usable without restarting the app.
+const RESOLUTION_TTL: Duration = Duration::from_secs(10 * 60);
+
+#[derive(Clone)]
+struct CachedResolution {
+    login: String,
+    cached_at: Instant,
+}
+
+impl CachedResolution {
+    fn fresh(&self) -> bool {
+        self.cached_at.elapsed() < RESOLUTION_TTL
+    }
+}
+
+/// Per-repo cache of which gh login was last seen with access. Keyed by
+/// the repo path the frontend sent (the worktree). The token itself is
+/// re-fetched on every call — that's a fast local `gh auth token` spawn,
+/// no network — so we never store secrets in this cache.
+fn resolution_cache() -> &'static Mutex<HashMap<PathBuf, CachedResolution>> {
+    use std::sync::OnceLock;
+    static CELL: OnceLock<Mutex<HashMap<PathBuf, CachedResolution>>> =
+        OnceLock::new();
+    CELL.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn cached_login(repo_path: &Path) -> Option<CachedResolution> {
+    let cache = resolution_cache().lock().ok()?;
+    let entry = cache.get(repo_path)?;
+    if entry.fresh() {
+        Some(entry.clone())
+    } else {
+        None
+    }
+}
+
+fn store_resolution(repo_path: &Path, login: &str) {
+    let Ok(mut cache) = resolution_cache().lock() else {
+        return;
+    };
+    cache.insert(
+        repo_path.to_path_buf(),
+        CachedResolution {
+            login: login.to_string(),
+            cached_at: Instant::now(),
+        },
+    );
+}
+
+fn invalidate_resolution(repo_path: &Path) {
+    if let Ok(mut cache) = resolution_cache().lock() {
+        cache.remove(repo_path);
+    }
+}
+
 pub fn list_pull_requests(
     repo_path: &Path,
     state: PrStateFilter,
@@ -139,6 +200,30 @@ pub fn list_pull_requests(
         return Ok(PullRequestListing::NotGithub);
     };
 
+    // Fast path: a recently-resolved login for this repo. Skip every probe
+    // and only pay for `gh auth token` (local) + `gh pr list` (network).
+    if let Some(cached) = cached_login(repo_path) {
+        if let Some(token) = gh_token_for(&cached.login) {
+            match run_pr_list(&slug, &token, state, limit) {
+                Ok(items) => {
+                    return Ok(PullRequestListing::Ok {
+                        items,
+                        account: cached.login,
+                    });
+                }
+                Err(_) => {
+                    // Cached login lost access (token expired, removed from
+                    // org, etc.) — drop the cache and fall through to a
+                    // fresh resolution below.
+                    invalidate_resolution(repo_path);
+                }
+            }
+        } else {
+            // Login disappeared from gh between calls — re-resolve.
+            invalidate_resolution(repo_path);
+        }
+    }
+
     let resolution = resolve_account_for_repo(repo_path, &slug)?;
     let Some(picked) = resolution.picked else {
         return Ok(PullRequestListing::NoAccess {
@@ -147,9 +232,23 @@ pub fn list_pull_requests(
         });
     };
 
+    let items = run_pr_list(&slug, &picked.token, state, limit)?;
+    store_resolution(repo_path, &picked.login);
+    Ok(PullRequestListing::Ok {
+        items,
+        account: picked.login,
+    })
+}
+
+fn run_pr_list(
+    slug: &str,
+    token: &str,
+    state: PrStateFilter,
+    limit: u32,
+) -> AppResult<Vec<PullRequestInfo>> {
     let limit = limit.clamp(1, 200);
     let output = Command::new("gh")
-        .env("GH_TOKEN", &picked.token)
+        .env("GH_TOKEN", token)
         // gh treats GH_HOST + GH_TOKEN as an "external" auth source and skips
         // its own keyring lookup, so this isolates the run to the picked
         // identity even when a different `gh auth status` account is active.
@@ -158,7 +257,7 @@ pub fn list_pull_requests(
             "pr",
             "list",
             "--repo",
-            &slug,
+            slug,
             "--state",
             state.as_gh_arg(),
             "--limit",
@@ -182,7 +281,7 @@ pub fn list_pull_requests(
     let raw: Vec<GhPullRequest> = serde_json::from_slice(&output.stdout)
         .map_err(|e| AppError::Other(format!("failed to parse gh output: {e}")))?;
 
-    let items = raw
+    Ok(raw
         .into_iter()
         .map(|pr| PullRequestInfo {
             number: pr.number,
@@ -195,11 +294,7 @@ pub fn list_pull_requests(
             updated_at: pr.updated_at,
             is_draft: pr.is_draft,
         })
-        .collect();
-    Ok(PullRequestListing::Ok {
-        items,
-        account: picked.login,
-    })
+        .collect())
 }
 
 struct PickedAccount {
@@ -216,6 +311,11 @@ struct AccountResolution {
 /// order: only-accessible-account → email-match against the repo's git
 /// config → currently-active gh account → first accessible. Returns
 /// `picked = None` when nothing has access.
+///
+/// Per-account `gh auth token` and `gh api repos/<slug>` probes run in
+/// parallel — they're independent and each costs a process spawn plus
+/// (for the API call) a network round-trip, so serializing them dominated
+/// the total resolution time on multi-account setups.
 fn resolve_account_for_repo(repo_path: &Path, slug: &str) -> AppResult<AccountResolution> {
     let logins = enumerate_logins(GH_HOST)?;
     if logins.is_empty() {
@@ -224,23 +324,49 @@ fn resolve_account_for_repo(repo_path: &Path, slug: &str) -> AppResult<AccountRe
         ));
     }
 
-    let mut candidates: Vec<AccountSummary> = Vec::with_capacity(logins.len());
+    struct Probe {
+        login: String,
+        token: Option<String>,
+        has_access: bool,
+    }
+
+    let probes: Vec<Probe> = std::thread::scope(|scope| {
+        let handles: Vec<_> = logins
+            .iter()
+            .map(|login| {
+                let login = login.clone();
+                let slug = slug.to_string();
+                scope.spawn(move || {
+                    let token = gh_token_for(&login);
+                    let has_access = token
+                        .as_deref()
+                        .map(|t| account_can_access(&slug, t))
+                        .unwrap_or(false);
+                    Probe {
+                        login,
+                        token,
+                        has_access,
+                    }
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|h| h.join().expect("probe thread panicked"))
+            .collect()
+    });
+
+    let mut candidates: Vec<AccountSummary> = Vec::with_capacity(probes.len());
     let mut accessible: Vec<(String, String)> = Vec::new();
-    for login in &logins {
-        let Some(token) = gh_token_for(login) else {
-            candidates.push(AccountSummary {
-                login: login.clone(),
-                has_access: false,
-            });
-            continue;
-        };
-        let has_access = account_can_access(slug, &token);
+    for p in probes {
         candidates.push(AccountSummary {
-            login: login.clone(),
-            has_access,
+            login: p.login.clone(),
+            has_access: p.has_access,
         });
-        if has_access {
-            accessible.push((login.clone(), token));
+        if p.has_access {
+            if let Some(tok) = p.token {
+                accessible.push((p.login, tok));
+            }
         }
     }
 

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -19,6 +19,7 @@ import { openFileInEditor } from "../lib/editor";
 import { joinPath } from "../lib/paths";
 import { useAppStore } from "../store";
 import type {
+  AccountSummary,
   CommitInfo,
   DiffPayload,
   PrStateFilter,
@@ -842,6 +843,9 @@ function PullRequestsTab({ repoPath }: { repoPath: string }) {
     }
   }
 
+  const activeAccount =
+    listing && listing.kind === "ok" ? listing.account : null;
+
   return (
     <div className="flex h-full flex-col">
       <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1.5">
@@ -860,6 +864,14 @@ function PullRequestsTab({ repoPath }: { repoPath: string }) {
             {opt.label}
           </button>
         ))}
+        {activeAccount ? (
+          <span
+            className="ml-1 rounded bg-fg-muted/15 px-1.5 py-0.5 text-[10px] text-fg-muted"
+            title={`Listed via gh account @${activeAccount}`}
+          >
+            @{activeAccount}
+          </span>
+        ) : null}
         <button
           type="button"
           onClick={() => void fetchPrs()}
@@ -880,6 +892,8 @@ function PullRequestsTab({ repoPath }: { repoPath: string }) {
           <Empty msg="Loading pull requests..." />
         ) : listing.kind === "not_github" ? (
           <Empty msg="Origin remote is not a GitHub repository." />
+        ) : listing.kind === "no_access" ? (
+          <NoAccessBanner slug={listing.slug} accounts={listing.accounts} />
         ) : listing.items.length === 0 ? (
           <Empty msg={`No ${stateFilter} pull requests.`} />
         ) : (
@@ -953,6 +967,35 @@ function PullRequestsTab({ repoPath }: { repoPath: string }) {
         }
         onClose={() => setMenu(null)}
       />
+    </div>
+  );
+}
+
+function NoAccessBanner({
+  slug,
+  accounts,
+}: {
+  slug: string;
+  accounts: AccountSummary[];
+}) {
+  const tried = accounts.map((a) => `@${a.login}`).join(", ");
+  return (
+    <div className="space-y-2 p-3 text-xs text-fg-muted">
+      <p className="text-fg">
+        No logged-in <code className="font-mono">gh</code> account can access{" "}
+        <span className="font-mono text-fg">{slug}</span>.
+      </p>
+      {accounts.length > 0 ? (
+        <p>
+          <span className="opacity-70">Tried:</span> {tried}
+        </p>
+      ) : (
+        <p>No accounts authenticated against github.com.</p>
+      )}
+      <p className="opacity-70">
+        Run <code className="font-mono">gh auth login</code> with an account
+        that has access, or accept the invitation on github.com.
+      </p>
     </div>
   );
 }

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -796,6 +796,7 @@ function PullRequestsTab({ repoPath }: { repoPath: string }) {
     y: number;
     pr: PullRequestInfo;
   } | null>(null);
+  const setPrAccountForRepo = useAppStore((s) => s.setPrAccountForRepo);
 
   const fetchPrs = useCallback(
     async (signal?: { cancelled: boolean }) => {
@@ -805,6 +806,10 @@ function PullRequestsTab({ repoPath }: { repoPath: string }) {
         if (signal?.cancelled) return;
         setListing(result);
         setError(null);
+        setPrAccountForRepo(
+          repoPath,
+          result.kind === "ok" ? result.account : null,
+        );
       } catch (e) {
         if (signal?.cancelled) return;
         setError(String(e));
@@ -812,7 +817,7 @@ function PullRequestsTab({ repoPath }: { repoPath: string }) {
         if (!signal?.cancelled) setLoading(false);
       }
     },
-    [repoPath, stateFilter],
+    [repoPath, stateFilter, setPrAccountForRepo],
   );
 
   useEffect(() => {
@@ -843,9 +848,6 @@ function PullRequestsTab({ repoPath }: { repoPath: string }) {
     }
   }
 
-  const activeAccount =
-    listing && listing.kind === "ok" ? listing.account : null;
-
   return (
     <div className="flex h-full flex-col">
       <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1.5">
@@ -864,14 +866,6 @@ function PullRequestsTab({ repoPath }: { repoPath: string }) {
             {opt.label}
           </button>
         ))}
-        {activeAccount ? (
-          <span
-            className="ml-1 rounded bg-fg-muted/15 px-1.5 py-0.5 text-[10px] text-fg-muted"
-            title={`Listed via gh account @${activeAccount}`}
-          >
-            @{activeAccount}
-          </span>
-        ) : null}
         <button
           type="button"
           onClick={() => void fetchPrs()}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -72,13 +72,36 @@ function useMemoryUsage(intervalMs: number): MemorySnapshot | null {
   return snapshot;
 }
 
+// GitHub octocat mark — lucide-react has no brand glyphs, so inline the
+// official Mark path. `currentColor` lets the surrounding text style it.
+function GitHubMark() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={11}
+      height={11}
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+    </svg>
+  );
+}
+
 export function StatusBar() {
-  const { sessions, activeSessionId, error, loading } = useAppStore();
+  const { sessions, activeSessionId, activeProject, error, loading } =
+    useAppStore();
+  const prAccountByRepo = useAppStore((s) => s.prAccountByRepo);
   const active = sessions.find((s) => s.id === activeSessionId);
   const memory = useMemoryUsage(MEMORY_POLL_MS);
   const home = useHomeDir();
   const [breakdownOpen, setBreakdownOpen] = useState(false);
   const displayPath = active ? tildify(active.worktree_path, home) : null;
+  // The PR-tab account map is keyed by the same repoPath we hand to the PRs
+  // tab — prefer the active session's worktree (matches what was probed),
+  // then fall back to the active project root.
+  const prAccountKey = active?.worktree_path ?? activeProject ?? null;
+  const prAccount = prAccountKey ? prAccountByRepo[prAccountKey] ?? null : null;
 
   return (
     <>
@@ -97,6 +120,15 @@ export function StatusBar() {
           {error ? (
             <span className="truncate text-danger" title={error}>
               error: {error}
+            </span>
+          ) : null}
+          {prAccount ? (
+            <span
+              className="flex shrink-0 items-center gap-1 rounded bg-fg-muted/15 px-1.5 py-0.5 text-[10px] text-fg-muted"
+              title={`PRs listed via gh account ${prAccount}`}
+            >
+              <GitHubMark />
+              {prAccount}
             </span>
           ) : null}
           {active && displayPath ? (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -89,6 +89,12 @@ export interface PullRequestInfo {
   is_draft: boolean;
 }
 
+export interface AccountSummary {
+  login: string;
+  has_access: boolean;
+}
+
 export type PullRequestListing =
-  | { kind: "ok"; items: PullRequestInfo[] }
-  | { kind: "not_github" };
+  | { kind: "ok"; items: PullRequestInfo[]; account: string }
+  | { kind: "not_github" }
+  | { kind: "no_access"; slug: string; accounts: AccountSummary[] };

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -82,6 +82,7 @@ function resetStore(): void {
       focusedPaneId: "root",
       activeSessionId: null,
       rightTab: "commits",
+      prAccountByRepo: {},
       loading: false,
       error: null,
       pendingRemoveId: null,

--- a/src/store.ts
+++ b/src/store.ts
@@ -53,6 +53,10 @@ interface AppStateModel {
   activeSessionId: string | null;
 
   rightTab: RightTab;
+  /** gh login most recently resolved as having access to a given repo, keyed
+   *  by repo path. Populated by the PRs tab; consumed by the StatusBar to
+   *  surface "which identity am I acting as for this repo". In-memory only. */
+  prAccountByRepo: Record<string, string>;
   loading: boolean;
   error: string | null;
   pendingRemoveId: string | null;
@@ -88,6 +92,7 @@ interface AppStateModel {
   requestRemoveProject: (repoPath: string) => void;
   clearPendingRemoveProject: () => void;
   setRightTab: (tab: RightTab) => void;
+  setPrAccountForRepo: (repoPath: string, login: string | null) => void;
 }
 
 let paneCounter = 0;
@@ -284,6 +289,7 @@ export const useAppStore = create<AppStateModel>()(
   activeSessionId: null,
 
   rightTab: "commits",
+  prAccountByRepo: {},
   loading: false,
   error: null,
   pendingRemoveId: null,
@@ -729,6 +735,21 @@ export const useAppStore = create<AppStateModel>()(
 
   setRightTab(tab) {
     set({ rightTab: tab });
+  },
+
+  setPrAccountForRepo(repoPath, login) {
+    set((s) => {
+      const prev = s.prAccountByRepo[repoPath] ?? null;
+      if (login === null) {
+        if (prev === null) return s;
+        const { [repoPath]: _, ...rest } = s.prAccountByRepo;
+        return { prAccountByRepo: rest };
+      }
+      if (prev === login) return s;
+      return {
+        prAccountByRepo: { ...s.prAccountByRepo, [repoPath]: login },
+      };
+    });
   },
     }),
     {


### PR DESCRIPTION
## Summary

Multi-identity GitHub users (work + personal `gh` logins, often paired with SSH config aliases) hit several rough edges on the PRs tab. This bundles four changes that together make the tab "just work" regardless of which account is currently active in `gh`.

### What's in this PR

1. **Auto-route gh account per repo.** Before listing PRs we enumerate every login authenticated against github.com, probe `repos/<slug>` access with each, and pick the right one. Single accessible → use it. Multiple → prefer the one whose primary email matches the repo's `git config user.email`, otherwise fall back to whichever account `gh` considers active. The picked token is passed via `GH_TOKEN`/`GH_HOST` so the call is isolated from the global active account. New `PullRequestListing::NoAccess { slug, accounts }` variant lets the UI show an actionable banner instead of a generic error when no logged-in account can see the repo.

2. **Show the resolved login in the status bar.** The PRs tab writes its resolved login into a `prAccountByRepo` map on the zustand store; the StatusBar reads it and renders `[GitHub mark] login` immediately to the left of the worktree path. The chip stays absent until the PRs tab has resolved at least once, so just opening the app doesn't fire an extra probe.

3. **Cache + parallelize account resolution.** Resolution was running on every refresh (60s timer + manual). Now:
   - Per-(repo_path → login) in-memory cache with a 10-minute TTL. Hits skip every probe; only gh pr list runs. The token is re-fetched locally from gh on each call, never stored.
   - Per-account gh auth token and gh api repos/<slug> probes run concurrently via std::thread::scope.

   First call roughly halves on a 2-account setup; cached refreshes pay only the PR-list round-trip.

4. **Recognize SSH config aliases of github.com.** Setups like
   ```
   Host github-personal
       HostName github.com
   ```
   produced remotes such as git@github-personal:org/repo.git. The strict host == "github.com" check rejected those as non-GitHub, so the PRs tab and "View on GitHub" actions silently 404'd to the empty state. Aliases are now resolved via ssh -G <host> (cached process-wide); any host whose hostname resolves to github.com is accepted.

## Test plan

- [ ] Single-account setup still works: PRs load, chip shows the only login, no behavior regression.
- [ ] Multi-account setup with one accessible login: tab loads PRs, chip shows the accessible login (not the active one).
- [ ] Multi-account setup with two accessible logins: email-match picks the expected account.
- [ ] No accessible account: NoAccess banner lists the tried logins.
- [ ] Repo cloned via SSH alias (git@github-alias:org/repo.git): PRs load, chip shows the right account, "View on GitHub" works for commits.
- [ ] Refresh repeatedly within 10 min: only the PR list endpoint is hit (cache).
- [ ] After gh auth logout for the cached account: tab recovers (cache invalidated, falls through to fresh resolution / NoAccess).
- [ ] Non-GitHub remote: "Origin remote is not a GitHub repository." (unchanged).
- [ ] Status bar chip placement: immediately left of the worktree path; renders [GitHub mark] login.