### PR TITLE
feat(commits): show GitHub avatar + actions in commit rows and detail modal

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1224,6 +1224,14 @@ pub async fn get_pull_request_commit_diff(
 }
 
 #[tauri::command]
+pub async fn resolve_commit_logins(
+    repo_path: String,
+    shas: Vec<String>,
+) -> AppResult<std::collections::HashMap<String, Option<String>>> {
+    pull_requests::resolve_commit_logins(&PathBuf::from(repo_path), shas)
+}
+
+#[tauri::command]
 pub async fn merge_pull_request(
     repo_path: String,
     number: u64,

--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -10,6 +10,9 @@ pub struct CommitInfo {
     pub sha: String,
     pub short_sha: String,
     pub author: String,
+    /// Git author email. Surfaced so the UI can resolve a GitHub avatar
+    /// (e.g. parse the `users.noreply.github.com` pattern for a login).
+    pub author_email: String,
     pub timestamp: i64,
     pub summary: String,
     /// Commit message body — everything after the first-line headline. Empty
@@ -191,6 +194,7 @@ pub fn list_commits(
             sha: oid.to_string(),
             short_sha: oid.to_string().chars().take(7).collect(),
             author: author.name().unwrap_or("?").to_string(),
+            author_email: author.email().unwrap_or("").to_string(),
             timestamp: commit.time().seconds(),
             summary: commit.summary().unwrap_or("").to_string(),
             body: commit.body().unwrap_or("").to_string(),
@@ -451,3 +455,4 @@ fn image_data_uri_workdir(
     let bytes = std::fs::read(abs).ok()?;
     Some(encode_data_uri(&bytes, path))
 }
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -234,6 +234,7 @@ pub fn run() {
             commands::list_pull_requests,
             commands::get_pull_request_detail,
             commands::get_pull_request_commit_diff,
+            commands::resolve_commit_logins,
             commands::merge_pull_request,
             commands::close_pull_request,
             commands::update_pull_request_body,
@@ -271,3 +272,4 @@ pub fn run() {
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
+

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -926,6 +926,107 @@ pub fn get_pull_request_commit_diff(repo_path: &Path, sha: &str) -> AppResult<Di
     }
 }
 
+/// Map of git OID → GitHub login for commits in a repo. Resolves the
+/// missing chunk in one batched GraphQL call against `repository.object`
+/// nodes, then caches `(slug, sha) → Option<login>` so subsequent calls
+/// (re-paging, modal re-opens) are free.
+///
+/// `None` in the returned map means the commit exists on GitHub but its
+/// author email didn't resolve to a user account; missing keys mean we
+/// couldn't reach GitHub at all (no gh account with access, network
+/// failure, etc.) and the caller should not display an avatar.
+pub fn resolve_commit_logins(
+    repo_path: &Path,
+    shas: Vec<String>,
+) -> AppResult<HashMap<String, Option<String>>> {
+    let Some(slug) = github_owner_repo(repo_path)? else {
+        return Ok(HashMap::new());
+    };
+
+    let cache = commit_login_cache();
+    let mut result: HashMap<String, Option<String>> = HashMap::new();
+    let mut needed: Vec<String> = Vec::new();
+    {
+        let lock = cache
+            .lock()
+            .map_err(|_| AppError::Other("commit-login cache poisoned".into()))?;
+        for sha in &shas {
+            let key = (slug.clone(), sha.clone());
+            if let Some(login) = lock.get(&key) {
+                result.insert(sha.clone(), login.clone());
+            } else {
+                needed.push(sha.clone());
+            }
+        }
+    }
+    if needed.is_empty() {
+        return Ok(result);
+    }
+
+    let (owner, name) = slug
+        .split_once('/')
+        .ok_or_else(|| AppError::Other(format!("invalid slug: {slug}")))?;
+    let mut query = String::from("query{repository(owner:\"");
+    query.push_str(owner);
+    query.push_str("\",name:\"");
+    query.push_str(name);
+    query.push_str("\"){");
+    for (i, sha) in needed.iter().enumerate() {
+        query.push_str(&format!(
+            "c{i}:object(oid:\"{sha}\"){{...on Commit{{author{{user{{login}}}}}}}}",
+        ));
+    }
+    query.push_str("}}");
+
+    match try_with_account(repo_path, &slug, |token| {
+        let output = cli_resolver::run("gh", |cmd| {
+            cmd.env("GH_TOKEN", token)
+                .env("GH_HOST", GH_HOST)
+                .args(["api", "graphql", "-f", &format!("query={query}")]);
+        })?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(AppError::Other(if stderr.is_empty() {
+                format!("gh graphql exited with {}", output.status)
+            } else {
+                stderr
+            }));
+        }
+        let v: serde_json::Value = serde_json::from_slice(&output.stdout)
+            .map_err(|e| AppError::Other(format!("gh graphql parse: {e}")))?;
+        let mut out: HashMap<String, Option<String>> = HashMap::new();
+        if let Some(repo) = v.pointer("/data/repository").and_then(|x| x.as_object()) {
+            for (i, sha) in needed.iter().enumerate() {
+                let key = format!("c{i}");
+                let login = repo
+                    .get(&key)
+                    .and_then(|c| c.pointer("/author/user/login"))
+                    .and_then(|l| l.as_str())
+                    .map(|s| s.to_string());
+                out.insert(sha.clone(), login);
+            }
+        }
+        Ok(out)
+    })? {
+        AccountOutcome::Ok { value, .. } => {
+            if let Ok(mut lock) = cache.lock() {
+                for (sha, login) in value.iter() {
+                    lock.insert((slug.clone(), sha.clone()), login.clone());
+                }
+            }
+            result.extend(value);
+            Ok(result)
+        }
+        AccountOutcome::NoAccess { .. } => Ok(result),
+    }
+}
+
+fn commit_login_cache() -> &'static Mutex<HashMap<(String, String), Option<String>>> {
+    use std::sync::OnceLock;
+    static CELL: OnceLock<Mutex<HashMap<(String, String), Option<String>>>> = OnceLock::new();
+    CELL.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 /// For every image file in `payload`, fetch the actual blob bytes from
 /// GitHub at `sha` (new side) and `sha^` (old side) and encode them as
 /// `data:` URIs. Misses (deleted file → no `new_path`, parent fetch

--- a/src/components/AuthorAvatar.tsx
+++ b/src/components/AuthorAvatar.tsx
@@ -3,20 +3,22 @@ import { cn } from "../lib/cn";
 /**
  * Inline GitHub avatar. Uses the public `github.com/{login}.png` endpoint
  * so no API token is needed and `[bot]` accounts still resolve once the
- * suffix is stripped. Falls back invisibly via `alt=""` on load failure
- * so the surrounding list / timeline stays clean.
+ * suffix is stripped. Renders nothing when `login` is null, empty, or
+ * doesn't look like a GitHub handle (e.g. a git author name with spaces),
+ * so callers can pass nullable values without guarding.
  */
 export function AuthorAvatar({
   login,
   size = 24,
   className,
 }: {
-  login: string;
+  login: string | null | undefined;
   size?: number;
   className?: string;
 }) {
+  if (!login) return null;
   const slug = login.replace(/\[bot\]$/, "");
-  if (!slug) return null;
+  if (!/^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){0,38}$/i.test(slug)) return null;
   const pixelSize = Math.max(40, size * 2);
   return (
     <img

--- a/src/components/AuthorTag.tsx
+++ b/src/components/AuthorTag.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { ExternalLink } from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { AuthorAvatar } from "./AuthorAvatar";
+import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
+import { cn } from "../lib/cn";
+
+/**
+ * GitHub login regex. `[bot]` suffix is stripped before this check.
+ * Anything with whitespace, slashes, or other shell-y characters falls
+ * through — keeps us from sending `firstname lastname.png` to github.com
+ * when only a git author name (no resolved login) is available.
+ */
+function isLikelyLogin(value: string | null | undefined): value is string {
+  if (!value) return false;
+  const slug = value.replace(/\[bot\]$/, "");
+  return /^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){0,38}$/i.test(slug);
+}
+
+/**
+ * Extract a GitHub login from a git author email. GitHub's noreply
+ * addresses come in two flavors:
+ *   - `{id}+{login}@users.noreply.github.com` (current)
+ *   - `{login}@users.noreply.github.com` (legacy / pre-2017 opt-in)
+ * Returns null for any other domain — local git commits authored
+ * without a GitHub noreply address have no resolvable login.
+ */
+export function loginFromEmail(
+  email: string | null | undefined,
+): string | null {
+  if (!email) return null;
+  const m = email.match(
+    /^(?:\d+\+)?([a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){0,38})@users\.noreply\.github\.com$/i,
+  );
+  return m?.[1] ?? null;
+}
+
+/**
+ * Build a ContextMenuItem array for "Open GitHub profile". Empty when
+ * `login` doesn't look like a real handle, so callers can spread it into
+ * larger menus without checking first.
+ */
+export function buildProfileMenuItems(
+  login: string | null | undefined,
+): ContextMenuItem[] {
+  if (!isLikelyLogin(login)) return [];
+  const slug = login.replace(/\[bot\]$/, "");
+  return [
+    {
+      label: "Open GitHub profile",
+      icon: <ExternalLink size={12} />,
+      onClick: () => void openUrl(`https://github.com/${slug}`),
+    },
+  ];
+}
+
+/**
+ * Avatar + login pair with a right-click context menu offering "Open
+ * GitHub profile". When `login` isn't a resolvable GitHub handle, only
+ * `fallbackName` text renders (no avatar, no menu).
+ */
+export function AuthorTag({
+  login,
+  fallbackName,
+  size = 24,
+  nameClass,
+  avatarOnly = false,
+}: {
+  login: string | null | undefined;
+  /** Plain-text name shown when `login` isn't a resolvable GitHub handle. */
+  fallbackName?: string;
+  size?: number;
+  nameClass?: string;
+  /** When true, render only the avatar (no inline username text). */
+  avatarOnly?: boolean;
+}) {
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const hasLogin = isLikelyLogin(login);
+  const items = buildProfileMenuItems(login);
+
+  if (!hasLogin) {
+    if (!fallbackName) return null;
+    return (
+      <span className={cn("font-mono text-fg", nameClass)}>{fallbackName}</span>
+    );
+  }
+
+  return (
+    <>
+      <span
+        onContextMenu={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setMenu({ x: e.clientX, y: e.clientY });
+        }}
+        className="inline-flex shrink-0 items-center gap-1.5 align-middle"
+      >
+        <AuthorAvatar login={login} size={size} />
+        {avatarOnly ? null : (
+          <span className={cn("font-mono text-fg", nameClass)}>{login}</span>
+        )}
+      </span>
+      <ContextMenu
+        open={menu !== null}
+        x={menu?.x ?? 0}
+        y={menu?.y ?? 0}
+        items={items}
+        onClose={() => setMenu(null)}
+      />
+    </>
+  );
+}

--- a/src/components/DiffViewerModal.tsx
+++ b/src/components/DiffViewerModal.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from "react";
 import { Panel, PanelGroup } from "react-resizable-panels";
 import { DiffSplitView } from "./DiffSplitView";
 import { ResizeHandle } from "./ResizeHandle";
@@ -8,7 +9,9 @@ import { Markdown, Modal, ModalHeader } from "./ui";
 interface DiffViewerModalProps {
   payload: DiffPayload | null;
   title: string;
-  subtitle?: string;
+  subtitle?: ReactNode;
+  /** Right-side header actions (e.g. Copy SHA, Open on GitHub). */
+  headerActions?: ReactNode;
   /**
    * Commit message body to show above the diff (renders markdown including
    * inline images). Hidden entirely when empty / undefined — the diff then
@@ -28,6 +31,7 @@ export function DiffViewerModal({
   payload,
   title,
   subtitle,
+  headerActions,
   body,
   cwd,
   onClose,
@@ -50,7 +54,12 @@ export function DiffViewerModal({
     >
       {payload ? (
         <>
-          <ModalHeader title={title} subtitle={subtitle} onClose={onClose} />
+          <ModalHeader
+            title={title}
+            subtitle={subtitle}
+            actions={headerActions}
+            onClose={onClose}
+          />
           <div className="min-h-0 flex-1 overflow-hidden">
             {hasBody ? (
               <PanelGroup

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2,
   Circle,
   Clock,
+  Copy,
   ExternalLink,
   GitCommit,
   GitMerge,
@@ -33,7 +34,7 @@ import type {
   PullRequestDetailListing,
   PullRequestReview,
 } from "../lib/types";
-import { AuthorAvatar } from "./AuthorAvatar";
+import { AuthorTag, buildProfileMenuItems } from "./AuthorTag";
 import { ClosePullRequestDialog } from "./ClosePullRequestDialog";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { DiffSplitView } from "./DiffSplitView";
@@ -1006,65 +1007,6 @@ function ReviewBlock({ review }: { review: PullRequestReview }) {
   );
 }
 
-/**
- * Avatar + login pair with a right-click context menu offering "Open
- * GitHub profile". Used in the modal header and in each conversation
- * block. Strips the `[bot]` suffix when building the profile URL so it
- * resolves for bot accounts like `dependabot[bot]`.
- */
-function AuthorTag({
-  login,
-  size = 24,
-  nameClass,
-  avatarOnly = false,
-}: {
-  login: string;
-  size?: number;
-  nameClass?: string;
-  /** When true, render only the avatar (no inline username text). */
-  avatarOnly?: boolean;
-}) {
-  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
-  const slug = login.replace(/\[bot\]$/, "");
-  const profileUrl = slug ? `https://github.com/${slug}` : null;
-
-  const items: ContextMenuItem[] = profileUrl
-    ? [
-        {
-          label: "Open GitHub profile",
-          icon: <ExternalLink size={12} />,
-          onClick: () => void openUrl(profileUrl),
-        },
-      ]
-    : [];
-
-  return (
-    <>
-      <span
-        onContextMenu={(e) => {
-          if (!profileUrl) return;
-          e.preventDefault();
-          e.stopPropagation();
-          setMenu({ x: e.clientX, y: e.clientY });
-        }}
-        className="inline-flex shrink-0 items-center gap-1.5 align-middle"
-      >
-        <AuthorAvatar login={login} size={size} />
-        {avatarOnly ? null : (
-          <span className={cn("font-mono text-fg", nameClass)}>{login}</span>
-        )}
-      </span>
-      <ContextMenu
-        open={menu !== null}
-        x={menu?.x ?? 0}
-        y={menu?.y ?? 0}
-        items={items}
-        onClose={() => setMenu(null)}
-      />
-    </>
-  );
-}
-
 function ReviewStateBadge({ state }: { state: string }) {
   const upper = state.toUpperCase();
   const tone =
@@ -1140,6 +1082,7 @@ function CommitsPane({
               <CommitListItem
                 key={c.oid}
                 commit={c}
+                prUrl={prUrl}
                 selected={c.oid === selectedOid}
                 onSelect={() => setSelectedOid(c.oid)}
               />
@@ -1166,19 +1109,51 @@ function CommitsPane({
 
 function CommitListItem({
   commit,
+  prUrl,
   selected,
   onSelect,
 }: {
   commit: PullRequestCommit;
+  prUrl: string;
   selected: boolean;
   onSelect: () => void;
 }) {
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const primaryAuthor = commit.authors[0];
+  const commitUrl = buildCommitUrl(prUrl, commit.oid);
+  const profileItems = buildProfileMenuItems(primaryAuthor?.login);
+
+  const items: ContextMenuItem[] = [
+    ...(commitUrl
+      ? [
+          {
+            label: "View on GitHub",
+            icon: <ExternalLink size={12} />,
+            onClick: () => void openUrl(commitUrl),
+          },
+        ]
+      : []),
+    ...profileItems,
+    ...((commitUrl || profileItems.length > 0)
+      ? [{ type: "separator" as const }]
+      : []),
+    {
+      label: "Copy SHA",
+      icon: <Copy size={12} />,
+      onClick: () => void navigator.clipboard.writeText(commit.oid),
+    },
+  ];
+
   return (
     <li>
       <button
         type="button"
         onClick={onSelect}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setMenu({ x: e.clientX, y: e.clientY });
+        }}
         className={cn(
           "block w-full border-b border-border/40 px-3 py-2 text-left transition",
           selected
@@ -1192,7 +1167,8 @@ function CommitListItem({
         <div className="mt-1 flex items-center gap-1.5 text-[10.5px] text-fg-muted">
           {primaryAuthor ? (
             <AuthorTag
-              login={primaryAuthor.login ?? primaryAuthor.name ?? "unknown"}
+              login={primaryAuthor.login}
+              fallbackName={primaryAuthor.name || "unknown"}
               size={14}
               nameClass="text-[10.5px] text-fg-muted"
             />
@@ -1203,6 +1179,13 @@ function CommitListItem({
           </span>
         </div>
       </button>
+      <ContextMenu
+        open={menu !== null}
+        x={menu?.x ?? 0}
+        y={menu?.y ?? 0}
+        items={items}
+        onClose={() => setMenu(null)}
+      />
     </li>
   );
 }
@@ -1288,7 +1271,8 @@ function CommitDetailView({
           <div className="mt-1 flex items-center gap-1.5 text-[11px] text-fg-muted">
             {primaryAuthor ? (
               <AuthorTag
-                login={primaryAuthor.login ?? primaryAuthor.name ?? "unknown"}
+                login={primaryAuthor.login}
+                fallbackName={primaryAuthor.name || "unknown"}
                 size={16}
                 nameClass="text-[11px] text-fg-muted"
               />

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import {
   Check,
   Copy,
@@ -36,6 +36,7 @@ import type {
   TodoItem,
 } from "../lib/types";
 import { AuthorAvatar } from "./AuthorAvatar";
+import { loginFromEmail } from "./AuthorTag";
 import { ClosePullRequestDialog } from "./ClosePullRequestDialog";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { DiffView } from "./DiffView";
@@ -56,7 +57,10 @@ import { useDialogShortcuts } from "../lib/dialog";
 interface ExpandedDiff {
   payload: DiffPayload;
   title: string;
-  subtitle?: string;
+  /** Rich React subtitle — avatar + author + sha line for commit expansion. */
+  subtitle?: ReactNode;
+  /** Right-side header buttons (Copy SHA / Open on GitHub for commits). */
+  headerActions?: ReactNode;
   /**
    * Commit message body to show above the diff. Populated when expanding a
    * commit; omitted for staged-diff expansion (no commit context).
@@ -194,6 +198,7 @@ export function RightPanel() {
         payload={expanded?.payload ?? null}
         title={expanded?.title ?? ""}
         subtitle={expanded?.subtitle}
+        headerActions={expanded?.headerActions}
         body={expanded?.body}
         cwd={repoPath ?? undefined}
         onClose={() => setExpanded(null)}
@@ -527,6 +532,9 @@ function CommitsTab({
   onExpand: (e: ExpandedDiff) => void;
 }) {
   const [commits, setCommits] = useState<CommitInfo[]>([]);
+  const [commitLogins, setCommitLogins] = useState<
+    Record<string, string | null>
+  >({});
   const [selected, setSelected] = useState<string | null>(null);
   const [diff, setDiff] = useState<DiffPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -551,6 +559,7 @@ function CommitsTab({
     setLoadingMore(false);
     setLoadingFirst(true);
     setCommits([]);
+    setCommitLogins({});
     api
       .listCommits(repoPath, 0, COMMITS_PAGE_SIZE)
       .then((page) => {
@@ -569,6 +578,30 @@ function CommitsTab({
       cancelled = true;
     };
   }, [repoPath]);
+
+  // Resolve commit author logins via GitHub GraphQL for any sha we don't
+  // already have. The backend caches by (slug, sha) so re-fetches across
+  // pagination / project re-entry are free.
+  useEffect(() => {
+    if (commits.length === 0) return;
+    const missing = commits
+      .map((c) => c.sha)
+      .filter((sha) => !(sha in commitLogins));
+    if (missing.length === 0) return;
+    let cancelled = false;
+    api
+      .resolveCommitLogins(repoPath, missing)
+      .then((map) => {
+        if (cancelled) return;
+        setCommitLogins((prev) => ({ ...prev, ...map }));
+      })
+      .catch(() => {
+        // No gh access / network failure — leave rows without avatars.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repoPath, commits, commitLogins]);
 
   useEffect(() => {
     let cancelled = false;
@@ -625,13 +658,60 @@ function CommitsTab({
       .catch((e) => setError(String(e)));
   }
 
+  function buildSubtitle(c: CommitInfo): ReactNode {
+    const login = commitLogins[c.sha] ?? loginFromEmail(c.author_email);
+    return (
+      <span className="flex items-center gap-2 text-[11px] text-fg-muted">
+        <span className="flex items-center gap-1.5">
+          <AuthorAvatar login={login} size={16} />
+          <span>{c.author}</span>
+        </span>
+        <span className="opacity-50">·</span>
+        <Tooltip label={absoluteTime(c.timestamp)} side="bottom">
+          <span className="font-mono">{relativeTime(c.timestamp)}</span>
+        </Tooltip>
+      </span>
+    );
+  }
+
+  function buildHeaderActions(c: CommitInfo, webUrl: string | null): ReactNode {
+    return (
+      <>
+        <Tooltip label="Copy SHA" side="bottom">
+          <button
+            type="button"
+            onClick={() => void navigator.clipboard.writeText(c.sha)}
+            className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          >
+            {c.short_sha}
+          </button>
+        </Tooltip>
+        {webUrl ? (
+          <Tooltip label="Open on GitHub" side="bottom">
+            <button
+              type="button"
+              onClick={() => void openUrl(webUrl)}
+              className="shrink-0 rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+            >
+              <ExternalLink size={12} />
+            </button>
+          </Tooltip>
+        ) : null}
+      </>
+    );
+  }
+
   async function expandCommit(c: CommitInfo) {
     try {
-      const payload = await api.commitDiff(repoPath, c.sha);
+      const [payload, webUrl] = await Promise.all([
+        api.commitDiff(repoPath, c.sha),
+        api.commitWebUrl(repoPath, c.sha).catch(() => null),
+      ]);
       onExpand({
         payload,
         title: c.summary,
-        subtitle: `${c.short_sha} · ${c.author}`,
+        subtitle: buildSubtitle(c),
+        headerActions: buildHeaderActions(c, webUrl),
         body: c.body,
       });
     } catch (e) {
@@ -765,8 +845,16 @@ function CommitsTab({
                         <span className="min-w-0 flex-1 truncate text-fg">{c.summary}</span>
                       </Tooltip>
                     </span>
-                    <span className="flex w-full min-w-0 items-center gap-2 text-[10px] text-fg-muted">
-                      <span className="truncate">{c.author}</span>
+                    <span className="flex w-full min-w-0 items-center gap-2 text-[11px] text-fg-muted">
+                      <span className="flex min-w-0 shrink items-center gap-1.5">
+                        <AuthorAvatar
+                          login={
+                            commitLogins[c.sha] ?? loginFromEmail(c.author_email)
+                          }
+                          size={14}
+                        />
+                        <span className="truncate">{c.author}</span>
+                      </span>
                       <span className="opacity-50">·</span>
                       <Tooltip label={absoluteTime(c.timestamp)} side="top">
                         <span className="font-mono">
@@ -790,12 +878,15 @@ function CommitsTab({
               payload={diff}
               onExpand={() => {
                 const c = commits.find((x) => x.sha === selected);
-                onExpand({
-                  payload: diff,
-                  title: c?.summary ?? selected.slice(0, 12),
-                  subtitle: `${c?.short_sha ?? selected.slice(0, 7)} · ${c?.author ?? ""}`,
-                  body: c?.body,
-                });
+                if (c) {
+                  void expandCommit(c);
+                } else {
+                  onExpand({
+                    payload: diff,
+                    title: selected.slice(0, 12),
+                    subtitle: selected.slice(0, 7),
+                  });
+                }
               }}
             />
           ) : selected ? (
@@ -826,6 +917,7 @@ function CommitsTab({
                     void openOnGitHub(menu.commit);
                   },
                 },
+                { type: "separator" },
                 {
                   label: `Copy SHA (${menu.commit.short_sha})`,
                   icon: <Copy size={12} />,
@@ -989,7 +1081,7 @@ function StagedTab({
                 onExpand({
                   payload: diff,
                   title: "Working tree changes",
-                  subtitle: repoPath,
+                  subtitle: <span className="font-mono">{repoPath}</span>,
                 })
               }
             />

--- a/src/components/ui/ModalHeader.tsx
+++ b/src/components/ui/ModalHeader.tsx
@@ -5,7 +5,7 @@ import { type ModalVariant } from "./Modal";
 
 interface ModalHeaderProps {
   title: string;
-  subtitle?: string;
+  subtitle?: ReactNode;
   icon?: ReactNode;
   /** Rendered before the close button. Use for action buttons (e.g. external link). */
   actions?: ReactNode;
@@ -41,9 +41,7 @@ export function ModalHeader({
             {title}
           </h3>
           {subtitle ? (
-            <p className="truncate font-mono text-xs text-fg-muted">
-              {subtitle}
-            </p>
+            <div className="truncate text-xs text-fg-muted">{subtitle}</div>
           ) : null}
         </div>
       </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -123,6 +123,20 @@ export const api = {
       sha,
     });
   },
+  /**
+   * Batch-resolve git OIDs → GitHub login (when GitHub knows about them).
+   * Missing keys mean we couldn't reach GitHub; `null` values mean the
+   * commit exists but its author doesn't map to a GitHub account.
+   */
+  resolveCommitLogins(
+    repoPath: string,
+    shas: string[],
+  ): Promise<Record<string, string | null>> {
+    return invoke<Record<string, string | null>>("resolve_commit_logins", {
+      repoPath,
+      shas,
+    });
+  },
   mergePullRequest(
     repoPath: string,
     number: number,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,7 @@ export interface CommitInfo {
   sha: string;
   short_sha: string;
   author: string;
+  author_email: string;
   timestamp: number;
   summary: string;
   body: string;

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -33,6 +33,7 @@ export const tauriMockSource = `
     if (cmd === 'detect_session_statuses') return Promise.resolve([]);
     if (cmd === 'read_session_todos') return Promise.resolve([]);
     if (cmd === 'list_commits') return Promise.resolve([]);
+    if (cmd === 'resolve_commit_logins') return Promise.resolve({});
     if (cmd === 'list_staged') return Promise.resolve([]);
     if (cmd === 'list_pull_requests') {
       return Promise.resolve({ items: [], account: null, error: null });


### PR DESCRIPTION
## Summary

PR rows and the PR detail modal already render author avatars, but local Commits rows and the commit expand modal only showed the author as plain text — jarring once you switch between the two surfaces. This PR closes that gap and extracts the author + profile context-menu code into a reusable shape so other commit-displaying surfaces can pick it up.

- New backend `resolve_commit_logins` batches a single GraphQL `repository.object` lookup over a page of git OIDs and returns a `sha → login` map. A static `(slug, sha) → Option<login>` cache keeps re-pagination and modal re-opens free.
- `CommitInfo.author_email` is now exposed so the frontend can resolve the cheap `users.noreply.github.com` pattern without a round trip.
- `AuthorTag` lifts out of `PullRequestDetailModal` into `src/components/AuthorTag.tsx`, with `buildProfileMenuItems(login)` and `loginFromEmail(email)` helpers. `AuthorAvatar` now accepts a nullable login and guards against broken-image renders when the slug doesn't look like a GitHub handle.
- Commits row: avatar (size 14) sits left of the author name, matching PR row sizing (`text-[11px]`).
- DiffViewerModal: subtitle is now a `ReactNode` carrying `[avatar] author · relative time`, and the new `headerActions` slot holds a Copy SHA pill (hover tooltip, click copies) plus an Open-on-GitHub icon button — mirroring the PR detail commit detail header.
- PR detail modal commit list gains a right-click context menu: View on GitHub → Open author profile → separator → Copy SHA. Falls back to plain text when the commit's author has no resolvable GitHub login.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` (vitest) — 121 pass / 1 skipped
- [ ] Commits tab renders an avatar left of the author name at the same size as PR rows
- [ ] Expanding a commit opens the modal with `[avatar] author · relative time` on the left of the subtitle; hovering the SHA pill shows the "Copy SHA" tooltip, click copies the full SHA, the ↗ button opens the commit on GitHub
- [ ] Right-clicking a commit row in the PR detail modal shows View on GitHub / Open GitHub profile / separator / Copy SHA
- [ ] On a repo with no gh access (non-GitHub origin), commit rows still render without an avatar instead of erroring
