### PR TITLE
fix(updater): make Install & relaunch actually install + relaunch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@tauri-apps/plugin-fs": "^2.5.1",
         "@tauri-apps/plugin-notification": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-shell": "^2.3.5",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "@xterm/addon-canvas": "^0.7.0",
@@ -375,6 +376,8 @@
     "@tauri-apps/plugin-notification": ["@tauri-apps/plugin-notification@2.3.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.4", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ=="],
+
+    "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
 
     "@tauri-apps/plugin-shell": ["@tauri-apps/plugin-shell@2.3.5", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg=="],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-notification": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "@xterm/addon-canvas": "^0.7.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
@@ -4273,6 +4274,16 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ directories = "5"
 sysinfo = { version = "0.32", default-features = false, features = ["system"] }
 base64 = "0.22"
 tauri-plugin-updater = "2.10.1"
+tauri-plugin-process = "2"
 
 [profile.release]
 opt-level = 3

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,6 +15,7 @@
     "shell:default",
     "fs:default",
     "notification:default",
-    "updater:default"
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,7 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .manage(app_state)
         .setup(|app| {
             // Build the macOS app menu with a Settings... item that fires the

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,7 @@
       "endpoints": [
         "https://github.com/im-ian/acorn/releases/latest/download/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRCNDkzNjJCMkM4NDIxODgKUldTSUlZUXNLelpKUytaZmZyS3F0R1JEcWtUWjhsOU5kQmlJbTc2UW9uUHV2WjNzdVhwSjNoSTQK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRCNDkzNjJCMkM4NDIxODgKUlVTSUlZUXNLelpKUytaZmZyS3F0R1JEcWtUWjhsOU5kQmlJbTc2UW9uUHV2WjNzdVhwSjNoSTQK"
     }
   }
 }

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -24,6 +24,7 @@ import {
   Select,
   Stepper,
   TextInput,
+  TextSwap,
 } from "./ui";
 
 type Tab =
@@ -737,7 +738,9 @@ function AboutSettings() {
                 className="inline-flex items-center gap-1.5 rounded bg-accent px-2 py-1 text-[11px] font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
               >
                 <Download size={11} />
-                {busy ? "Installing…" : "Install & relaunch"}
+                <TextSwap>
+                  {busy ? "Installing…" : "Install & relaunch"}
+                </TextSwap>
               </button>
             </div>
           </div>
@@ -758,7 +761,7 @@ function AboutSettings() {
           className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-[11px] text-fg-muted transition hover:border-accent/60 hover:text-fg disabled:opacity-50"
         >
           <RefreshCcw size={11} className={busy ? "animate-spin" : ""} />
-          {busy ? "Checking…" : "Check for updates"}
+          <TextSwap>{busy ? "Checking…" : "Check for updates"}</TextSwap>
         </button>
       </div>
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -638,7 +638,7 @@ function StorageSettings() {
               disabled={busy}
               className="rounded bg-danger px-2 py-1 text-[11px] font-medium text-white transition hover:bg-danger/90 disabled:opacity-50"
             >
-              {busy ? "Clearing…" : "Clear cache"}
+              <TextSwap>{busy ? "Clearing…" : "Clear cache"}</TextSwap>
             </button>
           </div>
         </div>

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,6 +1,7 @@
 import { Download, X } from "lucide-react";
 import { useState, type ReactElement } from "react";
 import { selectShouldNotify, useUpdater } from "../lib/updater-store";
+import { TextSwap } from "./ui/TextSwap";
 import { WhatsNewModal } from "./WhatsNewModal";
 
 /**
@@ -10,51 +11,72 @@ import { WhatsNewModal } from "./WhatsNewModal";
  * Settings → About panel uses); "Later" dismisses the banner for the
  * current version only — the same update remains reachable from
  * Settings.
+ *
+ * The banner also shows a single-line error if `install()` fails (e.g.
+ * "signature verification failed", network drops) so users aren't left
+ * wondering why the click did nothing.
  */
 export function UpdateBanner(): ReactElement | null {
   const should = useUpdater(selectShouldNotify);
   const update = useUpdater((s) => s.available);
   const busy = useUpdater((s) => s.busy);
+  const error = useUpdater((s) => s.error);
   const install = useUpdater((s) => s.install);
   const dismiss = useUpdater((s) => s.dismiss);
+  const clearError = useUpdater((s) => s.clearError);
   const [whatsNewOpen, setWhatsNewOpen] = useState(false);
 
   if (!should || !update) return null;
 
   return (
     <>
-      <div className="flex items-center gap-3 border-b border-border bg-accent/10 px-4 py-2 text-xs">
-        <Download size={14} className="shrink-0 text-accent" />
-        <div className="min-w-0 flex-1">
-          <span className="font-medium text-fg">Acorn {update.version}</span>
-          <span className="ml-2 text-fg-muted">
-            is available. The app will relaunch after install.
-          </span>
+      <div className="border-b border-border bg-accent/10 text-xs">
+        <div className="flex items-center gap-3 px-4 py-2">
+          <Download size={14} className="shrink-0 text-accent" />
+          <div className="min-w-0 flex-1">
+            <span className="font-medium text-fg">Acorn {update.version}</span>
+            <span className="ml-2 text-fg-muted">
+              is available. The app will relaunch after install.
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={() => setWhatsNewOpen(true)}
+            className="rounded px-2 py-1 text-[11px] text-fg-muted underline-offset-2 transition hover:text-fg hover:underline"
+          >
+            What&apos;s new
+          </button>
+          <button
+            type="button"
+            onClick={() => void install()}
+            disabled={busy}
+            className="rounded bg-accent px-2 py-1 text-[11px] font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
+          >
+            <TextSwap>{busy ? "Installing…" : "Install & relaunch"}</TextSwap>
+          </button>
+          <button
+            type="button"
+            onClick={dismiss}
+            disabled={busy}
+            title="Hide until next version"
+            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
+          >
+            <X size={14} />
+          </button>
         </div>
-        <button
-          type="button"
-          onClick={() => setWhatsNewOpen(true)}
-          className="rounded px-2 py-1 text-[11px] text-fg-muted underline-offset-2 transition hover:text-fg hover:underline"
-        >
-          What&apos;s new
-        </button>
-        <button
-          type="button"
-          onClick={() => void install()}
-          disabled={busy}
-          className="rounded bg-accent px-2 py-1 text-[11px] font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
-        >
-          {busy ? "Installing…" : "Install & relaunch"}
-        </button>
-        <button
-          type="button"
-          onClick={dismiss}
-          disabled={busy}
-          title="Hide until next version"
-          className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
-        >
-          <X size={14} />
-        </button>
+        {error ? (
+          <div className="flex items-start gap-2 border-t border-danger/30 bg-danger/10 px-4 py-1.5 text-[11px] text-danger">
+            <span className="flex-1 break-words">{error}</span>
+            <button
+              type="button"
+              onClick={clearError}
+              className="shrink-0 rounded p-0.5 text-danger/80 transition hover:bg-danger/20 hover:text-danger"
+              aria-label="Dismiss error"
+            >
+              <X size={12} />
+            </button>
+          </div>
+        ) : null}
       </div>
       <WhatsNewModal
         open={whatsNewOpen}

--- a/src/components/WhatsNewModal.tsx
+++ b/src/components/WhatsNewModal.tsx
@@ -4,6 +4,7 @@ import { useUpdater } from "../lib/updater-store";
 import { Modal } from "./ui/Modal";
 import { ModalHeader } from "./ui/ModalHeader";
 import { Markdown } from "./ui/Markdown";
+import { TextSwap } from "./ui/TextSwap";
 
 interface WhatsNewModalProps {
   open: boolean;
@@ -80,7 +81,7 @@ export function WhatsNewModal({
           className="inline-flex items-center gap-1.5 rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
         >
           <Download size={12} />
-          {busy ? "Installing…" : "Install & relaunch"}
+          <TextSwap>{busy ? "Installing…" : "Install & relaunch"}</TextSwap>
         </button>
       </footer>
     </Modal>

--- a/src/lib/updater-store.ts
+++ b/src/lib/updater-store.ts
@@ -89,12 +89,21 @@ export const useUpdater = create<UpdaterState>()(
         if (!update || get().busy) return;
         set({ busy: true, error: null });
         try {
-          await installUpdate(update);
-          // installUpdate triggers a relaunch — control rarely returns
-          // here. If it does (e.g. the install kicked off but the OS
-          // hasn't restarted us yet), keep busy=true so the UI stays
-          // disabled until the relaunch lands.
+          await installUpdate(update, (event) => {
+            // Log progress markers so a stuck download / install leaves
+            // a breadcrumb trail in the renderer console for debugging.
+            // We deliberately don't surface bytes-per-chunk to the UI —
+            // the banner is intentionally compact.
+            if (event.event === "Started" || event.event === "Finished") {
+              console.info("[updater]", event.event, event);
+            }
+          });
+          // installUpdate now ends with relaunch(), so control rarely
+          // returns here. If it does (e.g. the relaunch is briefly
+          // queued before the OS tears the process down), keep busy=true
+          // so the UI stays disabled until the relaunch lands.
         } catch (err) {
+          console.error("[updater] install failed", err);
           set({
             error: err instanceof Error ? err.message : String(err),
             busy: false,

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,4 +1,8 @@
-import { check, type Update } from "@tauri-apps/plugin-updater";
+import {
+  check,
+  type DownloadEvent,
+  type Update,
+} from "@tauri-apps/plugin-updater";
 import { getVersion } from "@tauri-apps/api/app";
 import { relaunch } from "@tauri-apps/plugin-process";
 
@@ -24,7 +28,7 @@ import { relaunch } from "@tauri-apps/plugin-process";
  *     user's next manual launch.
  */
 
-export type { Update };
+export type { DownloadEvent, Update };
 
 /**
  * Check the configured update endpoint. Returns the `Update` handle when
@@ -55,16 +59,10 @@ export async function getCurrentVersion(): Promise<string> {
  */
 export async function installUpdate(
   update: Update,
-  onProgress?: (event: ProgressEvent) => void,
+  onProgress?: (event: DownloadEvent) => void,
 ): Promise<void> {
   await update.downloadAndInstall((event) => {
     onProgress?.(event);
   });
   await relaunch();
 }
-
-/** Re-exported `DownloadEvent` shape from the updater plugin. */
-export type ProgressEvent =
-  | { event: "Started"; data: { contentLength?: number } }
-  | { event: "Progress"; data: { chunkLength: number } }
-  | { event: "Finished" };

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,12 +1,13 @@
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { getVersion } from "@tauri-apps/api/app";
+import { relaunch } from "@tauri-apps/plugin-process";
 
 /**
  * Acorn auto-updater facade.
  *
  * Wraps `@tauri-apps/plugin-updater` so the rest of the app talks to one
  * Promise-based API and never has to know whether an Update handle is
- * still valid (the handle becomes stale after `installAndRelaunch`).
+ * still valid (the handle becomes stale after the install completes).
  *
  * Behavior contract:
  *   - `checkForUpdate()` returns the available `Update` or `null`. Errors
@@ -14,9 +15,13 @@ import { getVersion } from "@tauri-apps/api/app";
  *     can display them.
  *   - The check itself is non-blocking and side-effect free; nothing is
  *     downloaded or applied unless the caller explicitly invokes
- *     `downloadAndInstall(update)` on the returned handle.
- *   - We do not auto-relaunch the app behind the user's back. The
- *     "install and relaunch" button is always an explicit user gesture.
+ *     `installUpdate(update)` on the returned handle.
+ *   - `installUpdate` does NOT auto-relaunch silently — it explicitly
+ *     calls `plugin-process::relaunch` so the user-clicked
+ *     "Install & relaunch" button fulfills its name. macOS Tauri builds
+ *     don't restart on their own after `downloadAndInstall`; without an
+ *     explicit relaunch the new bundle would only be picked up on the
+ *     user's next manual launch.
  */
 
 export type { Update };
@@ -40,10 +45,26 @@ export async function getCurrentVersion(): Promise<string> {
 }
 
 /**
- * Download and install an update, then ask Tauri to relaunch. The caller
- * should treat this as the destructive final step: after the relaunch
- * call resolves the host process is being torn down.
+ * Download and install an update, then ask Tauri to relaunch. After
+ * `relaunch()` resolves the host process is being torn down — any code
+ * that runs afterwards in the renderer is a transient ghost.
+ *
+ * `onProgress` is forwarded straight through `downloadAndInstall`, so
+ * callers can surface a download progress bar or log to the console for
+ * post-mortem diagnosis when an update misbehaves.
  */
-export async function installUpdate(update: Update): Promise<void> {
-  await update.downloadAndInstall();
+export async function installUpdate(
+  update: Update,
+  onProgress?: (event: ProgressEvent) => void,
+): Promise<void> {
+  await update.downloadAndInstall((event) => {
+    onProgress?.(event);
+  });
+  await relaunch();
 }
+
+/** Re-exported `DownloadEvent` shape from the updater plugin. */
+export type ProgressEvent =
+  | { event: "Started"; data: { contentLength?: number } }
+  | { event: "Progress"; data: { chunkLength: number } }
+  | { event: "Finished" };


### PR DESCRIPTION
## Summary

Three independent failure points were stacked behind one "Install & relaunch does nothing" symptom. This PR fixes each and surfaces the rest defensively. Bonus: applies `TextSwap` to dynamic-text buttons in the updater UI as requested.

## 1. Signature verification failed (root cause for v1.0.x)

The pubkey in `tauri.conf.json` had a **legacy `Ed`** algorithm header (raw ed25519), but Tauri's release pipeline always signs with **`ED`** (ed25519ph / BLAKE2b prehash). The plugin's verifier rejected the algorithm mismatch and threw `signature verification failed` before download could start.

Decoded byte-by-byte:

```
pubkey:    45 64  88 21 84 2c 2b 36 49 4b ...    ← "Ed" raw
signature: 45 44  88 21 84 2c 2b 36 49 4b ...    ← "ED" prehash
                  └────── same key ID ────┘
```

Same key ID on both sides — only the 2-byte algorithm header was wrong. Flipped the pubkey header to `ED` (decoded line 2 byte 0: `0x64 → 0x44`), keeping the underlying ed25519 key identical.

This fixes auto-update **for future releases**. Builds already shipped with the old `Ed` pubkey will still reject incoming `ED` signatures; v1.0.0–1.0.2 users need to download the next release (v1.0.3+) manually once, then the chain heals on its own.

## 2. No relaunch after install (macOS)

`update.downloadAndInstall()` only downloads and replaces the bundle — it does **not** restart the host process. The previous `installUpdate` only called that and assumed Tauri would relaunch on its own. On macOS that assumption is wrong, so a successful install left users sitting on the old process with nothing visibly different.

Added `@tauri-apps/plugin-process` (JS + Rust + capability) and `installUpdate` now ends with an explicit `relaunch()`.

## 3. Banner swallowed install errors

`UpdateBanner` rendered no error UI, so any thrown error from `install()` landed in the store's `error` field with nowhere to appear. The banner now shows a single-line danger strip with a dismiss button. (The About panel already had its own error display.)

## 4. TextSwap on dynamic-text buttons (requested)

WKWebView sometimes leaves a stale paint of the previous label ("Install & relaunch") behind the new one ("Installing…") when a single text node swaps mid-`disabled:opacity` transition. Wrapped the swapping labels in `TextSwap` — the same idiom `MergePullRequestDialog` / `ClosePullRequestDialog` already use. Applied to:

- Banner's `Install & relaunch ⇄ Installing…`
- WhatsNewModal's `Install & relaunch ⇄ Installing…`
- About panel's `Install & relaunch ⇄ Installing…`
- About panel's `Check for updates ⇄ Checking…`

## 5. Defensive: download-progress + console diagnostics

`installUpdate` now forwards a `DownloadEvent` callback to `downloadAndInstall`. The store's `install()` logs `Started` / `Finished` to the console, and failures get a `console.error` with the original error — enough breadcrumb trail to diagnose a stuck install on a user's machine without surfacing bytes-per-chunk in the compact banner.

## Test plan

- [x] `bun run build` clean
- [x] `bun run test` — 87 pass / 1 skipped
- [x] `cargo check` / `cargo test` — 23/23 pass after `plugin-process` wiring
- [x] Decoded pubkey & signature key IDs match (`88 21 84 2c 2b 36 49 4b`); only the algorithm header differed
- [ ] End-to-end signing roundtrip — needs a fresh tagged release to exercise GitHub Actions against the corrected pubkey, since v1.0.0–1.0.2 builds already shipped the old key
