### PR TITLE
fix(git): discover repo from any subdirectory instead of failing on cwd

### DIFF
--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -8,7 +8,17 @@ const ACORN_DIR: &str = ".acorn";
 const EXCLUDE_ENTRY: &str = ".acorn/";
 
 pub fn ensure_repo(path: &Path) -> AppResult<Repository> {
-    Repository::open(path).map_err(AppError::from)
+    // `discover` walks up from `path` to find the nearest `.git`, so callers
+    // can pass any subdirectory (e.g. a session's PTY cwd that drifted into
+    // `<repo>/src-tauri`) without the open failing. Also handles linked
+    // worktrees, where `.git` is a file pointing at the parent repo.
+    Repository::discover(path).map_err(|e| {
+        AppError::Other(format!(
+            "could not find git repository from '{}': {}",
+            path.display(),
+            e.message()
+        ))
+    })
 }
 
 pub fn worktree_root(repo_path: &Path) -> PathBuf {
@@ -103,4 +113,56 @@ pub fn current_branch(repo_path: &Path) -> AppResult<String> {
         .shorthand()
         .map(|s| s.to_string())
         .unwrap_or_else(|| "HEAD".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-worktree-test-{label}-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    #[test]
+    fn ensure_repo_discovers_from_subdirectory() {
+        let root = unique_temp_dir("subdir");
+        let repo = Repository::init(&root).expect("init repo");
+        // Drop borrow before recreating Repository via discover.
+        drop(repo);
+
+        let subdir = root.join("nested").join("deeper");
+        std::fs::create_dir_all(&subdir).expect("nested dirs");
+
+        let opened = ensure_repo(&subdir).expect("discover from subdir");
+        let workdir = opened.workdir().expect("workdir present");
+        assert_eq!(
+            workdir.canonicalize().unwrap(),
+            root.canonicalize().unwrap(),
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn ensure_repo_errors_when_no_repo_in_ancestry() {
+        let root = unique_temp_dir("norepo");
+        let msg = match ensure_repo(&root) {
+            Ok(_) => panic!("expected discover failure outside any repo"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("could not find git repository from"),
+            "unexpected error message: {msg}"
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
 }


### PR DESCRIPTION
## Summary

Sessions whose PTY cwd drifted into a subdirectory (e.g. `<repo>/src-tauri`) surfaced a `git error: could not find repository at '...'` when any read-only git command fired (worktree snapshot before/after `pty_spawn`, etc.). `worktree::ensure_repo` was calling `Repository::open(path)`, which only succeeds when `path` is itself a git working directory.

Switch to `Repository::discover` so the repo is located by walking up from `path` to the nearest `.git`. Linked worktrees (where `.git` is a file pointing back at the main repo's `worktrees/` dir) keep working — `discover` handles both shapes natively.

Also wrapped the failure with a typed message that includes the queried path, so when discovery genuinely fails the UI surfaces something actionable.

## Changes

- `src-tauri/src/worktree.rs`
  - `ensure_repo`: `Repository::open` → `Repository::discover`, with a path-aware error message.
  - Added two unit tests: discovery from a nested subdirectory, and the no-repo-in-ancestry failure path.

## Why this is the right place

`ensure_repo` is the single funnel for every git operation in the backend (`git_ops::*`, `worktree::*`). Fixing it here repairs every read-only call site at once — `git_worktrees`, `list_commits`, `list_staged`, `current_branch`, `diff_for_commit`, etc. — without touching individual commands or the frontend's cwd-passing code.

Worktree creation (`create_worktree`) still receives the project root from `state.projects` (set via `add_project`), so its `worktree_root(repo_path)` path math is unchanged.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 43 pass / 0 fail (was 41; +2 new tests cover the fix).
- [ ] Manual: open a session, let its PTY cwd drift into a subdir, confirm the `git error: could not find repository` toast no longer appears on subsequent worktree snapshots.
