### PR TITLE
fix(projects): track shell session liveness via PTY output recency

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -629,7 +629,11 @@ pub async fn detect_session_statuses(
                 .and_then(|uuid| state.sessions.get(&uuid).ok())
                 .map(|s| s.status)
                 .unwrap_or(SessionStatus::Idle);
-            let status = session_status::detect(&id, previous).unwrap_or(previous);
+            // Shell sessions have no Claude transcript — fall back to PTY
+            // output recency for liveness. `None` = no live PTY → Idle.
+            let last_pty_output = parsed_id.and_then(|uuid| state.pty.last_output_at(&uuid));
+            let status = session_status::detect(&id, previous, last_pty_output)
+                .unwrap_or(previous);
             // Mirror the detected status into the in-memory store so persisted
             // sessions reflect liveness on next save. Best-effort: ignore errors
             // (e.g. UUID parse failure for a stale id from the frontend).

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -16,6 +16,7 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 
 use dashmap::DashMap;
 use parking_lot::Mutex;
@@ -42,6 +43,11 @@ struct PtyHandle {
     killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
     /// When set, the reader task will exit on its next loop iteration.
     stop: Arc<AtomicBool>,
+    /// Last instant the reader saw bytes from the PTY. Updated on every
+    /// non-empty read so `session_status::detect` can report shell sessions
+    /// (which have no Claude transcript) as `Running` while there's recent
+    /// output, and `Idle` once the PTY has been quiet for a threshold.
+    last_output: Arc<Mutex<Instant>>,
     /// PID of the spawned PTY child. Captured at spawn time because the
     /// `Child` handle moves into the wait thread. `None` if the platform
     /// did not return one (portable-pty allows that).
@@ -196,11 +202,13 @@ impl PtyManager {
         let pid = child.process_id();
 
         let stop = Arc::new(AtomicBool::new(false));
+        let last_output = Arc::new(Mutex::new(Instant::now()));
         let handle = Arc::new(PtyHandle {
             master: Mutex::new(pair.master),
             writer: Mutex::new(writer),
             killer: Mutex::new(killer),
             stop: stop.clone(),
+            last_output: last_output.clone(),
             pid,
         });
 
@@ -208,10 +216,17 @@ impl PtyManager {
 
         let app_for_reader = app.clone();
         let stop_for_reader = stop.clone();
+        let last_output_for_reader = last_output.clone();
         std::thread::Builder::new()
             .name(format!("acorn-pty-read-{session_id}"))
             .spawn(move || {
-                read_loop(app_for_reader, session_id, reader, stop_for_reader);
+                read_loop(
+                    app_for_reader,
+                    session_id,
+                    reader,
+                    stop_for_reader,
+                    last_output_for_reader,
+                );
             })
             .map_err(|e| AppError::Pty(format!("spawn reader thread: {e}")))?;
 
@@ -286,6 +301,14 @@ impl PtyManager {
         self.handles.contains_key(session_id)
     }
 
+    /// Most recent instant the PTY reader saw output bytes for a session.
+    /// `None` when no PTY is registered (session was killed or never spawned).
+    pub fn last_output_at(&self, session_id: &Uuid) -> Option<Instant> {
+        self.handles
+            .get(session_id)
+            .map(|h| *h.last_output.lock())
+    }
+
     /// PID of the immediate PTY child for a session, if known. Used by the
     /// frontend to discover the actual current working directory of the
     /// running process (and any descendants), so the right panel can follow
@@ -301,6 +324,7 @@ fn read_loop<R: Runtime>(
     session_id: Uuid,
     mut reader: Box<dyn Read + Send>,
     stop: Arc<AtomicBool>,
+    last_output: Arc<Mutex<Instant>>,
 ) {
     let event = format!("pty:output:{session_id}");
     let mut buf = [0u8; READ_BUFFER_SIZE];
@@ -311,6 +335,7 @@ fn read_loop<R: Runtime>(
         match reader.read(&mut buf) {
             Ok(0) => break, // EOF — child closed the slave
             Ok(n) => {
+                *last_output.lock() = Instant::now();
                 let payload = OutputPayload {
                     data: base64_encode(&buf[..n]),
                 };

--- a/src-tauri/src/session_status.rs
+++ b/src-tauri/src/session_status.rs
@@ -17,6 +17,7 @@
 
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
+use std::time::{Duration, Instant};
 
 use crate::error::AppResult;
 use crate::session::SessionStatus;
@@ -27,8 +28,15 @@ use crate::todos;
 // response can be many KB on a single line.
 const TAIL_BYTES: u64 = 262_144;
 
+/// Window during which a shell session counts as `Running` after its PTY
+/// last emitted bytes. Polling runs every 1s on the frontend, so 2.5s
+/// gives at least two polls of stable `Running` after each output burst
+/// before flipping back to `Idle`.
+const PTY_ACTIVE_THRESHOLD: Duration = Duration::from_millis(2500);
+
 /// Locate the JSONL transcript via `todos::locate_transcript` and infer the
-/// session's status from its tail.
+/// session's status from its tail. Falls back to PTY output recency when
+/// the session has no Claude transcript (i.e. plain shell sessions).
 ///
 /// `previous` is the last status the caller observed for this session. It is
 /// only consulted when the transcript file exists but the tail buffer is
@@ -38,12 +46,20 @@ const TAIL_BYTES: u64 = 262_144;
 /// window). Without this fallback, polling momentarily reclassifies a live
 /// session as Idle, leaving the Sidebar dot stuck at Idle until claude
 /// emits another user/assistant line within the tail window — which for
-/// long sessions can be never. Sessions with no transcript on disk still
-/// resolve to Idle regardless of `previous`.
-pub fn detect(session_id: &str, previous: SessionStatus) -> AppResult<SessionStatus> {
+/// long sessions can be never.
+///
+/// `last_pty_output` is the most recent instant the session's PTY reader
+/// saw bytes. Used as the activity signal for shell sessions, which never
+/// produce a Claude transcript and would otherwise be perma-`Idle`. `None`
+/// means the session has no live PTY (process exited, or never spawned).
+pub fn detect(
+    session_id: &str,
+    previous: SessionStatus,
+    last_pty_output: Option<Instant>,
+) -> AppResult<SessionStatus> {
     let path = match todos::locate_transcript_for(session_id)? {
         Some(p) => p,
-        None => return Ok(SessionStatus::Idle),
+        None => return Ok(pty_status(last_pty_output)),
     };
 
     let file_size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
@@ -60,6 +76,16 @@ pub fn detect(session_id: &str, previous: SessionStatus) -> AppResult<SessionSta
         // Idle. The next poll that lands on a real turn line corrects it.
         None => previous,
     })
+}
+
+/// Map PTY output recency to a status for sessions without a Claude
+/// transcript. Recent output → `Running`, otherwise `Idle`. `None`
+/// (no PTY) is also `Idle`.
+fn pty_status(last_pty_output: Option<Instant>) -> SessionStatus {
+    match last_pty_output {
+        Some(t) if t.elapsed() < PTY_ACTIVE_THRESHOLD => SessionStatus::Running,
+        _ => SessionStatus::Idle,
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -246,5 +272,21 @@ mod tests {
             last_meaningful_kind(&tail, true),
             Some(LastKind::User),
         );
+    }
+
+    #[test]
+    fn pty_status_none_means_idle() {
+        assert_eq!(pty_status(None), SessionStatus::Idle);
+    }
+
+    #[test]
+    fn pty_status_recent_output_is_running() {
+        assert_eq!(pty_status(Some(Instant::now())), SessionStatus::Running);
+    }
+
+    #[test]
+    fn pty_status_old_output_is_idle() {
+        let stale = Instant::now() - PTY_ACTIVE_THRESHOLD - Duration::from_millis(100);
+        assert_eq!(pty_status(Some(stale)), SessionStatus::Idle);
     }
 }


### PR DESCRIPTION
## Summary
Follow-up to #73. Shell sessions never produce a Claude Code transcript at `~/.claude/projects/*/<id>.jsonl`, so the existing status detector had no signal for them and forever reported `Idle`. The Sidebar status dot stayed grey for plain `$SHELL` sessions even while the user was actively typing or running commands.

This wires a PTY output timestamp into the detector:

- `PtyHandle` now holds an `Arc<Mutex<Instant>>` initialized at spawn.
- The PTY reader thread updates it on every non-empty `read()`.
- `PtyManager::last_output_at(session_id)` exposes the latest instant.
- `session_status::detect` takes `Option<Instant>` and falls back to PTY recency when no Claude transcript exists — `< 2500 ms` since last output → `Running`, otherwise `Idle`.
- Claude (Agent) sessions still use the transcript walker → finer-grained `NeedsInput` vs `Running` classification.
- `commands::detect_session_statuses` threads `state.pty.last_output_at(uuid)` through.

The 2500 ms window covers two 1 s frontend polls, so `Running` stays stable for at least 2 ticks after each output burst before flipping back to `Idle`. Long commands with sparse output may briefly oscillate; that's intentional — the dot reflects "did anything happen recently" not "is a process alive".

## Test plan
- [x] `cargo test --lib session_status` 12 pass (3 new for PTY fallback)
- [x] `cargo check` clean
- [x] `bun run build` clean
- [x] `bun run test` 87 pass / 1 skipped
- [ ] Live: open a shell session, dot is `Idle` while quiet
- [ ] Live: type / run a command in shell, dot flips to `Running`
- [ ] Live: dot returns to `Idle` ~2.5 s after output stops
- [ ] Live: Claude Agent session dot still reflects transcript-based status (`NeedsInput`/`Running`)
