### PR TITLE
fix(terminal): pass xterm cols/rows at PTY spawn so wrap stays in sync

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -647,12 +647,22 @@ export function Terminal({
             : [...startup.args, "--session-id", sessionId];
         }
         if (disposed) return;
+        // Pass the post-fit xterm dimensions so the PTY starts in sync with
+        // what the renderer will paint. Otherwise the PTY falls back to
+        // 80x24 and zsh-autosuggestions / prompt redraws compute wrap
+        // positions for a wider line than xterm renders, leaving the cursor
+        // and echoed characters offset from where the shell believes they
+        // are. The earlier `fit()`-driven `onResize` cannot fix this — it
+        // fires before `pty_spawn` and `pty_resize` errors out with
+        // "no pty for session".
         await invoke("pty_spawn", {
           sessionId,
           cwd,
           command: startup.command,
           args,
           env: {},
+          cols: term.cols,
+          rows: term.rows,
         });
         if (disposed) {
           // Cleanup ran mid-spawn — the pty just got created has no UI.


### PR DESCRIPTION
## Summary

`pty_spawn` was invoked without `cols` / `rows`, so the PTY started at the default 80x24 regardless of how wide the pane actually was.

The `fit()`-driven `term.onResize` that runs right after `term.open` fires *before* `pty_spawn` and triggers a `pty_resize`, but that command errors out with `"no pty for session"` because the handle is not in the registry yet. The PTY then comes up at 80x24 and stays out of sync with what the renderer paints.

Symptom: in narrower panes, zsh + zsh-autosuggestions compute wrap positions for an 80-column line while xterm renders at the actual pane width. Once the prompt + buffer + suggestion crosses the visible right edge, the cursor and echoed characters land in the wrong cells — typing `c` shows `% c` plus a phantom `la`, with `claude -w` appearing on the next row.

## Fix

Pass the post-fit `term.cols` / `term.rows` straight to `pty_spawn` so the PTY opens at the same size the renderer is already using. The existing ResizeObserver path keeps the two in sync afterwards.

## Test plan

- [ ] Open a narrow pane; confirm `stty size` matches the visible width / height
- [ ] In a narrow pane with a long command in zsh history (e.g. `claude --worktree …`), type one character at a time; autosuggestion wraps cleanly with no phantom characters
- [ ] Wide pane: same scenario, suggestion fits on the prompt line without wrapping
- [ ] Drag the pane divider; debounced resize still works, no garbled prompt
- [ ] Restart a session via Enter after `exit`; the new PTY uses the current pane size
- [ ] App restart: restored sessions render the prompt correctly on first input
