### PR TITLE
feat(prs): toggle body task checkboxes from detail modal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,12 @@ bun run build          # tsc + vite build
 
 `src-tauri/binaries/acorn-ipc-<target-triple>` is `.gitignore`d, so every fresh checkout — including each new `git worktree add` — starts without it, and Tauri's `externalBin` existence check fails the build before anything else runs. Run `bun run build:sidecar` once per worktree (and again after any IPC change); plain `cargo build --bin acorn-ipc` is not enough because it skips the target-tripled staging step. See [`docs/CONTROL_SESSIONS.md`](docs/CONTROL_SESSIONS.md#the-acorn-ipc-cli) for details.
 
+## Reading webview logs in dev
+
+`vite-console-forward-plugin` is wired in `vite.config.ts` (dev only). Every `console.log` / `warn` / `error` / `info` / `debug` call inside the running webview is POSTed to the Vite dev server and printed to the same terminal `bun run tauri dev` is logging to, prefixed with `[browser]`. AI agents and humans can read app logs without opening the WKWebView inspector (which is blocked anyway by the keybinding guards in `src/main.tsx`).
+
+The plugin no-ops in `vite build` and is not loaded by Vitest (it only injects via `transformIndexHtml` + `configureServer`, neither of which fire during unit tests).
+
 ## When in doubt
 
 - Reading: `docs/TESTING.md`, `docs/E2E_TESTING.md`, `docs/PR_LABELS.md`, `docs/COMMENTS.md`.

--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
         "tailwindcss": "^4.2.4",
         "typescript": "~5.8.3",
         "vite": "^7.0.4",
+        "vite-console-forward-plugin": "^2.0.1",
         "vitest": "^4.1.5",
       },
     },
@@ -942,6 +943,8 @@
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
+    "vite-console-forward-plugin": ["vite-console-forward-plugin@2.0.1", "", { "peerDependencies": { "vite": "^6.0.0 || ^7.0.0" } }, "sha512-cA2vIWauvEvVwk5H10lRxdxpIGK5JK9Rz4PRDBWhj855aJVxWrZ7v+u6RyTjSpJ+fUPIMwHLN/5FjXyywcpkow=="],
 
     "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "tailwindcss": "^4.2.4",
     "typescript": "~5.8.3",
     "vite": "^7.0.4",
+    "vite-console-forward-plugin": "^2.0.1",
     "vitest": "^4.1.5"
   }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1018,6 +1018,15 @@ pub async fn close_pull_request(repo_path: String, number: u64) -> AppResult<()>
 }
 
 #[tauri::command]
