### PR TITLE
fix(terminal): restore image paste via WKWebView native handler

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -596,7 +596,7 @@ export function Terminal({
     container.addEventListener("input", onInput, true);
     container.addEventListener("keydown", onKeydown, true);
 
-    // Own the paste path. xterm's built-in listener emits the
+    // Own the paste path for text. xterm's built-in listener emits the
     // pasted text but only calls `stopPropagation()` — it never
     // `preventDefault()`s, so the browser's default action still
     // re-inserts the text into the helper textarea. That residue
@@ -610,9 +610,21 @@ export function Terminal({
     // enabled the mode) and clears the textarea. `preventDefault`
     // blocks the browser reinsertion; `stopImmediatePropagation`
     // blocks xterm's listener so the data emits exactly once.
+    //
+    // Skip this path when the clipboard carries an image-only
+    // payload (macOS screencapture, copy-image-from-browser). The
+    // WKWebView's native paste relays the underlying NSPasteboard
+    // image to the running CLI (Claude Code surfaces it as
+    // `[Image #N]`), which only works if we let the default
+    // action proceed. Text-mixed payloads still take the owned
+    // path because the textarea residue + IME race outweighs the
+    // image relay there.
     const onPaste = (e: Event) => {
       const ev = e as ClipboardEvent;
-      const text = ev.clipboardData?.getData("text/plain") ?? "";
+      const cd = ev.clipboardData;
+      const text = cd?.getData("text/plain") ?? "";
+      const hasFiles = (cd?.files?.length ?? 0) > 0;
+      if (!text && hasFiles) return;
       if (text) term.paste(text);
       ev.preventDefault();
       ev.stopImmediatePropagation();


### PR DESCRIPTION
## Summary

PR #117 took ownership of the terminal paste path to stop a duplicate-on-space emit and IME textarea-residue race. The owned listener calls `preventDefault()` + `stopImmediatePropagation()` on every paste — including image-only payloads, which silently broke clipboard image attachment. macOS `Cmd+Ctrl+Shift+4` screenshots, browser "Copy Image", Preview.app image copies — all used to land as `[Image #N]` in Claude Code through the WKWebView's native paste relay. After #117 the native action never fires for those payloads, so the CLI receives nothing.

This gates the owned path on whether the clipboard actually carries text. Image-only payloads (empty `text/plain`, non-empty `files`) bail out before `preventDefault()` and let the WebView's default paste reach the CLI, restoring `[Image #N]`. Text-only and text+image keep the owned path so the IME-residue fix from #117 stays intact.

## Test plan

- **Image paste regression fix (PR #117 recovery)**
  - [x] 1.1 macOS region screenshot (Cmd+Ctrl+Shift+4) → Cmd+V in Claude session → `[Image #N]` shows. **Verified in dev build off this branch.**
  - [ ] 1.2 macOS full screenshot (Cmd+Ctrl+Shift+3) → Cmd+V → `[Image #N]` shows
  - [ ] 1.3 Browser image right-click → "Copy Image" → Cmd+V → image attached (text fallback acceptable if mixed)
  - [ ] 1.4 Finder PNG file copy → Cmd+V → image attached or path inserted
  - [ ] 1.5 Preview.app image copy → Cmd+V → `[Image #N]`
- **PR #117 fix retained (no regression)**
  - [ ] 2.1 Text paste then Space → no duplicate
  - [ ] 2.2 Text paste then Enter → command runs once
  - [ ] 2.3 Multi-line code paste → line breaks preserved, no duplication
- **Korean IME duplication still suppressed**
  - [ ] 3.1 Korean paste + additional Korean typing → no syllable duplication
  - [ ] 3.2 Korean paste + Space → trailing space appended once
  - [ ] 3.3 ssang-jamo (ㅆ) typed post-paste → no duplicate emit
- **Mixed / edge cases**
  - [ ] 4.1 Text+image clipboard (Slack-style) → text pastes, image silently dropped (documented tradeoff)
  - [ ] 4.2 Empty clipboard Cmd+V → no-op, no error
  - [ ] 4.3 Plain zsh session text paste → bracketed paste still wraps correctly
  - [ ] 4.4 Plain zsh session image paste → no crash
  - [ ] 4.5 Two pastes back-to-back → both land correctly

## Notes

- WKWebView's native handler is what actually surfaces the image to Claude Code; we don't touch the relay, only stop blocking it.
- Mixed text+image stays on the owned path on purpose. Text input is the common case and emitting duplicate syllables (the #117 failure mode) is the worse user experience than losing the image half of a mixed paste.
- Claude Code CLI's `[Image #N]` placeholder includes a trailing space by design; not introduced here.
