### PR TITLE
fix(sessions): forward user .zshenv when Acorn redirects ZDOTDIR

### DIFF
--- a/src-tauri/shell-init/zshenv
+++ b/src-tauri/shell-init/zshenv
@@ -1,0 +1,28 @@
+# Acorn zsh env init.
+#
+# Acorn redirects `ZDOTDIR` to its staged dir on PTY spawn so the staged
+# `.zshrc` can install an OSC 7 emitter. zsh resolves `.zshenv` relative
+# to `$ZDOTDIR` too, so without this file the user's real `.zshenv` —
+# typically the only place rustup, asdf, and similar installers drop
+# `. "$HOME/.cargo/env"` style PATH bootstrapping — would never load
+# inside Acorn sessions.
+#
+# Forward to the user's `.zshenv`, then pin `ZDOTDIR` back to Acorn's
+# staged dir so `.zshrc` / `.zlogin` still hit our files. If the user's
+# `.zshenv` reset `ZDOTDIR` itself (XDG `~/.config/zsh` pattern), remember
+# the new target via `ACORN_USER_ZDOTDIR` so the staged `.zshrc` can
+# source the user's real rc.
+
+_acorn_zd=$ZDOTDIR
+if [ -n "${ACORN_USER_ZDOTDIR-}" ]; then
+    [ -f "$ACORN_USER_ZDOTDIR/.zshenv" ] && . "$ACORN_USER_ZDOTDIR/.zshenv"
+elif [ -f "$HOME/.zshenv" ]; then
+    . "$HOME/.zshenv"
+fi
+# If user .zshenv reset ZDOTDIR, treat that as their real rc dir for
+# .zshrc lookup. Otherwise keep whatever Acorn injected.
+if [ "$ZDOTDIR" != "$_acorn_zd" ]; then
+    ACORN_USER_ZDOTDIR=$ZDOTDIR
+fi
+ZDOTDIR=$_acorn_zd
+unset _acorn_zd

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -882,9 +882,10 @@ pub async fn pty_spawn<R: Runtime>(
     // OSC 7 emitter — only zsh needs file-side help (bash/fish self-serve).
     // Override `ZDOTDIR` with Acorn's staged dir so our `.zshrc` runs; stash
     // the user's original under `ACORN_USER_ZDOTDIR` so the staged rc can
-    // restore it before sourcing their real config. `.zshenv` from $HOME
-    // still runs unconditionally, so user config that has to land before
-    // any rc is untouched.
+    // restore it before sourcing their real config. zsh resolves `.zshenv`
+    // off `$ZDOTDIR` too, so the staged dir also ships a `.zshenv` that
+    // forwards to the user's `$HOME/.zshenv` (rustup, asdf etc. live there
+    // and break without it) before pinning `ZDOTDIR` back to ours.
     if let Ok(dir) = crate::shell_init::ensure_shell_init_dir() {
         let user_zdotdir = effective_env
             .get("ZDOTDIR")

--- a/src-tauri/src/shell_init.rs
+++ b/src-tauri/src/shell_init.rs
@@ -1,11 +1,13 @@
 //! Acorn-managed shell rc files materialised under the data dir.
 //!
-//! Set `ZDOTDIR` on PTY spawn to point zsh at our staged `.zshrc` instead
-//! of the user's. Our rc sources the user's real `.zshrc` first, then
-//! registers an OSC 7 emitter so the host learns the live cwd every
-//! prompt without polling. The same pattern iTerm2 / Wezterm / VS Code
-//! use; ZDOTDIR is the only env handle zsh provides for "load an extra
-//! interactive rc before the user's".
+//! Set `ZDOTDIR` on PTY spawn to point zsh at our staged `.zshenv` +
+//! `.zshrc`. The `.zshrc` registers an OSC 7 emitter so the host learns
+//! the live cwd every prompt without polling, and the `.zshenv` forwards
+//! to the user's real `.zshenv` so rustup / asdf style env bootstrap
+//! still runs (zsh resolves both files via `$ZDOTDIR`, not `$HOME`).
+//! The same pattern iTerm2 / Wezterm / VS Code use; `ZDOTDIR` is the
+//! only env handle zsh provides for "load an extra interactive rc
+//! before the user's".
 //!
 //! bash and fish are out of scope today — bash supports `PROMPT_COMMAND`
 //! from the env directly, and fish emits OSC 7 by default. zsh is the
@@ -16,8 +18,10 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 const SHELL_INIT_DIR_NAME: &str = "shell-init";
+const ZSHENV_NAME: &str = ".zshenv";
 const ZSHRC_NAME: &str = ".zshrc";
 
+const ZSHENV_BODY: &str = include_str!("../shell-init/zshenv");
 const ZSHRC_BODY: &str = include_str!("../shell-init/zshrc");
 
 /// Materialise the shell-init dir under Acorn's data dir, returning the
@@ -31,6 +35,7 @@ pub fn ensure_shell_init_dir() -> io::Result<PathBuf> {
 fn ensure_shell_init_dir_at(base: &Path) -> io::Result<PathBuf> {
     let dir = base.join(SHELL_INIT_DIR_NAME);
     fs::create_dir_all(&dir)?;
+    fs::write(dir.join(ZSHENV_NAME), ZSHENV_BODY)?;
     fs::write(dir.join(ZSHRC_NAME), ZSHRC_BODY)?;
     Ok(dir)
 }
@@ -69,6 +74,18 @@ mod tests {
         assert!(body.contains("_acorn_osc7"));
         assert!(body.contains("precmd_functions"));
         assert!(body.contains("ACORN_USER_ZDOTDIR"));
+    }
+
+    #[test]
+    fn writes_zshenv_forwarding_to_user() {
+        let base = ScratchDir::new("zshenv");
+        let dir = ensure_shell_init_dir_at(base.path()).unwrap();
+        let zshenv = dir.join(ZSHENV_NAME);
+        assert!(zshenv.exists());
+        let body = fs::read_to_string(&zshenv).unwrap();
+        assert!(body.contains("ACORN_USER_ZDOTDIR"));
+        assert!(body.contains(".zshenv"));
+        assert!(body.contains("ZDOTDIR=$_acorn_zd"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR #158 redirected `ZDOTDIR` to Acorn's staged dir so the staged `.zshrc` could install an OSC 7 emitter. zsh resolves **both** `.zshenv` and `.zshrc` off `$ZDOTDIR`, so the user's `$HOME/.zshenv` silently stopped loading inside Acorn sessions.

rustup installs `. "$HOME/.cargo/env"` into `.zshenv` by default, so this turns into a real regression for every Rust user: `cargo` disappears from PATH inside any Acorn PTY.

## Repro (before this PR)

Clean parent PATH, rustup's default `.zshenv`:

```sh
$ env -i HOME=$HOME PATH=/usr/bin:/bin \
    ZDOTDIR=<acorn-staged> ACORN_USER_ZDOTDIR=$HOME zsh -i -c 'which cargo'
cargo not found
```

After this PR: `/Users/<u>/.cargo/bin/cargo`.

## Fix

Stage a sibling `.zshenv` that:

1. Saves the `ZDOTDIR` Acorn injected.
2. Sources the user's real `.zshenv` (from `$ACORN_USER_ZDOTDIR`, falling back to `$HOME`).
3. If the user's `.zshenv` reset `ZDOTDIR` itself (XDG `~/.config/zsh` pattern), captures the new target in `ACORN_USER_ZDOTDIR` so the staged `.zshrc` still sources the right user rc.
4. Restores `ZDOTDIR` to Acorn's dir so `.zshrc` / `.zlogin` still hit our files.

Also corrects the misleading `commands.rs` comment claiming `.zshenv` from `$HOME` still loads unconditionally — it does not.

## Persona coverage (manual, off-branch)

| Persona | Result |
| --- | --- |
| Plain zsh + `.zshrc` | user rc loads + OSC 7 emit |
| Oh My Zsh (own `precmd_functions`) | omz hook + `_acorn_osc7` coexist |
| Powerlevel10k | p10k hook + `_acorn_osc7` coexist |
| Rust user (`.zshenv` sources cargo) | **fixed** — `which cargo` resolves |
| XDG user (`.zshenv` sets `ZDOTDIR=~/.config/zsh`) | user rc still loads, OSC 7 still installs |
| No `.zshrc` | OSC 7 installs without error |
| User already emits OSC 7 | dedup harmless (extra escape per prompt) |
| Broken `.zshrc` (error mid-file) | rc continues, hook still installs |
| `exec zsh` reload | `typeset -gaU` dedups — no stacked emitters |
| bash | ZDOTDIR ignored, falls back to #156 focus-refresh |
| fish | ZDOTDIR ignored, fish emits OSC 7 natively |

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (172 pass)
- [x] `bun run test:e2e` (47 pass)
- [x] `cargo test --lib shell_init` (3 pass — new `writes_zshenv_forwarding_to_user` covers staging)
- [x] Manual repro of cargo-from-zshenv regression on this branch
