### PR TITLE
fix(palette): align session creation with hotkey path

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from "react";
 import { Command, useCommandState } from "cmdk";
-import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import {
   Bot,
+  FolderPlus,
+  GitBranch,
   GitCommit,
   GitPullRequest,
   ListChecks,
@@ -18,7 +19,6 @@ import { useAppStore } from "../store";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useToasts } from "../lib/toasts";
-import type { Session } from "../lib/types";
 
 interface CommandPaletteProps {
   open: boolean;
@@ -36,42 +36,29 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     onOpenChange(false);
   }
 
-  async function handleNewSession() {
-    try {
-      const repoPath = await openDialog({
-        directory: true,
-        multiple: false,
-        title: "Select a git repository",
-      });
-      if (!repoPath || typeof repoPath !== "string") {
-        close();
-        return;
-      }
-      const name = deriveSessionName(repoPath, sessionItems);
-      await useAppStore.getState().createSession(name, repoPath);
-    } finally {
-      close();
-    }
+  // Session-creation actions delegate to Sidebar via window events so the
+  // palette matches the hotkey path: when a project is active, Sidebar reuses
+  // its repoPath and skips the directory picker. Duplicating the dialog/create
+  // logic here previously made these items ignore activeProject and always
+  // prompt for a directory, which felt like a project-import flow.
+  function handleNewSession() {
+    window.dispatchEvent(new CustomEvent("acorn:new-session"));
+    close();
   }
 
-  async function handleNewControlSession() {
-    try {
-      const repoPath = await openDialog({
-        directory: true,
-        multiple: false,
-        title: "Select a directory (control session)",
-      });
-      if (!repoPath || typeof repoPath !== "string") {
-        close();
-        return;
-      }
-      const name = deriveSessionName(repoPath, sessionItems, "control");
-      await useAppStore
-        .getState()
-        .createSession(name, repoPath, false, "control");
-    } finally {
-      close();
-    }
+  function handleNewIsolatedSession() {
+    window.dispatchEvent(new CustomEvent("acorn:new-isolated-session"));
+    close();
+  }
+
+  function handleNewControlSession() {
+    window.dispatchEvent(new CustomEvent("acorn:new-control-session"));
+    close();
+  }
+
+  function handleAddProject() {
+    window.dispatchEvent(new CustomEvent("acorn:add-project"));
+    close();
   }
 
   async function handleRefresh() {
@@ -180,6 +167,20 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           <Command.Item value="new-session" onSelect={handleNewSession}>
             <Plus size={14} className="text-accent" />
             <span>New session</span>
+            <span className="ml-auto truncate text-xs text-fg-muted/80">
+              ⌘T
+            </span>
+          </Command.Item>
+          <Command.Item
+            value="new-isolated-session"
+            onSelect={handleNewIsolatedSession}
+            keywords={["worktree", "isolated", "branch"]}
+          >
+            <GitBranch size={14} className="text-accent" />
+            <span>New isolated session</span>
+            <span className="ml-auto truncate text-xs text-fg-muted/80">
+              ⌥⌘T
+            </span>
           </Command.Item>
           <Command.Item
             value="new-control-session"
@@ -188,6 +189,20 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           >
             <Bot size={14} className="text-accent" />
             <span>New control session</span>
+            <span className="ml-auto truncate text-xs text-fg-muted/80">
+              ⌥⇧⌘T
+            </span>
+          </Command.Item>
+          <Command.Item
+            value="add-project"
+            onSelect={handleAddProject}
+            keywords={["project", "import", "repository", "repo", "folder"]}
+          >
+            <FolderPlus size={14} className="text-accent" />
+            <span>Add project</span>
+            <span className="ml-auto truncate text-xs text-fg-muted/80">
+              ⇧⌘N
+            </span>
           </Command.Item>
           <Command.Item value="refresh-sessions" onSelect={handleRefresh}>
             <RefreshCw size={14} className="text-fg-muted" />
@@ -339,22 +354,3 @@ function ShakeTreeItem({ onSelect }: { onSelect: () => void }) {
   );
 }
 
-function deriveSessionName(
-  repoPath: string,
-  existing: Session[],
-  kind: "regular" | "control" = "regular",
-): string {
-  const folder =
-    repoPath.split(/[\\/]/).filter(Boolean).pop() ??
-    `session-${existing.length + 1}`;
-  // Mirror Sidebar.tsx's "control-" prefix so the kind is obvious from the
-  // name alone, even when the row's accessory icon is not in view.
-  const base = kind === "control" ? `control-${folder}` : folder;
-  let candidate = base;
-  let n = 2;
-  const taken = new Set(existing.map((s) => s.name));
-  while (taken.has(candidate)) {
-    candidate = `${base}-${n++}`;
-  }
-  return candidate;
-}


### PR DESCRIPTION
## Summary

Command palette's "New session" / "New control session" items diverged from the hotkey path. Names said "New session" but behavior opened a directory picker, making it feel like a project-import flow.

- Hotkey path (⌘T etc.) → `acorn:new-session` event → Sidebar reuses `activeProject.repoPath` and skips the picker
- Palette → called `openDialog` directly, ignored `activeProject`, always forced directory selection

This PR removes the palette's local session-creation logic and dispatches the same window events (`acorn:new-session`, `acorn:new-control-session`) so Sidebar is the single source of truth.

## What changed

- `handleNewSession` / `handleNewControlSession`: drop local `openDialog` + `createSession`, dispatch window events instead
- Add missing parity entries
  - `New isolated session` (⌥⌘T) → `acorn:new-isolated-session`
  - `Add project` (⇧⌘N) → `acorn:add-project`
- Surface shortcut next to each session-creation item (same pattern as `Reload shell environment`)
- Drop dead `deriveSessionName` + unused imports (`openDialog`, `Session` type)

## Why this is safe

Sidebar's `acorn:new-session` handler already covers both cases:
- `activeProject` present → passed as `repoOverride`, picker skipped
- `activeProject` absent → picker shown as before

So palette with no active project behaves identically to the old code; with an active project it now matches the hotkey.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 14 files / 123 passed (1 skipped)
- [ ] Active project + palette → "New session" creates session in that project without picker
- [ ] No active project + palette → "New session" still opens directory picker
- [ ] Palette → "New isolated session" → isolated worktree flow (both with/without active project)
- [ ] Palette → "New control session" → control session created
- [ ] Palette → "Add project" → directory picker + project added
- [ ] Behavior matches hotkeys (⌘T / ⌥⌘T / ⌥⇧⌘T / ⇧⌘N)
