### PR TITLE
demo: all-failed Checks state (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   frontend:
     name: Frontend
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.head_ref != 'demo/checks-all-fail'
     steps:
       - uses: actions/checkout@v4
 
@@ -40,3 +41,11 @@ jobs:
 
       - name: Build
         run: bun run build
+
+  demo-fail-all:
+    name: Demo Failing Job (intentional)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.head_ref == 'demo/checks-all-fail'
+    steps:
+      - name: Always fail
+        run: exit 1


### PR DESCRIPTION
## Purpose
Throwaway draft PR to exercise the **all-failed** branch of the Checks badge in #16. Skips the real Frontend job on this branch and runs only an always-failing job, so this PR resolves to **0 passed / 1 failed**.

The Frontend job is `if`-gated to skip on this branch, and `demo-fail-all` is `if`-gated to only run on this branch — main and other PRs are unaffected.

## Expected acorn behavior
- Checks tab badge: small red `X` icon (no number).
- Left tab icon: default neutral check.

## Cleanup
Close + delete branch after verification.