### PR TITLE
fix(pty): wrap agent commands in user shell so PATH resolves on GUI launch

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -370,22 +370,120 @@ pub async fn pty_spawn<R: Runtime>(
     if state.pty.contains(&id) {
         return Ok(());
     }
-    // An empty/missing command means "use the user's default shell". This is
-    // how the frontend signals the "Terminal" startup mode from settings.
-    let resolved_command = match command {
-        Some(c) if !c.trim().is_empty() => c,
-        _ => std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string()),
+    // Resolve the actual (command, args) pair to spawn:
+    //
+    //   * Terminal mode  — frontend sends an empty/missing command, asking us
+    //     to drop the user into their interactive shell. Spawn $SHELL directly
+    //     so the prompt is the user's real shell.
+    //
+    //   * Agent / Custom mode — frontend sends e.g. `claude` with args. On
+    //     macOS GUI launches (Dock/Spotlight) the parent process inherits a
+    //     sanitized PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) and never sources
+    //     `~/.zshrc` / `~/.zprofile`, so binaries installed via Homebrew, npm,
+    //     bun, pnpm, pyenv, asdf, mise, etc. are invisible to spawn_command
+    //     and PTY creation fails with "No viable candidates found in PATH".
+    //
+    //     To fix this without acorn having to know each shell's rc-file
+    //     conventions, we wrap the target through the user's login+interactive
+    //     shell. The shell sources its rc files (picking up PATH, aliases,
+    //     env vars, shims) and then `exec`s the target — replacing itself
+    //     in-place so the PTY's child is the requested binary, not the shell.
+    let user_command_raw = match command {
+        Some(c) if !c.trim().is_empty() => Some(c),
+        _ => None,
+    };
+    let user_args = args.unwrap_or_default();
+    let (resolved_command, resolved_args) = match user_command_raw {
+        None => {
+            let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+            (shell, user_args)
+        }
+        Some(user_command) => {
+            let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+            let mut script = String::from("exec ");
+            script.push_str(&shell_quote(&user_command));
+            for a in &user_args {
+                script.push(' ');
+                script.push_str(&shell_quote(a));
+            }
+            (shell, vec!["-l".to_string(), "-i".to_string(), "-c".to_string(), script])
+        }
     };
     state.pty.spawn(
         app,
         id,
         cwd,
         resolved_command,
-        args.unwrap_or_default(),
+        resolved_args,
         env.unwrap_or_default(),
         cols.unwrap_or(0),
         rows.unwrap_or(0),
     )
+}
+
+/// Quote `s` so a POSIX shell parses it as a single argument verbatim.
+/// Returns `s` unquoted when it is composed solely of safe characters that
+/// the shell would not interpret (alphanumerics and a small allow-list);
+/// otherwise wraps it in single quotes with embedded `'` escaped as `'\''`.
+fn shell_quote(s: &str) -> String {
+    if s.is_empty() {
+        return "''".to_string();
+    }
+    let safe = s.bytes().all(|b| {
+        b.is_ascii_alphanumeric()
+            || matches!(b, b'_' | b'-' | b'/' | b'.' | b'=' | b':' | b',' | b'@' | b'+')
+    });
+    if safe {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+#[cfg(test)]
+mod shell_quote_tests {
+    use super::shell_quote;
+
+    #[test]
+    fn safe_inputs_pass_through() {
+        assert_eq!(shell_quote("claude"), "claude");
+        assert_eq!(shell_quote("--session-id"), "--session-id");
+        assert_eq!(shell_quote("a1b2-c3d4"), "a1b2-c3d4");
+        assert_eq!(shell_quote("/usr/local/bin/foo"), "/usr/local/bin/foo");
+        assert_eq!(shell_quote("KEY=value"), "KEY=value");
+    }
+
+    #[test]
+    fn empty_becomes_empty_quotes() {
+        assert_eq!(shell_quote(""), "''");
+    }
+
+    #[test]
+    fn space_triggers_quoting() {
+        assert_eq!(shell_quote("hello world"), "'hello world'");
+    }
+
+    #[test]
+    fn embedded_single_quote_is_escaped() {
+        assert_eq!(shell_quote("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn shell_metacharacters_are_quoted() {
+        assert_eq!(shell_quote("a;b"), "'a;b'");
+        assert_eq!(shell_quote("$HOME"), "'$HOME'");
+        assert_eq!(shell_quote("`ls`"), "'`ls`'");
+        assert_eq!(shell_quote("a|b"), "'a|b'");
+    }
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary

Fixes agent-mode session startup failing with `No viable candidates found in PATH "/usr/bin:/bin:/usr/sbin:/sbin"` when acorn is launched from Dock/Spotlight/Finder.

## Problem

macOS hands GUI-launched apps a sanitized PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) and never sources the user's shell rc files. Agent-mode startup asks `portable_pty` to spawn `claude` (or `gemini`/`codex`/...) directly, but those CLIs live under user-specific prefixes (Homebrew, npm, bun, `~/.local/bin`, volta/asdf shims, …) that only get added to PATH from `~/.zshrc` or `~/.zprofile`. Result: PTY creation fails immediately.

Launching acorn from a terminal masks the bug because the terminal's full PATH is inherited; this is why the issue only reproduces on Dock-style launches.

## Fix

Wrap the requested command through the user's login+interactive shell:

```
$SHELL -l -i -c 'exec <quoted cmd> <quoted args>'
```

- The shell sources its rc files, so PATH/env/aliases/shims get loaded — without acorn having to know rc-file locations or syntax.
- `exec` replaces the shell with the target binary in-place, so the PTY child is the real target and no extra shell process lingers.
- Terminal mode (frontend sends no command) is unchanged: `$SHELL` is still spawned directly so the user gets their normal interactive prompt.

A small POSIX-safe `shell_quote` helper handles arg quoting (single-quote wrap with `'\''` escape; alphanumerics + safe punctuation pass through unquoted).

## Test plan

- [x] `cargo test` — 14/14 pass (9 existing + 5 new `shell_quote` tests)
- [x] `bun run test` — 87 pass / 1 skipped
- [x] **Reproduce bug**: build debug, launch with `env -i HOME=$HOME USER=$USER SHELL=/bin/zsh PATH=/usr/bin:/bin:/usr/sbin:/sbin ./target/debug/acorn` — agent session fails with the PATH error
- [x] **Verify fix**: rebuild, relaunch with same sanitized env — Claude Code starts normally with full UI
- [x] **Regression — Terminal mode**: still spawns `$SHELL` directly; prompt comes up as expected
- [x] No `console.log`/debug statements left behind

## Notes

- Adds a per-spawn cost of one shell startup (typically ~50–200 ms; up to ~1 s with heavy zsh setups). Acceptable trade-off for "just works on Dock launches".
- `-i` is required so `~/.zshrc` is sourced (most users put PATH there). `-l` covers `~/.zprofile`.
- p10k instant-prompt / oh-my-zsh banners didn't surface in testing because `exec` fires before they print to the PTY, but a setting to disable shell wrapping could be added later if a particular setup misbehaves.