### PR TITLE
feat(settings): add 'Send test notification' button

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -2,6 +2,7 @@ import { Settings as SettingsIcon } from "lucide-react";
 import { useState } from "react";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
+import { sendTestNotification } from "../lib/notifications";
 import {
   AGENT_OPTIONS,
   type SelectedAgent,
@@ -280,6 +281,37 @@ function NotificationSettings() {
   const settings = useSettings((s) => s.settings);
   const patchNotifications = useSettings((s) => s.patchNotifications);
   const enabled = settings.notifications.enabled;
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<
+    | { tone: "success" | "warning" | "danger"; text: string }
+    | null
+  >(null);
+
+  async function handleTest() {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await sendTestNotification();
+      if (result === "sent") {
+        setTestResult({
+          tone: "success",
+          text: "Sent. Check your notification center if it didn't appear.",
+        });
+      } else if (result === "denied") {
+        setTestResult({
+          tone: "warning",
+          text: "Permission denied. Allow Acorn under System Settings → Notifications.",
+        });
+      } else {
+        setTestResult({
+          tone: "danger",
+          text: "Failed to send. See the console for details.",
+        });
+      }
+    } finally {
+      setTesting(false);
+    }
+  }
 
   return (
     <section className="space-y-4">
@@ -326,6 +358,36 @@ function NotificationSettings() {
               patchNotifications({ events: { completed: v } })
             }
           />
+        </div>
+      </Field>
+      <Field
+        label="Test"
+        hint="Verifies the OS permission and that a notification can actually appear, independent of the Enable / Trigger settings above."
+      >
+        <div className="flex flex-col items-start gap-2">
+          <button
+            type="button"
+            onClick={() => void handleTest()}
+            disabled={testing}
+            className="rounded-md bg-accent/20 px-3 py-1.5 text-xs font-medium text-fg transition hover:bg-accent/30 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {testing ? "Sending…" : "Send test notification"}
+          </button>
+          {testResult ? (
+            <p
+              className={cn(
+                "rounded-md border px-3 py-1.5 text-[11px]",
+                testResult.tone === "success" &&
+                  "border-emerald-500/40 bg-emerald-500/10 text-emerald-300",
+                testResult.tone === "warning" &&
+                  "border-warning/40 bg-warning/10 text-warning",
+                testResult.tone === "danger" &&
+                  "border-danger/40 bg-danger/10 text-danger",
+              )}
+            >
+              {testResult.text}
+            </p>
+          ) : null}
         </div>
       </Field>
       <p className="text-[11px] text-fg-muted">

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -97,3 +97,28 @@ async function fire(session: Session): Promise<void> {
     console.error("[notifications] sendNotification failed", err);
   }
 }
+
+/**
+ * Send a one-off "this is a test" system notification, surfaced from the
+ * Notifications settings tab so the user can confirm the OS-level
+ * permission and sound/visibility plumbing works without waiting for a
+ * real session-status transition. Returns the resolved status:
+ *
+ * - `"sent"`  — fire-and-forget succeeded
+ * - `"denied"` — the OS rejected (or the user dismissed) the permission prompt
+ * - `"error"` — `sendNotification` threw; details are logged to the console
+ */
+export async function sendTestNotification(): Promise<"sent" | "denied" | "error"> {
+  const ok = await ensurePermission();
+  if (!ok) return "denied";
+  try {
+    sendNotification({
+      title: "Acorn — test notification",
+      body: "If you can see this, system notifications are working.",
+    });
+    return "sent";
+  } catch (err) {
+    console.error("[notifications] test sendNotification failed", err);
+    return "error";
+  }
+}


### PR DESCRIPTION
## Summary

Without a self-test path the user has no way to confirm whether system notifications actually fire — they have to wait for a real session-status transition and then investigate from cold. This PR adds a dedicated test button on the Notifications tab that calls the same `sendNotification` plumbing used by the watcher.

## Result feedback

The button surfaces a tone-coded result inline:

- **Sent** — fire-and-forget succeeded; the user should see it in Notification Center.
- **Permission denied** — the OS prompt was rejected; the hint points at System Settings → Notifications.
- **Send failed** — `sendNotification` threw; details land in the console.

## Test plan

- [ ] Click the button → notification appears in macOS Notification Center; inline message says "Sent."
- [ ] Reject permission on first prompt → button reports "Permission denied" with the System Settings hint.
- [ ] Test path runs regardless of the Enable / Trigger checkboxes — its purpose is OS plumbing verification.
- [ ] `bun run typecheck` clean.
- [ ] `bun run test` passing.
- [ ] `bun run build` clean.
