### PR TITLE
fix(release): arch-suffix .app.tar.gz so updater sig matches tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,16 +61,41 @@ jobs:
           mkdir -p "$out"
           target="${{ matrix.target }}"
           bundle_dir="src-tauri/target/${target}/release/bundle"
-          # Copy DMG, updater tarball, and the updater signature side-file.
-          # The signature is what tauri's updater plugin verifies against
-          # `latest.json`'s `signature` field — it must travel with the
-          # tarball as a release asset.
+
+          # Tauri produces `.app.tar.gz` / `.app.tar.gz.sig` with a
+          # NON-arch-tagged name (the DMG is arch-tagged by tauri itself,
+          # the updater tarball is not). Both matrix jobs would then
+          # upload artifacts containing identically-named files. The
+          # publish job downloads both with `merge-multiple: true`,
+          # which collapses same-named files: the surviving `.tar.gz`
+          # and `.sig` can end up coming from DIFFERENT jobs, so the
+          # signature no longer matches the tarball bytes and Tauri's
+          # updater rejects the release with "signature verification
+          # failed". Fix: rename to include the arch suffix BEFORE
+          # uploading, so each arch's pair survives the merge intact.
+          case "$target" in
+            aarch64-*) suffix="aarch64" ;;
+            x86_64-*)  suffix="x86_64"  ;;
+            *)         suffix="$target" ;;
+          esac
+
+          # DMG (already arch-tagged by tauri — `Acorn_<ver>_<arch>.dmg`)
           find "${bundle_dir}/dmg" -name "*.dmg" -maxdepth 2 -print0 \
             | xargs -0 -I{} cp -v {} "$out/"
-          find "${bundle_dir}/macos" -name "*.app.tar.gz" -maxdepth 2 -print0 \
-            | xargs -0 -I{} cp -v {} "$out/"
-          find "${bundle_dir}/macos" -name "*.app.tar.gz.sig" -maxdepth 2 -print0 \
-            | xargs -0 -I{} cp -v {} "$out/"
+
+          # Updater tarball + signature, renamed to add the arch suffix.
+          # The publish job's `latest.json` generator already greps for
+          # `aarch64` / `x86_64` in the filename, so once the names are
+          # tagged here it picks the right pair per platform.
+          while IFS= read -r -d '' f; do
+            base=$(basename "$f" .app.tar.gz)
+            cp -v "$f" "$out/${base}_${suffix}.app.tar.gz"
+          done < <(find "${bundle_dir}/macos" -name "*.app.tar.gz" -maxdepth 2 -print0)
+          while IFS= read -r -d '' f; do
+            base=$(basename "$f" .app.tar.gz.sig)
+            cp -v "$f" "$out/${base}_${suffix}.app.tar.gz.sig"
+          done < <(find "${bundle_dir}/macos" -name "*.app.tar.gz.sig" -maxdepth 2 -print0)
+
           ls -la "$out/"
           echo "dir=$out" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

v1.0.4's auto-update fails with **\"signature verification failed\"**. Root cause is a long-standing race in `release.yml`'s artifact pipeline that previous releases (1.0.1–1.0.3) hit too but luckily survived.

## Evidence

Downloading the v1.0.4 release assets and the per-job artifacts directly:

```
$ file v1.0.4/Acorn.app.tar.gz extracted → Mach-O 64-bit executable arm64
$ diff bundles-aarch64-apple-darwin/Acorn.app.tar.gz.sig v1.0.4-Acorn.app.tar.gz.sig
  (different)
$ diff bundles-x86_64-apple-darwin/Acorn.app.tar.gz.sig v1.0.4-Acorn.app.tar.gz.sig
  identical
```

So the released **tarball is the aarch64 build** but the released **signature is for the x86_64 tarball**. Tauri's updater verifies bytes against the listed signature → fails.

## Why this happens

Tauri's bundler produces:
- `Acorn_<ver>_<arch>.dmg` — arch-tagged by tauri itself
- `Acorn.app.tar.gz` + `Acorn.app.tar.gz.sig` — **NOT arch-tagged**

Both matrix jobs (`aarch64-apple-darwin`, `x86_64-apple-darwin`) stage and upload the latter pair under identical filenames. The publish job uses:

```yaml
- uses: actions/download-artifact@v4
  with:
    pattern: bundles-*
    merge-multiple: true
```

`merge-multiple: true` collapses same-named files — last write wins, order is non-deterministic. The `.tar.gz` and `.sig` can end up from different jobs.

1.0.1–1.0.3 lucked out: both files survived from the same arch job (signature matched the wrong-arch tarball it shipped). 1.0.4 lost that lottery.

## Fix

Rename to include arch suffix in the **stage** step, before upload:

```
Acorn.app.tar.gz       → Acorn_aarch64.app.tar.gz
Acorn.app.tar.gz.sig   → Acorn_aarch64.app.tar.gz.sig
```

(and `_x86_64` for the other arch)

Each arch's pair now has unique filenames, so `merge-multiple` keeps them all. `latest.json` generation already greps for `aarch64` / `x86_64` in filenames — once tagged here, it picks the right pair per platform.

## Follow-up

After this lands, a v1.0.5 release runs with the fixed pipeline. Users on 1.0.3 will skip the broken 1.0.4 since GitHub's "latest release" pointer moves to 1.0.5, and 1.0.5's manifest will reference correctly-paired artifacts. Users who already installed 1.0.4 manually (DMG download bypasses the updater) get the next update fine.

## Test plan
- [x] Local diff inspection — release.yml changes are minimal and localized to the stage step
- [x] CI Frontend job passes
- [ ] After merge + v1.0.5 tag, both arch tarballs land as separate assets in the release page
- [ ] After v1.0.5 release: download `latest.json`, then for each arch download the referenced `.tar.gz` and `.sig`, verify the sig file's `file:` field references match and the timestamps come from the same build job
- [ ] Auto-update from 1.0.3 to 1.0.5 succeeds without "signature verification failed"