### PR TITLE
feat(sessions): auto-focus xterm on create + carry kind on Pane duplicate

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -1,4 +1,5 @@
 import {
+  CircleX,
   Columns2,
   Copy,
   Files,
@@ -9,6 +10,7 @@ import {
   PencilLine,
   SplitSquareHorizontal,
   SplitSquareVertical,
+  SquareX,
   Terminal as TerminalIcon,
   X,
 } from "lucide-react";
@@ -506,6 +508,7 @@ function TabItem({
         });
       },
     },
+    { type: "separator" },
     {
       label: "Copy Worktree Path",
       icon: <Copy size={12} />,
@@ -543,11 +546,13 @@ function TabItem({
     },
     {
       label: "Close Others",
+      icon: <CircleX size={12} />,
       onClick: onCloseOthers,
       disabled: siblingCount <= 1,
     },
     {
       label: "Close All",
+      icon: <SquareX size={12} />,
       onClick: onCloseAll,
     },
   ];
@@ -743,6 +748,7 @@ function buildPaneMenuItems({
             );
           },
         },
+        { type: "separator" },
         {
           label: "Copy Worktree Path",
           icon: <Copy size={12} />,

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -38,7 +38,7 @@ import { useSettings } from "../lib/settings";
 import type { Direction, PaneId } from "../lib/layout";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { PaneDropOverlay } from "./PaneDropOverlay";
-import type { Session, SessionStatus } from "../lib/types";
+import type { Session, SessionKind, SessionStatus } from "../lib/types";
 
 const STATUS_DOT: Record<SessionStatus, string> = {
   idle: "bg-fg-muted",
@@ -116,10 +116,13 @@ export function Pane({ paneId }: PaneProps) {
   // `store.createSession` lands the new tab next to *this* pane's active
   // tab, then routes through the store wrapper for consistent placement
   // and selection (browser-style "next to active").
-  async function spawnSession(repoPath: string) {
+  async function spawnSession(
+    repoPath: string,
+    kind: SessionKind = "regular",
+  ) {
     setFocusedPane(paneId);
     const name = suggestSessionName(repoPath, sessions);
-    await createSession(name, repoPath, false);
+    await createSession(name, repoPath, false, kind);
   }
 
   async function handleNewTabFromStrip() {
@@ -178,8 +181,8 @@ export function Pane({ paneId }: PaneProps) {
               splitSide: "after",
             });
           }}
-          onDuplicate={(repoPath) => {
-            void spawnSession(repoPath);
+          onDuplicate={(repoPath, kind) => {
+            void spawnSession(repoPath, kind);
           }}
         />
       ) : null}
@@ -304,7 +307,7 @@ interface TabStripProps {
   ) => void;
   onNewTab: () => void;
   onSplitTab: (sessionId: string, direction: Direction) => void;
-  onDuplicate: (repoPath: string) => void;
+  onDuplicate: (repoPath: string, kind: SessionKind) => void;
 }
 
 function TabStrip({
@@ -387,7 +390,7 @@ function TabStrip({
             for (const t of tabs) onClose(t.id);
           }}
           onSplitTab={(direction) => onSplitTab(tab.id, direction)}
-          onDuplicate={() => onDuplicate(tab.repo_path)}
+          onDuplicate={() => onDuplicate(tab.repo_path, tab.kind)}
           siblingCount={tabs.length}
           registerRef={(el) => {
             if (el) tabRefs.current.set(tab.id, el);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,8 @@
 import {
   Bot,
   ChevronRight,
+  CircleX,
+  Columns2,
   Copy,
   Files,
   FolderOpen,
@@ -10,6 +12,7 @@ import {
   Pencil,
   PencilLine,
   Plus,
+  SquareX,
   Trash2,
   X,
 } from "lucide-react";
@@ -40,6 +43,7 @@ import { useAppStore } from "../store";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
+import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import {
   useSettings,
   type AcornSettings,
@@ -826,6 +830,12 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
     }
   }
 
+  const projectSiblings = useMemo(
+    () => sessions.filter((s) => s.repo_path === session.repo_path),
+    [sessions, session.repo_path],
+  );
+  const otherSiblings = projectSiblings.filter((s) => s.id !== session.id);
+
   const sessionMenuItems: ContextMenuItem[] = [
     {
       label: "Rename",
@@ -836,6 +846,14 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
       label: "Duplicate Session",
       icon: <Files size={12} />,
       onClick: () => void duplicate(),
+    },
+    { type: "separator" },
+    {
+      label: "Equalize Pane Sizes",
+      icon: <Columns2 size={12} />,
+      onClick: () => {
+        window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
+      },
     },
     { type: "separator" },
     {
@@ -859,6 +877,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
         });
       },
     },
+    { type: "separator" },
     {
       label: "Copy Worktree Path",
       icon: <Copy size={12} />,
@@ -885,6 +904,24 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
       label: "Remove",
       icon: <Trash2 size={12} />,
       onClick: onRemove,
+    },
+    {
+      label: "Remove Others in Project",
+      icon: <CircleX size={12} />,
+      disabled: otherSiblings.length === 0,
+      onClick: () => {
+        const request = useAppStore.getState().requestRemoveSession;
+        for (const s of otherSiblings) request(s.id);
+      },
+    },
+    {
+      label: "Remove All in Project",
+      icon: <SquareX size={12} />,
+      disabled: projectSiblings.length === 0,
+      onClick: () => {
+        const request = useAppStore.getState().requestRemoveSession;
+        for (const s of projectSiblings) request(s.id);
+      },
     },
   ];
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -40,7 +40,6 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useAppStore } from "../store";
-import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
@@ -816,15 +815,14 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
       n += 1;
     }
     try {
-      // Carry the source session's kind onto the duplicate so a control
-      // session stays a control session and keeps its IPC-dispatch role.
-      await api.createSession(
-        next,
-        session.repo_path,
-        session.isolated,
-        session.kind,
-      );
-      await useAppStore.getState().refreshAll();
+      // Route through the store wrapper so the duplicate gets the same
+      // post-create treatment as Cmd+T and Pane "Duplicate Session": land
+      // next to the active tab, auto-select, and auto-focus xterm. Carries
+      // the source session's `kind` so a control session stays a control
+      // session (preserves its IPC-dispatch role).
+      await useAppStore
+        .getState()
+        .createSession(next, session.repo_path, session.isolated, session.kind);
     } catch (err) {
       console.error("[Sidebar] duplicate session failed", err);
     }

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1069,6 +1069,20 @@ export function Terminal({
     };
   }, [sessionId, cwd]);
 
