### PR TITLE
chore(release): v1.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.12",
+  "version": "1.0.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.12"
+version = "1.0.13"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "bun run dev:sidecar && bun run dev",


### PR DESCRIPTION
## Summary
Bump version to 1.0.13.

Includes since v1.0.12:
- feat(input): add multi-input pane controls (#157)
- fix(pty): refuse empty TERM/COLORTERM in child env (#165, #166)

## Test plan
- [x] `bun run typecheck`
- [ ] CI green
