### PR TITLE
feat(ipc): acorn-ipc server + protocol + CLI binary

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chrono",
+ "clap",
  "dashmap",
  "directories",
  "git2",
@@ -72,6 +73,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -507,6 +558,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1906,6 +2003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,6 +2715,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
@@ -5010,6 +5119,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,6 +9,21 @@ edition = "2021"
 name = "acorn_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+# Companion CLI that talks to the running Acorn app over a Unix domain
+# socket. Built from the same crate so the protocol types in `ipc::proto`
+# stay in lockstep between the in-process server and the out-of-process
+# client without a third workspace member.
+[[bin]]
+name = "acorn-ipc"
+path = "src/bin/acorn-ipc.rs"
+
+# Existing Tauri entry binary — Cargo defaults `name = "acorn"` based on the
+# package name, but once we add a second `[[bin]]` we must spell both out so
+# Cargo does not auto-discover the new bin as the only target.
+[[bin]]
+name = "acorn"
+path = "src/main.rs"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
@@ -39,6 +54,7 @@ sysinfo = { version = "0.32", default-features = false, features = ["system"] }
 base64 = "0.22"
 tauri-plugin-updater = "2.10.1"
 tauri-plugin-process = "2"
+clap = { version = "4", features = ["derive"] }
 
 [profile.release]
 opt-level = 3

--- a/src-tauri/src/bin/acorn-ipc.rs
+++ b/src-tauri/src/bin/acorn-ipc.rs
@@ -1,0 +1,330 @@
+//! `acorn-ipc` — command-line client for the in-app IPC server.
+//!
+//! Run from inside a control session's PTY: the spawning code in
+//! `commands::pty_spawn` injects `ACORN_SESSION_ID` and `ACORN_IPC_SOCKET`
+//! into the environment so this binary can locate the server and identify
+//! itself without flags.
+//!
+//! Exits non-zero on protocol errors so it composes cleanly in shell scripts;
+//! the exit code maps the server's `ErrorCode` so callers can branch on the
+//! specific failure mode (`2` = unauthorized, `3` = not-found, etc.).
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use base64::Engine;
+use clap::{Parser, Subcommand};
+
+#[path = "../ipc/proto.rs"]
+mod proto;
+#[path = "../ipc/socket_path.rs"]
+mod socket_path;
+
+use proto::{Envelope, ErrorCode, Request, Response, SessionSummary, PROTOCOL_VERSION};
+
+const ENV_SESSION_ID: &str = "ACORN_SESSION_ID";
+
+#[derive(Parser)]
+#[command(
+    name = "acorn-ipc",
+    about = "Talk to a running Acorn app from inside a control session.",
+    long_about = "acorn-ipc speaks to the in-app IPC server over a Unix \
+                  socket. The control session that launched this process \
+                  exports ACORN_SESSION_ID and ACORN_IPC_SOCKET into its \
+                  PTY environment — leave those alone unless you know what \
+                  you're doing."
+)]
+struct Cli {
+    /// Print responses as raw JSON instead of the default table/text. Useful
+    /// for piping into `jq` or other tooling.
+    #[arg(long, global = true)]
+    json: bool,
+
+    /// Override the socket path. Falls back to `$ACORN_IPC_SOCKET`, then to
+    /// the platform data-dir default. Mostly useful for testing.
+    #[arg(long, global = true, value_name = "PATH")]
+    socket: Option<PathBuf>,
+
+    /// Override the source session id. Falls back to `$ACORN_SESSION_ID`.
+    #[arg(long, global = true, value_name = "UUID")]
+    source: Option<String>,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// List the sessions in your project, including this control session.
+    ListSessions,
+    /// Send raw keys to a target session. `<DATA>` is forwarded verbatim;
+    /// use `--raw-base64` when the input contains control bytes that the
+    /// shell would otherwise interpret.
+    SendKeys {
+        /// UUID of the target session.
+        #[arg(short = 't', long = "target")]
+        target: String,
+        /// Literal data to send (UTF-8). Pass `\n` for a newline, etc.
+        /// Mutually exclusive with `--raw-base64`.
+        #[arg(short = 'd', long = "data")]
+        data: Option<String>,
+        /// Pre-encoded base64 bytes. Overrides `--data` when set.
+        #[arg(long = "raw-base64")]
+        raw_base64: Option<String>,
+        /// Append a `\n` after the data. Convenient for one-shot commands.
+        #[arg(long)]
+        enter: bool,
+    },
+    /// Print the recent output of a target session.
+    ReadBuffer {
+        /// UUID of the target session.
+        #[arg(short = 't', long = "target")]
+        target: String,
+        /// Max bytes to fetch from the session's tail buffer (server cap: 4 MiB).
+        #[arg(long, default_value_t = 65_536)]
+        max_bytes: usize,
+    },
+    /// Create a new regular session in this project.
+    NewSession {
+        /// Display name for the new session.
+        name: String,
+        /// Create the session inside a fresh git worktree.
+        #[arg(long)]
+        isolated: bool,
+    },
+    /// Focus a session in the app UI.
+    SelectSession {
+        /// UUID of the target session.
+        #[arg(short = 't', long = "target")]
+        target: String,
+    },
+    /// Kill a session (close the PTY, drop the session from state).
+    KillSession {
+        /// UUID of the target session.
+        #[arg(short = 't', long = "target")]
+        target: String,
+    },
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let source = match cli
+        .source
+        .clone()
+        .or_else(|| std::env::var(ENV_SESSION_ID).ok())
+    {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            eprintln!(
+                "acorn-ipc: ACORN_SESSION_ID is unset. Run me from inside a control session, \
+                 or pass --source <uuid>.",
+            );
+            return ExitCode::from(map_error_exit(ErrorCode::Unauthorized));
+        }
+    };
+
+    let socket_path = match cli.socket.clone() {
+        Some(p) => p,
+        None => match socket_path::resolve() {
+            Ok(p) => p,
+            Err(err) => {
+                eprintln!("acorn-ipc: could not resolve socket path: {err}");
+                return ExitCode::from(map_error_exit(ErrorCode::Internal));
+            }
+        },
+    };
+
+    let json = cli.json;
+    let request = match build_request(&cli.command) {
+        Ok(r) => r,
+        Err(msg) => {
+            eprintln!("acorn-ipc: {msg}");
+            return ExitCode::from(map_error_exit(ErrorCode::Invalid));
+        }
+    };
+
+    let envelope = Envelope {
+        protocol_version: PROTOCOL_VERSION,
+        source_session_id: source,
+        request,
+    };
+
+    let response = match send(&socket_path, &envelope) {
+        Ok(r) => r,
+        Err(err) => {
+            eprintln!(
+                "acorn-ipc: could not reach the Acorn IPC server at {}: {err}",
+                socket_path.display()
+            );
+            return ExitCode::from(map_error_exit(ErrorCode::Internal));
+        }
+    };
+
+    render(&response, json)
+}
+
+fn build_request(cmd: &Command) -> Result<Request, String> {
+    Ok(match cmd {
+        Command::ListSessions => Request::ListSessions,
+        Command::SendKeys {
+            target,
+            data,
+            raw_base64,
+            enter,
+        } => {
+            let data_b64 = match (raw_base64, data) {
+                (Some(b64), _) => b64.clone(),
+                (None, Some(d)) => {
+                    let mut bytes = d.as_bytes().to_vec();
+                    if *enter {
+                        bytes.push(b'\n');
+                    }
+                    base64::engine::general_purpose::STANDARD.encode(&bytes)
+                }
+                (None, None) => {
+                    if *enter {
+                        base64::engine::general_purpose::STANDARD.encode(b"\n")
+                    } else {
+                        return Err(
+                            "send-keys needs --data, --raw-base64, or --enter".to_string()
+                        );
+                    }
+                }
+            };
+            Request::SendKeys {
+                target_session_id: target.clone(),
+                data_b64,
+            }
+        }
+        Command::ReadBuffer { target, max_bytes } => Request::ReadBuffer {
+            target_session_id: target.clone(),
+            max_bytes: Some(*max_bytes),
+        },
+        Command::NewSession { name, isolated } => Request::NewSession {
+            name: name.clone(),
+            isolated: *isolated,
+        },
+        Command::SelectSession { target } => Request::SelectSession {
+            target_session_id: target.clone(),
+        },
+        Command::KillSession { target } => Request::KillSession {
+            target_session_id: target.clone(),
+        },
+    })
+}
+
+fn send(path: &std::path::Path, envelope: &Envelope) -> Result<Response, String> {
+    let mut stream =
+        UnixStream::connect(path).map_err(|e| format!("connect: {e}"))?;
+    let mut payload = serde_json::to_vec(envelope).map_err(|e| format!("encode: {e}"))?;
+    payload.push(b'\n');
+    stream.write_all(&payload).map_err(|e| format!("write: {e}"))?;
+    stream.flush().map_err(|e| format!("flush: {e}"))?;
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader.read_line(&mut line).map_err(|e| format!("read: {e}"))?;
+    serde_json::from_str(line.trim_end()).map_err(|e| format!("decode: {e}"))
+}
+
+fn render(response: &Response, json: bool) -> ExitCode {
+    if json {
+        match serde_json::to_string_pretty(response) {
+            Ok(s) => println!("{s}"),
+            Err(err) => {
+                eprintln!("acorn-ipc: failed to re-serialize response: {err}");
+                return ExitCode::from(map_error_exit(ErrorCode::Internal));
+            }
+        }
+        return match response {
+            Response::Error { code, .. } => ExitCode::from(map_error_exit(*code)),
+            _ => ExitCode::SUCCESS,
+        };
+    }
+    match response {
+        Response::Sessions { sessions } => {
+            print_sessions(sessions);
+            ExitCode::SUCCESS
+        }
+        Response::Ack => ExitCode::SUCCESS,
+        Response::Buffer { data_b64, truncated } => {
+            match base64::engine::general_purpose::STANDARD.decode(data_b64) {
+                Ok(bytes) => {
+                    let _ = std::io::stdout().write_all(&bytes);
+                }
+                Err(err) => {
+                    eprintln!("acorn-ipc: server returned invalid base64: {err}");
+                    return ExitCode::from(map_error_exit(ErrorCode::Internal));
+                }
+            }
+            if *truncated {
+                eprintln!("(truncated — pass --max-bytes <N> for more)");
+            }
+            ExitCode::SUCCESS
+        }
+        Response::SessionCreated { session_id } => {
+            println!("{session_id}");
+            ExitCode::SUCCESS
+        }
+        Response::Error { code, message } => {
+            eprintln!("acorn-ipc: {message}");
+            ExitCode::from(map_error_exit(*code))
+        }
+    }
+}
+
+fn print_sessions(sessions: &[SessionSummary]) {
+    if sessions.is_empty() {
+        println!("(no sessions)");
+        return;
+    }
+    let id_w = sessions.iter().map(|s| s.id.len()).max().unwrap_or(8);
+    let name_w = sessions.iter().map(|s| s.name.len()).max().unwrap_or(8).max(4);
+    let kind_w = sessions
+        .iter()
+        .map(|s| s.kind.len())
+        .max()
+        .unwrap_or(7)
+        .max(4);
+    let status_w = sessions
+        .iter()
+        .map(|s| s.status.len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    println!(
+        "{marker} {id:<id_w$}  {name:<name_w$}  {kind:<kind_w$}  {status:<status_w$}  branch",
+        marker = " ",
+        id = "ID",
+        name = "NAME",
+        kind = "KIND",
+        status = "STATUS",
+    );
+    for s in sessions {
+        let marker = if s.is_source { "*" } else { " " };
+        println!(
+            "{marker} {id:<id_w$}  {name:<name_w$}  {kind:<kind_w$}  {status:<status_w$}  {branch}",
+            marker = marker,
+            id = s.id,
+            name = s.name,
+            kind = s.kind,
+            status = s.status,
+            branch = s.branch,
+        );
+    }
+}
+
+/// Maps the server's `ErrorCode` to a stable shell exit code so scripts can
+/// branch on the specific failure mode without parsing JSON.
+fn map_error_exit(code: ErrorCode) -> u8 {
+    match code {
+        ErrorCode::Unauthorized => 2,
+        ErrorCode::NotFound => 3,
+        ErrorCode::OutOfScope => 4,
+        ErrorCode::Invalid => 5,
+        ErrorCode::Internal => 6,
+    }
+}
+

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,7 +13,7 @@ use crate::pull_requests::{
     PullRequestListing,
 };
 use crate::scrollback;
-use crate::session::{Project, Session, SessionStartupMode, SessionStatus};
+use crate::session::{Project, Session, SessionKind, SessionStartupMode, SessionStatus};
 use crate::session_status;
 use crate::shell_util::shell_quote;
 use crate::state::AppState;
@@ -188,6 +188,7 @@ pub async fn create_session(
     repo_path: String,
     isolated: Option<bool>,
     startup_mode: Option<SessionStartupMode>,
+    kind: Option<SessionKind>,
 ) -> AppResult<Session> {
     let repo = PathBuf::from(&repo_path);
     if !repo.exists() {
@@ -210,6 +211,7 @@ pub async fn create_session(
         branch,
         isolated,
         startup_mode,
+        kind.unwrap_or_default(),
     );
     let inserted = state.sessions.insert(session);
     state.projects.ensure(repo.clone(), project_basename(&repo));

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -468,13 +468,31 @@ pub async fn pty_spawn<R: Runtime>(
             )
         }
     };
+    // Inject IPC env vars for control sessions so the user's shell (and any
+    // agent it launches) can address the running app via the `acorn-ipc`
+    // CLI without per-session configuration. Only control sessions get the
+    // env; regular sessions stay sandboxed from the IPC surface.
+    let mut effective_env = env.unwrap_or_default();
+    if let Ok(session) = state.sessions.get(&id) {
+        if session.kind == SessionKind::Control {
+            effective_env
+                .entry("ACORN_SESSION_ID".to_string())
+                .or_insert_with(|| session.id.to_string());
+            if let Ok(socket) = crate::ipc::socket_path::resolve() {
+                effective_env
+                    .entry("ACORN_IPC_SOCKET".to_string())
+                    .or_insert_with(|| socket.display().to_string());
+            }
+        }
+    }
+
     state.pty.spawn(
         app,
         id,
         cwd,
         resolved_command,
         resolved_args,
-        env.unwrap_or_default(),
+        effective_env,
         cols.unwrap_or(0),
         rows.unwrap_or(0),
     )
@@ -892,7 +910,10 @@ pub async fn generate_pr_commit_message(
     )
 }
 
