### PR TITLE
feat(terminal): open clicked links in external browser

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -5,6 +5,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import "@xterm/xterm/css/xterm.css";
 import { api } from "../lib/api";
 import { registerScrollbackFlusher } from "../lib/scrollback-coordinator";
@@ -116,7 +117,15 @@ export function Terminal({
     });
 
     const fitAddon = new FitAddon();
-    const webLinksAddon = new WebLinksAddon();
+    // Hand link clicks to the OS so URLs open in the user's default browser
+    // instead of trying to navigate the Tauri WebView (which is gated by the
+    // app's CSP and would either fail or replace the app shell).
+    const webLinksAddon = new WebLinksAddon((event, uri) => {
+      event.preventDefault();
+      void openUrl(uri).catch((err: unknown) => {
+        console.error("failed to open terminal link", uri, err);
+      });
+    });
     const serializeAddon = new SerializeAddon();
     term.loadAddon(fitAddon);
     term.loadAddon(webLinksAddon);


### PR DESCRIPTION
## Summary
- Terminal links (http/https) in output now open in the OS default browser when clicked
- `WebLinksAddon` constructor receives a custom handler that delegates to `@tauri-apps/plugin-opener` `openUrl()` and calls `event.preventDefault()` so the Tauri WebView does not try to navigate or replace the app shell

## Why
Previously the addon fell back to `window.open`, which is gated by the app CSP inside the WebView — clicking a URL in the terminal did nothing user-visible.

## Test plan
- [ ] `bun run tauri dev`, print `https://github.com` in a terminal pane, click the link — verify it opens in Safari (or system default browser)
- [ ] Hover styling (underline) still appears
- [ ] Text selection / copy in terminal still works around link regions
