### PR TITLE
fix(pty): refuse empty TERM/COLORTERM in child env

### DIFF
--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -32,6 +32,19 @@ use crate::error::{AppError, AppResult};
 const DEFAULT_COLS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
 const READ_BUFFER_SIZE: usize = 4096;
+
+/// Render-capability env we advertise to the child shell so zsh's terminfo
+/// lookups (used by zsh-autosuggestions for cursor save/restore) and
+/// color-aware CLIs (claude, fzf, …) emit sequences xterm.js can paint.
+/// Treated as a non-empty contract: leaving either of these empty
+/// collapses zsh to dumb terminfo (no `el`, no cursor moves, no
+/// truecolor), which surfaces as plugin redraw artifacts, prompt parser
+/// leaks, broken Backspace render, and color-aware CLIs falling back to
+/// plain output.
+const RENDER_CAPABILITY: &[(&str, &str)] = &[
+    ("TERM", "xterm-256color"),
+    ("COLORTERM", "truecolor"),
+];
 /// Hard cap on the per-session in-memory tail buffer used by the
 /// `acorn-ipc read-buffer` command. Sized to roughly match xterm.js's
 /// configured scrollback so the buffer the CLI can read mirrors what the
@@ -174,10 +187,6 @@ impl PtyManager {
         // save/restore) and color-aware CLIs (claude, fzf, …) emit
         // sequences we can actually paint. Without this, GUI-launched
         // acorn inherits an empty TERM and color/redraw goes wrong.
-        const RENDER_CAPABILITY: &[(&str, &str)] = &[
-            ("TERM", "xterm-256color"),
-            ("COLORTERM", "truecolor"),
-        ];
         for (k, v) in RENDER_CAPABILITY {
             if !applied.contains(*k) && !shell_env.contains_key(*k) {
                 cmd.env(k, v);
@@ -213,6 +222,20 @@ impl PtyManager {
         // any value we'd otherwise pick.
         for (k, v) in env {
             cmd.env(k, v);
+        }
+
+        // Refuse to let `TERM` / `COLORTERM` reach the child as an empty
+        // string. Earlier layers can deposit empties — a caller-supplied
+        // `env: { TERM: "" }`, or `CommandBuilder`'s base env inheriting
+        // an empty `TERM` from launchd-launched Acorn. Empty `TERM`
+        // collapses zsh's terminfo lookup to dumb (no `el`, no cursor
+        // moves, no truecolor), which surfaces downstream as plugin
+        // redraw artifacts, prompt parser leaks, broken Backspace render,
+        // and color-aware CLIs falling back to plain output.
+        for (k, v) in RENDER_CAPABILITY {
+            if cmd.get_env(*k).map_or(true, |s| s.is_empty()) {
+                cmd.env(k, v);
+            }
         }
 
         let child = pair
@@ -589,5 +612,70 @@ mod tests {
         let buf = tail.lock();
         let collected: Vec<u8> = buf.iter().copied().collect();
         assert_eq!(&collected, b"hello world");
+    }
+
+    /// Replays the spawn-time backstop against an isolated `CommandBuilder`
+    /// so this test covers the exact predicate `spawn()` runs on the
+    /// final-layer env, without having to actually fork a child.
+    fn apply_render_capability_backstop(cmd: &mut CommandBuilder) {
+        for (k, v) in RENDER_CAPABILITY {
+            if cmd.get_env(*k).map_or(true, |s| s.is_empty()) {
+                cmd.env(k, v);
+            }
+        }
+    }
+
+    #[test]
+    fn render_capability_backstop_fills_missing_keys() {
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.env_clear();
+        apply_render_capability_backstop(&mut cmd);
+        assert_eq!(
+            cmd.get_env("TERM").and_then(|s| s.to_str()),
+            Some("xterm-256color"),
+        );
+        assert_eq!(
+            cmd.get_env("COLORTERM").and_then(|s| s.to_str()),
+            Some("truecolor"),
+        );
+    }
+
+    #[test]
+    fn render_capability_backstop_overrides_empty_string() {
+        // Reproduces the bug shape: a layer wrote `TERM=""` to the child
+        // env. Without the backstop, zsh would inherit empty TERM and
+        // collapse terminfo to dumb.
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.env_clear();
+        cmd.env("TERM", "");
+        cmd.env("COLORTERM", "");
+        apply_render_capability_backstop(&mut cmd);
+        assert_eq!(
+            cmd.get_env("TERM").and_then(|s| s.to_str()),
+            Some("xterm-256color"),
+        );
+        assert_eq!(
+            cmd.get_env("COLORTERM").and_then(|s| s.to_str()),
+            Some("truecolor"),
+        );
+    }
+
+    #[test]
+    fn render_capability_backstop_preserves_caller_nonempty() {
+        // A caller (test harness, future per-session UI) that explicitly
+        // wants a non-default TERM should not be clobbered by the backstop.
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.env_clear();
+        cmd.env("TERM", "screen-256color");
+        cmd.env("COLORTERM", "24bit");
+        apply_render_capability_backstop(&mut cmd);
+        assert_eq!(
+            cmd.get_env("TERM").and_then(|s| s.to_str()),
+            Some("screen-256color"),
+        );
+        assert_eq!(
+            cmd.get_env("COLORTERM").and_then(|s| s.to_str()),
+            Some("24bit"),
+        );
     }
 }


### PR DESCRIPTION
## Summary

`TERM` (and `COLORTERM`) can reach the PTY child as an empty string and the existing layer (A) guard in `PtyManager::spawn` cannot detect that. When empty, zsh collapses its terminfo lookup to dumb — no `el`, no cursor moves, no truecolor — which cascades into a pile of seemingly-unrelated symptoms.

Add a backstop run after every other env layer: if the final `cmd.get_env(TERM)` (or `COLORTERM`) is absent or empty, write the default. Promote `RENDER_CAPABILITY` to module scope so the (A) layer, the backstop, and the tests all share one source of truth.

Fixes #165.

## Why the existing layer isn't enough

```rust
for (k, v) in RENDER_CAPABILITY {
    if !applied.contains(*k) && !shell_env.contains_key(*k) {
        cmd.env(k, v);
        ...
    }
}
```

Two leak paths:

1. **`CommandBuilder::new()` seeds itself from `std::env::vars_os()`** (the Acorn process env). A launchd-launched GUI app can carry `TERM=""` in its process env, which becomes the base entry for the new builder. Layer (A) still fires for empty `applied` / `shell_env`, so this case is normally rescued — but it lays the groundwork for path 2.

2. **The final `for (k, v) in env { cmd.env(k, v); }` writes caller env unconditionally.** A caller that hands in `env: { TERM: "" }` (or any caller-side construction that produces an empty `TERM`) gets that empty value into the child env *after* layer (A) ran. Same for `COLORTERM`.

Either path lands an empty `TERM` in the child. The backstop closes both — it runs last, looks at the actual final value on `cmd`, and only writes when it's missing or empty.

## Downstream symptoms this fixes

The originating environment (Korean-region macOS, fresh Acorn install) hit all four at once. Each looks like a separate bug:

- `zsh-syntax-highlighting` + `zsh-autosuggestions` redraws leave the previous text on screen because `el` (erase-line) terminfo entry is missing — Korean syllables accumulate as `안안녕하세요?안녕하녕하세하세요세요요?`; English suggestion ghosts as `claudelaude e  de   ude    aude     laude`.
- Literal `?` at column 0 of every prompt, even with a custom `PROMPT='%F{green}%1{➜%}%f ...'` that contains no `%(?:...)` or `%{%}` blocks.
- Backspace doesn't visually erase. `\x7f` arrives, `bindkey '^?'` is correct, but the redraw can't clear what was painted.
- Claude CLI renders banner / mascot / badges in default white — Ink reads `$COLORTERM`/`$TERM` to decide whether to emit color.

`#165` has the full bisection chain.

## Tests

Three new unit tests in `mod tests`, each replaying the spawn-time predicate against an isolated `CommandBuilder`:

- `render_capability_backstop_fills_missing_keys` — empty builder env (`env_clear()`) → both keys end up at defaults.
- `render_capability_backstop_overrides_empty_string` — direct repro of the bug shape: `TERM=""` / `COLORTERM=""` → both rewritten to defaults.
- `render_capability_backstop_preserves_caller_nonempty` — a deliberate `TERM=screen-256color` from a caller is left alone.

```
test result: ok. 15 passed; 0 failed
```

## Test plan

- [x] `cargo test --lib pty::` passes (15 tests, 3 new)
- [ ] Manual: fresh `bun run tauri dev` → new terminal → `echo "TERM=$TERM COLORTERM=$COLORTERM"` shows `xterm-256color` / `truecolor`
- [ ] Manual: type `안녕하세요?` — no syllable duplication
- [ ] Manual: type `claude`, observe history suggestion — no ghost trailing artifact
- [ ] Manual: prompt shows `➜  ...` (no `?` at column 0)
- [ ] Manual: type `"abc` → Backspace×3 → `"` → buffer renders as `""` (not `"abc   "`)
- [ ] Manual: `claude` CLI banner renders with the orange mascot / colored badges