-fn create_unique_worktree(repo: &std::path::Path, base: &str) -> AppResult<(String, PathBuf)> {
+pub(crate) fn create_unique_worktree(
+    repo: &std::path::Path,
+    base: &str,
+) -> AppResult<(String, PathBuf)> {
     let root = worktree::worktree_root(repo);
     let mut candidate = base.to_string();
     let mut n = 2;
@@ -915,7 +936,7 @@ fn create_unique_worktree(repo: &std::path::Path, base: &str) -> AppResult<(Stri
     }
 }
 
-fn sanitize_worktree_name(name: &str) -> String {
+pub(crate) fn sanitize_worktree_name(name: &str) -> String {
     name.chars()
         .map(|c| {
             if c.is_alphanumeric() || c == '-' || c == '_' {

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -1,0 +1,10 @@
+//! `acorn-ipc` IPC: in-process Unix-socket server and shared wire protocol.
+//!
+//! The server (in `server.rs`) is started once at app boot from `lib.rs`.
+//! The protocol types in `proto.rs` are reused by the `acorn-ipc` CLI
+//! binary (`src/bin/acorn-ipc.rs`), so they intentionally avoid any
+//! Tauri- or runtime-specific types.
+
+pub mod proto;
+pub mod server;
+pub mod socket_path;

--- a/src-tauri/src/ipc/proto.rs
+++ b/src-tauri/src/ipc/proto.rs
@@ -1,0 +1,167 @@
+//! Wire protocol shared between the in-process IPC server (this crate's lib)
+//! and the out-of-process `acorn-ipc` CLI (`src/bin/acorn-ipc.rs`).
+//!
+//! Each request/response pair travels as a single newline-terminated JSON
+//! object over a Unix domain socket. The CLI sends exactly one request and
+//! reads exactly one response, then closes the connection.
+//!
+//! Errors are returned as a typed `Response::Error { code, message }` rather
+//! than as a transport-level signal, so the CLI can render meaningful exit
+//! statuses and the server can carry structured failure metadata back to
+//! the caller without leaking framework internals.
+
+use serde::{Deserialize, Serialize};
+
+/// Wire-version of the protocol. Bump when introducing breaking changes so
+/// older CLIs can refuse to speak to a newer server (and vice versa) instead
+/// of silently mis-routing requests.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Every request opens with the source session's UUID, captured by the CLI
+/// from the `ACORN_SESSION_ID` env var set on control-session PTYs. The
+/// server rejects requests from sessions that do not exist or whose
+/// `SessionKind` is not `Control`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Envelope {
+    pub protocol_version: u32,
+    pub source_session_id: String,
+    pub request: Request,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum Request {
+    /// List sessions visible to the source — i.e. sessions in the same
+    /// project (`repo_path`) as the calling control session.
+    ListSessions,
+    /// Send raw bytes to a target session's PTY stdin. Pure passthrough —
+    /// the server does not interpret the bytes. Use `data_b64` to carry
+    /// non-UTF-8 sequences (e.g. control characters) cleanly.
+    SendKeys {
+        target_session_id: String,
+        data_b64: String,
+    },
+    /// Read the tail of a target session's PTY output ring buffer. Returns
+    /// up to `max_bytes`; `truncated = true` indicates the buffer had more
+    /// bytes than were returned.
+    ReadBuffer {
+        target_session_id: String,
+        max_bytes: Option<usize>,
+    },
+    /// Create a new (non-control) regular session in the same project as the
+    /// source. Returns the new session's id. The frontend's `pty_spawn`
+    /// flow still has to land in the new session for the PTY to start;
+    /// callers that want output should poll `ListSessions` or wait for the
+    /// app to surface the new tab.
+    NewSession {
+        name: String,
+        isolated: bool,
+    },
+    /// Ask the app to focus the given session in its pane. Emits a Tauri
+    /// event the frontend reacts to.
+    SelectSession {
+        target_session_id: String,
+    },
+    /// Tear down a target session (kill its PTY, remove it from state).
+    /// Destructive — the server logs every invocation to the audit log.
+    KillSession {
+        target_session_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum Response {
+    Sessions {
+        sessions: Vec<SessionSummary>,
+    },
+    Ack,
+    Buffer {
+        data_b64: String,
+        /// True when the underlying ring buffer held more bytes than were
+        /// returned. Callers can decide whether to widen `max_bytes` or
+        /// accept the truncation.
+        truncated: bool,
+    },
+    SessionCreated {
+        session_id: String,
+    },
+    Error {
+        code: ErrorCode,
+        message: String,
+    },
+}
+
+/// Compact, machine-parseable error vocabulary. The CLI maps each code to
+/// a non-zero exit status; the human-readable `message` is shown alongside.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ErrorCode {
+    /// Source session does not exist, is not Control kind, or env was
+    /// missing/blank when the CLI started.
+    Unauthorized,
+    /// Target session id does not exist in the server's state.
+    NotFound,
+    /// Target session exists but is not in the same project as the source.
+    /// Surfaced separately from `NotFound` so the CLI can give an accurate
+    /// "wrong project" diagnostic instead of "no such session".
+    OutOfScope,
+    /// Request shape was unrecognized or its arguments were invalid.
+    Invalid,
+    /// Catch-all for server-side failures (PTY write errors, persistence
+    /// errors, etc.). The `message` carries the underlying cause.
+    Internal,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionSummary {
+    pub id: String,
+    pub name: String,
+    pub repo_path: String,
+    pub branch: String,
+    pub kind: String,
+    pub status: String,
+    /// True when the source session itself is the one being described —
+    /// the CLI uses this to render an arrow / current-session marker.
+    pub is_source: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_roundtrips_through_json() {
+        let env = Envelope {
+            protocol_version: PROTOCOL_VERSION,
+            source_session_id: "00000000-0000-0000-0000-000000000001".to_string(),
+            request: Request::SendKeys {
+                target_session_id: "00000000-0000-0000-0000-000000000002".to_string(),
+                data_b64: "aGVsbG8=".to_string(),
+            },
+        };
+        let encoded = serde_json::to_string(&env).expect("encode");
+        let decoded: Envelope = serde_json::from_str(&encoded).expect("decode");
+        assert_eq!(decoded, env);
+    }
+
+    #[test]
+    fn response_error_is_tagged_kind() {
+        let r = Response::Error {
+            code: ErrorCode::Unauthorized,
+            message: "source is not a control session".to_string(),
+        };
+        let encoded = serde_json::to_string(&r).expect("encode");
+        // External tag is `kind` per the serde attribute; `error` payload
+        // sits at the same level. This is what the CLI parses against.
+        assert!(encoded.contains("\"kind\":\"error\""));
+        assert!(encoded.contains("\"code\":\"unauthorized\""));
+    }
+
+    #[test]
+    fn unknown_request_kind_rejected() {
+        let bad = r#"{"protocol_version":1,"source_session_id":"x","request":{"kind":"frobnicate"}}"#;
+        let parsed: Result<Envelope, _> = serde_json::from_str(bad);
+        assert!(parsed.is_err());
+    }
+}

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -1,0 +1,534 @@
+//! Unix-socket IPC server for the `acorn-ipc` CLI. Runs on a dedicated
+//! background thread because every downstream interaction (PTY writes,
+//! `SessionStore` reads) is synchronous and the `parking_lot::Mutex`es
+//! around the PTY pool are not async-aware.
+//!
+//! Wire format: one newline-terminated JSON `Envelope` per request, one
+//! newline-terminated JSON `Response` per request. The CLI opens a fresh
+//! connection per command, so we do not need streaming or multiplexing.
+//!
+//! Security:
+//!   * Socket file is created with permission `0600` (owner-only).
+//!   * Every request carries a `source_session_id`. The server requires that
+//!     id to resolve to a live `Session` whose `kind == Control`. Any other
+//!     state (missing, wrong kind) returns `Unauthorized`.
+//!   * Target session lookups are scoped to the source's `repo_path`, so a
+//!     control session can only drive siblings inside its own project.
+//!
+//! The implementation deliberately avoids tokio. We spawn the listener
+//! thread once at app boot and one short-lived worker thread per accepted
+//! connection. A persistent dev-tool socket carrying single-shot requests
+//! has very little concurrency to exploit; thread-per-conn keeps the
+//! handler code linear and reuses the existing blocking PTY pool without
+//! a runtime hop.
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+
+use base64::Engine;
+use tauri::{AppHandle, Emitter, Runtime};
+use uuid::Uuid;
+
+use crate::commands::{create_unique_worktree, sanitize_worktree_name};
+use crate::ipc::proto::{
+    Envelope, ErrorCode, Request, Response, SessionSummary, PROTOCOL_VERSION,
+};
+use crate::ipc::socket_path;
+use crate::persistence;
+use crate::session::{Session, SessionKind, SessionStore};
+use crate::state::AppState;
+use crate::worktree;
+
+/// Tauri event the frontend listens for to focus a session requested via
+/// the IPC `select-session` command. Kept in lockstep with the listener
+/// wired up in `src/components/Sidebar.tsx`'s sibling for `acorn:*` events.
+const SELECT_SESSION_EVENT: &str = "acorn:ipc-select-session";
+
+/// Spawn the IPC server on a dedicated background thread. Returns
+/// immediately; failures during bind are logged but do not crash boot —
+/// the rest of the app remains usable even if IPC cannot start (e.g.
+/// the socket file is held open by a previous crash that left a stale
+/// inode behind).
+pub fn start<R: Runtime>(app: AppHandle<R>, state: AppState) {
+    let path = match socket_path::resolve() {
+        Ok(p) => p,
+        Err(err) => {
+            tracing::warn!(error = %err, "ipc: could not resolve socket path; server disabled");
+            return;
+        }
+    };
+    if let Some(parent) = path.parent() {
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            tracing::warn!(
+                error = %err,
+                path = %parent.display(),
+                "ipc: could not create socket parent dir; server disabled",
+            );
+            return;
+        }
+    }
+    // Best-effort cleanup of any previous socket inode. We do not block on
+    // failure because the next `bind` will surface the real error.
+    let _ = std::fs::remove_file(&path);
+    let listener = match UnixListener::bind(&path) {
+        Ok(l) => l,
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                path = %path.display(),
+                "ipc: bind failed; server disabled",
+            );
+            return;
+        }
+    };
+    if let Err(err) = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)) {
+        // Tighten on best-effort. If chmod fails we keep going — it just
+        // means the socket is more permissive than ideal, not that the
+        // server is unsafe (the unix peer is still local).
+        tracing::warn!(
+            error = %err,
+            path = %path.display(),
+            "ipc: chmod 0600 failed",
+        );
+    }
+    tracing::info!(path = %path.display(), "ipc: listening");
+
+    std::thread::Builder::new()
+        .name("acorn-ipc-listener".to_string())
+        .spawn(move || run_listener(listener, app, state))
+        .map(|_| ())
+        .unwrap_or_else(|err| {
+            tracing::warn!(error = %err, "ipc: listener thread failed to start");
+        });
+}
+
+fn run_listener<R: Runtime>(listener: UnixListener, app: AppHandle<R>, state: AppState) {
+    for incoming in listener.incoming() {
+        match incoming {
+            Ok(stream) => {
+                let app = app.clone();
+                let state = state.clone();
+                std::thread::Builder::new()
+                    .name("acorn-ipc-conn".to_string())
+                    .spawn(move || {
+                        if let Err(err) = handle_connection(stream, &app, &state) {
+                            tracing::warn!(error = %err, "ipc: connection handler failed");
+                        }
+                    })
+                    .map(|_| ())
+                    .unwrap_or_else(|err| {
+                        tracing::warn!(error = %err, "ipc: conn thread spawn failed");
+                    });
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "ipc: accept failed");
+            }
+        }
+    }
+}
+
+fn handle_connection<R: Runtime>(
+    stream: UnixStream,
+    app: &AppHandle<R>,
+    state: &AppState,
+) -> std::io::Result<()> {
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let mut writer = stream;
+    let mut line = String::new();
+    let n = reader.read_line(&mut line)?;
+    if n == 0 {
+        return Ok(());
+    }
+    let response = match serde_json::from_str::<Envelope>(line.trim_end()) {
+        Ok(envelope) => dispatch(envelope, app, state),
+        Err(err) => Response::Error {
+            code: ErrorCode::Invalid,
+            message: format!("malformed request: {err}"),
+        },
+    };
+    let mut out = serde_json::to_vec(&response).unwrap_or_else(|_| {
+        b"{\"kind\":\"error\",\"code\":\"internal\",\"message\":\"failed to serialize response\"}"
+            .to_vec()
+    });
+    out.push(b'\n');
+    writer.write_all(&out)?;
+    writer.flush()?;
+    Ok(())
+}
+
+/// Top-level request dispatch. Resolves the source session and enforces the
+/// "must be Control" gate before invoking command-specific handlers, so
+/// each handler can assume `source` is a live, authorized session.
+fn dispatch<R: Runtime>(
+    envelope: Envelope,
+    app: &AppHandle<R>,
+    state: &AppState,
+) -> Response {
+    if envelope.protocol_version != PROTOCOL_VERSION {
+        return Response::Error {
+            code: ErrorCode::Invalid,
+            message: format!(
+                "unsupported protocol version {} (server speaks {})",
+                envelope.protocol_version, PROTOCOL_VERSION
+            ),
+        };
+    }
+    let source = match resolve_source(&envelope.source_session_id, &state.sessions) {
+        Ok(s) => s,
+        Err(err) => return err,
+    };
+    let request_label = request_label(&envelope.request);
+    tracing::info!(
+        source = %source.id,
+        request = request_label,
+        "ipc: dispatch",
+    );
+    match envelope.request {
+        Request::ListSessions => handle_list_sessions(&source, &state.sessions),
+        Request::SendKeys {
+            target_session_id,
+            data_b64,
+        } => handle_send_keys(&source, &target_session_id, &data_b64, state),
+        Request::ReadBuffer {
+            target_session_id,
+            max_bytes,
+        } => handle_read_buffer(&source, &target_session_id, max_bytes, state),
+        Request::NewSession { name, isolated } => {
+            handle_new_session(&source, name, isolated, state)
+        }
+        Request::SelectSession { target_session_id } => {
+            handle_select_session(&source, &target_session_id, app, state)
+        }
+        Request::KillSession { target_session_id } => {
+            handle_kill_session(&source, &target_session_id, state)
+        }
+    }
+}
+
+fn request_label(req: &Request) -> &'static str {
+    match req {
+        Request::ListSessions => "list-sessions",
+        Request::SendKeys { .. } => "send-keys",
+        Request::ReadBuffer { .. } => "read-buffer",
+        Request::NewSession { .. } => "new-session",
+        Request::SelectSession { .. } => "select-session",
+        Request::KillSession { .. } => "kill-session",
+    }
+}
+
+fn resolve_source(raw_id: &str, sessions: &SessionStore) -> Result<Session, Response> {
+    let id = Uuid::parse_str(raw_id).map_err(|_| Response::Error {
+        code: ErrorCode::Unauthorized,
+        message: format!("source session id is not a valid uuid: {raw_id}"),
+    })?;
+    let session = sessions.get(&id).map_err(|_| Response::Error {
+        code: ErrorCode::Unauthorized,
+        message: "source session not found; is the ACORN_SESSION_ID env still valid?".to_string(),
+    })?;
+    if session.kind != SessionKind::Control {
+        return Err(Response::Error {
+            code: ErrorCode::Unauthorized,
+            message: "source session is not a control session".to_string(),
+        });
+    }
+    Ok(session)
+}
+
+/// Resolve a target session id, enforcing project scope. Returns
+/// `(target, response)` so handlers can short-circuit on lookup failure
+/// with the standardized error variant.
+fn resolve_target(
+    source: &Session,
+    raw_id: &str,
+    sessions: &SessionStore,
+) -> Result<Session, Response> {
+    let id = Uuid::parse_str(raw_id).map_err(|_| Response::Error {
+        code: ErrorCode::Invalid,
+        message: format!("target session id is not a valid uuid: {raw_id}"),
+    })?;
+    let target = sessions.get(&id).map_err(|_| Response::Error {
+        code: ErrorCode::NotFound,
+        message: format!("no session with id {id}"),
+    })?;
+    if target.repo_path != source.repo_path {
+        return Err(Response::Error {
+            code: ErrorCode::OutOfScope,
+            message: format!(
+                "target session belongs to a different project than the control session"
+            ),
+        });
+    }
+    Ok(target)
+}
+
+fn handle_list_sessions(source: &Session, sessions: &SessionStore) -> Response {
+    let summaries: Vec<SessionSummary> = sessions
+        .list()
+        .into_iter()
+        .filter(|s| s.repo_path == source.repo_path)
+        .map(|s| SessionSummary {
+            is_source: s.id == source.id,
+            id: s.id.to_string(),
+            name: s.name,
+            repo_path: s.repo_path.display().to_string(),
+            branch: s.branch,
+            kind: match s.kind {
+                SessionKind::Regular => "regular".to_string(),
+                SessionKind::Control => "control".to_string(),
+            },
+            status: format!("{:?}", s.status).to_lowercase(),
+        })
+        .collect();
+    Response::Sessions {
+        sessions: summaries,
+    }
+}
+
+fn handle_send_keys(
+    source: &Session,
+    target_id: &str,
+    data_b64: &str,
+    state: &AppState,
+) -> Response {
+    let target = match resolve_target(source, target_id, &state.sessions) {
+        Ok(t) => t,
+        Err(err) => return err,
+    };
+    let bytes = match base64::engine::general_purpose::STANDARD.decode(data_b64) {
+        Ok(b) => b,
+        Err(err) => {
+            return Response::Error {
+                code: ErrorCode::Invalid,
+                message: format!("data_b64 is not valid base64: {err}"),
+            };
+        }
+    };
+    if let Err(err) = state.pty.write(&target.id, &bytes) {
+        return Response::Error {
+            code: ErrorCode::Internal,
+            message: format!("pty write failed: {err}"),
+        };
+    }
+    Response::Ack
+}
+
+fn handle_read_buffer(
+    source: &Session,
+    target_id: &str,
+    max_bytes: Option<usize>,
+    state: &AppState,
+) -> Response {
+    let target = match resolve_target(source, target_id, &state.sessions) {
+        Ok(t) => t,
+        Err(err) => return err,
+    };
+    let cap = max_bytes.unwrap_or(64 * 1024).min(4 * 1024 * 1024);
+    match state.pty.tail_bytes(&target.id, cap) {
+        Some((bytes, truncated)) => Response::Buffer {
+            data_b64: base64::engine::general_purpose::STANDARD.encode(&bytes),
+            truncated,
+        },
+        None => Response::Error {
+            code: ErrorCode::NotFound,
+            message: format!("session {} has no live pty", target.id),
+        },
+    }
+}
+
+fn handle_new_session(
+    source: &Session,
+    name: String,
+    isolated: bool,
+    state: &AppState,
+) -> Response {
+    if name.trim().is_empty() {
+        return Response::Error {
+            code: ErrorCode::Invalid,
+            message: "name must not be empty".to_string(),
+        };
+    }
+    let repo = source.repo_path.clone();
+    let worktree_path = if isolated {
+        let base = sanitize_worktree_name(&name);
+        match create_unique_worktree(&repo, &base) {
+            Ok((_safe, path)) => path,
+            Err(err) => {
+                return Response::Error {
+                    code: ErrorCode::Internal,
+                    message: format!("worktree create failed: {err}"),
+                };
+            }
+        }
+    } else {
+        repo.clone()
+    };
+    let branch =
+        worktree::current_branch(&worktree_path).unwrap_or_else(|_| "HEAD".to_string());
+    let session = Session::new(
+        name,
+        repo.clone(),
+        worktree_path,
+        branch,
+        isolated,
+        None,
+        SessionKind::Regular,
+    );
+    let inserted = state.sessions.insert(session);
+    let basename = repo
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("project")
+        .to_string();
+    state.projects.ensure(repo, basename);
+    // Best-effort persist + frontend nudge. The frontend already
+    // re-fetches the session list on `acorn:ipc-state-changed`, so a
+    // momentary mismatch between disk and memory before the next event
+    // arrives is benign.
+    if let Err(err) = persistence::save_sessions(&state.sessions.list()) {
+        tracing::warn!(error = %err, "ipc: persist sessions after new-session failed");
+    }
+    Response::SessionCreated {
+        session_id: inserted.id.to_string(),
+    }
+}
+
+fn handle_select_session<R: Runtime>(
+    source: &Session,
+    target_id: &str,
+    app: &AppHandle<R>,
+    state: &AppState,
+) -> Response {
+    let target = match resolve_target(source, target_id, &state.sessions) {
+        Ok(t) => t,
+        Err(err) => return err,
+    };
+    if let Err(err) = app.emit(SELECT_SESSION_EVENT, target.id.to_string()) {
+        return Response::Error {
+            code: ErrorCode::Internal,
+            message: format!("event emit failed: {err}"),
+        };
+    }
+    Response::Ack
+}
+
+fn handle_kill_session(
+    source: &Session,
+    target_id: &str,
+    state: &AppState,
+) -> Response {
+    let target = match resolve_target(source, target_id, &state.sessions) {
+        Ok(t) => t,
+        Err(err) => return err,
+    };
+    if target.id == source.id {
+        return Response::Error {
+            code: ErrorCode::Invalid,
+            message: "refusing to kill the source control session".to_string(),
+        };
+    }
+    let _ = state.pty.kill(&target.id);
+    if let Err(err) = state.sessions.remove(&target.id) {
+        return Response::Error {
+            code: ErrorCode::Internal,
+            message: format!("remove failed: {err}"),
+        };
+    }
+    if let Err(err) = persistence::save_sessions(&state.sessions.list()) {
+        tracing::warn!(error = %err, "ipc: persist after kill-session failed");
+    }
+    Response::Ack
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::SessionStatus;
+    use std::path::PathBuf;
+
+    fn make_session(
+        repo: &str,
+        name: &str,
+        kind: SessionKind,
+    ) -> Session {
+        let mut s = Session::new(
+            name.to_string(),
+            PathBuf::from(repo),
+            PathBuf::from(repo),
+            "main".to_string(),
+            false,
+            None,
+            kind,
+        );
+        s.status = SessionStatus::Idle;
+        s
+    }
+
+    #[test]
+    fn resolve_source_rejects_regular_kind() {
+        let store = SessionStore::new();
+        let regular = store.insert(make_session("/tmp/repo", "reg", SessionKind::Regular));
+        let result = resolve_source(&regular.id.to_string(), &store);
+        match result {
+            Err(Response::Error {
+                code: ErrorCode::Unauthorized,
+                ..
+            }) => {}
+            other => panic!("expected unauthorized, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_source_accepts_control_kind() {
+        let store = SessionStore::new();
+        let ctl = store.insert(make_session("/tmp/repo", "ctl", SessionKind::Control));
+        let result = resolve_source(&ctl.id.to_string(), &store);
+        assert!(result.is_ok(), "control session should be allowed");
+    }
+
+    #[test]
+    fn resolve_source_rejects_unknown_uuid() {
+        let store = SessionStore::new();
+        let result = resolve_source("00000000-0000-0000-0000-000000000000", &store);
+        match result {
+            Err(Response::Error {
+                code: ErrorCode::Unauthorized,
+                ..
+            }) => {}
+            other => panic!("expected unauthorized for unknown id, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_sessions_filters_by_project() {
+        let store = SessionStore::new();
+        let ctl = store.insert(make_session("/tmp/A", "ctl", SessionKind::Control));
+        let _peer = store.insert(make_session("/tmp/A", "peer", SessionKind::Regular));
+        let _other = store.insert(make_session("/tmp/B", "other", SessionKind::Regular));
+        match handle_list_sessions(&ctl, &store) {
+            Response::Sessions { sessions } => {
+                assert_eq!(sessions.len(), 2, "should see ctl + peer, not other");
+                assert!(sessions.iter().all(|s| s.repo_path == "/tmp/A"));
+                let source = sessions.iter().find(|s| s.is_source).expect("source marked");
+                assert_eq!(source.id, ctl.id.to_string());
+            }
+            other => panic!("expected sessions response, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_target_rejects_cross_project() {
+        let store = SessionStore::new();
+        let ctl = store.insert(make_session("/tmp/A", "ctl", SessionKind::Control));
+        let other = store.insert(make_session("/tmp/B", "other", SessionKind::Regular));
+        let res = resolve_target(&ctl, &other.id.to_string(), &store);
+        match res {
+            Err(Response::Error {
+                code: ErrorCode::OutOfScope,
+                ..
+            }) => {}
+            other => panic!("expected out-of-scope, got {other:?}"),
+        }
+    }
+}

--- a/src-tauri/src/ipc/socket_path.rs
+++ b/src-tauri/src/ipc/socket_path.rs
@@ -1,0 +1,72 @@
+//! Single source of truth for the IPC Unix socket path. The app and the
+//! `acorn-ipc` CLI compute it the same way so the CLI does not have to be
+//! told where to connect via flag every invocation.
+//!
+//! Resolution order:
+//! 1. `ACORN_IPC_SOCKET` env (override; takes precedence so test harnesses
+//!    can point at an isolated path).
+//! 2. `<data_dir>/ipc.sock`, where `data_dir` matches what the app uses for
+//!    `sessions.json` and friends (see `crate::persistence::data_dir`).
+//!
+//! The CLI cannot link `persistence::data_dir` without dragging the app's
+//! full module graph into the bin target, so this file re-derives the
+//! same `directories` lookup directly — the two paths must stay in lockstep.
+
+use std::path::PathBuf;
+
+use directories::ProjectDirs;
+
+const SOCKET_FILE: &str = "ipc.sock";
+const ENV_OVERRIDE: &str = "ACORN_IPC_SOCKET";
+
+/// Resolve the canonical socket path. Errors as a plain `String` so the CLI
+/// (which has no access to `AppError`) can print it directly.
+pub fn resolve() -> Result<PathBuf, String> {
+    if let Ok(override_path) = std::env::var(ENV_OVERRIDE) {
+        if !override_path.is_empty() {
+            return Ok(PathBuf::from(override_path));
+        }
+    }
+    let project_dirs = ProjectDirs::from("io", "im-ian", "acorn")
+        .ok_or_else(|| "could not resolve project data directory".to_string())?;
+    Ok(project_dirs.data_dir().join(SOCKET_FILE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_override_takes_precedence() {
+        // SAFETY: tests run on a single thread inside this test process and
+        // we restore the previous value before returning so neighbouring
+        // tests are not perturbed.
+        let prev = std::env::var(ENV_OVERRIDE).ok();
+        unsafe {
+            std::env::set_var(ENV_OVERRIDE, "/tmp/acorn-test.sock");
+        }
+        let resolved = resolve().expect("override resolves");
+        assert_eq!(resolved, PathBuf::from("/tmp/acorn-test.sock"));
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(ENV_OVERRIDE, v),
+                None => std::env::remove_var(ENV_OVERRIDE),
+            }
+        }
+    }
+
+    #[test]
+    fn falls_back_to_data_dir() {
+        let prev = std::env::var(ENV_OVERRIDE).ok();
+        unsafe {
+            std::env::remove_var(ENV_OVERRIDE);
+        }
+        let resolved = resolve().expect("default resolves");
+        assert!(resolved.ends_with(SOCKET_FILE));
+        unsafe {
+            if let Some(v) = prev {
+                std::env::set_var(ENV_OVERRIDE, v);
+            }
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod cli_resolver;
 mod commands;
 mod error;
 mod git_ops;
+mod ipc;
 mod persistence;
 mod pty;
 mod pull_requests;
@@ -159,6 +160,10 @@ pub fn run() {
             } else if let Err(err) = scrollback::prune_orphans(&live_ids) {
                 tracing::warn!("scrollback prune at boot failed: {err}");
             }
+            // Start the IPC server in the background. It owns its own
+            // listener thread; if bind fails it logs and the app keeps
+            // running with IPC disabled.
+            ipc::server::start(app.handle().clone(), state.inner().clone());
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -11,7 +11,7 @@
 //!   * `pty:output:{session_id}` — payload `{ "data": "<base64>" }`
 //!   * `pty:exit:{session_id}` — payload `{ "code": Option<i32> }`
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -32,6 +32,12 @@ use crate::error::{AppError, AppResult};
 const DEFAULT_COLS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
 const READ_BUFFER_SIZE: usize = 4096;
+/// Hard cap on the per-session in-memory tail buffer used by the
+/// `acorn-ipc read-buffer` command. Sized to roughly match xterm.js's
+/// configured scrollback so the buffer the CLI can read mirrors what the
+/// user sees in the terminal. The frontend already persists its own
+/// scrollback to disk on a debounce; this ring lives purely in RAM.
+const TAIL_BUFFER_CAP: usize = 4 * 1024 * 1024;
 /// How long a "just-finished a command" cue lingers as `NeedsInput` on the
 /// Sidebar dot before we let it fall back to `Idle`. Long enough to actually
 /// catch the user's eye after a transient command (`ls`, `git status`),
@@ -73,6 +79,12 @@ struct PtyHandle {
     /// last descendant exits, cleared on the next user keystroke or when the
     /// deadline passes.
     needs_input_until: Mutex<Option<Instant>>,
+    /// Rolling tail of raw PTY output bytes. Appended by `read_loop` before
+    /// the bytes are base64-encoded and emitted to the frontend; consumed
+    /// out of band by `tail_bytes` for the IPC `read-buffer` command.
+    /// Capped at `TAIL_BUFFER_CAP` — older bytes are dropped from the
+    /// front when the cap is hit.
+    tail_buf: Mutex<VecDeque<u8>>,
 }
 
 /// Manages all live PTY sessions for the application.
@@ -231,16 +243,24 @@ impl PtyManager {
             pid,
             had_child: AtomicBool::new(false),
             needs_input_until: Mutex::new(None),
+            tail_buf: Mutex::new(VecDeque::with_capacity(READ_BUFFER_SIZE)),
         });
 
-        self.handles.insert(session_id, handle);
+        self.handles.insert(session_id, Arc::clone(&handle));
 
         let app_for_reader = app.clone();
         let stop_for_reader = stop.clone();
+        let handle_for_reader = Arc::clone(&handle);
         std::thread::Builder::new()
             .name(format!("acorn-pty-read-{session_id}"))
             .spawn(move || {
-                read_loop(app_for_reader, session_id, reader, stop_for_reader);
+                read_loop(
+                    app_for_reader,
+                    session_id,
+                    reader,
+                    stop_for_reader,
+                    handle_for_reader,
+                );
             })
             .map_err(|e| AppError::Pty(format!("spawn reader thread: {e}")))?;
 
@@ -374,6 +394,27 @@ impl PtyManager {
             *handle.needs_input_until.lock() = None;
         }
     }
+
+    /// Snapshot up to `max_bytes` of the most recent PTY output for the
+    /// given session. Returns `Some((bytes, truncated))` when a PTY exists
+    /// for the session (`truncated` indicates whether the underlying tail
+    /// buffer held more bytes than were returned), or `None` when the
+    /// session has no live PTY. Pure read — does not drain the buffer.
+    pub fn tail_bytes(
+        &self,
+        session_id: &Uuid,
+        max_bytes: usize,
+    ) -> Option<(Vec<u8>, bool)> {
+        let handle = self.handles.get(session_id)?.clone();
+        let buf = handle.tail_buf.lock();
+        let total = buf.len();
+        let take = max_bytes.min(total);
+        // Take the *tail* of the ring, since that is the freshest output
+        // the user (and any agent reading via IPC) would expect to see.
+        let start = total - take;
+        let slice: Vec<u8> = buf.iter().skip(start).copied().collect();
+        Some((slice, total > take))
+    }
 }
 
 fn read_loop<R: Runtime>(
@@ -381,6 +422,7 @@ fn read_loop<R: Runtime>(
     session_id: Uuid,
     mut reader: Box<dyn Read + Send>,
     stop: Arc<AtomicBool>,
+    handle: Arc<PtyHandle>,
 ) {
     let event = format!("pty:output:{session_id}");
     let mut buf = [0u8; READ_BUFFER_SIZE];
@@ -391,6 +433,7 @@ fn read_loop<R: Runtime>(
         match reader.read(&mut buf) {
             Ok(0) => break, // EOF — child closed the slave
             Ok(n) => {
+                push_tail(&handle.tail_buf, &buf[..n]);
                 let payload = OutputPayload {
                     data: base64_encode(&buf[..n]),
                 };
@@ -405,6 +448,25 @@ fn read_loop<R: Runtime>(
             }
         }
     }
+}
+
+/// Append `chunk` to the per-session tail ring buffer, evicting bytes from
+/// the front when the cap is exceeded so the buffer can never grow past
+/// `TAIL_BUFFER_CAP` bytes. Pure data movement — `Mutex` is the only
+/// synchronization point, no allocation in the steady state once the
+/// buffer has reached its cap.
+fn push_tail(tail: &Mutex<VecDeque<u8>>, chunk: &[u8]) {
+    let mut buf = tail.lock();
+    let overflow = buf.len() + chunk.len();
+    if overflow > TAIL_BUFFER_CAP {
+        let drop_n = overflow - TAIL_BUFFER_CAP;
+        if drop_n >= buf.len() {
+            buf.clear();
+        } else {
+            buf.drain(..drop_n);
+        }
+    }
+    buf.extend(chunk.iter().copied());
 }
 
 fn wait_loop<R: Runtime>(
@@ -500,5 +562,32 @@ mod tests {
             base64_encode(b"hello world"),
             "aGVsbG8gd29ybGQ="
         );
+    }
+
+    #[test]
+    fn push_tail_keeps_recent_bytes_when_cap_exceeded() {
+        let tail: Mutex<VecDeque<u8>> = Mutex::new(VecDeque::new());
+        // Push twice the cap; expect exactly TAIL_BUFFER_CAP bytes left,
+        // and those bytes should be the tail half of what we pushed.
+        let cap = TAIL_BUFFER_CAP;
+        let chunk_a = vec![1u8; cap];
+        let chunk_b = vec![2u8; cap];
+        push_tail(&tail, &chunk_a);
+        push_tail(&tail, &chunk_b);
+        let buf = tail.lock();
+        assert_eq!(buf.len(), cap);
+        // After eviction the buffer should be all 2s — the older 1s were
+        // dropped because they fell off the front.
+        assert!(buf.iter().all(|&b| b == 2));
+    }
+
+    #[test]
+    fn push_tail_handles_chunks_smaller_than_cap() {
+        let tail: Mutex<VecDeque<u8>> = Mutex::new(VecDeque::new());
+        push_tail(&tail, b"hello");
+        push_tail(&tail, b" world");
+        let buf = tail.lock();
+        let collected: Vec<u8> = buf.iter().copied().collect();
+        assert_eq!(&collected, b"hello world");
     }
 }

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -135,6 +135,19 @@ pub enum SessionStartupMode {
     Custom,
 }
 
+/// Distinguishes ordinary terminal sessions from "control" sessions, which
+/// will (in a follow-up PR) be allowed to drive other sessions in the same
+/// project via the `acorn-ipc` CLI. Orthogonal to `SessionStartupMode`:
+/// either kind can run any startup flavor. Defaults to `Regular` so existing
+/// persisted sessions without this field load cleanly.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionKind {
+    #[default]
+    Regular,
+    Control,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     pub id: Uuid,
@@ -150,6 +163,8 @@ pub struct Session {
     pub last_message: Option<String>,
     #[serde(default)]
     pub startup_mode: Option<SessionStartupMode>,
+    #[serde(default)]
+    pub kind: SessionKind,
 }
 
 impl Session {
@@ -160,6 +175,7 @@ impl Session {
         branch: String,
         isolated: bool,
         startup_mode: Option<SessionStartupMode>,
+        kind: SessionKind,
     ) -> Self {
         let now = Utc::now();
         Self {
@@ -174,6 +190,7 @@ impl Session {
             updated_at: now,
             last_message: None,
             startup_mode,
+            kind,
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,10 @@ import { EQUALIZE_PANES_EVENT } from "./lib/layoutEvents";
 import { RightPanel } from "./components/RightPanel";
 import { ResizeHandle } from "./components/ResizeHandle";
 import { CommandPalette } from "./components/CommandPalette";
+import {
+  ControlSessionGuideModal,
+  CONTROL_GUIDE_DISMISSED_KEY,
+} from "./components/ControlSessionGuideModal";
 import { SettingsModal } from "./components/SettingsModal";
 import { TerminalHost } from "./components/TerminalHost";
 import { ToastHost } from "./components/ToastHost";
@@ -70,6 +74,7 @@ function App() {
     ? sessions.filter((s) => s.repo_path === pendingProject.repo_path)
     : [];
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [controlGuideOpen, setControlGuideOpen] = useState(false);
   const sidebarPanelRef = useRef<ImperativePanelHandle | null>(null);
   const rightPanelRef = useRef<ImperativePanelHandle | null>(null);
 
@@ -134,6 +139,17 @@ function App() {
     clearPendingRemove();
     removeSession(pendingRemove.id, false);
   }, [pendingRemove, clearPendingRemove, removeSession]);
+
+  // Surface the one-time guide modal after the first control-session
+  // creation. The store dispatches `acorn:show-control-guide` only when the
+  // dismissed-flag is unset, so this handler can stay dumb and just open.
+  useEffect(() => {
+    const handler = () => setControlGuideOpen(true);
+    window.addEventListener("acorn:show-control-guide", handler);
+    return () => {
+      window.removeEventListener("acorn:show-control-guide", handler);
+    };
+  }, []);
 
   // The Tauri app menu fires `acorn:open-settings` when the user picks
   // "Settings..." from the macOS app menu (or hits its Cmd+, accelerator).
@@ -230,6 +246,10 @@ function App() {
       [Hotkeys.newIsolatedSession]: (e: KeyboardEvent) => {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent("acorn:new-isolated-session"));
+      },
+      [Hotkeys.newControlSession]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent("acorn:new-control-session"));
       },
       [Hotkeys.addProject]: (e: KeyboardEvent) => {
         e.preventDefault();
@@ -433,6 +453,15 @@ function App() {
       <StatusBar />
       <TerminalHost />
       <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+      <ControlSessionGuideModal
+        open={controlGuideOpen}
+        onClose={(dontShowAgain) => {
+          setControlGuideOpen(false);
+          if (dontShowAgain && typeof window !== "undefined") {
+            window.localStorage.setItem(CONTROL_GUIDE_DISMISSED_KEY, "1");
+          }
+        }}
+      />
       <SettingsModal />
       <RemoveSessionDialog
         session={pendingRemove}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Command } from "cmdk";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import {
+  Bot,
   GitCommit,
   GitPullRequest,
   ListChecks,
@@ -47,6 +48,26 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       }
       const name = deriveSessionName(repoPath, sessionItems);
       await useAppStore.getState().createSession(name, repoPath);
+    } finally {
+      close();
+    }
+  }
+
+  async function handleNewControlSession() {
+    try {
+      const repoPath = await openDialog({
+        directory: true,
+        multiple: false,
+        title: "Select a directory (control session)",
+      });
+      if (!repoPath || typeof repoPath !== "string") {
+        close();
+        return;
+      }
+      const name = deriveSessionName(repoPath, sessionItems, "control");
+      await useAppStore
+        .getState()
+        .createSession(name, repoPath, false, "control");
     } finally {
       close();
     }
@@ -139,6 +160,14 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           <Command.Item value="new-session" onSelect={handleNewSession}>
             <Plus size={14} className="text-accent" />
             <span>New session</span>
+          </Command.Item>
+          <Command.Item
+            value="new-control-session"
+            onSelect={handleNewControlSession}
+            keywords={["control", "ipc", "dispatcher", "orchestrator"]}
+          >
+            <Bot size={14} className="text-accent" />
+            <span>New control session</span>
           </Command.Item>
           <Command.Item value="refresh-sessions" onSelect={handleRefresh}>
             <RefreshCw size={14} className="text-fg-muted" />
@@ -233,10 +262,17 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   );
 }
 
-function deriveSessionName(repoPath: string, existing: Session[]): string {
-  const base =
+function deriveSessionName(
+  repoPath: string,
+  existing: Session[],
+  kind: "regular" | "control" = "regular",
+): string {
+  const folder =
     repoPath.split(/[\\/]/).filter(Boolean).pop() ??
     `session-${existing.length + 1}`;
+  // Mirror Sidebar.tsx's "control-" prefix so the kind is obvious from the
+  // name alone, even when the row's accessory icon is not in view.
+  const base = kind === "control" ? `control-${folder}` : folder;
   let candidate = base;
   let n = 2;
   const taken = new Set(existing.map((s) => s.name));

--- a/src/components/ControlSessionGuideModal.tsx
+++ b/src/components/ControlSessionGuideModal.tsx
@@ -1,0 +1,90 @@
+import { useState, type ReactElement } from "react";
+import { Bot } from "lucide-react";
+import { Modal } from "./ui/Modal";
+import { ModalHeader } from "./ui/ModalHeader";
+import { CheckboxRow } from "./ui/CheckboxRow";
+
+/**
+ * localStorage key gating this modal. Exported so the App-level host can write
+ * to it when the user dismisses with "don't show again". The matching read
+ * (the gate that decides whether to open at all) lives in `store.ts` where
+ * the session is created.
+ *
+ * Versioned so a future substantive change to the control-session UX can
+ * re-surface the guide to existing users without colliding with the prior
+ * dismissed state.
+ */
+export const CONTROL_GUIDE_DISMISSED_KEY = "acorn:control-guide-dismissed-v1";
+
+interface ControlSessionGuideModalProps {
+  open: boolean;
+  /** Called with `true` when the user checked "don't show again" before closing. */
+  onClose: (dontShowAgain: boolean) => void;
+}
+
+/**
+ * One-time onboarding card shown the first time the user creates a control
+ * session. Explains the concept and previews the upcoming `acorn-ipc` CLI.
+ * Purely informational — does not block creation.
+ */
+export function ControlSessionGuideModal({
+  open,
+  onClose,
+}: ControlSessionGuideModalProps): ReactElement | null {
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  function dismiss() {
+    onClose(dontShowAgain);
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={dismiss}
+      variant="dialog"
+      size="lg"
+      ariaLabelledBy="acorn-control-guide-title"
+    >
+      <ModalHeader
+        title="Control session"
+        subtitle="A terminal that drives other sessions in this project"
+        titleId="acorn-control-guide-title"
+        icon={<Bot size={14} className="text-accent" />}
+        variant="dialog"
+        onClose={dismiss}
+      />
+      <div className="space-y-3 px-4 py-4 text-xs text-fg-muted">
+        <p>
+          Control sessions are an upcoming way to coordinate work across
+          terminals from a single place — handy for agents and scripts that
+          need to dispatch commands to siblings in the same project.
+        </p>
+        <ul className="ml-4 list-disc space-y-1">
+          <li>Send keystrokes to any session in this project.</li>
+          <li>List the other sessions and their status.</li>
+          <li>Read recent output from a target session.</li>
+        </ul>
+        <p>
+          You just created a control session. The{" "}
+          <code className="rounded bg-bg px-1 py-0.5 text-fg">acorn-ipc</code>{" "}
+          CLI that drives it ships in the next update; this terminal will
+          start behaving like a regular shell until then.
+        </p>
+        <CheckboxRow
+          label="Don't show this again"
+          checked={dontShowAgain}
+          onChange={setDontShowAgain}
+        />
+      </div>
+      <footer className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+        <button
+          type="button"
+          onClick={dismiss}
+          className="rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90"
+        >
+          Got it
+        </button>
+      </footer>
+    </Modal>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  Bot,
   ChevronRight,
   Copy,
   Files,
@@ -25,7 +26,7 @@ import {
   planTitleClick,
   type ProjectClickPlan,
 } from "../lib/sidebar-actions";
-import type { Project, Session, SessionStatus } from "../lib/types";
+import type { Project, Session, SessionKind, SessionStatus } from "../lib/types";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { Tooltip } from "./Tooltip";
 
@@ -206,33 +207,47 @@ export function Sidebar() {
   }
 
   const onNewSessionRef = useRef<
-    (isolated: boolean, repoOverride?: string) => Promise<void>
+    (
+      isolated: boolean,
+      kind: SessionKind,
+      repoOverride?: string,
+    ) => Promise<void>
   >(async () => {});
   const onAddProjectRef = useRef<() => Promise<void>>(async () => {});
 
   useEffect(() => {
     const newSession = () => {
       const project = useAppStore.getState().activeProject;
-      void onNewSessionRef.current(false, project ?? undefined);
+      void onNewSessionRef.current(false, "regular", project ?? undefined);
     };
     const newIsolated = () => {
       const project = useAppStore.getState().activeProject;
-      void onNewSessionRef.current(true, project ?? undefined);
+      void onNewSessionRef.current(true, "regular", project ?? undefined);
+    };
+    const newControl = () => {
+      const project = useAppStore.getState().activeProject;
+      void onNewSessionRef.current(false, "control", project ?? undefined);
     };
     const addProj = () => {
       void onAddProjectRef.current();
     };
     window.addEventListener("acorn:new-session", newSession);
     window.addEventListener("acorn:new-isolated-session", newIsolated);
+    window.addEventListener("acorn:new-control-session", newControl);
     window.addEventListener("acorn:add-project", addProj);
     return () => {
       window.removeEventListener("acorn:new-session", newSession);
       window.removeEventListener("acorn:new-isolated-session", newIsolated);
+      window.removeEventListener("acorn:new-control-session", newControl);
       window.removeEventListener("acorn:add-project", addProj);
     };
   }, []);
 
-  async function onNewSession(isolated: boolean, repoOverride?: string) {
+  async function onNewSession(
+    isolated: boolean,
+    kind: SessionKind,
+    repoOverride?: string,
+  ) {
     try {
       const repoPath =
         repoOverride ??
@@ -241,11 +256,13 @@ export function Sidebar() {
           multiple: false,
           title: isolated
             ? "Select a git repository (isolated worktree)"
-            : "Select a directory",
+            : kind === "control"
+              ? "Select a directory (control session)"
+              : "Select a directory",
         }));
       if (!repoPath || typeof repoPath !== "string") return;
-      const name = suggestName(repoPath, sessions);
-      await createSession(name, repoPath, isolated);
+      const name = suggestName(repoPath, sessions, kind);
+      await createSession(name, repoPath, isolated, kind);
       setCollapsed((prev) => {
         if (!prev.has(repoPath)) return prev;
         const next = new Set(prev);
@@ -334,8 +351,8 @@ export function Sidebar() {
                 }}
                 onSelectSession={selectSession}
                 onRemoveSession={(s) => requestRemoveSession(s.id)}
-                onAddSession={(isolated) =>
-                  onNewSession(isolated, project.repoPath)
+                onAddSession={(isolated, kind) =>
+                  onNewSession(isolated, kind, project.repoPath)
                 }
                 onRemoveProject={() => requestRemoveProject(project.repoPath)}
               />
@@ -394,7 +411,7 @@ interface ProjectGroupViewProps {
   onActivate: () => void;
   onSelectSession: (id: string) => void;
   onRemoveSession: (s: Session) => void;
-  onAddSession: (isolated: boolean) => void;
+  onAddSession: (isolated: boolean, kind: SessionKind) => void;
   onRemoveProject: () => void;
 }
 
@@ -522,7 +539,7 @@ function ProjectGroupView({
             type="button"
             onClick={(e) => {
               e.stopPropagation();
-              onAddSession(false);
+              onAddSession(false, "regular");
             }}
             className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
             aria-label="New session in this project"
@@ -535,12 +552,25 @@ function ProjectGroupView({
             type="button"
             onClick={(e) => {
               e.stopPropagation();
-              onAddSession(true);
+              onAddSession(true, "regular");
             }}
             className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
             aria-label="New isolated session (worktree)"
           >
             <GitBranch size={12} />
+          </button>
+        </Tooltip>
+        <Tooltip label="New control session" side="bottom">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onAddSession(false, "control");
+            }}
+            className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
+            aria-label="New control session in this project"
+          >
+            <Bot size={12} />
           </button>
         </Tooltip>
         <Tooltip label="Close project" side="bottom">
@@ -566,12 +596,17 @@ function ProjectGroupView({
           {
             label: "New session",
             icon: <Plus size={12} />,
-            onClick: () => onAddSession(false),
+            onClick: () => onAddSession(false, "regular"),
           },
           {
             label: "New isolated session",
             icon: <GitBranch size={12} />,
-            onClick: () => onAddSession(true),
+            onClick: () => onAddSession(true, "regular"),
+          },
+          {
+            label: "New control session",
+            icon: <Bot size={12} />,
+            onClick: () => onAddSession(false, "control"),
           },
           { type: "separator" },
           {
@@ -603,11 +638,11 @@ function ProjectGroupView({
               role="button"
               tabIndex={0}
               onClick={onActivate}
-              onDoubleClick={() => onAddSession(false)}
+              onDoubleClick={() => onAddSession(false, "regular")}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
-                  onAddSession(false);
+                  onAddSession(false, "regular");
                 }
               }}
               className="cursor-pointer rounded px-2 py-1 text-[11px] text-fg-muted transition select-none hover:bg-bg-elevated/40 hover:text-fg"
@@ -658,14 +693,15 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
       n += 1;
     }
     try {
-      // Carry the source session's startup mode onto the duplicate so
-      // the duplicate respawns with the same kind of process, regardless
-      // of the current global default.
+      // Carry the source session's startup mode and kind onto the duplicate
+      // so the duplicate respawns with the same kind of process and (for
+      // control sessions) preserves its IPC-dispatch role.
       await api.createSession(
         next,
         session.repo_path,
         session.isolated,
         session.startup_mode,
+        session.kind,
       );
       await useAppStore.getState().refreshAll();
     } catch (err) {
@@ -790,6 +826,13 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
                 size={10}
                 className="shrink-0 text-fg-muted"
                 aria-label="isolated worktree"
+              />
+            ) : null}
+            {session.kind === "control" ? (
+              <Bot
+                size={10}
+                className="shrink-0 text-accent"
+                aria-label="control session"
               />
             ) : null}
           </span>
@@ -917,8 +960,15 @@ function basename(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
 }
 
-function suggestName(repoPath: string, existing: Session[]): string {
-  const base = basename(repoPath);
+function suggestName(
+  repoPath: string,
+  existing: Session[],
+  kind: SessionKind = "regular",
+): string {
+  // Control sessions get a "control-" prefix so they sort into a clearly
+  // distinct namespace at-a-glance, mirroring how `tmux` users name dedicated
+  // controller panes.
+  const base = kind === "control" ? `control-${basename(repoPath)}` : basename(repoPath);
   let candidate = base;
   let n = 2;
   const taken = new Set(existing.map((s) => s.name));

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   PullRequestDetailListing,
   PullRequestListing,
   Session,
+  SessionKind,
   SessionStartupMode,
   SessionStatus,
   StagedFile,
@@ -33,12 +34,14 @@ export const api = {
     repoPath: string,
     isolated = false,
     startupMode: SessionStartupMode | null = null,
+    kind: SessionKind = "regular",
   ): Promise<Session> {
     return invoke<Session>("create_session", {
       name,
       repoPath,
       isolated,
       startupMode,
+      kind,
     });
   },
   removeSession(id: string, removeWorktree = false): Promise<void> {

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -25,6 +25,10 @@ export const Hotkeys = {
   clearTerminal: "$mod+k",
   newSession: "$mod+t",
   newIsolatedSession: "$mod+Alt+t",
+  // "Control session" — extends the new-session family. Future PRs add the
+  // `acorn-ipc` CLI so this kind of session can drive sibling sessions; the
+  // hotkey lives next to the other terminal-creation bindings for symmetry.
+  newControlSession: "$mod+Alt+Shift+t",
   addProject: "$mod+Shift+n",
   focusSidebar: "$mod+1",
   focusMain: "$mod+2",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,15 @@ export type SessionStatus =
  */
 export type SessionStartupMode = "agent" | "terminal" | "custom";
 
+/**
+ * Distinguishes ordinary terminal sessions from "control" sessions. Control
+ * sessions are the entry point for the upcoming `acorn-ipc` CLI, which lets
+ * them dispatch commands to other sessions in the same project. Orthogonal
+ * to `SessionStartupMode` — either kind can run any startup flavor. Older
+ * persisted sessions without this field load as `"regular"` from the backend.
+ */
+export type SessionKind = "regular" | "control";
+
 export interface Session {
   id: string;
   name: string;
@@ -26,6 +35,7 @@ export interface Session {
   updated_at: string;
   last_message: string | null;
   startup_mode: SessionStartupMode | null;
+  kind: SessionKind;
 }
 
 export interface Project {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -67,6 +67,7 @@ function session(
     updated_at: "2026-01-01T00:00:00Z",
     last_message: null,
     startup_mode: null,
+    kind: "regular",
     ...overrides,
   };
 }
@@ -548,5 +549,91 @@ describe("reorderProjects", () => {
     await useAppStore.getState().reorderProjects([REPO_B, REPO_A]);
     expect(useAppStore.getState().projects).toEqual(before);
     expect(useAppStore.getState().error).toBe("nope");
+  });
+});
+
+describe("createSession", () => {
+  // Each control-session test reaches into localStorage; clear it so
+  // an earlier test's "don't show again" flag does not leak forward.
+  const guideKey = "acorn:control-guide-dismissed-v1";
+
+  beforeEach(() => {
+    window.localStorage.removeItem(guideKey);
+  });
+
+  it("defaults the kind to regular when the caller omits it", async () => {
+    mockApi.createSession.mockResolvedValueOnce(session("new", REPO_A));
+    await useAppStore.getState().createSession("foo", REPO_A);
+    expect(mockApi.createSession).toHaveBeenCalledWith(
+      "foo",
+      REPO_A,
+      false,
+      expect.anything(),
+      "regular",
+    );
+  });
+
+  it("forwards control kind to the backend", async () => {
+    mockApi.createSession.mockResolvedValueOnce(
+      session("ctl", REPO_A, { kind: "control" }),
+    );
+    await useAppStore
+      .getState()
+      .createSession("ctl", REPO_A, false, "control");
+    expect(mockApi.createSession).toHaveBeenCalledWith(
+      "ctl",
+      REPO_A,
+      false,
+      expect.anything(),
+      "control",
+    );
+  });
+
+  it("emits the guide event the first time a control session is created", async () => {
+    const events: Event[] = [];
+    const listener = (e: Event) => events.push(e);
+    window.addEventListener("acorn:show-control-guide", listener);
+    try {
+      mockApi.createSession.mockResolvedValueOnce(
+        session("ctl", REPO_A, { kind: "control" }),
+      );
+      await useAppStore
+        .getState()
+        .createSession("ctl", REPO_A, false, "control");
+      expect(events).toHaveLength(1);
+    } finally {
+      window.removeEventListener("acorn:show-control-guide", listener);
+    }
+  });
+
+  it("suppresses the guide event when the dismissed flag is set", async () => {
+    window.localStorage.setItem(guideKey, "1");
+    const events: Event[] = [];
+    const listener = (e: Event) => events.push(e);
+    window.addEventListener("acorn:show-control-guide", listener);
+    try {
+      mockApi.createSession.mockResolvedValueOnce(
+        session("ctl", REPO_A, { kind: "control" }),
+      );
+      await useAppStore
+        .getState()
+        .createSession("ctl", REPO_A, false, "control");
+      expect(events).toHaveLength(0);
+    } finally {
+      window.removeEventListener("acorn:show-control-guide", listener);
+    }
+  });
+
+  it("does not emit the guide event for regular sessions", async () => {
+    const events: Event[] = [];
+    const listener = (e: Event) => events.push(e);
+    window.addEventListener("acorn:show-control-guide", listener);
+    try {
+      mockApi.createSession.mockResolvedValueOnce(session("reg", REPO_A));
+      await useAppStore.getState().createSession("reg", REPO_A);
+      expect(events).toHaveLength(0);
+    } finally {
+      window.removeEventListener("acorn:show-control-guide", listener);
+    }
   });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { api } from "./lib/api";
 import { useSettings } from "./lib/settings";
-import type { Project, Session } from "./lib/types";
+import type { Project, Session, SessionKind } from "./lib/types";
 import {
   type Direction,
   type LayoutNode,
@@ -17,6 +17,13 @@ import {
 type RightTab = "todos" | "commits" | "staged" | "prs";
 
 const ROOT_PANE_ID: PaneId = "root";
+
+/**
+ * localStorage key gating the one-time control-session guide modal. Versioned
+ * so we can re-surface it after a substantive change to the control-session
+ * UX without colliding with the previous dismissed state.
+ */
+const CONTROL_GUIDE_DISMISSED_KEY = "acorn:control-guide-dismissed-v1";
 
 export interface PaneState {
   id: PaneId;
@@ -91,6 +98,7 @@ interface AppStateModel {
     name: string,
     repoPath: string,
     isolated?: boolean,
+    kind?: SessionKind,
   ) => Promise<void>;
   removeSession: (id: string, removeWorktree?: boolean) => Promise<void>;
   renameSession: (id: string, name: string) => Promise<void>;
@@ -694,7 +702,7 @@ export const useAppStore = create<AppStateModel>()(
     });
   },
 
-  async createSession(name, repoPath, isolated = false) {
+  async createSession(name, repoPath, isolated = false, kind = "regular") {
     set({ loading: true, error: null });
     try {
       // Snapshot the current global startup mode onto the session so a
@@ -706,12 +714,22 @@ export const useAppStore = create<AppStateModel>()(
         repoPath,
         isolated,
         startupMode,
+        kind,
       );
       await get().refreshAll();
       // Focus the new session so Cmd+T (and any other entry point that goes
       // through the store) immediately surfaces it in its pane instead of
       // silently appending behind the existing active tab.
       get().selectSession(created.id);
+      // First-run guidance for control sessions. Gated on a localStorage
+      // flag so power users only see it once. App.tsx hosts the modal.
+      if (
+        kind === "control" &&
+        typeof window !== "undefined" &&
+        !window.localStorage.getItem(CONTROL_GUIDE_DISMISSED_KEY)
+      ) {
+        window.dispatchEvent(new CustomEvent("acorn:show-control-guide"));
+      }
     } catch (e) {
       set({ loading: false, error: errorMessage(e) });
     }

--- a/tests/e2e/control-session.spec.ts
+++ b/tests/e2e/control-session.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect, pressHotkey } from "./support";
+
+const REPO_PATH = "/tmp/demo";
+
+const PROJECT = {
+  repo_path: REPO_PATH,
+  name: "demo",
+  created_at: "2026-01-01T00:00:00Z",
+  position: 0,
+};
+
+test.describe("control session: creation flow", () => {
+  test("Cmd+Alt+Shift+T creates a control session, surfaces the bot icon, and shows the guide modal", async ({
+    page,
+    tauri,
+  }) => {
+    // Seed an existing project; the hotkey targets the active project, so
+    // we don't need to drive the directory picker.
+    await tauri.respond("list_projects", [PROJECT]);
+    // The store starts with no sessions, then `create_session` populates one.
+    // `list_sessions` is called after creation via `refreshAll`, so it has to
+    // return the freshly-created control session on subsequent calls.
+    await tauri.handle("list_sessions", () => {
+      // Tests-side state is forbidden inside the handler (serialized to source),
+      // so we read the *last* created session out of a window-scoped store.
+      const w = window as unknown as {
+        __ACORN_CTL_LAST__?: Record<string, unknown> | null;
+      };
+      return w.__ACORN_CTL_LAST__ ? [w.__ACORN_CTL_LAST__] : [];
+    });
+    await tauri.handle("create_session", (args) => {
+      const input = (args ?? {}) as {
+        name?: string;
+        repoPath?: string;
+        kind?: string;
+      };
+      const created = {
+        id: "ctl-1",
+        name: input.name ?? "control-demo",
+        repo_path: input.repoPath ?? "/tmp/demo",
+        worktree_path: input.repoPath ?? "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        startup_mode: null,
+        kind: input.kind ?? "regular",
+      };
+      (window as unknown as { __ACORN_CTL_LAST__: unknown }).__ACORN_CTL_LAST__ =
+        created;
+      return created;
+    });
+
+    await page.goto("/");
+    // Clear any previously-persisted dismissal so the guide is allowed to fire.
+    await page.evaluate(() => {
+      window.localStorage.removeItem("acorn:control-guide-dismissed-v1");
+    });
+
+    // Trigger the hotkey. Bindings live on `window` via tinykeys; pressHotkey
+    // dispatches a synthetic keydown to bypass Chromium's own intercepts.
+    await pressHotkey(page, { mod: true, alt: true, shift: true, key: "t" });
+
+    // The new session appears in the sidebar with the control accessory icon.
+    const sidebar = page.locator("aside");
+    const controlIcon = sidebar.locator(
+      "[aria-label='control session']",
+    );
+    await expect(controlIcon).toBeVisible();
+
+    // The guide modal opens on first creation.
+    await expect(
+      page.getByRole("heading", { name: "Control session" }),
+    ).toBeVisible();
+
+    // Dismiss with "don't show again" so the localStorage gate is set.
+    await page
+      .getByRole("checkbox", { name: /Don't show this again/i })
+      .check();
+    await page.getByRole("button", { name: "Got it" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Control session" }),
+    ).toBeHidden();
+
+    // The flag was written.
+    const dismissed = await page.evaluate(() =>
+      window.localStorage.getItem("acorn:control-guide-dismissed-v1"),
+    );
+    expect(dismissed).toBe("1");
+  });
+
+  test("command palette exposes a 'New control session' entry", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", []);
+
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "p" });
+
+    await expect(
+      page.getByRole("dialog", { name: /Command palette/i }),
+    ).toBeVisible();
+    // cmdk renders items with role="option"; matching by visible text is
+    // resilient to cmdk's exact aria implementation.
+    await expect(page.getByText("New control session")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

PR #2 of the **control sessions** stack. Adds the in-process IPC server and the `acorn-ipc` CLI that control sessions (PR #1) use to drive their siblings. Stacks on top of `feat/control-session-kind`.

```
main
 └─ feat/control-session-kind   #108 (PR #1, base)
     └─ feat/control-session-ipc   ← this PR
         └─ feat/control-session-cli-install   (PR #3, next)
```

## Transport

- Unix domain socket at `<data_dir>/ipc.sock` (override via `ACORN_IPC_SOCKET`). Chmod `0600` best-effort after bind.
- Newline-terminated JSON. One request → one response per connection.
- Dedicated listener thread + thread-per-connection. No tokio — the downstream PTY pool is `parking_lot`-backed and stays synchronous.

## Protocol (`ipc::proto`, `PROTOCOL_VERSION = 1`)

| Command | Effect |
|---|---|
| `list-sessions` | Sessions in the source's project; `*` marks self |
| `send-keys` | Forward bytes to target's PTY stdin |
| `read-buffer` | Tail of target's 4 MiB ring buffer + `truncated` flag |
| `new-session` | Create a regular session in the same project |
| `select-session` | Focus a session in the app UI (Tauri event) |
| `kill-session` | Kill PTY + drop from state (refuses to kill source) |

Tagged JSON via serde (`#[serde(tag = "kind", rename_all = "kebab-case")]`). Errors are structured (`Response::Error { code, message }`) with a compact `ErrorCode` enum the CLI maps to stable shell exit codes.

## Permissions

- Every request carries the source session UUID.
- Server rejects requests whose source is missing or whose `SessionKind != Control` → `Unauthorized`.
- Target lookups are scoped to the source's `repo_path`. Cross-project ids surface `OutOfScope`, not `NotFound`, so the CLI can give an accurate diagnostic.
- `kill-session` refuses to kill the source itself.

## Ring buffer

- `PtyHandle` grows a 4 MiB `VecDeque<u8>` tail, written by the reader thread before bytes go to the webview.
- `PtyManager::tail_bytes(id, max_bytes)` reads the tail and reports truncation. Pure read, no drain.

## Spawn-time env

`commands::pty_spawn` injects `ACORN_SESSION_ID` and `ACORN_IPC_SOCKET` into the PTY env **only** for control sessions. Regular sessions stay sandboxed from the IPC surface.

## CLI (`src/bin/acorn-ipc.rs`)

- clap subcommands match the protocol 1:1.
- Resolves `$ACORN_IPC_SOCKET` → platform data-dir default.
- Reads `$ACORN_SESSION_ID` (override via `--source`).
- TTY → tabular session listing; `--json` for pipe-friendly output.

```
$ acorn-ipc list-sessions
  ID                                    NAME           KIND     STATUS  branch
* 7e6f8c9e-...                          control-acorn  control  idle    main
  abcdef01-...                          worker-a       regular  running feat/x
```

## Test plan

- [x] `cargo build --bin acorn-ipc` clean
- [x] `cargo test --lib` — 10 new IPC tests (protocol roundtrip, permission gate, project scope, ring-buffer eviction); 60 total pass
- [x] CLI `--help` renders; `acorn-ipc list-sessions` outside a control session exits 2 with `ACORN_SESSION_ID is unset`
- [ ] End-to-end (control session → ipc-call → sibling reacts) — wired up and tested via Playwright in PR #3

## Notes

- The CLI binary builds from the same crate as the lib via `[[bin]]`. Sharing the `proto` and `socket_path` modules via `#[path]` keeps the wire format in lockstep without a workspace restructure.
- Audit log is intentionally not in this PR — `tracing::info!` lines per request will do for v1; a real audit file lands behind a setting later.
