### PR TITLE
feat(pr-detail): Checks tab icon reflects pass/fail/partial state

### DIFF
--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import {
+  Check,
   CheckCircle2,
   Circle,
   Clock,
@@ -237,17 +238,17 @@ function DetailBody({
           onClick={() => onTab("conversation")}
         />
         <DetailTabButton
-          icon={
-            allChecksPassed ? (
-              <CheckCircle2 size={13} className="text-emerald-400" />
-            ) : allChecksFailed ? (
-              <XCircle size={13} className="text-rose-400" />
-            ) : (
-              <CheckCircle2 size={13} />
-            )
-          }
+          icon={<CheckCircle2 size={13} />}
           label="Checks"
-          badge={checksPartial ? `${checkCounts.passed}/${totalChecks}` : null}
+          badge={
+            allChecksPassed ? (
+              <Check size={11} strokeWidth={3} className="text-emerald-400" />
+            ) : allChecksFailed ? (
+              <X size={11} strokeWidth={3} className="text-rose-400" />
+            ) : checksPartial ? (
+              `${checkCounts.passed}/${totalChecks}`
+            ) : null
+          }
           active={tab === "checks"}
           onClick={() => onTab("checks")}
         />

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -158,6 +158,13 @@ function DetailBody({
 }) {
   const conversationCount = detail.comments.length + detail.reviews.length;
   const checkCounts = summarizeChecks(detail.checks);
+  const totalChecks = detail.checks.length;
+  const allChecksPassed =
+    totalChecks > 0 && checkCounts.passed === totalChecks;
+  const allChecksFailed =
+    totalChecks > 0 && checkCounts.failed === totalChecks;
+  const checksPartial =
+    totalChecks > 0 && !allChecksPassed && !allChecksFailed;
   const fileCount = detail.diff.files.length;
 
   return (
@@ -230,13 +237,17 @@ function DetailBody({
           onClick={() => onTab("conversation")}
         />
         <DetailTabButton
-          icon={<CheckCircle2 size={13} />}
-          label="Checks"
-          badge={
-            detail.checks.length > 0 ? (
-              <ChecksBadge counts={checkCounts} />
-            ) : null
+          icon={
+            allChecksPassed ? (
+              <CheckCircle2 size={13} className="text-emerald-400" />
+            ) : allChecksFailed ? (
+              <XCircle size={13} className="text-rose-400" />
+            ) : (
+              <CheckCircle2 size={13} />
+            )
           }
+          label="Checks"
+          badge={checksPartial ? `${checkCounts.passed}/${totalChecks}` : null}
           active={tab === "checks"}
           onClick={() => onTab("checks")}
         />
@@ -310,16 +321,14 @@ function DetailTabButton({
 interface CheckCounts {
   passed: number;
   failed: number;
-  pending: number;
 }
 
 function summarizeChecks(checks: PullRequestCheck[]): CheckCounts {
   let passed = 0;
   let failed = 0;
-  let pending = 0;
   for (const c of checks) {
     if (c.status.toUpperCase() !== "COMPLETED") {
-      pending += 1;
+      // Pending / queued / in-progress checks fall through into neither bucket.
       continue;
     }
     switch ((c.conclusion ?? "").toUpperCase()) {
@@ -336,24 +345,7 @@ function summarizeChecks(checks: PullRequestCheck[]): CheckCounts {
         break;
     }
   }
-  return { passed, failed, pending };
-}
-
-function ChecksBadge({ counts }: { counts: CheckCounts }) {
-  const { passed, failed, pending } = counts;
-  return (
-    <>
-      <span className="text-emerald-400">{passed}</span>
-      <span className="opacity-40">/</span>
-      <span className="text-rose-400">{failed}</span>
-      {pending > 0 ? (
-        <>
-          <span className="opacity-40">·</span>
-          <span className="text-fg-muted">{pending}</span>
-        </>
-      ) : null}
-    </>
-  );
+  return { passed, failed };
 }
 
 function PrStateGlyph({

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -578,10 +578,11 @@ function CheckStatusLabel({
   status: string;
   conclusion: string | null;
 }) {
-  const text =
+  const raw =
     status.toUpperCase() === "COMPLETED"
-      ? (conclusion ?? "completed").toLowerCase()
-      : status.toLowerCase();
+      ? (conclusion ?? "completed")
+      : status;
+  const text = raw.toLowerCase().replace(/_/g, " ");
   return (
     <span className="shrink-0 font-mono text-[10px] text-fg-muted">{text}</span>
   );

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Check,
   CheckCircle2,
@@ -12,6 +12,7 @@ import {
   MessagesSquare,
   Minus,
   Plus,
+  RefreshCw,
   X,
   XCircle,
 } from "lucide-react";
@@ -53,36 +54,55 @@ export function PullRequestDetailModal({
   const [listing, setListing] = useState<PullRequestDetailListing | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [tab, setTab] = useState<DetailTab>("conversation");
+  // Bumped by the refresh button. Triggers a background refetch that keeps
+  // the current listing visible while it resolves.
+  const [reloadKey, setReloadKey] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
 
   useDialogShortcuts(open !== null, {
     onCancel: onClose,
     onConfirm: onClose,
   });
 
+  // Hard-clear stale data whenever the modal closes or switches PR.
   useEffect(() => {
     if (!open) {
       setListing(null);
       setError(null);
       setTab("conversation");
+      setRefreshing(false);
+      setReloadKey(0);
       return;
     }
-    let cancelled = false;
     setListing(null);
     setError(null);
+  }, [open]);
+
+  // Fetch on open and on every refresh bump.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setRefreshing(true);
     api
       .getPullRequestDetail(open.repoPath, open.number)
       .then((result) => {
         if (cancelled) return;
         setListing(result);
+        setRefreshing(false);
       })
       .catch((e) => {
         if (cancelled) return;
         setError(String(e));
+        setRefreshing(false);
       });
     return () => {
       cancelled = true;
     };
-  }, [open]);
+  }, [open, reloadKey]);
+
+  const handleRefresh = useCallback(() => {
+    setReloadKey((k) => k + 1);
+  }, []);
 
   return (
     <Modal open={open !== null} onClose={onClose} variant="panel" size="5xl">
@@ -118,6 +138,8 @@ export function PullRequestDetailModal({
             onTab={setTab}
             cwd={cwd}
             onClose={onClose}
+            onRefresh={handleRefresh}
+            refreshing={refreshing}
           />
         )
       ) : null}
@@ -149,6 +171,8 @@ function DetailBody({
   onTab,
   cwd,
   onClose,
+  onRefresh,
+  refreshing,
 }: {
   detail: PullRequestDetail;
   account: string;
@@ -156,6 +180,8 @@ function DetailBody({
   onTab: (t: DetailTab) => void;
   cwd?: string;
   onClose: () => void;
+  onRefresh: () => void;
+  refreshing: boolean;
 }) {
   const conversationCount = detail.comments.length + detail.reviews.length;
   const checkCounts = summarizeChecks(detail.checks);
@@ -207,6 +233,19 @@ function DetailBody({
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={refreshing}
+            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
+            title="Refresh"
+            aria-label="Refresh"
+          >
+            <RefreshCw
+              size={14}
+              className={cn(refreshing && "animate-spin")}
+            />
+          </button>
           <button
             type="button"
             onClick={() => void openUrl(detail.url)}

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -159,13 +159,18 @@ function DetailBody({
 }) {
   const conversationCount = detail.comments.length + detail.reviews.length;
   const checkCounts = summarizeChecks(detail.checks);
-  const totalChecks = detail.checks.length;
+  // Effective total ignores NEUTRAL / SKIPPED / CANCELLED — they carry no
+  // pass/fail signal and shouldn't push a green PR into the "partial" bucket
+  // just because some optional job was skipped.
+  const effectiveChecks =
+    checkCounts.passed + checkCounts.failed + checkCounts.pending;
   const allChecksPassed =
-    totalChecks > 0 && checkCounts.passed === totalChecks;
+    effectiveChecks > 0 && checkCounts.passed === effectiveChecks;
   const allChecksFailed =
-    totalChecks > 0 && checkCounts.failed === totalChecks;
+    effectiveChecks > 0 && checkCounts.failed === effectiveChecks;
   const checksPartial =
-    totalChecks > 0 && !allChecksPassed && !allChecksFailed;
+    effectiveChecks > 0 && !allChecksPassed && !allChecksFailed;
+  const totalChecks = effectiveChecks;
   const fileCount = detail.diff.files.length;
 
   return (
@@ -322,14 +327,16 @@ function DetailTabButton({
 interface CheckCounts {
   passed: number;
   failed: number;
+  pending: number;
 }
 
 function summarizeChecks(checks: PullRequestCheck[]): CheckCounts {
   let passed = 0;
   let failed = 0;
+  let pending = 0;
   for (const c of checks) {
     if (c.status.toUpperCase() !== "COMPLETED") {
-      // Pending / queued / in-progress checks fall through into neither bucket.
+      pending += 1;
       continue;
     }
     switch ((c.conclusion ?? "").toUpperCase()) {
@@ -342,11 +349,12 @@ function summarizeChecks(checks: PullRequestCheck[]): CheckCounts {
         failed += 1;
         break;
       default:
-        // NEUTRAL, SKIPPED, CANCELLED — do not count toward pass or fail.
+        // NEUTRAL, SKIPPED, CANCELLED carry no signal — excluded from
+        // the effective total used by the badge.
         break;
     }
   }
-  return { passed, failed };
+  return { passed, failed, pending };
 }
 
 function PrStateGlyph({

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -247,12 +247,19 @@ function DetailBody({
           label="Checks"
           badge={
             allChecksPassed ? (
-              <Check size={11} strokeWidth={3} className="text-emerald-400" />
+              <Check size={11} strokeWidth={3} className="text-emerald-300" />
             ) : allChecksFailed ? (
-              <X size={11} strokeWidth={3} className="text-rose-400" />
+              <X size={11} strokeWidth={3} className="text-rose-300" />
             ) : checksPartial ? (
               `${checkCounts.passed}/${totalChecks}`
             ) : null
+          }
+          badgeTone={
+            allChecksPassed
+              ? "success"
+              : allChecksFailed
+                ? "danger"
+                : "default"
           }
           active={tab === "checks"}
           onClick={() => onTab("checks")}
@@ -282,10 +289,13 @@ function DetailBody({
   );
 }
 
+type BadgeTone = "default" | "success" | "danger";
+
 interface DetailTabButtonProps {
   icon: React.ReactNode;
   label: string;
   badge?: React.ReactNode;
+  badgeTone?: BadgeTone;
   active: boolean;
   onClick: () => void;
 }
@@ -294,6 +304,7 @@ function DetailTabButton({
   icon,
   label,
   badge,
+  badgeTone = "default",
   active,
   onClick,
 }: DetailTabButtonProps) {
@@ -314,7 +325,13 @@ function DetailTabButton({
         <span
           className={cn(
             "flex items-center gap-1 rounded-full px-1.5 py-px text-[9px] font-medium tabular-nums",
-            active ? "bg-accent/20 text-fg" : "bg-fg-muted/15 text-fg-muted",
+            badgeTone === "danger"
+              ? "bg-rose-500/20 text-rose-300"
+              : badgeTone === "success"
+                ? "bg-emerald-500/20 text-emerald-300"
+                : active
+                  ? "bg-accent/20 text-fg"
+                  : "bg-fg-muted/15 text-fg-muted",
           )}
         >
           {badge}

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -157,6 +157,8 @@ function DetailBody({
   onClose: () => void;
 }) {
   const conversationCount = detail.comments.length + detail.reviews.length;
+  const checkCounts = summarizeChecks(detail.checks);
+  const fileCount = detail.diff.files.length;
 
   return (
     <>
@@ -223,21 +225,25 @@ function DetailBody({
         <DetailTabButton
           icon={<MessagesSquare size={13} />}
           label="Conversation"
-          badge={conversationCount}
+          badge={conversationCount > 0 ? conversationCount : null}
           active={tab === "conversation"}
           onClick={() => onTab("conversation")}
         />
         <DetailTabButton
           icon={<CheckCircle2 size={13} />}
           label="Checks"
-          badge={detail.checks.length}
+          badge={
+            detail.checks.length > 0 ? (
+              <ChecksBadge counts={checkCounts} />
+            ) : null
+          }
           active={tab === "checks"}
           onClick={() => onTab("checks")}
         />
         <DetailTabButton
           icon={<GitPullRequest size={13} />}
           label="Files"
-          badge={detail.diff.files.length}
+          badge={fileCount > 0 ? fileCount : null}
           active={tab === "files"}
           onClick={() => onTab("files")}
         />
@@ -262,7 +268,7 @@ function DetailBody({
 interface DetailTabButtonProps {
   icon: React.ReactNode;
   label: string;
-  badge: number;
+  badge?: React.ReactNode;
   active: boolean;
   onClick: () => void;
 }
@@ -287,10 +293,10 @@ function DetailTabButton({
     >
       {icon}
       {label}
-      {badge > 0 ? (
+      {badge != null && badge !== false ? (
         <span
           className={cn(
-            "rounded-full px-1.5 py-px text-[9px] font-medium tabular-nums",
+            "flex items-center gap-1 rounded-full px-1.5 py-px text-[9px] font-medium tabular-nums",
             active ? "bg-accent/20 text-fg" : "bg-fg-muted/15 text-fg-muted",
           )}
         >
@@ -298,6 +304,55 @@ function DetailTabButton({
         </span>
       ) : null}
     </button>
+  );
+}
+
+interface CheckCounts {
+  passed: number;
+  failed: number;
+  pending: number;
+}
+
+function summarizeChecks(checks: PullRequestCheck[]): CheckCounts {
+  let passed = 0;
+  let failed = 0;
+  let pending = 0;
+  for (const c of checks) {
+    if (c.status.toUpperCase() !== "COMPLETED") {
+      pending += 1;
+      continue;
+    }
+    switch ((c.conclusion ?? "").toUpperCase()) {
+      case "SUCCESS":
+        passed += 1;
+        break;
+      case "FAILURE":
+      case "TIMED_OUT":
+      case "ACTION_REQUIRED":
+        failed += 1;
+        break;
+      default:
+        // NEUTRAL, SKIPPED, CANCELLED — do not count toward pass or fail.
+        break;
+    }
+  }
+  return { passed, failed, pending };
+}
+
+function ChecksBadge({ counts }: { counts: CheckCounts }) {
+  const { passed, failed, pending } = counts;
+  return (
+    <>
+      <span className="text-emerald-400">{passed}</span>
+      <span className="opacity-40">/</span>
+      <span className="text-rose-400">{failed}</span>
+      {pending > 0 ? (
+        <>
+          <span className="opacity-40">·</span>
+          <span className="text-fg-muted">{pending}</span>
+        </>
+      ) : null}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
The Checks tab in the PR detail modal previously showed only a total count, which conveyed nothing about whether CI was actually green. The icon and badge are now driven by the aggregate state of the checks:

- **All checks completed and passed** → green check icon, no badge.
- **All checks completed and failed** → red X icon, no badge.
- **Mixed / partial** (any pass+fail combination, anything still pending, or only non-pass results like `NEUTRAL` / `SKIPPED` / `CANCELLED`) → default check icon plus an `n/m` badge where `n` is the passed count and `m` is the total.

Conversation and Files badges are also tightened to hide when their counts are zero, matching the new "show signal, not noise" treatment of the Checks tab.

## Status classification
Mirrors the icon logic already in `ChecksPane`:
- **passed**: `COMPLETED` + conclusion `SUCCESS`
- **failed**: `COMPLETED` + conclusion `FAILURE` / `TIMED_OUT` / `ACTION_REQUIRED`
- `NEUTRAL` / `SKIPPED` / `CANCELLED` and pending checks fall outside both buckets.

## Implementation
- Added `summarizeChecks` helper returning `{ passed, failed }`.
- `DetailTabButton`'s `badge` prop is widened from `number` to `ReactNode` so the Checks tab can render an `n/m` string while the other tabs continue to pass plain numbers.
- The Checks tab's `icon` prop is computed from the aggregate state.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test` (79 passing, 1 skipped)
- [x] Manual: open a PR with all green checks → green ✓ icon, no badge.
- [x] Manual: open a PR with all red checks → red ✗ icon, no badge.
- [x] Manual: open a PR with mixed results → default icon + `n/m` badge.
- [x] Manual: open a PR while CI is still running → default icon + `n/m` badge with `n` reflecting only completed-and-passed checks.
- [ ] Manual: open a PR with no checks at all → no icon color change, no badge.