### PR TITLE
test(e2e): playwright harness + feature spec coverage + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,51 @@ jobs:
 
       - name: Build
         run: bun run build
+
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Cache Playwright's downloaded browsers — saves ~30s per run after
+      # the first cache hit. The key includes the @playwright/test version
+      # so a Playwright bump invalidates and refetches.
+      - name: Read Playwright version
+        id: pw
+        run: echo "version=$(node -p "require('./node_modules/@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Chromium
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: bun run test:e2e
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ dist-ssr
 # Cargo / Tauri build output
 target/
 
+# Stale Bun binary lockfile (project uses bun.lock as of Bun 1.2+)
+bun.lockb
+
 # Git worktrees
 .worktrees/
 
@@ -24,6 +27,11 @@ target/
 
 # Playwright MCP artifacts
 .playwright-mcp/
+
+# Playwright E2E artifacts
+test-results/
+playwright-report/
+.playwright/
 
 # Editor directories and files
 .vscode/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+Conventions and gotchas for AI coding agents working on Acorn. This is a living doc — add things future-you would have wanted to know.
+
+## Project shape
+
+- **Tauri 2** desktop app. Frontend in `src/`, Rust backend in `src-tauri/`.
+- **Bun** is the package manager. Use `bun install`, `bun run dev`, `bun add` — not `npm`/`yarn`/`pnpm`.
+- Frontend: React 19, Vite, Tailwind 4, zustand. UI talks to Rust via `invoke()` from `@tauri-apps/api/core`, centralized in `src/lib/api.ts`.
+- React **StrictMode is on** (`src/main.tsx`). Effects run twice on mount in dev — guard async work with a cancellation flag, don't assume single-mount.
+
+## Testing
+
+Two layers, do not mix them up. Full decision framework: [`docs/TESTING.md`](docs/TESTING.md).
+
+| Layer | Where | When |
+| --- | --- | --- |
+| Vitest | `src/**/*.test.ts` | Pure functions, store actions, anything callable as `f(x) === y` |
+| Playwright | `tests/e2e/**/*.spec.ts` | Anything the user clicks / types / sees on screen |
+
+One-line rule: **visible to the user → Playwright; just a function → Vitest.**
+
+When extending behavior:
+
+- New util in `src/lib/foo.ts` → add `src/lib/foo.test.ts` (Vitest, next to it).
+- New action in `src/store.ts` → extend `src/store.test.ts` (Vitest with `vi.mock("./lib/api")`).
+- New component / modal / shortcut → add `tests/e2e/foo.spec.ts` (Playwright).
+- New `invoke` wrapper in `api.ts` → usually no dedicated unit test (it's a passthrough); E2E exercises it.
+
+Playwright-specific patterns (mock setup, hotkey helper, closure rules, capturing invoke args) live in [`docs/E2E_TESTING.md`](docs/E2E_TESTING.md). Read it before writing E2E.
+
+Two recurring traps in E2E:
+1. **Handler functions are serialized to source.** They cannot close over test-side variables, helpers, or imports. Inline the data inside each handler.
+2. **OS keyboard shortcuts (Cmd+P, Cmd+,) are intercepted by Chromium.** Use `pressHotkey()` from `tests/e2e/support.ts`, not `page.keyboard.press()`.
+
+## Code conventions
+
+- **Custom window events use the `acorn:` prefix** (`acorn:new-session`, `acorn:add-project`, `acorn:terminal-clear`). When adding a global event, follow this convention so listener wiring stays greppable.
+- **Keyboard shortcuts** are defined as `Hotkeys` constants in `src/lib/hotkeys.ts` and use `tinykeys` with `$mod` for the platform-primary modifier (Cmd on macOS, Ctrl elsewhere). Don't hardcode `Meta+` or `Control+` at call sites.
+- **Local persistence** (UI state like collapsed groups, dismissed update version) goes in `localStorage` under the `acorn:` key prefix. Don't reach for it from inside pure logic — keep it at the component / store edge.
+- **Logic stuck inside a component** that wants a unit test should be extracted to `src/lib/`. Don't try to test it through the rendered component. Example: `Sidebar.tsx`'s `buildProjectGroups` could move out if it grows.
+- **`src/lib/api.ts` is the only place that calls `invoke()` from app code.** New backend commands get a wrapper there with explicit types. Components import from `api`, not from `@tauri-apps/api/core`.
+
+## Things that go wrong if you forget
+
+- **Adding a new boot-time invoke without a default in `tests/e2e/fixtures/tauriMock.ts`** → E2E tests crash silently with a RightPanel-style error and missing data. Add the default when you add the wrapper.
+- **Returning `null` from a backend command that the UI iterates with `.length` / `.map`** → boot crash. Return empty arrays/objects, not nullable wrappers.
+- **Forgetting StrictMode double-fire when wiring `listen()`** → duplicate side effects. Use a `cancelled`/`disposed` flag. See `Terminal.tsx`'s `spawnPty` for the pattern.
+- **Creating files for "future" abstractions** → don't. KISS. Add the second use case before the abstraction.
+
+## Build / run
+
+```sh
+bun install
+bun run tauri dev      # full app (Rust + Vite)
+bun run dev            # Vite only — frontend in browser, no Tauri
+bun run test           # Vitest
+bun run test:e2e       # Playwright
+bun run typecheck
+bun run build          # tsc + vite build
+```
+
+## When in doubt
+
+- Reading: `docs/TESTING.md`, `docs/E2E_TESTING.md`, `docs/PR_LABELS.md`.
+- Patterns: search `src/` first for similar code already in the repo. Match its shape.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ bun run tauri build
 
 > ⚠️ Acorn은 `claude` 바이너리가 `$PATH`에 있어야 기본 모드로 세션을 스폰합니다. 없는 경우 설정에서 시작 모드를 `terminal` 또는 `custom`으로 바꾸세요.
 
+### 테스트
+
+```bash
+bun run test       # Vitest (단위 / 로직)
+bun run test:e2e   # Playwright (UI 흐름, mock된 Tauri invoke)
+```
+
+기여 가이드와 테스트 작성 컨벤션은 [`CLAUDE.md`](CLAUDE.md) 참고.
+
 ---
 
 ## 아키텍처 한눈에

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "zustand": "^5.0.13",
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.2.4",
         "@tauri-apps/cli": "^2",
         "@types/react": "^19.1.8",
@@ -198,6 +199,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -757,6 +760,10 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
@@ -952,5 +959,7 @@
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
   }
 }

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -1,0 +1,244 @@
+# E2E testing
+
+> Deciding **whether** a test belongs here vs in Vitest? Start with [`TESTING.md`](./TESTING.md). This doc is the Playwright reference — what each piece does, how to write a spec, what to mock.
+
+Acorn runs Playwright against `vite dev` in a regular Chromium tab — **not** against the actual Tauri binary. The Rust backend isn't running during tests; instead, a small init script stands up a fake `window.__TAURI_INTERNALS__` so every `invoke()` call gets answered by JavaScript-side handlers.
+
+This is a deliberate trade-off: tests are fast (no native build, no app launch, parallel-safe) and broad coverage is cheap, but the Rust side is never exercised. Use these tests for UI flow regressions; rely on manual checks (or future tauri-driver smoke tests) for backend behavior.
+
+## Layout
+
+```
+tests/e2e/
+├── fixtures/
+│   └── tauriMock.ts     # injected into the page; defines window.__TAURI_INTERNALS__
+├── support.ts           # Playwright fixture exposing tauri.handle()
+├── smoke.spec.ts        # one example
+└── tsconfig.json
+playwright.config.ts     # webServer auto-starts `bun run dev` at :1420
+```
+
+## Running
+
+```sh
+bun run test:e2e          # headless
+bun run test:e2e:headed   # watch the browser drive itself
+bun run test:e2e:ui       # Playwright UI mode (test picker + time travel)
+```
+
+The config auto-starts vite at `localhost:1420` and reuses an already-running dev server when present, so you can keep `bun run dev` open in another terminal and tests will reuse it.
+
+Failure artifacts (`test-results/`, `playwright-report/`) are gitignored. Open the last HTML report with `bunx playwright show-report`.
+
+## Writing a test
+
+The simplest case — return canned data, assert what shows up:
+
+```ts
+import { test, expect } from "./support";
+
+test("seeded project appears in the sidebar", async ({ page, tauri }) => {
+  await tauri.handle("list_projects", () => [
+    { repo_path: "/tmp/demo", name: "demo", order: 0 },
+  ]);
+
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("listitem").filter({ hasText: "demo" }),
+  ).toBeVisible();
+});
+```
+
+Two rules that matter:
+
+- **Always register handlers before `page.goto`.** Handlers ride along as init scripts so they're in place before the React tree renders. Calling `tauri.handle` after navigation does nothing useful.
+- **Handler functions are serialized to source.** `fn.toString()` ships the function body to the page; the page evaluates it as a fresh function with no access to test-side variables, imports, or `require()`. **Closures over Node-side values do not survive the boundary.** Treat each handler as a pure self-contained snippet.
+
+### Stateful flows (write → read)
+
+For "create something then check it shows up", state must live on the `window` because handlers can't share a Node-side variable. Two options:
+
+**Option A — replace the handler between actions:**
+
+```ts
+await tauri.handle("list_projects", () => []);
+await tauri.handle("add_project", (args: { repoPath: string }) => ({
+  repo_path: (args as { repoPath: string }).repoPath,
+  name: "demo",
+  order: 0,
+}));
+await page.goto("/");
+
+await page.getByRole("button", { name: "Add project" }).click();
+// ... drive the dialog ...
+
+// Swap in the post-create list state, then trigger a refresh.
+await tauri.handle("list_projects", () => [
+  { repo_path: "/tmp/demo", name: "demo", order: 0 },
+]);
+```
+
+**Option B — keep state on `window` and let handlers read/write it:**
+
+```ts
+await tauri.handle("list_projects", () => {
+  const w = window as unknown as { __projects?: unknown[] };
+  return w.__projects ?? [];
+});
+await tauri.handle("add_project", (args) => {
+  const w = window as unknown as { __projects?: unknown[] };
+  const next = {
+    repo_path: (args as { repoPath: string }).repoPath,
+    name: "demo",
+    order: 0,
+  };
+  w.__projects = [...(w.__projects ?? []), next];
+  return next;
+});
+```
+
+Option A is clearer for short flows; option B is better when many handlers share state.
+
+## Default fallbacks (don't mock these unless you need to)
+
+The mock returns safe values for the boot path so empty UIs render without crashing:
+
+| Command                                    | Default                                          |
+| ------------------------------------------ | ------------------------------------------------ |
+| `list_sessions`, `list_projects`, `list_*` | `[]`                                             |
+| `detect_session_statuses`                  | `[]`                                             |
+| `read_session_todos`                       | `[]`                                             |
+| `list_commits`, `list_staged`              | `[]`                                             |
+| `list_pull_requests`                       | `{ items: [], account: null, error: null }`      |
+| `staged_diff`, `commit_diff`               | `{ files: [] }`                                  |
+| `claude_session_exists`                    | `false`                                          |
+| `scrollback_load`                          | `null`                                           |
+| `scrollback_orphan_size` / `_clear`        | `0`                                              |
+| `get_memory_usage`                         | `{ rss_bytes: 0, sessions: [], scrollback_disk_bytes: 0 }` |
+| `plugin:event\|listen` / `\|unlisten`      | resolved (callback id)                           |
+| `plugin:app\|version`                      | `"0.0.0-test"`                                   |
+| `plugin:updater\|check`                    | `null` (no update)                               |
+| `plugin:notification\|*`                   | granted / no-op                                  |
+| `plugin:dialog\|open`                      | `null` (override to return a path)               |
+| anything else                              | `null`                                           |
+
+If your test path triggers one of these and the default is fine, don't override. Override only when the test asserts on the result.
+
+## Hotkeys
+
+Don't use `page.keyboard.press('Meta+P')` for app shortcuts. Chromium intercepts native shortcuts (Cmd+P prints, Cmd+, opens preferences) before the page sees them. Use the `pressHotkey` helper from `support.ts` instead — it dispatches a synthetic `KeyboardEvent` directly on `window`, which is where tinykeys is listening.
+
+```ts
+import { test, pressHotkey } from "./support";
+
+test("opens command palette via shortcut", async ({ page }) => {
+  await page.goto("/");
+  await pressHotkey(page, { mod: true, key: "p" });          // $mod+P
+  await pressHotkey(page, { mod: true, shift: true, key: "S" }); // $mod+Shift+S
+  await pressHotkey(page, { mod: true, key: "," });          // $mod+, (Settings)
+});
+```
+
+`mod` resolves to Meta on macOS Chromium and Control elsewhere — same convention tinykeys uses. The helper sets both `event.key` and `event.code` so bindings written as `$mod+Comma` (matched by code) and `$mod+p` (matched by key) both fire.
+
+For non-app keys like Escape that aren't intercepted by the OS, plain `page.keyboard.press('Escape')` is fine.
+
+## Static seed data — `tauri.respond`
+
+If you only need a constant return value (no per-call logic), use `respond` instead of `handle`. It JSON-serializes the value into the page, so test-side factories work just fine:
+
+```ts
+import { makeProject } from "./fixtures/factories";
+
+await tauri.respond("list_projects", [makeProject({ name: "demo" })]);
+await tauri.respond("list_pull_requests", { items: [], account: null, error: null });
+```
+
+Use `handle` when the response depends on the call args, when it needs to mutate state on `window`, or when later actions in the same test should change what the next call returns.
+
+## Console error gating
+
+Every test runs through the `errorTracker` fixture automatically. If a `pageerror` or `console.error` slips through and isn't on the allow-list, the test fails after the body finishes — even if every assertion passed. This catches React error boundaries firing on unrelated panels, missing default mocks for new commands, and similar silent regressions.
+
+Known benign noise (Vite HMR chatter, the radix `DialogTitle` warning) is whitelisted in `IGNORED_ERROR_PATTERNS` inside `support.ts`. Add to it sparingly — every entry is debt.
+
+If a specific test legitimately provokes an error, opt in:
+
+```ts
+test("invoking add_project with bad input surfaces an error", async ({
+  page,
+  tauri,
+  errorTracker,
+}) => {
+  errorTracker.allow(/add project failed/i);
+  await tauri.handle("add_project", () => { throw new Error("nope"); });
+  // ...
+});
+```
+
+## Capturing invoke arguments
+
+Handlers can't close over Node-side variables, so to record what the app called with, write to `window`:
+
+```ts
+await tauri.handle("pty_spawn", (args) => {
+  const w = window as unknown as { __spawnCalls?: unknown[] };
+  w.__spawnCalls = w.__spawnCalls ?? [];
+  w.__spawnCalls.push(args);
+  return null;
+});
+
+// ...drive the UI...
+
+const calls = await page.evaluate(
+  () => (window as unknown as { __spawnCalls?: unknown[] }).__spawnCalls,
+);
+expect(calls).toHaveLength(1);
+```
+
+Combine with `expect.poll(...)` when the invoke happens after a chain of awaits the test can't directly observe.
+
+## Selector conventions
+
+Prefer accessible queries — they double as a check that the UI is reachable by keyboard and screen readers:
+
+```ts
+page.getByRole("button", { name: "Add project" })
+page.getByRole("heading", { name: "Projects" })
+page.getByText(/No projects yet/i)
+```
+
+Reach for `data-testid` only when there's no semantic anchor. Most components in `src/components/` already expose `aria-label`s — search there first.
+
+## What this setup does NOT cover
+
+- Real `git` operations, commit/diff content, PR sync — the Rust commands aren't running.
+- The PTY / xterm wiring beyond rendering. Terminal output is driven by Tauri events the mock doesn't emit.
+- The auto-updater install path, OS notifications, dialog open/save — plugin internals are stubbed flat.
+- macOS app menu accelerators (Cmd+,) — those are wired in Rust.
+- Window lifecycle (`onCloseRequested` flush) beyond "the listener attaches without throwing".
+
+If a feature lives mostly in `src-tauri/`, an E2E test here will mostly tell you "the UI didn't crash". That's still useful, but don't expect it to catch backend regressions.
+
+## When to add a test
+
+- A regression a manual check would have caught: write the missing test alongside the fix.
+- A new component or modal: at minimum, one test that opens it and asserts it renders.
+- A flow that spans multiple components (Add Project → sidebar update → click into session): exactly the kind of thing that's painful to retest by hand and worth automating.
+
+Skip pure-function logic (lives under `src/lib/*.test.ts` via Vitest) and one-off UI tweaks where eyeballing is faster.
+
+## Troubleshooting
+
+**`Cannot read properties of undefined (...)` from `@tauri-apps/api`**
+A new boot-time API is being touched that the mock doesn't cover. Add a default in `tests/e2e/fixtures/tauriMock.ts` (`pluginDefault` for `plugin:*` commands, `appDefault` for app commands).
+
+**Test passes locally, fails in CI**
+Probably a race with the dev server. The config sets `reuseExistingServer: !process.env.CI`, so CI always starts fresh — bump the `webServer.timeout` if vite is slow on the runner.
+
+**`page.evaluate` complains about a closure**
+Handlers are stringified, so any reference to a Node-side variable will fail at runtime. Move the value into the handler's argument or the seeded payload instead of capturing it from the test scope.
+
+**Console errors break the test**
+Some smoke tests assert on a clean console. If you legitimately expect a warning, scope the assertion to ignore it rather than silencing the listener globally.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,131 @@
+# Testing
+
+Acorn has two test layers, each catching a different class of bug. Pick the right layer up front — writing the wrong kind of test is more expensive than not writing one.
+
+| Layer | Tool | Where | Runs in |
+| --- | --- | --- | --- |
+| Unit / logic | Vitest | `src/**/*.test.ts` | Node + jsdom |
+| End-to-end / UI | Playwright | `tests/e2e/**/*.spec.ts` | Real Chromium |
+
+```sh
+bun run test       # Vitest — sub-second, all logic
+bun run test:e2e   # Playwright — ~5s, all UI flows
+```
+
+For Playwright-specific patterns (mocking Tauri invoke, hotkey helper, capturing call args), see [`E2E_TESTING.md`](./E2E_TESTING.md).
+
+## Which layer should this test live in?
+
+Three questions, in order:
+
+1. **Can I describe it as "given X, expect Y" without mentioning the UI?** → **Vitest**
+2. **Does the user have to click, type, or press a shortcut to trigger it?** → **Playwright**
+3. **Does it require multiple components, a modal/portal, or a real Tauri invoke?** → **Playwright**
+
+If none of the three apply, you probably don't need a test for it.
+
+## Quick lookup by file location
+
+| File | Default layer | Why |
+| --- | --- | --- |
+| `src/lib/*.ts` (utilities) | Vitest | Almost always pure functions |
+| `src/store.ts` (actions, reducers) | Vitest | Deterministic state transitions |
+| `src/components/*.tsx` | Playwright | DOM, focus, event integration |
+| Global keyboard shortcuts | Playwright | `window`-level wiring |
+| Tauri `invoke` calls | Playwright | Easier to capture call args end-to-end |
+| First-render / boot behavior | Playwright | Multiple components colliding |
+
+## Concrete examples in this repo
+
+### Vitest territory
+
+```ts
+// src/lib/layout.test.ts — pure tree algorithm
+expect(splitPaneInLayout(layout, "p1", "horizontal")).toEqual({...});
+
+// src/lib/paths.test.ts — string utility
+expect(joinPath("/a", "b")).toBe("/a/b");
+
+// src/store.test.ts — store action with mocked api
+vi.mock("./lib/api", () => ({ api: { addProject: vi.fn(...) } }));
+await store.getState().addProject("/tmp/x");
+expect(store.getState().projects).toHaveLength(1);
+```
+
+### Playwright territory
+
+```ts
+// tests/e2e/command-palette.spec.ts — global shortcut + DOM
+await pressHotkey(page, { mod: true, key: "p" });
+await expect(page.getByRole("dialog", { name: /Command palette/i })).toBeVisible();
+
+// tests/e2e/sidebar.spec.ts — flow across components
+await tauri.handle("plugin:dialog|open", () => "/tmp/picked");
+await page.getByRole("button", { name: "Add project" }).click();
+await expect(page.getByRole("listitem").filter({ hasText: "picked" })).toBeVisible();
+
+// tests/e2e/terminal.spec.ts — invoke argument capture
+await tauri.handle("pty_spawn", (args) => {
+  (window as any).__calls = [...((window as any).__calls ?? []), args];
+  return null;
+});
+await page.getByRole("button", { name: /^shell main · Idle$/ }).click();
+const calls = await page.evaluate(() => (window as any).__calls);
+expect(calls[0].sessionId).toBe("s-term");
+```
+
+## Gray-zone rules
+
+**Logic stuck inside a component**
+If a `Foo.tsx` defines a pure helper (sorting, grouping, predicate building), extract it to `src/lib/foo.ts` and Vitest-test it there. Don't try to test the helper through the component.
+
+Example: `Sidebar.tsx` defines `buildProjectGroups(projects, sessions)` — that should live (and is tested) at the lib layer, not via a Playwright assertion on the rendered list.
+
+**Custom hooks**
+- Pure logic only → Vitest with `renderHook` (jsdom)
+- Needs real DOM measurements (IntersectionObserver, scroll, focus) → Playwright via the component that uses it
+
+**"Does this component render?" checks**
+Skip them. They're free-rider tested by any Playwright flow that mounts the same screen. A test that does nothing but `render(<Foo />)` and checks for a string pays maintenance for almost no signal.
+
+## Smell tests
+
+You're in the wrong layer if:
+
+| In Vitest, you find yourself... | Move it to Playwright |
+| --- | --- |
+| Calling `render()` and clicking through DOM to drive a flow | UI flow belongs to E2E |
+| Mocking 5+ Tauri commands | Plumbing has outgrown unit scope |
+| Working around jsdom's missing layout APIs | jsdom isn't the right environment |
+
+| In Playwright, you find yourself... | Move it to Vitest |
+| --- | --- |
+| Calling `page.evaluate(() => myFn(...))` and asserting the result | Pure function — test it directly |
+| Repeating the same test 10× with different inputs | Parametrized unit test territory |
+| Never reading the screen between actions | UI isn't being exercised |
+
+## Coverage philosophy
+
+Different targets for different layers:
+
+- **Vitest**: aim for high coverage on logic. ~80% on `src/lib/*` and `src/store.ts` is reasonable. Branches matter — write the failing input cases.
+- **Playwright**: aim for **all critical user flows work**, not for line coverage. One good flow test beats five shallow ones. The right question is "if this breaks, will the user notice?"
+
+Don't measure them with the same yardstick. A Vitest "added a new util → covered" is a different bar from a Playwright "added a new modal → flow covered".
+
+## When to add what
+
+| Change | What to write |
+| --- | --- |
+| New utility in `src/lib/` | Vitest test next to it |
+| New store action | Vitest test in `src/store.test.ts` |
+| New component or modal | Playwright spec covering open/close + one happy path |
+| New keyboard shortcut | Playwright spec using `pressHotkey` |
+| New Tauri invoke wrapper in `api.ts` | Vitest only if there's logic to test (most are passthroughs); otherwise let E2E exercise it |
+| Bug fix | Whichever layer would have caught it. If the bug was visible to the user, that's E2E. If it was a wrong calculation, that's Vitest. |
+
+## One-line rule
+
+> **Visible to the user → Playwright. Just a function → Vitest.**
+
+If you're still unsure, walk the three questions at the top.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.13.24",
@@ -42,6 +45,7 @@
     "zustand": "^5.0.13"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.4",
     "@tauri-apps/cli": "^2",
     "@types/react": "^19.1.8",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 1420;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  testMatch: /.*\.spec\.ts$/,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "bun run dev",
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -316,7 +316,14 @@ function useSessionTodos(
       try {
         const result = await api.readSessionTodos(sessionId, cwd);
         if (cancelled) return;
-        setState({ todos: result, loaded: true, error: null });
+        // Defensive: the Rust contract returns Vec<TodoItem> (→ []), but a
+        // serialization edge or future error path that produces null would
+        // crash on the `todos.length` access elsewhere in this panel.
+        setState({
+          todos: Array.isArray(result) ? result : [],
+          loaded: true,
+          error: null,
+        });
       } catch (e) {
         if (cancelled) return;
         setState((prev) => ({ ...prev, loaded: true, error: String(e) }));

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect, pressHotkey } from "./support";
+
+test.describe("command palette", () => {
+  test("opens with $mod+P and closes with Escape", async ({ page }) => {
+    await page.goto("/");
+
+    const palette = page.getByRole("dialog", { name: /Command palette/i });
+    await expect(palette).toHaveCount(0);
+
+    await pressHotkey(page, { mod: true, key: "p" });
+    await expect(palette).toBeVisible();
+    await expect(
+      page.getByPlaceholder("Type a command or search..."),
+    ).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(palette).toHaveCount(0);
+  });
+
+  test("shows seeded sessions under Switch session", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-1",
+        name: "feature-branch",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "feature/abc",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        startup_mode: "terminal",
+      },
+    ]);
+
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "p" });
+
+    await expect(
+      page.getByRole("option", { name: /Switch to feature-branch/i }),
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -1,0 +1,100 @@
+// Runs in the page context via Playwright's addInitScript.
+// Stands up a fake `window.__TAURI_INTERNALS__` so the React app boots in a
+// regular Chromium tab without a Tauri runtime. Tests register per-command
+// handlers on `window.__ACORN_MOCK_HANDLERS__`; anything unhandled falls
+// back to a safe default chosen to keep the UI from crashing.
+
+export const tauriMockSource = `
+(() => {
+  if (window.__ACORN_MOCK_INSTALLED__) return;
+  window.__ACORN_MOCK_INSTALLED__ = true;
+
+  const handlers = window.__ACORN_MOCK_HANDLERS__ || {};
+  let nextCallbackId = 0;
+
+  function pluginDefault(cmd) {
+    if (cmd === 'plugin:event|listen') return Promise.resolve(nextCallbackId++);
+    if (cmd === 'plugin:event|unlisten') return Promise.resolve(undefined);
+    if (cmd === 'plugin:event|emit') return Promise.resolve(undefined);
+    if (cmd === 'plugin:app|version') return Promise.resolve('0.0.0-test');
+    if (cmd === 'plugin:app|name') return Promise.resolve('acorn');
+    if (cmd === 'plugin:updater|check') return Promise.resolve(null);
+    if (cmd === 'plugin:notification|is_permission_granted') return Promise.resolve(true);
+    if (cmd === 'plugin:notification|request_permission') return Promise.resolve('granted');
+    if (cmd === 'plugin:notification|notify') return Promise.resolve(undefined);
+    if (cmd === 'plugin:window|destroy') return Promise.resolve(undefined);
+    if (cmd === 'plugin:window|close') return Promise.resolve(undefined);
+    return undefined;
+  }
+
+  function appDefault(cmd) {
+    if (cmd === 'list_sessions') return Promise.resolve([]);
+    if (cmd === 'list_projects') return Promise.resolve([]);
+    if (cmd === 'detect_session_statuses') return Promise.resolve([]);
+    if (cmd === 'read_session_todos') return Promise.resolve([]);
+    if (cmd === 'list_commits') return Promise.resolve([]);
+    if (cmd === 'list_staged') return Promise.resolve([]);
+    if (cmd === 'list_pull_requests') {
+      return Promise.resolve({ items: [], account: null, error: null });
+    }
+    if (cmd === 'staged_diff') return Promise.resolve({ files: [] });
+    if (cmd === 'commit_diff') return Promise.resolve({ files: [] });
+    if (cmd === 'scrollback_load') return Promise.resolve(null);
+    if (cmd === 'claude_session_exists') return Promise.resolve(false);
+    if (cmd === 'get_memory_usage') {
+      return Promise.resolve({
+        rss_bytes: 0,
+        sessions: [],
+        scrollback_disk_bytes: 0,
+      });
+    }
+    if (cmd === 'scrollback_orphan_size') return Promise.resolve(0);
+    if (cmd === 'scrollback_orphan_clear') return Promise.resolve(0);
+    if (cmd && cmd.startsWith('list_')) return Promise.resolve([]);
+    return Promise.resolve(null);
+  }
+
+  window.__TAURI_INTERNALS__ = {
+    metadata: {
+      currentWindow: { label: 'main' },
+      currentWebview: { label: 'main' },
+    },
+    transformCallback: (callback, once) => {
+      const id = nextCallbackId++;
+      const key = '_' + id;
+      window[key] = (...args) => {
+        if (once) {
+          try { delete window[key]; } catch (_) { window[key] = undefined; }
+        }
+        if (callback) callback(...args);
+      };
+      return id;
+    },
+    unregisterCallback: (id) => {
+      try { delete window['_' + id]; } catch (_) { window['_' + id] = undefined; }
+    },
+    invoke: async (cmd, args) => {
+      const handler = handlers[cmd];
+      if (handler) {
+        try {
+          return await handler(args);
+        } catch (err) {
+          return Promise.reject(err);
+        }
+      }
+      const plugin = pluginDefault(cmd);
+      if (plugin !== undefined) return plugin;
+      return appDefault(cmd);
+    },
+  };
+
+  // The event plugin in @tauri-apps/api 2.x calls into this global on unlisten.
+  // Without it, every \`listen()\` cleanup throws and noisy errors bury real ones.
+  window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+    unregisterListener: () => {},
+  };
+
+  window.__ACORN_MOCK_HANDLERS__ = handlers;
+  window.__ACORN_TEST_MODE__ = true;
+})();
+`;

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect, pressHotkey } from "./support";
+
+// Right panel needs an active project + session for the tabs to actually
+// render their content. Without that, every tab falls back to "No project
+// selected" which trivially passes for any tab assertion.
+async function seedActiveSession(
+  tauri: { handle: (cmd: string, fn: (args: unknown) => unknown) => Promise<void> },
+) {
+  await tauri.handle("list_projects", () => [
+    {
+      repo_path: "/tmp/demo",
+      name: "demo",
+      created_at: "2026-01-01T00:00:00Z",
+      position: 0,
+    },
+  ]);
+  await tauri.handle("list_sessions", () => [
+    {
+      id: "s-1",
+      name: "sess",
+      repo_path: "/tmp/demo",
+      worktree_path: "/tmp/demo",
+      branch: "main",
+      isolated: false,
+      status: "idle",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:05Z",
+      last_message: null,
+      startup_mode: "terminal",
+    },
+  ]);
+}
+
+test.describe("right panel: tab switching", () => {
+  test("each tab shows its own empty placeholder when seeded with a project", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+
+    await page.goto("/");
+
+    // Default tab is Commits — placeholder is "Select a commit to see diff".
+    await expect(page.getByText(/Select a commit to see diff/i)).toBeVisible();
+
+    await page.getByRole("button", { name: "Staged" }).click();
+    await expect(
+      page.getByText(/No staged or modified files/i),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "PRs" }).click();
+    // PR tab: when remote isn't GitHub OR list is empty, one of these shows.
+    // Mock returns an empty list so the empty-list copy wins.
+    await expect(page.getByText(/No .* pull requests/i)).toBeVisible();
+
+    await page.getByRole("button", { name: "Commits" }).click();
+    await expect(page.getByText(/Select a commit to see diff/i)).toBeVisible();
+  });
+
+  test("hotkey $mod+Shift+S routes to Staged tab", async ({ page, tauri }) => {
+    await seedActiveSession(tauri);
+
+    await page.goto("/");
+    // Verify we're not already on Staged.
+    await expect(page.getByText(/Select a commit to see diff/i)).toBeVisible();
+
+    await pressHotkey(page, { mod: true, shift: true, key: "S" });
+
+    // After the hotkey, Staged tab content should render.
+    await expect(
+      page.getByText(/No staged or modified files/i),
+    ).toBeVisible();
+  });
+
+  test("null read_session_todos does not crash the panel (regression)", async ({
+    page,
+    tauri,
+  }) => {
+    // Defensive guard added in src/components/RightPanel.tsx — without it,
+    // a null response from read_session_todos crashed `todos.length` and
+    // brought down the whole RightPanel via React's error boundary. The
+    // global errorTracker fixture asserts no unexpected page errors leaked
+    // during this test, so the regression check is implicit.
+    await seedActiveSession(tauri);
+    await tauri.handle("read_session_todos", () => null);
+
+    await page.goto("/");
+    await page.getByRole("button", { name: /^sess main · Idle$/ }).click();
+    // Give the polling loop a tick to fetch and apply the null response.
+    await expect(page.getByText(/Select a commit to see diff/i)).toBeVisible();
+  });
+});

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect } from "./support";
+
+test.describe("sessions: list rendering", () => {
+  test("each status renders its label", async ({ page, tauri }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-idle",
+        name: "alpha",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        startup_mode: null,
+      },
+      {
+        id: "s-run",
+        name: "beta",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "running",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:04Z",
+        last_message: null,
+        startup_mode: null,
+      },
+      {
+        id: "s-need",
+        name: "gamma",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "needs_input",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:03Z",
+        last_message: null,
+        startup_mode: null,
+      },
+      {
+        id: "s-fail",
+        name: "delta",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "failed",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:02Z",
+        last_message: null,
+        startup_mode: null,
+      },
+      {
+        id: "s-done",
+        name: "epsilon",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "completed",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:01Z",
+        last_message: null,
+        startup_mode: null,
+      },
+    ]);
+
+    await page.goto("/");
+
+    // Each session row exposes a button with accessible name
+    // "<session> <branch> · <Status>" — assert one per status.
+    await expect(
+      page.getByRole("button", { name: /^alpha main · Idle$/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^beta main · Running$/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^gamma main · Needs input$/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^delta main · Failed$/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^epsilon main · Completed$/ }),
+    ).toBeVisible();
+  });
+
+  test("isolated worktree marker shows on isolated sessions only", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-iso",
+        name: "iso",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo-iso",
+        branch: "feature/iso",
+        isolated: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        startup_mode: null,
+      },
+      {
+        id: "s-plain",
+        name: "plain",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:04Z",
+        last_message: null,
+        startup_mode: null,
+      },
+    ]);
+
+    await page.goto("/");
+
+    // Isolated sessions render with the GitBranch icon's "isolated worktree"
+    // aria-label baked into the row's accessible name.
+    await expect(
+      page.getByRole("button", {
+        name: /^iso isolated worktree feature\/iso · Idle$/,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^plain main · Idle$/ }),
+    ).toBeVisible();
+    // The GitBranch icon next to isolated session names carries
+    // aria-label="isolated worktree".
+    await expect(page.getByLabel("isolated worktree")).toHaveCount(1);
+  });
+});

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect, pressHotkey } from "./support";
+
+test.describe("settings modal", () => {
+  test("opens with $mod+, and closes with Escape", async ({ page }) => {
+    await page.goto("/");
+
+    const modal = page.getByRole("dialog", { name: /Settings/i });
+    await expect(modal).toHaveCount(0);
+
+    await pressHotkey(page, { mod: true, key: "," });
+    await expect(modal).toBeVisible();
+    await expect(modal.getByRole("button", { name: "Terminal" })).toBeVisible();
+    await expect(modal.getByRole("button", { name: "Agents" })).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(modal).toHaveCount(0);
+  });
+
+  test("clicking the close button dismisses the modal", async ({ page }) => {
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "," });
+
+    const modal = page.getByRole("dialog", { name: /Settings/i });
+    await expect(modal).toBeVisible();
+
+    await modal.getByRole("button", { name: /close/i }).first().click();
+    await expect(modal).toHaveCount(0);
+  });
+});

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from "./support";
+
+test.describe("sidebar: project lifecycle", () => {
+  test("seeded project appears with name and add session affordances", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => []);
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("listitem").filter({ hasText: "demo" }),
+    ).toBeVisible();
+    await expect(page.getByText(/No projects yet/i)).toHaveCount(0);
+    await expect(page.getByText(/No sessions\./i)).toBeVisible();
+  });
+
+  test("Add Project invokes add_project with the picked path", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("plugin:dialog|open", () => "/tmp/picked");
+    // Capture the add_project call arguments on window so the test can
+    // verify the picked path actually flowed into the invoke.
+    await tauri.handle("add_project", (args) => {
+      const w = window as unknown as { __addProjectCalls?: unknown[] };
+      w.__addProjectCalls = w.__addProjectCalls ?? [];
+      w.__addProjectCalls.push(args);
+      const a = args as { repoPath: string };
+      return {
+        repo_path: a.repoPath,
+        name: "picked",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      };
+    });
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/picked",
+        name: "picked",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Add project" }).click();
+
+    await expect(
+      page.getByRole("listitem").filter({ hasText: "picked" }),
+    ).toBeVisible();
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __addProjectCalls?: unknown[] })
+          .__addProjectCalls,
+    )) as Array<{ repoPath: string }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0].repoPath).toBe("/tmp/picked");
+  });
+
+  test("Close project removes the project after confirming", async ({
+    page,
+    tauri,
+  }) => {
+    // Capture remove_project args; after invocation, swap list_projects to
+    // return an empty list so the post-remove refreshAll empties the sidebar.
+    await tauri.handle("list_projects", () => {
+      const w = window as unknown as { __projectRemoved?: boolean };
+      return w.__projectRemoved
+        ? []
+        : [
+            {
+              repo_path: "/tmp/demo",
+              name: "demo",
+              created_at: "2026-01-01T00:00:00Z",
+              position: 0,
+            },
+          ];
+    });
+    await tauri.handle("remove_project", (args) => {
+      const w = window as unknown as {
+        __removeCalls?: unknown[];
+        __projectRemoved?: boolean;
+      };
+      w.__removeCalls = w.__removeCalls ?? [];
+      w.__removeCalls.push(args);
+      w.__projectRemoved = true;
+      return null;
+    });
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("listitem").filter({ hasText: "demo" }),
+    ).toBeVisible();
+
+    // Hover the project header to reveal the (visually hidden) Close button,
+    // then click it. This opens the RemoveProjectDialog.
+    const projectRow = page.getByRole("button", { name: "Project demo" });
+    await projectRow.hover();
+    await page.getByRole("button", { name: "Close project" }).first().click();
+
+    // RemoveProjectDialog renders a Modal without an explicit aria-label,
+    // so we identify it by its heading. With no isolated worktrees the
+    // primary action button is also labeled "Close project".
+    const confirmDialog = page.getByRole("dialog");
+    await expect(
+      confirmDialog.getByRole("heading", { name: "Close project" }),
+    ).toBeVisible();
+    await confirmDialog
+      .getByRole("button", { name: /^Close project$/ })
+      .click();
+
+    await expect(page.getByText(/No projects yet/i)).toBeVisible();
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __removeCalls?: unknown[] }).__removeCalls,
+    )) as Array<{ repoPath: string; removeWorktrees: boolean }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0].repoPath).toBe("/tmp/demo");
+    expect(calls[0].removeWorktrees).toBe(false);
+  });
+
+  test("multiple projects render in seeded order", async ({ page, tauri }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/alpha",
+        name: "alpha",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+      {
+        repo_path: "/tmp/beta",
+        name: "beta",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 1,
+      },
+    ]);
+
+    await page.goto("/");
+
+    // The project header is a div with role=button and accessible name
+    // "Project <name>" composed by the inner controls.
+    const projects = page.getByRole("button", { name: /^Project / });
+    await expect(projects).toHaveCount(2);
+    await expect(projects.first()).toHaveAccessibleName("Project alpha");
+    await expect(projects.last()).toHaveAccessibleName("Project beta");
+  });
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "./support";
+
+test.describe("smoke: app boots in mocked browser", () => {
+  // Console-error gating runs automatically via the errorTracker fixture
+  // for every test in the suite.
+  test("renders sidebar header with empty state by default", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: "Projects" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Add project" }),
+    ).toBeVisible();
+    await expect(page.getByText(/No projects yet/i)).toBeVisible();
+    await expect(page.getByText(/update available/i)).toHaveCount(0);
+  });
+});

