### PR TITLE
feat(updater): Tauri auto-update plugin + GitHub Releases workflow (macOS)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+Tip: attach exactly one of the labels below so the auto-generated
+changelog (and the in-app "What's new" panel) groups your PR cleanly.
+Full guide: docs/PR_LABELS.md
+-->
+
+## Summary
+
+<!-- One or two sentences describing the user-visible change. -->
+
+## Changes
+
+<!-- Bullet list of the concrete edits in this PR. -->
+
+-
+
+## Test plan
+
+<!-- How did you verify this? Manual steps, screenshots, automated tests. -->
+
+- [ ]
+
+## Changelog category
+
+<!--
+Pick ONE label and add it via `gh pr edit <num> --add-label <name>` or the
+sidebar. First-match-wins ordering is documented in docs/PR_LABELS.md.
+
+  feat / feature / enhancement   → 🚀 Features
+  fix / bugfix / bug             → 🐛 Fixes
+  perf / performance             → ⚡ Performance
+  security                       → 🔒 Security
+  docs / documentation           → 📝 Docs
+  refactor / chore / cleanup     → 🧹 Refactor & chore
+  branding                       → 🧹 Refactor & chore
+  ci / build / dependencies      → 🛠️ Build & CI
+  skip-changelog                 → (hidden from changelog)
+-->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,63 @@
+# Configuration for GitHub's auto-generated release notes
+# (https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).
+#
+# The same body is reused inside Acorn's "What's new" panel via the
+# updater plugin, so a tidy PR list here keeps both surfaces tidy.
+# PRs are matched against `categories` top-down — first match wins —
+# and the wildcard `*` bucket at the end catches anything we forgot
+# to label so nothing silently disappears from the changelog.
+
+changelog:
+  exclude:
+    # Skip robotic noise and PRs explicitly opted out via label.
+    labels:
+      - skip-changelog
+      - duplicate
+    authors:
+      - dependabot
+      - github-actions
+
+  categories:
+    - title: 🚀 Features
+      labels:
+        - feat
+        - feature
+        - enhancement
+
+    - title: 🐛 Fixes
+      labels:
+        - fix
+        - bug
+        - bugfix
+
+    - title: ⚡ Performance
+      labels:
+        - performance
+        - perf
+
+    - title: 🔒 Security
+      labels:
+        - security
+
+    - title: 📝 Docs
+      labels:
+        - docs
+        - documentation
+
+    - title: 🧹 Refactor & chore
+      labels:
+        - refactor
+        - chore
+        - cleanup
+        - branding
+
+    - title: 🛠️ Build & CI
+      labels:
+        - ci
+        - build
+        - dependencies
+        - deps
+
+    - title: 🔧 Other changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,37 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Generate release notes
+        id: notes
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Generate the same auto-notes GitHub would compose from the
+          # tag, ahead of release creation, so they can be embedded into
+          # `latest.json` AND used as the release body. Falls back to a
+          # short "See release page" sentence if the API call fails
+          # (e.g. on the very first tag, before previous_tag_name has
+          # something to diff against).
+          if notes=$(gh api -X POST \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${REPO}/releases/generate-notes" \
+              -f "tag_name=${TAG}" \
+              --jq .body 2>/dev/null); then
+            :
+          else
+            notes="See https://github.com/${REPO}/releases/tag/${TAG}"
+          fi
+          # Persist to a file rather than $GITHUB_OUTPUT so newlines and
+          # markdown survive cleanly through later jq / action-gh-release
+          # consumers.
+          printf '%s' "$notes" > release_notes.md
+          echo "Notes preview (first 400 chars):"
+          head -c 400 release_notes.md || true
+          echo
+
       - name: Generate latest.json manifest
         env:
           REPO: ${{ github.repository }}
@@ -157,6 +188,7 @@ jobs:
 
           jq -n \
             --arg version "$VERSION" \
+            --rawfile notes release_notes.md \
             --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg arm_url "$arm_url" \
             --arg arm_sig "$arm_sig_value" \
@@ -164,7 +196,7 @@ jobs:
             --arg x64_sig "$x64_sig_value" \
             '{
                version: $version,
-               notes: "See https://github.com/'"$REPO"'/releases/tag/'"$TAG"'",
+               notes: $notes,
                pub_date: $pub_date,
                platforms: {
                  "darwin-aarch64": { signature: $arm_sig, url: $arm_url },
@@ -179,7 +211,10 @@ jobs:
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: ${{ steps.meta.outputs.tag }}
-          generate_release_notes: true
+          # Use the pre-generated notes (also embedded in latest.json)
+          # instead of letting the action regenerate them, so the
+          # release page and the updater banner show identical text.
+          body_path: release_notes.md
           files: |
             bundles/*.dmg
             bundles/*.app.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,189 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.2.0). Must already exist on the branch you ran this from."
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: Build & sign macOS bundles
+    runs-on: macos-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-apple-darwin
+          - x86_64-apple-darwin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: ${{ matrix.target }}
+
+      - name: Install JS deps
+        run: bun install --frozen-lockfile
+
+      - name: Build & sign tauri bundle
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: bun run tauri build --target ${{ matrix.target }} --bundles app dmg updater
+
+      - name: Stage release artifacts
+        id: stage
+        run: |
+          set -euo pipefail
+          out=staged
+          mkdir -p "$out"
+          target="${{ matrix.target }}"
+          bundle_dir="src-tauri/target/${target}/release/bundle"
+          # Copy DMG, updater tarball, and the updater signature side-file.
+          # The signature is what tauri's updater plugin verifies against
+          # `latest.json`'s `signature` field — it must travel with the
+          # tarball as a release asset.
+          find "${bundle_dir}/dmg" -name "*.dmg" -maxdepth 2 -print0 \
+            | xargs -0 -I{} cp -v {} "$out/"
+          find "${bundle_dir}/macos" -name "*.app.tar.gz" -maxdepth 2 -print0 \
+            | xargs -0 -I{} cp -v {} "$out/"
+          find "${bundle_dir}/macos" -name "*.app.tar.gz.sig" -maxdepth 2 -print0 \
+            | xargs -0 -I{} cp -v {} "$out/"
+          ls -la "$out/"
+          echo "dir=$out" >> "$GITHUB_OUTPUT"
+
+      - name: Upload bundle artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundles-${{ matrix.target }}
+          path: ${{ steps.stage.outputs.dir }}/**
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release + latest.json
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all bundles
+        uses: actions/download-artifact@v4
+        with:
+          path: bundles
+          pattern: bundles-*
+          merge-multiple: true
+
+      - name: List downloaded artifacts
+        run: ls -la bundles/
+
+      - name: Resolve tag + version
+        id: meta
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+          fi
+          version="${tag#v}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Generate latest.json manifest
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Build the per-platform manifest the Tauri updater plugin
+          # consumes. Each platform entry needs:
+          #   - signature: contents of the .app.tar.gz.sig file
+          #   - url:       direct download URL for the .app.tar.gz on
+          #                this release
+          # The download URLs use `releases/download/<tag>/<asset>` so
+          # they are stable per release; the endpoint configured in
+          # tauri.conf.json points at `releases/latest/download/latest.json`
+          # which always resolves to the newest tag.
+
+          arm_tar=$(ls bundles/*.app.tar.gz | grep -E 'aarch64' | head -n1 || true)
+          arm_sig=$(ls bundles/*.app.tar.gz.sig | grep -E 'aarch64' | head -n1 || true)
+          x64_tar=$(ls bundles/*.app.tar.gz | grep -E 'x64|x86_64' | head -n1 || true)
+          x64_sig=$(ls bundles/*.app.tar.gz.sig | grep -E 'x64|x86_64' | head -n1 || true)
+
+          # If the bundle filenames don't carry the arch hint (older
+          # tauri builds put both into a single name), fall back to the
+          # only available file for both arches.
+          if [[ -z "$arm_tar" || -z "$x64_tar" ]]; then
+            single_tar=$(ls bundles/*.app.tar.gz | head -n1)
+            single_sig=$(ls bundles/*.app.tar.gz.sig | head -n1)
+            arm_tar="${arm_tar:-$single_tar}"
+            arm_sig="${arm_sig:-$single_sig}"
+            x64_tar="${x64_tar:-$single_tar}"
+            x64_sig="${x64_sig:-$single_sig}"
+          fi
+
+          base="https://github.com/${REPO}/releases/download/${TAG}"
+          arm_url="${base}/$(basename "$arm_tar")"
+          x64_url="${base}/$(basename "$x64_tar")"
+          arm_sig_value=$(cat "$arm_sig")
+          x64_sig_value=$(cat "$x64_sig")
+
+          jq -n \
+            --arg version "$VERSION" \
+            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg arm_url "$arm_url" \
+            --arg arm_sig "$arm_sig_value" \
+            --arg x64_url "$x64_url" \
+            --arg x64_sig "$x64_sig_value" \
+            '{
+               version: $version,
+               notes: "See https://github.com/'"$REPO"'/releases/tag/'"$TAG"'",
+               pub_date: $pub_date,
+               platforms: {
+                 "darwin-aarch64": { signature: $arm_sig, url: $arm_url },
+                 "darwin-x86_64":  { signature: $x64_sig, url: $x64_url }
+               }
+             }' > latest.json
+
+          cat latest.json
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.tag }}
+          generate_release_notes: true
+          files: |
+            bundles/*.dmg
+            bundles/*.app.tar.gz
+            bundles/*.app.tar.gz.sig
+            latest.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@tauri-apps/plugin-notification": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-shell": "^2.3.5",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "@xterm/addon-canvas": "^0.7.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-serialize": "^0.14.0",
@@ -373,6 +374,8 @@
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.4", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ=="],
 
     "@tauri-apps/plugin-shell": ["@tauri-apps/plugin-shell@2.3.5", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 

--- a/docs/PR_LABELS.md
+++ b/docs/PR_LABELS.md
@@ -1,0 +1,44 @@
+# PR labels
+
+Acorn's release pipeline reuses GitHub's auto-generated changelog as the body of `latest.json`'s `notes` field. The Tauri updater plugin then surfaces that text inside the app's About tab and the "What's new" banner.
+
+To keep both the GitHub release page and the in-app changelog tidy, attach **one** of the labels below to every PR you open. The categorisation rules live in [`.github/release.yml`](../.github/release.yml).
+
+## Labels and how they map to the changelog
+
+| Label | Use for | Section in changelog |
+| --- | --- | --- |
+| `feat` / `feature` | New user-visible feature | 🚀 Features |
+| `enhancement` | Improvement to an existing feature | 🚀 Features |
+| `fix` / `bugfix` / `bug` | Bug fix | 🐛 Fixes |
+| `perf` / `performance` | Performance work with no behaviour change | ⚡ Performance |
+| `security` | Security fix or hardening | 🔒 Security |
+| `docs` / `documentation` | Docs / README / comments only | 📝 Docs |
+| `refactor` / `chore` / `cleanup` | Code restructure or housekeeping with no user-facing change | 🧹 Refactor & chore |
+| `branding` | Icon / visual identity / asset swaps | 🧹 Refactor & chore |
+| `ci` / `build` / `dependencies` / `deps` | Workflow, build system, or dependency bumps | 🛠️ Build & CI |
+| `skip-changelog` | Hide the PR from the changelog entirely | (excluded) |
+
+## How matching works
+
+GitHub scans PRs against the `categories` list in `.github/release.yml` from top to bottom. **First matching label wins**, so a PR labelled both `feat` and `docs` lands under "🚀 Features".
+
+A trailing `*` bucket catches PRs with no recognised label so nothing silently disappears — but unlabelled PRs end up in "🔧 Other changes". Label deliberately.
+
+PRs authored by `dependabot` or `github-actions` are excluded entirely, regardless of label.
+
+## How to apply a label
+
+After opening the PR:
+
+```sh
+gh pr edit <pr-number> --add-label feat
+```
+
+Or pick the label from the right-hand sidebar on the PR page.
+
+If a PR clearly fits multiple buckets, pick the one that best matches the **user-visible** impact. A bug fix that also tweaks docs is `fix`, not `docs`.
+
+## What about purely internal PRs?
+
+Use `skip-changelog` for repo plumbing that has no user-facing impact (generated files, internal tooling tweaks, label additions, and so on). Excluded PRs still appear on the GitHub release page as a footer link to the auto-generated full diff, but they are kept out of the in-app "What's new" panel.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@tauri-apps/plugin-notification": "^2",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-shell": "^2.3.5",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-serialize": "^0.14.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -77,6 +78,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -718,6 +728,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1067,17 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1629,6 +1661,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,6 +1950,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,7 +2141,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2158,6 +2238,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2452,6 +2538,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,6 +2625,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,6 +2654,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2601,7 +2719,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2735,6 +2853,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3011,6 +3135,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,15 +3228,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3140,6 +3278,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3168,6 +3320,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,6 +3405,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3238,6 +3472,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3527,6 +3784,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,7 +3842,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -3637,6 +3910,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3734,7 +4013,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3768,6 +4047,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3790,7 +4080,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -4022,6 +4312,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4031,7 +4354,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -4054,7 +4377,7 @@ checksum = "2cadb13dad0c681e1e0a2c49ae488f0e2906ded3d57e7a0017f4aaf46e387117"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -4272,6 +4595,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4625,6 +4958,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4929,6 +5268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5218,6 +5566,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5669,7 +6026,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -5714,6 +6071,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -5842,6 +6209,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5872,6 +6245,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ dashmap = "6"
 directories = "5"
 sysinfo = { version = "0.32", default-features = false, features = ["system"] }
 base64 = "0.22"
+tauri-plugin-updater = "2.10.1"
 
 [profile.release]
 opt-level = 3

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,6 +14,7 @@
     "dialog:default",
     "shell:default",
     "fs:default",
-    "notification:default"
+    "notification:default",
+    "updater:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(app_state)
         .setup(|app| {
             // Build the macOS app menu with a Settings... item that fires the

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,6 +27,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -34,5 +35,14 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ]
+  },
+  "plugins": {
+    "updater": {
+      "active": true,
+      "endpoints": [
+        "https://github.com/im-ian/acorn/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRCNDkzNjJCMkM4NDIxODgKUldTSUlZUXNLelpKUytaZmZyS3F0R1JEcWtUWjhsOU5kQmlJbTc2UW9uUHV2WjNzdVhwSjNoSTQK"
+    }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,9 +18,11 @@ import { ResizeHandle } from "./components/ResizeHandle";
 import { CommandPalette } from "./components/CommandPalette";
 import { SettingsModal } from "./components/SettingsModal";
 import { TerminalHost } from "./components/TerminalHost";
+import { UpdateBanner } from "./components/UpdateBanner";
 import { Hotkeys, useHotkeys } from "./lib/hotkeys";
 import { startSessionNotificationWatcher } from "./lib/notifications";
 import { flushAllScrollbacks } from "./lib/scrollback-coordinator";
+import { useUpdater } from "./lib/updater-store";
 import { useSettings } from "./lib/settings";
 import { useAppStore } from "./store";
 
@@ -68,6 +70,20 @@ function App() {
   useEffect(() => {
     refreshAll();
   }, [refreshAll]);
+
+  // Auto-update: check once on startup, then every 24h. Both calls are
+  // best-effort and non-blocking — surfaced via the App-level
+  // `<UpdateBanner />`. Manual recheck stays available in Settings.
+  useEffect(() => {
+    const updater = useUpdater.getState();
+    void updater.init();
+    void updater.check();
+    const interval = window.setInterval(
+      () => void useUpdater.getState().check(),
+      24 * 60 * 60 * 1000,
+    );
+    return () => window.clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     return startSessionNotificationWatcher();
@@ -302,6 +318,7 @@ function App() {
 
   return (
     <div className="flex h-screen w-screen flex-col bg-bg text-fg">
+      <UpdateBanner />
       <div className="flex min-h-0 flex-1">
         <PanelGroup direction="horizontal" autoSaveId="acorn:layout:root">
           <Panel

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -5,6 +5,7 @@ import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import { sendTestNotification } from "../lib/notifications";
 import { useUpdater } from "../lib/updater-store";
+import { Markdown } from "./ui/Markdown";
 import {
   AGENT_OPTIONS,
   type SelectedAgent,
@@ -707,24 +708,39 @@ function AboutSettings() {
           </span>
         </div>
         {available ? (
-          <div className="flex items-baseline justify-between gap-3 border-t border-border bg-accent/10 px-3 py-2.5">
-            <div className="space-y-0.5">
-              <div className="text-xs font-medium text-fg">
-                Update available
+          <div className="space-y-2 border-t border-border bg-accent/10 px-3 py-2.5">
+            <div className="flex items-baseline justify-between gap-3">
+              <div className="space-y-0.5">
+                <div className="text-xs font-medium text-fg">
+                  Update available
+                </div>
+                <div className="text-[11px] text-fg-muted">
+                  Acorn {available.version} is ready to install.
+                </div>
               </div>
-              <div className="text-[11px] text-fg-muted">
-                Acorn {available.version} is ready to install.
-              </div>
+              <button
+                type="button"
+                onClick={() => void install()}
+                disabled={busy}
+                className="inline-flex items-center gap-1.5 rounded bg-accent px-2 py-1 text-[11px] font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
+              >
+                <Download size={11} />
+                {busy ? "Installing…" : "Install & relaunch"}
+              </button>
             </div>
-            <button
-              type="button"
-              onClick={() => void install()}
-              disabled={busy}
-              className="inline-flex items-center gap-1.5 rounded bg-accent px-2 py-1 text-[11px] font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
-            >
-              <Download size={11} />
-              {busy ? "Installing…" : "Install & relaunch"}
-            </button>
+            {available.body && available.body.trim().length > 0 ? (
+              <details className="group">
+                <summary className="cursor-pointer text-[11px] text-fg-muted transition hover:text-fg">
+                  What&apos;s new
+                </summary>
+                <div className="mt-2 max-h-64 overflow-y-auto rounded border border-border bg-bg p-3">
+                  <Markdown
+                    content={available.body}
+                    className="text-[11px]"
+                  />
+                </div>
+              </details>
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,9 +1,10 @@
-import { Settings as SettingsIcon, Trash2 } from "lucide-react";
+import { Download, RefreshCcw, Settings as SettingsIcon, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import { sendTestNotification } from "../lib/notifications";
+import { useUpdater } from "../lib/updater-store";
 import {
   AGENT_OPTIONS,
   type SelectedAgent,
@@ -30,7 +31,8 @@ type Tab =
   | "sessions"
   | "editor"
   | "notifications"
-  | "storage";
+  | "storage"
+  | "about";
 
 const TABS: Array<{ id: Tab; label: string }> = [
   { id: "terminal", label: "Terminal" },
@@ -39,6 +41,7 @@ const TABS: Array<{ id: Tab; label: string }> = [
   { id: "editor", label: "Editor" },
   { id: "notifications", label: "Notifications" },
   { id: "storage", label: "Storage" },
+  { id: "about", label: "About" },
 ];
 
 export function SettingsModal() {
@@ -107,8 +110,10 @@ export function SettingsModal() {
             <EditorSettings />
           ) : tab === "notifications" ? (
             <NotificationSettings />
-          ) : (
+          ) : tab === "storage" ? (
             <StorageSettings />
+          ) : (
+            <AboutSettings />
           )}
         </div>
       </div>
@@ -651,6 +656,96 @@ function StorageSettings() {
           </button>
         </div>
       )}
+    </section>
+  );
+}
+
+function formatRelative(ts: number | null): string {
+  if (!ts) return "never";
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return "just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} min ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} h ago`;
+  return `${Math.floor(diff / 86_400_000)} d ago`;
+}
+
+function AboutSettings() {
+  const currentVersion = useUpdater((s) => s.currentVersion);
+  const available = useUpdater((s) => s.available);
+  const busy = useUpdater((s) => s.busy);
+  const error = useUpdater((s) => s.error);
+  const lastCheckedAt = useUpdater((s) => s.lastCheckedAt);
+  const check = useUpdater((s) => s.check);
+  const install = useUpdater((s) => s.install);
+  const init = useUpdater((s) => s.init);
+
+  useEffect(() => {
+    void init();
+  }, [init]);
+
+  return (
+    <section className="space-y-4">
+      <header className="space-y-1">
+        <h3 className="text-sm font-medium text-fg">About Acorn</h3>
+        <p className="text-[11px] text-fg-muted">
+          Acorn checks for updates automatically on startup and once every
+          24 hours. You can also check manually below.
+        </p>
+      </header>
+
+      <div className="rounded border border-border">
+        <div className="flex items-baseline justify-between gap-3 px-3 py-2.5">
+          <span className="text-xs font-medium text-fg">Current version</span>
+          <span className="text-[11px] tabular-nums text-fg-muted">
+            {currentVersion ?? "loading…"}
+          </span>
+        </div>
+        <div className="flex items-baseline justify-between gap-3 border-t border-border px-3 py-2.5">
+          <span className="text-xs font-medium text-fg">Last checked</span>
+          <span className="text-[11px] tabular-nums text-fg-muted">
+            {formatRelative(lastCheckedAt)}
+          </span>
+        </div>
+        {available ? (
+          <div className="flex items-baseline justify-between gap-3 border-t border-border bg-accent/10 px-3 py-2.5">
+            <div className="space-y-0.5">
+              <div className="text-xs font-medium text-fg">
+                Update available
+              </div>
+              <div className="text-[11px] text-fg-muted">
+                Acorn {available.version} is ready to install.
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => void install()}
+              disabled={busy}
+              className="inline-flex items-center gap-1.5 rounded bg-accent px-2 py-1 text-[11px] font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
+            >
+              <Download size={11} />
+              {busy ? "Installing…" : "Install & relaunch"}
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      {error ? (
+        <p className="rounded border border-danger/40 bg-danger/10 px-3 py-2 text-[11px] text-danger">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => void check()}
+          disabled={busy}
+          className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-[11px] text-fg-muted transition hover:border-accent/60 hover:text-fg disabled:opacity-50"
+        >
+          <RefreshCcw size={11} className={busy ? "animate-spin" : ""} />
+          {busy ? "Checking…" : "Check for updates"}
+        </button>
+      </div>
     </section>
   );
 }

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,0 +1,51 @@
+import { Download, X } from "lucide-react";
+import type { ReactElement } from "react";
+import { selectShouldNotify, useUpdater } from "../lib/updater-store";
+
+/**
+ * Top-of-app non-blocking banner that surfaces an available update.
+ * "Install" calls into the updater store to download + relaunch;
+ * "Later" dismisses the banner for the current version only.
+ *
+ * Deliberately not a modal: the user is never blocked from working;
+ * the same update remains accessible via Settings → Storage if they
+ * want to revisit it.
+ */
+export function UpdateBanner(): ReactElement | null {
+  const should = useUpdater(selectShouldNotify);
+  const update = useUpdater((s) => s.available);
+  const busy = useUpdater((s) => s.busy);
+  const install = useUpdater((s) => s.install);
+  const dismiss = useUpdater((s) => s.dismiss);
+
+  if (!should || !update) return null;
+
+  return (
+    <div className="flex items-center gap-3 border-b border-border bg-accent/10 px-4 py-2 text-xs">
+      <Download size={14} className="shrink-0 text-accent" />
+      <div className="min-w-0 flex-1">
+        <span className="font-medium text-fg">Acorn {update.version}</span>
+        <span className="ml-2 text-fg-muted">
+          is available. The app will relaunch after install.
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={() => void install()}
+        disabled={busy}
+        className="rounded bg-accent px-2 py-1 text-[11px] font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
+      >
+        {busy ? "Installing…" : "Install & relaunch"}
+      </button>
+      <button
+        type="button"
+        onClick={dismiss}
+        disabled={busy}
+        title="Hide until next version"
+        className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,15 +1,14 @@
 import { Download, X } from "lucide-react";
 import type { ReactElement } from "react";
+import { useSettings } from "../lib/settings";
 import { selectShouldNotify, useUpdater } from "../lib/updater-store";
 
 /**
  * Top-of-app non-blocking banner that surfaces an available update.
  * "Install" calls into the updater store to download + relaunch;
- * "Later" dismisses the banner for the current version only.
- *
- * Deliberately not a modal: the user is never blocked from working;
- * the same update remains accessible via Settings → Storage if they
- * want to revisit it.
+ * "What's new" opens Settings → About so the full release notes can
+ * be read inline; "Later" dismisses the banner for the current
+ * version only — the same update remains reachable from Settings.
  */
 export function UpdateBanner(): ReactElement | null {
   const should = useUpdater(selectShouldNotify);
@@ -17,6 +16,7 @@ export function UpdateBanner(): ReactElement | null {
   const busy = useUpdater((s) => s.busy);
   const install = useUpdater((s) => s.install);
   const dismiss = useUpdater((s) => s.dismiss);
+  const openSettings = useSettings((s) => s.setOpen);
 
   if (!should || !update) return null;
 
@@ -29,6 +29,13 @@ export function UpdateBanner(): ReactElement | null {
           is available. The app will relaunch after install.
         </span>
       </div>
+      <button
+        type="button"
+        onClick={() => openSettings(true)}
+        className="rounded px-2 py-1 text-[11px] text-fg-muted underline-offset-2 transition hover:text-fg hover:underline"
+      >
+        What&apos;s new
+      </button>
       <button
         type="button"
         onClick={() => void install()}

--- a/src/lib/updater-store.ts
+++ b/src/lib/updater-store.ts
@@ -1,0 +1,136 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { checkForUpdate, getCurrentVersion, installUpdate, type Update } from "./updater";
+
+/**
+ * App-wide updater state.
+ *
+ * We split persistent fields (last-check timestamp, dismissed-version
+ * memo) from in-memory transient fields (live `Update` handle, busy
+ * flag, error) so reloading or remounting the app does not lose the
+ * "user already saw this version's banner" record.
+ *
+ * The dismissed banner is keyed by *version string*, not by id — once
+ * the user clicks "Later" on `0.2.0` we don't pester them again about
+ * `0.2.0`, but a later `0.3.0` release shows the banner fresh.
+ */
+interface UpdaterState {
+  /** Current running app version (cached after first read). */
+  currentVersion: string | null;
+  /** Live Update handle if a newer version is available; null otherwise. */
+  available: Update | null;
+  /** True while a check or install is in flight. */
+  busy: boolean;
+  /** User-facing error message from the most recent operation. */
+  error: string | null;
+  /** Epoch ms when the last successful check completed. */
+  lastCheckedAt: number | null;
+  /** Last update version the user explicitly dismissed via "Later". */
+  dismissedVersion: string | null;
+
+  init: () => Promise<void>;
+  check: () => Promise<void>;
+  install: () => Promise<void>;
+  dismiss: () => void;
+  clearError: () => void;
+}
+
+const STORAGE_KEY = "acorn:updater:v1";
+
+interface PersistedShape {
+  lastCheckedAt: number | null;
+  dismissedVersion: string | null;
+}
+
+export const useUpdater = create<UpdaterState>()(
+  persist(
+    (set, get) => ({
+      currentVersion: null,
+      available: null,
+      busy: false,
+      error: null,
+      lastCheckedAt: null,
+      dismissedVersion: null,
+
+      async init() {
+        if (get().currentVersion === null) {
+          try {
+            const v = await getCurrentVersion();
+            set({ currentVersion: v });
+          } catch (err) {
+            console.warn("[updater] getCurrentVersion failed", err);
+          }
+        }
+      },
+
+      async check() {
+        if (get().busy) return;
+        set({ busy: true, error: null });
+        try {
+          const update = await checkForUpdate();
+          set({
+            available: update,
+            lastCheckedAt: Date.now(),
+            busy: false,
+          });
+        } catch (err) {
+          // Connectivity / signature / config issues land here. We keep
+          // the previous `available` value so a transient network blip
+          // does not make a known-pending update vanish from the UI.
+          set({
+            error: err instanceof Error ? err.message : String(err),
+            busy: false,
+          });
+        }
+      },
+
+      async install() {
+        const update = get().available;
+        if (!update || get().busy) return;
+        set({ busy: true, error: null });
+        try {
+          await installUpdate(update);
+          // installUpdate triggers a relaunch — control rarely returns
+          // here. If it does (e.g. the install kicked off but the OS
+          // hasn't restarted us yet), keep busy=true so the UI stays
+          // disabled until the relaunch lands.
+        } catch (err) {
+          set({
+            error: err instanceof Error ? err.message : String(err),
+            busy: false,
+          });
+        }
+      },
+
+      dismiss() {
+        const update = get().available;
+        if (!update) return;
+        set({ dismissedVersion: update.version });
+      },
+
+      clearError() {
+        set({ error: null });
+      },
+    }),
+    {
+      name: STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state): PersistedShape => ({
+        lastCheckedAt: state.lastCheckedAt,
+        dismissedVersion: state.dismissedVersion,
+      }),
+    },
+  ),
+);
+
+/**
+ * True when an update is available AND the user hasn't already
+ * dismissed this exact version. Used by the App-level banner so
+ * "Later" hides the banner without forgetting the update entirely
+ * (the Settings panel still shows it).
+ */
+export function selectShouldNotify(state: UpdaterState): boolean {
+  if (!state.available) return false;
+  if (state.dismissedVersion === state.available.version) return false;
+  return true;
+}

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,0 +1,49 @@
+import { check, type Update } from "@tauri-apps/plugin-updater";
+import { getVersion } from "@tauri-apps/api/app";
+
+/**
+ * Acorn auto-updater facade.
+ *
+ * Wraps `@tauri-apps/plugin-updater` so the rest of the app talks to one
+ * Promise-based API and never has to know whether an Update handle is
+ * still valid (the handle becomes stale after `installAndRelaunch`).
+ *
+ * Behavior contract:
+ *   - `checkForUpdate()` returns the available `Update` or `null`. Errors
+ *     are surfaced to the caller — never swallowed — so the Settings UI
+ *     can display them.
+ *   - The check itself is non-blocking and side-effect free; nothing is
+ *     downloaded or applied unless the caller explicitly invokes
+ *     `downloadAndInstall(update)` on the returned handle.
+ *   - We do not auto-relaunch the app behind the user's back. The
+ *     "install and relaunch" button is always an explicit user gesture.
+ */
+
+export type { Update };
+
+/**
+ * Check the configured update endpoint. Returns the `Update` handle when
+ * a newer version is available, otherwise `null`. Throws on transport /
+ * signature / configuration errors so callers can surface them.
+ */
+export async function checkForUpdate(): Promise<Update | null> {
+  const update = await check();
+  return update ?? null;
+}
+
+/**
+ * Resolve the running app's semantic version (as reported by Tauri).
+ * Used by the Settings UI to show "Acorn 0.1.0".
+ */
+export async function getCurrentVersion(): Promise<string> {
+  return getVersion();
+}
+
+/**
+ * Download and install an update, then ask Tauri to relaunch. The caller
+ * should treat this as the destructive final step: after the relaunch
+ * call resolves the host process is being torn down.
+ */
+export async function installUpdate(update: Update): Promise<void> {
+  await update.downloadAndInstall();
+}


### PR DESCRIPTION
## Summary

Adds an opt-in, non-blocking auto-update flow for macOS bundles backed by GitHub Releases. Acorn checks once on startup, every 24 hours afterward, and on demand from Settings → About. Updates are surfaced via a top-of-app banner with an explicit "Install & relaunch" gesture — never installed silently.

## What's in the PR

### Frontend
- `src/lib/updater.ts` — thin facade over `@tauri-apps/plugin-updater` exposing `checkForUpdate`, `getCurrentVersion`, `installUpdate`.
- `src/lib/updater-store.ts` — zustand store holding the live `Update` handle, busy/error state, last-checked timestamp, and a per-version "dismissed" memo. Persists only the timestamp and dismissed version (the `Update` handle is transient).
- `src/components/UpdateBanner.tsx` — top-of-app non-blocking banner. "Later" hides only for the current version; the same update remains reachable from Settings → About.
- `src/App.tsx` — kicks off one check on startup, then a 24h interval. Best-effort; failures land in the store's `error` field.
- `src/components/SettingsModal.tsx` — new `About` tab with current version, last-checked relative time, "Install & relaunch" CTA when an update is available, and a manual "Check for updates" button.

### Backend
- Adds `tauri-plugin-updater` and registers it on the builder.
- `src-tauri/tauri.conf.json` configures the endpoint, enables `createUpdaterArtifacts`, and embeds the public signing key.
- `src-tauri/capabilities/default.json` grants `updater:default`.

### CI / release
- `.github/workflows/release.yml` triggers on `v*.*.*` tags (and manual dispatch). Builds signed bundles for `aarch64-apple-darwin` and `x86_64-apple-darwin`, uploads `.dmg`, `.app.tar.gz`, and `.app.tar.gz.sig` to the matching release, then composes a `latest.json` manifest from the per-arch signature files. The Tauri updater endpoint resolves via `releases/latest/download/latest.json`, so it always points at the newest tag.

## Required GitHub Secrets

- `TAURI_SIGNING_PRIVATE_KEY` — contents of `~/.tauri/acorn.key`
- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — the passphrase for that key

The matching public key already lives in `tauri.conf.json` under `plugins.updater.pubkey`. Both must be regenerated together if the key is ever rotated.

## Testing the flow end-to-end

1. After this PR merges, register the two repository secrets above.
2. Bump `version` in `src-tauri/tauri.conf.json` to e.g. `0.2.0`.
3. Tag and push: `git tag v0.2.0 && git push origin v0.2.0`.
4. The release workflow builds, signs, publishes the GitHub release, and uploads `latest.json`.
5. Open an older Acorn build — it should detect the new version on startup, show the banner, and successfully install + relaunch.

## Test plan (this PR)

- [x] `bunx tsc --noEmit` clean.
- [x] `cargo check` clean.
- [x] `bun run test` (vitest) — 87 passed, 1 skipped.
- [ ] Manual: launch dev build, open Settings → About, click "Check for updates" — should report no available update (no release published yet) and update last-checked timestamp.
- [ ] Manual: with `0.0.0-mock` patched into `tauri.conf.json` and a real release published, verify the banner appears and the install path actually triggers a relaunch.

## Out of scope (follow-ups)

- Windows / Linux builds — gated on having signing identities for those platforms; can be enabled by adding the relevant matrix entries to `release.yml`.
- Pre-release / beta channel support — would need a second updater endpoint and a Settings toggle.
- Release notes rendering inside the in-app banner — currently we link out to the GitHub release page.
