### PR TITLE
fix(pr-detail): show text cursor over PR summary and diff content

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -73,6 +73,17 @@ textarea,
   cursor: text;
 }
 
+.acorn-selectable {
+  cursor: text;
+}
+
+.acorn-selectable a,
+.acorn-selectable button,
+.acorn-selectable [role="button"],
+.acorn-selectable summary {
+  cursor: pointer;
+}
+
 /*
  * WKWebView (used by Tauri on macOS) blocks HTML5 drag on arbitrary elements
  * unless `-webkit-user-drag: element` is set. The body rule above disables


### PR DESCRIPTION
## Summary
- Show the I-beam text cursor when hovering over the PR detail modal's summary (`.acorn-selectable` body) and diff areas
- The global `body { cursor: default }` was inherited by descendants, making it visually unclear that those regions were selectable
- Set `cursor: text` on `.acorn-selectable`, and restore `cursor: pointer` for `a` / `button` / `[role="button"]` / `summary` inside it

## Test plan
- [x] `bun run build` passes
- [ ] Open the PR detail modal
- [ ] Hover the summary area (top markdown body) → verify text cursor
- [ ] Hover the Files tab diff area → verify text cursor
- [ ] Hover a comment body in the Conversation tab → verify text cursor
- [ ] Hover a link inside the summary → verify pointer cursor is preserved
