### PR TITLE
feat(ui): RefreshButton with success-tick animation

### DIFF
--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -12,7 +12,6 @@ import {
   MessagesSquare,
   Minus,
   Plus,
-  RefreshCw,
   X,
   XCircle,
 } from "lucide-react";
@@ -28,7 +27,7 @@ import type {
   PullRequestReview,
 } from "../lib/types";
 import { DiffSplitView } from "./DiffSplitView";
-import { Markdown, Modal, ModalHeader } from "./ui";
+import { Markdown, Modal, ModalHeader, RefreshButton } from "./ui";
 
 type DetailTab = "conversation" | "checks" | "files";
 
@@ -233,19 +232,7 @@ function DetailBody({
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-1">
-          <button
-            type="button"
-            onClick={onRefresh}
-            disabled={refreshing}
-            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
-            title="Refresh"
-            aria-label="Refresh"
-          >
-            <RefreshCw
-              size={14}
-              className={cn(refreshing && "animate-spin")}
-            />
-          </button>
+          <RefreshButton onClick={onRefresh} loading={refreshing} size={14} />
           <button
             type="button"
             onClick={() => void openUrl(detail.url)}

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -8,7 +8,6 @@ import {
   Globe,
   ListTodo,
   Maximize2,
-  RefreshCw,
 } from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Panel, PanelGroup } from "react-resizable-panels";
@@ -33,6 +32,7 @@ import { DiffView } from "./DiffView";
 import { DiffViewerModal } from "./DiffViewerModal";
 import { PullRequestDetailModal } from "./PullRequestDetailModal";
 import { ResizeHandle } from "./ResizeHandle";
+import { RefreshButton } from "./ui";
 
 interface ExpandedDiff {
   payload: DiffPayload;
@@ -1003,18 +1003,12 @@ function PullRequestsTab({
             {opt.label}
           </button>
         ))}
-        <button
-          type="button"
+        <RefreshButton
           onClick={() => void fetchPrs()}
-          className="ml-auto rounded p-1 text-fg-muted transition hover:text-fg"
-          title="Refresh"
-          disabled={loading}
-        >
-          <RefreshCw
-            size={12}
-            className={cn(loading && "animate-spin")}
-          />
-        </button>
+          loading={loading}
+          size={12}
+          className="ml-auto"
+        />
       </div>
       <div className="flex-1 overflow-y-auto">
         {error ? (

--- a/src/components/ui/RefreshButton.tsx
+++ b/src/components/ui/RefreshButton.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, RefreshCw } from "lucide-react";
+import { cn } from "../../lib/cn";
+
+interface RefreshButtonProps {
+  onClick: () => void | Promise<void>;
+  /** Parent-owned in-flight flag. true → spin, false→true edge → show ✓. */
+  loading: boolean;
+  /** Icon size in px. Default 14. */
+  size?: number;
+  /** Tooltip + accessible name. */
+  title?: string;
+  ariaLabel?: string;
+  /** Extra classes for the button element. */
+  className?: string;
+}
+
+const SUCCESS_HOLD_MS = 1100;
+const FADE_MS = 250;
+
+/**
+ * Refresh icon button that briefly swaps to a green ✓ when an in-flight
+ * refresh completes, then fades back to the refresh glyph. The parent owns
+ * the `loading` flag; the button only animates the visual feedback layer.
+ */
+export function RefreshButton({
+  onClick,
+  loading,
+  size = 14,
+  title = "Refresh",
+  ariaLabel,
+  className,
+}: RefreshButtonProps) {
+  const [showSuccess, setShowSuccess] = useState(false);
+  const prevLoadingRef = useRef(loading);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    // Trigger success only on a true → false edge (an actual completion),
+    // not on initial mount with `loading=false`.
+    if (prevLoadingRef.current && !loading) {
+      setShowSuccess(true);
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+      }
+      timerRef.current = window.setTimeout(() => {
+        setShowSuccess(false);
+        timerRef.current = null;
+      }, SUCCESS_HOLD_MS);
+    }
+    prevLoadingRef.current = loading;
+  }, [loading]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={loading}
+      title={title}
+      aria-label={ariaLabel ?? title}
+      className={cn(
+        "relative inline-flex items-center justify-center rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-not-allowed disabled:opacity-60",
+        className,
+      )}
+    >
+      {/* Reserve space so the absolute icons don't collapse the button. */}
+      <span
+        aria-hidden
+        className="inline-block"
+        style={{ width: size, height: size }}
+      />
+      <RefreshCw
+        size={size}
+        aria-hidden
+        className={cn(
+          "absolute transition-opacity",
+          loading && "animate-spin",
+          showSuccess ? "opacity-0" : "opacity-100",
+        )}
+        style={{ transitionDuration: `${FADE_MS}ms` }}
+      />
+      <Check
+        size={size}
+        strokeWidth={3}
+        aria-hidden
+        className={cn(
+          "absolute text-emerald-400 transition-opacity",
+          showSuccess ? "opacity-100" : "opacity-0",
+        )}
+        style={{ transitionDuration: `${FADE_MS}ms` }}
+      />
+    </button>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -7,3 +7,4 @@ export { Stepper } from "./Stepper";
 export { CheckboxRow } from "./CheckboxRow";
 export { RadioCard } from "./RadioCard";
 export { Markdown } from "./Markdown";
+export { RefreshButton } from "./RefreshButton";


### PR DESCRIPTION
## Summary
The existing inline refresh buttons spin while loading and then silently revert, so it's hard to tell whether a refresh actually completed. Introduce a reusable `RefreshButton` primitive that briefly swaps to a green check when the in-flight fetch resolves, then fades back to the refresh glyph.

## Behavior
- **Idle** → refresh icon at full opacity.
- **Loading** → refresh icon spins; button disabled to block rapid double-clicks.
- **Just completed** → green ✓ fades in for ~1.1s, then refresh icon fades back.
- The success state is triggered only on a real `loading: true → false` edge, so initial mounts with `loading=false` don't flash a check.

## Replacements
- `PullRequestDetailModal.tsx` header refresh button.
- `RightPanel.tsx` PRs tab toolbar refresh button.

(`CommandPalette.tsx` also references `RefreshCw` but it's a list-item icon for the "Refresh sessions" command, not an action button — left untouched.)

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test` (79 passing, 1 skipped)
- [x] `bun run build`
- [x] Manual: open the PR detail modal, click refresh → spinner → green ✓ → fade back to refresh.
- [x] Manual: PRs tab toolbar refresh → same behavior at smaller (12px) size.
- [x] Manual: rapid clicks while loading should be blocked (button disabled).
