### PR TITLE
feat(session): persist per-session PTY startup mode

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,7 +13,7 @@ use crate::pull_requests::{
     PullRequestListing,
 };
 use crate::scrollback;
-use crate::session::{Project, Session, SessionStatus};
+use crate::session::{Project, Session, SessionStartupMode, SessionStatus};
 use crate::session_status;
 use crate::state::AppState;
 use crate::todos::{self, TodoItem};
@@ -154,6 +154,7 @@ pub async fn create_session(
     name: String,
     repo_path: String,
     isolated: Option<bool>,
+    startup_mode: Option<SessionStartupMode>,
 ) -> AppResult<Session> {
     let repo = PathBuf::from(&repo_path);
     if !repo.exists() {
@@ -169,7 +170,14 @@ pub async fn create_session(
     } else {
         repo.clone()
     };
-    let session = Session::new(name, repo.clone(), worktree_path, branch, isolated);
+    let session = Session::new(
+        name,
+        repo.clone(),
+        worktree_path,
+        branch,
+        isolated,
+        startup_mode,
+    );
     let inserted = state.sessions.insert(session);
     state
         .projects

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -121,6 +121,20 @@ pub enum SessionStatus {
     Completed,
 }
 
+/// Persisted per-session PTY startup mode. Captured when the session is
+/// created (and updated whenever a future UI lets the user re-pick), so
+/// changing the global `sessionStartup.mode` setting does not retroactively
+/// change how existing sessions respawn after an app restart. Older
+/// persisted sessions without this field load as `None`, in which case
+/// the frontend falls back to the current global setting.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionStartupMode {
+    Agent,
+    Terminal,
+    Custom,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     pub id: Uuid,
@@ -134,6 +148,8 @@ pub struct Session {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub last_message: Option<String>,
+    #[serde(default)]
+    pub startup_mode: Option<SessionStartupMode>,
 }
 
 impl Session {
@@ -143,6 +159,7 @@ impl Session {
         worktree_path: PathBuf,
         branch: String,
         isolated: bool,
+        startup_mode: Option<SessionStartupMode>,
     ) -> Self {
         let now = Utc::now();
         Self {
@@ -156,6 +173,7 @@ impl Session {
             created_at: now,
             updated_at: now,
             last_message: None,
+            startup_mode,
         }
     }
 }

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -92,7 +92,17 @@ export function Pane({ paneId }: PaneProps) {
     setFocusedPane(paneId);
     const name = suggestSessionName(repoPath, sessions);
     try {
-      const created = await api.createSession(name, repoPath, false);
+      // Snapshot the current global startup mode onto the new session so
+      // changing the default later does not retroactively swap how this
+      // session respawns after an app restart.
+      const startupMode =
+        useSettings.getState().settings.sessionStartup.mode;
+      const created = await api.createSession(
+        name,
+        repoPath,
+        false,
+        startupMode,
+      );
       await useAppStore.getState().refreshAll();
       selectSession(created.id);
     } catch (err) {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -660,7 +660,15 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
       n += 1;
     }
     try {
-      await api.createSession(next, session.repo_path, session.isolated);
+      // Carry the source session's startup mode onto the duplicate so
+      // the duplicate respawns with the same kind of process, regardless
+      // of the current global default.
+      await api.createSession(
+        next,
+        session.repo_path,
+        session.isolated,
+        session.startup_mode,
+      );
       await useAppStore.getState().refreshAll();
     } catch (err) {
       console.error("[Sidebar] duplicate session failed", err);

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -7,10 +7,18 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import "@xterm/xterm/css/xterm.css";
 import { resolveStartupCommand, useSettings } from "../lib/settings";
+import type { SessionStartupMode } from "../lib/types";
 
 interface TerminalProps {
   sessionId: string;
   cwd: string;
+  /**
+   * Per-session startup mode persisted on `Session.startup_mode`. `null`
+   * (or omitted) means the session has no recorded preference (legacy
+   * sessions created before this field existed) — the spawn falls back
+   * to the global `sessionStartup.mode` setting in that case.
+   */
+  startupMode?: SessionStartupMode | null;
   /**
    * When the terminal is hidden behind another tab in the same pane and then
    * made visible again, the DOM renderer can leave the rows blank because it
@@ -62,6 +70,7 @@ function encodeStringToBase64(input: string): string {
 export function Terminal({
   sessionId,
   cwd,
+  startupMode = null,
   isActive = true,
 }: TerminalProps): ReactElement {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -470,6 +479,7 @@ export function Terminal({
       try {
         const startup = resolveStartupCommand(
           useSettings.getState().settings,
+          startupMode,
         );
         // When launching the `claude` CLI, pin the transcript path to our
         // session UUID. claude refuses `--session-id` for an id that

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -105,6 +105,7 @@ function PortaledTerminal({ session }: { session: Session }) {
     <Terminal
       sessionId={session.id}
       cwd={session.worktree_path}
+      startupMode={session.startup_mode}
       isActive={visiblePaneId !== null}
     />,
     targetRef.current,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   PullRequestDetailListing,
   PullRequestListing,
   Session,
+  SessionStartupMode,
   SessionStatus,
   StagedFile,
   TodoItem,
@@ -23,8 +24,14 @@ export const api = {
     name: string,
     repoPath: string,
     isolated = false,
+    startupMode: SessionStartupMode | null = null,
   ): Promise<Session> {
-    return invoke<Session>("create_session", { name, repoPath, isolated });
+    return invoke<Session>("create_session", {
+      name,
+      repoPath,
+      isolated,
+      startupMode,
+    });
   },
   removeSession(id: string, removeWorktree = false): Promise<void> {
     return invoke<void>("remove_session", { id, removeWorktree });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -56,7 +56,8 @@ export const AGENT_OPTIONS: ReadonlyArray<{
   },
 ];
 
-export type SessionStartupMode = "agent" | "terminal" | "custom";
+export type { SessionStartupMode } from "./types";
+import type { SessionStartupMode } from "./types";
 
 export type TerminalFontWeight =
   | 100
@@ -526,9 +527,18 @@ function tokenizeCustom(raw: string): ResolvedCommand | null {
  *                the agent custom command when selected === "custom"
  * - `custom`   → sessionStartup.customCommand (separate from the agent
  *                custom command), falls back to terminal when blank
+ *
+ * `modeOverride` lets a per-session preference (persisted on `Session`)
+ * win over the global setting so changing `sessionStartup.mode` does not
+ * retroactively swap the startup of existing sessions on respawn. `null`
+ * or `undefined` means "no per-session preference" → use the global.
  */
-export function resolveStartupCommand(s: AcornSettings): ResolvedCommand {
-  if (s.sessionStartup.mode === "agent") {
+export function resolveStartupCommand(
+  s: AcornSettings,
+  modeOverride?: SessionStartupMode | null,
+): ResolvedCommand {
+  const mode = modeOverride ?? s.sessionStartup.mode;
+  if (mode === "agent") {
     if (s.agents.selected === "custom") {
       return (
         tokenizeCustom(s.agents.customCommand) ??
@@ -537,7 +547,7 @@ export function resolveStartupCommand(s: AcornSettings): ResolvedCommand {
     }
     return agentInteractiveCommand(s.agents.selected, s.agents);
   }
-  if (s.sessionStartup.mode === "custom") {
+  if (mode === "custom") {
     return tokenizeCustom(s.sessionStartup.customCommand) ?? {
       command: "",
       args: [],

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,15 @@ export type SessionStatus =
   | "failed"
   | "completed";
 
+/**
+ * Per-session PTY startup mode persisted on the backend `Session` so the
+ * choice survives an app restart and is decoupled from the global
+ * `sessionStartup.mode` setting. `null` means "no per-session preference
+ * recorded yet" (legacy sessions); the Terminal falls back to the global
+ * setting in that case.
+ */
+export type SessionStartupMode = "agent" | "terminal" | "custom";
+
 export interface Session {
   id: string;
   name: string;
@@ -16,6 +25,7 @@ export interface Session {
   created_at: string;
   updated_at: string;
   last_message: string | null;
+  startup_mode: SessionStartupMode | null;
 }
 
 export interface Project {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -62,6 +62,7 @@ function session(
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     last_message: null,
+    startup_mode: null,
     ...overrides,
   };
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { api } from "./lib/api";
+import { useSettings } from "./lib/settings";
 import type { Project, Session } from "./lib/types";
 import {
   type Direction,
@@ -633,7 +634,11 @@ export const useAppStore = create<AppStateModel>()(
   async createSession(name, repoPath, isolated = false) {
     set({ loading: true, error: null });
     try {
-      await api.createSession(name, repoPath, isolated);
+      // Snapshot the current global startup mode onto the session so a
+      // later change to `sessionStartup.mode` does not retroactively swap
+      // how this session respawns after an app restart.
+      const startupMode = useSettings.getState().settings.sessionStartup.mode;
+      await api.createSession(name, repoPath, isolated, startupMode);
       await get().refreshAll();
       // Ensure the project of the new session is active so its tab shows up.
       set((s) => {


### PR DESCRIPTION
## Summary

Sessions now persist the `sessionStartup.mode` they were created under, so toggling the global default later does not retroactively change how existing sessions respawn after an app restart.

## Bug being fixed

A session opened as `Terminal` (or `Agent`, or `Custom`) would respawn with whatever the user's *current* global `sessionStartup.mode` was, not the mode it had when the user originally opened it. Repro:

1. Set global `sessionStartup.mode = Terminal`. Open session A → A spawns a shell.
2. Open session B → also a shell. In B, run `claude`, then exit it.
3. Open session C with global flipped to `Agent` → C spawns claude.
4. Quit and reopen the app. Expected: A=shell, B=shell, C=claude. Actual: all three follow the *current* global, so flipping the global to e.g. `Agent` makes A and B both come back as claude.

Root cause: `Session` had no `startup_mode` field, and `resolveStartupCommand` always read `settings.sessionStartup.mode`.

## Implementation

- **Backend** (`session.rs`, `commands.rs`):
  - New `SessionStartupMode` enum (`agent` | `terminal` | `custom`).
  - `Session.startup_mode: Option<SessionStartupMode>` persisted on disk via `#[serde(default)]` so legacy session files deserialize cleanly as `None`.
  - `create_session(... , startup_mode: Option<SessionStartupMode>)` accepts and stores the mode.
- **Frontend** (`types.ts`, `api.ts`, `settings.ts`, `store.ts`, `Terminal.tsx`, `TerminalHost.tsx`):
  - `Session.startup_mode: SessionStartupMode | null` in the TS mirror.
  - `resolveStartupCommand(settings, modeOverride?)` — the per-session value wins over the global; `null`/`undefined` keeps the legacy "follow global" fallback.
  - `useAppStore.createSession` snapshots the current global mode and forwards it to `api.createSession`.
  - `Terminal` takes a new `startupMode` prop, wired in `TerminalHost` from `Session.startup_mode`.

## Migration

- Sessions persisted before this PR have no `startup_mode` field on disk → load as `None` → fall back to the global setting (current behavior). They will only acquire a persisted mode the next time the user re-creates them.
- A future PR can add a per-session UI to set `startup_mode` in place so legacy sessions can be migrated without recreation.

## Test plan

- [x] Fresh app start with `startup = Terminal`. Create A, B, C. Set B's terminal to run `claude` then exit it. Quit app, flip global to `Agent`, reopen — verify A, B come back as shell, C still as claude.
- [x] Reverse: create with `Agent`, flip global to `Terminal`, reopen — verify each session keeps its original mode.
- [x] Open a session created on the prior version (no `startup_mode` on disk). Verify it follows the *current* global setting (legacy fallback).
- [x] `bunx tsc --noEmit` clean.
- [x] `cargo check` + `cargo test` clean.
- [x] `bun run test` (vitest) — 87 passed, 1 skipped.
