### PR TITLE
docs: codify comment policy and rewrite rotting comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Two recurring traps in E2E:
 - **Local persistence** (UI state like collapsed groups, dismissed update version) goes in `localStorage` under the `acorn:` key prefix. Don't reach for it from inside pure logic — keep it at the component / store edge.
 - **Logic stuck inside a component** that wants a unit test should be extracted to `src/lib/`. Don't try to test it through the rendered component. Example: `Sidebar.tsx`'s `buildProjectGroups` could move out if it grows.
 - **`src/lib/api.ts` is the only place that calls `invoke()` from app code.** New backend commands get a wrapper there with explicit types. Components import from `api`, not from `@tauri-apps/api/core`.
+- **Comments describe current state only.** No history accumulation, no "previously/legacy/v1/PR #N" framing, no WHAT restatement. Present-tense WHY only — see [`docs/COMMENTS.md`](docs/COMMENTS.md).
 
 ## Things that go wrong if you forget
 
@@ -63,5 +64,5 @@ bun run build          # tsc + vite build
 
 ## When in doubt
 
-- Reading: `docs/TESTING.md`, `docs/E2E_TESTING.md`, `docs/PR_LABELS.md`.
+- Reading: `docs/TESTING.md`, `docs/E2E_TESTING.md`, `docs/PR_LABELS.md`, `docs/COMMENTS.md`.
 - Patterns: search `src/` first for similar code already in the repo. Match its shape.

