### PR TITLE
fix(prs): resolve gh CLI absolute path under sanitized GUI launch PATH

### DIFF
--- a/src-tauri/src/cli_resolver.rs
+++ b/src-tauri/src/cli_resolver.rs
@@ -1,0 +1,261 @@
+//! Resolve absolute paths of external CLIs (`gh`, AI provider binaries, …)
+//! through the user's login+interactive shell, then cache the result.
+//!
+//! ## Why
+//!
+//! macOS hands GUI-launched apps a sanitized PATH (`/usr/bin:/bin:/usr/sbin:/sbin`)
+//! and never sources the user's shell rc files, so binaries installed via
+//! Homebrew, npm, bun, asdf, mise, etc. are invisible to a plain
+//! `Command::new("gh")`. The result is the "`gh` CLI not found" error users
+//! see in the PRs tab when launching from Dock/Spotlight/Finder.
+//!
+//! PR #51 fixed this for long-lived PTY sessions by wrapping every spawn in
+//! `$SHELL -l -i -c 'exec <cmd>'`. That trade-off is fine for one-shot agent
+//! sessions but would add 50–200ms of shell startup *per* gh invocation, and
+//! the multi-account picker in `pull_requests.rs` makes 5–10 gh calls per
+//! refresh — enough to feel sluggish.
+//!
+//! Instead we resolve `<name>` to an absolute path (`/opt/homebrew/bin/gh`,
+//! `~/.local/bin/gh`, etc.) once via the user shell, cache it, and then spawn
+//! the binary directly. Subsequent calls skip the shell entirely.
+//!
+//! ## Self-healing
+//!
+//! Caches are dropped on the first `NotFound` spawn error so that:
+//!   * a binary installed mid-session is picked up on the next attempt,
+//!   * a binary uninstalled mid-session surfaces a clean error rather than a
+//!     stale-cache mystery.
+//!
+//! Other errors (auth failures, non-zero exits, network) leave the cache
+//! intact — they aren't a path problem.
+//!
+//! Resolution itself is best-effort: if the user's shell can't find `<name>`
+//! either, we surface a "not found in your shell PATH" error so the frontend
+//! can show actionable guidance.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::{Mutex, OnceLock};
+
+use crate::error::{AppError, AppResult};
+use crate::shell_util::shell_quote;
+
+/// Per-name absolute-path cache. Keyed by the bare CLI name passed to
+/// [`resolve`]. Lazily initialized so we don't pay for the HashMap when no
+/// CLI has been touched yet (many sessions never open the PRs tab).
+fn cache() -> &'static Mutex<HashMap<String, PathBuf>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, PathBuf>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Return an absolute path to the binary named `name`, resolving via the
+/// user's login+interactive shell on first miss and caching the result for
+/// subsequent calls.
+///
+/// Errors when the shell itself can't locate the binary — surfaces a
+/// human-readable message the UI can show as-is.
+pub fn resolve(name: &str) -> AppResult<PathBuf> {
+    if let Some(cached) = cache().lock().unwrap().get(name).cloned() {
+        return Ok(cached);
+    }
+    // Resolve outside the lock — shell startup can take 50–200ms and
+    // holding the mutex would serialize concurrent first-time lookups for
+    // unrelated CLIs.
+    let resolved = shell_resolve(name)?;
+    cache()
+        .lock()
+        .unwrap()
+        .insert(name.to_string(), resolved.clone());
+    Ok(resolved)
+}
+
+/// Drop the cached resolution for `name`. The next [`resolve`] call will
+/// re-consult the user's shell. Call after a spawn returns `NotFound` so
+/// freshly-installed binaries are picked up and uninstalled ones surface a
+/// clean error instead of a stale path.
+pub fn invalidate(name: &str) {
+    cache().lock().unwrap().remove(name);
+}
+
+/// Spawn `name` and capture its `Output`, retrying once after invalidating
+/// the cache if the spawn fails with `NotFound`. Other errors propagate
+/// verbatim through [`AppError::Other`].
+///
+/// `configure` is called with a freshly-built `Command` (already pointed at
+/// the resolved absolute path) so callers can stack on `args`, `env`, etc.
+/// in their normal builder style. The closure may be invoked twice if a
+/// retry happens, so it must be idempotent — don't move values into it.
+pub fn run<F>(name: &str, mut configure: F) -> AppResult<Output>
+where
+    F: FnMut(&mut Command),
+{
+    let path = resolve(name)?;
+    let mut cmd = Command::new(&path);
+    configure(&mut cmd);
+    match cmd.output() {
+        Ok(out) => Ok(out),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Cache is stale — binary moved/uninstalled since last resolve.
+            // Drop the entry and retry once with a fresh shell lookup.
+            invalidate(name);
+            let path = resolve(name)?;
+            let mut cmd = Command::new(&path);
+            configure(&mut cmd);
+            cmd.output().map_err(|e| spawn_error(name, e))
+        }
+        Err(e) => Err(spawn_error(name, e)),
+    }
+}
+
+/// Map a spawn-time IO error into a user-facing message. `NotFound` becomes
+/// the canonical "CLI not found" string the frontend keys off of.
+pub fn spawn_error(name: &str, e: std::io::Error) -> AppError {
+    if e.kind() == std::io::ErrorKind::NotFound {
+        AppError::Other(format!(
+            "`{name}` CLI not found. Install it and ensure it's on your shell's PATH."
+        ))
+    } else {
+        AppError::Other(format!("failed to invoke {name}: {e}"))
+    }
+}
+
+/// Run `$SHELL -l -i -c 'command -v <name>'` and parse stdout for the
+/// resolved absolute path. The shell sources rc files (so PATH from
+/// Homebrew/npm/asdf/etc. is loaded) before running `command -v`, mirroring
+/// the rc-loading approach in `commands.rs::pty_spawn` (PR #51).
+fn shell_resolve(name: &str) -> AppResult<PathBuf> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    // Wrap `command -v` in an exclusive marker so we can pull the path out
+    // even if the user's rc files print banners (p10k, oh-my-zsh, login
+    // greetings) to stdout during shell startup.
+    let script = format!(
+        "printf '<<<ACORN_CLI_PATH>>>%s<<<END>>>' \"$(command -v {} 2>/dev/null)\"",
+        shell_quote(name)
+    );
+    let out = Command::new(&shell)
+        .args(["-l", "-i", "-c", &script])
+        .output()
+        .map_err(|e| {
+            AppError::Other(format!(
+                "failed to invoke shell {shell} to resolve {name}: {e}"
+            ))
+        })?;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let extracted = extract_path(&stdout).map(str::trim).unwrap_or("");
+    if extracted.is_empty() {
+        return Err(AppError::Other(format!(
+            "`{name}` not found in your shell PATH. Install it and ensure it's available in your login shell."
+        )));
+    }
+    let path = PathBuf::from(extracted);
+    if !path.is_absolute() {
+        return Err(AppError::Other(format!(
+            "shell returned a non-absolute path for `{name}`: {extracted}"
+        )));
+    }
+    Ok(path)
+}
+
+/// Pull the resolved-path payload out of the marker we wrap around
+/// `command -v`. Returns `None` if the markers are missing (shell crashed,
+/// rc file errored mid-startup, etc.).
+fn extract_path(stdout: &str) -> Option<&str> {
+    let start_marker = "<<<ACORN_CLI_PATH>>>";
+    let end_marker = "<<<END>>>";
+    let start = stdout.find(start_marker)? + start_marker.len();
+    let rest = &stdout[start..];
+    let end = rest.find(end_marker)?;
+    Some(&rest[..end])
+}
+
+/// Test-only helper to manipulate the cache directly. Production code should
+/// go through [`resolve`] / [`invalidate`].
+#[cfg(test)]
+fn seed_cache(name: &str, path: &std::path::Path) {
+    cache()
+        .lock()
+        .unwrap()
+        .insert(name.to_string(), path.to_path_buf());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn extract_path_pulls_value_between_markers() {
+        let stdout = "<<<ACORN_CLI_PATH>>>/opt/homebrew/bin/gh<<<END>>>";
+        assert_eq!(extract_path(stdout), Some("/opt/homebrew/bin/gh"));
+    }
+
+    #[test]
+    fn extract_path_ignores_rc_banner_before_markers() {
+        let stdout = "p10k instant-prompt loaded\n\
+                      Last login: Mon Jan  1 12:00:00\n\
+                      <<<ACORN_CLI_PATH>>>/usr/local/bin/gh<<<END>>>";
+        assert_eq!(extract_path(stdout), Some("/usr/local/bin/gh"));
+    }
+
+    #[test]
+    fn extract_path_returns_none_when_markers_missing() {
+        assert_eq!(extract_path("garbage output"), None);
+        assert_eq!(extract_path(""), None);
+    }
+
+    #[test]
+    fn extract_path_handles_empty_payload() {
+        // `command -v` prints nothing when the binary is missing; we get an
+        // empty payload between markers and the caller treats it as "not
+        // found".
+        let stdout = "<<<ACORN_CLI_PATH>>><<<END>>>";
+        assert_eq!(extract_path(stdout), Some(""));
+    }
+
+    #[test]
+    fn invalidate_removes_only_the_named_entry() {
+        seed_cache("acorn-test-keep", Path::new("/tmp/keep"));
+        seed_cache("acorn-test-drop", Path::new("/tmp/drop"));
+
+        invalidate("acorn-test-drop");
+
+        let guard = cache().lock().unwrap();
+        assert!(guard.contains_key("acorn-test-keep"));
+        assert!(!guard.contains_key("acorn-test-drop"));
+    }
+
+    #[test]
+    fn invalidate_is_a_noop_for_uncached_name() {
+        // Should not panic or error when the name was never cached.
+        invalidate("acorn-test-never-existed");
+    }
+
+    #[test]
+    fn resolve_returns_cached_path_without_shelling_out() {
+        // Use an obviously-fake path so any accidental spawn would fail
+        // loudly. If the cache is honored we never touch the shell, so the
+        // path comes back verbatim.
+        seed_cache("acorn-test-cached", Path::new("/never/exists/binary"));
+
+        let resolved = resolve("acorn-test-cached").expect("cached lookup");
+        assert_eq!(resolved, Path::new("/never/exists/binary"));
+    }
+
+    #[test]
+    fn spawn_error_maps_notfound_to_canonical_message() {
+        let err = spawn_error("gh", std::io::Error::from(std::io::ErrorKind::NotFound));
+        let msg = err.to_string();
+        assert!(msg.contains("`gh` CLI not found"), "got: {msg}");
+    }
+
+    #[test]
+    fn spawn_error_passes_through_other_io_kinds() {
+        let err = spawn_error(
+            "gh",
+            std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("failed to invoke gh"), "got: {msg}");
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15,6 +15,7 @@ use crate::pull_requests::{
 use crate::scrollback;
 use crate::session::{Project, Session, SessionStartupMode, SessionStatus};
 use crate::session_status;
+use crate::shell_util::shell_quote;
 use crate::state::AppState;
 use crate::todos::{self, TodoItem};
 use crate::worktree;
@@ -179,9 +180,7 @@ pub async fn create_session(
         startup_mode,
     );
     let inserted = state.sessions.insert(session);
-    state
-        .projects
-        .ensure(repo.clone(), project_basename(&repo));
+    state.projects.ensure(repo.clone(), project_basename(&repo));
     persist(&state);
     Ok(inserted)
 }
@@ -197,18 +196,13 @@ pub fn add_project(state: State<'_, AppState>, repo_path: String) -> AppResult<P
     if !path.exists() {
         return Err(AppError::InvalidPath(repo_path));
     }
-    let project = state
-        .projects
-        .ensure(path.clone(), project_basename(&path));
+    let project = state.projects.ensure(path.clone(), project_basename(&path));
     persist(&state);
     Ok(project)
 }
 
 #[tauri::command]
-pub fn reorder_projects(
-    state: State<'_, AppState>,
-    order: Vec<String>,
-) -> AppResult<Vec<Project>> {
+pub fn reorder_projects(state: State<'_, AppState>, order: Vec<String>) -> AppResult<Vec<Project>> {
     let paths: Vec<PathBuf> = order.into_iter().map(PathBuf::from).collect();
     state.projects.reorder(&paths);
     persist(&state);
@@ -278,11 +272,7 @@ pub fn set_session_status(
 }
 
 #[tauri::command]
-pub fn rename_session(
-    state: State<'_, AppState>,
-    id: String,
-    name: String,
-) -> AppResult<Session> {
+pub fn rename_session(state: State<'_, AppState>, id: String, name: String) -> AppResult<Session> {
     let id = Uuid::parse_str(&id).map_err(|e| AppError::Other(e.to_string()))?;
     let trimmed = name.trim().to_string();
     if trimmed.is_empty() {
@@ -315,10 +305,7 @@ fn decode_base64(input: &str) -> Option<Vec<u8>> {
             _ => INVALID,
         }
     }
-    let bytes: Vec<u8> = input
-        .bytes()
-        .filter(|b| !b.is_ascii_whitespace())
-        .collect();
+    let bytes: Vec<u8> = input.bytes().filter(|b| !b.is_ascii_whitespace()).collect();
     if bytes.len() % 4 != 0 {
         return None;
     }
@@ -406,7 +393,10 @@ pub async fn pty_spawn<R: Runtime>(
                 script.push(' ');
                 script.push_str(&shell_quote(a));
             }
-            (shell, vec!["-l".to_string(), "-i".to_string(), "-c".to_string(), script])
+            (
+                shell,
+                vec!["-l".to_string(), "-i".to_string(), "-c".to_string(), script],
+            )
         }
     };
     state.pty.spawn(
@@ -421,77 +411,8 @@ pub async fn pty_spawn<R: Runtime>(
     )
 }
 
-/// Quote `s` so a POSIX shell parses it as a single argument verbatim.
-/// Returns `s` unquoted when it is composed solely of safe characters that
-/// the shell would not interpret (alphanumerics and a small allow-list);
-/// otherwise wraps it in single quotes with embedded `'` escaped as `'\''`.
-fn shell_quote(s: &str) -> String {
-    if s.is_empty() {
-        return "''".to_string();
-    }
-    let safe = s.bytes().all(|b| {
-        b.is_ascii_alphanumeric()
-            || matches!(b, b'_' | b'-' | b'/' | b'.' | b'=' | b':' | b',' | b'@' | b'+')
-    });
-    if safe {
-        return s.to_string();
-    }
-    let mut out = String::with_capacity(s.len() + 2);
-    out.push('\'');
-    for c in s.chars() {
-        if c == '\'' {
-            out.push_str("'\\''");
-        } else {
-            out.push(c);
-        }
-    }
-    out.push('\'');
-    out
-}
-
-#[cfg(test)]
-mod shell_quote_tests {
-    use super::shell_quote;
-
-    #[test]
-    fn safe_inputs_pass_through() {
-        assert_eq!(shell_quote("claude"), "claude");
-        assert_eq!(shell_quote("--session-id"), "--session-id");
-        assert_eq!(shell_quote("a1b2-c3d4"), "a1b2-c3d4");
-        assert_eq!(shell_quote("/usr/local/bin/foo"), "/usr/local/bin/foo");
-        assert_eq!(shell_quote("KEY=value"), "KEY=value");
-    }
-
-    #[test]
-    fn empty_becomes_empty_quotes() {
-        assert_eq!(shell_quote(""), "''");
-    }
-
-    #[test]
-    fn space_triggers_quoting() {
-        assert_eq!(shell_quote("hello world"), "'hello world'");
-    }
-
-    #[test]
-    fn embedded_single_quote_is_escaped() {
-        assert_eq!(shell_quote("it's"), "'it'\\''s'");
-    }
-
-    #[test]
-    fn shell_metacharacters_are_quoted() {
-        assert_eq!(shell_quote("a;b"), "'a;b'");
-        assert_eq!(shell_quote("$HOME"), "'$HOME'");
-        assert_eq!(shell_quote("`ls`"), "'`ls`'");
-        assert_eq!(shell_quote("a|b"), "'a|b'");
-    }
-}
-
 #[tauri::command]
-pub fn pty_write(
-    state: State<'_, AppState>,
-    session_id: String,
-    data: String,
-) -> AppResult<()> {
+pub fn pty_write(state: State<'_, AppState>, session_id: String, data: String) -> AppResult<()> {
     let id = parse_id(&session_id)?;
     let bytes = decode_b64(&data)?;
     state.pty.write(&id, &bytes)
@@ -670,11 +591,7 @@ pub async fn claude_session_exists(_cwd: String, session_id: String) -> bool {
 /// the binary themselves at runtime — adding it to a static capability scope
 /// would defeat the configurability.
 #[tauri::command]
-pub async fn open_in_editor(
-    command: String,
-    args: Vec<String>,
-    path: String,
-) -> AppResult<()> {
+pub async fn open_in_editor(command: String, args: Vec<String>, path: String) -> AppResult<()> {
     let trimmed = command.trim();
     if trimmed.is_empty() {
         return Err(AppError::Other(
@@ -754,10 +671,7 @@ pub async fn generate_pr_commit_message(
     )
 }
 
-fn create_unique_worktree(
-    repo: &std::path::Path,
-    base: &str,
-) -> AppResult<(String, PathBuf)> {
+fn create_unique_worktree(repo: &std::path::Path, base: &str) -> AppResult<(String, PathBuf)> {
     let root = worktree::worktree_root(repo);
     let mut candidate = base.to_string();
     let mut n = 2;
@@ -782,7 +696,13 @@ fn create_unique_worktree(
 
 fn sanitize_worktree_name(name: &str) -> String {
     name.chars()
-        .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
         .collect::<String>()
         .trim_matches('-')
         .to_string()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod cli_resolver;
 mod commands;
 mod error;
 mod git_ops;
@@ -7,6 +8,7 @@ mod pull_requests;
 mod scrollback;
 mod session;
 mod session_status;
+mod shell_util;
 mod state;
 mod todos;
 mod unified_diff;
@@ -74,9 +76,7 @@ pub fn run() {
                 .paste()
                 .select_all()
                 .build()?;
-            let view_submenu = SubmenuBuilder::new(app, "View")
-                .fullscreen()
-                .build()?;
+            let view_submenu = SubmenuBuilder::new(app, "View").fullscreen().build()?;
             let window_submenu = SubmenuBuilder::new(app, "Window")
                 .minimize()
                 .maximize()

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -34,6 +34,7 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
+use crate::cli_resolver;
 use crate::error::{AppError, AppResult};
 use crate::git_ops::{github_owner_repo, DiffPayload};
 
@@ -172,8 +173,7 @@ impl CachedResolution {
 /// no network — so we never store secrets in this cache.
 fn resolution_cache() -> &'static Mutex<HashMap<PathBuf, CachedResolution>> {
     use std::sync::OnceLock;
-    static CELL: OnceLock<Mutex<HashMap<PathBuf, CachedResolution>>> =
-        OnceLock::new();
+    static CELL: OnceLock<Mutex<HashMap<PathBuf, CachedResolution>>> = OnceLock::new();
     CELL.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
@@ -240,11 +240,7 @@ enum AccountOutcome<T> {
 /// Run `op` with the right gh token for `slug`. Tries the cached login
 /// first; on failure (or cache miss / stale login) falls through to a
 /// fresh resolution and stores the picked login on success.
-fn try_with_account<T, F>(
-    repo_path: &Path,
-    slug: &str,
-    op: F,
-) -> AppResult<AccountOutcome<T>>
+fn try_with_account<T, F>(repo_path: &Path, slug: &str, op: F) -> AppResult<AccountOutcome<T>>
 where
     F: Fn(&str) -> AppResult<T>,
 {
@@ -289,27 +285,28 @@ fn run_pr_list(
     limit: u32,
 ) -> AppResult<Vec<PullRequestInfo>> {
     let limit = limit.clamp(1, 200);
-    let output = Command::new("gh")
-        .env("GH_TOKEN", token)
-        // gh treats GH_HOST + GH_TOKEN as an "external" auth source and skips
-        // its own keyring lookup, so this isolates the run to the picked
-        // identity even when a different `gh auth status` account is active.
-        .env("GH_HOST", GH_HOST)
-        .args([
-            "pr",
-            "list",
-            "--repo",
-            slug,
-            "--state",
-            state.as_gh_arg(),
-            "--limit",
-            &limit.to_string(),
-            "--json",
-            "number,title,state,author,headRefName,baseRefName,url,updatedAt,\
-             isDraft,statusCheckRollup",
-        ])
-        .output()
-        .map_err(map_gh_spawn_error)?;
+    let limit_s = limit.to_string();
+    let output = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token)
+            // gh treats GH_HOST + GH_TOKEN as an "external" auth source and
+            // skips its own keyring lookup, so this isolates the run to the
+            // picked identity even when a different `gh auth status` account
+            // is active.
+            .env("GH_HOST", GH_HOST)
+            .args([
+                "pr",
+                "list",
+                "--repo",
+                slug,
+                "--state",
+                state.as_gh_arg(),
+                "--limit",
+                &limit_s,
+                "--json",
+                "number,title,state,author,headRefName,baseRefName,url,updatedAt,\
+                 isDraft,statusCheckRollup",
+            ]);
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -467,10 +464,7 @@ fn resolve_account_for_repo(repo_path: &Path, slug: &str) -> AppResult<AccountRe
     Ok(AccountResolution { candidates, picked })
 }
 
-fn pick_from_multiple(
-    repo_path: &Path,
-    accessible: &[(String, String)],
-) -> PickedAccount {
+fn pick_from_multiple(repo_path: &Path, accessible: &[(String, String)]) -> PickedAccount {
     // 1. Prefer an account whose primary email matches the repo's
     //    git user.email. Best-effort; either side may be missing.
     if let Some(repo_email) = git_user_email(repo_path) {
@@ -489,9 +483,7 @@ fn pick_from_multiple(
     // 2. Fall back to whatever account `gh` currently considers active —
     //    matches the user's existing mental model.
     if let Some(active) = gh_active_token() {
-        if let Some((login, token)) =
-            accessible.iter().find(|(_, t)| t == &active)
-        {
+        if let Some((login, token)) = accessible.iter().find(|(_, t)| t == &active) {
             return PickedAccount {
                 login: login.clone(),
                 token: token.clone(),
@@ -506,26 +498,14 @@ fn pick_from_multiple(
     }
 }
 
-fn map_gh_spawn_error(e: std::io::Error) -> AppError {
-    if e.kind() == std::io::ErrorKind::NotFound {
-        AppError::Other(
-            "`gh` CLI not found. Install it from https://cli.github.com and run `gh auth login`."
-                .to_string(),
-        )
-    } else {
-        AppError::Other(format!("failed to invoke gh: {e}"))
-    }
-}
-
 /// Parse `gh auth status --hostname <host>` output and pull out logins.
 /// gh writes the human-readable status block to *stderr*, so we read both
 /// streams. Lines look like:
 ///   "  ✓ Logged in to github.com account jtf-ian (keyring)"
 fn enumerate_logins(host: &str) -> AppResult<Vec<String>> {
-    let out = Command::new("gh")
-        .args(["auth", "status", "--hostname", host])
-        .output()
-        .map_err(map_gh_spawn_error)?;
+    let out = cli_resolver::run("gh", |cmd| {
+        cmd.args(["auth", "status", "--hostname", host]);
+    })?;
     // Unauthenticated returns non-zero — empty list, not an error, so the
     // caller can produce a single canonical "not authenticated" message.
     let combined = format!(
@@ -537,12 +517,11 @@ fn enumerate_logins(host: &str) -> AppResult<Vec<String>> {
     let needle = " account ";
     let mut logins: Vec<String> = Vec::new();
     for line in combined.lines() {
-        let Some(idx) = line.find(needle) else { continue };
+        let Some(idx) = line.find(needle) else {
+            continue;
+        };
         let after = &line[idx + needle.len()..];
-        let login: String = after
-            .chars()
-            .take_while(|c| !c.is_whitespace())
-            .collect();
+        let login: String = after.chars().take_while(|c| !c.is_whitespace()).collect();
         if !login.is_empty() && !logins.iter().any(|l| l == &login) {
             logins.push(login);
         }
@@ -551,10 +530,10 @@ fn enumerate_logins(host: &str) -> AppResult<Vec<String>> {
 }
 
 fn gh_token_for(login: &str) -> Option<String> {
-    let out = Command::new("gh")
-        .args(["auth", "token", "--user", login])
-        .output()
-        .ok()?;
+    let out = cli_resolver::run("gh", |cmd| {
+        cmd.args(["auth", "token", "--user", login]);
+    })
+    .ok()?;
     if !out.status.success() {
         return None;
     }
@@ -567,7 +546,10 @@ fn gh_token_for(login: &str) -> Option<String> {
 }
 
 fn gh_active_token() -> Option<String> {
-    let out = Command::new("gh").args(["auth", "token"]).output().ok()?;
+    let out = cli_resolver::run("gh", |cmd| {
+        cmd.args(["auth", "token"]);
+    })
+    .ok()?;
     if !out.status.success() {
         return None;
     }
@@ -583,11 +565,11 @@ fn gh_active_token() -> Option<String> {
 /// non-zero on 403/404, success on 200 — exactly the signal we need.
 fn account_can_access(slug: &str, token: &str) -> bool {
     let endpoint = format!("repos/{slug}");
-    let out = Command::new("gh")
-        .env("GH_TOKEN", token)
-        .env("GH_HOST", GH_HOST)
-        .args(["api", &endpoint, "--silent"])
-        .output();
+    let out = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token)
+            .env("GH_HOST", GH_HOST)
+            .args(["api", &endpoint, "--silent"]);
+    });
     match out {
         Ok(o) => o.status.success(),
         Err(_) => false,
@@ -595,12 +577,12 @@ fn account_can_access(slug: &str, token: &str) -> bool {
 }
 
 fn primary_email_for(token: &str) -> Option<String> {
-    let out = Command::new("gh")
-        .env("GH_TOKEN", token)
-        .env("GH_HOST", GH_HOST)
-        .args(["api", "user", "--jq", ".email"])
-        .output()
-        .ok()?;
+    let out = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token)
+            .env("GH_HOST", GH_HOST)
+            .args(["api", "user", "--jq", ".email"]);
+    })
+    .ok()?;
     if !out.status.success() {
         return None;
     }
@@ -732,11 +714,7 @@ pub fn get_pull_request_detail(
     }
 }
 
-fn build_detail(
-    number: u64,
-    view: GhPullRequestView,
-    diff_text: String,
-) -> PullRequestDetail {
+fn build_detail(number: u64, view: GhPullRequestView, diff_text: String) -> PullRequestDetail {
     let comments = view
         .comments
         .unwrap_or_default()
@@ -814,22 +792,20 @@ fn build_detail(
 }
 
 fn run_pr_view(slug: &str, number: u64, token: &str) -> AppResult<GhPullRequestView> {
-    let output = Command::new("gh")
-        .env("GH_TOKEN", token)
-        .env("GH_HOST", GH_HOST)
-        .args([
+    let number_s = number.to_string();
+    let output = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token).env("GH_HOST", GH_HOST).args([
             "pr",
             "view",
-            &number.to_string(),
+            &number_s,
             "--repo",
             slug,
             "--json",
             "number,title,body,state,isDraft,author,headRefName,baseRefName,url,\
-             createdAt,updatedAt,mergedAt,additions,deletions,changedFiles,\
-             mergeable,comments,reviews,statusCheckRollup",
-        ])
-        .output()
-        .map_err(map_gh_spawn_error)?;
+                 createdAt,updatedAt,mergedAt,additions,deletions,changedFiles,\
+                 mergeable,comments,reviews,statusCheckRollup",
+        ]);
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -846,18 +822,12 @@ fn run_pr_view(slug: &str, number: u64, token: &str) -> AppResult<GhPullRequestV
 }
 
 fn run_pr_diff(slug: &str, number: u64, token: &str) -> AppResult<String> {
-    let output = Command::new("gh")
-        .env("GH_TOKEN", token)
-        .env("GH_HOST", GH_HOST)
-        .args([
-            "pr",
-            "diff",
-            &number.to_string(),
-            "--repo",
-            slug,
-        ])
-        .output()
-        .map_err(map_gh_spawn_error)?;
+    let number_s = number.to_string();
+    let output = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token)
+            .env("GH_HOST", GH_HOST)
+            .args(["pr", "diff", &number_s, "--repo", slug]);
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -1013,9 +983,7 @@ pub fn close_pull_request(repo_path: &Path, number: u64) -> AppResult<()> {
         ));
     };
 
-    match try_with_account(repo_path, &slug, |token| {
-        run_pr_close(&slug, number, token)
-    })? {
+    match try_with_account(repo_path, &slug, |token| run_pr_close(&slug, number, token))? {
         AccountOutcome::Ok { value, .. } => Ok(value),
         AccountOutcome::NoAccess { .. } => Err(AppError::Other(
             "No logged-in gh account can close this PR.".to_string(),
@@ -1034,17 +1002,20 @@ fn run_pr_merge(
     use std::io::Write;
     use std::process::Stdio;
 
-    let mut cmd = Command::new("gh");
-    cmd.env("GH_TOKEN", token)
-        .env("GH_HOST", GH_HOST)
-        .args([
-            "pr",
-            "merge",
-            &number.to_string(),
-            "--repo",
-            slug,
-            method.flag(),
-        ]);
+    // stdin-piped invocation can't go through `cli_resolver::run` (which is
+    // shaped for `output()`-style calls), so resolve the path manually and
+    // build the Command ourselves. NotFound during spawn invalidates the
+    // cache so the next attempt re-resolves.
+    let gh_path = cli_resolver::resolve("gh")?;
+    let mut cmd = Command::new(&gh_path);
+    cmd.env("GH_TOKEN", token).env("GH_HOST", GH_HOST).args([
+        "pr",
+        "merge",
+        &number.to_string(),
+        "--repo",
+        slug,
+        method.flag(),
+    ]);
 
     if method.accepts_message_override() {
         if let Some(title) = commit_title {
@@ -1068,7 +1039,12 @@ fn run_pr_merge(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(map_gh_spawn_error)?;
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                cli_resolver::invalidate("gh");
+            }
+            cli_resolver::spawn_error("gh", e)
+        })?;
     if let Some(stdin) = child.stdin.as_mut() {
         let _ = stdin.write_all(b"y\n");
     }
@@ -1088,18 +1064,12 @@ fn run_pr_merge(
 }
 
 fn run_pr_close(slug: &str, number: u64, token: &str) -> AppResult<()> {
-    let output = Command::new("gh")
-        .env("GH_TOKEN", token)
-        .env("GH_HOST", GH_HOST)
-        .args([
-            "pr",
-            "close",
-            &number.to_string(),
-            "--repo",
-            slug,
-        ])
-        .output()
-        .map_err(map_gh_spawn_error)?;
+    let number_s = number.to_string();
+    let output = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token)
+            .env("GH_HOST", GH_HOST)
+            .args(["pr", "close", &number_s, "--repo", slug]);
+    })?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let msg = if stderr.is_empty() {
@@ -1213,11 +1183,7 @@ fn build_commit_message_prompt(
 fn parse_commit_message_response(raw: &str) -> GeneratedCommitMessage {
     let trimmed = raw.trim_matches(|c: char| c.is_whitespace() || c == '`');
     let mut lines = trimmed.lines();
-    let title = lines
-        .next()
-        .map(str::trim)
-        .unwrap_or("")
-        .to_string();
+    let title = lines.next().map(str::trim).unwrap_or("").to_string();
     let remaining: String = lines.collect::<Vec<_>>().join("\n");
     let body = remaining.trim_start_matches('\n').trim().to_string();
     GeneratedCommitMessage { title, body }
@@ -1227,11 +1193,20 @@ fn parse_commit_message_response(raw: &str) -> GeneratedCommitMessage {
 /// `args`, the prompt is piped in via stdin, and stdout is returned. We
 /// surface a typed error when the binary is missing so the frontend can
 /// point the user at install instructions for the configured provider.
+///
+/// Routes through `cli_resolver` so user-installed AI CLIs (claude, gemini,
+/// ollama, llm, …) resolve correctly even under the sanitized PATH that
+/// macOS hands GUI-launched apps.
 fn run_ai_oneshot(command: &str, args: &[String], prompt: &str) -> AppResult<String> {
     use std::io::Write;
     use std::process::Stdio;
 
-    let mut child = Command::new(command)
+    let resolved = cli_resolver::resolve(command).map_err(|_| {
+        AppError::Other(format!(
+            "`{command}` not found. Install the configured AI CLI or change the provider in Settings → Commit message AI."
+        ))
+    })?;
+    let mut child = Command::new(&resolved)
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -1239,6 +1214,7 @@ fn run_ai_oneshot(command: &str, args: &[String], prompt: &str) -> AppResult<Str
         .spawn()
         .map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
+                cli_resolver::invalidate(command);
                 AppError::Other(format!(
                     "`{command}` not found. Install the configured AI CLI or change the provider in Settings → Commit message AI."
                 ))

--- a/src-tauri/src/shell_util.rs
+++ b/src-tauri/src/shell_util.rs
@@ -1,0 +1,71 @@
+//! Small POSIX shell helpers shared across modules that have to splice values
+//! into a `$SHELL -c '...'` script (e.g. PTY command wrapping in `commands.rs`
+//! and CLI absolute-path resolution in `cli_resolver.rs`).
+
+/// Quote `s` so a POSIX shell parses it as a single argument verbatim.
+/// Returns `s` unquoted when it is composed solely of safe characters that
+/// the shell would not interpret (alphanumerics and a small allow-list);
+/// otherwise wraps it in single quotes with embedded `'` escaped as `'\''`.
+pub fn shell_quote(s: &str) -> String {
+    if s.is_empty() {
+        return "''".to_string();
+    }
+    let safe = s.bytes().all(|b| {
+        b.is_ascii_alphanumeric()
+            || matches!(
+                b,
+                b'_' | b'-' | b'/' | b'.' | b'=' | b':' | b',' | b'@' | b'+'
+            )
+    });
+    if safe {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shell_quote;
+
+    #[test]
+    fn safe_inputs_pass_through() {
+        assert_eq!(shell_quote("claude"), "claude");
+        assert_eq!(shell_quote("--session-id"), "--session-id");
+        assert_eq!(shell_quote("a1b2-c3d4"), "a1b2-c3d4");
+        assert_eq!(shell_quote("/usr/local/bin/foo"), "/usr/local/bin/foo");
+        assert_eq!(shell_quote("KEY=value"), "KEY=value");
+    }
+
+    #[test]
+    fn empty_becomes_empty_quotes() {
+        assert_eq!(shell_quote(""), "''");
+    }
+
+    #[test]
+    fn space_triggers_quoting() {
+        assert_eq!(shell_quote("hello world"), "'hello world'");
+    }
+
+    #[test]
+    fn embedded_single_quote_is_escaped() {
+        assert_eq!(shell_quote("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn shell_metacharacters_are_quoted() {
+        assert_eq!(shell_quote("a;b"), "'a;b'");
+        assert_eq!(shell_quote("$HOME"), "'$HOME'");
+        assert_eq!(shell_quote("`ls`"), "'`ls`'");
+        assert_eq!(shell_quote("a|b"), "'a|b'");
+    }
+}


### PR DESCRIPTION
## Summary

Mirrors the macOS GUI-launch PATH issue [#51](https://github.com/im-ian/acorn/pull/51) fixed for PTY commands, applied to the `gh` CLI calls behind the PRs tab.

When acorn is launched from Dock/Spotlight/Finder, macOS hands it a sanitized PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that does not include Homebrew/npm/etc., so the PRs tab surfaces a red **gh CLI not found** error because the bare `Command::new("gh")` call can't resolve the binary.

## Problem vs PR #51

PR #51 wrapped every PTY spawn through `$SHELL -l -i -c 'exec <cmd>'`. That trade-off is fine for one-shot agent sessions (one shell startup at session start), but the PRs tab fires 5–10 gh calls per refresh through the multi-account picker — paying 50–200ms of shell startup per call would add 0.5–2s of latency to every refresh.

## Fix

A small `cli_resolver` module that:

- resolves `<name>` once via `$SHELL -l -i -c 'command -v <name>'` (same login+interactive shell PR #51 used, so rc files supply the full PATH);
- caches the absolute path so subsequent calls skip the shell entirely;
- **invalidates on NotFound** — binaries installed or uninstalled mid-session are picked up on the next attempt;
- surfaces a clean "not found in your shell PATH" error otherwise.

A unique-marker wraps the `command -v` output so rc-file banners (p10k instant-prompt, login greetings, oh-my-zsh init, …) cannot interfere with parsing:

```bash
printf '<<<ACORN_CLI_PATH>>>%s<<<END>>>' "$(command -v gh 2>/dev/null)"
```

`shell_quote` moves from `commands.rs` to a shared `shell_util.rs` so PR #51's PTY wrapping and the new resolver share the same quoting helper.

`pull_requests.rs` routes every gh callsite through the resolver. The provider-agnostic `run_ai_oneshot` (commit-message generation, which shells out to user-installed claude / gemini / etc.) gets the same treatment for free — same root cause, same fix.

## Test plan

- [x] `cargo test` — 23/23 pass (14 existing + 9 new resolver tests)
- [x] `cargo fmt --check` clean, `cargo clippy` no new warnings
- [x] `bun run test` — 87 pass / 1 skipped
- [x] Reproduce bug: under sanitized env, plain gh fails with "No such file or directory"
- [x] Verify resolver mechanism: same sanitized env, resolver's shell invocation extracts `/opt/homebrew/bin/gh` from the marker
- [x] Verify GUI: launch debug build under `env -i HOME=$HOME USER=$USER SHELL=$SHELL PATH=/usr/bin:/bin:/usr/sbin:/sbin ./target/debug/acorn`, open PRs tab — PR list loads normally, no "gh CLI not found" banner

## Notes

- Cache scope is per-CLI name, so the resolver also covers the user-configured AI CLI (claude / gemini / ollama / llm / …) used by the commit-message generator. Adding a future CLI is a one-call `cli_resolver::resolve("name")` away.
- Other errors (auth failures, non-zero exits, network) leave the cache intact — they aren't a path problem.
- p10k instant-prompt etc. did not surface during testing because the marker isolates parsing from any rc-file noise.
