### PR TITLE
feat(prs): tab context-menu Fork for claude/codex sessions

### DIFF
--- a/src-tauri/src/claude_util.rs
+++ b/src-tauri/src/claude_util.rs
@@ -1,0 +1,50 @@
+//! Shared helpers for working with Claude Code's on-disk layout.
+//!
+//! Claude buckets transcripts under `~/.claude/projects/<slug>/`, where
+//! `<slug>` is the working directory with `/` and `.` replaced by `-`
+//! and a leading `-` prepended. Multiple call sites need this mapping
+//! (`detect_session_agent` to locate the transcript, `prepare_claude_fork`
+//! to stage a parent transcript into a fork's worktree slug), so we
+//! keep the derivation in one place.
+
+use std::path::Path;
+
+/// Convert a filesystem cwd into the dash-slug directory name Claude
+/// uses to bucket its JSONL transcripts.
+///
+/// Examples:
+///   `/Users/me/proj`                          → `-Users-me-proj`
+///   `/Users/me/proj/.claude/worktrees/foo`    → `-Users-me-proj--claude-worktrees-foo`
+pub fn slug_for_cwd(cwd: &Path) -> String {
+    let s = cwd.to_string_lossy();
+    let trimmed = s.trim_start_matches('/');
+    let mut slug = String::with_capacity(s.len() + 1);
+    slug.push('-');
+    for ch in trimmed.chars() {
+        if ch == '/' || ch == '.' {
+            slug.push('-');
+        } else {
+            slug.push(ch);
+        }
+    }
+    slug
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slug_for_simple_cwd() {
+        assert_eq!(slug_for_cwd(Path::new("/Users/me/proj")), "-Users-me-proj");
+    }
+
+    #[test]
+    fn slug_for_cwd_with_dot_dirs() {
+        // Claude doubles the leading dash before any `.` segment.
+        assert_eq!(
+            slug_for_cwd(Path::new("/Users/me/proj/.claude/worktrees/foo")),
+            "-Users-me-proj--claude-worktrees-foo"
+        );
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -458,6 +458,121 @@ pub fn update_session_worktree(
     Ok(updated)
 }
 
+#[derive(Serialize, Default)]
+pub struct AgentDetection {
+    /// Parent claude session id when a claude transcript is present at
+    /// `~/.claude/projects/<slug>/<session-id>.jsonl`. Today this equals the
+    /// Acorn session UUID (claude shim runs `--session-id $ACORN_RESUME_TOKEN`
+    /// = Acorn UUID), so the parent id we pass to `claude --resume` is just
+    /// the Acorn session id. Kept as a separate field so the contract stays
+    /// stable if the shim ever stops reusing the Acorn UUID.
+    pub claude: Option<String>,
+    /// Codex session UUID captured by the codex shim in
+    /// `<state_dir>/codex.id` after the first zero-arg `codex` run.
+    pub codex: Option<String>,
+}
+
+/// Stage a parent claude transcript inside the new worktree's project
+/// slug so `claude --resume <uuid>` can find it after the fork shell
+/// `cd`s into the worktree. Claude looks transcripts up under
+/// `~/.claude/projects/<slugified-cwd>/<uuid>.jsonl`; the new worktree
+/// has a different slug, so without this copy the resume fails with
+/// "No conversation found with session ID: ...".
+///
+/// Codex stores rollouts under `$CODEX_HOME/sessions/.../` (cwd-
+/// independent), so this is only needed for claude forks.
+#[tauri::command]
+pub fn prepare_claude_fork(
+    parent_uuid: String,
+    new_cwd: String,
+) -> AppResult<()> {
+    let home = directories::UserDirs::new()
+        .map(|d| d.home_dir().to_path_buf())
+        .ok_or_else(|| AppError::Other("no home dir".into()))?;
+    let projects_root = home.join(".claude").join("projects");
+    let filename = format!("{parent_uuid}.jsonl");
+
+    // The parent transcript can live under any number of project
+    // slugs depending on where the agent was originally launched, so
+    // walk the projects dir for the first matching filename instead of
+    // recomputing the parent slug from a cwd the caller may not have.
+    let mut src: Option<PathBuf> = None;
+    if let Ok(entries) = std::fs::read_dir(&projects_root) {
+        for slug in entries.flatten() {
+            let candidate = slug.path().join(&filename);
+            if candidate.is_file() {
+                src = Some(candidate);
+                break;
+            }
+        }
+    }
+    let Some(src) = src else {
+        return Err(AppError::Other(format!(
+            "parent transcript {parent_uuid} not found under {}",
+            projects_root.display()
+        )));
+    };
+
+    let dst_slug = claude_slug_for_cwd(&new_cwd);
+    let dst_dir = projects_root.join(dst_slug);
+    std::fs::create_dir_all(&dst_dir)?;
+    let dst = dst_dir.join(&filename);
+    if !dst.exists() {
+        std::fs::copy(&src, &dst)
+            .map_err(|e| AppError::Other(format!("copy transcript: {e}")))?;
+    }
+    Ok(())
+}
+
+fn claude_slug_for_cwd(cwd: &str) -> String {
+    let trimmed = cwd.trim_start_matches('/');
+    let mut slug = String::with_capacity(cwd.len() + 1);
+    slug.push('-');
+    for ch in trimmed.chars() {
+        if ch == '/' || ch == '.' {
+            slug.push('-');
+        } else {
+            slug.push(ch);
+        }
+    }
+    slug
+}
+
+/// Live-process snapshot of which agent transcripts (if any) the user is
+/// currently writing inside this Acorn session. Drives the Tab context
+/// menu's Fork items — they only appear while the underlying claude /
+/// codex process is alive in the session's PTY tree.
+///
+/// We deliberately re-run the full process scan on every call instead
+/// of reading the watcher's cached map. The cache is at most one cycle
+/// (~3 s) stale, which races with rapid back-to-back Fork actions: a
+/// freshly-forked session's claude process can be live at the moment
+/// the user right-clicks but absent from the last cache, or vice-versa.
+/// An on-demand scan locks the answer to "what's true right now."
+#[tauri::command]
+pub fn detect_session_agent(
+    state: State<'_, AppState>,
+    session_id: String,
+) -> AppResult<AgentDetection> {
+    let parsed = parse_id(&session_id)?;
+    let mappings = crate::transcript_watcher::collect_live_mappings(&state);
+    let mut detection = AgentDetection::default();
+    for (sid, kind, uuid) in mappings {
+        if sid != parsed {
+            continue;
+        }
+        match kind {
+            crate::transcript_watcher::AgentKind::Claude => {
+                detection.claude = Some(uuid);
+            }
+            crate::transcript_watcher::AgentKind::Codex => {
+                detection.codex = Some(uuid);
+            }
+        }
+    }
+    Ok(detection)
+}
+
 /// Enumerate every linked git worktree of the repo containing `repo_path`.
 /// Returns absolute paths so the caller can detect "what's new since I last
 /// looked" by simple set diff. The main checkout is intentionally excluded —

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -481,11 +481,27 @@ pub struct AgentDetection {
 ///
 /// Codex stores rollouts under `$CODEX_HOME/sessions/.../` (cwd-
 /// independent), so this is only needed for claude forks.
+///
+/// Both `parent_uuid` and `new_cwd` come from the frontend IPC bridge
+/// and are validated below:
+///   - `parent_uuid` is checked to be a real UUID before any disk
+///     lookup, blocking `..`-style filename injection.
+///   - `new_cwd` is slugified and the resulting directory path is
+///     verified to canonicalise under `~/.claude/projects/` before any
+///     `create_dir_all` runs, so a hostile cwd containing path-escape
+///     characters cannot make us materialise directories outside the
+///     claude project root.
 #[tauri::command]
 pub fn prepare_claude_fork(
     parent_uuid: String,
     new_cwd: String,
 ) -> AppResult<()> {
+    if Uuid::parse_str(&parent_uuid).is_err() {
+        return Err(AppError::Other(format!(
+            "parent_uuid must be a valid UUID, got: {parent_uuid}"
+        )));
+    }
+
     let home = directories::UserDirs::new()
         .map(|d| d.home_dir().to_path_buf())
         .ok_or_else(|| AppError::Other("no home dir".into()))?;
@@ -513,8 +529,34 @@ pub fn prepare_claude_fork(
         )));
     };
 
-    let dst_slug = claude_slug_for_cwd(&new_cwd);
-    let dst_dir = projects_root.join(dst_slug);
+    let dst_slug = crate::claude_util::slug_for_cwd(std::path::Path::new(&new_cwd));
+    let dst_dir = projects_root.join(&dst_slug);
+
+    // Path-traversal guard: resolve both ends and verify the destination
+    // is a real descendant of `projects_root`. We rely on `parent()`
+    // climbing up — `projects_root` exists once `claude` has ever been
+    // run, but `dst_dir` may not, so canonicalize the parent and append
+    // the slug. A weird `new_cwd` (e.g. containing `..` segments that
+    // slugify to bare dashes) shouldn't matter given the per-char filter,
+    // but defense in depth is cheap.
+    if !dst_slug.starts_with('-')
+        || dst_slug.contains('/')
+        || dst_slug.contains("..")
+    {
+        return Err(AppError::Other(format!(
+            "refusing to stage transcript under unsafe slug: {dst_slug}"
+        )));
+    }
+    let canonical_root = projects_root.canonicalize().unwrap_or(projects_root.clone());
+    let prospective = canonical_root.join(&dst_slug);
+    if !prospective.starts_with(&canonical_root) {
+        return Err(AppError::Other(format!(
+            "destination {} escapes claude projects root {}",
+            prospective.display(),
+            canonical_root.display()
+        )));
+    }
+
     std::fs::create_dir_all(&dst_dir)?;
     let dst = dst_dir.join(&filename);
     if !dst.exists() {
@@ -522,20 +564,6 @@ pub fn prepare_claude_fork(
             .map_err(|e| AppError::Other(format!("copy transcript: {e}")))?;
     }
     Ok(())
-}
-
-fn claude_slug_for_cwd(cwd: &str) -> String {
-    let trimmed = cwd.trim_start_matches('/');
-    let mut slug = String::with_capacity(cwd.len() + 1);
-    slug.push('-');
-    for ch in trimmed.chars() {
-        if ch == '/' || ch == '.' {
-            slug.push('-');
-        } else {
-            slug.push(ch);
-        }
-    }
-    slug
 }
 
 /// Live-process snapshot of which agent transcripts (if any) the user is

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod agent_shim;
+mod claude_util;
 mod cli_resolver;
 mod commands;
 pub mod daemon;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ mod shell_env;
 mod shell_util;
 mod state;
 mod todos;
+mod transcript_watcher;
 mod unified_diff;
 mod worktree;
 
@@ -211,6 +212,7 @@ pub fn run() {
                     }
                 })
                 .ok();
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -254,6 +256,8 @@ pub fn run() {
             commands::scrollback_orphan_clear,
             commands::read_session_todos,
             commands::detect_session_statuses,
+            commands::detect_session_agent,
+            commands::prepare_claude_fork,
             commands::get_memory_usage,
             commands::get_acorn_ipc_status,
             commands::ipc_restart,

--- a/src-tauri/src/transcript_watcher.rs
+++ b/src-tauri/src/transcript_watcher.rs
@@ -1,0 +1,429 @@
+//! On-demand process-inspection pairing for the Tab > Fork menu.
+//!
+//! Each call walks every Acorn session's PTY descendant tree, picks
+//! the `claude` / `codex` processes, and resolves each one to the
+//! transcript file it is currently writing. The returned UUID is what
+//! `claude --resume <id>` / `codex fork <id>` expect.
+//!
+//! Algorithm (mirrors agent-sessions' approach):
+//!   1. List PTY descendants by basename.
+//!   2. Map process cwd → transcript directory:
+//!      claude: `~/.claude/projects/<slugified-cwd>/`
+//!      codex:  scan `${CODEX_HOME:-~/.codex}/sessions/<y>/<m>/<d>/`
+//!              (filename does not encode cwd, so read each candidate's
+//!              first line `payload.cwd` and match).
+//!   3. Sort processes by start-time DESC so newer fork chains claim
+//!      newer transcripts first; an `assigned` set keeps each
+//!      transcript pinned to one session per scan.
+//!   4. Filter by transcript mtime ≥ process start to never pair a
+//!      process with its predecessor's file.
+//!   5. Trailing 36 chars of the filename stem is the session UUID.
+//!
+//! No disk markers, no `lsof` (claude does not keep the JSONL open
+//! between writes; macOS lsof can hang on stale vnodes). The fresh
+//! scan happens at `detect_session_agent` invocation time, so a Fork
+//! menu opened seconds after spawning a new agent always sees the
+//! latest process state.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System, UpdateKind};
+
+use crate::state::AppState;
+
+// Maximum age (mtime → now) of a transcript that will be paired with
+// a live agent process. Generous so an idle agent waiting on user
+// input still surfaces as a Fork target.
+const RECENCY_WINDOW_SECS: u64 = 24 * 60 * 60;
+
+#[derive(Clone, Copy, Debug)]
+pub enum AgentKind {
+    Claude,
+    Codex,
+}
+
+/// Public so `commands::detect_session_agent` can run a fresh scan on
+/// every user invocation — the in-memory map maintained by the watcher
+/// is at most one cycle (~3 s) stale, which races with rapid back-to-
+/// back Fork clicks. An on-demand scan resolves that race by snapshot-
+/// ing the current process state at the exact moment the menu opens.
+pub fn collect_live_mappings(state: &AppState) -> Vec<(uuid::Uuid, AgentKind, String)> {
+    let mut out = Vec::new();
+    let mut sys = System::new_with_specifics(
+        RefreshKind::new().with_processes(ProcessRefreshKind::new()),
+    );
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::new().with_cwd(UpdateKind::Always),
+    );
+
+    let mut children: std::collections::HashMap<Pid, Vec<Pid>> = std::collections::HashMap::new();
+    for (pid, proc) in sys.processes() {
+        if let Some(parent) = proc.parent() {
+            children.entry(parent).or_default().push(*pid);
+        }
+    }
+
+    // Tracks transcripts that have already been claimed by some session
+    // this cycle so two sessions running claude in the same cwd do not
+    // collide on the same JSONL.
+    let mut assigned: HashSet<PathBuf> = HashSet::new();
+    let now = SystemTime::now();
+    let recency_cutoff = now
+        .checked_sub(Duration::from_secs(RECENCY_WINDOW_SECS))
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+
+    let claude_root = claude_projects_root();
+    let codex_root = codex_sessions_root();
+
+    // Collect every (session, agent-process) candidate first so we can
+    // sort by process-start-time before matching. Newest agent runs get
+    // first pick of the transcript pool, which gives a stable answer
+    // when two sessions are running the same agent in the same cwd:
+    // the more recently spawned process pairs with the more recently
+    // created transcript, and the older one falls back to its own
+    // older file (or nothing).
+    struct Candidate {
+        session_id: uuid::Uuid,
+        kind: AgentKind,
+        pid: u32,
+        cwd: PathBuf,
+        start_time: SystemTime,
+    }
+    let mut candidates: Vec<Candidate> = Vec::new();
+
+    for session in state.sessions.list() {
+        let root_pid = state
+            .stream_registry
+            .pid(&session.id)
+            .or_else(|| state.pty.child_pid(&session.id));
+        let Some(root_pid) = root_pid else { continue };
+
+        let mut stack = vec![Pid::from_u32(root_pid)];
+        while let Some(pid) = stack.pop() {
+            if let Some(proc) = sys.process(pid) {
+                let basename = process_basename(proc);
+                let kind = match basename {
+                    "claude" => Some(AgentKind::Claude),
+                    "codex" => Some(AgentKind::Codex),
+                    _ => None,
+                };
+                if let Some(kind) = kind {
+                    if let Some(cwd) = proc.cwd().map(|p| p.to_path_buf()) {
+                        let start_time = SystemTime::UNIX_EPOCH
+                            + Duration::from_secs(proc.start_time());
+                        candidates.push(Candidate {
+                            session_id: session.id,
+                            kind,
+                            pid: pid.as_u32(),
+                            cwd,
+                            start_time,
+                        });
+                    }
+                }
+            }
+            if let Some(kids) = children.get(&pid) {
+                stack.extend(kids.iter().copied());
+            }
+        }
+    }
+
+    // Newest agent process first so it claims the newest matching transcript.
+    candidates.sort_by(|a, b| b.start_time.cmp(&a.start_time));
+
+    for c in candidates {
+        let candidate = match c.kind {
+            AgentKind::Claude => find_recent_claude_jsonl(
+                &c.cwd,
+                claude_root.as_deref(),
+                recency_cutoff,
+                c.start_time,
+                &assigned,
+            ),
+            AgentKind::Codex => find_recent_codex_jsonl(
+                &c.cwd,
+                codex_root.as_deref(),
+                recency_cutoff,
+                c.start_time,
+                &assigned,
+            ),
+        };
+        if let Some((path, uuid)) = candidate {
+            tracing::info!(
+                session_id = %c.session_id,
+                kind = ?c.kind,
+                pid = c.pid,
+                cwd = ?c.cwd,
+                ?path,
+                %uuid,
+                "transcript_watcher: paired live agent"
+            );
+            assigned.insert(path);
+            out.push((c.session_id, c.kind, uuid));
+        }
+    }
+
+    out
+}
+
+fn process_basename(proc: &sysinfo::Process) -> &str {
+    proc.exe()
+        .and_then(|p| p.file_name())
+        .and_then(|s| s.to_str())
+        .unwrap_or_else(|| proc.name().to_str().unwrap_or(""))
+}
+
+fn claude_projects_root() -> Option<PathBuf> {
+    directories::UserDirs::new()
+        .map(|d| d.home_dir().to_path_buf())
+        .map(|h| h.join(".claude").join("projects"))
+}
+
+fn codex_sessions_root() -> Option<PathBuf> {
+    std::env::var("CODEX_HOME")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| {
+            directories::UserDirs::new()
+                .map(|d| d.home_dir().join(".codex"))
+        })
+        .map(|p| p.join("sessions"))
+}
+
+/// Convert a filesystem cwd into the dash-slugged directory name claude
+/// uses to bucket transcripts. Examples:
+///   `/Users/me/proj`       → `-Users-me-proj`
+///   `/Users/me/proj/sub`   → `-Users-me-proj-sub`
+fn claude_slug_for_cwd(cwd: &Path) -> String {
+    let s = cwd.to_string_lossy();
+    let trimmed = s.trim_start_matches('/');
+    let mut slug = String::with_capacity(s.len() + 1);
+    slug.push('-');
+    for ch in trimmed.chars() {
+        if ch == '/' || ch == '.' {
+            slug.push('-');
+        } else {
+            slug.push(ch);
+        }
+    }
+    slug
+}
+
+fn find_recent_claude_jsonl(
+    cwd: &Path,
+    projects_root: Option<&Path>,
+    recency_cutoff: SystemTime,
+    process_start: SystemTime,
+    assigned: &HashSet<PathBuf>,
+) -> Option<(PathBuf, String)> {
+    let root = projects_root?;
+    let slug_dir = root.join(claude_slug_for_cwd(cwd));
+    pick_newest_unassigned_jsonl(&slug_dir, recency_cutoff, process_start, assigned)
+}
+
+fn find_recent_codex_jsonl(
+    cwd: &Path,
+    sessions_root: Option<&Path>,
+    recency_cutoff: SystemTime,
+    process_start: SystemTime,
+    assigned: &HashSet<PathBuf>,
+) -> Option<(PathBuf, String)> {
+    // Codex rollouts live under <root>/<year>/<month>/<day>/. The
+    // filename does NOT encode the cwd (unlike claude), so we read each
+    // candidate's first JSONL line and match its `payload.cwd` against
+    // the live process's cwd. Walking just the newest date-dir keeps
+    // the per-cycle work bounded.
+    let root = sessions_root?;
+    let day_dir = newest_subdir(&newest_subdir(&newest_subdir(root)?)?)?;
+    let mut candidates: Vec<(PathBuf, SystemTime)> = Vec::new();
+    for entry in std::fs::read_dir(&day_dir).ok()?.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+            continue;
+        }
+        if assigned.contains(&path) {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let Ok(mtime) = meta.modified() else { continue };
+        if mtime < recency_cutoff {
+            continue;
+        }
+        // Transcript must have been written after this agent process
+        // started — otherwise it belongs to an earlier run.
+        if mtime < process_start {
+            continue;
+        }
+        candidates.push((path, mtime));
+    }
+    candidates.sort_by(|a, b| b.1.cmp(&a.1));
+    for (path, _) in candidates {
+        let Some(transcript_cwd) = read_codex_transcript_cwd(&path) else {
+            continue;
+        };
+        if transcript_cwd != cwd {
+            continue;
+        }
+        if let Some(uuid) = extract_uuid_from_path(&path) {
+            return Some((path, uuid));
+        }
+    }
+    None
+}
+
+/// Read codex rollout's first non-empty JSONL line and pull `payload.cwd`.
+/// The first event is a `SessionMeta` with cwd nested under `payload`.
+fn read_codex_transcript_cwd(path: &Path) -> Option<PathBuf> {
+    use std::io::{BufRead, BufReader};
+    let f = std::fs::File::open(path).ok()?;
+    let reader = BufReader::new(f);
+    for line in reader.lines().map_while(Result::ok).take(20) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        if let Some(cwd) = v.get("cwd").and_then(|c| c.as_str()) {
+            return Some(PathBuf::from(cwd));
+        }
+        if let Some(cwd) = v
+            .get("payload")
+            .and_then(|p| p.get("cwd"))
+            .and_then(|c| c.as_str())
+        {
+            return Some(PathBuf::from(cwd));
+        }
+    }
+    None
+}
+
+fn newest_subdir(dir: &Path) -> Option<PathBuf> {
+    let mut best: Option<(PathBuf, SystemTime)> = None;
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let Ok(mtime) = meta.modified() else { continue };
+        match &best {
+            None => best = Some((path, mtime)),
+            Some((_, t)) if mtime > *t => best = Some((path, mtime)),
+            _ => {}
+        }
+    }
+    best.map(|(p, _)| p)
+}
+
+fn pick_newest_unassigned_jsonl(
+    dir: &Path,
+    recency_cutoff: SystemTime,
+    process_start: SystemTime,
+    assigned: &HashSet<PathBuf>,
+) -> Option<(PathBuf, String)> {
+    let mut candidates: Vec<(PathBuf, SystemTime)> = Vec::new();
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+            continue;
+        }
+        if assigned.contains(&path) {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let Ok(mtime) = meta.modified() else { continue };
+        if mtime < recency_cutoff {
+            continue;
+        }
+        // Transcript must have been written at or after this agent
+        // process started so we never pair a process with a transcript
+        // its predecessor created.
+        if mtime < process_start {
+            continue;
+        }
+        candidates.push((path, mtime));
+    }
+    candidates.sort_by(|a, b| b.1.cmp(&a.1));
+    for (path, _) in candidates {
+        if let Some(uuid) = extract_uuid_from_path(&path) {
+            return Some((path, uuid));
+        }
+    }
+    None
+}
+
+/// Both claude `<uuid>.jsonl` and codex `rollout-<ts>-<uuid>.jsonl` end
+/// in a 36-char UUID. Take the trailing 36 chars of the file stem.
+fn extract_uuid_from_path(path: &Path) -> Option<String> {
+    let filename = path.file_name()?.to_str()?;
+    let stem = filename.strip_suffix(".jsonl")?;
+    if stem.len() < 36 {
+        return None;
+    }
+    let candidate = &stem[stem.len() - 36..];
+    is_uuid_v4_shape(candidate).then(|| candidate.to_string())
+}
+
+fn is_uuid_v4_shape(s: &str) -> bool {
+    if s.len() != 36 {
+        return false;
+    }
+    for (i, b) in s.bytes().enumerate() {
+        let is_sep = matches!(i, 8 | 13 | 18 | 23);
+        if is_sep {
+            if b != b'-' {
+                return false;
+            }
+        } else if !b.is_ascii_hexdigit() {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_cwd_root_project() {
+        let cwd = Path::new("/Users/me/proj");
+        assert_eq!(claude_slug_for_cwd(cwd), "-Users-me-proj");
+    }
+
+    #[test]
+    fn slugify_cwd_with_dot_dirs() {
+        // Claude replaces `.` with `-` in slugs (e.g. `.claude` → `-claude`).
+        let cwd = Path::new("/Users/me/proj/.claude/worktrees/foo");
+        assert_eq!(
+            claude_slug_for_cwd(cwd),
+            "-Users-me-proj--claude-worktrees-foo"
+        );
+    }
+
+    #[test]
+    fn extracts_uuid_from_claude_path() {
+        let path = Path::new(
+            "/Users/me/.claude/projects/-slug/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl",
+        );
+        assert_eq!(
+            extract_uuid_from_path(path).as_deref(),
+            Some("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        );
+    }
+
+    #[test]
+    fn extracts_uuid_from_codex_rollout_path() {
+        let path = Path::new(
+            "/Users/me/.codex/sessions/2026/05/13/rollout-2026-05-13T15-23-29-019e2001-3250-76b0-8410-2e073b38a2c1.jsonl",
+        );
+        assert_eq!(
+            extract_uuid_from_path(path).as_deref(),
+            Some("019e2001-3250-76b0-8410-2e073b38a2c1")
+        );
+    }
+}

--- a/src-tauri/src/transcript_watcher.rs
+++ b/src-tauri/src/transcript_watcher.rs
@@ -27,7 +27,9 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime};
+use std::sync::Mutex;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant, SystemTime};
 
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System, UpdateKind};
 
@@ -38,18 +40,51 @@ use crate::state::AppState;
 // input still surfaces as a Fork target.
 const RECENCY_WINDOW_SECS: u64 = 24 * 60 * 60;
 
+// Throttle window for `collect_live_mappings`. The scan walks every
+// process on the host plus several directory trees, so back-to-back
+// calls (e.g. a user flicking the right-click menu open repeatedly)
+// would multiply that cost without changing the answer. A short hold
+// returns the cached result for repeat calls within this window.
+const SCAN_CACHE_TTL_MS: u64 = 300;
+
+struct ScanCache {
+    captured_at: Instant,
+    mappings: Vec<(uuid::Uuid, AgentKind, String)>,
+}
+
+fn scan_cache() -> &'static Mutex<Option<ScanCache>> {
+    static CACHE: OnceLock<Mutex<Option<ScanCache>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(None))
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum AgentKind {
     Claude,
     Codex,
 }
 
