### PR TITLE
feat(terminal): settings toggle for click vs modifier-click link activation

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -17,6 +17,7 @@ import {
   type SelectedAgent,
   type SessionStartupMode,
   type TerminalFontWeight,
+  type TerminalLinkActivation,
   TERMINAL_FONT_WEIGHTS,
   selectedAgentLabel,
   useSettings,
@@ -194,9 +195,37 @@ function TerminalSettings() {
           onChange={(n) => patchTerminal({ lineHeight: n })}
         />
       </Field>
+      <Field
+        label="Open links on"
+        hint="How to follow URLs that xterm detects in terminal output."
+      >
+        <div className="flex flex-col gap-1.5">
+          <RadioCard<TerminalLinkActivation>
+            name="terminal-link-activation"
+            value="click"
+            current={settings.terminal.linkActivation}
+            label="Click (default)"
+            description="A single mouse click opens the URL in your default browser."
+            onSelect={(v) => patchTerminal({ linkActivation: v })}
+          />
+          <RadioCard<TerminalLinkActivation>
+            name="terminal-link-activation"
+            value="modifier-click"
+            current={settings.terminal.linkActivation}
+            label={`${MODIFIER_LABEL}-click`}
+            description={`Hold ${MODIFIER_LABEL} while clicking to open. Stops stray clicks on output containing URLs from yanking focus to the browser.`}
+            onSelect={(v) => patchTerminal({ linkActivation: v })}
+          />
+        </div>
+      </Field>
     </section>
   );
 }
