### PR TITLE
fix(daemon-pty): share render-capability env layering with daemon spawn path

### DIFF
--- a/src-tauri/src/daemon/pty.rs
+++ b/src-tauri/src/daemon/pty.rs
@@ -132,9 +132,14 @@ impl PtyManager {
             cmd.arg(arg);
         }
         cmd.cwd(&spec.cwd);
-        for (k, v) in &spec.env {
-            cmd.env(k, v);
-        }
+        // Apply the same TERM/COLORTERM/LANG/shell-env layering the
+        // in-process `pty::PtyManager` uses, then a backstop that refuses
+        // an empty `TERM` / `COLORTERM`. Without this the daemon path
+        // shipped raw caller env to the child, which left zsh with an
+        // empty TERM whenever the daemon process inherited a sanitized
+        // env from launchd-launched Acorn — surfacing as #166's redraw /
+        // color regressions whenever the daemon killswitch was on.
+        crate::pty_env::apply_layered_env(&mut cmd, spec.env.clone());
 
         let child = pair
             .slave

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod git_ops;
 mod ipc;
 mod persistence;
 mod pty;
+mod pty_env;
 mod pull_requests;
 mod scrollback;
 mod session;

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -33,18 +33,6 @@ const DEFAULT_COLS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
 const READ_BUFFER_SIZE: usize = 4096;
 
-/// Render-capability env we advertise to the child shell so zsh's terminfo
-/// lookups (used by zsh-autosuggestions for cursor save/restore) and
-/// color-aware CLIs (claude, fzf, …) emit sequences xterm.js can paint.
-/// Treated as a non-empty contract: leaving either of these empty
-/// collapses zsh to dumb terminfo (no `el`, no cursor moves, no
-/// truecolor), which surfaces as plugin redraw artifacts, prompt parser
-/// leaks, broken Backspace render, and color-aware CLIs falling back to
-/// plain output.
-const RENDER_CAPABILITY: &[(&str, &str)] = &[
-    ("TERM", "xterm-256color"),
-    ("COLORTERM", "truecolor"),
-];
 /// Hard cap on the per-session in-memory tail buffer used by the
 /// `acorn-ipc read-buffer` command. Sized to roughly match xterm.js's
 /// configured scrollback so the buffer the CLI can read mirrors what the
@@ -158,85 +146,7 @@ impl PtyManager {
             cmd.arg(arg);
         }
         cmd.cwd(&cwd);
