### PR TITLE
feat(prs): commits tab in PR detail modal

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -996,6 +996,14 @@ pub async fn get_pull_request_detail(
 }
 
 #[tauri::command]
+pub async fn get_pull_request_commit_diff(
+    repo_path: String,
+    sha: String,
+) -> AppResult<DiffPayload> {
+    pull_requests::get_pull_request_commit_diff(&PathBuf::from(repo_path), &sha)
+}
+
+#[tauri::command]
 pub async fn merge_pull_request(
     repo_path: String,
     number: u64,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -187,6 +187,7 @@ pub fn run() {
             commands::staged_diff,
             commands::list_pull_requests,
             commands::get_pull_request_detail,
+            commands::get_pull_request_commit_diff,
             commands::merge_pull_request,
             commands::close_pull_request,
             commands::update_pull_request_body,

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -869,6 +869,42 @@ fn run_pr_view(slug: &str, number: u64, token: &str) -> AppResult<GhPullRequestV
         .map_err(|e| AppError::Other(format!("failed to parse gh output: {e}")))
 }
 
+pub fn get_pull_request_commit_diff(repo_path: &Path, sha: &str) -> AppResult<DiffPayload> {
+    let Some(slug) = github_owner_repo(repo_path)? else {
+        return Err(AppError::Other(
+            "origin remote is not a GitHub repository".into(),
+        ));
+    };
+    match try_with_account(repo_path, &slug, |token| run_commit_diff(&slug, sha, token))? {
+        AccountOutcome::Ok { value, .. } => Ok(crate::unified_diff::parse_unified_diff(&value)),
+        AccountOutcome::NoAccess { .. } => Err(AppError::Other(format!(
+            "no logged-in gh account can access {slug}"
+        ))),
+    }
+}
+
+fn run_commit_diff(slug: &str, sha: &str, token: &str) -> AppResult<String> {
+    let endpoint = format!("repos/{slug}/commits/{sha}");
+    let output = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token).env("GH_HOST", GH_HOST).args([
+            "api",
+            "-H",
+            "Accept: application/vnd.github.diff",
+            &endpoint,
+        ]);
+    })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("gh exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
 fn run_pr_diff(slug: &str, number: u64, token: &str) -> AppResult<String> {
     let number_s = number.to_string();
     let output = cli_resolver::run("gh", |cmd| {

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -638,6 +638,25 @@ pub struct PullRequestReview {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct PullRequestCommitAuthor {
+    pub name: String,
+    pub email: String,
+    /// GitHub login when gh resolved one. None for unattributed commits
+    /// (e.g. authored locally with an email not linked to any account).
+    pub login: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PullRequestCommit {
+    /// Full SHA — the UI shortens it for display but the link target needs the full id.
+    pub oid: String,
+    pub message_headline: String,
+    pub message_body: String,
+    pub committed_date: String,
+    pub authors: Vec<PullRequestCommitAuthor>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct PullRequestCheck {
     pub name: String,
     /// `QUEUED` / `IN_PROGRESS` / `COMPLETED` / `PENDING` (status checks).
@@ -676,6 +695,7 @@ pub struct PullRequestDetail {
     pub comments: Vec<PullRequestComment>,
     pub reviews: Vec<PullRequestReview>,
     pub checks: Vec<PullRequestCheck>,
+    pub commits: Vec<PullRequestCommit>,
     pub diff: DiffPayload,
 }
 
@@ -768,6 +788,28 @@ fn build_detail(number: u64, view: GhPullRequestView, diff_text: String) -> Pull
         })
         .collect();
 
+    let commits = view
+        .commits
+        .unwrap_or_default()
+        .into_iter()
+        .map(|c| PullRequestCommit {
+            oid: c.oid.unwrap_or_default(),
+            message_headline: c.message_headline.unwrap_or_default(),
+            message_body: c.message_body.unwrap_or_default(),
+            committed_date: c.committed_date.unwrap_or_default(),
+            authors: c
+                .authors
+                .unwrap_or_default()
+                .into_iter()
+                .map(|a| PullRequestCommitAuthor {
+                    name: a.name.unwrap_or_default(),
+                    email: a.email.unwrap_or_default(),
+                    login: a.login,
+                })
+                .collect(),
+        })
+        .collect();
+
     PullRequestDetail {
         number,
         title: view.title.unwrap_or_default(),
@@ -792,6 +834,7 @@ fn build_detail(number: u64, view: GhPullRequestView, diff_text: String) -> Pull
         comments,
         reviews,
         checks,
+        commits,
         diff: crate::unified_diff::parse_unified_diff(&diff_text),
     }
 }
@@ -808,7 +851,7 @@ fn run_pr_view(slug: &str, number: u64, token: &str) -> AppResult<GhPullRequestV
             "--json",
             "number,title,body,state,isDraft,author,headRefName,baseRefName,url,\
                  createdAt,updatedAt,mergedAt,additions,deletions,changedFiles,\
-                 mergeable,comments,reviews,statusCheckRollup",
+                 mergeable,comments,reviews,statusCheckRollup,commits",
         ]);
     })?;
 
@@ -878,6 +921,26 @@ struct GhPullRequestView {
     reviews: Option<Vec<GhReview>>,
     #[serde(rename = "statusCheckRollup")]
     status_check_rollup: Option<Vec<GhCheck>>,
+    commits: Option<Vec<GhCommit>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhCommit {
+    oid: Option<String>,
+    #[serde(rename = "messageHeadline")]
+    message_headline: Option<String>,
+    #[serde(rename = "messageBody")]
+    message_body: Option<String>,
+    #[serde(rename = "committedDate")]
+    committed_date: Option<String>,
+    authors: Option<Vec<GhCommitAuthor>>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GhCommitAuthor {
+    name: Option<String>,
+    email: Option<String>,
+    login: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/components/PullRequestDetailModal.modal.test.tsx
+++ b/src/components/PullRequestDetailModal.modal.test.tsx
@@ -54,6 +54,7 @@ function fakeDetail(body: string): PullRequestDetail {
     comments: [],
     reviews: [],
     checks: [],
+    commits: [],
     diff: { files: [] },
   };
 }

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -23,6 +23,7 @@ import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import type {
+  DiffPayload,
   PullRequestCheck,
   PullRequestComment,
   PullRequestCommit,
@@ -224,6 +225,7 @@ export function PullRequestDetailModal({
             bodySaveError={bodySaveError}
             tab={tab}
             onTab={setTab}
+            repoPath={open.repoPath}
             cwd={cwd}
             onClose={onClose}
             onRefresh={handleRefresh}
@@ -286,6 +288,7 @@ function DetailBody({
   bodySaveError,
   tab,
   onTab,
+  repoPath,
   cwd,
   onClose,
   onRefresh,
@@ -300,6 +303,7 @@ function DetailBody({
   bodySaveError: string | null;
   tab: DetailTab;
   onTab: (t: DetailTab) => void;
+  repoPath: string;
   cwd?: string;
   onClose: () => void;
   onRefresh: () => void;
@@ -461,7 +465,12 @@ function DetailBody({
             reviews={detail.reviews}
           />
         ) : tab === "commits" ? (
-          <CommitsPane commits={detail.commits} prUrl={detail.url} />
+          <CommitsPane
+            commits={detail.commits}
+            prUrl={detail.url}
+            repoPath={repoPath}
+            cwd={cwd}
+          />
         ) : tab === "checks" ? (
           <ChecksPane checks={detail.checks} />
         ) : (
@@ -1080,10 +1089,32 @@ function ReviewStateBadge({ state }: { state: string }) {
 function CommitsPane({
   commits,
   prUrl,
+  repoPath,
+  cwd,
 }: {
   commits: PullRequestCommit[];
   prUrl: string;
+  repoPath: string;
+  cwd?: string;
 }) {
+  const [selectedOid, setSelectedOid] = useState<string | null>(
+    commits[0]?.oid ?? null,
+  );
+
+  // Re-select first commit whenever the list identity changes (PR switch /
+  // refresh adds new commits). Compare by joined oid list to avoid resetting
+  // on every render.
+  const oidsKey = useMemo(() => commits.map((c) => c.oid).join(","), [commits]);
+  useEffect(() => {
+    if (commits.length === 0) {
+      setSelectedOid(null);
+      return;
+    }
+    setSelectedOid((cur) =>
+      cur && commits.some((c) => c.oid === cur) ? cur : commits[0].oid,
+    );
+  }, [oidsKey, commits]);
+
   if (commits.length === 0) {
     return (
       <div className="flex h-full items-center justify-center text-xs text-fg-muted">
@@ -1091,96 +1122,222 @@ function CommitsPane({
       </div>
     );
   }
+
+  const selected = commits.find((c) => c.oid === selectedOid) ?? null;
+
   return (
-    <ul className="flex h-full flex-col overflow-y-auto text-xs">
-      {commits.map((c) => (
-        <CommitRow key={c.oid} commit={c} prUrl={prUrl} />
-      ))}
-    </ul>
+    <div className="flex h-full min-h-0">
+      <aside className="flex w-72 shrink-0 flex-col overflow-y-auto border-r border-border text-xs">
+        <ul className="flex flex-col">
+          {commits.map((c) => (
+            <CommitListItem
+              key={c.oid}
+              commit={c}
+              selected={c.oid === selectedOid}
+              onSelect={() => setSelectedOid(c.oid)}
+            />
+          ))}
+        </ul>
+      </aside>
+      <div className="flex min-w-0 flex-1 flex-col">
+        {selected ? (
+          <CommitDetailView
+            commit={selected}
+            prUrl={prUrl}
+            repoPath={repoPath}
+            cwd={cwd}
+          />
+        ) : null}
+      </div>
+    </div>
   );
 }
 
-function CommitRow({
+function CommitListItem({
+  commit,
+  selected,
+  onSelect,
+}: {
+  commit: PullRequestCommit;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const primaryAuthor = commit.authors[0];
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onSelect}
+        className={cn(
+          "block w-full border-b border-border/40 px-3 py-2 text-left transition",
+          selected
+            ? "bg-accent/15 text-fg"
+            : "text-fg-muted hover:bg-bg-elevated hover:text-fg",
+        )}
+      >
+        <div className="truncate text-[12px] font-medium text-fg" title={commit.message_headline}>
+          {commit.message_headline || "(no message)"}
+        </div>
+        <div className="mt-1 flex items-center gap-1.5 text-[10.5px] text-fg-muted">
+          {primaryAuthor ? (
+            <AuthorTag
+              login={primaryAuthor.login ?? primaryAuthor.name ?? "unknown"}
+              size={14}
+              nameClass="text-[10.5px] text-fg-muted"
+            />
+          ) : null}
+          <span className="opacity-50">·</span>
+          <span className="font-mono opacity-70">
+            {formatRelativeTime(commit.committed_date)}
+          </span>
+        </div>
+      </button>
+    </li>
+  );
+}
+
+function CommitDetailView({
   commit,
   prUrl,
+  repoPath,
+  cwd,
 }: {
   commit: PullRequestCommit;
   prUrl: string;
+  repoPath: string;
+  cwd?: string;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [diff, setDiff] = useState<DiffPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
   const shortOid = commit.oid.slice(0, 7);
-  const hasBody = commit.message_body.trim().length > 0;
   const commitUrl = buildCommitUrl(prUrl, commit.oid);
+  const hasBody = commit.message_body.trim().length > 0;
   const primaryAuthor = commit.authors[0];
 
+  useEffect(() => {
+    let cancelled = false;
+    setDiff(null);
+    setError(null);
+    setLoading(true);
+    api
+      .getPullRequestCommitDiff(repoPath, commit.oid)
+      .then((payload) => {
+        if (cancelled) return;
+        setDiff(payload);
+        setLoading(false);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(String(e));
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repoPath, commit.oid]);
+
   return (
-    <li className="border-b border-border/40">
-      <div className="flex items-start gap-2 px-3 py-2">
-        <GitCommit size={13} className="mt-[3px] shrink-0 text-fg-muted" />
-        <div className="min-w-0 flex-1">
-          <button
-            type="button"
-            onClick={() => hasBody && setExpanded((v) => !v)}
-            disabled={!hasBody}
-            className={cn(
-              "block w-full truncate text-left text-fg",
-              hasBody
-                ? "cursor-pointer hover:text-accent"
-                : "cursor-default",
-            )}
-            title={commit.message_headline}
-          >
-            {commit.message_headline || "(no message)"}
-          </button>
-          <div className="mt-1 flex items-center gap-1.5 text-[10.5px] text-fg-muted">
-            {primaryAuthor ? (
-              <AuthorTag
-                login={primaryAuthor.login ?? primaryAuthor.name ?? "unknown"}
-                size={16}
-                nameClass="text-[10.5px] text-fg-muted"
-              />
-            ) : null}
-            {commit.authors.length > 1 ? (
-              <span className="opacity-70">
-                +{commit.authors.length - 1}
+    <>
+      <header className="shrink-0 border-b border-border bg-bg-sidebar/40 px-4 py-2.5">
+        <div className="flex items-start gap-2">
+          <GitCommit size={14} className="mt-[3px] shrink-0 text-fg-muted" />
+          <div className="min-w-0 flex-1">
+            <div
+              className="truncate text-[13px] font-semibold tracking-tight text-fg"
+              title={commit.message_headline}
+            >
+              {commit.message_headline || "(no message)"}
+            </div>
+            <div className="mt-1 flex items-center gap-1.5 text-[11px] text-fg-muted">
+              {primaryAuthor ? (
+                <AuthorTag
+                  login={primaryAuthor.login ?? primaryAuthor.name ?? "unknown"}
+                  size={16}
+                  nameClass="text-[11px] text-fg-muted"
+                />
+              ) : null}
+              {commit.authors.length > 1 ? (
+                <span className="opacity-70">
+                  +{commit.authors.length - 1}
+                </span>
+              ) : null}
+              <span className="opacity-50">·</span>
+              <span className="font-mono opacity-70">
+                {formatTimestamp(commit.committed_date)}
               </span>
-            ) : null}
-            <span className="opacity-50">·</span>
-            <span className="font-mono opacity-70">
-              {formatTimestamp(commit.committed_date)}
-            </span>
+            </div>
           </div>
-          {expanded && hasBody ? (
-            <pre className="acorn-selectable mt-2 max-h-64 overflow-y-auto whitespace-pre-wrap rounded border border-border bg-bg-sidebar/40 px-2 py-1.5 font-mono text-[11px] text-fg">
-              {commit.message_body}
-            </pre>
-          ) : null}
-        </div>
-        <Tooltip label="Copy SHA" side="top">
-          <button
-            type="button"
-            onClick={() => {
-              void navigator.clipboard.writeText(commit.oid);
-            }}
-            className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-          >
-            {shortOid}
-          </button>
-        </Tooltip>
-        {commitUrl ? (
-          <Tooltip label="Open commit on GitHub" side="top">
+          <Tooltip label="Copy SHA" side="bottom">
             <button
               type="button"
-              onClick={() => void openUrl(commitUrl)}
-              className="shrink-0 rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+              onClick={() => {
+                void navigator.clipboard.writeText(commit.oid);
+              }}
+              className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
             >
-              <ExternalLink size={11} />
+              {shortOid}
             </button>
           </Tooltip>
+          {commitUrl ? (
+            <Tooltip label="Open commit on GitHub" side="bottom">
+              <button
+                type="button"
+                onClick={() => void openUrl(commitUrl)}
+                className="shrink-0 rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+              >
+                <ExternalLink size={12} />
+              </button>
+            </Tooltip>
+          ) : null}
+        </div>
+        {hasBody ? (
+          <pre className="acorn-selectable mt-2 max-h-32 overflow-y-auto whitespace-pre-wrap rounded border border-border bg-bg/50 px-2 py-1.5 font-mono text-[11px] text-fg">
+            {commit.message_body}
+          </pre>
         ) : null}
+      </header>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {error ? (
+          <div className="flex h-full items-center justify-center px-4 text-center text-xs text-danger">
+            {error}
+          </div>
+        ) : loading || !diff ? (
+          <div className="flex h-full items-center justify-center text-xs text-fg-muted">
+            Loading diff…
+          </div>
+        ) : diff.files.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-xs text-fg-muted">
+            No file changes in this commit.
+          </div>
+        ) : (
+          <DiffSplitView payload={diff} cwd={cwd} />
+        )}
       </div>
-    </li>
+    </>
   );
+}
+
+/**
+ * Compact "23h" / "2d" / "May 4" — keeps the commit list narrow. Falls back
+ * to the raw string when parsing fails.
+ */
+function formatRelativeTime(iso: string): string {
+  if (!iso) return "—";
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return iso;
+  const diff = Date.now() - ms;
+  const min = Math.floor(diff / 60_000);
+  if (min < 1) return "now";
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d`;
+  return new Date(ms).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
 }
 
 /**

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -19,9 +19,11 @@ import {
   XCircle,
 } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { Panel, PanelGroup } from "react-resizable-panels";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
+import { ResizeHandle } from "./ResizeHandle";
 import type {
   DiffPayload,
   PullRequestCheck,
@@ -1126,30 +1128,39 @@ function CommitsPane({
   const selected = commits.find((c) => c.oid === selectedOid) ?? null;
 
   return (
-    <div className="flex h-full min-h-0">
-      <aside className="flex w-72 shrink-0 flex-col overflow-y-auto border-r border-border text-xs">
-        <ul className="flex flex-col">
-          {commits.map((c) => (
-            <CommitListItem
-              key={c.oid}
-              commit={c}
-              selected={c.oid === selectedOid}
-              onSelect={() => setSelectedOid(c.oid)}
+    <PanelGroup
+      direction="horizontal"
+      autoSaveId="acorn:pr-commits-split"
+      className="h-full min-h-0"
+    >
+      <Panel id="list" order={1} defaultSize={28} minSize={18} maxSize={50}>
+        <aside className="flex h-full flex-col overflow-y-auto border-r border-border text-xs">
+          <ul className="flex flex-col">
+            {commits.map((c) => (
+              <CommitListItem
+                key={c.oid}
+                commit={c}
+                selected={c.oid === selectedOid}
+                onSelect={() => setSelectedOid(c.oid)}
+              />
+            ))}
+          </ul>
+        </aside>
+      </Panel>
+      <ResizeHandle />
+      <Panel id="detail" order={2} defaultSize={72} minSize={40}>
+        <div className="flex h-full min-w-0 flex-col">
+          {selected ? (
+            <CommitDetailView
+              commit={selected}
+              prUrl={prUrl}
+              repoPath={repoPath}
+              cwd={cwd}
             />
-          ))}
-        </ul>
-      </aside>
-      <div className="flex min-w-0 flex-1 flex-col">
-        {selected ? (
-          <CommitDetailView
-            commit={selected}
-            prUrl={prUrl}
-            repoPath={repoPath}
-            cwd={cwd}
-          />
-        ) : null}
-      </div>
-    </div>
+          ) : null}
+        </div>
+      </Panel>
+    </PanelGroup>
   );
 }
 
@@ -1237,81 +1248,102 @@ function CommitDetailView({
     };
   }, [repoPath, commit.oid]);
 
+  const diffSection = (
+    <div className="h-full min-h-0 overflow-hidden">
+      {error ? (
+        <div className="flex h-full items-center justify-center px-4 text-center text-xs text-danger">
+          {error}
+        </div>
+      ) : loading || !diff ? (
+        <div className="flex h-full items-center justify-center text-xs text-fg-muted">
+          Loading diff…
+        </div>
+      ) : diff.files.length === 0 ? (
+        <div className="flex h-full items-center justify-center text-xs text-fg-muted">
+          No file changes in this commit.
+        </div>
+      ) : (
+        <DiffSplitView payload={diff} cwd={cwd} />
+      )}
+    </div>
+  );
+
+  const bodySection = (
+    <pre className="acorn-selectable h-full overflow-y-auto whitespace-pre-wrap bg-bg-sidebar/40 px-4 py-2 font-mono text-[11px] text-fg">
+      {commit.message_body}
+    </pre>
+  );
+
   return (
     <>
-      <header className="shrink-0 border-b border-border bg-bg-sidebar/40 px-4 py-2.5">
-        <div className="flex items-start gap-2">
-          <GitCommit size={14} className="mt-[3px] shrink-0 text-fg-muted" />
-          <div className="min-w-0 flex-1">
-            <div
-              className="truncate text-[13px] font-semibold tracking-tight text-fg"
-              title={commit.message_headline}
-            >
-              {commit.message_headline || "(no message)"}
-            </div>
-            <div className="mt-1 flex items-center gap-1.5 text-[11px] text-fg-muted">
-              {primaryAuthor ? (
-                <AuthorTag
-                  login={primaryAuthor.login ?? primaryAuthor.name ?? "unknown"}
-                  size={16}
-                  nameClass="text-[11px] text-fg-muted"
-                />
-              ) : null}
-              {commit.authors.length > 1 ? (
-                <span className="opacity-70">
-                  +{commit.authors.length - 1}
-                </span>
-              ) : null}
-              <span className="opacity-50">·</span>
-              <span className="font-mono opacity-70">
-                {formatTimestamp(commit.committed_date)}
-              </span>
-            </div>
+      <header className="flex shrink-0 items-start gap-2 border-b border-border bg-bg-sidebar/40 px-4 py-2.5">
+        <GitCommit size={14} className="mt-[3px] shrink-0 text-fg-muted" />
+        <div className="min-w-0 flex-1">
+          <div
+            className="truncate text-[13px] font-semibold tracking-tight text-fg"
+            title={commit.message_headline}
+          >
+            {commit.message_headline || "(no message)"}
           </div>
-          <Tooltip label="Copy SHA" side="bottom">
+          <div className="mt-1 flex items-center gap-1.5 text-[11px] text-fg-muted">
+            {primaryAuthor ? (
+              <AuthorTag
+                login={primaryAuthor.login ?? primaryAuthor.name ?? "unknown"}
+                size={16}
+                nameClass="text-[11px] text-fg-muted"
+              />
+            ) : null}
+            {commit.authors.length > 1 ? (
+              <span className="opacity-70">
+                +{commit.authors.length - 1}
+              </span>
+            ) : null}
+            <span className="opacity-50">·</span>
+            <span className="font-mono opacity-70">
+              {formatTimestamp(commit.committed_date)}
+            </span>
+          </div>
+        </div>
+        <Tooltip label="Copy SHA" side="bottom">
+          <button
+            type="button"
+            onClick={() => {
+              void navigator.clipboard.writeText(commit.oid);
+            }}
+            className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          >
+            {shortOid}
+          </button>
+        </Tooltip>
+        {commitUrl ? (
+          <Tooltip label="Open commit on GitHub" side="bottom">
             <button
               type="button"
-              onClick={() => {
-                void navigator.clipboard.writeText(commit.oid);
-              }}
-              className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+              onClick={() => void openUrl(commitUrl)}
+              className="shrink-0 rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
             >
-              {shortOid}
+              <ExternalLink size={12} />
             </button>
           </Tooltip>
-          {commitUrl ? (
-            <Tooltip label="Open commit on GitHub" side="bottom">
-              <button
-                type="button"
-                onClick={() => void openUrl(commitUrl)}
-                className="shrink-0 rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-              >
-                <ExternalLink size={12} />
-              </button>
-            </Tooltip>
-          ) : null}
-        </div>
-        {hasBody ? (
-          <pre className="acorn-selectable mt-2 max-h-32 overflow-y-auto whitespace-pre-wrap rounded border border-border bg-bg/50 px-2 py-1.5 font-mono text-[11px] text-fg">
-            {commit.message_body}
-          </pre>
         ) : null}
       </header>
       <div className="min-h-0 flex-1 overflow-hidden">
-        {error ? (
-          <div className="flex h-full items-center justify-center px-4 text-center text-xs text-danger">
-            {error}
-          </div>
-        ) : loading || !diff ? (
-          <div className="flex h-full items-center justify-center text-xs text-fg-muted">
-            Loading diff…
-          </div>
-        ) : diff.files.length === 0 ? (
-          <div className="flex h-full items-center justify-center text-xs text-fg-muted">
-            No file changes in this commit.
-          </div>
+        {hasBody ? (
+          <PanelGroup
+            direction="vertical"
+            autoSaveId="acorn:pr-commit-body-diff"
+            className="h-full"
+          >
+            <Panel id="body" order={1} defaultSize={20} minSize={8} maxSize={70}>
+              {bodySection}
+            </Panel>
+            <ResizeHandle direction="vertical" />
+            <Panel id="diff" order={2} defaultSize={80} minSize={20}>
+              {diffSection}
+            </Panel>
+          </PanelGroup>
         ) : (
-          <DiffSplitView payload={diff} cwd={cwd} />
+          diffSection
         )}
       </div>
     </>

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -7,6 +7,7 @@ import {
   Circle,
   Clock,
   ExternalLink,
+  GitCommit,
   GitMerge,
   GitPullRequest,
   GitPullRequestClosed,
@@ -24,6 +25,7 @@ import { useDialogShortcuts } from "../lib/dialog";
 import type {
   PullRequestCheck,
   PullRequestComment,
+  PullRequestCommit,
   PullRequestDetail,
   PullRequestDetailListing,
   PullRequestReview,
@@ -36,7 +38,7 @@ import { MergePullRequestDialog } from "./MergePullRequestDialog";
 import { Tooltip } from "./Tooltip";
 import { Markdown, Modal, ModalHeader, RefreshButton } from "./ui";
 
-type DetailTab = "conversation" | "checks" | "files";
+type DetailTab = "conversation" | "commits" | "checks" | "files";
 
 interface PullRequestDetailModalProps {
   /**
@@ -320,6 +322,7 @@ function DetailBody({
     effectiveChecks > 0 && !allChecksPassed && !allChecksFailed;
   const totalChecks = effectiveChecks;
   const fileCount = detail.diff.files.length;
+  const commitCount = detail.commits.length;
 
   return (
     <>
@@ -414,6 +417,13 @@ function DetailBody({
           onClick={() => onTab("conversation")}
         />
         <DetailTabButton
+          icon={<GitCommit size={13} />}
+          label="Commits"
+          badge={commitCount > 0 ? commitCount : null}
+          active={tab === "commits"}
+          onClick={() => onTab("commits")}
+        />
+        <DetailTabButton
           icon={<CheckCircle2 size={13} />}
           label="Checks"
           badge={
@@ -450,6 +460,8 @@ function DetailBody({
             comments={detail.comments}
             reviews={detail.reviews}
           />
+        ) : tab === "commits" ? (
+          <CommitsPane commits={detail.commits} prUrl={detail.url} />
         ) : tab === "checks" ? (
           <ChecksPane checks={detail.checks} />
         ) : (
@@ -533,6 +545,7 @@ function DetailSkeleton({
       <nav className="flex shrink-0 border-b border-border">
         {[
           { icon: <MessagesSquare size={13} />, w: "w-20" },
+          { icon: <GitCommit size={13} />, w: "w-14" },
           { icon: <CheckCircle2 size={13} />, w: "w-12" },
           { icon: <GitPullRequest size={13} />, w: "w-10" },
         ].map((tab, i) => (
@@ -1062,6 +1075,125 @@ function ReviewStateBadge({ state }: { state: string }) {
       {label}
     </span>
   );
+}
+
+function CommitsPane({
+  commits,
+  prUrl,
+}: {
+  commits: PullRequestCommit[];
+  prUrl: string;
+}) {
+  if (commits.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-fg-muted">
+        No commits in this pull request.
+      </div>
+    );
+  }
+  return (
+    <ul className="flex h-full flex-col overflow-y-auto text-xs">
+      {commits.map((c) => (
+        <CommitRow key={c.oid} commit={c} prUrl={prUrl} />
+      ))}
+    </ul>
+  );
+}
+
+function CommitRow({
+  commit,
+  prUrl,
+}: {
+  commit: PullRequestCommit;
+  prUrl: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const shortOid = commit.oid.slice(0, 7);
+  const hasBody = commit.message_body.trim().length > 0;
+  const commitUrl = buildCommitUrl(prUrl, commit.oid);
+  const primaryAuthor = commit.authors[0];
+
+  return (
+    <li className="border-b border-border/40">
+      <div className="flex items-start gap-2 px-3 py-2">
+        <GitCommit size={13} className="mt-[3px] shrink-0 text-fg-muted" />
+        <div className="min-w-0 flex-1">
+          <button
+            type="button"
+            onClick={() => hasBody && setExpanded((v) => !v)}
+            disabled={!hasBody}
+            className={cn(
+              "block w-full truncate text-left text-fg",
+              hasBody
+                ? "cursor-pointer hover:text-accent"
+                : "cursor-default",
+            )}
+            title={commit.message_headline}
+          >
+            {commit.message_headline || "(no message)"}
+          </button>
+          <div className="mt-1 flex items-center gap-1.5 text-[10.5px] text-fg-muted">
+            {primaryAuthor ? (
+              <AuthorTag
+                login={primaryAuthor.login ?? primaryAuthor.name ?? "unknown"}
+                size={16}
+                nameClass="text-[10.5px] text-fg-muted"
+              />
+            ) : null}
+            {commit.authors.length > 1 ? (
+              <span className="opacity-70">
+                +{commit.authors.length - 1}
+              </span>
+            ) : null}
+            <span className="opacity-50">·</span>
+            <span className="font-mono opacity-70">
+              {formatTimestamp(commit.committed_date)}
+            </span>
+          </div>
+          {expanded && hasBody ? (
+            <pre className="acorn-selectable mt-2 max-h-64 overflow-y-auto whitespace-pre-wrap rounded border border-border bg-bg-sidebar/40 px-2 py-1.5 font-mono text-[11px] text-fg">
+              {commit.message_body}
+            </pre>
+          ) : null}
+        </div>
+        <Tooltip label="Copy SHA" side="top">
+          <button
+            type="button"
+            onClick={() => {
+              void navigator.clipboard.writeText(commit.oid);
+            }}
+            className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          >
+            {shortOid}
+          </button>
+        </Tooltip>
+        {commitUrl ? (
+          <Tooltip label="Open commit on GitHub" side="top">
+            <button
+              type="button"
+              onClick={() => void openUrl(commitUrl)}
+              className="shrink-0 rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+            >
+              <ExternalLink size={11} />
+            </button>
+          </Tooltip>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+/**
+ * `detail.url` is the PR URL (`.../pull/N`). Rewrite to the standalone
+ * commit page (`.../commit/{sha}`); returns null when the PR URL is empty
+ * or unrecognized so the link button can be skipped instead of opening a
+ * broken target.
+ */
+function buildCommitUrl(prUrl: string, oid: string): string | null {
+  if (!prUrl || !oid) return null;
+  const m = prUrl.match(/^(.*)\/pull\/\d+(?:\/.*)?$/);
+  if (!m) return null;
+  return `${m[1]}/commit/${oid}`;
 }
 
 function ChecksPane({ checks }: { checks: PullRequestCheck[] }) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -114,6 +114,15 @@ export const api = {
       number,
     });
   },
+  getPullRequestCommitDiff(
+    repoPath: string,
+    sha: string,
+  ): Promise<DiffPayload> {
+    return invoke<DiffPayload>("get_pull_request_commit_diff", {
+      repoPath,
+      sha,
+    });
+  },
   mergePullRequest(
     repoPath: string,
     number: number,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -144,6 +144,22 @@ export interface PullRequestReview {
   submitted_at: string;
 }
 
+export interface PullRequestCommitAuthor {
+  name: string;
+  email: string;
+  /** GitHub login when resolvable, otherwise null. */
+  login: string | null;
+}
+
+export interface PullRequestCommit {
+  /** Full SHA — UI shortens for display but full id is needed for the GitHub link. */
+  oid: string;
+  message_headline: string;
+  message_body: string;
+  committed_date: string;
+  authors: PullRequestCommitAuthor[];
+}
+
 export interface PullRequestCheck {
   name: string;
   /** QUEUED | IN_PROGRESS | COMPLETED | PENDING */
@@ -177,6 +193,7 @@ export interface PullRequestDetail {
   comments: PullRequestComment[];
   reviews: PullRequestReview[];
   checks: PullRequestCheck[];
+  commits: PullRequestCommit[];
   diff: DiffPayload;
 }
 


### PR DESCRIPTION
## Summary

- PR detail modal `Commits` tab — GitHub Desktop style split: left commit list, right commit detail.
- Detail pane: header metadata + resizable commit message body and per-commit diff viewer.
- Per-commit diff fetched lazily via new `get_pull_request_commit_diff` Tauri command (`gh api ... -H "Accept: application/vnd.github.diff"`), reuses `parse_unified_diff` + `DiffSplitView`.
- Layout uses `react-resizable-panels` (`acorn:pr-commits-split`, `acorn:pr-commit-body-diff`) so sizes persist.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [x] `cargo check`
- [ ] Open PR modal → `Commits` tab → select commits → drag splitters → verify diff loads
