### PR TITLE
feat(pr-tab): in-app PR detail viewer

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8,7 +8,9 @@ use uuid::Uuid;
 use crate::error::{AppError, AppResult};
 use crate::git_ops::{self, CommitInfo, DiffPayload, StagedFile};
 use crate::persistence;
-use crate::pull_requests::{self, PrStateFilter, PullRequestListing};
+use crate::pull_requests::{
+    self, PrStateFilter, PullRequestDetailListing, PullRequestListing,
+};
 use crate::scrollback;
 use crate::session::{Project, Session, SessionStatus};
 use crate::session_status;
@@ -567,6 +569,14 @@ pub fn list_pull_requests(
         state.unwrap_or(PrStateFilter::Open),
         limit.unwrap_or(50),
     )
+}
+
+#[tauri::command]
+pub fn get_pull_request_detail(
+    repo_path: String,
+    number: u64,
+) -> AppResult<PullRequestDetailListing> {
+    pull_requests::get_pull_request_detail(&PathBuf::from(repo_path), number)
 }
 
 fn create_unique_worktree(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod session;
 mod session_status;
 mod state;
 mod todos;
+mod unified_diff;
 mod worktree;
 
 use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
@@ -146,6 +147,7 @@ pub fn run() {
             commands::open_in_editor,
             commands::staged_diff,
             commands::list_pull_requests,
+            commands::get_pull_request_detail,
             commands::pty_spawn,
             commands::pty_write,
             commands::pty_resize,

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -35,7 +35,7 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, AppResult};
-use crate::git_ops::github_owner_repo;
+use crate::git_ops::{github_owner_repo, DiffPayload};
 
 /// PR state filter accepted from the frontend. Mirrors the values gh
 /// understands so we can pass it straight through.
@@ -200,43 +200,70 @@ pub fn list_pull_requests(
         return Ok(PullRequestListing::NotGithub);
     };
 
-    // Fast path: a recently-resolved login for this repo. Skip every probe
-    // and only pay for `gh auth token` (local) + `gh pr list` (network).
+    match try_with_account(repo_path, &slug, |token| {
+        run_pr_list(&slug, token, state, limit)
+    })? {
+        AccountOutcome::Ok { account, value } => Ok(PullRequestListing::Ok {
+            items: value,
+            account,
+        }),
+        AccountOutcome::NoAccess { accounts } => {
+            Ok(PullRequestListing::NoAccess { slug, accounts })
+        }
+    }
+}
+
+/// Outcome of running an authenticated gh operation for a repo. `Ok` carries
+/// the gh login that ultimately serviced the call so the frontend can render
+/// "via @login" context. `NoAccess` lets callers branch into a typed empty
+/// state without going through the error path.
+enum AccountOutcome<T> {
+    Ok { account: String, value: T },
+    NoAccess { accounts: Vec<AccountSummary> },
+}
+
+/// Run `op` with the right gh token for `slug`. Tries the cached login
+/// first; on failure (or cache miss / stale login) falls through to a
+/// fresh resolution and stores the picked login on success.
+fn try_with_account<T, F>(
+    repo_path: &Path,
+    slug: &str,
+    op: F,
+) -> AppResult<AccountOutcome<T>>
+where
+    F: Fn(&str) -> AppResult<T>,
+{
     if let Some(cached) = cached_login(repo_path) {
         if let Some(token) = gh_token_for(&cached.login) {
-            match run_pr_list(&slug, &token, state, limit) {
-                Ok(items) => {
-                    return Ok(PullRequestListing::Ok {
-                        items,
+            match op(&token) {
+                Ok(value) => {
+                    return Ok(AccountOutcome::Ok {
                         account: cached.login,
+                        value,
                     });
                 }
                 Err(_) => {
-                    // Cached login lost access (token expired, removed from
-                    // org, etc.) — drop the cache and fall through to a
-                    // fresh resolution below.
+                    // Cached login lost access — drop and fall through.
                     invalidate_resolution(repo_path);
                 }
             }
         } else {
-            // Login disappeared from gh between calls — re-resolve.
             invalidate_resolution(repo_path);
         }
     }
 
-    let resolution = resolve_account_for_repo(repo_path, &slug)?;
+    let resolution = resolve_account_for_repo(repo_path, slug)?;
     let Some(picked) = resolution.picked else {
-        return Ok(PullRequestListing::NoAccess {
-            slug,
+        return Ok(AccountOutcome::NoAccess {
             accounts: resolution.candidates,
         });
     };
 
-    let items = run_pr_list(&slug, &picked.token, state, limit)?;
+    let value = op(&picked.token)?;
     store_resolution(repo_path, &picked.login);
-    Ok(PullRequestListing::Ok {
-        items,
+    Ok(AccountOutcome::Ok {
         account: picked.login,
+        value,
     })
 }
 
@@ -543,4 +570,315 @@ fn git_user_email(repo_path: &Path) -> Option<String> {
     } else {
         Some(s)
     }
+}
+
+// ---------------------------------------------------------------------------
+// PR detail
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PullRequestComment {
+    pub author: String,
+    pub body: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PullRequestReview {
+    pub author: String,
+    /// Review state from GitHub: `APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` / `DISMISSED` / `PENDING`.
+    pub state: String,
+    pub body: String,
+    pub submitted_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PullRequestCheck {
+    pub name: String,
+    /// `QUEUED` / `IN_PROGRESS` / `COMPLETED` / `PENDING` (status checks).
+    pub status: String,
+    /// `SUCCESS` / `FAILURE` / `CANCELLED` / `NEUTRAL` / `SKIPPED` / `TIMED_OUT` / `ACTION_REQUIRED`.
+    /// None while the run is still in progress.
+    pub conclusion: Option<String>,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub url: Option<String>,
+    /// Workflow display name (CheckRun) — empty for legacy StatusContext entries.
+    pub workflow_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PullRequestDetail {
+    pub number: u64,
+    pub title: String,
+    pub body: String,
+    pub state: String,
+    pub is_draft: bool,
+    pub author: String,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub url: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub merged_at: Option<String>,
+    pub additions: u64,
+    pub deletions: u64,
+    pub changed_files: u64,
+    pub comments: Vec<PullRequestComment>,
+    pub reviews: Vec<PullRequestReview>,
+    pub checks: Vec<PullRequestCheck>,
+    pub diff: DiffPayload,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PullRequestDetailListing {
+    Ok {
+        account: String,
+        detail: PullRequestDetail,
+    },
+    NotGithub,
+    NoAccess {
+        slug: String,
+        accounts: Vec<AccountSummary>,
+    },
+}
+
+pub fn get_pull_request_detail(
+    repo_path: &Path,
+    number: u64,
+) -> AppResult<PullRequestDetailListing> {
+    let Some(slug) = github_owner_repo(repo_path)? else {
+        return Ok(PullRequestDetailListing::NotGithub);
+    };
+
+    match try_with_account(repo_path, &slug, |token| {
+        let view = run_pr_view(&slug, number, token)?;
+        let diff_text = run_pr_diff(&slug, number, token)?;
+        Ok((view, diff_text))
+    })? {
+        AccountOutcome::Ok {
+            account,
+            value: (view, diff_text),
+        } => {
+            let detail = build_detail(number, view, diff_text);
+            Ok(PullRequestDetailListing::Ok { account, detail })
+        }
+        AccountOutcome::NoAccess { accounts } => {
+            Ok(PullRequestDetailListing::NoAccess { slug, accounts })
+        }
+    }
+}
+
+fn build_detail(
+    number: u64,
+    view: GhPullRequestView,
+    diff_text: String,
+) -> PullRequestDetail {
+    let comments = view
+        .comments
+        .unwrap_or_default()
+        .into_iter()
+        .map(|c| PullRequestComment {
+            author: c.author.login.unwrap_or_else(|| "unknown".to_string()),
+            body: c.body.unwrap_or_default(),
+            created_at: c.created_at.unwrap_or_default(),
+        })
+        .collect();
+
+    let reviews = view
+        .reviews
+        .unwrap_or_default()
+        .into_iter()
+        // Keep only reviews that actually carry a verdict or message — gh
+        // emits a noisy stream of "PENDING" / empty COMMENTED entries that
+        // would otherwise flood the conversation tab.
+        .filter(|r| {
+            !r.body.as_deref().unwrap_or("").is_empty()
+                || r.state
+                    .as_deref()
+                    .map(|s| s == "APPROVED" || s == "CHANGES_REQUESTED" || s == "DISMISSED")
+                    .unwrap_or(false)
+        })
+        .map(|r| PullRequestReview {
+            author: r.author.login.unwrap_or_else(|| "unknown".to_string()),
+            state: r.state.unwrap_or_default(),
+            body: r.body.unwrap_or_default(),
+            submitted_at: r.submitted_at.unwrap_or_default(),
+        })
+        .collect();
+
+    let checks = view
+        .status_check_rollup
+        .unwrap_or_default()
+        .into_iter()
+        .map(|c| PullRequestCheck {
+            name: c.name.unwrap_or_else(|| c.context.unwrap_or_default()),
+            status: c.status.unwrap_or_default(),
+            conclusion: c.conclusion,
+            started_at: c.started_at,
+            completed_at: c.completed_at,
+            url: c.details_url.or(c.target_url),
+            workflow_name: c.workflow_name,
+        })
+        .collect();
+
+    PullRequestDetail {
+        number,
+        title: view.title.unwrap_or_default(),
+        body: view.body.unwrap_or_default(),
+        state: view.state.unwrap_or_default(),
+        is_draft: view.is_draft.unwrap_or(false),
+        author: view
+            .author
+            .unwrap_or_default()
+            .login
+            .unwrap_or_else(|| "unknown".to_string()),
+        head_branch: view.head_ref_name.unwrap_or_default(),
+        base_branch: view.base_ref_name.unwrap_or_default(),
+        url: view.url.unwrap_or_default(),
+        created_at: view.created_at.unwrap_or_default(),
+        updated_at: view.updated_at.unwrap_or_default(),
+        merged_at: view.merged_at,
+        additions: view.additions.unwrap_or(0),
+        deletions: view.deletions.unwrap_or(0),
+        changed_files: view.changed_files.unwrap_or(0),
+        comments,
+        reviews,
+        checks,
+        diff: crate::unified_diff::parse_unified_diff(&diff_text),
+    }
+}
+
+fn run_pr_view(slug: &str, number: u64, token: &str) -> AppResult<GhPullRequestView> {
+    let output = Command::new("gh")
+        .env("GH_TOKEN", token)
+        .env("GH_HOST", GH_HOST)
+        .args([
+            "pr",
+            "view",
+            &number.to_string(),
+            "--repo",
+            slug,
+            "--json",
+            "number,title,body,state,isDraft,author,headRefName,baseRefName,url,\
+             createdAt,updatedAt,mergedAt,additions,deletions,changedFiles,\
+             comments,reviews,statusCheckRollup",
+        ])
+        .output()
+        .map_err(map_gh_spawn_error)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("gh exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+
+    serde_json::from_slice(&output.stdout)
+        .map_err(|e| AppError::Other(format!("failed to parse gh output: {e}")))
+}
+
+fn run_pr_diff(slug: &str, number: u64, token: &str) -> AppResult<String> {
+    let output = Command::new("gh")
+        .env("GH_TOKEN", token)
+        .env("GH_HOST", GH_HOST)
+        .args([
+            "pr",
+            "diff",
+            &number.to_string(),
+            "--repo",
+            slug,
+        ])
+        .output()
+        .map_err(map_gh_spawn_error)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("gh exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+    // gh writes the patch to stdout as UTF-8. Lossy decode keeps things
+    // working for the rare diff containing invalid bytes (binary files,
+    // mojibake) — those segments are non-renderable anyway and the parser
+    // ultimately routes them into the binary-placeholder branch.
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GhPullRequestView {
+    title: Option<String>,
+    body: Option<String>,
+    state: Option<String>,
+    #[serde(rename = "isDraft")]
+    is_draft: Option<bool>,
+    author: Option<GhAuthor>,
+    #[serde(rename = "headRefName")]
+    head_ref_name: Option<String>,
+    #[serde(rename = "baseRefName")]
+    base_ref_name: Option<String>,
+    url: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: Option<String>,
+    #[serde(rename = "updatedAt")]
+    updated_at: Option<String>,
+    #[serde(rename = "mergedAt")]
+    merged_at: Option<String>,
+    additions: Option<u64>,
+    deletions: Option<u64>,
+    #[serde(rename = "changedFiles")]
+    changed_files: Option<u64>,
+    comments: Option<Vec<GhComment>>,
+    reviews: Option<Vec<GhReview>>,
+    #[serde(rename = "statusCheckRollup")]
+    status_check_rollup: Option<Vec<GhCheck>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhComment {
+    #[serde(default)]
+    author: GhAuthor,
+    body: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhReview {
+    #[serde(default)]
+    author: GhAuthor,
+    state: Option<String>,
+    body: Option<String>,
+    #[serde(rename = "submittedAt")]
+    submitted_at: Option<String>,
+}
+
+/// gh blends two shapes into `statusCheckRollup`: `CheckRun` (from GitHub
+/// Actions / app check-runs) and `StatusContext` (legacy commit statuses).
+/// Field availability differs, so every key is optional.
+#[derive(Debug, Deserialize)]
+struct GhCheck {
+    name: Option<String>,
+    /// Legacy StatusContext label.
+    context: Option<String>,
+    status: Option<String>,
+    conclusion: Option<String>,
+    #[serde(rename = "startedAt")]
+    started_at: Option<String>,
+    #[serde(rename = "completedAt")]
+    completed_at: Option<String>,
+    #[serde(rename = "detailsUrl")]
+    details_url: Option<String>,
+    /// StatusContext exposes `targetUrl` instead of `detailsUrl`.
+    #[serde(rename = "targetUrl")]
+    target_url: Option<String>,
+    #[serde(rename = "workflowName")]
+    workflow_name: Option<String>,
 }

--- a/src-tauri/src/unified_diff.rs
+++ b/src-tauri/src/unified_diff.rs
@@ -1,0 +1,140 @@
+//! Parse the unified-diff text gh emits (e.g. from `gh pr diff <num>`)
+//! into the same `DiffPayload` shape we render elsewhere. Lets the PR
+//! detail viewer reuse `DiffSplitView` without standing up a new format.
+//!
+//! This is intentionally simple: it preserves hunk lines verbatim with
+//! their leading prefix (' ', '+', '-') so the renderer can colour them
+//! the same way it colours libgit2-produced patches.
+
+use crate::git_ops::{DiffFile, DiffPayload};
+
+/// File-extension list mirrors the one in `git_ops::is_image_path` — we
+/// can't reach across module privacy without churning that file, and
+/// keeping a small standalone copy is cheaper than exposing it.
+fn looks_like_image(path: &str) -> bool {
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+    matches!(
+        ext.as_str(),
+        "png" | "jpg" | "jpeg" | "gif" | "webp" | "svg" | "bmp" | "ico" | "avif"
+    )
+}
+
+fn parse_diff_marker(rest: &str) -> Option<String> {
+    let trimmed = rest.trim();
+    if trimmed == "/dev/null" {
+        return None;
+    }
+    // Marker lines look like: `--- a/path` or `+++ b/path`. Strip the
+    // `a/` / `b/` prefix so the path matches what libgit2 emits.
+    let path = trimmed
+        .strip_prefix("a/")
+        .or_else(|| trimmed.strip_prefix("b/"))
+        .unwrap_or(trimmed);
+    if path.is_empty() {
+        None
+    } else {
+        Some(path.to_string())
+    }
+}
+
+/// Best-effort split of a `diff --git a/X b/Y` header into (old_path, new_path).
+/// `--- a/...` / `+++ b/...` markers below override these, but headers are
+/// the only signal we have when one side of the pair is absent (e.g. binary
+/// diffs that never emit `---`/`+++`).
+fn split_diff_git_header(rest: &str) -> (Option<String>, Option<String>) {
+    // Naive split on " b/": good enough for paths that don't contain that
+    // exact substring, which is the overwhelming majority. Quoted paths
+    // (filenames with spaces) would land here too — gh emits them
+    // unquoted so we accept the same.
+    let mut old_path = None;
+    let mut new_path = None;
+    if let Some(idx) = rest.find(" b/") {
+        let (left, right) = rest.split_at(idx);
+        let l = left.trim().trim_start_matches("a/");
+        let r = right[1..].trim().trim_start_matches("b/");
+        if !l.is_empty() {
+            old_path = Some(l.to_string());
+        }
+        if !r.is_empty() {
+            new_path = Some(r.to_string());
+        }
+    }
+    (old_path, new_path)
+}
+
+/// Convert a unified-diff text blob into a `DiffPayload`. Unknown metadata
+/// lines (`index ...`, `new file mode ...`, etc.) are dropped from the
+/// patch body to match libgit2's hunk-only view; `Binary files ...` lines
+/// are kept so the renderer can fall back to a "binary" placeholder.
+pub fn parse_unified_diff(text: &str) -> DiffPayload {
+    let mut files: Vec<DiffFile> = Vec::new();
+    let mut current: Option<DiffFile> = None;
+
+    for line in text.split('\n') {
+        if let Some(rest) = line.strip_prefix("diff --git ") {
+            if let Some(prev) = current.take() {
+                files.push(prev);
+            }
+            let (old_path, new_path) = split_diff_git_header(rest);
+            let is_image = looks_like_image(
+                new_path.as_deref().or(old_path.as_deref()).unwrap_or(""),
+            );
+            current = Some(DiffFile {
+                old_path,
+                new_path,
+                patch: String::new(),
+                old_image: None,
+                new_image: None,
+                is_image,
+            });
+            continue;
+        }
+
+        let Some(file) = current.as_mut() else {
+            continue;
+        };
+
+        if let Some(rest) = line.strip_prefix("--- ") {
+            file.old_path = parse_diff_marker(rest);
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("+++ ") {
+            file.new_path = parse_diff_marker(rest);
+            // Recompute is_image now that the actual path is known.
+            let path_for_type = file
+                .new_path
+                .as_deref()
+                .or(file.old_path.as_deref())
+                .unwrap_or("");
+            file.is_image = looks_like_image(path_for_type);
+            continue;
+        }
+        if line.starts_with("index ")
+            || line.starts_with("new file mode")
+            || line.starts_with("deleted file mode")
+            || line.starts_with("old mode")
+            || line.starts_with("new mode")
+            || line.starts_with("similarity ")
+            || line.starts_with("dissimilarity ")
+            || line.starts_with("rename ")
+            || line.starts_with("copy ")
+        {
+            continue;
+        }
+
+        // Hunk header (`@@ -1,3 +1,4 @@`), context, additions, removals,
+        // and the "Binary files differ" sentinel all flow into the patch
+        // body verbatim. Append a newline because we split on '\n'.
+        file.patch.push_str(line);
+        file.patch.push('\n');
+    }
+
+    if let Some(prev) = current.take() {
+        files.push(prev);
+    }
+    DiffPayload { files }
+}

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -1,0 +1,542 @@
+import { useEffect, useState } from "react";
+import {
+  CheckCircle2,
+  Circle,
+  Clock,
+  ExternalLink,
+  GitMerge,
+  GitPullRequest,
+  GitPullRequestClosed,
+  GitPullRequestDraft,
+  MessagesSquare,
+  Minus,
+  Plus,
+  X,
+  XCircle,
+} from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { api } from "../lib/api";
+import { cn } from "../lib/cn";
+import { useDialogShortcuts } from "../lib/dialog";
+import type {
+  PullRequestCheck,
+  PullRequestComment,
+  PullRequestDetail,
+  PullRequestDetailListing,
+  PullRequestReview,
+} from "../lib/types";
+import { DiffSplitView } from "./DiffSplitView";
+
+type DetailTab = "conversation" | "checks" | "files";
+
+interface PullRequestDetailModalProps {
+  /**
+   * Set this to open the modal. PR identity travels in `repoPath` + `number`
+   * so re-opening is a single state transition; clearing closes the modal.
+   */
+  open: { repoPath: string; number: number } | null;
+  /**
+   * Working directory passed to `DiffSplitView` so its "Open in editor"
+   * context menu can resolve repo-relative paths to absolute ones.
+   */
+  cwd?: string;
+  onClose: () => void;
+}
+
+export function PullRequestDetailModal({
+  open,
+  cwd,
+  onClose,
+}: PullRequestDetailModalProps) {
+  const [listing, setListing] = useState<PullRequestDetailListing | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<DetailTab>("conversation");
+
+  useDialogShortcuts(open !== null, {
+    onCancel: onClose,
+    onConfirm: onClose,
+  });
+
+  useEffect(() => {
+    if (!open) {
+      setListing(null);
+      setError(null);
+      setTab("conversation");
+      return;
+    }
+    let cancelled = false;
+    setListing(null);
+    setError(null);
+    api
+      .getPullRequestDetail(open.repoPath, open.number)
+      .then((result) => {
+        if (cancelled) return;
+        setListing(result);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex flex-col bg-black/60 px-4 py-6"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="mx-auto flex h-full w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-border bg-bg shadow-2xl">
+        {error ? (
+          <ModalShell title={`#${open.number}`} onClose={onClose}>
+            <div className="p-4 text-xs text-danger">{error}</div>
+          </ModalShell>
+        ) : !listing ? (
+          <ModalShell title={`#${open.number}`} onClose={onClose}>
+            <div className="flex h-full items-center justify-center text-xs text-fg-muted">
+              Loading PR…
+            </div>
+          </ModalShell>
+        ) : listing.kind === "not_github" ? (
+          <ModalShell title={`#${open.number}`} onClose={onClose}>
+            <div className="p-4 text-xs text-fg-muted">
+              Origin remote is not a GitHub repository.
+            </div>
+          </ModalShell>
+        ) : listing.kind === "no_access" ? (
+          <ModalShell title={`#${open.number}`} onClose={onClose}>
+            <div className="p-4 text-xs text-fg-muted">
+              No logged-in <code className="font-mono">gh</code> account can
+              access {listing.slug}.
+            </div>
+          </ModalShell>
+        ) : (
+          <DetailBody
+            detail={listing.detail}
+            account={listing.account}
+            tab={tab}
+            onTab={setTab}
+            cwd={cwd}
+            onClose={onClose}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ModalShell({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
+        <h3 className="truncate text-sm font-semibold tracking-tight text-fg">
+          {title}
+        </h3>
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+        >
+          <X size={16} />
+        </button>
+      </header>
+      <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
+    </>
+  );
+}
+
+function DetailBody({
+  detail,
+  account,
+  tab,
+  onTab,
+  cwd,
+  onClose,
+}: {
+  detail: PullRequestDetail;
+  account: string;
+  tab: DetailTab;
+  onTab: (t: DetailTab) => void;
+  cwd?: string;
+  onClose: () => void;
+}) {
+  const conversationCount = detail.comments.length + detail.reviews.length;
+
+  return (
+    <>
+      <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <PrStateGlyph state={detail.state} isDraft={detail.is_draft} />
+            <span className="font-mono text-xs text-fg-muted">
+              #{detail.number}
+            </span>
+            <h3 className="truncate text-sm font-semibold tracking-tight text-fg">
+              {detail.title}
+            </h3>
+          </div>
+          <p className="mt-1 truncate text-[11px] text-fg-muted">
+            <span className="font-mono">{detail.author}</span>
+            <span className="opacity-50"> · </span>
+            <span className="font-mono">
+              {detail.head_branch} → {detail.base_branch}
+            </span>
+            <span className="opacity-50"> · </span>
+            <span className="font-mono text-emerald-400">
+              +{detail.additions}
+            </span>
+            <span className="opacity-50"> </span>
+            <span className="font-mono text-rose-400">
+              −{detail.deletions}
+            </span>
+            <span className="opacity-50"> · </span>
+            <span>{detail.changed_files} files</span>
+            <span className="opacity-50"> · </span>
+            <span title={`Listed via gh account ${account}`}>@{account}</span>
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={() => void openUrl(detail.url)}
+            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+            title="Open on GitHub"
+          >
+            <ExternalLink size={14} />
+          </button>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      </header>
+
+      {detail.body.trim().length > 0 ? (
+        <div className="max-h-48 shrink-0 overflow-y-auto border-b border-border bg-bg-sidebar/40 px-4 py-3">
+          <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-fg">
+            {detail.body}
+          </pre>
+        </div>
+      ) : null}
+
+      <nav className="flex shrink-0 border-b border-border">
+        <DetailTabButton
+          icon={<MessagesSquare size={13} />}
+          label="Conversation"
+          badge={conversationCount}
+          active={tab === "conversation"}
+          onClick={() => onTab("conversation")}
+        />
+        <DetailTabButton
+          icon={<CheckCircle2 size={13} />}
+          label="Checks"
+          badge={detail.checks.length}
+          active={tab === "checks"}
+          onClick={() => onTab("checks")}
+        />
+        <DetailTabButton
+          icon={<GitPullRequest size={13} />}
+          label="Files"
+          badge={detail.diff.files.length}
+          active={tab === "files"}
+          onClick={() => onTab("files")}
+        />
+      </nav>
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {tab === "conversation" ? (
+          <ConversationPane
+            comments={detail.comments}
+            reviews={detail.reviews}
+          />
+        ) : tab === "checks" ? (
+          <ChecksPane checks={detail.checks} />
+        ) : (
+          <DiffSplitView payload={detail.diff} cwd={cwd} />
+        )}
+      </div>
+    </>
+  );
+}
+
+interface DetailTabButtonProps {
+  icon: React.ReactNode;
+  label: string;
+  badge: number;
+  active: boolean;
+  onClick: () => void;
+}
+
+function DetailTabButton({
+  icon,
+  label,
+  badge,
+  active,
+  onClick,
+}: DetailTabButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "relative flex shrink-0 items-center gap-1.5 px-3 py-2 text-xs transition",
+        active
+          ? "text-fg after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-accent/30"
+          : "text-fg-muted hover:text-fg",
+      )}
+    >
+      {icon}
+      {label}
+      {badge > 0 ? (
+        <span
+          className={cn(
+            "rounded-full px-1.5 py-px text-[9px] font-medium tabular-nums",
+            active ? "bg-accent/20 text-fg" : "bg-fg-muted/15 text-fg-muted",
+          )}
+        >
+          {badge}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function PrStateGlyph({
+  state,
+  isDraft,
+}: {
+  state: string;
+  isDraft: boolean;
+}) {
+  const upper = state.toUpperCase();
+  if (isDraft) {
+    return <GitPullRequestDraft size={14} className="text-fg-muted" />;
+  }
+  if (upper === "MERGED") {
+    return <GitMerge size={14} className="text-purple-400" />;
+  }
+  if (upper === "CLOSED") {
+    return <GitPullRequestClosed size={14} className="text-rose-400" />;
+  }
+  return <GitPullRequest size={14} className="text-emerald-400" />;
+}
+
+function ConversationPane({
+  comments,
+  reviews,
+}: {
+  comments: PullRequestComment[];
+  reviews: PullRequestReview[];
+}) {
+  // Merge into a single chronological timeline. Keep `kind` along for the
+  // ride so we can render reviews with their verdict badge.
+  type Entry =
+    | { kind: "comment"; ts: string; comment: PullRequestComment }
+    | { kind: "review"; ts: string; review: PullRequestReview };
+  const entries: Entry[] = [
+    ...comments.map<Entry>((c) => ({
+      kind: "comment",
+      ts: c.created_at,
+      comment: c,
+    })),
+    ...reviews.map<Entry>((r) => ({
+      kind: "review",
+      ts: r.submitted_at,
+      review: r,
+    })),
+  ].sort((a, b) => a.ts.localeCompare(b.ts));
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-fg-muted">
+        No comments or reviews yet.
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex h-full flex-col gap-3 overflow-y-auto px-4 py-3">
+      {entries.map((entry, i) =>
+        entry.kind === "comment" ? (
+          <CommentBlock key={`c-${i}`} comment={entry.comment} />
+        ) : (
+          <ReviewBlock key={`r-${i}`} review={entry.review} />
+        ),
+      )}
+    </ul>
+  );
+}
+
+function CommentBlock({ comment }: { comment: PullRequestComment }) {
+  return (
+    <li className="rounded border border-border bg-bg-sidebar/40 p-3">
+      <div className="mb-2 flex items-center gap-2 text-[10px] text-fg-muted">
+        <span className="font-mono text-fg">{comment.author}</span>
+        <span className="opacity-60">commented</span>
+        <span className="font-mono opacity-60">
+          {formatTimestamp(comment.created_at)}
+        </span>
+      </div>
+      <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-fg">
+        {comment.body || <span className="text-fg-muted">(empty)</span>}
+      </pre>
+    </li>
+  );
+}
+
+function ReviewBlock({ review }: { review: PullRequestReview }) {
+  return (
+    <li className="rounded border border-border bg-bg-sidebar/40 p-3">
+      <div className="mb-2 flex items-center gap-2 text-[10px] text-fg-muted">
+        <span className="font-mono text-fg">{review.author}</span>
+        <ReviewStateBadge state={review.state} />
+        <span className="font-mono opacity-60">
+          {formatTimestamp(review.submitted_at)}
+        </span>
+      </div>
+      {review.body.trim().length > 0 ? (
+        <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-fg">
+          {review.body}
+        </pre>
+      ) : (
+        <p className="text-[11px] text-fg-muted">
+          (no review comment)
+        </p>
+      )}
+    </li>
+  );
+}
+
+function ReviewStateBadge({ state }: { state: string }) {
+  const upper = state.toUpperCase();
+  const tone =
+    upper === "APPROVED"
+      ? "bg-emerald-500/15 text-emerald-400"
+      : upper === "CHANGES_REQUESTED"
+        ? "bg-rose-500/15 text-rose-400"
+        : upper === "DISMISSED"
+          ? "bg-fg-muted/15 text-fg-muted line-through"
+          : "bg-fg-muted/15 text-fg-muted";
+  const label = upper.replace("_", " ").toLowerCase();
+  return (
+    <span
+      className={cn(
+        "rounded px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide",
+        tone,
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function ChecksPane({ checks }: { checks: PullRequestCheck[] }) {
+  if (checks.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-fg-muted">
+        No checks reported.
+      </div>
+    );
+  }
+  return (
+    <ul className="flex h-full flex-col overflow-y-auto text-xs">
+      {checks.map((c, i) => (
+        <li
+          key={`${c.name}-${i}`}
+          className="flex items-center gap-2 border-b border-border/40 px-3 py-2"
+        >
+          <CheckIcon status={c.status} conclusion={c.conclusion} />
+          <span className="min-w-0 flex-1 truncate text-fg">
+            {c.workflow_name ? (
+              <span className="text-fg-muted">{c.workflow_name} / </span>
+            ) : null}
+            {c.name}
+          </span>
+          <CheckStatusLabel status={c.status} conclusion={c.conclusion} />
+          {c.url ? (
+            <button
+              type="button"
+              onClick={() => {
+                if (c.url) void openUrl(c.url);
+              }}
+              className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+              title="Open run"
+            >
+              <ExternalLink size={11} />
+            </button>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function CheckIcon({
+  status,
+  conclusion,
+}: {
+  status: string;
+  conclusion: string | null;
+}) {
+  if (status.toUpperCase() !== "COMPLETED") {
+    return <Clock size={13} className="text-fg-muted animate-pulse" />;
+  }
+  switch (conclusion?.toUpperCase()) {
+    case "SUCCESS":
+      return <CheckCircle2 size={13} className="text-emerald-400" />;
+    case "FAILURE":
+    case "TIMED_OUT":
+    case "ACTION_REQUIRED":
+      return <XCircle size={13} className="text-rose-400" />;
+    case "CANCELLED":
+      return <Minus size={13} className="text-fg-muted" />;
+    case "NEUTRAL":
+    case "SKIPPED":
+      return <Circle size={13} className="text-fg-muted" />;
+    default:
+      return <Plus size={13} className="text-fg-muted" />;
+  }
+}
+
+function CheckStatusLabel({
+  status,
+  conclusion,
+}: {
+  status: string;
+  conclusion: string | null;
+}) {
+  const text =
+    status.toUpperCase() === "COMPLETED"
+      ? (conclusion ?? "completed").toLowerCase()
+      : status.toLowerCase();
+  return (
+    <span className="shrink-0 font-mono text-[10px] text-fg-muted">{text}</span>
+  );
+}
+
+function formatTimestamp(iso: string): string {
+  if (!iso) return "—";
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return iso;
+  return new Date(ms).toLocaleString();
+}

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -31,6 +31,7 @@ import type {
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { DiffView } from "./DiffView";
 import { DiffViewerModal } from "./DiffViewerModal";
+import { PullRequestDetailModal } from "./PullRequestDetailModal";
 import { ResizeHandle } from "./ResizeHandle";
 
 interface ExpandedDiff {
@@ -48,6 +49,10 @@ export function RightPanel() {
   const active = sessions.find((s) => s.id === activeSessionId);
   const repoPath = active?.worktree_path ?? activeProject ?? null;
   const [expanded, setExpanded] = useState<ExpandedDiff | null>(null);
+  const [prDetail, setPrDetail] = useState<{
+    repoPath: string;
+    number: number;
+  } | null>(null);
 
   // Polling lives at the panel level (not inside TodosTab) so we can hide the
   // Todos tab when the active session has none — without requiring the tab to
@@ -123,7 +128,10 @@ export function RightPanel() {
             <Empty msg="No project selected" />
           )
         ) : repoPath ? (
-          <PullRequestsTab repoPath={repoPath} />
+          <PullRequestsTab
+            repoPath={repoPath}
+            onOpenDetail={(number) => setPrDetail({ repoPath, number })}
+          />
         ) : (
           <Empty msg="No project selected" />
         )}
@@ -134,6 +142,11 @@ export function RightPanel() {
         subtitle={expanded?.subtitle}
         cwd={repoPath ?? undefined}
         onClose={() => setExpanded(null)}
+      />
+      <PullRequestDetailModal
+        open={prDetail}
+        cwd={repoPath ?? undefined}
+        onClose={() => setPrDetail(null)}
       />
     </aside>
   );
@@ -786,7 +799,13 @@ const PR_STATE_OPTIONS: { value: PrStateFilter; label: string }[] = [
 
 const PR_REFRESH_INTERVAL_MS = 60_000;
 
-function PullRequestsTab({ repoPath }: { repoPath: string }) {
+function PullRequestsTab({
+  repoPath,
+  onOpenDetail,
+}: {
+  repoPath: string;
+  onOpenDetail: (number: number) => void;
+}) {
   const [stateFilter, setStateFilter] = useState<PrStateFilter>("open");
   const [listing, setListing] = useState<PullRequestListing | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -840,7 +859,7 @@ function PullRequestsTab({ repoPath }: { repoPath: string }) {
     }
   }
 
-  async function openPr(pr: PullRequestInfo) {
+  async function openPrInBrowser(pr: PullRequestInfo) {
     try {
       await openUrl(pr.url);
     } catch (e) {
@@ -896,7 +915,7 @@ function PullRequestsTab({ repoPath }: { repoPath: string }) {
               <li key={pr.number}>
                 <button
                   type="button"
-                  onClick={() => void openPr(pr)}
+                  onClick={() => onOpenDetail(pr.number)}
                   onContextMenu={(e) => {
                     e.preventDefault();
                     setMenu({ x: e.clientX, y: e.clientY, pr });
@@ -936,10 +955,17 @@ function PullRequestsTab({ repoPath }: { repoPath: string }) {
           menu
             ? ([
                 {
+                  label: "Open detail",
+                  icon: <Maximize2 size={12} />,
+                  onClick: () => {
+                    onOpenDetail(menu.pr.number);
+                  },
+                },
+                {
                   label: "Open in browser",
                   icon: <ExternalLink size={12} />,
                   onClick: () => {
-                    void openPr(menu.pr);
+                    void openPrInBrowser(menu.pr);
                   },
                 },
                 {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   MemoryUsage,
   Project,
   PrStateFilter,
+  PullRequestDetailListing,
   PullRequestListing,
   Session,
   SessionStatus,
@@ -82,6 +83,15 @@ export const api = {
       repoPath,
       state,
       limit,
+    });
+  },
+  getPullRequestDetail(
+    repoPath: string,
+    number: number,
+  ): Promise<PullRequestDetailListing> {
+    return invoke<PullRequestDetailListing>("get_pull_request_detail", {
+      repoPath,
+      number,
     });
   },
   getMemoryUsage(): Promise<MemoryUsage> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -98,3 +98,56 @@ export type PullRequestListing =
   | { kind: "ok"; items: PullRequestInfo[]; account: string }
   | { kind: "not_github" }
   | { kind: "no_access"; slug: string; accounts: AccountSummary[] };
+
+export interface PullRequestComment {
+  author: string;
+  body: string;
+  created_at: string;
+}
+
+export interface PullRequestReview {
+  author: string;
+  /** APPROVED | CHANGES_REQUESTED | COMMENTED | DISMISSED | PENDING */
+  state: string;
+  body: string;
+  submitted_at: string;
+}
+
+export interface PullRequestCheck {
+  name: string;
+  /** QUEUED | IN_PROGRESS | COMPLETED | PENDING */
+  status: string;
+  /** SUCCESS | FAILURE | CANCELLED | NEUTRAL | SKIPPED | TIMED_OUT | ACTION_REQUIRED. null while still running. */
+  conclusion: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  url: string | null;
+  workflow_name: string | null;
+}
+
+export interface PullRequestDetail {
+  number: number;
+  title: string;
+  body: string;
+  state: string;
+  is_draft: boolean;
+  author: string;
+  head_branch: string;
+  base_branch: string;
+  url: string;
+  created_at: string;
+  updated_at: string;
+  merged_at: string | null;
+  additions: number;
+  deletions: number;
+  changed_files: number;
+  comments: PullRequestComment[];
+  reviews: PullRequestReview[];
+  checks: PullRequestCheck[];
+  diff: DiffPayload;
+}
+
+export type PullRequestDetailListing =
+  | { kind: "ok"; account: string; detail: PullRequestDetail }
+  | { kind: "not_github" }
+  | { kind: "no_access"; slug: string; accounts: AccountSummary[] };


### PR DESCRIPTION
## Summary

Click a PR row in the PRs tab and a modal opens inside acorn — same skeleton as the existing diff viewer — instead of bouncing out to the browser. Three tabs render the parts of a GitHub PR review most often wanted at a glance:

- **Conversation** — comments and reviews merged into one chronological timeline. Reviews carry their verdict badge (approved / changes requested / dismissed); empty PENDING reviews are filtered out so the timeline stays readable.
- **Checks** — status check rollup (CheckRun + StatusContext) with per-check status, conclusion, and a link out to the run.
- **Files** — PR diff rendered through the existing DiffSplitView. Per-file selector, syntax highlight, and "Open in editor" context menu all come for free.

The header packs PR identity into one line: state glyph, #number, title, author, branch pair, additions/deletions, file count, resolving gh account. A quick "open on GitHub" action stays available next to the close button.

## Backend

- New `get_pull_request_detail` Tauri command shells `gh pr view <num> --json ...` for metadata + body + comments + reviews + statusCheckRollup, and `gh pr diff <num>` for the unified-diff text.
- New `unified_diff` Rust module parses gh's unified-diff text into the existing `DiffPayload` shape so the UI doesn't need a second renderer. Drops `index` / `new file mode` / `rename` metadata to match libgit2's hunk-only stream.
- Both `list_pull_requests` and `get_pull_request_detail` now flow through a freshly extracted `try_with_account` helper so the cached/parallel account routing is shared. Same observable behaviour, half the duplication.

## UX changes in PRs tab

- Click row → opens detail modal (was: opens in browser).
- Row context menu gains "Open detail" (mirrors click) and keeps "Open in browser", "Copy URL", "Copy branch".

## Test plan

- [ ] Click a PR row → detail modal opens, body renders, three tabs are populated for a PR with comments + reviews + checks.
- [ ] Conversation tab interleaves comments and reviews chronologically, badges show review verdicts, empty reviews are absent.
- [ ] Checks tab lists each run with its status/conclusion; clicking the link icon opens the run in browser.
- [ ] Files tab renders a real PR diff via DiffSplitView; "Open in editor" context menu works on each file when a session worktree is active.
- [ ] PR with no checks / no comments / empty body → graceful empty states; no overflow / scroll glitches.
- [ ] Modal Esc / Enter / outside-click closes it. "Open on GitHub" button still works.
- [ ] Right-click row → "Open detail" matches click; "Open in browser" still goes to browser.
- [ ] Account routing: detail loads using the same gh account the list resolved, and a missing-access scenario falls into a NoAccess message inside the modal instead of throwing.
- [ ] Repo cloned via SSH alias (e.g. `git@github-personal:org/repo.git`): detail loads identically to a plain `git@github.com` clone.