### PR TITLE
chore(release): bump version to 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.3"
+version = "1.0.4"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- Patch release bundling #62 (`fix(pty): inject TERM, system locale, and dotfile env into spawned children`).
- Bumps the four in-repo version sources in lockstep: `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`.
- After this lands on `main`, pushing the `v1.0.4` tag triggers `.github/workflows/release.yml`:
  - macOS arm64 + x86_64 build, sign with `TAURI_SIGNING_PRIVATE_KEY`
  - upload `.dmg` / `.app.tar.gz` / `.app.tar.gz.sig` to a new GitHub Release
  - emit `latest.json` updater manifest — clients on 1.0.3 will see 1.0.4 and update

## What 1.0.4 contains (since v1.0.3)
- `fix(pty): inject TERM, system locale, and dotfile env into spawned children` (#62)
  - claude (agent) tab now renders with colors
  - zsh-autosuggestions no longer scrambles typed input
  - Korean / multi-byte input no longer renders as `<0085><0087>`
  - New `Cmd+Shift+,` shortcut + Command Palette entry to reload captured dotfile env

## Test plan
- [x] `bun run typecheck` passes locally
- [x] `cargo check --offline` passes locally (Cargo.lock matches Cargo.toml)
- [x] No remaining `acorn` package at `1.0.3` (only unrelated deps `siphasher` / `typeid` carry that version)
- [x] Local `bun run tauri build --bundles app` produced a working .app; manual verification of all three bug fixes confirmed
- [ ] CI Frontend job passes on this PR
- [ ] After merge, pushing `v1.0.4` produces a successful release run with both arch bundles + `latest.json` attached