### PR TITLE
feat(dev): allow multiple Acorn instances in debug builds

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,14 +31,20 @@ pub fn run() {
 
     let app_state = AppState::new();
 
-    tauri::Builder::default()
-        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+    #[allow(unused_mut)]
+    let mut builder = tauri::Builder::default();
+    // Release-only: lets `bun run tauri dev` run alongside an installed Acorn.
+    #[cfg(not(debug_assertions))]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.unminimize();
                 let _ = window.show();
                 let _ = window.set_focus();
             }
-        }))
+        }));
+    }
+    builder
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())


### PR DESCRIPTION
## Summary
`tauri-plugin-single-instance` blocks any second Acorn from launching while one is already running. That's correct for release builds — but during development it prevents `bun run tauri dev` from coming up alongside an already-installed Acorn, so we can't test a local change without quitting the production app first.

Gate the plugin to release builds via `#[cfg(not(debug_assertions))]`:

- **Release**: behaviour unchanged. Single-instance lock still active.
- **Debug** (`bun run tauri dev`, `cargo test`, etc.): plugin not initialized → multiple Acorn instances can coexist.

`#[allow(unused_mut)]` silences the warning the cfg gate would otherwise produce in debug, where `builder` is never reassigned.

## Test plan
- [x] `cargo check` clean (debug profile)
- [x] Verified live: dev build launches alongside installed Acorn
- [ ] Verify a release build (`bun run tauri build`) still single-instance locks
- [ ] Verify two `bun run tauri dev` instances can coexist (rare but should work)
