### PR TITLE
fix(pr-detail): drop redundant tooltip on enabled merge button

### DIFF
--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -480,26 +480,30 @@ function MergeActionButton({
   const upper = mergeable?.toUpperCase() ?? null;
   const ready = upper === "MERGEABLE";
   const conflicting = upper === "CONFLICTING";
-  const title = ready
-    ? "Merge"
-    : conflicting
-      ? "Cannot merge — conflicting branch"
-      : "Merge readiness still being determined…";
+  const button = (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!ready}
+      className={cn(
+        "rounded-md px-2.5 py-1 text-[11px] font-medium transition",
+        ready
+          ? "bg-emerald-500/20 text-emerald-300 hover:bg-emerald-500/30"
+          : "cursor-not-allowed bg-bg-elevated text-fg-muted opacity-70",
+      )}
+    >
+      Merge
+    </button>
+  );
+  if (ready) {
+    return button;
+  }
+  const title = conflicting
+    ? "Cannot merge — conflicting branch"
+    : "Merge readiness still being determined…";
   return (
     <Tooltip label={title} side="bottom">
-      <button
-        type="button"
-        onClick={onClick}
-        disabled={!ready}
-        className={cn(
-          "rounded-md px-2.5 py-1 text-[11px] font-medium transition",
-          ready
-            ? "bg-emerald-500/20 text-emerald-300 hover:bg-emerald-500/30"
-            : "cursor-not-allowed bg-bg-elevated text-fg-muted opacity-70",
-        )}
-      >
-        Merge
-      </button>
+      {button}
     </Tooltip>
   );
 }


### PR DESCRIPTION
## Summary
- Remove the redundant "Merge" tooltip that rendered on the merge button when the PR was already mergeable, duplicating the button label.
- Keep the tooltip only for the disabled states so the user still gets the reason ("conflicting branch" or "readiness still being determined").

## Test plan
- [x] Open the PR Detail Modal on a mergeable PR → hovering the **Merge** button shows no tooltip.
- [x] Open a PR with conflicts → button is disabled and tooltip reads "Cannot merge — conflicting branch".
- [x] Open a PR while merge readiness is unknown → button is disabled and tooltip reads "Merge readiness still being determined…".