-        // Suppress macOS zsh's per-session restore (`/etc/zshrc_Apple_Terminal`).
-        // When acorn is launched from Terminal.app the child PTY inherits
-        // `TERM_PROGRAM=Apple_Terminal` and zsh treats every fresh PTY as a
-        // resumable Terminal.app session, printing "Restored session: ..."
-        // / "Saving session...completed." and writing per-session files into
-        // `~/.zsh_sessions/`. acorn manages its own session lifecycle and
-        // does not want zsh layering its own on top. `~/.zsh_history`
-        // (HISTFILE) is unaffected — only the dirstack/last-commands
-        // restore feature is disabled.
-        //
-        // Set this *before* applying the user-provided env so a user can
-        // still opt back in by passing `SHELL_SESSIONS_DISABLE=0`.
-        cmd.env("SHELL_SESSIONS_DISABLE", "1");
-
-        // Layered env applied lowest-to-highest priority. Each layer skips
-        // keys that a higher-priority layer would overwrite, so the user's
-        // dotfile (C) wins over our locale guess (B) wins over our
-        // render-capability declaration (A) — and the caller's explicit
-        // `env` argument trumps everything. This mirrors how Terminal.app /
-        // iTerm2 inject TERM and LANG before the shell runs while still
-        // letting `~/.zshenv` override.
-        let shell_env = crate::shell_env::resolve();
-        let mut applied: std::collections::HashSet<String> = env.keys().cloned().collect();
-
-        // (A) Render capability — TERM advertises what xterm.js renders, so
-        // zsh's terminfo lookups (used by zsh-autosuggestions for cursor
-        // save/restore) and color-aware CLIs (claude, fzf, …) emit
-        // sequences we can actually paint. Without this, GUI-launched
-        // acorn inherits an empty TERM and color/redraw goes wrong.
-        for (k, v) in RENDER_CAPABILITY {
-            if !applied.contains(*k) && !shell_env.contains_key(*k) {
-                cmd.env(k, v);
-                applied.insert((*k).to_string());
-            }
-        }
-
-        // (B) System locale — Terminal.app's "Set locale environment
-        // variables on startup" injects LANG from the user's macOS
-        // Language & Region preference. We do the same so PTY children
-        // start with a UTF-8 locale even on a fresh macOS install with
-        // no LANG in any dotfile.
-        if !applied.contains("LANG") && !shell_env.contains_key("LANG") {
-            let lang = crate::shell_env::system_locale_lang()
-                .unwrap_or_else(|| "en_US.UTF-8".to_string());
-            cmd.env("LANG", &lang);
-            applied.insert("LANG".to_string());
-        }
-
-        // (C) Dotfile-set environment captured from the user's login shell
-        // (`~/.zshenv` / `~/.zprofile` / `~/.zshrc`). Honors anything the
-        // user explicitly exported — LANG, EDITOR, PAGER, TZ, etc. —
-        // without acorn having to know each shell's rc-file conventions.
-        for (k, v) in &shell_env {
-            if !applied.contains(k) {
-                cmd.env(k, v);
-                applied.insert(k.clone());
-            }
-        }
-
-        // (caller) Frontend-supplied env wins over everything above. Lets a
-        // future per-session settings UI (or a test harness) force-override
-        // any value we'd otherwise pick.
-        for (k, v) in env {
-            cmd.env(k, v);
-        }
-
-        // Refuse to let `TERM` / `COLORTERM` reach the child as an empty
-        // string. Earlier layers can deposit empties — a caller-supplied
-        // `env: { TERM: "" }`, or `CommandBuilder`'s base env inheriting
-        // an empty `TERM` from launchd-launched Acorn. Empty `TERM`
-        // collapses zsh's terminfo lookup to dumb (no `el`, no cursor
-        // moves, no truecolor), which surfaces downstream as plugin
-        // redraw artifacts, prompt parser leaks, broken Backspace render,
-        // and color-aware CLIs falling back to plain output.
-        for (k, v) in RENDER_CAPABILITY {
-            if cmd.get_env(*k).map_or(true, |s| s.is_empty()) {
-                cmd.env(k, v);
-            }
-        }
+        crate::pty_env::apply_layered_env(&mut cmd, env);
 
         let child = pair
             .slave
@@ -612,70 +522,5 @@ mod tests {
         let buf = tail.lock();
         let collected: Vec<u8> = buf.iter().copied().collect();
         assert_eq!(&collected, b"hello world");
-    }
-
-    /// Replays the spawn-time backstop against an isolated `CommandBuilder`
-    /// so this test covers the exact predicate `spawn()` runs on the
-    /// final-layer env, without having to actually fork a child.
-    fn apply_render_capability_backstop(cmd: &mut CommandBuilder) {
-        for (k, v) in RENDER_CAPABILITY {
-            if cmd.get_env(*k).map_or(true, |s| s.is_empty()) {
-                cmd.env(k, v);
-            }
-        }
-    }
-
-    #[test]
-    fn render_capability_backstop_fills_missing_keys() {
-        let mut cmd = CommandBuilder::new("/bin/sh");
-        cmd.env_clear();
-        apply_render_capability_backstop(&mut cmd);
-        assert_eq!(
-            cmd.get_env("TERM").and_then(|s| s.to_str()),
-            Some("xterm-256color"),
-        );
-        assert_eq!(
-            cmd.get_env("COLORTERM").and_then(|s| s.to_str()),
-            Some("truecolor"),
-        );
-    }
-
-    #[test]
-    fn render_capability_backstop_overrides_empty_string() {
-        // Reproduces the bug shape: a layer wrote `TERM=""` to the child
-        // env. Without the backstop, zsh would inherit empty TERM and
-        // collapse terminfo to dumb.
-        let mut cmd = CommandBuilder::new("/bin/sh");
-        cmd.env_clear();
-        cmd.env("TERM", "");
-        cmd.env("COLORTERM", "");
-        apply_render_capability_backstop(&mut cmd);
-        assert_eq!(
-            cmd.get_env("TERM").and_then(|s| s.to_str()),
-            Some("xterm-256color"),
-        );
-        assert_eq!(
-            cmd.get_env("COLORTERM").and_then(|s| s.to_str()),
-            Some("truecolor"),
-        );
-    }
-
-    #[test]
-    fn render_capability_backstop_preserves_caller_nonempty() {
-        // A caller (test harness, future per-session UI) that explicitly
-        // wants a non-default TERM should not be clobbered by the backstop.
-        let mut cmd = CommandBuilder::new("/bin/sh");
-        cmd.env_clear();
-        cmd.env("TERM", "screen-256color");
-        cmd.env("COLORTERM", "24bit");
-        apply_render_capability_backstop(&mut cmd);
-        assert_eq!(
-            cmd.get_env("TERM").and_then(|s| s.to_str()),
-            Some("screen-256color"),
-        );
-        assert_eq!(
-            cmd.get_env("COLORTERM").and_then(|s| s.to_str()),
-            Some("24bit"),
-        );
     }
 }

