### PR TITLE
chore(release): bump version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.0"
+version = "1.0.1"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- Bumps the four in-repo version sources in lockstep: `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`.
- After this lands on `main`, pushing the `v1.0.1` tag triggers `.github/workflows/release.yml`:
  - macOS arm64 + x86_64 build, sign with `TAURI_SIGNING_PRIVATE_KEY`
  - upload `.dmg` / `.app.tar.gz` / `.app.tar.gz.sig` to a new GitHub Release
  - emit `latest.json` updater manifest for the Tauri updater plugin

## What 1.0.1 contains (since v1.0.0)
- `fix(pty): wrap agent commands in user shell so PATH resolves on GUI launch` (#51)
- `docs(readme): explain quarantine workaround for ad-hoc signed DMG` (#50)
- `fix(pr-detail): drop redundant tooltip on enabled merge button` (#52)
- `test(e2e): playwright harness + feature spec coverage + CI` (#53)
- `test(e2e): cover session lifecycle, settings tabs, pane shortcuts` (#54)
- `fix(prs): resolve gh CLI absolute path under sanitized GUI launch PATH` (#55, if landed)
- `fix(pr-list): truncate long head/base branches independently` (#56)
- backend refactor of CLI/shell resolution (commit on main: cli_resolver.rs, shell_util.rs split)

## Test plan
- [x] `bun run typecheck` passes locally
- [x] `cargo check --offline` passes locally (Cargo.lock matches Cargo.toml)
- [x] No leftover `1.0.0` strings in the four version files (grep clean)
- [ ] CI Frontend job passes on this PR
- [ ] After merge, pushing `v1.0.1` produces a successful release run with both arch bundles + `latest.json` attached