### PR TITLE
feat(settings): add Storage tab with orphan-cache cleanup

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -442,6 +442,34 @@ pub async fn scrollback_delete(session_id: String) -> AppResult<()> {
     scrollback::delete(&session_id)
 }
 
+/// Return the on-disk size (in bytes) of scrollback files whose session
+/// id no longer matches a known session. Live sessions' buffers are not
+/// counted — only the reclaimable orphan portion is surfaced.
+#[tauri::command]
+pub async fn scrollback_orphan_size(state: State<'_, AppState>) -> AppResult<u64> {
+    let live_ids: Vec<String> = state
+        .sessions
+        .list()
+        .iter()
+        .map(|s| s.id.to_string())
+        .collect();
+    scrollback::orphan_size_bytes(live_ids)
+}
+
+/// Delete scrollback files whose session id no longer matches a known
+/// session. Live sessions are untouched — their buffers stay on disk
+/// and will keep being kept up to date by the debounced output save.
+#[tauri::command]
+pub async fn scrollback_orphan_clear(state: State<'_, AppState>) -> AppResult<usize> {
+    let live_ids: Vec<String> = state
+        .sessions
+        .list()
+        .iter()
+        .map(|s| s.id.to_string())
+        .collect();
+    scrollback::prune_orphans(live_ids)
+}
+
 #[tauri::command]
 pub async fn read_session_todos(session_id: String, cwd: String) -> AppResult<Vec<TodoItem>> {
     let cwd = PathBuf::from(cwd);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -158,6 +158,8 @@ pub fn run() {
             commands::scrollback_save,
             commands::scrollback_load,
             commands::scrollback_delete,
+            commands::scrollback_orphan_size,
+            commands::scrollback_orphan_clear,
             commands::read_session_todos,
             commands::detect_session_statuses,
             commands::get_memory_usage,

--- a/src-tauri/src/scrollback.rs
+++ b/src-tauri/src/scrollback.rs
@@ -122,6 +122,42 @@ where
     Ok(removed)
 }
 
+/// Sum of bytes used by orphan scrollback files — files whose session
+/// id no longer exists in `keep`. Files for live sessions are not
+/// counted because they cannot be safely reclaimed without losing the
+/// session's restorable buffer; the user-facing "Clear cache" UI only
+/// surfaces the reclaimable portion. Returns 0 on read errors.
+pub fn orphan_size_bytes<I, S>(keep: I) -> AppResult<u64>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let dir = scrollback_dir()?;
+    let keep_set: std::collections::HashSet<String> =
+        keep.into_iter().map(|s| s.as_ref().to_string()).collect();
+    let entries = match fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return Ok(0),
+    };
+    let mut total: u64 = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("txt") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if keep_set.contains(stem) {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata() {
+            total = total.saturating_add(meta.len());
+        }
+    }
+    Ok(total)
+}
+
 fn write_atomic(final_path: &Path, bytes: &[u8]) -> AppResult<()> {
     let tmp_path = final_path.with_extension("txt.tmp");
     fs::write(&tmp_path, bytes)?;

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,5 +1,6 @@
-import { Settings as SettingsIcon } from "lucide-react";
-import { useState } from "react";
+import { Settings as SettingsIcon, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import { sendTestNotification } from "../lib/notifications";
@@ -28,7 +29,8 @@ type Tab =
   | "agents"
   | "sessions"
   | "editor"
-  | "notifications";
+  | "notifications"
+  | "storage";
 
 const TABS: Array<{ id: Tab; label: string }> = [
   { id: "terminal", label: "Terminal" },
@@ -36,6 +38,7 @@ const TABS: Array<{ id: Tab; label: string }> = [
   { id: "sessions", label: "Sessions" },
   { id: "editor", label: "Editor" },
   { id: "notifications", label: "Notifications" },
+  { id: "storage", label: "Storage" },
 ];
 
 export function SettingsModal() {
@@ -102,8 +105,10 @@ export function SettingsModal() {
             <SessionSettings />
           ) : tab === "editor" ? (
             <EditorSettings />
-          ) : (
+          ) : tab === "notifications" ? (
             <NotificationSettings />
+          ) : (
+            <StorageSettings />
           )}
         </div>
       </div>
@@ -477,6 +482,175 @@ function AgentSettings() {
         authenticated on this machine. Surfaces a clear error when the
         binary is missing.
       </p>
+    </section>
+  );
+}
+
+/**
+ * Per-category cache descriptor surfaced in the Storage settings tab.
+ * `loadSize` returns the on-disk byte total; `clear` deletes everything
+ * the category owns and returns the number of items removed (purely for
+ * the success message). New cache categories should drop in here as
+ * additional entries — the UI iterates the list and renders one row per
+ * entry, so no further wiring is required.
+ */
+interface CacheCategory {
+  id: string;
+  label: string;
+  description: string;
+  loadSize: () => Promise<number>;
+  clear: () => Promise<number>;
+}
+
+const CACHE_CATEGORIES: CacheCategory[] = [
+  {
+    id: "scrollback-orphans",
+    label: "Orphan terminal scrollback",
+    description:
+      "ANSI scrollback files left behind by sessions that no longer exist (e.g. removed while acorn was offline, or before the prune-on-boot logic existed). Live sessions' scrollback is not touched — only the unreclaimable leftovers are surfaced.",
+    loadSize: () => api.scrollbackOrphanSize(),
+    clear: () => api.scrollbackOrphanClear(),
+  },
+];
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  return `${(mb / 1024).toFixed(2)} GB`;
+}
+
+function StorageSettings() {
+  const [sizes, setSizes] = useState<Record<string, number | null>>(() =>
+    Object.fromEntries(CACHE_CATEGORIES.map((c) => [c.id, null])),
+  );
+  const [busy, setBusy] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const refreshSizes = useCallback(async () => {
+    const results = await Promise.allSettled(
+      CACHE_CATEGORIES.map((c) => c.loadSize()),
+    );
+    setSizes(
+      Object.fromEntries(
+        CACHE_CATEGORIES.map((c, i) => {
+          const r = results[i];
+          return [c.id, r.status === "fulfilled" ? r.value : null];
+        }),
+      ),
+    );
+  }, []);
+
+  useEffect(() => {
+    void refreshSizes();
+  }, [refreshSizes]);
+
+  const totalBytes = Object.values(sizes).reduce<number>(
+    (sum, n) => sum + (n ?? 0),
+    0,
+  );
+
+  async function handleClear() {
+    setBusy(true);
+    setStatus(null);
+    try {
+      const results = await Promise.allSettled(
+        CACHE_CATEGORIES.map((c) => c.clear()),
+      );
+      const totalRemoved = results.reduce<number>(
+        (sum, r) => sum + (r.status === "fulfilled" ? r.value : 0),
+        0,
+      );
+      setStatus(
+        totalRemoved > 0
+          ? `Cleared ${totalRemoved} cached file${totalRemoved === 1 ? "" : "s"}.`
+          : "Nothing to clear.",
+      );
+      await refreshSizes();
+    } catch (err) {
+      console.error("[Settings] cache clear failed", err);
+      setStatus("Clear failed — see console.");
+    } finally {
+      setBusy(false);
+      setConfirming(false);
+    }
+  }
+
+  return (
+    <section className="space-y-4">
+      <header className="space-y-1">
+        <h3 className="text-sm font-medium text-fg">Reclaimable cache</h3>
+        <p className="text-[11px] text-fg-muted">
+          Disk artifacts that acorn cannot clean up through its normal
+          session lifecycle (e.g. files orphaned by a crash or by edits
+          made while acorn was offline). Sessions, projects, settings,
+          and live terminal scrollback are never touched.
+        </p>
+      </header>
+
+      <ul className="divide-y divide-border rounded border border-border">
+        {CACHE_CATEGORIES.map((cat) => {
+          const size = sizes[cat.id];
+          return (
+            <li key={cat.id} className="space-y-1 px-3 py-2.5">
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="text-xs font-medium text-fg">
+                  {cat.label}
+                </span>
+                <span className="text-[11px] tabular-nums text-fg-muted">
+                  {size === null ? "—" : formatBytes(size)}
+                </span>
+              </div>
+              <p className="text-[11px] text-fg-muted">{cat.description}</p>
+            </li>
+          );
+        })}
+      </ul>
+
+      {confirming ? (
+        <div className="space-y-2 rounded border border-warning/40 bg-warning/10 p-3">
+          <p className="text-[11px] text-fg">
+            This will permanently delete the cached data listed above
+            ({formatBytes(totalBytes)}). Continue?
+          </p>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              disabled={busy}
+              className="rounded border border-border px-2 py-1 text-[11px] text-fg-muted transition hover:text-fg disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleClear()}
+              disabled={busy}
+              className="rounded bg-danger px-2 py-1 text-[11px] font-medium text-white transition hover:bg-danger/90 disabled:opacity-50"
+            >
+              {busy ? "Clearing…" : "Clear cache"}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-[11px] text-fg-muted">
+            {status ?? `Total: ${formatBytes(totalBytes)}`}
+          </span>
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            disabled={busy || totalBytes === 0}
+            className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-[11px] text-fg-muted transition hover:border-danger/60 hover:text-danger disabled:opacity-50"
+          >
+            <Trash2 size={11} />
+            Clear cache
+          </button>
+        </div>
+      )}
     </section>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -150,4 +150,10 @@ export const api = {
       { ids },
     );
   },
+  scrollbackOrphanSize(): Promise<number> {
+    return invoke<number>("scrollback_orphan_size");
+  },
+  scrollbackOrphanClear(): Promise<number> {
+    return invoke<number>("scrollback_orphan_clear");
+  },
 };


### PR DESCRIPTION
## Summary

Adds a "Storage" tab to the Settings modal that surfaces and clears on-disk artifacts acorn cannot reclaim through its normal session lifecycle. Live sessions are never touched.

## Why orphan-only

Scrollback files for live sessions are not "cache" in any meaningful sense — they are the session's restorable buffer. A blanket "Clear cache" button would either be a no-op against live sessions (the next debounced save just rewrites the file from xterm memory) or would have to invasively wipe the live xterm buffer too, which is way more aggressive than what users want from a cache-clear button.

The actual target is files that slip past `prune_orphans` — e.g. left over from a crash before persistence finished, or from sessions removed while acorn was offline.

## Implementation

### Backend

- `scrollback::orphan_size_bytes(keep)` walks the scrollback directory and sums the size of every `<id>.txt` whose stem is not in `keep`.
- Two new tauri commands collect the current session id list off `state.sessions` so the frontend never has to send the list:
  - `scrollback_orphan_size` → bytes
  - `scrollback_orphan_clear` → number of files removed (delegates to existing `prune_orphans`)

### Frontend

- Settings modal gets a new "Storage" tab.
- The cache list is data-driven via a `CACHE_CATEGORIES` array. Adding a future reclaimable artifact only requires appending one entry; the UI iterates and renders one row per category (label, description, size).
- Confirmation step shows the total to be reclaimed before the destructive call; row sizes refresh in place after clear.

## Test plan

- [ ] `bun run tauri dev`. Open Settings → Storage. Verify the orphan total reflects what `ls -l <data_dir>/scrollback/` shows minus the live session files.
- [ ] Manually drop a fake `<random-uuid>.txt` into the scrollback dir. Reopen Settings → Storage — its size should be reflected. Click Clear cache — file should be gone, sizes should refresh.
- [ ] Open a live terminal, type some output, confirm its scrollback file exists. Click Clear cache — verify the live session's file is *not* deleted.
- [x] `bunx tsc --noEmit` clean.
- [x] `cargo check` clean.
- [x] `bun run test` (vitest) — 87 passed, 1 skipped.
