### PR TITLE
fix(panes): land new tab next to active tab + sync focusedPaneId from DOM focus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import {
   startNotificationClickHandler,
   startSessionNotificationWatcher,
 } from "./lib/notifications";
+import { findFocusedSessionId } from "./lib/focus";
 import { flushAllScrollbacks } from "./lib/scrollback-coordinator";
 import { useToasts } from "./lib/toasts";
 import { useUpdater } from "./lib/updater-store";
@@ -87,6 +88,32 @@ function App() {
     // from zeroing out the persisted layout.
     void useAppStore.getState().loadInitialStatus().then(() => refreshAll());
   }, [refreshAll]);
+
+  // Keep `focusedPaneId` synced with the terminal whose helper textarea
+  // currently owns DOM focus. The pane body's mousedown listener handles
+  // the click-into-terminal case; this `focusin` syncer covers
+  // keyboard-driven focus moves (Tab cycling, programmatic .focus(),
+  // workspace switches) so every focus-dependent hotkey — Cmd+T, Cmd+W,
+  // Cmd+Shift+D, Cmd+]/[ — targets the pane the user is actually
+  // working in.
+  useEffect(() => {
+    const handler = () => {
+      const sid = findFocusedSessionId();
+      if (!sid) return;
+      const state = useAppStore.getState();
+      if (!state.activeProject) return;
+      const ws = state.workspaces[state.activeProject];
+      if (!ws) return;
+      for (const [pid, pane] of Object.entries(ws.panes)) {
+        if (pane.sessionIds.includes(sid)) {
+          if (ws.focusedPaneId !== pid) state.setFocusedPane(pid);
+          return;
+        }
+      }
+    };
+    document.addEventListener("focusin", handler);
+    return () => document.removeEventListener("focusin", handler);
+  }, []);
 
   // Sync the daemon killswitch from localStorage into the backend on
   // boot. The backend defaults to ENABLED (Q16), and the frontend
