### PR TITLE
fix(ci): strip GitHub provenance HTML comment from release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,12 @@ jobs:
           else
             notes="See https://github.com/${REPO}/releases/tag/${TAG}"
           fi
+          # Strip GitHub's provenance HTML comment
+          # (`<!-- Release notes generated using configuration in
+          # .github/release.yml at vX.Y.Z -->`). It is purely informational
+          # — not parsed back by the regenerate API — and renders as
+          # literal text in Acorn's in-app "What's new" modal.
+          notes=$(printf '%s' "$notes" | sed -E '/^[[:space:]]*<!--.*-->[[:space:]]*$/d')
           # Persist to a file rather than $GITHUB_OUTPUT so newlines and
           # markdown survive cleanly through later jq / action-gh-release
           # consumers.


### PR DESCRIPTION
## Summary
- GitHub's `releases/generate-notes` API prepends `<!-- Release notes generated using configuration in .github/release.yml at vX.Y.Z -->` to the body
- Marker is provenance-only (not parsed back by GitHub) but rendered as literal text in Acorn's in-app "What's new" modal via Tauri updater `latest.json`
- `sed` line strip removes the comment from `notes` before `release_notes.md` is written, cleaning both the GitHub release page and the updater payload

## Test plan
- [ ] Cut next release tag; confirm release body on GitHub no longer contains the marker
- [ ] Confirm `latest.json` body is also clean
- [ ] In-app "What's new" modal renders without the literal HTML comment line