+  // Steal keyboard focus for newly created sessions so the user can type
+  // immediately after Cmd+T (or any other creation path). Store dispatches
+  // `acorn:focus-session` after rAF so the slot has reattached to its pane
+  // body before we call `term.focus()`.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ sessionId: string }>).detail;
+      if (!detail || detail.sessionId !== sessionId) return;
+      termRef.current?.focus();
+    };
+    window.addEventListener("acorn:focus-session", handler);
+    return () => window.removeEventListener("acorn:focus-session", handler);
+  }, [sessionId]);
+
   // When this terminal is hidden behind another tab in the same pane and
   // then made visible again, the DOM renderer may not have repainted while
   // CSS visibility was `hidden`. Force a fit + full-buffer refresh so the

--- a/src/store.ts
+++ b/src/store.ts
@@ -770,6 +770,18 @@ export const useAppStore = create<AppStateModel>()(
       // through the store) immediately surfaces it in its pane instead of
       // silently appending behind the existing active tab.
       get().selectSession(created.id);
+      // Grab keyboard focus for the new session's xterm. rAF defers past the
+      // portal reattach in `TerminalHost` so the slot is mounted in its pane
+      // body by the time `Terminal` calls `term.focus()`.
+      if (typeof window !== "undefined") {
+        requestAnimationFrame(() => {
+          window.dispatchEvent(
+            new CustomEvent("acorn:focus-session", {
+              detail: { sessionId: created.id },
+            }),
+          );
+        });
+      }
       // First-run guidance for control sessions. Gated on a localStorage
       // flag so power users only see it once. App.tsx hosts the modal.
       if (


### PR DESCRIPTION
## Summary

Cmd+T (and every other session creation path) now puts the keyboard cursor directly inside the new xterm — typing works without a click. Pane tab's "Duplicate Session" no longer downgrades a control session to a regular one. Sidebar's "Duplicate Session" picks up the same post-create UX (next to active, selected, focused) for free.

## Changes

- `feat(panes)` — Pane tab "Duplicate Session" carries `tab.kind` through `spawnSession` → `store.createSession`. Default stays `"regular"` for `handleNewTabFromStrip` / `handleNewTabFromEmpty`. Symmetric with Sidebar's existing kind carry-over.
- `feat(sessions)` — `store.createSession` dispatches an `acorn:focus-session` custom event under `requestAnimationFrame` (waits for `TerminalHost` to reattach the per-session portal slot). `Terminal` listens, matches `sessionId`, calls `term.focus()`. App-level `focusin` syncer then keeps `focusedPaneId` consistent — no new state machinery.
- `feat(sidebar)` — `SessionRow.duplicate` was the only creation path skipping the store wrapper (called `api.createSession` + `refreshAll` directly). Routing through `useAppStore.getState().createSession(...)` lands it next to the active tab, auto-selects it, and triggers the new auto-focus dispatch. Drops unused `api` import.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 123 passed, 1 skipped
- [x] Cmd+T → new tab → type immediately, no extra click required
- [x] Pane tab context menu → "Duplicate Session" on a control session → duplicate stays `control`, xterm focused
- [x] Sidebar context menu → "Duplicate Session" → new tab lands next to active, auto-selected, xterm focused
- [x] Sidebar / Pane "+ New Tab", double-click filler — all still auto-focus
