### PR TITLE
chore(ui): remove forced cursor-pointer from row UIs

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1066,7 +1066,7 @@ function PullRequestsTab({
                     onOpenDetail(pr.number);
                   }
                 }}
-                className="flex w-full cursor-pointer flex-col items-start gap-0.5 border-b border-border/40 px-3 py-2 text-left transition hover:bg-bg-elevated/50 focus-visible:outline-none focus-visible:bg-bg-elevated/60"
+                className="flex w-full flex-col items-start gap-0.5 border-b border-border/40 px-3 py-2 text-left transition hover:bg-bg-elevated/50 focus-visible:outline-none focus-visible:bg-bg-elevated/60"
                 title={`${absoluteTime(toUnixSeconds(pr.updated_at))} · double-click to open`}
               >
                 <span className="flex w-full min-w-0 items-center gap-2">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -447,7 +447,7 @@ function ProjectGroupView({
         }}
         aria-label={`Project ${project.name}`}
         className={cn(
-          "group flex cursor-pointer items-center gap-1 rounded-md px-1 py-1.5 hover:bg-bg-elevated/40",
+          "group flex items-center gap-1 rounded-md px-1 py-1.5 hover:bg-bg-elevated/40",
           isActiveProject && "bg-bg-elevated/30",
         )}
       >
@@ -722,7 +722,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
           setMenu({ x: e.clientX, y: e.clientY });
         }}
         className={cn(
-          "group flex w-full cursor-pointer items-start gap-1.5 rounded-md px-2 py-1 text-left transition",
+          "group flex w-full items-start gap-1.5 rounded-md px-2 py-1 text-left transition",
           active ? "bg-bg-elevated" : "hover:bg-bg-elevated/60",
         )}
       >


### PR DESCRIPTION
## Summary

Remove forced `cursor-pointer` from row-style UIs so the app feels closer to a native macOS application (where clickable rows don't show a pointer cursor).

### Changes
- `RightPanel.tsx` — PR list row
- `Sidebar.tsx` — project header row
- `Sidebar.tsx` — session item row

### Kept
Form labels (`CheckboxRow`, `RadioCard`, `RemoveSessionDialog`) and cmdk items keep `cursor-pointer` because that's conventional for those controls.

## Test plan
- [x] PR list rows: no pointer cursor on hover, still clickable (double-click opens detail)
- [x] Sidebar project header: no pointer cursor, click still selects
- [x] Sidebar session item: no pointer cursor, click still activates
- [x] Checkbox/radio labels still show pointer cursor
