### PR TITLE
fix(persistence): guard pane layout against corrupt session loads

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -37,6 +37,28 @@ fn project_basename(repo_path: &std::path::Path) -> String {
         .to_string()
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoadStatus {
+    pub sessions_clean: bool,
+    pub projects_clean: bool,
+}
+
+/// Report whether boot-time persistence loads were clean. Frontend consults
+/// this once at startup to decide whether the empty-list reconcile path is
+/// safe (clean = true) or a likely sign of disk corruption (clean = false).
+#[tauri::command]
+pub fn load_status(state: State<'_, AppState>) -> LoadStatus {
+    LoadStatus {
+        sessions_clean: state
+            .sessions_loaded_cleanly
+            .load(std::sync::atomic::Ordering::SeqCst),
+        projects_clean: state
+            .projects_loaded_cleanly
+            .load(std::sync::atomic::Ordering::SeqCst),
+    }
+}
+
 #[tauri::command]
 pub fn list_sessions(state: State<'_, AppState>) -> Vec<Session> {
     state

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -107,12 +107,28 @@ pub fn run() {
             });
 
             let state = app.state::<AppState>();
-            for session in persistence::load_sessions().unwrap_or_default() {
+            let (sessions_loaded, sessions_clean) = persistence::load_sessions_with_status()
+                .unwrap_or_else(|err| {
+                    tracing::warn!("session path resolution failed at boot: {err}");
+                    (Vec::new(), false)
+                });
+            for session in sessions_loaded {
                 state.sessions.insert(session);
             }
-            for project in persistence::load_projects().unwrap_or_default() {
+            let (projects_loaded, projects_clean) = persistence::load_projects_with_status()
+                .unwrap_or_else(|err| {
+                    tracing::warn!("project path resolution failed at boot: {err}");
+                    (Vec::new(), false)
+                });
+            for project in projects_loaded {
                 state.projects.insert(project);
             }
+            state
+                .sessions_loaded_cleanly
+                .store(sessions_clean, std::sync::atomic::Ordering::SeqCst);
+            state
+                .projects_loaded_cleanly
+                .store(projects_clean, std::sync::atomic::Ordering::SeqCst);
             // Backfill projects from sessions if any sessions reference a path
             // that has no project entry (e.g. older versions that did not
             // persist projects).
@@ -127,18 +143,26 @@ pub fn run() {
             }
             // Drop scrollback files for sessions that no longer exist (e.g.
             // removed while the app was offline, or pre-feature debris).
+            // Skip when the session load was unclean — otherwise a transient
+            // disk failure would silently delete every scrollback file on the
+            // way to a fully empty session list.
             let live_ids: Vec<String> = state
                 .sessions
                 .list()
                 .iter()
                 .map(|s| s.id.to_string())
                 .collect();
-            if let Err(err) = scrollback::prune_orphans(&live_ids) {
+            if live_ids.is_empty() && !sessions_clean {
+                tracing::warn!(
+                    "skipping scrollback prune: session load was unclean and no live ids"
+                );
+            } else if let Err(err) = scrollback::prune_orphans(&live_ids) {
                 tracing::warn!("scrollback prune at boot failed: {err}");
             }
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            commands::load_status,
             commands::list_sessions,
             commands::create_session,
             commands::remove_session,

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -1,5 +1,6 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use directories::ProjectDirs;
 
@@ -10,6 +11,36 @@ const SESSIONS_FILE: &str = "sessions.json";
 const SESSIONS_TMP_FILE: &str = "sessions.json.tmp";
 const PROJECTS_FILE: &str = "projects.json";
 const PROJECTS_TMP_FILE: &str = "projects.json.tmp";
+
+/// Side-channel a corrupt persistence file before we mask it with an empty
+/// in-memory store. Without this the only evidence of a parse failure is a
+/// log line that scrolls away. The backup name embeds a unix timestamp so
+/// repeated boots do not overwrite earlier evidence.
+fn backup_corrupt_file(path: &Path) {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_default();
+    let mut name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("data.json")
+        .to_string();
+    name.push_str(&format!(".broken-{ts}"));
+    let backup = path.with_file_name(name);
+    if let Err(err) = fs::copy(path, &backup) {
+        tracing::warn!(
+            error = %err,
+            path = %path.display(),
+            "failed to back up corrupt persistence file"
+        );
+    } else {
+        tracing::warn!(
+            backup = %backup.display(),
+            "backed up corrupt persistence file"
+        );
+    }
+}
 
 /// Resolve the application's data directory, creating it if missing.
 pub fn data_dir() -> AppResult<PathBuf> {
@@ -30,29 +61,42 @@ fn sessions_tmp_path() -> AppResult<PathBuf> {
 
 /// Load sessions from disk. Returns an empty Vec on any recoverable failure
 /// (missing file, IO error, parse error) — these are logged but not propagated.
+/// Boot uses `load_sessions_with_status` instead so it can branch on cleanliness;
+/// this thin wrapper exists for tests and external callers that do not care.
+#[allow(dead_code)]
 pub fn load_sessions() -> AppResult<Vec<Session>> {
+    Ok(load_sessions_with_status()?.0)
+}
+
+/// Same as `load_sessions` but also reports whether the load was clean.
+/// `clean = false` means the file existed but could not be read or parsed —
+/// a signal that downstream wipe-on-empty paths (scrollback prune, frontend
+/// pane reconciliation) should hold off rather than treat the empty result
+/// as authoritative. A missing file is considered clean (legitimate empty).
+pub fn load_sessions_with_status() -> AppResult<(Vec<Session>, bool)> {
     let path = sessions_path()?;
     if !path.exists() {
         tracing::info!(path = %path.display(), "sessions file missing, starting empty");
-        return Ok(Vec::new());
+        return Ok((Vec::new(), true));
     }
 
     let bytes = match fs::read(&path) {
         Ok(b) => b,
         Err(err) => {
             tracing::warn!(path = %path.display(), error = %err, "failed to read sessions file");
-            return Ok(Vec::new());
+            return Ok((Vec::new(), false));
         }
     };
 
     match serde_json::from_slice::<Vec<Session>>(&bytes) {
         Ok(sessions) => {
             tracing::info!(count = sessions.len(), "loaded sessions from disk");
-            Ok(sessions)
+            Ok((sessions, true))
         }
         Err(err) => {
             tracing::warn!(path = %path.display(), error = %err, "failed to parse sessions file");
-            Ok(Vec::new())
+            backup_corrupt_file(&path);
+            Ok((Vec::new(), false))
         }
     }
 }
@@ -83,27 +127,33 @@ fn projects_tmp_path() -> AppResult<PathBuf> {
     Ok(data_dir()?.join(PROJECTS_TMP_FILE))
 }
 
+#[allow(dead_code)]
 pub fn load_projects() -> AppResult<Vec<Project>> {
+    Ok(load_projects_with_status()?.0)
+}
+
+pub fn load_projects_with_status() -> AppResult<(Vec<Project>, bool)> {
     let path = projects_path()?;
     if !path.exists() {
         tracing::info!(path = %path.display(), "projects file missing, starting empty");
-        return Ok(Vec::new());
+        return Ok((Vec::new(), true));
     }
     let bytes = match fs::read(&path) {
         Ok(b) => b,
         Err(err) => {
             tracing::warn!(path = %path.display(), error = %err, "failed to read projects file");
-            return Ok(Vec::new());
+            return Ok((Vec::new(), false));
         }
     };
     match serde_json::from_slice::<Vec<Project>>(&bytes) {
         Ok(projects) => {
             tracing::info!(count = projects.len(), "loaded projects from disk");
-            Ok(projects)
+            Ok((projects, true))
         }
         Err(err) => {
             tracing::warn!(path = %path.display(), error = %err, "failed to parse projects file");
-            Ok(Vec::new())
+            backup_corrupt_file(&path);
+            Ok((Vec::new(), false))
         }
     }
 }
@@ -138,5 +188,32 @@ mod tests {
         let sessions = load_sessions().expect("load should not error on missing file");
         // Cannot assert empty without test isolation — at least confirm it returns.
         let _ = sessions;
+    }
+
+    #[test]
+    fn backup_corrupt_file_writes_sibling_with_broken_suffix() {
+        let tmp = std::env::temp_dir().join(format!(
+            "acorn-persist-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("sessions.json");
+        fs::write(&path, b"not json").unwrap();
+        backup_corrupt_file(&path);
+        let entries: Vec<_> = fs::read_dir(&tmp)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            entries
+                .iter()
+                .any(|n| n.starts_with("sessions.json.broken-")),
+            "expected a sessions.json.broken-* file, got {entries:?}"
+        );
+        let _ = fs::remove_dir_all(&tmp);
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use crate::pty::PtyManager;
@@ -8,6 +9,13 @@ pub struct AppState {
     pub sessions: Arc<SessionStore>,
     pub projects: Arc<ProjectStore>,
     pub pty: Arc<PtyManager>,
+    /// Set to false at boot if `persistence::load_sessions_with_status`
+    /// reported a recoverable load failure (file existed but could not be
+    /// read or parsed). Frontend reads this via `load_status` and skips the
+    /// pane-wipe code path so a transient disk glitch does not erase the
+    /// persisted layout. Defaults to true (clean) for fresh installs.
+    pub sessions_loaded_cleanly: Arc<AtomicBool>,
+    pub projects_loaded_cleanly: Arc<AtomicBool>,
 }
 
 impl AppState {
@@ -16,6 +24,8 @@ impl AppState {
             sessions: SessionStore::new(),
             projects: ProjectStore::new(),
             pty: PtyManager::new(),
+            sessions_loaded_cleanly: Arc::new(AtomicBool::new(true)),
+            projects_loaded_cleanly: Arc::new(AtomicBool::new(true)),
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,7 +71,11 @@ function App() {
   const rightPanelRef = useRef<ImperativePanelHandle | null>(null);
 
   useEffect(() => {
-    refreshAll();
+    // Order matters: `loadInitialStatus` arms the pane-wipe guard before the
+    // first reconcile can run. If the backend reports sessions.json failed
+    // to load (corrupt/IO error), the guard prevents the empty session list
+    // from zeroing out the persisted layout.
+    void useAppStore.getState().loadInitialStatus().then(() => refreshAll());
   }, [refreshAll]);
 
   // Auto-update: check once on startup, then every 24h. Both calls are

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -16,7 +16,15 @@ import type {
   TodoItem,
 } from "./types";
 
+export interface LoadStatus {
+  sessionsClean: boolean;
+  projectsClean: boolean;
+}
+
 export const api = {
+  loadStatus(): Promise<LoadStatus> {
+    return invoke<LoadStatus>("load_status");
+  },
   listSessions(): Promise<Session[]> {
     return invoke<Session[]>("list_sessions");
   },

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -6,6 +6,10 @@ import type { Project, Session, SessionStatus } from "./lib/types";
 vi.mock("./lib/api", () => {
   return {
     api: {
+      loadStatus: vi.fn(async () => ({
+        sessionsClean: true,
+        projectsClean: true,
+      })),
       listSessions: vi.fn(async () => [] as Session[]),
       listProjects: vi.fn(async () => [] as Project[]),
       detectSessionStatuses: vi.fn(
@@ -88,6 +92,7 @@ function resetStore(): void {
       error: null,
       pendingRemoveId: null,
       pendingRemoveProject: null,
+      sessionsLoadedCleanly: true,
     },
     false,
   );
@@ -108,6 +113,10 @@ beforeEach(() => {
   // intact, which can leak between tests under some runtimes.
   vi.resetAllMocks();
   // Re-establish the safe defaults that resetAllMocks just wiped.
+  mockApi.loadStatus.mockResolvedValue({
+    sessionsClean: true,
+    projectsClean: true,
+  });
   mockApi.listSessions.mockResolvedValue([]);
   mockApi.listProjects.mockResolvedValue([]);
   mockApi.detectSessionStatuses.mockResolvedValue([]);
@@ -423,6 +432,48 @@ describe("reconcile via refreshSessions", () => {
     await useAppStore.getState().refreshSessions();
     const s = useAppStore.getState();
     expect(s.panes[s.focusedPaneId].sessionIds.sort()).toEqual(["a1", "a2"]);
+  });
+
+  it("does NOT wipe persisted sessionIds when load_status reports unclean", async () => {
+    // Seed: persisted layout with two sessions in one pane.
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A), session("a2", REPO_A)],
+    );
+    expect(
+      useAppStore.getState().panes[useAppStore.getState().focusedPaneId]
+        .sessionIds.sort(),
+    ).toEqual(["a1", "a2"]);
+
+    // Simulate boot-time corruption: backend returns empty + reports unclean.
+    mockApi.loadStatus.mockResolvedValueOnce({
+      sessionsClean: false,
+      projectsClean: true,
+    });
+    mockApi.listSessions.mockResolvedValueOnce([]);
+    await useAppStore.getState().loadInitialStatus();
+    await useAppStore.getState().refreshSessions();
+
+    // Pane retains the original ids — guard prevented wipe.
+    const s = useAppStore.getState();
+    expect(s.sessions).toEqual([]);
+    expect(s.sessionsLoadedCleanly).toBe(false);
+    expect(s.panes[s.focusedPaneId].sessionIds.sort()).toEqual(["a1", "a2"]);
+  });
+
+  it("clears the wipe guard once backend returns at least one session", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+    mockApi.loadStatus.mockResolvedValueOnce({
+      sessionsClean: false,
+      projectsClean: true,
+    });
+    await useAppStore.getState().loadInitialStatus();
+    expect(useAppStore.getState().sessionsLoadedCleanly).toBe(false);
+
+    mockApi.listSessions.mockResolvedValueOnce([session("a1", REPO_A)]);
+    await useAppStore.getState().refreshSessions();
+    // Non-empty result → guard armed off → subsequent empty wipes work.
+    expect(useAppStore.getState().sessionsLoadedCleanly).toBe(true);
   });
 });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -63,6 +63,17 @@ interface AppStateModel {
   pendingRemoveId: string | null;
   pendingRemoveProject: string | null;
 
+  /**
+   * Set to false at boot if the backend reports that `sessions.json` failed
+   * to load (file existed but could not be read or parsed). When false,
+   * `reconcileWorkspace` refuses to wipe a pane's `sessionIds` on the basis
+   * of an empty backend list — protecting layouts from being destroyed by a
+   * transient disk failure or a schema-incompatible build run from another
+   * worktree. Cleared (set back to true) once the user takes any action that
+   * results in a non-empty backend session list.
+   */
+  sessionsLoadedCleanly: boolean;
+  loadInitialStatus: () => Promise<void>;
   refreshSessions: () => Promise<void>;
   refreshProjects: () => Promise<void>;
   refreshAll: () => Promise<void>;
@@ -151,11 +162,26 @@ function mirrorActive(
  * Reconcile a single project's pane state with that project's session list.
  * New sessions land in the focused pane. Removed sessions are dropped.
  * Empty non-only panes are collapsed.
+ *
+ * `allowEmptyWipe` is the safety knob for the boot-time disk-corruption
+ * scenario. When `false` and `sessions` is empty *while the workspace still
+ * remembers session ids*, this function returns the workspace unchanged
+ * rather than zeroing every pane's `sessionIds`. This avoids the cascade
+ * where a transient `sessions.json` read failure (or a schema-incompatible
+ * build from another worktree) erases the persisted layout permanently.
  */
 function reconcileWorkspace(
   ws: ProjectWorkspace,
   sessions: Session[],
+  allowEmptyWipe = true,
 ): ProjectWorkspace {
+  if (
+    !allowEmptyWipe &&
+    sessions.length === 0 &&
+    Object.values(ws.panes).some((p) => p.sessionIds.length > 0)
+  ) {
+    return ws;
+  }
   const knownIds = new Set(sessions.map((s) => s.id));
   const validPaneIds = new Set(listPaneIds(ws.layout));
 
@@ -218,6 +244,7 @@ function reconcileWorkspaces(
   projects: Project[],
   workspaces: Record<string, ProjectWorkspace>,
   activeProject: string | null,
+  allowEmptyWipe = true,
 ): {
   workspaces: Record<string, ProjectWorkspace>;
   activeProject: string | null;
@@ -233,7 +260,11 @@ function reconcileWorkspaces(
   const newWorkspaces: Record<string, ProjectWorkspace> = {};
   for (const [repoPath, projSessions] of Object.entries(byProject)) {
     const existing = workspaces[repoPath] ?? emptyWorkspace();
-    newWorkspaces[repoPath] = reconcileWorkspace(existing, projSessions);
+    newWorkspaces[repoPath] = reconcileWorkspace(
+      existing,
+      projSessions,
+      allowEmptyWipe,
+    );
   }
 
   // Resolve active project: keep current if still valid; else first project
@@ -296,21 +327,47 @@ export const useAppStore = create<AppStateModel>()(
   error: null,
   pendingRemoveId: null,
   pendingRemoveProject: null,
+  sessionsLoadedCleanly: true,
+
+  async loadInitialStatus() {
+    try {
+      const status = await api.loadStatus();
+      set({ sessionsLoadedCleanly: status.sessionsClean });
+      if (!status.sessionsClean) {
+        console.warn(
+          "[store] backend reports sessions.json failed to load; pane wipe guard active",
+        );
+      }
+    } catch (e) {
+      // Treat status RPC failure as "assume unclean" so we err on the side
+      // of preserving the persisted layout. The user can still recover by
+      // creating sessions, which clears the guard automatically.
+      console.warn("[store] load_status RPC failed", e);
+      set({ sessionsLoadedCleanly: false });
+    }
+  },
 
   async refreshSessions() {
     set({ loading: true, error: null });
     try {
       const sessions = await api.listSessions();
       set((s) => {
+        const allowEmptyWipe = s.sessionsLoadedCleanly;
         const reconciled = reconcileWorkspaces(
           sessions,
           s.projects,
           s.workspaces,
           s.activeProject,
+          allowEmptyWipe,
         );
+        // Once the backend returns any sessions we trust subsequent empty
+        // results to be intentional (user removed them all). Drop the guard.
+        const nextSessionsLoadedCleanly =
+          s.sessionsLoadedCleanly || sessions.length > 0;
         return {
           sessions,
           loading: false,
+          sessionsLoadedCleanly: nextSessionsLoadedCleanly,
           workspaces: reconciled.workspaces,
           activeProject: reconciled.activeProject,
           ...mirrorActive(reconciled.workspaces, reconciled.activeProject),
@@ -325,11 +382,13 @@ export const useAppStore = create<AppStateModel>()(
     try {
       const projects = await api.listProjects();
       set((s) => {
+        const allowEmptyWipe = s.sessionsLoadedCleanly;
         const reconciled = reconcileWorkspaces(
           s.sessions,
           projects,
           s.workspaces,
           s.activeProject,
+          allowEmptyWipe,
         );
         return {
           projects,


### PR DESCRIPTION
## Summary

Persisted pane layouts could be silently destroyed when `sessions.json` failed to load at boot — the empty backend list flowed straight into `reconcileWorkspace`, which interpreted "no known sessions" as "every pane should drop its `sessionIds`", and the resulting empty panes were then re-saved to localStorage. Triggers in practice include transient disk failures and running an incompatible build from a sibling git worktree (since the bundle id and data directory are shared).

This change introduces a load-status signal that flows from backend persistence through to the frontend reconcile path so a recoverable failure no longer wipes the layout.

### Backend
- `persistence::load_sessions_with_status` / `load_projects_with_status` return `(Vec<T>, clean: bool)` and back the offending file up as `*.broken-{ts}` on parse failure.
- `AppState` carries `sessions_loaded_cleanly` / `projects_loaded_cleanly` atomics, populated at boot from the new loaders.
- `commands::load_status` exposes the flags to the frontend.
- `lib.rs` skips `scrollback::prune_orphans` when no live ids exist *and* the session load was unclean — preventing a transient disk failure from also wiping every scrollback file.

### Frontend
- `api.loadStatus()` wraps the new command.
- `useAppStore` adds a `sessionsLoadedCleanly` flag and a `loadInitialStatus` action; `App.tsx` calls it before `refreshAll`.
- `reconcileWorkspace` accepts an `allowEmptyWipe` parameter; when the guard is armed and the backend returns zero sessions, panes that still remember session ids are returned unchanged. The guard is cleared automatically the moment the backend reports any sessions, so legitimate "user removed everything" paths still reconcile normally.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` — 89 pass, 1 skip; new cases cover both arms of the guard
- [x] `cargo test persistence` — 3 pass, including new `backup_corrupt_file_writes_sibling_with_broken_suffix`
- [ ] CI green
- [ ] Manual: corrupt `sessions.json` (`echo not-json > ~/Library/Application\ Support/io.im-ian.acorn/sessions.json`), launch app, verify panes retain previous `sessionIds` and a `sessions.json.broken-*` backup is created
- [ ] Manual: from a sibling worktree with an incompatible `Session` schema, launch app, verify panes are preserved
