### PR TITLE
fix(pr-list): respect MERGED/CLOSED over DRAFT in state badge

### DIFF
--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -507,14 +507,14 @@ function PrStateGlyph({
   isDraft: boolean;
 }) {
   const upper = state.toUpperCase();
-  if (isDraft) {
-    return <GitPullRequestDraft size={14} className="text-fg-muted" />;
-  }
   if (upper === "MERGED") {
     return <GitMerge size={14} className="text-purple-400" />;
   }
   if (upper === "CLOSED") {
     return <GitPullRequestClosed size={14} className="text-rose-400" />;
+  }
+  if (isDraft) {
+    return <GitPullRequestDraft size={14} className="text-fg-muted" />;
   }
   return <GitPullRequest size={14} className="text-emerald-400" />;
 }

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1164,8 +1164,9 @@ function NoAccessBanner({
 
 function PrStateBadge({ state, isDraft }: { state: string; isDraft: boolean }) {
   const upper = state.toUpperCase();
-  const label = isDraft ? "DRAFT" : upper;
-  const tone = isDraft
+  const showDraft = isDraft && upper === "OPEN";
+  const label = showDraft ? "DRAFT" : upper;
+  const tone = showDraft
     ? "bg-fg-muted/15 text-fg-muted"
     : upper === "OPEN"
       ? "bg-emerald-500/15 text-emerald-400"


### PR DESCRIPTION
## Summary

Fix bug where the `DRAFT` badge/icon was shown in the PR list and detail modal whenever `is_draft` was true, regardless of the PR's actual state (closed/merged).

Apply the standard precedence: **MERGED > CLOSED > DRAFT > OPEN**. `DRAFT` is only meaningful while a PR is OPEN.

### Changes
- `RightPanel.tsx` `PrStateBadge` — show `DRAFT` label only when `state === "OPEN"`
- `PullRequestDetailModal.tsx` `PrStateGlyph` — reorder so MERGED/CLOSED branches take precedence over the draft branch

## Test plan
- [x] Draft PR that was closed: list + modal both show `CLOSED` badge
- [x] Merged PR (previously a draft): shows `MERGED` badge
- [x] Open draft PR: still shows `DRAFT` badge
- [x] Open ready PR: shows `OPEN` badge
