### PR TITLE
fix(panes): make tab drag-to-split detection reliable

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -11,7 +11,13 @@ import {
   Terminal as TerminalIcon,
   X,
 } from "lucide-react";
-import { useMemo, useRef, useState, useEffect } from "react";
+import {
+  useMemo,
+  useRef,
+  useState,
+  useEffect,
+  type CSSProperties,
+} from "react";
 import { openPath } from "@tauri-apps/plugin-opener";
 import { useAppStore } from "../store";
 import { api } from "../lib/api";
@@ -528,6 +534,11 @@ function TabItem({
         role="button"
         tabIndex={0}
         draggable={!editing}
+        style={
+          !editing
+            ? ({ WebkitUserDrag: "element" } as CSSProperties)
+            : undefined
+        }
         onDragStart={(e) => {
           setTabDragPayload(e, { sessionId: tab.id, fromPaneId: paneId });
         }}
@@ -555,7 +566,7 @@ function TabItem({
           }
         }}
         className={cn(
-          "group relative flex shrink-0 cursor-pointer items-center gap-1.5 border-r border-border pl-3 pr-1 text-xs transition",
+          "group relative flex shrink-0 cursor-pointer select-none items-center gap-1.5 border-r border-border pl-3 pr-1 text-xs transition",
           active
             ? "bg-bg text-fg"
             : "bg-bg-elevated/40 text-fg-muted hover:bg-bg-elevated/70 hover:text-fg",

--- a/src/components/PaneDropOverlay.tsx
+++ b/src/components/PaneDropOverlay.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { cn } from "../lib/cn";
 import {
   classifyDropZone,
@@ -26,7 +26,11 @@ export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [zone, setZone] = useState<DropZone | null>(null);
 
-  if (!dragging) return null;
+  // Clear any lingering highlight when the drag ends without a dragleave
+  // event firing on this overlay (e.g., dropped on a sibling pane).
+  useEffect(() => {
+    if (!dragging && zone) setZone(null);
+  }, [dragging, zone]);
 
   function computeZone(e: React.DragEvent): DropZone | null {
     const el = containerRef.current;
@@ -38,10 +42,17 @@ export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
     );
   }
 
+  // Always mount so the very first dragenter into a pane body is captured;
+  // toggle pointer-events so the overlay only intercepts events while a tab
+  // drag is actually in progress.
   return (
     <div
       ref={containerRef}
-      className="absolute inset-0 z-20"
+      className={
+        dragging
+          ? "absolute inset-0 z-20"
+          : "pointer-events-none absolute inset-0 z-20"
+      }
       onDragEnter={(e) => {
         if (!isTabDrag(e)) return;
         e.preventDefault();

--- a/src/lib/dnd.test.ts
+++ b/src/lib/dnd.test.ts
@@ -4,7 +4,7 @@ import { classifyDropZone } from "./dnd";
 const RECT = { left: 0, top: 0, width: 100, height: 100 };
 
 describe("classifyDropZone", () => {
-  it("returns center when pointer is past the 25% edge threshold on all sides", () => {
+  it("returns center when pointer is past the edge threshold on all sides", () => {
     expect(classifyDropZone({ x: 50, y: 50 }, RECT)).toEqual({ kind: "center" });
   });
 
@@ -40,9 +40,22 @@ describe("classifyDropZone", () => {
     });
   });
 
-  it("respects the 25% threshold boundary as center", () => {
-    // 25% in from the left = relX 0.25, distLeft 0.25 → still center.
-    expect(classifyDropZone({ x: 25, y: 50 }, RECT)).toEqual({ kind: "center" });
+  it("treats the threshold boundary as center (not edge)", () => {
+    // 100x100 rect → edge band = min(64px, 40% × 100) = 40px. distLeft = 40
+    // is the exact boundary, so it should classify as center.
+    expect(classifyDropZone({ x: 40, y: 50 }, RECT)).toEqual({ kind: "center" });
+  });
+
+  it("clamps edge band to 40% of the smaller dimension on narrow panes", () => {
+    // 50px wide × 200px tall pane. Horizontal threshold = min(64, 20) = 20px.
+    // distLeft = 21 sits just outside the edge band → center.
+    const narrow = { left: 0, top: 0, width: 50, height: 200 };
+    expect(classifyDropZone({ x: 21, y: 100 }, narrow)).toEqual({ kind: "center" });
+    expect(classifyDropZone({ x: 5, y: 100 }, narrow)).toEqual({
+      kind: "edge",
+      direction: "horizontal",
+      side: "before",
+    });
   });
 
   it("handles non-zero rect origin", () => {

--- a/src/lib/dnd.ts
+++ b/src/lib/dnd.ts
@@ -84,29 +84,37 @@ export function useTabDragInProgress(): boolean {
 
 /**
  * Drop zone classification based on pointer position relative to a rectangle.
- * Edge zones occupy the outer 25% of each side; the center zone is everything
- * else.
+ * Edge zones occupy a pixel-based band on each side (clamped so they never
+ * exceed ~40% of the smaller pane dimension); the center zone is everything
+ * else. Pixel-based thresholds feel consistent across narrow split panes and
+ * wide single panes — a fixed percentage made narrow panes nearly all-center.
  */
 export type DropZone =
   | { kind: "center" }
   | { kind: "edge"; direction: Direction; side: SplitSide };
 
-const EDGE_THRESHOLD = 0.25;
+const EDGE_PX = 64;
+const EDGE_MAX_FRACTION = 0.4;
 
 export function classifyDropZone(
   pointer: { x: number; y: number },
   rect: { left: number; top: number; width: number; height: number },
 ): DropZone {
-  const relX = (pointer.x - rect.left) / rect.width;
-  const relY = (pointer.y - rect.top) / rect.height;
-
-  const distLeft = relX;
-  const distRight = 1 - relX;
-  const distTop = relY;
-  const distBottom = 1 - relY;
+  const distLeft = pointer.x - rect.left;
+  const distRight = rect.left + rect.width - pointer.x;
+  const distTop = pointer.y - rect.top;
+  const distBottom = rect.top + rect.height - pointer.y;
   const minDist = Math.min(distLeft, distRight, distTop, distBottom);
 
-  if (minDist >= EDGE_THRESHOLD) return { kind: "center" };
+  const thresholdX = Math.min(EDGE_PX, rect.width * EDGE_MAX_FRACTION);
+  const thresholdY = Math.min(EDGE_PX, rect.height * EDGE_MAX_FRACTION);
+
+  const isHorizontalEdge =
+    (minDist === distLeft || minDist === distRight) && minDist < thresholdX;
+  const isVerticalEdge =
+    (minDist === distTop || minDist === distBottom) && minDist < thresholdY;
+
+  if (!isHorizontalEdge && !isVerticalEdge) return { kind: "center" };
 
   if (minDist === distLeft) {
     return { kind: "edge", direction: "horizontal", side: "before" };


### PR DESCRIPTION
## Summary

Tab drag-to-split judging was flaky — both starting a drag from a tab and getting the right drop zone often felt off, especially on narrow split panes. Three small wins, all in the frontend:

- **Tab dragstart on WKWebView:** the tab `<div>` in `Pane.tsx` was draggable, but a mousedown on its text label would trigger a native text-selection drag instead of an element drag. Added `select-none` and `-webkit-user-drag: element` (via inline style + `CSSProperties` cast since React's type doesn't list it).
- **Overlay was mounted late:** `PaneDropOverlay` only rendered while `useTabDragInProgress()` was `true`, so the first `dragenter` into a pane body during a drag was being lost to the overlay's initial commit. Now it's always mounted with `pointer-events-none` until a drag is active, and a small effect clears any stale highlight when the drag ends without firing a dragleave on this overlay.
- **Edge zones were a fixed fraction:** `classifyDropZone` used a 25% threshold of the pane's width/height, which made narrow split panes have a tiny edge band and wide single panes overshoot. Switched to a pixel band of 64px, clamped to 40% of the smaller dimension. Unit tests updated.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` — 10 files / 102 tests pass (1 skipped)
- [x] Manual: `bun run tauri dev`, dragged tabs across panes, dropped on center + each edge, confirmed split direction matches the highlight on both wide and narrow panes.
