### PR TITLE
fix(ci): adapt release build to @tauri-apps/cli 2.10+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,13 @@ jobs:
         # `--profile release-ci` swaps fat LTO + codegen-units=1 for
         # thin LTO + codegen-units=16 (defined in src-tauri/Cargo.toml).
         # Output lands in target/<arch>/release-ci/ instead of release/.
-        run: bun run tauri build --target ${{ matrix.target }} --profile release-ci --bundles app dmg updater
+        #
+        # @tauri-apps/cli 2.10+ removed the top-level `--profile` flag and
+        # the `updater` bundle value. Pass `--profile` to cargo via `--`,
+        # and rely on `bundle.createUpdaterArtifacts: true` in
+        # tauri.conf.json to emit the updater tarball alongside the app
+        # bundle automatically.
+        run: bun run tauri build --target ${{ matrix.target }} --bundles app dmg -- --profile release-ci
 
       - name: Stage release artifacts
         id: stage


### PR DESCRIPTION
## Summary
`v1.0.8` release build crashed with `error: unexpected argument '--profile' found`. Newer `@tauri-apps/cli` (2.10+, currently resolves to 2.11.0) removed the top-level `--profile` flag and the `updater` value from `--bundles`. Adapt the release workflow.

## Changes
- `--profile release-ci` is now passed to cargo via `--` instead of to the tauri CLI directly.
- Dropped `updater` from `--bundles`. `bundle.createUpdaterArtifacts: true` in `tauri.conf.json` already produces the updater tarball alongside the app bundle.

## Test plan
- [ ] Re-tag (or push `v1.0.8` again after force-deleting the broken tag) and confirm the Release workflow succeeds for both `aarch64-apple-darwin` and `x86_64-apple-darwin`.
- [ ] Updater tarball + signature land in the release alongside the DMG.
