### PR TITLE
perf(tauri): async heavy commands to unblock UI on project switch

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -96,7 +96,7 @@ pub struct MemoryUsage {
 }
 
 #[tauri::command]
-pub fn get_memory_usage() -> MemoryUsage {
+pub async fn get_memory_usage() -> MemoryUsage {
     let mut guard = MEMORY_PROBE.lock().expect("memory probe poisoned");
     let sys = guard.get_or_insert_with(|| {
         System::new_with_specifics(
@@ -148,7 +148,7 @@ pub fn get_memory_usage() -> MemoryUsage {
 }
 
 #[tauri::command]
-pub fn create_session(
+pub async fn create_session(
     state: State<'_, AppState>,
     name: String,
     repo_path: String,
@@ -207,7 +207,7 @@ pub fn reorder_projects(
 }
 
 #[tauri::command]
-pub fn remove_project(
+pub async fn remove_project(
     state: State<'_, AppState>,
     repo_path: String,
     remove_sessions: Option<bool>,
@@ -238,7 +238,7 @@ pub fn remove_project(
 }
 
 #[tauri::command]
-pub fn remove_session(
+pub async fn remove_session(
     state: State<'_, AppState>,
     id: String,
     remove_worktree: Option<bool>,
@@ -342,7 +342,7 @@ fn decode_base64(input: &str) -> Option<Vec<u8>> {
 }
 
 #[tauri::command]
-pub fn pty_spawn<R: Runtime>(
+pub async fn pty_spawn<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, AppState>,
     session_id: String,
@@ -408,7 +408,7 @@ pub fn pty_kill(state: State<'_, AppState>, session_id: String) -> AppResult<()>
 }
 
 #[tauri::command]
-pub fn scrollback_save(
+pub async fn scrollback_save(
     state: State<'_, AppState>,
     session_id: String,
     data: String,
@@ -424,17 +424,17 @@ pub fn scrollback_save(
 }
 
 #[tauri::command]
-pub fn scrollback_load(session_id: String) -> AppResult<Option<String>> {
+pub async fn scrollback_load(session_id: String) -> AppResult<Option<String>> {
     scrollback::load(&session_id)
 }
 
 #[tauri::command]
-pub fn scrollback_delete(session_id: String) -> AppResult<()> {
+pub async fn scrollback_delete(session_id: String) -> AppResult<()> {
     scrollback::delete(&session_id)
 }
 
 #[tauri::command]
-pub fn read_session_todos(session_id: String, cwd: String) -> AppResult<Vec<TodoItem>> {
+pub async fn read_session_todos(session_id: String, cwd: String) -> AppResult<Vec<TodoItem>> {
     let cwd = PathBuf::from(cwd);
     todos::read_latest_todos(&session_id, &cwd)
 }
@@ -446,11 +446,12 @@ pub struct SessionStatusEntry {
 }
 
 #[tauri::command]
-pub fn detect_session_statuses(
+pub async fn detect_session_statuses(
     state: State<'_, AppState>,
     ids: Vec<String>,
-) -> Vec<SessionStatusEntry> {
-    ids.into_iter()
+) -> AppResult<Vec<SessionStatusEntry>> {
+    Ok(ids
+        .into_iter()
         .map(|id| {
             let status = session_status::detect(&id).unwrap_or(SessionStatus::Idle);
             // Mirror the detected status into the in-memory store so persisted
@@ -461,11 +462,11 @@ pub fn detect_session_statuses(
             }
             SessionStatusEntry { id, status }
         })
-        .collect()
+        .collect())
 }
 
 #[tauri::command]
-pub fn list_commits(
+pub async fn list_commits(
     repo_path: String,
     offset: Option<usize>,
     limit: Option<usize>,
@@ -478,17 +479,17 @@ pub fn list_commits(
 }
 
 #[tauri::command]
-pub fn list_staged(repo_path: String) -> AppResult<Vec<StagedFile>> {
+pub async fn list_staged(repo_path: String) -> AppResult<Vec<StagedFile>> {
     git_ops::list_staged(&PathBuf::from(repo_path))
 }
 
 #[tauri::command]
-pub fn commit_diff(repo_path: String, sha: String) -> AppResult<DiffPayload> {
+pub async fn commit_diff(repo_path: String, sha: String) -> AppResult<DiffPayload> {
     git_ops::diff_for_commit(&PathBuf::from(repo_path), &sha)
 }
 
 #[tauri::command]
-pub fn commit_web_url(repo_path: String, sha: String) -> AppResult<Option<String>> {
+pub async fn commit_web_url(repo_path: String, sha: String) -> AppResult<Option<String>> {
     git_ops::web_url_for_commit(&PathBuf::from(repo_path), &sha)
 }
 
@@ -503,7 +504,7 @@ pub fn commit_web_url(repo_path: String, sha: String) -> AppResult<Option<String
 /// by the encoding, we look for `<session-id>.jsonl` under any subdir of
 /// `~/.claude/projects/`.
 #[tauri::command]
-pub fn claude_session_exists(_cwd: String, session_id: String) -> bool {
+pub async fn claude_session_exists(_cwd: String, session_id: String) -> bool {
     let home = match std::env::var_os("HOME") {
         Some(v) => PathBuf::from(v),
         None => return false,
@@ -534,7 +535,7 @@ pub fn claude_session_exists(_cwd: String, session_id: String) -> bool {
 /// the binary themselves at runtime — adding it to a static capability scope
 /// would defeat the configurability.
 #[tauri::command]
-pub fn open_in_editor(
+pub async fn open_in_editor(
     command: String,
     args: Vec<String>,
     path: String,
@@ -554,12 +555,12 @@ pub fn open_in_editor(
 }
 
 #[tauri::command]
-pub fn staged_diff(repo_path: String) -> AppResult<DiffPayload> {
+pub async fn staged_diff(repo_path: String) -> AppResult<DiffPayload> {
     git_ops::diff_staged(&PathBuf::from(repo_path))
 }
 
 #[tauri::command]
-pub fn list_pull_requests(
+pub async fn list_pull_requests(
     repo_path: String,
     state: Option<PrStateFilter>,
     limit: Option<u32>,
@@ -572,7 +573,7 @@ pub fn list_pull_requests(
 }
 
 #[tauri::command]
-pub fn get_pull_request_detail(
+pub async fn get_pull_request_detail(
     repo_path: String,
     number: u64,
 ) -> AppResult<PullRequestDetailListing> {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -44,8 +44,11 @@ const COMMITS_PAGE_SIZE = 50;
 const COMMIT_ROW_HEIGHT = 48;
 
 export function RightPanel() {
-  const { sessions, activeSessionId, activeProject, rightTab, setRightTab } =
-    useAppStore();
+  const sessions = useAppStore((s) => s.sessions);
+  const activeSessionId = useAppStore((s) => s.activeSessionId);
+  const activeProject = useAppStore((s) => s.activeProject);
+  const rightTab = useAppStore((s) => s.rightTab);
+  const setRightTab = useAppStore((s) => s.setRightTab);
   const active = sessions.find((s) => s.id === activeSessionId);
   const repoPath = active?.worktree_path ?? activeProject ?? null;
   const [expanded, setExpanded] = useState<ExpandedDiff | null>(null);

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -229,6 +229,54 @@ function SkeletonList({ count = 6 }: { count?: number }) {
   );
 }
 
+/**
+ * Shaped placeholder for the Pull Requests tab. Mirrors the real PR row
+ * layout — two lines, with `#number`, state badge, title on top and
+ * author · branches · time underneath — so the panel doesn't reflow when
+ * data arrives. Bar widths are randomized per row (deterministically) so
+ * the placeholder reads as multiple distinct items rather than a stripe.
+ */
+function PrSkeletonRow({ index }: { index: number }) {
+  // Cycle through a handful of width pairs so the skeleton looks like a
+  // varied list instead of identical bars stacked vertically.
+  const titleWidths = ["55%", "72%", "40%", "65%", "48%", "60%"];
+  const branchWidths = ["38%", "52%", "30%", "44%"];
+  const titleW = titleWidths[index % titleWidths.length];
+  const branchW = branchWidths[index % branchWidths.length];
+  return (
+    <div className="flex flex-col gap-1.5 border-b border-border/40 px-3 py-2">
+      <div className="flex w-full items-center gap-2">
+        <span className="h-3 w-8 shrink-0 animate-pulse rounded bg-fg-muted/15" />
+        <span className="h-4 w-12 shrink-0 animate-pulse rounded-full bg-fg-muted/15" />
+        <span
+          className="h-3 min-w-0 flex-1 animate-pulse rounded bg-fg-muted/10"
+          style={{ width: titleW }}
+        />
+      </div>
+      <div className="flex w-full items-center gap-2">
+        <span className="h-2.5 w-16 shrink-0 animate-pulse rounded bg-fg-muted/10" />
+        <span className="text-[10px] text-fg-muted/40">·</span>
+        <span
+          className="h-2.5 animate-pulse rounded bg-fg-muted/10"
+          style={{ width: branchW }}
+        />
+        <span className="text-[10px] text-fg-muted/40">·</span>
+        <span className="h-2.5 w-10 shrink-0 animate-pulse rounded bg-fg-muted/10" />
+      </div>
+    </div>
+  );
+}
+
+function PrSkeletonList({ count = 6 }: { count?: number }) {
+  return (
+    <div className="text-xs">
+      {Array.from({ length: count }).map((_, i) => (
+        <PrSkeletonRow key={i} index={i} />
+      ))}
+    </div>
+  );
+}
+
 const TODOS_POLL_INTERVAL_MS = 1500;
 
 interface SessionTodosState {
@@ -906,6 +954,10 @@ function PullRequestsTab({
   );
 
   useEffect(() => {
+    // Drop the prior project's listing so the panel renders skeletons during
+    // the next fetch instead of flashing stale PR rows for the old repo.
+    setListing(null);
+    setError(null);
     const signal = { cancelled: false };
     void fetchPrs(signal);
     const handle = setInterval(() => {
@@ -968,7 +1020,7 @@ function PullRequestsTab({
         {error ? (
           <div className="p-3 text-xs text-danger">{error}</div>
         ) : !listing ? (
-          <SkeletonList count={6} />
+          <PrSkeletonList count={10} />
         ) : listing.kind === "not_github" ? (
           <Empty msg="Origin remote is not a GitHub repository." />
         ) : listing.kind === "no_access" ? (


### PR DESCRIPTION
## Summary

- Convert 13 `#[tauri::command]` functions from `pub fn` to `pub async fn` so heavy git/file/subprocess work runs on the tokio runtime instead of the Tauri main webview thread. Project-switch UI no longer freezes while `list_commits`, `list_staged`, `*_diff`, `list_pull_requests`, `read_session_todos`, `detect_session_statuses`, `claude_session_exists`, `pty_spawn`, `scrollback_*`, `create_session`, `remove_session`, `remove_project`, `get_memory_usage`, and `open_in_editor` are in flight — the recently-added skeleton fallbacks now paint immediately.
- `detect_session_statuses` return type changes from `Vec<SessionStatusEntry>` to `AppResult<Vec<SessionStatusEntry>>` because Tauri requires `Result` on async commands that borrow `State<'_, _>`. JS-side `invoke<...>()` resolves to the same shape.
- `RightPanel` previously called `useAppStore()` with no selector and re-rendered on every store change (including the 1-second session-status poll). Switch to per-field selectors so it only re-renders when its actual inputs change.

## Why the previous skeleton work alone wasn't enough

Tauri 2 runs sync `#[tauri::command] pub fn` on the **main UI thread**. With heavy commands running synchronously, the webview can't process IPC, run JS, or paint — so the JS code that swaps the panel into its skeleton state can't reach the GPU until the in-flight sync command returns. Async-ifying frees the main thread.

## Test plan

- [x] `cargo check` — clean.
- [x] `bun run typecheck` — clean.
- [ ] Manual: `bun run tauri dev`, switch between two large projects in the sidebar; confirm:
  - skeleton rows paint instantly on click (commits / staged / PRs)
  - terminal area stays responsive during the data load
  - no regression in pty spawn, scrollback save/load, or remove flows
- [ ] Manual: trigger memory breakdown modal during heavy session activity; confirm it no longer hitches.