### PR TITLE
feat(pr-modal): layout-shaped skeleton for PR detail modal

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,8 @@
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^3",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "shiki": "^4.0.2",
         "tailwind-merge": "^3.5.0",
@@ -557,11 +559,23 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
+    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
+
+    "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
+
+    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
+
+    "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
+
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
+    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
+
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 
@@ -799,6 +813,10 @@
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
+    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
+
+    "rehype-sanitize": ["rehype-sanitize@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-sanitize": "^5.0.0" } }, "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg=="],
+
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
@@ -905,6 +923,8 @@
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
+    "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
+
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
@@ -912,6 +932,8 @@
     "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
@@ -959,10 +981,14 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "hast-util-raw/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.0.2",
     "tailwind-merge": "^3.5.0",

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -1,0 +1,88 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { ExternalLink, X } from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+interface ImageLightboxProps {
+  image: { src: string; alt?: string } | null;
+  onClose: () => void;
+}
+
+/**
+ * Fullscreen image viewer triggered from markdown `<img>` clicks. Uses a
+ * dedicated portal so it renders above any other Modal (e.g. the PR detail
+ * panel) and avoids stacking-context surprises. Backdrop click, Escape, and
+ * the close button all dismiss; the "Open in browser" button hands the URL
+ * to Tauri's opener so users can save / share the original.
+ */
+export function ImageLightbox({ image, onClose }: ImageLightboxProps) {
+  // The lightbox is the topmost overlay when it's open. Setting the
+  // `acorn-image-preview-open` flag on <body> lets useDialogShortcuts in
+  // underlying dialogs (e.g. the PR detail modal) bail out of their Escape
+  // handler so the lightbox dismisses first — keydown listeners on `window`
+  // capture-phase always fire in registration order, so the older listener
+  // can't be preempted without this signal.
+  useEffect(() => {
+    if (!image) return;
+    const body = document.body;
+    const previousOverflow = body.style.overflow;
+    body.style.overflow = "hidden";
+    body.dataset.acornImagePreviewOpen = "1";
+
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+      onClose();
+    }
+    window.addEventListener("keydown", onKey, { capture: true });
+
+    return () => {
+      body.style.overflow = previousOverflow;
+      delete body.dataset.acornImagePreviewOpen;
+      window.removeEventListener("keydown", onKey, { capture: true });
+    };
+  }, [image, onClose]);
+
+  if (!image) return null;
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Image preview"
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/85 p-6"
+      onClick={onClose}
+    >
+      <div className="absolute right-3 top-3 flex items-center gap-1">
+        <button
+          type="button"
+          aria-label="Open in browser"
+          onClick={(e) => {
+            e.stopPropagation();
+            void openUrl(image.src);
+          }}
+          className="rounded p-1.5 text-white/70 transition hover:bg-white/10 hover:text-white"
+        >
+          <ExternalLink size={16} />
+        </button>
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="rounded p-1.5 text-white/70 transition hover:bg-white/10 hover:text-white"
+        >
+          <X size={18} />
+        </button>
+      </div>
+      <img
+        src={image.src}
+        alt={image.alt ?? ""}
+        onClick={(e) => e.stopPropagation()}
+        className="max-h-[90vh] max-w-[90vw] cursor-default rounded border border-white/10 object-contain shadow-2xl"
+      />
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -481,8 +481,14 @@ function DetailSkeleton({
         ))}
       </nav>
 
