### PR TITLE
fix(terminal): guard PTY spawn against StrictMode double-mount race

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -466,6 +466,7 @@ export function Terminal({
     let exited = false;
 
     async function spawnPty() {
+      if (disposed) return;
       try {
         const startup = resolveStartupCommand(
           useSettings.getState().settings,
@@ -490,10 +491,12 @@ export function Terminal({
           } catch (e) {
             console.error("[Terminal] claude_session_exists failed", e);
           }
+          if (disposed) return;
           args = exists
             ? [...startup.args, "--resume", sessionId]
             : [...startup.args, "--session-id", sessionId];
         }
+        if (disposed) return;
         await invoke("pty_spawn", {
           sessionId,
           cwd,
@@ -501,6 +504,14 @@ export function Terminal({
           args,
           env: {},
         });
+        if (disposed) {
+          // Cleanup ran mid-spawn — the pty just got created has no UI.
+          // Issue a kill so we do not leak a child process.
+          invoke("pty_kill", { sessionId }).catch(() => {
+            // best effort
+          });
+          return;
+        }
         exited = false;
       } catch (err) {
         if (!disposed) {
@@ -511,6 +522,15 @@ export function Terminal({
       }
     }
 
+    // React StrictMode in dev runs effects twice (mount → cleanup → mount).
+    // Without per-await `disposed` guards, the first IIFE keeps progressing
+    // after its cleanup has run, and ends up issuing `pty_spawn` for a
+    // session whose UI (term, listeners) was already torn down. Combined
+    // with the second mount's IIFE issuing its own spawn, two real PTY
+    // children get forked for the same session id; the backend insert
+    // collision then orphans one PTY, which exits and triggers the second
+    // PTY to also exit (zsh prints "Saving session..." twice). Guard every
+    // await resumption point so a disposed mount short-circuits cleanly.
     (async () => {
       try {
         const unlistenOutput = await listen<PtyOutputPayload>(
@@ -525,6 +545,10 @@ export function Terminal({
             }
           },
         );
+        if (disposed) {
+          unlistenOutput();
+          return;
+        }
         unlistenFns.push(unlistenOutput);
 
         const unlistenExit = await listen(`pty:exit:${sessionId}`, () => {
@@ -534,6 +558,10 @@ export function Terminal({
             `\r\n${ANSI_DIM}[process exited — press Enter to restart]${ANSI_RESET}\r\n`,
           );
         });
+        if (disposed) {
+          unlistenExit();
+          return;
+        }
         unlistenFns.push(unlistenExit);
       } catch (err) {
         if (!disposed) {
@@ -541,7 +569,10 @@ export function Terminal({
             `\r\n${ANSI_RED}[acorn] Failed to attach pty listeners: ${formatError(err)}${ANSI_RESET}\r\n`,
           );
         }
+        return;
       }
+
+      if (disposed) return;
 
       // Intercept Enter while exited to respawn the same session in-place.
       const restartDisposable = term.onKey(({ domEvent }) => {
@@ -563,7 +594,8 @@ export function Terminal({
         const saved = await invoke<string | null>("scrollback_load", {
           sessionId,
         });
-        if (!disposed && saved && saved.length > 0) {
+        if (disposed) return;
+        if (saved && saved.length > 0) {
           term.write(saved);
           term.write(
             `\r\n${ANSI_DIM}— restored from previous session —${ANSI_RESET}\r\n`,
@@ -573,6 +605,7 @@ export function Terminal({
         console.warn("[Terminal] scrollback_load failed", err);
       }
 
+      if (disposed) return;
       await spawnPty();
     })();
 


### PR DESCRIPTION
## Summary

Fixes a `React.StrictMode` race in `Terminal.tsx` that caused new sessions (especially with `startup = Terminal`) to spawn two PTY children for the same session id, both of which immediately died with zsh's "Saving session..." + "[process exited — press Enter to restart]" message appearing twice.

## Root cause

`React.StrictMode` runs every `useEffect` twice in dev (mount → cleanup → mount). The Terminal IIFE had no `disposed` checks at its await resumption points, so:

1. Mount A's IIFE kept progressing after cleanup A → issued `pty_spawn` for a session whose UI was torn down.
2. Mount B's IIFE issued its own `pty_spawn` for the same session id.
3. A backend `contains_key` + `insert` race in `pty.rs::spawn` let both real PTY children get forked.
4. The orphaned PtyHandle was dropped → its `wait_loop` removed the *live* handle from `DashMap` (same key) → the live PTY also EOF'd.
5. User saw two zsh logout sequences and two "[process exited]" banners.

Existing sessions worked because `scrollback_load` adds enough latency that the spawn arrives at the backend after cleanup's `pty_kill`, hiding the race.

## Fix (frontend-only, minimal)

Add `disposed` guards after every `await` in the Terminal IIFE and inside `spawnPty()`:

- Listener registration: if cleanup ran while `await listen(...)` was pending, immediately invoke the just-returned unsubscribe and return — no leak.
- `spawnPty`: short-circuit before each invoke if `disposed`. If cleanup races a `pty_spawn` that already returned, fire a `pty_kill` so we do not orphan a real child process.

## Out of scope (follow-up)

The backend `contains_key` + `insert` in `pty.rs::spawn` is still non-atomic, and `wait_loop` does an unconditional `remove` that can evict a sibling handle. A future PR should make those atomic and use `remove_if(Arc::ptr_eq)` semantics. With this PR's guards in place, the frontend no longer issues concurrent spawns for the same session, so the latent backend race is no longer reachable from the normal app flow.

## Test plan

- [x] `bun run tauri dev`, create a fresh session with `startup = Terminal`. Verify zsh prompt appears once, no "Saving session..." spam.
- [x] Restart app with the same session present. Verify scrollback restore + single fresh spawn.
- [x] Create a session with `startup = Agent` (claude). Verify single spawn, no duplicate `--session-id` rejection.
- [x] Run `bunx tsc --noEmit`. No errors.
- [x] Run `cargo check` in `src-tauri`. No errors.
