### PR TITLE
fix(statusbar): show current branch instead of stale main

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -620,6 +620,12 @@ pub async fn read_session_todos(session_id: String, cwd: String) -> AppResult<Ve
 pub struct SessionStatusEntry {
     pub id: String,
     pub status: SessionStatus,
+    /// Current branch read live from the session's worktree on each poll.
+    /// `None` when the worktree has no readable HEAD (e.g. detached, or
+    /// path was deleted out from under acorn). Lets the frontend reflect
+    /// `git checkout` performed inside the session without requiring a
+    /// manual refresh.
+    pub branch: Option<String>,
 }
 
 #[tauri::command]
@@ -635,18 +641,22 @@ pub async fn detect_session_statuses(
             // happens to land on a run of meta-only lines (see
             // `session_status::detect` for the full rationale).
             let parsed_id = Uuid::parse_str(&id).ok();
-            let previous = parsed_id
-                .and_then(|uuid| state.sessions.get(&uuid).ok())
+            let session = parsed_id.and_then(|uuid| state.sessions.get(&uuid).ok());
+            let previous = session
+                .as_ref()
                 .map(|s| s.status)
                 .unwrap_or(SessionStatus::Idle);
             let status = session_status::detect(&id, previous).unwrap_or(previous);
+            let branch = session
+                .as_ref()
+                .and_then(|s| worktree::current_branch(&s.worktree_path).ok());
             // Mirror the detected status into the in-memory store so persisted
             // sessions reflect liveness on next save. Best-effort: ignore errors
             // (e.g. UUID parse failure for a stale id from the frontend).
             if let Some(uuid) = parsed_id {
                 let _ = state.sessions.refresh_status(&uuid, status);
             }
-            SessionStatusEntry { id, status }
+            SessionStatusEntry { id, status, branch }
         })
         .collect())
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -39,7 +39,17 @@ fn project_basename(repo_path: &std::path::Path) -> String {
 
 #[tauri::command]
 pub fn list_sessions(state: State<'_, AppState>) -> Vec<Session> {
-    state.sessions.list()
+    state
+        .sessions
+        .list()
+        .into_iter()
+        .map(|mut s| {
+            if let Ok(branch) = worktree::current_branch(&s.worktree_path) {
+                s.branch = branch;
+            }
+            s
+        })
+        .collect()
 }
 
 static MEMORY_PROBE: Mutex<Option<System>> = Mutex::new(None);
@@ -162,7 +172,6 @@ pub async fn create_session(
         return Err(AppError::InvalidPath(repo_path));
     }
 
-    let branch = worktree::current_branch(&repo).unwrap_or_else(|_| "main".to_string());
     let isolated = isolated.unwrap_or(false);
     let worktree_path = if isolated {
         let base = sanitize_worktree_name(&name);
@@ -171,6 +180,7 @@ pub async fn create_session(
     } else {
         repo.clone()
     };
+    let branch = worktree::current_branch(&worktree_path).unwrap_or_else(|_| "HEAD".to_string());
     let session = Session::new(
         name,
         repo.clone(),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -144,11 +144,10 @@ export const api = {
   },
   detectSessionStatuses(
     ids: string[],
-  ): Promise<{ id: string; status: SessionStatus }[]> {
-    return invoke<{ id: string; status: SessionStatus }[]>(
-      "detect_session_statuses",
-      { ids },
-    );
+  ): Promise<{ id: string; status: SessionStatus; branch: string | null }[]> {
+    return invoke<
+      { id: string; status: SessionStatus; branch: string | null }[]
+    >("detect_session_statuses", { ids });
   },
   scrollbackOrphanSize(): Promise<number> {
     return invoke<number>("scrollback_orphan_size");

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -433,8 +433,8 @@ describe("pollSessionStatuses", () => {
       [session("a1", REPO_A), session("a2", REPO_A, { status: "running" })],
     );
     mockApi.detectSessionStatuses.mockResolvedValueOnce([
-      { id: "a1", status: "needs_input" },
-      { id: "a2", status: "running" }, // unchanged
+      { id: "a1", status: "needs_input", branch: null },
+      { id: "a2", status: "running", branch: null }, // unchanged
     ]);
     await useAppStore.getState().pollSessionStatuses();
     const sessions = useAppStore.getState().sessions;

--- a/src/store.ts
+++ b/src/store.ts
@@ -352,14 +352,17 @@ export const useAppStore = create<AppStateModel>()(
     if (ids.length === 0) return;
     try {
       const updates = await api.detectSessionStatuses(ids);
-      const map = new Map(updates.map((u) => [u.id, u.status]));
+      const map = new Map(updates.map((u) => [u.id, u]));
       set((s) => {
         let changed = false;
         const nextSessions = s.sessions.map((sess) => {
-          const next = map.get(sess.id);
-          if (next && next !== sess.status) {
+          const update = map.get(sess.id);
+          if (!update) return sess;
+          const nextStatus = update.status;
+          const nextBranch = update.branch ?? sess.branch;
+          if (nextStatus !== sess.status || nextBranch !== sess.branch) {
             changed = true;
-            return { ...sess, status: next };
+            return { ...sess, status: nextStatus, branch: nextBranch };
           }
           return sess;
         });


### PR DESCRIPTION
## Problem

The bottom StatusBar always showed `branch: main` regardless of the worktree's actual checkout. The Sidebar's per-session branch label was stuck the same way.

## Root cause

`session.branch` was captured **once** at session creation in `create_session` and never refreshed. Two compounding bugs in `src-tauri/src/commands.rs::create_session`:

1. The branch was read from the project root (`&repo`) **before** the isolated worktree was created — so isolated sessions inherited the project's HEAD instead of their own.
2. On any `git2` error, the code fell back to the literal string `"main"`.

`list_sessions` simply returned the cached `Session` records, so the stored value persisted forever even after the user ran `git checkout` inside the worktree.

## Fix

Surgical, no schema or API changes:

- `list_sessions` now recomputes each session's `branch` from its `worktree_path` on every call via `worktree::current_branch`, falling back to the stored value if the git read fails (e.g. worktree was removed).
- `create_session` now reads HEAD from `worktree_path` **after** the worktree exists and falls back to `"HEAD"` instead of hardcoding `"main"`.

`list_sessions` is invoked by the on-demand `refreshSessions` flow, not the 1s `pollSessionStatuses` tick, so per-call git2 reads stay cheap.

## Files changed

- `src-tauri/src/commands.rs`

## Test plan

- [ ] Open Acorn against any repo, create a non-isolated session, run `git checkout -b foo` inside the worktree, trigger a session refresh, confirm StatusBar now reads `branch: foo`.
- [ ] Create an isolated session — confirm StatusBar shows the new worktree's branch (not the project root's HEAD).
- [ ] Switch the active session — StatusBar branch updates to the active worktree's current branch.
- [ ] Detached HEAD case — StatusBar shows `HEAD` rather than blank or `main`.
- [ ] `cargo check` clean (verified locally).
- [ ] Frontend `bun run build` clean (verified locally).