+
+const IS_MAC =
+  typeof navigator !== "undefined" &&
+  /Mac|iP(hone|od|ad)/.test(navigator.platform);
+const MODIFIER_LABEL = IS_MAC ? "⌘" : "Ctrl";
 
 interface WeightSelectProps {
   value: TerminalFontWeight;

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -9,7 +9,11 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import "@xterm/xterm/css/xterm.css";
 import { api } from "../lib/api";
 import { registerScrollbackFlusher } from "../lib/scrollback-coordinator";
-import { resolveStartupCommand, useSettings } from "../lib/settings";
+import {
+  resolveStartupCommand,
+  useSettings,
+  type TerminalLinkActivation,
+} from "../lib/settings";
 import { useToasts } from "../lib/toasts";
 import type { SessionStartupMode } from "../lib/types";
 import { useAppStore } from "../store";
@@ -54,6 +58,16 @@ const TERMINAL_THEME: ITheme = {
 const ANSI_RED = "\x1b[31m";
 const ANSI_RESET = "\x1b[0m";
 const ANSI_DIM = "\x1b[2m";
+
+// macOS uses Cmd (metaKey); other platforms use Ctrl. Matches the
+// platform-primary modifier `tinykeys` resolves `$mod` to.
+const IS_MAC =
+  typeof navigator !== "undefined" &&
+  /Mac|iP(hone|od|ad)/.test(navigator.platform);
+
+function modifierHeld(event: MouseEvent): boolean {
+  return IS_MAC ? event.metaKey : event.ctrlKey;
+}
 
 function decodeBase64ToBytes(b64: string): Uint8Array {
   const binary = atob(b64);
@@ -116,11 +130,18 @@ export function Terminal({
     });
 
     const fitAddon = new FitAddon();
+    // Tracks the current link-activation setting so the addon callback below
+    // sees live changes without rebuilding the terminal.
+    let linkActivation: TerminalLinkActivation =
+      initialSettings.terminal.linkActivation;
     // Hand link clicks to the OS so URLs open in the user's default browser
     // instead of trying to navigate the Tauri WebView (which is gated by the
-    // app's CSP and would either fail or replace the app shell).
+    // app's CSP and would either fail or replace the app shell). When the user
+    // opts into modifier-click activation, plain clicks are swallowed so a
+    // stray click on a URL in shell output doesn't steal focus.
     const webLinksAddon = new WebLinksAddon((event, uri) => {
       event.preventDefault();
+      if (linkActivation === "modifier-click" && !modifierHeld(event)) return;
       void openUrl(uri).catch((err: unknown) => {
         console.error("failed to open terminal link", uri, err);
       });
@@ -168,6 +189,9 @@ export function Terminal({
       if (next.lineHeight !== previous.lineHeight) {
         term.options.lineHeight = next.lineHeight;
         changed = true;
+      }
+      if (next.linkActivation !== previous.linkActivation) {
+        linkActivation = next.linkActivation;
       }
       if (changed) {
         try {

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -130,3 +130,9 @@ describe("resolveStartupCommand", () => {
     ).toEqual({ command: "bash", args: ["-lc", "echo"] });
   });
 });
+
+describe("terminal.linkActivation default", () => {
+  it("defaults to plain click so xterm's stock behaviour is preserved", () => {
+    expect(DEFAULT_SETTINGS.terminal.linkActivation).toBe("click");
+  });
+});

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -88,6 +88,14 @@ export type TerminalFontWeight =
   | 800
   | 900;
 
+/**
+ * How the terminal activates links. `click` opens on a plain mouse click;
+ * `modifier-click` requires the platform-primary modifier (Cmd on macOS,
+ * Ctrl elsewhere) so a stray click on a URL in shell output does not yank
+ * focus to the browser.
+ */
+export type TerminalLinkActivation = "click" | "modifier-click";
+
 export const TERMINAL_FONT_WEIGHTS: ReadonlyArray<{
   value: TerminalFontWeight;
   label: string;
@@ -115,6 +123,12 @@ export interface AcornSettings {
      * cramped. Range 1.0–2.0 keeps the cursor / link hit boxes sensible.
      */
     lineHeight: number;
+    /**
+     * Gesture required to follow a URL in terminal output. Plain click is
+     * the xterm default; modifier-click matches iTerm2 / Terminal.app so a
+     * stray click on output containing a URL doesn't steal focus.
+     */
+    linkActivation: TerminalLinkActivation;
   };
   /**
    * The single AI agent acorn uses everywhere: Sessions startup (when
@@ -201,6 +215,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     fontWeight: 400,
     fontWeightBold: 700,
     lineHeight: 1.0,
+    linkActivation: "click",
   },
   agents: {
     selected: "claude",
@@ -259,6 +274,14 @@ const VALID_PR_STATES = new Set<PrStateFilter>([
 const VALID_PR_INTERVALS = new Set<number>(
   PR_REFRESH_INTERVAL_OPTIONS.map((o) => o.value),
 );
+
+function normalizeLinkActivation(
+  v: unknown,
+  fallback: TerminalLinkActivation,
+): TerminalLinkActivation {
+  if (v === "click" || v === "modifier-click") return v;
+  return fallback;
+}
 
 function normalizeLineHeight(v: unknown, fallback: number): number {
   if (typeof v !== "number" || !Number.isFinite(v)) return fallback;
@@ -387,6 +410,10 @@ function loadSettings(): AcornSettings {
         lineHeight: normalizeLineHeight(
           (terminalRaw as { lineHeight?: unknown }).lineHeight,
           DEFAULT_SETTINGS.terminal.lineHeight,
+        ),
+        linkActivation: normalizeLinkActivation(
+          (terminalRaw as { linkActivation?: unknown }).linkActivation,
+          DEFAULT_SETTINGS.terminal.linkActivation,
         ),
       },
       agents: {


### PR DESCRIPTION
## Summary

- Add Settings → Terminal toggle for link activation: **Click (default)** vs **⌘/Ctrl-click**.
- When `modifier-click` is selected, `WebLinksAddon` swallows plain clicks so a stray click on shell output containing a URL no longer steals focus to the browser. Holding the platform-primary modifier still hands the URL to `openUrl()` (the OS default browser, unchanged).
- Live-applied: changing the setting updates open terminals without respawning the PTY (same subscription path used by font settings).
- Legacy stored settings without `linkActivation` load as `"click"`, preserving today's behaviour.

## Test plan

- [ ] `bun run typecheck`
- [ ] `bun run test` (added a default-value assertion in `settings.test.ts`)
- [ ] Open the app, Settings → Terminal: confirm both radios render with the correct modifier label per platform.
- [ ] Switch to `⌘-click`: plain click on a URL in terminal output should do nothing; Cmd-click (Ctrl on Linux/Windows) should open it in the default browser.
- [ ] Switch back to `Click`: plain click opens the URL again with no app respawn.
