### PR TITLE
fix(projects): preserve session status when transcript tail holds only meta lines

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -620,11 +620,20 @@ pub async fn detect_session_statuses(
     Ok(ids
         .into_iter()
         .map(|id| {
-            let status = session_status::detect(&id).unwrap_or(SessionStatus::Idle);
+            // Hand the detector the in-memory previous status so it can
+            // preserve a live session's classification when the tail buffer
+            // happens to land on a run of meta-only lines (see
+            // `session_status::detect` for the full rationale).
+            let parsed_id = Uuid::parse_str(&id).ok();
+            let previous = parsed_id
+                .and_then(|uuid| state.sessions.get(&uuid).ok())
+                .map(|s| s.status)
+                .unwrap_or(SessionStatus::Idle);
+            let status = session_status::detect(&id, previous).unwrap_or(previous);
             // Mirror the detected status into the in-memory store so persisted
             // sessions reflect liveness on next save. Best-effort: ignore errors
             // (e.g. UUID parse failure for a stale id from the frontend).
-            if let Ok(uuid) = Uuid::parse_str(&id) {
+            if let Some(uuid) = parsed_id {
                 let _ = state.sessions.refresh_status(&uuid, status);
             }
             SessionStatusEntry { id, status }

--- a/src-tauri/src/session_status.rs
+++ b/src-tauri/src/session_status.rs
@@ -29,7 +29,18 @@ const TAIL_BYTES: u64 = 262_144;
 
 /// Locate the JSONL transcript via `todos::locate_transcript` and infer the
 /// session's status from its tail.
-pub fn detect(session_id: &str) -> AppResult<SessionStatus> {
+///
+/// `previous` is the last status the caller observed for this session. It is
+/// only consulted when the transcript file exists but the tail buffer is
+/// filled entirely with non-`user`/`assistant` entries (long bursts of
+/// `system`/`last-prompt`/`attachment`/`file-history-snapshot` lines from
+/// recent claude versions can push the actual turn out of the 256 KiB tail
+/// window). Without this fallback, polling momentarily reclassifies a live
+/// session as Idle, leaving the Sidebar dot stuck at Idle until claude
+/// emits another user/assistant line within the tail window — which for
+/// long sessions can be never. Sessions with no transcript on disk still
+/// resolve to Idle regardless of `previous`.
+pub fn detect(session_id: &str, previous: SessionStatus) -> AppResult<SessionStatus> {
     let path = match todos::locate_transcript_for(session_id)? {
         Some(p) => p,
         None => return Ok(SessionStatus::Idle),
@@ -44,11 +55,14 @@ pub fn detect(session_id: &str) -> AppResult<SessionStatus> {
         Some(LastKind::AssistantEndTurn) => SessionStatus::NeedsInput,
         Some(LastKind::AssistantToolUse) => SessionStatus::Running,
         Some(LastKind::User) => SessionStatus::Running,
-        None => SessionStatus::Idle,
+        // Transcript exists but the tail held no user/assistant lines; keep
+        // whatever the caller previously observed instead of regressing to
+        // Idle. The next poll that lands on a real turn line corrects it.
+        None => previous,
     })
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum LastKind {
     AssistantEndTurn,
     AssistantToolUse,
@@ -110,4 +124,127 @@ fn last_meaningful_kind(tail: &str, read_full: bool) -> Option<LastKind> {
         };
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assistant(stop_reason: &str) -> String {
+        format!(
+            r#"{{"type":"assistant","message":{{"role":"assistant","stop_reason":"{stop_reason}","content":[]}}}}"#
+        )
+    }
+
+    fn user_turn() -> &'static str {
+        r#"{"type":"user","message":{"role":"user","content":"hi"}}"#
+    }
+
+    fn meta_lines() -> Vec<&'static str> {
+        vec![
+            r#"{"type":"last-prompt","lastPrompt":"x"}"#,
+            r#"{"type":"permission-mode","mode":"acceptEdits"}"#,
+            r#"{"type":"attachment"}"#,
+            r#"{"type":"file-history-snapshot"}"#,
+            // System lines (turn_duration, away_summary) get appended after the
+            // assistant's `end_turn`. The walker must skip past them and still
+            // classify the trailing assistant turn — otherwise the sidebar
+            // dot regresses to Idle the moment claude finishes a turn.
+            r#"{"type":"system","subtype":"turn_duration","durationMs":1234}"#,
+            r#"{"type":"system","subtype":"away_summary","content":"…"}"#,
+        ]
+    }
+
+    #[test]
+    fn empty_tail_returns_none() {
+        assert_eq!(last_meaningful_kind("", true), None);
+    }
+
+    #[test]
+    fn user_turn_maps_to_user() {
+        assert_eq!(
+            last_meaningful_kind(user_turn(), true),
+            Some(LastKind::User),
+        );
+    }
+
+    #[test]
+    fn assistant_end_turn_wins_over_trailing_meta() {
+        let mut tail = String::new();
+        tail.push_str(&assistant("end_turn"));
+        tail.push('\n');
+        for m in meta_lines() {
+            tail.push_str(m);
+            tail.push('\n');
+        }
+        assert_eq!(
+            last_meaningful_kind(&tail, true),
+            Some(LastKind::AssistantEndTurn),
+        );
+    }
+
+    #[test]
+    fn assistant_tool_use_maps_to_tool_use() {
+        assert_eq!(
+            last_meaningful_kind(&assistant("tool_use"), true),
+            Some(LastKind::AssistantToolUse),
+        );
+    }
+
+    #[test]
+    fn unknown_stop_reason_treated_as_tool_use() {
+        assert_eq!(
+            last_meaningful_kind(&assistant("max_tokens"), true),
+            Some(LastKind::AssistantToolUse),
+        );
+    }
+
+    #[test]
+    fn truncated_first_line_is_dropped_when_not_read_full() {
+        // Synthesize a buffer whose first line is a partial JSON fragment
+        // (the kind tail-reading produces when the file exceeds TAIL_BYTES).
+        // The walker must drop it and still find the user turn behind it
+        // instead of bailing to None.
+        let tail = format!("ent\":[]}}}}\n{}\n", user_turn());
+        assert_eq!(
+            last_meaningful_kind(&tail, false),
+            Some(LastKind::User),
+        );
+    }
+
+    #[test]
+    fn intact_first_line_is_kept_when_read_full() {
+        // When the entire file fits in the buffer, the first line is intact
+        // and must be considered — otherwise short transcripts with a single
+        // user turn would report Idle.
+        assert_eq!(
+            last_meaningful_kind(user_turn(), true),
+            Some(LastKind::User),
+        );
+    }
+
+    #[test]
+    fn meta_only_tail_returns_none() {
+        // Documents the case the `previous`-status fallback in
+        // `detect()` exists to compensate for: a tail packed with
+        // meta lines (no user/assistant turn within the window) leaves
+        // the walker with nothing to classify.
+        let tail = meta_lines().join("\n");
+        assert_eq!(last_meaningful_kind(&tail, true), None);
+    }
+
+    #[test]
+    fn assistant_without_message_is_skipped() {
+        // Defensive: a malformed assistant line without a `message` field
+        // must not be classified — the walker should keep looking.
+        let tail = format!(
+            "{}\n{}\n",
+            r#"{"type":"assistant"}"#,
+            user_turn(),
+        );
+        assert_eq!(
+            last_meaningful_kind(&tail, true),
+            Some(LastKind::User),
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Sidebar sessions could get stuck reporting **Idle** even though claude was actively running.

Recent claude versions append a stream of `system` (`turn_duration`, `away_summary`), `last-prompt`, `permission-mode`, `attachment`, and `file-history-snapshot` lines after every turn. For a busy long-running session, these can fill the entire 256 KiB tail buffer and push the actual user/assistant turn out of view. `session_status::detect` then walked back without finding any classifiable line and fell through to `SessionStatus::Idle`, which polling mirrored into the in-memory store and onto the Sidebar dot.

The fix passes the previously-observed status into `detect` and uses it as the fallback when `last_meaningful_kind` returns `None` but the transcript file *does* exist. Sessions with no transcript at all still resolve to `Idle`, so brand-new sessions render correctly. The next poll that lands on a real turn line still corrects the classification — this only stops the spurious downgrade in the meta-only tail window.

## Changes

- `session_status::detect(session_id, previous)` — new `previous` parameter consulted only when the transcript exists but the tail held no `user`/`assistant` line.
- `commands::detect_session_statuses` — pulls the in-memory `SessionStatus` from the store and threads it through.
- Added unit tests for `last_meaningful_kind` covering the full classification matrix, the truncation-guard behavior, and the meta-only-tail case that motivates the fallback. The detector previously had zero tests.

## Test plan

- [x] `cargo test --lib session_status` — 9/9 passing
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` clean
- [x] `bun run build` (frontend) clean
- [x] `bun run test` (vitest) — 87 passing, 1 pre-existing skip
- [ ] Manual: long-running claude session with many `file-history-snapshot` / `system` entries — sidebar dot stays Running/NeedsInput across polls instead of flickering to Idle
- [ ] Manual: brand-new session with no transcript yet still renders as Idle
