### PR TITLE
feat(ui): clickable CommandHint with run/copy dialog for shell hints

### DIFF
--- a/src/components/CommandRunDialog.tsx
+++ b/src/components/CommandRunDialog.tsx
@@ -1,0 +1,183 @@
+import { useState, type ReactElement } from "react";
+import { Copy, Play, Terminal as TerminalIcon } from "lucide-react";
+import { useAppStore } from "../store";
+import { useToasts } from "../lib/toasts";
+import { useDialogShortcuts } from "../lib/dialog";
+import { Modal, ModalHeader, TextSwap } from "./ui";
+
+interface CommandRunDialogProps {
+  open: boolean;
+  command: string;
+  /**
+   * Working directory for the new session created by the "Run" action.
+   * When `null`, the dialog falls back to the first known project's repo
+   * path so callers without a repo context (e.g. Settings) still resolve
+   * a workspace. If no project is registered the Run button is disabled.
+   */
+  repoPath: string | null;
+  onClose: () => void;
+}
+
+/**
+ * Truncate the command so the auto-generated session tab stays readable
+ * in the sidebar — full command still runs inside the PTY, only the
+ * label is shortened.
+ */
+function deriveSessionName(command: string): string {
+  const trimmed = command.trim();
+  if (trimmed.length <= 32) return trimmed;
+  return `${trimmed.slice(0, 29)}…`;
+}
+
+/**
+ * Confirmation modal opened by [`CommandHint`]. Offers two paths so the
+ * user never executes a suggested command from a single accidental click:
+ *
+ * - **Copy** — writes the command to the clipboard and emits a toast.
+ * - **Run** — creates a new regular session in the resolved repo, then
+ *   queues the command via [`setPendingTerminalInput`] so `Terminal.tsx`
+ *   writes it once the PTY has spawned. The shell buffers the input
+ *   until its prompt is ready, so we do not coordinate with a
+ *   prompt-ready signal.
+ */
+export function CommandRunDialog({
+  open,
+  command,
+  repoPath,
+  onClose,
+}: CommandRunDialogProps): ReactElement {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const projects = useAppStore((s) => s.projects);
+  const createSession = useAppStore((s) => s.createSession);
+  const setPendingTerminalInput = useAppStore(
+    (s) => s.setPendingTerminalInput,
+  );
+  const showToast = useToasts((s) => s.show);
+
+  const resolvedRepoPath = repoPath ?? projects[0]?.repo_path ?? null;
+
+  function close() {
+    if (busy) return;
+    setError(null);
+    onClose();
+  }
+
+  useDialogShortcuts(open, {
+    onCancel: close,
+    onConfirm: () => {
+      if (busy || !resolvedRepoPath) return;
+      void handleRun();
+    },
+  });
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(command);
+      showToast(`Copied: ${command}`);
+      onClose();
+    } catch (e) {
+      setError(`Copy failed: ${String(e)}`);
+    }
+  }
+
+  async function handleRun() {
+    if (!resolvedRepoPath) {
+      setError("No project available to host the new session.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const created = await createSession(
+        deriveSessionName(command),
+        resolvedRepoPath,
+      );
+      if (!created) {
+        const storeError = useAppStore.getState().error;
+        setError(storeError ?? "Failed to create session.");
+        setBusy(false);
+        return;
+      }
+      // Queue BEFORE the Terminal mounts. The Terminal effect drains the
+      // queue inside its own `pty_spawn` resolver, so the value just has
+      // to be present by the time the spawn completes.
+      setPendingTerminalInput(created.id, command);
+      showToast(`Running: ${command}`);
+      setBusy(false);
+      onClose();
+    } catch (e) {
+      setError(String(e));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={close}
+      variant="dialog"
+      size="md"
+      ariaLabel="Run command"
+    >
+      <ModalHeader
+        title="Run this command?"
+        icon={<TerminalIcon size={14} className="text-accent" />}
+        variant="dialog"
+        onClose={close}
+      />
+      <div className="space-y-3 px-4 py-4 text-xs text-fg-muted">
+        <p className="text-fg">
+          A new terminal session will open and run:
+        </p>
+        <pre className="overflow-x-auto rounded-md border border-border bg-bg-sidebar/70 px-3 py-2 font-mono text-[12px] text-fg">
+          {command}
+        </pre>
+        {resolvedRepoPath ? (
+          <p>
+            <span className="opacity-70">cwd:</span>{" "}
+            <span className="font-mono text-fg">{resolvedRepoPath}</span>
+          </p>
+        ) : (
+          <p className="text-danger">
+            No project is registered — add a project before running this
+            command, or use "Copy" to paste it into an existing terminal.
+          </p>
+        )}
+        {error ? (
+          <p className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-[11px] text-danger">
+            {error}
+          </p>
+        ) : null}
+      </div>
+      <footer className="flex items-center justify-end gap-2 border-t border-border bg-bg-sidebar/40 px-4 py-3">
+        <button
+          type="button"
+          onClick={close}
+          disabled={busy}
+          className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleCopy()}
+          disabled={busy}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs text-fg transition hover:bg-bg-elevated disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <Copy size={12} />
+          Copy
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleRun()}
+          disabled={busy || !resolvedRepoPath}
+          className="inline-flex items-center gap-1.5 rounded-md bg-accent/20 px-3 py-1.5 text-xs font-medium text-accent transition hover:bg-accent/30 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <Play size={12} />
+          <TextSwap>{busy ? "Running…" : "Run"}</TextSwap>
+        </button>
+      </footer>
+    </Modal>
+  );
+}

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -42,7 +42,7 @@ import { MergePullRequestDialog } from "./MergePullRequestDialog";
 import { PullRequestDetailModal } from "./PullRequestDetailModal";
 import { ResizeHandle } from "./ResizeHandle";
 import { Tooltip } from "./Tooltip";
