### PR TITLE
fix(sessions): focus new session after store.createSession

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -701,18 +701,17 @@ export const useAppStore = create<AppStateModel>()(
       // later change to `sessionStartup.mode` does not retroactively swap
       // how this session respawns after an app restart.
       const startupMode = useSettings.getState().settings.sessionStartup.mode;
-      await api.createSession(name, repoPath, isolated, startupMode);
+      const created = await api.createSession(
+        name,
+        repoPath,
+        isolated,
+        startupMode,
+      );
       await get().refreshAll();
-      // Ensure the project of the new session is active so its tab shows up.
-      set((s) => {
-        if (s.workspaces[repoPath] && s.activeProject !== repoPath) {
-          return {
-            activeProject: repoPath,
-            ...mirrorActive(s.workspaces, repoPath),
-          };
-        }
-        return s;
-      });
+      // Focus the new session so Cmd+T (and any other entry point that goes
+      // through the store) immediately surfaces it in its pane instead of
+      // silently appending behind the existing active tab.
+      get().selectSession(created.id);
     } catch (e) {
       set({ loading: false, error: errorMessage(e) });
     }


### PR DESCRIPTION
## Summary
- Cmd+T (and any other entry point that calls `useAppStore.createSession`) now focuses the newly created session instead of leaving the previously active tab selected.
- Replaces the manual `activeProject` patch with `selectSession(created.id)`, which already sets both `activeProject` and `activeSessionId` via the workspace mirror.

## Test plan
- [ ] Cmd+T opens a new session and that session becomes the active tab in its pane.
- [ ] Sidebar highlight follows the new tab (no stale highlight on the previous session).
- [ ] Existing flows that route through `store.createSession` (sidebar "+" buttons, isolated session shortcut) still land the new session correctly.
