### PR TITLE
feat(sidebar): split activate vs toggle on project title

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -433,19 +433,30 @@ function ProjectGroupView({
         />
       ) : null}
       <div
+        role="button"
+        tabIndex={0}
+        onClick={onTitleClick}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onTitleClick();
+          }
+        }}
         onContextMenu={(e) => {
           e.preventDefault();
           e.stopPropagation();
           setMenu({ x: e.clientX, y: e.clientY });
         }}
+        aria-label={`Project ${project.name}`}
         className={cn(
-          "group flex items-center gap-1 rounded-md px-1 py-1.5 hover:bg-bg-elevated/40",
+          "group flex cursor-pointer items-center gap-1 rounded-md px-1 py-1.5 hover:bg-bg-elevated/40",
           isActiveProject && "bg-bg-elevated/30",
         )}
       >
         <span
           draggable
           onDragStart={onDragStart}
+          onClick={(e) => e.stopPropagation()}
           aria-label="Drag to reorder project"
           title="Drag to reorder"
           className="invisible flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
@@ -470,11 +481,7 @@ function ProjectGroupView({
             )}
           />
         </button>
-        <button
-          type="button"
-          onClick={onTitleClick}
-          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
-        >
+        <span className="flex min-w-0 flex-1 items-center gap-1.5">
           <FolderGit2 size={12} className="shrink-0 text-fg-muted" />
           <span className="truncate text-sm font-medium text-fg">
             {project.name}
@@ -482,7 +489,7 @@ function ProjectGroupView({
           <span className="ml-1 shrink-0 rounded bg-bg-elevated/80 px-1 text-[10px] text-fg-muted">
             {project.sessions.length}
           </span>
-        </button>
+        </span>
         <Tooltip label="New session" side="bottom">
           <button
             type="button"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -168,6 +168,15 @@ export function Sidebar() {
     });
   }
 
