### PR TITLE
fix(terminal): stop StatusBar from clipping prompt row

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -738,12 +738,14 @@ export function Terminal({
     };
   }, [isActive]);
 
+  // FitAddon subtracts padding from xterm.element, not its parent — keep the gutter on the outer wrapper so xterm's parent stays padding-free and rows don't overflow past the pane body.
   return (
     <div
-      ref={containerRef}
-      className="acorn-terminal h-full w-full"
+      className="relative h-full w-full"
       style={{ padding: "16px 8px", background: TERMINAL_BG }}
-    />
+    >
+      <div ref={containerRef} className="acorn-terminal h-full w-full" />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

When terminal output fills the viewport, the bottom of the terminal — including the live prompt row the user is typing into — was hidden behind the StatusBar.

## Root cause

`@xterm/addon-fit` proposes rows from
`parentElement.height - terminal.element.padding`,
**not** from `parentElement.padding`.

`Terminal.tsx` had `padding: 16px 8px` on the xterm-parent `<div>`, while xterm's own root element (`terminal.element`) had no padding. FitAddon therefore never subtracted the 32px vertical gutter and proposed `floor(containerH / cellH)` rows. xterm rendered the full row count starting at the parent's content-box top (offset by the 16px top padding), so its bottom edge extended up to 16px past the pane body.

The pane body sits directly above the StatusBar in the App-level flex column. With nothing clipping the overflow, the StatusBar (later in DOM order, no z-index) painted over the bottom strip of the terminal — exactly the height of the prompt cursor.

## Fix

Restructure the terminal render so padding lives on an outer wrapper and `containerRef` (the xterm parent) is padding-free:

```tsx
<div className="relative h-full w-full" style={{ padding: "16px 8px", background: TERMINAL_BG }}>
  <div ref={containerRef} className="acorn-terminal h-full w-full" />
</div>
```

`parentElement.height` now equals the real visible content area, so `rows = floor((paneBodyH - 32) / cellH)` and xterm fits cleanly within the pane body. The visual gutter is preserved by the outer wrapper.

No behavioral change to event handling — `containerRef` is still the direct ancestor of xterm's helper textarea, so capture-phase listeners (`input`, `keydown`) and `ResizeObserver` continue to work.

## Test plan

- [x] Open a session, fill the terminal with output (`yes | head -200`).
- [x] Confirm the prompt row stays fully visible above the StatusBar.
- [x] Type a long command — the cursor and last line of input remain visible.
- [x] Resize the window vertically — no row count drift, no clipping.
- [ ] Split the pane horizontally and vertically — both panes' last rows remain visible.
- [ ] CJK IME composition still anchors at the cursor (composition-view query path unchanged).