--- a/docs/COMMENTS.md
+++ b/docs/COMMENTS.md
@@ -1,0 +1,178 @@
+# Comment policy
+
+This doc spells out how comments are written in this repo. The short version: **no history, no WHAT restatement, no task/PR references — only non-obvious WHY, in the present tense, current state only.**
+
+## Why a policy
+
+Comments rot. Without a policy they accumulate, each PR adding another "previously did X" or "changed Y to support Z" line, until the comment block reads like a changelog and tells a new reader almost nothing about what the code does *now*.
+
+Git already tracks history. `git log` and `git blame` are authoritative. A comment that duplicates them is dead weight; a comment that contradicts them is actively misleading.
+
+The rule of thumb for every comment in `src/` and `src-tauri/`:
+
+> If a reader who has never seen this codebase landed on this file today, would this comment help them understand what the code does and why? If not, delete it.
+
+## Keep
+
+A comment is worth keeping when **all** of these hold:
+
+- It explains a non-obvious **WHY** — a hidden constraint, a subtle invariant, a workaround for a specific bug in a dependency, a browser/OS quirk, a security reason, a performance reason.
+- It is written in the **present tense** and describes **current behavior** as if the code has always been this way.
+- It is still accurate. If it drifts out of sync with the code it gates, it must be updated or removed in the same change.
+
+Examples of comments worth keeping:
+
+```rust
+// Resolve outside the lock — shell startup can take 50–200ms and
+// holding the mutex would serialize concurrent first-time lookups for
+// unrelated CLIs.
+```
+
+```ts
+// On WKWebView the `input` event sometimes arrives BEFORE its keydown,
+// so we still treat IME-driven `insertText` as a composition signal.
+```
+
+```rust
+// SAFETY: `ptr` is non-null, aligned, points to an initialized Widget,
+// and no mutable references or mutations exist for its lifetime.
+```
+
+These are load-bearing: deleting them would lose information that a future reader cannot reconstruct from the code or the type system alone.
+
+## Drop or rewrite
+
+A comment should be deleted (or rewritten as a clean present-tense WHY) when it matches **any** of these patterns:
+
+### 1. History accumulation
+
+References to past changes, removed code, prior behavior, PR/issue numbers, or dates.
+
+```ts
+// BAD
+// Previously we used X but switched to Y in PR #51.
+// Added in v2.3.
+// Removed while the app was offline, or pre-feature debris.
+// `--yes` was added in a recent gh release; older installs reject it.
+
+// GOOD
+// Older `gh` releases reject `--yes` — pipe the confirmation through
+// stdin instead so any "Continue with merge?" prompt is answered without
+// depending on a flag the local CLI may not have.
+```
+
+### 2. WHAT restatement
+
+The comment paraphrases code that already reads clearly.
+
+```ts
+// BAD
+// loop over items
+for (const item of items) { ... }
+
+// BAD
+// returns the user id
+function getUserId(...) { ... }
+```
+
+If the code is unclear, **rename the variable, function, or type** before reaching for a comment.
+
+### 3. Task or PR context
+
+References to the current task, ticket, caller, or owner.
+
+```ts
+// BAD
+// used by ChatPanel
+// added for the auth flow
+// part of refactor X
+// kept for backwards-compat with the old chat flow
+```
+
+The PR description is the right place for "why this change happened in this PR". The comment is the wrong place — it'll outlive the PR and confuse readers years later.
+
+### 4. "Legacy" / "v1" / "migration" framing
+
+Past-tense framing for code that still runs in production today.
+
+```ts
+// BAD
+// Sessions startup migration: legacy `mode === "claude"` collapses
+// into the new agent-mode + global selected agent.
+
+// GOOD
+// `mode === "claude"` from older storage maps to agent mode with the
+// global selected agent.
+```
+
+If the migration code is live, describe what it does **now**, not the history it came from.
+
+### 5. "Why we removed X" leftovers
+
+Comments documenting code that no longer exists.
+
+```ts
+// BAD
+// We removed the retry loop here because it was masking real errors.
+```
+
+If the code is gone, the comment goes with it. If a reader needs the rationale, `git log -S "retry"` is the right tool.
+
+### 6. Stale TODO / FIXME / XXX
+
+Unowned, undated TODOs with no ticket and no clear trigger for resolution.
+
+A TODO is acceptable only when:
+- It is gated to specific, observable code (e.g. `it.skip(...)` with a TODO above it explaining the platform-specific failure).
+- It names a concrete next step ("file an issue", "re-enable once root-caused").
+- Its existence is verifiable from the code itself (a skipped test, a feature flag, a fallback branch).
+
+Unfocused `// TODO: clean this up later` lines should be deleted on sight.
+
+## Replacing a rotting comment
+
+When you notice a comment that violates this policy while doing other work, **fix it in the same commit**. Two-line rewrites don't need their own PR. The cost of leaving rotten comments in place is much higher than the cost of a one-line drive-by cleanup.
+
+When rewriting, ask:
+
+1. Is this comment load-bearing? (If no → delete.)
+2. Can I rewrite it in the present tense, describing what is true today? (If yes → rewrite.)
+3. Is the WHY actually non-obvious? (If no → delete.)
+
+## Doc comments (`///`, JSDoc)
+
+Same rules apply, with one addition: doc comments on exported public surface (types, functions, components) should describe **what callers need to know to use it correctly** — invariants, gotchas, fallback behavior. They should not describe internal implementation.
+
+```ts
+// GOOD — caller-facing invariant
+/**
+ * Per-session PTY startup mode persisted on `Session.startup_mode`. `null`
+ * (or omitted) means no per-session preference is recorded; the spawn
+ * falls back to the global `sessionStartup.mode` setting.
+ */
+export type SessionStartupMode = ...
+
+// BAD — implementation narrative
+/**
+ * Used to be a boolean before we added the "custom" mode. The check inside
+ * Terminal.tsx still falls back to the old behavior for sessions created
+ * before v0.4.
+ */
+```
+
+## What about commit messages and PR descriptions?
+
+Commit messages and PR descriptions are the **right place** for the things that don't belong in code comments:
+
+- "Why this change exists" → commit body.
+- "What this PR accomplishes" → PR description.
+- "What it replaces" → PR description / commit body.
+- "Ticket / issue link" → PR description.
+
+Keep the diff between commit history and code comments sharp. Code answers "what is true right now"; git answers "how did we get here".
+
+## Enforcement
+
+There is no automated gate today; this is a convention. Reviewers should flag comments that violate the policy on every PR, and authors are expected to do drive-by cleanups when they touch nearby code.
+
+If a recurring pattern shows up in review (e.g. PRs keep adding `// previously...` lines), we will revisit and add a `hookify` rule or lint check.

