### PR TITLE
feat(terminal): pin last user prompt above terminal (experiments)

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -46,6 +46,7 @@ type Tab =
   | "editor"
   | "notifications"
   | "storage"
+  | "experiments"
   | "about";
 
 const TABS: Array<{ id: Tab; label: string }> = [
@@ -57,6 +58,7 @@ const TABS: Array<{ id: Tab; label: string }> = [
   { id: "editor", label: "Editor" },
   { id: "notifications", label: "Notifications" },
   { id: "storage", label: "Storage" },
+  { id: "experiments", label: "Experiments" },
   { id: "about", label: "About" },
 ];
 
@@ -151,6 +153,8 @@ export function SettingsModal() {
             <NotificationSettings />
           ) : tab === "storage" ? (
             <StorageSettings />
+          ) : tab === "experiments" ? (
+            <ExperimentsSettings />
           ) : (
             <AboutSettings />
           )}
@@ -1063,6 +1067,27 @@ type WhatsNewSource =
        */
       isFallback: boolean;
     };
+
+function ExperimentsSettings() {
+  const experiments = useSettings((s) => s.settings.experiments);
+  const patchExperiments = useSettings((s) => s.patchExperiments);
+
+  return (
+    <section className="space-y-4">
+      <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] leading-snug text-fg-muted">
+        <Sparkles size={11} className="mr-1 inline align-text-bottom text-warning" />
+        Unfinished features. Behaviour may change between releases; the toggles
+        themselves are stable.
+      </div>
+      <CheckboxRow
+        checked={experiments.stickyPrompt}
+        onChange={(checked) => patchExperiments({ stickyPrompt: checked })}
+        label="Pin last user prompt above terminal"
+        description="Detects the most recent claude prompt line in the rendered terminal buffer and pins it at the top of the pane so it stays in view while reading the reply. Cmd+K clears it along with the rest of the scrollback."
+      />
+    </section>
+  );
+}
 
 function AboutSettings() {
   const currentVersion = useUpdater((s) => s.currentVersion);

--- a/src/components/StickyUserPrompt.tsx
+++ b/src/components/StickyUserPrompt.tsx
@@ -1,0 +1,152 @@
+import { ChevronDown, MessageSquare } from "lucide-react";
+import { useEffect, useState, type ReactElement } from "react";
+
+interface StickyUserPromptProps {
+  sessionId: string;
+}
+
+// Custom event the Terminal dispatches whenever its buffer changes shape
+// in a way the banner cares about (new PTY output, scroll, clear). The
+// banner is a pure consumer here — no polling, no backend round-trip.
+// Detection happens against xterm's rendered buffer so a Cmd+K clear
+// implicitly empties the banner (the buffer has no prompt rows to find).
+const CONTEXT_PROMPT_EVENT = "acorn:context-prompt";
+
+interface ContextPromptDetail {
+  sessionId: string;
+  /** Most recent prompt-marker line at-or-above the topmost-visible row. */
+  prompt: string | null;
+}
+
+const EXPANDED_MAX_HEIGHT_PX = 160;
+
+export function StickyUserPrompt({
+  sessionId,
+}: StickyUserPromptProps): ReactElement | null {
+  const [prompt, setPrompt] = useState<string | null>(null);
+  // Compact by default so a freshly-arrived prompt never pushes an
+  // outsized panel over the terminal. Clicking the row (or the chevron)
+  // toggles expanded; a new prompt resets the toggle.
+  const [collapsed, setCollapsed] = useState(true);
+
+  useEffect(() => {
+    setPrompt(null);
+    setCollapsed(true);
+    const onContext = (event: Event) => {
+      const detail = (event as CustomEvent<ContextPromptDetail>).detail;
+      if (!detail || detail.sessionId !== sessionId) return;
+      setPrompt((prev) => {
+        // Only reset the collapsed state when the prompt's first line
+        // changes — claude's TUI repaints the prompt area on every
+        // assistant chunk, which produced micro-diffs that kept
+        // flipping `collapsed` back to true the instant the user
+        // expanded. The first line is stable across those redraws
+        // because it carries the marker + user-typed head.
+        const prevHead = (prev ?? "").split("\n", 1)[0];
+        const nextHead = (detail.prompt ?? "").split("\n", 1)[0];
+        if (prev !== null && prevHead !== nextHead) {
+          setCollapsed(true);
+        }
+        return detail.prompt;
+      });
+    };
+    window.addEventListener(CONTEXT_PROMPT_EVENT, onContext);
+    return () => {
+      window.removeEventListener(CONTEXT_PROMPT_EVENT, onContext);
+    };
+  }, [sessionId]);
+
+  if (!prompt) return null;
+  // Heuristic for "is there anything to expand?" — we collect
+  // continuation rows in the scanner and join them with `\n`, so any
+  // newline means hidden content under the 1-line clamp. Length-based
+  // checks are unreliable across font widths / CJK, so we keep this to
+  // the unambiguous signal.
+  const expandable = prompt.includes("\n");
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-0 top-0 z-10"
+      data-acorn-sticky-prompt
+    >
+      <div
+        // The whole row toggles collapsed/expanded ONLY when there's
+        // actually a second line to reveal. For single-line prompts the
+        // row stays passive — no cursor change, no click handler, no
+        // chevron — so the affordance reflects the real state.
+        className={`pointer-events-auto border-b border-white/10 bg-[#1a1d20]/95 px-3 py-2 text-xs leading-snug text-white/80 shadow-[0_2px_8px_rgba(0,0,0,0.35)] backdrop-blur-sm transition-colors ${
+          expandable ? "cursor-pointer hover:bg-[#1a1d20]" : ""
+        }`}
+        role={expandable ? "button" : undefined}
+        tabIndex={expandable ? 0 : undefined}
+        aria-expanded={expandable ? !collapsed : undefined}
+        aria-label={
+          expandable
+            ? collapsed
+              ? "Expand pinned prompt"
+              : "Collapse pinned prompt"
+            : undefined
+        }
+        onClick={expandable ? () => setCollapsed((c) => !c) : undefined}
+        onKeyDown={
+          expandable
+            ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setCollapsed((c) => !c);
+                }
+              }
+            : undefined
+        }
+      >
+        <div className="flex items-start gap-2">
+          <span
+            className="flex h-[16.5px] shrink-0 items-center text-white/50"
+            aria-hidden
+          >
+            <MessageSquare size={12} />
+          </span>
+          <div
+            className="min-w-0 flex-1 whitespace-pre-wrap break-words"
+            style={
+              collapsed
+                ? {
+                    display: "-webkit-box",
+                    WebkitLineClamp: 1,
+                    WebkitBoxOrient: "vertical",
+                    overflow: "hidden",
+                  }
+                : {
+                    // Explicit `display: block` overrides the lingering
+                    // `-webkit-box` that the collapsed style set last
+                    // render — WebKit otherwise sometimes retains the
+                    // single-line layout on toggle until reflow.
+                    display: "block",
+                    WebkitLineClamp: "unset",
+                    WebkitBoxOrient: "horizontal",
+                    maxHeight: EXPANDED_MAX_HEIGHT_PX,
+                    overflowY: "auto",
+                    paddingRight: 4,
+                  }
+            }
+          >
+            {prompt}
+          </div>
+          {expandable ? (
+            <span
+              className="flex h-[16.5px] shrink-0 items-center text-white/50"
+              aria-hidden
+            >
+              <ChevronDown
+                size={12}
+                className={`transition-transform ${
+                  collapsed ? "" : "rotate-180"
+                }`}
+              />
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useRef, type ReactElement } from "react";
-import { Terminal as XTerm, type ITheme } from "@xterm/xterm";
+import {
+  Terminal as XTerm,
+  type IBuffer,
+  type ITheme,
+} from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
@@ -16,6 +20,7 @@ import {
 } from "../lib/settings";
 import { useToasts } from "../lib/toasts";
 import { useAppStore } from "../store";
+import { StickyUserPrompt } from "./StickyUserPrompt";
 
 interface TerminalProps {
   sessionId: string;
@@ -51,6 +56,108 @@ const TERMINAL_THEME: ITheme = {
 const ANSI_RED = "\x1b[31m";
 const ANSI_RESET = "\x1b[0m";
 const ANSI_DIM = "\x1b[2m";
+
+// Custom event the sticky-prompt banner listens to. Fired whenever the user
+// scrolls the terminal so the banner can swap to the prompt "in scope" at
+// the top of the viewport, then revert to the JSONL-latest prompt when the
+// user scrolls back to live tail.
+const CONTEXT_PROMPT_EVENT = "acorn:context-prompt";
+
+interface ContextPromptDetail {
+  sessionId: string;
+  /** Prompt text to pin, or `null` to revert to JSONL-latest. */
+  prompt: string | null;
+}
+
+// Markers Claude TUI uses to introduce a user turn. v2.1.x renders `›`
+// (U+203A); older versions used `>`; `❯` shows up in some shell-prompt
+// theming. Matching any of these lets the scroll-aware banner cope with
+// claude version churn without code changes.
+const PROMPT_MARKER_RE = /^[›>❯]\s+/u;
+// Lines that look like the *start* of an assistant turn or another
+// claude UI element — used to bound the continuation walk so a long
+// stream of assistant output doesn't get spliced into the pinned prompt.
+const TURN_BOUNDARY_RE = /^[●○*✱⏺·]\s/u;
+const BOX_DRAWING_RE = /^[\s│╭╮╰╯─┃┏┓┗┛━]+/u;
+
+/**
+ * Walk xterm buffer rows upwards from `startY` to find the nearest
+ * user-prompt marker line, then walk down to collect the rest of the
+ * prompt body (continuation rows are either xterm wrap-continuations
+ * or indented rows beneath the marker). The result is the full prompt
+ * text the user typed, joined with `\n` between hard-wrapped rows so
+ * the banner's `whitespace-pre-wrap` styling preserves line breaks.
+ *
+ * Returns `null` when no prompt line is reachable above the start row —
+ * e.g. user scrolled past the top of scrollback, or the buffer contains
+ * raw shell output rather than a claude conversation.
+ */
+function scanForContextPrompt(buf: IBuffer, startY: number): string | null {
+  // Max walk distance. Bounded so a terminal with a massive scrollback
+  // (claude conversations easily push tens of thousands of rows) doesn't
+  // freeze the UI on every scroll event. 5000 rows ≈ the default xterm
+  // scrollback limit (`scrollback: 5000` in this file).
+  const MAX_WALK = 5000;
+  const MAX_CONTINUATION = 200;
+  const limit = Math.max(0, startY - MAX_WALK);
+  for (let y = startY; y >= limit; y--) {
+    const line = buf.getLine(y);
+    if (!line) continue;
+    const raw = line.translateToString(true);
+    const stripped = raw.replace(BOX_DRAWING_RE, "");
+    const match = stripped.match(PROMPT_MARKER_RE);
+    if (!match) continue;
+    const headBody = stripped
+      .slice(match[0].length)
+      .replace(/\s*[│┃]?\s*$/u, "")
+      .trim();
+    if (headBody.length === 0) continue;
+    const parts: string[] = [headBody];
+    for (let yy = y + 1; yy <= y + MAX_CONTINUATION; yy++) {
+      const cont = buf.getLine(yy);
+      if (!cont) break;
+      const contRaw = cont.translateToString(true);
+      // Use the raw line (not the box-stripped form) to detect "blank-ish"
+      // continuation gutters that still belong to the same turn.
+      const trimmedTail = contRaw.replace(/\s+$/u, "");
+      const contStripped = trimmedTail.replace(BOX_DRAWING_RE, "");
+      // Hit the next prompt marker → previous user turn ended.
+      if (PROMPT_MARKER_RE.test(contStripped)) break;
+      // Hit an assistant or other turn-class marker.
+      if (TURN_BOUNDARY_RE.test(contStripped)) break;
+      // An xterm wrap-continuation row is unambiguously the same logical
+      // line, so always accept it.
+      if (cont.isWrapped) {
+        const wrapBody = contStripped.replace(/\s*[│┃]?\s*$/u, "");
+        if (wrapBody.length > 0) parts.push(wrapBody);
+        continue;
+      }
+      // Hard-wrapped continuation rows in claude's TUI keep a leading
+      // indent (so the body lines up under the `> ` marker). Accept
+      // rows whose first non-whitespace column matches the marker's,
+      // and bail on anything that looks like a new gutter / divider.
+      if (trimmedTail.length === 0) {
+        // Single blank row inside a long pasted prompt is part of the
+        // same turn (the user pressed Enter twice). Treat as line
+        // break, keep collecting.
+        parts.push("");
+        continue;
+      }
+      if (/^\s{2,}/u.test(contRaw) && contStripped.length > 0) {
+        parts.push(contStripped.replace(/\s*[│┃]?\s*$/u, ""));
+        continue;
+      }
+      break;
+    }
+    // Strip trailing blank-string entries the loop may have collected
+    // before hitting the boundary.
+    while (parts.length > 0 && parts[parts.length - 1] === "") {
+      parts.pop();
+    }
+    return parts.join("\n");
+  }
+  return null;
+}
 
 // macOS uses Cmd (metaKey); other platforms use Ctrl. Matches the
 // platform-primary modifier `tinykeys` resolves `$mod` to.
@@ -667,6 +774,59 @@ export function Terminal({
     const scrollDisposable = term.onScroll(repositionComposing);
     const cursorMoveDisposable = term.onCursorMove(repositionComposing);
 
+    // Sticky-prompt detection. The banner above the terminal pins the
+    // most recent user-prompt line found in xterm's rendered buffer
+    // at-or-above the topmost-visible row. Detection is buffer-only —
+    // a Cmd+K clear empties the buffer and the dispatch naturally
+    // settles to `null`, hiding the banner without any side-channel
+    // bookkeeping. Triggers:
+    //   - scroll          (user navigates scrollback)
+    //   - PTY output      (a new turn just landed)
+    //   - terminal clear  (buffer wiped)
+    // All three coalesce through a single rAF so a flurry of events
+    // emits one buffer scan + one dispatch per animation frame.
+    //
+    // The Experiments → "Pin last user prompt" toggle short-circuits
+    // every dispatch when off, AND emits a one-shot `null` so a banner
+    // already showing from a prior render disappears immediately.
+    let contextDispatchPending = false;
+    let lastDispatchedContext: string | null | undefined = undefined;
+    const dispatchContextPrompt = () => {
+      contextDispatchPending = false;
+      if (disposed) return;
+      const enabled =
+        useSettings.getState().settings.experiments.stickyPrompt;
+      const next = enabled
+        ? scanForContextPrompt(term.buffer.active, term.buffer.active.viewportY)
+        : null;
+      if (next === lastDispatchedContext) return;
+      lastDispatchedContext = next;
+      window.dispatchEvent(
+        new CustomEvent<ContextPromptDetail>(CONTEXT_PROMPT_EVENT, {
+          detail: { sessionId, prompt: next },
+        }),
+      );
+    };
+    const scheduleContextDispatch = () => {
+      if (contextDispatchPending || disposed) return;
+      contextDispatchPending = true;
+      requestAnimationFrame(dispatchContextPrompt);
+    };
+    const contextScrollDisposable = term.onScroll(scheduleContextDispatch);
+    // Initial dispatch so the banner reflects whatever was restored from
+    // scrollback before the first scroll/output event fires.
+    scheduleContextDispatch();
+    // Toggle off mid-session must hide the banner without waiting for
+    // the next scroll/output event; toggle back on rescans the buffer.
+    const unsubStickyToggle = useSettings.subscribe((state, prev) => {
+      if (
+        state.settings.experiments.stickyPrompt !==
+        prev.settings.experiments.stickyPrompt
+      ) {
+        scheduleContextDispatch();
+      }
+    });
+
     // Custom event hook so a global hotkey (Cmd+K) can clear THIS terminal
     // without needing a cross-component ref registry. The dispatcher passes
     // the target sessionId in `detail.sessionId`; terminals match against
@@ -675,6 +835,11 @@ export function Terminal({
       const detail = (e as CustomEvent<{ sessionId: string }>).detail;
       if (!detail || detail.sessionId !== sessionId) return;
       term.clear();
+      // Sticky-prompt banner watches the buffer for `> ` lines; after a
+      // clear there are none, so explicitly schedule a dispatch so the
+      // banner picks up the now-empty state without waiting for the
+      // next scroll/output event.
+      scheduleContextDispatch();
       // Also redraw the shell prompt so the user sees a clean state.
       sendToPty("\x0c");
     };
@@ -810,6 +975,10 @@ export function Terminal({
               // so a TUI redraw interrupted mid-stream doesn't leave stale
               // glyphs from a wider previous line painted on screen.
               scheduleViewportRepaint();
+              // A new prompt row may have just been rendered. Rescan the
+              // buffer so the sticky banner picks it up in the same frame
+              // (instead of waiting for the user's next scroll).
+              scheduleContextDispatch();
             } catch (err) {
               console.error("[Terminal] decode payload failed", err);
             }
@@ -1053,6 +1222,8 @@ export function Terminal({
       renderDisposable.dispose();
       scrollDisposable.dispose();
       cursorMoveDisposable.dispose();
+      contextScrollDisposable.dispose();
+      unsubStickyToggle();
       resizeDisposable.dispose();
       for (const off of unlistenFns) {
         try { off(); } catch { /* ignore */ }
@@ -1118,13 +1289,21 @@ export function Terminal({
     };
   }, [isActive]);
 
-  // FitAddon subtracts padding from xterm.element, not its parent — keep the gutter on the outer wrapper so xterm's parent stays padding-free and rows don't overflow past the pane body.
+  // FitAddon subtracts padding from xterm.element, not its parent — keep the
+  // gutter on the outer wrapper so xterm's parent stays padding-free and rows
+  // don't overflow past the pane body. The pinned-prompt banner overlays the
+  // top edge as an `absolute` element so it never changes the terminal's
+  // computed dimensions — a flex layout that shrunk the xterm container
+  // mid-render fired SIGWINCH at claude's TUI and shredded its box-drawing
+  // characters into half-rendered lines.
   return (
     <div
       className="relative h-full w-full"
       style={{ padding: "16px 8px", background: TERMINAL_BG }}
     >
       <div ref={containerRef} className="acorn-terminal h-full w-full" />
+      {/* Pinned-prompt overlay. */}
+      <StickyUserPrompt sessionId={sessionId} />
     </div>
   );
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -256,6 +256,20 @@ export interface AcornSettings {
      */
     showDetailsOnHover: boolean;
   };
+  /**
+   * Opt-in toggles for unfinished features. Anything under here is
+   * unstable on purpose — the contract is "we keep the toggle, the
+   * implementation can churn".
+   */
+  experiments: {
+    /**
+     * Pins the most recent user-prompt line from the claude TUI to the
+     * top of the terminal so the user keeps it in view while reading
+     * the assistant's reply. Detection is buffer-driven, so Cmd+K
+     * naturally clears the banner along with the rest of the scrollback.
+     */
+    stickyPrompt: boolean;
+  };
 }
 
 export const DEFAULT_SETTINGS: AcornSettings = {
@@ -312,6 +326,9 @@ export const DEFAULT_SETTINGS: AcornSettings = {
       sessionKind: true,
     },
     showDetailsOnHover: true,
+  },
+  experiments: {
+    stickyPrompt: false,
   },
 };
 
@@ -538,6 +555,14 @@ function loadSettings(): AcornSettings {
             ? parsed.sessionDisplay.showDetailsOnHover
             : DEFAULT_SETTINGS.sessionDisplay.showDetailsOnHover,
       },
+      experiments: {
+        ...DEFAULT_SETTINGS.experiments,
+        ...(parsed.experiments ?? {}),
+        stickyPrompt:
+          typeof parsed.experiments?.stickyPrompt === "boolean"
+            ? parsed.experiments.stickyPrompt
+            : DEFAULT_SETTINGS.experiments.stickyPrompt,
+      },
     };
   } catch {
     return DEFAULT_SETTINGS;
@@ -592,6 +617,7 @@ interface SettingsState {
       icons?: Partial<AcornSettings["sessionDisplay"]["icons"]>;
     },
   ) => void;
+  patchExperiments: (patch: Partial<AcornSettings["experiments"]>) => void;
   reset: () => void;
 }
 
@@ -704,6 +730,15 @@ export const useSettings = create<SettingsState>((set, get) => ({
           metadata,
           icons,
         },
+      };
+      persist(next);
+      return { settings: next };
+    }),
+  patchExperiments: (patch) =>
+    set((s) => {
+      const next: AcornSettings = {
+        ...s.settings,
+        experiments: { ...s.settings.experiments, ...patch },
       };
       persist(next);
       return { settings: next };


### PR DESCRIPTION
## Summary

- New **Experiments → Pin last user prompt above terminal** toggle (default off) that overlays the most recent user prompt at the top of each terminal so it stays in view while reading the assistant's reply.
- Detection is buffer-only: `Terminal.tsx` scans xterm rows for the `›` / `>` / `❯` marker, collects wrap-continuations + indented continuation rows, and dispatches an `acorn:context-prompt` event. `Cmd+K` empties the buffer → banner disappears naturally.
- New `Settings → Experiments` tab houses the toggle alongside a "subject to change" disclaimer.

## Test plan

- [x] `bun run typecheck`
- [x] manual: type a multi-line prompt to claude, scroll down past the response → banner stays pinned at top with chevron + click-to-expand
- [x] manual: `Cmd+K` → banner disappears with cleared scrollback
- [x] manual: toggle off via Settings → banner disappears immediately
- [x] manual: toggle on → banner reappears on next scroll / output
- [ ] e2e regression spec (deferred — feature is experiments-gated, default off)
