### PR TITLE
feat(ui): extract reusable primitives + Modal shell

### DIFF
--- a/src/components/DiffViewerModal.tsx
+++ b/src/components/DiffViewerModal.tsx
@@ -1,7 +1,7 @@
-import { X } from "lucide-react";
 import { DiffSplitView } from "./DiffSplitView";
 import type { DiffPayload } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
+import { Modal, ModalHeader } from "./ui";
 
 interface DiffViewerModalProps {
   payload: DiffPayload | null;
@@ -30,42 +30,21 @@ export function DiffViewerModal({
     onConfirm: onClose,
   });
 
-  if (!payload) return null;
-
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      className="fixed inset-0 z-50 flex flex-col bg-black/60 px-4 py-6"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
+    <Modal
+      open={payload !== null}
+      onClose={onClose}
+      variant="panel"
+      size="5xl"
     >
-      <div className="mx-auto flex h-full w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-border bg-bg shadow-2xl">
-        <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
-          <div className="min-w-0">
-            <h3 className="truncate text-sm font-semibold tracking-tight text-fg">
-              {title}
-            </h3>
-            {subtitle ? (
-              <p className="truncate font-mono text-xs text-fg-muted">
-                {subtitle}
-              </p>
-            ) : null}
+      {payload ? (
+        <>
+          <ModalHeader title={title} subtitle={subtitle} onClose={onClose} />
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <DiffSplitView payload={payload} cwd={cwd} />
           </div>
-          <button
-            type="button"
-            aria-label="Close"
-            onClick={onClose}
-            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-          >
-            <X size={16} />
-          </button>
-        </header>
-        <div className="min-h-0 flex-1 overflow-hidden">
-          <DiffSplitView payload={payload} cwd={cwd} />
-        </div>
-      </div>
-    </div>
+        </>
+      ) : null}
+    </Modal>
   );
 }

--- a/src/components/MemoryBreakdownModal.tsx
+++ b/src/components/MemoryBreakdownModal.tsx
@@ -1,7 +1,7 @@
-import { X } from "lucide-react";
 import { useMemo } from "react";
 import type { MemoryProcess } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
