### PR TITLE
feat(settings): UI tweaks — project icon, status bar toggles, PR defaults, terminal line-height

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -7,7 +7,6 @@ interface ContextMenuButton {
   label: string;
   icon?: React.ReactNode;
   onClick: () => void;
-  danger?: boolean;
   disabled?: boolean;
 }
 
@@ -109,9 +108,7 @@ export function ContextMenu({ open, x, y, items, onClose }: ContextMenuProps) {
                   "flex w-full items-center gap-1.5 px-2.5 py-1 text-left transition",
                   item.disabled
                     ? "cursor-not-allowed text-fg-muted/50"
-                    : item.danger
-                      ? "text-danger hover:bg-danger/15"
-                      : "text-fg hover:bg-bg-sidebar",
+                    : "text-fg hover:bg-bg-sidebar",
                 )}
               >
                 {item.icon ? (

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -515,7 +515,6 @@ function TabItem({
     {
       label: "Close All",
       onClick: onCloseAll,
-      danger: true,
     },
   ];
 
@@ -747,7 +746,6 @@ function buildPaneMenuItems({
       icon: <X size={12} />,
       onClick: onClose,
       disabled: totalPanes <= 1,
-      danger: true,
     },
   ];
 }

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -18,6 +18,7 @@ import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openFileInEditor } from "../lib/editor";
 import { joinPath } from "../lib/paths";
+import { useSettings } from "../lib/settings";
 import { useAppStore } from "../store";
 import type {
   AccountSummary,
@@ -1004,8 +1005,6 @@ const PR_STATE_OPTIONS: { value: PrStateFilter; label: string }[] = [
   { value: "all", label: "All" },
 ];
 
-const PR_REFRESH_INTERVAL_MS = 60_000;
-
 function PullRequestsTab({
   repoPath,
   onOpenDetail,
@@ -1016,7 +1015,13 @@ function PullRequestsTab({
   /** Bumped by the parent to force an out-of-band refetch (e.g. after a PR is merged via the modal). */
   refreshKey: number;
 }) {
-  const [stateFilter, setStateFilter] = useState<PrStateFilter>("open");
+  const defaultPrState = useSettings(
+    (s) => s.settings.pullRequests.defaultState,
+  );
+  const refreshIntervalMs = useSettings(
+    (s) => s.settings.pullRequests.refreshIntervalMs,
+  );
+  const [stateFilter, setStateFilter] = useState<PrStateFilter>(defaultPrState);
   const [listing, setListing] = useState<PullRequestListing | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -1058,12 +1063,12 @@ function PullRequestsTab({
     void fetchPrs(signal);
     const handle = setInterval(() => {
       void fetchPrs(signal);
-    }, PR_REFRESH_INTERVAL_MS);
+    }, refreshIntervalMs);
     return () => {
       signal.cancelled = true;
       clearInterval(handle);
     };
-  }, [fetchPrs]);
+  }, [fetchPrs, refreshIntervalMs]);
 
   // Out-of-band refresh when the parent bumps `refreshKey` (e.g. PR merged via
   // the detail modal). Skip the very first render since the effect above

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -8,6 +8,7 @@ import { useUpdater } from "../lib/updater-store";
 import { WhatsNewModal } from "./WhatsNewModal";
 import {
   AGENT_OPTIONS,
+  PR_REFRESH_INTERVAL_OPTIONS,
   type SelectedAgent,
   type SessionStartupMode,
   type TerminalFontWeight,
@@ -15,6 +16,7 @@ import {
   selectedAgentLabel,
   useSettings,
 } from "../lib/settings";
+import type { PrStateFilter } from "../lib/types";
 import {
   CheckboxRow,
   Field,
@@ -31,6 +33,8 @@ type Tab =
   | "terminal"
   | "agents"
   | "sessions"
+  | "pull-requests"
+  | "appearance"
   | "editor"
   | "notifications"
   | "storage"
@@ -40,6 +44,8 @@ const TABS: Array<{ id: Tab; label: string }> = [
   { id: "terminal", label: "Terminal" },
   { id: "agents", label: "Agents" },
   { id: "sessions", label: "Sessions" },
+  { id: "pull-requests", label: "Pull Requests" },
+  { id: "appearance", label: "Appearance" },
   { id: "editor", label: "Editor" },
   { id: "notifications", label: "Notifications" },
   { id: "storage", label: "Storage" },
@@ -108,6 +114,10 @@ export function SettingsModal() {
             <AgentSettings />
           ) : tab === "sessions" ? (
             <SessionSettings />
+          ) : tab === "pull-requests" ? (
+            <PullRequestsSettings />
+          ) : tab === "appearance" ? (
+            <AppearanceSettings />
           ) : tab === "editor" ? (
             <EditorSettings />
           ) : tab === "notifications" ? (
@@ -163,6 +173,19 @@ function TerminalSettings() {
         <WeightSelect
           value={settings.terminal.fontWeightBold}
           onChange={(v) => patchTerminal({ fontWeightBold: v })}
+        />
+      </Field>
+      <Field
+        label="Line height"
+        hint="Cell-height multiplier. 1.00 packs rows flush; raise for more vertical breathing room. Range 1.00–2.00."
+      >
+        <Stepper
+          value={settings.terminal.lineHeight}
+          min={1.0}
+          max={2.0}
+          step={0.05}
+          format={(n) => n.toFixed(2)}
+          onChange={(n) => patchTerminal({ lineHeight: n })}
         />
       </Field>
     </section>
@@ -260,6 +283,88 @@ function SessionSettings() {
           />
           Show confirmation dialog
         </label>
+      </Field>
+    </section>
+  );
+}
+
+function PullRequestsSettings() {
+  const settings = useSettings((s) => s.settings);
+  const patchPullRequests = useSettings((s) => s.patchPullRequests);
+
+  return (
+    <section className="space-y-4">
+      <Field
+        label="Default tab"
+        hint="Filter pre-selected when the PRs panel first opens for a repo. Switching tabs by hand still works as before."
+      >
+        <Select
+          value={settings.pullRequests.defaultState}
+          onChange={(e) =>
+            patchPullRequests({
+              defaultState: e.target.value as PrStateFilter,
+            })
+          }
+          className="w-48"
+        >
+          <option value="open">Open</option>
+          <option value="closed">Closed</option>
+          <option value="merged">Merged</option>
+          <option value="all">All</option>
+        </Select>
+      </Field>
+      <Field
+        label="Refresh interval"
+        hint="How often the PRs tab auto-refetches from gh. Lower values feel snappier but spend more API budget."
+      >
+        <Select
+          value={settings.pullRequests.refreshIntervalMs}
+          onChange={(e) =>
+            patchPullRequests({
+              refreshIntervalMs: Number(e.target.value),
+            })
+          }
+          className="w-48"
+        >
+          {PR_REFRESH_INTERVAL_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </Select>
+      </Field>
+      <p className="text-[11px] text-fg-muted">
+        Manual refresh (the icon in the PRs tab) always works regardless of
+        this interval.
+      </p>
+    </section>
+  );
+}
+
+function AppearanceSettings() {
+  const settings = useSettings((s) => s.settings);
+  const patchStatusBar = useSettings((s) => s.patchStatusBar);
+
+  return (
+    <section className="space-y-4">
+      <Field
+        label="Status bar"
+        hint="Choose which optional badges show in the bottom status bar."
+      >
+        <div className="flex flex-col gap-1">
+          <CheckboxRow
+            label="GitHub account"
+            description="The `gh` account used to list pull requests for the active repo."
+            checked={settings.statusBar.showGithubAccount}
+            onChange={(v) => patchStatusBar({ showGithubAccount: v })}
+          />
+          <CheckboxRow
+            label="Memory usage"
+            description="Live memory readout for acorn and its child shells. Disabling also stops the 2-second polling loop, so it costs nothing when hidden."
+            checked={settings.statusBar.showMemory}
+            onChange={(v) => patchStatusBar({ showMemory: v })}
+          />
+        </div>
       </Field>
     </section>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,7 +2,6 @@ import {
   ChevronRight,
   Copy,
   Files,
-  FolderGit2,
   FolderOpen,
   FolderPlus,
   GitBranch,
@@ -511,7 +510,6 @@ function ProjectGroupView({
           />
         </button>
         <span className="flex min-w-0 flex-1 items-center gap-1.5">
-          <FolderGit2 size={12} className="shrink-0 text-fg-muted" />
           <span className="truncate text-sm font-medium text-fg">
             {project.name}
           </span>
@@ -734,7 +732,6 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
       label: "Remove",
       icon: <Trash2 size={12} />,
       onClick: onRemove,
-      danger: true,
     },
   ];
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { homeDir } from "@tauri-apps/api/path";
 import { api } from "../lib/api";
+import { useSettings } from "../lib/settings";
 import type { MemoryProcess } from "../lib/types";
 import { useAppStore } from "../store";
 import { MemoryBreakdownModal } from "./MemoryBreakdownModal";
@@ -47,10 +48,19 @@ function formatBytes(bytes: number): string {
   return `${fixed} ${units[i]}`;
 }
 
-function useMemoryUsage(intervalMs: number): MemorySnapshot | null {
+function useMemoryUsage(
+  intervalMs: number,
+  enabled: boolean,
+): MemorySnapshot | null {
   const [snapshot, setSnapshot] = useState<MemorySnapshot | null>(null);
 
   useEffect(() => {
+    if (!enabled) {
+      // Drop any stale reading when the user hides the memory readout so
+      // the breakdown modal cannot reopen with an outdated process list.
+      setSnapshot(null);
+      return;
+    }
     let cancelled = false;
     const tick = async () => {
       try {
@@ -68,7 +78,7 @@ function useMemoryUsage(intervalMs: number): MemorySnapshot | null {
       cancelled = true;
       window.clearInterval(id);
     };
-  }, [intervalMs]);
+  }, [intervalMs, enabled]);
 
   return snapshot;
 }
@@ -93,8 +103,12 @@ export function StatusBar() {
   const { sessions, activeSessionId, activeProject, error, loading } =
     useAppStore();
   const prAccountByRepo = useAppStore((s) => s.prAccountByRepo);
+  const showGithubAccount = useSettings(
+    (s) => s.settings.statusBar.showGithubAccount,
+  );
+  const showMemory = useSettings((s) => s.settings.statusBar.showMemory);
   const active = sessions.find((s) => s.id === activeSessionId);
-  const memory = useMemoryUsage(MEMORY_POLL_MS);
+  const memory = useMemoryUsage(MEMORY_POLL_MS, showMemory);
   const home = useHomeDir();
   const [breakdownOpen, setBreakdownOpen] = useState(false);
   const displayPath = active ? tildify(active.worktree_path, home) : null;
@@ -127,7 +141,7 @@ export function StatusBar() {
               <span className="truncate text-danger">error: {error}</span>
             </Tooltip>
           ) : null}
-          {prAccount ? (
+          {showGithubAccount && prAccount ? (
             <Tooltip label={`PRs listed via gh account ${prAccount}`} side="top">
               <span className="flex shrink-0 items-center gap-1 rounded bg-fg-muted/15 px-1.5 py-0.5 text-[10px] text-fg-muted">
                 <GitHubMark />
@@ -151,22 +165,26 @@ export function StatusBar() {
               </Tooltip>
             </>
           ) : null}
-          <span className="text-fg-muted/50">|</span>
-          <Tooltip label="Click to view per-process breakdown" side="top">
-            <button
-              type="button"
-              disabled={!memory}
-              onClick={() => setBreakdownOpen(true)}
-              className="rounded px-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-fg-muted"
-            >
-              memory: {memory ? formatBytes(memory.bytes) : "–"}
-            </button>
-          </Tooltip>
+          {showMemory ? (
+            <>
+              <span className="text-fg-muted/50">|</span>
+              <Tooltip label="Click to view per-process breakdown" side="top">
+                <button
+                  type="button"
+                  disabled={!memory}
+                  onClick={() => setBreakdownOpen(true)}
+                  className="rounded px-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+                >
+                  memory: {memory ? formatBytes(memory.bytes) : "–"}
+                </button>
+              </Tooltip>
+            </>
+          ) : null}
         </span>
       </footer>
 
       <MemoryBreakdownModal
-        open={breakdownOpen && memory !== null}
+        open={showMemory && breakdownOpen && memory !== null}
         totalBytes={memory?.bytes ?? 0}
         processes={memory?.processes ?? []}
         onClose={() => setBreakdownOpen(false)}

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -94,6 +94,7 @@ export function Terminal({
       fontSize: initialSettings.terminal.fontSize,
       fontWeight: initialSettings.terminal.fontWeight,
       fontWeightBold: initialSettings.terminal.fontWeightBold,
+      lineHeight: initialSettings.terminal.lineHeight,
       cursorBlink: true,
       allowProposedApi: true,
       scrollback: 5000,
@@ -151,6 +152,10 @@ export function Terminal({
       }
       if (next.fontWeightBold !== previous.fontWeightBold) {
         term.options.fontWeightBold = next.fontWeightBold;
+        changed = true;
+      }
+      if (next.lineHeight !== previous.lineHeight) {
+        term.options.lineHeight = next.lineHeight;
         changed = true;
       }
       if (changed) {

--- a/src/components/ui/Stepper.tsx
+++ b/src/components/ui/Stepper.tsx
@@ -6,6 +6,12 @@ interface StepperProps {
   max: number;
   step?: number;
   unit?: string;
+  /**
+   * Optional value formatter for floating-point steppers — keeps the
+   * displayed number stable (e.g. 1.05 vs 1.0500000000001) without
+   * forcing callers to round their canonical value.
+   */
+  format?: (v: number) => string;
   onChange: (v: number) => void;
 }
 
@@ -15,11 +21,16 @@ export function Stepper({
   max,
   step = 1,
   unit,
+  format,
   onChange,
 }: StepperProps) {
   const clamp = (n: number) => Math.max(min, Math.min(max, n));
-  const dec = () => onChange(clamp(value - step));
-  const inc = () => onChange(clamp(value + step));
+  // Round-to-step keeps fractional steps (e.g. 0.05) from accumulating
+  // FP drift after many clicks.
+  const snap = (n: number) => Math.round(n / step) * step;
+  const dec = () => onChange(clamp(snap(value - step)));
+  const inc = () => onChange(clamp(snap(value + step)));
+  const display = format ? format(value) : String(value);
   return (
     <div className="inline-flex h-7 w-fit items-stretch self-start overflow-hidden rounded-md border border-border bg-bg">
       <button
@@ -32,7 +43,7 @@ export function Stepper({
         <Minus size={12} />
       </button>
       <div className="flex min-w-[3.5rem] items-center justify-center border-x border-border px-2 font-mono text-xs tabular-nums text-fg">
-        {value}
+        {display}
         {unit ? <span className="ml-0.5 text-fg-muted">{unit}</span> : null}
       </div>
       <button

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -57,7 +57,25 @@ export const AGENT_OPTIONS: ReadonlyArray<{
 ];
 
 export type { SessionStartupMode } from "./types";
-import type { SessionStartupMode } from "./types";
+import type { PrStateFilter, SessionStartupMode } from "./types";
+
+/**
+ * Allowed PRs-tab refresh intervals shown in the Settings UI. Picked to
+ * cover the common cases ("snappy", "default", "background-quiet") without
+ * exposing a free-form numeric field where users could accidentally hammer
+ * `gh` with sub-second polling.
+ */
+export const PR_REFRESH_INTERVAL_OPTIONS: ReadonlyArray<{
+  value: number;
+  label: string;
+}> = [
+  { value: 15_000, label: "15 seconds" },
+  { value: 30_000, label: "30 seconds" },
+  { value: 60_000, label: "1 minute (default)" },
+  { value: 120_000, label: "2 minutes" },
+  { value: 300_000, label: "5 minutes" },
+  { value: 600_000, label: "10 minutes" },
+];
 
 export type TerminalFontWeight =
   | 100
@@ -91,6 +109,12 @@ export interface AcornSettings {
     fontSize: number;
     fontWeight: TerminalFontWeight;
     fontWeightBold: TerminalFontWeight;
+    /**
+     * xterm.js cell-height multiplier. 1.0 packs rows flush; 1.2–1.4 adds
+     * vertical breathing room for fonts whose intrinsic metrics feel
+     * cramped. Range 1.0–2.0 keeps the cursor / link hit boxes sensible.
+     */
+    lineHeight: number;
   };
   /**
    * The single AI agent acorn uses everywhere: Sessions startup (when
@@ -145,6 +169,21 @@ export interface AcornSettings {
       completed: boolean;
     };
   };
+  /**
+   * Toggles for the bottom status bar items. Disabling `showMemory`
+   * also short-circuits the memory polling loop in the StatusBar, so it
+   * actually reduces the work acorn does — not just hides the readout.
+   */
+  statusBar: {
+    showGithubAccount: boolean;
+    showMemory: boolean;
+  };
+  pullRequests: {
+    /** Tab pre-selected when the PRs panel first mounts for a repo. */
+    defaultState: PrStateFilter;
+    /** Auto-refresh cadence for the PRs tab in milliseconds. */
+    refreshIntervalMs: number;
+  };
 }
 
 export const DEFAULT_SETTINGS: AcornSettings = {
@@ -154,6 +193,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     fontSize: 12,
     fontWeight: 400,
     fontWeightBold: 700,
+    lineHeight: 1.0,
   },
   agents: {
     selected: "claude",
@@ -179,6 +219,14 @@ export const DEFAULT_SETTINGS: AcornSettings = {
       completed: false,
     },
   },
+  statusBar: {
+    showGithubAccount: true,
+    showMemory: true,
+  },
+  pullRequests: {
+    defaultState: "open",
+    refreshIntervalMs: 60_000,
+  },
 };
 
 const VALID_WEIGHTS = new Set<TerminalFontWeight>([
@@ -192,6 +240,36 @@ const VALID_AGENTS = new Set<AgentProvider>([
   "llm",
   "codex",
 ]);
+
+const VALID_PR_STATES = new Set<PrStateFilter>([
+  "open",
+  "closed",
+  "merged",
+  "all",
+]);
+
+const VALID_PR_INTERVALS = new Set<number>(
+  PR_REFRESH_INTERVAL_OPTIONS.map((o) => o.value),
+);
+
+function normalizeLineHeight(v: unknown, fallback: number): number {
+  if (typeof v !== "number" || !Number.isFinite(v)) return fallback;
+  // Clamp to the same range the Stepper enforces in the UI so a hand-
+  // edited localStorage value can't make the terminal unusable.
+  return Math.max(1.0, Math.min(2.0, v));
+}
+
+function normalizePrState(v: unknown, fallback: PrStateFilter): PrStateFilter {
+  if (typeof v === "string" && VALID_PR_STATES.has(v as PrStateFilter)) {
+    return v as PrStateFilter;
+  }
+  return fallback;
+}
+
+function normalizePrInterval(v: unknown, fallback: number): number {
+  if (typeof v === "number" && VALID_PR_INTERVALS.has(v)) return v;
+  return fallback;
+}
 
 function normalizeWeight(
   v: unknown,
@@ -299,6 +377,10 @@ function loadSettings(): AcornSettings {
           terminalRaw.fontWeightBold,
           DEFAULT_SETTINGS.terminal.fontWeightBold,
         ),
+        lineHeight: normalizeLineHeight(
+          (terminalRaw as { lineHeight?: unknown }).lineHeight,
+          DEFAULT_SETTINGS.terminal.lineHeight,
+        ),
       },
       agents: {
         selected,
@@ -327,6 +409,20 @@ function loadSettings(): AcornSettings {
           ...DEFAULT_SETTINGS.notifications.events,
           ...(parsed.notifications?.events ?? {}),
         },
+      },
+      statusBar: {
+        ...DEFAULT_SETTINGS.statusBar,
+        ...(parsed.statusBar ?? {}),
+      },
+      pullRequests: {
+        defaultState: normalizePrState(
+          parsed.pullRequests?.defaultState,
+          DEFAULT_SETTINGS.pullRequests.defaultState,
+        ),
+        refreshIntervalMs: normalizePrInterval(
+          parsed.pullRequests?.refreshIntervalMs,
+          DEFAULT_SETTINGS.pullRequests.refreshIntervalMs,
+        ),
       },
     };
   } catch {
@@ -365,6 +461,8 @@ interface SettingsState {
       events?: Partial<AcornSettings["notifications"]["events"]>;
     },
   ) => void;
+  patchStatusBar: (patch: Partial<AcornSettings["statusBar"]>) => void;
+  patchPullRequests: (patch: Partial<AcornSettings["pullRequests"]>) => void;
   reset: () => void;
 }
 
@@ -438,6 +536,24 @@ export const useSettings = create<SettingsState>((set) => ({
           ...rest,
           events,
         },
+      };
+      persist(next);
+      return { settings: next };
+    }),
+  patchStatusBar: (patch) =>
+    set((s) => {
+      const next: AcornSettings = {
+        ...s.settings,
+        statusBar: { ...s.settings.statusBar, ...patch },
+      };
+      persist(next);
+      return { settings: next };
+    }),
+  patchPullRequests: (patch) =>
+    set((s) => {
+      const next: AcornSettings = {
+        ...s.settings,
+        pullRequests: { ...s.settings.pullRequests, ...patch },
       };
       persist(next);
       return { settings: next };


### PR DESCRIPTION
## Summary

Several UI tweaks bundled into one PR.

### 1. Project icon removed
Sidebar no longer renders the `FolderGit2` glyph next to the project title — the title alone reads cleaner.

### 2. Status bar toggles
New **Appearance** settings tab with two checkboxes:
- **GitHub account** — show/hide the `gh` account badge.
- **Memory usage** — show/hide the live memory readout.

Disabling memory **also stops the 2-second polling loop** (`api.getMemoryUsage()` is gated by `enabled`), so it genuinely reduces work — not just visual hiding.

### 3. PRs default tab
**Pull Requests** settings tab. `open` / `closed` / `merged` / `all` is pre-selected when the PRs panel first opens for a repo. User-chosen tab during a session is preserved.

### 4. PRs refresh interval
Same tab. Discrete options 15s / 30s / 1m / 2m / 5m / 10m (default 1m). Manual refresh button still works at any interval. Effect re-runs on interval change.

### 5. Terminal line-height
**Terminal** settings tab gains a Stepper for `lineHeight` (1.00–2.00, step 0.05). Wired through xterm's `options.lineHeight`; live-applies via existing settings subscription. Default 1.00 = current behavior.

### Bonus
- Context menu items (`Close Pane`, `Remove`, `Close All`) no longer render in red. The `danger` prop on `ContextMenu` is gone.
- `Stepper` gained an optional `format` callback for floating-point values, with round-to-step guard so 1.0 + 0.05 doesn't drift into 1.0500000001.

## Test plan

- [ ] Open Settings → Appearance, toggle GitHub badge → status bar updates instantly.
- [ ] Toggle Memory badge off → memory readout disappears AND verify (e.g. via process trace or Rust logs) that `get_memory_usage` is no longer called every 2s.
- [ ] Settings → Pull Requests, change default tab to "All", close and reopen the panel for a repo → "All" is selected.
- [ ] Same tab, change refresh interval to 15s, watch the PRs tab → fetch fires every 15s.
- [ ] Settings → Terminal, raise line-height to 1.40 → live terminal rows breathe; lower back to 1.00 → packed flush.
- [ ] Right-click a session/tab → "Remove" / "Close Pane" / "Close All" render in regular menu color, not red.
- [ ] Sidebar project rows no longer show the folder/git icon next to the name.
- [ ] `npx tsc --noEmit` clean, `npx vitest run` 87 passing.
