### PR TITLE
chore(release): v1.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.9",
+  "version": "1.0.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.9"
+version = "1.0.10"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

Bumps `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.lock` from `1.0.9` to `1.0.10` so the next `v1.0.10` tag has matching manifest metadata.

## Notable since v1.0.9

- **IPC status + in-app bot restart (#122)** — `acorn-ipc status` subcommand reports server state; in-app status bar surfaces an inline bot button to restart the IPC server when it falls over, without leaving the app.
- **Clickable shell command hints (#119)** — `CommandHint` is now interactive: clicking opens a run/copy dialog so suggested shell commands can be executed or copied without retyping.
- **Drag-to-reorder sidebar (#116)** — projects and sessions can be reordered via `dnd-kit` drag-and-drop; ordering persists across reloads.
- **Right-panel non-repo guard (#120)** — switching the PTY cwd to a non-repo dir no longer floods the right panel with a red error banner; the panel quietly empties out instead.
- **Claude resume hardening (#118)** — stop trying to resume Claude sessions Claude itself no longer tracks, eliminating the "session not found" loop on launch.
- **Terminal paste fix (#117)** — owns the paste path end-to-end so a Space immediately after paste no longer duplicates the pasted block.
- **Pane drag-to-split reliability (#115)** — tab drag-to-split hit detection now triggers consistently at pane edges.
- **Sidecar target triple (#114)** — release builds now compile the `acorn-ipc` sidecar for the matrix target triple instead of the host, fixing cross-arch macOS bundles.
- **Comment policy + rewrites (#121)** — codifies the present-tense-WHY comment rule in `docs/COMMENTS.md` and sweeps existing rotting comments.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — 110 pass / 1 skip
- [ ] `cargo test --lib`
- [ ] `cargo test --bin acorn-ipc`
- [ ] CI on this PR (Frontend + E2E)
- [ ] Tag `v1.0.10` after merge to trigger `release.yml` macOS bundle build
