### PR TITLE
chore(release): v1.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.7"
+version = "1.0.8"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
Version bump 1.0.7 → 1.0.8.

## Included in this release
- `feat(ui)`: unify terminal scrollbar, hide horizontal scroll on commits/staged/PRs lists, ellipsize long titles/paths/summaries (#94)
- `docs(readme)`: focus on features, drop implementation details, refresh screenshot, add product stance (#95)

## Release flow
After merge, tag `v1.0.8` on `main` and push the tag — the `Release` workflow builds + signs macOS bundles for `aarch64` and `x86_64` and attaches them to the GitHub release.
