### PR TITLE
feat(dev): isolate debug-build data dir from installed Acorn

### DIFF
--- a/src-tauri/src/ipc/socket_path.rs
+++ b/src-tauri/src/ipc/socket_path.rs
@@ -11,6 +11,14 @@
 //! The CLI cannot link `persistence::data_dir` without dragging the app's
 //! full module graph into the bin target, so this file re-derives the
 //! same `directories` lookup directly — the two paths must stay in lockstep.
+//!
+//! Debug vs release: `cfg!(debug_assertions)` swaps the project name to
+//! `acorn-dev` so `bun run tauri dev` cannot collide with the installed
+//! app. The sidecar `acorn-ipc` CLI is normally built `--release` (see
+//! `scripts/build-sidecar.sh`), so its fallback resolves to `acorn` even
+//! when the host runs debug. This is fine in practice because every
+//! control-session PTY gets `ACORN_IPC_SOCKET` injected and never reaches
+//! the fallback branch.
 
 use std::path::PathBuf;
 
@@ -27,7 +35,12 @@ pub fn resolve() -> Result<PathBuf, String> {
             return Ok(PathBuf::from(override_path));
         }
     }
-    let project_dirs = ProjectDirs::from("io", "im-ian", "acorn")
+    let app_name = if cfg!(debug_assertions) {
+        "acorn-dev"
+    } else {
+        "acorn"
+    };
+    let project_dirs = ProjectDirs::from("io", "im-ian", app_name)
         .ok_or_else(|| "could not resolve project data directory".to_string())?;
     Ok(project_dirs.data_dir().join(SOCKET_FILE))
 }

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -43,8 +43,16 @@ fn backup_corrupt_file(path: &Path) {
 }
 
 /// Resolve the application's data directory, creating it if missing.
+///
+/// Debug builds (`bun run tauri dev`) write to `acorn-dev` so local testing
+/// does not clobber the installed Acorn's sessions/projects.
 pub fn data_dir() -> AppResult<PathBuf> {
-    let project_dirs = ProjectDirs::from("io", "im-ian", "acorn")
+    let app_name = if cfg!(debug_assertions) {
+        "acorn-dev"
+    } else {
+        "acorn"
+    };
+    let project_dirs = ProjectDirs::from("io", "im-ian", app_name)
         .ok_or_else(|| AppError::Other("could not resolve project data directory".to_string()))?;
     let dir = project_dirs.data_dir().to_path_buf();
     fs::create_dir_all(&dir)?;


### PR DESCRIPTION
## Summary

Debug builds now write to `acorn-dev` instead of `acorn`, so `bun run tauri dev` cannot collide with an installed Acorn's persisted state.

`ProjectDirs::from("io", "im-ian", ...)` picks the project name at runtime via `cfg!(debug_assertions)`:

- `target/debug/acorn` → `~/Library/Application Support/io.im-ian.acorn-dev/`
- shipped `Acorn.app` → `~/Library/Application Support/io.im-ian.acorn/` (unchanged)

Applied the same swap in `ipc::socket_path::resolve` so the socket fallback stays in lockstep with `persistence::data_dir`. Control sessions are unaffected at runtime because every PTY gets `ACORN_IPC_SOCKET` injected and never hits the fallback branch.

## Why

Running `bun run tauri dev` against the same data directory as the installed Acorn meant dev sessions clobbered real work, and a corrupt dev save risked the production `sessions.json`. With the data dir split, both builds can run side by side with fully separate state.

## Test plan

- [x] `cargo check` clean
- [x] `bunx tsc --noEmit` clean
- [x] Booted `bun run tauri dev` — `~/Library/Application Support/io.im-ian.acorn-dev/` created with `ipc.sock` + `scrollback/`; installed `io.im-ian.acorn/` untouched
- [ ] Open both builds simultaneously, confirm session lists are independent
- [ ] Production build (`bun run tauri build`) still writes to `io.im-ian.acorn`
