### PR TITLE
fix(terminal): suppress duplicate IME commit on Family A terminator

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -342,6 +342,19 @@ export function Terminal({
     // differentiates an IME-driven `insertText` from a plain ASCII one.
     let sentPrefix = "";
     let lastKeyCode229 = false;
+    // Tracks which IME event family is currently driving composition.
+    // Set to "A" when `insertCompositionText` fires (Family A IME — clean
+    // commit via `insertFromComposition`). Set to "B" when
+    // `insertReplacementText` / IME-flavored `insertText` fires (no commit
+    // event; commits are inferred from textarea diffs).
+    //
+    // We need this to suppress the keydown-driven `flushTrailing` on
+    // terminator keys (space/Enter/…): Family A will deliver the commit via
+    // its own `insertFromComposition` shortly after the keydown, so flushing
+    // the textarea preview here would double-emit the syllable (the bug:
+    // "는 는 강강 격 격 강력력 력"). Family B has no such follow-up event, so
+    // it still needs the flush.
+    let compositionFamily: "A" | "B" | null = null;
     // Hangul jamo, Hangul syllables, Hiragana, Katakana, CJK ideographs.
     // Used to recognise IME-driven `insertText` events even when the
     // accompanying `keydown` (with keyCode 229) hasn't fired yet — on
@@ -360,6 +373,7 @@ export function Terminal({
       }
       sentPrefix = "";
       ta.value = "";
+      compositionFamily = null;
       hideComposing();
     };
 
@@ -371,14 +385,17 @@ export function Terminal({
       switch (ev.inputType) {
         // Family A — composition-clean
         case "insertCompositionText":
+          compositionFamily = "A";
           showComposing(ev.data ?? "");
           ev.stopImmediatePropagation();
           return;
         case "deleteCompositionText":
+          compositionFamily = "A";
           ev.stopImmediatePropagation();
           return;
         case "insertFromComposition":
           if (ev.data) sendToPty(ev.data);
+          compositionFamily = null;
           hideComposing();
           ev.stopImmediatePropagation();
           return;
@@ -387,6 +404,7 @@ export function Terminal({
         case "insertReplacementText": {
           // In-syllable replacement; trailing char being recomposed.
           // Don't commit; show preview of trailing.
+          compositionFamily = "B";
           if (ta) {
             // Stale sentPrefix detection: if textarea no longer starts
             // with the prefix we tracked, a non-IME keystroke (Space,
@@ -412,9 +430,11 @@ export function Terminal({
             // sentPrefix or the next IME insertText will re-emit it as
             // part of its committed-prefix diff.
             hideComposing();
+            compositionFamily = null;
             if (ta) sentPrefix = ta.value;
             return;
           }
+          compositionFamily = "B";
           if (!ta) return;
           const value = ta.value;
           const newCharLen = ev.data?.length ?? 0;
@@ -512,7 +532,16 @@ export function Terminal({
       // will emit the printable char, and we sync sentPrefix to the
       // textarea length so the next IME insertText diff treats those
       // already-emitted chars as committed.
-      if (lastKeyCode229) {
+      //
+      // Family A skip: Family A IME (`insertCompositionText` driven)
+      // delivers the commit through a follow-up `insertFromComposition`
+      // event after this keydown. Calling `flushTrailing` here would
+      // emit the preview from the textarea AND then `insertFromComposition`
+      // would emit the same syllable a second time — the intermittent
+      // doubling bug ("는 는", "강강", "강력력 력"). The intermittent feel
+      // comes from macOS Korean IME flipping between Family A and Family B
+      // event shapes based on input mode / pending state.
+      if (lastKeyCode229 && compositionFamily !== "A") {
         flushTrailing();
       }
       lastKeyCode229 = false;


### PR DESCRIPTION
## Summary

- Fix intermittent duplicate-syllable bug on Korean IME input (`는 는`, `강강`, `강력력 력`, etc.)
- macOS WKWebView emits IME via two event families — when Family A (`insertCompositionText` + `insertFromComposition`) is active, the keydown terminator handler's `flushTrailing()` committed the syllable a second time
- Track active family with `compositionFamily` flag → skip `flushTrailing` for Family A, keep existing behavior for Family B

## Root cause

On terminator keys (space / Enter):
1. `onKeydown(keyCode=229, terminator)` → `flushTrailing()` sends textarea preview `는` to PTY
2. Follow-up `insertFromComposition` event sends the same `는` again → **duplicate**

Family B has no commit event so flush is required. Family A delivers the commit via `insertFromComposition` so flushing produces the dup. The original code did not differentiate and always flushed.

Why intermittent: macOS Korean IME flips between Family A and Family B depending on input mode and pending state.

## Changes

`src/components/Terminal.tsx`:

- New `compositionFamily: "A" | "B" | null` state
- `insertCompositionText` / `deleteCompositionText` → `"A"`
- `insertReplacementText` / IME-flavored `insertText` → `"B"`
- `insertFromComposition` / plain ASCII / `flushTrailing` → reset to `null`
- Keydown terminator branch: `if (lastKeyCode229 && compositionFamily !== "A") flushTrailing()`

## Test plan

- [ ] Korean + space: syllable commits exactly once (`AI는 강력` renders cleanly)
- [ ] Korean + Enter: syllable commits once, line breaks
- [ ] Korean → English immediate switch: order preserved
- [ ] Double consonants `ㅆ` (`있`, `갔`): combines correctly
- [ ] Backspace mid-composition: preview shrinks, no PTY emit
- [ ] Consecutive syllables (`강력강력`): no duplicates
- [ ] IME off, plain English: unaffected
