### PR TITLE
fix(pty): inject TERM, system locale, and dotfile env into spawned children

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -435,6 +435,16 @@ pub fn pty_kill(state: State<'_, AppState>, session_id: String) -> AppResult<()>
     state.pty.kill(&id)
 }
 
+/// Drop the cached snapshot of the user's shell environment. The next PTY
+/// spawn re-runs `$SHELL -l -i -c` and picks up dotfile edits the user has
+/// made since the last capture. Existing PTY children are unaffected —
+/// their environment is fixed at fork time, so the frontend should tell
+/// the user "restart sessions to apply".
+#[tauri::command]
+pub fn pty_reload_shell_env() {
+    crate::shell_env::invalidate();
+}
+
 #[tauri::command]
 pub async fn scrollback_save(
     state: State<'_, AppState>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod pull_requests;
 mod scrollback;
 mod session;
 mod session_status;
+mod shell_env;
 mod shell_util;
 mod state;
 mod todos;
@@ -157,6 +158,7 @@ pub fn run() {
             commands::pty_write,
             commands::pty_resize,
             commands::pty_kill,
+            commands::pty_reload_shell_env,
             commands::scrollback_save,
             commands::scrollback_load,
             commands::scrollback_delete,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -115,6 +115,59 @@ impl PtyManager {
         // Set this *before* applying the user-provided env so a user can
         // still opt back in by passing `SHELL_SESSIONS_DISABLE=0`.
         cmd.env("SHELL_SESSIONS_DISABLE", "1");
+
+        // Layered env applied lowest-to-highest priority. Each layer skips
+        // keys that a higher-priority layer would overwrite, so the user's
+        // dotfile (C) wins over our locale guess (B) wins over our
+        // render-capability declaration (A) — and the caller's explicit
+        // `env` argument trumps everything. This mirrors how Terminal.app /
+        // iTerm2 inject TERM and LANG before the shell runs while still
+        // letting `~/.zshenv` override.
+        let shell_env = crate::shell_env::resolve();
+        let mut applied: std::collections::HashSet<String> = env.keys().cloned().collect();
+
+        // (A) Render capability — TERM advertises what xterm.js renders, so
+        // zsh's terminfo lookups (used by zsh-autosuggestions for cursor
+        // save/restore) and color-aware CLIs (claude, fzf, …) emit
+        // sequences we can actually paint. Without this, GUI-launched
+        // acorn inherits an empty TERM and color/redraw goes wrong.
+        const RENDER_CAPABILITY: &[(&str, &str)] = &[
+            ("TERM", "xterm-256color"),
+            ("COLORTERM", "truecolor"),
+        ];
+        for (k, v) in RENDER_CAPABILITY {
+            if !applied.contains(*k) && !shell_env.contains_key(*k) {
+                cmd.env(k, v);
+                applied.insert((*k).to_string());
+            }
+        }
+
+        // (B) System locale — Terminal.app's "Set locale environment
+        // variables on startup" injects LANG from the user's macOS
+        // Language & Region preference. We do the same so PTY children
+        // start with a UTF-8 locale even on a fresh macOS install with
+        // no LANG in any dotfile.
+        if !applied.contains("LANG") && !shell_env.contains_key("LANG") {
+            let lang = crate::shell_env::system_locale_lang()
+                .unwrap_or_else(|| "en_US.UTF-8".to_string());
+            cmd.env("LANG", &lang);
+            applied.insert("LANG".to_string());
+        }
+
+        // (C) Dotfile-set environment captured from the user's login shell
+        // (`~/.zshenv` / `~/.zprofile` / `~/.zshrc`). Honors anything the
+        // user explicitly exported — LANG, EDITOR, PAGER, TZ, etc. —
+        // without acorn having to know each shell's rc-file conventions.
+        for (k, v) in &shell_env {
+            if !applied.contains(k) {
+                cmd.env(k, v);
+                applied.insert(k.clone());
+            }
+        }
+
+        // (caller) Frontend-supplied env wins over everything above. Lets a
+        // future per-session settings UI (or a test harness) force-override
+        // any value we'd otherwise pick.
         for (k, v) in env {
             cmd.env(k, v);
         }

--- a/src-tauri/src/shell_env.rs
+++ b/src-tauri/src/shell_env.rs
@@ -1,0 +1,368 @@
+//! Capture a small whitelist of environment variables out of the user's
+//! login+interactive shell so PTY children we spawn see the same locale,
+//! editor, pager, etc. that the user gets in Terminal.app — without acorn
+//! having to know each shell's rc-file conventions.
+//!
+//! ## Why
+//!
+//! When acorn is launched from Finder/Dock/Spotlight, macOS LaunchServices
+//! hands the parent process a sanitized environment: no `LANG`, no `EDITOR`,
+//! no `LC_*`. portable-pty's `CommandBuilder` then inherits that sanitized
+//! env into every PTY child, so:
+//!   * zsh treats UTF-8 input bytes as Latin-1 single bytes, rendering
+//!     Korean/Japanese/Chinese as `<0085><0087>...`,
+//!   * zsh-autosuggestions' redraw escapes go out of sync with xterm.js'
+//!     real cursor position, scrambling typed input, and
+//!   * tools that respect `EDITOR` / `PAGER` (git, less, kubectl, …) fall
+//!     back to system defaults instead of the user's nvim/less/etc.
+//!
+//! Real terminal emulators (Terminal.app, iTerm2, Ghostty) work around this
+//! by injecting the relevant env vars themselves — partly from the system
+//! locale, partly inherited from the user's shell. We follow the same model:
+//!   * [`system_locale_lang`] handles the locale half (mirrors Terminal.app's
+//!     "Set locale environment variables on startup" preference),
+//!   * [`resolve`] handles the dotfile half by capturing a whitelisted set
+//!     of vars from the user's shell.
+//!
+//! ## Pattern
+//!
+//! Mirrors [`crate::cli_resolver`]'s shell-bootstrap-and-cache approach:
+//!   1. Run `$SHELL -l -i -c` with a script that prints each whitelisted
+//!      variable, base64-encoded so newlines/spaces in values can't break
+//!      parsing, between known marker pairs.
+//!   2. Parse the output bracketed by markers, base64-decode each value.
+//!   3. Cache the resulting map in a `OnceLock`-backed `Mutex` so subsequent
+//!      PTY spawns pay zero shell-startup cost.
+//!
+//! [`invalidate`] drops the cache so the next [`resolve`] call re-runs the
+//! shell. The frontend exposes this as the `pty_reload_shell_env` Tauri
+//! command, bound to `Cmd+Shift+,` — the same "reload config" gesture
+//! Ghostty uses. Existing PTY children are unaffected: their environment is
+//! fixed at fork time. New sessions spawned after the reload pick up the
+//! refreshed values.
+
+use std::collections::HashMap;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+use base64::Engine;
+
+use crate::shell_util::shell_quote;
+
+/// Environment variables we propagate from the user's shell into PTY
+/// children. Restricted to a known-safe set so we don't accidentally leak
+/// shell-internal bookkeeping (`SHLVL`, `OLDPWD`, …) or sensitive secrets
+/// the user might keep in their shell.
+///
+/// Categories:
+///   * Locale family — what zsh's ZLE and tools use to interpret bytes,
+///     pick message languages, and sort.
+///   * Tool prefs — what editor / pager / man pager subcommands honor.
+///   * Misc — `TZ` for time-aware tools, `HISTFILE` so the user's expected
+///     history file location is honored.
+const CAPTURED_VARS: &[&str] = &[
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "LANGUAGE",
+    "LC_COLLATE",
+    "LC_MESSAGES",
+    "LC_NUMERIC",
+    "LC_TIME",
+    "LC_MONETARY",
+    "EDITOR",
+    "VISUAL",
+    "PAGER",
+    "MANPAGER",
+    "TZ",
+    "HISTFILE",
+];
+
+const ENV_BEGIN: &str = "<<<ACORN_ENV_BEGIN>>>";
+const ENV_END: &str = "<<<ACORN_ENV_END>>>";
+
+fn cache() -> &'static Mutex<Option<HashMap<String, String>>> {
+    static CACHE: OnceLock<Mutex<Option<HashMap<String, String>>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(None))
+}
+
+/// Return the cached shell environment, running the shell once on miss.
+///
+/// Returns an empty map if the shell can't be invoked or its output can't
+/// be parsed — PTY spawn falls back to the hardcoded defaults in
+/// [`crate::pty`] in that case, so a missing shell never blocks session
+/// startup.
+pub fn resolve() -> HashMap<String, String> {
+    if let Some(cached) = cache().lock().unwrap().as_ref() {
+        return cached.clone();
+    }
+    // Resolve outside the lock — shell startup can take 50–200ms and
+    // holding the mutex would serialize concurrent first-time spawns.
+    let resolved = shell_capture().unwrap_or_default();
+    *cache().lock().unwrap() = Some(resolved.clone());
+    resolved
+}
+
+/// Drop the cached snapshot. Subsequent [`resolve`] calls re-run the
+/// shell, picking up dotfile edits the user has made since the last
+/// capture.
+pub fn invalidate() {
+    *cache().lock().unwrap() = None;
+}
+
+/// macOS-only: read the system preferred locale and turn it into a `LANG`
+/// value (e.g. `ko_KR` → `ko_KR.UTF-8`). Returns `None` on non-macOS or
+/// when `defaults` isn't available / returns an empty string.
+///
+/// Mirrors Terminal.app's "Set locale environment variables on startup"
+/// behavior: the user's macOS Language & Region preference, not their
+/// dotfile, drives the value. Dotfile-set `LANG` overrides this via the
+/// [`resolve`] (C) layer in PTY spawn.
+pub fn system_locale_lang() -> Option<String> {
+    if !cfg!(target_os = "macos") {
+        return None;
+    }
+    let out = Command::new("defaults")
+        .args(["read", "-g", "AppleLocale"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let locale = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    if locale.is_empty() {
+        return None;
+    }
+    Some(format!("{locale}.UTF-8"))
+}
+
+/// Run `$SHELL -l -i -c '<script>'` and parse the marker-bracketed output
+/// into a `HashMap<String, String>`. The script base64-encodes each
+/// captured value so values containing newlines, spaces, or shell
+/// metacharacters round-trip cleanly.
+fn shell_capture() -> Option<HashMap<String, String>> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    let script = build_capture_script(CAPTURED_VARS);
+    let out = Command::new(&shell)
+        .args(["-l", "-i", "-c", &script])
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    parse_env_block(&stdout)
+}
+
+/// Build the shell script that prints the captured vars between markers.
+/// `printenv` is POSIX-portable; `base64 | tr -d '\n'` works identically
+/// on macOS BSD `base64` (no wrapping) and Linux GNU `base64` (default
+/// 76-col wrap removed by `tr`).
+fn build_capture_script(vars: &[&str]) -> String {
+    let mut script = String::with_capacity(256 + vars.len() * 64);
+    script.push_str("printf '%s' ");
+    script.push_str(&shell_quote(ENV_BEGIN));
+    script.push_str("; for var in ");
+    for (i, v) in vars.iter().enumerate() {
+        if i > 0 {
+            script.push(' ');
+        }
+        script.push_str(&shell_quote(v));
+    }
+    // Each var: emit "KEY=<b64>\n" only when the var is set. We avoid
+    // `set -u` and `${VAR:-}` expansion so this works in the most
+    // permissive shell mode possible.
+    script.push_str(
+        "; do val=$(printenv \"$var\" 2>/dev/null); \
+         if [ -n \"$val\" ]; then \
+           enc=$(printf '%s' \"$val\" | base64 | tr -d '\\n'); \
+           printf '%s=%s\\n' \"$var\" \"$enc\"; \
+         fi; done; ",
+    );
+    script.push_str("printf '%s' ");
+    script.push_str(&shell_quote(ENV_END));
+    script
+}
+
+/// Pull the marker-bracketed env block out of `stdout`, base64-decode each
+/// `KEY=value` line, and collect into a map. Returns `None` only when both
+/// markers can't be found (shell crashed before printing anything useful);
+/// any malformed line within the block is skipped silently rather than
+/// failing the whole capture.
+fn parse_env_block(stdout: &str) -> Option<HashMap<String, String>> {
+    let start = stdout.find(ENV_BEGIN)? + ENV_BEGIN.len();
+    let rest = &stdout[start..];
+    let end = rest.find(ENV_END)?;
+    let body = &rest[..end];
+    let mut map = HashMap::new();
+    for line in body.lines() {
+        if let Some((key, value)) = parse_env_line(line) {
+            map.insert(key, value);
+        }
+    }
+    Some(map)
+}
+
+/// Parse a single `KEY=base64_value` line. Returns `None` for empty lines,
+/// missing `=`, or invalid base64 — the caller skips silently so one bad
+/// var doesn't drop the rest.
+fn parse_env_line(line: &str) -> Option<(String, String)> {
+    let line = line.trim();
+    if line.is_empty() {
+        return None;
+    }
+    let (key, encoded) = line.split_once('=')?;
+    if key.is_empty() {
+        return None;
+    }
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .ok()?;
+    let value = String::from_utf8(bytes).ok()?;
+    Some((key.to_string(), value))
+}
+
+#[cfg(test)]
+fn seed_cache(map: HashMap<String, String>) {
+    *cache().lock().unwrap() = Some(map);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn b64(s: &str) -> String {
+        base64::engine::general_purpose::STANDARD.encode(s)
+    }
+
+    #[test]
+    fn parse_env_line_round_trips_simple_value() {
+        let line = format!("LANG={}", b64("en_US.UTF-8"));
+        let (k, v) = parse_env_line(&line).expect("valid");
+        assert_eq!(k, "LANG");
+        assert_eq!(v, "en_US.UTF-8");
+    }
+
+    #[test]
+    fn parse_env_line_handles_value_with_spaces_and_equals() {
+        // `EDITOR="code --wait"` is a real-world value containing both a
+        // space and characters that would confuse a naive parser.
+        let line = format!("EDITOR={}", b64("code --wait"));
+        let (k, v) = parse_env_line(&line).expect("valid");
+        assert_eq!(k, "EDITOR");
+        assert_eq!(v, "code --wait");
+    }
+
+    #[test]
+    fn parse_env_line_rejects_empty_or_malformed() {
+        assert_eq!(parse_env_line(""), None);
+        assert_eq!(parse_env_line("   "), None);
+        assert_eq!(parse_env_line("no_equals_sign"), None);
+        assert_eq!(parse_env_line("=missing_key"), None);
+        assert_eq!(parse_env_line("LANG=not!valid!base64!"), None);
+    }
+
+    #[test]
+    fn parse_env_block_extracts_lines_between_markers() {
+        let stdout = format!(
+            "p10k instant-prompt banner here\n\
+             {ENV_BEGIN}LANG={lang}\n\
+             EDITOR={editor}\n\
+             {ENV_END}\n\
+             trailing rc-file noise",
+            lang = b64("ko_KR.UTF-8"),
+            editor = b64("nvim"),
+        );
+        let map = parse_env_block(&stdout).expect("markers found");
+        assert_eq!(map.get("LANG").unwrap(), "ko_KR.UTF-8");
+        assert_eq!(map.get("EDITOR").unwrap(), "nvim");
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn parse_env_block_returns_none_when_markers_missing() {
+        assert!(parse_env_block("garbage output").is_none());
+        assert!(parse_env_block("").is_none());
+        // Begin without End is also unusable.
+        assert!(parse_env_block(&format!("{ENV_BEGIN}LANG=ZW4=\n")).is_none());
+    }
+
+    #[test]
+    fn parse_env_block_skips_malformed_lines_without_aborting() {
+        let stdout = format!(
+            "{ENV_BEGIN}LANG={lang}\n\
+             totally_bogus_line\n\
+             EDITOR={editor}\n\
+             {ENV_END}",
+            lang = b64("en_US.UTF-8"),
+            editor = b64("vim"),
+        );
+        let map = parse_env_block(&stdout).expect("markers found");
+        assert_eq!(map.get("LANG").unwrap(), "en_US.UTF-8");
+        assert_eq!(map.get("EDITOR").unwrap(), "vim");
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn build_capture_script_includes_each_var() {
+        let script = build_capture_script(&["LANG", "EDITOR"]);
+        assert!(script.contains(ENV_BEGIN));
+        assert!(script.contains(ENV_END));
+        assert!(script.contains("LANG"));
+        assert!(script.contains("EDITOR"));
+        assert!(script.contains("printenv"));
+        assert!(script.contains("base64"));
+    }
+
+    #[test]
+    fn resolve_returns_cached_snapshot_without_shelling_out() {
+        let mut seeded = HashMap::new();
+        seeded.insert("LANG".to_string(), "ko_KR.UTF-8".to_string());
+        seed_cache(seeded);
+
+        let resolved = resolve();
+        assert_eq!(resolved.get("LANG").unwrap(), "ko_KR.UTF-8");
+    }
+
+    /// End-to-end smoke test: actually invoke the user's shell, capture
+    /// LANG, and round-trip it through our parser. Marked `#[ignore]` so
+    /// CI does not depend on the runner having LANG exported in its
+    /// dotfiles. Run locally with `cargo test -- --ignored` to verify the
+    /// shell-script generation + parsing pipeline against a real shell.
+    #[test]
+    #[ignore]
+    fn shell_capture_round_trips_against_real_shell() {
+        // Force a known value into the shell's startup env so this test
+        // is independent of the developer's dotfile content.
+        // SAFETY: Single-threaded test — `set_var` is unsafe in
+        // multi-threaded contexts but we only run one test at a time per
+        // process for shell_capture (no other test touches the same env).
+        unsafe {
+            std::env::set_var("ACORN_SHELL_ENV_TEST", "round-trip-ok");
+        }
+
+        // Re-purpose CAPTURED_VARS to include our marker var temporarily.
+        let probe_vars = ["LANG", "ACORN_SHELL_ENV_TEST"];
+        let script = build_capture_script(&probe_vars);
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        let out = Command::new(&shell)
+            .args(["-l", "-i", "-c", &script])
+            .output()
+            .expect("shell should run");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let map = parse_env_block(&stdout)
+            .expect("markers present in real shell output");
+        assert_eq!(
+            map.get("ACORN_SHELL_ENV_TEST").map(String::as_str),
+            Some("round-trip-ok")
+        );
+    }
+
+    #[test]
+    fn invalidate_drops_cached_snapshot() {
+        let mut seeded = HashMap::new();
+        seeded.insert("LANG".to_string(), "en_US.UTF-8".to_string());
+        seed_cache(seeded);
+        assert!(cache().lock().unwrap().is_some());
+
+        invalidate();
+        assert!(cache().lock().unwrap().is_none());
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,10 +18,13 @@ import { ResizeHandle } from "./components/ResizeHandle";
 import { CommandPalette } from "./components/CommandPalette";
 import { SettingsModal } from "./components/SettingsModal";
 import { TerminalHost } from "./components/TerminalHost";
+import { ToastHost } from "./components/ToastHost";
 import { UpdateBanner } from "./components/UpdateBanner";
+import { api } from "./lib/api";
 import { Hotkeys, useHotkeys } from "./lib/hotkeys";
 import { startSessionNotificationWatcher } from "./lib/notifications";
 import { flushAllScrollbacks } from "./lib/scrollback-coordinator";
+import { useToasts } from "./lib/toasts";
 import { useUpdater } from "./lib/updater-store";
 import { useSettings } from "./lib/settings";
 import { useAppStore } from "./store";
@@ -299,6 +302,22 @@ function App() {
         e.preventDefault();
         useSettings.getState().setOpen(true);
       },
+      [Hotkeys.reloadShellEnv]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        const show = useToasts.getState().show;
+        api
+          .reloadShellEnv()
+          .then(() => {
+            // Existing PTY children keep the env they forked with —
+            // surfacing this so the user knows why their already-open
+            // session didn't change.
+            show("Shell environment reloaded. Open a new session to apply.");
+          })
+          .catch((err: unknown) => {
+            console.error("[App] reloadShellEnv failed", err);
+            show("Failed to reload shell environment.");
+          });
+      },
       [Hotkeys.closeEmptyPane]: (e: KeyboardEvent) => {
         // Only collapse the focused pane when it's empty, so Escape stays
         // available for inputs, dialogs, and the command palette.
@@ -319,6 +338,7 @@ function App() {
   return (
     <div className="flex h-screen w-screen flex-col bg-bg text-fg">
       <UpdateBanner />
+      <ToastHost />
       <div className="flex min-h-0 flex-1">
         <PanelGroup direction="horizontal" autoSaveId="acorn:layout:root">
           <Panel

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -9,10 +9,13 @@ import {
   Plus,
   RefreshCw,
   Sparkles,
+  Terminal,
   Trash2,
 } from "lucide-react";
 import { useAppStore } from "../store";
+import { api } from "../lib/api";
 import { cn } from "../lib/cn";
+import { useToasts } from "../lib/toasts";
 import type { Session } from "../lib/types";
 
 interface CommandPaletteProps {
@@ -73,6 +76,19 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   function handleSetTab(tab: "todos" | "commits" | "staged" | "prs") {
     useAppStore.getState().setRightTab(tab);
     close();
+  }
+
+  async function handleReloadShellEnv() {
+    const show = useToasts.getState().show;
+    try {
+      await api.reloadShellEnv();
+      show("Shell environment reloaded. Open a new session to apply.");
+    } catch (err) {
+      console.error("[CommandPalette] reloadShellEnv failed", err);
+      show("Failed to reload shell environment.");
+    } finally {
+      close();
+    }
   }
 
   return (
@@ -178,6 +194,20 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           >
             <GitPullRequest size={14} className="text-fg-muted" />
             <span>View Pull Requests</span>
+          </Command.Item>
+        </Command.Group>
+
+        <Command.Group heading="Terminal">
+          <Command.Item
+            value="reload-shell-env"
+            onSelect={() => void handleReloadShellEnv()}
+            keywords={["dotfile", "zshenv", "lang", "editor", "env", "locale"]}
+          >
+            <Terminal size={14} className="text-fg-muted" />
+            <span>Reload shell environment</span>
+            <span className="ml-auto truncate text-xs text-fg-muted/80">
+              ⇧⌘,
+            </span>
           </Command.Item>
         </Command.Group>
 

--- a/src/components/ToastHost.tsx
+++ b/src/components/ToastHost.tsx
@@ -1,0 +1,25 @@
+import type { ReactElement } from "react";
+import { useToasts } from "../lib/toasts";
+
+/**
+ * Renders the active toast (if any) at the bottom-center of the viewport.
+ * Pointer-events disabled so the toast never blocks clicks on the
+ * underlying UI. Auto-dismisses via the store's TTL — there is no manual
+ * close affordance because every existing trigger is a deliberate user
+ * action whose feedback is fine to fade.
+ */
+export function ToastHost(): ReactElement | null {
+  const message = useToasts((s) => s.message);
+  if (!message) return null;
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-6 z-50 flex justify-center">
+      <div
+        role="status"
+        aria-live="polite"
+        className="rounded border border-border bg-bg-elevated px-3 py-1.5 text-xs text-fg shadow-md"
+      >
+        {message}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -156,4 +156,14 @@ export const api = {
   scrollbackOrphanClear(): Promise<number> {
     return invoke<number>("scrollback_orphan_clear");
   },
+  /**
+   * Drop the cached snapshot of the user's shell environment. The next PTY
+   * spawn re-runs `$SHELL -l -i -c` and re-captures locale / editor / pager
+   * vars from the user's dotfiles. Already-running sessions are unaffected
+   * because their environment was fixed at fork time — surface that fact to
+   * the user when invoking this.
+   */
+  reloadShellEnv(): Promise<void> {
+    return invoke<void>("pty_reload_shell_env");
+  },
 };

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -44,6 +44,11 @@ export const Hotkeys = {
   closeTab: "$mod+w",
   closeEmptyPane: "Escape",
   openSettings: "$mod+Comma",
+  // Mirrors Ghostty's "Reload Config" gesture. Dotfile env values
+  // (LANG, EDITOR, PAGER, …) are captured once on first PTY spawn and
+  // cached; this shortcut invalidates the cache so the next session
+  // picks up edits the user has made since.
+  reloadShellEnv: "$mod+Shift+Comma",
   // Tab / project navigation. Use literal Control (not $mod) — Cmd+Tab is
   // reserved by macOS for OS-level app switching.
   nextTab: "Control+Tab",

--- a/src/lib/toasts.ts
+++ b/src/lib/toasts.ts
@@ -1,0 +1,39 @@
+import { create } from "zustand";
+
+/**
+ * Lightweight one-shot toast store. A single message at a time — calling
+ * `show` while another is visible replaces it and resets the timer. Used
+ * for transient confirmations that don't deserve a full dialog (e.g.
+ * "Shell environment reloaded"). Mount [`ToastHost`] once near the app
+ * root for these to render.
+ */
+interface ToastState {
+  message: string | null;
+  show: (message: string) => void;
+  hide: () => void;
+}
+
+const TOAST_TTL_MS = 3000;
+
+let dismissTimer: ReturnType<typeof setTimeout> | null = null;
+
+export const useToasts = create<ToastState>((set) => ({
+  message: null,
+  show: (message: string) => {
+    if (dismissTimer !== null) {
+      clearTimeout(dismissTimer);
+    }
+    set({ message });
+    dismissTimer = setTimeout(() => {
+      set({ message: null });
+      dismissTimer = null;
+    }, TOAST_TTL_MS);
+  },
+  hide: () => {
+    if (dismissTimer !== null) {
+      clearTimeout(dismissTimer);
+      dismissTimer = null;
+    }
+    set({ message: null });
+  },
+}));


### PR DESCRIPTION
## Summary

PTY children we spawn inherited acorn's GUI-launched env, which is sanitized by macOS LaunchServices: no `TERM`, no `LANG`, no `EDITOR`/`PAGER` from the user's dotfiles. Three user-visible symptoms fell out of this:

1. **claude CLI rendered without colors** — claude gates ANSI on `TERM`.
2. **zsh-autosuggestions scrambled typed input** (`cclaudecllaauu…`) — zsh's terminfo lookup for cursor save/restore fails without `TERM`, so the redraw escapes go out of sync with xterm.js' real cursor.
3. **Korean (and other multi-byte) input rendered as `<0085><0087>`** — zsh treated UTF-8 bytes as Latin-1 under a C locale.

Fix: layer the spawned env to mirror what real terminal emulators (Terminal.app, iTerm2, Ghostty) do, with explicit override priority.

## Layered env (low → high priority)

| Layer | Source | Purpose |
|---|---|---|
| A. Render capability | hardcoded `TERM=xterm-256color`, `COLORTERM=truecolor` | advertise what xterm.js actually paints |
| B. System locale | `defaults read -g AppleLocale` → `LANG` | mirrors Terminal.app's "Set locale environment variables on startup" |
| C. Dotfile env | `$SHELL -l -i -c` capture of LANG/LC_*/EDITOR/VISUAL/PAGER/MANPAGER/TZ/HISTFILE | honors anything exported in `~/.zshenv`/`~/.zprofile`/`~/.zshrc` |
| caller | frontend-supplied `env` arg | future per-session settings; overrides everything above |

Each layer skips keys already set by a higher-priority layer. Result: a Korean macOS user gets `ko_KR.UTF-8` automatically; a Korean dev with English macOS gets `en_US.UTF-8` (matching their Terminal.app); a power user with `export LANG=...` in their dotfile gets that value (C overrides B).

## Reload shortcut

C is captured lazily on first PTY spawn and cached. `Cmd+Shift+,` (mirrors Ghostty's Reload Config) and a Command Palette entry call `pty_reload_shell_env`, which invalidates the cache. The next spawn re-runs `$SHELL` and picks up dotfile edits.

Existing PTY children keep their original env (fork-time fixed); a toast surfaces this fact: *"Shell environment reloaded. Open a new session to apply."*

## Files

**Backend (`src-tauri/`):**
- `src/shell_env.rs` (new, ~270 lines) — mirrors `cli_resolver.rs` pattern: marker-bracketed, base64-per-value capture script; `OnceLock<Mutex<...>>` cache; `resolve()` / `invalidate()` / `system_locale_lang()`.
- `src/pty.rs` — apply layered env before spawn.
- `src/commands.rs` — `pty_reload_shell_env` Tauri command.
- `src/lib.rs` — register module + command.

**Frontend (`src/`):**
- `lib/toasts.ts` (new) — minimal `useToasts` zustand store with auto-dismiss.
- `components/ToastHost.tsx` (new) — bottom-center, pointer-events-none renderer.
- `lib/hotkeys.ts` — add `reloadShellEnv: "$mod+Shift+Comma"`.
- `lib/api.ts` — `reloadShellEnv()` wrapper.
- `App.tsx` — mount `ToastHost`, hotkey handler that calls api + toast.
- `components/CommandPalette.tsx` — "Reload shell environment" item.

## Test plan

### Automated (CI)
- [x] `cargo test --offline` — 32 pass (includes 9 new shell_env tests: parse/build/cache).
- [x] `cargo test -- --ignored shell_capture` — round-trip test against real `$SHELL` passes locally (~2s shell startup).
- [x] `cargo check --offline` — clean.
- [x] `cargo clippy --offline` — no new warnings introduced (pre-existing `pull_requests.rs:205` and `commands.rs:309` unrelated).
- [x] `bun run typecheck` — clean.
- [x] `bun run test` — 87 pass / 1 skipped.

### Manual (must verify before merge)
- [ ] Issue #1: open agent (claude) tab — claude output renders with colors (not all-white).
- [ ] Issue #2: open Terminal mode tab with zsh-autosuggest enabled, type a command — characters appear in order without `cclaudecllaauu…` scrambling.
- [ ] Issue #3: open Terminal mode tab, type Korean ㅇ — appears as ㅇ, not `<0085><0087>`.
- [ ] Cmd+Shift+, fires the toast: "Shell environment reloaded. Open a new session to apply."
- [ ] Command Palette has "Reload shell environment" with shortcut hint, same behavior.
- [ ] Existing open sessions don't change after Cmd+Shift+, — only newly-spawned ones reflect dotfile changes.
- [ ] Power user override: add `export LANG=ko_KR.UTF-8` to `~/.zshenv`, press Cmd+Shift+,, open new session, run `echo $LANG` → `ko_KR.UTF-8` (overrides system locale).

## Out of scope
- v1.0.4 version bump (will go in a separate `chore(release)` PR after this lands and manual verification passes).
- Settings UI to edit captured env explicitly (YAGNI; dotfile + reload shortcut covers known cases).