### PR TITLE
fix(panes): focus pane on terminal click; auto-close empty panes

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -72,6 +72,22 @@ export function Pane({ paneId }: PaneProps) {
   const [paneMenu, setPaneMenu] = useState<{ x: number; y: number } | null>(
     null,
   );
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+
+  // Pane body hosts the active session's Terminal via a portal target
+  // `appendChild`-moved in by TerminalHost. The terminal is rendered at App
+  // level, so its React fiber tree is a sibling of every pane — React
+  // synthetic `onMouseDown` on this pane never fires for clicks inside the
+  // terminal. Without this listener, clicking into a terminal leaves
+  // `focusedPaneId` pointing at the previously focused pane, and split / tab
+  // shortcuts (Cmd+Shift+D, Cmd+W, …) act on the wrong pane.
+  useEffect(() => {
+    const node = bodyRef.current;
+    if (!node) return;
+    const handler = () => setFocusedPane(paneId);
+    node.addEventListener("mousedown", handler);
+    return () => node.removeEventListener("mousedown", handler);
+  }, [paneId, setFocusedPane]);
 
   const tabs = useMemo<Session[]>(() => {
     if (!pane) return [];
@@ -166,6 +182,7 @@ export function Pane({ paneId }: PaneProps) {
         />
       ) : null}
       <div
+        ref={bodyRef}
         className="relative min-h-0 flex-1"
         data-pane-body={paneId}
         onContextMenu={(e) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -736,8 +736,39 @@ export const useAppStore = create<AppStateModel>()(
 
   async removeSession(id, removeWorktree = false) {
     try {
+      // Track which project + pane held this session so we can collapse the
+      // pane after reconcile if removing the tab leaves it empty. We only
+      // collapse panes that *became* empty as a side effect of this close —
+      // pre-existing empty panes (e.g. a split waiting for a drop target)
+      // stay untouched.
+      const before = get();
+      let owning: { repoPath: string; paneId: PaneId } | null = null;
+      for (const [repoPath, ws] of Object.entries(before.workspaces)) {
+        for (const [pid, p] of Object.entries(ws.panes)) {
+          if (p.sessionIds.includes(id)) {
+            owning = { repoPath, paneId: pid as PaneId };
+            break;
+          }
+        }
+        if (owning) break;
+      }
+
       await api.removeSession(id, removeWorktree);
       await get().refreshAll();
+
+      if (!owning) return;
+      const after = get();
+      const ws = after.workspaces[owning.repoPath];
+      if (!ws) return;
+      const pane = ws.panes[owning.paneId];
+      if (!pane) return;
+      if (pane.sessionIds.length > 0) return;
+      if (Object.keys(ws.panes).length <= 1) return;
+      // Only auto-collapse for the currently active workspace's panes —
+      // closePane operates on the active workspace, so applying it to a
+      // background project would silently misfire.
+      if (after.activeProject !== owning.repoPath) return;
+      get().closePane(owning.paneId);
     } catch (e) {
       set({ error: errorMessage(e) });
     }


### PR DESCRIPTION
## Summary

- Native `mousedown` listener on pane body so clicking into a terminal updates `focusedPaneId`. The active terminal lives at App level and is portaled into the pane body via `appendChild`, so its fiber tree is a sibling of every pane — React synthetic events on the pane wrapper never fired for terminal clicks, leaving focus stuck on the previously focused pane. Cmd+Shift+D / Cmd+W then targeted the wrong pane.
- Auto-collapse a pane that becomes empty as a side effect of closing its last tab. `removeSession` now remembers which pane held the session and calls `closePane` after reconcile when that pane has zero sessions and at least one sibling. Pre-existing empty panes (an explicit split waiting for a drop target) keep their current behavior because they had no session to remove.

## Test plan

- [x] Focus pane A, click into a terminal in pane B, press `Cmd+Shift+D` → split happens in pane B (not A).
- [x] Same flow with `Cmd+W` → closes the active tab in pane B.
- [x] Pane with 2 tabs: close the second tab → pane stays.
- [x] Pane with 1 tab in a split layout: close that tab → pane collapses; sibling pane keeps its own sessions.
- [x] Single-pane workspace, last tab closes → pane stays (no orphan empty workspace).
- [x] Split into an empty drop-target pane, leave it empty → empty pane is preserved (no regression).
- [x] `bun run typecheck` / `bun run test` green.
