### PR TITLE
feat(sessions): auto-show worktree icon when session lives inside a worktree

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -171,13 +171,20 @@ pub fn list_sessions(state: State<'_, AppState>) -> Vec<Session> {
         .sessions
         .list()
         .into_iter()
-        .map(|mut s| {
-            if let Ok(branch) = worktree::current_branch(&s.worktree_path) {
-                s.branch = branch;
-            }
-            s
-        })
+        .map(enrich_session)
         .collect()
+}
+
+/// Attach derived fields (`branch`, `in_worktree`) computed from the
+/// session's current on-disk state. Pure: never mutates the persisted
+/// store. Called on every Session leaving the backend so the frontend
+/// sees fresh values without a second round-trip.
+fn enrich_session(mut s: Session) -> Session {
+    if let Ok(branch) = worktree::current_branch(&s.worktree_path) {
+        s.branch = branch;
+    }
+    s.in_worktree = worktree::is_linked_worktree_root(&s.worktree_path);
+    s
 }
 
 static MEMORY_PROBE: Mutex<Option<System>> = Mutex::new(None);
@@ -320,7 +327,7 @@ pub async fn create_session(
     let inserted = state.sessions.insert(session);
     state.projects.ensure(repo.clone(), project_basename(&repo));
     persist(&state);
-    Ok(inserted)
+    Ok(enrich_session(inserted))
 }
 
 #[tauri::command]
@@ -360,7 +367,7 @@ pub fn reorder_sessions(
         .collect();
     state.sessions.reorder(&path, &ids);
     persist(&state);
-    Ok(state.sessions.list())
+    Ok(state.sessions.list().into_iter().map(enrich_session).collect())
 }
 
 #[tauri::command]
@@ -434,7 +441,7 @@ pub fn rename_session(state: State<'_, AppState>, id: String, name: String) -> A
     }
     let updated = state.sessions.rename(&id, trimmed)?;
     persist(&state);
-    Ok(updated)
+    Ok(enrich_session(updated))
 }
 
 /// Re-point a session at a new worktree directory and persist the change.
@@ -455,7 +462,7 @@ pub fn update_session_worktree(
     }
     let updated = state.sessions.update_worktree_path(&id, path)?;
     persist(&state);
-    Ok(updated)
+    Ok(enrich_session(updated))
 }
 
 /// Enumerate every linked git worktree of the repo containing `repo_path`.
@@ -954,6 +961,55 @@ fn deepest_descendant_cwd(sys: &System, root: Pid) -> Option<String> {
         }
     }
     best.map(|(_, p)| p)
