### PR TITLE
chore(release): bump version to 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.5"
+version = "1.0.6"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

Patch release shipping #67 and #68. Bumps the four in-repo version sources in lockstep: \`package.json\`, \`src-tauri/tauri.conf.json\`, \`src-tauri/Cargo.toml\`, \`src-tauri/Cargo.lock\`.

## What 1.0.6 contains (since v1.0.5)

- **fix(dev) + enhancement: handle \`claude --worktree\` without breaking acorn (#67)** — Vite watch excludes worktree checkouts so \`claude -w\` no longer triggers a full page reload; right panel follows live PTY cwd via \`pty_cwd\` + \`useLiveRepoPath\`; PTY-exit path adopts freshly-created worktrees as the session's home so the next spawn lands inside the new worktree; tab inner spacing tightened.
- **fix(terminal): drain scrollback restore before spawning new shell (#68)** — serializes restore writes and resets bracketed-paste / mouse modes explicitly so the post-restore cursor is deterministic and input no longer intermittently echoes off-screen.

## Test plan

- [x] \`bun run typecheck\` passes locally
- [x] \`cargo check\` passes locally
- [ ] CI Frontend + E2E pass on this PR
- [ ] After merge + \`v1.0.6\` tag push, the release page lists per-arch \`.app.tar.gz\` assets with matching \`.sig\` files (no signature mismatch like 1.0.4)
- [ ] \`latest.json\` references both \`darwin-aarch64\` and \`darwin-x86_64\` builds correctly
- [ ] Auto-update from 1.0.5 to 1.0.6 succeeds — verify on a separate machine or by pinning local install to 1.0.5 first
- [ ] Smoke check after install: \`claude -w\` in a Terminal session no longer white-flashes the app
- [ ] Smoke check after install: closing + reopening acorn restores scrollback with cursor at the new shell's prompt and accepts input first try