+import { Modal, ModalHeader } from "./ui";
 
 interface MemoryBreakdownModalProps {
   open: boolean;
@@ -121,42 +121,22 @@ export function MemoryBreakdownModal({
 
   const rows = useMemo(() => buildTree(processes), [processes]);
 
-  if (!open) return null;
-
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="memory-breakdown-title"
-      className="fixed inset-0 z-50 flex flex-col bg-black/60 px-4 py-6"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
+    <Modal
+      open={open}
+      onClose={onClose}
+      variant="panel"
+      size="3xl"
+      ariaLabelledBy="memory-breakdown-title"
     >
-      <div className="mx-auto flex h-full w-full max-w-3xl flex-col overflow-hidden rounded-lg border border-border bg-bg shadow-2xl">
-        <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
-          <div className="min-w-0">
-            <h3
-              id="memory-breakdown-title"
-              className="truncate text-sm font-semibold tracking-tight text-fg"
-            >
-              Memory breakdown
-            </h3>
-            <p className="truncate font-mono text-xs text-fg-muted">
-              total (RSS, sum): {formatBytes(totalBytes)} · {processes.length} processes
-            </p>
-          </div>
-          <button
-            type="button"
-            aria-label="Close"
-            onClick={onClose}
-            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-          >
-            <X size={16} />
-          </button>
-        </header>
+      <ModalHeader
+        title="Memory breakdown"
+        titleId="memory-breakdown-title"
+        subtitle={`total (RSS, sum): ${formatBytes(totalBytes)} · ${processes.length} processes`}
+        onClose={onClose}
+      />
 
-        <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="min-h-0 flex-1 overflow-y-auto">
           <table className="w-full font-mono text-xs">
             <thead className="sticky top-0 bg-bg-sidebar text-fg-muted">
               <tr className="border-b border-border">
@@ -211,12 +191,11 @@ export function MemoryBreakdownModal({
           </table>
         </div>
 
-        <footer className="shrink-0 border-t border-border px-4 py-2 font-mono text-[11px] text-fg-muted">
-          Tree ordered by parent→child (DFS). Siblings sorted by subtree RSS desc.
-          Sum-of-RSS overcounts shared memory; WebView helpers and PTY children
-          (claude, node) included.
-        </footer>
-      </div>
-    </div>
+      <footer className="shrink-0 border-t border-border px-4 py-2 font-mono text-[11px] text-fg-muted">
+        Tree ordered by parent→child (DFS). Siblings sorted by subtree RSS desc.
+        Sum-of-RSS overcounts shared memory; WebView helpers and PTY children
+        (claude, node) included.
+      </footer>
+    </Modal>
   );
 }

--- a/src/components/MemoryBreakdownModal.tsx
+++ b/src/components/MemoryBreakdownModal.tsx
@@ -137,59 +137,64 @@ export function MemoryBreakdownModal({
       />
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-          <table className="w-full font-mono text-xs">
-            <thead className="sticky top-0 bg-bg-sidebar text-fg-muted">
-              <tr className="border-b border-border">
-                <th className="px-4 py-2 text-left font-medium">PID</th>
-                <th className="px-4 py-2 text-left font-medium">Process tree</th>
-                <th className="px-4 py-2 text-right font-medium">RSS</th>
-                <th className="px-4 py-2 text-right font-medium" title="Sum of this process and all descendants">
-                  Subtree
-                </th>
-                <th className="px-4 py-2 text-right font-medium">Share</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map(({ process, subtreeBytes, prefix }) => {
-                const share = totalBytes > 0 ? (process.bytes / totalBytes) * 100 : 0;
-                return (
-                  <tr
-                    key={process.pid}
-                    className="border-b border-border/50 hover:bg-bg-elevated"
-                  >
-                    <td className="px-4 py-1.5 text-fg-muted">{process.pid}</td>
-                    <td className="px-4 py-1.5 text-fg">
-                      <span className="whitespace-pre text-fg-muted/60">{prefix}</span>
-                      <span title={process.command_line || undefined}>
-                        {process.name}
+        <table className="w-full font-mono text-xs">
+          <thead className="sticky top-0 bg-bg-sidebar text-fg-muted">
+            <tr className="border-b border-border">
+              <th className="px-4 py-2 text-left font-medium">PID</th>
+              <th className="px-4 py-2 text-left font-medium">Process tree</th>
+              <th className="px-4 py-2 text-right font-medium">RSS</th>
+              <th
+                className="px-4 py-2 text-right font-medium"
+                title="Sum of this process and all descendants"
+              >
+                Subtree
+              </th>
+              <th className="px-4 py-2 text-right font-medium">Share</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(({ process, subtreeBytes, prefix }) => {
+              const share =
+                totalBytes > 0 ? (process.bytes / totalBytes) * 100 : 0;
+              return (
+                <tr
+                  key={process.pid}
+                  className="border-b border-border/50 hover:bg-bg-elevated"
+                >
+                  <td className="px-4 py-1.5 text-fg-muted">{process.pid}</td>
+                  <td className="px-4 py-1.5 text-fg">
+                    <span className="whitespace-pre text-fg-muted/60">
+                      {prefix}
+                    </span>
+                    <span title={process.command_line || undefined}>
+                      {process.name}
+                    </span>
+                    {process.command_line ? (
+                      <span
+                        className="ml-2 truncate text-fg-muted/60"
+                        title={process.command_line}
+                      >
+                        {truncateMiddle(process.command_line, 80)}
                       </span>
-                      {process.command_line ? (
-                        <span
-                          className="ml-2 truncate text-fg-muted/60"
-                          title={process.command_line}
-                        >
-                          {truncateMiddle(process.command_line, 80)}
-                        </span>
-                      ) : null}
-                    </td>
-                    <td className="px-4 py-1.5 text-right text-fg">
-                      {formatBytes(process.bytes)}
-                    </td>
-                    <td className="px-4 py-1.5 text-right text-fg-muted">
-                      {process.depth === 0 ||
-                      subtreeBytes !== process.bytes
-                        ? formatBytes(subtreeBytes)
-                        : ""}
-                    </td>
-                    <td className="px-4 py-1.5 text-right text-fg-muted">
-                      {share.toFixed(1)}%
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-1.5 text-right text-fg">
+                    {formatBytes(process.bytes)}
+                  </td>
+                  <td className="px-4 py-1.5 text-right text-fg-muted">
+                    {process.depth === 0 || subtreeBytes !== process.bytes
+                      ? formatBytes(subtreeBytes)
+                      : ""}
+                  </td>
+                  <td className="px-4 py-1.5 text-right text-fg-muted">
+                    {share.toFixed(1)}%
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
 
       <footer className="shrink-0 border-t border-border px-4 py-2 font-mono text-[11px] text-fg-muted">
         Tree ordered by parent→child (DFS). Siblings sorted by subtree RSS desc.

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -26,6 +26,7 @@ import type {
   PullRequestReview,
 } from "../lib/types";
 import { DiffSplitView } from "./DiffSplitView";
+import { Modal, ModalHeader } from "./ui";
 
 type DetailTab = "conversation" | "checks" | "files";
 
@@ -82,19 +83,10 @@ export function PullRequestDetailModal({
     };
   }, [open]);
 
-  if (!open) return null;
-
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      className="fixed inset-0 z-50 flex flex-col bg-black/60 px-4 py-6"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
-      <div className="mx-auto flex h-full w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-border bg-bg shadow-2xl">
-        {error ? (
+    <Modal open={open !== null} onClose={onClose} variant="panel" size="5xl">
+      {open ? (
+        error ? (
           <ModalShell title={`#${open.number}`} onClose={onClose}>
             <div className="p-4 text-xs text-danger">{error}</div>
           </ModalShell>
@@ -126,9 +118,9 @@ export function PullRequestDetailModal({
             cwd={cwd}
             onClose={onClose}
           />
-        )}
-      </div>
-    </div>
+        )
+      ) : null}
+    </Modal>
   );
 }
 
@@ -143,19 +135,7 @@ function ModalShell({
 }) {
   return (
     <>
-      <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
-        <h3 className="truncate text-sm font-semibold tracking-tight text-fg">
-          {title}
-        </h3>
-        <button
-          type="button"
-          aria-label="Close"
-          onClick={onClose}
-          className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-        >
-          <X size={16} />
-        </button>
-      </header>
+      <ModalHeader title={title} onClose={onClose} />
       <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
     </>
   );

--- a/src/components/RemoveProjectDialog.tsx
+++ b/src/components/RemoveProjectDialog.tsx
@@ -40,6 +40,7 @@ export function RemoveProjectDialog({
           <ModalHeader
             title="Close project"
             icon={<AlertTriangle size={16} className="text-warning" />}
+            variant="dialog"
             onClose={() => onClose("cancel")}
           />
           <div className="space-y-3 px-4 py-3 text-sm text-fg">

--- a/src/components/RemoveProjectDialog.tsx
+++ b/src/components/RemoveProjectDialog.tsx
@@ -1,6 +1,7 @@
-import { AlertTriangle, X } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import type { Project, Session } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
+import { Modal, ModalHeader } from "./ui";
 
 type RemoveProjectChoice =
   | "project_only"
@@ -27,83 +28,70 @@ export function RemoveProjectDialog({
     onConfirm: () => onClose(primaryChoice),
   });
 
-  if (!project) return null;
-
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 px-4 pt-32"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose("cancel");
-      }}
+    <Modal
+      open={project !== null}
+      onClose={() => onClose("cancel")}
+      variant="dialog"
+      size="md"
     >
-      <div className="w-full max-w-md overflow-hidden rounded-lg border border-border bg-bg-elevated shadow-2xl">
-        <header className="flex items-center justify-between border-b border-border px-4 py-3">
-          <div className="flex items-center gap-2">
-            <AlertTriangle size={16} className="text-warning" />
-            <h3 className="text-sm font-semibold tracking-tight text-fg">
-              Close project
-            </h3>
-          </div>
-          <button
-            type="button"
-            aria-label="Close"
-            onClick={() => onClose("cancel")}
-            className="rounded p-1 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
-          >
-            <X size={14} />
-          </button>
-        </header>
-        <div className="space-y-3 px-4 py-3 text-sm text-fg">
-          <p>
-            Close project{" "}
-            <span className="font-mono text-accent">{project.name}</span>?
-          </p>
-          <div className="space-y-1 rounded-md border border-border bg-bg-sidebar/60 p-3 text-xs">
-            <p className="break-all font-mono text-fg-muted">
-              {project.repo_path}
+      {project ? (
+        <>
+          <ModalHeader
+            title="Close project"
+            icon={<AlertTriangle size={16} className="text-warning" />}
+            onClose={() => onClose("cancel")}
+          />
+          <div className="space-y-3 px-4 py-3 text-sm text-fg">
+            <p>
+              Close project{" "}
+              <span className="font-mono text-accent">{project.name}</span>?
             </p>
-            <p className="text-fg-muted">
-              {sessions.length} session{sessions.length === 1 ? "" : "s"} will
-              be removed
-              {isolatedCount > 0
-                ? ` (${isolatedCount} isolated worktree${isolatedCount === 1 ? "" : "s"})`
-                : ""}
-              .
-            </p>
+            <div className="space-y-1 rounded-md border border-border bg-bg-sidebar/60 p-3 text-xs">
+              <p className="break-all font-mono text-fg-muted">
+                {project.repo_path}
+              </p>
+              <p className="text-fg-muted">
+                {sessions.length} session{sessions.length === 1 ? "" : "s"}{" "}
+                will be removed
+                {isolatedCount > 0
+                  ? ` (${isolatedCount} isolated worktree${isolatedCount === 1 ? "" : "s"})`
+                  : ""}
+                .
+              </p>
+            </div>
           </div>
-        </div>
-        <footer className="flex items-center justify-end gap-2 border-t border-border bg-bg-sidebar/40 px-4 py-3">
-          <button
-            type="button"
-            onClick={() => onClose("cancel")}
-            className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
-          >
-            Cancel
-          </button>
-          {isolatedCount > 0 ? (
+          <footer className="flex items-center justify-end gap-2 border-t border-border bg-bg-sidebar/40 px-4 py-3">
             <button
               type="button"
-              onClick={() => onClose("project_only")}
-              className="rounded-md px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
+              onClick={() => onClose("cancel")}
+              className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
             >
-              Close · keep worktrees
+              Cancel
             </button>
-          ) : null}
-          <button
-            type="button"
-            onClick={() =>
-              onClose(
-                isolatedCount > 0 ? "project_and_worktrees" : "project_only",
-              )
-            }
-            className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
-          >
-            {isolatedCount > 0 ? "Close · delete worktrees" : "Close project"}
-          </button>
-        </footer>
-      </div>
-    </div>
+            {isolatedCount > 0 ? (
+              <button
+                type="button"
+                onClick={() => onClose("project_only")}
+                className="rounded-md px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
+              >
+                Close · keep worktrees
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={() =>
+                onClose(
+                  isolatedCount > 0 ? "project_and_worktrees" : "project_only",
+                )
+              }
+              className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
+            >
+              {isolatedCount > 0 ? "Close · delete worktrees" : "Close project"}
+            </button>
+          </footer>
+        </>
+      ) : null}
+    </Modal>
   );
 }

--- a/src/components/RemoveSessionDialog.tsx
+++ b/src/components/RemoveSessionDialog.tsx
@@ -1,8 +1,9 @@
-import { AlertTriangle, X } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { Session } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
 import { useSettings } from "../lib/settings";
+import { Modal, ModalHeader } from "./ui";
 
 type RemoveChoice = "session_only" | "session_and_worktree" | "cancel";
 
@@ -39,104 +40,91 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
     onConfirm: () => commit(primaryChoice),
   });
 
-  if (!session) return null;
-
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 px-4 pt-32"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) commit("cancel");
-      }}
+    <Modal
+      open={session !== null}
+      onClose={() => commit("cancel")}
+      variant="dialog"
+      size="md"
     >
-      <div className="w-full max-w-md overflow-hidden rounded-lg border border-border bg-bg-elevated shadow-2xl">
-        <header className="flex items-center justify-between border-b border-border px-4 py-3">
-          <div className="flex items-center gap-2">
-            <AlertTriangle size={16} className="text-warning" />
-            <h3 className="text-sm font-semibold tracking-tight text-fg">
-              Remove session
-            </h3>
-          </div>
-          <button
-            type="button"
-            aria-label="Close"
-            onClick={() => commit("cancel")}
-            className="rounded p-1 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
-          >
-            <X size={14} />
-          </button>
-        </header>
-        <div className="space-y-3 px-4 py-3 text-sm text-fg">
-          <p>
-            Remove session{" "}
-            <span className="font-mono text-accent">{session.name}</span>?
-          </p>
-          {isolated ? (
-            <div className="space-y-2 rounded-md border border-border bg-bg-sidebar/60 p-3">
-              <p className="text-xs text-fg-muted">
-                This is an isolated worktree:
-              </p>
-              <p className="break-all font-mono text-xs text-fg">
-                {session.worktree_path}
-              </p>
-              <p className="text-xs text-fg-muted">
-                Also delete the worktree from disk?
-              </p>
-            </div>
-          ) : (
-            <p className="text-xs text-fg-muted">
-              Files in {session.worktree_path} will not be touched.
+      {session ? (
+        <>
+          <ModalHeader
+            title="Remove session"
+            icon={<AlertTriangle size={16} className="text-warning" />}
+            onClose={() => commit("cancel")}
+          />
+          <div className="space-y-3 px-4 py-3 text-sm text-fg">
+            <p>
+              Remove session{" "}
+              <span className="font-mono text-accent">{session.name}</span>?
             </p>
-          )}
-          {!isolated ? (
-            <label className="flex cursor-pointer items-center gap-2 pt-1 text-xs text-fg-muted">
-              <input
-                type="checkbox"
-                checked={dontAskAgain}
-                onChange={(e) => setDontAskAgain(e.target.checked)}
-                className="accent-[var(--color-accent)]"
-              />
-              Don't ask again (toggle in Settings → Sessions)
-            </label>
-          ) : null}
-        </div>
-        <footer className="flex items-center justify-end gap-2 border-t border-border bg-bg-sidebar/40 px-4 py-3">
-          <button
-            type="button"
-            onClick={() => commit("cancel")}
-            className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
-          >
-            Cancel
-          </button>
-          {isolated ? (
-            <>
+            {isolated ? (
+              <div className="space-y-2 rounded-md border border-border bg-bg-sidebar/60 p-3">
+                <p className="text-xs text-fg-muted">
+                  This is an isolated worktree:
+                </p>
+                <p className="break-all font-mono text-xs text-fg">
+                  {session.worktree_path}
+                </p>
+                <p className="text-xs text-fg-muted">
+                  Also delete the worktree from disk?
+                </p>
+              </div>
+            ) : (
+              <p className="text-xs text-fg-muted">
+                Files in {session.worktree_path} will not be touched.
+              </p>
+            )}
+            {!isolated ? (
+              <label className="flex cursor-pointer items-center gap-2 pt-1 text-xs text-fg-muted">
+                <input
+                  type="checkbox"
+                  checked={dontAskAgain}
+                  onChange={(e) => setDontAskAgain(e.target.checked)}
+                  className="accent-[var(--color-accent)]"
+                />
+                Don't ask again (toggle in Settings → Sessions)
+              </label>
+            ) : null}
+          </div>
+          <footer className="flex items-center justify-end gap-2 border-t border-border bg-bg-sidebar/40 px-4 py-3">
+            <button
+              type="button"
+              onClick={() => commit("cancel")}
+              className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
+            >
+              Cancel
+            </button>
+            {isolated ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => commit("session_only")}
+                  className="rounded-md px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
+                >
+                  Keep worktree
+                </button>
+                <button
+                  type="button"
+                  onClick={() => commit("session_and_worktree")}
+                  className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
+                >
+                  Delete worktree
+                </button>
+              </>
+            ) : (
               <button
                 type="button"
                 onClick={() => commit("session_only")}
-                className="rounded-md px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
-              >
-                Keep worktree
-              </button>
-              <button
-                type="button"
-                onClick={() => commit("session_and_worktree")}
                 className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
               >
-                Delete worktree
+                Remove
               </button>
-            </>
-          ) : (
-            <button
-              type="button"
-              onClick={() => commit("session_only")}
-              className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
-            >
-              Remove
-            </button>
-          )}
-        </footer>
-      </div>
-    </div>
+            )}
+          </footer>
+        </>
+      ) : null}
+    </Modal>
   );
 }

--- a/src/components/RemoveSessionDialog.tsx
+++ b/src/components/RemoveSessionDialog.tsx
@@ -52,6 +52,7 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
           <ModalHeader
             title="Remove session"
             icon={<AlertTriangle size={16} className="text-warning" />}
+            variant="dialog"
             onClose={() => commit("cancel")}
           />
           <div className="space-y-3 px-4 py-3 text-sm text-fg">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { Settings as SettingsIcon, X } from "lucide-react";
+import { Settings as SettingsIcon } from "lucide-react";
 import { useState } from "react";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
@@ -8,6 +8,16 @@ import {
   TERMINAL_FONT_WEIGHTS,
   useSettings,
 } from "../lib/settings";
+import {
+  CheckboxRow,
+  Field,
+  Modal,
+  ModalHeader,
+  RadioCard,
+  Select,
+  Stepper,
+  TextInput,
+} from "./ui";
 
 type Tab = "terminal" | "sessions" | "editor" | "notifications";
 
@@ -31,79 +41,60 @@ export function SettingsModal() {
     onConfirm: () => setOpen(false),
   });
 
-  if (!open) return null;
-
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="acorn-settings-title"
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/55 px-4 pt-24"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) setOpen(false);
-      }}
+    <Modal
+      open={open}
+      onClose={() => setOpen(false)}
+      variant="dialog"
+      size="2xl"
+      ariaLabelledBy="acorn-settings-title"
     >
-      <div className="w-full max-w-2xl overflow-hidden rounded-lg border border-border bg-bg-elevated shadow-2xl">
-        <header className="flex items-center justify-between border-b border-border px-4 py-3">
-          <div className="flex items-center gap-2">
-            <SettingsIcon size={14} className="text-fg-muted" />
-            <h3
-              id="acorn-settings-title"
-              className="text-sm font-semibold tracking-tight text-fg"
+      <ModalHeader
+        title="Settings"
+        titleId="acorn-settings-title"
+        icon={<SettingsIcon size={14} className="text-fg-muted" />}
+        onClose={() => setOpen(false)}
+      />
+      <div className="flex min-h-[20rem]">
+        <nav className="flex w-40 shrink-0 flex-col border-r border-border bg-bg-sidebar/40 py-2">
+          {TABS.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTab(t.id)}
+              className={cn(
+                "px-4 py-1.5 text-left text-xs transition",
+                tab === t.id
+                  ? "bg-bg-elevated text-fg"
+                  : "text-fg-muted hover:bg-bg-elevated/50 hover:text-fg",
+              )}
             >
-              Settings
-            </h3>
+              {t.label}
+            </button>
+          ))}
+          <div className="mt-auto px-4 pb-2">
+            <button
+              type="button"
+              onClick={reset}
+              className="text-[11px] text-fg-muted transition hover:text-danger"
+            >
+              Reset to defaults
+            </button>
           </div>
