### PR TITLE
fix(terminal): repaint viewport after PTY output idle

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -199,6 +199,42 @@ export function Terminal({
       }, SCROLLBACK_SAVE_DEBOUNCE_MS);
     };
 
+    // Force a viewport repaint shortly after a PTY output burst goes idle.
+    //
+    // xterm's DOM renderer reuses per-row DOM elements and incrementally
+    // patches glyphs as the buffer changes. When a streaming TUI (Claude
+    // CLI, `htop`, `claude --print`) is interrupted mid-redraw — user
+    // presses Esc/Ctrl+C, or the stream simply stops — the parser settles
+    // but the last set of cell-diffs may never trigger a paint that
+    // overwrites stale glyphs left by an earlier wider line. The xterm
+    // buffer is correct (copy-to-clipboard yields clean text); only the
+    // DOM rendition is stale. Forcing `refresh(0, rows-1)` rebuilds every
+    // visible row from the buffer, which clears the leftover characters.
+    //
+    // Mid-burst paints already happen naturally as each chunk lands, so
+    // we only fire this when the stream goes quiet. 120ms after the last
+    // chunk: short enough that the stale frame is rarely visible, long
+    // enough to coalesce a Claude-CLI streaming burst (where natural
+    // gaps run ~10-60ms) into one refresh instead of one per chunk.
+    const VIEWPORT_REPAINT_IDLE_MS = 120;
+    let viewportRepaintTimer: number | null = null;
+    const scheduleViewportRepaint = () => {
+      if (disposed) return;
+      if (viewportRepaintTimer !== null) {
+        window.clearTimeout(viewportRepaintTimer);
+      }
+      viewportRepaintTimer = window.setTimeout(() => {
+        viewportRepaintTimer = null;
+        if (disposed) return;
+        try {
+          term.refresh(0, term.rows - 1);
+        } catch {
+          // ignore — terminal may have been disposed between the timer
+          // firing and reaching the call.
+        }
+      }, VIEWPORT_REPAINT_IDLE_MS);
+    };
+
     const sendToPty = (data: string) => {
       if (data.length === 0) return;
       invoke("pty_write", {
@@ -703,6 +739,10 @@ export function Terminal({
               // Output landed in the buffer — schedule a debounced save
               // so the new content reaches disk ~1s after activity ends.
               scheduleScrollbackSave();
+              // Also schedule a viewport repaint once the burst goes quiet,
+              // so a TUI redraw interrupted mid-stream doesn't leave stale
+              // glyphs from a wider previous line painted on screen.
+              scheduleViewportRepaint();
             } catch (err) {
               console.error("[Terminal] decode payload failed", err);
             }
@@ -917,6 +957,10 @@ export function Terminal({
       if (scrollbackSaveTimer !== null) {
         window.clearTimeout(scrollbackSaveTimer);
         scrollbackSaveTimer = null;
+      }
+      if (viewportRepaintTimer !== null) {
+        window.clearTimeout(viewportRepaintTimer);
+        viewportRepaintTimer = null;
       }
       // No cleanup-time save: under React.StrictMode the cleanup of the
       // first dev mount fires while the buffer is still empty (load


### PR DESCRIPTION
## Summary
- Unified terminal scrollbar styling: target xterm v6's widget scrollbar (`.xterm-scrollable-element > .scrollbar.vertical`) since v6 dropped the legacy `.xterm-viewport` native scrollbar. Width 6px, thumb colors set via xterm `ITheme` (`scrollbarSlider*`). Added `cursor: default` on `.xterm-viewport` so the scrollbar gutter no longer inherits the terminal's text cursor.
- Hide horizontal scroll on Commits / Staged / PRs lists (`overflow-x-hidden`) and ellipsize long titles / paths / commit summaries.
- Tooltip wrappers around long text now use `flex! min-w-0 flex-1` (Tailwind v4 important suffix) so the wrapper becomes a real flex item of its row — this overrides Tooltip's hardcoded `inline-flex` while preserving the wrapper's layout box (and therefore its hover / focus / click handlers). The inner `flex-1 min-w-0 truncate` span then shrinks to its parent and the ellipsis fires.

## Why
- Previously the Commits / Staged / PRs list rows would horizontally scroll past the viewport on long content. We want consistent ellipsis behavior across all three tabs.
- The Tooltip wrapper hardcodes `inline-flex`, which prevents inner truncate spans from shrinking below content width. Using a `flex!` override on three call sites is less invasive than changing the Tooltip component itself.
- xterm v6 doesn't use the native viewport scrollbar anymore, so the old `.xterm-viewport::-webkit-scrollbar` rules were dead code.

## Notes
- An earlier iteration used `contents!` on the Tooltip wrappers. That worked for layout but broke hover detection (mouse events do not reliably fire on `display: contents` elements). Reverted to `flex!`, which preserves the box.
- Tried `overflow: overlay` for true overlay scrollbars on the lists. WKWebView 17+ treats `overlay` as `auto`, so it's a no-op. Left the lists with the system overlay scrollbar (no custom `::-webkit-scrollbar` rule globally) — auto-hides and reserves no permanent gutter on macOS.

## Test plan
- [ ] Open Commits tab. Long commit subjects ellipsize, no horizontal scroll. Hover summary → tooltip appears.
- [ ] Open Staged tab. Long file paths ellipsize, no horizontal scroll. Hover path → tooltip appears.
- [ ] Open PRs tab. Long PR titles ellipsize, no horizontal scroll. Hover title → tooltip appears.
- [ ] Terminal: widget scrollbar appears at 6px width with thumb that matches the app palette. Mouse over the scrollbar gutter shows the default cursor, mouse over the terminal text area still shows the text cursor.
- [ ] `bunx tsc --noEmit` clean.