--- a/src-tauri/src/cli_resolver.rs
+++ b/src-tauri/src/cli_resolver.rs
@@ -9,11 +9,11 @@
 //! `Command::new("gh")`. The result is the "`gh` CLI not found" error users
 //! see in the PRs tab when launching from Dock/Spotlight/Finder.
 //!
-//! PR #51 fixed this for long-lived PTY sessions by wrapping every spawn in
-//! `$SHELL -l -i -c 'exec <cmd>'`. That trade-off is fine for one-shot agent
-//! sessions but would add 50–200ms of shell startup *per* gh invocation, and
-//! the multi-account picker in `pull_requests.rs` makes 5–10 gh calls per
-//! refresh — enough to feel sluggish.
+//! PTY sessions handle this by wrapping every spawn in
+//! `$SHELL -l -i -c 'exec <cmd>'`, which is fine for one-shot agent sessions
+//! but would add 50–200ms of shell startup *per* gh invocation. The
+//! multi-account picker in `pull_requests.rs` makes 5–10 gh calls per refresh
+//! — enough to feel sluggish.
 //!
 //! Instead we resolve `<name>` to an absolute path (`/opt/homebrew/bin/gh`,
 //! `~/.local/bin/gh`, etc.) once via the user shell, cache it, and then spawn
