### PR TITLE
fix(claude): stop resuming sessions claude itself can't find

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -933,32 +933,37 @@ pub async fn commit_web_url(repo_path: String, sha: String) -> AppResult<Option<
 /// (new conversation) and `--resume` (existing) when (re)spawning claude —
 /// claude refuses `--session-id` for an id that already has a transcript.
 ///
-/// Claude's project-directory encoding has changed across versions
-/// (underscores were once normalised to dashes; newer versions preserve
-/// them; future versions could change again). To avoid getting tripped up
-/// by the encoding, we look for `<session-id>.jsonl` under any subdir of
-/// `~/.claude/projects/`.
+/// Match claude's *current* project-directory encoding for `cwd` only. Older
+/// claude versions preserved `.` in the encoded path; the current version
+/// replaces both `/` and `.` with `-`. An earlier implementation scanned every
+/// subdirectory under `~/.claude/projects/` to dodge the encoding drift, but
+/// that returned true for jsonl files left behind under the old encoding —
+/// after which claude itself, looking only at the new encoded dir, printed a
+/// persistent `error: session not found` on `--resume`. If claude changes its
+/// encoding again, update [`encode_claude_project_dir`].
 #[tauri::command]
-pub async fn claude_session_exists(_cwd: String, session_id: String) -> bool {
+pub async fn claude_session_exists(cwd: String, session_id: String) -> bool {
     let home = match std::env::var_os("HOME") {
         Some(v) => PathBuf::from(v),
         None => return false,
     };
-    let projects = home.join(".claude").join("projects");
-    let target = format!("{session_id}.jsonl");
-    let Ok(entries) = std::fs::read_dir(&projects) else {
-        return false;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        if path.join(&target).exists() {
-            return true;
-        }
-    }
-    false
+    let dir_name = encode_claude_project_dir(&cwd);
+    let jsonl = home
+        .join(".claude")
+        .join("projects")
+        .join(dir_name)
+        .join(format!("{session_id}.jsonl"));
+    jsonl.is_file()
+}
+
+/// Encode `cwd` the way the current `claude` CLI does when locating its
+/// per-project transcript directory under `~/.claude/projects/`. Replaces
+/// `/` and `.` with `-`; everything else (including underscores) is
+/// preserved verbatim.
+fn encode_claude_project_dir(cwd: &str) -> String {
+    cwd.chars()
+        .map(|c| if c == '/' || c == '.' { '-' } else { c })
+        .collect()
 }
 
 /// Spawn an external editor on `path`. Used by the "Open in editor" action
@@ -1088,4 +1093,35 @@ pub(crate) fn sanitize_worktree_name(name: &str) -> String {
         .collect::<String>()
         .trim_matches('-')
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_plain_repo_path() {
+        assert_eq!(
+            encode_claude_project_dir("/Users/me/Documents/Personal/acorn"),
+            "-Users-me-Documents-Personal-acorn"
+        );
+    }
+
+    #[test]
+    fn encodes_dotted_segment_as_double_dash() {
+        assert_eq!(
+            encode_claude_project_dir(
+                "/Users/me/Documents/Personal/acorn/.claude/worktrees/foo"
+            ),
+            "-Users-me-Documents-Personal-acorn--claude-worktrees-foo"
+        );
+    }
+
+    #[test]
+    fn preserves_underscores() {
+        assert_eq!(
+            encode_claude_project_dir("/Users/me/Documents/GitHub/jtf_web"),
+            "-Users-me-Documents-GitHub-jtf_web"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Stop calling `claude --resume <uuid>` for sessions whose transcript lives under an old project-directory encoding that the current claude CLI no longer reads from.
- Drives a persistent `error: session not found` line at the top of the terminal that the user couldn't dismiss or act on.

## Root cause

`claude_session_exists` scanned every subdirectory under `~/.claude/projects/` for `<uuid>.jsonl`. Claude's project-directory encoding has shifted between versions:

| version | `/` | `.` | `_` |
| --- | --- | --- | --- |
| older  | `-` | preserved | preserved |
| current | `-` | `-` | preserved |

Both encodings can coexist on disk:

```
~/.claude/projects/-Users-me-Documents-GitHub-jtf_web-.claude-worktrees-foo   # older
~/.claude/projects/-Users-me-Documents-Personal-acorn--claude-worktrees-foo   # current
```

For a worktree whose transcript was created under the older encoding, the directory walk found the jsonl and Acorn switched to `--resume`. The current claude CLI, looking only at its current encoded dir for `cwd`, didn't find anything → `error: session not found` printed to stderr inside the PTY.

## Fix

Encode `cwd` the way the current claude CLI does (`/` and `.` → `-`, everything else preserved) and probe that single directory. The check now mirrors what claude itself will read on `--resume`, so the false positive that was driving the error message goes away.

If claude changes its encoding again, update `encode_claude_project_dir` in `src-tauri/src/commands.rs`.

## Test plan

- [x] `cargo test --lib encodes_` — plain repo path and dotted-segment encoding
- [x] `cargo test --lib preserves_underscores` — underscores stay intact
- [x] `cargo clippy --lib` — no new warnings in changed area
- [ ] Manual: spawn a claude session in a worktree that has an orphan `.jsonl` under the old encoding, restart it via Acorn, confirm no `error: session not found` line at the top
- [ ] Manual: spawn a fresh claude session, exit, reopen the same session, confirm `--resume` still works
