### PR TITLE
perf(ci): speed up release build with thin LTO, sccache, and caches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,20 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          # Pinned to match .github/workflows/ci.yml so the GHA-managed
+          # bun cache key stays stable across runs (`latest` invalidates
+          # whenever upstream cuts a new release).
+          bun-version: 1.3.12
+
+      # Cache bun's package store. setup-bun does not cache install
+      # output; `bun install` re-fetches every dep without this.
+      - name: Cache bun store
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -42,7 +55,17 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
-          key: ${{ matrix.target }}
+          # Per-target shared key (default key already factors in
+          # Cargo.lock + rustc version). `cache-on-failure` lets the
+          # next run pick up partial progress when a build dies late.
+          shared-key: ${{ matrix.target }}
+          cache-on-failure: true
+
+      # sccache backed by GitHub Actions cache. Speeds up COLD cargo
+      # builds (when Swatinem/rust-cache misses, e.g. after Cargo.lock
+      # bumps). Wraps rustc to memoize per-crate compilation outputs.
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Install JS deps
         run: bun install --frozen-lockfile
@@ -51,7 +74,16 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: bun run tauri build --target ${{ matrix.target }} --bundles app dmg updater
+          # sccache wiring. CARGO_INCREMENTAL must be off — incremental
+          # compilation is incompatible with sccache and silently
+          # disables caching.
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
+          CARGO_INCREMENTAL: "0"
+        # `--profile release-ci` swaps fat LTO + codegen-units=1 for
+        # thin LTO + codegen-units=16 (defined in src-tauri/Cargo.toml).
+        # Output lands in target/<arch>/release-ci/ instead of release/.
+        run: bun run tauri build --target ${{ matrix.target }} --profile release-ci --bundles app dmg updater
 
       - name: Stage release artifacts
         id: stage
@@ -60,7 +92,9 @@ jobs:
           out=staged
           mkdir -p "$out"
           target="${{ matrix.target }}"
-          bundle_dir="src-tauri/target/${target}/release/bundle"
+          # Custom profile name = target subdir name. Build step uses
+          # `--profile release-ci`, so artifacts live under release-ci/.
+          bundle_dir="src-tauri/target/${target}/release-ci/bundle"
 
           # Tauri produces `.app.tar.gz` / `.app.tar.gz.sig` with a
           # NON-arch-tagged name (the DMG is arch-tagged by tauri itself,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,3 +45,12 @@ opt-level = 3
 lto = true
 codegen-units = 1
 strip = true
+
+# CI release profile — trades a small binary-size increase for much faster
+# compile time. Used by `.github/workflows/release.yml`. Local releases
+# (developers running `bun run tauri build`) still use [profile.release]
+# above, so shipped artifact size is unchanged for ad-hoc builds.
+[profile.release-ci]
+inherits = "release"
+lto = "thin"
+codegen-units = 16


### PR DESCRIPTION
## Summary

Cuts release-workflow wall time on `macos-latest` by reducing rust compile cost and adding the cache layers the workflow was missing.

## Changes

- **`src-tauri/Cargo.toml`** — new `[profile.release-ci]` (`lto = "thin"`, `codegen-units = 16`) inheriting from `release`. Workflow uses this; local `bun run tauri build` still gets the original fat-LTO profile so ad-hoc artifact size is unchanged.
- **`.github/workflows/release.yml`**
  - Pin `bun-version: 1.3.12` (matches `ci.yml`) so `oven-sh/setup-bun` cache key stays stable.
  - Add explicit `actions/cache@v4` for `~/.bun/install/cache`, keyed on `bun.lock`.
  - Drop the narrow `key: ${{ matrix.target }}` on `Swatinem/rust-cache` (it overrode the default Cargo.lock-aware key); replace with `shared-key` + `cache-on-failure: true`.
  - Wire `mozilla-actions/sccache-action@v0.0.6` with `RUSTC_WRAPPER=sccache`, `SCCACHE_GHA_ENABLED=true`, `CARGO_INCREMENTAL=0`.
  - Switch tauri build to `--profile release-ci`; update staging-step `bundle_dir` to `release-ci/`.

## Expected impact

| Layer | Wall-time win (per matrix job) |
|---|---|
| Thin LTO + 16 codegen-units | -2 to -4 min |
| sccache (cold cargo) | -1 to -3 min |
| bun cache | -10 to -30 s |

## Test plan

- [ ] Tag a dry-run release (or `workflow_dispatch` an existing tag) and confirm both matrix jobs finish faster than the previous baseline.
- [ ] Verify both `Acorn_<ver>_aarch64.dmg` and `Acorn_<ver>_x86_64.dmg` are produced and signed.
- [ ] Verify `latest.json` is generated with both `darwin-aarch64` and `darwin-x86_64` entries.
- [ ] Smoke test the produced `.app` launches on Apple Silicon.
- [ ] Confirm Tauri updater still accepts the signature on the produced `.app.tar.gz` (signature must match tarball bytes; the rename-before-upload logic in the staging step is unchanged).
