### PR TITLE
fix(terminal): drain scrollback restore before spawning new shell

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -707,32 +707,56 @@ export function Terminal({
         });
         if (disposed) return;
         if (saved && saved.length > 0) {
-          // Wait for the snapshot to fully drain into the buffer before
-          // we issue the post-restore mode reset, so the reset is not
-          // re-overwritten by trailing escape sequences in the snapshot.
-          await new Promise<void>((resolve) => term.write(saved, resolve));
+          // Each step is awaited individually. Previously the mode
+          // resets and marker were fired without awaiting and `spawnPty`
+          // was called immediately after, so the new shell's first
+          // prompt could arrive via the pty:output listener while our
+          // own writes were still sitting in xterm's parser queue.
+          // Interleaving with the shell's prompt-redraw escape sequences
+          // intermittently parked the cursor at column 0 of the new
+          // prompt line and left input invisible (the user typed but
+          // echo landed off-screen). Strict serial drain makes the
+          // post-restore cursor position deterministic.
+          const writeAndDrain = (data: string): Promise<void> =>
+            new Promise<void>((resolve) => term.write(data, resolve));
+
+          await writeAndDrain(saved);
           if (disposed) return;
-          // Reset just the mode bits that actually break the next
-          // session: scroll region, auto-wrap, cursor visibility. We
-          // intentionally do NOT issue `\e[?1049l` (alt-screen exit)
-          // unless the snapshot left us inside the alt buffer — in
-          // xterm.js that sequence pushes the alt buffer contents into
-          // the normal buffer's scrollback when there is no matching
-          // entry, doubling the apparent scroll history.
+          // Only exit alt-screen if the snapshot actually left us in it
+          // — issuing `\x1b[?1049l` from the normal buffer pushes the
+          // alt buffer's contents into the normal buffer's scrollback,
+          // doubling the apparent history.
           if (term.buffer.active.type === "alternate") {
-            term.write("\x1b[?1049l");
+            await writeAndDrain("\x1b[?1049l");
+            if (disposed) return;
           }
-          term.write("\x1b[r");    // reset DECSTBM (full-screen scroll region)
-          term.write("\x1b[?7h");  // DECAWM auto-wrap on
-          term.write("\x1b[?25h"); // DECTCEM cursor visible
-          term.write("\x1b[!p");   // DECSTR soft reset (mop up the rest)
-          // Park the cursor on column 0 of a fresh row so the marker
-          // (and the about-to-spawn shell prompt) start from a known
-          // baseline regardless of where the snapshot left the cursor.
-          term.write("\r");
-          term.write(
+          // Targeted mode resets. We deliberately skip DECSTR (`\x1b[!p`)
+          // because its soft-reset coverage in xterm.js leaves
+          // bracketed-paste and mouse-tracking modes untouched — and
+          // those are exactly the modes a stale snapshot can leave
+          // enabled (zsh enables `?2004` per prompt; vim/claude enable
+          // `?1000`–`?1006`). When the new shell inherits an unexpected
+          // tracker, paste arrives wrapped in `\e[200~ … \e[201~` and
+          // mouse clicks emit escape sequences instead of focusing the
+          // pane — both of which read as "input is broken" to the user.
+          // Listing each mode explicitly makes the post-restore state
+          // deterministic regardless of what the snapshot ended in.
+          const RESETS =
+            "\x1b[r" +     // DECSTBM full-screen scroll region
+            "\x1b[?7h" +   // DECAWM auto-wrap on
+            "\x1b[?25h" +  // DECTCEM cursor visible
+            "\x1b[?2004l" + // bracketed paste off
+            "\x1b[?1000l" + // X11 mouse tracking off
+            "\x1b[?1002l" + // mouse btn-event tracking off
+            "\x1b[?1003l" + // mouse any-event tracking off
+            "\x1b[?1006l" + // SGR mouse mode off
+            "\r"; //          park cursor at column 0
+          await writeAndDrain(RESETS);
+          if (disposed) return;
+          await writeAndDrain(
             `\r\n${ANSI_DIM}— restored from previous session —${ANSI_RESET}\r\n`,
           );
+          if (disposed) return;
         }
       } catch (err) {
         console.warn("[Terminal] scrollback_load failed", err);


### PR DESCRIPTION
## Summary

Fixes the intermittent "after restore the cursor sits at column 0 of the new prompt and input is invisible" report.

Two changes, same root cause area:

- **Serial drain**. Every restore-side write (alt-screen exit, mode resets, marker) now awaits xterm's parser callback before the next sequence, and \`spawnPty\` runs strictly after the marker drains. Previously the writes were fired without awaiting and \`spawnPty\` was kicked off immediately, so the new shell's first prompt could arrive via the pty:output listener while our own writes were still in xterm's parser queue — interleaving with the prompt's redraw escapes was what intermittently parked the cursor at the wrong column.
- **Drop DECSTR; reset paste/mouse modes explicitly**. \`\\x1b[!p\` in xterm.js leaves \`?2004\`, \`?1000\`, \`?1002\`, \`?1003\`, \`?1006\` alone — exactly the modes a stale snapshot can leave on. zsh turns \`?2004\` on per prompt; vim/claude turn the mouse trackers on. When the new shell inherits leftover state, pastes arrive wrapped in \`\\e[200~ … \\e[201~\` and clicks emit escape sequences, both reading as "input doesn't work."

Restore takes a few extra ms (4 awaits instead of fire-and-forget) — not perceptible.

## Test plan

- [ ] Open a session, type a few commands so there is real scrollback, close acorn, reopen it. The session restores, the marker shows, the new shell prompt is on its own line, and typing immediately echoes after the prompt.
- [ ] Repeat 5–10 times; the previously intermittent "cursor at col 0, no echo" state should not reproduce.
- [ ] Trigger a session that ends inside an alt-screen TUI (e.g. \`vim\` then quit acorn while it's open). Restore on next launch — alt-screen content does not get pushed into the normal-buffer scrollback (no doubled history).
- [ ] Paste text into the restored shell — characters land directly, NOT wrapped in \`\\e[200~ … \\e[201~\` markers.
- [ ] Click in the restored terminal — focuses the pane, no escape sequences leak into the buffer.
- [ ] Sessions with no saved scrollback (fresh sessions) behave unchanged.
- [ ] \`bun run typecheck\` clean (verified locally).