### PR TITLE
feat(ui): unify terminal scrollbar, hide horizontal scroll, truncate long list items

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -20,17 +20,13 @@
   background-color: transparent !important;
 }
 
-.acorn-terminal .xterm-viewport::-webkit-scrollbar {
-  width: 8px;
+.acorn-terminal .xterm-scrollable-element > .scrollbar.vertical {
+  width: 6px !important;
 }
 
-.acorn-terminal .xterm-viewport::-webkit-scrollbar-thumb {
-  background-color: rgba(255, 255, 255, 0.08);
+.acorn-terminal .xterm-scrollable-element > .scrollbar.vertical > .slider {
+  width: 6px !important;
   border-radius: 4px;
-}
-
-.acorn-terminal .xterm-viewport::-webkit-scrollbar-thumb:hover {
-  background-color: rgba(255, 255, 255, 0.16);
 }
 
 * {
@@ -71,6 +67,10 @@ textarea,
 .acorn-terminal,
 .acorn-terminal * {
   cursor: text;
+}
+
+.acorn-terminal .xterm-viewport {
+  cursor: default;
 }
 
 .acorn-selectable {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -665,7 +665,7 @@ function CommitsTab({
       <Panel id="commits-list" order={1} defaultSize={50} minSize={20}>
         <div
           ref={scrollRef}
-          className="h-full overflow-y-auto"
+          className="h-full overflow-x-hidden overflow-y-auto"
         >
         <div
           style={{ height: virtualizer.getTotalSize(), position: "relative" }}
@@ -723,8 +723,8 @@ function CommitsTab({
                           {c.short_sha}
                         </span>
                       </Tooltip>
-                      <Tooltip label={c.summary} side="top" multiline>
-                        <span className="truncate text-fg">{c.summary}</span>
+                      <Tooltip label={c.summary} side="top" multiline className="flex! min-w-0 flex-1">
+                        <span className="min-w-0 flex-1 truncate text-fg">{c.summary}</span>
                       </Tooltip>
                     </span>
                     <span className="flex w-full min-w-0 items-center gap-2 text-[10px] text-fg-muted">
@@ -916,7 +916,7 @@ function StagedTab({
   return (
     <PanelGroup direction="vertical" autoSaveId="acorn:layout:staged">
       <Panel id="staged-list" order={1} defaultSize={35} minSize={15}>
-        <ul className="h-full overflow-y-auto">
+        <ul className="h-full overflow-x-hidden overflow-y-auto">
           {files.map((f) => (
             <li
               key={f.path}
@@ -933,8 +933,8 @@ function StagedTab({
               <span className="w-24 shrink-0 truncate text-fg-muted">
                 {f.status}
               </span>
-              <Tooltip label={f.path} side="top" multiline>
-                <span className="truncate text-fg">{f.path}</span>
+              <Tooltip label={f.path} side="top" multiline className="flex! min-w-0 flex-1">
+                <span className="min-w-0 flex-1 truncate text-fg">{f.path}</span>
               </Tooltip>
             </li>
           ))}
@@ -1127,7 +1127,7 @@ function PullRequestsTab({
           className="ml-auto"
         />
       </div>
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-x-hidden overflow-y-auto">
         {error ? (
           <div className="p-3 text-xs text-danger">{error}</div>
         ) : !listing ? (
@@ -1163,8 +1163,8 @@ function PullRequestsTab({
                     #{pr.number}
                   </span>
                   <PrStateBadge state={pr.state} isDraft={pr.is_draft} />
-                  <Tooltip label={pr.title} side="top" multiline>
-                    <span className="truncate text-fg">{pr.title}</span>
+                  <Tooltip label={pr.title} side="top" multiline className="flex! min-w-0 flex-1">
+                    <span className="min-w-0 flex-1 truncate text-fg">{pr.title}</span>
                   </Tooltip>
                 </span>
                 <span className="flex w-full min-w-0 items-center gap-2 text-[10px] text-fg-muted">

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -41,6 +41,9 @@ const TERMINAL_BG = "#1f2326";
 const TERMINAL_THEME: ITheme = {
   background: TERMINAL_BG, foreground: "#ededed", cursor: "#ededed",
   cursorAccent: TERMINAL_BG, selectionBackground: "#3a3f44",
+  scrollbarSliderBackground: "rgba(255, 255, 255, 0.08)",
+  scrollbarSliderHoverBackground: "rgba(255, 255, 255, 0.16)",
+  scrollbarSliderActiveBackground: "rgba(255, 255, 255, 0.24)",
   black: TERMINAL_BG, red: "#e06c75", green: "#98c379", yellow: "#e5c07b",
   blue: "#61afef", magenta: "#c678dd", cyan: "#56b6c2", white: "#ededed",
   brightBlack: "#5c6370", brightRed: "#e06c75", brightGreen: "#98c379",


### PR DESCRIPTION
## Summary
- Unified terminal scrollbar styling: target xterm v6's widget scrollbar (`.xterm-scrollable-element > .scrollbar.vertical`) since v6 dropped the legacy `.xterm-viewport` native scrollbar. Width 6px, thumb colors set via xterm `ITheme` (`scrollbarSlider*`). Added `cursor: default` on `.xterm-viewport` so the scrollbar gutter no longer inherits the terminal's text cursor.
- Hide horizontal scroll on Commits / Staged / PRs lists (`overflow-x-hidden`) and ellipsize long titles / paths / commit summaries.
- Tooltip wrappers around long text now use `flex! min-w-0 flex-1` (Tailwind v4 important suffix) so the wrapper becomes a real flex item of its row — this overrides Tooltip's hardcoded `inline-flex` while preserving the wrapper's layout box (and therefore its hover / focus / click handlers). The inner `flex-1 min-w-0 truncate` span then shrinks to its parent and the ellipsis fires.

## Why
- Previously the Commits / Staged / PRs list rows would horizontally scroll past the viewport on long content. We want consistent ellipsis behavior across all three tabs.
- The Tooltip wrapper hardcodes `inline-flex`, which prevents inner truncate spans from shrinking below content width. Using a `flex!` override on three call sites is less invasive than changing the Tooltip component itself.
- xterm v6 doesn't use the native viewport scrollbar anymore, so the old `.xterm-viewport::-webkit-scrollbar` rules were dead code.

## Notes
- An earlier iteration used `contents!` on the Tooltip wrappers. That worked for layout but broke hover detection (mouse events do not reliably fire on `display: contents` elements). Reverted to `flex!`, which preserves the box.
- Tried `overflow: overlay` for true overlay scrollbars on the lists. WKWebView 17+ treats `overlay` as `auto`, so it's a no-op. Left the lists with the system overlay scrollbar (no custom `::-webkit-scrollbar` rule globally) — auto-hides and reserves no permanent gutter on macOS.

## Test plan
- [ ] Open Commits tab. Long commit subjects ellipsize, no horizontal scroll. Hover summary → tooltip appears.
- [ ] Open Staged tab. Long file paths ellipsize, no horizontal scroll. Hover path → tooltip appears.
- [ ] Open PRs tab. Long PR titles ellipsize, no horizontal scroll. Hover title → tooltip appears.
- [ ] Terminal: widget scrollbar appears at 6px width with thumb that matches the app palette. Mouse over the scrollbar gutter shows the default cursor, mouse over the terminal text area still shows the text cursor.
- [ ] `bunx tsc --noEmit` clean.
