### PR TITLE
feat(prs): render commit message body and image previews in PR diffs

### DIFF
--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -395,7 +395,7 @@ fn is_image_path(path: &str) -> bool {
     )
 }
 
-fn image_mime(path: &str) -> &'static str {
+pub(crate) fn image_mime(path: &str) -> &'static str {
     let ext = std::path::Path::new(path)
         .extension()
         .and_then(|s| s.to_str())
@@ -414,7 +414,7 @@ fn image_mime(path: &str) -> &'static str {
     }
 }
 
-fn encode_data_uri(bytes: &[u8], path: &str) -> String {
+pub(crate) fn encode_data_uri(bytes: &[u8], path: &str) -> String {
     use base64::Engine as _;
     format!(
         "data:{};base64,{}",

--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -12,6 +12,10 @@ pub struct CommitInfo {
     pub author: String,
     pub timestamp: i64,
     pub summary: String,
+    /// Commit message body — everything after the first-line headline. Empty
+    /// when the commit has no body. Surfaced so the RightPanel commits view
+    /// can render the description (with markdown / images) alongside the diff.
+    pub body: String,
     pub pushed: bool,
 }
 
@@ -189,6 +193,7 @@ pub fn list_commits(
             author: author.name().unwrap_or("?").to_string(),
             timestamp: commit.time().seconds(),
             summary: commit.summary().unwrap_or("").to_string(),
+            body: commit.body().unwrap_or("").to_string(),
             pushed: pushed_set.contains(&oid),
         });
     }

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -724,17 +724,51 @@ pub fn get_pull_request_detail(
     match try_with_account(repo_path, &slug, |token| {
         let view = run_pr_view(&slug, number, token)?;
         let diff_text = run_pr_diff(&slug, number, token)?;
-        Ok((view, diff_text))
+        let mut detail = build_detail(number, view, diff_text);
+        // The unified diff `gh pr diff` returns reduces binary changes to a
+        // "Binary files ... differ" line. Enrich image entries with actual
+        // bytes fetched from the head/base refs so the renderer can show
+        // before/after previews instead of that placeholder text.
+        let head = detail.head_branch.clone();
+        let base = detail.base_branch.clone();
+        enrich_image_previews_against_refs(&slug, &head, &base, token, &mut detail.diff);
+        Ok(detail)
     })? {
         AccountOutcome::Ok {
             account,
-            value: (view, diff_text),
-        } => {
-            let detail = build_detail(number, view, diff_text);
-            Ok(PullRequestDetailListing::Ok { account, detail })
-        }
+            value: detail,
+        } => Ok(PullRequestDetailListing::Ok { account, detail }),
         AccountOutcome::NoAccess { accounts } => {
             Ok(PullRequestDetailListing::NoAccess { slug, accounts })
+        }
+    }
+}
+
+/// Image enrichment variant used for the overall PR diff. Resolves the
+/// "new" side at the PR's head ref and the "old" side at the base ref.
+fn enrich_image_previews_against_refs(
+    slug: &str,
+    head_ref: &str,
+    base_ref: &str,
+    token: &str,
+    payload: &mut crate::git_ops::DiffPayload,
+) {
+    for file in &mut payload.files {
+        if !file.is_image {
+            continue;
+        }
+        if let Some(path) = file.new_path.clone() {
+            if let Ok(bytes) = fetch_raw_blob(slug, head_ref, &path, token) {
+                file.new_image = Some(crate::git_ops::encode_data_uri(&bytes, &path));
+            }
+        }
+        if let Some(path) = file.old_path.clone() {
+            if let Ok(bytes) = fetch_raw_blob(slug, base_ref, &path, token) {
+                file.old_image = Some(crate::git_ops::encode_data_uri(&bytes, &path));
+            }
+        }
+        if file.new_image.is_some() || file.old_image.is_some() {
+            file.patch.clear();
         }
     }
 }
@@ -875,12 +909,77 @@ pub fn get_pull_request_commit_diff(repo_path: &Path, sha: &str) -> AppResult<Di
             "origin remote is not a GitHub repository".into(),
         ));
     };
