### PR TITLE
feat(input): add multi-input pane controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:sidecar": "cd src-tauri && cargo build --bin acornd --bin acorn-ipc",
+    "dev:sidecar": "TAURI_SIDECAR_PROFILE=debug ./src-tauri/scripts/build-sidecar.sh",
     "build": "tsc && vite build",
     "build:sidecar": "./src-tauri/scripts/build-sidecar.sh",
     "preview": "vite preview",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,6 +90,10 @@ pub fn run() {
                 .paste()
                 .select_all()
                 .build()?;
+            let multi_input_item = MenuItemBuilder::new("Toggle Multi Input")
+                .id("toggle-multi-input")
+                .accelerator("CmdOrCtrl+Alt+I")
+                .build(app)?;
             // Dev-only Reload (Cmd+R) so frontend edits that don't HMR cleanly
             // can be re-bootstrapped without restarting the whole Tauri host.
             // The release menu omits it on purpose — Acorn ships as a single
@@ -102,12 +106,18 @@ pub fn run() {
                 .build(app)?;
             #[cfg(debug_assertions)]
             let view_submenu = SubmenuBuilder::new(app, "View")
+                .item(&multi_input_item)
+                .separator()
                 .item(&reload_item)
                 .separator()
                 .fullscreen()
                 .build()?;
             #[cfg(not(debug_assertions))]
-            let view_submenu = SubmenuBuilder::new(app, "View").fullscreen().build()?;
+            let view_submenu = SubmenuBuilder::new(app, "View")
+                .item(&multi_input_item)
+                .separator()
+                .fullscreen()
+                .build()?;
             let window_submenu = SubmenuBuilder::new(app, "Window")
                 .minimize()
                 .maximize()
@@ -125,6 +135,11 @@ pub fn run() {
                 if event.id() == "settings" {
                     if let Err(err) = handle.emit("acorn:open-settings", ()) {
                         tracing::warn!("failed to emit open-settings: {err}");
+                    }
+                }
+                if event.id() == "toggle-multi-input" {
+                    if let Err(err) = handle.emit("acorn:toggle-multi-input", ()) {
+                        tracing::warn!("failed to emit toggle-multi-input: {err}");
                     }
                 }
                 #[cfg(debug_assertions)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "height": 800,
         "minWidth": 900,
         "minHeight": 600,
-        "dragDropEnabled": false
+        "dragDropEnabled": false,
+        "devtools": false
       }
     ],
     "security": {

--- a/src/App.css
+++ b/src/App.css
@@ -21,6 +21,13 @@
   background-color: transparent !important;
 }
 
+.acorn-terminal-inactive .xterm-cursor,
+.acorn-terminal-inactive .xterm-cursor.xterm-cursor-block {
+  outline: 1px solid color-mix(in oklab, var(--color-fg-muted) 70%, transparent);
+  background-color: transparent !important;
+  opacity: 0.55;
+}
+
 .acorn-terminal .xterm-scrollable-element > .scrollbar.vertical {
   width: 6px !important;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,11 @@ import { TerminalHost } from "./components/TerminalHost";
 import { ToastHost } from "./components/ToastHost";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { api } from "./lib/api";
-import { Hotkeys, useHotkeys } from "./lib/hotkeys";
+import {
+  Hotkeys,
+  shouldUseTinykeysToggleMultiInputFallback,
+  useHotkeys,
+} from "./lib/hotkeys";
 import {
   startNotificationClickHandler,
   startSessionNotificationWatcher,
@@ -526,6 +530,7 @@ function App() {
       },
       [Hotkeys.toggleMultiInput]: (e: KeyboardEvent) => {
         e.preventDefault();
+        if (!shouldUseTinykeysToggleMultiInputFallback()) return;
         toggleMultiInput();
       },
       [Hotkeys.focusPaneLeft]: (e: KeyboardEvent) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Panel,
   PanelGroup,
@@ -59,6 +59,27 @@ function focusPanel(id: "sidebar" | "main" | "right") {
   target?.focus();
 }
 
+function focusPaneTerminal(paneId: string) {
+  const escaped =
+    typeof CSS !== "undefined" && typeof CSS.escape === "function"
+      ? CSS.escape(paneId)
+      : paneId.replace(/(["\\\]\[])/g, "\\$1");
+  const pane = document.querySelector(
+    `[data-pane-body="${escaped}"]`,
+  ) as HTMLElement | null;
+  const target =
+    (pane?.querySelector(".xterm-helper-textarea") as HTMLElement | null) ??
+    (pane?.querySelector(FOCUSABLE_SELECTOR) as HTMLElement | null);
+  target?.focus();
+}
+
+function focusAdjacentPane(direction: "left" | "right" | "up" | "down") {
+  useAppStore.getState().focusAdjacentPane(direction);
+  requestAnimationFrame(() => {
+    focusPaneTerminal(useAppStore.getState().focusedPaneId);
+  });
+}
+
 function App() {
   const refreshAll = useAppStore((s) => s.refreshAll);
   const sessions = useAppStore((s) => s.sessions);
@@ -80,6 +101,13 @@ function App() {
     : [];
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [controlGuideOpen, setControlGuideOpen] = useState(false);
+
+  const toggleMultiInput = useCallback(() => {
+    const enabled = useAppStore.getState().toggleMultiInput();
+    useToasts
+      .getState()
+      .show(enabled ? "Multi-input on." : "Multi-input off.");
+  }, []);
   const sidebarPanelRef = useRef<ImperativePanelHandle | null>(null);
   const rightPanelRef = useRef<ImperativePanelHandle | null>(null);
   const themes = useThemes((s) => s.themes);
@@ -149,6 +177,29 @@ function App() {
     document.addEventListener("focusin", handler);
     return () => document.removeEventListener("focusin", handler);
   }, []);
+
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+    listen<unknown>("acorn:toggle-multi-input", () => {
+      toggleMultiInput();
+    })
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      })
+      .catch((err) => {
+        console.error("[App] failed to attach multi-input listener", err);
+      });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [toggleMultiInput]);
 
   // Sync the daemon killswitch from localStorage into the backend on
   // boot. The backend defaults to ENABLED (Q16), and the frontend
@@ -472,6 +523,26 @@ function App() {
       [Hotkeys.togglePrs]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().setRightTab("prs");
+      },
+      [Hotkeys.toggleMultiInput]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        toggleMultiInput();
+      },
+      [Hotkeys.focusPaneLeft]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        focusAdjacentPane("left");
+      },
+      [Hotkeys.focusPaneRight]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        focusAdjacentPane("right");
+      },
+      [Hotkeys.focusPaneUp]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        focusAdjacentPane("up");
+      },
+      [Hotkeys.focusPaneDown]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        focusAdjacentPane("down");
       },
       [Hotkeys.splitVertical]: (e: KeyboardEvent) => {
         e.preventDefault();

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -105,6 +105,7 @@ function GitHubMark() {
 export function StatusBar() {
   const { sessions, activeSessionId, activeProject, error, loading } =
     useAppStore();
+  const multiInputEnabled = useAppStore((s) => s.multiInputEnabled);
   const prAccountByRepo = useAppStore((s) => s.prAccountByRepo);
   const showSessionCount = useSettings(
     (s) => s.settings.statusBar.showSessionCount,
@@ -145,6 +146,16 @@ export function StatusBar() {
               <span className="text-fg-muted/50">|</span>
             ) : null}
             <span>status: {active.status}</span>
+          </>
+        ) : null}
+        {multiInputEnabled ? (
+          <>
+            {showSessionCount || (showSessionStatus && active) ? (
+              <span className="text-fg-muted/50">|</span>
+            ) : null}
+            <span className="rounded bg-accent/15 px-1.5 py-0.5 text-accent">
+              multi-input: on
+            </span>
           </>
         ) : null}
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -14,6 +14,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import "@xterm/xterm/css/xterm.css";
 import { api } from "../lib/api";
 import type { BackgroundState } from "../lib/background";
+import { visibleMultiInputSessionIds } from "../lib/multiInput";
 import { registerScrollbackFlusher } from "../lib/scrollback-coordinator";
 import {
   useSettings,
@@ -35,6 +36,7 @@ interface TerminalProps {
    * activate triggers a `fit()` + `refresh()` cycle so the buffer redraws.
    */
   isActive?: boolean;
+  isFocusedPane?: boolean;
 }
 
 interface PtyOutputPayload {
@@ -210,6 +212,7 @@ export function Terminal({
   sessionId,
   cwd,
   isActive = true,
+  isFocusedPane = true,
 }: TerminalProps): ReactElement {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<XTerm | null>(null);
@@ -232,7 +235,7 @@ export function Terminal({
       fontWeight: initialSettings.terminal.fontWeight,
       fontWeightBold: initialSettings.terminal.fontWeightBold,
       lineHeight: initialSettings.terminal.lineHeight,
-      cursorBlink: true,
+      cursorBlink: isFocusedPane,
       allowProposedApi: true,
       scrollback: 5000,
       // `convertEol` rewrites every bare `\n` from the PTY into `\r\n` before
@@ -429,14 +432,28 @@ export function Terminal({
       }, VIEWPORT_REPAINT_IDLE_MS);
     };
 
-    const sendToPty = (data: string) => {
+    const writeToPty = (targetSessionId: string, data: string) => {
       if (data.length === 0) return;
       invoke("pty_write", {
-        sessionId,
+        sessionId: targetSessionId,
         data: encodeStringToBase64(data),
       }).catch((err: unknown) => {
         console.error("[Terminal] pty_write failed", err);
       });
+    };
+    const sendToPty = (data: string) => {
+      writeToPty(sessionId, data);
+    };
+    const sendUserInputToPty = (data: string) => {
+      if (data.length === 0) return;
+      const state = useAppStore.getState();
+      const targets = state.multiInputEnabled
+        ? visibleMultiInputSessionIds(state.panes)
+        : [sessionId];
+      const targetIds = targets.length > 0 ? targets : [sessionId];
+      for (const targetId of targetIds) {
+        writeToPty(targetId, data);
+      }
     };
 
     // CJK IME path. xterm.js's built-in handler only processes plain
@@ -543,7 +560,7 @@ export function Terminal({
         ? ta.value.slice(sentPrefix.length)
         : "";
       const data = tail || explicit || "";
-      if (data) sendToPty(data);
+      if (data) sendUserInputToPty(data);
       if (ta) ta.value = "";
       sentPrefix = "";
       composing = false;
@@ -613,7 +630,7 @@ export function Terminal({
           }
           const committedEnd = value.length - newCharLen;
           if (committedEnd > sentPrefix.length) {
-            sendToPty(value.slice(sentPrefix.length, committedEnd));
+            sendUserInputToPty(value.slice(sentPrefix.length, committedEnd));
             sentPrefix = value.slice(0, committedEnd);
           }
           showComposing(value.slice(sentPrefix.length));
@@ -713,7 +730,7 @@ export function Terminal({
       // Claude CLI cannot tell them apart. Send a literal LF and stop the
       // event so xterm does not emit its own \r on top.
       if (ev.key === "Enter" && ev.shiftKey && !ev.metaKey && !ev.ctrlKey && !ev.altKey) {
-        sendToPty("\n");
+        sendUserInputToPty("\n");
         ev.preventDefault();
         ev.stopImmediatePropagation();
         return;
@@ -728,13 +745,13 @@ export function Terminal({
         !ev.shiftKey
       ) {
         if (ev.key === "ArrowLeft") {
-          sendToPty("\x01");
+          sendUserInputToPty("\x01");
           ev.preventDefault();
           ev.stopImmediatePropagation();
           return;
         }
         if (ev.key === "ArrowRight") {
-          sendToPty("\x05");
+          sendUserInputToPty("\x05");
           ev.preventDefault();
           ev.stopImmediatePropagation();
           return;
@@ -796,7 +813,7 @@ export function Terminal({
     container.addEventListener("compositionend", swallowComposition, true);
 
     const inputDisposable = term.onData((data: string) => {
-      sendToPty(data);
+      sendUserInputToPty(data);
     });
 
     // Re-anchor the composition preview to the cursor on every xterm render.
@@ -1297,6 +1314,17 @@ export function Terminal({
     };
   }, [sessionId, cwd]);
 
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.cursorBlink = isFocusedPane;
+    try {
+      term.refresh(0, term.rows - 1);
+    } catch {
+      // ignore
+    }
+  }, [isFocusedPane]);
+
   // Steal keyboard focus for newly created sessions so the user can type
   // immediately after Cmd+T (or any other creation path). Store dispatches
   // `acorn:focus-session` after rAF so the slot has reattached to its pane
@@ -1376,7 +1404,13 @@ export function Terminal({
       }}
     >
       <div className="acorn-bg-terminal" aria-hidden="true" />
-      <div ref={containerRef} className="acorn-terminal relative z-10 h-full w-full" />
+      <div className="acorn-bg-terminal" aria-hidden="true" />
+      <div
+        ref={containerRef}
+        className={`acorn-terminal relative z-10 h-full w-full ${
+          isFocusedPane ? "" : "acorn-terminal-inactive"
+        }`}
+      />
       {/* Pinned-prompt overlay. */}
       <StickyUserPrompt sessionId={sessionId} />
     </div>

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1404,7 +1404,6 @@ export function Terminal({
       }}
     >
       <div className="acorn-bg-terminal" aria-hidden="true" />
-      <div className="acorn-bg-terminal" aria-hidden="true" />
       <div
         ref={containerRef}
         className={`acorn-terminal relative z-10 h-full w-full ${

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { getTerminalLimbo } from "../lib/terminalLimbo";
+import { isSessionInFocusedPane } from "../lib/multiInput";
 import { useAppStore } from "../store";
 import type { Session } from "../lib/types";
 import { Terminal } from "./Terminal";
@@ -59,6 +60,9 @@ function PortaledTerminal({ session }: { session: Session }) {
       ? state.workspaces[state.activeProject]?.layout ?? null
       : null,
   );
+  const isFocusedPane = useAppStore((state) =>
+    isSessionInFocusedPane(session.id, state.panes, state.focusedPaneId),
+  );
 
   // Park the target in limbo immediately on mount so React's createPortal
   // has a connected DOM node to render into; full unmount returns it to
@@ -106,6 +110,7 @@ function PortaledTerminal({ session }: { session: Session }) {
       sessionId={session.id}
       cwd={session.worktree_path}
       isActive={visiblePaneId !== null}
+      isFocusedPane={isFocusedPane}
     />,
     targetRef.current,
   );

--- a/src/lib/hotkeys.test.ts
+++ b/src/lib/hotkeys.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { shouldUseTinykeysToggleMultiInputFallback } from "./hotkeys";
+
+type TauriWindow = Window & { __TAURI_INTERNALS__?: unknown };
+
+function clearTauriInternals() {
+  delete (window as TauriWindow).__TAURI_INTERNALS__;
+}
+
+describe("shouldUseTinykeysToggleMultiInputFallback", () => {
+  afterEach(() => {
+    clearTauriInternals();
+  });
+
+  it("keeps the tinykeys fallback active outside Tauri", () => {
+    clearTauriInternals();
+
+    expect(shouldUseTinykeysToggleMultiInputFallback()).toBe(true);
+  });
+
+  it("defers to the native menu accelerator inside Tauri", () => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      value: {},
+      configurable: true,
+    });
+
+    expect(shouldUseTinykeysToggleMultiInputFallback()).toBe(false);
+  });
+});

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -39,6 +39,11 @@ export const Hotkeys = {
   toggleCommits: "$mod+Shift+c",
   toggleStaged: "$mod+Shift+s",
   togglePrs: "$mod+Shift+p",
+  toggleMultiInput: "$mod+Alt+i",
+  focusPaneLeft: "$mod+Alt+ArrowLeft",
+  focusPaneRight: "$mod+Alt+ArrowRight",
+  focusPaneUp: "$mod+Alt+ArrowUp",
+  focusPaneDown: "$mod+Alt+ArrowDown",
   splitVertical: "$mod+d",
   splitHorizontal: "$mod+Shift+d",
   // Cmd+= mirrors VS Code's "Workbench: Toggle Centered Layout" pattern of

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -72,6 +72,19 @@ export type HotkeyHandler = (event: KeyboardEvent) => void;
 
 export type HotkeyBindings = Record<string, HotkeyHandler>;
 
+type TauriRuntimeWindow = Window & { __TAURI_INTERNALS__?: unknown };
+
+function isTauriRuntime(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    "__TAURI_INTERNALS__" in (window as TauriRuntimeWindow)
+  );
+}
+
+export function shouldUseTinykeysToggleMultiInputFallback(): boolean {
+  return !isTauriRuntime();
+}
+
 /**
  * Subscribes the given keybinding map to `window` for the lifetime of the
  * component. Bindings are re-attached whenever the map identity changes,

--- a/src/lib/layout.test.ts
+++ b/src/lib/layout.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  findAdjacentPaneId,
   findPaneNode,
   listPaneIds,
   makePaneNode,
@@ -52,6 +53,34 @@ describe("findPaneNode", () => {
 
   it("returns null when missing", () => {
     expect(findPaneNode(layout, "nope")).toBeNull();
+  });
+});
+
+describe("findAdjacentPaneId", () => {
+  const layout: LayoutNode = {
+    kind: "split",
+    id: "root-split",
+    direction: "horizontal",
+    a: makePaneNode("left"),
+    b: {
+      kind: "split",
+      id: "right-split",
+      direction: "vertical",
+      a: makePaneNode("top-right"),
+      b: makePaneNode("bottom-right"),
+    },
+  };
+
+  it("finds the nearest pane in the requested visual direction", () => {
+    expect(findAdjacentPaneId(layout, "left", "right")).toBe("top-right");
+    expect(findAdjacentPaneId(layout, "top-right", "down")).toBe("bottom-right");
+    expect(findAdjacentPaneId(layout, "bottom-right", "up")).toBe("top-right");
+    expect(findAdjacentPaneId(layout, "top-right", "left")).toBe("left");
+  });
+
+  it("returns null when no pane exists in that direction", () => {
+    expect(findAdjacentPaneId(layout, "left", "left")).toBeNull();
+    expect(findAdjacentPaneId(layout, "top-right", "up")).toBeNull();
   });
 });
 

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -14,6 +14,7 @@
 
 export type Direction = "horizontal" | "vertical";
 export type PaneId = string;
+export type PaneFocusDirection = "left" | "right" | "up" | "down";
 
 export interface PaneNode {
   kind: "pane";
@@ -49,6 +50,101 @@ export function findPaneNode(
     return layout.id === paneId ? layout : null;
   }
   return findPaneNode(layout.a, paneId) ?? findPaneNode(layout.b, paneId);
+}
+
+interface PaneBounds {
+  id: PaneId;
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+function collectPaneBounds(
+  layout: LayoutNode,
+  left: number,
+  top: number,
+  right: number,
+  bottom: number,
+  out: PaneBounds[],
+): void {
+  if (layout.kind === "pane") {
+    out.push({ id: layout.id, left, top, right, bottom });
+    return;
+  }
+
+  if (layout.direction === "horizontal") {
+    const mid = (left + right) / 2;
+    collectPaneBounds(layout.a, left, top, mid, bottom, out);
+    collectPaneBounds(layout.b, mid, top, right, bottom, out);
+    return;
+  }
+
+  const mid = (top + bottom) / 2;
+  collectPaneBounds(layout.a, left, top, right, mid, out);
+  collectPaneBounds(layout.b, left, mid, right, bottom, out);
+}
+
+function overlaps(a1: number, a2: number, b1: number, b2: number): boolean {
+  return Math.max(a1, b1) < Math.min(a2, b2);
+}
+
+export function findAdjacentPaneId(
+  layout: LayoutNode,
+  fromPaneId: PaneId,
+  direction: PaneFocusDirection,
+): PaneId | null {
+  const bounds: PaneBounds[] = [];
+  collectPaneBounds(layout, 0, 0, 1, 1, bounds);
+  const current = bounds.find((b) => b.id === fromPaneId);
+  if (!current) return null;
+
+  let best: { id: PaneId; distance: number; offset: number } | null = null;
+  const currentX = (current.left + current.right) / 2;
+  const currentY = (current.top + current.bottom) / 2;
+
+  for (const candidate of bounds) {
+    if (candidate.id === current.id) continue;
+    let distance: number | null = null;
+    let offset = 0;
+
+    if (direction === "left" && candidate.right <= current.left) {
+      if (!overlaps(current.top, current.bottom, candidate.top, candidate.bottom)) {
+        continue;
+      }
+      distance = current.left - candidate.right;
+      offset = Math.abs(currentY - (candidate.top + candidate.bottom) / 2);
+    } else if (direction === "right" && candidate.left >= current.right) {
+      if (!overlaps(current.top, current.bottom, candidate.top, candidate.bottom)) {
+        continue;
+      }
+      distance = candidate.left - current.right;
+      offset = Math.abs(currentY - (candidate.top + candidate.bottom) / 2);
+    } else if (direction === "up" && candidate.bottom <= current.top) {
+      if (!overlaps(current.left, current.right, candidate.left, candidate.right)) {
+        continue;
+      }
+      distance = current.top - candidate.bottom;
+      offset = Math.abs(currentX - (candidate.left + candidate.right) / 2);
+    } else if (direction === "down" && candidate.top >= current.bottom) {
+      if (!overlaps(current.left, current.right, candidate.left, candidate.right)) {
+        continue;
+      }
+      distance = candidate.top - current.bottom;
+      offset = Math.abs(currentX - (candidate.left + candidate.right) / 2);
+    }
+
+    if (distance === null) continue;
+    if (
+      !best ||
+      distance < best.distance ||
+      (distance === best.distance && offset < best.offset)
+    ) {
+      best = { id: candidate.id, distance, offset };
+    }
+  }
+
+  return best?.id ?? null;
 }
 
 /**

--- a/src/lib/multiInput.test.ts
+++ b/src/lib/multiInput.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSessionInFocusedPane,
+  visibleMultiInputSessionIds,
+} from "./multiInput";
+
+describe("visibleMultiInputSessionIds", () => {
+  it("returns the active session from each visible pane", () => {
+    expect(
+      visibleMultiInputSessionIds({
+        left: { activeSessionId: "s1" },
+        right: { activeSessionId: "s2" },
+      }),
+    ).toEqual(["s1", "s2"]);
+  });
+
+  it("skips empty panes and de-duplicates sessions", () => {
+    expect(
+      visibleMultiInputSessionIds({
+        left: { activeSessionId: "s1" },
+        middle: { activeSessionId: null },
+        right: { activeSessionId: "s1" },
+      }),
+    ).toEqual(["s1"]);
+  });
+});
+
+describe("isSessionInFocusedPane", () => {
+  it("returns true only for the active session in the focused pane", () => {
+    const panes = {
+      left: { activeSessionId: "s1" },
+      right: { activeSessionId: "s2" },
+    };
+
+    expect(isSessionInFocusedPane("s1", panes, "left")).toBe(true);
+    expect(isSessionInFocusedPane("s2", panes, "left")).toBe(false);
+  });
+});

--- a/src/lib/multiInput.ts
+++ b/src/lib/multiInput.ts
@@ -1,0 +1,25 @@
+interface PaneLike {
+  activeSessionId: string | null;
+}
+
+export function visibleMultiInputSessionIds(
+  panes: Record<string, PaneLike>,
+): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const pane of Object.values(panes)) {
+    const id = pane.activeSessionId;
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids;
+}
+
+export function isSessionInFocusedPane(
+  sessionId: string,
+  panes: Record<string, PaneLike>,
+  focusedPaneId: string,
+): boolean {
+  return panes[focusedPaneId]?.activeSessionId === sessionId;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,11 +9,11 @@ window.addEventListener("contextmenu", (e) => e.preventDefault());
 window.addEventListener("keydown", (e) => {
   const meta = e.metaKey || e.ctrlKey;
   const key = e.key.toLowerCase();
-  // F12, Cmd/Ctrl+Shift+I, Cmd/Ctrl+Alt+I, Cmd/Ctrl+Shift+J, Cmd/Ctrl+Shift+C
+  // F12, Cmd/Ctrl+Shift+I, Cmd/Ctrl+Shift+J, Cmd/Ctrl+Shift+C.
+  // Cmd/Ctrl+Alt+I belongs to Acorn's multi-input toggle.
   if (
     key === "f12" ||
-    (meta && e.shiftKey && (key === "i" || key === "j" || key === "c")) ||
-    (meta && e.altKey && key === "i")
+    (meta && e.shiftKey && (key === "i" || key === "j" || key === "c"))
   ) {
     e.preventDefault();
     e.stopPropagation();

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -93,6 +93,7 @@ function resetStore(): void {
       rightTab: "commits",
       prAccountByRepo: {},
       pendingTerminalInput: {},
+      multiInputEnabled: false,
       loading: false,
       error: null,
       pendingRemoveId: null,
@@ -128,6 +129,16 @@ beforeEach(() => {
   mockApi.removeSession.mockResolvedValue(undefined);
   mockApi.removeProject.mockResolvedValue(undefined);
   resetStore();
+});
+
+describe("multi-input", () => {
+  it("starts disabled and toggles in memory", () => {
+    expect(useAppStore.getState().multiInputEnabled).toBe(false);
+    expect(useAppStore.getState().toggleMultiInput()).toBe(true);
+    expect(useAppStore.getState().multiInputEnabled).toBe(true);
+    expect(useAppStore.getState().toggleMultiInput()).toBe(false);
+    expect(useAppStore.getState().multiInputEnabled).toBe(false);
+  });
 });
 
 describe("refreshAll", () => {
@@ -203,6 +214,21 @@ describe("splitFocusedPane", () => {
     expect(Object.keys(s.panes)).toHaveLength(2);
     expect(s.panes[s.focusedPaneId].sessionIds).toEqual([]);
     expect(s.activeSessionId).toBeNull();
+  });
+
+  it("focuses the adjacent pane by visual direction", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+    const rootPaneId = useAppStore.getState().focusedPaneId;
+
+    useAppStore.getState().splitFocusedPane("horizontal");
+    const rightPaneId = useAppStore.getState().focusedPaneId;
+    expect(rightPaneId).not.toBe(rootPaneId);
+
+    useAppStore.getState().focusAdjacentPane("left");
+    expect(useAppStore.getState().focusedPaneId).toBe(rootPaneId);
+
+    useAppStore.getState().focusAdjacentPane("right");
+    expect(useAppStore.getState().focusedPaneId).toBe(rightPaneId);
   });
 });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,8 +6,10 @@ import { CONTROL_GUIDE_DISMISSED_KEY } from "./components/ControlSessionGuideMod
 import {
   type Direction,
   type LayoutNode,
+  type PaneFocusDirection,
   type PaneId,
   type SplitSide,
+  findAdjacentPaneId,
   listPaneIds,
   makePaneNode,
   removePaneFromLayout,
@@ -66,6 +68,7 @@ interface AppStateModel {
    * resolver, so the value is in-memory only and never persisted.
    */
   pendingTerminalInput: Record<string, string>;
+  multiInputEnabled: boolean;
   loading: boolean;
   error: string | null;
   pendingRemoveId: string | null;
@@ -91,6 +94,7 @@ interface AppStateModel {
   selectSession: (id: string | null) => void;
   setActiveProject: (repoPath: string) => void;
   setFocusedPane: (paneId: PaneId) => void;
+  focusAdjacentPane: (direction: PaneFocusDirection) => void;
   splitFocusedPane: (direction: Direction) => void;
   closeFocusedTab: () => void;
   closePane: (paneId: PaneId) => void;
@@ -120,6 +124,7 @@ interface AppStateModel {
   setPendingTerminalInput: (sessionId: string, command: string) => void;
   /** Atomically read and remove the queued command for `sessionId`. */
   consumePendingTerminalInput: (sessionId: string) => string | null;
+  toggleMultiInput: () => boolean;
 }
 
 let paneCounter = 0;
@@ -338,6 +343,7 @@ export const useAppStore = create<AppStateModel>()(
   rightTab: "commits",
   prAccountByRepo: {},
   pendingTerminalInput: {},
+  multiInputEnabled: false,
   loading: false,
   error: null,
   pendingRemoveId: null,
@@ -519,6 +525,21 @@ export const useAppStore = create<AppStateModel>()(
         if (!ws.panes[paneId]) return ws;
         if (ws.focusedPaneId === paneId) return ws;
         return { ...ws, focusedPaneId: paneId };
+      });
+      return patch ?? s;
+    });
+  },
+
+  focusAdjacentPane(direction) {
+    set((s) => {
+      const patch = updateActiveWorkspace(s, (ws) => {
+        const nextPaneId = findAdjacentPaneId(
+          ws.layout,
+          ws.focusedPaneId,
+          direction,
+        );
+        if (!nextPaneId || !ws.panes[nextPaneId]) return ws;
+        return { ...ws, focusedPaneId: nextPaneId };
       });
       return patch ?? s;
     });
@@ -981,6 +1002,15 @@ export const useAppStore = create<AppStateModel>()(
       return { pendingTerminalInput: rest };
     });
     return consumed;
+  },
+
+  toggleMultiInput() {
+    let enabled = false;
+    set((s) => {
+      enabled = !s.multiInputEnabled;
+      return { multiInputEnabled: enabled };
+    });
+    return enabled;
   },
     }),
     {


### PR DESCRIPTION
## 바뀐점
- `Option + Command + I`로 멀티 입력 모드를 켜고 끌 수 있습니다.
- 멀티 입력이 켜져 있으면 화면에 보이는 모든 pane의 active session에 같은 입력이 들어갑니다.
- `Option + Command + 방향키`로 pane 사이 active focus를 이동할 수 있습니다.
- focus가 없는 터미널은 커서 깜빡임을 끄고 흐린 outline 커서로 보여서, 실제 active pane과 구분됩니다.
- WebView 개발자 도구를 비활성화하고, `Option + Command + I`가 Inspector 대신 Acorn 멀티 입력 토글로 잡히게 했습니다.
- `bun run tauri dev`에서 sidecar binary가 없어서 실패하던 문제를 기존 sidecar staging 스크립트 사용으로 정리했습니다.

## 핵심!!
- 멀티 입력은 “현재 보이는 각 pane의 active session” 기준입니다.
- 숨겨진 tab이나 다른 project의 session에는 입력을 보내지 않습니다.
- 터미널 내부 제어 입력, 예를 들면 clear 같은 앱 내부 동작은 broadcast하지 않습니다.
- pane 이동 단축키는 store focus만 바꾸지 않고 실제 xterm textarea focus도 함께 옮깁니다. 그래서 이동 직후 바로 입력해도 새 pane으로 들어갑니다.

## 주의!
- Tauri 설정과 Rust 메뉴 코드가 바뀌어서 앱 재시작이 필요합니다.
- 이미 열려 있는 Web Inspector 창은 닫아야 합니다. 재시작 후에는 `Option + Command + I`로 Inspector가 열리지 않아야 합니다.
- 테스트 실행 중 `--localstorage-file was provided without a valid path` 경고가 반복되지만, 현재 테스트는 통과합니다. 기존 런타임 경고로 보고 기능 실패로 보지는 않았습니다.
- Vite build의 chunk size/import 경고도 기존 경고입니다.

## 검증
- `bun run typecheck`
- `bun run test` — 20 files, 179 passed, 1 skipped
- `bun run build`
- `cargo check`
- `git diff --check`