### PR TITLE
fix(ui): portal Modals + TextSwap helper to fix WKWebView paint duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ target/
 # Claude Code project-local state
 .claude/
 
+# Playwright MCP artifacts
+.playwright-mcp/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/components/ClosePullRequestDialog.tsx
+++ b/src/components/ClosePullRequestDialog.tsx
@@ -3,7 +3,7 @@ import { GitPullRequestClosed } from "lucide-react";
 import { api } from "../lib/api";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { PullRequestDetail } from "../lib/types";
-import { Modal, ModalHeader } from "./ui";
+import { Modal, ModalHeader, TextSwap } from "./ui";
 
 interface ClosePullRequestDialogProps {
   open: boolean;
@@ -98,7 +98,7 @@ export function ClosePullRequestDialog({
               disabled={submitting}
               className="rounded-md bg-rose-500/20 px-3 py-1.5 text-xs font-medium text-rose-300 transition hover:bg-rose-500/30 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {submitting ? "Closing…" : "Close PR"}
+              <TextSwap>{submitting ? "Closing…" : "Close PR"}</TextSwap>
             </button>
           </footer>
         </>

--- a/src/components/MergePullRequestDialog.tsx
+++ b/src/components/MergePullRequestDialog.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
-import { GitMerge, Loader2, Sparkles } from "lucide-react";
+import { GitMerge, Sparkles } from "lucide-react";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import { loadLastMergeMethod, saveLastMergeMethod } from "../lib/merge-prefs";
 import type { MergeMethod, PullRequestDetail } from "../lib/types";
-import { Modal, ModalHeader } from "./ui";
+import { Modal, ModalHeader, TextSwap } from "./ui";
 
 const METHOD_OPTIONS: ReadonlyArray<{
   value: MergeMethod;
@@ -157,23 +157,29 @@ export function MergePullRequestDialog({
             {acceptsMessage ? (
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
-                  <p className="text-fg-muted">
-                    {generating ? "Generating commit message…" : "Commit message"}
-                  </p>
-                  <button
-                    type="button"
-                    onClick={() => void handleGenerate()}
-                    disabled={busy}
-                    title={generating ? "Generating…" : "Generate with AI (Claude)"}
-                    aria-label={generating ? "Generating commit message" : "Generate commit message with AI"}
-                    className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    {generating ? (
-                      <Loader2 size={13} className="animate-spin" />
-                    ) : (
-                      <Sparkles size={13} />
-                    )}
-                  </button>
+                  <p className="text-fg-muted">Commit message</p>
+                  {generating ? (
+                    <button
+                      key="gen-button-loading"
+                      type="button"
+                      disabled
+                      className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-fg-muted opacity-60"
+                    >
+                      <Sparkles size={11} />
+                      Generating…
+                    </button>
+                  ) : (
+                    <button
+                      key="gen-button-idle"
+                      type="button"
+                      onClick={() => void handleGenerate()}
+                      className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+                      title="Generate via Claude"
+                    >
+                      <Sparkles size={11} />
+                      Generate with AI
+                    </button>
+                  )}
                 </div>
                 <input
                   type="text"
@@ -221,7 +227,7 @@ export function MergePullRequestDialog({
               disabled={busy}
               className="rounded-md bg-emerald-500/20 px-3 py-1.5 text-xs font-medium text-emerald-300 transition hover:bg-emerald-500/30 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {submitting ? "Merging…" : "Merge"}
+              <TextSwap>{submitting ? "Merging…" : "Merge"}</TextSwap>
             </button>
           </footer>
         </>

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,4 +1,5 @@
-import { type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "../../lib/cn";
 
 export type ModalVariant = "dialog" | "panel";
@@ -37,6 +38,21 @@ const CONTENT_DIALOG =
 const CONTENT_PANEL =
   "mx-auto flex h-full w-full flex-col overflow-hidden rounded-lg border border-border bg-bg shadow-2xl";
 
+/**
+ * Returns true once the component has mounted on the client. Used to delay
+ * `createPortal` until `document` is available — Tauri's WKWebView always
+ * runs in a browser context, but guarding the first render keeps the
+ * Modal robust if the component is ever rendered server-side or under a
+ * test runner without a DOM.
+ */
+function useHasMounted(): boolean {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  return mounted;
+}
+
 export function Modal({
   open,
   onClose,
@@ -47,9 +63,14 @@ export function Modal({
   className,
   children,
 }: ModalProps) {
-  if (!open) return null;
+  const mounted = useHasMounted();
+  if (!open || !mounted) return null;
   const isDialog = variant === "dialog";
-  return (
+  // Portal to <body> so every Modal renders as a top-level sibling. This
+  // prevents stacking-context surprises (transformed/clipped ancestors
+  // breaking `position: fixed`) and avoids the WKWebView paint artifacts
+  // we saw when one Modal contained another.
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -72,6 +93,7 @@ export function Modal({
       >
         {children}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/components/ui/TextSwap.tsx
+++ b/src/components/ui/TextSwap.tsx
@@ -1,0 +1,22 @@
+/**
+ * Wraps a string that flips between states (e.g. "Merge" ↔ "Merging…")
+ * so the rendered span gets a fresh `key` whenever the text changes.
+ *
+ * Why this exists: WKWebView (Tauri's macOS webview) sometimes leaves a
+ * stale paint of the previous text alongside the new one when a single
+ * DOM node's text content swaps mid-CSS-transition (typically when
+ * `disabled:opacity-60` + Tailwind's blanket `transition` class are both
+ * in play). Forcing React to unmount and remount the span on every text
+ * change sidesteps the buggy layer reuse.
+ *
+ * Usage:
+ *
+ * ```tsx
+ * <button disabled={busy}>
+ *   <TextSwap>{busy ? "Saving…" : "Save"}</TextSwap>
+ * </button>
+ * ```
+ */
+export function TextSwap({ children }: { children: string }) {
+  return <span key={children}>{children}</span>;
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -8,3 +8,4 @@ export { CheckboxRow } from "./CheckboxRow";
 export { RadioCard } from "./RadioCard";
 export { Markdown } from "./Markdown";
 export { RefreshButton } from "./RefreshButton";
+export { TextSwap } from "./TextSwap";


### PR DESCRIPTION
## Why
The PR detail panel hosting a merge / close confirm dialog (introduced in #22) exposed a WKWebView paint bug where button content (icon + label) appeared duplicated when a button entered its disabled+loading state. Repros in `bun run tauri dev` AND a fresh `bun run tauri build` (so it isn't HMR or React StrictMode), and the DOM only contains a single `<svg>` + text — so it's a paint-only artifact.

This is a known class of issue: nested-Modal stacking ([react #26240](https://github.com/facebook/react/issues/26240), [react-bootstrap #1621](https://github.com/react-bootstrap/react-bootstrap/issues/1621), [react-modal #544](https://github.com/reactjs/react-modal/issues/544)), and WebKit's well-documented stale-paint-on-content-change bug.

## What

### 1. Portal Modal contents to `document.body`
`Modal` now renders into `document.body` via `createPortal`. Every Modal becomes a top-level sibling of `#root`, eliminating the nested-stacking-context issue when one Modal contains another. `useHasMounted` keeps the first render server-safe so the vitest jsdom environment isn't affected.

### 2. `TextSwap` primitive for loading-state buttons
A tiny helper:

```tsx
export function TextSwap({ children }: { children: string }) {
  return <span key={children}>{children}</span>;
}
```

Re-keys the rendered span on every text change so React unmounts and remounts the node. Applied to:

- `MergePullRequestDialog` Merge button (`Merge` ↔ `Merging…`).
- `ClosePullRequestDialog` Close PR button (`Close PR` ↔ `Closing…`).
- The Generate-with-AI affordance is split into two keyed buttons (idle vs loading) because the icon glyph also changes — keying the whole button is the simplest repaint hint when both icon and label flip.

The original `icon + text` Generate-with-AI affordance is restored — with the keyed split it now renders cleanly. The icon-only fallback added in #22 was a workaround for this exact bug.

### 3. `.playwright-mcp/` ignored
Inspector snapshot artifacts shouldn't get committed.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test` (82 passing, 1 skipped)
- [x] `bun run build`
- [x] Manual: open PR detail → Merge → trigger merge — `Merge` ↔ `Merging…` flips with no paint duplication.
- [ ] Manual: open PR detail → Close — `Close PR` ↔ `Closing…` flips cleanly.
- [x] Manual: in the Merge dialog, click Generate with AI — the button glyph + label flip without ghosting.
- [x] Manual: `Esc` on the inner dialog only closes the inner dialog; PR detail panel stays.
- [ ] Manual: clicking the merge-dialog backdrop only closes the inner dialog.
- [ ] Manual: every other modal still works — Settings modal, Diff viewer modal, Remove session/project dialogs, Memory breakdown.
