### PR TITLE
fix(terminal): render wide emoji at correct width

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@xterm/addon-canvas": "^0.7.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-serialize": "^0.14.0",
+        "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "clsx": "^2.1.1",
@@ -453,6 +454,8 @@
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 
     "@xterm/addon-serialize": ["@xterm/addon-serialize@0.14.0", "", {}, "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA=="],
+
+    "@xterm/addon-unicode11": ["@xterm/addon-unicode11@0.9.0", "", {}, "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw=="],
 
     "@xterm/addon-web-links": ["@xterm/addon-web-links@0.12.0", "", {}, "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw=="],
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-serialize": "^0.14.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "clsx": "^2.1.1",

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, type ReactElement } from "react";
 import { Terminal as XTerm, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
@@ -147,9 +148,16 @@ export function Terminal({
       });
     });
     const serializeAddon = new SerializeAddon();
+    const unicode11Addon = new Unicode11Addon();
     term.loadAddon(fitAddon);
     term.loadAddon(webLinksAddon);
     term.loadAddon(serializeAddon);
+    term.loadAddon(unicode11Addon);
+    // xterm.js defaults to Unicode 6 width tables that treat most emoji as
+    // width 1. The glyph then overflows its cell and adjacent cells overwrite
+    // it, producing the half-rendered / crammed look. Unicode 11 tables mark
+    // modern emoji as width 2 so cell allocation matches the glyph footprint.
+    term.unicode.activeVersion = "11";
     termRef.current = term;
     fitRef.current = fitAddon;
 


### PR DESCRIPTION
## Summary

- Load `@xterm/addon-unicode11` in `Terminal.tsx` and switch xterm's active Unicode version to `"11"`.
- Fixes wide-emoji rendering: with the default Unicode 6 width tables xterm.js allocates width 1 for most modern emoji, so the glyph overflows its single cell and adjacent cells repaint over it — producing half-rendered or crammed-together emoji (e.g. `🌰🐿️🍂🌳🍁`). Unicode 11 tables mark these as width 2, matching the glyph footprint.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (111 passed)
- [ ] `bun run tauri dev` → paste `echo 🌰🐿️🍂🌳🍁🦊🌙⭐🔥🌊` in a terminal session, verify each emoji renders fully and spacing is even
- [ ] Confirm CJK and ASCII text still render at the previous spacing (no regression on width-1 glyphs)
