### PR TITLE
feat(settings): add "What's new" button to Settings → About tab

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,9 +1,14 @@
-import { Download, RefreshCcw, Settings as SettingsIcon, Trash2 } from "lucide-react";
+import { Download, RefreshCcw, Settings as SettingsIcon, Sparkles, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import { sendTestNotification } from "../lib/notifications";
+import {
+  fetchLatestReleaseNotes,
+  fetchReleaseNotes,
+  type ReleaseNotes,
+} from "../lib/releases";
 import { useUpdater } from "../lib/updater-store";
 import { WhatsNewModal } from "./WhatsNewModal";
 import {
@@ -792,6 +797,21 @@ function formatRelative(ts: number | null): string {
   return `${Math.floor(diff / 86_400_000)} d ago`;
 }
 
+type WhatsNewSource =
+  | { kind: "update"; version: string; body: string; htmlUrl?: string }
+  | {
+      kind: "current";
+      version: string;
+      body: string;
+      htmlUrl: string;
+      /**
+       * True when the running version doesn't have its own public
+       * release and we're showing the latest published one as a
+       * fallback. Surfaces a subtitle hint in the modal.
+       */
+      isFallback: boolean;
+    };
+
 function AboutSettings() {
   const currentVersion = useUpdater((s) => s.currentVersion);
   const available = useUpdater((s) => s.available);
@@ -801,13 +821,68 @@ function AboutSettings() {
   const check = useUpdater((s) => s.check);
   const install = useUpdater((s) => s.install);
   const init = useUpdater((s) => s.init);
-  const [whatsNewOpen, setWhatsNewOpen] = useState(false);
+  const [whatsNewSource, setWhatsNewSource] = useState<WhatsNewSource | null>(
+    null,
+  );
+  const [currentNotes, setCurrentNotes] = useState<ReleaseNotes | null>(null);
+  const [notesLoading, setNotesLoading] = useState(false);
+  const [notesError, setNotesError] = useState<string | null>(null);
 
   useEffect(() => {
     void init();
   }, [init]);
 
   const hasNotes = (available?.body?.trim().length ?? 0) > 0;
+
+  const openCurrentNotes = useCallback(async () => {
+    if (!currentVersion) return;
+    setNotesError(null);
+    // Cache: skip the fetch if we already have notes for this version.
+    if (currentNotes && currentNotes.version === currentVersion) {
+      setWhatsNewSource({
+        kind: "current",
+        version: currentNotes.version,
+        body: currentNotes.body,
+        htmlUrl: currentNotes.htmlUrl,
+        isFallback: false,
+      });
+      return;
+    }
+    setNotesLoading(true);
+    try {
+      const notes = await fetchReleaseNotes(currentVersion);
+      if (notes !== null) {
+        setCurrentNotes(notes);
+        setWhatsNewSource({
+          kind: "current",
+          version: notes.version,
+          body: notes.body,
+          htmlUrl: notes.htmlUrl,
+          isFallback: false,
+        });
+        return;
+      }
+      // The running version doesn't have its own public release (e.g. a
+      // private hotfix that was overwritten, a locally bumped dev build,
+      // or a pre-release tag). Fall back to the latest published release
+      // so the user still sees something meaningful instead of an empty
+      // placeholder.
+      const latest = await fetchLatestReleaseNotes();
+      setWhatsNewSource({
+        kind: "current",
+        version: latest.version,
+        body: latest.body,
+        htmlUrl: latest.htmlUrl,
+        isFallback: true,
+      });
+    } catch (err) {
+      setNotesError(
+        err instanceof Error ? err.message : "Failed to fetch release notes",
+      );
+    } finally {
+      setNotesLoading(false);
+    }
+  }, [currentVersion, currentNotes]);
 
   return (
     <section className="space-y-4">
@@ -843,10 +918,16 @@ function AboutSettings() {
               </div>
             </div>
             <div className="flex shrink-0 items-center gap-2">
-              {hasNotes ? (
+              {hasNotes && available ? (
                 <button
                   type="button"
-                  onClick={() => setWhatsNewOpen(true)}
+                  onClick={() =>
+                    setWhatsNewSource({
+                      kind: "update",
+                      version: available.version,
+                      body: available.body ?? "",
+                    })
+                  }
                   className="rounded px-2 py-1 text-[11px] text-fg-muted underline-offset-2 transition hover:text-fg hover:underline"
                 >
                   What&apos;s new
@@ -874,7 +955,28 @@ function AboutSettings() {
         </p>
       ) : null}
 
-      <div className="flex justify-end">
+      {notesError ? (
+        <p className="rounded border border-danger/40 bg-danger/10 px-3 py-2 text-[11px] text-danger">
+          {notesError}
+        </p>
+      ) : null}
+
+      <div className="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={() => void openCurrentNotes()}
+          disabled={!currentVersion || notesLoading}
+          className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-[11px] text-fg-muted transition hover:border-accent/60 hover:text-fg disabled:opacity-50"
+        >
+          <Sparkles size={11} className={notesLoading ? "animate-pulse" : ""} />
+          <TextSwap>
+            {notesLoading
+              ? "Loading…"
+              : currentVersion
+                ? `What's new in ${currentVersion}`
+                : "What's new"}
+          </TextSwap>
+        </button>
         <button
           type="button"
           onClick={() => void check()}
@@ -887,8 +989,23 @@ function AboutSettings() {
       </div>
 
       <WhatsNewModal
-        open={whatsNewOpen}
-        onClose={() => setWhatsNewOpen(false)}
+        open={whatsNewSource !== null}
+        onClose={() => setWhatsNewSource(null)}
+        version={whatsNewSource?.version ?? ""}
+        body={whatsNewSource?.body ?? ""}
+        currentVersion={currentVersion}
+        showInstall={whatsNewSource?.kind === "update"}
+        busy={busy}
+        error={whatsNewSource?.kind === "update" ? error : null}
+        onInstall={
+          whatsNewSource?.kind === "update" ? () => void install() : undefined
+        }
+        htmlUrl={
+          whatsNewSource?.kind === "current" ? whatsNewSource.htmlUrl : undefined
+        }
+        isFallback={
+          whatsNewSource?.kind === "current" ? whatsNewSource.isFallback : false
+        }
       />
     </section>
   );

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -19,6 +19,7 @@ import { WhatsNewModal } from "./WhatsNewModal";
 export function UpdateBanner(): ReactElement | null {
   const should = useUpdater(selectShouldNotify);
   const update = useUpdater((s) => s.available);
+  const currentVersion = useUpdater((s) => s.currentVersion);
   const busy = useUpdater((s) => s.busy);
   const error = useUpdater((s) => s.error);
   const install = useUpdater((s) => s.install);
@@ -81,6 +82,13 @@ export function UpdateBanner(): ReactElement | null {
       <WhatsNewModal
         open={whatsNewOpen}
         onClose={() => setWhatsNewOpen(false)}
+        version={update.version}
+        body={update.body ?? ""}
+        currentVersion={currentVersion}
+        showInstall
+        busy={busy}
+        error={error}
+        onInstall={() => void install()}
       />
     </>
   );

--- a/src/components/WhatsNewModal.tsx
+++ b/src/components/WhatsNewModal.tsx
@@ -1,6 +1,5 @@
-import { Download, Sparkles } from "lucide-react";
+import { Download, ExternalLink, Sparkles } from "lucide-react";
 import type { ReactElement } from "react";
-import { useUpdater } from "../lib/updater-store";
 import { Modal } from "./ui/Modal";
 import { ModalHeader } from "./ui/ModalHeader";
 import { Markdown } from "./ui/Markdown";
@@ -9,30 +8,71 @@ import { TextSwap } from "./ui/TextSwap";
 interface WhatsNewModalProps {
   open: boolean;
   onClose: () => void;
+  /** Version whose notes are being shown, e.g. "1.0.8". */
+  version: string;
+  /** Raw markdown release body. Empty string shows the placeholder. */
+  body: string;
+  /** Currently-running app version, rendered in the subtitle for context. */
+  currentVersion: string | null;
+  /**
+   * When true, the modal renders the "Install & relaunch" action — used
+   * by the update banner / settings update row. Omit (or set false) for
+   * the "browse current version's notes" flow on the About tab.
+   */
+  showInstall?: boolean;
+  /** Disables the install button while a download/install is running. */
+  busy?: boolean;
+  /** Error message shown above the footer. */
+  error?: string | null;
+  /** Invoked when the install button is clicked. Required if showInstall. */
+  onInstall?: () => void;
+  /** Optional public release URL — renders a "View on GitHub" affordance. */
+  htmlUrl?: string;
+  /**
+   * When true, the modal subtitle explains that these notes belong to a
+   * *different* version than the one the user is running — used when the
+   * running version doesn't have a public release and we fall back to
+   * the latest one.
+   */
+  isFallback?: boolean;
 }
 
 /**
- * Standalone release-notes dialog. Triggered both from the top-of-app
- * `UpdateBanner` and from the Settings → About panel so the same content
- * surfaces in one place regardless of entry point.
+ * Standalone release-notes dialog. Fed from two surfaces:
  *
- * Reads `available` / `currentVersion` directly from the updater store —
- * the modal renders nothing when no update is pending, which is the same
- * lifecycle the banner already obeys.
+ *   1. The pending-update flow (UpdateBanner + the inline button on the
+ *      Settings → About update row) — passes the pending `Update` body
+ *      and `showInstall=true` to expose the install action.
+ *   2. The browse-current-version flow on the Settings → About tab —
+ *      passes notes fetched from GitHub Releases for the running
+ *      version, with `showInstall=false`.
+ *
+ * Keeping the modal fully prop-driven (no store reads) makes both flows
+ * trivially testable in isolation and avoids the previous coupling
+ * where the modal silently rendered nothing whenever the updater store
+ * had no `available` update.
  */
 export function WhatsNewModal({
   open,
   onClose,
+  version,
+  body,
+  currentVersion,
+  showInstall = false,
+  busy = false,
+  error,
+  onInstall,
+  htmlUrl,
+  isFallback = false,
 }: WhatsNewModalProps): ReactElement | null {
-  const update = useUpdater((s) => s.available);
-  const currentVersion = useUpdater((s) => s.currentVersion);
-  const busy = useUpdater((s) => s.busy);
-  const error = useUpdater((s) => s.error);
-  const install = useUpdater((s) => s.install);
-
-  if (!update) return null;
-
-  const body = update.body?.trim() ?? "";
+  const trimmedBody = body.trim();
+  const subtitle = isFallback
+    ? `latest published — no public release for ${currentVersion ?? "your version"}`
+    : currentVersion && currentVersion !== version
+      ? `currently running ${currentVersion}`
+      : currentVersion === version
+        ? "you're on this version"
+        : undefined;
 
   return (
     <Modal
@@ -43,18 +83,16 @@ export function WhatsNewModal({
       ariaLabelledBy="acorn-whatsnew-title"
     >
       <ModalHeader
-        title={`What's new in Acorn ${update.version}`}
-        subtitle={
-          currentVersion ? `currently running ${currentVersion}` : undefined
-        }
+        title={`What's new in Acorn ${version}`}
+        subtitle={subtitle}
         titleId="acorn-whatsnew-title"
         icon={<Sparkles size={14} className="text-accent" />}
         variant="dialog"
         onClose={onClose}
       />
       <div className="max-h-[28rem] overflow-y-auto px-4 py-4">
-        {body.length > 0 ? (
-          <Markdown content={body} className="text-xs" />
+        {trimmedBody.length > 0 ? (
+          <Markdown content={trimmedBody} className="text-xs" />
         ) : (
           <p className="text-xs text-fg-muted">
             No release notes were published with this version.
@@ -67,6 +105,17 @@ export function WhatsNewModal({
         </p>
       ) : null}
       <footer className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+        {htmlUrl ? (
+          <a
+            href={htmlUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center gap-1.5 rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          >
+            <ExternalLink size={12} />
+            View on GitHub
+          </a>
+        ) : null}
         <button
           type="button"
           onClick={onClose}
@@ -74,15 +123,17 @@ export function WhatsNewModal({
         >
           Close
         </button>
-        <button
-          type="button"
-          onClick={() => void install()}
-          disabled={busy}
-          className="inline-flex items-center gap-1.5 rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
-        >
-          <Download size={12} />
-          <TextSwap>{busy ? "Installing…" : "Install & relaunch"}</TextSwap>
-        </button>
+        {showInstall && onInstall ? (
+          <button
+            type="button"
+            onClick={onInstall}
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
+          >
+            <Download size={12} />
+            <TextSwap>{busy ? "Installing…" : "Install & relaunch"}</TextSwap>
+          </button>
+        ) : null}
       </footer>
     </Modal>
   );

--- a/src/lib/releases.test.ts
+++ b/src/lib/releases.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchLatestReleaseNotes, fetchReleaseNotes } from "./releases";
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+afterEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("fetchReleaseNotes", () => {
+  it("hits the GitHub releases-by-tag endpoint with a v-prefixed tag", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          tag_name: "v1.0.8",
+          body: "release body",
+          html_url: "https://github.com/im-ian/acorn/releases/tag/v1.0.8",
+          published_at: "2026-05-11T07:00:00Z",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const notes = await fetchReleaseNotes("1.0.8");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "https://api.github.com/repos/im-ian/acorn/releases/tags/v1.0.8",
+    );
+    expect(notes).toEqual({
+      version: "1.0.8",
+      body: "release body",
+      htmlUrl: "https://github.com/im-ian/acorn/releases/tag/v1.0.8",
+      publishedAt: "2026-05-11T07:00:00Z",
+    });
+  });
+
+  it("does not double-prefix a tag that already starts with v", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          tag_name: "v2.0.0",
+          body: "",
+          html_url: "https://github.com/im-ian/acorn/releases/tag/v2.0.0",
+          published_at: "2026-05-12T00:00:00Z",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await fetchReleaseNotes("v2.0.0");
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "https://api.github.com/repos/im-ian/acorn/releases/tags/v2.0.0",
+    );
+  });
+
+  it("returns null on 404 so callers can render an 'unpublished' state", async () => {
+    fetchMock.mockResolvedValue(new Response("not found", { status: 404 }));
+
+    const notes = await fetchReleaseNotes("99.0.0");
+
+    expect(notes).toBeNull();
+  });
+
+  it("throws on other non-OK responses so the UI can surface the failure", async () => {
+    fetchMock.mockResolvedValue(new Response("rate limit", { status: 403 }));
+
+    await expect(fetchReleaseNotes("1.0.8")).rejects.toThrow(/403/);
+  });
+
+  it("coerces null body to an empty string for tag fetches", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          tag_name: "v1.0.8",
+          body: null,
+          html_url: "https://github.com/im-ian/acorn/releases/tag/v1.0.8",
+          published_at: "2026-05-11T07:00:00Z",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const notes = await fetchReleaseNotes("1.0.8");
+
+    expect(notes?.body).toBe("");
+  });
+});
+
+describe("fetchLatestReleaseNotes", () => {
+  it("hits the /releases/latest endpoint and parses the payload", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          tag_name: "v1.0.7",
+          body: "latest body",
+          html_url: "https://github.com/im-ian/acorn/releases/tag/v1.0.7",
+          published_at: "2026-05-11T01:59:13Z",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const notes = await fetchLatestReleaseNotes();
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "https://api.github.com/repos/im-ian/acorn/releases/latest",
+    );
+    expect(notes).toEqual({
+      version: "1.0.7",
+      body: "latest body",
+      htmlUrl: "https://github.com/im-ian/acorn/releases/tag/v1.0.7",
+      publishedAt: "2026-05-11T01:59:13Z",
+    });
+  });
+
+  it("throws on non-OK responses", async () => {
+    fetchMock.mockResolvedValue(new Response("rate limit", { status: 403 }));
+
+    await expect(fetchLatestReleaseNotes()).rejects.toThrow(/403/);
+  });
+});

--- a/src/lib/releases.ts
+++ b/src/lib/releases.ts
@@ -1,0 +1,82 @@
+/**
+ * GitHub Releases fetcher for the in-app "What's new" surface.
+ *
+ * The Tauri updater only ships notes for the *next* version (the one
+ * waiting to install). To surface notes for the version the user is
+ * already running — even when no update is pending — we query the
+ * public GitHub Releases API directly. Unauthenticated requests get
+ * 60/hour per IP, which is more than enough for occasional clicks from
+ * the About tab.
+ */
+
+const RELEASE_OWNER = "im-ian";
+const RELEASE_REPO = "acorn";
+
+export interface ReleaseNotes {
+  /** Tag stripped of leading "v" — matches `tauri --version` output. */
+  version: string;
+  /** Raw markdown body of the release (may be empty). */
+  body: string;
+  /** Public URL of the release on GitHub. */
+  htmlUrl: string;
+  /** ISO timestamp the release was published. */
+  publishedAt: string;
+}
+
+interface GithubReleasePayload {
+  tag_name: string;
+  body: string | null;
+  html_url: string;
+  published_at: string;
+}
+
+/**
+ * Fetch release notes for a specific version. Returns `null` when GitHub
+ * has no release for that tag (404) so the caller can render an
+ * "unpublished" message instead of an error. Network / 5xx / parse
+ * failures throw — the UI surfaces them inline.
+ */
+export async function fetchReleaseNotes(
+  version: string,
+): Promise<ReleaseNotes | null> {
+  const tag = version.startsWith("v") ? version : `v${version}`;
+  const url = `https://api.github.com/repos/${RELEASE_OWNER}/${RELEASE_REPO}/releases/tags/${encodeURIComponent(tag)}`;
+  const res = await fetch(url, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`GitHub releases request failed: ${res.status}`);
+  }
+  const json = (await res.json()) as GithubReleasePayload;
+  return {
+    version: json.tag_name.replace(/^v/, ""),
+    body: json.body ?? "",
+    htmlUrl: json.html_url,
+    publishedAt: json.published_at,
+  };
+}
+
+/**
+ * Fetch the most recently published release. Used as a fallback when the
+ * currently installed version doesn't have a corresponding public
+ * release on GitHub (private hotfix tags, locally bumped dev builds,
+ * pre-release versions, etc.). Throws on any non-200 — there is no
+ * meaningful "no releases exist" UX, so the caller surfaces the error.
+ */
+export async function fetchLatestReleaseNotes(): Promise<ReleaseNotes> {
+  const url = `https://api.github.com/repos/${RELEASE_OWNER}/${RELEASE_REPO}/releases/latest`;
+  const res = await fetch(url, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub releases request failed: ${res.status}`);
+  }
+  const json = (await res.json()) as GithubReleasePayload;
+  return {
+    version: json.tag_name.replace(/^v/, ""),
+    body: json.body ?? "",
+    htmlUrl: json.html_url,
+    publishedAt: json.published_at,
+  };
+}

--- a/tests/e2e/whats-new.spec.ts
+++ b/tests/e2e/whats-new.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect, pressHotkey } from "./support";
+
+// The base tauriMock returns "0.0.0-test" for plugin:app|version, which is
+// what the updater store records as `currentVersion`. The About tab's
+// "What's new in {currentVersion}" button echoes that string in its label.
+const TEST_VERSION = "0.0.0-test";
+
+async function openAboutTab(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await pressHotkey(page, { mod: true, key: "," });
+  const modal = page.getByRole("dialog", { name: /Settings/i });
+  await expect(modal).toBeVisible();
+  await modal.getByRole("button", { name: "About", exact: true }).click();
+  await expect(
+    modal.getByRole("heading", { name: "About Acorn" }),
+  ).toBeVisible();
+  return modal;
+}
+
+test.describe("about tab: what's new button", () => {
+  test("renders a 'What's new in {currentVersion}' button on the About tab", async ({
+    page,
+  }) => {
+    const modal = await openAboutTab(page);
+
+    await expect(
+      modal.getByRole("button", {
+        name: new RegExp(`What's new in ${TEST_VERSION}`),
+      }),
+    ).toBeVisible();
+  });
+
+  test("clicking the button fetches release notes from GitHub and opens the modal", async ({
+    page,
+  }) => {
+    // Mock GitHub Releases API at the network layer so the fetch in
+    // src/lib/releases.ts hits a deterministic payload.
+    await page.route(
+      "https://api.github.com/repos/im-ian/acorn/releases/tags/v0.0.0-test",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            tag_name: "v0.0.0-test",
+            body: "## Highlights\n\n- Test release body",
+            html_url: "https://github.com/im-ian/acorn/releases/tag/v0.0.0-test",
+            published_at: "2026-05-11T07:00:00Z",
+          }),
+        });
+      },
+    );
+
+    const modal = await openAboutTab(page);
+    await modal
+      .getByRole("button", {
+        name: new RegExp(`What's new in ${TEST_VERSION}`),
+      })
+      .click();
+
+    const dialog = page.getByRole("dialog", {
+      name: new RegExp(`What's new in Acorn ${TEST_VERSION}`),
+    });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(/Test release body/)).toBeVisible();
+    // The "current version" subtitle should NOT show the running-version
+    // hint because the modal is showing notes for the running version
+    // itself ("you're on this version").
+    await expect(dialog.getByText(/you're on this version/i)).toBeVisible();
+    // No install action on the current-version flow.
+    await expect(
+      dialog.getByRole("button", { name: /Install & relaunch/i }),
+    ).toHaveCount(0);
+    // External link to the release page is available.
+    await expect(
+      dialog.getByRole("link", { name: /View on GitHub/i }),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/im-ian/acorn/releases/tag/v0.0.0-test",
+    );
+  });
+
+  test("falls back to the latest release when the running version has no public tag", async ({
+    page,
+    errorTracker,
+  }) => {
+    // Chromium logs a "Failed to load resource: 404" console.error for
+    // any 4xx response regardless of how the app handles it. That's a
+    // network-layer artifact, not an app bug.
+    errorTracker.allow(/Failed to load resource/);
+    await page.route(
+      "https://api.github.com/repos/im-ian/acorn/releases/tags/v0.0.0-test",
+      async (route) => {
+        await route.fulfill({ status: 404, body: "not found" });
+      },
+    );
+    await page.route(
+      "https://api.github.com/repos/im-ian/acorn/releases/latest",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            tag_name: "v1.0.7",
+            body: "## v1.0.7\n\n- public release body",
+            html_url: "https://github.com/im-ian/acorn/releases/tag/v1.0.7",
+            published_at: "2026-05-11T01:59:13Z",
+          }),
+        });
+      },
+    );
+
+    const modal = await openAboutTab(page);
+    await modal
+      .getByRole("button", {
+        name: new RegExp(`What's new in ${TEST_VERSION}`),
+      })
+      .click();
+
+    const dialog = page.getByRole("dialog", {
+      name: /What's new in Acorn 1\.0\.7/,
+    });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(/public release body/)).toBeVisible();
+    await expect(
+      dialog.getByText(
+        new RegExp(`latest published .* no public release for ${TEST_VERSION}`),
+      ),
+    ).toBeVisible();
+  });
+
+  test("surfaces a network/rate-limit error inline without opening the modal", async ({
+    page,
+    errorTracker,
+  }) => {
+    // Same Chromium-level network warning as the 404 case — plus our own
+    // inline error rendering.
+    errorTracker.allow(/Failed to load resource/);
+    errorTracker.allow(/GitHub releases request failed/);
+    await page.route(
+      "https://api.github.com/repos/im-ian/acorn/releases/tags/v0.0.0-test",
+      async (route) => {
+        await route.fulfill({ status: 403, body: "rate limit" });
+      },
+    );
+
+    const modal = await openAboutTab(page);
+    await modal
+      .getByRole("button", {
+        name: new RegExp(`What's new in ${TEST_VERSION}`),
+      })
+      .click();
+
+    await expect(modal.getByText(/GitHub releases request failed: 403/)).toBeVisible();
+    // The dialog must not have opened on failure.
+    await expect(
+      page.getByRole("dialog", { name: /What's new in Acorn/ }),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an always-visible **"What's new in {currentVersion}"** button to the **Settings → About** tab. Clicking it fetches release notes for the running version directly from the public GitHub Releases API and opens the existing release-notes modal.

The Tauri updater only ships notes for the *next* version (the one waiting to install). This PR closes the gap: users can revisit "what changed in the version I'm on right now" without leaving the app.

## What changed

### New library

- `src/lib/releases.ts` — `fetchReleaseNotes(version)` hits `/repos/im-ian/acorn/releases/tags/v{version}`; `fetchLatestReleaseNotes()` hits `/releases/latest` for the fallback path.

### Modal refactor

- `WhatsNewModal` is now fully prop-driven (no store reads). The same component serves three flows:
  1. `UpdateBanner` — pending update with install action.
  2. About tab pending-update row — same content, same install affordance.
  3. About tab new "browse current" button — notes for the running version, **no install button**, optional `View on GitHub` link.

### Fallback for unreleased versions

- When `/releases/tags/v{version}` returns 404 (e.g. the running version's public release was overwritten, never published, or is a locally bumped dev build), the modal falls back to `/releases/latest` with a subtitle hint:
  > _latest published — no public release for 1.0.8_
- Network / rate-limit errors are caught and rendered **inline in the About tab**; the modal stays closed in that case so the user isn't confused by an empty dialog.

### Caching

- The fetched current-version notes are memoised in component state so reopening the modal in the same session does not refetch.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` — 10 files, 97 passed
  - 7 new unit cases in `src/lib/releases.test.ts` cover tag prefix normalisation, 404 → null, 403 → throw, null-body coercion, and the latest-release helper
- [x] `bun run test:e2e` — 30 files, all passing
  - 4 new Playwright cases in `tests/e2e/whats-new.spec.ts` exercise the button render, the 200 happy path, the 404 → latest-release fallback, and the inline-error path against `page.route()`-mocked GitHub
- [x] Manual smoke against the running dev build on `1.0.8` (no public release for that tag) — fallback subtitle shows v1.0.7 notes with the explanatory hint as designed
- [ ] After this lands, when the next public release is cut, verify the primary path (exact-tag match → `you're on this version` subtitle) on the upgraded build
