### PR TITLE
feat(projects): track shell session liveness via child-process transitions

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -633,6 +633,19 @@ pub async fn detect_session_statuses(
     state: State<'_, AppState>,
     ids: Vec<String>,
 ) -> AppResult<Vec<SessionStatusEntry>> {
+    // One process-table snapshot covers every session in this poll; cwd
+    // refresh isn't needed here (we only walk parent→child edges to ask
+    // "does this PTY tree have any descendant?").
+    let mut sys = System::new_with_specifics(
+        RefreshKind::new().with_processes(ProcessRefreshKind::new()),
+    );
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::new(),
+    );
+    let children = build_children_map(&sys);
+
     Ok(ids
         .into_iter()
         .map(|id| {
@@ -646,7 +659,13 @@ pub async fn detect_session_statuses(
                 .as_ref()
                 .map(|s| s.status)
                 .unwrap_or(SessionStatus::Idle);
-            let status = session_status::detect(&id, previous).unwrap_or(previous);
+            let shell_hint = parsed_id.and_then(|uuid| {
+                let root = state.pty.child_pid(&uuid)?;
+                let has_child_now = has_live_descendant(&children, Pid::from_u32(root));
+                state.pty.update_shell_state(&uuid, has_child_now)
+            });
+            let status =
+                session_status::detect(&id, previous, shell_hint).unwrap_or(previous);
             let branch = session
                 .as_ref()
                 .and_then(|s| worktree::current_branch(&s.worktree_path).ok());
@@ -659,6 +678,28 @@ pub async fn detect_session_statuses(
             SessionStatusEntry { id, status, branch }
         })
         .collect())
+}
+
+/// One pass over `sys.processes()` that yields parent→children adjacency.
+/// Built once per poll so the per-session BFS does not rescan the whole
+/// table for every PTY root.
+fn build_children_map(sys: &System) -> HashMap<Pid, Vec<Pid>> {
+    let mut map: HashMap<Pid, Vec<Pid>> = HashMap::new();
+    for (pid, proc) in sys.processes() {
+        if let Some(parent) = proc.parent() {
+            map.entry(parent).or_default().push(*pid);
+        }
+    }
+    map
+}
+
+/// `true` if any descendant of `root` exists in the children map. The root
+/// itself does not count — we only care about commands launched *under* the
+/// PTY shell, which is what flips Idle ↔ Running for terminal sessions.
+fn has_live_descendant(children: &HashMap<Pid, Vec<Pid>>, root: Pid) -> bool {
+    children
+        .get(&root)
+        .is_some_and(|direct| !direct.is_empty())
 }
 
 #[tauri::command]

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -16,6 +16,7 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use parking_lot::Mutex;
@@ -31,6 +32,24 @@ use crate::error::{AppError, AppResult};
 const DEFAULT_COLS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
 const READ_BUFFER_SIZE: usize = 4096;
+/// How long a "just-finished a command" cue lingers as `NeedsInput` on the
+/// Sidebar dot before we let it fall back to `Idle`. Long enough to actually
+/// catch the user's eye after a transient command (`ls`, `git status`),
+/// short enough that an abandoned shell does not look perpetually pending.
+const NEEDS_INPUT_STICKY: Duration = Duration::from_secs(5);
+
+/// Coarse classification of a shell-mode session's liveness, derived purely
+/// from "does the PTY child have any descendant processes right now?".
+/// Mirrors the `SessionStatus` variants the Sidebar dot already knows how to
+/// render — we keep this enum private to the backend so the
+/// transcript-driven detector can map it without leaking shell-specific
+/// vocabulary into the public session status type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShellHint {
+    Running,
+    NeedsInput,
+    Idle,
+}
 
 /// Per-session PTY state held by the manager.
 struct PtyHandle {
@@ -46,6 +65,14 @@ struct PtyHandle {
     /// `Child` handle moves into the wait thread. `None` if the platform
     /// did not return one (portable-pty allows that).
     pid: Option<u32>,
+    /// Whether the previous liveness poll observed a live descendant of the
+    /// PTY child. The Idle→Running and Running→NeedsInput edges drive the
+    /// Sidebar status dot for shell-mode sessions.
+    had_child: AtomicBool,
+    /// Deadline for the post-command "still waiting on you" cue. Set when the
+    /// last descendant exits, cleared on the next user keystroke or when the
+    /// deadline passes.
+    needs_input_until: Mutex<Option<Instant>>,
 }
 
 /// Manages all live PTY sessions for the application.
@@ -202,6 +229,8 @@ impl PtyManager {
             killer: Mutex::new(killer),
             stop: stop.clone(),
             pid,
+            had_child: AtomicBool::new(false),
+            needs_input_until: Mutex::new(None),
         });
 
         self.handles.insert(session_id, handle);
