### PR TITLE
fix(right-panel): swallow non-repo PTY cwd instead of red-banner error

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -708,6 +708,34 @@ pub fn pty_cwd(state: State<'_, AppState>, session_id: String) -> AppResult<Opti
     Ok(deepest_descendant_cwd(&sys, Pid::from_u32(root_pid)))
 }
 
+/// Like [`pty_cwd`], but resolves the cwd to its enclosing git repository's
+/// working directory via `Repository::discover`. Returns `None` whenever
+/// either the PTY has no live cwd or that cwd lies outside any git repo —
+/// the latter happens routinely when the user `cd`s into a Cargo registry
+/// source dir or any other non-repo path.
+///
+/// Callers (currently `RightPanel`'s live-repo resolver) use the returned
+/// path verbatim as the `repo_path` argument to git commands. The frontend
+/// falls back to the session's recorded `worktree_path` on `None`, which
+/// avoids a persistent "could not find git repository from '<cargo-dir>'"
+/// banner appearing inside the panel any time the PTY drifts outside a
+/// repo.
+#[tauri::command]
+pub fn pty_repo_root(
+    state: State<'_, AppState>,
+    session_id: String,
+) -> AppResult<Option<String>> {
+    let Some(cwd) = pty_cwd(state, session_id)? else {
+        return Ok(None);
+    };
+    let Ok(repo) = git2::Repository::discover(&cwd) else {
+        return Ok(None);
+    };
+    Ok(repo
+        .workdir()
+        .map(|p| p.to_string_lossy().into_owned()))
+}
+
 /// BFS over `sys`, starting at `root`, returning the cwd of the deepest
 /// reachable descendant that has one. Falls back to `root`'s own cwd at
 /// depth 0 when no deeper descendant exposes a cwd. `None` if the root PID

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -196,6 +196,7 @@ pub fn run() {
             commands::pty_kill,
             commands::pty_reload_shell_env,
             commands::pty_cwd,
+            commands::pty_repo_root,
             commands::update_session_worktree,
             commands::git_worktrees,
             commands::scrollback_save,

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -319,37 +319,40 @@ interface SessionTodosState {
 }
 
 /**
- * Resolve the live working directory of a session's PTY tree, with the
- * recorded `fallback` path as the immediate (and final) fallback. Re-resolves
- * lazily — only on session change, tab change, and window refocus. Cost per
- * resolve is one Tauri command + a single sysinfo refresh on the backend, so
- * a few invocations per minute is essentially free; we deliberately do *not*
- * poll on a timer.
+ * Resolve the live working directory of a session's PTY tree to the git
+ * repo it sits inside, with the recorded `fallback` path as the immediate
+ * (and final) fallback. Backed by `pty_repo_root`, which does the
+ * `Repository::discover` walk server-side and returns `null` when the cwd
+ * lies outside any git repo — so a user `cd`-ing into e.g. a Cargo registry
+ * dir doesn't push a non-repo path into git commands and produce a
+ * persistent "could not find git repository from '<…>'" banner. Re-resolves
+ * lazily on session change, tab change, and window refocus; deliberately
+ * not polled on a timer.
  */
 function useLiveRepoPath(
   sessionId: string | null,
   fallback: string | null,
   rightTab: string,
 ): string | null {
-  const [liveCwd, setLiveCwd] = useState<string | null>(null);
+  const [liveRepo, setLiveRepo] = useState<string | null>(null);
   const [tick, setTick] = useState(0);
 
   useEffect(() => {
     if (!sessionId) {
-      setLiveCwd(null);
+      setLiveRepo(null);
       return;
     }
     let cancelled = false;
     api
-      .ptyCwd(sessionId)
-      .then((cwd) => {
-        if (!cancelled) setLiveCwd(cwd);
+      .ptyRepoRoot(sessionId)
+      .then((repo) => {
+        if (!cancelled) setLiveRepo(repo);
       })
       .catch((err: unknown) => {
         // Don't blow away a previously resolved path on a transient backend
-        // error — the static fallback will kick in only if liveCwd was never
+        // error — the static fallback will kick in only if liveRepo was never
         // set in the first place. Logging stays at debug to avoid noise.
-        console.debug("[RightPanel] ptyCwd resolve failed", err);
+        console.debug("[RightPanel] ptyRepoRoot resolve failed", err);
       });
     return () => {
       cancelled = true;
@@ -365,7 +368,7 @@ function useLiveRepoPath(
     return () => window.removeEventListener("focus", onFocus);
   }, []);
 
-  return liveCwd ?? fallback;
+  return liveRepo ?? fallback;
 }
 
 function useSessionTodos(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -200,6 +200,15 @@ export const api = {
     return invoke<string | null>("pty_cwd", { sessionId });
   },
   /**
+   * Like {@link ptyCwd}, but resolves the cwd to its enclosing git repo's
+   * working directory. Returns `null` when the PTY has no live cwd or that
+   * cwd is outside any git repo (e.g. inside a Cargo registry dir). Callers
+   * should fall back to the session's recorded `worktree_path` on `null`.
+   */
+  ptyRepoRoot(sessionId: string): Promise<string | null> {
+    return invoke<string | null>("pty_repo_root", { sessionId });
+  },
+  /**
    * Re-point a session at a different worktree directory. Used after an
    * in-PTY command creates a worktree and exits — adopting it lets the next
    * spawn land inside the new worktree instead of the original cwd.


### PR DESCRIPTION
## Summary

- Stop the right panel from rendering `could not find git repository from '<…>': could not find repository at '<…>'` as a red banner whenever the PTY's cwd drifts outside any git repo.
- Most common trigger: `cd ~/.cargo/registry/src/index.crates.io-*/<dep>/` to inspect a dependency. The path persisted in the panel for as long as the cwd stayed outside a repo, and the user could do nothing about it.

## Root cause

`useLiveRepoPath` in `src/components/RightPanel.tsx` resolved the live working directory by calling `pty_cwd`, which returns the deepest descendant cwd of the session's PTY tree. Whatever path came back was passed straight to `list_commits` / `staged_diff` / etc. as `repo_path`, and `worktree::ensure_repo` then ran `Repository::discover` on it. For a cargo-registry dir the walk reached `/` without finding a `.git`, libgit2 returned `ENOTFOUND`, and Acorn's wrapper produced the persistent error banner above.

Other `current_branch` / `ensure_repo` callers swallow this error (`.ok()` / `unwrap_or_else`), but the right panel surfaced it via `setError(String(e))`.

## Fix

Add `pty_repo_root`, a sibling of `pty_cwd` that runs the `Repository::discover` walk inside the backend and returns `None` when the cwd lies outside any git repo. The right panel resolver swaps over to it; on `None` the existing fallback to the session's recorded `worktree_path` kicks in, so the panel keeps showing the session's project (commits, staged, PRs against the project's `origin`) instead of flashing an error.

`pty_cwd` itself is unchanged — IPC / primer callers that genuinely want the live cwd (regardless of repo-ness) still get it.

## Test plan

- [x] `cargo check --lib`
- [x] `bun run typecheck`
- [x] `bun run test` (10 files, 104 passed)
- [ ] Manual: in a session, `cd ~/.cargo/registry/src/...` and confirm no red banner; the right-panel tabs continue to show the session's recorded repo
- [ ] Manual: `cd` back into a project subdir and confirm the panel re-targets the live repo (e.g. switching from main repo into a worktree)
