### PR TITLE
fix(merge-dialog): drop in-flight AI generation result after dialog close

### DIFF
--- a/src/components/MergePullRequestDialog.tsx
+++ b/src/components/MergePullRequestDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { GitMerge, Sparkles } from "lucide-react";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
@@ -58,10 +58,19 @@ export function MergePullRequestDialog({
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Monotonic counter that bumps on every open/close so in-flight AI
+  // generation calls can detect that the dialog was reset under them. The
+  // Tauri invoke itself can't be aborted, so we instead drop the result
+  // when the captured epoch no longer matches `epochRef.current` — without
+  // this, closing the dialog mid-generate and reopening it would let the
+  // original response silently overwrite the freshly-reset commit message.
+  const epochRef = useRef(0);
+
   // Reset to a clean state every time the dialog opens against a new PR. The
   // method is loaded from prefs so the user's last choice persists across PRs.
   useEffect(() => {
     if (!open || !detail) return;
+    epochRef.current += 1;
     setMethod(loadLastMergeMethod());
     setTitle(detail.title);
     setBody(detail.body);
@@ -69,6 +78,16 @@ export function MergePullRequestDialog({
     setSubmitting(false);
     setGenerating(false);
   }, [open, detail]);
+
+  // Close also bumps the epoch — a generate kicked off right before the
+  // user dismissed the dialog must be invalidated even if they never
+  // reopen, so its `setGenerating(false)` (and any error) doesn't leak
+  // back into a future open.
+  useEffect(() => {
+    if (!open) {
+      epochRef.current += 1;
+    }
+  }, [open]);
 
   useDialogShortcuts(open, {
     onCancel: () => {
@@ -103,6 +122,7 @@ export function MergePullRequestDialog({
 
   async function handleGenerate() {
     if (!detail) return;
+    const epoch = epochRef.current;
     setGenerating(true);
     setError(null);
     try {
@@ -114,12 +134,17 @@ export function MergePullRequestDialog({
         command,
         args,
       );
+      // Dialog was closed (or reopened against another PR) while the
+      // CLI was running — drop the result so it doesn't clobber whatever
+      // the dialog is currently showing.
+      if (epoch !== epochRef.current) return;
       if (result.title.trim()) setTitle(result.title);
       setBody(result.body);
     } catch (e) {
+      if (epoch !== epochRef.current) return;
       setError(String(e));
     } finally {
-      setGenerating(false);
+      if (epoch === epochRef.current) setGenerating(false);
     }
   }
 


### PR DESCRIPTION
## Summary

If the user clicked **Generate with AI** in the merge dialog and then dismissed the dialog while the CLI was still running, reopening the dialog allowed the original response to silently overwrite the freshly-reset commit message. The user never asked to generate this time — they just reopened the dialog — but the prior generation's title + body landed anyway.

Tauri invokes can't be aborted from the frontend, so the fix is to invalidate the in-flight call instead. The dialog now tracks a monotonic `epochRef` that bumps on every open and every close. `handleGenerate` captures the epoch at start and drops its result (plus skips the trailing `setGenerating(false)` and `setError`) when the epoch no longer matches.

## Reproduce on `main`

1. Open a PR's merge dialog.
2. Click **Generate with AI** — `Generating…` shows.
3. While that CLI is running, click **Cancel** to close the dialog.
4. Reopen the merge dialog for the same PR.
5. Wait a moment.

Old behavior: the title + body fields silently get overwritten with the prior generation's output once the CLI finishes.
New behavior: the original generation's result is dropped; the reopened dialog stays clean until the user asks to generate again.

## Test plan

- [x] Reproduce the steps above on this branch — original generation no longer leaks into the reopened dialog.
- [x] Open dialog → Generate with AI → wait for completion (no close) → result still applies as before.
- [x] Open dialog → Generate → close → never reopen. No console error from stale state updates.
- [ ] `bun run typecheck` clean.
- [ ] `bun run test` passing.
