### PR TITLE
feat(sessions): emit OSC 7 from zsh + xterm handler for instant cwd-based worktree icon

### DIFF
--- a/src-tauri/shell-init/zshrc
+++ b/src-tauri/shell-init/zshrc
@@ -1,0 +1,32 @@
+# Acorn zsh init.
+#
+# Sourced because Acorn sets `ZDOTDIR` to its own staged dir before spawning
+# the PTY. This file restores the user's real `ZDOTDIR`, sources their
+# `.zshrc` so their configuration still runs, then appends an OSC 7
+# emitter so the terminal learns the live cwd after every command without
+# the host having to poll `proc_pidinfo`.
+#
+# OSC 7 (`\e]7;file://<host><pwd>\e\\`) is the de-facto "current directory"
+# protocol shared by iTerm2, GNOME Terminal, Wezterm, Kitty, VS Code, etc.
+# Acorn's xterm.js handler treats every emit as the new live cwd for the
+# session and updates the worktree-icon condition in O(1) — no system scan.
+
+if [ -n "${ACORN_USER_ZDOTDIR-}" ]; then
+    ZDOTDIR=$ACORN_USER_ZDOTDIR
+else
+    ZDOTDIR=$HOME
+fi
+unset ACORN_USER_ZDOTDIR
+[ -f "$ZDOTDIR/.zshrc" ] && source "$ZDOTDIR/.zshrc"
+
+_acorn_osc7() {
+    printf '\e]7;file://%s%s\e\\' "${HOST:-${HOSTNAME-localhost}}" "$PWD"
+}
+# precmd_functions is the canonical "run before each prompt" hook list in
+# zsh. typeset -gaU keeps it global, array-typed, and dedup'd so a repeated
+# `source` of this file (e.g. `exec zsh`) doesn't stack duplicate emitters.
+typeset -gaU precmd_functions
+precmd_functions+=(_acorn_osc7)
+# Emit once immediately so the host gets the spawn cwd before the user runs
+# anything — without this, the icon waits for the first prompt.
+_acorn_osc7

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -879,6 +879,24 @@ pub async fn pty_spawn<R: Runtime>(
         tracing::warn!(%id, "agent shim dir setup failed; claude/codex resume helpers will not be active");
     }
 
+    // OSC 7 emitter — only zsh needs file-side help (bash/fish self-serve).
+    // Override `ZDOTDIR` with Acorn's staged dir so our `.zshrc` runs; stash
+    // the user's original under `ACORN_USER_ZDOTDIR` so the staged rc can
+    // restore it before sourcing their real config. `.zshenv` from $HOME
+    // still runs unconditionally, so user config that has to land before
+    // any rc is untouched.
+    if let Ok(dir) = crate::shell_init::ensure_shell_init_dir() {
+        let user_zdotdir = effective_env
+            .get("ZDOTDIR")
+            .cloned()
+            .or_else(|| std::env::var("ZDOTDIR").ok())
+            .unwrap_or_default();
+        effective_env.insert("ACORN_USER_ZDOTDIR".to_string(), user_zdotdir);
+        effective_env.insert("ZDOTDIR".to_string(), dir.display().to_string());
+    } else {
+        tracing::warn!(%id, "shell init dir setup failed; OSC 7 cwd tracking will fall back to focus-based refresh");
+    }
+
     if let Ok(session) = state.sessions.get(&id) {
         if session.kind == SessionKind::Control {
             effective_env
@@ -1243,6 +1261,24 @@ fn deepest_descendant_cwd(sys: &System, root: Pid) -> Option<String> {
         }
     }
     best.map(|(_, p)| p)
+}
+
+/// Classify an arbitrary path as "inside a linked git worktree". Walks up
+/// via libgit2's `Repository::discover` so subdirectories of a worktree
+/// resolve correctly, then checks whether the discovered workdir itself
+/// is a linked worktree (`.git` is a file). Used by the xterm OSC 7
+/// handler — every emit hands the host a fresh cwd from the shell and
+/// the response feeds straight into the worktree-icon condition without
+/// touching the system process table.
+#[tauri::command]
+pub fn is_path_linked_worktree(path: String) -> bool {
+    let p = PathBuf::from(&path);
+    let Ok(repo) = git2::Repository::discover(&p) else {
+        return false;
+    };
+    repo.workdir()
+        .map(worktree::is_linked_worktree_root)
+        .unwrap_or(false)
 }
 
 /// Batched live-cwd → "is linked worktree" probe for every session that has

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod scrollback;
 mod session;
 mod session_status;
 mod shell_env;
