### PR TITLE
fix(pty): suppress macOS zsh per-session restore in spawned terminals

### DIFF
--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -102,6 +102,19 @@ impl PtyManager {
             cmd.arg(arg);
         }
         cmd.cwd(&cwd);
+        // Suppress macOS zsh's per-session restore (`/etc/zshrc_Apple_Terminal`).
+        // When acorn is launched from Terminal.app the child PTY inherits
+        // `TERM_PROGRAM=Apple_Terminal` and zsh treats every fresh PTY as a
+        // resumable Terminal.app session, printing "Restored session: ..."
+        // / "Saving session...completed." and writing per-session files into
+        // `~/.zsh_sessions/`. acorn manages its own session lifecycle and
+        // does not want zsh layering its own on top. `~/.zsh_history`
+        // (HISTFILE) is unaffected — only the dirstack/last-commands
+        // restore feature is disabled.
+        //
+        // Set this *before* applying the user-provided env so a user can
+        // still opt back in by passing `SHELL_SESSIONS_DISABLE=0`.
+        cmd.env("SHELL_SESSIONS_DISABLE", "1");
         for (k, v) in env {
             cmd.env(k, v);
         }


### PR DESCRIPTION
## Summary

Set `SHELL_SESSIONS_DISABLE=1` in the PTY environment so child shells stop layering macOS Terminal.app's per-session save/restore on top of acorn's own session lifecycle.

## Background

When acorn is launched from Terminal.app the child PTY inherits `TERM_PROGRAM=Apple_Terminal`. macOS's `/etc/zshrc_Apple_Terminal` then treats every fresh PTY as a resumable Terminal.app session, which produces:

- `Restored session: <date>` on every new terminal open
- `Saving session...completed.` (and sometimes `Deleting expired sessions...`) on every exit
- A growing pile of per-session files under `~/.zsh_sessions/<UUID>.session`

None of that has any effect inside acorn — acorn manages its own session lifecycle — and the extra output is just visual noise that other users would not recognise.

## What changes

`pty.rs::spawn` now sets `SHELL_SESSIONS_DISABLE=1` on the spawned command's env, *before* layering the caller-provided env so a user who really wants the feature can still opt back in by passing `SHELL_SESSIONS_DISABLE=0` in `pty_spawn`'s env arg.

## What does not change

- `~/.zsh_history` (`HISTFILE` / `HISTSIZE` / `SAVEHIST`) is independent of `SHELL_SESSIONS_DISABLE`. Up-arrow recall, `Ctrl+R` history search, and the `history` command keep working exactly as before.
- `pushd` / `popd` / the dirstack still work within a single shell — only the cross-restart restore is suppressed.
- Non-zsh shells and Linux/Windows are unaffected (the env var is unknown to them, so it is a no-op).

## Test plan

- [x] `bun run tauri dev`. Open a fresh terminal session. Verify no `Restored session: ...` line is printed.
- [x] Run a few commands, exit the shell. Verify no `Saving session...completed.` line is printed.
- [x] Start a new shell. Press `Up` — verify command history is intact across shells.
- [x] Run `echo $HISTFILE; echo $SAVEHIST` inside the shell — verify they are populated as before.
- [x] `cargo check` clean.
