### PR TITLE
chore(release): bump version to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.4"
+version = "1.0.5"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- Patch release shipping #64 (release.yml `.app.tar.gz` arch-suffix fix).
- v1.0.4's auto-update fails with **signature verification failed** because the matrix artifact race paired the aarch64 tarball with the x86_64 signature. v1.0.5 runs through the corrected pipeline.
- Bumps the four in-repo version sources in lockstep: `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`.

## What 1.0.5 contains (since v1.0.3)
- `fix(pty): inject TERM, system locale, and dotfile env into spawned children` (#62) — already in 1.0.4 but unreleasable
- `fix(release): arch-suffix .app.tar.gz so updater sig matches tarball` (#64) — pipeline fix that makes the above actually deliver via the updater

## Test plan
- [x] `bun run typecheck` passes locally
- [x] `cargo check --offline` passes locally
- [ ] CI Frontend job passes
- [ ] After merge + v1.0.5 tag, the release page lists **two distinct** `.app.tar.gz` assets (arch-tagged) plus matching `.sig` files
- [ ] `latest.json` `darwin-aarch64` and `darwin-x86_64` reference different URLs (not the same one)
- [ ] Downloading each per-arch tarball + sig and inspecting timestamps shows they come from the same arch's build job
- [ ] Auto-update from 1.0.3 to 1.0.5 succeeds (no "signature verification failed")