### PR TITLE
feat(sessions): add control-session kind (UI foundation)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,7 +13,7 @@ use crate::pull_requests::{
     PullRequestListing,
 };
 use crate::scrollback;
-use crate::session::{Project, Session, SessionStartupMode, SessionStatus};
+use crate::session::{Project, Session, SessionKind, SessionStartupMode, SessionStatus};
 use crate::session_status;
 use crate::shell_util::shell_quote;
 use crate::state::AppState;
@@ -188,6 +188,7 @@ pub async fn create_session(
     repo_path: String,
     isolated: Option<bool>,
     startup_mode: Option<SessionStartupMode>,
+    kind: Option<SessionKind>,
 ) -> AppResult<Session> {
     let repo = PathBuf::from(&repo_path);
     if !repo.exists() {
@@ -210,6 +211,7 @@ pub async fn create_session(
         branch,
         isolated,
         startup_mode,
+        kind.unwrap_or_default(),
     );
     let inserted = state.sessions.insert(session);
     state.projects.ensure(repo.clone(), project_basename(&repo));

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -135,6 +135,19 @@ pub enum SessionStartupMode {
     Custom,
 }
 
+/// Distinguishes ordinary terminal sessions from "control" sessions, which
+/// will (in a follow-up PR) be allowed to drive other sessions in the same
+/// project via the `acorn-ipc` CLI. Orthogonal to `SessionStartupMode`:
+/// either kind can run any startup flavor. Defaults to `Regular` so existing
+/// persisted sessions without this field load cleanly.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionKind {
+    #[default]
+    Regular,
+    Control,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     pub id: Uuid,
@@ -150,6 +163,8 @@ pub struct Session {
     pub last_message: Option<String>,
     #[serde(default)]
     pub startup_mode: Option<SessionStartupMode>,
+    #[serde(default)]
+    pub kind: SessionKind,
 }
 
 impl Session {
@@ -160,6 +175,7 @@ impl Session {
         branch: String,
         isolated: bool,
         startup_mode: Option<SessionStartupMode>,
+        kind: SessionKind,
     ) -> Self {
         let now = Utc::now();
         Self {
@@ -174,6 +190,7 @@ impl Session {
             updated_at: now,
             last_message: None,
             startup_mode,
+            kind,
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,10 @@ import { EQUALIZE_PANES_EVENT } from "./lib/layoutEvents";
 import { RightPanel } from "./components/RightPanel";
 import { ResizeHandle } from "./components/ResizeHandle";
 import { CommandPalette } from "./components/CommandPalette";
+import {
+  ControlSessionGuideModal,
+  CONTROL_GUIDE_DISMISSED_KEY,
+} from "./components/ControlSessionGuideModal";
 import { SettingsModal } from "./components/SettingsModal";
 import { TerminalHost } from "./components/TerminalHost";
 import { ToastHost } from "./components/ToastHost";
@@ -70,6 +74,7 @@ function App() {
     ? sessions.filter((s) => s.repo_path === pendingProject.repo_path)
     : [];
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [controlGuideOpen, setControlGuideOpen] = useState(false);
   const sidebarPanelRef = useRef<ImperativePanelHandle | null>(null);
   const rightPanelRef = useRef<ImperativePanelHandle | null>(null);
 
@@ -134,6 +139,17 @@ function App() {
     clearPendingRemove();
     removeSession(pendingRemove.id, false);
   }, [pendingRemove, clearPendingRemove, removeSession]);
+
+  // Surface the one-time guide modal after the first control-session
+  // creation. The store dispatches `acorn:show-control-guide` only when the
+  // dismissed-flag is unset, so this handler can stay dumb and just open.
+  useEffect(() => {
+    const handler = () => setControlGuideOpen(true);
+    window.addEventListener("acorn:show-control-guide", handler);
+    return () => {
+      window.removeEventListener("acorn:show-control-guide", handler);
+    };
+  }, []);
 
   // The Tauri app menu fires `acorn:open-settings` when the user picks
   // "Settings..." from the macOS app menu (or hits its Cmd+, accelerator).
@@ -230,6 +246,10 @@ function App() {
       [Hotkeys.newIsolatedSession]: (e: KeyboardEvent) => {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent("acorn:new-isolated-session"));
+      },
+      [Hotkeys.newControlSession]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent("acorn:new-control-session"));
       },
       [Hotkeys.addProject]: (e: KeyboardEvent) => {
         e.preventDefault();
@@ -433,6 +453,15 @@ function App() {
       <StatusBar />
       <TerminalHost />
       <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+      <ControlSessionGuideModal
+        open={controlGuideOpen}
+        onClose={(dontShowAgain) => {
+          setControlGuideOpen(false);
+          if (dontShowAgain && typeof window !== "undefined") {
+            window.localStorage.setItem(CONTROL_GUIDE_DISMISSED_KEY, "1");
+          }
+        }}
+      />
       <SettingsModal />
       <RemoveSessionDialog
         session={pendingRemove}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Command } from "cmdk";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import {
+  Bot,
   GitCommit,
   GitPullRequest,
   ListChecks,
@@ -47,6 +48,26 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       }
       const name = deriveSessionName(repoPath, sessionItems);
       await useAppStore.getState().createSession(name, repoPath);
+    } finally {
+      close();
+    }
+  }
+
+  async function handleNewControlSession() {
+    try {
+      const repoPath = await openDialog({
+        directory: true,
+        multiple: false,
+        title: "Select a directory (control session)",
+      });
+      if (!repoPath || typeof repoPath !== "string") {
+        close();
+        return;
+      }
+      const name = deriveSessionName(repoPath, sessionItems, "control");
+      await useAppStore
+        .getState()
+        .createSession(name, repoPath, false, "control");
     } finally {
       close();
     }
@@ -139,6 +160,14 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           <Command.Item value="new-session" onSelect={handleNewSession}>
             <Plus size={14} className="text-accent" />
             <span>New session</span>
+          </Command.Item>
+          <Command.Item
+            value="new-control-session"
+            onSelect={handleNewControlSession}
+            keywords={["control", "ipc", "dispatcher", "orchestrator"]}
+          >
+            <Bot size={14} className="text-accent" />
+            <span>New control session</span>
           </Command.Item>
           <Command.Item value="refresh-sessions" onSelect={handleRefresh}>
             <RefreshCw size={14} className="text-fg-muted" />
@@ -233,10 +262,17 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   );
 }
 
-function deriveSessionName(repoPath: string, existing: Session[]): string {
-  const base =
+function deriveSessionName(
+  repoPath: string,
+  existing: Session[],
+  kind: "regular" | "control" = "regular",
+): string {
+  const folder =
     repoPath.split(/[\\/]/).filter(Boolean).pop() ??
     `session-${existing.length + 1}`;
+  // Mirror Sidebar.tsx's "control-" prefix so the kind is obvious from the
+  // name alone, even when the row's accessory icon is not in view.
+  const base = kind === "control" ? `control-${folder}` : folder;
   let candidate = base;
   let n = 2;
   const taken = new Set(existing.map((s) => s.name));

--- a/src/components/ControlSessionGuideModal.tsx
+++ b/src/components/ControlSessionGuideModal.tsx
@@ -1,0 +1,90 @@
+import { useState, type ReactElement } from "react";
+import { Bot } from "lucide-react";
+import { Modal } from "./ui/Modal";
+import { ModalHeader } from "./ui/ModalHeader";
+import { CheckboxRow } from "./ui/CheckboxRow";
+
+/**
+ * localStorage key gating this modal. Exported so the App-level host can write
+ * to it when the user dismisses with "don't show again". The matching read
+ * (the gate that decides whether to open at all) lives in `store.ts` where
+ * the session is created.
+ *
+ * Versioned so a future substantive change to the control-session UX can
+ * re-surface the guide to existing users without colliding with the prior
+ * dismissed state.
+ */
+export const CONTROL_GUIDE_DISMISSED_KEY = "acorn:control-guide-dismissed-v1";
+
+interface ControlSessionGuideModalProps {
+  open: boolean;
+  /** Called with `true` when the user checked "don't show again" before closing. */
+  onClose: (dontShowAgain: boolean) => void;
+}
+
+/**
+ * One-time onboarding card shown the first time the user creates a control
+ * session. Explains the concept and previews the upcoming `acorn-ipc` CLI.
+ * Purely informational — does not block creation.
+ */
+export function ControlSessionGuideModal({
+  open,
+  onClose,
+}: ControlSessionGuideModalProps): ReactElement | null {
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  function dismiss() {
+    onClose(dontShowAgain);
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={dismiss}
+      variant="dialog"
+      size="lg"
+      ariaLabelledBy="acorn-control-guide-title"
+    >
+      <ModalHeader
+        title="Control session"
+        subtitle="A terminal that drives other sessions in this project"
+        titleId="acorn-control-guide-title"
+        icon={<Bot size={14} className="text-accent" />}
+        variant="dialog"
+        onClose={dismiss}
+      />
+      <div className="space-y-3 px-4 py-4 text-xs text-fg-muted">
+        <p>
+          Control sessions are an upcoming way to coordinate work across
+          terminals from a single place — handy for agents and scripts that
+          need to dispatch commands to siblings in the same project.
+        </p>
+        <ul className="ml-4 list-disc space-y-1">
+          <li>Send keystrokes to any session in this project.</li>
+          <li>List the other sessions and their status.</li>
+          <li>Read recent output from a target session.</li>
+        </ul>
+        <p>
+          You just created a control session. The{" "}
+          <code className="rounded bg-bg px-1 py-0.5 text-fg">acorn-ipc</code>{" "}
+          CLI that drives it ships in the next update; this terminal will
+          start behaving like a regular shell until then.
+        </p>
+        <CheckboxRow
+          label="Don't show this again"
+          checked={dontShowAgain}
+          onChange={setDontShowAgain}
+        />
+      </div>
+      <footer className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+        <button
+          type="button"
+          onClick={dismiss}
+          className="rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90"
+        >
+          Got it
+        </button>
+      </footer>
+    </Modal>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  Bot,
   ChevronRight,
   Copy,
   Files,
@@ -25,7 +26,7 @@ import {
   planTitleClick,
   type ProjectClickPlan,
 } from "../lib/sidebar-actions";
-import type { Project, Session, SessionStatus } from "../lib/types";
+import type { Project, Session, SessionKind, SessionStatus } from "../lib/types";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { Tooltip } from "./Tooltip";
 
@@ -206,33 +207,47 @@ export function Sidebar() {
   }
 
   const onNewSessionRef = useRef<
-    (isolated: boolean, repoOverride?: string) => Promise<void>
+    (
+      isolated: boolean,
+      kind: SessionKind,
+      repoOverride?: string,
+    ) => Promise<void>
   >(async () => {});
   const onAddProjectRef = useRef<() => Promise<void>>(async () => {});
 
   useEffect(() => {
     const newSession = () => {
       const project = useAppStore.getState().activeProject;
-      void onNewSessionRef.current(false, project ?? undefined);
+      void onNewSessionRef.current(false, "regular", project ?? undefined);
     };
     const newIsolated = () => {
       const project = useAppStore.getState().activeProject;
-      void onNewSessionRef.current(true, project ?? undefined);
+      void onNewSessionRef.current(true, "regular", project ?? undefined);
+    };
+    const newControl = () => {
+      const project = useAppStore.getState().activeProject;
+      void onNewSessionRef.current(false, "control", project ?? undefined);
     };
     const addProj = () => {
       void onAddProjectRef.current();
     };
     window.addEventListener("acorn:new-session", newSession);
     window.addEventListener("acorn:new-isolated-session", newIsolated);
+    window.addEventListener("acorn:new-control-session", newControl);
     window.addEventListener("acorn:add-project", addProj);
     return () => {
       window.removeEventListener("acorn:new-session", newSession);
       window.removeEventListener("acorn:new-isolated-session", newIsolated);
+      window.removeEventListener("acorn:new-control-session", newControl);
       window.removeEventListener("acorn:add-project", addProj);
     };
   }, []);
 
-  async function onNewSession(isolated: boolean, repoOverride?: string) {
+  async function onNewSession(
+    isolated: boolean,
+    kind: SessionKind,
+    repoOverride?: string,
+  ) {
     try {
       const repoPath =
         repoOverride ??
@@ -241,11 +256,13 @@ export function Sidebar() {
           multiple: false,
           title: isolated
             ? "Select a git repository (isolated worktree)"
-            : "Select a directory",
+            : kind === "control"
+              ? "Select a directory (control session)"
+              : "Select a directory",
         }));
       if (!repoPath || typeof repoPath !== "string") return;
-      const name = suggestName(repoPath, sessions);
-      await createSession(name, repoPath, isolated);
+      const name = suggestName(repoPath, sessions, kind);
+      await createSession(name, repoPath, isolated, kind);
       setCollapsed((prev) => {
         if (!prev.has(repoPath)) return prev;
         const next = new Set(prev);
@@ -334,8 +351,8 @@ export function Sidebar() {
                 }}
                 onSelectSession={selectSession}
                 onRemoveSession={(s) => requestRemoveSession(s.id)}
-                onAddSession={(isolated) =>
-                  onNewSession(isolated, project.repoPath)
+                onAddSession={(isolated, kind) =>
+                  onNewSession(isolated, kind, project.repoPath)
                 }
                 onRemoveProject={() => requestRemoveProject(project.repoPath)}
               />
@@ -394,7 +411,7 @@ interface ProjectGroupViewProps {
   onActivate: () => void;
   onSelectSession: (id: string) => void;
   onRemoveSession: (s: Session) => void;
-  onAddSession: (isolated: boolean) => void;
+  onAddSession: (isolated: boolean, kind: SessionKind) => void;
   onRemoveProject: () => void;
 }
 
@@ -522,7 +539,7 @@ function ProjectGroupView({
             type="button"
             onClick={(e) => {
               e.stopPropagation();
-              onAddSession(false);
+              onAddSession(false, "regular");
             }}
             className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
             aria-label="New session in this project"
@@ -535,12 +552,25 @@ function ProjectGroupView({
             type="button"
             onClick={(e) => {
               e.stopPropagation();
-              onAddSession(true);
+              onAddSession(true, "regular");
             }}
             className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
             aria-label="New isolated session (worktree)"
           >
             <GitBranch size={12} />
+          </button>
+        </Tooltip>
+        <Tooltip label="New control session" side="bottom">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onAddSession(false, "control");
+            }}
+            className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
+            aria-label="New control session in this project"
+          >
+            <Bot size={12} />
           </button>
         </Tooltip>
         <Tooltip label="Close project" side="bottom">
@@ -566,12 +596,17 @@ function ProjectGroupView({
           {
             label: "New session",
             icon: <Plus size={12} />,
-            onClick: () => onAddSession(false),
+            onClick: () => onAddSession(false, "regular"),
           },
           {
             label: "New isolated session",
             icon: <GitBranch size={12} />,
-            onClick: () => onAddSession(true),
+            onClick: () => onAddSession(true, "regular"),
+          },
+          {
+            label: "New control session",
+            icon: <Bot size={12} />,
+            onClick: () => onAddSession(false, "control"),
           },
           { type: "separator" },
           {
@@ -603,11 +638,11 @@ function ProjectGroupView({
               role="button"
               tabIndex={0}
               onClick={onActivate}
-              onDoubleClick={() => onAddSession(false)}
+              onDoubleClick={() => onAddSession(false, "regular")}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
-                  onAddSession(false);
+                  onAddSession(false, "regular");
                 }
               }}
               className="cursor-pointer rounded px-2 py-1 text-[11px] text-fg-muted transition select-none hover:bg-bg-elevated/40 hover:text-fg"
@@ -658,14 +693,15 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
       n += 1;
     }
     try {
-      // Carry the source session's startup mode onto the duplicate so
-      // the duplicate respawns with the same kind of process, regardless
-      // of the current global default.
+      // Carry the source session's startup mode and kind onto the duplicate
+      // so the duplicate respawns with the same kind of process and (for
+      // control sessions) preserves its IPC-dispatch role.
       await api.createSession(
         next,
         session.repo_path,
         session.isolated,
         session.startup_mode,
+        session.kind,
       );
       await useAppStore.getState().refreshAll();
     } catch (err) {
@@ -790,6 +826,13 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
                 size={10}
                 className="shrink-0 text-fg-muted"
                 aria-label="isolated worktree"
+              />
+            ) : null}
+            {session.kind === "control" ? (
+              <Bot
+                size={10}
+                className="shrink-0 text-accent"
+                aria-label="control session"
               />
             ) : null}
           </span>
@@ -917,8 +960,15 @@ function basename(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
 }
 
-function suggestName(repoPath: string, existing: Session[]): string {
-  const base = basename(repoPath);
+function suggestName(
+  repoPath: string,
+  existing: Session[],
+  kind: SessionKind = "regular",
+): string {
+  // Control sessions get a "control-" prefix so they sort into a clearly
+  // distinct namespace at-a-glance, mirroring how `tmux` users name dedicated
+  // controller panes.
+  const base = kind === "control" ? `control-${basename(repoPath)}` : basename(repoPath);
   let candidate = base;
   let n = 2;
   const taken = new Set(existing.map((s) => s.name));

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   PullRequestDetailListing,
   PullRequestListing,
   Session,
+  SessionKind,
   SessionStartupMode,
   SessionStatus,
   StagedFile,
@@ -33,12 +34,14 @@ export const api = {
     repoPath: string,
     isolated = false,
     startupMode: SessionStartupMode | null = null,
+    kind: SessionKind = "regular",
   ): Promise<Session> {
     return invoke<Session>("create_session", {
       name,
       repoPath,
       isolated,
       startupMode,
+      kind,
     });
   },
   removeSession(id: string, removeWorktree = false): Promise<void> {

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -25,6 +25,10 @@ export const Hotkeys = {
   clearTerminal: "$mod+k",
   newSession: "$mod+t",
   newIsolatedSession: "$mod+Alt+t",
+  // "Control session" — extends the new-session family. Future PRs add the
+  // `acorn-ipc` CLI so this kind of session can drive sibling sessions; the
+  // hotkey lives next to the other terminal-creation bindings for symmetry.
+  newControlSession: "$mod+Alt+Shift+t",
   addProject: "$mod+Shift+n",
   focusSidebar: "$mod+1",
   focusMain: "$mod+2",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,15 @@ export type SessionStatus =
  */
 export type SessionStartupMode = "agent" | "terminal" | "custom";
 
+/**
+ * Distinguishes ordinary terminal sessions from "control" sessions. Control
+ * sessions are the entry point for the upcoming `acorn-ipc` CLI, which lets
+ * them dispatch commands to other sessions in the same project. Orthogonal
+ * to `SessionStartupMode` — either kind can run any startup flavor. Older
+ * persisted sessions without this field load as `"regular"` from the backend.
+ */
+export type SessionKind = "regular" | "control";
+
 export interface Session {
   id: string;
   name: string;
@@ -26,6 +35,7 @@ export interface Session {
   updated_at: string;
   last_message: string | null;
   startup_mode: SessionStartupMode | null;
+  kind: SessionKind;
 }
 
 export interface Project {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -67,6 +67,7 @@ function session(
     updated_at: "2026-01-01T00:00:00Z",
     last_message: null,
     startup_mode: null,
+    kind: "regular",
     ...overrides,
   };
 }
@@ -548,5 +549,91 @@ describe("reorderProjects", () => {
     await useAppStore.getState().reorderProjects([REPO_B, REPO_A]);
     expect(useAppStore.getState().projects).toEqual(before);
     expect(useAppStore.getState().error).toBe("nope");
+  });
+});
+
+describe("createSession", () => {
+  // Each control-session test reaches into localStorage; clear it so
+  // an earlier test's "don't show again" flag does not leak forward.
+  const guideKey = "acorn:control-guide-dismissed-v1";
+
+  beforeEach(() => {
+    window.localStorage.removeItem(guideKey);
+  });
+
+  it("defaults the kind to regular when the caller omits it", async () => {
+    mockApi.createSession.mockResolvedValueOnce(session("new", REPO_A));
+    await useAppStore.getState().createSession("foo", REPO_A);
+    expect(mockApi.createSession).toHaveBeenCalledWith(
+      "foo",
+      REPO_A,
+      false,
+      expect.anything(),
+      "regular",
+    );
+  });
+
+  it("forwards control kind to the backend", async () => {
+    mockApi.createSession.mockResolvedValueOnce(
+      session("ctl", REPO_A, { kind: "control" }),
+    );
+    await useAppStore
+      .getState()
+      .createSession("ctl", REPO_A, false, "control");
+    expect(mockApi.createSession).toHaveBeenCalledWith(
+      "ctl",
+      REPO_A,
+      false,
+      expect.anything(),
+      "control",
+    );
+  });
+
+  it("emits the guide event the first time a control session is created", async () => {
+    const events: Event[] = [];
+    const listener = (e: Event) => events.push(e);
+    window.addEventListener("acorn:show-control-guide", listener);
+    try {
+      mockApi.createSession.mockResolvedValueOnce(
+        session("ctl", REPO_A, { kind: "control" }),
+      );
+      await useAppStore
+        .getState()
+        .createSession("ctl", REPO_A, false, "control");
+      expect(events).toHaveLength(1);
+    } finally {
+      window.removeEventListener("acorn:show-control-guide", listener);
+    }
+  });
+
+  it("suppresses the guide event when the dismissed flag is set", async () => {
+    window.localStorage.setItem(guideKey, "1");
+    const events: Event[] = [];
+    const listener = (e: Event) => events.push(e);
+    window.addEventListener("acorn:show-control-guide", listener);
+    try {
+      mockApi.createSession.mockResolvedValueOnce(
+        session("ctl", REPO_A, { kind: "control" }),
+      );
+      await useAppStore
+        .getState()
+        .createSession("ctl", REPO_A, false, "control");
+      expect(events).toHaveLength(0);
+    } finally {
+      window.removeEventListener("acorn:show-control-guide", listener);
+    }
+  });
+
+  it("does not emit the guide event for regular sessions", async () => {
+    const events: Event[] = [];
+    const listener = (e: Event) => events.push(e);
+    window.addEventListener("acorn:show-control-guide", listener);
+    try {
+      mockApi.createSession.mockResolvedValueOnce(session("reg", REPO_A));
+      await useAppStore.getState().createSession("reg", REPO_A);
+      expect(events).toHaveLength(0);
+    } finally {
+      window.removeEventListener("acorn:show-control-guide", listener);
+    }
   });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { api } from "./lib/api";
 import { useSettings } from "./lib/settings";
-import type { Project, Session } from "./lib/types";
+import type { Project, Session, SessionKind } from "./lib/types";
 import {
   type Direction,
   type LayoutNode,
@@ -17,6 +17,13 @@ import {
 type RightTab = "todos" | "commits" | "staged" | "prs";
 
 const ROOT_PANE_ID: PaneId = "root";
+
+/**
+ * localStorage key gating the one-time control-session guide modal. Versioned
+ * so we can re-surface it after a substantive change to the control-session
+ * UX without colliding with the previous dismissed state.
+ */
+const CONTROL_GUIDE_DISMISSED_KEY = "acorn:control-guide-dismissed-v1";
 
 export interface PaneState {
   id: PaneId;
@@ -91,6 +98,7 @@ interface AppStateModel {
     name: string,
     repoPath: string,
     isolated?: boolean,
+    kind?: SessionKind,
   ) => Promise<void>;
   removeSession: (id: string, removeWorktree?: boolean) => Promise<void>;
   renameSession: (id: string, name: string) => Promise<void>;
@@ -694,7 +702,7 @@ export const useAppStore = create<AppStateModel>()(
     });
   },
 
-  async createSession(name, repoPath, isolated = false) {
+  async createSession(name, repoPath, isolated = false, kind = "regular") {
     set({ loading: true, error: null });
     try {
       // Snapshot the current global startup mode onto the session so a
@@ -706,12 +714,22 @@ export const useAppStore = create<AppStateModel>()(
         repoPath,
         isolated,
         startupMode,
+        kind,
       );
       await get().refreshAll();
       // Focus the new session so Cmd+T (and any other entry point that goes
       // through the store) immediately surfaces it in its pane instead of
       // silently appending behind the existing active tab.
       get().selectSession(created.id);
+      // First-run guidance for control sessions. Gated on a localStorage
+      // flag so power users only see it once. App.tsx hosts the modal.
+      if (
+        kind === "control" &&
+        typeof window !== "undefined" &&
+        !window.localStorage.getItem(CONTROL_GUIDE_DISMISSED_KEY)
+      ) {
+        window.dispatchEvent(new CustomEvent("acorn:show-control-guide"));
+      }
     } catch (e) {
       set({ loading: false, error: errorMessage(e) });
     }

--- a/tests/e2e/control-session.spec.ts
+++ b/tests/e2e/control-session.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect, pressHotkey } from "./support";
+
+const REPO_PATH = "/tmp/demo";
+
+const PROJECT = {
+  repo_path: REPO_PATH,
+  name: "demo",
+  created_at: "2026-01-01T00:00:00Z",
+  position: 0,
+};
+
+test.describe("control session: creation flow", () => {
+  test("Cmd+Alt+Shift+T creates a control session, surfaces the bot icon, and shows the guide modal", async ({
+    page,
+    tauri,
+  }) => {
+    // Seed an existing project; the hotkey targets the active project, so
+    // we don't need to drive the directory picker.
+    await tauri.respond("list_projects", [PROJECT]);
+    // The store starts with no sessions, then `create_session` populates one.
+    // `list_sessions` is called after creation via `refreshAll`, so it has to
+    // return the freshly-created control session on subsequent calls.
+    await tauri.handle("list_sessions", () => {
+      // Tests-side state is forbidden inside the handler (serialized to source),
+      // so we read the *last* created session out of a window-scoped store.
+      const w = window as unknown as {
+        __ACORN_CTL_LAST__?: Record<string, unknown> | null;
+      };
+      return w.__ACORN_CTL_LAST__ ? [w.__ACORN_CTL_LAST__] : [];
+    });
+    await tauri.handle("create_session", (args) => {
+      const input = (args ?? {}) as {
+        name?: string;
+        repoPath?: string;
+        kind?: string;
+      };
+      const created = {
+        id: "ctl-1",
+        name: input.name ?? "control-demo",
+        repo_path: input.repoPath ?? "/tmp/demo",
+        worktree_path: input.repoPath ?? "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        startup_mode: null,
+        kind: input.kind ?? "regular",
+      };
+      (window as unknown as { __ACORN_CTL_LAST__: unknown }).__ACORN_CTL_LAST__ =
+        created;
+      return created;
+    });
+
+    await page.goto("/");
+    // Clear any previously-persisted dismissal so the guide is allowed to fire.
+    await page.evaluate(() => {
+      window.localStorage.removeItem("acorn:control-guide-dismissed-v1");
+    });
+
+    // Trigger the hotkey. Bindings live on `window` via tinykeys; pressHotkey
+    // dispatches a synthetic keydown to bypass Chromium's own intercepts.
+    await pressHotkey(page, { mod: true, alt: true, shift: true, key: "t" });
+
+    // The new session appears in the sidebar with the control accessory icon.
+    const sidebar = page.locator("aside");
+    const controlIcon = sidebar.locator(
+      "[aria-label='control session']",
+    );
+    await expect(controlIcon).toBeVisible();
+
+    // The guide modal opens on first creation.
+    await expect(
+      page.getByRole("heading", { name: "Control session" }),
+    ).toBeVisible();
+
+    // Dismiss with "don't show again" so the localStorage gate is set.
+    await page
+      .getByRole("checkbox", { name: /Don't show this again/i })
+      .check();
+    await page.getByRole("button", { name: "Got it" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Control session" }),
+    ).toBeHidden();
+
+    // The flag was written.
+    const dismissed = await page.evaluate(() =>
+      window.localStorage.getItem("acorn:control-guide-dismissed-v1"),
+    );
+    expect(dismissed).toBe("1");
+  });
+
+  test("command palette exposes a 'New control session' entry", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", []);
+
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "p" });
+
+    await expect(
+      page.getByRole("dialog", { name: /Command palette/i }),
+    ).toBeVisible();
+    // cmdk renders items with role="option"; matching by visible text is
+    // resilient to cmdk's exact aria implementation.
+    await expect(page.getByText("New control session")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

PR #1 of a 3-PR stack adding **control sessions** — a new session kind that will (in PRs #2/#3) be allowed to dispatch commands to sibling sessions via the upcoming `acorn-ipc` CLI.

This PR ships the **UI foundation only**. A control session created today behaves like a regular shell; the IPC plumbing lands in PR #2.

## What changed

- **Data model**: `SessionKind` enum (`regular` | `control`) added to the persisted `Session`. `#[serde(default)]` keeps existing `sessions.json` loading clean.
- **Hotkey**: `Cmd+Alt+Shift+T` (`Hotkeys.newControlSession`).
- **Command palette**: new `New control session` entry.
- **Sidebar**: per-project Bot button, matching context-menu item, and a Bot accessory icon on each control session row.
- **First-run modal**: `ControlSessionGuideModal`, gated by `localStorage["acorn:control-guide-dismissed-v1"]`. Triggered by the store after the first successful control-session creation.

## Stack

This branch is the base of a 3-PR series:

1. **#this — UI foundation** _(here)_
2. #2 — `acorn-ipc` server + protocol (Unix socket, JSON line proto, 6 commands)
3. #3 — CLI installer (Settings button) + docs + end-to-end Playwright

## Test plan

- [x] `cargo check` clean
- [x] `tsc --noEmit` clean
- [x] Vitest: 5 new `createSession` cases cover kind forwarding, guide event firing, and dismiss-flag suppression — 101 total tests pass
- [ ] Playwright (`control-session.spec.ts`) — runs in CI (bun not available locally)
- [ ] Manual: open the app, hit `⌘⌥⇧T`, confirm the Bot icon and the guide modal appear; check "Don't show again", reopen — modal stays hidden

## Notes for reviewer

- Branch name `feat/control-session-kind` (the term landed on "control" after considering "harness", "pilot", "orchestrator" — tmux pedigree, shortest, clearest to power users).
- `Cmd+Shift+T` was the first instinct but already binds `toggleTodos`; `Cmd+Alt+Shift+T` extends the existing `newSession` / `newIsolatedSession` family.
