### PR TITLE
demo: pending Checks state (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,11 @@ jobs:
 
       - name: Build
         run: bun run build
+
+  demo-pending:
+    name: Demo Long-Running Job (intentional)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.head_ref == 'demo/checks-pending'
+    steps:
+      - name: Sleep 10 minutes
+        run: sleep 600


### PR DESCRIPTION
## Purpose
Throwaway draft PR to exercise the **pending** Checks state. Adds a 10-minute sleep job gated to this branch, so while CI is running this PR shows **1 passed (Frontend)** + **1 pending (sleep)**.

## Expected acorn behavior (during the sleep window)
- Frontend completes in ~30s (passed).
- Demo Long-Running Job stays in IN_PROGRESS for ~10 min.
- Checks badge: partial → `1/2` (passed/effective-total, pending counted in denominator).
- After sleep finishes (success): both passed → green check (all-passed).

## Cleanup
Close + delete branch after verification — do not merge.
