### PR TITLE
fix(status): map end_turn to NeedsInput so notifications fire

### DIFF
--- a/src-tauri/src/session_status.rs
+++ b/src-tauri/src/session_status.rs
@@ -1,10 +1,13 @@
 //! Detects a Claude Code session's live status by inspecting the tail of its
 //! JSONL transcript. Status mapping:
 //!
-//! - last assistant turn with `stop_reason=end_turn` → Idle (waiting on user)
+//! - last assistant turn with `stop_reason=end_turn` → NeedsInput (claude
+//!   has finished its turn and is awaiting the user's next prompt). Surfaces
+//!   the warning-tone status dot in the Sidebar and triggers the
+//!   `needsInput` system notification when the user has it enabled.
 //! - last assistant turn with `stop_reason=tool_use` → Running (tool pending)
 //! - last user turn (new prompt or tool_result) → Running (assistant pending)
-//! - no transcript yet → Idle
+//! - no transcript yet → Idle (session has not produced any conversation)
 //!
 //! Meta-only lines (type `last-prompt`, `permission-mode`, `attachment`,
 //! `file-history-snapshot`) are ignored when picking the last message. The
@@ -38,7 +41,7 @@ pub fn detect(session_id: &str) -> AppResult<SessionStatus> {
     let last_kind = last_meaningful_kind(&tail, read_full);
 
     Ok(match last_kind {
-        Some(LastKind::AssistantEndTurn) => SessionStatus::Idle,
+        Some(LastKind::AssistantEndTurn) => SessionStatus::NeedsInput,
         Some(LastKind::AssistantToolUse) => SessionStatus::Running,
         Some(LastKind::User) => SessionStatus::Running,
         None => SessionStatus::Idle,


### PR DESCRIPTION
## Summary

System notifications never fire in practice because `session_status::detect` only ever returns `Idle` or `Running`, but the watcher (`startSessionNotificationWatcher`) only notifies on transitions to `needs_input`, `failed`, or `completed`.

The mapping that should have been `NeedsInput` — claude finished its turn (`stop_reason=end_turn`) and is awaiting the user — was attached to `Idle`. The docstring even said "(waiting on user)" in parentheses, which describes `NeedsInput` exactly. Switch the enum to match the semantic.

## Effects

- Sessions where claude has just finished a turn now show the warning-tone status dot in the Sidebar instead of the muted "idle" tone, matching what the dot is supposed to mean.
- The `needsInput` system notification fires when a session transitions to that state, provided the user has notifications enabled (Settings → Notifications).
- Sessions with no transcript yet still map to `Idle`.

## Out of scope

`Failed` and `Completed` still aren't produced — those would need PTY exit-code wiring from `pty.rs::wait_loop` and a separate plumb-through. The current change addresses the most common case (claude waiting on user input) which is also the most useful notification.

## Test plan

- [ ] Open a session, send claude a prompt, wait for it to finish a turn → status dot turns warning-tone, system notification fires (with notifications enabled in Settings).
- [ ] While claude is still processing (tool use or generating) → status dot stays at the running tone, no notification.
- [ ] Brand new session with no transcript yet → idle tone, no notification.
- [ ] `cargo check` clean.
- [ ] `bun run test` passing.
