### PR TITLE
feat(prs): search, infinite scroll, avatars, and shared row actions

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1062,11 +1062,13 @@ pub async fn list_pull_requests(
     repo_path: String,
     state: Option<PrStateFilter>,
     limit: Option<u32>,
+    query: Option<String>,
 ) -> AppResult<PullRequestListing> {
     pull_requests::list_pull_requests(
         &PathBuf::from(repo_path),
         state.unwrap_or(PrStateFilter::Open),
         limit.unwrap_or(50),
+        query.as_deref().map(str::trim).filter(|s| !s.is_empty()),
     )
 }
 

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -210,13 +210,14 @@ pub fn list_pull_requests(
     repo_path: &Path,
     state: PrStateFilter,
     limit: u32,
+    query: Option<&str>,
 ) -> AppResult<PullRequestListing> {
     let Some(slug) = github_owner_repo(repo_path)? else {
         return Ok(PullRequestListing::NotGithub);
     };
 
     match try_with_account(repo_path, &slug, |token| {
-        run_pr_list(&slug, token, state, limit)
+        run_pr_list(&slug, token, state, limit, query)
     })? {
         AccountOutcome::Ok { account, value } => Ok(PullRequestListing::Ok {
             items: value,
@@ -283,8 +284,9 @@ fn run_pr_list(
     token: &str,
     state: PrStateFilter,
     limit: u32,
+    query: Option<&str>,
 ) -> AppResult<Vec<PullRequestInfo>> {
-    let limit = limit.clamp(1, 200);
+    let limit = limit.clamp(1, 1000);
     let limit_s = limit.to_string();
     let output = cli_resolver::run("gh", |cmd| {
         cmd.env("GH_TOKEN", token)
@@ -306,6 +308,9 @@ fn run_pr_list(
                 "number,title,state,author,headRefName,baseRefName,url,updatedAt,\
                  isDraft,statusCheckRollup",
             ]);
+        if let Some(q) = query {
+            cmd.args(["--search", q]);
+        }
     })?;
 
     if !output.status.success() {

--- a/src/components/AuthorAvatar.tsx
+++ b/src/components/AuthorAvatar.tsx
@@ -1,0 +1,36 @@
+import { cn } from "../lib/cn";
+
+/**
+ * Inline GitHub avatar. Uses the public `github.com/{login}.png` endpoint
+ * so no API token is needed and `[bot]` accounts still resolve once the
+ * suffix is stripped. Falls back invisibly via `alt=""` on load failure
+ * so the surrounding list / timeline stays clean.
+ */
+export function AuthorAvatar({
+  login,
+  size = 24,
+  className,
+}: {
+  login: string;
+  size?: number;
+  className?: string;
+}) {
+  const slug = login.replace(/\[bot\]$/, "");
+  if (!slug) return null;
+  const pixelSize = Math.max(40, size * 2);
+  return (
+    <img
+      src={`https://github.com/${encodeURIComponent(slug)}.png?size=${pixelSize}`}
+      alt=""
+      title={login}
+      width={size}
+      height={size}
+      loading="lazy"
+      style={{ width: size, height: size }}
+      className={cn(
+        "shrink-0 rounded-full bg-bg-elevated align-middle",
+        className,
+      )}
+    />
+  );
+}

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -159,7 +159,6 @@ export function PullRequestDetailModal({
         ) : (
           <DetailBody
             detail={listing.detail}
-            account={listing.account}
             tab={tab}
             onTab={setTab}
             cwd={cwd}
@@ -219,7 +218,6 @@ function ModalShell({
 
 function DetailBody({
   detail,
-  account,
   tab,
   onTab,
   cwd,
@@ -230,7 +228,6 @@ function DetailBody({
   onOpenClose,
 }: {
   detail: PullRequestDetail;
-  account: string;
   tab: DetailTab;
   onTab: (t: DetailTab) => void;
   cwd?: string;
@@ -289,10 +286,6 @@ function DetailBody({
             </span>
             <span className="opacity-50"> · </span>
             <span>{detail.changed_files} files</span>
-            <span className="opacity-50"> · </span>
-            <Tooltip label={`Listed via gh account ${account}`} side="bottom">
-              <span>@{account}</span>
-            </Tooltip>
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-1">

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -28,6 +28,7 @@ import type {
   PullRequestDetailListing,
   PullRequestReview,
 } from "../lib/types";
+import { AuthorAvatar } from "./AuthorAvatar";
 import { ClosePullRequestDialog } from "./ClosePullRequestDialog";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { DiffSplitView } from "./DiffSplitView";
@@ -912,41 +913,6 @@ function ReviewBlock({ review }: { review: PullRequestReview }) {
         </p>
       )}
     </li>
-  );
-}
-
-/**
- * Inline 18px GitHub avatar. Uses the public `github.com/{login}.png`
- * endpoint — no API token needed and it works for `[bot]` accounts when
- * the `[bot]` suffix is stripped. Falls back invisibly via `alt=""` on
- * load failure so the timeline stays clean.
- */
-function AuthorAvatar({
-  login,
-  size = 24,
-  className,
-}: {
-  login: string;
-  size?: number;
-  className?: string;
-}) {
-  const slug = login.replace(/\[bot\]$/, "");
-  if (!slug) return null;
-  const pixelSize = Math.max(40, size * 2);
-  return (
-    <img
-      src={`https://github.com/${encodeURIComponent(slug)}.png?size=${pixelSize}`}
-      alt=""
-      title={login}
-      width={size}
-      height={size}
-      loading="lazy"
-      style={{ width: size, height: size }}
-      className={cn(
-        "shrink-0 rounded-full bg-bg-elevated align-middle",
-        className,
-      )}
-    />
   );
 }
 

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -11,6 +11,7 @@ import {
   Globe,
   ListTodo,
   Maximize2,
+  Search,
   X,
 } from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -42,7 +43,14 @@ import { MergePullRequestDialog } from "./MergePullRequestDialog";
 import { PullRequestDetailModal } from "./PullRequestDetailModal";
 import { ResizeHandle } from "./ResizeHandle";
 import { Tooltip } from "./Tooltip";
-import { CommandHint, RefreshButton } from "./ui";
+import {
+  CommandHint,
+  Modal,
+  ModalHeader,
+  RefreshButton,
+  TextInput,
+} from "./ui";
+import { useDialogShortcuts } from "../lib/dialog";
 
 interface ExpandedDiff {
   payload: DiffPayload;
@@ -72,6 +80,10 @@ export function RightPanel() {
     repoPath: string;
     number: number;
   } | null>(null);
+  // Open state for the PR search modal. Carries `repoPath` so the modal can
+  // run its own search fetches scoped to whichever repo was active when
+  // search was triggered.
+  const [prSearch, setPrSearch] = useState<{ repoPath: string } | null>(null);
   // Bumped from the PR detail modal after a merge/close so the PRs tab
   // refetches without waiting for the next polling tick.
   const [prListVersion, setPrListVersion] = useState(0);
@@ -165,6 +177,7 @@ export function RightPanel() {
             key={repoPath}
             repoPath={repoPath}
             onOpenDetail={(number) => setPrDetail({ repoPath, number })}
+            onOpenSearch={() => setPrSearch({ repoPath })}
             refreshKey={prListVersion}
           />
         ) : (
@@ -183,6 +196,15 @@ export function RightPanel() {
         cwd={repoPath ?? undefined}
         onClose={() => setPrDetail(null)}
         onMutated={() => setPrListVersion((v) => v + 1)}
+      />
+      <PullRequestSearchModal
+        open={prSearch}
+        onClose={() => setPrSearch(null)}
+        onOpenDetail={(number) => {
+          if (!prSearch) return;
+          setPrDetail({ repoPath: prSearch.repoPath, number });
+          setPrSearch(null);
+        }}
       />
     </aside>
   );
@@ -1013,13 +1035,20 @@ const PR_STATE_OPTIONS: { value: PrStateFilter; label: string }[] = [
   { value: "all", label: "All" },
 ];
 
+/** Initial page size and per-scroll growth increment for PR list pagination. */
+const PR_PAGE_SIZE = 50;
+/** Backend clamps to 1000; mirror that here so the UI stops growing the limit. */
+const PR_PAGE_MAX = 1000;
+
 function PullRequestsTab({
   repoPath,
   onOpenDetail,
+  onOpenSearch,
   refreshKey,
 }: {
   repoPath: string;
   onOpenDetail: (number: number) => void;
+  onOpenSearch: () => void;
   /** Bumped by the parent to force an out-of-band refetch (e.g. after a PR is merged via the modal). */
   refreshKey: number;
 }) {
@@ -1033,6 +1062,9 @@ function PullRequestsTab({
   const [listing, setListing] = useState<PullRequestListing | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  // Grows by PR_PAGE_SIZE each time the user scrolls to the bottom. Resets on
+  // project / state-filter change so a fresh context starts at one page.
+  const [limit, setLimit] = useState(PR_PAGE_SIZE);
   const [menu, setMenu] = useState<{
     x: number;
     y: number;
@@ -1055,7 +1087,7 @@ function PullRequestsTab({
     async (signal?: { cancelled: boolean }) => {
       setLoading(true);
       try {
-        const result = await api.listPullRequests(repoPath, stateFilter);
+        const result = await api.listPullRequests(repoPath, stateFilter, limit);
         if (signal?.cancelled) return;
         setListing(result);
         setError(null);
@@ -1070,14 +1102,19 @@ function PullRequestsTab({
         if (!signal?.cancelled) setLoading(false);
       }
     },
-    [repoPath, stateFilter, setPrAccountForRepo],
+    [repoPath, stateFilter, limit, setPrAccountForRepo],
   );
 
+  // Reset list state on context change (project / filter) but NOT on limit
+  // growth — keeping the existing rows during a "load more" prevents the
+  // skeleton from flashing while the larger page lands.
   useEffect(() => {
-    // Drop the prior project's listing so the panel renders skeletons during
-    // the next fetch instead of flashing stale PR rows for the old repo.
     setListing(null);
     setError(null);
+    setLimit(PR_PAGE_SIZE);
+  }, [repoPath, stateFilter]);
+
+  useEffect(() => {
     const signal = { cancelled: false };
     void fetchPrs(signal);
     const handle = setInterval(() => {
@@ -1153,6 +1190,24 @@ function PullRequestsTab({
     setCloseFor({ number: pr.number, detail });
   }
 
+  function handleScroll(e: React.UIEvent<HTMLDivElement>) {
+    if (loading) return;
+    if (!listing || listing.kind !== "ok") return;
+    // Fewer items than the page size means gh returned everything — nothing
+    // more to load. limit hitting the backend clamp is also terminal.
+    if (listing.items.length < limit) return;
+    if (limit >= PR_PAGE_MAX) return;
+    const el = e.currentTarget;
+    if (el.scrollHeight - el.scrollTop - el.clientHeight < 200) {
+      setLimit((prev) => Math.min(prev + PR_PAGE_SIZE, PR_PAGE_MAX));
+    }
+  }
+
+  const reachedMax =
+    listing?.kind === "ok" &&
+    listing.items.length >= limit &&
+    limit >= PR_PAGE_MAX;
+
   return (
     <div className="flex h-full flex-col">
       <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1.5">
@@ -1171,14 +1226,25 @@ function PullRequestsTab({
             {opt.label}
           </button>
         ))}
+        <button
+          type="button"
+          onClick={onOpenSearch}
+          aria-label="Search pull requests"
+          title="Search pull requests"
+          className="ml-auto rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+        >
+          <Search size={12} />
+        </button>
         <RefreshButton
           onClick={() => void fetchPrs()}
           loading={loading}
           size={12}
-          className="ml-auto"
         />
       </div>
-      <div className="flex-1 overflow-x-hidden overflow-y-auto">
+      <div
+        className="flex-1 overflow-x-hidden overflow-y-auto"
+        onScroll={handleScroll}
+      >
         {error ? (
           <div className="p-3 text-xs text-danger">{error}</div>
         ) : !listing ? (
@@ -1196,63 +1262,26 @@ function PullRequestsTab({
         ) : (
           <ul className="text-xs">
             {listing.items.map((pr) => (
-              <li
+              <PrRow
                 key={pr.number}
-                role="button"
-                tabIndex={0}
-                onDoubleClick={() => onOpenDetail(pr.number)}
+                pr={pr}
+                onOpen={() => onOpenDetail(pr.number)}
                 onContextMenu={(e) => {
                   e.preventDefault();
                   setMenu({ x: e.clientX, y: e.clientY, pr });
                 }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    onOpenDetail(pr.number);
-                  }
-                }}
-                className="flex w-full flex-col items-start gap-0.5 border-b border-border/40 px-3 py-2 text-left transition hover:bg-bg-elevated/50 focus-visible:outline-none focus-visible:bg-bg-elevated/60"
-              >
-                <span className="flex w-full min-w-0 items-center gap-2">
-                  <span className="shrink-0 font-mono text-fg-muted">
-                    #{pr.number}
-                  </span>
-                  <PrStateBadge state={pr.state} isDraft={pr.is_draft} />
-                  <Tooltip label={pr.title} side="top" multiline className="flex! min-w-0 flex-1">
-                    <span className="min-w-0 flex-1 truncate text-fg">{pr.title}</span>
-                  </Tooltip>
-                </span>
-                <span className="flex w-full min-w-0 items-center gap-2 text-[10px] text-fg-muted">
-                  <span className="truncate">{pr.author}</span>
-                  <span className="opacity-50">·</span>
-                  <span className="flex min-w-0 items-center gap-1">
-                    <Tooltip
-                      label={`${pr.head_branch} → ${pr.base_branch}`}
-                      side="top"
-                      multiline
-                      className="min-w-0"
-                    >
-                      <span className="flex min-w-0 items-center gap-1 font-mono">
-                        <span className="truncate">{pr.head_branch}</span>
-                        <span className="shrink-0">→</span>
-                        <span className="truncate">{pr.base_branch}</span>
-                      </span>
-                    </Tooltip>
-                    <PrChecksBadge checks={pr.checks} />
-                  </span>
-                  <span className="shrink-0 opacity-50">·</span>
-                  <Tooltip
-                    label={absoluteTime(toUnixSeconds(pr.updated_at))}
-                    side="top"
-                    className="shrink-0"
-                  >
-                    <span className="whitespace-nowrap font-mono">
-                      {relativeTime(toUnixSeconds(pr.updated_at))}
-                    </span>
-                  </Tooltip>
-                </span>
-              </li>
+              />
             ))}
+            {loading && listing.items.length >= limit ? (
+              <li className="px-3 py-2 text-[10px] text-fg-muted">
+                Loading more…
+              </li>
+            ) : null}
+            {reachedMax ? (
+              <li className="px-3 py-2 text-[10px] text-fg-muted">
+                Showing first {PR_PAGE_MAX}. Use search to find older PRs.
+              </li>
+            ) : null}
           </ul>
         )}
       </div>
@@ -1457,4 +1486,276 @@ function toUnixSeconds(iso: string): number {
   const ms = Date.parse(iso);
   if (Number.isNaN(ms)) return Math.floor(Date.now() / 1000);
   return Math.floor(ms / 1000);
+}
+
+/**
+ * Shared row used by the PRs tab and the PR search modal. Keeps the visual
+ * shape identical across both surfaces so the search modal feels like a
+ * filtered view of the same list.
+ */
+function PrRow({
+  pr,
+  onOpen,
+  onContextMenu,
+}: {
+  pr: PullRequestInfo;
+  onOpen: () => void;
+  onContextMenu?: (e: React.MouseEvent<HTMLLIElement>) => void;
+}) {
+  return (
+    <li
+      role="button"
+      tabIndex={0}
+      onDoubleClick={onOpen}
+      onContextMenu={onContextMenu}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className="flex w-full flex-col items-start gap-0.5 border-b border-border/40 px-3 py-2 text-left transition hover:bg-bg-elevated/50 focus-visible:outline-none focus-visible:bg-bg-elevated/60"
+    >
+      <span className="flex w-full min-w-0 items-center gap-2">
+        <span className="shrink-0 font-mono text-fg-muted">#{pr.number}</span>
+        <PrStateBadge state={pr.state} isDraft={pr.is_draft} />
+        <Tooltip
+          label={pr.title}
+          side="top"
+          multiline
+          className="flex! min-w-0 flex-1"
+        >
+          <span className="min-w-0 flex-1 truncate text-fg">{pr.title}</span>
+        </Tooltip>
+      </span>
+      <span className="flex w-full min-w-0 items-center gap-2 text-[10px] text-fg-muted">
+        <span className="truncate">{pr.author}</span>
+        <span className="opacity-50">·</span>
+        <span className="flex min-w-0 items-center gap-1">
+          <Tooltip
+            label={`${pr.head_branch} → ${pr.base_branch}`}
+            side="top"
+            multiline
+            className="min-w-0"
+          >
+            <span className="flex min-w-0 items-center gap-1 font-mono">
+              <span className="truncate">{pr.head_branch}</span>
+              <span className="shrink-0">→</span>
+              <span className="truncate">{pr.base_branch}</span>
+            </span>
+          </Tooltip>
+          <PrChecksBadge checks={pr.checks} />
+        </span>
+        <span className="shrink-0 opacity-50">·</span>
+        <Tooltip
+          label={absoluteTime(toUnixSeconds(pr.updated_at))}
+          side="top"
+          className="shrink-0"
+        >
+          <span className="whitespace-nowrap font-mono">
+            {relativeTime(toUnixSeconds(pr.updated_at))}
+          </span>
+        </Tooltip>
+      </span>
+    </li>
+  );
+}
+
+const PR_SEARCH_STATE_OPTIONS: { value: PrStateFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "open", label: "Open" },
+  { value: "closed", label: "Closed" },
+  { value: "merged", label: "Merged" },
+];
+
+/**
+ * Modal-scoped PR search. Queries gh server-side via `--search`, so it
+ * reaches every PR in the repo rather than filtering the (capped) list that
+ * the PRs tab currently displays. Empty query → no fetch; results paginate
+ * by growing `limit` on scroll, mirroring the main tab's pattern.
+ */
+function PullRequestSearchModal({
+  open,
+  onClose,
+  onOpenDetail,
+}: {
+  open: { repoPath: string } | null;
+  onClose: () => void;
+  onOpenDetail: (number: number) => void;
+}) {
+  const repoPath = open?.repoPath ?? null;
+  const [rawQuery, setRawQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [stateFilter, setStateFilter] = useState<PrStateFilter>("all");
+  const [listing, setListing] = useState<PullRequestListing | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [limit, setLimit] = useState(PR_PAGE_SIZE);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useDialogShortcuts(open !== null, { onCancel: onClose });
+
+  // Wipe transient state every time the modal opens so a reopen never shows
+  // results from the previous session.
+  useEffect(() => {
+    if (!open) return;
+    setRawQuery("");
+    setDebouncedQuery("");
+    setStateFilter("all");
+    setListing(null);
+    setError(null);
+    setLimit(PR_PAGE_SIZE);
+    // Defer focus until after the portal mounts so autoFocus on the input
+    // wins over Modal's own focus handling.
+    queueMicrotask(() => inputRef.current?.focus());
+  }, [open]);
+
+  // Debounce the input so typing doesn't fire a `gh` spawn per keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(rawQuery.trim()), 250);
+    return () => clearTimeout(t);
+  }, [rawQuery]);
+
+  // Reset pagination when the search inputs change — a new query starts at
+  // the first page rather than inheriting the previous query's growth.
+  useEffect(() => {
+    setLimit(PR_PAGE_SIZE);
+    setListing(null);
+  }, [debouncedQuery, stateFilter]);
+
+  useEffect(() => {
+    if (!open || !repoPath) return;
+    if (!debouncedQuery) {
+      setListing(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    const signal = { cancelled: false };
+    setLoading(true);
+    api
+      .listPullRequests(repoPath, stateFilter, limit, debouncedQuery)
+      .then((result) => {
+        if (signal.cancelled) return;
+        setListing(result);
+        setError(null);
+      })
+      .catch((e) => {
+        if (signal.cancelled) return;
+        setError(String(e));
+      })
+      .finally(() => {
+        if (!signal.cancelled) setLoading(false);
+      });
+    return () => {
+      signal.cancelled = true;
+    };
+  }, [open, repoPath, debouncedQuery, stateFilter, limit]);
+
+  function handleScroll(e: React.UIEvent<HTMLDivElement>) {
+    if (loading) return;
+    if (!listing || listing.kind !== "ok") return;
+    if (listing.items.length < limit) return;
+    if (limit >= PR_PAGE_MAX) return;
+    const el = e.currentTarget;
+    if (el.scrollHeight - el.scrollTop - el.clientHeight < 200) {
+      setLimit((prev) => Math.min(prev + PR_PAGE_SIZE, PR_PAGE_MAX));
+    }
+  }
+
+  const reachedMax =
+    listing?.kind === "ok" &&
+    listing.items.length >= limit &&
+    limit >= PR_PAGE_MAX;
+
+  return (
+    <Modal
+      open={open !== null}
+      onClose={onClose}
+      variant="dialog"
+      size="2xl"
+      ariaLabel="Search pull requests"
+    >
+      <ModalHeader
+        title="Search pull requests"
+        icon={<Search size={14} className="text-fg-muted" />}
+        variant="dialog"
+        onClose={onClose}
+      />
+      <div className="flex shrink-0 flex-col gap-2 border-b border-border px-4 py-3">
+        <TextInput
+          ref={inputRef}
+          value={rawQuery}
+          onChange={(e) => setRawQuery(e.currentTarget.value)}
+          placeholder="Search title, author, label, branch…"
+          autoFocus
+        />
+        <div className="flex items-center gap-1 text-[11px]">
+          {PR_SEARCH_STATE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setStateFilter(opt.value)}
+              className={cn(
+                "rounded px-2 py-0.5 transition",
+                stateFilter === opt.value
+                  ? "bg-bg text-fg"
+                  : "text-fg-muted hover:text-fg",
+              )}
+            >
+              {opt.label}
+            </button>
+          ))}
+          {loading ? (
+            <span className="ml-auto text-fg-muted">Searching…</span>
+          ) : listing?.kind === "ok" ? (
+            <span className="ml-auto font-mono text-fg-muted">
+              {listing.items.length}
+              {listing.items.length >= limit && limit < PR_PAGE_MAX ? "+" : ""}
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <div
+        className="max-h-[60vh] min-h-[200px] overflow-y-auto"
+        onScroll={handleScroll}
+      >
+        {!debouncedQuery ? (
+          <Empty msg="Type to search pull requests." />
+        ) : error ? (
+          <div className="p-3 text-xs text-danger">{error}</div>
+        ) : !listing ? (
+          <PrSkeletonList count={6} />
+        ) : listing.kind === "not_github" ? (
+          <Empty msg="Origin remote is not a GitHub repository." />
+        ) : listing.kind === "no_access" ? (
+          <div className="p-3 text-xs text-fg-muted">
+            No logged-in gh account can access this repo.
+          </div>
+        ) : listing.items.length === 0 ? (
+          <Empty msg="No matching pull requests." />
+        ) : (
+          <ul className="text-xs">
+            {listing.items.map((pr) => (
+              <PrRow
+                key={pr.number}
+                pr={pr}
+                onOpen={() => onOpenDetail(pr.number)}
+              />
+            ))}
+            {loading && listing.items.length >= limit ? (
+              <li className="px-3 py-2 text-[10px] text-fg-muted">
+                Loading more…
+              </li>
+            ) : null}
+            {reachedMax ? (
+              <li className="px-3 py-2 text-[10px] text-fg-muted">
+                Showing first {PR_PAGE_MAX}. Refine the query for older PRs.
+              </li>
+            ) : null}
+          </ul>
+        )}
+      </div>
+    </Modal>
+  );
 }

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1559,7 +1559,7 @@ function PrRow({
   // Avatar rows get a touch more leading + larger text so the avatar
   // doesn't dominate visually. Plain rows stay compact at the prior size.
   const titleSize = showAvatar ? "text-[13px]" : "text-xs";
-  const metaSize = showAvatar ? "text-[12px]" : "text-[10px]";
+  const metaSize = showAvatar ? "text-[11px]" : "text-[10px]";
   return (
     <li
       role="button"
@@ -1601,7 +1601,7 @@ function PrRow({
         )}
       >
         <span className="flex min-w-0 shrink-0 items-center gap-1.5">
-          {showAvatar ? <AuthorAvatar login={pr.author} size={18} /> : null}
+          {showAvatar ? <AuthorAvatar login={pr.author} size={14} /> : null}
           <span className="truncate">{pr.author}</span>
         </span>
         <span className="opacity-50">·</span>

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1159,6 +1159,11 @@ function usePrRowActions(
                   icon: <Copy size={12} />,
                   onClick: () => void copyText(menu.pr.head_branch),
                 },
+                {
+                  label: "Copy reference",
+                  icon: <Copy size={12} />,
+                  onClick: () => void copyText(`#${menu.pr.number}`),
+                },
                 { type: "separator" },
                 {
                   label: "Merge…",

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -35,6 +35,7 @@ import type {
   StagedFile,
   TodoItem,
 } from "../lib/types";
+import { AuthorAvatar } from "./AuthorAvatar";
 import { ClosePullRequestDialog } from "./ClosePullRequestDialog";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { DiffView } from "./DiffView";
@@ -1234,6 +1235,9 @@ function PullRequestsTab({
   const refreshIntervalMs = useSettings(
     (s) => s.settings.pullRequests.refreshIntervalMs,
   );
+  const showAvatars = useSettings(
+    (s) => s.settings.pullRequests.showAvatars,
+  );
   const [stateFilter, setStateFilter] = useState<PrStateFilter>(defaultPrState);
   const [listing, setListing] = useState<PullRequestListing | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -1383,6 +1387,7 @@ function PullRequestsTab({
               <PrRow
                 key={pr.number}
                 pr={pr}
+                showAvatar={showAvatars}
                 onOpen={() => onOpenDetail(pr.number)}
                 onContextMenu={(e) => rowActions.openContextMenu(e, pr)}
               />
@@ -1529,6 +1534,7 @@ function PrRow({
   onOpen,
   onContextMenu,
   surface = "panel",
+  showAvatar = false,
 }: {
   pr: PullRequestInfo;
   onOpen: () => void;
@@ -1539,28 +1545,19 @@ function PrRow({
    * needs a different hover color to actually feel interactive.
    */
   surface?: "panel" | "dialog";
+  /**
+   * Render the author's GitHub avatar to the left of the row. Bumps the
+   * row's vertical footprint slightly in exchange for at-a-glance author
+   * recognition. Controlled by the `pullRequests.showAvatars` setting.
+   */
+  showAvatar?: boolean;
 }) {
   const hoverBg =
     surface === "dialog"
       ? "hover:bg-bg-sidebar focus-visible:bg-bg-sidebar"
       : "hover:bg-bg-elevated/50 focus-visible:bg-bg-elevated/60";
-  return (
-    <li
-      role="button"
-      tabIndex={0}
-      onDoubleClick={onOpen}
-      onContextMenu={onContextMenu}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") {
-          e.preventDefault();
-          onOpen();
-        }
-      }}
-      className={cn(
-        "flex w-full flex-col items-start gap-0.5 border-b border-border/40 px-3 py-2 text-left transition focus-visible:outline-none",
-        hoverBg,
-      )}
-    >
+  const content = (
+    <>
       <span className="flex w-full min-w-0 items-center gap-2">
         <span className="shrink-0 font-mono text-fg-muted">#{pr.number}</span>
         <PrStateBadge state={pr.state} isDraft={pr.is_draft} />
@@ -1602,6 +1599,36 @@ function PrRow({
           </span>
         </Tooltip>
       </span>
+    </>
+  );
+  return (
+    <li
+      role="button"
+      tabIndex={0}
+      onDoubleClick={onOpen}
+      onContextMenu={onContextMenu}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className={cn(
+        "w-full border-b border-border/40 px-3 py-2 text-left transition focus-visible:outline-none",
+        showAvatar ? "flex items-center gap-2.5" : "flex flex-col items-start gap-0.5",
+        hoverBg,
+      )}
+    >
+      {showAvatar ? (
+        <>
+          <AuthorAvatar login={pr.author} size={28} />
+          <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+            {content}
+          </span>
+        </>
+      ) : (
+        content
+      )}
     </li>
   );
 }
@@ -1635,6 +1662,9 @@ function PullRequestSearchModal({
   onOpenDetail: (number: number) => void;
 }) {
   const repoPath = open?.repoPath ?? null;
+  const showAvatars = useSettings(
+    (s) => s.settings.pullRequests.showAvatars,
+  );
   const [rawQuery, setRawQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [stateFilter, setStateFilter] = useState<PrStateFilter>("all");
@@ -1803,6 +1833,7 @@ function PullRequestSearchModal({
                 key={pr.number}
                 pr={pr}
                 surface="dialog"
+                showAvatar={showAvatars}
                 onOpen={() => onOpenDetail(pr.number)}
                 onContextMenu={(e) => rowActions.openContextMenu(e, pr)}
               />

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1148,6 +1148,7 @@ function usePrRowActions(
                   icon: <ExternalLink size={12} />,
                   onClick: () => void openPrInBrowser(menu.pr),
                 },
+                { type: "separator" },
                 {
                   label: "Copy URL",
                   icon: <Copy size={12} />,

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -191,20 +191,20 @@ export function RightPanel() {
         cwd={repoPath ?? undefined}
         onClose={() => setExpanded(null)}
       />
+      <PullRequestSearchModal
+        open={prSearch}
+        detailOpen={prDetail !== null}
+        onClose={() => setPrSearch(null)}
+        onOpenDetail={(number) => {
+          if (!prSearch) return;
+          setPrDetail({ repoPath: prSearch.repoPath, number });
+        }}
+      />
       <PullRequestDetailModal
         open={prDetail}
         cwd={repoPath ?? undefined}
         onClose={() => setPrDetail(null)}
         onMutated={() => setPrListVersion((v) => v + 1)}
-      />
-      <PullRequestSearchModal
-        open={prSearch}
-        onClose={() => setPrSearch(null)}
-        onOpenDetail={(number) => {
-          if (!prSearch) return;
-          setPrDetail({ repoPath: prSearch.repoPath, number });
-          setPrSearch(null);
-        }}
       />
     </aside>
   );
@@ -1040,6 +1040,176 @@ const PR_PAGE_SIZE = 50;
 /** Backend clamps to 1000; mirror that here so the UI stops growing the limit. */
 const PR_PAGE_MAX = 1000;
 
+/**
+ * Shared PR row actions: context menu, copy/open helpers, and the
+ * merge/close dialog overlays. Lets the PRs tab and the search modal
+ * render the same right-click menu without duplicating handlers or state.
+ *
+ * `onMutated` fires after a merge or close so callers can refetch their
+ * own listing.
+ */
+function usePrRowActions(
+  repoPath: string,
+  onOpenDetail: (number: number) => void,
+  onMutated?: () => void,
+) {
+  const [menu, setMenu] = useState<{
+    x: number;
+    y: number;
+    pr: PullRequestInfo;
+  } | null>(null);
+  const [mergeFor, setMergeFor] = useState<{
+    number: number;
+    detail: PullRequestDetail;
+  } | null>(null);
+  const [closeFor, setCloseFor] = useState<{
+    number: number;
+    detail: PullRequestDetail;
+  } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // Bumped on every detail fetch / dialog dismiss so stale getPullRequestDetail
+  // responses can't open a dialog after the user moved on.
+  const dialogEpochRef = useRef(0);
+
+  async function copyText(text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function openPrInBrowser(pr: PullRequestInfo) {
+    try {
+      await openUrl(pr.url);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function loadDetailFor(
+    pr: PullRequestInfo,
+  ): Promise<PullRequestDetail | null> {
+    const epoch = ++dialogEpochRef.current;
+    try {
+      const listing = await api.getPullRequestDetail(repoPath, pr.number);
+      if (epoch !== dialogEpochRef.current) return null;
+      if (listing.kind !== "ok") {
+        setError(
+          listing.kind === "not_github"
+            ? "Origin remote is not a GitHub repository."
+            : `No access to ${listing.slug}.`,
+        );
+        return null;
+      }
+      return listing.detail;
+    } catch (e) {
+      if (epoch === dialogEpochRef.current) setError(String(e));
+      return null;
+    }
+  }
+
+  async function openMergeFor(pr: PullRequestInfo) {
+    const detail = await loadDetailFor(pr);
+    if (!detail) return;
+    setMergeFor({ number: pr.number, detail });
+  }
+
+  async function openCloseFor(pr: PullRequestInfo) {
+    const detail = await loadDetailFor(pr);
+    if (!detail) return;
+    setCloseFor({ number: pr.number, detail });
+  }
+
+  function openContextMenu(
+    e: React.MouseEvent<HTMLLIElement>,
+    pr: PullRequestInfo,
+  ) {
+    e.preventDefault();
+    setMenu({ x: e.clientX, y: e.clientY, pr });
+  }
+
+  const overlays = (
+    <>
+      <ContextMenu
+        open={menu !== null}
+        x={menu?.x ?? 0}
+        y={menu?.y ?? 0}
+        items={
+          menu
+            ? ([
+                {
+                  label: "Open detail",
+                  icon: <Maximize2 size={12} />,
+                  onClick: () => onOpenDetail(menu.pr.number),
+                },
+                {
+                  label: "Open in browser",
+                  icon: <ExternalLink size={12} />,
+                  onClick: () => void openPrInBrowser(menu.pr),
+                },
+                {
+                  label: "Copy URL",
+                  icon: <Copy size={12} />,
+                  onClick: () => void copyText(menu.pr.url),
+                },
+                {
+                  label: `Copy branch (${menu.pr.head_branch})`,
+                  icon: <Copy size={12} />,
+                  onClick: () => void copyText(menu.pr.head_branch),
+                },
+                { type: "separator" },
+                {
+                  label: "Merge…",
+                  icon: <GitMerge size={12} />,
+                  disabled: menu.pr.state.toUpperCase() !== "OPEN",
+                  onClick: () => void openMergeFor(menu.pr),
+                },
+                {
+                  label: "Close…",
+                  icon: <GitPullRequestClosed size={12} />,
+                  disabled: menu.pr.state.toUpperCase() !== "OPEN",
+                  onClick: () => void openCloseFor(menu.pr),
+                },
+              ] satisfies ContextMenuItem[])
+            : []
+        }
+        onClose={() => setMenu(null)}
+      />
+      <MergePullRequestDialog
+        open={mergeFor !== null}
+        repoPath={repoPath}
+        detail={mergeFor?.detail ?? null}
+        onClose={() => {
+          dialogEpochRef.current += 1;
+          setMergeFor(null);
+        }}
+        onMerged={() => {
+          dialogEpochRef.current += 1;
+          setMergeFor(null);
+          onMutated?.();
+        }}
+      />
+      <ClosePullRequestDialog
+        open={closeFor !== null}
+        repoPath={repoPath}
+        detail={closeFor?.detail ?? null}
+        onClose={() => {
+          dialogEpochRef.current += 1;
+          setCloseFor(null);
+        }}
+        onClosed={() => {
+          dialogEpochRef.current += 1;
+          setCloseFor(null);
+          onMutated?.();
+        }}
+      />
+    </>
+  );
+
+  return { openContextMenu, overlays, error };
+}
+
 function PullRequestsTab({
   repoPath,
   onOpenDetail,
@@ -1065,22 +1235,6 @@ function PullRequestsTab({
   // Grows by PR_PAGE_SIZE each time the user scrolls to the bottom. Resets on
   // project / state-filter change so a fresh context starts at one page.
   const [limit, setLimit] = useState(PR_PAGE_SIZE);
-  const [menu, setMenu] = useState<{
-    x: number;
-    y: number;
-    pr: PullRequestInfo;
-  } | null>(null);
-  const [mergeFor, setMergeFor] = useState<{
-    number: number;
-    detail: PullRequestDetail;
-  } | null>(null);
-  const [closeFor, setCloseFor] = useState<{
-    number: number;
-    detail: PullRequestDetail;
-  } | null>(null);
-  // Bumped on every detail fetch / dialog dismiss so stale getPullRequestDetail
-  // responses can't open a dialog after the user moved on.
-  const dialogEpochRef = useRef(0);
   const setPrAccountForRepo = useAppStore((s) => s.setPrAccountForRepo);
 
   const fetchPrs = useCallback(
@@ -1142,53 +1296,9 @@ function PullRequestsTab({
     };
   }, [refreshKey, fetchPrs]);
 
-  async function copyText(text: string) {
-    try {
-      await navigator.clipboard.writeText(text);
-    } catch (e) {
-      setError(String(e));
-    }
-  }
-
-  async function openPrInBrowser(pr: PullRequestInfo) {
-    try {
-      await openUrl(pr.url);
-    } catch (e) {
-      setError(String(e));
-    }
-  }
-
-  async function loadDetailFor(pr: PullRequestInfo): Promise<PullRequestDetail | null> {
-    const epoch = ++dialogEpochRef.current;
-    try {
-      const listing = await api.getPullRequestDetail(repoPath, pr.number);
-      if (epoch !== dialogEpochRef.current) return null;
-      if (listing.kind !== "ok") {
-        setError(
-          listing.kind === "not_github"
-            ? "Origin remote is not a GitHub repository."
-            : `No access to ${listing.slug}.`,
-        );
-        return null;
-      }
-      return listing.detail;
-    } catch (e) {
-      if (epoch === dialogEpochRef.current) setError(String(e));
-      return null;
-    }
-  }
-
-  async function openMergeFor(pr: PullRequestInfo) {
-    const detail = await loadDetailFor(pr);
-    if (!detail) return;
-    setMergeFor({ number: pr.number, detail });
-  }
-
-  async function openCloseFor(pr: PullRequestInfo) {
-    const detail = await loadDetailFor(pr);
-    if (!detail) return;
-    setCloseFor({ number: pr.number, detail });
-  }
+  const rowActions = usePrRowActions(repoPath, onOpenDetail, () => {
+    void fetchPrs();
+  });
 
   function handleScroll(e: React.UIEvent<HTMLDivElement>) {
     if (loading) return;
@@ -1245,8 +1355,10 @@ function PullRequestsTab({
         className="flex-1 overflow-x-hidden overflow-y-auto"
         onScroll={handleScroll}
       >
-        {error ? (
-          <div className="p-3 text-xs text-danger">{error}</div>
+        {error || rowActions.error ? (
+          <div className="p-3 text-xs text-danger">
+            {error ?? rowActions.error}
+          </div>
         ) : !listing ? (
           <PrSkeletonList count={10} />
         ) : listing.kind === "not_github" ? (
@@ -1266,10 +1378,7 @@ function PullRequestsTab({
                 key={pr.number}
                 pr={pr}
                 onOpen={() => onOpenDetail(pr.number)}
-                onContextMenu={(e) => {
-                  e.preventDefault();
-                  setMenu({ x: e.clientX, y: e.clientY, pr });
-                }}
+                onContextMenu={(e) => rowActions.openContextMenu(e, pr)}
               />
             ))}
             {loading && listing.items.length >= limit ? (
@@ -1285,91 +1394,7 @@ function PullRequestsTab({
           </ul>
         )}
       </div>
-      <ContextMenu
-        open={menu !== null}
-        x={menu?.x ?? 0}
-        y={menu?.y ?? 0}
-        items={
-          menu
-            ? ([
-                {
-                  label: "Open detail",
-                  icon: <Maximize2 size={12} />,
-                  onClick: () => {
-                    onOpenDetail(menu.pr.number);
-                  },
-                },
-                {
-                  label: "Open in browser",
-                  icon: <ExternalLink size={12} />,
-                  onClick: () => {
-                    void openPrInBrowser(menu.pr);
-                  },
-                },
-                {
-                  label: "Copy URL",
-                  icon: <Copy size={12} />,
-                  onClick: () => {
-                    void copyText(menu.pr.url);
-                  },
-                },
-                {
-                  label: `Copy branch (${menu.pr.head_branch})`,
-                  icon: <Copy size={12} />,
-                  onClick: () => {
-                    void copyText(menu.pr.head_branch);
-                  },
-                },
-                { type: "separator" },
-                {
-                  label: "Merge…",
-                  icon: <GitMerge size={12} />,
-                  disabled: menu.pr.state.toUpperCase() !== "OPEN",
-                  onClick: () => {
-                    void openMergeFor(menu.pr);
-                  },
-                },
-                {
-                  label: "Close…",
-                  icon: <GitPullRequestClosed size={12} />,
-                  disabled: menu.pr.state.toUpperCase() !== "OPEN",
-                  onClick: () => {
-                    void openCloseFor(menu.pr);
-                  },
-                },
-              ] satisfies ContextMenuItem[])
-            : []
-        }
-        onClose={() => setMenu(null)}
-      />
-      <MergePullRequestDialog
-        open={mergeFor !== null}
-        repoPath={repoPath}
-        detail={mergeFor?.detail ?? null}
-        onClose={() => {
-          dialogEpochRef.current += 1;
-          setMergeFor(null);
-        }}
-        onMerged={() => {
-          dialogEpochRef.current += 1;
-          setMergeFor(null);
-          void fetchPrs();
-        }}
-      />
-      <ClosePullRequestDialog
-        open={closeFor !== null}
-        repoPath={repoPath}
-        detail={closeFor?.detail ?? null}
-        onClose={() => {
-          dialogEpochRef.current += 1;
-          setCloseFor(null);
-        }}
-        onClosed={() => {
-          dialogEpochRef.current += 1;
-          setCloseFor(null);
-          void fetchPrs();
-        }}
-      />
+      {rowActions.overlays}
     </div>
   );
 }
@@ -1497,11 +1522,22 @@ function PrRow({
   pr,
   onOpen,
   onContextMenu,
+  surface = "panel",
 }: {
   pr: PullRequestInfo;
   onOpen: () => void;
   onContextMenu?: (e: React.MouseEvent<HTMLLIElement>) => void;
+  /**
+   * Background context the row sits on. `panel` is the right-panel
+   * (`bg-bg`), `dialog` is the modal surface (`bg-bg-elevated`) — each
+   * needs a different hover color to actually feel interactive.
+   */
+  surface?: "panel" | "dialog";
 }) {
+  const hoverBg =
+    surface === "dialog"
+      ? "hover:bg-bg-sidebar focus-visible:bg-bg-sidebar"
+      : "hover:bg-bg-elevated/50 focus-visible:bg-bg-elevated/60";
   return (
     <li
       role="button"
@@ -1514,7 +1550,10 @@ function PrRow({
           onOpen();
         }
       }}
-      className="flex w-full flex-col items-start gap-0.5 border-b border-border/40 px-3 py-2 text-left transition hover:bg-bg-elevated/50 focus-visible:outline-none focus-visible:bg-bg-elevated/60"
+      className={cn(
+        "flex w-full flex-col items-start gap-0.5 border-b border-border/40 px-3 py-2 text-left transition focus-visible:outline-none",
+        hoverBg,
+      )}
     >
       <span className="flex w-full min-w-0 items-center gap-2">
         <span className="shrink-0 font-mono text-fg-muted">#{pr.number}</span>
@@ -1576,10 +1615,16 @@ const PR_SEARCH_STATE_OPTIONS: { value: PrStateFilter; label: string }[] = [
  */
 function PullRequestSearchModal({
   open,
+  detailOpen,
   onClose,
   onOpenDetail,
 }: {
   open: { repoPath: string } | null;
+  /**
+   * True while the PR detail modal stacks on top. Used to suppress this
+   * modal's ESC handler so the top-of-stack closes first.
+   */
+  detailOpen: boolean;
   onClose: () => void;
   onOpenDetail: (number: number) => void;
 }) {
@@ -1593,7 +1638,16 @@ function PullRequestSearchModal({
   const [limit, setLimit] = useState(PR_PAGE_SIZE);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  useDialogShortcuts(open !== null, { onCancel: onClose });
+  // Refetch trigger used by row actions after a merge/close so the modal
+  // updates without the user reopening it.
+  const [refetchTick, setRefetchTick] = useState(0);
+  const rowActions = usePrRowActions(
+    repoPath ?? "",
+    onOpenDetail,
+    () => setRefetchTick((v) => v + 1),
+  );
+
+  useDialogShortcuts(open !== null && !detailOpen, { onCancel: onClose });
 
   // Wipe transient state every time the modal opens so a reopen never shows
   // results from the previous session.
@@ -1650,7 +1704,7 @@ function PullRequestSearchModal({
     return () => {
       signal.cancelled = true;
     };
-  }, [open, repoPath, debouncedQuery, stateFilter, limit]);
+  }, [open, repoPath, debouncedQuery, stateFilter, limit, refetchTick]);
 
   function handleScroll(e: React.UIEvent<HTMLDivElement>) {
     if (loading) return;
@@ -1717,13 +1771,15 @@ function PullRequestSearchModal({
         </div>
       </div>
       <div
-        className="max-h-[60vh] min-h-[200px] overflow-y-auto"
+        className="h-[60vh] overflow-y-auto"
         onScroll={handleScroll}
       >
         {!debouncedQuery ? (
           <Empty msg="Type to search pull requests." />
-        ) : error ? (
-          <div className="p-3 text-xs text-danger">{error}</div>
+        ) : error || rowActions.error ? (
+          <div className="p-3 text-xs text-danger">
+            {error ?? rowActions.error}
+          </div>
         ) : !listing ? (
           <PrSkeletonList count={6} />
         ) : listing.kind === "not_github" ? (
@@ -1740,7 +1796,9 @@ function PullRequestSearchModal({
               <PrRow
                 key={pr.number}
                 pr={pr}
+                surface="dialog"
                 onOpen={() => onOpenDetail(pr.number)}
+                onContextMenu={(e) => rowActions.openContextMenu(e, pr)}
               />
             ))}
             {loading && listing.items.length >= limit ? (
@@ -1756,6 +1814,7 @@ function PullRequestSearchModal({
           </ul>
         )}
       </div>
+      {rowActions.overlays}
     </Modal>
   );
 }

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1559,7 +1559,7 @@ function PrRow({
   // Avatar rows get a touch more leading + larger text so the avatar
   // doesn't dominate visually. Plain rows stay compact at the prior size.
   const titleSize = showAvatar ? "text-[13px]" : "text-xs";
-  const metaSize = showAvatar ? "text-[11px]" : "text-[10px]";
+  const metaSize = showAvatar ? "text-[12px]" : "text-[10px]";
   return (
     <li
       role="button"

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1151,7 +1151,7 @@ function usePrRowActions(
                 },
                 { type: "separator" },
                 {
-                  label: "Copy reference",
+                  label: "Copy PR number",
                   icon: <Copy size={12} />,
                   onClick: () => void copyText(`#${menu.pr.number}`),
                 },

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1150,6 +1150,11 @@ function usePrRowActions(
                 },
                 { type: "separator" },
                 {
+                  label: "Copy reference",
+                  icon: <Copy size={12} />,
+                  onClick: () => void copyText(`#${menu.pr.number}`),
+                },
+                {
                   label: "Copy URL",
                   icon: <Copy size={12} />,
                   onClick: () => void copyText(menu.pr.url),
@@ -1158,11 +1163,6 @@ function usePrRowActions(
                   label: `Copy branch (${menu.pr.head_branch})`,
                   icon: <Copy size={12} />,
                   onClick: () => void copyText(menu.pr.head_branch),
-                },
-                {
-                  label: "Copy reference",
-                  icon: <Copy size={12} />,
-                  onClick: () => void copyText(`#${menu.pr.number}`),
                 },
                 { type: "separator" },
                 {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1556,9 +1556,33 @@ function PrRow({
     surface === "dialog"
       ? "hover:bg-bg-sidebar focus-visible:bg-bg-sidebar"
       : "hover:bg-bg-elevated/50 focus-visible:bg-bg-elevated/60";
-  const content = (
-    <>
-      <span className="flex w-full min-w-0 items-center gap-2">
+  // Avatar rows get a touch more leading + larger text so the avatar
+  // doesn't dominate visually. Plain rows stay compact at the prior size.
+  const titleSize = showAvatar ? "text-[13px]" : "text-xs";
+  const metaSize = showAvatar ? "text-[11px]" : "text-[10px]";
+  return (
+    <li
+      role="button"
+      tabIndex={0}
+      onDoubleClick={onOpen}
+      onContextMenu={onContextMenu}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className={cn(
+        "flex w-full flex-col items-start gap-0.5 border-b border-border/40 px-3 py-2 text-left transition focus-visible:outline-none",
+        hoverBg,
+      )}
+    >
+      <span
+        className={cn(
+          "flex w-full min-w-0 items-center gap-2",
+          titleSize,
+        )}
+      >
         <span className="shrink-0 font-mono text-fg-muted">#{pr.number}</span>
         <PrStateBadge state={pr.state} isDraft={pr.is_draft} />
         <Tooltip
@@ -1570,8 +1594,16 @@ function PrRow({
           <span className="min-w-0 flex-1 truncate text-fg">{pr.title}</span>
         </Tooltip>
       </span>
-      <span className="flex w-full min-w-0 items-center gap-2 text-[10px] text-fg-muted">
-        <span className="truncate">{pr.author}</span>
+      <span
+        className={cn(
+          "flex w-full min-w-0 items-center gap-2 text-fg-muted",
+          metaSize,
+        )}
+      >
+        <span className="flex min-w-0 shrink-0 items-center gap-1.5">
+          {showAvatar ? <AuthorAvatar login={pr.author} size={18} /> : null}
+          <span className="truncate">{pr.author}</span>
+        </span>
         <span className="opacity-50">·</span>
         <span className="flex min-w-0 items-center gap-1">
           <Tooltip
@@ -1599,36 +1631,6 @@ function PrRow({
           </span>
         </Tooltip>
       </span>
-    </>
-  );
-  return (
-    <li
-      role="button"
-      tabIndex={0}
-      onDoubleClick={onOpen}
-      onContextMenu={onContextMenu}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") {
-          e.preventDefault();
-          onOpen();
-        }
-      }}
-      className={cn(
-        "w-full border-b border-border/40 px-3 py-2 text-left transition focus-visible:outline-none",
-        showAvatar ? "flex items-center gap-2.5" : "flex flex-col items-start gap-0.5",
-        hoverBg,
-      )}
-    >
-      {showAvatar ? (
-        <>
-          <AuthorAvatar login={pr.author} size={28} />
-          <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
-            {content}
-          </span>
-        </>
-      ) : (
-        content
-      )}
     </li>
   );
 }

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -497,6 +497,17 @@ function PullRequestsSettings() {
         Manual refresh (the icon in the PRs tab) always works regardless of
         this interval.
       </p>
+      <Field
+        label="List density"
+        hint="Author avatars make rows easier to scan at a glance, but each row gets thicker."
+      >
+        <CheckboxRow
+          label="Show author avatars"
+          description="Render the GitHub avatar next to each PR row."
+          checked={settings.pullRequests.showAvatars}
+          onChange={(v) => patchPullRequests({ showAvatars: v })}
+        />
+      </Field>
     </section>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -102,11 +102,13 @@ export const api = {
     repoPath: string,
     state: PrStateFilter = "open",
     limit = 50,
+    query: string | null = null,
   ): Promise<PullRequestListing> {
     return invoke<PullRequestListing>("list_pull_requests", {
       repoPath,
       state,
       limit,
+      query,
     });
   },
   getPullRequestDetail(

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -233,6 +233,12 @@ export interface AcornSettings {
     defaultState: PrStateFilter;
     /** Auto-refresh cadence for the PRs tab in milliseconds. */
     refreshIntervalMs: number;
+    /**
+     * Show the author's GitHub avatar on each PR row. Trades a thicker
+     * row for at-a-glance author recognition, mirroring the PR detail
+     * modal which already shows avatars in its header / conversation.
+     */
+    showAvatars: boolean;
   };
   /**
    * Sidebar session-row presentation. Mirrors Warp's "View as / Pane
@@ -312,6 +318,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   pullRequests: {
     defaultState: "open",
     refreshIntervalMs: 60_000,
+    showAvatars: true,
   },
   sessionDisplay: {
     title: "name",
@@ -552,6 +559,10 @@ function loadSettings(): AcornSettings {
           parsed.pullRequests?.refreshIntervalMs,
           DEFAULT_SETTINGS.pullRequests.refreshIntervalMs,
         ),
+        showAvatars:
+          typeof parsed.pullRequests?.showAvatars === "boolean"
+            ? parsed.pullRequests.showAvatars
+            : DEFAULT_SETTINGS.pullRequests.showAvatars,
       },
       sessionDisplay: {
         title: normalizeSessionTitle(


### PR DESCRIPTION
## Summary

- Adds a search modal to the PRs tab (new icon in the header). Queries `gh` server-side via `--search`, reaches every PR in the repo, paginates by growing the limit on scroll, and stacks above the PR detail modal so opening a detail row no longer dismisses search.
- Adds infinite scroll to the PRs tab: the page size grows by 50 each time the user scrolls near the bottom, capped at the backend's 1000-PR ceiling.
- Adds `pullRequests.showAvatars` setting (default on). Each PR row then renders the author's GitHub avatar inline next to the author name, and the row text bumps slightly so the line cadence stays balanced. The toggle lives under Settings → Pull Requests.
- Adds a "Copy PR number" context-menu item that puts `#<number>` on the clipboard, ideal for handing a PR off to an agent in a prompt. Context-menu separators now split navigation, copy, and mutation groups.
- Right-click on any PR row — in the tab or in the search modal — exposes the same actions (Open detail / Open in browser / Copy PR number / Copy URL / Copy branch / Merge… / Close…) via a shared `usePrRowActions` hook.
- Drops the "Listed via @account" chip from the PR detail header; the same gh-account context is already visible in the status bar.
- Backend `list_pull_requests` gains an optional `query` argument forwarded to `gh pr list --search`, and its per-call limit clamp grows from 200 to 1000.

## Test plan

- [x] `bun run typecheck`
- [x] `cargo check --lib --tests`
- [x] `bun run test` (Vitest, 111 pass)
- [x] Manual: search modal opens, typing a query lists matching PRs across all states, and double-clicking a row opens the PR detail modal without closing search.
- [x] Manual: avatars render on each PR row when the setting is on, disappear when toggled off, and live next to the author login on the meta line.
- [x] Manual: context menu's "Copy PR number" lands `#<number>` on the clipboard.
- [ ] Manual: PRs tab scroll loads more pages until the 1000-PR ceiling notice appears.
- [ ] Manual: switching project / state filter resets the page size back to 50 without flashing the skeleton.