-          <button
-            type="button"
-            aria-label="Close"
-            onClick={() => setOpen(false)}
-            className="rounded p-1 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
-          >
-            <X size={14} />
-          </button>
-        </header>
-        <div className="flex min-h-[20rem]">
-          <nav className="flex w-40 shrink-0 flex-col border-r border-border bg-bg-sidebar/40 py-2">
-            {TABS.map((t) => (
-              <button
-                key={t.id}
-                type="button"
-                onClick={() => setTab(t.id)}
-                className={cn(
-                  "px-4 py-1.5 text-left text-xs transition",
-                  tab === t.id
-                    ? "bg-bg-elevated text-fg"
-                    : "text-fg-muted hover:bg-bg-elevated/50 hover:text-fg",
-                )}
-              >
-                {t.label}
-              </button>
-            ))}
-            <div className="mt-auto px-4 pb-2">
-              <button
-                type="button"
-                onClick={reset}
-                className="text-[11px] text-fg-muted transition hover:text-danger"
-              >
-                Reset to defaults
-              </button>
-            </div>
-          </nav>
-          <div className="flex-1 overflow-y-auto p-4">
-            {tab === "terminal" ? (
-              <TerminalSettings />
-            ) : tab === "sessions" ? (
-              <SessionSettings />
-            ) : tab === "editor" ? (
-              <EditorSettings />
-            ) : (
-              <NotificationSettings />
-            )}
-          </div>
+        </nav>
+        <div className="flex-1 overflow-y-auto p-4">
+          {tab === "terminal" ? (
+            <TerminalSettings />
+          ) : tab === "sessions" ? (
+            <SessionSettings />
+          ) : tab === "editor" ? (
+            <EditorSettings />
+          ) : (
+            <NotificationSettings />
+          )}
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }
 
