### PR TITLE
feat(pr): multi-provider AI commit message generation

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -608,8 +608,16 @@ pub async fn generate_pr_commit_message(
     repo_path: String,
     number: u64,
     method: MergeMethod,
+    command: String,
+    args: Vec<String>,
 ) -> AppResult<GeneratedCommitMessage> {
-    pull_requests::generate_pr_commit_message(&PathBuf::from(repo_path), number, method)
+    pull_requests::generate_pr_commit_message(
+        &PathBuf::from(repo_path),
+        number,
+        method,
+        command,
+        args,
+    )
 }
 
 fn create_unique_worktree(

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -1119,14 +1119,26 @@ pub struct GeneratedCommitMessage {
 }
 
 /// Generate a squash/merge commit message by spawning a one-shot headless
-/// `claude` CLI invocation. The user must already have `claude` installed
-/// and authenticated; otherwise we surface a typed error so the frontend can
-/// guide them.
+/// AI CLI invocation. The provider command + args are resolved on the
+/// frontend (so each provider's invocation conventions live in one place,
+/// alongside the Settings UI) and passed in here. The CLI is expected to
+/// follow the standard `stdin = prompt, stdout = response` convention —
+/// `claude -p --output-format text`, `gemini -p`, `ollama run <model>`,
+/// `llm -m <model>`, or any user-supplied custom command all fit.
 pub fn generate_pr_commit_message(
     repo_path: &Path,
     number: u64,
     method: MergeMethod,
+    command: String,
+    args: Vec<String>,
 ) -> AppResult<GeneratedCommitMessage> {
+    if command.trim().is_empty() {
+        return Err(AppError::Other(
+            "No AI command configured. Open Settings → Commit message AI to pick a provider."
+                .to_string(),
+        ));
+    }
+
     let Some(slug) = github_owner_repo(repo_path)? else {
         return Err(AppError::Other(
             "Origin remote is not a GitHub repository.".to_string(),
@@ -1148,7 +1160,7 @@ pub fn generate_pr_commit_message(
 
     let (view, diff) = context;
     let prompt = build_commit_message_prompt(method, &view, &diff);
-    let raw = run_claude_oneshot(&prompt)?;
+    let raw = run_ai_oneshot(&command, &args, &prompt)?;
     Ok(parse_commit_message_response(&raw))
 }
 
@@ -1211,23 +1223,27 @@ fn parse_commit_message_response(raw: &str) -> GeneratedCommitMessage {
     GeneratedCommitMessage { title, body }
 }
 
-fn run_claude_oneshot(prompt: &str) -> AppResult<String> {
+/// Provider-agnostic one-shot CLI invocation: `command` is spawned with
+/// `args`, the prompt is piped in via stdin, and stdout is returned. We
+/// surface a typed error when the binary is missing so the frontend can
+/// point the user at install instructions for the configured provider.
+fn run_ai_oneshot(command: &str, args: &[String], prompt: &str) -> AppResult<String> {
     use std::io::Write;
     use std::process::Stdio;
 
-    let mut child = Command::new("claude")
-        .args(["-p", "--output-format", "text"])
+    let mut child = Command::new(command)
+        .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
-                AppError::Other(
-                    "`claude` CLI not found. Install Claude Code (https://docs.anthropic.com/claude/code) and run `claude login`.".to_string(),
-                )
+                AppError::Other(format!(
+                    "`{command}` not found. Install the configured AI CLI or change the provider in Settings → Commit message AI."
+                ))
             } else {
-                AppError::Other(format!("failed to invoke claude: {e}"))
+                AppError::Other(format!("failed to invoke {command}: {e}"))
             }
         })?;
 
@@ -1235,20 +1251,20 @@ fn run_claude_oneshot(prompt: &str) -> AppResult<String> {
         let stdin = child
             .stdin
             .as_mut()
-            .ok_or_else(|| AppError::Other("claude stdin missing".to_string()))?;
+            .ok_or_else(|| AppError::Other(format!("{command} stdin missing")))?;
         stdin
             .write_all(prompt.as_bytes())
-            .map_err(|e| AppError::Other(format!("failed to write to claude: {e}")))?;
+            .map_err(|e| AppError::Other(format!("failed to write to {command}: {e}")))?;
     }
 
     let output = child
         .wait_with_output()
-        .map_err(|e| AppError::Other(format!("failed waiting for claude: {e}")))?;
+        .map_err(|e| AppError::Other(format!("failed waiting for {command}: {e}")))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let msg = if stderr.is_empty() {
-            format!("claude exited with status {}", output.status)
+            format!("{command} exited with status {}", output.status)
         } else {
             stderr
         };

--- a/src/components/MergePullRequestDialog.tsx
+++ b/src/components/MergePullRequestDialog.tsx
@@ -4,6 +4,11 @@ import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import { loadLastMergeMethod, saveLastMergeMethod } from "../lib/merge-prefs";
+import {
+  aiCommitProviderLabel,
+  resolveAiCommitCommand,
+  useSettings,
+} from "../lib/settings";
 import type { MergeMethod, PullRequestDetail } from "../lib/types";
 import { Tooltip } from "./Tooltip";
 import { Modal, ModalHeader, TextSwap } from "./ui";
@@ -45,6 +50,7 @@ export function MergePullRequestDialog({
   onClose,
   onMerged,
 }: MergePullRequestDialogProps) {
+  const settings = useSettings((s) => s.settings);
   const [method, setMethod] = useState<MergeMethod>(() => loadLastMergeMethod());
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
@@ -100,10 +106,13 @@ export function MergePullRequestDialog({
     setGenerating(true);
     setError(null);
     try {
+      const { command, args } = resolveAiCommitCommand(settings);
       const result = await api.generatePrCommitMessage(
         repoPath,
         detail.number,
         method,
+        command,
+        args,
       );
       if (result.title.trim()) setTitle(result.title);
       setBody(result.body);
@@ -114,6 +123,7 @@ export function MergePullRequestDialog({
     }
   }
 
+  const providerLabel = aiCommitProviderLabel(settings);
   const busy = submitting || generating;
 
   return (
@@ -170,7 +180,10 @@ export function MergePullRequestDialog({
                       Generating…
                     </button>
                   ) : (
-                    <Tooltip label="Generate via Claude" side="top">
+                    <Tooltip
+                      label={`Generate via ${providerLabel}`}
+                      side="top"
+                    >
                       <button
                         key="gen-button-idle"
                         type="button"

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import {
+  AI_COMMIT_PROVIDER_OPTIONS,
+  type AiCommitProvider,
   type SessionStartupMode,
   type TerminalFontWeight,
   TERMINAL_FONT_WEIGHTS,
@@ -19,13 +21,19 @@ import {
   TextInput,
 } from "./ui";
 
-type Tab = "terminal" | "sessions" | "editor" | "notifications";
+type Tab =
+  | "terminal"
+  | "sessions"
+  | "editor"
+  | "notifications"
+  | "pullRequests";
 
 const TABS: Array<{ id: Tab; label: string }> = [
   { id: "terminal", label: "Terminal" },
   { id: "sessions", label: "Sessions" },
   { id: "editor", label: "Editor" },
   { id: "notifications", label: "Notifications" },
+  { id: "pullRequests", label: "Pull Requests" },
 ];
 
 export function SettingsModal() {
@@ -90,6 +98,8 @@ export function SettingsModal() {
             <SessionSettings />
           ) : tab === "editor" ? (
             <EditorSettings />
+          ) : tab === "pullRequests" ? (
+            <PullRequestSettings />
           ) : (
             <NotificationSettings />
           )}
@@ -318,6 +328,82 @@ function NotificationSettings() {
       </Field>
       <p className="text-[11px] text-fg-muted">
         macOS may ask once for permission the first time a notification fires.
+      </p>
+    </section>
+  );
+}
+
+function PullRequestSettings() {
+  const settings = useSettings((s) => s.settings);
+  const patchCommitMessage = useSettings((s) => s.patchCommitMessage);
+  const provider = settings.commitMessage.provider;
+
+  return (
+    <section className="space-y-4">
+      <Field
+        label="Commit message AI"
+        hint='Used by "Generate with AI" in the merge dialog. The CLI must follow the standard `stdin = prompt, stdout = response` convention.'
+      >
+        <div className="flex flex-col gap-1.5">
+          {AI_COMMIT_PROVIDER_OPTIONS.map((opt) => (
+            <RadioCard<AiCommitProvider>
+              key={opt.value}
+              name="commit-message-provider"
+              value={opt.value}
+              current={provider}
+              label={opt.label}
+              description={opt.hint}
+              onSelect={(v) => patchCommitMessage({ provider: v })}
+            />
+          ))}
+        </div>
+      </Field>
+      {provider === "ollama" ? (
+        <Field
+          label="Ollama model"
+          hint="Passed to `ollama run <model>`. Defaults to `llama3` when blank."
+        >
+          <TextInput
+            value={settings.commitMessage.ollamaModel}
+            onChange={(e) =>
+              patchCommitMessage({ ollamaModel: e.target.value })
+            }
+            placeholder="e.g. llama3:8b"
+          />
+        </Field>
+      ) : null}
+      {provider === "llm" ? (
+        <Field
+          label="llm model"
+          hint="Passed via `llm -m <model>`. Leave blank to use the llm-configured default."
+        >
+          <TextInput
+            value={settings.commitMessage.llmModel}
+            onChange={(e) =>
+              patchCommitMessage({ llmModel: e.target.value })
+            }
+            placeholder="e.g. gpt-4o-mini"
+          />
+        </Field>
+      ) : null}
+      {provider === "custom" ? (
+        <Field
+          label="Custom command"
+          hint="Whitespace-separated; no shell expansion. Falls back to claude when blank."
+        >
+          <TextInput
+            value={settings.commitMessage.customCommand}
+            onChange={(e) =>
+              patchCommitMessage({ customCommand: e.target.value })
+            }
+            placeholder="e.g. codex --short"
+          />
+        </Field>
+      ) : null}
+      <p className="text-[11px] text-fg-muted">
+        The selected provider's CLI must already be installed and
+        authenticated on this machine. The merge dialog falls back to a
+        clear error when the binary is missing.
       </p>
     </section>
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -118,11 +118,15 @@ export const api = {
     repoPath: string,
     number: number,
     method: MergeMethod,
+    command: string,
+    args: string[],
   ): Promise<GeneratedCommitMessage> {
     return invoke<GeneratedCommitMessage>("generate_pr_commit_message", {
       repoPath,
       number,
       method,
+      command,
+      args,
     });
   },
   getMemoryUsage(): Promise<MemoryUsage> {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -4,6 +4,47 @@ const STORAGE_KEY = "acorn:settings:v1";
 
 export type SessionStartupMode = "claude" | "terminal" | "custom";
 
+/**
+ * AI CLI used by "Generate with AI" in the merge dialog. The actual command
+ * + argv is resolved via `resolveAiCommitCommand` so each provider's
+ * invocation conventions live in one place. All providers must follow the
+ * `stdin = prompt, stdout = response` convention.
+ */
+export type AiCommitProvider =
+  | "claude"
+  | "gemini"
+  | "ollama"
+  | "llm"
+  | "custom";
+
+export const AI_COMMIT_PROVIDER_OPTIONS: ReadonlyArray<{
+  value: AiCommitProvider;
+  label: string;
+  hint: string;
+}> = [
+  {
+    value: "claude",
+    label: "Claude Code",
+    hint: "claude -p --output-format text",
+  },
+  { value: "gemini", label: "Gemini CLI", hint: "gemini -p" },
+  {
+    value: "ollama",
+    label: "Ollama (local)",
+    hint: "ollama run <model>",
+  },
+  {
+    value: "llm",
+    label: "Simon Willison's llm",
+    hint: "llm [-m <model>]",
+  },
+  {
+    value: "custom",
+    label: "Custom command",
+    hint: "Whitespace-separated, no shell expansion",
+  },
+];
+
 export type TerminalFontWeight =
   | 100
   | 200
@@ -66,6 +107,19 @@ export interface AcornSettings {
       completed: boolean;
     };
   };
+  commitMessage: {
+    /** Which AI CLI handles "Generate with AI" in the merge dialog. */
+    provider: AiCommitProvider;
+    /** Model name for `ollama run <model>`. Falls back to `llama3` when blank. */
+    ollamaModel: string;
+    /** Optional `-m <model>` arg for the `llm` CLI. Empty = use llm default. */
+    llmModel: string;
+    /**
+     * Used when `provider === "custom"`. Whitespace-separated; no shell
+     * expansion. Empty = fall back to claude.
+     */
+    customCommand: string;
+  };
 }
 
 export const DEFAULT_SETTINGS: AcornSettings = {
@@ -93,6 +147,12 @@ export const DEFAULT_SETTINGS: AcornSettings = {
       failed: true,
       completed: false,
     },
+  },
+  commitMessage: {
+    provider: "claude",
+    ollamaModel: "",
+    llmModel: "",
+    customCommand: "",
   },
 };
 
@@ -151,6 +211,10 @@ function loadSettings(): AcornSettings {
           ...(parsed.notifications?.events ?? {}),
         },
       },
+      commitMessage: {
+        ...DEFAULT_SETTINGS.commitMessage,
+        ...(parsed.commitMessage ?? {}),
+      },
     };
   } catch {
     return DEFAULT_SETTINGS;
@@ -179,6 +243,9 @@ interface SettingsState {
     patch: Partial<Omit<AcornSettings["notifications"], "events">> & {
       events?: Partial<AcornSettings["notifications"]["events"]>;
     },
+  ) => void;
+  patchCommitMessage: (
+    patch: Partial<AcornSettings["commitMessage"]>,
   ) => void;
   reset: () => void;
 }
@@ -240,6 +307,15 @@ export const useSettings = create<SettingsState>((set) => ({
       persist(next);
       return { settings: next };
     }),
+  patchCommitMessage: (patch) =>
+    set((s) => {
+      const next: AcornSettings = {
+        ...s.settings,
+        commitMessage: { ...s.settings.commitMessage, ...patch },
+      };
+      persist(next);
+      return { settings: next };
+    }),
   reset: () => {
     persist(DEFAULT_SETTINGS);
     set({ settings: DEFAULT_SETTINGS });
@@ -269,4 +345,56 @@ export function resolveStartupCommand(s: AcornSettings): {
     return { command: parts[0], args: parts.slice(1) };
   }
   return { command: "", args: [] };
+}
+
+/**
+ * Resolve the AI CLI invocation for the merge dialog's "Generate with AI"
+ * action. Each provider has its own argv convention; `custom` lets the user
+ * plug in anything that follows the standard `stdin = prompt, stdout =
+ * response` shape. The resolved value is sent to the Rust backend as
+ * `(command, args)` so the backend stays provider-agnostic.
+ */
+export function resolveAiCommitCommand(s: AcornSettings): {
+  command: string;
+  args: string[];
+} {
+  const c = s.commitMessage;
+  switch (c.provider) {
+    case "claude":
+      return { command: "claude", args: ["-p", "--output-format", "text"] };
+    case "gemini":
+      return { command: "gemini", args: ["-p"] };
+    case "ollama": {
+      const model = c.ollamaModel.trim() || "llama3";
+      return { command: "ollama", args: ["run", model] };
+    }
+    case "llm": {
+      const model = c.llmModel.trim();
+      return model
+        ? { command: "llm", args: ["-m", model] }
+        : { command: "llm", args: [] };
+    }
+    case "custom": {
+      const trimmed = c.customCommand.trim();
+      if (!trimmed) {
+        // Empty custom falls back to claude so the button still does
+        // something predictable rather than failing with "No AI command".
+        return { command: "claude", args: ["-p", "--output-format", "text"] };
+      }
+      const parts = trimmed.split(/\s+/);
+      return { command: parts[0], args: parts.slice(1) };
+    }
+  }
+}
+
+/**
+ * Human-friendly label for the currently configured AI provider — used in
+ * the merge dialog's tooltip ("Generate via Claude Code", "Generate via
+ * Ollama", etc.) so the user can see at a glance which CLI will run.
+ */
+export function aiCommitProviderLabel(s: AcornSettings): string {
+  const opt = AI_COMMIT_PROVIDER_OPTIONS.find(
+    (o) => o.value === s.commitMessage.provider,
+  );
+  return opt?.label ?? "AI";
 }


### PR DESCRIPTION
## Summary

Replaces the hardcoded `claude -p` invocation in `generate_pr_commit_message` with a provider-agnostic spawn driven from **Settings → Pull Requests → Commit message AI**.

The "Generate with AI" button in the merge dialog now resolves the configured provider to a `(command, args)` pair on the frontend and forwards it to the Rust backend, which simply spawns the binary with `stdin = prompt, stdout = response`. The backend stays provider-agnostic so adding more CLIs later only touches `resolveAiCommitCommand` plus the Settings copy.

## Built-in providers

| Provider | Invocation |
| --- | --- |
| Claude Code | `claude -p --output-format text` |
| Gemini CLI | `gemini -p` |
| Ollama (local) | `ollama run <model>` — model field, defaults to `llama3` |
| Simon Willison's `llm` | `llm [-m <model>]` |
| Custom | arbitrary whitespace-tokenised command (no shell expansion), falls back to claude when blank |

The merge dialog tooltip updates to reflect the active provider ("Generate via Claude Code", "Generate via Ollama", …) so the user can see which CLI will run before clicking. Missing binaries surface a typed error that points at the Settings tab.

## Backend changes

- `generate_pr_commit_message(repo, number, method)` → `generate_pr_commit_message(repo, number, method, command, args)`
- `run_claude_oneshot(prompt)` renamed to `run_ai_oneshot(command, args, prompt)`
- Generic "command not found" error referencing the configured provider

## Frontend changes

- `AcornSettings.commitMessage` (provider, ollamaModel, llmModel, customCommand) with backwards-compatible loader
- `resolveAiCommitCommand(settings)` and `aiCommitProviderLabel(settings)` helpers
- New "Pull Requests" tab in `SettingsModal` with provider radio cards and per-provider input fields
- `MergePullRequestDialog` reads settings and passes the resolved command + args through `api.generatePrCommitMessage`

## Test plan

- [ ] Default settings still spawn Claude Code; existing flow unchanged for users who did nothing.
- [ ] Switching to Ollama with a custom model fires `ollama run <model>` against a running ollama daemon.
- [ ] Switching to a missing CLI surfaces the "not found" error pointing at Settings.
- [ ] Custom provider with a blank command falls back to Claude.
- [ ] The merge dialog tooltip reflects the active provider name.
- [ ] `bun run typecheck` clean.
- [ ] `bun run test` passing.
- [ ] `cargo check` clean for `src-tauri`.
- [ ] `bun run build` clean.
