### PR TITLE
docs: call out bun run build:sidecar as a required first-time step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Two recurring traps in E2E:
 
 ```sh
 bun install
+bun run build:sidecar  # stage acorn-ipc — required for fresh checkouts / worktrees
 bun run tauri dev      # full app (Rust + Vite)
 bun run dev            # Vite only — frontend in browser, no Tauri
 bun run test           # Vitest
@@ -61,6 +62,8 @@ bun run test:e2e       # Playwright
 bun run typecheck
 bun run build          # tsc + vite build
 ```
+
+`src-tauri/binaries/acorn-ipc-<target-triple>` is `.gitignore`d, so every fresh checkout — including each new `git worktree add` — starts without it, and Tauri's `externalBin` existence check fails the build before anything else runs. Run `bun run build:sidecar` once per worktree (and again after any IPC change); plain `cargo build --bin acorn-ipc` is not enough because it skips the target-tripled staging step. See [`docs/CONTROL_SESSIONS.md`](docs/CONTROL_SESSIONS.md#the-acorn-ipc-cli) for details.
 
 ## When in doubt
 

--- a/README.md
+++ b/README.md
@@ -142,9 +142,12 @@ xattr -dr com.apple.quarantine /Applications/Acorn.app
 
 ```bash
 bun install
+bun run build:sidecar  # acorn-ipc 사이드카 빌드 (최초 1회 + IPC 변경 시)
 bun run tauri dev      # 개발 모드
 bun run tauri build    # 프로덕션 빌드
 ```
+
+> ℹ️ `bun run tauri dev` / `tauri build`는 Tauri의 `externalBin` 규약에 따라 `src-tauri/binaries/acorn-ipc-<target-triple>` 파일이 존재해야 시작합니다. 이 경로는 `.gitignore`에 포함돼 있어 fresh checkout(특히 `git worktree add`로 만들어진 worktree)에서는 비어 있고, 미리 빌드해두지 않으면 `resource path 'binaries/acorn-ipc-...' doesn't exist` 에러로 빌드가 실패합니다. `bun run build:sidecar`가 호스트 타깃에 맞는 바이너리를 빌드하고 올바른 위치에 stage합니다.
 
 > ⚠️ 기본 세션 시작 명령은 `claude` CLI입니다. `$PATH`에 없거나 다른 에이전트를 쓰고 싶다면 Settings → Sessions에서 `codex` / `gemini` / `ollama` / `llm` / `$SHELL` / 임의의 커스텀 명령으로 전환하세요.
 

--- a/docs/CONTROL_SESSIONS.md
+++ b/docs/CONTROL_SESSIONS.md
@@ -101,9 +101,17 @@ If you are building from source rather than installing a release, the
 sidecar is staged for you when you run `tauri build`. For a dev loop:
 
 ```sh
-cargo build --bin acorn-ipc   # one-time; run again after IPC changes
+bun run build:sidecar   # one-time; run again after IPC changes
 bun run tauri dev
 ```
+
+`bun run build:sidecar` shells out to `src-tauri/scripts/build-sidecar.sh`
+which both compiles `acorn-ipc` *and* stages it at
+`src-tauri/binaries/acorn-ipc-<target-triple>`, the path Tauri's
+`externalBin` existence check requires before `tauri dev` / `tauri build`
+will even start. Plain `cargo build --bin acorn-ipc` skips the staging
+step, so the build fails with
+`resource path 'binaries/acorn-ipc-...' doesn't exist`.
 
 Settings → Sessions → "Control sessions" shows the resolved binary path
 Acorn currently sees (it looks for `acorn-ipc` next to the running app


### PR DESCRIPTION
## Summary
- `src-tauri/binaries/acorn-ipc-<target-triple>` is `.gitignore`d, so fresh clones and every `git worktree add` start without it. Tauri's `externalBin` existence check fires before anything else, so the first `bun run tauri dev` fails with `resource path 'binaries/acorn-ipc-...' doesn't exist` and no hint that there's a one-line fix.
- Codify `bun run build:sidecar` as a required first-time / per-worktree step in README, CLAUDE.md, and CONTROL_SESSIONS.md. Explain *why* plain `cargo build --bin acorn-ipc` is not enough (it skips the target-tripled staging step).

## Test plan
- [x] `git grep` shows every build-from-source path now mentions `bun run build:sidecar` and the externalBin existence check
- [x] CONTROL_SESSIONS.md no longer recommends the incomplete `cargo build --bin acorn-ipc` line
- [x] CLAUDE.md anchor `#the-acorn-ipc-cli` resolves on GitHub
