### PR TITLE
fix(sidecar): build for the target triple, not the host triple

### DIFF
--- a/src-tauri/scripts/build-sidecar.sh
+++ b/src-tauri/scripts/build-sidecar.sh
@@ -1,28 +1,39 @@
 #!/usr/bin/env bash
 # Build the `acorn-ipc` CLI and stage it where Tauri's externalBin expects
-# it: `src-tauri/binaries/acorn-ipc-<host-triple>`.
+# it: `src-tauri/binaries/acorn-ipc-<target-triple>`.
 #
-# Tauri 2's externalBin convention requires the file name to end with the
-# build target triple; this script asks rustc for the host triple, builds
-# in release mode, and copies the binary into place with the right name.
-# Invoke before `tauri build` (wired via `beforeBuildCommand`).
+# Tauri 2's externalBin convention names the staged file after the *target*
+# triple — the one being built for, not the host the script is running on.
+# When `tauri build --target X` runs, the matching `acorn-ipc-X` file must
+# exist before the build script's existence check fires. For the release
+# matrix on Apple-Silicon `macos-latest` runners that means producing an
+# x86_64 binary alongside the aarch64 one, even though the host is aarch64.
 #
-# Exits non-zero on any failure so the build fails loudly instead of
-# silently shipping a `.app` without the CLI sidecar.
+# Tauri passes the active target through `TAURI_ENV_TARGET_TRIPLE` to
+# commands spawned via `beforeBuildCommand`. Standalone callers (local
+# `bun run build:sidecar`, manual runs) fall back to the host triple so
+# the script keeps working without extra setup.
+#
+# Exits non-zero on any failure so the build surfaces the problem instead
+# of silently shipping a `.app` without the CLI sidecar.
 
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
 profile="${TAURI_SIDECAR_PROFILE:-release}"
-target_triple="$(rustc -vV | sed -n 's|host: ||p')"
+target_triple="${TAURI_ENV_TARGET_TRIPLE:-$(rustc -vV | sed -n 's|host: ||p')}"
 
 if [ -z "$target_triple" ]; then
-  echo "error: could not read host triple from \`rustc -vV\`" >&2
+  echo "error: could not determine target triple (TAURI_ENV_TARGET_TRIPLE unset and \`rustc -vV\` produced no host line)" >&2
   exit 1
 fi
 
-cargo_flags=(--bin acorn-ipc)
+# Always cross-compile with `--target` so the output lands in
+# `target/<triple>/<profile>/` even when host == target. The uniform
+# layout removes a branching copy step below and matches how the rest of
+# the release workflow already invokes cargo for the main binary.
+cargo_flags=(--bin acorn-ipc --target "$target_triple")
 if [ "$profile" = "release" ]; then
   cargo_flags+=(--release)
 fi
@@ -40,10 +51,10 @@ if [ ! -f "$dest" ]; then
   : > "$dest"
 fi
 
-echo "build-sidecar: cargo build ${cargo_flags[*]} (triple=$target_triple)"
+echo "build-sidecar: cargo build ${cargo_flags[*]}"
 cargo build "${cargo_flags[@]}"
 
-src="target/$profile/acorn-ipc"
+src="target/$target_triple/$profile/acorn-ipc"
 if [ ! -f "$src" ]; then
   echo "error: expected built binary at $src" >&2
   exit 1


### PR DESCRIPTION
## Summary

The v1.0.9 release run failed on the `x86_64-apple-darwin` matrix slot. `macos-latest` is now an Apple-Silicon (aarch64) runner, so `rustc -vV | grep host` always returned `aarch64-apple-darwin` regardless of which `--target` the parent `tauri build` was invoked with. The script staged `binaries/acorn-ipc-aarch64-apple-darwin`, Tauri's build.rs then looked for `binaries/acorn-ipc-x86_64-apple-darwin` (the active build target), did not find it, and aborted before the bundler ran.

Workflow run: https://github.com/im-ian/acorn/actions/runs/25676244798

## Fix

- Read `TAURI_ENV_TARGET_TRIPLE` first — Tauri exports it to commands spawned via `beforeBuildCommand`. Fall back to the host triple for standalone callers (local `bun run build:sidecar`) so the script keeps working without extra setup.
- Always pass `--target <triple>` to cargo and read the output from `target/<triple>/<profile>/`. The uniform layout removes the implicit "host build only" assumption.

## Test plan

- [x] Local aarch64 smoke: `bun run build:sidecar` (no env var, fallback path) produces `binaries/acorn-ipc-aarch64-apple-darwin` from `target/aarch64-apple-darwin/release/acorn-ipc`
- [ ] CI on this PR (Frontend + E2E)
- [ ] Move `v1.0.9` tag forward to the merge commit and let `release.yml` rerun on both matrix slots

## Follow-up

Once this merges, `v1.0.9` tag gets force-updated to the merge commit so the `release.yml` workflow re-runs on a passing source tree. v1.0.9 was never actually published (the failed run skipped the publish step) so the tag move has no public consumers.