### PR TITLE
demo: partial Checks state (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,11 @@ jobs:
 
       - name: Build
         run: bun run build
+
+  demo-fail:
+    name: Demo Failing Job (intentional)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.head_ref == 'demo/checks-partial-state'
+    steps:
+      - name: Always fail
+        run: exit 1


### PR DESCRIPTION
## Purpose
Throwaway draft PR to exercise the **partial** Checks state introduced in #16. Adds an intentionally failing CI job, so this PR ends up with **1 passed / 1 failed** checks and the Checks tab badge in acorn should display `1/2`.

The failing job is gated to this branch only (`github.head_ref == 'demo/checks-partial-state'`), so merging anything else is unaffected.

## How to test in acorn
1. Wait for both CI jobs to finish on this PR.
2. Open acorn on a checkout of `feat/checks-pass-fail-badge`.
3. PRs tab → double-click this PR row → Checks tab → confirm:
   - Left icon: default neutral check (unchanged).
   - Right badge: `1/2` (partial state).
4. While the failing job is still running you should see `1/2` (or `0/2` while both still pending) — covering the pending-counts-as-not-passed case too.

## Cleanup
Close this PR and delete the branch after verification — do **not** merge.
