### PR TITLE
chore(release): v1.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.10",
+  "version": "1.0.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.10"
+version = "1.0.11"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

Bumps `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.lock` from `1.0.10` to `1.0.11` so the next `v1.0.11` tag has matching manifest metadata.

## Notable since v1.0.10

- **Click-to-open link toggle (#124)** — Settings now exposes whether terminal links activate on a plain click or only when held with the platform modifier, so power-users who copy text by dragging don't fire links accidentally.
- **Wide emoji width fix (#125)** — restores correct cell width for double-width emoji in the terminal so glyphs no longer collide with neighbouring characters.
- **Image paste via WKWebView (#127)** — re-enables pasting clipboard images into the terminal by relaying them through the native WKWebView handler again; tmp files are written by the Rust side and consumed by the agent.
- **Sidebar session row customization (#128)** — session rows render a user-defined title plus metadata and hover details, replacing the previous fixed format.
- **Worktree HMR (#129)** — Vite's HMR keeps working when `bun run tauri dev` runs from inside a git worktree, so worktree-based dev sessions no longer need full reloads on every edit.
- **README multi-agent wording (#126)** — generalizes Claude-only phrasing across the README to reflect that Acorn already drives multiple coding agents.
- **First-time sidecar build note (#130)** — README/dev docs now call out `bun run build:sidecar` as a required first-time step so the `acorn-ipc` binary is present before the first `tauri dev`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — 111 pass / 1 skip
- [ ] `cargo test --lib`
- [ ] `cargo test --bin acorn-ipc`
- [ ] CI on this PR (Frontend + E2E)
- [ ] Tag `v1.0.11` after merge to trigger `release.yml` macOS bundle build
