### PR TITLE
fix(terminal): include baseY in IME composition cursor coordinates

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -246,13 +246,18 @@ export function Terminal({
       compositionView.textContent = text;
       if (cell) {
         const buf = term.buffer.active;
-        // `cursorY` is buffer-relative (includes scrollback); the
-        // composition overlay's CSS coords are viewport-relative, so
-        // subtract the viewport's scrollback offset (`viewportY`) to
-        // get the cursor's row inside the visible area. Without this,
-        // a session restored from a long scrollback positions the
-        // overlay thousands of pixels below the visible terminal.
-        const cursorViewportY = buf.cursorY - buf.viewportY;
+        // xterm's visible cursor row = `baseY + cursorY - viewportY`
+        // (mirrors xterm's own `Buffer.ts`: `absoluteY = ybase + y;
+        // relativeY = absoluteY - ydisp`). `cursorY` is the cursor's
+        // offset within the current page (0..rows-1), `baseY` is the
+        // buffer line where that page starts, and `viewportY` is the
+        // buffer line currently shown at the top of the viewport (they
+        // diverge when the user scrolls into scrollback). Subtracting
+        // `viewportY` alone — without adding `baseY` — leaves a session
+        // with non-empty scrollback computing `cursorY - viewportY ≈
+        // -ybase`, parking the overlay thousands of pixels above the
+        // visible terminal so the preview vanishes off-screen.
+        const cursorViewportY = buf.baseY + buf.cursorY - buf.viewportY;
         compositionView.style.left = `${buf.cursorX * cell.width}px`;
         compositionView.style.top = `${cursorViewportY * cell.height}px`;
         compositionView.style.minHeight = `${cell.height}px`;
@@ -532,8 +537,8 @@ export function Terminal({
       const cell = getCellDims();
       if (!cell) return;
       const buf = term.buffer.active;
-      // See `showComposing` for why we subtract `viewportY` here.
-      const cursorViewportY = buf.cursorY - buf.viewportY;
+      // See `showComposing` for the full derivation of this formula.
+      const cursorViewportY = buf.baseY + buf.cursorY - buf.viewportY;
       compositionView.style.left = `${buf.cursorX * cell.width}px`;
       compositionView.style.top = `${cursorViewportY * cell.height}px`;
     };


### PR DESCRIPTION
## Summary

- IME composition preview positioned by `cursorY - viewportY` was missing the `baseY` term, so the overlay sat thousands of rows above the visible terminal in sessions that boot with scrollback already in the normal buffer (restored sessions).
- Fix mirrors xterm's own visible-row math (`baseY + cursorY - viewportY` — see `Buffer.ts`: `absoluteY = ybase + y; relativeY = absoluteY - ydisp`).
- Applied to both `showComposing` (initial position on composition start) and `repositionComposing` (anchor reapplied on render/scroll/cursor-move).

## Why Cmd+K appeared to "fix" it

`term.clear()` resets the buffer's `ybase`/`ydisp` to 0, so the previously missing term happened to be zero — the overlay coordinate worked by accident. After this patch the formula is correct regardless of scrollback depth.

## Test plan

- [ ] In a session restored with non-empty scrollback (e.g. after app restart), launch `claude` and type Korean — composition preview tracks the cursor.
- [ ] Scroll into scrollback, return to bottom, compose Korean — preview still anchors to the live cursor cell.
- [ ] Long running shell with lots of accumulated output — preview stays glued to the prompt.
- [ ] Regression check: fresh session (empty scrollback) still shows preview at the cursor.

## Label

- `fix`
