### PR TITLE
fix(terminal): block xterm compositionend to stop IME duplicate emit

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -598,6 +598,24 @@ export function Terminal({
     container.addEventListener("input", onInput, true);
     container.addEventListener("keydown", onKeydown, true);
 
+    // Block xterm.js's own compositionstart/update/end listeners on the
+    // helper textarea. xterm registers them in CoreBrowserTerminal.ts and
+    // its CompositionHelper.compositionend → _finalizeComposition →
+    // triggerDataEvent re-emits the textarea contents (the whole composed
+    // phrase) on top of the per-syllable PTY writes we already issued via
+    // `onInput`. The duplication surfaces when PTY output bursts, refresh,
+    // fit, or scroll cause the WKWebView IME stack to fire native
+    // compositionend even though our W3C InputEvent path is the source of
+    // truth. Stop the events at container capture phase so xterm's
+    // listeners never see them; our own onInput handler covers preview,
+    // partial commits, and final commit for both Family A and Family B.
+    const swallowComposition = (e: Event) => {
+      e.stopImmediatePropagation();
+    };
+    container.addEventListener("compositionstart", swallowComposition, true);
+    container.addEventListener("compositionupdate", swallowComposition, true);
+    container.addEventListener("compositionend", swallowComposition, true);
+
     const inputDisposable = term.onData((data: string) => {
       sendToPty(data);
     });
@@ -1018,6 +1036,9 @@ export function Terminal({
       resizeObserver.disconnect();
       container.removeEventListener("input", onInput, true);
       container.removeEventListener("keydown", onKeydown, true);
+      container.removeEventListener("compositionstart", swallowComposition, true);
+      container.removeEventListener("compositionupdate", swallowComposition, true);
+      container.removeEventListener("compositionend", swallowComposition, true);
       window.removeEventListener("acorn:terminal-clear", onClearRequested);
       inputDisposable.dispose();
       renderDisposable.dispose();


### PR DESCRIPTION
## Summary

- xterm.js fires its own `compositionstart/update/end` listeners on the helper textarea. `CompositionHelper.compositionend` → `_finalizeComposition` → `triggerDataEvent` re-emits the whole composed textarea contents on top of the per-syllable writes our W3C `InputEvent` path already issued.
- Quiet typing hides it. PTY output bursts, `refresh()`, `fit()`, or scroll cause WKWebView to fire native `compositionend` → every Korean syllable lands at the shell 2–3×, producing strings like `텍텍스스트 트 텍스트` for `텍스트`.
- Block `compositionstart/update/end` at container capture phase. The existing `onInput` handler covers Family A (`insertFromComposition`) and Family B (`insertText` diff vs `sentPrefix`), so xterm's silent path goes away with no loss of behavior.

## Test plan

- [x] `안녕하세요` — each syllable arrives once
- [x] Double consonants: `있`, `갔`, `깠`, `없`
- [x] Korean + space + Korean, Korean + Enter, Shift+Enter (LF)
- [x] Backspace mid-composition keeps preview consistent
- [x] Korean ↔ English toggle
- [x] Type Korean during `yes` / `ls -R` / Claude CLI prompt redraws
- [x] Type Korean while scrolling scrollback
- [x] Type Korean after Cmd+K clear
- [x] ASCII fast-typing unchanged, Cmd+Arrow line nav unchanged
- [x] Composition preview overlay still tracks cursor on render / scroll / cursor-move