-    match try_with_account(repo_path, &slug, |token| run_commit_diff(&slug, sha, token))? {
-        AccountOutcome::Ok { value, .. } => Ok(crate::unified_diff::parse_unified_diff(&value)),
+    match try_with_account(repo_path, &slug, |token| {
+        let diff_text = run_commit_diff(&slug, sha, token)?;
+        let mut payload = crate::unified_diff::parse_unified_diff(&diff_text);
+        // GitHub's `application/vnd.github.diff` reduces binary changes to a
+        // single "Binary files ... differ" sentinel line. Re-fetch the actual
+        // image bytes via the contents API so the renderer can show before /
+        // after previews instead of leaking that sentinel into the patch body.
+        enrich_image_previews(&slug, sha, token, &mut payload);
+        Ok(payload)
+    })? {
+        AccountOutcome::Ok { value, .. } => Ok(value),
         AccountOutcome::NoAccess { .. } => Err(AppError::Other(format!(
             "no logged-in gh account can access {slug}"
         ))),
     }
+}
+
+/// For every image file in `payload`, fetch the actual blob bytes from
+/// GitHub at `sha` (new side) and `sha^` (old side) and encode them as
+/// `data:` URIs. Misses (deleted file → no `new_path`, parent fetch
+/// failures, files too large for the contents API, etc.) are tolerated:
+/// the renderer falls back to a "no preview available" placeholder.
+fn enrich_image_previews(
+    slug: &str,
+    sha: &str,
+    token: &str,
+    payload: &mut crate::git_ops::DiffPayload,
+) {
+    let parent = format!("{sha}^");
+    for file in &mut payload.files {
+        if !file.is_image {
+            continue;
+        }
+        if let Some(path) = file.new_path.clone() {
+            if let Ok(bytes) = fetch_raw_blob(slug, sha, &path, token) {
+                file.new_image = Some(crate::git_ops::encode_data_uri(&bytes, &path));
+            }
+        }
+        if let Some(path) = file.old_path.clone() {
+            if let Ok(bytes) = fetch_raw_blob(slug, &parent, &path, token) {
+                file.old_image = Some(crate::git_ops::encode_data_uri(&bytes, &path));
+            }
+        }
+        // Once a preview is attached the renderer no longer needs the
+        // "Binary files ... differ" placeholder lurking in the patch body.
+        if file.new_image.is_some() || file.old_image.is_some() {
+            file.patch.clear();
+        }
+    }
+}
+
+fn fetch_raw_blob(slug: &str, git_ref: &str, path: &str, token: &str) -> AppResult<Vec<u8>> {
+    let endpoint = format!("repos/{slug}/contents/{path}?ref={git_ref}");
+    let output = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token).env("GH_HOST", GH_HOST).args([
+            "api",
+            "-H",
+            "Accept: application/vnd.github.raw",
+            &endpoint,
+        ]);
+    })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("gh exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+    Ok(output.stdout)
 }
 
 fn run_commit_diff(slug: &str, sha: &str, token: &str) -> AppResult<String> {

--- a/src/components/DiffSplitView.tsx
+++ b/src/components/DiffSplitView.tsx
@@ -218,11 +218,81 @@ export function DiffSplitView({ payload, cwd }: DiffSplitViewProps) {
 function DiffSplitContent({ entry }: { entry: FileEntry }) {
   const path = entry.file.new_path ?? entry.file.old_path ?? entry.path;
   const highlighted = useHighlightedDiff(entry.lines, path);
+  if (entry.file.is_image) {
+    return <ImageDiffPane file={entry.file} />;
+  }
   return (
     <div className="acorn-selectable min-h-0 flex-1 select-text overflow-auto font-mono text-[11px] leading-5">
       {entry.lines.map((line, i) => (
         <DiffLine key={i} line={line} html={highlighted[i] ?? null} />
       ))}
+    </div>
+  );
+}
+
+function ImageDiffPane({ file }: { file: DiffFile }) {
+  const hasOld = !!file.old_image;
+  const hasNew = !!file.new_image;
+  if (!hasOld && !hasNew) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-xs text-fg-muted">
+        Binary image change (no preview available)
+      </div>
+    );
+  }
+  if (!hasOld) {
+    return (
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        <ImagePreview label="Added" src={file.new_image!} accent="add" />
+      </div>
+    );
+  }
+  if (!hasNew) {
+    return (
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        <ImagePreview label="Deleted" src={file.old_image!} accent="del" />
+      </div>
+    );
+  }
+  return (
+    <div className="grid min-h-0 flex-1 grid-cols-2 gap-3 overflow-auto p-4">
+      <ImagePreview label="Before" src={file.old_image!} accent="del" />
+      <ImagePreview label="After" src={file.new_image!} accent="add" />
+    </div>
+  );
+}
+
+function ImagePreview({
+  label,
+  src,
+  accent,
+}: {
+  label: string;
+  src: string;
+  accent: "add" | "del";
+}) {
+  const ringCls =
+    accent === "add"
+      ? "ring-1 ring-[oklch(35%_0.10_145_/_0.6)]"
+      : "ring-1 ring-[oklch(35%_0.16_25_/_0.6)]";
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-[10px] uppercase tracking-wide text-fg-muted">
+        {label}
+      </span>
+      <div
+        className={cn(
+          "flex max-h-[60vh] items-center justify-center overflow-hidden rounded bg-bg-elevated/40 p-2",
+          ringCls,
+        )}
+      >
+        <img
+          src={src}
+          alt={label}
+          loading="lazy"
+          className="max-h-full max-w-full object-contain"
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/DiffViewerModal.tsx
+++ b/src/components/DiffViewerModal.tsx
@@ -1,12 +1,20 @@
+import { Panel, PanelGroup } from "react-resizable-panels";
 import { DiffSplitView } from "./DiffSplitView";
+import { ResizeHandle } from "./ResizeHandle";
 import type { DiffPayload } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
-import { Modal, ModalHeader } from "./ui";
+import { Markdown, Modal, ModalHeader } from "./ui";
 
 interface DiffViewerModalProps {
   payload: DiffPayload | null;
   title: string;
   subtitle?: string;
+  /**
+   * Commit message body to show above the diff (renders markdown including
+   * inline images). Hidden entirely when empty / undefined — the diff then
+   * fills the whole viewer.
+   */
+  body?: string;
   /**
    * Working directory for resolving repo-relative diff paths to absolute paths
    * (used by the file context menu's "Open in editor" action). Typically the
@@ -20,6 +28,7 @@ export function DiffViewerModal({
   payload,
   title,
   subtitle,
+  body,
   cwd,
   onClose,
 }: DiffViewerModalProps) {
@@ -29,6 +38,8 @@ export function DiffViewerModal({
     onCancel: onClose,
     onConfirm: onClose,
   });
+
+  const hasBody = !!body && body.trim().length > 0;
 
   return (
     <Modal
@@ -41,7 +52,25 @@ export function DiffViewerModal({
         <>
           <ModalHeader title={title} subtitle={subtitle} onClose={onClose} />
           <div className="min-h-0 flex-1 overflow-hidden">
-            <DiffSplitView payload={payload} cwd={cwd} />
+            {hasBody ? (
+              <PanelGroup
+                direction="vertical"
+                autoSaveId="acorn:commit-viewer-body-diff"
+                className="h-full"
+              >
+                <Panel id="body" order={1} defaultSize={25} minSize={8} maxSize={70}>
+                  <div className="acorn-selectable h-full overflow-y-auto bg-bg-sidebar/40 px-4 py-2">
+                    <Markdown content={body!} />
+                  </div>
+                </Panel>
+                <ResizeHandle direction="vertical" />
+                <Panel id="diff" order={2} defaultSize={75} minSize={20}>
+                  <DiffSplitView payload={payload} cwd={cwd} />
+                </Panel>
+              </PanelGroup>
+            ) : (
+              <DiffSplitView payload={payload} cwd={cwd} />
+            )}
           </div>
         </>
       ) : null}

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -1269,9 +1269,9 @@ function CommitDetailView({
   );
 
   const bodySection = (
-    <pre className="acorn-selectable h-full overflow-y-auto whitespace-pre-wrap bg-bg-sidebar/40 px-4 py-2 font-mono text-[11px] text-fg">
-      {commit.message_body}
-    </pre>
+    <div className="acorn-selectable h-full overflow-y-auto bg-bg-sidebar/40 px-4 py-2">
+      <Markdown content={commit.message_body} />
+    </div>
   );
 
   return (

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -57,6 +57,11 @@ interface ExpandedDiff {
   payload: DiffPayload;
   title: string;
   subtitle?: string;
+  /**
+   * Commit message body to show above the diff. Populated when expanding a
+   * commit; omitted for staged-diff expansion (no commit context).
+   */
+  body?: string;
 }
 
 const COMMITS_PAGE_SIZE = 50;
@@ -189,6 +194,7 @@ export function RightPanel() {
         payload={expanded?.payload ?? null}
         title={expanded?.title ?? ""}
         subtitle={expanded?.subtitle}
+        body={expanded?.body}
         cwd={repoPath ?? undefined}
         onClose={() => setExpanded(null)}
       />
@@ -626,6 +632,7 @@ function CommitsTab({
         payload,
         title: c.summary,
         subtitle: `${c.short_sha} · ${c.author}`,
+        body: c.body,
       });
     } catch (e) {
       setError(String(e));
@@ -787,6 +794,7 @@ function CommitsTab({
                   payload: diff,
                   title: c?.summary ?? selected.slice(0, 12),
                   subtitle: `${c?.short_sha ?? selected.slice(0, 7)} · ${c?.author ?? ""}`,
+                  body: c?.body,
                 });
               }}
             />

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,7 @@ export interface CommitInfo {
   author: string;
   timestamp: number;
   summary: string;
+  body: string;
   pushed: boolean;
 }
 


