### PR TITLE
feat(ipc): status subcommand and in-app restart with bot button

### DIFF
--- a/src-tauri/src/bin/acorn-ipc.rs
+++ b/src-tauri/src/bin/acorn-ipc.rs
@@ -11,7 +11,7 @@
 
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use base64::Engine;
@@ -115,10 +115,32 @@ enum Command {
         #[arg(short = 't', long = "target")]
         target: String,
     },
+    /// Report IPC reachability: socket path, file presence, and whether
+    /// the in-app server accepts connections. No `ACORN_SESSION_ID`
+    /// required — `status` is the only command that works before the
+    /// control-session env has been set up.
+    Status,
 }
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
+
+    let socket_path = match cli.socket.clone() {
+        Some(p) => p,
+        None => match socket_path::resolve() {
+            Ok(p) => p,
+            Err(err) => {
+                eprintln!("acorn-ipc: could not resolve socket path: {err}");
+                return ExitCode::from(map_error_exit(ErrorCode::Internal));
+            }
+        },
+    };
+
+    // `status` is the one command that runs without an authorized source —
+    // it is a pure connectivity probe, so we handle it before the auth gate.
+    if matches!(cli.command, Command::Status) {
+        return run_status(&socket_path, cli.json);
+    }
 
     let source = match cli
         .source
@@ -133,17 +155,6 @@ fn main() -> ExitCode {
             );
             return ExitCode::from(map_error_exit(ErrorCode::Unauthorized));
         }
-    };
-
-    let socket_path = match cli.socket.clone() {
-        Some(p) => p,
-        None => match socket_path::resolve() {
-            Ok(p) => p,
-            Err(err) => {
-                eprintln!("acorn-ipc: could not resolve socket path: {err}");
-                return ExitCode::from(map_error_exit(ErrorCode::Internal));
-            }
-        },
     };
 
     let json = cli.json;
@@ -222,7 +233,62 @@ fn build_request(cmd: &Command) -> Result<Request, String> {
         Command::KillSession { target } => Request::KillSession {
             target_session_id: target.clone(),
         },
+        Command::Status => {
+            // Routed before `build_request` in `main`. Reaching here means
+            // the dispatch chain is wired wrong, not a user error.
+            return Err("status is handled out-of-band; this is a bug".to_string());
+        }
     })
