### PR TITLE
chore(release): bump version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.1"
+version = "1.0.2"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- Patch release bundling #58 (`fix(updater): show release notes in dedicated modal instead of opening Settings`).
- Bumps the four in-repo version sources in lockstep: `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`.
- After this lands on `main`, pushing the `v1.0.2` tag triggers `.github/workflows/release.yml`:
  - macOS arm64 + x86_64 build, sign with `TAURI_SIGNING_PRIVATE_KEY`
  - upload `.dmg` / `.app.tar.gz` / `.app.tar.gz.sig` to a new GitHub Release
  - emit `latest.json` updater manifest — clients on 1.0.1 will see 1.0.2 and update

## What 1.0.2 contains (since v1.0.1)
- `fix(updater): show release notes in dedicated modal instead of opening Settings` (#58)

## Test plan
- [x] `bun run typecheck` passes locally
- [x] `cargo check --offline` passes locally (Cargo.lock matches Cargo.toml)
- [x] No remaining `acorn` package at `1.0.1` (only unrelated deps `http-body` / `ident_case` carry that version)
- [ ] CI Frontend job passes on this PR
- [ ] After merge, pushing `v1.0.2` produces a successful release run with both arch bundles + `latest.json` attached