@@ -241,6 +270,11 @@ impl PtyManager {
         writer
             .flush()
             .map_err(|e| AppError::Pty(format!("flush failed: {e}")))?;
+        // The user typed — they've moved on from the previous "command just
+        // exited" cue, so suppress the sticky NeedsInput before the next
+        // liveness poll lands.
+        drop(writer);
+        *handle.needs_input_until.lock() = None;
         Ok(())
     }
 
@@ -293,6 +327,52 @@ impl PtyManager {
     /// the cwd we set at spawn time.
     pub fn child_pid(&self, session_id: &Uuid) -> Option<u32> {
         self.handles.get(session_id).and_then(|h| h.pid)
+    }
+
+    /// Per-poll state machine for shell-mode liveness. The caller has just
+    /// computed `has_child_now` from a process-table snapshot; we fold it
+    /// against the previous observation and the sticky NeedsInput deadline
+    /// to produce the hint the Sidebar dot should show.
+    ///
+    /// Returns `None` when the session has no live PTY (e.g. exited between
+    /// the snapshot and this call) — the caller should treat that as Idle.
+    pub fn update_shell_state(
+        &self,
+        session_id: &Uuid,
+        has_child_now: bool,
+    ) -> Option<ShellHint> {
+        let handle = self.handles.get(session_id)?.clone();
+        let had_child = handle.had_child.swap(has_child_now, Ordering::SeqCst);
+        let mut sticky = handle.needs_input_until.lock();
+        let hint = if has_child_now {
+            *sticky = None;
+            ShellHint::Running
+        } else if had_child {
+            // Just transitioned from "child running" → "no child"; arm the
+            // sticky window so a quick command surfaces NeedsInput before
+            // the next poll erases the signal.
+            *sticky = Some(Instant::now() + NEEDS_INPUT_STICKY);
+            ShellHint::NeedsInput
+        } else {
+            match *sticky {
+                Some(deadline) if Instant::now() < deadline => ShellHint::NeedsInput,
+                _ => {
+                    *sticky = None;
+                    ShellHint::Idle
+                }
+            }
+        };
+        Some(hint)
+    }
+
+    /// Drop the sticky NeedsInput cue, if any. Exposed so callers other than
+    /// `write` (e.g. a future "user focused the terminal" hook) can also
+    /// dismiss the cue without typing.
+    #[allow(dead_code)]
+    pub fn clear_needs_input(&self, session_id: &Uuid) {
+        if let Some(handle) = self.handles.get(session_id) {
+            *handle.needs_input_until.lock() = None;
+        }
     }
 }
 

--- a/src-tauri/src/session_status.rs
+++ b/src-tauri/src/session_status.rs
@@ -19,6 +19,7 @@ use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 
 use crate::error::AppResult;
+use crate::pty::ShellHint;
 use crate::session::SessionStatus;
 use crate::todos;
 
@@ -38,12 +39,20 @@ const TAIL_BYTES: u64 = 262_144;
 /// window). Without this fallback, polling momentarily reclassifies a live
 /// session as Idle, leaving the Sidebar dot stuck at Idle until claude
 /// emits another user/assistant line within the tail window — which for
-/// long sessions can be never. Sessions with no transcript on disk still
-/// resolve to Idle regardless of `previous`.
-pub fn detect(session_id: &str, previous: SessionStatus) -> AppResult<SessionStatus> {
+/// long sessions can be never.
+///
+/// `shell_hint` carries the descendant-process snapshot for shell-mode
+/// sessions (no transcript on disk). It is the only signal we have for
+/// terminal sessions, so when the transcript path is empty we map it
+/// directly to a status. `None` means "no live PTY" → Idle.
+pub fn detect(
+    session_id: &str,
+    previous: SessionStatus,
+    shell_hint: Option<ShellHint>,
+) -> AppResult<SessionStatus> {
     let path = match todos::locate_transcript_for(session_id)? {
         Some(p) => p,
-        None => return Ok(SessionStatus::Idle),
+        None => return Ok(map_shell_hint(shell_hint)),
     };
 
     let file_size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
@@ -60,6 +69,14 @@ pub fn detect(session_id: &str, previous: SessionStatus) -> AppResult<SessionSta
         // Idle. The next poll that lands on a real turn line corrects it.
         None => previous,
     })
