### PR TITLE
fix(commits): break resolveCommitLogins effect loop when no logins resolve

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -589,14 +589,35 @@ function CommitsTab({
       .filter((sha) => !(sha in commitLogins));
     if (missing.length === 0) return;
     let cancelled = false;
+    // Mark every attempted sha in `commitLogins` (resolved or not) so this
+    // effect doesn't re-fire forever for unknown authors. Without this, the
+    // `missing` filter keeps matching the same shas — backend returns only
+    // the subset with a known login, and `setCommitLogins` always produces
+    // a fresh object reference, which retriggers the effect via the
+    // `commitLogins` dep.
+    const settle = (map: Record<string, string | null>) => {
+      setCommitLogins((prev) => {
+        const next: Record<string, string | null> = { ...prev };
+        for (const sha of missing) {
+          if (!(sha in next)) next[sha] = null;
+        }
+        for (const [sha, login] of Object.entries(map)) {
+          next[sha] = login;
+        }
+        return next;
+      });
+    };
     api
       .resolveCommitLogins(repoPath, missing)
       .then((map) => {
         if (cancelled) return;
-        setCommitLogins((prev) => ({ ...prev, ...map }));
+        settle(map);
       })
       .catch(() => {
-        // No gh access / network failure — leave rows without avatars.
+        // No gh access / network failure — record null entries so we don't
+        // retry the same shas every render.
+        if (cancelled) return;
+        settle({});
       });
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Summary

CI has failed since #145 (`feat(commits): show GitHub avatar...`) merged. Test `right-panel.spec.ts:92` "loadMore from previous project does not leak after switch" times out on its first `sess-a` click.

Root cause: the `resolveCommitLogins` `useEffect` in `RightPanel.tsx` retried forever when the backend returned no entries for the requested shas:

- Effect deps include `commitLogins`.
- `setCommitLogins((prev) => ({ ...prev, ...map }))` always produces a new object reference, even when `map` is `{}`.
- `missing = commits.filter((sha) => !(sha in commitLogins))` keeps matching the same shas because none of them ended up as keys.
- → effect re-fires → new ref → re-fires …

In CI the render storm starved the event loop enough that Playwright's "performing click action" never completed inside the 30s test timeout. Local Macs absorbed the cost so it didn't surface pre-merge.

## Fix

Mark every attempted sha (resolved or not) in `commitLogins` after the fetch settles — success or failure. `commitLogins[c.sha] ?? loginFromEmail(c.author_email)` already handles `null`, so render-side behavior is unchanged.

## Test plan

- [x] `bun run test` — 123 passed
- [x] `bun run typecheck`
- [x] `bunx playwright test` — 47 passed (including the previously-failing `right-panel.spec.ts:92`)
