### PR TITLE
feat(ui): align Sidebar and Pane tab context menus

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -1,4 +1,5 @@
 import {
+  CircleX,
   Columns2,
   Copy,
   Files,
@@ -9,6 +10,7 @@ import {
   PencilLine,
   SplitSquareHorizontal,
   SplitSquareVertical,
+  SquareX,
   Terminal as TerminalIcon,
   X,
 } from "lucide-react";
@@ -506,6 +508,7 @@ function TabItem({
         });
       },
     },
+    { type: "separator" },
     {
       label: "Copy Worktree Path",
       icon: <Copy size={12} />,
@@ -543,11 +546,13 @@ function TabItem({
     },
     {
       label: "Close Others",
+      icon: <CircleX size={12} />,
       onClick: onCloseOthers,
       disabled: siblingCount <= 1,
     },
     {
       label: "Close All",
+      icon: <SquareX size={12} />,
       onClick: onCloseAll,
     },
   ];
@@ -743,6 +748,7 @@ function buildPaneMenuItems({
             );
           },
         },
+        { type: "separator" },
         {
           label: "Copy Worktree Path",
           icon: <Copy size={12} />,

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,8 @@
 import {
   Bot,
   ChevronRight,
+  CircleX,
+  Columns2,
   Copy,
   Files,
   FolderOpen,
@@ -10,6 +12,7 @@ import {
   Pencil,
   PencilLine,
   Plus,
+  SquareX,
   Trash2,
   X,
 } from "lucide-react";
@@ -40,6 +43,7 @@ import { useAppStore } from "../store";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
+import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import {
   useSettings,
   type AcornSettings,
@@ -826,6 +830,12 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
     }
   }
 
+  const projectSiblings = useMemo(
+    () => sessions.filter((s) => s.repo_path === session.repo_path),
+    [sessions, session.repo_path],
+  );
+  const otherSiblings = projectSiblings.filter((s) => s.id !== session.id);
+
   const sessionMenuItems: ContextMenuItem[] = [
     {
       label: "Rename",
@@ -836,6 +846,14 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
       label: "Duplicate Session",
       icon: <Files size={12} />,
       onClick: () => void duplicate(),
+    },
+    { type: "separator" },
+    {
+      label: "Equalize Pane Sizes",
+      icon: <Columns2 size={12} />,
+      onClick: () => {
+        window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
+      },
     },
     { type: "separator" },
     {
@@ -859,6 +877,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
         });
       },
     },
+    { type: "separator" },
     {
       label: "Copy Worktree Path",
       icon: <Copy size={12} />,
@@ -885,6 +904,24 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
       label: "Remove",
       icon: <Trash2 size={12} />,
       onClick: onRemove,
+    },
+    {
+      label: "Remove Others in Project",
+      icon: <CircleX size={12} />,
+      disabled: otherSiblings.length === 0,
+      onClick: () => {
+        const request = useAppStore.getState().requestRemoveSession;
+        for (const s of otherSiblings) request(s.id);
+      },
+    },
+    {
+      label: "Remove All in Project",
+      icon: <SquareX size={12} />,
+      disabled: projectSiblings.length === 0,
+      onClick: () => {
+        const request = useAppStore.getState().requestRemoveSession;
+        for (const s of projectSiblings) request(s.id);
+      },
     },
   ];
 


### PR DESCRIPTION
## Summary

Sidebar (Projects-side) session context menu and Pane tab context menu now share the same non-split feature set, and the icon-less items get icons.

- Sidebar session row: add `Equalize Pane Sizes`, `Remove Others in Project`, `Remove All in Project`.
- Pane tab menu: add `CircleX` / `SquareX` icons to `Close Others` / `Close All`.
- Both menus: extra separator between the open/reveal group and the copy group for cleaner visual grouping.
- Split actions stay pane-only by design.

## Test plan

- [x] Source review — Sidebar session row builds the new Equalize / Remove Others / Remove All items with icons; `Remove Others` `disabled: otherSiblings.length === 0`.
- [x] Source review — Pane tab menu items for `Close Others` / `Close All` carry `CircleX` / `SquareX` icons; new separator sits between `Reveal in Finder` and `Copy Worktree Path`.
- [x] Source review — Pane body menu (`buildPaneMenuItems`) gets the same separator between Reveal and Copy entries.
- [x] Source review — Sidebar's Equalize entry dispatches the same `EQUALIZE_PANES_EVENT` window event as the Pane menu version.
- [x] `tsc --noEmit -p tsconfig.json` clean.
- [ ] Runtime click-through in dev app — deferred to live verification in the running `bun run tauri dev` window.