+pub async fn update_pull_request_body(
+    repo_path: String,
+    number: u64,
+    body: String,
+) -> AppResult<()> {
+    pull_requests::update_pull_request_body(&PathBuf::from(repo_path), number, &body)
+}
+
+#[tauri::command]
 pub async fn generate_pr_commit_message(
     repo_path: String,
     number: u64,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -189,6 +189,7 @@ pub fn run() {
             commands::get_pull_request_detail,
             commands::merge_pull_request,
             commands::close_pull_request,
+            commands::update_pull_request_body,
             commands::generate_pr_commit_message,
             commands::pty_spawn,
             commands::pty_write,

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -996,6 +996,23 @@ pub fn close_pull_request(repo_path: &Path, number: u64) -> AppResult<()> {
     }
 }
 
+pub fn update_pull_request_body(repo_path: &Path, number: u64, body: &str) -> AppResult<()> {
+    let Some(slug) = github_owner_repo(repo_path)? else {
+        return Err(AppError::Other(
+            "Origin remote is not a GitHub repository.".to_string(),
+        ));
+    };
+
+    match try_with_account(repo_path, &slug, |token| {
+        run_pr_edit_body(&slug, number, token, body)
+    })? {
+        AccountOutcome::Ok { value, .. } => Ok(value),
+        AccountOutcome::NoAccess { .. } => Err(AppError::Other(
+            "No logged-in gh account can edit this PR.".to_string(),
+        )),
+    }
+}
+
 fn run_pr_merge(
     slug: &str,
     number: u64,
@@ -1074,6 +1091,56 @@ fn run_pr_close(slug: &str, number: u64, token: &str) -> AppResult<()> {
             .env("GH_HOST", GH_HOST)
             .args(["pr", "close", &number_s, "--repo", slug]);
     })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("gh exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+    Ok(())
+}
+
+/// Pipe the new body via stdin (`--body-file -`) to dodge shell escaping
+/// pitfalls — bodies routinely contain backticks, `$`, and other characters
+/// that would need defensive quoting if passed as `--body "..."`.
+fn run_pr_edit_body(slug: &str, number: u64, token: &str, body: &str) -> AppResult<()> {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let gh_path = cli_resolver::resolve("gh")?;
+    let mut cmd = Command::new(&gh_path);
+    cmd.env("GH_TOKEN", token).env("GH_HOST", GH_HOST).args([
+        "pr",
+        "edit",
+        &number.to_string(),
+        "--repo",
+        slug,
+        "--body-file",
+        "-",
+    ]);
+
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                cli_resolver::invalidate("gh");
+            }
+            cli_resolver::spawn_error("gh", e)
+        })?;
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin
+            .write_all(body.as_bytes())
+            .map_err(|e| AppError::Other(format!("failed writing body to gh: {e}")))?;
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|e| AppError::Other(format!("failed waiting for gh: {e}")))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let msg = if stderr.is_empty() {

--- a/src/components/PullRequestDetailModal.modal.test.tsx
+++ b/src/components/PullRequestDetailModal.modal.test.tsx
@@ -1,0 +1,170 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type {
+  PullRequestDetail,
+  PullRequestDetailListing,
+} from "../lib/types";
+
+vi.mock("../lib/api", () => {
+  return {
+    api: {
+      getPullRequestDetail: vi.fn<
+        (repoPath: string, n: number) => Promise<PullRequestDetailListing>
+      >(),
+      updatePullRequestBody: vi.fn<
+        (repoPath: string, n: number, body: string) => Promise<void>
+      >(),
+    },
+  };
+});
+
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
+
+import { api } from "../lib/api";
+import { PullRequestDetailModal } from "./PullRequestDetailModal";
+
+const mockApi = vi.mocked(api);
+
+function fakeDetail(body: string): PullRequestDetail {
+  return {
+    number: 999,
+    title: "test",
+    body,
+    state: "OPEN",
+    is_draft: false,
+    author: "tester",
+    head_branch: "feat",
+    base_branch: "main",
+    url: "https://github.com/x/y/pull/999",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    merged_at: null,
+    additions: 0,
+    deletions: 0,
+    changed_files: 0,
+    mergeable: "MERGEABLE",
+    comments: [],
+    reviews: [],
+    checks: [],
+    diff: { files: [] },
+  };
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("PullRequestDetailModal — body checkbox toggle", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockApi.getPullRequestDetail.mockReset();
+    mockApi.updatePullRequestBody.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("optimistically toggles a checkbox and calls updatePullRequestBody with the rewritten body", async () => {
+    const initialBody = "- [ ] alpha\n- [ ] beta";
+    mockApi.getPullRequestDetail.mockResolvedValueOnce({
+      kind: "ok",
+      account: "tester",
+      detail: fakeDetail(initialBody),
+    });
+    mockApi.updatePullRequestBody.mockResolvedValue();
+
+    await act(async () => {
+      root.render(
+        <PullRequestDetailModal
+          open={{ repoPath: "/r", number: 999 }}
+          onClose={() => {}}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const boxes = document.body.querySelectorAll<HTMLInputElement>(
+      'input[type="checkbox"]',
+    );
+    expect(boxes.length).toBe(2);
+    expect(boxes[0]?.disabled).toBe(false);
+
+    // Second one for some variety in indexing.
+    mockApi.getPullRequestDetail.mockResolvedValueOnce({
+      kind: "ok",
+      account: "tester",
+      detail: fakeDetail("- [ ] alpha\n- [x] beta"),
+    });
+
+    await act(async () => {
+      boxes[1]!.click();
+    });
+
+    expect(mockApi.updatePullRequestBody).toHaveBeenCalledWith(
+      "/r",
+      999,
+      "- [ ] alpha\n- [x] beta",
+    );
+
+    // Optimistic UI: the second checkbox should be reflected as checked in
+    // the rendered DOM right after the click (before the refetch resolves).
+    const updated = document.body.querySelectorAll<HTMLInputElement>(
+      'input[type="checkbox"]',
+    );
+    expect(updated[0]?.checked).toBe(false);
+    expect(updated[1]?.checked).toBe(true);
+  });
+
+  it("reverts and surfaces an error when updatePullRequestBody rejects", async () => {
+    mockApi.getPullRequestDetail.mockResolvedValueOnce({
+      kind: "ok",
+      account: "tester",
+      detail: fakeDetail("- [ ] only"),
+    });
+    mockApi.updatePullRequestBody.mockRejectedValue(
+      new Error("Resource not accessible"),
+    );
+
+    await act(async () => {
+      root.render(
+        <PullRequestDetailModal
+          open={{ repoPath: "/r", number: 999 }}
+          onClose={() => {}}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const box = document.body.querySelector<HTMLInputElement>(
+      'input[type="checkbox"]',
+    )!;
+    await act(async () => {
+      box.click();
+    });
+    await flushPromises();
+
+    const after = document.body.querySelector<HTMLInputElement>(
+      'input[type="checkbox"]',
+    )!;
+    expect(after.checked).toBe(false);
+    expect(document.body.textContent).toContain("Couldn't save checkbox");
+  });
+});

--- a/src/components/PullRequestDetailModal.test.ts
+++ b/src/components/PullRequestDetailModal.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { toggleTaskMarker } from "./PullRequestDetailModal";
+
+describe("toggleTaskMarker", () => {
+  it("checks an unchecked task by index", () => {
+    const body = "- [ ] one\n- [ ] two\n- [ ] three";
+    expect(toggleTaskMarker(body, 1, true)).toBe(
+      "- [ ] one\n- [x] two\n- [ ] three",
+    );
+  });
+
+  it("unchecks a checked task by index", () => {
+    const body = "- [x] one\n- [x] two";
+    expect(toggleTaskMarker(body, 0, false)).toBe("- [ ] one\n- [x] two");
+  });
+
+  it("handles ordered list task items", () => {
+    const body = "1. [ ] alpha\n2. [ ] beta";
+    expect(toggleTaskMarker(body, 1, true)).toBe(
+      "1. [ ] alpha\n2. [x] beta",
+    );
+  });
+
+  it("preserves indentation of nested task items", () => {
+    const body = "- [ ] root\n  - [ ] nested";
+    expect(toggleTaskMarker(body, 1, true)).toBe(
+      "- [ ] root\n  - [x] nested",
+    );
+  });
+
+  it("skips task-looking lines inside fenced code blocks", () => {
+    const body = [
+      "- [ ] real one",
+      "",
+      "```",
+      "- [ ] not a task",
+      "```",
+      "",
+      "- [ ] real two",
+    ].join("\n");
+    const next = toggleTaskMarker(body, 1, true);
+    expect(next).toBe(
+      [
+        "- [ ] real one",
+        "",
+        "```",
+        "- [ ] not a task",
+        "```",
+        "",
+        "- [x] real two",
+      ].join("\n"),
+    );
+  });
+
+  it("returns null when the index is out of range", () => {
+    expect(toggleTaskMarker("- [ ] only", 5, true)).toBeNull();
+    expect(toggleTaskMarker("no tasks here", 0, true)).toBeNull();
+  });
+
+  it("accepts uppercase X as checked", () => {
+    const body = "- [X] done";
+    expect(toggleTaskMarker(body, 0, false)).toBe("- [ ] done");
+  });
+});

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -175,8 +175,6 @@ export function PullRequestDetailModal({
         .updatePullRequestBody(open.repoPath, open.number, next)
         .then(() => {
           if (seq !== bodyWriteSeqRef.current) return;
-          // Fold the canonical state into the override silently in the
-          // background — no spinner flash, no flicker if the body is unchanged.
           setReloadKey((k) => k + 1);
         })
         .catch((e) => {

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -72,6 +72,15 @@ export function PullRequestDetailModal({
   const [refreshing, setRefreshing] = useState(false);
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
   const [closeDialogOpen, setCloseDialogOpen] = useState(false);
+  // Optimistic body override while a task-list checkbox toggle is in flight
+  // (or after one succeeds, until the next fetch overwrites it). Keyed by
+  // PR identity so a stale override never bleeds into a different PR.
+  const [bodyOverride, setBodyOverride] = useState<{
+    key: string;
+    body: string;
+  } | null>(null);
+  const [bodySaveError, setBodySaveError] = useState<string | null>(null);
+  const bodyWriteSeqRef = useRef(0);
 
   useDialogShortcuts(open !== null, {
     onCancel: onClose,
@@ -88,10 +97,14 @@ export function PullRequestDetailModal({
       setReloadKey(0);
       setMergeDialogOpen(false);
       setCloseDialogOpen(false);
+      setBodyOverride(null);
+      setBodySaveError(null);
       return;
     }
     setListing(null);
     setError(null);
+    setBodyOverride(null);
+    setBodySaveError(null);
   }, [open]);
 
   // Fetch on open and on every refresh bump.
@@ -127,6 +140,53 @@ export function PullRequestDetailModal({
 
   const detail =
     listing && listing.kind === "ok" ? listing.detail : null;
+  const prKey = open ? `${open.repoPath}#${open.number}` : null;
+  // Whenever a fresh detail arrives, the canonical body wins unless we have
+  // an unsynced override from a click that happened mid-fetch. The override
+  // is cleared opportunistically when it matches the server again.
+  useEffect(() => {
+    if (!detail || !prKey) return;
+    setBodyOverride((prev) => {
+      if (!prev || prev.key !== prKey) return null;
+      if (prev.body === detail.body) return null;
+      return prev;
+    });
+  }, [detail, prKey]);
+
+  const displayBody = useMemo(() => {
+    if (!detail || !prKey) return null;
+    if (bodyOverride && bodyOverride.key === prKey) return bodyOverride.body;
+    return detail.body;
+  }, [detail, bodyOverride, prKey]);
+
+  const handleTaskToggle = useCallback(
+    (index: number, checked: boolean) => {
+      if (!open || !detail || !prKey) return;
+      const current =
+        bodyOverride && bodyOverride.key === prKey
+          ? bodyOverride.body
+          : detail.body;
+      const next = toggleTaskMarker(current, index, checked);
+      if (next === null || next === current) return;
+      const seq = ++bodyWriteSeqRef.current;
+      setBodyOverride({ key: prKey, body: next });
+      setBodySaveError(null);
+      api
+        .updatePullRequestBody(open.repoPath, open.number, next)
+        .then(() => {
+          if (seq !== bodyWriteSeqRef.current) return;
+          // Fold the canonical state into the override silently in the
+          // background — no spinner flash, no flicker if the body is unchanged.
+          setReloadKey((k) => k + 1);
+        })
+        .catch((e) => {
+          if (seq !== bodyWriteSeqRef.current) return;
+          setBodyOverride(null);
+          setBodySaveError(String(e));
+        });
+    },
+    [open, detail, prKey, bodyOverride],
+  );
 
   return (
     <>
@@ -159,6 +219,9 @@ export function PullRequestDetailModal({
         ) : (
           <DetailBody
             detail={listing.detail}
+            body={displayBody ?? listing.detail.body}
+            onTaskToggle={handleTaskToggle}
+            bodySaveError={bodySaveError}
             tab={tab}
             onTab={setTab}
             cwd={cwd}
@@ -218,6 +281,9 @@ function ModalShell({
 
 function DetailBody({
   detail,
+  body,
+  onTaskToggle,
+  bodySaveError,
   tab,
   onTab,
   cwd,
@@ -228,6 +294,10 @@ function DetailBody({
   onOpenClose,
 }: {
   detail: PullRequestDetail;
+  /** Optimistically-overridden body (or `detail.body` if no edit is pending). */
+  body: string;
+  onTaskToggle: (index: number, checked: boolean) => void;
+  bodySaveError: string | null;
   tab: DetailTab;
   onTab: (t: DetailTab) => void;
   cwd?: string;
@@ -326,9 +396,14 @@ function DetailBody({
         </div>
       </header>
 
-      {detail.body.trim().length > 0 ? (
+      {body.trim().length > 0 ? (
         <ResizableBody>
-          <Markdown content={detail.body} />
+          <Markdown content={body} onTaskToggle={onTaskToggle} />
+          {bodySaveError ? (
+            <p className="mt-2 text-[10.5px] text-danger">
+              Couldn't save checkbox: {bodySaveError}
+            </p>
+          ) : null}
         </ResizableBody>
       ) : null}
 
@@ -1075,6 +1150,48 @@ function CheckStatusLabel({
   return (
     <span className="shrink-0 font-mono text-[10px] text-fg-muted">{text}</span>
   );
+}
+
+/**
+ * Toggle the Nth GFM task-list marker in `body` to the requested state.
+ * Returns the new body, or `null` if the index is out of range.
+ *
+ * Walks line-by-line so fenced code blocks (which may contain literal
+ * `- [ ]` text) don't get counted. Matches the same list markers GFM
+ * accepts: `-`, `*`, `+`, `1.`, `1)`.
+ */
+export function toggleTaskMarker(
+  body: string,
+  index: number,
+  checked: boolean,
+): string | null {
+  const lineRe = /^([ \t]*(?:[-*+]|\d+[.)])[ \t]+)\[([ xX])\](?=[ \t])/;
+  const fenceRe = /^[ \t]{0,3}(```+|~~~+)/;
+  let inFence = false;
+  let pos = 0;
+  let n = 0;
+  const lines = body.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (fenceRe.test(line)) {
+      inFence = !inFence;
+    } else if (!inFence) {
+      const m = lineRe.exec(line);
+      if (m) {
+        if (n === index) {
+          const bracketStart = pos + m[1].length;
+          return (
+            body.slice(0, bracketStart) +
+            `[${checked ? "x" : " "}]` +
+            body.slice(bracketStart + 3)
+          );
+        }
+        n++;
+      }
+    }
+    pos += line.length + 1;
+  }
+  return null;
 }
 
 function formatTimestamp(iso: string): string {

--- a/src/components/ui/Markdown.test.tsx
+++ b/src/components/ui/Markdown.test.tsx
@@ -1,0 +1,70 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Markdown } from "./Markdown";
+
+describe("Markdown — interactive task list", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders task checkboxes as enabled when onTaskToggle is supplied", () => {
+    act(() => {
+      root.render(
+        <Markdown
+          content={"- [ ] one\n- [x] two"}
+          onTaskToggle={() => {}}
+        />,
+      );
+    });
+    const boxes = container.querySelectorAll<HTMLInputElement>(
+      'input[type="checkbox"]',
+    );
+    expect(boxes).toHaveLength(2);
+    for (const box of boxes) {
+      expect(box.disabled).toBe(false);
+    }
+    expect(boxes[0]?.checked).toBe(false);
+    expect(boxes[1]?.checked).toBe(true);
+  });
+
+  it("invokes onTaskToggle with the correct index when clicked", () => {
+    const handler = vi.fn();
+    act(() => {
+      root.render(
+        <Markdown
+          content={"- [ ] one\n- [ ] two\n- [ ] three"}
+          onTaskToggle={handler}
+        />,
+      );
+    });
+    const boxes = container.querySelectorAll<HTMLInputElement>(
+      'input[type="checkbox"]',
+    );
+    act(() => {
+      boxes[1]!.click();
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(1, true);
+  });
+
+  it("keeps checkboxes read-only when no handler is given", () => {
+    act(() => {
+      root.render(<Markdown content={"- [ ] one"} />);
+    });
+    const box = container.querySelector<HTMLInputElement>(
+      'input[type="checkbox"]',
+    );
+    expect(box?.disabled).toBe(true);
+  });
+});

--- a/src/components/ui/Markdown.tsx
+++ b/src/components/ui/Markdown.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useRef, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
@@ -30,6 +30,12 @@ const sanitizeSchema = {
       "target",
       "rel",
     ],
+    input: [
+      ...(defaultSchema.attributes?.input ?? []),
+      // Stamped by `rehypeTaskIndex` below so the React input component can
+      // map a click back to its source-order checkbox.
+      "dataTaskIndex",
+    ],
   },
   tagNames: [
     ...(defaultSchema.tagNames ?? []),
@@ -37,6 +43,35 @@ const sanitizeSchema = {
     "summary",
   ],
 };
+
+// Walks the HAST tree once (outside React's render cycle, so immune to
+// StrictMode double-invocation) and stamps each task-list checkbox input
+// with a `data-task-index` attribute reflecting its source-order position.
+// Runs after `rehypeRaw` (whose tree-rebuild strips positions) and before
+// `rehypeSanitize`, which is configured above to allow the data attr.
+function rehypeTaskIndex() {
+  return (tree: { children?: unknown[]; [k: string]: unknown }) => {
+    let i = 0;
+    const walk = (node: unknown) => {
+      if (!node || typeof node !== "object") return;
+      const n = node as {
+        type?: string;
+        tagName?: string;
+        properties?: Record<string, unknown>;
+        children?: unknown[];
+      };
+      if (
+        n.type === "element" &&
+        n.tagName === "input" &&
+        n.properties?.type === "checkbox"
+      ) {
+        n.properties = { ...n.properties, dataTaskIndex: i++ };
+      }
+      n.children?.forEach(walk);
+    };
+    walk(tree);
+  };
+}
 
 interface MarkdownProps {
   content: string;
@@ -196,13 +231,6 @@ function MarkdownImpl({ content, className, onTaskToggle }: MarkdownProps) {
     { src: string; alt?: string } | null
   >(null);
 
-  // ReactMarkdown walks the tree in source order, so a per-render counter
-  // gives every checkbox a stable zero-based index that lines up with the
-  // Nth task marker in the markdown source. Reset on each render so we
-  // don't accumulate across mounts.
-  const taskCounterRef = useRef(0);
-  taskCounterRef.current = 0;
-
   const components = useMemo<Components>(
     () => ({
       ...baseComponents,
@@ -223,7 +251,8 @@ function MarkdownImpl({ content, className, onTaskToggle }: MarkdownProps) {
           />
         );
       },
-      input({ type, checked, disabled }) {
+      input(props) {
+        const { type, checked, disabled } = props;
         if (type !== "checkbox") return null;
         if (!onTaskToggle) {
           return (
@@ -236,13 +265,26 @@ function MarkdownImpl({ content, className, onTaskToggle }: MarkdownProps) {
             />
           );
         }
-        const index = taskCounterRef.current;
-        taskCounterRef.current = index + 1;
+        // `rehypeTaskIndex` stamps this on each checkbox input during the
+        // HAST tree walk — a single-pass numbering that survives StrictMode's
+        // double-invocation of the React renderer.
+        const indexRaw = (props as { "data-task-index"?: unknown })[
+          "data-task-index"
+        ];
+        const index =
+          typeof indexRaw === "number"
+            ? indexRaw
+            : typeof indexRaw === "string"
+              ? Number(indexRaw)
+              : -1;
         return (
           <input
             type="checkbox"
             checked={!!checked}
-            onChange={(e) => onTaskToggle(index, e.currentTarget.checked)}
+            onChange={(e) => {
+              if (!Number.isFinite(index) || index < 0) return;
+              onTaskToggle(index, e.currentTarget.checked);
+            }}
             className="mr-1 cursor-pointer align-middle accent-accent"
           />
         );
@@ -256,7 +298,11 @@ function MarkdownImpl({ content, className, onTaskToggle }: MarkdownProps) {
       <div className={cn("text-[11.5px] leading-relaxed text-fg", className)}>
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
-          rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema]]}
+          rehypePlugins={[
+            rehypeRaw,
+            rehypeTaskIndex,
+            [rehypeSanitize, sanitizeSchema],
+          ]}
           components={components}
         >
           {content}

--- a/src/components/ui/Markdown.tsx
+++ b/src/components/ui/Markdown.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState } from "react";
+import { memo, useMemo, useRef, useState } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
@@ -41,6 +41,14 @@ const sanitizeSchema = {
 interface MarkdownProps {
   content: string;
   className?: string;
+  /**
+   * Optional handler invoked when a GFM task-list checkbox is toggled.
+   * The `index` is the zero-based position of the checkbox in source order
+   * — so the caller can update the underlying body by toggling the Nth
+   * `- [ ]` / `- [x]` marker. Providing this prop also enables the checkbox
+   * (default rendering is read-only).
+   */
+  onTaskToggle?: (index: number, checked: boolean) => void;
 }
 
 const baseComponents: Components = {
@@ -165,7 +173,8 @@ const baseComponents: Components = {
     );
   },
   // img is overridden per-instance in MarkdownImpl so it can hook into the
-  // lightbox state.
+  // lightbox state. The input renderer is overridden too when `onTaskToggle`
+  // is supplied, so this is just the read-only fallback.
   input({ type, checked, disabled }) {
     if (type === "checkbox") {
       return (
@@ -182,10 +191,17 @@ const baseComponents: Components = {
   },
 };
 
-function MarkdownImpl({ content, className }: MarkdownProps) {
+function MarkdownImpl({ content, className, onTaskToggle }: MarkdownProps) {
   const [lightbox, setLightbox] = useState<
     { src: string; alt?: string } | null
   >(null);
+
+  // ReactMarkdown walks the tree in source order, so a per-render counter
+  // gives every checkbox a stable zero-based index that lines up with the
+  // Nth task marker in the markdown source. Reset on each render so we
+  // don't accumulate across mounts.
+  const taskCounterRef = useRef(0);
+  taskCounterRef.current = 0;
 
   const components = useMemo<Components>(
     () => ({
@@ -207,8 +223,32 @@ function MarkdownImpl({ content, className }: MarkdownProps) {
           />
         );
       },
+      input({ type, checked, disabled }) {
+        if (type !== "checkbox") return null;
+        if (!onTaskToggle) {
+          return (
+            <input
+              type="checkbox"
+              checked={!!checked}
+              disabled={disabled ?? true}
+              readOnly
+              className="mr-1 align-middle accent-accent"
+            />
+          );
+        }
+        const index = taskCounterRef.current;
+        taskCounterRef.current = index + 1;
+        return (
+          <input
+            type="checkbox"
+            checked={!!checked}
+            onChange={(e) => onTaskToggle(index, e.currentTarget.checked)}
+            className="mr-1 cursor-pointer align-middle accent-accent"
+          />
+        );
+      },
     }),
-    [],
+    [onTaskToggle],
   );
 
   return (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -132,6 +132,17 @@ export const api = {
   closePullRequest(repoPath: string, number: number): Promise<void> {
     return invoke<void>("close_pull_request", { repoPath, number });
   },
+  updatePullRequestBody(
+    repoPath: string,
+    number: number,
+    body: string,
+  ): Promise<void> {
+    return invoke<void>("update_pull_request_body", {
+      repoPath,
+      number,
+      body,
+    });
+  },
   generatePrCommitMessage(
     repoPath: string,
     number: number,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { consoleForwardPlugin } from "vite-console-forward-plugin";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
@@ -11,7 +12,16 @@ const projectRoot: string = process.cwd();
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    // Forward webview console.{log,warn,error,info,debug} to the Vite dev
+    // server stdout so AI agents (and humans) can read app logs without
+    // opening the WKWebView inspector. Dev-only; the plugin no-ops in build.
+    consoleForwardPlugin({
+      levels: ["log", "warn", "error", "info", "debug"],
+    }),
+  ],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //


### PR DESCRIPTION
## Summary

Make GFM task checkboxes in the PR detail modal body interactive — clicking one rewrites the underlying PR body via `gh pr edit`, matching the GitHub UI behavior.

- `Markdown` gains an optional `onTaskToggle(index, checked)` prop. When omitted, checkboxes stay read-only — existing call sites (WhatsNew modal, conversation comments) are unaffected.
- The modal wires the body markdown to an optimistic toggle: rewrite the Nth `[ ]` / `[x]` marker, fire `update_pull_request_body`, and revert + show an inline error on failure.
- Backend calls `gh pr edit <number> --body-file -` with the new body piped via stdin, so embedded backticks / `$` / quotes never get shell-escaped.
- `toggleTaskMarker` skips fenced code blocks so a literal `- [ ]` inside ``` ``` is never miscounted. Covered by a Vitest suite next to the modal.

Permission note: `gh pr edit` requires write/maintain access. A viewer without that permission sees the checkbox flip for a moment, then revert with a red inline error under the body. Pre-disabling the checkbox based on `viewerCanUpdate` is left for a follow-up.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test src/components/PullRequestDetailModal.test.ts` (toggleTaskMarker — 7 cases)
- [x] Local: open PR detail modal — verified via console-forward logs (click → toggleTaskMarker returns next body → updatePullRequestBody invoke → `api success`)
- [ ] Local: click a checkbox on a PR you can't edit — checkbox briefly toggles then reverts, with a red error line below the body
- [ ] Local: other Markdown call sites (WhatsNew modal, conversation comments) stay read-only


