### PR TITLE
fix(git): scope git data fetches to active project to prevent cross-project leak

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -133,18 +133,30 @@ export function RightPanel() {
           )
         ) : rightTab === "commits" ? (
           repoPath ? (
-            <CommitsTab repoPath={repoPath} onExpand={setExpanded} />
+            // `key` forces a full remount on project switch so any in-flight
+            // git request from the previous repo cannot land its `setState`
+            // into the new repo's component (cross-project data leak).
+            <CommitsTab
+              key={repoPath}
+              repoPath={repoPath}
+              onExpand={setExpanded}
+            />
           ) : (
             <Empty msg="No project selected" />
           )
         ) : rightTab === "staged" ? (
           repoPath ? (
-            <StagedTab repoPath={repoPath} onExpand={setExpanded} />
+            <StagedTab
+              key={repoPath}
+              repoPath={repoPath}
+              onExpand={setExpanded}
+            />
           ) : (
             <Empty msg="No project selected" />
           )
         ) : repoPath ? (
           <PullRequestsTab
+            key={repoPath}
             repoPath={repoPath}
             onOpenDetail={(number) => setPrDetail({ repoPath, number })}
             refreshKey={prListVersion}

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -89,4 +89,134 @@ test.describe("right panel: tab switching", () => {
     // Give the polling loop a tick to fetch and apply the null response.
     await expect(page.getByText(/Select a commit to see diff/i)).toBeVisible();
   });
+
+  test("loadMore from previous project does not leak after switch (regression)", async ({
+    page,
+    tauri,
+  }) => {
+    // Cross-project leak: CommitsTab.loadMore() has no cancellation guard —
+    // if the user scroll-triggers loadMore in project A, then switches to B
+    // before the page resolves, project A's commits get appended onto B's
+    // list via `setCommits(prev => [...prev, ...page])`. The per-repoPath
+    // remount (key={repoPath}) unmounts A's component so its setter no
+    // longer reaches the live tree.
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/repo-a",
+        name: "repo-a",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+      {
+        repo_path: "/tmp/repo-b",
+        name: "repo-b",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 1,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-a",
+        name: "sess-a",
+        repo_path: "/tmp/repo-a",
+        worktree_path: "/tmp/repo-a",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        startup_mode: "terminal",
+      },
+      {
+        id: "s-b",
+        name: "sess-b",
+        repo_path: "/tmp/repo-b",
+        worktree_path: "/tmp/repo-b",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        startup_mode: "terminal",
+      },
+    ]);
+    // list_commits: page 0 returns 50 commits per repo (so hasMore=true and
+    // loadMore can be triggered). Page 1 (offset=50) for repo A is delayed
+    // so its resolve races the project switch.
+    await tauri.handle("list_commits", (args) => {
+      const a = args as { repoPath: string; offset: number; limit: number };
+      const isA = a.repoPath.endsWith("repo-a");
+      const tag = isA ? "AAA" : "BBB";
+      // Trace each call so the test can wait until A's loadMore was issued.
+      const w = window as unknown as {
+        __listCommitsCalls?: { repoPath: string; offset: number }[];
+      };
+      w.__listCommitsCalls = w.__listCommitsCalls ?? [];
+      w.__listCommitsCalls.push({ repoPath: a.repoPath, offset: a.offset });
+      const page0 = Array.from({ length: 50 }, (_, i) => ({
+        sha: tag + String(i).padStart(16, "0"),
+        short_sha: tag.toLowerCase() + String(i).padStart(4, "0"),
+        author: tag + " author",
+        summary: "p0 " + tag + " #" + i,
+        timestamp: 1700000000 - i,
+        pushed: true,
+      }));
+      const page1 = [
+        {
+          sha: tag + "PAGE1XXXXXXXXXXX",
+          short_sha: tag.toLowerCase() + "p1",
+          author: tag + " author",
+          summary: "leak-marker-" + tag,
+          timestamp: 1699000000,
+          pushed: true,
+        },
+      ];
+      const data = a.offset === 0 ? page0 : page1;
+      const delayMs = isA && a.offset > 0 ? 700 : 0;
+      return new Promise((resolve) => {
+        setTimeout(() => resolve(data), delayMs);
+      });
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: /^sess-a main · Idle$/ }).click();
+    // Wait for A's first page to render.
+    await expect(page.getByText("p0 AAA #0")).toBeVisible();
+    // Trigger loadMore by scrolling the commits panel to the bottom — the
+    // virtualizer's `lastItem.index >= commits.length - 1` check fires the
+    // page-1 fetch, which is delayed for repo A.
+    await page.evaluate(() => {
+      const scrollers = document.querySelectorAll(".overflow-y-auto");
+      scrollers.forEach((s) => {
+        (s as HTMLElement).scrollTop = (s as HTMLElement).scrollHeight;
+      });
+    });
+    // Confirm A's page-1 fetch was actually issued before we switch.
+    await page.waitForFunction(() => {
+      const w = window as unknown as {
+        __listCommitsCalls?: { repoPath: string; offset: number }[];
+      };
+      return (w.__listCommitsCalls ?? []).some(
+        (c) => c.repoPath.endsWith("repo-a") && c.offset > 0,
+      );
+    });
+    // Switch to project B before A's page-1 resolves.
+    await page.getByRole("button", { name: /^sess-b main · Idle$/ }).click();
+    // Wait for B's first page to render — confirms switch landed.
+    await expect(page.getByText("p0 BBB #0")).toBeVisible();
+    // Give A's delayed page-1 plenty of time to resolve.
+    await page.waitForTimeout(1200);
+    // Scroll B to the bottom so any virtualized rows (including a leaked
+    // AAA row appended via setCommits) become visible to the assertion.
+    await page.evaluate(() => {
+      const scrollers = document.querySelectorAll(".overflow-y-auto");
+      scrollers.forEach((s) => {
+        (s as HTMLElement).scrollTop = (s as HTMLElement).scrollHeight;
+      });
+    });
+    // Regression: A's page-1 marker must never appear in B's panel.
+    await expect(page.getByText(/leak-marker-AAA/)).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## Summary

Fix the intermittent "right panel shows another project's git data" bug.

When switching projects, in-flight git fetches from the previous project (commits, staged files, PRs, diffs) could resolve **after** the switch and land their `setState` into the now-active project's tab — visible as wrong-project commits/files/PRs briefly or persistently.

## Root cause

`CommitsTab` / `StagedTab` / `PullRequestsTab` kept the same component instance across project switches and relied on per-effect `cancelled` flags. User-triggered async ops (`loadMore`, `selectCommit`, manual PR refresh) had **no** cancellation guard, so their resolutions applied to the new project's state.

## Fix

Add `key={repoPath}` to each tab so React unmounts the previous project's instance and mounts a fresh one when `repoPath` changes. Setters from the unmounted instance no longer reach the live tree (React no-ops setState on unmounted fibers).

Surgical: 16 lines in `RightPanel.tsx`, no behavior change to the per-project flow.

## Files changed

- `src/components/RightPanel.tsx` — `key={repoPath}` on `CommitsTab`, `StagedTab`, `PullRequestsTab`
- `tests/e2e/right-panel.spec.ts` — regression test: races `loadMore` against a project switch, asserts the prior project's commits do not leak

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run build` clean
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` clean (pre-existing dead-code warning unrelated)
- [x] `bun run test` — 87 vitest tests pass
- [x] `bun run test:e2e` — all 26 e2e tests pass including new regression
- [x] Verified test fails without the fix (catches the leak: 2 stray AAA rows in B's panel)
- [x] Verified test passes with the fix