@@ -362,22 +389,12 @@ function App() {
       },
       [Hotkeys.clearTerminal]: (e: KeyboardEvent) => {
         // Prefer the terminal whose helper textarea currently owns DOM
-        // focus over `state.activeSessionId`. The store's `focusedPaneId`
-        // only updates on a mouse-down inside a pane, but typing into an
-        // xterm (or pressing a hotkey while the helper textarea has
-        // focus) does not — so Cmd+K would otherwise clear whichever
-        // pane the user last clicked, not the terminal they are actually
-        // working in. Walking up from `document.activeElement` to the
-        // nearest `[data-acorn-terminal-slot]` resolves the terminal the
-        // user is really looking at.
-        let sessionId: string | null = null;
-        const focused = document.activeElement as HTMLElement | null;
-        const slot = focused?.closest<HTMLElement>(
-          "[data-acorn-terminal-slot]",
-        );
-        if (slot?.dataset.acornTerminalSlot) {
-          sessionId = slot.dataset.acornTerminalSlot;
-        }
+        // focus over `state.activeSessionId`. The app-level `focusin`
+        // listener keeps `focusedPaneId` synced for clicks, but a hotkey
+        // pressed *while* an xterm has focus has no intervening event
+        // that would have re-synced — so resolve the real target via
+        // `document.activeElement` walk.
+        let sessionId = findFocusedSessionId();
         // Fall back to the store when focus is elsewhere (sidebar,
         // command palette, an empty pane after a split, etc.). Scan all
         // panes so a freshly-split empty pane doesn't silently no-op the

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -21,7 +21,6 @@ import {
 } from "react";
 import { openPath } from "@tauri-apps/plugin-opener";
 import { useAppStore } from "../store";
-import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import {
   getCurrentDragPayload,
@@ -67,6 +66,7 @@ export function Pane({ paneId }: PaneProps) {
   const focusedPaneId = useAppStore((s) => s.focusedPaneId);
   const setFocusedPane = useAppStore((s) => s.setFocusedPane);
   const selectSession = useAppStore((s) => s.selectSession);
+  const createSession = useAppStore((s) => s.createSession);
   const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
   const moveTab = useAppStore((s) => s.moveTab);
   const splitFocusedPane = useAppStore((s) => s.splitFocusedPane);
@@ -110,18 +110,14 @@ export function Pane({ paneId }: PaneProps) {
   const isFocused = focusedPaneId === paneId;
 
   // Spawn a new session in the given project. Triggered by double-clicking
-  // the empty pane body or the tab strip. We bypass the store wrapper so we
-  // can grab the new session id and immediately focus its tab in this pane.
+  // the empty pane body or the tab strip. `setFocusedPane` first so
+  // `store.createSession` lands the new tab next to *this* pane's active
+  // tab, then routes through the store wrapper for consistent placement
+  // and selection (browser-style "next to active").
   async function spawnSession(repoPath: string) {
     setFocusedPane(paneId);
     const name = suggestSessionName(repoPath, sessions);
-    try {
-      const created = await api.createSession(name, repoPath, false);
-      await useAppStore.getState().refreshAll();
-      selectSession(created.id);
-    } catch (err) {
-      console.error("[Pane] new session spawn failed", err);
-    }
+    await createSession(name, repoPath, false);
   }
 
   async function handleNewTabFromStrip() {

--- a/src/lib/focus.ts
+++ b/src/lib/focus.ts
@@ -1,0 +1,16 @@
+/**
+ * DOM-focus resolvers used by hotkey handlers and the focus syncer.
+ *
+ * Every terminal is rendered into a stable target div tagged with
+ * `data-acorn-terminal-slot="<sessionId>"`. Walking up from the document's
+ * `activeElement` to the nearest such slot is the only reliable way to learn
+ * which terminal the user is actually interacting with — `focusedPaneId` in
+ * the store only updates on synthetic React events, and the terminal's
+ * helper textarea sits outside that fiber tree.
+ */
+export function findFocusedSessionId(): string | null {
+  if (typeof document === "undefined") return null;
+  const focused = document.activeElement as HTMLElement | null;
+  const slot = focused?.closest<HTMLElement>("[data-acorn-terminal-slot]");
+  return slot?.dataset.acornTerminalSlot ?? null;
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -638,6 +638,45 @@ describe("createSession", () => {
       window.removeEventListener("acorn:show-control-guide", listener);
     }
   });
+
+  it("inserts the new tab right after the previously-active tab", async () => {
+    // Seed three sessions in REPO_A; reconcile makes "a1" active.
+    const a1 = session("a1", REPO_A);
+    const a2 = session("a2", REPO_A);
+    const a3 = session("a3", REPO_A);
+    await seed([project(REPO_A, 0)], [a1, a2, a3]);
+    // Move active to "a2" so the next tab should land between a2 and a3.
+    useAppStore.getState().selectSession("a2");
+    expect(useAppStore.getState().activeSessionId).toBe("a2");
+
+    const newSess = session("a4", REPO_A);
+    mockApi.createSession.mockResolvedValueOnce(newSess);
+    mockApi.listSessions.mockResolvedValueOnce([a1, a2, a3, newSess]);
+    mockApi.listProjects.mockResolvedValueOnce([project(REPO_A, 0)]);
+    await useAppStore.getState().createSession("new", REPO_A);
+
+    const s = useAppStore.getState();
+    expect(s.panes[s.focusedPaneId].sessionIds).toEqual([
+      "a1",
+      "a2",
+      "a4",
+      "a3",
+    ]);
+    expect(s.activeSessionId).toBe("a4");
+  });
+
+  it("appends when the focused pane has no active tab yet", async () => {
+    await seed([project(REPO_A, 0)], []);
+    const newSess = session("first", REPO_A);
+    mockApi.createSession.mockResolvedValueOnce(newSess);
+    mockApi.listSessions.mockResolvedValueOnce([newSess]);
+    mockApi.listProjects.mockResolvedValueOnce([project(REPO_A, 0)]);
+    await useAppStore.getState().createSession("first", REPO_A);
+
+    const s = useAppStore.getState();
+    expect(s.panes[s.focusedPaneId].sessionIds).toEqual(["first"]);
+    expect(s.activeSessionId).toBe("first");
+  });
 });
 
 describe("reorderSessions", () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -712,8 +712,60 @@ export const useAppStore = create<AppStateModel>()(
   async createSession(name, repoPath, isolated = false, kind = "regular") {
     set({ loading: true, error: null });
     try {
+      // Snapshot the previously-active tab's index in the focused pane so
+      // we can land the new tab right after it (browser-style). Captured
+      // before `api.createSession` so the post-refresh reorder is anchored
+      // to the user's view at hotkey-press time, not the post-reconcile
+      // append position.
+      const beforeSnap = (() => {
+        const s = get();
+        const ws = s.workspaces[repoPath];
+        if (!ws) return null;
+        const paneId = ws.focusedPaneId;
+        const pane = ws.panes[paneId];
+        if (!pane?.activeSessionId) return null;
+        const idx = pane.sessionIds.indexOf(pane.activeSessionId);
+        return idx >= 0 ? { paneId, idx } : null;
+      })();
+
       const created = await api.createSession(name, repoPath, isolated, kind);
       await get().refreshAll();
+
+      // Reorder so the new tab sits immediately after the previously-active
+      // tab in the same pane. `reconcileWorkspace` always appends new
+      // sessions at the end of `focusedPaneId.sessionIds`; this step
+      // converts that to "next to active" without changing reconcile's
+      // boot-time behavior.
+      if (beforeSnap) {
+        set((s) => {
+          const ws = s.workspaces[repoPath];
+          if (!ws) return s;
+          const pane = ws.panes[beforeSnap.paneId];
+          if (!pane) return s;
+          const currentIdx = pane.sessionIds.indexOf(created.id);
+          if (currentIdx < 0) return s;
+          const targetIdx = Math.min(
+            beforeSnap.idx + 1,
+            pane.sessionIds.length - 1,
+          );
+          if (currentIdx === targetIdx) return s;
+          const ids = pane.sessionIds.filter((id) => id !== created.id);
+          ids.splice(targetIdx, 0, created.id);
+          const newPane = { ...pane, sessionIds: ids };
+          const newWs = {
+            ...ws,
+            panes: { ...ws.panes, [beforeSnap.paneId]: newPane },
+          };
+          const workspaces = { ...s.workspaces, [repoPath]: newWs };
+          return {
+            workspaces,
+            ...(s.activeProject === repoPath
+              ? mirrorActive(workspaces, repoPath)
+              : {}),
+          };
+        });
+      }
+
       // Focus the new session so Cmd+T (and any other entry point that goes
       // through the store) immediately surfaces it in its pane instead of
       // silently appending behind the existing active tab.


### PR DESCRIPTION
## Summary

Cmd+T (and other new-session entry points) opened the new tab in the wrong pane and at the end of the pane instead of next to the active tab. Root cause is the same recurring issue addressed by #85 / #91 / #137: `focusedPaneId` only resyncs on a pane-body mousedown, so keyboard nav, programmatic focus, workspace switches, and helper-textarea focus restores leave it stale; on top of that, `reconcileWorkspace` always appends new sessions at the end of `focusedPaneId.sessionIds`.

- App-level `focusin` listener treats DOM focus as the single source of truth for `focusedPaneId` whenever focus lands inside a `[data-acorn-terminal-slot]`. Covers every focus-dependent hotkey at once: Cmd+T, Cmd+W, Cmd+Shift+D, Cmd+]/[.
- Extract the existing Cmd+K walk (`document.activeElement` → terminal slot) into `src/lib/focus.ts` and reuse it from the hotkey handler.
- `store.createSession` now snapshots the active tab index before the backend call, then splices the new session to `activeIdx + 1` after `refreshAll`. Browser/VSCode-style "next to active". Boot reconcile keeps its append-in-order behavior.
- Consolidate `Pane.spawnSession` onto `store.createSession` so every new-tab entry point (Cmd+T, palette, double-click, CommandRunDialog) shares the same placement logic. Removes the duplicate `api.createSession` + `refreshAll` + `selectSession` inline path.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (123 passed, includes 2 new createSession placement cases)
- [x] In `bun run tauri dev`: split pane, click into right pane's terminal, Cmd+T → new tab opens in right pane, immediately to the right of the active tab.
- [x] Cmd+T while typing into a terminal (no prior mousedown on bodyRef) → new tab still lands in the typed-into pane.
- [x] Cmd+K still clears the currently-focused terminal.
- [x] Double-click an empty split pane → new tab lands in that pane (not appended elsewhere).
- [x] Palette → "New session" places the new tab next to the active tab in the focused pane.