+}
+
+fn map_shell_hint(hint: Option<ShellHint>) -> SessionStatus {
+    match hint {
+        Some(ShellHint::Running) => SessionStatus::Running,
+        Some(ShellHint::NeedsInput) => SessionStatus::NeedsInput,
+        Some(ShellHint::Idle) | None => SessionStatus::Idle,
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -231,6 +248,29 @@ mod tests {
         // the walker with nothing to classify.
         let tail = meta_lines().join("\n");
         assert_eq!(last_meaningful_kind(&tail, true), None);
+    }
+
+    #[test]
+    fn shell_hint_running_maps_to_running() {
+        assert_eq!(map_shell_hint(Some(ShellHint::Running)), SessionStatus::Running);
+    }
+
+    #[test]
+    fn shell_hint_needs_input_maps_to_needs_input() {
+        assert_eq!(
+            map_shell_hint(Some(ShellHint::NeedsInput)),
+            SessionStatus::NeedsInput,
+        );
+    }
+
+    #[test]
+    fn shell_hint_idle_maps_to_idle() {
+        assert_eq!(map_shell_hint(Some(ShellHint::Idle)), SessionStatus::Idle);
+    }
+
+    #[test]
+    fn shell_hint_none_maps_to_idle() {
+        assert_eq!(map_shell_hint(None), SessionStatus::Idle);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Brings shell-mode sessions (Terminal startup mode, no Claude transcript) to status-dot parity with Agent sessions. The Sidebar dot now flips between `Idle` / `Running` / `NeedsInput` based on whether the PTY child has live descendant processes.

Supersedes #76, which used PTY output recency as the activity signal. That approach conflated typing (the shell echoes keystrokes) with command execution and could not surface `NeedsInput` distinctly from `Running`. The child-process signal is unambiguous: a descendant exists iff the user is running something.

### Behaviour

| Previous state | Has child now? | Sticky window | Result |
|---|---|---|---|
| (any) | Yes | (cleared) | `Running` |
| Had child last poll | No (just exited) | Armed (5s) | `NeedsInput` |
| No child | No | Active | `NeedsInput` |
| No child | No | Expired / unset | `Idle` |

The 5-second `NeedsInput` window is dismissed immediately on the next `pty_write`, so a keystroke moves the dot off `NeedsInput` before the next 1-second poll lands.

### Implementation

- **`src-tauri/src/pty.rs`** — added `ShellHint` enum + per-handle `had_child: AtomicBool` and `needs_input_until: Mutex<Option<Instant>>`. New `PtyManager::update_shell_state` runs the state machine; `PtyManager::write` clears the sticky cue.
- **`src-tauri/src/session_status.rs`** — `detect()` now takes `Option<ShellHint>`. Transcript-driven path is unchanged; the no-transcript branch maps the hint instead of always returning `Idle`.
- **`src-tauri/src/commands.rs::detect_session_statuses`** — builds one `sysinfo::System` snapshot + a `HashMap<Pid, Vec<Pid>>` parent→children map per poll, so cost stays O(processes) instead of O(sessions x processes). Direct-child presence is sufficient evidence of a live descendant — no full BFS needed for a yes/no signal.

### Why label `feat`

Net-new visible behaviour for terminal sessions (a status dot that previously never moved now does). Users who never use Agent mode get a status dot for the first time. Calling it `fix` would understate the scope.

### Files changed

- `src-tauri/src/commands.rs`
- `src-tauri/src/pty.rs`
- `src-tauri/src/session_status.rs`

No frontend changes — `SessionStatus::NeedsInput` is already in the enum and the dot color already maps it.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean (1 pre-existing dead-code warning unrelated)
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 47 passed, 1 ignored (4 new `shell_hint_*` tests in `session_status::tests`)
- [x] `bun run build` — clean
- [x] `bun run test` — 87 passed, 1 skipped
- [x] `bun run typecheck` — clean
- [ ] Manual: Terminal-mode session, run `sleep 3` — dot turns yellow (Running) for ~3s, then orange (NeedsInput) for 5s, then grey (Idle)
- [ ] Manual: Type a character mid-sticky window — dot returns to Idle on the next poll
- [ ] Manual: Agent-mode session — transcript-driven dot still works (regression check on the unchanged path)
