### PR TITLE
fix(statusbar): read branch from live PTY cwd instead of worktree_path

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -655,16 +655,21 @@ pub async fn detect_session_statuses(
     state: State<'_, AppState>,
     ids: Vec<String>,
 ) -> AppResult<Vec<SessionStatusEntry>> {
-    // One process-table snapshot covers every session in this poll; cwd
-    // refresh isn't needed here (we only walk parent→child edges to ask
-    // "does this PTY tree have any descendant?").
+    // One process-table snapshot covers every session in this poll. cwd is
+    // refreshed because the live PTY descendant cwd drives branch detection
+    // — a non-isolated session whose terminal `cd`'d into a git worktree
+    // (or whose Claude Code invocation used `-w` to spawn one) has a HEAD
+    // distinct from the recorded `worktree_path` (which is the project
+    // root). Without this, the StatusBar/Sidebar branch stays pinned to the
+    // project root's branch regardless of `git checkout` performed inside
+    // the PTY.
     let mut sys = System::new_with_specifics(
         RefreshKind::new().with_processes(ProcessRefreshKind::new()),
     );
     sys.refresh_processes_specifics(
         ProcessesToUpdate::All,
         true,
-        ProcessRefreshKind::new(),
+        ProcessRefreshKind::new().with_cwd(UpdateKind::Always),
     );
     let children = build_children_map(&sys);
 
@@ -688,9 +693,20 @@ pub async fn detect_session_statuses(
             });
             let status =
                 session_status::detect(&id, previous, shell_hint).unwrap_or(previous);
-            let branch = session
-                .as_ref()
-                .and_then(|s| worktree::current_branch(&s.worktree_path).ok());
+            // Branch source priority:
+            //  1. deepest PTY descendant cwd — reflects `cd` + `git checkout`
+            //     performed inside the terminal (and `claude -w` worktrees)
+            //  2. recorded session worktree_path — fallback when no live PTY
+            //     or descendant cwd lies outside any git repo
+            let live_cwd_branch = parsed_id
+                .and_then(|uuid| state.pty.child_pid(&uuid))
+                .and_then(|pid| deepest_descendant_cwd(&sys, Pid::from_u32(pid)))
+                .and_then(|p| worktree::current_branch(std::path::Path::new(&p)).ok());
+            let branch = live_cwd_branch.or_else(|| {
+                session
+                    .as_ref()
+                    .and_then(|s| worktree::current_branch(&s.worktree_path).ok())
+            });
             // Mirror the detected status into the in-memory store so persisted
             // sessions reflect liveness on next save. Best-effort: ignore errors
             // (e.g. UUID parse failure for a stale id from the frontend).


### PR DESCRIPTION
## Summary

`detect_session_statuses` was reading HEAD from each session's recorded `worktree_path`. For non-isolated sessions (where `worktree_path == repo_path`), this pinned the StatusBar/Sidebar branch to the project root's HEAD regardless of `git checkout` performed inside the PTY — common when users `cd` into a linked worktree or invoke `claude -w` (which spawns Claude in a short-lived worktree).

The fix resolves the branch from the deepest descendant cwd of the session's PTY tree, reusing the `deepest_descendant_cwd` helper already used by the `pty_cwd` command. Falls back to the recorded `worktree_path` when there is no live PTY or the descendant cwd has no git ancestry.

## Changes

- `detect_session_statuses` per-poll `sysinfo` refresh now includes `with_cwd(UpdateKind::Always)` so descendant cwd is populated
- Branch lookup priority: live PTY descendant cwd → recorded `worktree_path`

## Test plan

- [ ] In a non-isolated session, `cd` into a different worktree and run `git checkout other-branch`
- [ ] Within ~1s, StatusBar `branch:` field reflects `other-branch`
- [ ] Sidebar's session row branch text also updates
- [ ] `claude -w` session: branch tracks the temporary worktree's HEAD, not the project root
- [ ] No regression for isolated sessions (worktree_path is unique per session)
