### PR TITLE
feat(sidebar): dnd-kit reorder for projects and sessions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,9 @@
     "": {
       "name": "acorn",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@tanstack/react-virtual": "^3.13.24",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",
@@ -114,6 +117,14 @@
     "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.3", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg=="],
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@emotion/babel-plugin": ["@emotion/babel-plugin@11.13.5", "", { "dependencies": { "@babel/helper-module-imports": "^7.16.7", "@babel/runtime": "^7.18.3", "@emotion/hash": "^0.9.2", "@emotion/memoize": "^0.9.0", "@emotion/serialize": "^1.3.3", "babel-plugin-macros": "^3.1.0", "convert-source-map": "^1.5.0", "escape-string-regexp": "^4.0.0", "find-root": "^1.1.0", "source-map": "^0.5.7", "stylis": "4.2.0" } }, "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ=="],
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tanstack/react-virtual": "^3.13.24",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.1",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -317,6 +317,22 @@ pub fn reorder_projects(state: State<'_, AppState>, order: Vec<String>) -> AppRe
 }
 
 #[tauri::command]
+pub fn reorder_sessions(
+    state: State<'_, AppState>,
+    repo_path: String,
+    order: Vec<String>,
+) -> AppResult<Vec<Session>> {
+    let path = PathBuf::from(&repo_path);
+    let ids: Vec<Uuid> = order
+        .into_iter()
+        .filter_map(|s| Uuid::parse_str(&s).ok())
+        .collect();
+    state.sessions.reorder(&path, &ids);
+    persist(&state);
+    Ok(state.sessions.list())
+}
+
+#[tauri::command]
 pub async fn remove_project(
     state: State<'_, AppState>,
     repo_path: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -177,6 +177,7 @@ pub fn run() {
             commands::add_project,
             commands::remove_project,
             commands::reorder_projects,
+            commands::reorder_sessions,
             commands::list_commits,
             commands::list_staged,
             commands::commit_diff,

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -165,6 +165,12 @@ pub struct Session {
     pub startup_mode: Option<SessionStartupMode>,
     #[serde(default)]
     pub kind: SessionKind,
+    /// User-defined display order within the project group. `None` means the
+    /// session has never been reordered — the frontend falls back to
+    /// `updated_at DESC` for these. Once any session in a project is dragged,
+    /// every session in that project gets an explicit position.
+    #[serde(default)]
+    pub position: Option<i64>,
 }
 
 impl Session {
@@ -191,6 +197,7 @@ impl Session {
             last_message: None,
             startup_mode,
             kind,
+            position: None,
         }
     }
 }
@@ -283,5 +290,42 @@ impl SessionStore {
             .remove(id)
             .map(|(_, v)| v)
             .ok_or_else(|| AppError::SessionNotFound(id.to_string()))
+    }
+
+    /// Assign explicit positions (0..N) to the sessions listed in `order`,
+    /// scoped to a single project (`repo_path`). Sessions belonging to the
+    /// same project but missing from `order` keep their existing position
+    /// where set, otherwise get appended after the explicit ones. Sessions
+    /// from other projects are untouched. Unknown ids in `order` are ignored.
+    pub fn reorder(&self, repo_path: &std::path::Path, order: &[Uuid]) {
+        let mut seen = std::collections::HashSet::new();
+        let mut pos: i64 = 0;
+        for id in order {
+            if let Some(mut entry) = self.inner.get_mut(id) {
+                if entry.repo_path != repo_path {
+                    continue;
+                }
+                entry.position = Some(pos);
+                pos += 1;
+                seen.insert(*id);
+            }
+        }
+        let mut remaining: Vec<(Uuid, Option<i64>, DateTime<Utc>)> = self
+            .inner
+            .iter()
+            .filter(|r| r.value().repo_path == repo_path && !seen.contains(r.key()))
+            .map(|r| (*r.key(), r.value().position, r.value().updated_at))
+            .collect();
+        remaining.sort_by(|a, b| {
+            let ap = a.1.unwrap_or(i64::MAX);
+            let bp = b.1.unwrap_or(i64::MAX);
+            ap.cmp(&bp).then_with(|| b.2.cmp(&a.2))
+        });
+        for (id, _, _) in remaining {
+            if let Some(mut entry) = self.inner.get_mut(&id) {
+                entry.position = Some(pos);
+                pos += 1;
+            }
+        }
     }
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,6 +16,26 @@ import {
 import { openPath } from "@tauri-apps/plugin-opener";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { useAppStore } from "../store";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
@@ -48,20 +68,14 @@ const STATUS_LABEL: Record<SessionStatus, string> = {
 
 const COLLAPSED_KEY = "acorn:sidebar:collapsed-projects";
 
+const PROJECT_DRAG_PREFIX = "project:";
+const SESSION_DRAG_PREFIX = "session:";
+
 interface ProjectGroup {
   repoPath: string;
   name: string;
   sessions: Session[];
 }
-
-type DropPosition = "before" | "after";
-
-interface ProjectDropTarget {
-  repoPath: string;
-  position: DropPosition;
-}
-
-const PROJECT_DRAG_MIME = "application/x-acorn-project";
 
 export function Sidebar() {
   const {
@@ -76,10 +90,10 @@ export function Sidebar() {
     requestRemoveProject,
     addProject,
     reorderProjects,
+    reorderSessions,
   } = useAppStore();
   const [collapsed, setCollapsed] = useState<Set<string>>(() => loadCollapsed());
-  const [draggingProject, setDraggingProject] = useState<string | null>(null);
-  const [dropTarget, setDropTarget] = useState<ProjectDropTarget | null>(null);
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
 
   useEffect(() => {
     saveCollapsed(collapsed);
@@ -90,76 +104,15 @@ export function Sidebar() {
     [projects, sessions],
   );
 
-  function onProjectDragStart(e: React.DragEvent, repoPath: string) {
-    setDraggingProject(repoPath);
-    try {
-      e.dataTransfer.setData(PROJECT_DRAG_MIME, repoPath);
-      e.dataTransfer.setData("text/plain", repoPath);
-    } catch {
-      // Some webviews block setData during dragstart; module-level state
-      // (`draggingProject`) covers this fallback.
-    }
-    e.dataTransfer.effectAllowed = "move";
-  }
-
-  function onProjectDragOver(
-    e: React.DragEvent,
-    repoPath: string,
-  ) {
-    if (draggingProject === null) return;
-    if (draggingProject === repoPath) {
-      // Hovering over self — clear any preview.
-      if (dropTarget !== null) setDropTarget(null);
-      return;
-    }
-    e.preventDefault();
-    e.dataTransfer.dropEffect = "move";
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    const position: DropPosition =
-      e.clientY - rect.top < rect.height / 2 ? "before" : "after";
-    if (
-      dropTarget?.repoPath !== repoPath ||
-      dropTarget.position !== position
-    ) {
-      setDropTarget({ repoPath, position });
-    }
-  }
-
-  function onProjectDragLeave() {
-    // Defer clearing — another sibling's dragover will fire immediately.
-    // We rely on the next dragover or dragend to update state.
-  }
-
-  async function onProjectDrop(e: React.DragEvent) {
-    if (draggingProject === null || dropTarget === null) {
-      setDraggingProject(null);
-      setDropTarget(null);
-      return;
-    }
-    e.preventDefault();
-    const sourcePath = draggingProject;
-    const target = dropTarget;
-    setDraggingProject(null);
-    setDropTarget(null);
-
-    const currentOrder = projectGroups.map((p) => p.repoPath);
-    const without = currentOrder.filter((p) => p !== sourcePath);
-    const targetIndex = without.indexOf(target.repoPath);
-    if (targetIndex < 0) return;
-    const insertAt = target.position === "before" ? targetIndex : targetIndex + 1;
-    const next = [
-      ...without.slice(0, insertAt),
-      sourcePath,
-      ...without.slice(insertAt),
-    ];
-    if (arraysEqual(next, currentOrder)) return;
-    await reorderProjects(next);
-  }
-
-  function onProjectDragEnd() {
-    setDraggingProject(null);
-    setDropTarget(null);
-  }
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      // 5px movement avoids hijacking clicks on the project header / session row.
+      activationConstraint: { distance: 5 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
 
   function expandProject(repoPath: string) {
     setCollapsed((prev) => {
@@ -277,6 +230,78 @@ export function Sidebar() {
   onNewSessionRef.current = onNewSession;
   onAddProjectRef.current = onAddProject;
 
+  const projectIds = useMemo(
+    () => projectGroups.map((p) => projectDragId(p.repoPath)),
+    [projectGroups],
+  );
+
+  // Scoped collision detection: only consider droppables sharing the active
+  // item's namespace. Without this, dragging a project over an expanded
+  // project's child session row makes `over.id` resolve to the session,
+  // which gets dropped on the floor by onDragEnd.
+  const scopedCollision: CollisionDetection = (args) => {
+    const activeId = String(args.active.id);
+    const prefix = activeId.startsWith(PROJECT_DRAG_PREFIX)
+      ? PROJECT_DRAG_PREFIX
+      : SESSION_DRAG_PREFIX;
+    const filtered = args.droppableContainers.filter((c) =>
+      String(c.id).startsWith(prefix),
+    );
+    return closestCenter({ ...args, droppableContainers: filtered });
+  };
+
+  function onDragStart(event: DragStartEvent) {
+    setActiveDragId(String(event.active.id));
+  }
+
+  function onDragEnd(event: DragEndEvent) {
+    setActiveDragId(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const activeId = String(active.id);
+    const overId = String(over.id);
+
+    if (
+      activeId.startsWith(PROJECT_DRAG_PREFIX) &&
+      overId.startsWith(PROJECT_DRAG_PREFIX)
+    ) {
+      const currentOrder = projectGroups.map((p) => p.repoPath);
+      const fromIdx = currentOrder.indexOf(
+        activeId.slice(PROJECT_DRAG_PREFIX.length),
+      );
+      const toIdx = currentOrder.indexOf(
+        overId.slice(PROJECT_DRAG_PREFIX.length),
+      );
+      if (fromIdx < 0 || toIdx < 0 || fromIdx === toIdx) return;
+      const next = arrayMove(currentOrder, fromIdx, toIdx);
+      void reorderProjects(next);
+      return;
+    }
+
+    if (
+      activeId.startsWith(SESSION_DRAG_PREFIX) &&
+      overId.startsWith(SESSION_DRAG_PREFIX)
+    ) {
+      const activeSid = activeId.slice(SESSION_DRAG_PREFIX.length);
+      const overSid = overId.slice(SESSION_DRAG_PREFIX.length);
+      const activeSession = sessions.find((s) => s.id === activeSid);
+      const overSession = sessions.find((s) => s.id === overSid);
+      if (!activeSession || !overSession) return;
+      // Cross-project drops are not supported yet — silently ignore.
+      if (activeSession.repo_path !== overSession.repo_path) return;
+      const group = projectGroups.find(
+        (g) => g.repoPath === activeSession.repo_path,
+      );
+      if (!group) return;
+      const ids = group.sessions.map((s) => s.id);
+      const fromIdx = ids.indexOf(activeSid);
+      const toIdx = ids.indexOf(overSid);
+      if (fromIdx < 0 || toIdx < 0 || fromIdx === toIdx) return;
+      const next = arrayMove(ids, fromIdx, toIdx);
+      void reorderSessions(activeSession.repo_path, next);
+    }
+  }
+
   return (
     <aside className="flex h-full w-full flex-col bg-bg-sidebar">
       <header className="flex items-center justify-between gap-2 px-3 py-3">
@@ -298,76 +323,162 @@ export function Sidebar() {
         {projectGroups.length === 0 ? (
           <EmptyState />
         ) : (
-          <ul
-            className="flex flex-col divide-y divide-border/40 [&>li]:py-1.5 [&>li:first-child]:pt-0.5 [&>li:last-child]:pb-0.5"
-            onDrop={onProjectDrop}
-            onDragOver={(e) => {
-              if (draggingProject !== null) e.preventDefault();
-            }}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={scopedCollision}
+            onDragStart={onDragStart}
+            onDragEnd={onDragEnd}
+            onDragCancel={() => setActiveDragId(null)}
           >
-            {projectGroups.map((project) => (
-              <ProjectGroupView
-                key={project.repoPath}
-                project={project}
-                collapsed={collapsed.has(project.repoPath)}
-                activeSessionId={activeSessionId}
-                isActiveProject={activeProject === project.repoPath}
-                isDragging={draggingProject === project.repoPath}
-                dropIndicator={
-                  dropTarget?.repoPath === project.repoPath
-                    ? dropTarget.position
-                    : null
-                }
-                onDragStart={(e) => onProjectDragStart(e, project.repoPath)}
-                onDragOver={(e) => onProjectDragOver(e, project.repoPath)}
-                onDragLeave={onProjectDragLeave}
-                onDragEnd={onProjectDragEnd}
-                onTitleClick={() =>
-                  applyClickPlan(
-                    planTitleClick({
-                      wasActive: activeProject === project.repoPath,
-                      wasCollapsed: collapsed.has(project.repoPath),
-                    }),
-                    project,
-                  )
-                }
-                onChevronClick={() =>
-                  applyClickPlan(
-                    planChevronClick({
-                      wasActive: activeProject === project.repoPath,
-                      wasCollapsed: collapsed.has(project.repoPath),
-                    }),
-                    project,
-                  )
-                }
-                onActivate={() => {
-                  setActiveProject(project.repoPath);
-                  expandProject(project.repoPath);
-                  const target = pickSessionToActivate(
-                    project.sessions,
-                    activeSessionId,
-                  );
-                  if (target) selectSession(target);
-                }}
-                onSelectSession={selectSession}
-                onRemoveSession={(s) => requestRemoveSession(s.id)}
-                onAddSession={(isolated, kind) =>
-                  onNewSession(isolated, kind, project.repoPath)
-                }
-                onRemoveProject={() => requestRemoveProject(project.repoPath)}
-              />
-            ))}
-          </ul>
+            <SortableContext
+              items={projectIds}
+              strategy={verticalListSortingStrategy}
+            >
+              <ul className="flex flex-col divide-y divide-border/40 [&>li]:py-1.5 [&>li:first-child]:pt-0.5 [&>li:last-child]:pb-0.5">
+                {projectGroups.map((project) => (
+                  <ProjectGroupView
+                    key={project.repoPath}
+                    project={project}
+                    collapsed={collapsed.has(project.repoPath)}
+                    activeSessionId={activeSessionId}
+                    isActiveProject={activeProject === project.repoPath}
+                    onTitleClick={() =>
+                      applyClickPlan(
+                        planTitleClick({
+                          wasActive: activeProject === project.repoPath,
+                          wasCollapsed: collapsed.has(project.repoPath),
+                        }),
+                        project,
+                      )
+                    }
+                    onChevronClick={() =>
+                      applyClickPlan(
+                        planChevronClick({
+                          wasActive: activeProject === project.repoPath,
+                          wasCollapsed: collapsed.has(project.repoPath),
+                        }),
+                        project,
+                      )
+                    }
+                    onActivate={() => {
+                      setActiveProject(project.repoPath);
+                      expandProject(project.repoPath);
+                      const target = pickSessionToActivate(
+                        project.sessions,
+                        activeSessionId,
+                      );
+                      if (target) selectSession(target);
+                    }}
+                    onSelectSession={selectSession}
+                    onRemoveSession={(s) => requestRemoveSession(s.id)}
+                    onAddSession={(isolated, kind) =>
+                      onNewSession(isolated, kind, project.repoPath)
+                    }
+                    onRemoveProject={() =>
+                      requestRemoveProject(project.repoPath)
+                    }
+                  />
+                ))}
+              </ul>
+            </SortableContext>
+            <DragOverlay dropAnimation={null}>
+              {activeDragId
+                ? renderDragOverlay(activeDragId, projectGroups, sessions)
+                : null}
+            </DragOverlay>
+          </DndContext>
         )}
       </div>
     </aside>
   );
 }
 
+function renderDragOverlay(
+  activeDragId: string,
+  projectGroups: ProjectGroup[],
+  sessions: Session[],
+): React.ReactNode {
+  if (activeDragId.startsWith(PROJECT_DRAG_PREFIX)) {
+    const repoPath = activeDragId.slice(PROJECT_DRAG_PREFIX.length);
+    const group = projectGroups.find((g) => g.repoPath === repoPath);
+    if (!group) return null;
+    return <ProjectHeaderPreview name={group.name} count={group.sessions.length} />;
+  }
+  if (activeDragId.startsWith(SESSION_DRAG_PREFIX)) {
+    const sid = activeDragId.slice(SESSION_DRAG_PREFIX.length);
+    const session = sessions.find((s) => s.id === sid);
+    if (!session) return null;
+    return <SessionRowPreview session={session} />;
+  }
+  return null;
+}
+
+function ProjectHeaderPreview({
+  name,
+  count,
+}: {
+  name: string;
+  count: number;
+}) {
+  return (
+    <div className="flex items-center gap-1 rounded-md bg-bg-elevated/95 px-1 py-1.5 shadow-lg ring-1 ring-border/60">
+      <span className="flex shrink-0 items-center text-fg-muted/60">
+        <GripVertical size={12} />
+      </span>
+      <span className="flex shrink-0 items-center justify-center rounded p-1 text-fg-muted">
+        <ChevronRight size={14} />
+      </span>
+      <span className="flex min-w-0 items-center gap-1.5 pr-2">
+        <span className="truncate text-sm font-medium text-fg">{name}</span>
+        <span className="ml-1 shrink-0 rounded bg-bg-elevated/80 px-1 text-[10px] text-fg-muted">
+          {count}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+function SessionRowPreview({ session }: { session: Session }) {
+  return (
+    <div className="flex w-full items-start gap-1.5 rounded-md bg-bg-elevated/95 px-2 py-1 shadow-lg ring-1 ring-border/60">
+      <span className="mt-1 flex shrink-0 items-center text-fg-muted/60">
+        <GripVertical size={10} />
+      </span>
+      <span
+        className={cn(
+          "mt-1.5 size-1.5 shrink-0 rounded-full",
+          STATUS_DOT[session.status],
+        )}
+      />
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-1">
+          <span className="truncate text-[13px] font-medium text-fg">
+            {session.name}
+          </span>
+          {session.isolated ? (
+            <GitBranch size={10} className="shrink-0 text-fg-muted" />
+          ) : null}
+        </span>
+        <span className="block truncate text-[11px] text-fg-muted">
+          {session.branch} · {STATUS_LABEL[session.status]}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+function projectDragId(repoPath: string): string {
+  return `${PROJECT_DRAG_PREFIX}${repoPath}`;
+}
+
+function sessionDragId(id: string): string {
+  return `${SESSION_DRAG_PREFIX}${id}`;
+}
+
 /**
  * Choose which session to activate when the user clicks a project header.
  * If the already-active session belongs to this project, keep it. Otherwise
- * fall back to the first listed session (backend lists newest-first).
+ * fall back to the first listed session.
  * Returns null when the project has no sessions.
  */
 function pickSessionToActivate(
@@ -384,25 +495,11 @@ function pickSessionToActivate(
   return projectSessions[0]?.id ?? null;
 }
 
-function arraysEqual<T>(a: readonly T[], b: readonly T[]): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i += 1) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-}
-
 interface ProjectGroupViewProps {
   project: ProjectGroup;
   collapsed: boolean;
   activeSessionId: string | null;
   isActiveProject: boolean;
-  isDragging: boolean;
-  dropIndicator: "before" | "after" | null;
-  onDragStart: (e: React.DragEvent) => void;
-  onDragOver: (e: React.DragEvent) => void;
-  onDragLeave: (e: React.DragEvent) => void;
-  onDragEnd: (e: React.DragEvent) => void;
   /** Title click: activate (preserve collapse if inactive); ensure expanded if already active. */
   onTitleClick: () => void;
   /** Chevron click: activate + toggle expand. */
@@ -420,12 +517,6 @@ function ProjectGroupView({
   collapsed,
   activeSessionId,
   isActiveProject,
-  isDragging,
-  dropIndicator,
-  onDragStart,
-  onDragOver,
-  onDragLeave,
-  onDragEnd,
   onTitleClick,
   onChevronClick,
   onActivate,
@@ -434,8 +525,26 @@ function ProjectGroupView({
   onAddSession,
   onRemoveProject,
 }: ProjectGroupViewProps) {
-  const rowRef = useRef<HTMLLIElement>(null);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: projectDragId(project.repoPath) });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const sessionIds = useMemo(
+    () => project.sessions.map((s) => sessionDragId(s.id)),
+    [project.sessions],
+  );
 
   async function copyText(text: string) {
     try {
@@ -455,27 +564,10 @@ function ProjectGroupView({
 
   return (
     <li
-      ref={rowRef}
-      onDragOver={onDragOver}
-      onDragLeave={onDragLeave}
-      onDragEnd={onDragEnd}
-      className={cn(
-        "relative",
-        isDragging && "opacity-40",
-      )}
+      ref={setNodeRef}
+      style={style}
+      className={cn("relative", isDragging && "opacity-40")}
     >
-      {dropIndicator === "before" ? (
-        <span
-          aria-hidden
-          className="pointer-events-none absolute inset-x-1 -top-px h-0.5 rounded bg-accent"
-        />
-      ) : null}
-      {dropIndicator === "after" ? (
-        <span
-          aria-hidden
-          className="pointer-events-none absolute inset-x-1 -bottom-px h-0.5 rounded bg-accent"
-        />
-      ) : null}
       <div
         role="button"
         tabIndex={0}
@@ -499,8 +591,9 @@ function ProjectGroupView({
       >
         <Tooltip label="Drag to reorder" side="bottom">
           <span
-            draggable
-            onDragStart={onDragStart}
+            ref={setActivatorNodeRef}
+            {...attributes}
+            {...listeners}
             onClick={(e) => e.stopPropagation()}
             aria-label="Drag to reorder project"
             className="invisible flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
@@ -520,10 +613,7 @@ function ProjectGroupView({
         >
           <ChevronRight
             size={14}
-            className={cn(
-              "transition-transform",
-              !collapsed && "rotate-90",
-            )}
+            className={cn("transition-transform", !collapsed && "rotate-90")}
           />
         </button>
         <span className="flex min-w-0 flex-1 items-center gap-1.5">
@@ -632,37 +722,42 @@ function ProjectGroupView({
         ]}
       />
       {!collapsed ? (
-        <ul className="ml-3 flex flex-col gap-0.5 border-l border-border pl-1 pt-0.5">
-          {project.sessions.length === 0 ? (
-            <li
-              role="button"
-              tabIndex={0}
-              onClick={onActivate}
-              onDoubleClick={() => onAddSession(false, "regular")}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  onAddSession(false, "regular");
-                }
-              }}
-              className="cursor-pointer rounded px-2 py-1 text-[11px] text-fg-muted transition select-none hover:bg-bg-elevated/40 hover:text-fg"
-            >
-              No sessions. Add one with{" "}
-              <Plus size={10} className="inline" /> or{" "}
-              <GitBranch size={10} className="inline" />, or double-click here.
-            </li>
-          ) : (
-            project.sessions.map((session) => (
-              <SessionRow
-                key={session.id}
-                session={session}
-                active={session.id === activeSessionId}
-                onSelect={() => onSelectSession(session.id)}
-                onRemove={() => onRemoveSession(session)}
-              />
-            ))
-          )}
-        </ul>
+        <SortableContext
+          items={sessionIds}
+          strategy={verticalListSortingStrategy}
+        >
+          <ul className="ml-3 flex flex-col gap-0.5 border-l border-border pl-1 pt-0.5">
+            {project.sessions.length === 0 ? (
+              <li
+                role="button"
+                tabIndex={0}
+                onClick={onActivate}
+                onDoubleClick={() => onAddSession(false, "regular")}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onAddSession(false, "regular");
+                  }
+                }}
+                className="cursor-pointer rounded px-2 py-1 text-[11px] text-fg-muted transition select-none hover:bg-bg-elevated/40 hover:text-fg"
+              >
+                No sessions. Add one with{" "}
+                <Plus size={10} className="inline" /> or{" "}
+                <GitBranch size={10} className="inline" />, or double-click here.
+              </li>
+            ) : (
+              project.sessions.map((session) => (
+                <SessionRow
+                  key={session.id}
+                  session={session}
+                  active={session.id === activeSessionId}
+                  onSelect={() => onSelectSession(session.id)}
+                  onRemove={() => onRemoveSession(session)}
+                />
+              ))
+            )}
+          </ul>
+        </SortableContext>
       ) : null}
     </li>
   );
@@ -682,6 +777,20 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
   const editorConfigured = editorCommand.trim().length > 0;
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: sessionDragId(session.id) });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
 
   async function duplicate() {
     const base = session.name;
@@ -772,7 +881,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
   ];
 
   return (
-    <li>
+    <li ref={setNodeRef} style={style}>
       <div
         role="button"
         tabIndex={0}
@@ -795,8 +904,19 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
         className={cn(
           "group flex w-full items-start gap-1.5 rounded-md px-2 py-1 text-left transition",
           active ? "bg-bg-elevated" : "hover:bg-bg-elevated/60",
+          isDragging && "opacity-40",
         )}
       >
+        <span
+          ref={setActivatorNodeRef}
+          {...attributes}
+          {...listeners}
+          onClick={(e) => e.stopPropagation()}
+          aria-label="Drag to reorder session"
+          className="invisible mt-1 flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
+        >
+          <GripVertical size={10} />
+        </span>
         <span
           className={cn(
             "mt-1.5 size-1.5 shrink-0 rounded-full",
@@ -948,10 +1068,12 @@ function buildProjectGroups(
     group.sessions.push(session);
   }
   for (const group of map.values()) {
-    group.sessions.sort(
-      (a, b) =>
-        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
-    );
+    group.sessions.sort((a, b) => {
+      const ap = a.position ?? Number.POSITIVE_INFINITY;
+      const bp = b.position ?? Number.POSITIVE_INFINITY;
+      if (ap !== bp) return ap - bp;
+      return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+    });
   }
   return Array.from(map.values());
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -74,6 +74,9 @@ export const api = {
   reorderProjects(order: string[]): Promise<Project[]> {
     return invoke<Project[]>("reorder_projects", { order });
   },
+  reorderSessions(repoPath: string, order: string[]): Promise<Session[]> {
+    return invoke<Session[]>("reorder_sessions", { repoPath, order });
+  },
   listCommits(repoPath: string, offset = 0, limit = 50): Promise<CommitInfo[]> {
     return invoke<CommitInfo[]>("list_commits", { repoPath, offset, limit });
   },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,6 +36,7 @@ export interface Session {
   last_message: string | null;
   startup_mode: SessionStartupMode | null;
   kind: SessionKind;
+  position: number | null;
 }
 
 export interface Project {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -29,6 +29,9 @@ vi.mock("./lib/api", () => {
           position: i,
         })),
       ),
+      reorderSessions: vi.fn(async (_repoPath: string, _ids: string[]) =>
+        [] as Session[],
+      ),
     },
   };
 });
@@ -68,6 +71,7 @@ function session(
     last_message: null,
     startup_mode: null,
     kind: "regular",
+    position: null,
     ...overrides,
   };
 }
@@ -635,5 +639,38 @@ describe("createSession", () => {
     } finally {
       window.removeEventListener("acorn:show-control-guide", listener);
     }
+  });
+});
+
+describe("reorderSessions", () => {
+  it("optimistically assigns positions and commits server-returned sessions", async () => {
+    const s1 = session("s1", REPO_A);
+    const s2 = session("s2", REPO_A);
+    const s3 = session("s3", REPO_B);
+    await seed([project(REPO_A, 0), project(REPO_B, 1)], [s1, s2, s3]);
+
+    mockApi.reorderSessions.mockResolvedValueOnce([
+      { ...s2, position: 0 },
+      { ...s1, position: 1 },
+      s3,
+    ]);
+
+    await useAppStore.getState().reorderSessions(REPO_A, ["s2", "s1"]);
+    const result = useAppStore.getState().sessions;
+    expect(result.find((s) => s.id === "s2")?.position).toBe(0);
+    expect(result.find((s) => s.id === "s1")?.position).toBe(1);
+    expect(result.find((s) => s.id === "s3")?.position).toBeNull();
+    expect(mockApi.reorderSessions).toHaveBeenCalledWith(REPO_A, ["s2", "s1"]);
+  });
+
+  it("rolls back sessions on failure", async () => {
+    const s1 = session("s1", REPO_A);
+    const s2 = session("s2", REPO_A);
+    await seed([project(REPO_A, 0)], [s1, s2]);
+    const before = useAppStore.getState().sessions;
+    mockApi.reorderSessions.mockRejectedValueOnce(new Error("boom"));
+    await useAppStore.getState().reorderSessions(REPO_A, ["s2", "s1"]);
+    expect(useAppStore.getState().sessions).toEqual(before);
+    expect(useAppStore.getState().error).toBe("boom");
   });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -104,6 +104,7 @@ interface AppStateModel {
   addProject: (repoPath: string) => Promise<void>;
   removeProject: (repoPath: string, removeWorktrees?: boolean) => Promise<void>;
   reorderProjects: (orderedRepoPaths: string[]) => Promise<void>;
+  reorderSessions: (repoPath: string, orderedIds: string[]) => Promise<void>;
   requestRemoveProject: (repoPath: string) => void;
   clearPendingRemoveProject: () => void;
   setRightTab: (tab: RightTab) => void;
@@ -810,6 +811,24 @@ export const useAppStore = create<AppStateModel>()(
       set({ projects: updated });
     } catch (e) {
       set({ projects: previous, error: errorMessage(e) });
+    }
+  },
+
+  async reorderSessions(repoPath, orderedIds) {
+    const previous = get().sessions;
+    const indexOf = new Map<string, number>();
+    orderedIds.forEach((id, i) => indexOf.set(id, i));
+    const optimistic = previous.map((s) => {
+      if (s.repo_path !== repoPath) return s;
+      const pos = indexOf.get(s.id);
+      return pos === undefined ? s : { ...s, position: pos };
+    });
+    set({ sessions: optimistic });
+    try {
+      const updated = await api.reorderSessions(repoPath, orderedIds);
+      set({ sessions: updated });
+    } catch (e) {
+      set({ sessions: previous, error: errorMessage(e) });
     }
   },
 

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -50,6 +50,8 @@ export const tauriMockSource = `
     }
     if (cmd === 'scrollback_orphan_size') return Promise.resolve(0);
     if (cmd === 'scrollback_orphan_clear') return Promise.resolve(0);
+    if (cmd === 'reorder_projects') return Promise.resolve([]);
+    if (cmd === 'reorder_sessions') return Promise.resolve([]);
     if (cmd && cmd.startsWith('list_')) return Promise.resolve([]);
     return Promise.resolve(null);
   }


### PR DESCRIPTION
## Summary

- Replace native HTML5 DnD with `@dnd-kit/sortable` for both **project** and **session** reordering in the sidebar.
- Sessions now reorder within their project group via a per-row grip handle, mirroring the project drag UX.
- Custom `DragOverlay` renders a compact header-only floating preview so dragging an expanded project no longer drags the full session list.

## Changes

**Backend**
- `Session.position: Option<i64>` with `#[serde(default)]` so legacy `sessions.json` loads cleanly.
- `SessionStore::reorder(repo_path, ids)` assigns `0..N` positions scoped to a single project. Sessions not in `order` get appended after.
- New `reorder_sessions` Tauri command, registered in `lib.rs`.

**Frontend**
- `bun add @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities`.
- Single `DndContext` wraps both a project `SortableContext` and per-project session `SortableContext`s. Id namespaces (`project:<path>` / `session:<id>`) route `onDragEnd`.
- **Scoped collision detection** filters droppables by the active item's prefix so dragging a project over an expanded project's session row resolves to the project, not the session underneath.
- `DragOverlay` renders compact `ProjectHeaderPreview` / `SessionRowPreview` components at the cursor.
- `buildProjectGroups` sorts by `position asc` with `updated_at desc` as tiebreaker — untouched groups preserve the prior "newest-first" behavior.
- `api.reorderSessions` wrapper, `store.reorderSessions` action with optimistic update + rollback on error.
- Cross-project session drops are silently ignored for now (single-container scope only).

## Tests

- Vitest: new `reorderSessions` describe (optimistic + rollback). 104 passed, 1 skipped.
- Playwright sidebar + smoke specs green (5/5).
- `tauriMock` defaults `reorder_projects` / `reorder_sessions` to `[]` so e2e never crashes from a missing handler.
- `bun run typecheck` clean. `cargo check` clean.

## Test plan

- [ ] Drag a project header by its grip — order persists after restart.
- [ ] Expand a project, drag a session row — order persists after restart.
- [ ] Drag a project over an *expanded* project — drop resolves to the project, not a session inside it.
- [ ] Drag preview is compact (header only), not the full expanded project block.
- [ ] Existing single-click activate / chevron collapse / context menu unaffected.
- [ ] Cross-project session drop is a no-op.
