### PR TITLE
feat(dev): wire Cmd+R to reload the webview in dev builds

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,6 +90,23 @@ pub fn run() {
                 .paste()
                 .select_all()
                 .build()?;
+            // Dev-only Reload (Cmd+R) so frontend edits that don't HMR cleanly
+            // can be re-bootstrapped without restarting the whole Tauri host.
+            // The release menu omits it on purpose — Acorn ships as a single
+            // long-lived app and an accidental Cmd+R would drop every PTY's
+            // in-memory state.
+            #[cfg(debug_assertions)]
+            let reload_item = MenuItemBuilder::new("Reload")
+                .id("reload")
+                .accelerator("CmdOrCtrl+R")
+                .build(app)?;
+            #[cfg(debug_assertions)]
+            let view_submenu = SubmenuBuilder::new(app, "View")
+                .item(&reload_item)
+                .separator()
+                .fullscreen()
+                .build()?;
+            #[cfg(not(debug_assertions))]
             let view_submenu = SubmenuBuilder::new(app, "View").fullscreen().build()?;
             let window_submenu = SubmenuBuilder::new(app, "Window")
                 .minimize()
@@ -108,6 +125,14 @@ pub fn run() {
                 if event.id() == "settings" {
                     if let Err(err) = handle.emit("acorn:open-settings", ()) {
                         tracing::warn!("failed to emit open-settings: {err}");
+                    }
+                }
+                #[cfg(debug_assertions)]
+                if event.id() == "reload" {
+                    if let Some(window) = handle.get_webview_window("main") {
+                        if let Err(err) = window.eval("window.location.reload()") {
+                            tracing::warn!("failed to reload webview: {err}");
+                        }
                     }
                 }
             });


### PR DESCRIPTION
## Summary

Frontend edits that don't HMR cleanly (zustand store wiring, init-time effects, anything past the Vite boundary in `tauri dev`) currently force a full restart of the Tauri host, killing every running PTY. Browsers and Electron-class apps default `Cmd+R` to "reload the visible document," and the muscle memory carries over.

Add a "Reload" item to the View submenu with a `CmdOrCtrl+R` accelerator, gated on `#[cfg(debug_assertions)]`. The handler grabs the main webview window and `eval`s `window.location.reload()`. Release builds omit the item on purpose — Acorn is a long-lived shell and an accidental `Cmd+R` would drop every session's in-memory state.

## Test plan

- [x] `cargo check` (dev) — clean
- [x] `cargo check --release` — `reload_item` / dev branch correctly cfg-gated out
- [ ] `bun run tauri dev`, confirm View → Reload + `Cmd+R` both reload the webview
- [ ] Confirm the menu item is absent in a release build
