### PR TITLE
feat(sidebar): customize session row title, metadata, hover details

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -14,8 +14,10 @@ import { WhatsNewModal } from "./WhatsNewModal";
 import {
   AGENT_OPTIONS,
   PR_REFRESH_INTERVAL_OPTIONS,
+  SESSION_TITLE_OPTIONS,
   type SelectedAgent,
   type SessionStartupMode,
+  type SessionTitleSource,
   type TerminalFontWeight,
   type TerminalLinkActivation,
   TERMINAL_FONT_WEIGHTS,
@@ -502,9 +504,76 @@ function PullRequestsSettings() {
 function AppearanceSettings() {
   const settings = useSettings((s) => s.settings);
   const patchStatusBar = useSettings((s) => s.patchStatusBar);
+  const patchSessionDisplay = useSettings((s) => s.patchSessionDisplay);
+  const sessionDisplay = settings.sessionDisplay;
 
   return (
     <section className="space-y-4">
+      <Field
+        label="Session title"
+        hint="Which field becomes the bold first line of each sidebar session row."
+      >
+        <div className="flex flex-col gap-1.5">
+          {SESSION_TITLE_OPTIONS.map((opt) => (
+            <RadioCard<SessionTitleSource>
+              key={opt.value}
+              name="acorn-session-title"
+              value={opt.value}
+              current={sessionDisplay.title}
+              label={opt.label}
+              description={opt.description}
+              onSelect={(v) => patchSessionDisplay({ title: v })}
+            />
+          ))}
+        </div>
+      </Field>
+      <Field
+        label="Additional metadata"
+        hint="Secondary line under the title. Toggle off everything for a single-line row."
+      >
+        <div className="flex flex-col gap-1">
+          <CheckboxRow
+            label="Branch"
+            description="Active git branch."
+            checked={sessionDisplay.metadata.branch}
+            onChange={(v) =>
+              patchSessionDisplay({ metadata: { branch: v } })
+            }
+          />
+          <CheckboxRow
+            label="Working directory"
+            description="Worktree directory basename."
+            checked={sessionDisplay.metadata.workingDirectory}
+            onChange={(v) =>
+              patchSessionDisplay({ metadata: { workingDirectory: v } })
+            }
+          />
+          <CheckboxRow
+            label="Status"
+            description="Idle / Running / Needs input / Failed / Completed."
+            checked={sessionDisplay.metadata.status}
+            onChange={(v) =>
+              patchSessionDisplay({ metadata: { status: v } })
+            }
+          />
+        </div>
+      </Field>
+      <Field
+        label="Show details on hover"
+        hint="Pop a tooltip with every field when hovering a session row, regardless of which fields the row itself shows."
+      >
+        <label className="flex items-center gap-2 text-xs text-fg">
+          <input
+            type="checkbox"
+            checked={sessionDisplay.showDetailsOnHover}
+            onChange={(e) =>
+              patchSessionDisplay({ showDetailsOnHover: e.target.checked })
+            }
+            className="accent-[var(--color-accent)]"
+          />
+          Enable hover tooltip
+        </label>
+      </Field>
       <Field
         label="Status bar"
         hint="Choose which optional badges show in the bottom status bar."

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -556,22 +556,6 @@ function AppearanceSettings() {
               patchSessionDisplay({ metadata: { status: v } })
             }
           />
-          <CheckboxRow
-            label="Last activity"
-            description="Relative timestamp from the session's last update (e.g. 2m ago)."
-            checked={sessionDisplay.metadata.lastActivity}
-            onChange={(v) =>
-              patchSessionDisplay({ metadata: { lastActivity: v } })
-            }
-          />
-          <CheckboxRow
-            label="Last message"
-            description="First line of the agent's last message, truncated."
-            checked={sessionDisplay.metadata.lastMessage}
-            onChange={(v) =>
-              patchSessionDisplay({ metadata: { lastMessage: v } })
-            }
-          />
         </div>
       </Field>
       <Field

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -556,6 +556,45 @@ function AppearanceSettings() {
               patchSessionDisplay({ metadata: { status: v } })
             }
           />
+          <CheckboxRow
+            label="Last activity"
+            description="Relative timestamp from the session's last update (e.g. 2m ago)."
+            checked={sessionDisplay.metadata.lastActivity}
+            onChange={(v) =>
+              patchSessionDisplay({ metadata: { lastActivity: v } })
+            }
+          />
+          <CheckboxRow
+            label="Last message"
+            description="First line of the agent's last message, truncated."
+            checked={sessionDisplay.metadata.lastMessage}
+            onChange={(v) =>
+              patchSessionDisplay({ metadata: { lastMessage: v } })
+            }
+          />
+        </div>
+      </Field>
+      <Field
+        label="Inline icons"
+        hint="Glyphs that decorate each session row. Hide to make the list denser."
+      >
+        <div className="flex flex-col gap-1">
+          <CheckboxRow
+            label="Status dot"
+            description="Colored bullet at the row start. Redundant when Status is enabled in metadata."
+            checked={sessionDisplay.icons.statusDot}
+            onChange={(v) =>
+              patchSessionDisplay({ icons: { statusDot: v } })
+            }
+          />
+          <CheckboxRow
+            label="Session kind icons"
+            description="Branch glyph for isolated worktrees and bot glyph for control sessions."
+            checked={sessionDisplay.icons.sessionKind}
+            onChange={(v) =>
+              patchSessionDisplay({ icons: { sessionKind: v } })
+            }
+          />
         </div>
       </Field>
       <Field

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -911,6 +911,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
           e.stopPropagation();
           setMenu({ x: e.clientX, y: e.clientY });
         }}
+        title={hoverDetails ?? undefined}
         className={cn(
           "group flex w-full items-start gap-1.5 rounded-md px-2 py-1 text-left transition",
           active ? "bg-bg-elevated" : "hover:bg-bg-elevated/60",
@@ -927,18 +928,20 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
         >
           <GripVertical size={10} />
         </span>
-        <span
-          className={cn(
-            "mt-1.5 size-1.5 shrink-0 rounded-full",
-            STATUS_DOT[session.status],
-          )}
-        />
+        {sessionDisplay.icons.statusDot ? (
+          <span
+            className={cn(
+              "mt-1.5 size-1.5 shrink-0 rounded-full",
+              STATUS_DOT[session.status],
+            )}
+          />
+        ) : null}
         <SessionRowLabel
           editing={editing}
           session={session}
           titleText={titleText}
           metadataText={metadataText}
-          hoverDetails={hoverDetails}
+          showKindIcons={sessionDisplay.icons.sessionKind}
           onSubmitRename={async (next) => {
             setEditing(false);
             if (next && next !== session.name) {
@@ -983,7 +986,7 @@ interface SessionRowLabelProps {
   session: Session;
   titleText: string;
   metadataText: string;
-  hoverDetails: string | null;
+  showKindIcons: boolean;
   onSubmitRename: (value: string) => void | Promise<void>;
   onCancelRename: () => void;
 }
@@ -993,7 +996,7 @@ function SessionRowLabel({
   session,
   titleText,
   metadataText,
-  hoverDetails,
+  showKindIcons,
   onSubmitRename,
   onCancelRename,
 }: SessionRowLabelProps) {
@@ -1011,14 +1014,14 @@ function SessionRowLabel({
             {titleText}
           </span>
         )}
-        {session.isolated ? (
+        {showKindIcons && session.isolated ? (
           <GitBranch
             size={10}
             className="shrink-0 text-fg-muted"
             aria-label="isolated worktree"
           />
         ) : null}
-        {session.kind === "control" ? (
+        {showKindIcons && session.kind === "control" ? (
           <Bot
             size={10}
             className="shrink-0 text-accent"
@@ -1034,14 +1037,7 @@ function SessionRowLabel({
     </span>
   );
 
-  // Tooltip swallows pointer events on the trigger; while renaming we
-  // need clean focus on the input, so skip the wrapper entirely.
-  if (!hoverDetails || editing) return body;
-  return (
-    <Tooltip label={hoverDetails} side="right" multiline>
-      {body}
-    </Tooltip>
-  );
+  return body;
 }
 
 async function copyToClipboard(text: string): Promise<void> {
@@ -1161,7 +1157,29 @@ function composeSessionMetadata(
     if (dir) parts.push(dir);
   }
   if (metadata.status) parts.push(STATUS_LABEL[session.status]);
+  if (metadata.lastActivity) {
+    const rel = formatRelativeTime(session.updated_at);
+    if (rel) parts.push(rel);
+  }
+  if (metadata.lastMessage && session.last_message) {
+    const preview = session.last_message
+      .split(/\r?\n/)[0]
+      ?.trim()
+      .slice(0, 60);
+    if (preview) parts.push(preview);
+  }
   return parts.join(" · ");
+}
+
+function formatRelativeTime(iso: string): string | null {
+  const ts = Date.parse(iso);
+  if (Number.isNaN(ts)) return null;
+  const diff = Date.now() - ts;
+  if (diff < 0) return "just now";
+  if (diff < 60_000) return "just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
 }
 
 function buildSessionHoverDetails(session: Session): string {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -40,7 +40,11 @@ import { useAppStore } from "../store";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
-import { useSettings } from "../lib/settings";
+import {
+  useSettings,
+  type AcornSettings,
+  type SessionTitleSource,
+} from "../lib/settings";
 import {
   planChevronClick,
   planTitleClick,
@@ -304,7 +308,7 @@ export function Sidebar() {
 
   return (
     <aside className="flex h-full w-full flex-col bg-bg-sidebar">
-      <header className="flex items-center justify-between gap-2 px-3 py-3">
+      <header className="flex h-9 shrink-0 items-center justify-between gap-2 px-3">
         <h2 className="text-sm font-medium tracking-tight text-fg-muted">
           Projects
         </h2>
@@ -775,6 +779,12 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
   const sessions = useAppStore((s) => s.sessions);
   const editorCommand = useSettings((s) => s.settings.editor.command);
   const editorConfigured = editorCommand.trim().length > 0;
+  const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
+  const titleText = resolveSessionTitle(session, sessionDisplay.title);
+  const metadataText = composeSessionMetadata(session, sessionDisplay.metadata);
+  const hoverDetails = sessionDisplay.showDetailsOnHover
+    ? buildSessionHoverDetails(session)
+    : null;
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const {
@@ -923,43 +933,20 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
             STATUS_DOT[session.status],
           )}
         />
-        <span className="min-w-0 flex-1">
-          <span className="flex items-center gap-1">
-            {editing ? (
-              <RenameInput
-                initial={session.name}
-                onSubmit={async (next) => {
-                  setEditing(false);
-                  if (next && next !== session.name) {
-                    await renameSession(session.id, next);
-                  }
-                }}
-                onCancel={() => setEditing(false)}
-              />
-            ) : (
-              <span className="truncate text-[13px] font-medium text-fg">
-                {session.name}
-              </span>
-            )}
-            {session.isolated ? (
-              <GitBranch
-                size={10}
-                className="shrink-0 text-fg-muted"
-                aria-label="isolated worktree"
-              />
-            ) : null}
-            {session.kind === "control" ? (
-              <Bot
-                size={10}
-                className="shrink-0 text-accent"
-                aria-label="control session"
-              />
-            ) : null}
-          </span>
-          <span className="block truncate text-[11px] text-fg-muted">
-            {session.branch} · {STATUS_LABEL[session.status]}
-          </span>
-        </span>
+        <SessionRowLabel
+          editing={editing}
+          session={session}
+          titleText={titleText}
+          metadataText={metadataText}
+          hoverDetails={hoverDetails}
+          onSubmitRename={async (next) => {
+            setEditing(false);
+            if (next && next !== session.name) {
+              await renameSession(session.id, next);
+            }
+          }}
+          onCancelRename={() => setEditing(false)}
+        />
         <span
           role="button"
           aria-label="Remove session"
@@ -988,6 +975,72 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
         items={sessionMenuItems}
       />
     </li>
+  );
+}
+
+interface SessionRowLabelProps {
+  editing: boolean;
+  session: Session;
+  titleText: string;
+  metadataText: string;
+  hoverDetails: string | null;
+  onSubmitRename: (value: string) => void | Promise<void>;
+  onCancelRename: () => void;
+}
+
+function SessionRowLabel({
+  editing,
+  session,
+  titleText,
+  metadataText,
+  hoverDetails,
+  onSubmitRename,
+  onCancelRename,
+}: SessionRowLabelProps) {
+  const body = (
+    <span className="min-w-0 flex-1">
+      <span className="flex items-center gap-1">
+        {editing ? (
+          <RenameInput
+            initial={session.name}
+            onSubmit={onSubmitRename}
+            onCancel={onCancelRename}
+          />
+        ) : (
+          <span className="truncate text-[13px] font-medium text-fg">
+            {titleText}
+          </span>
+        )}
+        {session.isolated ? (
+          <GitBranch
+            size={10}
+            className="shrink-0 text-fg-muted"
+            aria-label="isolated worktree"
+          />
+        ) : null}
+        {session.kind === "control" ? (
+          <Bot
+            size={10}
+            className="shrink-0 text-accent"
+            aria-label="control session"
+          />
+        ) : null}
+      </span>
+      {metadataText ? (
+        <span className="block truncate text-[11px] text-fg-muted">
+          {metadataText}
+        </span>
+      ) : null}
+    </span>
+  );
+
+  // Tooltip swallows pointer events on the trigger; while renaming we
+  // need clean focus on the input, so skip the wrapper entirely.
+  if (!hoverDetails || editing) return body;
+  return (
+    <Tooltip label={hoverDetails} side="right" multiline>
+      {body}
+    </Tooltip>
   );
 }
 
@@ -1080,6 +1133,47 @@ function buildProjectGroups(
 
 function basename(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
+}
+
+function resolveSessionTitle(
+  session: Session,
+  source: SessionTitleSource,
+): string {
+  switch (source) {
+    case "workingDirectory":
+      return basename(session.worktree_path) || session.name;
+    case "branch":
+      return session.branch || session.name;
+    case "name":
+    default:
+      return session.name;
+  }
+}
+
+function composeSessionMetadata(
+  session: Session,
+  metadata: AcornSettings["sessionDisplay"]["metadata"],
+): string {
+  const parts: string[] = [];
+  if (metadata.branch && session.branch) parts.push(session.branch);
+  if (metadata.workingDirectory) {
+    const dir = basename(session.worktree_path);
+    if (dir) parts.push(dir);
+  }
+  if (metadata.status) parts.push(STATUS_LABEL[session.status]);
+  return parts.join(" · ");
+}
+
+function buildSessionHoverDetails(session: Session): string {
+  const lines = [
+    `Name: ${session.name}`,
+    `Branch: ${session.branch || "(detached)"}`,
+    `Working directory: ${session.worktree_path}`,
+    `Status: ${STATUS_LABEL[session.status]}`,
+  ];
+  if (session.kind === "control") lines.push("Kind: Control session");
+  if (session.isolated) lines.push("Isolated worktree");
+  return lines.join("\n");
 }
 
 function suggestName(

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1157,29 +1157,7 @@ function composeSessionMetadata(
     if (dir) parts.push(dir);
   }
   if (metadata.status) parts.push(STATUS_LABEL[session.status]);
-  if (metadata.lastActivity) {
-    const rel = formatRelativeTime(session.updated_at);
-    if (rel) parts.push(rel);
-  }
-  if (metadata.lastMessage && session.last_message) {
-    const preview = session.last_message
-      .split(/\r?\n/)[0]
-      ?.trim()
-      .slice(0, 60);
-    if (preview) parts.push(preview);
-  }
   return parts.join(" · ");
-}
-
-function formatRelativeTime(iso: string): string | null {
-  const ts = Date.parse(iso);
-  if (Number.isNaN(ts)) return null;
-  const diff = Date.now() - ts;
-  if (diff < 0) return "just now";
-  if (diff < 60_000) return "just now";
-  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
-  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
-  return `${Math.floor(diff / 86_400_000)}d ago`;
 }
 
 function buildSessionHoverDetails(session: Session): string {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -251,6 +251,19 @@ export interface AcornSettings {
       branch: boolean;
       workingDirectory: boolean;
       status: boolean;
+      /** Relative timestamp (e.g. "2 min ago") derived from updated_at. */
+      lastActivity: boolean;
+      /** First line of the session's last_message snapshot, truncated. */
+      lastMessage: boolean;
+    };
+    /**
+     * Inline icon toggles. Status dot is the colored bullet at row start;
+     * sessionKind covers the isolated-worktree (GitBranch) and control
+     * (Bot) glyphs trailing the title.
+     */
+    icons: {
+      statusDot: boolean;
+      sessionKind: boolean;
     };
     /**
      * When true, hovering a row pops a tooltip with every available
@@ -310,6 +323,12 @@ export const DEFAULT_SETTINGS: AcornSettings = {
       branch: true,
       workingDirectory: false,
       status: true,
+      lastActivity: false,
+      lastMessage: false,
+    },
+    icons: {
+      statusDot: true,
+      sessionKind: true,
     },
     showDetailsOnHover: true,
   },
@@ -549,6 +568,10 @@ function loadSettings(): AcornSettings {
           ...DEFAULT_SETTINGS.sessionDisplay.metadata,
           ...(parsed.sessionDisplay?.metadata ?? {}),
         },
+        icons: {
+          ...DEFAULT_SETTINGS.sessionDisplay.icons,
+          ...(parsed.sessionDisplay?.icons ?? {}),
+        },
         showDetailsOnHover:
           typeof parsed.sessionDisplay?.showDetailsOnHover === "boolean"
             ? parsed.sessionDisplay.showDetailsOnHover
@@ -594,8 +617,11 @@ interface SettingsState {
   patchStatusBar: (patch: Partial<AcornSettings["statusBar"]>) => void;
   patchPullRequests: (patch: Partial<AcornSettings["pullRequests"]>) => void;
   patchSessionDisplay: (
-    patch: Partial<Omit<AcornSettings["sessionDisplay"], "metadata">> & {
+    patch: Partial<
+      Omit<AcornSettings["sessionDisplay"], "metadata" | "icons">
+    > & {
       metadata?: Partial<AcornSettings["sessionDisplay"]["metadata"]>;
+      icons?: Partial<AcornSettings["sessionDisplay"]["icons"]>;
     },
   ) => void;
   reset: () => void;
@@ -698,13 +724,17 @@ export const useSettings = create<SettingsState>((set) => ({
       const metadata = patch.metadata
         ? { ...s.settings.sessionDisplay.metadata, ...patch.metadata }
         : s.settings.sessionDisplay.metadata;
-      const { metadata: _ignored, ...rest } = patch;
+      const icons = patch.icons
+        ? { ...s.settings.sessionDisplay.icons, ...patch.icons }
+        : s.settings.sessionDisplay.icons;
+      const { metadata: _m, icons: _i, ...rest } = patch;
       const next: AcornSettings = {
         ...s.settings,
         sessionDisplay: {
           ...s.settings.sessionDisplay,
           ...rest,
           metadata,
+          icons,
         },
       };
       persist(next);

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -251,10 +251,6 @@ export interface AcornSettings {
       branch: boolean;
       workingDirectory: boolean;
       status: boolean;
-      /** Relative timestamp (e.g. "2 min ago") derived from updated_at. */
-      lastActivity: boolean;
-      /** First line of the session's last_message snapshot, truncated. */
-      lastMessage: boolean;
     };
     /**
      * Inline icon toggles. Status dot is the colored bullet at row start;
@@ -323,8 +319,6 @@ export const DEFAULT_SETTINGS: AcornSettings = {
       branch: true,
       workingDirectory: false,
       status: true,
-      lastActivity: false,
-      lastMessage: false,
     },
     icons: {
       statusDot: true,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -96,6 +96,35 @@ export type TerminalFontWeight =
  */
 export type TerminalLinkActivation = "click" | "modifier-click";
 
+/**
+ * Which field acorn shows as the primary line of a sidebar session row.
+ * Mirrors Warp's "Pane title as" picker — `name` is the editable session
+ * name (default), the other two surface git/repo metadata directly.
+ */
+export type SessionTitleSource = "name" | "workingDirectory" | "branch";
+
+export const SESSION_TITLE_OPTIONS: ReadonlyArray<{
+  value: SessionTitleSource;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "name",
+    label: "Session name",
+    description: "The editable name you give each session (default).",
+  },
+  {
+    value: "workingDirectory",
+    label: "Working directory",
+    description: "Worktree directory basename.",
+  },
+  {
+    value: "branch",
+    label: "Branch",
+    description: "Active git branch.",
+  },
+];
+
 export const TERMINAL_FONT_WEIGHTS: ReadonlyArray<{
   value: TerminalFontWeight;
   label: string;
@@ -205,6 +234,31 @@ export interface AcornSettings {
     /** Auto-refresh cadence for the PRs tab in milliseconds. */
     refreshIntervalMs: number;
   };
+  /**
+   * Sidebar session-row presentation. Mirrors Warp's "View as / Pane
+   * title as / Additional metadata / Show details on hover" panel so
+   * users can pick what each session shows at a glance.
+   */
+  sessionDisplay: {
+    /** Which field becomes the bold first line of the row. */
+    title: SessionTitleSource;
+    /**
+     * Secondary metadata shown beneath the title. Each toggle is
+     * independent; status falls back to "Idle" so the row never goes
+     * blank when everything is off.
+     */
+    metadata: {
+      branch: boolean;
+      workingDirectory: boolean;
+      status: boolean;
+    };
+    /**
+     * When true, hovering a row pops a tooltip with every available
+     * field (name, working directory, branch, status) regardless of
+     * which ones the row itself shows.
+     */
+    showDetailsOnHover: boolean;
+  };
 }
 
 export const DEFAULT_SETTINGS: AcornSettings = {
@@ -249,6 +303,15 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   pullRequests: {
     defaultState: "open",
     refreshIntervalMs: 60_000,
+  },
+  sessionDisplay: {
+    title: "name",
+    metadata: {
+      branch: true,
+      workingDirectory: false,
+      status: true,
+    },
+    showDetailsOnHover: true,
   },
 };
 
@@ -299,6 +362,25 @@ function normalizePrState(v: unknown, fallback: PrStateFilter): PrStateFilter {
 
 function normalizePrInterval(v: unknown, fallback: number): number {
   if (typeof v === "number" && VALID_PR_INTERVALS.has(v)) return v;
+  return fallback;
+}
+
+const VALID_SESSION_TITLE_SOURCES = new Set<SessionTitleSource>([
+  "name",
+  "workingDirectory",
+  "branch",
+]);
+
+function normalizeSessionTitle(
+  v: unknown,
+  fallback: SessionTitleSource,
+): SessionTitleSource {
+  if (
+    typeof v === "string" &&
+    VALID_SESSION_TITLE_SOURCES.has(v as SessionTitleSource)
+  ) {
+    return v as SessionTitleSource;
+  }
   return fallback;
 }
 
@@ -458,6 +540,20 @@ function loadSettings(): AcornSettings {
           DEFAULT_SETTINGS.pullRequests.refreshIntervalMs,
         ),
       },
+      sessionDisplay: {
+        title: normalizeSessionTitle(
+          parsed.sessionDisplay?.title,
+          DEFAULT_SETTINGS.sessionDisplay.title,
+        ),
+        metadata: {
+          ...DEFAULT_SETTINGS.sessionDisplay.metadata,
+          ...(parsed.sessionDisplay?.metadata ?? {}),
+        },
+        showDetailsOnHover:
+          typeof parsed.sessionDisplay?.showDetailsOnHover === "boolean"
+            ? parsed.sessionDisplay.showDetailsOnHover
+            : DEFAULT_SETTINGS.sessionDisplay.showDetailsOnHover,
+      },
     };
   } catch {
     return DEFAULT_SETTINGS;
@@ -497,6 +593,11 @@ interface SettingsState {
   ) => void;
   patchStatusBar: (patch: Partial<AcornSettings["statusBar"]>) => void;
   patchPullRequests: (patch: Partial<AcornSettings["pullRequests"]>) => void;
+  patchSessionDisplay: (
+    patch: Partial<Omit<AcornSettings["sessionDisplay"], "metadata">> & {
+      metadata?: Partial<AcornSettings["sessionDisplay"]["metadata"]>;
+    },
+  ) => void;
   reset: () => void;
 }
 
@@ -588,6 +689,23 @@ export const useSettings = create<SettingsState>((set) => ({
       const next: AcornSettings = {
         ...s.settings,
         pullRequests: { ...s.settings.pullRequests, ...patch },
+      };
+      persist(next);
+      return { settings: next };
+    }),
+  patchSessionDisplay: (patch) =>
+    set((s) => {
+      const metadata = patch.metadata
+        ? { ...s.settings.sessionDisplay.metadata, ...patch.metadata }
+        : s.settings.sessionDisplay.metadata;
+      const { metadata: _ignored, ...rest } = patch;
+      const next: AcornSettings = {
+        ...s.settings,
+        sessionDisplay: {
+          ...s.settings.sessionDisplay,
+          ...rest,
+          metadata,
+        },
       };
       persist(next);
       return { settings: next };


### PR DESCRIPTION
## Summary

Mirrors Warp's pane-title / additional-metadata / hover panel for the Acorn sidebar. Settings → Appearance gains a Session display section so each user can pick what their session rows show at a glance.

- **Session title** (radio, single choice): Session name (default), Working directory, Branch.
- **Additional metadata** (independent toggles): Branch, Working directory, Status. Picking nothing yields a single-line row.
- **Inline icons** (independent toggles): Status dot bullet at row start, Session-kind icons (isolated worktree GitBranch + control Bot glyphs).
- **Show details on hover** (toggle): native `title` attribute on the row carrying every field — name, branch, working directory, status, plus isolated/control flags — regardless of which fields the row itself shows. Native attribute (not a React Tooltip wrapper) so the rename input mounting on F2 stays unaffected.

Sidebar header height also lines up with the Pane tab strip (`h-9`) so the two columns share a baseline.

Settings persist under the existing `acorn:settings:v1` key with a normalizer that defaults missing fields to the prior behaviour (title=name, branch+status visible, both icons on, hover on), so older `localStorage` values keep working unchanged.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (111 passed, 1 skipped)
- [x] `bunx playwright test` locally (47 passed)
- [x] CI: Frontend + E2E both pass
- [x] Manual: Settings → Appearance shows the new section; switching title source updates every visible session row immediately
- [x] Manual: toggling each metadata checkbox adds/removes its segment in the secondary line; turning all off collapses to a single-line row
- [x] Manual: status-dot and session-kind icon toggles hide/show their respective glyphs without breaking layout
- [x] Manual: hovering a session row with the toggle on shows native browser tooltip with every field; toggle off suppresses it
- [x] Manual: reload — choices survive a restart via `localStorage`

## Notes

`last_message` is unwritten on the backend and `updated_at` only bumps on status / rename / worktree-path changes, so "Last activity" / "Last message" toggles would mislead users today. Tracked separately; revisit once the PTY pipeline writes those fields.