--- a/src-tauri/src/pty_env.rs
+++ b/src-tauri/src/pty_env.rs
@@ -1,0 +1,171 @@
+//! Shared env layering for PTY child spawn. Used by both the in-process
+//! [`crate::pty::PtyManager`] and the daemon-side
+//! [`crate::daemon::pty::PtyManager`] so the two spawn paths produce
+//! identical child env regardless of which one services a session — the
+//! daemon used to skip the layering entirely, which left zsh with empty
+//! `TERM` whenever the daemon process inherited a sanitized env from
+//! launchd-launched Acorn (see #165 / #166 follow-up).
+
+use std::collections::{HashMap, HashSet};
+
+use portable_pty::CommandBuilder;
+
+/// Render-capability env we advertise to the child shell so zsh's terminfo
+/// lookups (used by zsh-autosuggestions for cursor save/restore) and
+/// color-aware CLIs (claude, fzf, …) emit sequences xterm.js can paint.
+/// Treated as a non-empty contract: leaving either of these empty
+/// collapses zsh to dumb terminfo (no `el`, no cursor moves, no
+/// truecolor), which surfaces as plugin redraw artifacts, prompt parser
+/// leaks, broken Backspace render, and color-aware CLIs falling back to
+/// plain output.
+pub const RENDER_CAPABILITY: &[(&str, &str)] =
+    &[("TERM", "xterm-256color"), ("COLORTERM", "truecolor")];
+
+/// Apply layered env to `cmd`, lowest-to-highest priority:
+///   * (A) Render capability — TERM / COLORTERM defaults.
+///   * (B) System locale — LANG default.
+///   * (C) Login-shell dotfile env — `~/.zshenv` exports captured by
+///     [`crate::shell_env::resolve`].
+///   * (D) Caller env — `env` argument trumps everything above.
+///
+/// Followed by [`apply_render_capability_backstop`] which refuses empty
+/// `TERM` / `COLORTERM` regardless of source.
+///
+/// `SHELL_SESSIONS_DISABLE=1` is stamped first so macOS zsh's per-session
+/// restore (`/etc/zshrc_Apple_Terminal`) stays out of acorn's way; a
+/// caller can opt back in by passing `SHELL_SESSIONS_DISABLE=0` in `env`,
+/// which still wins via layer (D).
+pub fn apply_layered_env(cmd: &mut CommandBuilder, env: HashMap<String, String>) {
+    // Suppress macOS zsh's per-session restore. When acorn is launched
+    // from Terminal.app the child PTY inherits
+    // `TERM_PROGRAM=Apple_Terminal` and zsh treats every fresh PTY as a
+    // resumable Terminal.app session, printing "Restored session: ..." /
+    // "Saving session...completed." and writing per-session files into
+    // `~/.zsh_sessions/`. acorn manages its own session lifecycle and
+    // does not want zsh layering its own on top. `~/.zsh_history`
+    // (HISTFILE) is unaffected — only the dirstack/last-commands
+    // restore feature is disabled.
+    cmd.env("SHELL_SESSIONS_DISABLE", "1");
+
+    let shell_env = crate::shell_env::resolve();
+    let mut applied: HashSet<String> = env.keys().cloned().collect();
+
+    // (A) Render capability — TERM advertises what xterm.js renders, so
+    // zsh's terminfo lookups (used by zsh-autosuggestions for cursor
+    // save/restore) and color-aware CLIs (claude, fzf, …) emit
+    // sequences we can actually paint. Without this, GUI-launched
+    // acorn inherits an empty TERM and color/redraw goes wrong.
+    for (k, v) in RENDER_CAPABILITY {
+        if !applied.contains(*k) && !shell_env.contains_key(*k) {
+            cmd.env(k, v);
+            applied.insert((*k).to_string());
+        }
+    }
+
+    // (B) System locale — Terminal.app's "Set locale environment
+    // variables on startup" injects LANG from the user's macOS
+    // Language & Region preference. We do the same so PTY children
+    // start with a UTF-8 locale even on a fresh macOS install with
+    // no LANG in any dotfile.
+    if !applied.contains("LANG") && !shell_env.contains_key("LANG") {
+        let lang =
+            crate::shell_env::system_locale_lang().unwrap_or_else(|| "en_US.UTF-8".to_string());
+        cmd.env("LANG", &lang);
+        applied.insert("LANG".to_string());
+    }
+
+    // (C) Dotfile-set environment captured from the user's login shell
+    // (`~/.zshenv` / `~/.zprofile` / `~/.zshrc`). Honors anything the
+    // user explicitly exported — LANG, EDITOR, PAGER, TZ, etc. —
+    // without acorn having to know each shell's rc-file conventions.
+    for (k, v) in &shell_env {
+        if !applied.contains(k) {
+            cmd.env(k, v);
+            applied.insert(k.clone());
+        }
+    }
+
+    // (D) Caller env wins over everything above. Lets a future
+    // per-session settings UI (or a test harness) force-override any
+    // value we'd otherwise pick.
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+
+    apply_render_capability_backstop(cmd);
+}
+
+/// Refuse empty `TERM` / `COLORTERM`. Replays after every other layer
+/// because earlier layers can deposit empties — caller-supplied
+/// `env: { TERM: "" }`, or `CommandBuilder`'s base env inheriting an
+/// empty `TERM` from launchd-launched Acorn. Empty `TERM` collapses
+/// zsh's terminfo lookup to dumb (no `el`, no cursor moves, no
+/// truecolor), which surfaces downstream as plugin redraw artifacts,
+/// prompt parser leaks, broken Backspace render, and color-aware CLIs
+/// falling back to plain output.
+pub fn apply_render_capability_backstop(cmd: &mut CommandBuilder) {
+    for (k, v) in RENDER_CAPABILITY {
+        if cmd.get_env(*k).map_or(true, |s| s.is_empty()) {
+            cmd.env(k, v);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_capability_backstop_fills_missing_keys() {
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.env_clear();
+        apply_render_capability_backstop(&mut cmd);
+        assert_eq!(
+            cmd.get_env("TERM").and_then(|s| s.to_str()),
+            Some("xterm-256color"),
+        );
+        assert_eq!(
+            cmd.get_env("COLORTERM").and_then(|s| s.to_str()),
+            Some("truecolor"),
+        );
+    }
+
+    #[test]
+    fn render_capability_backstop_overrides_empty_string() {
+        // Reproduces the bug shape: a layer wrote `TERM=""` to the child
+        // env. Without the backstop, zsh would inherit empty TERM and
+        // collapse terminfo to dumb.
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.env_clear();
+        cmd.env("TERM", "");
+        cmd.env("COLORTERM", "");
+        apply_render_capability_backstop(&mut cmd);
+        assert_eq!(
+            cmd.get_env("TERM").and_then(|s| s.to_str()),
+            Some("xterm-256color"),
+        );
+        assert_eq!(
+            cmd.get_env("COLORTERM").and_then(|s| s.to_str()),
+            Some("truecolor"),
+        );
+    }
+
+    #[test]
+    fn render_capability_backstop_preserves_caller_nonempty() {
+        // A caller (test harness, future per-session UI) that explicitly
+        // wants a non-default TERM should not be clobbered by the backstop.
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.env_clear();
+        cmd.env("TERM", "screen-256color");
+        cmd.env("COLORTERM", "24bit");
+        apply_render_capability_backstop(&mut cmd);
+        assert_eq!(
+            cmd.get_env("TERM").and_then(|s| s.to_str()),
+            Some("screen-256color"),
+        );
+        assert_eq!(
+            cmd.get_env("COLORTERM").and_then(|s| s.to_str()),
+            Some("24bit"),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

#166 added a `TERM` / `COLORTERM` backstop and a layered env stack — `SHELL_SESSIONS_DISABLE` → render capability → system locale → login-shell dotfile env → caller env — to the in-process `pty::PtyManager::spawn`. The daemon-side spawn at `daemon::pty::PtyManager::spawn` shipped raw caller env to the child instead, so when the daemon killswitch was on the child shell inherited whatever `TERM` the daemon process had — typically empty under launchd — and zsh collapsed to dumb terminfo. The result was the same pile of redraw / color regressions #166 fixed for the in-process path: duplicated CJK syllables, ghosted history suggestions, broken Backspace render, color-aware CLIs falling back to plain output. Disabling the daemon (which routes through the in-process path) made the symptoms vanish; toggling it back on brought them straight back.

Extract the layering into a new `pty_env` module and call it from both spawn sites so the two paths produce identical child env regardless of which one services a session. Move the three backstop tests with it.

## Why this happened

`commands::pty_spawn` builds `effective_env` (`ACORN_*`, `PATH`, `ZDOTDIR`, etc.) and then either:

1. Calls `state.pty.spawn(...)` — the in-process branch, which applies the render-capability + locale + dotfile layers and the backstop after caller env.
2. Calls `bridge.spawn(...)` — the daemon branch, which RPCs the same `effective_env` over to the daemon. Daemon-side spawn was a single `for (k, v) in &spec.env { cmd.env(k, v); }`, no layering, no backstop.

Effective behavior: the fix from #166 only applied when the daemon was disabled. Daemon enabled = bug returned regardless of how recent the daemon binary was — the daemon source had never received the fix.

## Why pull the layering into a shared module

A daemon-only backstop would close this specific reported regression, but the daemon path would still skip the locale + login-shell-dotfile layers — so `LANG`, `EDITOR`, `PAGER`, etc. from `~/.zshenv` would only reach in-process sessions. Sharing one helper keeps the two spawn paths in lockstep and removes the next "why does behavior differ when the killswitch flips" surprise.

## Tests

```
cargo test --lib pty
test result: ok. 23 passed; 0 failed
```

The three `render_capability_backstop_*` tests now live under `pty_env::tests`. Same predicate, same coverage, just located with the helper they exercise.

## Test plan

- [x] `cargo build --bin acorn --bin acornd` — both binaries compile
- [x] `cargo test --lib pty` — 23 tests, including the 3 backstop tests now in `pty_env`
- [x] Manual (daemon ON, fresh `bun run tauri dev`): `echo "TERM=$TERM COLORTERM=$COLORTERM"` → `xterm-256color` / `truecolor`
- [x] Manual (daemon ON): type `안녕하세요?` — no syllable duplication
- [x] Manual (daemon ON): type `claude`, observe history suggestion — no ghost trailing artifact
- [x] Manual (daemon ON): prompt shows `➜  ...` (no `?` at column 0)
- [x] Manual (daemon ON): type `"abc` → Backspace×3 → `"` → buffer renders `""` (not `"abc   "`)
- [x] Manual (daemon ON): `claude` CLI banner renders with the orange mascot / colored badges
- [x] Manual (daemon OFF, regression check): same six checks still pass


