### PR TITLE
refactor(status-bar): group branch info next to GitHub account badge

### DIFF
--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -108,20 +108,22 @@ export function StatusBar() {
     <>
       <footer className="flex h-7 shrink-0 items-center gap-3 border-t border-border bg-bg-sidebar px-3 font-mono text-xs text-fg-muted">
         <span>sessions: {sessions.length}</span>
-        {active ? (
-          <>
-            <span className="text-fg-muted/50">|</span>
-            <span>branch: {active.branch}</span>
-            <span className="text-fg-muted/50">|</span>
-            <span>status: {active.status}</span>
-          </>
-        ) : null}
         <span className="ml-auto flex min-w-0 items-center gap-3">
           {loading ? <span>working...</span> : null}
           {error ? (
             <Tooltip label={error} side="top" multiline>
               <span className="truncate text-danger">error: {error}</span>
             </Tooltip>
+          ) : null}
+          {active ? (
+            <>
+              <span>branch: {active.branch}</span>
+              <span className="text-fg-muted/50">|</span>
+              <span>status: {active.status}</span>
+              {prAccount || displayPath ? (
+                <span className="text-fg-muted/50">|</span>
+              ) : null}
+            </>
           ) : null}
           {prAccount ? (
             <Tooltip label={`PRs listed via gh account ${prAccount}`} side="top">


### PR DESCRIPTION
## Summary
- Move `branch` / `status` from the left side of the status bar to the right side, just before the GitHub account badge, so repo-related metadata (branch, status, PR account, worktree path) is grouped together.
- Suppress the trailing `|` separator after `status` when neither the PR account badge nor the worktree path is rendered, avoiding double pipes.

## Test plan
- [ ] Open the app and confirm the bottom status bar shows: `sessions: N` on the left, then `branch | status | <github icon nickname> <path> | mem` on the right.
- [ ] Open a project with no resolved PR account and confirm no double `|` appears between `status` and `mem`.
- [ ] Resize the window narrow enough to truncate the path and verify the right cluster still wraps cleanly.
