### PR TITLE
feat(prs): pass/fail checks badge on PR list rows

### DIFF
--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -72,6 +72,19 @@ pub struct PullRequestInfo {
     /// ISO-8601 timestamp from gh; the frontend formats it for display.
     pub updated_at: String,
     pub is_draft: bool,
+    /// Aggregate of status checks on the head sha, mirroring the detail
+    /// modal's badge logic. `None` when gh returned no rollup entries.
+    pub checks: Option<ChecksSummary>,
+}
+
+/// Pass / fail / pending counts derived from `statusCheckRollup`. NEUTRAL,
+/// SKIPPED, CANCELLED conclusions are intentionally excluded so an optional
+/// skipped job doesn't push a green PR into the partial bucket.
+#[derive(Debug, Clone, Serialize)]
+pub struct ChecksSummary {
+    pub passed: u32,
+    pub failed: u32,
+    pub pending: u32,
 }
 
 /// One gh login that was probed during account resolution. `has_access` lets
@@ -100,6 +113,8 @@ struct GhPullRequest {
     updated_at: String,
     #[serde(rename = "isDraft", default)]
     is_draft: bool,
+    #[serde(rename = "statusCheckRollup", default)]
+    status_check_rollup: Option<Vec<GhCheck>>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -290,7 +305,8 @@ fn run_pr_list(
             "--limit",
             &limit.to_string(),
             "--json",
-            "number,title,state,author,headRefName,baseRefName,url,updatedAt,isDraft",
+            "number,title,state,author,headRefName,baseRefName,url,updatedAt,\
+             isDraft,statusCheckRollup",
         ])
         .output()
         .map_err(map_gh_spawn_error)?;
