### PR TITLE
fix(panes): make tab drag reliable from text and decoration children

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -573,7 +573,10 @@ function TabItem({
         )}
       >
         <span
-          className={cn("size-1.5 rounded-full", STATUS_DOT[tab.status])}
+          className={cn(
+            "pointer-events-none size-1.5 rounded-full",
+            STATUS_DOT[tab.status],
+          )}
         />
         {editing ? (
           <TabRenameInput
@@ -587,12 +590,14 @@ function TabItem({
             onCancel={() => setEditing(false)}
           />
         ) : (
-          <span className="max-w-[12rem] truncate">{tab.name}</span>
+          <span className="pointer-events-none max-w-[12rem] truncate">
+            {tab.name}
+          </span>
         )}
         {tab.isolated ? (
           <GitBranch
             size={10}
-            className="text-fg-muted"
+            className="pointer-events-none text-fg-muted"
             aria-label="isolated"
           />
         ) : null}


### PR DESCRIPTION
## Summary

Tab drag from the visible label area was flaky on macOS WKWebView. PR #115 fixed it for the bare tab body with `select-none` plus inline `-webkit-user-drag: element`, but a mousedown that landed on the inner text span, the status dot, or the `GitBranch` isolation icon still let WebKit resolve the drag origin to the child element. Children carry no `-webkit-user-drag` of their own, so the text-selection heuristic won and the parent's element-drag never started.

This change marks those decoration children `pointer-events-none` so mousedown lands on the draggable parent directly. The close button keeps its own pointer events.

## Test plan

- [ ] Grab a tab by the **text label**, drag onto another pane edge — drop zones light up, drop splits correctly.
- [ ] Same gesture starting from the **status dot**.
- [ ] Same gesture starting from the **isolation `GitBranch` icon** (isolated session).
- [ ] Close button still clicks (hover, focus, click).
- [ ] Double-click on label still enters rename mode.
- [ ] Right-click on label still shows context menu.
- [ ] `bun run typecheck` clean.