-      <div className="min-h-0 flex-1 overflow-hidden">
-        <ul className="flex h-full flex-col gap-3 overflow-y-auto px-4 py-3">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="flex shrink-0 items-center justify-end border-b border-border/40 px-3 py-1.5">
+          <div className="flex items-center gap-1 px-1.5 py-0.5">
+            <span className="h-3 w-3 shrink-0 animate-pulse rounded-sm bg-fg-muted/15" />
+            <span className="h-2.5 w-16 animate-pulse rounded bg-fg-muted/15" />
+          </div>
+        </div>
+        <ul className="flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-3">
           {[
             { titleW: "w-24", bodyWidths: ["95%", "82%", "60%"] },
             { titleW: "w-32", bodyWidths: ["70%", "45%"] },

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -27,6 +27,7 @@ import type {
   PullRequestReview,
 } from "../lib/types";
 import { ClosePullRequestDialog } from "./ClosePullRequestDialog";
+import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { DiffSplitView } from "./DiffSplitView";
 import { MergePullRequestDialog } from "./MergePullRequestDialog";
 import { Tooltip } from "./Tooltip";
@@ -266,7 +267,11 @@ function DetailBody({
             </h3>
           </div>
           <p className="mt-1 truncate text-[11px] text-fg-muted">
-            <span className="font-mono">{detail.author}</span>
+            <AuthorTag
+              login={detail.author}
+              size={16}
+              nameClass="text-[11px] text-fg-muted"
+            />
             <span className="opacity-50"> · </span>
             <span className="font-mono">
               {detail.head_branch} → {detail.base_branch}
@@ -486,10 +491,10 @@ function DetailSkeleton({
               className="rounded border border-border bg-bg-sidebar/40 p-3"
             >
               <div className="mb-2 flex items-center gap-2">
-                <span className="h-[18px] w-[18px] shrink-0 animate-pulse rounded-full bg-fg-muted/15" />
+                <span className="h-7 w-7 shrink-0 animate-pulse rounded-full bg-fg-muted/15" />
                 <span
                   className={cn(
-                    "h-2.5 animate-pulse rounded bg-fg-muted/15",
+                    "h-3 animate-pulse rounded bg-fg-muted/15",
                     row.titleW,
                   )}
                 />
@@ -787,9 +792,12 @@ function ConversationPane({
 function CommentBlock({ comment }: { comment: PullRequestComment }) {
   return (
     <li className="rounded border border-border bg-bg-sidebar/40 p-3">
-      <div className="mb-2 flex items-center gap-2 text-[10px] text-fg-muted">
-        <AuthorAvatar login={comment.author} />
-        <span className="font-mono text-fg">{comment.author}</span>
+      <div className="mb-2 flex items-center gap-2 text-[10.5px] text-fg-muted">
+        <AuthorTag
+          login={comment.author}
+          size={28}
+          nameClass="text-[12.5px] font-semibold tracking-tight"
+        />
         <span className="opacity-60">commented</span>
         <span className="font-mono opacity-60">
           {formatTimestamp(comment.created_at)}
@@ -809,9 +817,12 @@ function CommentBlock({ comment }: { comment: PullRequestComment }) {
 function ReviewBlock({ review }: { review: PullRequestReview }) {
   return (
     <li className="rounded border border-border bg-bg-sidebar/40 p-3">
-      <div className="mb-2 flex items-center gap-2 text-[10px] text-fg-muted">
-        <AuthorAvatar login={review.author} />
-        <span className="font-mono text-fg">{review.author}</span>
+      <div className="mb-2 flex items-center gap-2 text-[10.5px] text-fg-muted">
+        <AuthorTag
+          login={review.author}
+          size={28}
+          nameClass="text-[12.5px] font-semibold tracking-tight"
+        />
         <ReviewStateBadge state={review.state} />
         <span className="font-mono opacity-60">
           {formatTimestamp(review.submitted_at)}
@@ -836,18 +847,91 @@ function ReviewBlock({ review }: { review: PullRequestReview }) {
  * the `[bot]` suffix is stripped. Falls back invisibly via `alt=""` on
  * load failure so the timeline stays clean.
  */
-function AuthorAvatar({ login }: { login: string }) {
+function AuthorAvatar({
+  login,
+  size = 24,
+  className,
+}: {
+  login: string;
+  size?: number;
+  className?: string;
+}) {
   const slug = login.replace(/\[bot\]$/, "");
   if (!slug) return null;
+  const pixelSize = Math.max(40, size * 2);
   return (
     <img
-      src={`https://github.com/${encodeURIComponent(slug)}.png?size=40`}
+      src={`https://github.com/${encodeURIComponent(slug)}.png?size=${pixelSize}`}
       alt=""
-      width={18}
-      height={18}
+      title={login}
+      width={size}
+      height={size}
       loading="lazy"
-      className="h-[18px] w-[18px] shrink-0 rounded-full bg-bg-elevated"
+      style={{ width: size, height: size }}
+      className={cn(
+        "shrink-0 rounded-full bg-bg-elevated align-middle",
+        className,
+      )}
     />
+  );
+}
+
+/**
+ * Avatar + login pair with a right-click context menu offering "Open
+ * GitHub profile". Used in the modal header and in each conversation
+ * block. Strips the `[bot]` suffix when building the profile URL so it
+ * resolves for bot accounts like `dependabot[bot]`.
+ */
+function AuthorTag({
+  login,
+  size = 24,
+  nameClass,
+  avatarOnly = false,
+}: {
+  login: string;
+  size?: number;
+  nameClass?: string;
+  /** When true, render only the avatar (no inline username text). */
+  avatarOnly?: boolean;
+}) {
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const slug = login.replace(/\[bot\]$/, "");
+  const profileUrl = slug ? `https://github.com/${slug}` : null;
+
+  const items: ContextMenuItem[] = profileUrl
+    ? [
+        {
+          label: "Open GitHub profile",
+          icon: <ExternalLink size={12} />,
+          onClick: () => void openUrl(profileUrl),
+        },
+      ]
+    : [];
+
+  return (
+    <>
+      <span
+        onContextMenu={(e) => {
+          if (!profileUrl) return;
+          e.preventDefault();
+          e.stopPropagation();
+          setMenu({ x: e.clientX, y: e.clientY });
+        }}
+        className="inline-flex shrink-0 items-center gap-1.5 align-middle"
+      >
+        <AuthorAvatar login={login} size={size} />
+        {avatarOnly ? null : (
+          <span className={cn("font-mono text-fg", nameClass)}>{login}</span>
+        )}
+      </span>
+      <ContextMenu
+        open={menu !== null}
+        x={menu?.x ?? 0}
+        y={menu?.y ?? 0}
+        items={items}
+        onClose={() => setMenu(null)}
+      />
+    </>
   );
 }
 

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -1,5 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  ArrowDownNarrowWide,
+  ArrowUpNarrowWide,
   Check,
   CheckCircle2,
   Circle,
@@ -743,6 +745,20 @@ function PrStateGlyph({
   return <GitPullRequest size={14} className="text-emerald-400" />;
 }
 
+type ConversationSort = "oldest" | "newest";
+
+const CONVERSATION_SORT_STORAGE_KEY = "acorn:pr-conversation-sort";
+
+function readStoredSort(): ConversationSort {
+  if (typeof window === "undefined") return "oldest";
+  try {
+    const raw = window.localStorage.getItem(CONVERSATION_SORT_STORAGE_KEY);
+    return raw === "newest" ? "newest" : "oldest";
+  } catch {
+    return "oldest";
+  }
+}
+
 function ConversationPane({
   comments,
   reviews,
@@ -750,42 +766,94 @@ function ConversationPane({
   comments: PullRequestComment[];
   reviews: PullRequestReview[];
 }) {
+  const [sort, setSort] = useState<ConversationSort>(() => readStoredSort());
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(CONVERSATION_SORT_STORAGE_KEY, sort);
+    } catch {
+      // non-persistent preference is fine
+    }
+  }, [sort]);
+
   // Merge into a single chronological timeline. Keep `kind` along for the
   // ride so we can render reviews with their verdict badge.
   type Entry =
     | { kind: "comment"; ts: string; comment: PullRequestComment }
     | { kind: "review"; ts: string; review: PullRequestReview };
-  const entries: Entry[] = [
-    ...comments.map<Entry>((c) => ({
-      kind: "comment",
-      ts: c.created_at,
-      comment: c,
-    })),
-    ...reviews.map<Entry>((r) => ({
-      kind: "review",
-      ts: r.submitted_at,
-      review: r,
-    })),
-  ].sort((a, b) => a.ts.localeCompare(b.ts));
+  const entries: Entry[] = useMemo(() => {
+    const merged: Entry[] = [
+      ...comments.map<Entry>((c) => ({
+        kind: "comment",
+        ts: c.created_at,
+        comment: c,
+      })),
+      ...reviews.map<Entry>((r) => ({
+        kind: "review",
+        ts: r.submitted_at,
+        review: r,
+      })),
+    ];
+    merged.sort((a, b) =>
+      sort === "newest" ? b.ts.localeCompare(a.ts) : a.ts.localeCompare(b.ts),
+    );
+    return merged;
+  }, [comments, reviews, sort]);
+
+  const toolbar = (
+    <div className="flex shrink-0 items-center justify-end border-b border-border/40 px-3 py-1.5">
+      <SortToggle value={sort} onChange={setSort} />
+    </div>
+  );
 
   if (entries.length === 0) {
     return (
-      <div className="flex h-full items-center justify-center text-xs text-fg-muted">
-        No comments or reviews yet.
+      <div className="flex h-full flex-col">
+        {toolbar}
+        <div className="flex flex-1 items-center justify-center text-xs text-fg-muted">
+          No comments or reviews yet.
+        </div>
       </div>
     );
   }
 
   return (
-    <ul className="flex h-full flex-col gap-3 overflow-y-auto px-4 py-3">
-      {entries.map((entry, i) =>
-        entry.kind === "comment" ? (
-          <CommentBlock key={`c-${i}`} comment={entry.comment} />
-        ) : (
-          <ReviewBlock key={`r-${i}`} review={entry.review} />
-        ),
-      )}
-    </ul>
+    <div className="flex h-full flex-col">
+      {toolbar}
+      <ul className="flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-3">
+        {entries.map((entry, i) =>
+          entry.kind === "comment" ? (
+            <CommentBlock key={`c-${i}`} comment={entry.comment} />
+          ) : (
+            <ReviewBlock key={`r-${i}`} review={entry.review} />
+          ),
+        )}
+      </ul>
+    </div>
+  );
+}
+
+function SortToggle({
+  value,
+  onChange,
+}: {
+  value: ConversationSort;
+  onChange: (next: ConversationSort) => void;
+}) {
+  const isOldest = value === "oldest";
+  const label = isOldest ? "Oldest first" : "Newest first";
+  const Icon = isOldest ? ArrowDownNarrowWide : ArrowUpNarrowWide;
+  return (
+    <Tooltip label="Toggle sort order" side="bottom">
+      <button
+        type="button"
+        onClick={() => onChange(isOldest ? "newest" : "oldest")}
+        className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+      >
+        <Icon size={12} />
+        {label}
+      </button>
+    </Tooltip>
   );
 }
 

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -486,6 +486,7 @@ function DetailSkeleton({
               className="rounded border border-border bg-bg-sidebar/40 p-3"
             >
               <div className="mb-2 flex items-center gap-2">
+                <span className="h-[18px] w-[18px] shrink-0 animate-pulse rounded-full bg-fg-muted/15" />
                 <span
                   className={cn(
                     "h-2.5 animate-pulse rounded bg-fg-muted/15",
@@ -787,6 +788,7 @@ function CommentBlock({ comment }: { comment: PullRequestComment }) {
   return (
     <li className="rounded border border-border bg-bg-sidebar/40 p-3">
       <div className="mb-2 flex items-center gap-2 text-[10px] text-fg-muted">
+        <AuthorAvatar login={comment.author} />
         <span className="font-mono text-fg">{comment.author}</span>
         <span className="opacity-60">commented</span>
         <span className="font-mono opacity-60">
@@ -808,6 +810,7 @@ function ReviewBlock({ review }: { review: PullRequestReview }) {
   return (
     <li className="rounded border border-border bg-bg-sidebar/40 p-3">
       <div className="mb-2 flex items-center gap-2 text-[10px] text-fg-muted">
+        <AuthorAvatar login={review.author} />
         <span className="font-mono text-fg">{review.author}</span>
         <ReviewStateBadge state={review.state} />
         <span className="font-mono opacity-60">
@@ -824,6 +827,27 @@ function ReviewBlock({ review }: { review: PullRequestReview }) {
         </p>
       )}
     </li>
+  );
+}
+
+/**
+ * Inline 18px GitHub avatar. Uses the public `github.com/{login}.png`
+ * endpoint — no API token needed and it works for `[bot]` accounts when
+ * the `[bot]` suffix is stripped. Falls back invisibly via `alt=""` on
+ * load failure so the timeline stays clean.
+ */
+function AuthorAvatar({ login }: { login: string }) {
+  const slug = login.replace(/\[bot\]$/, "");
+  if (!slug) return null;
+  return (
+    <img
+      src={`https://github.com/${encodeURIComponent(slug)}.png?size=40`}
+      alt=""
+      width={18}
+      height={18}
+      loading="lazy"
+      className="h-[18px] w-[18px] shrink-0 rounded-full bg-bg-elevated"
+    />
   );
 }
 

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -133,11 +133,12 @@ export function PullRequestDetailModal({
             <div className="p-4 text-xs text-danger">{error}</div>
           </ModalShell>
         ) : !listing ? (
-          <ModalShell title={`#${open.number}`} onClose={onClose}>
-            <div className="flex h-full items-center justify-center text-xs text-fg-muted">
-              Loading PR…
-            </div>
-          </ModalShell>
+          <DetailSkeleton
+            number={open.number}
+            onClose={onClose}
+            onRefresh={handleRefresh}
+            refreshing={refreshing}
+          />
         ) : listing.kind === "not_github" ? (
           <ModalShell title={`#${open.number}`} onClose={onClose}>
             <div className="p-4 text-xs text-fg-muted">
@@ -380,6 +381,132 @@ function DetailBody({
         ) : (
           <DiffSplitView payload={detail.diff} cwd={cwd} />
         )}
+      </div>
+    </>
+  );
+}
+
+/**
+ * Loading placeholder that mirrors `DetailBody`'s layout — header line,
+ * meta line, body block, tab nav, and a stack of comment cards — so the
+ * modal doesn't reflow when real data lands. Refresh + close stay live
+ * during the fetch.
+ */
+function DetailSkeleton({
+  number,
+  onClose,
+  onRefresh,
+  refreshing,
+}: {
+  number: number;
+  onClose: () => void;
+  onRefresh: () => void;
+  refreshing: boolean;
+}) {
+  return (
+    <>
+      <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="h-3.5 w-3.5 shrink-0 animate-pulse rounded-full bg-fg-muted/20" />
+            <span className="font-mono text-xs text-fg-muted">#{number}</span>
+            <span className="h-3.5 w-[55%] animate-pulse rounded bg-fg-muted/15" />
+          </div>
+          <div className="mt-2 flex items-center gap-1.5">
+            <span className="h-2.5 w-16 shrink-0 animate-pulse rounded bg-fg-muted/10" />
+            <span className="text-[10px] text-fg-muted/40">·</span>
+            <span className="h-2.5 w-40 shrink-0 animate-pulse rounded bg-fg-muted/10" />
+            <span className="text-[10px] text-fg-muted/40">·</span>
+            <span className="h-2.5 w-8 shrink-0 animate-pulse rounded bg-fg-muted/10" />
+            <span className="h-2.5 w-8 shrink-0 animate-pulse rounded bg-fg-muted/10" />
+            <span className="text-[10px] text-fg-muted/40">·</span>
+            <span className="h-2.5 w-14 shrink-0 animate-pulse rounded bg-fg-muted/10" />
+            <span className="text-[10px] text-fg-muted/40">·</span>
+            <span className="h-2.5 w-16 shrink-0 animate-pulse rounded bg-fg-muted/10" />
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <RefreshButton onClick={onRefresh} loading={refreshing} size={14} />
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      </header>
+
+      <div
+        className="shrink-0 overflow-hidden border-b border-border bg-bg-sidebar/40 px-4 py-3"
+        style={{ height: BODY_HEIGHT_DEFAULT }}
+      >
+        <div className="flex flex-col gap-2">
+          <span className="h-3 w-[85%] animate-pulse rounded bg-fg-muted/10" />
+          <span className="h-3 w-[72%] animate-pulse rounded bg-fg-muted/10" />
+          <span className="h-3 w-[40%] animate-pulse rounded bg-fg-muted/10" />
+          <span className="mt-2 h-3 w-[60%] animate-pulse rounded bg-fg-muted/10" />
+          <span className="h-3 w-[78%] animate-pulse rounded bg-fg-muted/10" />
+          <span className="h-3 w-[35%] animate-pulse rounded bg-fg-muted/10" />
+        </div>
+      </div>
+      <div
+        aria-hidden
+        className="h-1.5 shrink-0 border-b border-border bg-bg-sidebar/40"
+      />
+
+      <nav className="flex shrink-0 border-b border-border">
+        {[
+          { icon: <MessagesSquare size={13} />, w: "w-20" },
+          { icon: <CheckCircle2 size={13} />, w: "w-12" },
+          { icon: <GitPullRequest size={13} />, w: "w-10" },
+        ].map((tab, i) => (
+          <div
+            key={i}
+            className="flex shrink-0 items-center gap-1.5 px-3 py-2 text-xs text-fg-muted/60"
+          >
+            {tab.icon}
+            <span
+              className={cn("h-2.5 animate-pulse rounded bg-fg-muted/15", tab.w)}
+            />
+          </div>
+        ))}
+      </nav>
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ul className="flex h-full flex-col gap-3 overflow-y-auto px-4 py-3">
+          {[
+            { titleW: "w-24", bodyWidths: ["95%", "82%", "60%"] },
+            { titleW: "w-32", bodyWidths: ["70%", "45%"] },
+            { titleW: "w-20", bodyWidths: ["88%", "76%", "52%", "30%"] },
+          ].map((row, i) => (
+            <li
+              key={i}
+              className="rounded border border-border bg-bg-sidebar/40 p-3"
+            >
+              <div className="mb-2 flex items-center gap-2">
+                <span
+                  className={cn(
+                    "h-2.5 animate-pulse rounded bg-fg-muted/15",
+                    row.titleW,
+                  )}
+                />
+                <span className="h-2.5 w-14 animate-pulse rounded bg-fg-muted/10" />
+                <span className="h-2.5 w-20 animate-pulse rounded bg-fg-muted/10" />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                {row.bodyWidths.map((w, j) => (
+                  <span
+                    key={j}
+                    className="h-3 animate-pulse rounded bg-fg-muted/10"
+                    style={{ width: w }}
+                  />
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
       </div>
     </>
   );

--- a/src/components/ui/Markdown.tsx
+++ b/src/components/ui/Markdown.tsx
@@ -1,8 +1,41 @@
 import { memo } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { cn } from "../../lib/cn";
+
+// Sanitize schema for PR/comment markdown bodies — they routinely embed raw
+// HTML (image uploads, GitHub's `<img width="…">` snippets, details/summary).
+// Extend the rehype default with the attrs GitHub commonly uses.
+const sanitizeSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    img: [
+      ...(defaultSchema.attributes?.img ?? []),
+      "src",
+      "alt",
+      "title",
+      "width",
+      "height",
+      "loading",
+    ],
+    a: [
+      ...(defaultSchema.attributes?.a ?? []),
+      "href",
+      "title",
+      "target",
+      "rel",
+    ],
+  },
+  tagNames: [
+    ...(defaultSchema.tagNames ?? []),
+    "details",
+    "summary",
+  ],
+};
 
 interface MarkdownProps {
   content: string;
@@ -130,11 +163,13 @@ const components: Components = {
       </td>
     );
   },
-  img({ src, alt }) {
+  img({ src, alt, width, height }) {
     return (
       <img
         src={typeof src === "string" ? src : undefined}
         alt={alt ?? ""}
+        width={width}
+        height={height}
         className="my-2 max-w-full rounded border border-border"
         loading="lazy"
       />
@@ -159,7 +194,11 @@ const components: Components = {
 function MarkdownImpl({ content, className }: MarkdownProps) {
   return (
     <div className={cn("text-[11.5px] leading-relaxed text-fg", className)}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema]]}
+        components={components}
+      >
         {content}
       </ReactMarkdown>
     </div>

--- a/src/components/ui/Markdown.tsx
+++ b/src/components/ui/Markdown.tsx
@@ -1,10 +1,11 @@
-import { memo } from "react";
+import { memo, useMemo, useState } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { cn } from "../../lib/cn";
+import { ImageLightbox } from "../ImageLightbox";
 
 // Sanitize schema for PR/comment markdown bodies — they routinely embed raw
 // HTML (image uploads, GitHub's `<img width="…">` snippets, details/summary).
@@ -42,7 +43,7 @@ interface MarkdownProps {
   className?: string;
 }
 
-const components: Components = {
+const baseComponents: Components = {
   a({ href, children, ...rest }) {
     return (
       <a
@@ -163,18 +164,8 @@ const components: Components = {
       </td>
     );
   },
-  img({ src, alt, width, height }) {
-    return (
-      <img
-        src={typeof src === "string" ? src : undefined}
-        alt={alt ?? ""}
-        width={width}
-        height={height}
-        className="my-2 max-w-full rounded border border-border"
-        loading="lazy"
-      />
-    );
-  },
+  // img is overridden per-instance in MarkdownImpl so it can hook into the
+  // lightbox state.
   input({ type, checked, disabled }) {
     if (type === "checkbox") {
       return (
@@ -192,16 +183,47 @@ const components: Components = {
 };
 
 function MarkdownImpl({ content, className }: MarkdownProps) {
+  const [lightbox, setLightbox] = useState<
+    { src: string; alt?: string } | null
+  >(null);
+
+  const components = useMemo<Components>(
+    () => ({
+      ...baseComponents,
+      img({ src, alt, width, height }) {
+        const url = typeof src === "string" ? src : undefined;
+        return (
+          <img
+            src={url}
+            alt={alt ?? ""}
+            width={width}
+            height={height}
+            loading="lazy"
+            onClick={() => {
+              if (!url) return;
+              setLightbox({ src: url, alt: alt ?? undefined });
+            }}
+            className="my-2 max-w-full cursor-zoom-in rounded border border-border transition hover:opacity-90"
+          />
+        );
+      },
+    }),
+    [],
+  );
+
   return (
-    <div className={cn("text-[11.5px] leading-relaxed text-fg", className)}>
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema]]}
-        components={components}
-      >
-        {content}
-      </ReactMarkdown>
-    </div>
+    <>
+      <div className={cn("text-[11.5px] leading-relaxed text-fg", className)}>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema]]}
+          components={components}
+        >
+          {content}
+        </ReactMarkdown>
+      </div>
+      <ImageLightbox image={lightbox} onClose={() => setLightbox(null)} />
+    </>
   );
 }
 

--- a/src/lib/dialog.ts
+++ b/src/lib/dialog.ts
@@ -24,6 +24,10 @@ export function useDialogShortcuts(
     if (!open) return;
 
     function onKey(e: KeyboardEvent) {
+      // A higher overlay (e.g. ImageLightbox) is on top — let it own the
+      // keyboard shortcuts until it dismisses.
+      if (document.body.dataset.acornImagePreviewOpen === "1") return;
+
       if (e.key === "Escape") {
         if (!onCancel) return;
         e.preventDefault();


### PR DESCRIPTION
## Summary

PR detail modal had a bare `Loading PR…` text fallback during fetch. Replaced with a skeleton that mirrors `DetailBody` layout so the modal doesn't reflow when data arrives.

## Changes

`src/components/PullRequestDetailModal.tsx`

- New `DetailSkeleton` component, replaces `!listing` branch
- Mirrors `DetailBody` shape:
  - Header: state-glyph circle, real `#number`, title bar, meta line (author · branches · `+`/`−` · files · account)
  - Body block: fixed at `BODY_HEIGHT_DEFAULT` (192px), six text-line bars
  - Resize separator strip
  - Tab nav: 3 tabs with real `MessagesSquare` / `CheckCircle2` / `GitPullRequest` icons + label bars
  - Content pane: 3 comment-card skeletons in the same `CommentBlock` shape
- Width variety per row so it reads as distinct items, not a stripe
- Reuses existing tokens (`animate-pulse`, `bg-fg-muted/10`, `bg-fg-muted/15`, `border-border`, `bg-bg-sidebar/40`) — consistent with `PrSkeletonRow` in `RightPanel.tsx`
- Refresh + close buttons stay live during fetch
- `ModalShell` retained for `error` / `not_github` / `no_access` branches

## Test plan

- [ ] Open Pull Requests panel → click any PR cold → skeleton flashes during `getPullRequestDetail` fetch
- [ ] Skeleton header `#number` matches the clicked PR
- [ ] Tabs (`Conversation` / `Checks` / `Files`) icons render in nav
- [ ] No layout shift when real data lands — header, body, tab nav, content pane sit at same y-offsets
- [ ] Close (`X`) + refresh buttons clickable during skeleton state
- [ ] `error` / `not_github` / `no_access` branches still render `ModalShell` fallback
- [ ] `bun run typecheck` clean
