### PR TITLE
fix(pr-list): truncate long head/base branches independently

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1102,19 +1102,23 @@ function PullRequestsTab({
                       label={`${pr.head_branch} → ${pr.base_branch}`}
                       side="top"
                       multiline
+                      className="min-w-0"
                     >
-                      <span className="truncate font-mono">
-                        {pr.head_branch} → {pr.base_branch}
+                      <span className="flex min-w-0 items-center gap-1 font-mono">
+                        <span className="truncate">{pr.head_branch}</span>
+                        <span className="shrink-0">→</span>
+                        <span className="truncate">{pr.base_branch}</span>
                       </span>
                     </Tooltip>
                     <PrChecksBadge checks={pr.checks} />
                   </span>
-                  <span className="opacity-50">·</span>
+                  <span className="shrink-0 opacity-50">·</span>
                   <Tooltip
                     label={absoluteTime(toUnixSeconds(pr.updated_at))}
                     side="top"
+                    className="shrink-0"
                   >
-                    <span className="font-mono">
+                    <span className="whitespace-nowrap font-mono">
                       {relativeTime(toUnixSeconds(pr.updated_at))}
                     </span>
                   </Tooltip>


### PR DESCRIPTION
## Summary
- The PR row's `head → base` line was a single truncated text node, so when the head branch was long the trailing relative-time got squeezed and wrapped onto a second line (`relativeTime` returns strings like `"2h ago"`, and the time's tooltip wrapper had no shrink guard).
- Split the branch label into three flex children — head / arrow / base — each `head` and `base` independently `truncate`, so a long name on either side renders as `br… → main` or `br… → br…` instead of cutting only at the very end.
- Pinned the trailing separator + time element with `shrink-0` / `whitespace-nowrap` so the timestamp always stays on a single line.

## Test plan
- [x] `bun run typecheck` passes — verified locally before commit
- [x] CI Frontend + E2E jobs pass on this branch
- [ ] Visual: long head branch renders as `featur… → main` with `Nh ago` on the same line — **not manually verified**
- [ ] Visual: both head and base long renders as `br… → br…`, arrow stays visible — **not manually verified**
- [ ] Visual: short branches still render fully without ellipsis — **not manually verified**
- [ ] Hovering truncated branches still shows full `head → base` tooltip — **not manually verified**
- [ ] Hovering relative time still shows absolute timestamp tooltip — **not manually verified**

> Note: the visual items were not manually exercised in `bun run dev` before merge. Code review + CI only. If any regression surfaces, follow up on top of `main`.