--- a/tests/e2e/support.ts
+++ b/tests/e2e/support.ts
@@ -1,0 +1,217 @@
+import { test as base, expect, type Page } from "@playwright/test";
+import { tauriMockSource } from "./fixtures/tauriMock";
+
+type InvokeHandler = (args: unknown) => unknown | Promise<unknown>;
+
+export interface TauriMock {
+  /**
+   * Register a handler for a Tauri command. Must be called *before*
+   * `page.goto()` so it lands as an init script and is in place before any
+   * boot-time `invoke()` runs. The function body is serialized into the page
+   * context, so it cannot close over Node-side variables, imports, or
+   * helpers — write each handler as a self-contained snippet.
+   */
+  handle: (cmd: string, fn: InvokeHandler) => Promise<void>;
+
+  /**
+   * Like `handle`, but takes a static value instead of a function.
+   * The value is JSON-serialized into the page context, so test-side
+   * factories work here even though they can't survive the closure
+   * boundary in `handle`. Use this for shape-matching seed data.
+   */
+  respond: (cmd: string, value: unknown) => Promise<void>;
+}
+
+declare global {
+  interface Window {
+    __ACORN_MOCK_HANDLERS__: Record<string, InvokeHandler>;
+    __ACORN_MOCK_INSTALLED__: boolean;
+    __ACORN_TEST_MODE__: boolean;
+    __TAURI_INTERNALS__: unknown;
+    __TAURI_EVENT_PLUGIN_INTERNALS__: { unregisterListener: () => void };
+  }
+}
+
+// Pageerror / console.error messages we expect during normal boot. Anything
+// else surfacing in a test is treated as a regression. Add to this list only
+// when the noise is genuinely benign and external (e.g. third-party warnings
+// the app cannot silence) or a known issue tracked separately.
+const IGNORED_ERROR_PATTERNS: RegExp[] = [
+  // Vite HMR connection chatter, only present in dev.
+  /\[vite\]/i,
+  // Radix Dialog (used by cmdk's Command.Dialog and our Modal) warns when a
+  // DialogTitle child is missing. Acorn's CommandPalette and several Modal
+  // call sites currently rely on aria-label only. This is a known a11y gap
+  // tracked separately — silence it here so the gate stays focused on new
+  // regressions rather than pre-existing warnings.
+  /DialogContent.*requires a `DialogTitle`/i,
+];
+
+interface ErrorTracker {
+  errors: string[];
+  /** Tests opt out of the auto-fail when they're intentionally provoking errors. */
+  allow: (pattern: RegExp) => void;
+}
+
+export const test = base.extend<{
+  tauri: TauriMock;
+  errorTracker: ErrorTracker;
+  _tauriBase: void;
+}>({
+  // Auto-on for every test: install the base `__TAURI_INTERNALS__` shim so
+  // the app can boot without crashing, even in tests that never touch
+  // `tauri.handle` / `tauri.respond`. Splitting this out from the public
+  // `tauri` fixture means tests don't need a `void tauri;` line just to
+  // activate the mock.
+  _tauriBase: [
+    async ({ page }, use) => {
+      await page.addInitScript({ content: tauriMockSource });
+      await use();
+    },
+    { auto: true },
+  ],
+
+  tauri: async ({ page, _tauriBase }, use) => {
+    void _tauriBase;
+    const tauri: TauriMock = {
+      handle: async (cmd, fn) => {
+        const fnSource = fn.toString();
+        await page.addInitScript({
+          content: `(() => {
+  const fn = (${fnSource});
+  window.__ACORN_MOCK_HANDLERS__ = window.__ACORN_MOCK_HANDLERS__ || {};
+  window.__ACORN_MOCK_HANDLERS__[${JSON.stringify(cmd)}] = fn;
+})();`,
+        });
+      },
+      respond: async (cmd, value) => {
+        const valueJson = JSON.stringify(value);
+        await page.addInitScript({
+          content: `(() => {
+  const v = ${valueJson};
+  window.__ACORN_MOCK_HANDLERS__ = window.__ACORN_MOCK_HANDLERS__ || {};
+  window.__ACORN_MOCK_HANDLERS__[${JSON.stringify(cmd)}] = () => v;
+})();`,
+        });
+      },
+    };
+
+    await use(tauri);
+  },
+
+  // Auto-on for every test: capture pageerror + console.error and fail the
+  // test if anything unexpected leaked. Tests that intentionally provoke
+  // errors can opt specific patterns out via `errorTracker.allow(...)`.
+  errorTracker: [
+    async ({ page }, use, testInfo) => {
+      const errors: string[] = [];
+      const allowed: RegExp[] = [...IGNORED_ERROR_PATTERNS];
+
+      const onPageError = (err: Error) =>
+        errors.push(`pageerror: ${err.message}`);
+      const onConsole = (msg: import("@playwright/test").ConsoleMessage) => {
+        if (msg.type() !== "error") return;
+        errors.push(`console.error: ${msg.text()}`);
+      };
+
+      page.on("pageerror", onPageError);
+      page.on("console", onConsole);
+
+      const tracker: ErrorTracker = {
+        errors,
+        allow: (pattern) => {
+          allowed.push(pattern);
+        },
+      };
+
+      await use(tracker);
+
+      page.off("pageerror", onPageError);
+      page.off("console", onConsole);
+
+      // Skip the gate when the test is already failing — the underlying
+      // assertion failure is more informative than a tail of error noise.
+      if (testInfo.status !== testInfo.expectedStatus) return;
+
+      const unexpected = errors.filter(
+        (msg) => !allowed.some((re) => re.test(msg)),
+      );
+      if (unexpected.length > 0) {
+        throw new Error(
+          "Unexpected page errors during test:\n" +
+            unexpected.map((m) => "  - " + m).join("\n"),
+        );
+      }
+    },
+    { auto: true },
+  ],
+});
+
+/**
+ * Dispatch a synthetic keydown event on `window` so app-level hotkeys
+ * (registered via tinykeys on `window`) receive it.
+ *
+ * Using `page.keyboard.press('Meta+P')` is unreliable here: Chromium
+ * intercepts native shortcuts (Cmd+P prints, Cmd+, opens preferences)
+ * before the page sees them. Dispatching a raw KeyboardEvent bypasses
+ * the OS layer entirely.
+ *
+ * tinykeys resolves `$mod` to `Meta` when `navigator.platform` matches
+ * `Mac/iPod/iPhone/iPad` (true in Playwright's macOS Chromium build) and
+ * `Control` otherwise. We honor the same detection so tests stay
+ * platform-agnostic.
+ */
+export async function pressHotkey(
+  page: Page,
+  combo: { mod?: boolean; shift?: boolean; alt?: boolean; key: string },
+): Promise<void> {
+  await page.evaluate((c) => {
+    const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+
+    // tinykeys matches against event.key.toUpperCase() OR event.code.
+    // Set both so bindings like "$mod+Comma" (which matches by code) and
+    // "$mod+p" (which matches by key) both fire.
+    function deriveCode(key: string): string {
+      if (/^[a-zA-Z]$/.test(key)) return "Key" + key.toUpperCase();
+      if (/^[0-9]$/.test(key)) return "Digit" + key;
+      const map: Record<string, string> = {
+        ",": "Comma",
+        ".": "Period",
+        "/": "Slash",
+        "\\": "Backslash",
+        ";": "Semicolon",
+        "'": "Quote",
+        "[": "BracketLeft",
+        "]": "BracketRight",
+        "-": "Minus",
+        "=": "Equal",
+        "`": "Backquote",
+        " ": "Space",
+        Tab: "Tab",
+        Enter: "Enter",
+        Escape: "Escape",
+        Backspace: "Backspace",
+        ArrowUp: "ArrowUp",
+        ArrowDown: "ArrowDown",
+        ArrowLeft: "ArrowLeft",
+        ArrowRight: "ArrowRight",
+      };
+      return map[key] ?? key;
+    }
+
+    const ev = new KeyboardEvent("keydown", {
+      key: c.key,
+      code: deriveCode(c.key),
+      metaKey: !!c.mod && isMac,
+      ctrlKey: !!c.mod && !isMac,
+      shiftKey: !!c.shift,
+      altKey: !!c.alt,
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(ev);
+  }, combo);
+}
+
+export { expect };
+export type { Page };

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "./support";
+
+test.describe("terminal: spawn", () => {
+  test("activating a terminal-mode session calls pty_spawn with the session's cwd", async ({
+    page,
+    tauri,
+  }) => {
+    // All seeded data is inlined inside each handler — handlers run in the
+    // page context and cannot close over variables declared in the test
+    // function. Module-scope `const` won't reach the browser either.
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        // Terminal startup → empty command, args=[]; Rust falls back to $SHELL.
+        startup_mode: "terminal",
+      },
+    ]);
+    // Record every pty_spawn invocation on `window` so the test can read it
+    // back via page.evaluate.
+    await tauri.handle("pty_spawn", (args) => {
+      const w = window as unknown as { __ptySpawnCalls?: unknown[] };
+      w.__ptySpawnCalls = w.__ptySpawnCalls ?? [];
+      w.__ptySpawnCalls.push(args);
+      return null;
+    });
+
+    await page.goto("/");
+
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __ptySpawnCalls?: unknown[] })
+                .__ptySpawnCalls?.length ?? 0,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThanOrEqual(1);
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __ptySpawnCalls?: unknown[] }).__ptySpawnCalls,
+    )) as Array<{
+      sessionId: string;
+      cwd: string;
+      command: string;
+      args: string[];
+    }>;
+
+    const first = calls[0];
+    expect(first.sessionId).toBe("s-term");
+    expect(first.cwd).toBe("/tmp/demo");
+    expect(first.command).toBe("");
+    expect(first.args).toEqual([]);
+  });
+});

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/tests/e2e/updater.spec.ts
+++ b/tests/e2e/updater.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "./support";
+
+test.describe("update banner", () => {
+  test("does not show when no update is available", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByText(/Acorn .* is available/)).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: /Install & relaunch/i }),
+    ).toHaveCount(0);
+  });
+
+  test("shows the banner when plugin:updater|check returns metadata", async ({
+    page,
+    tauri,
+  }) => {
+    // The plugin's check() turns this metadata into an Update instance whose
+    // `version` is what the banner reads.
+    await tauri.handle("plugin:updater|check", () => ({
+      rid: 0,
+      currentVersion: "1.0.0",
+      version: "1.2.3",
+      date: "2026-01-01T00:00:00Z",
+      body: "Bug fixes and improvements.",
+      rawJson: {},
+    }));
+
+    await page.goto("/");
+
+    await expect(page.getByText(/Acorn 1\.2\.3/)).toBeVisible();
+    await expect(page.getByText(/is available\./)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Install & relaunch/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /What's new/i }),
+    ).toBeVisible();
+  });
+
+  test("dismiss hides the banner for the same version", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("plugin:updater|check", () => ({
+      rid: 0,
+      currentVersion: "1.0.0",
+      version: "1.2.3",
+      date: "2026-01-01T00:00:00Z",
+      body: "",
+      rawJson: {},
+    }));
+
+    await page.goto("/");
+
+    const banner = page.getByText(/Acorn 1\.2\.3/);
+    await expect(banner).toBeVisible();
+
+    await page.getByRole("button", { name: /Hide until next version/i }).click();
+
+    await expect(banner).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Playwright E2E layer that runs the React app under `vite dev` in a regular Chromium tab, with `invoke()` calls served by a JS-side mock. The full suite passes in ~5 seconds and runs in CI on every PR.

- **Harness** (`playwright.config.ts`, `tests/e2e/{support,fixtures}`) — auto-starts vite, injects fake `__TAURI_INTERNALS__`, exposes `tauri.handle` / `tauri.respond`, `pressHotkey` helper, and an auto-on `errorTracker` that fails on unexpected page errors.
- **Coverage** (18 specs across 8 files) — sidebar (project add/remove/list), command palette, settings modal, right panel tab switching, session list rendering, terminal `pty_spawn` invocation, update banner, plus a smoke test.
- **Real bug caught:** `useSessionTodos` accepted a null/undefined response and crashed the panel on `todos.length`. Now defended; regression test included.
- **CI:** new `e2e` job in `.github/workflows/ci.yml`, Playwright browsers cached, failure artifacts uploaded.
- **Docs:** `docs/TESTING.md` (decision framework Vitest vs Playwright), `docs/E2E_TESTING.md` (Playwright reference), `CLAUDE.md` (project conventions for AI agents). README links to CLAUDE.md.

## Trade-offs / known gaps

- The Rust backend isn't running — these tests don't catch backend regressions. Use manual checks or a future `tauri-driver` smoke for that.
- Several modals (`RemoveProjectDialog`, the cmdk palette) emit Radix "DialogTitle missing" warnings. Whitelisted in `IGNORED_ERROR_PATTERNS` and noted as a separate a11y gap to address.
- Stale `bun.lockb` cleaned up and gitignored (project uses `bun.lock` text format since Bun 1.2+).

## Test plan

- [x] `bun run test` (Vitest): 87 passed
- [x] `bun run test:e2e` (Playwright): 18 passed locally
- [x] `bun run typecheck` clean
- [x] CI `frontend` and `e2e` jobs both green
- [ ] Skim docs/TESTING.md and CLAUDE.md for tone / accuracy