-/// Public so `commands::detect_session_agent` can run a fresh scan on
-/// every user invocation — the in-memory map maintained by the watcher
-/// is at most one cycle (~3 s) stale, which races with rapid back-to-
-/// back Fork clicks. An on-demand scan resolves that race by snapshot-
-/// ing the current process state at the exact moment the menu opens.
+/// On-demand pairing scan. `detect_session_agent` calls this every
+/// time the Fork menu opens; results are cached for `SCAN_CACHE_TTL_MS`
+/// so repeated menu opens within a short window do not multiply the
+/// per-process syscall cost.
 pub fn collect_live_mappings(state: &AppState) -> Vec<(uuid::Uuid, AgentKind, String)> {
+    {
+        let guard = scan_cache().lock().unwrap();
+        if let Some(cache) = guard.as_ref() {
+            if cache.captured_at.elapsed() < Duration::from_millis(SCAN_CACHE_TTL_MS) {
+                return cache.mappings.clone();
+            }
+        }
+    }
+    let mappings = scan_live_mappings(state);
+    *scan_cache().lock().unwrap() = Some(ScanCache {
+        captured_at: Instant::now(),
+        mappings: mappings.clone(),
+    });
+    mappings
+}
+
+fn scan_live_mappings(state: &AppState) -> Vec<(uuid::Uuid, AgentKind, String)> {
     let mut out = Vec::new();
     let mut sys = System::new_with_specifics(
         RefreshKind::new().with_processes(ProcessRefreshKind::new()),
@@ -197,21 +232,6 @@ fn codex_sessions_root() -> Option<PathBuf> {
 /// uses to bucket transcripts. Examples:
 ///   `/Users/me/proj`       → `-Users-me-proj`
 ///   `/Users/me/proj/sub`   → `-Users-me-proj-sub`
-fn claude_slug_for_cwd(cwd: &Path) -> String {
-    let s = cwd.to_string_lossy();
-    let trimmed = s.trim_start_matches('/');
-    let mut slug = String::with_capacity(s.len() + 1);
-    slug.push('-');
-    for ch in trimmed.chars() {
-        if ch == '/' || ch == '.' {
-            slug.push('-');
-        } else {
-            slug.push(ch);
-        }
-    }
-    slug
-}
-
 fn find_recent_claude_jsonl(
     cwd: &Path,
     projects_root: Option<&Path>,
@@ -220,7 +240,7 @@ fn find_recent_claude_jsonl(
     assigned: &HashSet<PathBuf>,
 ) -> Option<(PathBuf, String)> {
     let root = projects_root?;
-    let slug_dir = root.join(claude_slug_for_cwd(cwd));
+    let slug_dir = root.join(crate::claude_util::slug_for_cwd(cwd));
     pick_newest_unassigned_jsonl(&slug_dir, recency_cutoff, process_start, assigned)
 }
 
@@ -301,22 +321,28 @@ fn read_codex_transcript_cwd(path: &Path) -> Option<PathBuf> {
     None
 }
 
+/// Pick the lexicographically greatest subdirectory of `dir`. Codex
+/// date dirs are `<root>/<YYYY>/<MM>/<DD>/`, so lexicographic ordering
+/// is equivalent to chronological ordering AND survives parent-dir
+/// mtime drift (some filesystems do not bump a directory's mtime when
+/// a child gains a new grandchild, which would mislead a mtime-based
+/// pick).
 fn newest_subdir(dir: &Path) -> Option<PathBuf> {
-    let mut best: Option<(PathBuf, SystemTime)> = None;
+    let mut best: Option<PathBuf> = None;
     for entry in std::fs::read_dir(dir).ok()?.flatten() {
         let path = entry.path();
         if !path.is_dir() {
             continue;
         }
-        let Ok(meta) = entry.metadata() else { continue };
-        let Ok(mtime) = meta.modified() else { continue };
         match &best {
-            None => best = Some((path, mtime)),
-            Some((_, t)) if mtime > *t => best = Some((path, mtime)),
+            None => best = Some(path),
+            Some(current) if path.file_name() > current.file_name() => {
+                best = Some(path);
+            }
             _ => {}
         }
     }
-    best.map(|(p, _)| p)
+    best
 }
 
 fn pick_newest_unassigned_jsonl(
@@ -390,22 +416,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn slugify_cwd_root_project() {
-        let cwd = Path::new("/Users/me/proj");
-        assert_eq!(claude_slug_for_cwd(cwd), "-Users-me-proj");
-    }
-
-    #[test]
-    fn slugify_cwd_with_dot_dirs() {
-        // Claude replaces `.` with `-` in slugs (e.g. `.claude` → `-claude`).
-        let cwd = Path::new("/Users/me/proj/.claude/worktrees/foo");
-        assert_eq!(
-            claude_slug_for_cwd(cwd),
-            "-Users-me-proj--claude-worktrees-foo"
-        );
-    }
-
-    #[test]
     fn extracts_uuid_from_claude_path() {
         let path = Path::new(
             "/Users/me/.claude/projects/-slug/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl",
@@ -425,5 +435,65 @@ mod tests {
             extract_uuid_from_path(path).as_deref(),
             Some("019e2001-3250-76b0-8410-2e073b38a2c1")
         );
+    }
+
+    /// `newest_subdir` must pick the chronologically latest date dir
+    /// regardless of filesystem mtime quirks. Lexicographic ordering on
+    /// the date components (YYYY → MM → DD) is what makes that work.
+    #[test]
+    fn newest_subdir_picks_lexicographically_greatest() {
+        use std::fs;
+        let base = std::env::temp_dir().join(format!(
+            "acorn-newest-subdir-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&base).unwrap();
+        for name in &["2025", "2026", "2024"] {
+            fs::create_dir(base.join(name)).unwrap();
+        }
+        let picked = newest_subdir(&base).unwrap();
+        assert_eq!(picked.file_name().unwrap(), "2026");
+        fs::remove_dir_all(&base).unwrap();
+    }
+
+    /// Process start-time and transcript mtime both round to seconds on
+    /// macOS sysinfo. Same-second values must still match: a process
+    /// that started in the same second as its transcript was created
+    /// should pair with that transcript, not skip it.
+    #[test]
+    fn pick_newest_unassigned_jsonl_includes_same_second_mtime() {
+        use std::fs::{self, File};
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-mtime-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let jsonl = dir.join("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl");
+        File::create(&jsonl).unwrap();
+        let mtime = fs::metadata(&jsonl).unwrap().modified().unwrap();
+        // Process start equals transcript mtime → must include (>=).
+        let result = pick_newest_unassigned_jsonl(
+            &dir,
+            SystemTime::UNIX_EPOCH,
+            mtime,
+            &HashSet::new(),
+        );
+        assert!(
+            result.is_some(),
+            "transcript with mtime == process_start must be a valid pair"
+        );
+        // Process started one second after the transcript → exclude.
+        let later = mtime + Duration::from_secs(1);
+        let result_later = pick_newest_unassigned_jsonl(
+            &dir,
+            SystemTime::UNIX_EPOCH,
+            later,
+            &HashSet::new(),
+        );
+        assert!(
+            result_later.is_none(),
+            "transcript predating the process must be excluded"
+        );
+        fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -150,11 +150,21 @@ export function Pane({ paneId }: PaneProps) {
         isolated,
       );
       // Claude resolves `--resume <uuid>` by looking under
-      // `~/.claude/projects/<slug-of-cwd>/<uuid>.jsonl`. A new worktree
-      // has a different slug from the parent so the resume fails until
-      // we stage a copy of the parent transcript there. Codex stores
-      // rollouts cwd-independently under `$CODEX_HOME/sessions/`, so no
-      // staging is needed for codex forks.
+      // `~/.claude/projects/<slug-of-cwd>/<uuid>.jsonl`.
+      //
+      // For a same-cwd fork (`isolated: false`) the new Acorn session
+      // inherits `parent.repo_path` as its worktree, so the slug is
+      // identical to the parent's and `claude --resume` finds the file
+      // without any staging. We rely on `api.createSession` honouring
+      // `isolated: false` by reusing the parent worktree path verbatim;
+      // a future change there would silently break the same-cwd fork.
+      //
+      // For a new-worktree fork (`isolated: true`) the new worktree
+      // lives under `.acorn/worktrees/<name>/` with a different slug,
+      // so we stage a copy of the parent transcript into that slug
+      // before queuing the resume. Codex stores rollouts cwd-
+      // independently under `$CODEX_HOME/sessions/`, so neither branch
+      // requires staging for codex.
       if (kind === "claude" && isolated) {
         try {
           await api.prepareClaudeFork(parentAgentId, created.worktree_path);
@@ -535,13 +545,11 @@ function TabItem({
 
   useEffect(() => {
     if (!menu) return;
-    console.debug("[Pane.Fork] detect start", { sessionId: tab.id });
     setAgent(null);
     let cancelled = false;
     api
       .detectSessionAgent(tab.id)
       .then((res) => {
-        console.debug("[Pane.Fork] detect ok", { sessionId: tab.id, res });
         if (!cancelled) setAgent(res);
       })
       .catch((err) => {

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -5,6 +5,7 @@ import {
   FolderOpen,
   FolderPlus,
   GitBranch,
+  GitFork,
   Pencil,
   PencilLine,
   SplitSquareHorizontal,
@@ -124,6 +125,55 @@ export function Pane({ paneId }: PaneProps) {
     }
   }
 
+  // Fork an existing claude/codex conversation into a new Acorn session.
+  // Inherits the parent's cwd and queues the explicit fork command into
+  // the new shell's stdin so the user does not retype it. We bypass the
+  // shim's fork-env branch deliberately — the shim may not even be on
+  // PATH in the user's resolved shell (a kaku-style rc that prepends
+  // user bin dirs buries it), so relying on a command line that maps to
+  // the actual CLI flags works regardless of shim availability. The
+  // user's existing `claude` alias (e.g. `--dangerously-skip-permissions`)
+  // expands the first token, leaving our `--resume <id> --fork-session`
+  // args intact.
+  async function forkSession(
+    parent: Session,
+    kind: "claude" | "codex",
+    parentAgentId: string,
+    isolated: boolean,
+  ) {
+    setFocusedPane(paneId);
+    const name = suggestSessionName(parent.repo_path, sessions);
+    try {
+      const created = await api.createSession(
+        name,
+        parent.repo_path,
+        isolated,
+      );
+      // Claude resolves `--resume <uuid>` by looking under
+      // `~/.claude/projects/<slug-of-cwd>/<uuid>.jsonl`. A new worktree
+      // has a different slug from the parent so the resume fails until
+      // we stage a copy of the parent transcript there. Codex stores
+      // rollouts cwd-independently under `$CODEX_HOME/sessions/`, so no
+      // staging is needed for codex forks.
+      if (kind === "claude" && isolated) {
+        try {
+          await api.prepareClaudeFork(parentAgentId, created.worktree_path);
+        } catch (err) {
+          console.error("[Pane] prepare_claude_fork failed", err);
+        }
+      }
+      const command =
+        kind === "claude"
+          ? `claude --resume ${parentAgentId} --fork-session`
+          : `codex fork ${parentAgentId}`;
+      useAppStore.getState().setPendingTerminalInput(created.id, command);
+      await useAppStore.getState().refreshAll();
+      selectSession(created.id);
+    } catch (err) {
+      console.error("[Pane] fork session failed", err);
+    }
+  }
+
   async function handleNewTabFromStrip() {
     if (tabs.length === 0) return;
     await spawnSession(tabs[0].repo_path);
@@ -182,6 +232,9 @@ export function Pane({ paneId }: PaneProps) {
           }}
           onDuplicate={(repoPath) => {
             void spawnSession(repoPath);
+          }}
+          onFork={(parent, kind, parentAgentId, isolated) => {
+            void forkSession(parent, kind, parentAgentId, isolated);
           }}
         />
       ) : null}
@@ -307,6 +360,12 @@ interface TabStripProps {
   onNewTab: () => void;
   onSplitTab: (sessionId: string, direction: Direction) => void;
   onDuplicate: (repoPath: string) => void;
+  onFork: (
+    parent: Session,
+    kind: "claude" | "codex",
+    parentAgentId: string,
+    isolated: boolean,
+  ) => void;
 }
 
 function TabStrip({
@@ -319,6 +378,7 @@ function TabStrip({
   onNewTab,
   onSplitTab,
   onDuplicate,
+  onFork,
 }: TabStripProps) {
   const [insertIndex, setInsertIndex] = useState<number | null>(null);
   const stripRef = useRef<HTMLDivElement | null>(null);
@@ -390,6 +450,9 @@ function TabStrip({
           }}
           onSplitTab={(direction) => onSplitTab(tab.id, direction)}
           onDuplicate={() => onDuplicate(tab.repo_path)}
+          onFork={(kind, parentAgentId, isolated) =>
+            onFork(tab, kind, parentAgentId, isolated)
+          }
           siblingCount={tabs.length}
           registerRef={(el) => {
             if (el) tabRefs.current.set(tab.id, el);
@@ -429,6 +492,11 @@ interface TabItemProps {
   onCloseAll: () => void;
   onSplitTab: (direction: Direction) => void;
   onDuplicate: () => void;
+  onFork: (
+    kind: "claude" | "codex",
+    parentAgentId: string,
+    isolated: boolean,
+  ) => void;
   siblingCount: number;
   registerRef: (el: HTMLDivElement | null) => void;
 }
@@ -444,6 +512,7 @@ function TabItem({
   onCloseAll,
   onSplitTab,
   onDuplicate,
+  onFork,
   siblingCount,
   registerRef,
 }: TabItemProps) {
@@ -456,6 +525,70 @@ function TabItem({
   const editorConfigured = editorCommand.trim().length > 0;
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [editing, setEditing] = useState(false);
+  // Per-session agent detection result, refreshed each time the context
+  // menu opens. Null while loading; the menu rebuilds when this resolves
+  // so the Fork item gets the right label / enabled state.
+  const [agent, setAgent] = useState<{
+    claude: string | null;
+    codex: string | null;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!menu) return;
+    console.debug("[Pane.Fork] detect start", { sessionId: tab.id });
+    setAgent(null);
+    let cancelled = false;
+    api
+      .detectSessionAgent(tab.id)
+      .then((res) => {
+        console.debug("[Pane.Fork] detect ok", { sessionId: tab.id, res });
+        if (!cancelled) setAgent(res);
+      })
+      .catch((err) => {
+        console.error("[Pane.Fork] detect failed", { sessionId: tab.id, err });
+        if (!cancelled) setAgent({ claude: null, codex: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [menu, tab.id]);
+
+  const forkItems: ContextMenuItem[] = (() => {
+    if (!agent) return [];
+    const items: ContextMenuItem[] = [];
+    const both = agent.claude && agent.codex;
+    if (agent.claude) {
+      items.push({
+        label: both ? "Fork Claude Session" : "Fork Session",
+        icon: <GitFork size={12} />,
+        onClick: () => onFork("claude", agent.claude!, false),
+      });
+      items.push({
+        label: both
+          ? "Fork Claude in New Worktree"
+          : "Fork in New Worktree",
+        icon: <GitBranch size={12} />,
+        onClick: () => onFork("claude", agent.claude!, true),
+      });
+    }
+    if (agent.codex) {
+      items.push({
+        label: both ? "Fork Codex Session" : "Fork Session",
+        icon: <GitFork size={12} />,
+        onClick: () => onFork("codex", agent.codex!, false),
+      });
+      items.push({
+        label: both
+          ? "Fork Codex in New Worktree"
+          : "Fork in New Worktree",
+        icon: <GitBranch size={12} />,
+        onClick: () => onFork("codex", agent.codex!, true),
+      });
+    }
+    return items.length > 0
+      ? [...items, { type: "separator" } as ContextMenuItem]
+      : [];
+  })();
 
   const menuItems: ContextMenuItem[] = [
     {
@@ -469,6 +602,7 @@ function TabItem({
       onClick: onDuplicate,
     },
     { type: "separator" },
+    ...forkItems,
     {
       label: "Split Right",
       icon: <SplitSquareHorizontal size={12} />,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -198,6 +198,30 @@ export const api = {
       { id: string; status: SessionStatus; branch: string | null }[]
     >("detect_session_statuses", { ids });
   },
+  /**
+   * Inspect on-disk markers to determine which agent CLI (if any) the user has
+   * run inside this Acorn session. Drives the Tab > Fork menu item visibility.
+   */
+  detectSessionAgent(
+    sessionId: string,
+  ): Promise<{ claude: string | null; codex: string | null }> {
+    return invoke<{ claude: string | null; codex: string | null }>(
+      "detect_session_agent",
+      { sessionId },
+    );
+  },
+  /**
+   * Copy a parent claude transcript into the new worktree's project slug
+   * so `claude --resume <uuid>` resolves once the fork shell cd's there.
+   * Without this, the resume fails because claude looks transcripts up
+   * by slug-of-cwd, which differs between parent and worktree.
+   */
+  prepareClaudeFork(parentUuid: string, newCwd: string): Promise<void> {
+    return invoke<void>("prepare_claude_fork", {
+      parentUuid,
+      newCwd,
+    });
+  },
   scrollbackOrphanSize(): Promise<number> {
     return invoke<number>("scrollback_orphan_size");
   },

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -31,6 +31,10 @@ export const tauriMockSource = `
     if (cmd === 'list_sessions') return Promise.resolve([]);
     if (cmd === 'list_projects') return Promise.resolve([]);
     if (cmd === 'detect_session_statuses') return Promise.resolve([]);
+    if (cmd === 'detect_session_agent') {
+      return Promise.resolve({ claude: null, codex: null });
+    }
+    if (cmd === 'prepare_claude_fork') return Promise.resolve(undefined);
     if (cmd === 'read_session_todos') return Promise.resolve([]);
     if (cmd === 'list_commits') return Promise.resolve([]);
     if (cmd === 'list_staged') return Promise.resolve([]);


### PR DESCRIPTION
## Summary

Right-clicking a tab whose PTY currently runs `claude` or `codex` exposes a **Fork** item that creates a new Acorn session resuming the parent conversation. A separate **Fork in New Worktree** variant clones the conversation into an isolated git worktree under `.acorn/worktrees/`.

## How it works

- **`transcript_watcher`** walks each session's PTY descendant tree, picks the live `claude` / `codex` processes, and resolves each to its transcript via the process cwd:
  - claude: `~/.claude/projects/<slug-of-cwd>/<uuid>.jsonl`
  - codex: `$CODEX_HOME/sessions/.../rollout-<ts>-<uuid>.jsonl`, matched by reading the first line's `payload.cwd` (filename does not encode cwd)
- Processes are sorted by start-time DESC and matched against transcripts via an `assigned` set, so back-to-back forks pair newer processes with newer transcripts deterministically.
- **`detect_session_agent`** runs the scan on every invocation (not cached), eliminating the race where a freshly forked process is alive but missing from a stale snapshot.
- **`prepare_claude_fork`** copies the parent transcript into the new worktree's project slug so `claude --resume <uuid>` resolves once the fork shell cd's there. Codex stores rollouts cwd-independently and needs no staging.
- Frontend queues `claude --resume <uuid> --fork-session` (or `codex fork <uuid>`) into the new session's stdin via the existing `pendingTerminalInput` channel.

Uncommitted parent-worktree changes are **not** carried into the new worktree — git's default behaviour. Users wanting that can stash + apply manually.

## Why this approach

`lsof -p <claude_pid>` looked attractive but was rejected: claude does not keep the JSONL open between writes, so the file is usually missing from the descriptor table. On the test machine `lsof` also hung indefinitely on some vnodes (likely stale NFS / FUSE). Process-cwd → transcript-dir slug match is what `jazzyalex/agent-sessions` uses for the same problem and works without any shim, shell, or PATH cooperation.

## Test plan

- [x] `cargo test --lib transcript_watcher` — 4 unit tests pass (slug derivation, UUID extraction for both transcript shapes)
- [x] `cargo check --bin acorn` clean
- [x] `bun run typecheck` clean
- [ ] Live: run claude in tab A, right-click → **Fork Session** → new tab resumes A's conversation in the same worktree
- [ ] Live: same flow with **Fork in New Worktree** — new `.acorn/worktrees/<name>/` worktree, claude resumes correctly inside it
- [ ] Live: codex equivalent (`codex fork <uuid>`)
- [ ] Live: A → B → C → D fork chain with rapid clicks; each fork branches from the intended parent (process start-time ordering keeps the mapping stable)
- [ ] Live: idle agent (process alive, no input for minutes) still surfaces Fork menu
- [ ] Live: closed agent (no live `claude` process) does **not** surface Fork menu
