### PR TITLE
chore(release): bump version to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.2"
+version = "1.0.3"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Bumps to v1.0.3 to ship the auto-updater fix from #60.

This release contains the corrected pubkey, explicit relaunch via plugin-process, banner error display, and TextSwap coverage on dynamic-text buttons (updater + cache clear). Tagging v1.0.3 after merge will trigger the release workflow.

**For 1.0.0–1.0.2 users**: this build still ships with the corrected pubkey (`ED` prehash), but their installed binaries shipped with the old (`Ed`) pubkey, so they will need to download v1.0.3 manually once from the GitHub Releases page. Auto-update will then work normally from 1.0.3 onward.