@@ -310,18 +326,60 @@ fn run_pr_list(
 
     Ok(raw
         .into_iter()
-        .map(|pr| PullRequestInfo {
-            number: pr.number,
-            title: pr.title,
-            state: pr.state,
-            author: pr.author.login.unwrap_or_else(|| "unknown".to_string()),
-            head_branch: pr.head_ref_name,
-            base_branch: pr.base_ref_name,
-            url: pr.url,
-            updated_at: pr.updated_at,
-            is_draft: pr.is_draft,
+        .map(|pr| {
+            let checks = pr.status_check_rollup.as_deref().and_then(|rollup| {
+                if rollup.is_empty() {
+                    None
+                } else {
+                    Some(summarize_checks(rollup))
+                }
+            });
+            PullRequestInfo {
+                number: pr.number,
+                title: pr.title,
+                state: pr.state,
+                author: pr.author.login.unwrap_or_else(|| "unknown".to_string()),
+                head_branch: pr.head_ref_name,
+                base_branch: pr.base_ref_name,
+                url: pr.url,
+                updated_at: pr.updated_at,
+                is_draft: pr.is_draft,
+                checks,
+            }
         })
         .collect())
+}
+
+/// Aggregate `statusCheckRollup` entries into pass/fail/pending counts.
+/// Mirrors the frontend's `summarizeChecks` so list and detail views agree.
+fn summarize_checks(checks: &[GhCheck]) -> ChecksSummary {
+    let mut passed = 0u32;
+    let mut failed = 0u32;
+    let mut pending = 0u32;
+    for c in checks {
+        let status = c.status.as_deref().unwrap_or("").to_ascii_uppercase();
+        if status != "COMPLETED" {
+            pending += 1;
+            continue;
+        }
+        match c
+            .conclusion
+            .as_deref()
+            .unwrap_or("")
+            .to_ascii_uppercase()
+            .as_str()
+        {
+            "SUCCESS" => passed += 1,
+            "FAILURE" | "TIMED_OUT" | "ACTION_REQUIRED" => failed += 1,
+            // NEUTRAL / SKIPPED / CANCELLED: no signal — excluded from totals.
+            _ => {}
+        }
+    }
+    ChecksSummary {
+        passed,
+        failed,
+        pending,
+    }
 }
 
 struct PickedAccount {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  Check,
   Copy,
   ExternalLink,
   FileDiff,
@@ -8,6 +9,7 @@ import {
   Globe,
   ListTodo,
   Maximize2,
+  X,
 } from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Panel, PanelGroup } from "react-resizable-panels";
@@ -22,6 +24,7 @@ import type {
   CommitInfo,
   DiffPayload,
   PrStateFilter,
+  PullRequestChecksSummary,
   PullRequestInfo,
   PullRequestListing,
   StagedFile,
@@ -1071,6 +1074,7 @@ function PullRequestsTab({
                     #{pr.number}
                   </span>
                   <PrStateBadge state={pr.state} isDraft={pr.is_draft} />
+                  <PrChecksBadge checks={pr.checks} />
                   <span className="truncate text-fg">{pr.title}</span>
                 </span>
                 <span className="flex w-full min-w-0 items-center gap-2 text-[10px] text-fg-muted">
@@ -1159,6 +1163,52 @@ function NoAccessBanner({
         that has access, or accept the invitation on github.com.
       </p>
     </div>
+  );
+}
+
+function PrChecksBadge({
+  checks,
+}: {
+  checks: PullRequestChecksSummary | null;
+}) {
+  if (!checks) return null;
+  // Effective total mirrors the PR detail modal: NEUTRAL/SKIPPED/CANCELLED
+  // are already excluded by the backend, so passed+failed+pending is what
+  // actually carries pass/fail signal.
+  const effective = checks.passed + checks.failed + checks.pending;
+  if (effective === 0) return null;
+
+  const allPassed = checks.passed === effective;
+  const allFailed = checks.failed === effective;
+
+  if (allPassed) {
+    return (
+      <span
+        className="flex shrink-0 items-center justify-center rounded-full bg-emerald-500/20 px-1 py-0.5 text-emerald-300"
+        title={`All ${effective} check${effective === 1 ? "" : "s"} passed`}
+      >
+        <Check size={10} strokeWidth={3} />
+      </span>
+    );
+  }
+  if (allFailed) {
+    return (
+      <span
+        className="flex shrink-0 items-center justify-center rounded-full bg-rose-500/20 px-1 py-0.5 text-rose-300"
+        title={`All ${effective} check${effective === 1 ? "" : "s"} failed`}
+      >
+        <X size={10} strokeWidth={3} />
+      </span>
+    );
+  }
+  // Partial: show passed/total in a muted pill, matching the modal tab style.
+  return (
+    <span
+      className="shrink-0 rounded-full bg-fg-muted/15 px-1.5 py-0.5 text-[9px] font-medium tabular-nums text-fg-muted"
+      title={`${checks.passed} passed, ${checks.failed} failed, ${checks.pending} pending`}
+    >
+      {checks.passed}/{effective}
+    </span>
   );
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -77,6 +77,12 @@ export interface TodoItem {
 
 export type PrStateFilter = "open" | "closed" | "merged" | "all";
 
+export interface PullRequestChecksSummary {
+  passed: number;
+  failed: number;
+  pending: number;
+}
+
 export interface PullRequestInfo {
   number: number;
   title: string;
@@ -87,6 +93,8 @@ export interface PullRequestInfo {
   url: string;
   updated_at: string;
   is_draft: boolean;
+  /** Aggregate of head-sha checks. null when gh returned no rollup entries. */
+  checks: PullRequestChecksSummary | null;
 }
 
 export interface AccountSummary {


### PR DESCRIPTION
## Summary

Mirror the PR detail modal's Checks tab indicator on each row in the PRs tab so users can see a PR's CI health at a glance without opening the detail.

- **Backend**: `gh pr list --json` now includes `statusCheckRollup`. Each `PullRequestInfo` carries an optional `checks` summary aggregating into `{ passed, failed, pending }` using the same exclusion rules as the detail modal (`NEUTRAL`, `SKIPPED`, `CANCELLED` carry no signal and are dropped from the totals).
- **Frontend**: a new `PrChecksBadge` sits next to `PrStateBadge` in each row — green check for all-passed, red X for all-failed, muted `n/m` pill for partial, hidden when there are no effective checks.
- **Parity**: backend `summarize_checks` keeps logic identical to `summarizeChecks` in `PullRequestDetailModal.tsx` so list and detail never disagree.

## Test plan

- [x] PR with all-green checks → green ✓ pill on the row.
- [x] PR with at least one failing check (and no other passing) → red ✕ pill.
- [x] PR with mixed / pending checks → `passed/total` muted pill matching the detail modal.
- [x] PR with no checks → no badge shown.
- [x] PR where every check is `SKIPPED` / `NEUTRAL` → no badge (effective total = 0).
- [x] Hover tooltip on each badge variant gives a useful summary.
- [x] `bun run typecheck` clean.
- [x] `bun run test` passing.
- [ ] `cargo check` clean for `src-tauri`.
