### PR TITLE
fix(terminal): keep IME composition cursor aligned when output grows

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -464,7 +464,7 @@ export function Terminal({
     // term.write); without this, the preview stays painted at the previous
     // cursor cell and visually appears one column to the left of the new
     // cursor until the user types again.
-    const renderDisposable = term.onRender(() => {
+    const repositionComposing = () => {
       if (!compositionView || !compositionView.classList.contains("active")) {
         return;
       }
@@ -475,7 +475,17 @@ export function Terminal({
       const cursorViewportY = buf.cursorY - buf.viewportY;
       compositionView.style.left = `${buf.cursorX * cell.width}px`;
       compositionView.style.top = `${cursorViewportY * cell.height}px`;
-    });
+    };
+    const renderDisposable = term.onRender(repositionComposing);
+    // PTY output that arrives while the user is mid-composition can scroll
+    // the viewport or move the prompt to a new row without producing an
+    // `onRender` event whose painted region overlaps the cursor cell — the
+    // overlay then stays pinned to the old screen coords and visually drifts
+    // away from the live prompt. `onScroll` fires on viewport shifts and
+    // `onCursorMove` fires when the shell redraws its prompt at a new row;
+    // both feed the same recompute so the overlay tracks the cursor.
+    const scrollDisposable = term.onScroll(repositionComposing);
+    const cursorMoveDisposable = term.onCursorMove(repositionComposing);
 
     // Custom event hook so a global hotkey (Cmd+K) can clear THIS terminal
     // without needing a cross-component ref registry. The dispatcher passes
@@ -842,6 +852,8 @@ export function Terminal({
       window.removeEventListener("acorn:terminal-clear", onClearRequested);
       inputDisposable.dispose();
       renderDisposable.dispose();
+      scrollDisposable.dispose();
+      cursorMoveDisposable.dispose();
       resizeDisposable.dispose();
       for (const off of unlistenFns) {
         try { off(); } catch { /* ignore */ }


### PR DESCRIPTION
## Summary

The IME composition overlay was re-anchored to the cursor only on xterm's `onRender` event. When PTY output arrived mid-composition (an async log line, a file watcher message, `claude` streaming), the viewport scrolled and the shell redrew its prompt at a new row, but the overlay stayed pinned to the previous screen coordinates — the user's in-progress Hangul preview visually drifted away from the live cursor cell.

## Root cause

`onRender` only fires for repaints whose painted region intersects the dirty rows. When new output scrolls the viewport or causes the prompt to redraw at a different row, the cursor cell can change screen position without an `onRender` invocation that we observe in time. The composition overlay's `top` / `left` then describe the *old* cursor cell.

## Fix

Extract the existing reposition logic into a `repositionComposing` helper and subscribe it to `onScroll` and `onCursorMove` in addition to `onRender`. Both events have proper xterm.js v6 disposables, cleaned up alongside the existing one. No behavioural change when no composition is active — the helper short-circuits unless `.composition-view` is in the active state.

Touched only `src/components/Terminal.tsx`. No new dependencies.

## Test plan

- [ ] Type Korean (e.g. `안녕`) into a session that is also receiving streaming output (run `while true; do echo line; sleep 0.3; done` in another pane that shares the buffer, or trigger `claude` with verbose output).
- [ ] Verify the in-progress Hangul preview stays glued to the live prompt cursor as new lines push the prompt down.
- [ ] Verify normal ASCII typing is unaffected.
- [ ] Verify commit-on-Enter / commit-on-space still lands the syllable correctly.
- [ ] Verify scroll-to-bottom on user wheel during composition does not double-fire saves.
- [ ] `bun run build` passes locally.

## Coordination

Touches the same file as the parallel Bug 3 fix (Korean ㅆ double-consonant input). Edits sit in different regions (overlay positioning vs. inputType handling), but whichever PR merges second may need a trivial rebase.