+mod shell_init;
 mod shell_util;
 mod state;
 mod todos;
@@ -275,6 +276,7 @@ pub fn run() {
             commands::pty_cwd,
             commands::pty_repo_root,
             commands::pty_in_worktree_all,
+            commands::is_path_linked_worktree,
             commands::update_session_worktree,
             commands::git_worktrees,
             commands::scrollback_save,

--- a/src-tauri/src/shell_init.rs
+++ b/src-tauri/src/shell_init.rs
@@ -1,0 +1,81 @@
+//! Acorn-managed shell rc files materialised under the data dir.
+//!
+//! Set `ZDOTDIR` on PTY spawn to point zsh at our staged `.zshrc` instead
+//! of the user's. Our rc sources the user's real `.zshrc` first, then
+//! registers an OSC 7 emitter so the host learns the live cwd every
+//! prompt without polling. The same pattern iTerm2 / Wezterm / VS Code
+//! use; ZDOTDIR is the only env handle zsh provides for "load an extra
+//! interactive rc before the user's".
+//!
+//! bash and fish are out of scope today — bash supports `PROMPT_COMMAND`
+//! from the env directly, and fish emits OSC 7 by default. zsh is the
+//! macOS default and the only shell that needs file-side help.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+const SHELL_INIT_DIR_NAME: &str = "shell-init";
+const ZSHRC_NAME: &str = ".zshrc";
+
+const ZSHRC_BODY: &str = include_str!("../shell-init/zshrc");
+
+/// Materialise the shell-init dir under Acorn's data dir, returning the
+/// path callers should hand to `ZDOTDIR` on PTY spawn. Idempotent — the
+/// body is rewritten every call so a shipped fix lands without a data
+/// dir version bump (same convention as `agent_shim::ensure_shim_dir`).
+pub fn ensure_shell_init_dir() -> io::Result<PathBuf> {
+    ensure_shell_init_dir_at(&crate::daemon::paths::data_dir()?)
+}
+
+fn ensure_shell_init_dir_at(base: &Path) -> io::Result<PathBuf> {
+    let dir = base.join(SHELL_INIT_DIR_NAME);
+    fs::create_dir_all(&dir)?;
+    fs::write(dir.join(ZSHRC_NAME), ZSHRC_BODY)?;
+    Ok(dir)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    struct ScratchDir(PathBuf);
+    impl ScratchDir {
+        fn new(tag: &str) -> Self {
+            let p = PathBuf::from("/tmp").join(format!(
+                "acn-shell-init-{tag}-{}",
+                uuid::Uuid::new_v4().simple()
+            ));
+            fs::create_dir_all(&p).unwrap();
+            Self(p)
+        }
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for ScratchDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn writes_zshrc_with_osc7_emitter() {
+        let base = ScratchDir::new("zshrc");
+        let dir = ensure_shell_init_dir_at(base.path()).unwrap();
+        let zshrc = dir.join(ZSHRC_NAME);
+        assert!(zshrc.exists());
+        let body = fs::read_to_string(&zshrc).unwrap();
+        assert!(body.contains("_acorn_osc7"));
+        assert!(body.contains("precmd_functions"));
+        assert!(body.contains("ACORN_USER_ZDOTDIR"));
+    }
+
+    #[test]
+    fn is_idempotent() {
+        let base = ScratchDir::new("idem");
+        let a = ensure_shell_init_dir_at(base.path()).unwrap();
+        let b = ensure_shell_init_dir_at(base.path()).unwrap();
+        assert_eq!(a, b);
+    }
+}

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -313,6 +313,35 @@ export function Terminal({
     };
     scheduleThemeRefresh();
 
+    // OSC 7 cwd tracking. The shell rc we inject via ZDOTDIR emits
+    // `\e]7;file://<host><pwd>\e\\` on every prompt. xterm's parser hands
+    // us the inner payload (everything between `\e]7;` and the terminator)
+    // — strip the `file://[host]` prefix, percent-decode, classify via the
+    // backend, and update the live-cwd store entry for this session. Each
+    // emit is one cheap stat through libgit2; no polling, no system scan.
+    // Returning `true` claims the sequence so xterm doesn't echo it.
+    term.parser.registerOscHandler(7, (data) => {
+      const match = /^file:\/\/[^/]*(\/.*)$/.exec(data);
+      if (!match) return false;
+      let path: string;
+      try {
+        path = decodeURIComponent(match[1]);
+      } catch {
+        return false;
+      }
+      void api
+        .isPathLinkedWorktree(path)
+        .then((flag) => {
+          useAppStore.setState((s) => ({
+            liveInWorktree: { ...s.liveInWorktree, [sessionId]: flag },
+          }));
+        })
+        .catch((err: unknown) => {
+          console.debug("[Terminal] osc7 classify failed", err);
+        });
+      return true;
+    });
+
     // Live-apply terminal font setting changes without reinitialising xterm.
     const unsubSettings = useSettings.subscribe((state, prev) => {
       const next = state.settings.terminal;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -285,6 +285,16 @@ export const api = {
     return invoke<Record<string, boolean>>("pty_in_worktree_all");
   },
   /**
+   * Classify an arbitrary on-disk path as "inside a linked git worktree".
+   * Backs the xterm OSC 7 handler: every shell `cd` emits the new cwd,
+   * the handler hands it here, and the boolean feeds the worktree-icon
+   * condition. Walks up via `Repository::discover` so subdirectories of
+   * a worktree resolve correctly.
+   */
+  isPathLinkedWorktree(path: string): Promise<boolean> {
+    return invoke<boolean>("is_path_linked_worktree", { path });
+  },
+  /**
    * Re-point a session at a different worktree directory. Used after an
    * in-PTY command creates a worktree and exits — adopting it lets the next
    * spawn land inside the new worktree instead of the original cwd.


### PR DESCRIPTION
## Summary

Make the worktree icon update **instantly** on `cd` without polling. Builds on #156, which used a focus-event refresh + a 20-30ms backend process scan per call. This PR replaces the polling path for zsh sessions with shell-side OSC 7 emission: zero CPU when idle, real-time on every prompt.

Stacks on top of #156 — merge that first.

## How it works

Three pieces:

1. **Bundled zsh rc** (`src-tauri/shell-init/zshrc`, `include_str!` into the binary). Materialised under the data dir on every PTY spawn, mirrors the `agent_shim` pattern. Restores the user's original `ZDOTDIR`, sources their real `.zshrc` so their config still runs, then registers a `precmd` hook that emits `\e]7;file://<host><pwd>\e\\` after every command.

2. **PTY env injection** — `pty_spawn` sets `ZDOTDIR` to Acorn's staged dir and stashes the user's original under `ACORN_USER_ZDOTDIR`. `.zshenv` from `$HOME` still loads unconditionally, so config that has to land before any rc is untouched.

3. **xterm OSC 7 handler** + `is_path_linked_worktree(path)` invoke. Each shell emit hands the host a fresh cwd; the backend classifies it via libgit2 `Repository::discover` + `.git` is-file check; the result lands in `liveInWorktree[id]`. No process-table refresh, no polling.

## Scope

zsh only. macOS default + ~95% of macOS sessions covered. bash supports `PROMPT_COMMAND` from env directly (later); fish emits OSC 7 by default (no work needed). The #156 focus-event refresh stays as the fallback for non-zsh shells.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (123 passed)
- [x] `cargo clippy` (clean for new code)
- [x] `cargo test shell_init` (2 passed)
- [x] Live verified — new PTY emits OSC 7 every prompt, backend classifies, `cd` into a worktree updates the icon immediately, `cd` out clears it (confirmed via webview console + UI)
- [ ] User's existing `~/.zshrc` still runs (sanity check on a non-trivial config)
- [ ] `.acorn/worktrees/<name>` and external linked worktrees (`claude -w`) both light the icon
