### PR TITLE
fix(updater): show release notes in dedicated modal instead of opening Settings

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -5,7 +5,7 @@ import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import { sendTestNotification } from "../lib/notifications";
 import { useUpdater } from "../lib/updater-store";
-import { Markdown } from "./ui/Markdown";
+import { WhatsNewModal } from "./WhatsNewModal";
 import {
   AGENT_OPTIONS,
   type SelectedAgent,
@@ -679,10 +679,13 @@ function AboutSettings() {
   const check = useUpdater((s) => s.check);
   const install = useUpdater((s) => s.install);
   const init = useUpdater((s) => s.init);
+  const [whatsNewOpen, setWhatsNewOpen] = useState(false);
 
   useEffect(() => {
     void init();
   }, [init]);
+
+  const hasNotes = (available?.body?.trim().length ?? 0) > 0;
 
   return (
     <section className="space-y-4">
@@ -708,16 +711,25 @@ function AboutSettings() {
           </span>
         </div>
         {available ? (
-          <div className="space-y-2 border-t border-border bg-accent/10 px-3 py-2.5">
-            <div className="flex items-baseline justify-between gap-3">
-              <div className="space-y-0.5">
-                <div className="text-xs font-medium text-fg">
-                  Update available
-                </div>
-                <div className="text-[11px] text-fg-muted">
-                  Acorn {available.version} is ready to install.
-                </div>
+          <div className="flex items-baseline justify-between gap-3 border-t border-border bg-accent/10 px-3 py-2.5">
+            <div className="space-y-0.5">
+              <div className="text-xs font-medium text-fg">
+                Update available
               </div>
+              <div className="text-[11px] text-fg-muted">
+                Acorn {available.version} is ready to install.
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              {hasNotes ? (
+                <button
+                  type="button"
+                  onClick={() => setWhatsNewOpen(true)}
+                  className="rounded px-2 py-1 text-[11px] text-fg-muted underline-offset-2 transition hover:text-fg hover:underline"
+                >
+                  What&apos;s new
+                </button>
+              ) : null}
               <button
                 type="button"
                 onClick={() => void install()}
@@ -728,19 +740,6 @@ function AboutSettings() {
                 {busy ? "Installing…" : "Install & relaunch"}
               </button>
             </div>
-            {available.body && available.body.trim().length > 0 ? (
-              <details className="group">
-                <summary className="cursor-pointer text-[11px] text-fg-muted transition hover:text-fg">
-                  What&apos;s new
-                </summary>
-                <div className="mt-2 max-h-64 overflow-y-auto rounded border border-border bg-bg p-3">
-                  <Markdown
-                    content={available.body}
-                    className="text-[11px]"
-                  />
-                </div>
-              </details>
-            ) : null}
           </div>
         ) : null}
       </div>
@@ -762,6 +761,11 @@ function AboutSettings() {
           {busy ? "Checking…" : "Check for updates"}
         </button>
       </div>
+
+      <WhatsNewModal
+        open={whatsNewOpen}
+        onClose={() => setWhatsNewOpen(false)}
+      />
     </section>
   );
 }

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,14 +1,15 @@
 import { Download, X } from "lucide-react";
-import type { ReactElement } from "react";
-import { useSettings } from "../lib/settings";
+import { useState, type ReactElement } from "react";
 import { selectShouldNotify, useUpdater } from "../lib/updater-store";
+import { WhatsNewModal } from "./WhatsNewModal";
 
 /**
  * Top-of-app non-blocking banner that surfaces an available update.
  * "Install" calls into the updater store to download + relaunch;
- * "What's new" opens Settings → About so the full release notes can
- * be read inline; "Later" dismisses the banner for the current
- * version only — the same update remains reachable from Settings.
+ * "What's new" opens a dedicated release-notes dialog (same one the
+ * Settings → About panel uses); "Later" dismisses the banner for the
+ * current version only — the same update remains reachable from
+ * Settings.
  */
 export function UpdateBanner(): ReactElement | null {
   const should = useUpdater(selectShouldNotify);
@@ -16,43 +17,49 @@ export function UpdateBanner(): ReactElement | null {
   const busy = useUpdater((s) => s.busy);
   const install = useUpdater((s) => s.install);
   const dismiss = useUpdater((s) => s.dismiss);
-  const openSettings = useSettings((s) => s.setOpen);
+  const [whatsNewOpen, setWhatsNewOpen] = useState(false);
 
   if (!should || !update) return null;
 
   return (
-    <div className="flex items-center gap-3 border-b border-border bg-accent/10 px-4 py-2 text-xs">
-      <Download size={14} className="shrink-0 text-accent" />
-      <div className="min-w-0 flex-1">
-        <span className="font-medium text-fg">Acorn {update.version}</span>
-        <span className="ml-2 text-fg-muted">
-          is available. The app will relaunch after install.
-        </span>
+    <>
+      <div className="flex items-center gap-3 border-b border-border bg-accent/10 px-4 py-2 text-xs">
+        <Download size={14} className="shrink-0 text-accent" />
+        <div className="min-w-0 flex-1">
+          <span className="font-medium text-fg">Acorn {update.version}</span>
+          <span className="ml-2 text-fg-muted">
+            is available. The app will relaunch after install.
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={() => setWhatsNewOpen(true)}
+          className="rounded px-2 py-1 text-[11px] text-fg-muted underline-offset-2 transition hover:text-fg hover:underline"
+        >
+          What&apos;s new
+        </button>
+        <button
+          type="button"
+          onClick={() => void install()}
+          disabled={busy}
+          className="rounded bg-accent px-2 py-1 text-[11px] font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
+        >
+          {busy ? "Installing…" : "Install & relaunch"}
+        </button>
+        <button
+          type="button"
+          onClick={dismiss}
+          disabled={busy}
+          title="Hide until next version"
+          className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
+        >
+          <X size={14} />
+        </button>
       </div>
-      <button
-        type="button"
-        onClick={() => openSettings(true)}
-        className="rounded px-2 py-1 text-[11px] text-fg-muted underline-offset-2 transition hover:text-fg hover:underline"
-      >
-        What&apos;s new
-      </button>
-      <button
-        type="button"
-        onClick={() => void install()}
-        disabled={busy}
-        className="rounded bg-accent px-2 py-1 text-[11px] font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
-      >
-        {busy ? "Installing…" : "Install & relaunch"}
-      </button>
-      <button
-        type="button"
-        onClick={dismiss}
-        disabled={busy}
-        title="Hide until next version"
-        className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
-      >
-        <X size={14} />
-      </button>
-    </div>
+      <WhatsNewModal
+        open={whatsNewOpen}
+        onClose={() => setWhatsNewOpen(false)}
+      />
+    </>
   );
 }

--- a/src/components/WhatsNewModal.tsx
+++ b/src/components/WhatsNewModal.tsx
@@ -1,0 +1,88 @@
+import { Download, Sparkles } from "lucide-react";
+import type { ReactElement } from "react";
+import { useUpdater } from "../lib/updater-store";
+import { Modal } from "./ui/Modal";
+import { ModalHeader } from "./ui/ModalHeader";
+import { Markdown } from "./ui/Markdown";
+
+interface WhatsNewModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Standalone release-notes dialog. Triggered both from the top-of-app
+ * `UpdateBanner` and from the Settings → About panel so the same content
+ * surfaces in one place regardless of entry point.
+ *
+ * Reads `available` / `currentVersion` directly from the updater store —
+ * the modal renders nothing when no update is pending, which is the same
+ * lifecycle the banner already obeys.
+ */
+export function WhatsNewModal({
+  open,
+  onClose,
+}: WhatsNewModalProps): ReactElement | null {
+  const update = useUpdater((s) => s.available);
+  const currentVersion = useUpdater((s) => s.currentVersion);
+  const busy = useUpdater((s) => s.busy);
+  const error = useUpdater((s) => s.error);
+  const install = useUpdater((s) => s.install);
+
+  if (!update) return null;
+
+  const body = update.body?.trim() ?? "";
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      variant="dialog"
+      size="2xl"
+      ariaLabelledBy="acorn-whatsnew-title"
+    >
+      <ModalHeader
+        title={`What's new in Acorn ${update.version}`}
+        subtitle={
+          currentVersion ? `currently running ${currentVersion}` : undefined
+        }
+        titleId="acorn-whatsnew-title"
+        icon={<Sparkles size={14} className="text-accent" />}
+        variant="dialog"
+        onClose={onClose}
+      />
+      <div className="max-h-[28rem] overflow-y-auto px-4 py-4">
+        {body.length > 0 ? (
+          <Markdown content={body} className="text-xs" />
+        ) : (
+          <p className="text-xs text-fg-muted">
+            No release notes were published with this version.
+          </p>
+        )}
+      </div>
+      {error ? (
+        <p className="border-t border-danger/40 bg-danger/10 px-4 py-2 text-[11px] text-danger">
+          {error}
+        </p>
+      ) : null}
+      <footer className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+        >
+          Close
+        </button>
+        <button
+          type="button"
+          onClick={() => void install()}
+          disabled={busy}
+          className="inline-flex items-center gap-1.5 rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
+        >
+          <Download size={12} />
+          {busy ? "Installing…" : "Install & relaunch"}
+        </button>
+      </footer>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary

The update banner's "What's new" link used to call `openSettings(true)`, which:

1. opened the Settings modal,
2. on whatever tab was active last (usually Terminal),

so users clicked "What's new" and got dropped onto an unrelated Settings tab — confusing UX, even though the comment in `UpdateBanner.tsx` clearly intended Settings → About.

`SettingsModal.tsx` keeps the active tab in component-local `useState` initialized to `"terminal"`, so external callers cannot ask it to land on About. Rather than wire a tab-routing API into the settings store, this PR replaces the round-trip with a dedicated dialog.

## Fix

New `WhatsNewModal` component renders `available.body` (markdown release notes) with the same Install / Close actions the banner exposes. Two entry points share it:

- `UpdateBanner` — "What's new" now opens the modal directly. Settings is no longer involved.
- `SettingsModal` → About — the old inline `<details><summary>What's new</summary>…</details>` expansion is replaced with a "What's new" button that opens the same modal. One release-notes surface, consistent UX from either entry.

The modal pulls live state (`available`, `currentVersion`, `busy`, `error`, `install`) from `useUpdater`, so its content and disabled states stay in sync with the banner without prop plumbing.

## Test plan

- [x] `bun run build` clean
- [x] `bun run test` — 87 pass / 1 skipped
- [x] Banner "What's new" → modal opens with release notes; Settings modal stays closed
- [x] Settings → About → "What's new" → same modal
- [x] Install button inside the modal still triggers the same `useUpdater.install()` flow
- [x] Release-with-no-body case shows "No release notes were published with this version." instead of an empty body
