### PR TITLE
fix(terminal): preserve Korean double-consonant (ㅆ) jongseong during IME

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -379,17 +379,24 @@ export function Terminal({
       // when the user has uncommitted IME state. If we treat such a key
       // as IME, the subsequent `input` event takes the IME branch and
       // re-emits the terminator on top of xterm's own keypress emit,
-      // producing duplicate spaces / Enters. Detect ASCII-printable keys
-      // and fall through to the non-IME path instead.
+      // producing duplicate spaces / Enters. Detect ONLY true terminator
+      // keys (named non-printable keys + actual whitespace) and fall
+      // through to the non-IME path. Letter/digit/punctuation keys keep
+      // 229 → IME path because Korean 2-set IME reports them with
+      // `ev.key` set to the underlying ASCII (e.g. shift+ㅅ → key="T"),
+      // and treating those as terminators flushes mid-syllable —
+      // dropping the second jamo of double consonants like ㅆ in `있`.
       if (ev.keyCode === 229) {
-        const isAsciiTerminator =
-          ev.key.length === 1 && ev.key.charCodeAt(0) < 0x80;
-        if (!isAsciiTerminator) {
+        const TERMINATOR_KEYS = new Set([
+          "Enter", "Tab", "Escape", "Backspace", " ", "Spacebar",
+        ]);
+        const isTerminator = TERMINATOR_KEYS.has(ev.key);
+        if (!isTerminator) {
           lastKeyCode229 = true;
           ev.stopImmediatePropagation();
           return;
         }
-        // ASCII terminator under IME — treat as non-IME; the previous
+        // Terminator under IME — treat as non-IME; the previous
         // syllable still needs flushing, which happens below because
         // `lastKeyCode229` remains true from the prior real IME keydown.
       }


### PR DESCRIPTION
## Summary

Fix Korean double-consonant (쌍자음) input in the terminal so typing `이`+`ㅆ` correctly composes into `있` and `해`+`ㅆ` into `핬`/`했`. The second `ㅅ` jongseong was being dropped because the IME terminator-detection heuristic in `onKeydown` misclassified physical letter keys as composition terminators.

## Root cause

The previous fix in #47 added an "ASCII terminator" bypass to the `keyCode === 229` branch — intended to prevent duplicate Space/Enter when those keys finalize an IME composition. The check was:

```ts
const isAsciiTerminator =
  ev.key.length === 1 && ev.key.charCodeAt(0) < 0x80;
```

This matches **any** single-character ASCII key, including `a-z`, `A-Z`, `0-9`, and punctuation. Korean 2-set IME, however, reports its physical letter keys with `ev.key` set to the underlying ASCII letter (e.g. shift+ㅅ → `key: "T"`). So every keystroke after the first jamo of a syllable was misidentified as a terminator, falling through to `flushTrailing()` mid-composition and dropping the second jamo.

For `이ㅆ` the user expects `있`, but the second `ㅅ` keypress flushed `이시` and then lost the new `ㅅ`. Same root cause for `해ㅆ` → expected `핬`/`했`, observed `해ㅅ`.

## Fix

Restrict the terminator bypass to keys that actually end a composition: `Enter`, `Tab`, `Escape`, `Backspace`, and `Space`. Letter/digit/punctuation keys retain the IME path so `insertText` / `insertReplacementText` can complete the syllable normally. The original duplicate-Space/Enter prevention is preserved unchanged because Space and Enter are still in the terminator set.

## Files changed

- `src/components/Terminal.tsx` — narrow terminator detection in `onKeydown`'s 229 branch.

## Test plan

- [ ] Open Acorn, focus a terminal pane.
- [ ] Type `있` (ㅇ + ㅣ + shift+ㅅ + shift+ㅅ) — should appear as `있`, not `이ㅅ` or `이`.
- [ ] Type `했` (ㅎ + ㅐ + shift+ㅅ + shift+ㅅ) — should appear as `했`/`핬`.
- [ ] Type `있다`, `했다`, `갔어요`, `샀어` — verify all double-consonant jongseongs render.
- [ ] Type a regression line: `안녕하세요` (no double consonants) — verify normal Hangul still composes.
- [ ] Press Space to commit a syllable mid-composition — verify no duplicate space.
- [ ] Press Enter to commit a syllable — verify no duplicate Enter (single newline only).
- [ ] Type plain English (`ls -la`, `git status`) — verify no regression in ASCII typing.
- [ ] `bun run build` passes (verified locally; pre-existing `@tauri-apps/plugin-process` type error is unrelated).
- [ ] `bun run test` passes (87 passed locally).