@@ -123,7 +123,7 @@ pub fn spawn_error(name: &str, e: std::io::Error) -> AppError {
 /// Run `$SHELL -l -i -c 'command -v <name>'` and parse stdout for the
 /// resolved absolute path. The shell sources rc files (so PATH from
 /// Homebrew/npm/asdf/etc. is loaded) before running `command -v`, mirroring
-/// the rc-loading approach in `commands.rs::pty_spawn` (PR #51).
+/// the rc-loading approach in `commands.rs::pty_spawn`.
 fn shell_resolve(name: &str) -> AppResult<PathBuf> {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
     // Wrap `command -v` in an exclusive marker so we can pull the path out
@@ -227,7 +227,6 @@ mod tests {
 
     #[test]
     fn invalidate_is_a_noop_for_uncached_name() {
-        // Should not panic or error when the name was never cached.
         invalidate("acorn-test-never-existed");
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -142,8 +142,7 @@ pub fn run() {
                     .to_string();
                 state.projects.ensure(session.repo_path.clone(), name);
             }
-            // Drop scrollback files for sessions that no longer exist (e.g.
-            // removed while the app was offline, or pre-feature debris).
+            // Drop scrollback files that no longer have a matching session.
             // Skip when the session load was unclean — otherwise a transient
             // disk failure would silently delete every scrollback file on the
             // way to a fully empty session list.

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -1030,10 +1030,9 @@ fn run_pr_merge(
         }
     }
 
-    // gh's `--yes` confirmation flag was added in a recent release; older
-    // installs reject it as an unknown flag. Pipe a confirmation through
-    // stdin instead — it answers any "Continue with merge?" prompt without
-    // depending on a flag the local CLI may not have.
+    // Older `gh` releases reject `--yes` as an unknown flag. Pipe a
+    // confirmation through stdin instead — it answers any "Continue with
+    // merge?" prompt without depending on a flag the local CLI may not have.
     let mut child = cmd
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/src-tauri/src/scrollback.rs
+++ b/src-tauri/src/scrollback.rs
@@ -79,8 +79,7 @@ pub fn delete(session_id: &str) -> AppResult<()> {
 }
 
 /// Remove scrollback files for any session id not present in `keep`.
-/// Called at boot to evict files belonging to sessions that were deleted
-/// while the app was offline (or before this feature existed).
+/// Called at boot to evict files left behind by sessions that no longer exist.
 pub fn prune_orphans<I, S>(keep: I) -> AppResult<usize>
 where
     I: IntoIterator<Item = S>,

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -970,11 +970,10 @@ function AboutSettings() {
         });
         return;
       }
-      // The running version doesn't have its own public release (e.g. a
-      // private hotfix that was overwritten, a locally bumped dev build,
-      // or a pre-release tag). Fall back to the latest published release
-      // so the user still sees something meaningful instead of an empty
-      // placeholder.
+      // The running version has no matching public release (locally bumped
+      // dev build, pre-release tag, or unpublished build). Fall back to the
+      // latest published release so the user still sees something meaningful
+      // instead of an empty placeholder.
       const latest = await fetchLatestReleaseNotes();
       setWhatsNewSource({
         kind: "current",

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -19,9 +19,8 @@ interface TerminalProps {
   cwd: string;
   /**
    * Per-session startup mode persisted on `Session.startup_mode`. `null`
-   * (or omitted) means the session has no recorded preference (legacy
-   * sessions created before this field existed) — the spawn falls back
-   * to the global `sessionStartup.mode` setting in that case.
+   * (or omitted) means no per-session preference is recorded; the spawn
+   * falls back to the global `sessionStartup.mode` setting.
    */
   startupMode?: SessionStartupMode | null;
   /**

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -10,9 +10,9 @@ import { createPortal } from "react-dom";
 
 interface TooltipProps {
   /**
-   * Tooltip content. A string keeps the legacy single-line look; pass a
-   * `ReactNode` (e.g. multiple lines) and set `multiline` to switch the
-   * container to a wrappable layout.
+   * Tooltip content. A string renders single-line; pass a `ReactNode`
+   * (e.g. multiple lines) and set `multiline` to switch the container to a
+   * wrappable layout.
    */
   label: ReactNode;
   /** Where the tooltip appears relative to the trigger. Default: "bottom". */

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -11,8 +11,8 @@ import type { Session, SessionStatus } from "./types";
 
 // Notification body copy keyed by the status the session transitioned *into*.
 // The watcher only fires on transitions to `needs_input` / `failed` /
-// `completed`, so `idle` / `running` entries are placeholders that never get
-// surfaced — kept to keep the record exhaustive.
+// `completed`; `idle` / `running` entries are placeholders so the record
+// stays exhaustive against `SessionStatus`.
 const STATUS_SENTENCE: Record<SessionStatus, string> = {
   idle: "Session is idle.",
   running: "Session is running.",

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -326,8 +326,8 @@ function loadSettings(): AcornSettings {
     if (!parsed || typeof parsed !== "object") return DEFAULT_SETTINGS;
     const terminalRaw: Partial<AcornSettings["terminal"]> = parsed.terminal ?? {};
 
-    // Sessions startup migration: legacy `mode === "claude"` collapses
-    // into the new agent-mode + global selected agent.
+    // `mode === "claude"` from older storage maps to agent mode with the
+    // global selected agent.
     const startupRaw = (parsed.sessionStartup ?? {}) as {
       mode?: string;
       customCommand?: string;
@@ -341,10 +341,9 @@ function loadSettings(): AcornSettings {
         ? startupRaw.mode
         : DEFAULT_SETTINGS.sessionStartup.mode;
 
-    // Agents migration: prefer existing `agents` block, otherwise lift
-    // values from the v1 `commitMessage` block, otherwise fall back to
-    // a Claude default. Legacy `mode === "claude"` also seeds
-    // `selected` if nothing else has set it.
+    // Prefer the `agents` block; fall back to values stored under the older
+    // `commitMessage` shape, then to the Claude default. `mode === "claude"`
+    // from older storage seeds `selected` when nothing else has set it.
     const agentsRaw = (parsed.agents ?? {}) as {
       selected?: string;
       customCommand?: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,18 +8,17 @@ export type SessionStatus =
 /**
  * Per-session PTY startup mode persisted on the backend `Session` so the
  * choice survives an app restart and is decoupled from the global
- * `sessionStartup.mode` setting. `null` means "no per-session preference
- * recorded yet" (legacy sessions); the Terminal falls back to the global
- * setting in that case.
+ * `sessionStartup.mode` setting. `null` means no per-session preference is
+ * recorded and the Terminal falls back to the global setting.
  */
 export type SessionStartupMode = "agent" | "terminal" | "custom";
 
 /**
  * Distinguishes ordinary terminal sessions from "control" sessions. Control
- * sessions are the entry point for the upcoming `acorn-ipc` CLI, which lets
- * them dispatch commands to other sessions in the same project. Orthogonal
- * to `SessionStartupMode` — either kind can run any startup flavor. Older
- * persisted sessions without this field load as `"regular"` from the backend.
+ * sessions are the entry point for the `acorn-ipc` CLI, which lets them
+ * dispatch commands to other sessions in the same project. Orthogonal to
+ * `SessionStartupMode` — either kind can run any startup flavor. Persisted
+ * sessions without this field load as `"regular"` from the backend.
  */
 export type SessionKind = "regular" | "control";
 


### PR DESCRIPTION
## Summary

Codify a comment policy that drops history accumulation and keeps **only the present-tense WHY**, then apply it across the current tree.

- Add `docs/COMMENTS.md` — keep/drop/rewrite criteria, BAD/GOOD examples per pattern, role separation between commit messages and code comments.
- Add a one-line rule + doc link to the code-conventions section of `CLAUDE.md`.
- Clean rotting comments across `src/` and `src-tauri/`. Load-bearing WHY (browser quirks, lock-release rationale, SAFETY blocks, etc.) is preserved.

## Why

- Accumulated changelog-style comments are noise for both new humans and new agents joining the codebase.
- `git log` / `git blame` already own history — duplicating it in comments only adds rot.
- Keeping comments to "why is the code shaped like this right now" cuts the decision cost of future work.

## What's in the doc

`docs/COMMENTS.md` covers:

- When a comment is worth keeping (non-obvious WHY, present tense, still accurate).
- Six patterns to delete or rewrite:
  1. History accumulation (PR #N, "previously", "added in vX")
  2. WHAT restatement
  3. Task / PR context ("used by X", "added for Y flow")
  4. legacy / v1 / migration framing for code that still runs today
  5. "Why we removed X" leftovers
  6. Stale, unowned TODO / FIXME
- Doc comments (`///`, JSDoc) rules — caller-facing invariants, not implementation narrative.
- Role split between commit messages, PR descriptions, and code comments.
- Note that there is no automated gate yet; a `hookify` rule may follow if the pattern recurs.

## Cleaned files

Comments only — no behavior changes.

- `src-tauri/src/cli_resolver.rs` — drop PR #51 references, trim a WHAT-only test comment.
- `src-tauri/src/lib.rs`, `scrollback.rs` — strip "while the app was offline / pre-feature debris" framing.
- `src-tauri/src/pull_requests.rs` — rewrite the `gh --yes` note in the present tense.
- `src/lib/settings.ts` — drop "Sessions startup migration / Agents migration / v1" framing, describe what the fallback code does now.
- `src/lib/types.ts` — remove "legacy" framing on `SessionStartupMode` and `SessionKind` docstrings.
- `src/components/Tooltip.tsx`, `Terminal.tsx`, `SettingsModal.tsx` — strip legacy / hotfix narrative.
- `src/lib/notifications.ts` — replace "kept to keep the record exhaustive" with the actual invariant (exhaustiveness against `SessionStatus`).

## Test plan

- [x] `bun run typecheck` (tsc --noEmit) clean
- [x] `bun run test` (vitest) — 110 passed, 1 skipped (unchanged)
- [x] `cd src-tauri && cargo check` — clean aside from the pre-existing dead-code warning
- [x] `cargo test --lib` — 74 passed, 0 failed
- [ ] Reviewer: confirm no load-bearing WHY comment was deleted by mistake
