### PR TITLE
test(e2e): session lifecycle, settings tabs, pane shortcuts

### DIFF
--- a/tests/e2e/panes.spec.ts
+++ b/tests/e2e/panes.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect, pressHotkey } from "./support";
+
+const PROJECT = {
+  repo_path: "/tmp/demo",
+  name: "demo",
+  created_at: "2026-01-01T00:00:00Z",
+  position: 0,
+};
+
+const SESSION = {
+  id: "s-1",
+  name: "alpha",
+  repo_path: "/tmp/demo",
+  worktree_path: "/tmp/demo",
+  branch: "main",
+  isolated: false,
+  status: "idle" as const,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:05Z",
+  last_message: null,
+  startup_mode: "terminal" as const,
+};
+
+test.describe("pane / sidebar shortcuts", () => {
+  // react-resizable-panels publishes the current size on `data-panel-size`
+  // (string, e.g. "18.0" for the default 18%). Collapsed panels get "0.0".
+  test("$mod+B collapses then re-expands the sidebar", async ({ page }) => {
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-panel-id="sidebar"]');
+    await expect(sidebar).not.toHaveAttribute("data-panel-size", "0.0");
+
+    await pressHotkey(page, { mod: true, key: "b" });
+    await expect(sidebar).toHaveAttribute("data-panel-size", "0.0");
+
+    await pressHotkey(page, { mod: true, key: "b" });
+    await expect(sidebar).not.toHaveAttribute("data-panel-size", "0.0");
+  });
+
+  test("$mod+J collapses then re-expands the right panel", async ({ page }) => {
+    await page.goto("/");
+
+    const right = page.locator('[data-panel-id="right"]');
+    await expect(right).not.toHaveAttribute("data-panel-size", "0.0");
+
+    await pressHotkey(page, { mod: true, key: "j" });
+    await expect(right).toHaveAttribute("data-panel-size", "0.0");
+
+    await pressHotkey(page, { mod: true, key: "j" });
+    await expect(right).not.toHaveAttribute("data-panel-size", "0.0");
+  });
+
+  test("$mod+D splits the focused pane horizontally", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [SESSION]);
+
+    await page.goto("/");
+
+    // Activate the session so a pane is focused with content.
+    await page
+      .locator('[data-panel-id="sidebar"]')
+      .getByRole("button", { name: /^alpha main · Idle/ })
+      .first()
+      .click();
+
+    const panes = page.locator("[data-pane-body]");
+    await expect(panes).toHaveCount(1);
+
+    await pressHotkey(page, { mod: true, key: "d" });
+    await expect(panes).toHaveCount(2);
+
+    // Horizontal split = side-by-side. Vertical split via $mod+Shift+D.
+    await pressHotkey(page, { mod: true, shift: true, key: "D" });
+    await expect(panes).toHaveCount(3);
+  });
+
+  test("$mod+W triggers the remove-session confirm flow for the active tab", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    // After remove_session fires, list_sessions returns empty so the pane
+    // visibly empties to the "Drop a tab here" placeholder.
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __removed?: boolean };
+      return w.__removed
+        ? []
+        : [
+            {
+              id: "s-1",
+              name: "alpha",
+              repo_path: "/tmp/demo",
+              worktree_path: "/tmp/demo",
+              branch: "main",
+              isolated: false,
+              status: "idle",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:05Z",
+              last_message: null,
+              startup_mode: "terminal",
+            },
+          ];
+    });
+    await tauri.handle("remove_session", () => {
+      const w = window as unknown as { __removed?: boolean };
+      w.__removed = true;
+      return null;
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-panel-id="sidebar"]');
+    await sidebar
+      .getByRole("button", { name: /^alpha main · Idle/ })
+      .first()
+      .click();
+
+    await expect(
+      page.getByText(/Drop a tab here or double-click/i),
+    ).toHaveCount(0);
+
+    // closeFocusedTab routes through requestRemoveSession, which opens the
+    // confirm dialog (matches the manual flow).
+    await pressHotkey(page, { mod: true, key: "w" });
+    const dialog = page.getByRole("dialog");
+    await expect(
+      dialog.getByRole("heading", { name: "Remove session" }),
+    ).toBeVisible();
+    await dialog.getByRole("button", { name: /^Remove$/ }).click();
+
+    await expect(
+      page.getByText(/Drop a tab here or double-click/i),
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/session-lifecycle.spec.ts
+++ b/tests/e2e/session-lifecycle.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from "./support";
+
+const PROJECT = {
+  repo_path: "/tmp/demo",
+  name: "demo",
+  created_at: "2026-01-01T00:00:00Z",
+  position: 0,
+};
+
+const BASE_SESSION = {
+  id: "s-1",
+  name: "alpha",
+  repo_path: "/tmp/demo",
+  worktree_path: "/tmp/demo",
+  branch: "main",
+  isolated: false,
+  status: "idle",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:05Z",
+  last_message: null,
+  startup_mode: "terminal",
+};
+
+test.describe("session lifecycle", () => {
+  test("F2 → type → Enter invokes rename_session with the new name", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [BASE_SESSION]);
+    // rename_session captures args and returns the renamed session shape so
+    // the post-rename refresh path doesn't crash. The store reads our
+    // updated list_sessions on the follow-up refresh — but to keep this
+    // focused on the invoke contract we just confirm the call was made.
+    await tauri.handle("rename_session", (args) => {
+      const w = window as unknown as { __renameCalls?: unknown[] };
+      w.__renameCalls = w.__renameCalls ?? [];
+      w.__renameCalls.push(args);
+      const a = args as { id: string; name: string };
+      return { ...BASE_SESSION, id: a.id, name: a.name };
+    });
+
+    await page.goto("/");
+
+    // Scope to the sidebar — once the session is activated, the main pane's
+    // tab and right panel's controls also surface the session name, breaking
+    // a global getByRole match.
+    const sidebar = page.locator('[data-panel-id="sidebar"]');
+    const row = sidebar
+      .getByRole("button", { name: /^alpha main · Idle/ })
+      .first();
+    await row.click();
+    // After activation the row's accessible name now includes the visible
+    // Remove button, so re-resolve via the rename input that opens on F2.
+    await page.keyboard.press("F2");
+
+    const input = sidebar.locator("input[type='text']");
+    await expect(input).toBeVisible();
+    await input.fill("renamed");
+    await input.press("Enter");
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __renameCalls?: unknown[] })
+                .__renameCalls?.length ?? 0,
+          ),
+        { timeout: 3_000 },
+      )
+      .toBe(1);
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __renameCalls?: unknown[] }).__renameCalls,
+    )) as Array<{ id: string; name: string }>;
+    expect(calls[0]).toEqual({ id: "s-1", name: "renamed" });
+  });
+
+  test("Remove session button → confirm → remove_session is invoked", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    // Switch list_sessions to empty after the remove fires so the post-remove
+    // refresh visibly empties the row. Handler runs in the page context — no
+    // closures, inline the seed.
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __sessionRemoved?: boolean };
+      return w.__sessionRemoved
+        ? []
+        : [
+            {
+              id: "s-1",
+              name: "alpha",
+              repo_path: "/tmp/demo",
+              worktree_path: "/tmp/demo",
+              branch: "main",
+              isolated: false,
+              status: "idle",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:05Z",
+              last_message: null,
+              startup_mode: "terminal",
+            },
+          ];
+    });
+    await tauri.handle("remove_session", (args) => {
+      const w = window as unknown as {
+        __removeCalls?: unknown[];
+        __sessionRemoved?: boolean;
+      };
+      w.__removeCalls = w.__removeCalls ?? [];
+      w.__removeCalls.push(args);
+      w.__sessionRemoved = true;
+      return null;
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-panel-id="sidebar"]');
+    const row = sidebar
+      .getByRole("button", { name: /^alpha main · Idle/ })
+      .first();
+    await expect(row).toBeVisible();
+
+    // Hover to reveal the (visually hidden until hover) Remove session button.
+    await row.hover();
+    await sidebar
+      .getByRole("button", { name: "Remove session", exact: true })
+      .click();
+
+    // RemoveSessionDialog has no aria-label on its dialog wrapper, so we
+    // identify it via the "Remove session" heading inside.
+    const dialog = page.getByRole("dialog");
+    await expect(
+      dialog.getByRole("heading", { name: "Remove session" }),
+    ).toBeVisible();
+    await dialog.getByRole("button", { name: /^Remove$/ }).click();
+
+    await expect(
+      sidebar.getByRole("button", { name: /^alpha main · Idle/ }),
+    ).toHaveCount(0);
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __removeCalls?: unknown[] }).__removeCalls,
+    )) as Array<{ id: string; removeWorktree: boolean }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0].id).toBe("s-1");
+    // Non-isolated session: primary button is "Remove" → session_only path,
+    // which the store passes as removeWorktree = false.
+    expect(calls[0].removeWorktree).toBe(false);
+  });
+});