+  function expandProject(repoPath: string) {
+    setCollapsed((prev) => {
+      if (!prev.has(repoPath)) return prev;
+      const next = new Set(prev);
+      next.delete(repoPath);
+      return next;
+    });
+  }
+
   async function onAddProject() {
     try {
       const repoPath = await open({
@@ -253,14 +262,20 @@ export function Sidebar() {
                 onDragLeave={onProjectDragLeave}
                 onDragEnd={onProjectDragEnd}
                 onToggle={() => {
-                  toggleProject(project.repoPath);
-                  // Activate a session belonging to this project so the
-                  // workspace's terminal becomes visible. Prefer the
-                  // currently-focused-pane session if it already belongs
-                  // to this project; otherwise pick the most recent
-                  // session (sessions are sorted newest-first by the
-                  // backend `list_sessions`).
+                  // Title click is context-aware:
+                  //   inactive  → activate (and expand if collapsed); never collapses
+                  //   active    → toggle expand/collapse
+                  // This decouples "switch project" from "fold sessions" so a
+                  // user switching projects can't accidentally hide their
+                  // session list, while a re-click on the active project
+                  // still gives a single-target toggle.
+                  const wasActive = activeProject === project.repoPath;
+                  if (wasActive) {
+                    toggleProject(project.repoPath);
+                    return;
+                  }
                   setActiveProject(project.repoPath);
+                  expandProject(project.repoPath);
                   const target = pickSessionToActivate(
                     project.sessions,
                     activeSessionId,
@@ -269,6 +284,7 @@ export function Sidebar() {
                 }}
                 onActivate={() => {
                   setActiveProject(project.repoPath);
+                  expandProject(project.repoPath);
                   const target = pickSessionToActivate(
                     project.sessions,
                     activeSessionId,
@@ -424,9 +440,9 @@ function ProjectGroupView({
           aria-expanded={!collapsed}
         >
           <ChevronRight
-            size={12}
+            size={14}
             className={cn(
-              "shrink-0 text-fg-muted transition-transform",
+              "-mx-0.5 shrink-0 text-fg-muted transition-transform",
               !collapsed && "rotate-90",
             )}
           />
@@ -672,13 +688,13 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
           setMenu({ x: e.clientX, y: e.clientY });
         }}
         className={cn(
-          "group flex w-full cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 text-left transition",
+          "group flex w-full cursor-pointer items-start gap-1.5 rounded-md px-2 py-1 text-left transition",
           active ? "bg-bg-elevated" : "hover:bg-bg-elevated/60",
         )}
       >
         <span
           className={cn(
-            "mt-1.5 size-2 shrink-0 rounded-full",
+            "mt-1.5 size-1.5 shrink-0 rounded-full",
             STATUS_DOT[session.status],
           )}
         />
@@ -696,7 +712,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
                 onCancel={() => setEditing(false)}
               />
             ) : (
-              <span className="truncate text-sm font-medium text-fg">
+              <span className="truncate text-[13px] font-medium text-fg">
                 {session.name}
               </span>
             )}
@@ -708,7 +724,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
               />
             ) : null}
           </span>
-          <span className="block truncate text-xs text-fg-muted">
+          <span className="block truncate text-[11px] text-fg-muted">
             {session.branch} · {STATUS_LABEL[session.status]}
           </span>
         </span>
@@ -779,7 +795,7 @@ function RenameInput({ initial, onSubmit, onCancel }: RenameInputProps) {
         }
       }}
       onBlur={() => onSubmit(value.trim())}
-      className="min-w-0 flex-1 rounded border border-accent/50 bg-bg px-1 py-0.5 text-sm font-medium text-fg outline-none focus:border-accent"
+      className="min-w-0 flex-1 rounded border border-accent/50 bg-bg px-1 py-0.5 text-[13px] font-medium text-fg outline-none focus:border-accent"
     />
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,6 +21,11 @@ import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
 import { useSettings } from "../lib/settings";
+import {
+  planChevronClick,
+  planTitleClick,
+  type ProjectClickPlan,
+} from "../lib/sidebar-actions";
 import type { Project, Session, SessionStatus } from "../lib/types";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { Tooltip } from "./Tooltip";
@@ -156,18 +161,6 @@ export function Sidebar() {
     setDropTarget(null);
   }
 
-  function toggleProject(repoPath: string) {
-    setCollapsed((prev) => {
-      const next = new Set(prev);
-      if (next.has(repoPath)) {
-        next.delete(repoPath);
-      } else {
-        next.add(repoPath);
-      }
-      return next;
-    });
-  }
-
   function expandProject(repoPath: string) {
     setCollapsed((prev) => {
       if (!prev.has(repoPath)) return prev;
@@ -175,6 +168,28 @@ export function Sidebar() {
       next.delete(repoPath);
       return next;
     });
+  }
+
+  function collapseProject(repoPath: string) {
+    setCollapsed((prev) => {
+      if (prev.has(repoPath)) return prev;
+      const next = new Set(prev);
+      next.add(repoPath);
+      return next;
+    });
+  }
+
+  function applyClickPlan(plan: ProjectClickPlan, project: ProjectGroup) {
+    if (plan.collapseChange === "expand") {
+      expandProject(project.repoPath);
+    } else if (plan.collapseChange === "collapse") {
+      collapseProject(project.repoPath);
+    }
+    if (plan.shouldActivate) {
+      setActiveProject(project.repoPath);
+      const target = pickSessionToActivate(project.sessions, activeSessionId);
+      if (target) selectSession(target);
+    }
   }
 
   async function onAddProject() {
@@ -261,41 +276,24 @@ export function Sidebar() {
                 onDragOver={(e) => onProjectDragOver(e, project.repoPath)}
                 onDragLeave={onProjectDragLeave}
                 onDragEnd={onProjectDragEnd}
-                onTitleClick={() => {
-                  // Title click never collapses. It activates an inactive
-                  // project (preserving its collapse state) and expands an
-                  // already-active collapsed one. Collapse is reserved for
-                  // the chevron, so a user switching between projects can't
-                  // accidentally hide the destination's session list.
-                  const wasActive = activeProject === project.repoPath;
-                  if (wasActive) {
-                    expandProject(project.repoPath);
-                    return;
-                  }
-                  setActiveProject(project.repoPath);
-                  const target = pickSessionToActivate(
-                    project.sessions,
-                    activeSessionId,
-                  );
-                  if (target) selectSession(target);
-                }}
-                onChevronClick={() => {
-                  // Chevron toggles expand. It activates the project only
-                  // when expanding an inactive collapsed one — collapsing
-                  // an inactive project must not steal focus from the
-                  // currently-active project.
-                  const wasActive = activeProject === project.repoPath;
-                  const wasCollapsed = collapsed.has(project.repoPath);
-                  toggleProject(project.repoPath);
-                  if (wasCollapsed && !wasActive) {
-                    setActiveProject(project.repoPath);
-                    const target = pickSessionToActivate(
-                      project.sessions,
-                      activeSessionId,
-                    );
-                    if (target) selectSession(target);
-                  }
-                }}
+                onTitleClick={() =>
+                  applyClickPlan(
+                    planTitleClick({
+                      wasActive: activeProject === project.repoPath,
+                      wasCollapsed: collapsed.has(project.repoPath),
+                    }),
+                    project,
+                  )
+                }
+                onChevronClick={() =>
+                  applyClickPlan(
+                    planChevronClick({
+                      wasActive: activeProject === project.repoPath,
+                      wasCollapsed: collapsed.has(project.repoPath),
+                    }),
+                    project,
+                  )
+                }
                 onActivate={() => {
                   setActiveProject(project.repoPath);
                   expandProject(project.repoPath);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -261,21 +261,31 @@ export function Sidebar() {
                 onDragOver={(e) => onProjectDragOver(e, project.repoPath)}
                 onDragLeave={onProjectDragLeave}
                 onDragEnd={onProjectDragEnd}
-                onToggle={() => {
-                  // Title click is context-aware:
-                  //   inactive  → activate (and expand if collapsed); never collapses
-                  //   active    → toggle expand/collapse
-                  // This decouples "switch project" from "fold sessions" so a
-                  // user switching projects can't accidentally hide their
-                  // session list, while a re-click on the active project
-                  // still gives a single-target toggle.
+                onTitleClick={() => {
+                  // Title click never collapses. It activates an inactive
+                  // project (preserving its collapse state) and expands an
+                  // already-active collapsed one. Collapse is reserved for
+                  // the chevron, so a user switching between projects can't
+                  // accidentally hide the destination's session list.
                   const wasActive = activeProject === project.repoPath;
                   if (wasActive) {
-                    toggleProject(project.repoPath);
+                    expandProject(project.repoPath);
                     return;
                   }
                   setActiveProject(project.repoPath);
-                  expandProject(project.repoPath);
+                  const target = pickSessionToActivate(
+                    project.sessions,
+                    activeSessionId,
+                  );
+                  if (target) selectSession(target);
+                }}
+                onChevronClick={() => {
+                  // Chevron always activates the project and toggles the
+                  // expand state. This is the single way to collapse a
+                  // project, and it pairs with title-click for "activate
+                  // and force-expand" on inactive collapsed projects.
+                  setActiveProject(project.repoPath);
+                  toggleProject(project.repoPath);
                   const target = pickSessionToActivate(
                     project.sessions,
                     activeSessionId,
@@ -345,7 +355,11 @@ interface ProjectGroupViewProps {
   onDragOver: (e: React.DragEvent) => void;
   onDragLeave: (e: React.DragEvent) => void;
   onDragEnd: (e: React.DragEvent) => void;
-  onToggle: () => void;
+  /** Title click: activate (preserve collapse if inactive); ensure expanded if already active. */
+  onTitleClick: () => void;
+  /** Chevron click: activate + toggle expand. */
+  onChevronClick: () => void;
+  /** Empty-state row click: activate + expand + select a session. */
   onActivate: () => void;
   onSelectSession: (id: string) => void;
   onRemoveSession: (s: Session) => void;
@@ -364,7 +378,8 @@ function ProjectGroupView({
   onDragOver,
   onDragLeave,
   onDragEnd,
-  onToggle,
+  onTitleClick,
+  onChevronClick,
   onActivate,
   onSelectSession,
   onRemoveSession,
@@ -435,17 +450,27 @@ function ProjectGroupView({
         </span>
         <button
           type="button"
-          onClick={onToggle}
-          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+          onClick={(e) => {
+            e.stopPropagation();
+            onChevronClick();
+          }}
+          aria-label={collapsed ? "Expand project" : "Collapse project"}
           aria-expanded={!collapsed}
+          className="flex shrink-0 items-center justify-center rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
         >
           <ChevronRight
             size={14}
             className={cn(
-              "-mx-0.5 shrink-0 text-fg-muted transition-transform",
+              "transition-transform",
               !collapsed && "rotate-90",
             )}
           />
+        </button>
+        <button
+          type="button"
+          onClick={onTitleClick}
+          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+        >
           <FolderGit2 size={12} className="shrink-0 text-fg-muted" />
           <span className="truncate text-sm font-medium text-fg">
             {project.name}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -280,17 +280,21 @@ export function Sidebar() {
                   if (target) selectSession(target);
                 }}
                 onChevronClick={() => {
-                  // Chevron always activates the project and toggles the
-                  // expand state. This is the single way to collapse a
-                  // project, and it pairs with title-click for "activate
-                  // and force-expand" on inactive collapsed projects.
-                  setActiveProject(project.repoPath);
+                  // Chevron toggles expand. It activates the project only
+                  // when expanding an inactive collapsed one — collapsing
+                  // an inactive project must not steal focus from the
+                  // currently-active project.
+                  const wasActive = activeProject === project.repoPath;
+                  const wasCollapsed = collapsed.has(project.repoPath);
                   toggleProject(project.repoPath);
-                  const target = pickSessionToActivate(
-                    project.sessions,
-                    activeSessionId,
-                  );
-                  if (target) selectSession(target);
+                  if (wasCollapsed && !wasActive) {
+                    setActiveProject(project.repoPath);
+                    const target = pickSessionToActivate(
+                      project.sessions,
+                      activeSessionId,
+                    );
+                    if (target) selectSession(target);
+                  }
                 }}
                 onActivate={() => {
                   setActiveProject(project.repoPath);

--- a/src/lib/sidebar-actions.test.ts
+++ b/src/lib/sidebar-actions.test.ts
@@ -1,13 +1,7 @@
 // @vitest-environment node
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { planChevronClick, planTitleClick } from "./sidebar-actions";
-
-const SIDEBAR_SOURCE = readFileSync(
-  resolve(__dirname, "../components/Sidebar.tsx"),
-  "utf8",
-);
+import SIDEBAR_SOURCE from "../components/Sidebar.tsx?raw";
 
 describe("planTitleClick", () => {
   it("inactive + collapsed → activates, preserves collapse state", () => {

--- a/src/lib/sidebar-actions.test.ts
+++ b/src/lib/sidebar-actions.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { planChevronClick, planTitleClick } from "./sidebar-actions";
+
+const SIDEBAR_SOURCE = readFileSync(
+  resolve(__dirname, "../components/Sidebar.tsx"),
+  "utf8",
+);
+
+describe("planTitleClick", () => {
+  it("inactive + collapsed → activates, preserves collapse state", () => {
+    expect(planTitleClick({ wasActive: false, wasCollapsed: true })).toEqual({
+      shouldActivate: true,
+      collapseChange: null,
+    });
+  });
+
+  it("inactive + expanded → activates, no collapse change", () => {
+    expect(planTitleClick({ wasActive: false, wasCollapsed: false })).toEqual({
+      shouldActivate: true,
+      collapseChange: null,
+    });
+  });
+
+  it("active + collapsed → expands, does not re-activate", () => {
+    expect(planTitleClick({ wasActive: true, wasCollapsed: true })).toEqual({
+      shouldActivate: false,
+      collapseChange: "expand",
+    });
+  });
+
+  it("active + expanded → no-op", () => {
+    expect(planTitleClick({ wasActive: true, wasCollapsed: false })).toEqual({
+      shouldActivate: false,
+      collapseChange: null,
+    });
+  });
+});
+
+describe("planChevronClick", () => {
+  it("inactive + collapsed → activates and expands", () => {
+    expect(planChevronClick({ wasActive: false, wasCollapsed: true })).toEqual({
+      shouldActivate: true,
+      collapseChange: "expand",
+    });
+  });
+
+  it("inactive + expanded → collapses without activating", () => {
+    expect(planChevronClick({ wasActive: false, wasCollapsed: false })).toEqual(
+      {
+        shouldActivate: false,
+        collapseChange: "collapse",
+      },
+    );
+  });
+
+  it("active + collapsed → expands, no re-activate", () => {
+    expect(planChevronClick({ wasActive: true, wasCollapsed: true })).toEqual({
+      shouldActivate: false,
+      collapseChange: "expand",
+    });
+  });
+
+  it("active + expanded → collapses", () => {
+    expect(planChevronClick({ wasActive: true, wasCollapsed: false })).toEqual({
+      shouldActivate: false,
+      collapseChange: "collapse",
+    });
+  });
+});
+
+describe("Sidebar source contract", () => {
+  it("empty-state row routes click through onActivate (which activates + expands + selects)", () => {
+    // The empty-state <li> must call onActivate, not onTitleClick — onActivate
+    // forces an expand so the session list region remains visible after the
+    // user creates their first session in this project.
+    expect(SIDEBAR_SOURCE).toMatch(
+      /role="button"[\s\S]{0,400}onClick=\{onActivate\}/,
+    );
+    expect(SIDEBAR_SOURCE).toMatch(
+      /onActivate=\{\(\) => \{[\s\S]{0,200}setActiveProject\(project\.repoPath\);[\s\S]{0,80}expandProject\(project\.repoPath\);/,
+    );
+  });
+
+  it("session row classes are tightened (py-1, gap-1.5, status dot 1.5, name 13px, subtitle 11px)", () => {
+    expect(SIDEBAR_SOURCE).toContain("gap-1.5 rounded-md px-2 py-1 text-left");
+    expect(SIDEBAR_SOURCE).toContain("size-1.5 shrink-0 rounded-full");
+    expect(SIDEBAR_SOURCE).toContain("truncate text-[13px] font-medium text-fg");
+    expect(SIDEBAR_SOURCE).toContain("block truncate text-[11px] text-fg-muted");
+  });
+
+  it("chevron is rendered as its own padded button with hover background", () => {
+    expect(SIDEBAR_SOURCE).toMatch(
+      /aria-label=\{collapsed \? "Expand project" : "Collapse project"\}/,
+    );
+    expect(SIDEBAR_SOURCE).toMatch(
+      /flex shrink-0 items-center justify-center rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg/,
+    );
+  });
+
+  it("title click target is the entire project row, not a thin button", () => {
+    // The title click handler is wired to the row container (<div role="button">),
+    // so the click area is the full row width minus chevron + action buttons.
+    expect(SIDEBAR_SOURCE).toMatch(
+      /role="button"[\s\S]{0,400}onClick=\{onTitleClick\}/,
+    );
+  });
+});

--- a/src/lib/sidebar-actions.ts
+++ b/src/lib/sidebar-actions.ts
@@ -1,0 +1,44 @@
+/**
+ * Planners for the project-row click behaviors in the sidebar accordion.
+ * Returned as plain descriptors so the click matrix can be unit-tested
+ * without rendering the whole sidebar tree.
+ *
+ * Behavior contract:
+ * - Title click never collapses an expanded project.
+ * - Title click on an inactive project preserves its collapse state.
+ * - Title click on an active collapsed project expands it.
+ * - Chevron click toggles expand/collapse.
+ * - Chevron click activates only when expanding an inactive project; collapsing
+ *   an inactive project must not steal focus from the active one.
+ */
+
+export type CollapseChange = "expand" | "collapse" | null;
+
+export interface ProjectClickPlan {
+  shouldActivate: boolean;
+  collapseChange: CollapseChange;
+}
+
+export interface ProjectClickState {
+  wasActive: boolean;
+  wasCollapsed: boolean;
+}
+
+export function planTitleClick(state: ProjectClickState): ProjectClickPlan {
+  if (!state.wasActive) {
+    return { shouldActivate: true, collapseChange: null };
+  }
+  return {
+    shouldActivate: false,
+    collapseChange: state.wasCollapsed ? "expand" : null,
+  };
+}
+
+export function planChevronClick(state: ProjectClickState): ProjectClickPlan {
+  const collapseChange: CollapseChange = state.wasCollapsed
+    ? "expand"
+    : "collapse";
+  const shouldActivate =
+    collapseChange === "expand" && !state.wasActive;
+  return { shouldActivate, collapseChange };
+}


### PR DESCRIPTION
## Summary

Project title click in the sidebar accordion was overloaded: one click both activated the project and toggled the session list collapse. Switching between projects accidentally hid the session list of the destination project.

### New behavior — independent click targets

| State | Title click | Chevron click |
|---|---|---|
| inactive + collapsed | activate (stays collapsed) | activate + expand |
| inactive + expanded | activate | collapse (does **not** activate) |
| active + collapsed | expand | expand |
| active + expanded | (no-op, stays expanded) | collapse |

Rules in plain words:

- **Title** = \"switch to this project.\" Never collapses, never force-expands an inactive collapsed project.
- **Chevron** = \"toggle expand for this project.\" Activates the project only when transitioning collapsed → expanded on an inactive project. Collapsing never steals focus from whatever you're working on.

### Polish

- Chevron is now its own padded button (p-1 + hover background) instead of a passive glyph — much larger hit area.
- Chevron icon 12 → 14px so the disclosure state reads better at a glance.
- Session rows tightened — `py-1.5 → py-1`, `gap-2 → gap-1.5`, status dot 8 → 6px, name 14 → 13px, subtitle 12 → 11px. Roughly one row shorter per ~6 sessions.

## Verification

- [x] `bunx tsc --noEmit` passes
- [x] Empty-state click path (PR #11) preserved — `onActivate` still expands + activates + selects a session
- [x] Chevron button stops event propagation so it can't accidentally trigger the title button

### Needs human UI smoke test

- [x] Inactive collapsed project → title click → activates, stays collapsed
- [x] Inactive expanded project → title click → activates, stays expanded
- [x] Active collapsed project → title click → expands
- [ ] Active expanded project → title click → no visible change
- [ ] Inactive collapsed project → chevron click → activates + expands
- [ ] Inactive expanded project → chevron click → collapses, active project unchanged
- [ ] Active collapsed project → chevron click → expands
- [ ] Active expanded project → chevron click → collapses
- [x] Empty-state row click (project with 0 sessions) still activates the project
- [x] Session rows visibly more compact, no overflow at typical sidebar widths