@@ -117,28 +108,18 @@ function TerminalSettings() {
         label="Font family"
         hint="Comma-separated stack. First family that resolves wins."
       >
-        <input
-          type="text"
+        <TextInput
           value={settings.terminal.fontFamily}
           onChange={(e) => patchTerminal({ fontFamily: e.target.value })}
-          spellCheck={false}
-          className="w-full rounded-md border border-border bg-bg px-2 py-1 font-mono text-xs text-fg outline-none focus:border-accent"
         />
       </Field>
       <Field label="Font size" hint="In CSS pixels. Range 8–32.">
-        <input
-          type="number"
+        <Stepper
+          value={settings.terminal.fontSize}
           min={8}
           max={32}
-          value={settings.terminal.fontSize}
-          onChange={(e) => {
-            const n = Number(e.target.value);
-            if (!Number.isFinite(n)) return;
-            patchTerminal({
-              fontSize: Math.max(8, Math.min(32, Math.round(n))),
-            });
-          }}
-          className="w-24 rounded-md border border-border bg-bg px-2 py-1 font-mono text-xs text-fg outline-none focus:border-accent"
+          unit="px"
+          onChange={(n) => patchTerminal({ fontSize: n })}
         />
       </Field>
       <Field
@@ -170,19 +151,17 @@ interface WeightSelectProps {
 
 function WeightSelect({ value, onChange }: WeightSelectProps) {
   return (
-    <select
+    <Select
       value={value}
-      onChange={(e) =>
-        onChange(Number(e.target.value) as TerminalFontWeight)
-      }
-      className="w-48 rounded-md border border-border bg-bg px-2 py-1 font-mono text-xs text-fg outline-none focus:border-accent"
+      onChange={(e) => onChange(Number(e.target.value) as TerminalFontWeight)}
+      className="w-48"
     >
       {TERMINAL_FONT_WEIGHTS.map((w) => (
         <option key={w.value} value={w.value}>
           {w.label}
         </option>
       ))}
-    </select>
+    </Select>
   );
 }
 
@@ -199,21 +178,24 @@ function SessionSettings() {
         hint="What to launch when you create a new session tab."
       >
         <div className="flex flex-col gap-1.5">
-          <ModeRadio
+          <RadioCard<SessionStartupMode>
+            name="session-startup"
             value="terminal"
             current={mode}
             label="Terminal (default)"
             description="Launch a plain shell using $SHELL."
             onSelect={(v) => patchSessionStartup({ mode: v })}
           />
-          <ModeRadio
+          <RadioCard<SessionStartupMode>
+            name="session-startup"
             value="claude"
             current={mode}
             label="Claude"
             description="Launch the `claude` CLI in the session worktree."
             onSelect={(v) => patchSessionStartup({ mode: v })}
           />
-          <ModeRadio
+          <RadioCard<SessionStartupMode>
+            name="session-startup"
             value="custom"
             current={mode}
             label="Custom command"
@@ -224,15 +206,12 @@ function SessionSettings() {
       </Field>
       {mode === "custom" ? (
         <Field label="Custom command" hint="Falls back to $SHELL when blank.">
-          <input
-            type="text"
+          <TextInput
             value={settings.sessionStartup.customCommand}
             onChange={(e) =>
               patchSessionStartup({ customCommand: e.target.value })
             }
             placeholder="e.g. claude --resume"
-            spellCheck={false}
-            className="w-full rounded-md border border-border bg-bg px-2 py-1 font-mono text-xs text-fg outline-none focus:border-accent"
           />
         </Field>
       ) : null}
@@ -270,13 +249,10 @@ function EditorSettings() {
         label="Editor command"
         hint='Leave blank for the OS default. Examples: "code", "cursor --wait", "subl", "idea". The file path is appended as the last argument.'
       >
-        <input
-          type="text"
+        <TextInput
           value={settings.editor.command}
           onChange={(e) => patchEditor({ command: e.target.value })}
           placeholder="(use OS default)"
-          spellCheck={false}
-          className="w-full rounded-md border border-border bg-bg px-2 py-1 font-mono text-xs text-fg outline-none focus:border-accent"
         />
       </Field>
       <p className="text-[11px] text-fg-muted">
@@ -312,7 +288,7 @@ function NotificationSettings() {
       </Field>
       <Field label="Trigger on">
         <div className="flex flex-col gap-1">
-          <EventCheckbox
+          <CheckboxRow
             label="Needs input"
             description="Claude is waiting on the user."
             checked={settings.notifications.events.needsInput}
@@ -321,14 +297,14 @@ function NotificationSettings() {
               patchNotifications({ events: { needsInput: v } })
             }
           />
-          <EventCheckbox
+          <CheckboxRow
             label="Failed"
             description="Session terminated with an error."
             checked={settings.notifications.events.failed}
             disabled={!enabled}
             onChange={(v) => patchNotifications({ events: { failed: v } })}
           />
-          <EventCheckbox
+          <CheckboxRow
             label="Completed"
             description="Session reached the completed state."
             checked={settings.notifications.events.completed}
@@ -343,99 +319,5 @@ function NotificationSettings() {
         macOS may ask once for permission the first time a notification fires.
       </p>
     </section>
-  );
-}
-
-interface EventCheckboxProps {
-  label: string;
-  description: string;
-  checked: boolean;
-  disabled?: boolean;
-  onChange: (v: boolean) => void;
-}
-
-function EventCheckbox({
-  label,
-  description,
-  checked,
-  disabled,
-  onChange,
-}: EventCheckboxProps) {
-  return (
-    <label
-      className={cn(
-        "flex cursor-pointer items-start gap-2 rounded-md border border-border bg-bg px-3 py-2 transition",
-        disabled && "cursor-not-allowed opacity-50",
-        !disabled && "hover:border-fg-muted/40",
-      )}
-    >
-      <input
-        type="checkbox"
-        checked={checked}
-        disabled={disabled}
-        onChange={(e) => onChange(e.target.checked)}
-        className="mt-0.5 accent-[var(--color-accent)]"
-      />
-      <span className="flex flex-col">
-        <span className="text-xs font-medium text-fg">{label}</span>
-        <span className="text-[11px] text-fg-muted">{description}</span>
-      </span>
-    </label>
-  );
-}
-
-interface ModeRadioProps {
-  value: SessionStartupMode;
-  current: SessionStartupMode;
-  label: string;
-  description: string;
-  onSelect: (v: SessionStartupMode) => void;
-}
-
-function ModeRadio({
-  value,
-  current,
-  label,
-  description,
-  onSelect,
-}: ModeRadioProps) {
-  const active = current === value;
-  return (
-    <label
-      className={cn(
-        "flex cursor-pointer items-start gap-2 rounded-md border px-3 py-2 transition",
-        active
-          ? "border-accent/60 bg-accent/10"
-          : "border-border bg-bg hover:border-fg-muted/40",
-      )}
-    >
-      <input
-        type="radio"
-        name="session-startup"
-        checked={active}
-        onChange={() => onSelect(value)}
-        className="mt-0.5 accent-[var(--color-accent)]"
-      />
-      <span className="flex flex-col">
-        <span className="text-xs font-medium text-fg">{label}</span>
-        <span className="text-[11px] text-fg-muted">{description}</span>
-      </span>
-    </label>
-  );
-}
-
-interface FieldProps {
-  label: string;
-  hint?: string;
-  children: React.ReactNode;
-}
-
-function Field({ label, hint, children }: FieldProps) {
-  return (
-    <div className="flex flex-col gap-1">
-      <span className="text-xs font-medium text-fg">{label}</span>
-      {children}
-      {hint ? <span className="text-[11px] text-fg-muted">{hint}</span> : null}
-    </div>
   );
 }

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -53,6 +53,7 @@ export function SettingsModal() {
         title="Settings"
         titleId="acorn-settings-title"
         icon={<SettingsIcon size={14} className="text-fg-muted" />}
+        variant="dialog"
         onClose={() => setOpen(false)}
       />
       <div className="flex min-h-[20rem]">

--- a/src/components/ui/CheckboxRow.tsx
+++ b/src/components/ui/CheckboxRow.tsx
@@ -1,0 +1,41 @@
+import { cn } from "../../lib/cn";
+
+interface CheckboxRowProps {
+  label: string;
+  description?: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (v: boolean) => void;
+}
+
+export function CheckboxRow({
+  label,
+  description,
+  checked,
+  disabled,
+  onChange,
+}: CheckboxRowProps) {
+  return (
+    <label
+      className={cn(
+        "flex cursor-pointer items-start gap-2 rounded-md border border-border bg-bg px-3 py-2 transition",
+        disabled && "cursor-not-allowed opacity-50",
+        !disabled && "hover:border-fg-muted/40",
+      )}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-0.5 accent-[var(--color-accent)]"
+      />
+      <span className="flex flex-col">
+        <span className="text-xs font-medium text-fg">{label}</span>
+        {description ? (
+          <span className="text-[11px] text-fg-muted">{description}</span>
+        ) : null}
+      </span>
+    </label>
+  );
+}

--- a/src/components/ui/Field.tsx
+++ b/src/components/ui/Field.tsx
@@ -1,0 +1,17 @@
+import { type ReactNode } from "react";
+
+interface FieldProps {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}
+
+export function Field({ label, hint, children }: FieldProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs font-medium text-fg">{label}</span>
+      {children}
+      {hint ? <span className="text-[11px] text-fg-muted">{hint}</span> : null}
+    </div>
+  );
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,77 @@
+import { type ReactNode } from "react";
+import { cn } from "../../lib/cn";
+
+export type ModalVariant = "dialog" | "panel";
+export type ModalSize = "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "5xl";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  variant?: ModalVariant;
+  size?: ModalSize;
+  ariaLabelledBy?: string;
+  ariaLabel?: string;
+  /**
+   * Extra className applied to the inner content container. Use sparingly —
+   * size + variant should cover most needs.
+   */
+  className?: string;
+  children: ReactNode;
+}
+
+const SIZE_CLASS: Record<ModalSize, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+  xl: "max-w-xl",
+  "2xl": "max-w-2xl",
+  "3xl": "max-w-3xl",
+  "5xl": "max-w-5xl",
+};
+
+const BACKDROP_DIALOG = "flex items-start justify-center px-4 pt-24";
+const BACKDROP_PANEL = "flex flex-col px-4 py-6";
+
+const CONTENT_DIALOG =
+  "w-full overflow-hidden rounded-lg border border-border bg-bg-elevated shadow-2xl";
+const CONTENT_PANEL =
+  "mx-auto flex h-full w-full flex-col overflow-hidden rounded-lg border border-border bg-bg shadow-2xl";
+
+export function Modal({
+  open,
+  onClose,
+  variant = "panel",
+  size = "md",
+  ariaLabelledBy,
+  ariaLabel,
+  className,
+  children,
+}: ModalProps) {
+  if (!open) return null;
+  const isDialog = variant === "dialog";
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={ariaLabelledBy}
+      aria-label={ariaLabel}
+      className={cn(
+        "fixed inset-0 z-50 bg-black/55",
+        isDialog ? BACKDROP_DIALOG : BACKDROP_PANEL,
+      )}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className={cn(
+          isDialog ? CONTENT_DIALOG : CONTENT_PANEL,
+          SIZE_CLASS[size],
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/ModalHeader.tsx
+++ b/src/components/ui/ModalHeader.tsx
@@ -1,0 +1,53 @@
+import { X } from "lucide-react";
+import { type ReactNode } from "react";
+
+interface ModalHeaderProps {
+  title: string;
+  subtitle?: string;
+  icon?: ReactNode;
+  /** Rendered before the close button. Use for action buttons (e.g. external link). */
+  actions?: ReactNode;
+  titleId?: string;
+  onClose: () => void;
+}
+
+export function ModalHeader({
+  title,
+  subtitle,
+  icon,
+  actions,
+  titleId,
+  onClose,
+}: ModalHeaderProps) {
+  return (
+    <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
+      <div className="flex min-w-0 items-center gap-2">
+        {icon}
+        <div className="min-w-0">
+          <h3
+            id={titleId}
+            className="truncate text-sm font-semibold tracking-tight text-fg"
+          >
+            {title}
+          </h3>
+          {subtitle ? (
+            <p className="truncate font-mono text-xs text-fg-muted">
+              {subtitle}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        {actions}
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="rounded p-1 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
+        >
+          <X size={14} />
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/ui/ModalHeader.tsx
+++ b/src/components/ui/ModalHeader.tsx
@@ -1,5 +1,7 @@
 import { X } from "lucide-react";
 import { type ReactNode } from "react";
+import { cn } from "../../lib/cn";
+import { type ModalVariant } from "./Modal";
 
 interface ModalHeaderProps {
   title: string;
@@ -8,6 +10,11 @@ interface ModalHeaderProps {
   /** Rendered before the close button. Use for action buttons (e.g. external link). */
   actions?: ReactNode;
   titleId?: string;
+  /**
+   * Surface variant for hover styling. "dialog" sits on bg-bg-elevated and
+   * hovers go darker; "panel" sits on bg-bg and hovers go lighter.
+   */
+  variant?: ModalVariant;
   onClose: () => void;
 }
 
@@ -17,8 +24,11 @@ export function ModalHeader({
   icon,
   actions,
   titleId,
+  variant = "panel",
   onClose,
 }: ModalHeaderProps) {
+  const hoverBg =
+    variant === "dialog" ? "hover:bg-bg-sidebar" : "hover:bg-bg-elevated";
   return (
     <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
       <div className="flex min-w-0 items-center gap-2">
@@ -43,7 +53,10 @@ export function ModalHeader({
           type="button"
           aria-label="Close"
           onClick={onClose}
-          className="rounded p-1 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
+          className={cn(
+            "rounded p-1 text-fg-muted transition hover:text-fg",
+            hoverBg,
+          )}
         >
           <X size={14} />
         </button>

--- a/src/components/ui/RadioCard.tsx
+++ b/src/components/ui/RadioCard.tsx
@@ -1,0 +1,45 @@
+import { cn } from "../../lib/cn";
+
+interface RadioCardProps<T extends string> {
+  name: string;
+  value: T;
+  current: T;
+  label: string;
+  description?: string;
+  onSelect: (v: T) => void;
+}
+
+export function RadioCard<T extends string>({
+  name,
+  value,
+  current,
+  label,
+  description,
+  onSelect,
+}: RadioCardProps<T>) {
+  const active = current === value;
+  return (
+    <label
+      className={cn(
+        "flex cursor-pointer items-start gap-2 rounded-md border px-3 py-2 transition",
+        active
+          ? "border-accent/60 bg-accent/10"
+          : "border-border bg-bg hover:border-fg-muted/40",
+      )}
+    >
+      <input
+        type="radio"
+        name={name}
+        checked={active}
+        onChange={() => onSelect(value)}
+        className="mt-0.5 accent-[var(--color-accent)]"
+      />
+      <span className="flex flex-col">
+        <span className="text-xs font-medium text-fg">{label}</span>
+        {description ? (
+          <span className="text-[11px] text-fg-muted">{description}</span>
+        ) : null}
+      </span>
+    </label>
+  );
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,17 @@
+import { forwardRef, type SelectHTMLAttributes } from "react";
+import { cn } from "../../lib/cn";
+
+type SelectProps = SelectHTMLAttributes<HTMLSelectElement>;
+
+export const SELECT_CLASS =
+  "h-7 rounded-md border border-border bg-bg px-2 font-mono text-xs text-fg outline-none focus:border-accent";
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  function Select({ className, children, ...rest }, ref) {
+    return (
+      <select ref={ref} className={cn(SELECT_CLASS, className)} {...rest}>
+        {children}
+      </select>
+    );
+  },
+);

--- a/src/components/ui/Stepper.tsx
+++ b/src/components/ui/Stepper.tsx
@@ -1,0 +1,49 @@
+import { Minus, Plus } from "lucide-react";
+
+interface StepperProps {
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  unit?: string;
+  onChange: (v: number) => void;
+}
+
+export function Stepper({
+  value,
+  min,
+  max,
+  step = 1,
+  unit,
+  onChange,
+}: StepperProps) {
+  const clamp = (n: number) => Math.max(min, Math.min(max, n));
+  const dec = () => onChange(clamp(value - step));
+  const inc = () => onChange(clamp(value + step));
+  return (
+    <div className="inline-flex h-7 w-fit items-stretch self-start overflow-hidden rounded-md border border-border bg-bg">
+      <button
+        type="button"
+        onClick={dec}
+        disabled={value <= min}
+        aria-label="Decrease"
+        className="flex w-8 items-center justify-center text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        <Minus size={12} />
+      </button>
+      <div className="flex min-w-[3.5rem] items-center justify-center border-x border-border px-2 font-mono text-xs tabular-nums text-fg">
+        {value}
+        {unit ? <span className="ml-0.5 text-fg-muted">{unit}</span> : null}
+      </div>
+      <button
+        type="button"
+        onClick={inc}
+        disabled={value >= max}
+        aria-label="Increase"
+        className="flex w-8 items-center justify-center text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        <Plus size={12} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/TextInput.tsx
+++ b/src/components/ui/TextInput.tsx
@@ -1,0 +1,21 @@
+import { forwardRef, type InputHTMLAttributes } from "react";
+import { cn } from "../../lib/cn";
+
+type TextInputProps = InputHTMLAttributes<HTMLInputElement>;
+
+export const TEXT_INPUT_CLASS =
+  "h-7 w-full rounded-md border border-border bg-bg px-2 font-mono text-xs text-fg outline-none focus:border-accent";
+
+export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
+  function TextInput({ className, type = "text", spellCheck = false, ...rest }, ref) {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        spellCheck={spellCheck}
+        className={cn(TEXT_INPUT_CLASS, className)}
+        {...rest}
+      />
+    );
+  },
+);

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,8 @@
+export { Modal, type ModalSize, type ModalVariant } from "./Modal";
+export { ModalHeader } from "./ModalHeader";
+export { Field } from "./Field";
+export { TextInput, TEXT_INPUT_CLASS } from "./TextInput";
+export { Select, SELECT_CLASS } from "./Select";
+export { Stepper } from "./Stepper";
+export { CheckboxRow } from "./CheckboxRow";
+export { RadioCard } from "./RadioCard";


### PR DESCRIPTION
## Summary

Pull repeated patterns out of all 6 modal/dialog files into `src/components/ui/`. Goal: stop copy-pasting backdrop/header/input/checkbox markup as Settings (and other surfaces) grow.

### New primitives

| Component | Purpose |
|---|---|
| `Modal` | Shared shell — `variant: \"dialog\" \| \"panel\"`, `size: sm…5xl`. Handles backdrop, role/aria, click-outside-to-close. |
| `ModalHeader` | Title + optional icon/subtitle/actions + close X. Hover tone follows `variant`. |
| `Field` | Label + hint + child slot. |
| `TextInput` | `h-7` mono input, exports `TEXT_INPUT_CLASS`. |
| `Select` | `h-7` mono select, exports `SELECT_CLASS`. |
| `Stepper` | Number control with −/+ buttons (replaces native number stepper). |
| `CheckboxRow` | Card-style checkbox with label + description. |
| `RadioCard` | Card-style radio with label + description. |

### Migrated

- `SettingsModal` (validation target — exercises every primitive)
- `RemoveSessionDialog`
- `RemoveProjectDialog`
- `DiffViewerModal`
- `MemoryBreakdownModal`
- `PullRequestDetailModal` (custom `DetailBody` header preserved — too rich for `ModalHeader`)

### Bonus UX from earlier in the session

- Settings → Font size: native `<input type=\"number\">` stepper → −/+ button `Stepper`
- All inputs and selects unified to `h-7` for consistent vertical rhythm

### Intentional visual standardization

Backdrop opacity and dialog top offset were inconsistent across the 6 modals. The shared `Modal` enforces:

- Backdrop: `bg-black/55` (was a mix of `/50`, `/55`, `/60`)
- Dialog top offset: `pt-24` (was a mix of `pt-24`, `pt-32`)

Net: confirm dialogs (RemoveSession/Project) now sit ~32px higher than before with a marginally darker backdrop; panel modals (Memory/Diff/PR) get a marginally lighter backdrop. Within visual noise, but worth flagging.

## Verification

### Automated (✅ run + green)

- [x] `bunx tsc --noEmit` — passes
- [x] `bunx vite build` — production build succeeds (no new warnings)
- [x] `bun test` — 44 / 45 pass; the single fail (`vi.mocked is not a function`) is a pre-existing bun test runner / vitest mismatch reproducible on `main`, unrelated to this PR

### Code audit (✅ verified by reading diffs)

- [x] All 6 callers' `if (!X) return null` guards now flow through `<Modal open={X !== null|false}>`
- [x] All 6 backdrop click handlers route through Modal's `onClose`
- [x] `useDialogShortcuts` (Esc/Enter) preserved in every modal
- [x] All action buttons in `RemoveSessionDialog` (Cancel / Keep worktree / Delete worktree / Remove) preserved with same `commit()` wiring
- [x] All action buttons in `RemoveProjectDialog` (Cancel / Close · keep worktrees / Close · delete worktrees / Close project) preserved
- [x] `SettingsModal` 4 tabs render the same content; `Reset to defaults` button preserved; ariaLabelledBy preserved
- [x] `PullRequestDetailModal` rich `DetailBody` header (PR state glyph + branch metadata + ExternalLink) untouched
- [x] App.tsx call sites unchanged — component prop signatures preserved
- [x] `MemoryBreakdownModal` table + footer + sticky thead preserved

### Needs human UI smoke test

- [ ] Settings: open, edit font size via −/+, change weight selects, switch tabs, close via Esc / X / backdrop
- [ ] Remove session dialog: trigger from a regular session and an isolated worktree session — verify Cancel / Remove / Keep worktree / Delete worktree
- [ ] Remove project dialog: trigger with and without isolated child worktrees
- [ ] Diff viewer modal: open from a session diff link, scroll, close via Esc / backdrop
- [ ] Memory breakdown modal: verify table renders, footer text intact
- [ ] PR detail modal: open a PR, switch tabs, click ExternalLink, close