### PR TITLE
feat(sidebar): activate project on empty-state click + right-panel skeleton loaders

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -198,6 +198,34 @@ function Empty({ msg }: { msg: string }) {
   );
 }
 
+/**
+ * Shimmer placeholder row used while a tab's initial fetch is in flight.
+ * Switching projects clears and refetches all the right-panel tabs at once;
+ * without these the panel goes briefly blank and the click feels janky.
+ */
+function SkeletonRow({ pulseDelayMs = 0 }: { pulseDelayMs?: number }) {
+  return (
+    <div
+      className="flex items-center gap-2 border-b border-border/40 px-3 py-2"
+      style={{ animationDelay: `${pulseDelayMs}ms` }}
+    >
+      <span className="h-3 w-12 shrink-0 animate-pulse rounded bg-fg-muted/15" />
+      <span className="h-3 w-full max-w-[60%] animate-pulse rounded bg-fg-muted/10" />
+      <span className="h-3 w-10 shrink-0 animate-pulse rounded bg-fg-muted/10 ml-auto" />
+    </div>
+  );
+}
+
+function SkeletonList({ count = 6 }: { count?: number }) {
+  return (
+    <div className="text-xs">
+      {Array.from({ length: count }).map((_, i) => (
+        <SkeletonRow key={i} pulseDelayMs={i * 80} />
+      ))}
+    </div>
+  );
+}
+
 const TODOS_POLL_INTERVAL_MS = 1500;
 
 interface SessionTodosState {
@@ -331,6 +359,9 @@ function CommitsTab({
   const [error, setError] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
+  // Tracks the very first fetch for the current `repoPath` so we can show
+  // skeleton rows instead of a blank panel on project switch.
+  const [loadingFirst, setLoadingFirst] = useState(true);
   const [menu, setMenu] = useState<{
     x: number;
     y: number;
@@ -345,6 +376,7 @@ function CommitsTab({
     setDiff(null);
     setHasMore(true);
     setLoadingMore(false);
+    setLoadingFirst(true);
     setCommits([]);
     api
       .listCommits(repoPath, 0, COMMITS_PAGE_SIZE)
@@ -356,6 +388,9 @@ function CommitsTab({
       .catch((e) => {
         if (cancelled) return;
         setError(String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingFirst(false);
       });
     return () => {
       cancelled = true;
@@ -469,6 +504,25 @@ function CommitsTab({
   }, [lastItem, hasMore, loadingMore, commits.length, loadMore]);
 
   if (error) return <div className="p-3 text-xs text-danger">{error}</div>;
+  if (loadingFirst && commits.length === 0) {
+    return (
+      <PanelGroup direction="vertical" autoSaveId="acorn:layout:commits">
+        <Panel id="commits-list" order={1} defaultSize={50} minSize={20}>
+          <div className="h-full overflow-y-auto">
+            <SkeletonList count={8} />
+          </div>
+        </Panel>
+        <ResizeHandle direction="vertical" />
+        <Panel id="commits-diff" order={2} defaultSize={50} minSize={15}>
+          <div className="h-full overflow-y-auto p-3">
+            <div className="h-3 w-1/2 animate-pulse rounded bg-fg-muted/15" />
+            <div className="mt-2 h-3 w-3/4 animate-pulse rounded bg-fg-muted/10" />
+            <div className="mt-2 h-3 w-2/3 animate-pulse rounded bg-fg-muted/10" />
+          </div>
+        </Panel>
+      </PanelGroup>
+    );
+  }
 
   return (
     <PanelGroup direction="vertical" autoSaveId="acorn:layout:commits">
@@ -635,6 +689,7 @@ function StagedTab({
   const [files, setFiles] = useState<StagedFile[]>([]);
   const [diff, setDiff] = useState<DiffPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [loadingFirst, setLoadingFirst] = useState(true);
   const [menu, setMenu] = useState<{
     x: number;
     y: number;
@@ -656,10 +711,15 @@ function StagedTab({
       } catch (e) {
         if (cancelled) return;
         setError(String(e));
+      } finally {
+        if (!cancelled) setLoadingFirst(false);
       }
     };
 
     setError(null);
+    setLoadingFirst(true);
+    setFiles([]);
+    setDiff(null);
     void refresh();
     const handle = setInterval(refresh, 2000);
     return () => {
@@ -705,7 +765,10 @@ function StagedTab({
   }
 
   if (error) return <div className="p-3 text-xs text-danger">{error}</div>;
-  if (files.length === 0) return <Empty msg="No staged or modified files" />;
+  if (files.length === 0) {
+    if (loadingFirst) return <SkeletonList count={6} />;
+    return <Empty msg="No staged or modified files" />;
+  }
 
   return (
     <PanelGroup direction="vertical" autoSaveId="acorn:layout:staged">
@@ -902,7 +965,7 @@ function PullRequestsTab({
         {error ? (
           <div className="p-3 text-xs text-danger">{error}</div>
         ) : !listing ? (
-          <Empty msg="Loading pull requests..." />
+          <SkeletonList count={6} />
         ) : listing.kind === "not_github" ? (
           <Empty msg="Origin remote is not a GitHub repository." />
         ) : listing.kind === "no_access" ? (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -254,13 +254,21 @@ export function Sidebar() {
                 onDragEnd={onProjectDragEnd}
                 onToggle={() => {
                   toggleProject(project.repoPath);
-                  setActiveProject(project.repoPath);
                   // Activate a session belonging to this project so the
                   // workspace's terminal becomes visible. Prefer the
                   // currently-focused-pane session if it already belongs
                   // to this project; otherwise pick the most recent
                   // session (sessions are sorted newest-first by the
                   // backend `list_sessions`).
+                  setActiveProject(project.repoPath);
+                  const target = pickSessionToActivate(
+                    project.sessions,
+                    activeSessionId,
+                  );
+                  if (target) selectSession(target);
+                }}
+                onActivate={() => {
+                  setActiveProject(project.repoPath);
                   const target = pickSessionToActivate(
                     project.sessions,
                     activeSessionId,
@@ -322,6 +330,7 @@ interface ProjectGroupViewProps {
   onDragLeave: (e: React.DragEvent) => void;
   onDragEnd: (e: React.DragEvent) => void;
   onToggle: () => void;
+  onActivate: () => void;
   onSelectSession: (id: string) => void;
   onRemoveSession: (s: Session) => void;
   onAddSession: (isolated: boolean) => void;
@@ -340,6 +349,7 @@ function ProjectGroupView({
   onDragLeave,
   onDragEnd,
   onToggle,
+  onActivate,
   onSelectSession,
   onRemoveSession,
   onAddSession,
@@ -513,6 +523,7 @@ function ProjectGroupView({
             <li
               role="button"
               tabIndex={0}
+              onClick={onActivate}
               onDoubleClick={() => onAddSession(false)}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
@@ -520,7 +531,7 @@ function ProjectGroupView({
                   onAddSession(false);
                 }
               }}
-              title="Double-click to add a session"
+              title="Click to activate · double-click to add a session"
               className="cursor-pointer rounded px-2 py-1 text-[11px] text-fg-muted transition select-none hover:bg-bg-elevated/40 hover:text-fg"
             >
               No sessions. Add one with{" "}


### PR DESCRIPTION
## Summary

Two related fixes for the project-switch UX.

### 1. Sidebar — empty project row activates the project

Inside an expanded but session-less project group, clicking the "No sessions. Add one with..." line now activates the project (same effect as clicking the project header). Double-click still adds a new session, matching the existing affordance.

### 2. Right panel — skeleton loaders on first fetch

Switching projects refetches commits / staged / PRs in parallel. Each tab previously went blank during its slowest network call, which read as lag. Each tab now renders shimmer skeleton rows on the very first fetch for a given `repoPath`:

- **Commits**: 8 skeleton rows + a placeholder diff block until `listCommits` resolves.
- **Staged**: 6 skeleton rows until `listStaged + stagedDiff` resolves.
- **PRs**: skeleton list replaces the "Loading pull requests..." text; the gh-account-resolution + `gh pr list` round-trips are usually the longest of the three.

Pulses are staggered 80ms apart so the panel reads as "loading" rather than a uniform grey block.

## Test plan

- [ ] Click an empty project's "No sessions..." row → project becomes active (header gets the active background).
- [ ] Double-click the same row → still opens the new-session dialog.
- [ ] Switch between two projects with content in commits/staged/PRs → each tab shows skeleton rows during the brief refetch instead of going blank.
- [ ] Switch into a freshly-added project (no commits, no staged, no PR access) → skeletons appear, then resolve to the appropriate empty / NoAccess state.
- [ ] No regressions in commits virtualisation / pagination / diff selection after the skeleton path resolves.
