### PR TITLE
chore(release): v1.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.11",
+  "version": "1.0.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.11"
+version = "1.0.12"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "bun run dev:sidecar && bun run dev",


### PR DESCRIPTION
## Summary

Cut v1.0.12.

## What lands since v1.0.11

- **#132** `feat(daemon)` — `acornd` background daemon for session persistence across app launches; agent conversation resume via PATH shims (`claude --session-id`, `codex resume <uuid>`).
- **#150** `feat(theme)` — appearance customization: built-in themes, user CSS themes, terminal font slots, background images.
- **#155** `feat(prs)` — tab context-menu Fork for claude/codex sessions.
- **#156** `feat(sessions)` — worktree icon auto-shows when session lives inside a linked git worktree.
- **#158** `feat(sessions)` — instant cwd-based worktree icon via OSC 7 from zsh + xterm handler.
- **#159** `fix(sessions)` — forward user `.zshenv` when Acorn redirects `ZDOTDIR` (fixes cargo / rustup PATH for Rust users inside Acorn PTYs).
- Plus tab/pane UX (#146, #152, #153), commits (#145, #147), PR diffs (#144), palette (#143, #148), settings (#142), and dev quality-of-life (#149, #154).

## Pre-release verification (manual, off-branch)

- `bun run typecheck` ✓
- `bun run test` ✓ (172 pass / 1 skip)
- `bun run test:e2e` ✓ (47 pass)
- `cargo test --lib shell_init` ✓
- Persona scan (shell): plain zsh, oh-my-zsh, powerlevel10k, XDG-`ZDOTDIR`, no `.zshrc`, user-supplied OSC 7, broken rc, `exec zsh` reload, bash/fish — all behave correctly post-#159.
- Persona scan (daemon): fresh install, v1.0.11 upgrade, killswitch off, binary missing, mid-session crash, multi-instance, missing claude/codex — fallback paths verified.
- Persona scan (theme): default fallback, corrupt CSS skip, empty/missing user themes dir, deleted background file, custom font missing — defensive code verified.
- Security pass: no release-blocking issues. macOS Library 0700 dir protects daemon socket; OSC 7 path probe is bool-only oracle within user privilege boundary; assetProtocol scoped; fs scope scoped; no new public surface.

## Test plan

- [x] CI: typecheck + vitest + Playwright + cargo
- [ ] Tag push triggers `release.yml` → matrix build (aarch64 + x86_64) → DMG + updater tarball + `latest.json` publish
- [ ] In-app updater banner surfaces on running v1.0.11 install
