### PR TITLE
feat(appearance): toggle working-directory readout in the status bar

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -877,6 +877,12 @@ function StatusBarSection({
           onChange={(v) => patch({ showGithubAccount: v })}
         />
         <CheckboxRow
+          label="Working directory"
+          description="The active session's worktree path (tildified against $HOME)."
+          checked={statusBar.showWorkingDirectory}
+          onChange={(v) => patch({ showWorkingDirectory: v })}
+        />
+        <CheckboxRow
           label="Memory usage"
           description="Live memory readout for acorn and its child shells. Disabling also stops the 2-second polling loop, so it costs nothing when hidden."
           checked={statusBar.showMemory}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -116,6 +116,9 @@ export function StatusBar() {
   const showGithubAccount = useSettings(
     (s) => s.settings.statusBar.showGithubAccount,
   );
+  const showWorkingDirectory = useSettings(
+    (s) => s.settings.statusBar.showWorkingDirectory,
+  );
   const showMemory = useSettings((s) => s.settings.statusBar.showMemory);
   const active = sessions.find((s) => s.id === activeSessionId);
   const memory = useMemoryUsage(MEMORY_POLL_MS, showMemory);
@@ -183,7 +186,7 @@ export function StatusBar() {
               <span>branch: {active.branch}</span>
             </>
           ) : null}
-          {active && displayPath ? (
+          {showWorkingDirectory && active && displayPath ? (
             <>
               <span className="text-fg-muted/50">|</span>
               <Tooltip label={active.worktree_path} side="top" multiline>

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -214,6 +214,7 @@ export interface AcornSettings {
     showSessionCount: boolean;
     showSessionStatus: boolean;
     showGithubAccount: boolean;
+    showWorkingDirectory: boolean;
     showMemory: boolean;
   };
   pullRequests: {
@@ -320,6 +321,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     showSessionCount: true,
     showSessionStatus: true,
     showGithubAccount: true,
+    showWorkingDirectory: true,
     showMemory: true,
   },
   pullRequests: {


### PR DESCRIPTION
## Summary

Adds a "Working directory" toggle under Appearance → Status bar. When on (the default), the active session's worktree path renders on the right of the status bar in tildified form; when off, both the separator `|` and the path span are hidden entirely.

Slots in as the fifth checkbox alongside the existing toggles (`Session count`, `Active session status`, `GitHub account`, `Memory usage`). No migration code needed — the settings loader's spread-merge already fills in the new default for users on an existing config.

## Test plan

- [x] `bun run typecheck` passes — verified locally
- [ ] Appearance → Status bar → uncheck "Working directory" → the `~/.../...` path and its preceding `|` disappear from the footer
- [ ] Re-check → path reappears in the same slot
- [ ] Default (on) preserves existing behavior
