### PR TITLE
fix(settings): fix Settings modal to a stable height

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -56,7 +56,7 @@ export function SettingsModal() {
         variant="dialog"
         onClose={() => setOpen(false)}
       />
-      <div className="flex min-h-[20rem]">
+      <div className="flex h-[28rem]">
         <nav className="flex w-40 shrink-0 flex-col border-r border-border bg-bg-sidebar/40 py-2">
           {TABS.map((t) => (
             <button


### PR DESCRIPTION
## Summary

The Settings modal used `min-h-[20rem]` with no upper bound, so the modal grew/shrank as the user switched tabs and the dialog visibly jumped on every tab switch.

Pin the body to a fixed `h-[28rem]` (448px). The right pane already has `overflow-y-auto`, so any tab whose content exceeds the height scrolls within the dialog rather than resizing the dialog itself.

## Test plan
- [x] Open Settings — dialog opens at 448px tall
- [x] Switch between Terminal / Sessions / Editor / Notifications — dialog height does not change
- [x] Tab whose content exceeds the height — right pane scrolls; dialog stays fixed
