### PR TITLE
chore(worktree): remove unused list_worktrees fn

### DIFF
--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -65,19 +65,10 @@ pub fn create_worktree(repo_path: &Path, name: &str) -> AppResult<PathBuf> {
     Ok(target)
 }
 
-pub fn list_worktrees(repo_path: &Path) -> AppResult<Vec<String>> {
-    let repo = ensure_repo(repo_path)?;
-    let names = repo.worktrees()?;
-    Ok(names
-        .iter()
-        .filter_map(|n| n.map(|s| s.to_string()))
-        .collect())
-}
-
-/// Like [`list_worktrees`] but returns absolute on-disk paths instead of
-/// names. Used by the post-PTY-exit "did claude just create a worktree?"
-/// detector — names alone aren't enough because we need to point a session
-/// at the new worktree's directory to respawn the child there.
+/// Returns absolute on-disk paths of linked worktrees. Used by the
+/// post-PTY-exit "did claude just create a worktree?" detector — names alone
+/// aren't enough because we need to point a session at the new worktree's
+/// directory to respawn the child there.
 ///
 /// Note: this only enumerates *linked* worktrees. The main repo checkout is
 /// excluded; libgit2's `worktrees()` only reports `.git/worktrees/<name>`


### PR DESCRIPTION
## Summary

Remove `list_worktrees` in `src-tauri/src/worktree.rs`. Function existed since the initial commit, has zero callers in the Rust source, and is not exported as a Tauri command. Each build emitted an `unused` / `dead_code` warning.

`list_worktree_paths` (used by `commands.rs::detect_worktree_after_pty_exit` flow) stays — its doc comment is reworded to stand on its own instead of referencing the deleted sibling.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml --lib` — no warnings, no errors
- [x] `grep -rn "list_worktrees" src/ src-tauri/` — only the removed line is gone; `list_worktree_paths` callsite in `commands.rs:468` intact
