### PR TITLE
feat(panes): prompt to add project on empty pane when none exist

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -286,7 +286,7 @@ function EmptyPane({
         <>
           <FolderPlus size={28} className="opacity-40" />
           <p className="text-xs">
-            No projects yet. Double-click here to add one.
+            Add a project to get started. Double-click here.
           </p>
         </>
       )}

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -3,6 +3,7 @@ import {
   Copy,
   Files,
   FolderOpen,
+  FolderPlus,
   GitBranch,
   Pencil,
   PencilLine,
@@ -60,6 +61,7 @@ interface PaneProps {
  */
 export function Pane({ paneId }: PaneProps) {
   const sessions = useAppStore((s) => s.sessions);
+  const projects = useAppStore((s) => s.projects);
   const pane = useAppStore((s) => s.panes[paneId]);
   const totalPanes = useAppStore((s) => Object.keys(s.panes).length);
   const focusedPaneId = useAppStore((s) => s.focusedPaneId);
@@ -138,6 +140,8 @@ export function Pane({ paneId }: PaneProps) {
     await spawnSession(repoPath);
   }
 
+  const hasProjects = projects.length > 0;
+
   return (
     <div
       className="relative flex h-full flex-col bg-bg"
@@ -206,7 +210,13 @@ export function Pane({ paneId }: PaneProps) {
         */}
         {active ? null : (
           <EmptyPane
-            onDoubleClick={handleNewTabFromEmpty}
+            hasProjects={hasProjects}
+            onDoubleClick={
+              hasProjects
+                ? handleNewTabFromEmpty
+                : () =>
+                    window.dispatchEvent(new CustomEvent("acorn:add-project"))
+            }
             onContextMenu={(x, y) => {
               setFocusedPane(paneId);
               setPaneMenu({ x, y });
@@ -245,9 +255,11 @@ function suggestSessionName(repoPath: string, existing: Session[]): string {
 }
 
 function EmptyPane({
+  hasProjects,
   onDoubleClick,
   onContextMenu,
 }: {
+  hasProjects: boolean;
   onDoubleClick: () => void;
   onContextMenu: (x: number, y: number) => void;
 }) {
@@ -263,8 +275,21 @@ function EmptyPane({
       role="button"
       tabIndex={0}
     >
-      <TerminalIcon size={28} className="opacity-40" />
-      <p className="text-xs">Drop a tab here or double-click to start a session</p>
+      {hasProjects ? (
+        <>
+          <TerminalIcon size={28} className="opacity-40" />
+          <p className="text-xs">
+            Drop a tab here or double-click to start a session
+          </p>
+        </>
+      ) : (
+        <>
+          <FolderPlus size={28} className="opacity-40" />
+          <p className="text-xs">
+            No projects yet. Double-click here to add one.
+          </p>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

빈 pane에서 더블클릭 시 프로젝트가 하나도 없으면 아무 일도 일어나지 않던 동작을 수정. 프로젝트가 없을 때는 add-project 플로우로 안내하는 별도 empty state를 표시.

## Test plan

- [x] 프로젝트가 0개인 상태에서 pane이 "No projects yet. Double-click here to add one." + `FolderPlus` 아이콘 표시
- [x] 그 상태에서 더블클릭 → Add project 모달 열림 (`acorn:add-project` 이벤트)
- [x] 프로젝트가 1개 이상이면 기존 메시지 + 세션 생성 동작 유지
- [x] `tsc --noEmit` 통과
