### PR TITLE
fix(terminal): Cmd+K targets the focused terminal, not the focused pane

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -241,7 +241,42 @@ function App() {
         else panel.collapse();
       },
       [Hotkeys.clearTerminal]: (e: KeyboardEvent) => {
-        const sessionId = useAppStore.getState().activeSessionId;
+        // Prefer the terminal whose helper textarea currently owns DOM
+        // focus over `state.activeSessionId`. The store's `focusedPaneId`
+        // only updates on a mouse-down inside a pane, but typing into an
+        // xterm (or pressing a hotkey while the helper textarea has
+        // focus) does not — so Cmd+K would otherwise clear whichever
+        // pane the user last clicked, not the terminal they are actually
+        // working in. Walking up from `document.activeElement` to the
+        // nearest `[data-acorn-terminal-slot]` resolves the terminal the
+        // user is really looking at.
+        let sessionId: string | null = null;
+        const focused = document.activeElement as HTMLElement | null;
+        const slot = focused?.closest<HTMLElement>(
+          "[data-acorn-terminal-slot]",
+        );
+        if (slot?.dataset.acornTerminalSlot) {
+          sessionId = slot.dataset.acornTerminalSlot;
+        }
+        // Fall back to the store when focus is elsewhere (sidebar,
+        // command palette, an empty pane after a split, etc.). Scan all
+        // panes so a freshly-split empty pane doesn't silently no-op the
+        // hotkey.
+        if (!sessionId) {
+          const s = useAppStore.getState();
+          sessionId = s.activeSessionId;
+          if (!sessionId && s.activeProject) {
+            const ws = s.workspaces[s.activeProject];
+            if (ws) {
+              for (const pane of Object.values(ws.panes)) {
+                if (pane.activeSessionId) {
+                  sessionId = pane.activeSessionId;
+                  break;
+                }
+              }
+            }
+          }
+        }
         if (!sessionId) return;
         e.preventDefault();
         window.dispatchEvent(


### PR DESCRIPTION
## Summary

`Cmd+K` used `useAppStore.getState().activeSessionId`, which mirrors the focused pane's active tab. But `focusedPaneId` only updates on a mouse-down inside a pane — typing into an xterm, pressing a hotkey while the helper textarea has focus, or splitting a pane (which focuses the new empty pane) all leave it pointing at a pane other than the one the user is actually working in. The result: `Cmd+K` cleared whichever tab the user last clicked, or silently no-op'd on a fresh empty split, instead of clearing the terminal currently under their attention.

This patch resolves the target by walking up from `document.activeElement` to the nearest `[data-acorn-terminal-slot]` (each `PortaledTerminal` already exposes the session id there). When DOM focus is on the sidebar, command palette, or an empty pane, it falls back to the store, and then to any non-empty pane in the workspace so a fresh empty split doesn't silently swallow the hotkey.

## Test plan

- [ ] Single pane: focus an xterm, press `Cmd+K` — that tab clears.
- [ ] Two panes (split): focus one pane's terminal, press `Cmd+K` — only the focused terminal clears, never the other pane's tab.
- [ ] Switch to a different tab inside a pane (no mouse), press `Cmd+K` — the visible tab clears, not the previously-clicked one.
- [ ] Split a pane (which auto-focuses the new empty pane), press `Cmd+K` — it clears one of the existing terminals instead of silently no-op'ing.
- [ ] Focus the sidebar / command palette, press `Cmd+K` — falls back to the active workspace's focused pane.

## Label

- `fix`
