### PR TITLE
fix(terminal): reset modes after scrollback restore + correct IME overlay coords

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -226,10 +226,16 @@ export function Terminal({
       const cell = getCellDims();
       compositionView.textContent = text;
       if (cell) {
-        const cursorX = term.buffer.active.cursorX;
-        const cursorY = term.buffer.active.cursorY;
-        compositionView.style.left = `${cursorX * cell.width}px`;
-        compositionView.style.top = `${cursorY * cell.height}px`;
+        const buf = term.buffer.active;
+        // `cursorY` is buffer-relative (includes scrollback); the
+        // composition overlay's CSS coords are viewport-relative, so
+        // subtract the viewport's scrollback offset (`viewportY`) to
+        // get the cursor's row inside the visible area. Without this,
+        // a session restored from a long scrollback positions the
+        // overlay thousands of pixels below the visible terminal.
+        const cursorViewportY = buf.cursorY - buf.viewportY;
+        compositionView.style.left = `${buf.cursorX * cell.width}px`;
+        compositionView.style.top = `${cursorViewportY * cell.height}px`;
         compositionView.style.minHeight = `${cell.height}px`;
         compositionView.style.lineHeight = `${cell.height}px`;
       }
@@ -454,10 +460,11 @@ export function Terminal({
       }
       const cell = getCellDims();
       if (!cell) return;
-      const cursorX = term.buffer.active.cursorX;
-      const cursorY = term.buffer.active.cursorY;
-      compositionView.style.left = `${cursorX * cell.width}px`;
-      compositionView.style.top = `${cursorY * cell.height}px`;
+      const buf = term.buffer.active;
+      // See `showComposing` for why we subtract `viewportY` here.
+      const cursorViewportY = buf.cursorY - buf.viewportY;
+      compositionView.style.left = `${buf.cursorX * cell.width}px`;
+      compositionView.style.top = `${cursorViewportY * cell.height}px`;
     });
 
     // Custom event hook so a global hotkey (Cmd+K) can clear THIS terminal
@@ -639,7 +646,29 @@ export function Terminal({
         });
         if (disposed) return;
         if (saved && saved.length > 0) {
-          term.write(saved);
+          // Wait for the snapshot to fully drain into the buffer before
+          // we issue the post-restore mode reset, so the reset is not
+          // re-overwritten by trailing escape sequences in the snapshot.
+          await new Promise<void>((resolve) => term.write(saved, resolve));
+          if (disposed) return;
+          // Reset just the mode bits that actually break the next
+          // session: scroll region, auto-wrap, cursor visibility. We
+          // intentionally do NOT issue `\e[?1049l` (alt-screen exit)
+          // unless the snapshot left us inside the alt buffer — in
+          // xterm.js that sequence pushes the alt buffer contents into
+          // the normal buffer's scrollback when there is no matching
+          // entry, doubling the apparent scroll history.
+          if (term.buffer.active.type === "alternate") {
+            term.write("\x1b[?1049l");
+          }
+          term.write("\x1b[r");    // reset DECSTBM (full-screen scroll region)
+          term.write("\x1b[?7h");  // DECAWM auto-wrap on
+          term.write("\x1b[?25h"); // DECTCEM cursor visible
+          term.write("\x1b[!p");   // DECSTR soft reset (mop up the rest)
+          // Park the cursor on column 0 of a fresh row so the marker
+          // (and the about-to-spawn shell prompt) start from a known
+          // baseline regardless of where the snapshot left the cursor.
+          term.write("\r");
           term.write(
             `\r\n${ANSI_DIM}— restored from previous session —${ANSI_RESET}\r\n`,
           );


### PR DESCRIPTION
## Summary

Fixes two bugs that combined to break CJK input on any session whose restored scrollback already filled the viewport on mount.

## Repro (before this PR)

1. Open a session, `yes | head -200` (or any other long output) so the next launch will restore a full viewport.
2. Quit acorn and reopen.
3. The session restores. The viewport is full and pinned at the bottom.
4. Type Hangul. The composition overlay appears in the wrong place (or off-screen entirely), the committed text wraps back onto the start of the same row, and shell prompt fragments overlap with the input.

## Root causes

### 1. Mode bits leak from the snapshot

The serialised ANSI we replay can include sequences that change DECSTBM (scroll region), enter/leave alt-screen, etc. Those mode flags survive past the snapshot replay and leak into the freshly spawned shell. With the bottom of the viewport pinned by the restored content, the next CJK input wraps back to column 0 of the same row instead of scrolling.

### 2. Composition overlay positioned in buffer coords, not viewport coords

`term.buffer.active.cursorY` is buffer-relative — it includes scrollback offset. Multiplying by `cell.height` therefore placed the IME composition preview thousands of pixels below the visible terminal whenever any scrollback existed (which is always after a restore). The user couldn't see what they were typing, so they committed blindly and got the garbled output above.

## Fix

### Mode reset
- Await snapshot drain via `term.write(saved, callback)` so the reset is not re-overwritten by trailing escape sequences inside the snapshot.
- Issue `\e[r` (reset DECSTBM), `\e[?7h` (DECAWM auto-wrap on), `\e[?25h` (cursor visible), `\e[!p` (DECSTR soft reset) — covers the common offenders.
- Issue `\e[?1049l` (alt-screen exit) **only** when `term.buffer.active.type === "alternate"` — issuing it unconditionally pushes the alt buffer's contents into normal scrollback in xterm.js, doubling the visible scroll history.
- Park the cursor on column 0 of a fresh row before the restore marker so the marker (and the about-to-spawn shell prompt) start from a known baseline.

### Overlay coords
- In both `showComposing` and the `term.onRender` re-anchor, compute `cursorViewportY = buf.cursorY - buf.viewportY` and use that for the overlay's CSS top.

## Test plan

- [x] Open a session, fill the viewport (e.g. `yes | head -200`), quit and reopen acorn. After restore, type Hangul. Verify the composition overlay sits over the live cursor and the committed text wraps to a new row instead of overlapping the prompt.
- [x] Confirm the restored scrollback is **not** doubled (regression from the in-progress fix that issued `\e[?1049l` unconditionally).
- [ ] Open a session whose snapshot was made inside an alt-screen TUI (e.g. `vim` exited cleanly) and verify the new conditional exit still leaves the post-restore terminal in the normal buffer.
- [x] `bunx tsc --noEmit` clean.
- [x] No vitest regressions.
