### PR TITLE
feat(ui): replace native title= with custom Tooltip + restore lost PR #25 follow-ups

### DIFF
--- a/src/components/DiffSplitView.tsx
+++ b/src/components/DiffSplitView.tsx
@@ -5,6 +5,7 @@ import { cn } from "../lib/cn";
 import { countStats, parseDiff } from "../lib/diff";
 import { openFileInEditor } from "../lib/editor";
 import type { DiffFile, DiffPayload } from "../lib/types";
+import { Tooltip } from "./Tooltip";
 import { joinPath } from "../lib/paths";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { DiffLine, useHighlightedDiff } from "./DiffView";
@@ -121,42 +122,48 @@ export function DiffSplitView({ payload, cwd }: DiffSplitViewProps) {
               const dir = dirnameOf(entry.path);
               return (
                 <li key={entry.index}>
-                  <button
-                    type="button"
-                    onClick={() => setSelectedIndex(entry.index)}
-                    onContextMenu={(e) => {
-                      if (!cwd) return;
-                      e.preventDefault();
-                      setSelectedIndex(entry.index);
-                      setMenu({ x: e.clientX, y: e.clientY, entry });
-                    }}
-                    title={entry.path}
-                    className={cn(
-                      "flex w-full flex-col items-stretch gap-0.5 px-3 py-1.5 text-left font-mono text-xs transition",
-                      active
-                        ? "bg-bg-elevated text-fg"
-                        : "text-fg-muted hover:bg-bg-elevated/60 hover:text-fg",
-                    )}
+                  <Tooltip
+                    label={entry.path}
+                    side="right"
+                    multiline
+                    className="w-full"
                   >
-                    <span className="flex items-center gap-2">
-                      <span className="min-w-0 flex-1 truncate">
-                        {basenameOf(entry.path)}
-                      </span>
-                      <span className="flex shrink-0 gap-1.5 text-[10px]">
-                        <span className="text-[oklch(72%_0.16_145)]">
-                          +{entry.add}
+                    <button
+                      type="button"
+                      onClick={() => setSelectedIndex(entry.index)}
+                      onContextMenu={(e) => {
+                        if (!cwd) return;
+                        e.preventDefault();
+                        setSelectedIndex(entry.index);
+                        setMenu({ x: e.clientX, y: e.clientY, entry });
+                      }}
+                      className={cn(
+                        "flex w-full flex-col items-stretch gap-0.5 px-3 py-1.5 text-left font-mono text-xs transition",
+                        active
+                          ? "bg-bg-elevated text-fg"
+                          : "text-fg-muted hover:bg-bg-elevated/60 hover:text-fg",
+                      )}
+                    >
+                      <span className="flex items-center gap-2">
+                        <span className="min-w-0 flex-1 truncate">
+                          {basenameOf(entry.path)}
                         </span>
-                        <span className="text-[oklch(62%_0.22_25)]">
-                          -{entry.del}
+                        <span className="flex shrink-0 gap-1.5 text-[10px]">
+                          <span className="text-[oklch(72%_0.16_145)]">
+                            +{entry.add}
+                          </span>
+                          <span className="text-[oklch(62%_0.22_25)]">
+                            -{entry.del}
+                          </span>
                         </span>
                       </span>
-                    </span>
-                    {dir ? (
-                      <span className="block truncate text-[10px] text-fg-muted/70">
-                        {dir}
-                      </span>
-                    ) : null}
-                  </button>
+                      {dir ? (
+                        <span className="block truncate text-[10px] text-fg-muted/70">
+                          {dir}
+                        </span>
+                      ) : null}
+                    </button>
+                  </Tooltip>
                 </li>
               );
             })}
