### PR TITLE
chore(release): v1.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.8",
+  "version": "1.0.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.8"
+version = "1.0.9"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

Bumps `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.lock` from `1.0.8` to `1.0.9` so the next `v1.0.9` tag has matching manifest metadata.

## Notable since v1.0.8

- **Control sessions stack (#108, #109, #110, #111)** — new `SessionKind::Control` (`⌘⌥⇧T`), in-app Unix-socket IPC server, bundled `acorn-ipc` CLI with 6 commands (`list-sessions`, `send-keys`, `read-buffer`, `new-session`, `select-session`, `kill-session`), agent priming (env vars + `--append-system-prompt` for Claude Code + `-s` for llm + `.acorn-control.md` marker), and Settings install affordance. CLI is bundled via Tauri `externalBin` so packaged users get it without a separate install; inside a control session the bundled-CLI dir is prepended to `PATH` for zero-install use. macOS / Linux only (Unix domain sockets); Windows untouched. See `docs/CONTROL_SESSIONS.md`.
- **PR detail modal skeleton (#107)** — layout-shaped placeholder for the PR detail surface, ready for incremental wiring.

## Test plan

- [x] `cargo test --lib` — 71 pass
- [x] `cargo test --bin acorn-ipc` — 10 pass
- [x] `bun run test` — 101 pass
- [x] `bun run typecheck` clean
- [ ] CI on this PR (Frontend + E2E)
- [ ] Tag `v1.0.9` after merge to trigger `release.yml` macOS bundle build