### PR TITLE
chore(settings): default new sessions to terminal, not claude

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -200,17 +200,17 @@ function SessionSettings() {
       >
         <div className="flex flex-col gap-1.5">
           <ModeRadio
-            value="claude"
+            value="terminal"
             current={mode}
-            label="Claude"
-            description="Launch the `claude` CLI in the session worktree (default)."
+            label="Terminal (default)"
+            description="Launch a plain shell using $SHELL."
             onSelect={(v) => patchSessionStartup({ mode: v })}
           />
           <ModeRadio
-            value="terminal"
+            value="claude"
             current={mode}
-            label="Terminal"
-            description="Launch a plain shell using $SHELL."
+            label="Claude"
+            description="Launch the `claude` CLI in the session worktree."
             onSelect={(v) => patchSessionStartup({ mode: v })}
           />
           <ModeRadio
@@ -223,7 +223,7 @@ function SessionSettings() {
         </div>
       </Field>
       {mode === "custom" ? (
-        <Field label="Custom command" hint="Falls back to `claude` when blank.">
+        <Field label="Custom command" hint="Falls back to $SHELL when blank.">
           <input
             type="text"
             value={settings.sessionStartup.customCommand}

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -11,32 +11,32 @@ function withStartup(
 }
 
 describe("resolveStartupCommand", () => {
-  it("returns claude with no args for the default `claude` mode", () => {
+  it("returns empty command for the default `terminal` mode (Rust falls back to $SHELL)", () => {
     expect(resolveStartupCommand(DEFAULT_SETTINGS)).toEqual({
-      command: "claude",
-      args: [],
-    });
-  });
-
-  it("returns empty command for `terminal` mode (Rust falls back to $SHELL)", () => {
-    expect(resolveStartupCommand(withStartup({ mode: "terminal" }))).toEqual({
       command: "",
       args: [],
     });
   });
 
-  it("falls back to claude when custom command is blank", () => {
-    expect(
-      resolveStartupCommand(withStartup({ mode: "custom", customCommand: "" })),
-    ).toEqual({ command: "claude", args: [] });
+  it("returns claude with no args for `claude` mode", () => {
+    expect(resolveStartupCommand(withStartup({ mode: "claude" }))).toEqual({
+      command: "claude",
+      args: [],
+    });
   });
 
-  it("falls back to claude when custom command is whitespace only", () => {
+  it("falls back to $SHELL (empty command) when custom command is blank", () => {
+    expect(
+      resolveStartupCommand(withStartup({ mode: "custom", customCommand: "" })),
+    ).toEqual({ command: "", args: [] });
+  });
+
+  it("falls back to $SHELL (empty command) when custom command is whitespace only", () => {
     expect(
       resolveStartupCommand(
         withStartup({ mode: "custom", customCommand: "   \t  " }),
       ),
-    ).toEqual({ command: "claude", args: [] });
+    ).toEqual({ command: "", args: [] });
   });
 
   it("tokenises a custom command on whitespace", () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -77,7 +77,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     fontWeightBold: 700,
   },
   sessionStartup: {
-    mode: "claude",
+    mode: "terminal",
     customCommand: "",
   },
   sessions: {
@@ -250,21 +250,23 @@ export const useSettings = create<SettingsState>((set) => ({
  * Resolve the command (and args) used to spawn a session's PTY based on the
  * current `sessionStartup` setting.
  *
- * - `claude` → `claude` binary
  * - `terminal` → empty string; the Rust pty_spawn falls back to `$SHELL`
- * - `custom` → user-provided command, falls back to claude when blank
+ * - `claude`   → `claude` binary
+ * - `custom`   → user-provided command, falls back to terminal when blank
  */
 export function resolveStartupCommand(s: AcornSettings): {
   command: string;
   args: string[];
 } {
-  if (s.sessionStartup.mode === "terminal") return { command: "", args: [] };
+  if (s.sessionStartup.mode === "claude") {
+    return { command: "claude", args: [] };
+  }
   if (s.sessionStartup.mode === "custom") {
     const trimmed = s.sessionStartup.customCommand.trim();
-    if (!trimmed) return { command: "claude", args: [] };
+    if (!trimmed) return { command: "", args: [] };
     // Light tokenisation: split on whitespace, no shell interpretation.
     const parts = trimmed.split(/\s+/);
     return { command: parts[0], args: parts.slice(1) };
   }
-  return { command: "claude", args: [] };
+  return { command: "", args: [] };
 }


### PR DESCRIPTION
## Summary

Switch the default sessionStartup.mode from claude to terminal so a fresh install opens a plain shell. Flipping to claude is one toggle away in Settings if the user wants it. Existing persisted settings are untouched — anyone with mode: "claude" already saved will keep launching claude.

## UI

In the session-startup radio group:
- Terminal moves to the top with a "(default)" label.
- Claude follows.
- Custom command stays last.

## Behaviour change

resolveStartupCommand now resolves blank custom commands to the empty string ($SHELL fallback) instead of claude. Picking "Custom" and leaving it empty no longer silently launches claude — it opens a shell, matching the new default.

## Test plan

- [ ] Fresh install (no localStorage entry) opens a session in $SHELL.
- [ ] Existing user with persisted mode: "claude" still gets claude.
- [ ] Settings → Session Startup shows Terminal first labelled "(default)", then Claude, then Custom.
- [ ] Switching modes in Settings persists across reload.
- [ ] Custom mode with blank command opens $SHELL (was: claude).
- [ ] Custom mode with "code --wait ." still tokenises correctly.