@@ -167,9 +174,9 @@ export function DiffSplitView({ payload, cwd }: DiffSplitViewProps) {
       <Panel id="content" order={2} defaultSize={72} minSize={40}>
         <section className="flex h-full flex-col bg-bg">
           <header className="flex shrink-0 items-center justify-between gap-2 border-b border-border bg-bg-elevated px-3 py-2 font-mono text-xs">
-            <span className="min-w-0 truncate text-fg" title={selected.path}>
-              {selected.path}
-            </span>
+            <Tooltip label={selected.path} side="bottom" multiline>
+              <span className="min-w-0 truncate text-fg">{selected.path}</span>
+            </Tooltip>
             <span className="flex shrink-0 gap-2">
               <span className="text-[oklch(72%_0.16_145)]">
                 +{selected.add}

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -4,6 +4,7 @@ import { cn } from "../lib/cn";
 import { countStats, parseDiff, type ParsedLine } from "../lib/diff";
 import { highlightDiff, langFromPath } from "../lib/highlight";
 import type { DiffFile, DiffPayload } from "../lib/types";
+import { Tooltip } from "./Tooltip";
 
 interface DiffViewProps {
   payload: DiffPayload;
@@ -65,15 +66,16 @@ export function DiffView({ payload, onExpand }: DiffViewProps) {
             </button>
           ) : null}
           {onExpand ? (
-            <button
-              type="button"
-              onClick={onExpand}
-              className="rounded p-1 transition hover:bg-bg-elevated hover:text-fg"
-              title="Open full diff"
-              aria-label="Open full diff"
-            >
-              <Maximize2 size={12} />
-            </button>
+            <Tooltip label="Open full diff" side="bottom">
+              <button
+                type="button"
+                onClick={onExpand}
+                className="rounded p-1 transition hover:bg-bg-elevated hover:text-fg"
+                aria-label="Open full diff"
+              >
+                <Maximize2 size={12} />
+              </button>
+            </Tooltip>
           ) : null}
         </span>
       </div>

--- a/src/components/MemoryBreakdownModal.tsx
+++ b/src/components/MemoryBreakdownModal.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import type { MemoryProcess } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
+import { Tooltip } from "./Tooltip";
 import { Modal, ModalHeader } from "./ui";
 
 interface MemoryBreakdownModalProps {
@@ -143,11 +144,13 @@ export function MemoryBreakdownModal({
               <th className="px-4 py-2 text-left font-medium">PID</th>
               <th className="px-4 py-2 text-left font-medium">Process tree</th>
               <th className="px-4 py-2 text-right font-medium">RSS</th>
-              <th
-                className="px-4 py-2 text-right font-medium"
-                title="Sum of this process and all descendants"
-              >
-                Subtree
+              <th className="px-4 py-2 text-right font-medium">
+                <Tooltip
+                  label="Sum of this process and all descendants"
+                  side="bottom"
+                >
+                  <span>Subtree</span>
+                </Tooltip>
               </th>
               <th className="px-4 py-2 text-right font-medium">Share</th>
             </tr>
@@ -166,16 +169,19 @@ export function MemoryBreakdownModal({
                     <span className="whitespace-pre text-fg-muted/60">
                       {prefix}
                     </span>
-                    <span title={process.command_line || undefined}>
-                      {process.name}
-                    </span>
                     {process.command_line ? (
-                      <span
-                        className="ml-2 truncate text-fg-muted/60"
-                        title={process.command_line}
-                      >
-                        {truncateMiddle(process.command_line, 80)}
-                      </span>
+                      <Tooltip label={process.command_line} side="top" multiline>
+                        <span>{process.name}</span>
+                      </Tooltip>
+                    ) : (
+                      <span>{process.name}</span>
+                    )}
+                    {process.command_line ? (
+                      <Tooltip label={process.command_line} side="top" multiline>
+                        <span className="ml-2 truncate text-fg-muted/60">
+                          {truncateMiddle(process.command_line, 80)}
+                        </span>
+                      </Tooltip>
                     ) : null}
                   </td>
                   <td className="px-4 py-1.5 text-right text-fg">

--- a/src/components/MergePullRequestDialog.tsx
+++ b/src/components/MergePullRequestDialog.tsx
@@ -5,6 +5,7 @@ import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import { loadLastMergeMethod, saveLastMergeMethod } from "../lib/merge-prefs";
 import type { MergeMethod, PullRequestDetail } from "../lib/types";
+import { Tooltip } from "./Tooltip";
 import { Modal, ModalHeader, TextSwap } from "./ui";
 
 const METHOD_OPTIONS: ReadonlyArray<{
@@ -169,16 +170,17 @@ export function MergePullRequestDialog({
                       Generating…
                     </button>
                   ) : (
-                    <button
-                      key="gen-button-idle"
-                      type="button"
-                      onClick={() => void handleGenerate()}
-                      className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-                      title="Generate via Claude"
-                    >
-                      <Sparkles size={11} />
-                      Generate with AI
-                    </button>
+                    <Tooltip label="Generate via Claude" side="top">
+                      <button
+                        key="gen-button-idle"
+                        type="button"
+                        onClick={() => void handleGenerate()}
+                        className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+                      >
+                        <Sparkles size={11} />
+                        Generate with AI
+                      </button>
+                    </Tooltip>
                   )}
                 </div>
                 <input

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -239,7 +239,6 @@ function EmptyPane({
       }}
       role="button"
       tabIndex={0}
-      title="Double-click to start a new session"
     >
       <TerminalIcon size={28} className="opacity-40" />
       <p className="text-xs">Drop a tab here or double-click to start a session</p>
@@ -362,7 +361,6 @@ function TabStrip({
       */}
       <div
         className="min-w-[2.5rem] flex-1"
-        title="Double-click to open a new session in this project"
         onDoubleClick={(e) => {
           if (e.target !== e.currentTarget) return;
           onNewTab();

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -29,6 +29,7 @@ import type {
 import { ClosePullRequestDialog } from "./ClosePullRequestDialog";
 import { DiffSplitView } from "./DiffSplitView";
 import { MergePullRequestDialog } from "./MergePullRequestDialog";
+import { Tooltip } from "./Tooltip";
 import { Markdown, Modal, ModalHeader, RefreshButton } from "./ui";
 
 type DetailTab = "conversation" | "checks" | "files";
@@ -280,7 +281,9 @@ function DetailBody({
             <span className="opacity-50"> · </span>
             <span>{detail.changed_files} files</span>
             <span className="opacity-50"> · </span>
-            <span title={`Listed via gh account ${account}`}>@{account}</span>
+            <Tooltip label={`Listed via gh account ${account}`} side="bottom">
+              <span>@{account}</span>
+            </Tooltip>
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-1">
@@ -301,14 +304,15 @@ function DetailBody({
             </>
           ) : null}
           <RefreshButton onClick={onRefresh} loading={refreshing} size={14} />
-          <button
-            type="button"
-            onClick={() => void openUrl(detail.url)}
-            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-            title="Open on GitHub"
-          >
-            <ExternalLink size={14} />
-          </button>
+          <Tooltip label="Open on GitHub" side="bottom">
+            <button
+              type="button"
+              onClick={() => void openUrl(detail.url)}
+              className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+            >
+              <ExternalLink size={14} />
+            </button>
+          </Tooltip>
           <button
             type="button"
             aria-label="Close"
@@ -482,20 +486,21 @@ function MergeActionButton({
       ? "Cannot merge — conflicting branch"
       : "Merge readiness still being determined…";
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={!ready}
-      title={title}
-      className={cn(
-        "rounded-md px-2.5 py-1 text-[11px] font-medium transition",
-        ready
-          ? "bg-emerald-500/20 text-emerald-300 hover:bg-emerald-500/30"
-          : "cursor-not-allowed bg-bg-elevated text-fg-muted opacity-70",
-      )}
-    >
-      Merge
-    </button>
+    <Tooltip label={title} side="bottom">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={!ready}
+        className={cn(
+          "rounded-md px-2.5 py-1 text-[11px] font-medium transition",
+          ready
+            ? "bg-emerald-500/20 text-emerald-300 hover:bg-emerald-500/30"
+            : "cursor-not-allowed bg-bg-elevated text-fg-muted opacity-70",
+        )}
+      >
+        Merge
+      </button>
+    </Tooltip>
   );
 }
 
@@ -656,16 +661,17 @@ function ChecksPane({ checks }: { checks: PullRequestCheck[] }) {
           </span>
           <CheckStatusLabel status={c.status} conclusion={c.conclusion} />
           {c.url ? (
-            <button
-              type="button"
-              onClick={() => {
-                if (c.url) void openUrl(c.url);
-              }}
-              className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-              title="Open run"
-            >
-              <ExternalLink size={11} />
-            </button>
+            <Tooltip label="Open run" side="top">
+              <button
+                type="button"
+                onClick={() => {
+                  if (c.url) void openUrl(c.url);
+                }}
+                className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+              >
+                <ExternalLink size={11} />
+              </button>
+            </Tooltip>
           ) : null}
         </li>
       ))}

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -35,6 +35,7 @@ import { DiffView } from "./DiffView";
 import { DiffViewerModal } from "./DiffViewerModal";
 import { PullRequestDetailModal } from "./PullRequestDetailModal";
 import { ResizeHandle } from "./ResizeHandle";
+import { Tooltip } from "./Tooltip";
 import { RefreshButton } from "./ui";
 
 interface ExpandedDiff {
@@ -630,27 +631,34 @@ function CommitsTab({
                         ? "bg-bg-elevated"
                         : "hover:bg-bg-elevated/50",
                     )}
-                    title={absoluteTime(c.timestamp)}
                     style={{ height: COMMIT_ROW_HEIGHT }}
                   >
                     <span className="flex w-full min-w-0 items-center gap-2">
-                      <span
-                        className={cn(
-                          "shrink-0 font-mono",
-                          c.pushed ? "text-accent" : "text-fg-muted",
-                        )}
-                        title={c.pushed ? "Pushed" : "Not pushed"}
+                      <Tooltip
+                        label={c.pushed ? "Pushed" : "Not pushed"}
+                        side="top"
                       >
-                        {c.short_sha}
-                      </span>
-                      <span className="truncate text-fg">{c.summary}</span>
+                        <span
+                          className={cn(
+                            "shrink-0 font-mono",
+                            c.pushed ? "text-accent" : "text-fg-muted",
+                          )}
+                        >
+                          {c.short_sha}
+                        </span>
+                      </Tooltip>
+                      <Tooltip label={c.summary} side="top" multiline>
+                        <span className="truncate text-fg">{c.summary}</span>
+                      </Tooltip>
                     </span>
                     <span className="flex w-full min-w-0 items-center gap-2 text-[10px] text-fg-muted">
                       <span className="truncate">{c.author}</span>
                       <span className="opacity-50">·</span>
-                      <span className="font-mono">
-                        {relativeTime(c.timestamp)}
-                      </span>
+                      <Tooltip label={absoluteTime(c.timestamp)} side="top">
+                        <span className="font-mono">
+                          {relativeTime(c.timestamp)}
+                        </span>
+                      </Tooltip>
                     </span>
                   </button>
                 )}
@@ -1067,26 +1075,40 @@ function PullRequestsTab({
                   }
                 }}
                 className="flex w-full flex-col items-start gap-0.5 border-b border-border/40 px-3 py-2 text-left transition hover:bg-bg-elevated/50 focus-visible:outline-none focus-visible:bg-bg-elevated/60"
-                title={`${absoluteTime(toUnixSeconds(pr.updated_at))} · double-click to open`}
               >
                 <span className="flex w-full min-w-0 items-center gap-2">
                   <span className="shrink-0 font-mono text-fg-muted">
                     #{pr.number}
                   </span>
                   <PrStateBadge state={pr.state} isDraft={pr.is_draft} />
-                  <PrChecksBadge checks={pr.checks} />
-                  <span className="truncate text-fg">{pr.title}</span>
+                  <Tooltip label={pr.title} side="top" multiline>
+                    <span className="truncate text-fg">{pr.title}</span>
+                  </Tooltip>
                 </span>
                 <span className="flex w-full min-w-0 items-center gap-2 text-[10px] text-fg-muted">
                   <span className="truncate">{pr.author}</span>
                   <span className="opacity-50">·</span>
-                  <span className="truncate font-mono">
-                    {pr.head_branch} → {pr.base_branch}
+                  <span className="flex min-w-0 items-center gap-1">
+                    <Tooltip
+                      label={`${pr.head_branch} → ${pr.base_branch}`}
+                      side="top"
+                      multiline
+                    >
+                      <span className="truncate font-mono">
+                        {pr.head_branch} → {pr.base_branch}
+                      </span>
+                    </Tooltip>
+                    <PrChecksBadge checks={pr.checks} />
                   </span>
                   <span className="opacity-50">·</span>
-                  <span className="font-mono">
-                    {relativeTime(toUnixSeconds(pr.updated_at))}
-                  </span>
+                  <Tooltip
+                    label={absoluteTime(toUnixSeconds(pr.updated_at))}
+                    side="top"
+                  >
+                    <span className="font-mono">
+                      {relativeTime(toUnixSeconds(pr.updated_at))}
+                    </span>
+                  </Tooltip>
                 </span>
               </li>
             ))}
@@ -1183,32 +1205,38 @@ function PrChecksBadge({
 
   if (allPassed) {
     return (
-      <span
-        className="flex shrink-0 items-center justify-center rounded-full bg-emerald-500/20 px-1 py-0.5 text-emerald-300"
-        title={`All ${effective} check${effective === 1 ? "" : "s"} passed`}
+      <Tooltip
+        label={`All ${effective} check${effective === 1 ? "" : "s"} passed`}
+        side="top"
       >
-        <Check size={10} strokeWidth={3} />
-      </span>
+        <Check
+          size={10}
+          strokeWidth={3}
+          className="shrink-0 text-emerald-400"
+        />
+      </Tooltip>
     );
   }
   if (allFailed) {
     return (
-      <span
-        className="flex shrink-0 items-center justify-center rounded-full bg-rose-500/20 px-1 py-0.5 text-rose-300"
-        title={`All ${effective} check${effective === 1 ? "" : "s"} failed`}
+      <Tooltip
+        label={`All ${effective} check${effective === 1 ? "" : "s"} failed`}
+        side="top"
       >
-        <X size={10} strokeWidth={3} />
-      </span>
+        <X size={10} strokeWidth={3} className="shrink-0 text-rose-400" />
+      </Tooltip>
     );
   }
-  // Partial: show passed/total in a muted pill, matching the modal tab style.
+  // Partial: tiny inline `passed/total` next to the branch name, no pill.
   return (
-    <span
-      className="shrink-0 rounded-full bg-fg-muted/15 px-1.5 py-0.5 text-[9px] font-medium tabular-nums text-fg-muted"
-      title={`${checks.passed} passed, ${checks.failed} failed, ${checks.pending} pending`}
+    <Tooltip
+      label={`${checks.passed} passed, ${checks.failed} failed, ${checks.pending} pending`}
+      side="top"
     >
-      {checks.passed}/{effective}
-    </span>
+      <span className="shrink-0 font-mono tabular-nums opacity-80">
+        {checks.passed}/{effective}
+      </span>
+    </Tooltip>
   );
 }
 

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -857,7 +857,9 @@ function StagedTab({
               <span className="w-24 shrink-0 truncate text-fg-muted">
                 {f.status}
               </span>
-              <span className="truncate text-fg">{f.path}</span>
+              <Tooltip label={f.path} side="top" multiline>
+                <span className="truncate text-fg">{f.path}</span>
+              </Tooltip>
             </li>
           ))}
         </ul>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -451,16 +451,17 @@ function ProjectGroupView({
           isActiveProject && "bg-bg-elevated/30",
         )}
       >
-        <span
-          draggable
-          onDragStart={onDragStart}
-          onClick={(e) => e.stopPropagation()}
-          aria-label="Drag to reorder project"
-          title="Drag to reorder"
-          className="invisible flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
-        >
-          <GripVertical size={12} />
-        </span>
+        <Tooltip label="Drag to reorder" side="bottom">
+          <span
+            draggable
+            onDragStart={onDragStart}
+            onClick={(e) => e.stopPropagation()}
+            aria-label="Drag to reorder project"
+            className="invisible flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
+          >
+            <GripVertical size={12} />
+          </span>
+        </Tooltip>
         <button
           type="button"
           onClick={(e) => {
@@ -581,7 +582,6 @@ function ProjectGroupView({
                   onAddSession(false);
                 }
               }}
-              title="Click to activate · double-click to add a session"
               className="cursor-pointer rounded px-2 py-1 text-[11px] text-fg-muted transition select-none hover:bg-bg-elevated/40 hover:text-fg"
             >
               No sessions. Add one with{" "}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -4,6 +4,7 @@ import { api } from "../lib/api";
 import type { MemoryProcess } from "../lib/types";
 import { useAppStore } from "../store";
 import { MemoryBreakdownModal } from "./MemoryBreakdownModal";
+import { Tooltip } from "./Tooltip";
 
 const MEMORY_POLL_MS = 2000;
 
@@ -118,37 +119,36 @@ export function StatusBar() {
         <span className="ml-auto flex min-w-0 items-center gap-3">
           {loading ? <span>working...</span> : null}
           {error ? (
-            <span className="truncate text-danger" title={error}>
-              error: {error}
-            </span>
+            <Tooltip label={error} side="top" multiline>
+              <span className="truncate text-danger">error: {error}</span>
+            </Tooltip>
           ) : null}
           {prAccount ? (
-            <span
-              className="flex shrink-0 items-center gap-1 rounded bg-fg-muted/15 px-1.5 py-0.5 text-[10px] text-fg-muted"
-              title={`PRs listed via gh account ${prAccount}`}
-            >
-              <GitHubMark />
-              {prAccount}
-            </span>
+            <Tooltip label={`PRs listed via gh account ${prAccount}`} side="top">
+              <span className="flex shrink-0 items-center gap-1 rounded bg-fg-muted/15 px-1.5 py-0.5 text-[10px] text-fg-muted">
+                <GitHubMark />
+                {prAccount}
+              </span>
+            </Tooltip>
           ) : null}
           {active && displayPath ? (
-            <span
-              className="truncate text-right text-fg-muted"
-              title={active.worktree_path}
-            >
-              {displayPath}
-            </span>
+            <Tooltip label={active.worktree_path} side="top" multiline>
+              <span className="truncate text-right text-fg-muted">
+                {displayPath}
+              </span>
+            </Tooltip>
           ) : null}
           <span className="text-fg-muted/50">|</span>
-          <button
-            type="button"
-            disabled={!memory}
-            onClick={() => setBreakdownOpen(true)}
-            title="Click to view per-process breakdown"
-            className="rounded px-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-fg-muted"
-          >
-            mem: {memory ? formatBytes(memory.bytes) : "–"}
-          </button>
+          <Tooltip label="Click to view per-process breakdown" side="top">
+            <button
+              type="button"
+              disabled={!memory}
+              onClick={() => setBreakdownOpen(true)}
+              className="rounded px-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+            >
+              mem: {memory ? formatBytes(memory.bytes) : "–"}
+            </button>
+          </Tooltip>
         </span>
       </footer>
 

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,12 +1,31 @@
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { createPortal } from "react-dom";
 
 interface TooltipProps {
-  label: string;
+  /**
+   * Tooltip content. A string keeps the legacy single-line look; pass a
+   * `ReactNode` (e.g. multiple lines) and set `multiline` to switch the
+   * container to a wrappable layout.
+   */
+  label: ReactNode;
   /** Where the tooltip appears relative to the trigger. Default: "bottom". */
   side?: "top" | "bottom" | "left" | "right";
   /** Delay before showing on hover, in ms. Default: 250. */
   delay?: number;
+  /**
+   * Allow the tooltip to span multiple lines. The container drops
+   * `whitespace-nowrap`, applies a sensible max width, and respects
+   * embedded newlines (`whitespace-pre-line`). Use for "full name + extra
+   * info" hovers on truncated rows.
+   */
+  multiline?: boolean;
   children: ReactNode;
   className?: string;
 }
@@ -62,10 +81,12 @@ export function Tooltip({
   label,
   side = "bottom",
   delay = 250,
+  multiline = false,
   children,
   className,
 }: TooltipProps) {
   const triggerRef = useRef<HTMLSpanElement>(null);
+  const tooltipRef = useRef<HTMLSpanElement>(null);
   const showTimer = useRef<number | null>(null);
   const [position, setPosition] = useState<TooltipPosition | null>(null);
 
@@ -108,6 +129,33 @@ export function Tooltip({
 
   useEffect(() => () => clearTimer(), [clearTimer]);
 
+  // Clamp the tooltip into the viewport AFTER it has been measured. The
+  // initial `computePosition` anchors at the trigger center, which can
+  // leave the bubble overflowing on the right (or above the top) when the
+  // trigger sits near a screen edge — e.g. the status bar or a sidebar.
+  useLayoutEffect(() => {
+    if (position === null) return;
+    const el = tooltipRef.current;
+    if (!el) return;
+    const PAD = 8;
+    const rect = el.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let dx = 0;
+    let dy = 0;
+    if (rect.left < PAD) dx = PAD - rect.left;
+    else if (rect.right > vw - PAD) dx = vw - PAD - rect.right;
+    if (rect.top < PAD) dy = PAD - rect.top;
+    else if (rect.bottom > vh - PAD) dy = vh - PAD - rect.bottom;
+    if (dx !== 0 || dy !== 0) {
+      // Mutate the style imperatively so we don't trigger a re-render and
+      // re-clamp loop. The transform that originated the centering is
+      // preserved; we only adjust the absolute origin.
+      el.style.left = `${position.left + dx}px`;
+      el.style.top = `${position.top + dy}px`;
+    }
+  }, [position]);
+
   return (
     <>
       <span
@@ -124,6 +172,7 @@ export function Tooltip({
       {position !== null
         ? createPortal(
             <span
+              ref={tooltipRef}
               role="tooltip"
               style={{
                 position: "fixed",
@@ -132,7 +181,11 @@ export function Tooltip({
                 transform: position.transform,
                 zIndex: 9999,
               }}
-              className="pointer-events-none whitespace-nowrap rounded border border-border bg-bg-elevated px-2 py-0.5 text-[11px] font-normal text-fg shadow-md"
+              className={
+                multiline
+                  ? "pointer-events-none max-w-xs whitespace-pre-line break-words rounded border border-border bg-bg-elevated px-2 py-1 text-[11px] font-normal leading-snug text-fg shadow-md"
+                  : "pointer-events-none whitespace-nowrap rounded border border-border bg-bg-elevated px-2 py-0.5 text-[11px] font-normal text-fg shadow-md"
+              }
             >
               {label}
             </span>,


### PR DESCRIPTION
## Summary

Native HTML `title` tooltips have inconsistent timing across browsers, no styling control, and clip awkwardly inside Tauri's WKWebView. The existing `Tooltip` component already wraps a portaled, styled bubble with predictable hover delay — this PR extends it and rolls it out everywhere so the whole app has a single tooltip surface.

This PR also re-applies two follow-up changes that were lost when PR #25 was squashed before its later commits made it to the remote (only the first commit was pushed at merge time):
- `PrChecksBadge` moved next to the branch arrow and slimmed to bare colored icons / `n/m` mono text (no pill).
- Branch arrow shows full `head → base` on hover.

## Tooltip changes

- `label` now accepts `ReactNode`, so multi-line / styled content can be passed inline.
- New `multiline` prop swaps the container to `max-w-xs whitespace-pre-line break-words`, so long file paths and command lines wrap instead of overflowing.
- After mount, the tooltip measures itself and clamps into the viewport. Triggers at the right edge (status bar mem button, gh account chip) no longer produce a tooltip that gets cut off.

## Conversions

- **RightPanel**: per-element tooltips on PR rows (title, branch, time) and commit rows (sha push state, summary, time). Row-level "double-click to open" hint dropped.
- **StatusBar**: error message, gh account chip, worktree path, memory button.
- **Sidebar**: drag handle. Redundant fallback removed where inline copy already explains.
- **PullRequestDetailModal**: gh account, "Open on GitHub", "Open run", merge-readiness button.
- **DiffSplitView**: file rows and selected path header (multiline).
- **DiffView**: "Open full diff" button.
- **MergePullRequestDialog**: "Generate via Claude" button.
- **MemoryBreakdownModal**: Subtree column header and process command line spans (multiline).
- **Pane**: redundant "Double-click to start a new session" titles dropped where inline copy already states the action.

## Test plan

- [ ] Hover any PR row's title — full title appears.
- [ ] Hover the branch arrow on a PR row — `head → base` shows fully.
- [ ] Hover the relative time on a PR or commit row — absolute timestamp shows.
- [ ] Hover the commit sha — "Pushed" / "Not pushed" shows.
- [ ] Hover a long file path in DiffSplitView — full path wraps in a multi-line tooltip.
- [ ] Hover the status bar memory button near the right viewport edge — tooltip stays inside the viewport, not clipped.
- [ ] `bun run typecheck` clean.
- [ ] `bun run test` passing.
- [ ] `bun run build` clean.
