### PR TITLE
feat(settings): toggle session count and status in status bar

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -615,6 +615,18 @@ function AppearanceSettings() {
       >
         <div className="flex flex-col gap-1">
           <CheckboxRow
+            label="Session count"
+            description="Total number of sessions across the active project (`sessions: N`)."
+            checked={settings.statusBar.showSessionCount}
+            onChange={(v) => patchStatusBar({ showSessionCount: v })}
+          />
+          <CheckboxRow
+            label="Active session status"
+            description="Lifecycle state of the active session (Idle / Running / Needs input / Failed / Completed)."
+            checked={settings.statusBar.showSessionStatus}
+            onChange={(v) => patchStatusBar({ showSessionStatus: v })}
+          />
+          <CheckboxRow
             label="GitHub account"
             description="The `gh` account used to list pull requests for the active repo."
             checked={settings.statusBar.showGithubAccount}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -106,6 +106,12 @@ export function StatusBar() {
   const { sessions, activeSessionId, activeProject, error, loading } =
     useAppStore();
   const prAccountByRepo = useAppStore((s) => s.prAccountByRepo);
+  const showSessionCount = useSettings(
+    (s) => s.settings.statusBar.showSessionCount,
+  );
+  const showSessionStatus = useSettings(
+    (s) => s.settings.statusBar.showSessionStatus,
+  );
   const showGithubAccount = useSettings(
     (s) => s.settings.statusBar.showGithubAccount,
   );
@@ -130,10 +136,14 @@ export function StatusBar() {
             control-session socket or a stopped daemon without leaving
             the main view. */}
         <ServicesStatusButton />
-        <span>sessions: {sessions.length}</span>
-        {active ? (
+        {showSessionCount ? (
+          <span>sessions: {sessions.length}</span>
+        ) : null}
+        {showSessionStatus && active ? (
           <>
-            <span className="text-fg-muted/50">|</span>
+            {showSessionCount ? (
+              <span className="text-fg-muted/50">|</span>
+            ) : null}
             <span>status: {active.status}</span>
           </>
         ) : null}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -205,6 +205,8 @@ export interface AcornSettings {
    * actually reduces the work acorn does — not just hides the readout.
    */
   statusBar: {
+    showSessionCount: boolean;
+    showSessionStatus: boolean;
     showGithubAccount: boolean;
     showMemory: boolean;
   };
@@ -288,6 +290,8 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     },
   },
   statusBar: {
+    showSessionCount: true,
+    showSessionStatus: true,
     showGithubAccount: true,
     showMemory: true,
   },


### PR DESCRIPTION
## Summary

Settings > Appearance > Status bar 섹션에 하단 상태바의 `sessions: N` 카운트와 `status: <state>` 표시 토글을 추가. 기본값은 둘 다 켜짐(기존 동작 유지).

- `statusBar.showSessionCount` — 좌측 `sessions: N` 표시 여부
- `statusBar.showSessionStatus` — 활성 세션의 `status: …` 표시 여부
- 두 항목이 동시에 꺼지거나 한 쪽만 꺼지면 사이 구분자 `|` 도 사라짐

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (121 passed)
- [x] CI: Frontend pass / E2E pass
