### PR TITLE
feat(settings): central Agents tab — single AI agent picker for all features

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -3,11 +3,12 @@ import { useState } from "react";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import {
-  AI_COMMIT_PROVIDER_OPTIONS,
-  type AiCommitProvider,
+  AGENT_OPTIONS,
+  type SelectedAgent,
   type SessionStartupMode,
   type TerminalFontWeight,
   TERMINAL_FONT_WEIGHTS,
+  selectedAgentLabel,
   useSettings,
 } from "../lib/settings";
 import {
@@ -23,17 +24,17 @@ import {
 
 type Tab =
   | "terminal"
+  | "agents"
   | "sessions"
   | "editor"
-  | "notifications"
-  | "pullRequests";
+  | "notifications";
 
 const TABS: Array<{ id: Tab; label: string }> = [
   { id: "terminal", label: "Terminal" },
+  { id: "agents", label: "Agents" },
   { id: "sessions", label: "Sessions" },
   { id: "editor", label: "Editor" },
   { id: "notifications", label: "Notifications" },
-  { id: "pullRequests", label: "Pull Requests" },
 ];
 
 export function SettingsModal() {
@@ -94,12 +95,12 @@ export function SettingsModal() {
         <div className="flex-1 overflow-y-auto p-4">
           {tab === "terminal" ? (
             <TerminalSettings />
+          ) : tab === "agents" ? (
+            <AgentSettings />
           ) : tab === "sessions" ? (
             <SessionSettings />
           ) : tab === "editor" ? (
             <EditorSettings />
-          ) : tab === "pullRequests" ? (
-            <PullRequestSettings />
           ) : (
             <NotificationSettings />
           )}
@@ -181,6 +182,7 @@ function SessionSettings() {
   const patchSessionStartup = useSettings((s) => s.patchSessionStartup);
   const patchSessions = useSettings((s) => s.patchSessions);
   const mode = settings.sessionStartup.mode;
+  const agentName = selectedAgentLabel(settings);
 
   return (
     <section className="space-y-4">
@@ -199,10 +201,10 @@ function SessionSettings() {
           />
           <RadioCard<SessionStartupMode>
             name="session-startup"
-            value="claude"
+            value="agent"
             current={mode}
-            label="Claude"
-            description="Launch the `claude` CLI in the session worktree."
+            label="Agent"
+            description={`Launch the agent selected under Agents — currently ${agentName}.`}
             onSelect={(v) => patchSessionStartup({ mode: v })}
           />
           <RadioCard<SessionStartupMode>
@@ -333,77 +335,85 @@ function NotificationSettings() {
   );
 }
 
-function PullRequestSettings() {
+function AgentSettings() {
   const settings = useSettings((s) => s.settings);
-  const patchCommitMessage = useSettings((s) => s.patchCommitMessage);
-  const provider = settings.commitMessage.provider;
+  const patchAgents = useSettings((s) => s.patchAgents);
+  const selected = settings.agents.selected;
 
   return (
     <section className="space-y-4">
-      <Field
-        label="Commit message AI"
-        hint='Used by "Generate with AI" in the merge dialog. The CLI must follow the standard `stdin = prompt, stdout = response` convention.'
-      >
+      <p className="rounded-md border border-border bg-bg-sidebar/40 px-3 py-2 text-[11px] text-fg-muted">
+        The selected agent powers every AI feature in acorn — the merge
+        dialog's <em>Generate with AI</em> button and Sessions startup's
+        <em> Agent</em> mode both run whichever CLI is picked here.
+      </p>
+      <Field label="Agent" hint="Choose which AI CLI acorn uses.">
         <div className="flex flex-col gap-1.5">
-          {AI_COMMIT_PROVIDER_OPTIONS.map((opt) => (
-            <RadioCard<AiCommitProvider>
+          {AGENT_OPTIONS.map((opt) => (
+            <RadioCard<SelectedAgent>
               key={opt.value}
-              name="commit-message-provider"
+              name="acorn-agent"
               value={opt.value}
-              current={provider}
+              current={selected}
               label={opt.label}
-              description={opt.hint}
-              onSelect={(v) => patchCommitMessage({ provider: v })}
+              description={`${opt.interactiveHint} · ${opt.oneshotHint}`}
+              onSelect={(v) => patchAgents({ selected: v })}
             />
           ))}
+          <RadioCard<SelectedAgent>
+            name="acorn-agent"
+            value="custom"
+            current={selected}
+            label="Custom command"
+            description="Use any CLI not in the list. Whitespace-separated; no shell expansion."
+            onSelect={(v) => patchAgents({ selected: v })}
+          />
         </div>
       </Field>
-      {provider === "ollama" ? (
+      {selected === "ollama" ? (
         <Field
           label="Ollama model"
           hint="Passed to `ollama run <model>`. Defaults to `llama3` when blank."
         >
           <TextInput
-            value={settings.commitMessage.ollamaModel}
+            value={settings.agents.ollama.model}
             onChange={(e) =>
-              patchCommitMessage({ ollamaModel: e.target.value })
+              patchAgents({ ollama: { model: e.target.value } })
             }
             placeholder="e.g. llama3:8b"
           />
         </Field>
       ) : null}
-      {provider === "llm" ? (
+      {selected === "llm" ? (
         <Field
           label="llm model"
-          hint="Passed via `llm -m <model>`. Leave blank to use the llm-configured default."
+          hint="Passed via `llm -m <model>` (and `llm chat -m <model>` for sessions). Blank uses the llm-configured default."
         >
           <TextInput
-            value={settings.commitMessage.llmModel}
-            onChange={(e) =>
-              patchCommitMessage({ llmModel: e.target.value })
-            }
+            value={settings.agents.llm.model}
+            onChange={(e) => patchAgents({ llm: { model: e.target.value } })}
             placeholder="e.g. gpt-4o-mini"
           />
         </Field>
       ) : null}
-      {provider === "custom" ? (
+      {selected === "custom" ? (
         <Field
           label="Custom command"
-          hint="Whitespace-separated; no shell expansion. Falls back to claude when blank."
+          hint="Used for both interactive sessions and one-shot AI generation. Falls back to Claude Code when blank."
         >
           <TextInput
-            value={settings.commitMessage.customCommand}
+            value={settings.agents.customCommand}
             onChange={(e) =>
-              patchCommitMessage({ customCommand: e.target.value })
+              patchAgents({ customCommand: e.target.value })
             }
-            placeholder="e.g. codex --short"
+            placeholder="e.g. codex --reply"
           />
         </Field>
       ) : null}
       <p className="text-[11px] text-fg-muted">
-        The selected provider's CLI must already be installed and
-        authenticated on this machine. The merge dialog falls back to a
-        clear error when the binary is missing.
+        The selected agent's CLI must already be installed and
+        authenticated on this machine. Surfaces a clear error when the
+        binary is missing.
       </p>
     </section>
   );

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -18,11 +18,86 @@ describe("resolveStartupCommand", () => {
     });
   });
 
-  it("returns claude with no args for `claude` mode", () => {
-    expect(resolveStartupCommand(withStartup({ mode: "claude" }))).toEqual({
+  it("returns claude with no args for agent mode + claude selected", () => {
+    expect(
+      resolveStartupCommand({
+        ...DEFAULT_SETTINGS,
+        agents: { ...DEFAULT_SETTINGS.agents, selected: "claude" },
+        sessionStartup: { ...DEFAULT_SETTINGS.sessionStartup, mode: "agent" },
+      }),
+    ).toEqual({
       command: "claude",
       args: [],
     });
+  });
+
+  it("returns gemini with no args for agent mode + gemini selected", () => {
+    expect(
+      resolveStartupCommand({
+        ...DEFAULT_SETTINGS,
+        agents: { ...DEFAULT_SETTINGS.agents, selected: "gemini" },
+        sessionStartup: { ...DEFAULT_SETTINGS.sessionStartup, mode: "agent" },
+      }),
+    ).toEqual({
+      command: "gemini",
+      args: [],
+    });
+  });
+
+  it("falls back to llama3 for ollama agent with blank model", () => {
+    expect(
+      resolveStartupCommand({
+        ...DEFAULT_SETTINGS,
+        agents: {
+          ...DEFAULT_SETTINGS.agents,
+          selected: "ollama",
+          ollama: { model: "" },
+        },
+        sessionStartup: { ...DEFAULT_SETTINGS.sessionStartup, mode: "agent" },
+      }),
+    ).toEqual({ command: "ollama", args: ["run", "llama3"] });
+  });
+
+  it("uses configured ollama model when set", () => {
+    expect(
+      resolveStartupCommand({
+        ...DEFAULT_SETTINGS,
+        agents: {
+          ...DEFAULT_SETTINGS.agents,
+          selected: "ollama",
+          ollama: { model: "llama3:8b" },
+        },
+        sessionStartup: { ...DEFAULT_SETTINGS.sessionStartup, mode: "agent" },
+      }),
+    ).toEqual({ command: "ollama", args: ["run", "llama3:8b"] });
+  });
+
+  it("agent mode + custom selected uses agents.customCommand", () => {
+    expect(
+      resolveStartupCommand({
+        ...DEFAULT_SETTINGS,
+        agents: {
+          ...DEFAULT_SETTINGS.agents,
+          selected: "custom",
+          customCommand: "codex --reply",
+        },
+        sessionStartup: { ...DEFAULT_SETTINGS.sessionStartup, mode: "agent" },
+      }),
+    ).toEqual({ command: "codex", args: ["--reply"] });
+  });
+
+  it("agent mode + custom selected with blank command falls back to claude", () => {
+    expect(
+      resolveStartupCommand({
+        ...DEFAULT_SETTINGS,
+        agents: {
+          ...DEFAULT_SETTINGS.agents,
+          selected: "custom",
+          customCommand: "",
+        },
+        sessionStartup: { ...DEFAULT_SETTINGS.sessionStartup, mode: "agent" },
+      }),
+    ).toEqual({ command: "claude", args: [] });
   });
 
   it("falls back to $SHELL (empty command) when custom command is blank", () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -44,7 +44,7 @@ export const AGENT_OPTIONS: ReadonlyArray<{
   },
   {
     value: "llm",
-    label: "Simon Willison's llm",
+    label: "llm CLI",
     oneshotHint: "llm [-m <model>]",
     interactiveHint: "llm chat [-m <model>]",
   },

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -2,48 +2,61 @@ import { create } from "zustand";
 
 const STORAGE_KEY = "acorn:settings:v1";
 
-export type SessionStartupMode = "claude" | "terminal" | "custom";
-
 /**
- * AI CLI used by "Generate with AI" in the merge dialog. The actual command
- * + argv is resolved via `resolveAiCommitCommand` so each provider's
- * invocation conventions live in one place. All providers must follow the
- * `stdin = prompt, stdout = response` convention.
+ * Catalog of AI agents acorn knows how to spawn. The user picks ONE
+ * `selected` agent under Settings → Agents; that choice powers every AI
+ * feature in the app (Sessions startup's Agent mode, the merge dialog's
+ * "Generate with AI" button, …). Each agent has its own invocation
+ * conventions for interactive PTY use and one-shot stdin/stdout use,
+ * captured in `agentInteractiveCommand` / `agentOneshotCommand` below.
  */
-export type AiCommitProvider =
-  | "claude"
-  | "gemini"
-  | "ollama"
-  | "llm"
-  | "custom";
+export type AgentProvider = "claude" | "gemini" | "ollama" | "llm" | "codex";
 
-export const AI_COMMIT_PROVIDER_OPTIONS: ReadonlyArray<{
-  value: AiCommitProvider;
+/** Agent selection accepts every catalogued agent plus an arbitrary custom
+ *  command for tools that don't fit the catalog. */
+export type SelectedAgent = AgentProvider | "custom";
+
+export const AGENT_OPTIONS: ReadonlyArray<{
+  value: AgentProvider;
   label: string;
-  hint: string;
+  /** One-shot invocation hint shown in Settings. */
+  oneshotHint: string;
+  /** Interactive PTY invocation hint shown in Settings. */
+  interactiveHint: string;
 }> = [
   {
     value: "claude",
     label: "Claude Code",
-    hint: "claude -p --output-format text",
+    oneshotHint: "claude -p --output-format text",
+    interactiveHint: "claude",
   },
-  { value: "gemini", label: "Gemini CLI", hint: "gemini -p" },
+  {
+    value: "gemini",
+    label: "Gemini CLI",
+    oneshotHint: "gemini -p",
+    interactiveHint: "gemini",
+  },
   {
     value: "ollama",
     label: "Ollama (local)",
-    hint: "ollama run <model>",
+    oneshotHint: "ollama run <model>",
+    interactiveHint: "ollama run <model>",
   },
   {
     value: "llm",
     label: "Simon Willison's llm",
-    hint: "llm [-m <model>]",
+    oneshotHint: "llm [-m <model>]",
+    interactiveHint: "llm chat [-m <model>]",
   },
   {
-    value: "custom",
-    label: "Custom command",
-    hint: "Whitespace-separated, no shell expansion",
+    value: "codex",
+    label: "OpenAI Codex CLI",
+    oneshotHint: "codex (interactive only)",
+    interactiveHint: "codex",
   },
 ];
+
+export type SessionStartupMode = "agent" | "terminal" | "custom";
 
 export type TerminalFontWeight =
   | 100
@@ -78,9 +91,33 @@ export interface AcornSettings {
     fontWeight: TerminalFontWeight;
     fontWeightBold: TerminalFontWeight;
   };
+  /**
+   * The single AI agent acorn uses everywhere: Sessions startup (when
+   * mode === "agent"), the merge dialog's "Generate with AI" button, and
+   * any future AI-powered features. Per-agent options (Ollama / llm
+   * model strings) live alongside so changing them once updates every
+   * call site.
+   */
+  agents: {
+    selected: SelectedAgent;
+    /**
+     * Used when `selected === "custom"`. Whitespace-separated; no shell
+     * expansion. The same string powers both interactive (Sessions) and
+     * one-shot (commit message) invocations — empty falls back to
+     * Claude Code in both cases.
+     */
+    customCommand: string;
+    ollama: { model: string };
+    llm: { model: string };
+  };
   sessionStartup: {
     mode: SessionStartupMode;
-    /** Used when `mode === "custom"`. Empty string falls back to claude. */
+    /**
+     * Used when `mode === "custom"`. Independent from
+     * `agents.customCommand` because session startup launches a long-
+     * lived PTY (your shell of choice), which has different needs from
+     * the AI one-shot command.
+     */
     customCommand: string;
   };
   sessions: {
@@ -107,19 +144,6 @@ export interface AcornSettings {
       completed: boolean;
     };
   };
-  commitMessage: {
-    /** Which AI CLI handles "Generate with AI" in the merge dialog. */
-    provider: AiCommitProvider;
-    /** Model name for `ollama run <model>`. Falls back to `llama3` when blank. */
-    ollamaModel: string;
-    /** Optional `-m <model>` arg for the `llm` CLI. Empty = use llm default. */
-    llmModel: string;
-    /**
-     * Used when `provider === "custom"`. Whitespace-separated; no shell
-     * expansion. Empty = fall back to claude.
-     */
-    customCommand: string;
-  };
 }
 
 export const DEFAULT_SETTINGS: AcornSettings = {
@@ -129,6 +153,12 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     fontSize: 12,
     fontWeight: 400,
     fontWeightBold: 700,
+  },
+  agents: {
+    selected: "claude",
+    customCommand: "",
+    ollama: { model: "" },
+    llm: { model: "" },
   },
   sessionStartup: {
     mode: "terminal",
@@ -148,16 +178,18 @@ export const DEFAULT_SETTINGS: AcornSettings = {
       completed: false,
     },
   },
-  commitMessage: {
-    provider: "claude",
-    ollamaModel: "",
-    llmModel: "",
-    customCommand: "",
-  },
 };
 
 const VALID_WEIGHTS = new Set<TerminalFontWeight>([
   100, 200, 300, 400, 500, 600, 700, 800, 900,
+]);
+
+const VALID_AGENTS = new Set<AgentProvider>([
+  "claude",
+  "gemini",
+  "ollama",
+  "llm",
+  "codex",
 ]);
 
 function normalizeWeight(
@@ -170,14 +202,90 @@ function normalizeWeight(
   return fallback;
 }
 
+function normalizeSelectedAgent(
+  v: unknown,
+  fallback: SelectedAgent,
+): SelectedAgent {
+  if (
+    typeof v === "string" &&
+    (VALID_AGENTS.has(v as AgentProvider) || v === "custom")
+  ) {
+    return v as SelectedAgent;
+  }
+  return fallback;
+}
+
+/**
+ * v1 commitMessage block from the multi-provider commit-message PR. The
+ * loader below lifts every field up into the new `agents.*` block so a
+ * single agent selection drives every AI feature.
+ */
+interface LegacyCommitMessage {
+  agent?: string;
+  provider?: string;
+  customCommand?: string;
+  ollamaModel?: string;
+  llmModel?: string;
+}
+
 function loadSettings(): AcornSettings {
   if (typeof localStorage === "undefined") return DEFAULT_SETTINGS;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULT_SETTINGS;
-    const parsed = JSON.parse(raw) as Partial<AcornSettings> | null;
+    const parsed = JSON.parse(raw) as
+      | (Partial<AcornSettings> & { commitMessage?: LegacyCommitMessage })
+      | null;
     if (!parsed || typeof parsed !== "object") return DEFAULT_SETTINGS;
     const terminalRaw: Partial<AcornSettings["terminal"]> = parsed.terminal ?? {};
+
+    // Sessions startup migration: legacy `mode === "claude"` collapses
+    // into the new agent-mode + global selected agent.
+    const startupRaw = (parsed.sessionStartup ?? {}) as {
+      mode?: string;
+      customCommand?: string;
+    };
+    const legacyClaudeMode = startupRaw.mode === "claude";
+    const startupMode: SessionStartupMode = legacyClaudeMode
+      ? "agent"
+      : startupRaw.mode === "agent" ||
+          startupRaw.mode === "terminal" ||
+          startupRaw.mode === "custom"
+        ? startupRaw.mode
+        : DEFAULT_SETTINGS.sessionStartup.mode;
+
+    // Agents migration: prefer existing `agents` block, otherwise lift
+    // values from the v1 `commitMessage` block, otherwise fall back to
+    // a Claude default. Legacy `mode === "claude"` also seeds
+    // `selected` if nothing else has set it.
+    const agentsRaw = (parsed.agents ?? {}) as {
+      selected?: string;
+      customCommand?: string;
+      ollama?: { model?: string };
+      llm?: { model?: string };
+    };
+    const commitRaw: LegacyCommitMessage = parsed.commitMessage ?? {};
+    const legacySelected =
+      commitRaw.agent ?? commitRaw.provider ?? undefined;
+    const selected = normalizeSelectedAgent(
+      agentsRaw.selected ??
+        legacySelected ??
+        (legacyClaudeMode ? "claude" : DEFAULT_SETTINGS.agents.selected),
+      DEFAULT_SETTINGS.agents.selected,
+    );
+    const customCommand =
+      agentsRaw.customCommand ??
+      commitRaw.customCommand ??
+      DEFAULT_SETTINGS.agents.customCommand;
+    const ollamaModel =
+      agentsRaw.ollama?.model ??
+      commitRaw.ollamaModel ??
+      DEFAULT_SETTINGS.agents.ollama.model;
+    const llmModel =
+      agentsRaw.llm?.model ??
+      commitRaw.llmModel ??
+      DEFAULT_SETTINGS.agents.llm.model;
+
     return {
       terminal: {
         ...DEFAULT_SETTINGS.terminal,
@@ -191,9 +299,17 @@ function loadSettings(): AcornSettings {
           DEFAULT_SETTINGS.terminal.fontWeightBold,
         ),
       },
+      agents: {
+        selected,
+        customCommand,
+        ollama: { model: ollamaModel },
+        llm: { model: llmModel },
+      },
       sessionStartup: {
-        ...DEFAULT_SETTINGS.sessionStartup,
-        ...(parsed.sessionStartup ?? {}),
+        mode: startupMode,
+        customCommand:
+          startupRaw.customCommand ??
+          DEFAULT_SETTINGS.sessionStartup.customCommand,
       },
       sessions: {
         ...DEFAULT_SETTINGS.sessions,
@@ -210,10 +326,6 @@ function loadSettings(): AcornSettings {
           ...DEFAULT_SETTINGS.notifications.events,
           ...(parsed.notifications?.events ?? {}),
         },
-      },
-      commitMessage: {
-        ...DEFAULT_SETTINGS.commitMessage,
-        ...(parsed.commitMessage ?? {}),
       },
     };
   } catch {
@@ -234,6 +346,14 @@ interface SettingsState {
   open: boolean;
   setOpen: (v: boolean) => void;
   patchTerminal: (patch: Partial<AcornSettings["terminal"]>) => void;
+  patchAgents: (
+    patch: Partial<{
+      selected: SelectedAgent;
+      customCommand: string;
+      ollama: Partial<AcornSettings["agents"]["ollama"]>;
+      llm: Partial<AcornSettings["agents"]["llm"]>;
+    }>,
+  ) => void;
   patchSessionStartup: (
     patch: Partial<AcornSettings["sessionStartup"]>,
   ) => void;
@@ -243,9 +363,6 @@ interface SettingsState {
     patch: Partial<Omit<AcornSettings["notifications"], "events">> & {
       events?: Partial<AcornSettings["notifications"]["events"]>;
     },
-  ) => void;
-  patchCommitMessage: (
-    patch: Partial<AcornSettings["commitMessage"]>,
   ) => void;
   reset: () => void;
 }
@@ -259,6 +376,23 @@ export const useSettings = create<SettingsState>((set) => ({
       const next: AcornSettings = {
         ...s.settings,
         terminal: { ...s.settings.terminal, ...patch },
+      };
+      persist(next);
+      return { settings: next };
+    }),
+  patchAgents: (patch) =>
+    set((s) => {
+      const next: AcornSettings = {
+        ...s.settings,
+        agents: {
+          ...s.settings.agents,
+          ...(patch.selected !== undefined ? { selected: patch.selected } : {}),
+          ...(patch.customCommand !== undefined
+            ? { customCommand: patch.customCommand }
+            : {}),
+          ollama: { ...s.settings.agents.ollama, ...(patch.ollama ?? {}) },
+          llm: { ...s.settings.agents.llm, ...(patch.llm ?? {}) },
+        },
       };
       persist(next);
       return { settings: next };
@@ -307,94 +441,138 @@ export const useSettings = create<SettingsState>((set) => ({
       persist(next);
       return { settings: next };
     }),
-  patchCommitMessage: (patch) =>
-    set((s) => {
-      const next: AcornSettings = {
-        ...s.settings,
-        commitMessage: { ...s.settings.commitMessage, ...patch },
-      };
-      persist(next);
-      return { settings: next };
-    }),
   reset: () => {
     persist(DEFAULT_SETTINGS);
     set({ settings: DEFAULT_SETTINGS });
   },
 }));
 
-/**
- * Resolve the command (and args) used to spawn a session's PTY based on the
- * current `sessionStartup` setting.
- *
- * - `terminal` → empty string; the Rust pty_spawn falls back to `$SHELL`
- * - `claude`   → `claude` binary
- * - `custom`   → user-provided command, falls back to terminal when blank
- */
-export function resolveStartupCommand(s: AcornSettings): {
+interface ResolvedCommand {
   command: string;
   args: string[];
-} {
-  if (s.sessionStartup.mode === "claude") {
-    return { command: "claude", args: [] };
+}
+
+/**
+ * Interactive PTY invocation for an agent. Used by Sessions startup when
+ * mode === "agent". Each provider's CLI launches into a chat/REPL loop.
+ */
+function agentInteractiveCommand(
+  agent: AgentProvider,
+  agents: AcornSettings["agents"],
+): ResolvedCommand {
+  switch (agent) {
+    case "claude":
+      return { command: "claude", args: [] };
+    case "gemini":
+      return { command: "gemini", args: [] };
+    case "codex":
+      return { command: "codex", args: [] };
+    case "ollama": {
+      const model = agents.ollama.model.trim() || "llama3";
+      return { command: "ollama", args: ["run", model] };
+    }
+    case "llm": {
+      const model = agents.llm.model.trim();
+      return model
+        ? { command: "llm", args: ["chat", "-m", model] }
+        : { command: "llm", args: ["chat"] };
+    }
+  }
+}
+
+/**
+ * One-shot stdin → stdout invocation for an agent. Used by the merge
+ * dialog's "Generate with AI" action. Codex has no documented headless
+ * mode here, so users who need codex specifically should select Custom
+ * and supply their own one-shot incantation.
+ */
+function agentOneshotCommand(
+  agent: AgentProvider,
+  agents: AcornSettings["agents"],
+): ResolvedCommand {
+  switch (agent) {
+    case "claude":
+      return { command: "claude", args: ["-p", "--output-format", "text"] };
+    case "gemini":
+      return { command: "gemini", args: ["-p"] };
+    case "codex":
+      return { command: "codex", args: [] };
+    case "ollama": {
+      const model = agents.ollama.model.trim() || "llama3";
+      return { command: "ollama", args: ["run", model] };
+    }
+    case "llm": {
+      const model = agents.llm.model.trim();
+      return model
+        ? { command: "llm", args: ["-m", model] }
+        : { command: "llm", args: [] };
+    }
+  }
+}
+
+function tokenizeCustom(raw: string): ResolvedCommand | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const parts = trimmed.split(/\s+/);
+  return { command: parts[0], args: parts.slice(1) };
+}
+
+/**
+ * Resolve the command (and args) used to spawn a session's PTY based on
+ * the current `sessionStartup` setting.
+ *
+ * - `terminal` → empty command; the Rust pty_spawn falls back to `$SHELL`
+ * - `agent`    → globally selected agent's interactive invocation, or
+ *                the agent custom command when selected === "custom"
+ * - `custom`   → sessionStartup.customCommand (separate from the agent
+ *                custom command), falls back to terminal when blank
+ */
+export function resolveStartupCommand(s: AcornSettings): ResolvedCommand {
+  if (s.sessionStartup.mode === "agent") {
+    if (s.agents.selected === "custom") {
+      return (
+        tokenizeCustom(s.agents.customCommand) ??
+        agentInteractiveCommand("claude", s.agents)
+      );
+    }
+    return agentInteractiveCommand(s.agents.selected, s.agents);
   }
   if (s.sessionStartup.mode === "custom") {
-    const trimmed = s.sessionStartup.customCommand.trim();
-    if (!trimmed) return { command: "", args: [] };
-    // Light tokenisation: split on whitespace, no shell interpretation.
-    const parts = trimmed.split(/\s+/);
-    return { command: parts[0], args: parts.slice(1) };
+    return tokenizeCustom(s.sessionStartup.customCommand) ?? {
+      command: "",
+      args: [],
+    };
   }
   return { command: "", args: [] };
 }
 
 /**
  * Resolve the AI CLI invocation for the merge dialog's "Generate with AI"
- * action. Each provider has its own argv convention; `custom` lets the user
- * plug in anything that follows the standard `stdin = prompt, stdout =
- * response` shape. The resolved value is sent to the Rust backend as
+ * action. The resolved value is sent to the Rust backend as
  * `(command, args)` so the backend stays provider-agnostic.
  */
-export function resolveAiCommitCommand(s: AcornSettings): {
-  command: string;
-  args: string[];
-} {
-  const c = s.commitMessage;
-  switch (c.provider) {
-    case "claude":
-      return { command: "claude", args: ["-p", "--output-format", "text"] };
-    case "gemini":
-      return { command: "gemini", args: ["-p"] };
-    case "ollama": {
-      const model = c.ollamaModel.trim() || "llama3";
-      return { command: "ollama", args: ["run", model] };
-    }
-    case "llm": {
-      const model = c.llmModel.trim();
-      return model
-        ? { command: "llm", args: ["-m", model] }
-        : { command: "llm", args: [] };
-    }
-    case "custom": {
-      const trimmed = c.customCommand.trim();
-      if (!trimmed) {
-        // Empty custom falls back to claude so the button still does
-        // something predictable rather than failing with "No AI command".
-        return { command: "claude", args: ["-p", "--output-format", "text"] };
-      }
-      const parts = trimmed.split(/\s+/);
-      return { command: parts[0], args: parts.slice(1) };
-    }
+export function resolveAiCommitCommand(s: AcornSettings): ResolvedCommand {
+  if (s.agents.selected === "custom") {
+    return (
+      tokenizeCustom(s.agents.customCommand) ??
+      agentOneshotCommand("claude", s.agents)
+    );
   }
+  return agentOneshotCommand(s.agents.selected, s.agents);
 }
 
 /**
- * Human-friendly label for the currently configured AI provider — used in
- * the merge dialog's tooltip ("Generate via Claude Code", "Generate via
- * Ollama", etc.) so the user can see at a glance which CLI will run.
+ * Human-friendly label for the global agent selection. Used by the merge
+ * dialog tooltip and the Sessions tab description so the user sees at a
+ * glance which CLI will run before clicking Generate or starting a
+ * session.
  */
-export function aiCommitProviderLabel(s: AcornSettings): string {
-  const opt = AI_COMMIT_PROVIDER_OPTIONS.find(
-    (o) => o.value === s.commitMessage.provider,
+export function selectedAgentLabel(s: AcornSettings): string {
+  if (s.agents.selected === "custom") return "Custom command";
+  return (
+    AGENT_OPTIONS.find((o) => o.value === s.agents.selected)?.label ?? "AI"
   );
-  return opt?.label ?? "AI";
 }
+
+/** Backwards-compat alias for callers that still read this name. */
+export const aiCommitProviderLabel = selectedAgentLabel;


### PR DESCRIPTION
## Summary

Reframes Settings as having a **single AI agent selection** that powers every AI feature in acorn. Pick one agent (or a Custom command) under the new **Agents** tab and both surfaces that spawn AI CLIs use it:

- **Sessions startup** — when mode is set to `Agent`, the session worktree launches the configured agent's interactive PTY.
- **Pull Requests → "Generate with AI"** — the merge dialog's commit-message generator runs the same agent as a one-shot CLI.

The previous design had a duplicated agent picker on every tab (Sessions had its own claude/terminal/custom switch, the now-removed Pull Requests tab had its own provider picker, and per-provider model fields were duplicated). The new flow:

1. Choose an agent once under **Agents**.
2. **Sessions** keeps a Terminal / Agent / Custom mode picker — the Agent card shows which agent will run.
3. The merge dialog's tooltip reflects the active agent ("Generate via Claude Code", "Generate via Ollama", …).

## Built-in agents

| Agent | Interactive | One-shot |
| --- | --- | --- |
| Claude Code | `claude` | `claude -p --output-format text` |
| Gemini CLI | `gemini` | `gemini -p` |
| Ollama (local) | `ollama run <model>` | `ollama run <model>` |
| llm CLI | `llm chat [-m <model>]` | `llm [-m <model>]` |
| OpenAI Codex CLI | `codex` | `codex` (no documented headless mode) |
| Custom | tokenised user command, no shell expansion | same |

## Schema changes (with backwards-compatible loader migration)

- New: `agents.selected: AgentProvider | "custom"` is the single source of truth.
- New: `agents.customCommand` powers both interactive and one-shot custom invocations. Empty falls back to Claude Code.
- New: `agents.ollama.model` / `agents.llm.model` live once at the top level so changing the model updates every call site.
- Old `commitMessage` block removed; loader lifts every field (`provider`, `customCommand`, `ollamaModel`, `llmModel`) into `agents.*`.
- `sessionStartup.agent` removed; loader collapses legacy `mode === "claude"` into `mode: "agent"` plus seeding `agents.selected = "claude"` if nothing else has set it.

## UI changes

- **Agents tab (new)**: leading notice that the selected agent powers every AI feature in acorn. Radio cards for the five agents plus Custom. Per-agent fields (Ollama model, llm model, custom command) appear only when the matching agent is selected.
- **Sessions tab**: still has the Terminal / Agent / Custom mode picker. The Agent card description now shows the currently selected agent name instead of offering a second picker.
- **Pull Requests tab removed entirely** (commit message generation falls back to the global selection).

## Test plan

- [x] Existing Claude users (default Terminal mode) → no change.
- [x] Switching to Agent mode + claude selected → session worktree spawns `claude` interactive.
- [ ] Switching to Agent mode + Ollama with a model field → spawns `ollama run <model>`.
- [x] Generate with AI in merge dialog reflects the agent name in its tooltip and runs the resolved one-shot command.
- [x] Custom agent with empty command falls back to Claude Code in both surfaces.
- [ ] Loader migration: install with old `commitMessage` block → new `agents.*` block populated correctly on first load.
- [x] `bun run typecheck` clean.
- [x] `bun run test` passing (87 + 1 skipped).
- [ ] `bun run build` clean.