### PR DESCRIPTION
## Summary

Three related gaps in the PR detail modal's diff rendering, plus a parity fix for the RightPanel commit viewer.

### Commit message body now renders as markdown

The PR detail modal's Commits tab rendered each commit's `message_body` as a raw `<pre>` block, so any markdown — lists, links, code blocks, and the inline `![](url)` images GitHub copies into squash-merge commit bodies — surfaced as the literal source text. `CommitDetailView` now reuses the existing `Markdown` component (same one the PR description / comments / reviews go through), so commit bodies render the same way everywhere.

### RightPanel commit viewer shows the message body

The RightPanel Commits tab opened the expanded diff viewer with title + diff only and dropped the commit's message body. `CommitInfo` gains a `body` field (populated from `git2`'s `commit.body()`); it flows through `ExpandedDiff` into `DiffViewerModal`, which now renders the body via `Markdown` in a resizable panel above the diff. Hidden entirely when empty so commits without a body keep the diff-only layout.

### Image previews in PR commit and overall PR diffs

`DiffSplitView` (used by the PR Files tab, the PR Commits-tab detail pane, and the RightPanel expanded viewer) had no image branch — image entries leaked the raw `Binary files /dev/null and b/path.png differ` sentinel into the diff line list. The underlying unified diff returned by `gh pr diff` / `gh api repos/{slug}/commits/{sha}` also stripped the image bytes, so the renderer had nothing to show even with an image branch.