--- a/tests/e2e/settings-tabs.spec.ts
+++ b/tests/e2e/settings-tabs.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect, pressHotkey } from "./support";
+
+// Each Settings tab has a label / heading unique enough to anchor against.
+// Asserting one element per tab is enough to catch "clicked tab N but
+// content M still rendered" regressions without locking us into specific
+// form widgets.
+const TAB_MARKERS: Array<{
+  tab: string;
+  marker: { kind: "text"; pattern: RegExp } | { kind: "heading"; name: string };
+}> = [
+  { tab: "Terminal", marker: { kind: "text", pattern: /Font family/i } },
+  { tab: "Agents", marker: { kind: "text", pattern: /which AI CLI acorn uses/i } },
+  { tab: "Sessions", marker: { kind: "text", pattern: /Default session startup/i } },
+  { tab: "Editor", marker: { kind: "text", pattern: /Editor command/i } },
+  { tab: "Notifications", marker: { kind: "text", pattern: /System notifications/i } },
+  { tab: "Storage", marker: { kind: "heading", name: "Reclaimable cache" } },
+  { tab: "About", marker: { kind: "heading", name: "About Acorn" } },
+];
+
+test.describe("settings modal: tab content", () => {
+  test("clicking each tab swaps the body content", async ({ page }) => {
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "," });
+
+    const modal = page.getByRole("dialog", { name: /Settings/i });
+    await expect(modal).toBeVisible();
+
+    for (const { tab, marker } of TAB_MARKERS) {
+      await modal.getByRole("button", { name: tab, exact: true }).click();
+      const expected =
+        marker.kind === "heading"
+          ? modal.getByRole("heading", { name: marker.name })
+          : modal.getByText(marker.pattern);
+      await expect(
+        expected,
+        `Settings → ${tab} should reveal its content marker`,
+      ).toBeVisible();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Follows #53. Adds 7 more E2E specs covering flows that previously had no coverage (or only structural checks). Total suite is now 25 specs / ~14s parallel.

- **`session-lifecycle.spec.ts`** — `F2` → rename input → Enter invokes `rename_session` with the right `id` + `name`. Remove session button → confirm dialog → `remove_session` invoked with `removeWorktree=false` for non-isolated sessions.
- **`settings-tabs.spec.ts`** — clicking each Settings tab (Terminal / Agents / Sessions / Editor / Notifications / Storage / About) reveals its own unique content marker. Catches \"tab clicked but body still shows previous tab\" regressions.
- **`panes.spec.ts`**:
  - \`\$mod+B\` / \`\$mod+J\` collapse / re-expand sidebar / right panel (verified via react-resizable-panels' `data-panel-size`).
  - \`\$mod+D\` / \`\$mod+Shift+D\` split the focused pane (`[data-pane-body]` count goes from 1 → 2 → 3).
  - \`\$mod+W\` routes the active tab through the remove-session confirm flow.

## Test plan

- [ ] CI \`Frontend\` job green (Vitest still 87 / 1 skipped, unchanged)
- [ ] CI \`E2E\` job green (25 specs)
- [ ] No new entries in `IGNORED_ERROR_PATTERNS`