+}
+
+/// Probe the IPC socket and print a short reachability report. Connection
+/// failure is *not* a CLI error — the whole point of `status` is to surface
+/// down servers, so we exit 0 in both branches and let callers parse the
+/// output (or the `reachable` JSON field).
+fn run_status(socket_path: &Path, json: bool) -> ExitCode {
+    let exists = socket_path.exists();
+    let (reachable, error) = match UnixStream::connect(socket_path) {
+        Ok(stream) => {
+            // Close immediately — the server treats every connection as a
+            // single request and would otherwise wait for one.
+            drop(stream);
+            (true, None)
+        }
+        Err(err) => (false, Some(err.to_string())),
+    };
+    let source_env = std::env::var(ENV_SESSION_ID).ok().filter(|s| !s.is_empty());
+    if json {
+        let payload = serde_json::json!({
+            "socket_path": socket_path.display().to_string(),
+            "socket_file_exists": exists,
+            "reachable": reachable,
+            "error": error,
+            "protocol_version": PROTOCOL_VERSION,
+            "source_session_id_env": source_env,
+        });
+        match serde_json::to_string_pretty(&payload) {
+            Ok(s) => println!("{s}"),
+            Err(err) => {
+                eprintln!("acorn-ipc: failed to encode status: {err}");
+                return ExitCode::from(map_error_exit(ErrorCode::Internal));
+            }
+        }
+        return ExitCode::SUCCESS;
+    }
+    println!("socket:           {}", socket_path.display());
+    println!("socket file:      {}", if exists { "present" } else { "missing" });
+    if reachable {
+        println!("reachable:        yes");
+    } else {
+        let reason = error.as_deref().unwrap_or("unknown");
+        println!("reachable:        no ({reason})");
+    }
+    println!("protocol version: {PROTOCOL_VERSION}");
+    println!(
+        "source env:       {}",
+        source_env.as_deref().unwrap_or("(unset)")
+    );
+    ExitCode::SUCCESS
 }
 
 fn send(path: &std::path::Path, envelope: &Envelope) -> Result<Response, String> {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -33,6 +33,10 @@ pub struct AcornIpcStatus {
     pub bundled_exists: bool,
     /// Canonical Unix-socket path used by the IPC server.
     pub socket_path: String,
+    /// True when the in-process IPC listener is currently running. Read
+    /// directly from the shutdown handle in `AppState`, so this is
+    /// authoritative — no socket round-trip needed.
+    pub server_running: bool,
     /// Common shim locations the user might have installed to. Each entry
     /// includes whether the file is present so the Settings UI can show a
     /// "Installed" / "Not installed" badge without round-tripping back to
@@ -52,7 +56,7 @@ pub struct AcornIpcShim {
 /// Used by the Sessions tab's "Control sessions" section to render an
 /// install hint with a copyable shell command.
 #[tauri::command]
-pub fn get_acorn_ipc_status() -> AcornIpcStatus {
+pub fn get_acorn_ipc_status(state: State<'_, AppState>) -> AcornIpcStatus {
     let bundled = std::env::current_exe()
         .ok()
         .and_then(|p| p.parent().map(|d| d.join("acorn-ipc")));
@@ -62,6 +66,12 @@ pub fn get_acorn_ipc_status() -> AcornIpcStatus {
         .unwrap_or_default();
     let bundled_exists = bundled.as_ref().map(|p| p.exists()).unwrap_or(false);
     let socket_path = crate::ipc::socket_path::resolve().unwrap_or_default();
+    let server_running = state
+        .ipc_handle
+        .lock()
+        .as_ref()
+        .map(|h| h.is_running())
+        .unwrap_or(false);
     let shim_paths = standard_shim_paths()
         .into_iter()
         .map(|p| AcornIpcShim {
@@ -73,7 +83,31 @@ pub fn get_acorn_ipc_status() -> AcornIpcStatus {
         bundled_path,
         bundled_exists,
         socket_path: socket_path.display().to_string(),
+        server_running,
         shim_paths,
+    }
+}
+
+/// Stop the running IPC listener (if any) and spawn a fresh one. Used by
+/// the Settings → Control sessions "Restart" button when the socket has
+/// gone stale (e.g. socket file removed under the app's feet). The signal
+/// → poll → exit cycle takes up to `ACCEPT_POLL_INTERVAL_MS`; we wait
+/// twice that before rebinding so the previous listener has dropped its
+/// file descriptor.
+#[tauri::command]
+pub fn ipc_restart<R: Runtime>(app: AppHandle<R>, state: State<'_, AppState>) -> Result<(), String> {
+    let previous = state.ipc_handle.lock().take();
+    if let Some(handle) = previous {
+        handle.signal_stop();
+        std::thread::sleep(std::time::Duration::from_millis(250));
+    }
+    let new_handle = crate::ipc::server::start(app.clone(), state.inner().clone());
+    let started = new_handle.is_some();
+    *state.ipc_handle.lock() = new_handle;
+    if started {
+        Ok(())
+    } else {
+        Err("ipc server failed to start; see app logs for details".to_string())
     }
 }
 

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -22,9 +22,12 @@
 //! handler code linear and reuses the existing blocking PTY pool without
 //! a runtime hop.
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, ErrorKind, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
 use base64::Engine;
 use tauri::{AppHandle, Emitter, Runtime};
@@ -52,17 +55,38 @@ const SELECT_SESSION_EVENT: &str = "acorn:ipc-select-session";
 /// frontend ignores the value today and just triggers a full refresh.
 const SESSIONS_CHANGED_EVENT: &str = "acorn:ipc-sessions-changed";
 
-/// Spawn the IPC server on a dedicated background thread. Returns
-/// immediately; failures during bind are logged but do not crash boot —
-/// the rest of the app remains usable even if IPC cannot start (e.g.
-/// the socket file is held open by a previous crash that left a stale
-/// inode behind).
-pub fn start<R: Runtime>(app: AppHandle<R>, state: AppState) {
+/// Shutdown signal for an active IPC listener. The listener thread polls
+/// `running` between non-blocking `accept` attempts; flipping it to false
+/// causes the thread to exit within ~`ACCEPT_POLL_INTERVAL_MS`. Stored in
+/// `AppState` so `ipc_restart` can swap a fresh listener in place.
+pub struct IpcServerHandle {
+    pub running: Arc<AtomicBool>,
+}
+
+impl IpcServerHandle {
+    pub fn is_running(&self) -> bool {
+        self.running.load(Ordering::SeqCst)
+    }
+
+    pub fn signal_stop(&self) {
+        self.running.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Poll cadence for the accept loop. Trades a tiny amount of idle CPU for a
+/// fast restart: the listener notices a stop signal within this window.
+const ACCEPT_POLL_INTERVAL_MS: u64 = 100;
+
+/// Spawn the IPC server on a dedicated background thread. Returns the
+/// shutdown handle on success, or `None` if bind failed (rest of the app
+/// remains usable). The listener is non-blocking and polls its `running`
+/// flag so `ipc_restart` can stop it without process-level signals.
+pub fn start<R: Runtime>(app: AppHandle<R>, state: AppState) -> Option<IpcServerHandle> {
     let path = match socket_path::resolve() {
         Ok(p) => p,
         Err(err) => {
             tracing::warn!(error = %err, "ipc: could not resolve socket path; server disabled");
-            return;
+            return None;
         }
     };
     if let Some(parent) = path.parent() {
@@ -72,7 +96,7 @@ pub fn start<R: Runtime>(app: AppHandle<R>, state: AppState) {
                 path = %parent.display(),
                 "ipc: could not create socket parent dir; server disabled",
             );
-            return;
+            return None;
         }
     }
     // Best-effort cleanup of any previous socket inode. We do not block on
@@ -86,9 +110,19 @@ pub fn start<R: Runtime>(app: AppHandle<R>, state: AppState) {
                 path = %path.display(),
                 "ipc: bind failed; server disabled",
             );
-            return;
+            return None;
         }
     };
+    if let Err(err) = listener.set_nonblocking(true) {
+        // Required for the shutdown poll. Bail rather than fall back to
+        // blocking accept — a blocking listener could never honour a stop
+        // signal and would leak its thread on every restart.
+        tracing::warn!(
+            error = %err,
+            "ipc: set_nonblocking failed; server disabled",
+        );
+        return None;
+    }
     if let Err(err) = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)) {
         // Tighten on best-effort. If chmod fails we keep going — it just
         // means the socket is more permissive than ideal, not that the
@@ -101,19 +135,36 @@ pub fn start<R: Runtime>(app: AppHandle<R>, state: AppState) {
     }
     tracing::info!(path = %path.display(), "ipc: listening");
 
-    std::thread::Builder::new()
+    let running = Arc::new(AtomicBool::new(true));
+    let running_for_thread = running.clone();
+    let spawn_result = std::thread::Builder::new()
         .name("acorn-ipc-listener".to_string())
-        .spawn(move || run_listener(listener, app, state))
-        .map(|_| ())
-        .unwrap_or_else(|err| {
+        .spawn(move || run_listener(listener, app, state, running_for_thread));
+    match spawn_result {
+        Ok(_) => Some(IpcServerHandle { running }),
+        Err(err) => {
             tracing::warn!(error = %err, "ipc: listener thread failed to start");
-        });
+            None
+        }
+    }
 }
 
-fn run_listener<R: Runtime>(listener: UnixListener, app: AppHandle<R>, state: AppState) {
-    for incoming in listener.incoming() {
-        match incoming {
-            Ok(stream) => {
+fn run_listener<R: Runtime>(
+    listener: UnixListener,
+    app: AppHandle<R>,
+    state: AppState,
+    running: Arc<AtomicBool>,
+) {
+    while running.load(Ordering::SeqCst) {
+        match listener.accept() {
+            Ok((stream, _addr)) => {
+                // Accepted streams inherit the listener's non-blocking flag,
+                // but the per-connection handler does blocking reads/writes.
+                // Restoring blocking mode here keeps the handler code simple.
+                if let Err(err) = stream.set_nonblocking(false) {
+                    tracing::warn!(error = %err, "ipc: stream set_blocking failed");
+                    continue;
+                }
                 let app = app.clone();
                 let state = state.clone();
                 std::thread::Builder::new()
@@ -128,11 +179,15 @@ fn run_listener<R: Runtime>(listener: UnixListener, app: AppHandle<R>, state: Ap
                         tracing::warn!(error = %err, "ipc: conn thread spawn failed");
                     });
             }
+            Err(ref err) if err.kind() == ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(ACCEPT_POLL_INTERVAL_MS));
+            }
             Err(err) => {
                 tracing::warn!(error = %err, "ipc: accept failed");
             }
         }
     }
+    tracing::info!("ipc: listener stopped");
 }
 
 fn handle_connection<R: Runtime>(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -161,8 +161,10 @@ pub fn run() {
             }
             // Start the IPC server in the background. It owns its own
             // listener thread; if bind fails it logs and the app keeps
-            // running with IPC disabled.
-            ipc::server::start(app.handle().clone(), state.inner().clone());
+            // running with IPC disabled. The returned handle lets
+            // `ipc_restart` cycle the listener without process restart.
+            let handle = ipc::server::start(app.handle().clone(), state.inner().clone());
+            *state.ipc_handle.lock() = handle;
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -207,6 +209,7 @@ pub fn run() {
             commands::detect_session_statuses,
             commands::get_memory_usage,
             commands::get_acorn_ipc_status,
+            commands::ipc_restart,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,6 +1,9 @@
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use parking_lot::Mutex;
+
+use crate::ipc::server::IpcServerHandle;
 use crate::pty::PtyManager;
 use crate::session::{ProjectStore, SessionStore};
 
@@ -16,6 +19,10 @@ pub struct AppState {
     /// persisted layout. Defaults to true (clean) for fresh installs.
     pub sessions_loaded_cleanly: Arc<AtomicBool>,
     pub projects_loaded_cleanly: Arc<AtomicBool>,
+    /// Shutdown handle for the currently running IPC listener thread.
+    /// `None` when bind failed at boot. `ipc_restart` swaps in a new handle
+    /// after signaling the previous listener to exit.
+    pub ipc_handle: Arc<Mutex<Option<IpcServerHandle>>>,
 }
 
 impl AppState {
@@ -26,6 +33,7 @@ impl AppState {
             pty: PtyManager::new(),
             sessions_loaded_cleanly: Arc::new(AtomicBool::new(true)),
             projects_loaded_cleanly: Arc::new(AtomicBool::new(true)),
+            ipc_handle: Arc::new(Mutex::new(None)),
         }
     }
 }

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -112,6 +112,20 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     }
   }
 
+  async function handleRestartIpc() {
+    const show = useToasts.getState().show;
+    try {
+      await api.ipcRestart();
+      show("IPC server restarted.");
+    } catch (err) {
+      console.error("[CommandPalette] ipcRestart failed", err);
+      const message = err instanceof Error ? err.message : String(err);
+      show(`Failed to restart IPC server: ${message}`);
+    } finally {
+      close();
+    }
+  }
+
   return (
     <Command.Dialog
       open={open}
@@ -237,6 +251,25 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             <span className="ml-auto truncate text-xs text-fg-muted/80">
               ⇧⌘,
             </span>
+          </Command.Item>
+        </Command.Group>
+
+        <Command.Group heading="IPC">
+          <Command.Item
+            value="restart-ipc"
+            onSelect={() => void handleRestartIpc()}
+            keywords={[
+              "ipc",
+              "control",
+              "socket",
+              "acorn-ipc",
+              "restart",
+              "reload",
+              "server",
+            ]}
+          >
+            <Bot size={14} className="text-accent" />
+            <span>Restart IPC server</span>
           </Command.Item>
         </Command.Group>
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { homeDir } from "@tauri-apps/api/path";
+import { Bot, Loader2 } from "lucide-react";
 import { api } from "../lib/api";
+import { cn } from "../lib/cn";
 import { useSettings } from "../lib/settings";
 import type { MemoryProcess } from "../lib/types";
 import { useAppStore } from "../store";
@@ -122,7 +124,10 @@ export function StatusBar() {
     <>
       <footer className="flex h-7 shrink-0 items-center gap-3 border-t border-border bg-bg-sidebar px-3 font-mono text-xs text-fg-muted">
         {/* Left: aggregate counters about acorn itself — total sessions and
-            the active session's lifecycle status. */}
+            the active session's lifecycle status. The IPC button sits first
+            so the user can recover from a dead control-session socket
+            without leaving the main view. */}
+        <IpcStatusButton />
         <span>sessions: {sessions.length}</span>
         {active ? (
           <>
@@ -190,5 +195,85 @@ export function StatusBar() {
         onClose={() => setBreakdownOpen(false)}
       />
     </>
+  );
+}
+
+// Bottom-bar IPC indicator + restart trigger. The badge reflects the in-app
+// listener thread state (authoritative for "can I still accept new
+// connections?"); clicking always cycles the listener so users can recover
+// from a stale socket file even when the thread itself is happy.
+function IpcStatusButton() {
+  const [running, setRunning] = useState<boolean | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const status = await api.getAcornIpcStatus();
+      setRunning(status.server_running);
+    } catch {
+      // Probe failure is a strong "the backend is unhappy" signal; surface
+      // it as down so the badge is honest rather than stuck on the last
+      // known good state.
+      setRunning(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleClick = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    setLastError(null);
+    try {
+      await api.ipcRestart();
+      await refresh();
+    } catch (err) {
+      setLastError(err instanceof Error ? err.message : String(err));
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, refresh]);
+
+  const tooltip = busy
+    ? "Restarting IPC server…"
+    : lastError
+      ? `IPC restart failed: ${lastError}`
+      : running === null
+        ? "IPC status: loading"
+        : running
+          ? "IPC server: running — click to restart"
+          : "IPC server: down — click to restart";
+
+  return (
+    <Tooltip label={tooltip} side="top" multiline>
+      <button
+        type="button"
+        onClick={() => void handleClick()}
+        disabled={busy}
+        className={cn(
+          "flex h-5 items-center gap-1 rounded px-1.5 transition",
+          "hover:bg-bg-elevated disabled:cursor-default disabled:hover:bg-transparent",
+          running === null
+            ? "text-fg-muted"
+            : running
+              ? "text-accent"
+              : "text-danger",
+        )}
+        aria-label="Restart IPC server"
+      >
+        {busy ? (
+          <Loader2 size={12} className="animate-spin" />
+        ) : (
+          <Bot size={12} />
+        )}
+        <span className="text-[10px]">
+          ipc: {running === null ? "…" : running ? "on" : "off"}
+        </span>
+      </button>
+    </Tooltip>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -163,6 +163,15 @@ export const api = {
   getAcornIpcStatus(): Promise<AcornIpcStatus> {
     return invoke<AcornIpcStatus>("get_acorn_ipc_status");
   },
+  /**
+   * Stop the in-process IPC listener and spawn a fresh one. Used when the
+   * socket has gone stale (e.g. file removed under the running app) so the
+   * user can recover without restarting the whole app. Resolves on success;
+   * rejects with the backend's error string if rebind fails.
+   */
+  ipcRestart(): Promise<void> {
+    return invoke<void>("ipc_restart");
+  },
   readSessionTodos(sessionId: string, cwd: string): Promise<TodoItem[]> {
     return invoke<TodoItem[]>("read_session_todos", { sessionId, cwd });
   },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -96,6 +96,7 @@ export interface AcornIpcStatus {
   bundled_path: string;
   bundled_exists: boolean;
   socket_path: string;
+  server_running: boolean;
   shim_paths: AcornIpcShim[];
 }
 

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -50,6 +50,16 @@ export const tauriMockSource = `
     }
     if (cmd === 'scrollback_orphan_size') return Promise.resolve(0);
     if (cmd === 'scrollback_orphan_clear') return Promise.resolve(0);
+    if (cmd === 'get_acorn_ipc_status') {
+      return Promise.resolve({
+        bundled_path: '',
+        bundled_exists: false,
+        socket_path: '',
+        server_running: false,
+        shim_paths: [],
+      });
+    }
+    if (cmd === 'ipc_restart') return Promise.resolve(undefined);
     if (cmd === 'reorder_projects') return Promise.resolve([]);
     if (cmd === 'reorder_sessions') return Promise.resolve([]);
     if (cmd && cmd.startsWith('list_')) return Promise.resolve([]);


### PR DESCRIPTION
## Summary
- `acorn-ipc status` CLI subcommand reports socket path, file presence, and reachability without needing `ACORN_SESSION_ID`. Pure connectivity probe; exits 0 in both reachable and unreachable cases so scripts can branch on the output (or the `reachable` JSON field).
- In-app IPC server restart with three surfaces:
  - Bottom-bar Bot-icon button (left of `sessions: N`) with a running/down badge.
  - Command palette entry "Restart IPC server" under the new "IPC" group (⌘K → "ipc").
  - `ipc_restart` Tauri command (used by both UIs).
- Backend gains a shutdown-aware listener: `IpcServerHandle { running: Arc<AtomicBool> }` paired with non-blocking accept + 100ms poll. `ipc_restart` signals stop, waits one poll cycle, removes the socket file, and rebinds.

## Why
The IPC socket can go stale (server hits a bind issue, socket file gets removed underneath the running app, etc.). Until now, the only fix was quitting and relaunching Acorn. `acorn-ipc status` makes the wedged state observable from any terminal, and the two in-app surfaces make recovery a one-action operation (click the button or fire it from the command palette).

## Files
- `src-tauri/src/bin/acorn-ipc.rs` — `Status` subcommand routed before the auth gate.
- `src-tauri/src/ipc/server.rs` — `IpcServerHandle`, non-blocking accept loop, signal-driven shutdown.
- `src-tauri/src/commands.rs` — `ipc_restart` command; `AcornIpcStatus.server_running` field.
- `src-tauri/src/state.rs` — `ipc_handle: Arc<Mutex<Option<IpcServerHandle>>>` in `AppState`.
- `src-tauri/src/lib.rs` — store boot-time handle; register `ipc_restart` invoke.
- `src/components/StatusBar.tsx` — `IpcStatusButton` with `Bot` icon, running/down badge, restart click.
- `src/components/CommandPalette.tsx` — "Restart IPC server" entry with toast feedback.
- `src/lib/api.ts`, `src/lib/types.ts` — `ipcRestart()` wrapper, `server_running` field.
- `tests/e2e/fixtures/tauriMock.ts` — defaults for `get_acorn_ipc_status` and `ipc_restart` so E2E does not crash on boot-time invokes (per `CLAUDE.md`).

## Test plan
- [x] `cargo test --lib --bin acorn-ipc` — 74 + 10 passing.
- [x] `cargo check --all-targets` — clean.
- [x] `bun run typecheck` — clean.
- [x] `bun run test` (vitest) — 110 passing, 1 skipped.
- [x] `acorn-ipc status` against down server — reports `reachable: no (Connection refused)` with exit 0.
- [x] `acorn-ipc status --json` — pretty-printed JSON output.
- [x] Local dev — button click restarts listener (log shows `listener stopped` → `listening` cycle).
- [x] Local dev — command palette "Restart IPC server" entry fires the same flow with toast feedback.
- [ ] Manual: rm the socket file, click button, confirm rebind + reachability recovers.

## Notes
- `ACCEPT_POLL_INTERVAL_MS = 100` — restart latency upper bound; tunable if the idle CPU is ever an issue.
- `ipc_restart` waits 250ms before rebinding to make sure the old listener has dropped its fd.
- Badge reflects the in-process listener thread state. If the socket file is externally removed but the listener thread is still alive, badge will say `on` while external CLI connects fail — clicking restart resolves this (rebind creates a fresh socket file).