- **Backend:** after parsing the unified diff for the overall PR diff (`gh pr diff`) and for a per-commit diff (`gh api repos/{slug}/commits/{sha}` with `Accept: application/vnd.github.diff`), fetch each image file's bytes through `gh api repos/{slug}/contents/{path}?ref=...` — head/base refs for the PR diff, sha and sha^ for the commit diff — and encode them as `data:` URIs. The image entries' patch text is cleared so the renderer doesn't fall back to the sentinel line. Helpers in `git_ops` (`image_mime`, `encode_data_uri`) are now `pub(crate)` so `pull_requests` can reuse them.
- **Frontend:** `DiffSplitView` now renders an Added / Deleted / Before-After image pane (matching the existing `DiffView` behavior) when an entry is flagged `is_image`. Falls back to a "no preview available" placeholder when the backend couldn't resolve the bytes (e.g. file too large for the contents API).

## Test plan

- [x] PR detail modal → Commits tab → pick a commit whose body has an image → image renders inline (and opens the lightbox on click)
- [x] PR detail modal → Commits tab → commit with image asset change → before/after panes appear in the commit diff
- [x] PR detail modal → Files tab → PR that adds/edits an image → before/after panes appear instead of "Binary files differ"
- [x] PR detail modal → Commits tab → commit with no body → body panel is hidden and the diff takes the full height
- [x] RightPanel → Commits tab → double-click a commit with a long message body → expanded viewer shows body (markdown / images rendered) above the diff in a resizable split
- [x] RightPanel → Commits tab → expand a commit with no body → modal falls back to diff-only
- [x] `bun run typecheck`
