### PR TITLE
fix(terminal): preserve cursor position during shell autosuggestion redraws

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -97,7 +97,18 @@ export function Terminal({
       cursorBlink: true,
       allowProposedApi: true,
       scrollback: 5000,
-      convertEol: true,
+      // `convertEol` rewrites every bare `\n` from the PTY into `\r\n` before
+      // the parser sees it. A real shell already emits `\r\n` for line
+      // breaks, but interactive plugins (zsh-autosuggestions, prompt
+      // redraws) also emit bare `\n` as "move cursor down one row, keep
+      // column" — bracketed by `\e7`/`\e8` (DECSC/DECRC) save/restore. With
+      // `convertEol: true` that bare LF gains a phantom CR, so the cursor
+      // jumps to column 0 mid-redraw; the following save/restore pair lands
+      // at the wrong x and subsequent shell echo overwrites previously
+      // rendered cells (e.g. the prompt user "jthefloor" renders as
+      // "rhefloor"). PTY output is the only writer here, so `false` is the
+      // correct setting.
+      convertEol: false,
     });
 
     const fitAddon = new FitAddon();


### PR DESCRIPTION
## Summary

Fixes a long-standing terminal corruption bug where typing into a shell with `zsh-autosuggestions` (or any plugin that paints a faded preview ahead of the cursor) intermittently caused the cursor to jump to column 0 (or somewhere mid-line), after which subsequent input/echo overwrote previously rendered cells.

Symptoms reported by the user:
- Cursor "goes back to the front" while typing a long command
- Username `jthefloor` renders as `rhefloor`
- `tauri dev` renders as `tauri de` with stray characters elsewhere
- The whole prompt line ends up visually corrupted

## Root cause

`Terminal.tsx` constructed the `XTerm` instance with `convertEol: true`. From the xterm.js docs:

> Whether to translate `\n` to `\r\n` when writing to the terminal.

That option is intended for callers that own their output stream and want to write Unix-style text. **It is not safe when the writer is a real PTY.**

A real interactive shell already emits `\r\n` for line breaks, but interactive plugins emit other things too:

- `zsh-autosuggestions` saves the cursor (`\e7` / DECSC), redraws the suggestion using a mix of cursor-positioning, color, and movement bytes, then restores (`\e8` / DECRC). Inside that block it routinely emits a bare `\n` meaning *"line feed: move cursor down one row, preserve column"*.
- Prompt redraws and multi-line prompts do the same.

With `convertEol: true`, that bare LF gets a phantom CR injected before xterm's parser sees it. The cursor now jumps to column 0 mid-redraw. The matching `\e8` restore lands at the wrong x because the save was relative to the line the parser thinks we're on. Following PTY echo paints into the wrong cells, producing exactly the visual corruption the user described.

This bug has existed since the initial commit (`0861c21`); it only surfaces when a plugin rapidly repaints around the cursor, which is why it manifested intermittently rather than every keystroke.

## Fix

`convertEol: false`. PTY output is the only writer to xterm in this component, and every internal `term.write` / `term.writeln` call in `Terminal.tsx` already uses explicit `\r\n` (or `writeln`, which appends `\r\n`), so nothing else needs to change.

Diff: 1 file, 12 insertions, 1 deletion (most of which is a `WHY` comment so this doesn't get re-flipped).

## Files changed

- `src/components/Terminal.tsx` — set `convertEol: false`, document why.

## Manual repro / verification

Before the fix:

1. Have `zsh-autosuggestions` enabled in your `~/.zshrc` (or equivalent).
2. Open an Acorn session.
3. Start typing a long command that the shell will autosuggest (e.g. recently-used `bun run tauri dev` or any history entry near a long prompt).
4. Type fast enough that the suggestion is constantly being repainted ahead of the cursor.
5. Observe the cursor occasionally snapping back to column 0 / mid-line, with characters dropping or shifting in the prompt.

After the fix: cursor stays where the shell parked it, autosuggestion repaints stay invisible to layout, no character corruption.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [ ] Manual: type long shell commands with `zsh-autosuggestions` active; confirm cursor never jumps to col 0 mid-line.
- [ ] Manual: confirm restored scrollback (after app restart) still renders cleanly — the SerializeAddon writes `\r\n` already, so this should be unaffected.
- [ ] Manual: confirm IME (Korean / Japanese / Chinese) composition still works — the IME path writes to the PTY, never directly to xterm, so it is independent of this option.
- [ ] Manual: confirm `Shift+Enter` (sends `\n` to the PTY) still works as expected — again, that path goes through `pty_write`, not `term.write`.

## Notes for reviewer

- A unit test wasn't added because the behavior depends on xterm.js's parser state and live PTY chunks; the fix is a one-line option flip with a clear contract from xterm.js docs. If we want regression coverage, the right place is an E2E test that spawns a shell and checks rendered DOM rows after a sequence containing a bare `\n`, but that is meaningfully more infrastructure than this surgical fix justifies.
- If anyone re-encounters this, the giveaway is: PTY emits `\n` between `\e7` and `\e8`. Keep `convertEol: false`.
