### PR TITLE
fix(status-bar): clamp footer to a single row at narrow widths

### DIFF
--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -130,7 +130,12 @@ export function StatusBar() {
 
   return (
     <>
-      <footer className="flex h-7 shrink-0 items-center gap-3 border-t border-border bg-bg-sidebar px-3 font-mono text-xs text-fg-muted">
+      {/* `overflow-hidden` + `whitespace-nowrap` on inline children keeps
+          the bar at a strict h-7 even at narrow widths. Without it, the
+          branch text wraps inside its span, the row grows to two lines,
+          and Terminal's ResizeObserver fires SIGWINCH mid-claude-launch —
+          which leaves cursor/cells offset until a tab-switch refit. */}
+      <footer className="flex h-7 shrink-0 items-center gap-3 overflow-hidden border-t border-border bg-bg-sidebar px-3 font-mono text-xs text-fg-muted">
         {/* Left: aggregate counters about acorn itself — total sessions and
             the active session's lifecycle status. The IPC and daemon
             buttons sit first so the user can recover from a dead
@@ -138,14 +143,14 @@ export function StatusBar() {
             the main view. */}
         <ServicesStatusButton />
         {showSessionCount ? (
-          <span>sessions: {sessions.length}</span>
+          <span className="whitespace-nowrap">sessions: {sessions.length}</span>
         ) : null}
         {showSessionStatus && active ? (
           <>
             {showSessionCount ? (
               <span className="text-fg-muted/50">|</span>
             ) : null}
-            <span>status: {active.status}</span>
+            <span className="whitespace-nowrap">status: {active.status}</span>
           </>
         ) : null}
         {multiInputEnabled ? (
@@ -153,7 +158,7 @@ export function StatusBar() {
             {showSessionCount || (showSessionStatus && active) ? (
               <span className="text-fg-muted/50">|</span>
             ) : null}
-            <span className="rounded bg-accent/15 px-1.5 py-0.5 text-accent">
+            <span className="whitespace-nowrap rounded bg-accent/15 px-1.5 py-0.5 text-accent">
               multi-input: on
             </span>
           </>
@@ -161,17 +166,19 @@ export function StatusBar() {
 
         {/* Right: per-active-session context — gh account, branch, working
             directory, memory. Grouped together so the eye scans them as
-            "where am I right now?". */}
+            "where am I right now?". `min-w-0` lets the truncatable
+            children (branch, path) shrink instead of forcing the row
+            wider than the footer. */}
         <span className="ml-auto flex min-w-0 items-center gap-3">
-          {loading ? <span>working...</span> : null}
+          {loading ? <span className="whitespace-nowrap">working...</span> : null}
           {error ? (
             <Tooltip label={error} side="top" multiline>
-              <span className="truncate text-danger">error: {error}</span>
+              <span className="truncate whitespace-nowrap text-danger">error: {error}</span>
             </Tooltip>
           ) : null}
           {showGithubAccount && prAccount ? (
             <Tooltip label={`PRs listed via gh account ${prAccount}`} side="top">
-              <span className="flex shrink-0 items-center gap-1 rounded bg-fg-muted/15 px-1.5 py-0.5 text-[10px] text-fg-muted">
+              <span className="flex shrink-0 items-center gap-1 whitespace-nowrap rounded bg-fg-muted/15 px-1.5 py-0.5 text-[10px] text-fg-muted">
                 <GitHubMark />
                 {prAccount}
               </span>
@@ -180,14 +187,16 @@ export function StatusBar() {
           {active ? (
             <>
               <span className="text-fg-muted/50">|</span>
-              <span>branch: {active.branch}</span>
+              <span className="min-w-0 truncate whitespace-nowrap">
+                branch: {active.branch}
+              </span>
             </>
           ) : null}
           {active && displayPath ? (
             <>
               <span className="text-fg-muted/50">|</span>
               <Tooltip label={active.worktree_path} side="top" multiline>
-                <span className="truncate text-right text-fg-muted">
+                <span className="min-w-0 truncate whitespace-nowrap text-right text-fg-muted">
                   {displayPath}
                 </span>
               </Tooltip>
@@ -201,7 +210,7 @@ export function StatusBar() {
                   type="button"
                   disabled={!memory}
                   onClick={() => setBreakdownOpen(true)}
-                  className="rounded px-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+                  className="whitespace-nowrap rounded px-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-fg-muted"
                 >
                   memory: {memory ? formatBytes(memory.bytes) : "–"}
                 </button>


### PR DESCRIPTION
## Summary

At narrow window widths, two problems fire together:

1. The bottom status bar wraps to two lines (the `branch:` text breaks mid-content, as in the screenshot below).
2. Launching `claude` (or any TUI) leaves the cursor offset and the layout broken until the user switches tabs and comes back.

### Root cause

`<footer>` is `flex h-7 shrink-0` and the inner `branch` span had no `whitespace-nowrap`. At narrow widths the branch text wraps inside its span; because `min-height: auto` is the default for flex items, the footer then grows past `h-7` to fit the wrapped content. The taller footer shrinks the terminal pane above it, Terminal's `ResizeObserver` fires `pty_resize` (SIGWINCH) after its 80 ms debounce, and if this collides with `claude`'s first TUI paint the cells are frozen offset. Switching tabs flips `isActive`, which forces a `fit() + refresh()` and papers over the damage — hence the "go away and come back" workaround.

### Fix

- Add `overflow-hidden` to `<footer>` → disables `min-height: auto` on the flex item so the box stays pinned to `h-7`.
- Add `whitespace-nowrap` to each text span → text cannot wrap inside a span.
- Add `min-w-0 truncate` to the truncatable spans (branch, working directory) → they clip cleanly when the right cluster runs out of room.

The same change addresses both symptoms.

## Test plan

- [x] `bun run typecheck` passes — verified locally
- [ ] Resize the window to ~600 px wide — the status bar stays on one line; long branch / cwd values clip on the right instead of wrapping
- [ ] Launch `claude` in a narrow window — first paint renders with correct cursor / layout, no tab-switch needed
- [ ] No visible change at normal widths