+}
+
+/// Batched live-cwd → "is linked worktree" probe for every session that has
+/// a live PTY. Single system process refresh, one descendant walk per
+/// session — ~20-30ms regardless of session count, vs. that cost × N when
+/// callers loop `pty_cwd` per session.
+///
+/// Key invariant: a session id appears in the map **iff** it currently has a
+/// live PTY. The value is `true` when its live cwd resolves inside a linked
+/// worktree, `false` otherwise. Absence means "no live PTY — fall back to
+/// the session's recorded `worktree_path` / `isolated` flags". Conflating
+/// "no live PTY" with "live but not in a worktree" would let a stale static
+/// signal override the fresh live one (e.g. user `cd`s out of an adopted
+/// worktree).
+#[tauri::command]
+pub fn pty_in_worktree_all(state: State<'_, AppState>) -> HashMap<String, bool> {
+    let sessions = state.sessions.list();
+    let pids: Vec<(Uuid, u32)> = sessions
+        .iter()
+        .filter_map(|s| state.pty.child_pid(&s.id).map(|pid| (s.id, pid)))
+        .collect();
+    if pids.is_empty() {
+        return HashMap::new();
+    }
+
+    let mut sys = System::new_with_specifics(
+        RefreshKind::new().with_processes(ProcessRefreshKind::new()),
+    );
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::new().with_cwd(UpdateKind::Always),
+    );
+
+    let mut out = HashMap::with_capacity(pids.len());
+    for (id, pid) in pids {
+        let in_worktree = match deepest_descendant_cwd(&sys, Pid::from_u32(pid)) {
+            Some(cwd) => match git2::Repository::discover(&cwd) {
+                Ok(repo) => repo
+                    .workdir()
+                    .map(|wd| worktree::is_linked_worktree_root(wd))
+                    .unwrap_or(false),
+                Err(_) => false,
+            },
+            None => false,
+        };
+        out.insert(id.to_string(), in_worktree);
+    }
+    out
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1001,7 +1001,7 @@ pub fn pty_in_worktree_all(state: State<'_, AppState>) -> HashMap<String, bool> 
             Some(cwd) => match git2::Repository::discover(&cwd) {
                 Ok(repo) => repo
                     .workdir()
-                    .map(|wd| worktree::is_linked_worktree_root(wd))
+                    .map(worktree::is_linked_worktree_root)
                     .unwrap_or(false),
                 Err(_) => false,
             },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -271,6 +271,7 @@ pub fn run() {
             commands::pty_reload_shell_env,
             commands::pty_cwd,
             commands::pty_repo_root,
+            commands::pty_in_worktree_all,
             commands::update_session_worktree,
             commands::git_worktrees,
             commands::scrollback_save,

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -173,6 +173,15 @@ pub struct Session {
     /// `None` for sessions whose agent has no known resume protocol.
     #[serde(default)]
     pub agent_resume_token: Option<String>,
+    /// Derived flag — `true` when `worktree_path` is the root of a linked git
+    /// worktree (`.git` is a file, not a directory). Computed at list-time
+    /// from the on-disk path; skipped on deserialize so persisted entries
+    /// load cleanly and never go stale. Drives the worktree icon on tabs and
+    /// in the sidebar, capturing not just Acorn-managed worktrees (`isolated`)
+    /// but also `claude -w` adoptions and projects that were already linked
+    /// worktrees when added.
+    #[serde(default, skip_deserializing)]
+    pub in_worktree: bool,
 }
 
 impl Session {
@@ -200,6 +209,7 @@ impl Session {
             position: None,
             daemon_session_id: None,
             agent_resume_token: None,
+            in_worktree: false,
         }
     }
 }

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -106,6 +106,19 @@ pub fn remove_worktree(repo_path: &Path, name: &str) -> AppResult<()> {
     Ok(())
 }
 
+/// Returns `true` when `path` is the root of a *linked* git worktree.
+/// Linked worktrees mark their root with a `.git` *file* (pointing at the
+/// parent repo's `worktrees/<name>` admin dir) instead of a `.git` directory.
+/// Cheap: a single stat, no libgit2 open. Used to surface a worktree
+/// indicator on session tabs regardless of how the worktree was created
+/// (Acorn's "new isolated session" button, `claude -w` adoption, or a
+/// repo that was already a worktree when added as a project).
+pub fn is_linked_worktree_root(path: &Path) -> bool {
+    std::fs::metadata(path.join(".git"))
+        .map(|m| m.is_file())
+        .unwrap_or(false)
+}
+
 pub fn current_branch(repo_path: &Path) -> AppResult<String> {
     let repo = ensure_repo(repo_path)?;
     let head = repo.head()?;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,6 +115,18 @@ function App() {
     return () => document.removeEventListener("focusin", handler);
   }, []);
 
+  // Refresh the "live cwd is inside a linked worktree" map whenever the
+  // window regains focus — the user may have `cd`'d into a worktree (or
+  // out of one) while we were backgrounded, and the icon should reflect
+  // that without waiting for the next session-list refresh.
+  useEffect(() => {
+    const onFocus = () => {
+      void useAppStore.getState().refreshLiveInWorktree();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, []);
+
   // Sync the daemon killswitch from localStorage into the backend on
   // boot. The backend defaults to ENABLED (Q16), and the frontend
   // localStorage entry is the canonical "user's last choice". On a

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -444,6 +444,7 @@ function TabItem({
   registerRef,
 }: TabItemProps) {
   const renameSession = useAppStore((s) => s.renameSession);
+  const liveInWorktree = useAppStore((s) => s.liveInWorktree[tab.id]);
   // Subscribe to the editor command so the menu's enabled/disabled state
   // updates immediately when the user configures an editor in Settings.
   const editorCommand = useSettings(
@@ -622,11 +623,11 @@ function TabItem({
             {tab.name}
           </span>
         )}
-        {tab.isolated ? (
+        {(liveInWorktree ?? (tab.isolated || tab.in_worktree)) ? (
           <GitBranch
             size={10}
             className="pointer-events-none text-fg-muted"
-            aria-label="isolated"
+            aria-label="worktree"
           />
         ) : null}
         <button

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -459,7 +459,7 @@ function SessionRowPreview({ session }: { session: Session }) {
           <span className="truncate text-[13px] font-medium text-fg">
             {session.name}
           </span>
-          {session.isolated ? (
+          {session.isolated || session.in_worktree ? (
             <GitBranch size={10} className="shrink-0 text-fg-muted" />
           ) : null}
         </span>
@@ -998,6 +998,13 @@ function SessionRowLabel({
   onSubmitRename,
   onCancelRename,
 }: SessionRowLabelProps) {
+  // Live cwd wins when a PTY is alive — a recorded worktree path doesn't
+  // describe where the user is *now*. Static flags (`isolated` / static
+  // `in_worktree`) only apply as fallback when the session has no live PTY,
+  // in which case `liveInWorktree[id]` is `undefined`.
+  const liveInWorktree = useAppStore((s) => s.liveInWorktree[session.id]);
+  const inWorktree =
+    liveInWorktree ?? (session.isolated || session.in_worktree);
   const body = (
     <span className="min-w-0 flex-1">
       <span className="flex items-center gap-1">
@@ -1012,11 +1019,11 @@ function SessionRowLabel({
             {titleText}
           </span>
         )}
-        {showKindIcons && session.isolated ? (
+        {showKindIcons && inWorktree ? (
           <GitBranch
             size={10}
             className="shrink-0 text-fg-muted"
-            aria-label="isolated worktree"
+            aria-label="worktree"
           />
         ) : null}
         {showKindIcons && session.kind === "control" ? (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -248,6 +248,16 @@ export const api = {
     return invoke<string | null>("pty_repo_root", { sessionId });
   },
   /**
+   * Batched live "is the session sitting inside a linked git worktree?"
+   * probe. Returns a map keyed by session id; missing entries mean
+   * "no live PTY, or live cwd is not inside a linked worktree". One
+   * backend syscall sweep covers every session — call this on focus /
+   * after refresh, not on a tight interval.
+   */
+  ptyInWorktreeAll(): Promise<Record<string, boolean>> {
+    return invoke<Record<string, boolean>>("pty_in_worktree_all");
+  },
+  /**
    * Re-point a session at a different worktree directory. Used after an
    * in-PTY command creates a worktree and exits — adopting it lets the next
    * spawn land inside the new worktree instead of the original cwd.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,6 +26,10 @@ export interface Session {
   last_message: string | null;
   kind: SessionKind;
   position: number | null;
+  /** Derived backend-side from `worktree_path`'s `.git` being a file (linked
+   * worktree marker). Surfaces the worktree icon regardless of whether Acorn,
+   * `claude -w`, or the user originally created the worktree. */
+  in_worktree: boolean;
 }
 
 export interface Project {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -71,6 +71,7 @@ function session(
     last_message: null,
     kind: "regular",
     position: null,
+    in_worktree: false,
     ...overrides,
   };
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -409,7 +409,11 @@ export const useAppStore = create<AppStateModel>()(
   async refreshLiveInWorktree() {
     try {
       const map = await api.ptyInWorktreeAll();
-      set({ liveInWorktree: map });
+      // Components do `s.liveInWorktree[id]`; null would crash that access.
+      // Backend returns an object in practice, but the mock fallback path
+      // (and any future RPC that returns null on degraded states) needs the
+      // guard to keep the store contract intact.
+      set({ liveInWorktree: map ?? {} });
     } catch (e) {
       console.debug("[store] refreshLiveInWorktree failed", e);
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -81,8 +81,19 @@ interface AppStateModel {
    * results in a non-empty backend session list.
    */
   sessionsLoadedCleanly: boolean;
+  /**
+   * Session ids whose *live* PTY cwd resolves inside a linked git worktree
+   * (`.git` is a file). Separate from `Session.in_worktree`, which only
+   * reflects the recorded `worktree_path` at spawn / adoption time — this
+   * map catches the user typing `cd /some/other/worktree` interactively.
+   * Populated event-driven (after `refreshSessions` and on window focus),
+   * never on an interval, so the batched probe stays cheap.
+   */
+  liveInWorktree: Record<string, boolean>;
   loadInitialStatus: () => Promise<void>;
   refreshSessions: () => Promise<void>;
+  /** Re-probe every session's live cwd in one batched backend call. */
+  refreshLiveInWorktree: () => Promise<void>;
   refreshProjects: () => Promise<void>;
   refreshAll: () => Promise<void>;
   /** Probe session liveness via JSONL transcripts; updates session statuses
@@ -343,6 +354,7 @@ export const useAppStore = create<AppStateModel>()(
   pendingRemoveId: null,
   pendingRemoveProject: null,
   sessionsLoadedCleanly: true,
+  liveInWorktree: {},
 
   async loadInitialStatus() {
     try {
@@ -388,8 +400,18 @@ export const useAppStore = create<AppStateModel>()(
           ...mirrorActive(reconciled.workspaces, reconciled.activeProject),
         };
       });
+      void get().refreshLiveInWorktree();
     } catch (e) {
       set({ loading: false, error: errorMessage(e) });
+    }
+  },
+
+  async refreshLiveInWorktree() {
+    try {
+      const map = await api.ptyInWorktreeAll();
+      set({ liveInWorktree: map });
+    } catch (e) {
+      console.debug("[store] refreshLiveInWorktree failed", e);
     }
   },
 

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -62,9 +62,8 @@ export const tauriMockSource = `
     if (cmd === 'ipc_restart') return Promise.resolve(undefined);
     if (cmd === 'reorder_projects') return Promise.resolve([]);
     if (cmd === 'reorder_sessions') return Promise.resolve([]);
-    // No live PTYs in E2E → no live cwd to classify; an empty map keeps
-    // the store's optional-chaining lookups safe and lets the static
-    // `isolated`/`in_worktree` flags drive the worktree icon.
+    // No live PTYs in E2E so the live-cwd map is empty and the static
+    // session flags (isolated, in_worktree) drive the worktree icon.
     if (cmd === 'pty_in_worktree_all') return Promise.resolve({});
     if (cmd === 'is_path_linked_worktree') return Promise.resolve(false);
     // Daemon-mode commands. E2E runs in-browser without a real acornd

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -62,6 +62,11 @@ export const tauriMockSource = `
     if (cmd === 'ipc_restart') return Promise.resolve(undefined);
     if (cmd === 'reorder_projects') return Promise.resolve([]);
     if (cmd === 'reorder_sessions') return Promise.resolve([]);
+    // No live PTYs in E2E → no live cwd to classify; an empty map keeps
+    // the store's optional-chaining lookups safe and lets the static
+    // `isolated`/`in_worktree` flags drive the worktree icon.
+    if (cmd === 'pty_in_worktree_all') return Promise.resolve({});
+    if (cmd === 'is_path_linked_worktree') return Promise.resolve(false);
     // Daemon-mode commands. E2E runs in-browser without a real acornd
     // bound to a socket, so every routed call short-circuits with a
     // realistic "disabled / not-running" response. Tests that need to

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -147,6 +147,10 @@ test.describe("sessions: list rendering", () => {
     await expect(
       page.getByRole("button", { name: /^plain main · Idle$/ }),
     ).toBeVisible();
-    await expect(page.getByLabel("worktree")).toHaveCount(1);
+    // Scope to the sidebar — the tab strip in the main pane renders the
+    // same icon, so a global count would conflate the two surfaces.
+    await expect(
+      page.locator('aside').getByLabel("worktree"),
+    ).toHaveCount(1);
   });
 });

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -147,10 +147,11 @@ test.describe("sessions: list rendering", () => {
     await expect(
       page.getByRole("button", { name: /^plain main · Idle$/ }),
     ).toBeVisible();
-    // Scope to the sidebar — the tab strip in the main pane renders the
-    // same icon, so a global count would conflate the two surfaces.
+    // Scope to the sidebar and use exact match — the tab strip renders the
+    // same icon, and the parent button's accessible name also contains
+    // "worktree" so a non-exact substring match double-counts.
     await expect(
-      page.locator('aside').getByLabel("worktree"),
+      page.locator('aside').getByLabel("worktree", { exact: true }),
     ).toHaveCount(1);
   });
 });

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -135,18 +135,18 @@ test.describe("sessions: list rendering", () => {
 
     await page.goto("/");
 
-    // Isolated sessions render with the GitBranch icon's "isolated worktree"
-    // aria-label baked into the row's accessible name.
+    // Worktree-marked sessions render with the GitBranch icon's "worktree"
+    // aria-label baked into the row's accessible name. The label is the same
+    // for Acorn-isolated sessions and for any other session whose
+    // worktree_path is a linked worktree — the icon doesn't distinguish.
     await expect(
       page.getByRole("button", {
-        name: /^iso isolated worktree feature\/iso · Idle$/,
+        name: /^iso worktree feature\/iso · Idle$/,
       }),
     ).toBeVisible();
     await expect(
       page.getByRole("button", { name: /^plain main · Idle$/ }),
     ).toBeVisible();
-    // The GitBranch icon next to isolated session names carries
-    // aria-label="isolated worktree".
-    await expect(page.getByLabel("isolated worktree")).toHaveCount(1);
+    await expect(page.getByLabel("worktree")).toHaveCount(1);
   });
 });


### PR DESCRIPTION
## Summary

Auto-show the worktree icon on session tabs and sidebar rows whenever the session lives inside a linked git worktree. Before, only Acorn's "new isolated session" button (`isolated=true`) lit the icon. Now `claude -w` adoptions, projects added at a worktree path, and interactive `cd` into a worktree all flag automatically.

## How it works

Three signals combined by precedence:

- `Session.isolated` — Acorn ownership (creation-time fact, unchanged removal semantics).
- `Session.in_worktree` — derived backend-side on every `list_sessions` by stat'ing `worktree_path/.git`. `skip_deserializing` so it never persists stale. Reflects `claude -w` adoptions as soon as the new worktree_path is recorded.
- `liveInWorktree[id]` — live PTY cwd walked through descendants. Refreshed event-driven only (after `refreshSessions` and on window focus). No interval polling.

Icon condition: `liveInWorktree ?? (isolated || in_worktree)`. When a live PTY exists, the live signal wins — `cd` out of a worktree clears the icon; `cd` into one lights it on the next focus. Without a live PTY the static flags apply as fallback.

## Cost

- `pty_in_worktree_all` does one `System::refresh_processes_specifics(All, with_cwd)` + a BFS per session. ~20-30ms total regardless of session count, vs. that cost × N when looping `pty_cwd` per session.
- Event-driven invocation only (window focus + post-refresh). No interval polling.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (123 passed)
- [x] `cargo check`
- [x] `cargo clippy` (new code clean; remaining warnings pre-existing)
- [ ] Acorn isolated session → icon shows on tab + sidebar
- [ ] `claude -w` creates worktree + adopts → icon shows immediately after adoption
- [ ] Inside a worktree, run `cd /tmp` → icon disappears on next focus
- [ ] Outside a worktree, run `cd <linked-worktree>` → icon appears on next focus
- [ ] `.acorn/worktrees/<name>` worktrees still flag (regression check)