-import { RefreshButton } from "./ui";
+import { CommandHint, RefreshButton } from "./ui";
 
 interface ExpandedDiff {
   payload: DiffPayload;
@@ -1183,7 +1183,11 @@ function PullRequestsTab({
         ) : listing.kind === "not_github" ? (
           <Empty msg="Origin remote is not a GitHub repository." />
         ) : listing.kind === "no_access" ? (
-          <NoAccessBanner slug={listing.slug} accounts={listing.accounts} />
+          <NoAccessBanner
+            slug={listing.slug}
+            accounts={listing.accounts}
+            repoPath={repoPath}
+          />
         ) : listing.items.length === 0 ? (
           <Empty msg={`No ${stateFilter} pull requests.`} />
         ) : (
@@ -1341,9 +1345,11 @@ function PullRequestsTab({
 function NoAccessBanner({
   slug,
   accounts,
+  repoPath,
 }: {
   slug: string;
   accounts: AccountSummary[];
+  repoPath: string;
 }) {
   const tried = accounts.map((a) => `@${a.login}`).join(", ");
   return (
@@ -1359,9 +1365,11 @@ function NoAccessBanner({
       ) : (
         <p>No accounts authenticated against github.com.</p>
       )}
-      <p className="opacity-70">
-        Run <code className="font-mono">gh auth login</code> with an account
-        that has access, or accept the invitation on github.com.
+      <p className="flex flex-wrap items-center gap-1.5 opacity-70">
+        Run
+        <CommandHint command="gh auth login" repoPath={repoPath} />
+        with an account that has access, or accept the invitation on
+        github.com.
       </p>
     </div>
   );

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -24,6 +24,7 @@ import {
 import type { PrStateFilter } from "../lib/types";
 import {
   CheckboxRow,
+  CommandHint,
   Field,
   Modal,
   ModalHeader,
@@ -315,7 +316,6 @@ function ControlSessionInstallSection() {
     import("../lib/types").AcornIpcStatus | null
   >(null);
   const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -360,18 +360,6 @@ function ControlSessionInstallSection() {
     ? `sudo ln -sf "${status.bundled_path}" "${installTarget}"`
     : "";
 
-  async function copyInstallCommand() {
-    if (!installCommand) return;
-    try {
-      await navigator.clipboard.writeText(installCommand);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // Clipboard can fail in dev when the webview is unfocused. Fall back
-      // to leaving the command visible so the user can select it.
-    }
-  }
-
   return (
     <Field
       label="Control sessions (acorn-ipc CLI)"
@@ -414,19 +402,8 @@ function ControlSessionInstallSection() {
             {activeShim ? activeShim.path : installTarget}
           </code>
         </div>
-        {!activeShim && status.bundled_exists ? (
-          <div className="flex items-center gap-2">
-            <code className="flex-1 overflow-x-auto rounded-md border border-border bg-bg px-2 py-1 font-mono text-[11px] text-fg">
-              {installCommand}
-            </code>
-            <button
-              type="button"
-              onClick={() => void copyInstallCommand()}
-              className="rounded bg-accent px-2 py-1 text-[11px] font-medium text-white transition hover:bg-accent/90"
-            >
-              <TextSwap>{copied ? "Copied" : "Copy"}</TextSwap>
-            </button>
-          </div>
+        {!activeShim && status.bundled_exists && installCommand ? (
+          <CommandHint command={installCommand} repoPath={null} />
         ) : null}
         <button
           type="button"

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -753,6 +753,22 @@ export function Terminal({
           return;
         }
         exited = false;
+        // CommandRunDialog may have queued a one-shot command for this
+        // session (e.g. `gh auth login` launched from the NoAccessBanner).
+        // Drain the queue once the PTY is alive — the shell buffers the
+        // bytes until its prompt is ready, so a small startup delay is
+        // tolerable without coordinating with the prompt-ready signal.
+        const queued = useAppStore
+          .getState()
+          .consumePendingTerminalInput(sessionId);
+        if (queued) {
+          const payload = encodeStringToBase64(queued + "\r");
+          invoke("pty_write", { sessionId, data: payload }).catch(
+            (err: unknown) => {
+              console.error("[Terminal] pending pty_write failed", err);
+            },
+          );
+        }
       } catch (err) {
         if (!disposed) {
           term.write(

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -761,7 +761,10 @@ export function Terminal({
         const queued = useAppStore
           .getState()
           .consumePendingTerminalInput(sessionId);
-        if (queued) {
+        // Cleanup can run between consume and write under StrictMode's
+        // mount/cleanup/mount sequence. Re-check `disposed` so we do not
+        // pty_write into a session whose PTY has already been killed.
+        if (queued && !disposed) {
           const payload = encodeStringToBase64(queued + "\r");
           invoke("pty_write", { sessionId, data: payload }).catch(
             (err: unknown) => {

--- a/src/components/ui/CommandHint.tsx
+++ b/src/components/ui/CommandHint.tsx
@@ -1,0 +1,56 @@
+import { useState, type ReactElement } from "react";
+import { CommandRunDialog } from "../CommandRunDialog";
+import { cn } from "../../lib/cn";
+
+interface CommandHintProps {
+  /**
+   * The shell command to suggest. Rendered verbatim in a monospace code
+   * block; on click opens [`CommandRunDialog`] so the user can copy or
+   * launch it in a fresh terminal session.
+   */
+  command: string;
+  /**
+   * Working directory for the "Run" path. When provided, the dialog
+   * spawns a regular session rooted here. When null, the dialog falls
+   * back to the first known project — the [`CommandRunDialog`] resolves
+   * this so callers without an obvious repo context (e.g. global
+   * settings) can still surface the hint.
+   */
+  repoPath: string | null;
+  className?: string;
+}
+
+/**
+ * Inline clickable code block for actionable shell commands surfaced in
+ * the UI (e.g. `gh auth login` inside the no-access banner). Clicking
+ * opens a confirmation dialog with copy / run actions, so the command
+ * never executes from a single accidental click.
+ */
+export function CommandHint({
+  command,
+  repoPath,
+  className,
+}: CommandHintProps): ReactElement {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        title="Click to copy or run"
+        className={cn(
+          "inline-flex max-w-full items-center rounded border border-border bg-bg-sidebar/70 px-1.5 py-0.5 text-left font-mono text-[11px] text-fg transition hover:border-accent/60 hover:bg-bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+          className,
+        )}
+      >
+        <span className="truncate">{command}</span>
+      </button>
+      <CommandRunDialog
+        open={open}
+        command={command}
+        repoPath={repoPath}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -9,3 +9,4 @@ export { RadioCard } from "./RadioCard";
 export { Markdown } from "./Markdown";
 export { RefreshButton } from "./RefreshButton";
 export { TextSwap } from "./TextSwap";
+export { CommandHint } from "./CommandHint";

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -93,6 +93,7 @@ function resetStore(): void {
       activeSessionId: null,
       rightTab: "commits",
       prAccountByRepo: {},
+      pendingTerminalInput: {},
       loading: false,
       error: null,
       pendingRemoveId: null,
@@ -672,5 +673,66 @@ describe("reorderSessions", () => {
     await useAppStore.getState().reorderSessions(REPO_A, ["s2", "s1"]);
     expect(useAppStore.getState().sessions).toEqual(before);
     expect(useAppStore.getState().error).toBe("boom");
+  });
+});
+
+describe("pendingTerminalInput", () => {
+  it("queues and consumes a command for a session id", () => {
+    const { setPendingTerminalInput, consumePendingTerminalInput } =
+      useAppStore.getState();
+    setPendingTerminalInput("sess-1", "gh auth login");
+    expect(useAppStore.getState().pendingTerminalInput["sess-1"]).toBe(
+      "gh auth login",
+    );
+    const consumed = consumePendingTerminalInput("sess-1");
+    expect(consumed).toBe("gh auth login");
+    expect(useAppStore.getState().pendingTerminalInput["sess-1"]).toBeUndefined();
+  });
+
+  it("returns null and is a no-op when no command is queued", () => {
+    const consumed = useAppStore
+      .getState()
+      .consumePendingTerminalInput("nope");
+    expect(consumed).toBeNull();
+  });
+
+  it("overwrites a previously queued command for the same session", () => {
+    const { setPendingTerminalInput, consumePendingTerminalInput } =
+      useAppStore.getState();
+    setPendingTerminalInput("sess-1", "first");
+    setPendingTerminalInput("sess-1", "second");
+    expect(consumePendingTerminalInput("sess-1")).toBe("second");
+  });
+
+  it("does not cross-contaminate session ids", () => {
+    const { setPendingTerminalInput, consumePendingTerminalInput } =
+      useAppStore.getState();
+    setPendingTerminalInput("sess-1", "one");
+    setPendingTerminalInput("sess-2", "two");
+    expect(consumePendingTerminalInput("sess-1")).toBe("one");
+    expect(useAppStore.getState().pendingTerminalInput["sess-2"]).toBe("two");
+  });
+});
+
+describe("createSession returns the created session", () => {
+  it("resolves to the api result on success so callers can react with the new id", async () => {
+    const created: Session = session("new-id", REPO_A);
+    mockApi.createSession.mockResolvedValueOnce(created);
+    await seed([project(REPO_A, 0)], []);
+    mockApi.listSessions.mockResolvedValueOnce([created]);
+    mockApi.listProjects.mockResolvedValueOnce([project(REPO_A, 0)]);
+    const result = await useAppStore
+      .getState()
+      .createSession("new-id", REPO_A);
+    expect(result?.id).toBe("new-id");
+  });
+
+  it("resolves to null when the api call fails", async () => {
+    mockApi.createSession.mockRejectedValueOnce(new Error("nope"));
+    const result = await useAppStore
+      .getState()
+      .createSession("x", REPO_A);
+    expect(result).toBeNull();
+    expect(useAppStore.getState().error).toBe("nope");
   });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -884,14 +884,19 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   consumePendingTerminalInput(sessionId) {
-    const queued = get().pendingTerminalInput[sessionId];
-    if (!queued) return null;
+    // Read and clear inside one `set` so concurrent consumers cannot both
+    // observe the same value before either of them clears it. Captures the
+    // resolved value via closure rather than as the `set` return so the
+    // function can still surface it to its caller.
+    let consumed: string | null = null;
     set((s) => {
-      if (!(sessionId in s.pendingTerminalInput)) return s;
+      const queued = s.pendingTerminalInput[sessionId];
+      if (!queued) return s;
+      consumed = queued;
       const { [sessionId]: _, ...rest } = s.pendingTerminalInput;
       return { pendingTerminalInput: rest };
     });
-    return queued;
+    return consumed;
   },
     }),
     {

--- a/src/store.ts
+++ b/src/store.ts
@@ -59,6 +59,14 @@ interface AppStateModel {
    *  by repo path. Populated by the PRs tab; consumed by the StatusBar to
    *  surface "which identity am I acting as for this repo". In-memory only. */
   prAccountByRepo: Record<string, string>;
+  /**
+   * One-shot command to write into a session's PTY immediately after its
+   * shell finishes spawning. Used by `CommandRunDialog` to launch a freshly
+   * created session that then executes a fixed command (e.g. `gh auth login`).
+   * Terminal.tsx consumes and clears the entry inside the `pty_spawn`
+   * resolver, so the value is in-memory only and never persisted.
+   */
+  pendingTerminalInput: Record<string, string>;
   loading: boolean;
   error: string | null;
   pendingRemoveId: string | null;
@@ -93,7 +101,7 @@ interface AppStateModel {
     repoPath: string,
     isolated?: boolean,
     kind?: SessionKind,
-  ) => Promise<void>;
+  ) => Promise<Session | null>;
   removeSession: (id: string, removeWorktree?: boolean) => Promise<void>;
   renameSession: (id: string, name: string) => Promise<void>;
   adoptSessionWorktree: (id: string, worktreePath: string) => Promise<void>;
@@ -109,6 +117,10 @@ interface AppStateModel {
   clearPendingRemoveProject: () => void;
   setRightTab: (tab: RightTab) => void;
   setPrAccountForRepo: (repoPath: string, login: string | null) => void;
+  /** Queue a command for the next successful `pty_spawn` of `sessionId`. */
+  setPendingTerminalInput: (sessionId: string, command: string) => void;
+  /** Atomically read and remove the queued command for `sessionId`. */
+  consumePendingTerminalInput: (sessionId: string) => string | null;
 }
 
 let paneCounter = 0;
@@ -326,6 +338,7 @@ export const useAppStore = create<AppStateModel>()(
 
   rightTab: "commits",
   prAccountByRepo: {},
+  pendingTerminalInput: {},
   loading: false,
   error: null,
   pendingRemoveId: null,
@@ -725,8 +738,10 @@ export const useAppStore = create<AppStateModel>()(
       ) {
         window.dispatchEvent(new CustomEvent("acorn:show-control-guide"));
       }
+      return created;
     } catch (e) {
       set({ loading: false, error: errorMessage(e) });
+      return null;
     }
   },
 
@@ -857,6 +872,26 @@ export const useAppStore = create<AppStateModel>()(
         prAccountByRepo: { ...s.prAccountByRepo, [repoPath]: login },
       };
     });
+  },
+
+  setPendingTerminalInput(sessionId, command) {
+    set((s) => ({
+      pendingTerminalInput: {
+        ...s.pendingTerminalInput,
+        [sessionId]: command,
+      },
+    }));
+  },
+
+  consumePendingTerminalInput(sessionId) {
+    const queued = get().pendingTerminalInput[sessionId];
+    if (!queued) return null;
+    set((s) => {
+      if (!(sessionId in s.pendingTerminalInput)) return s;
+      const { [sessionId]: _, ...rest } = s.pendingTerminalInput;
+      return { pendingTerminalInput: rest };
+    });
+    return queued;
   },
     }),
     {

--- a/tests/e2e/command-hint.spec.ts
+++ b/tests/e2e/command-hint.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "./support";
+
+// Seed a project + session and force list_pull_requests to return the
+// no_access listing variant so the NoAccessBanner renders. The banner is
+// the canonical CommandHint surface — clicking the `gh auth login` chip
+// opens the run/copy dialog without executing anything.
+async function seedNoAccess(
+  tauri: { handle: (cmd: string, fn: (args: unknown) => unknown) => Promise<void> },
+) {
+  await tauri.handle("list_projects", () => [
+    {
+      repo_path: "/tmp/demo",
+      name: "demo",
+      created_at: "2026-01-01T00:00:00Z",
+      position: 0,
+    },
+  ]);
+  await tauri.handle("list_sessions", () => [
+    {
+      id: "s-1",
+      name: "sess",
+      repo_path: "/tmp/demo",
+      worktree_path: "/tmp/demo",
+      branch: "main",
+      isolated: false,
+      status: "idle",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:05Z",
+      last_message: null,
+      startup_mode: "terminal",
+    },
+  ]);
+  await tauri.handle("list_pull_requests", () => ({
+    kind: "no_access",
+    slug: "acme/widget",
+    accounts: [{ login: "alice", has_access: false }],
+  }));
+}
+
+test.describe("CommandHint via NoAccessBanner", () => {
+  test("clicking the gh auth login chip opens the run/copy dialog", async ({
+    page,
+    tauri,
+  }) => {
+    await seedNoAccess(tauri);
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "PRs" }).click();
+
+    // Banner renders the command as a clickable chip with title attr.
+    const chip = page.getByRole("button", { name: /gh auth login/ });
+    await expect(chip).toBeVisible();
+    await chip.click();
+
+    // Dialog: title + command preview + Copy + Run buttons.
+    await expect(page.getByText(/Run this command\?/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Copy$/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Run$/ })).toBeVisible();
+  });
+
+  test("Cancel button dismisses without writing to the PTY", async ({
+    page,
+    tauri,
+  }) => {
+    await seedNoAccess(tauri);
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "PRs" }).click();
+    await page.getByRole("button", { name: /gh auth login/ }).click();
+    await page.getByRole("button", { name: /^Cancel$/ }).click();
+
+    await expect(page.getByText(/Run this command\?/i)).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Inline `CommandHint` chip for shell-command hints surfaced in the UI. Click → confirmation dialog with **Copy** / **Run** / **Cancel**.
- **Run** spawns a fresh regular session in the resolved repo, then writes the command into the PTY once `pty_spawn` resolves. Backed by an in-memory `pendingTerminalInput` queue on the store (not persisted).
- **Copy** writes to the clipboard and emits a toast.
- Wired into:
  - `RightPanel.tsx` `NoAccessBanner` — replaces the inline `gh auth login` hint
  - `SettingsModal.tsx` `ControlSessionInstallSection` — replaces the bespoke Copy button for the `sudo ln -sf …` shim install command

## Why

Acorn surfaces several "fix it by running this" hints in the UI, but the commands have always been read-only text. Users either retype, switch out to a terminal, or context-switch. Making the chip itself the affordance — with a confirm dialog so a stray click never executes a command — closes the loop without giving up safety.

## Changes

| Area | File |
|---|---|
| New UI primitive | `src/components/ui/CommandHint.tsx` |
| New confirm dialog | `src/components/CommandRunDialog.tsx` |
| Queue + return-type | `src/store.ts` (`pendingTerminalInput` map, `createSession` → `Session \| null`) |
| PTY drain after spawn | `src/components/Terminal.tsx` |
| Wire site 1 | `src/components/RightPanel.tsx` (`NoAccessBanner`) |
| Wire site 2 | `src/components/SettingsModal.tsx` (`ControlSessionInstallSection`) |

## Out of scope

- The backend error string from `pull_requests.rs:405`:

  ```
  gh CLI is not authenticated. Run `gh auth login`.
  ```

  still surfaces as plain text via the generic `{error}` slot in `PullRequestsTab`. Converting that requires a new structured `PullRequestListing` variant (e.g. `needs_auth`) — separate PR if we want chip treatment there too.
- Generic "Install it and ensure it's on your shell PATH" messages from `cli_resolver.rs` have no concrete command, so they stay as-is.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` — 110 passed, +5 new in `store.test.ts` covering the queue + `createSession` return-type contract
- [x] `bun run test:e2e` — 47 passed, including 2 new `command-hint.spec.ts` cases (chip click opens dialog; Cancel dismisses)
- [ ] Manual: clone a repo you have no access to → PRs tab → click the `gh auth login` chip → Run → confirm a fresh session opens and the command runs
- [ ] Manual: Settings → Sessions → with no shim installed → click the `sudo ln -sf …` chip → Copy → confirm clipboard + toast
