### PR TITLE
fix(terminal): three IME composition glitches (modifier flush, IME backspace race, stale sentPrefix)

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -327,7 +327,13 @@ export function Terminal({
         case "insertReplacementText": {
           // In-syllable replacement; trailing char being recomposed.
           // Don't commit; show preview of trailing.
-          if (ta) showComposing(ta.value.slice(sentPrefix.length));
+          if (ta) {
+            // Stale sentPrefix detection: if textarea no longer starts
+            // with the prefix we tracked, a non-IME keystroke (Space,
+            // Ctrl+C, …) reset the textarea between compositions.
+            if (!ta.value.startsWith(sentPrefix)) sentPrefix = "";
+            showComposing(ta.value.slice(sentPrefix.length));
+          }
           ev.stopImmediatePropagation();
           return;
         }
@@ -352,6 +358,14 @@ export function Terminal({
           if (!ta) return;
           const value = ta.value;
           const newCharLen = ev.data?.length ?? 0;
+          // Stale sentPrefix from a prior non-IME commit (e.g. Space
+          // committed "있 " then Ctrl+C cleared the line) leaves
+          // sentPrefix pointing past the start of this fresh composition.
+          // Detect mismatch and reset so slice() doesn't produce an
+          // empty preview, dropping the first jamo.
+          if (!value.startsWith(sentPrefix)) {
+            sentPrefix = value.slice(0, Math.max(0, value.length - newCharLen));
+          }
           const committedEnd = value.length - newCharLen;
           if (committedEnd > sentPrefix.length) {
             sendToPty(value.slice(sentPrefix.length, committedEnd));
@@ -387,6 +401,25 @@ export function Terminal({
       // and treating those as terminators flushes mid-syllable —
       // dropping the second jamo of double consonants like ㅆ in `있`.
       if (ev.keyCode === 229) {
+        const ta229 = container.querySelector<HTMLTextAreaElement>(
+          ".xterm-helper-textarea",
+        );
+        const hasComposition = !!ta229?.value;
+        // Backspace inside active IME composition is internal IME
+        // editing — the `input` event already updated the preview
+        // (e.g. "있" → "이"). Don't flush, don't let xterm emit \x7f,
+        // or the committed "이" would race with the backspace and
+        // leave the line in a broken state.
+        //
+        // Backspace WITHOUT composition (Korean input mode but nothing
+        // being composed) must behave like a normal backspace and
+        // reach the PTY, so it's left in TERMINATOR_KEYS below.
+        if (ev.key === "Backspace" && hasComposition) {
+          if (ta229) showComposing(ta229.value.slice(sentPrefix.length));
+          lastKeyCode229 = true;
+          ev.stopImmediatePropagation();
+          return;
+        }
         const TERMINATOR_KEYS = new Set([
           "Enter", "Tab", "Escape", "Backspace", " ", "Spacebar",
         ]);
@@ -399,6 +432,18 @@ export function Terminal({
         // Terminator under IME — treat as non-IME; the previous
         // syllable still needs flushing, which happens below because
         // `lastKeyCode229` remains true from the prior real IME keydown.
+      }
+      // Modifier-only keystrokes (Shift/Ctrl/Alt/Meta) are part of a
+      // chord, not a real key. They must NOT flush mid-composition or
+      // clear `lastKeyCode229` — Korean 2-set IME emits Shift before
+      // the second jamo of double consonants like ㅆ, and flushing here
+      // would commit the prior syllable (e.g. "이") before ㅆ has a
+      // chance to combine into "있".
+      const MODIFIER_KEYS = new Set([
+        "Shift", "Control", "Alt", "Meta", "CapsLock",
+      ]);
+      if (MODIFIER_KEYS.has(ev.key)) {
+        return;
       }
       // Non-IME key. If we just left IME mode (last keydown was 229),
       // flush whatever Korean syllable is mid-composition so it lands in


### PR DESCRIPTION
## Summary
Stacked fix on top of #72. Three additional IME composition glitches surfaced by live Korean ssang-jamo testing:

1. **Shift modifier between IME jamos prematurely flushed composition.** The 2-set Korean IME emits a Shift keydown right before the second jamo of double consonants (ㅆ, ㄲ, ㄸ, ㅃ, ㅉ). The previous handler treated Shift like any other non-IME key and ran `flushTrailing()`, so "이" was committed before ㅆ could combine into "있". **Fix:** skip flush + don't reset `lastKeyCode229` for modifier-only keystrokes (Shift, Ctrl, Alt, Meta, CapsLock).

2. **Backspace inside active IME composition double-consumed the keystroke.** macOS reports Backspace as keyCode 229 when an IME composition is live. The `input` event already updates the textarea (e.g. "있" → "이"), so the keystroke is internal IME editing — but the handler also flushed the new ta value to the PTY AND let xterm emit `\x7f`, racing the two and corrupting the line. **Fix:** when `keyCode === 229` + `key === "Backspace"` + textarea has content, treat as IME-internal and `stopImmediatePropagation`. Backspace WITHOUT composition still falls through to the normal terminator path.

3. **Stale `sentPrefix` carried over from a prior non-IME commit silently dropped the first jamo of the next composition.** After a Space (or Ctrl+C) committed "있 ", the non-IME `insertText` branch set `sentPrefix = ta.value` (= " "). Subsequent Korean composition started with `ta = "ㅇ"` but `sentPrefix = " "` — `slice()` returned an empty preview and the leading jamo was invisible. **Fix:** in both `insertText` and `insertReplacementText`, detect `ta.value.startsWith(sentPrefix)` mismatch and reset `sentPrefix` to the committed prefix of the new textarea state.

## Test plan
- [x] `bun run build` passes
- [x] Live: type `있` / `핬` / `했` — composes correctly (#72 base)
- [x] Live: `있` → backspace → preview becomes `이`, no PTY commit
- [x] Live: `있 ` → Ctrl+C → `있` → next composition's first jamo visible
- [ ] Regression: normal English Backspace still works in Korean input mode (composition empty)
- [ ] Regression: Ctrl+C / Ctrl+R / Ctrl+L chords still work
- [ ] Regression: Shift+Enter still emits LF
