### PR TITLE
enhancement: add divider between commit rows

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -633,7 +633,7 @@ function CommitsTab({
                       setMenu({ x: e.clientX, y: e.clientY, commit: c });
                     }}
                     className={cn(
-                      "flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-xs transition",
+                      "flex w-full flex-col items-start gap-0.5 border-b border-border/40 px-3 py-2 text-left text-xs transition",
                       selected === c.sha
                         ? "bg-bg-elevated"
                         : "hover:bg-bg-elevated/50",


### PR DESCRIPTION
## Summary
- Add `border-b border-border/40` to the commit row in the right panel so it has the same row divider as the PRs list.

## Test plan
- [ ] Open the right panel → Commits tab; confirm a thin divider appears between rows.
- [ ] Switch to the PRs tab and confirm the divider style matches.
- [ ] Hover/select a commit row; confirm hover and selected backgrounds still render correctly with the divider.
- [ ] Verify in both light and dark themes that the divider tone is subtle (border/40).