### PR TITLE
feat(sessions): optional auto-close on PTY exit

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -284,6 +284,22 @@ function SessionSettings() {
           Show confirmation dialog
         </label>
       </Field>
+      <Field
+        label="Close tab when the process exits"
+        hint="When the session's shell or agent exits (e.g. you type `exit`), close the tab automatically instead of showing the press-Enter restart prompt. The worktree is preserved either way."
+      >
+        <label className="flex items-center gap-2 text-xs text-fg">
+          <input
+            type="checkbox"
+            checked={settings.sessions.closeOnExit}
+            onChange={(e) =>
+              patchSessions({ closeOnExit: e.target.checked })
+            }
+            className="accent-[var(--color-accent)]"
+          />
+          Auto-close on exit
+        </label>
+      </Field>
     </section>
   );
 }

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -756,6 +756,14 @@ export function Terminal({
               // briefly flash on the way out.
               return;
             }
+            // User opted into auto-close: drop the session tab now instead
+            // of writing the press-Enter prompt. The worktree is preserved
+            // (removeSession(id, false)); only the in-app tab disappears.
+            if (useSettings.getState().settings.sessions.closeOnExit) {
+              exited = true;
+              void useAppStore.getState().removeSession(sessionId, false);
+              return;
+            }
             exited = true;
             term.write(
               `\r\n${ANSI_DIM}[process exited — press Enter to restart]${ANSI_RESET}\r\n`,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -152,6 +152,13 @@ export interface AcornSettings {
      * matters. Set false to skip the prompt for plain sessions.
      */
     confirmRemove: boolean;
+    /**
+     * When the session's PTY process exits (e.g. user typed `exit`), close
+     * the session tab automatically instead of showing the
+     * "[process exited — press Enter to restart]" prompt. The worktree is
+     * preserved either way; only the in-app tab is affected.
+     */
+    closeOnExit: boolean;
   };
   editor: {
     /**
@@ -207,6 +214,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   },
   sessions: {
     confirmRemove: true,
+    closeOnExit: false,
   },
   editor: {
     command: "",


### PR DESCRIPTION
## Summary
- Add `sessions.closeOnExit` setting (default off) so the session tab auto-closes when the PTY child exits, instead of parking on `[process exited — press Enter to restart]`.
- Settings → Sessions exposes a checkbox: "Close tab when the process exits".
- Worktree is preserved (`removeSession(id, false)`); only the in-app tab is dropped.
- Worktree-adoption branch still wins, so `claude --worktree` re-spawn flows are untouched.

## Test plan
- [ ] Default (off): `exit` in a session still prints `[process exited — press Enter to restart]` and Enter respawns.
- [ ] Enable "Close tab when the process exits" → `exit` in shell session: tab disappears, worktree intact.
- [ ] Same with Claude Code agent session (`exit` inside `claude`): tab disappears.
- [ ] With auto-close on, run a flow that creates a new worktree (e.g. `claude --worktree`): adoption toast fires, tab is NOT closed, session re-spawns inside the new worktree.
- [ ] Toggle setting, reload app: state persists in `acorn:settings:v1`.
