### PR TITLE
feat(actions): add GitHub Actions tab with run detail modal

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,7 +10,7 @@ use crate::git_ops::{self, CommitInfo, DiffPayload, StagedFile};
 use crate::persistence;
 use crate::pull_requests::{
     self, GeneratedCommitMessage, MergeMethod, PrStateFilter, PullRequestDetailListing,
-    PullRequestListing,
+    PullRequestListing, WorkflowRunDetailListing, WorkflowRunsListing,
 };
 use crate::scrollback;
 use crate::session::{Project, Session, SessionKind, SessionStatus};
@@ -1635,6 +1635,22 @@ pub async fn update_pull_request_body(
     body: String,
 ) -> AppResult<()> {
     pull_requests::update_pull_request_body(&PathBuf::from(repo_path), number, &body)
+}
+
+#[tauri::command]
+pub async fn list_workflow_runs(
+    repo_path: String,
+    limit: Option<u32>,
+) -> AppResult<WorkflowRunsListing> {
+    pull_requests::list_workflow_runs(&PathBuf::from(repo_path), limit.unwrap_or(50))
+}
+
+#[tauri::command]
+pub async fn get_workflow_run_detail(
+    repo_path: String,
+    run_id: u64,
+) -> AppResult<WorkflowRunDetailListing> {
+    pull_requests::get_workflow_run_detail(&PathBuf::from(repo_path), run_id)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -283,6 +283,8 @@ pub fn run() {
             commands::close_pull_request,
             commands::update_pull_request_body,
             commands::generate_pr_commit_message,
+            commands::list_workflow_runs,
+            commands::get_workflow_run_detail,
             commands::pty_spawn,
             commands::pty_write,
             commands::pty_resize,

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -1619,3 +1619,364 @@ fn run_ai_oneshot(command: &str, args: &[String], prompt: &str) -> AppResult<Str
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
+
+/// Single GitHub Actions workflow run. Mirrors the fields the Actions tab
+/// shows; richer detail (jobs, logs) intentionally omitted — clicking a row
+/// opens the run on GitHub where the user already has the full UI.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkflowRun {
+    pub id: u64,
+    /// `displayTitle` from gh — the commit message the run was triggered for,
+    /// or the manually entered title for `workflow_dispatch` runs.
+    pub display_title: String,
+    pub workflow_name: String,
+    /// `queued` | `in_progress` | `completed` | `requested` | `waiting` |
+    /// `pending` (gh REST status field, lower-case).
+    pub status: String,
+    /// `success` | `failure` | `cancelled` | `skipped` | `neutral` |
+    /// `timed_out` | `action_required` | `startup_failure`. None while the
+    /// run is still in progress.
+    pub conclusion: Option<String>,
+    /// Trigger event: `push`, `pull_request`, `workflow_dispatch`, ...
+    pub event: String,
+    pub head_branch: Option<String>,
+    pub head_sha: String,
+    pub url: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub attempt: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WorkflowRunsListing {
+    Ok {
+        items: Vec<WorkflowRun>,
+        account: String,
+    },
+    NotGithub,
+    NoAccess {
+        slug: String,
+        accounts: Vec<AccountSummary>,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct GhWorkflowRun {
+    #[serde(rename = "databaseId")]
+    database_id: u64,
+    #[serde(rename = "displayTitle", default)]
+    display_title: String,
+    #[serde(rename = "name", default)]
+    name: String,
+    #[serde(rename = "workflowName", default)]
+    workflow_name: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    conclusion: Option<String>,
+    #[serde(default)]
+    event: String,
+    #[serde(rename = "headBranch", default)]
+    head_branch: Option<String>,
+    #[serde(rename = "headSha", default)]
+    head_sha: String,
+    #[serde(default)]
+    url: String,
+    #[serde(rename = "createdAt", default)]
+    created_at: String,
+    #[serde(rename = "updatedAt", default)]
+    updated_at: String,
+    #[serde(default = "default_attempt")]
+    attempt: u32,
+}
+
+fn default_attempt() -> u32 {
+    1
+}
+
+pub fn list_workflow_runs(repo_path: &Path, limit: u32) -> AppResult<WorkflowRunsListing> {
+    let Some(slug) = github_owner_repo(repo_path)? else {
+        return Ok(WorkflowRunsListing::NotGithub);
+    };
+
+    match try_with_account(repo_path, &slug, |token| run_workflow_list(&slug, token, limit))? {
+        AccountOutcome::Ok { account, value } => Ok(WorkflowRunsListing::Ok {
+            items: value,
+            account,
+        }),
+        AccountOutcome::NoAccess { accounts } => {
+            Ok(WorkflowRunsListing::NoAccess { slug, accounts })
+        }
+    }
+}
+
+fn run_workflow_list(slug: &str, token: &str, limit: u32) -> AppResult<Vec<WorkflowRun>> {
+    let limit = limit.clamp(1, 200);
+    let limit_s = limit.to_string();
+    let output = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token).env("GH_HOST", GH_HOST).args([
+            "run",
+            "list",
+            "--repo",
+            slug,
+            "--limit",
+            &limit_s,
+            "--json",
+            "databaseId,displayTitle,name,workflowName,status,conclusion,event,\
+             headBranch,headSha,url,createdAt,updatedAt,attempt",
+        ]);
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("gh exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+
+    let raw: Vec<GhWorkflowRun> = serde_json::from_slice(&output.stdout)
+        .map_err(|e| AppError::Other(format!("failed to parse gh output: {e}")))?;
+
+    Ok(raw
+        .into_iter()
+        .map(|r| {
+            let workflow_name = if !r.workflow_name.is_empty() {
+                r.workflow_name
+            } else {
+                r.name
+            };
+            WorkflowRun {
+                id: r.database_id,
+                display_title: r.display_title,
+                workflow_name,
+                status: r.status,
+                conclusion: r.conclusion,
+                event: r.event,
+                head_branch: r.head_branch.filter(|s| !s.is_empty()),
+                head_sha: r.head_sha,
+                url: r.url,
+                created_at: r.created_at,
+                updated_at: r.updated_at,
+                attempt: r.attempt,
+            }
+        })
+        .collect())
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkflowJobStep {
+    pub name: String,
+    pub number: u32,
+    pub status: String,
+    pub conclusion: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkflowJob {
+    pub id: u64,
+    pub name: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub url: String,
+    pub steps: Vec<WorkflowJobStep>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkflowRunDetail {
+    pub id: u64,
+    pub display_title: String,
+    pub workflow_name: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub event: String,
+    pub head_branch: Option<String>,
+    pub head_sha: String,
+    pub url: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub started_at: Option<String>,
+    pub attempt: u32,
+    pub jobs: Vec<WorkflowJob>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WorkflowRunDetailListing {
+    Ok {
+        account: String,
+        detail: WorkflowRunDetail,
+    },
+    NotGithub,
+    NoAccess {
+        slug: String,
+        accounts: Vec<AccountSummary>,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct GhWorkflowJobStep {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    number: u32,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    conclusion: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhWorkflowJob {
+    #[serde(rename = "databaseId", default)]
+    database_id: u64,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    conclusion: Option<String>,
+    #[serde(rename = "startedAt", default)]
+    started_at: Option<String>,
+    #[serde(rename = "completedAt", default)]
+    completed_at: Option<String>,
+    #[serde(default)]
+    url: String,
+    #[serde(default)]
+    steps: Vec<GhWorkflowJobStep>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhWorkflowRunDetail {
+    #[serde(rename = "databaseId")]
+    database_id: u64,
+    #[serde(rename = "displayTitle", default)]
+    display_title: String,
+    #[serde(rename = "name", default)]
+    name: String,
+    #[serde(rename = "workflowName", default)]
+    workflow_name: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    conclusion: Option<String>,
+    #[serde(default)]
+    event: String,
+    #[serde(rename = "headBranch", default)]
+    head_branch: Option<String>,
+    #[serde(rename = "headSha", default)]
+    head_sha: String,
+    #[serde(default)]
+    url: String,
+    #[serde(rename = "createdAt", default)]
+    created_at: String,
+    #[serde(rename = "updatedAt", default)]
+    updated_at: String,
+    #[serde(rename = "startedAt", default)]
+    started_at: Option<String>,
+    #[serde(default = "default_attempt")]
+    attempt: u32,
+    #[serde(default)]
+    jobs: Vec<GhWorkflowJob>,
+}
+
+pub fn get_workflow_run_detail(
+    repo_path: &Path,
+    run_id: u64,
+) -> AppResult<WorkflowRunDetailListing> {
+    let Some(slug) = github_owner_repo(repo_path)? else {
+        return Ok(WorkflowRunDetailListing::NotGithub);
+    };
+
+    match try_with_account(repo_path, &slug, |token| {
+        run_workflow_view(&slug, token, run_id)
+    })? {
+        AccountOutcome::Ok { account, value } => Ok(WorkflowRunDetailListing::Ok {
+            account,
+            detail: value,
+        }),
+        AccountOutcome::NoAccess { accounts } => {
+            Ok(WorkflowRunDetailListing::NoAccess { slug, accounts })
+        }
+    }
+}
+
+fn run_workflow_view(slug: &str, token: &str, run_id: u64) -> AppResult<WorkflowRunDetail> {
+    let id_s = run_id.to_string();
+    let output = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token).env("GH_HOST", GH_HOST).args([
+            "run",
+            "view",
+            &id_s,
+            "--repo",
+            slug,
+            "--json",
+            "databaseId,displayTitle,name,workflowName,status,conclusion,event,\
+             headBranch,headSha,url,createdAt,updatedAt,startedAt,attempt,jobs",
+        ]);
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("gh exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+
+    let raw: GhWorkflowRunDetail = serde_json::from_slice(&output.stdout)
+        .map_err(|e| AppError::Other(format!("failed to parse gh output: {e}")))?;
+
+    let workflow_name = if !raw.workflow_name.is_empty() {
+        raw.workflow_name
+    } else {
+        raw.name
+    };
+    let jobs = raw
+        .jobs
+        .into_iter()
+        .map(|j| WorkflowJob {
+            id: j.database_id,
+            name: j.name,
+            status: j.status,
+            conclusion: j.conclusion,
+            started_at: j.started_at,
+            completed_at: j.completed_at,
+            url: j.url,
+            steps: j
+                .steps
+                .into_iter()
+                .map(|s| WorkflowJobStep {
+                    name: s.name,
+                    number: s.number,
+                    status: s.status,
+                    conclusion: s.conclusion,
+                })
+                .collect(),
+        })
+        .collect();
+
+    Ok(WorkflowRunDetail {
+        id: raw.database_id,
+        display_title: raw.display_title,
+        workflow_name,
+        status: raw.status,
+        conclusion: raw.conclusion,
+        event: raw.event,
+        head_branch: raw.head_branch.filter(|s| !s.is_empty()),
+        head_sha: raw.head_sha,
+        url: raw.url,
+        created_at: raw.created_at,
+        updated_at: raw.updated_at,
+        started_at: raw.started_at,
+        attempt: raw.attempt,
+        jobs,
+    })
+}

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import {
+  Activity,
   Check,
+  CircleAlert,
+  CircleCheck,
+  CircleDashed,
+  CircleX,
   Copy,
   ExternalLink,
   FileDiff,
@@ -9,8 +14,10 @@ import {
   GitPullRequest,
   GitPullRequestClosed,
   Globe,
+  Loader2,
   ListTodo,
   Maximize2,
+  MinusCircle,
   Search,
   X,
 } from "lucide-react";
@@ -34,6 +41,12 @@ import type {
   PullRequestListing,
   StagedFile,
   TodoItem,
+  WorkflowJob,
+  WorkflowJobStep,
+  WorkflowRun,
+  WorkflowRunDetail,
+  WorkflowRunDetailListing,
+  WorkflowRunsListing,
 } from "../lib/types";
 import { AuthorAvatar } from "./AuthorAvatar";
 import { loginFromEmail } from "./AuthorTag";
@@ -50,6 +63,7 @@ import {
   Modal,
   ModalHeader,
   RefreshButton,
+  Select,
   TextInput,
 } from "./ui";
 import { useDialogShortcuts } from "../lib/dialog";
@@ -151,6 +165,12 @@ export function RightPanel() {
           active={rightTab === "prs"}
           onClick={() => setRightTab("prs")}
         />
+        <TabButton
+          icon={<Activity size={14} />}
+          label="Actions"
+          active={rightTab === "actions"}
+          onClick={() => setRightTab("actions")}
+        />
       </nav>
       <div className="flex-1 overflow-hidden">
         {rightTab === "todos" ? (
@@ -182,14 +202,20 @@ export function RightPanel() {
           ) : (
             <Empty msg="No project selected" />
           )
+        ) : rightTab === "prs" ? (
+          repoPath ? (
+            <PullRequestsTab
+              key={repoPath}
+              repoPath={repoPath}
+              onOpenDetail={(number) => setPrDetail({ repoPath, number })}
+              onOpenSearch={() => setPrSearch({ repoPath })}
+              refreshKey={prListVersion}
+            />
+          ) : (
+            <Empty msg="No project selected" />
+          )
         ) : repoPath ? (
-          <PullRequestsTab
-            key={repoPath}
-            repoPath={repoPath}
-            onOpenDetail={(number) => setPrDetail({ repoPath, number })}
-            onOpenSearch={() => setPrSearch({ repoPath })}
-            refreshKey={prListVersion}
-          />
+          <ActionsTab key={repoPath} repoPath={repoPath} />
         ) : (
           <Empty msg="No project selected" />
         )}
@@ -1350,16 +1376,11 @@ function PullRequestsTab({
   /** Bumped by the parent to force an out-of-band refetch (e.g. after a PR is merged via the modal). */
   refreshKey: number;
 }) {
-  const defaultPrState = useSettings(
-    (s) => s.settings.pullRequests.defaultState,
-  );
   const refreshIntervalMs = useSettings(
-    (s) => s.settings.pullRequests.refreshIntervalMs,
+    (s) => s.settings.github.refreshIntervalMs,
   );
-  const showAvatars = useSettings(
-    (s) => s.settings.pullRequests.showAvatars,
-  );
-  const [stateFilter, setStateFilter] = useState<PrStateFilter>(defaultPrState);
+  const showAvatars = useSettings((s) => s.settings.github.showAvatars);
+  const [stateFilter, setStateFilter] = useState<PrStateFilter>("open");
   const [listing, setListing] = useState<PullRequestListing | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -1531,6 +1552,617 @@ function PullRequestsTab({
   );
 }
 
+const WORKFLOW_RUNS_LIMIT = 50;
+const ALL_WORKFLOWS = "__all__";
+
+function ActionsTab({ repoPath }: { repoPath: string }) {
+  const refreshIntervalMs = useSettings(
+    (s) => s.settings.github.refreshIntervalMs,
+  );
+  const [listing, setListing] = useState<WorkflowRunsListing | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [workflowFilter, setWorkflowFilter] = useState<string>(ALL_WORKFLOWS);
+  const [detailRunId, setDetailRunId] = useState<number | null>(null);
+
+  const fetchRuns = useCallback(
+    async (signal?: { cancelled: boolean }) => {
+      setLoading(true);
+      try {
+        const result = await api.listWorkflowRuns(repoPath, WORKFLOW_RUNS_LIMIT);
+        if (signal?.cancelled) return;
+        setListing(result);
+        setError(null);
+      } catch (e) {
+        if (signal?.cancelled) return;
+        setError(String(e));
+      } finally {
+        if (!signal?.cancelled) setLoading(false);
+      }
+    },
+    [repoPath],
+  );
+
+  useEffect(() => {
+    setListing(null);
+    setError(null);
+    setWorkflowFilter(ALL_WORKFLOWS);
+    setDetailRunId(null);
+  }, [repoPath]);
+
+  useEffect(() => {
+    const signal = { cancelled: false };
+    void fetchRuns(signal);
+    const handle = setInterval(() => {
+      void fetchRuns(signal);
+    }, refreshIntervalMs);
+    return () => {
+      signal.cancelled = true;
+      clearInterval(handle);
+    };
+  }, [fetchRuns, refreshIntervalMs]);
+
+  const workflowNames =
+    listing?.kind === "ok"
+      ? Array.from(new Set(listing.items.map((r) => r.workflow_name))).sort()
+      : [];
+  const visibleItems =
+    listing?.kind === "ok"
+      ? workflowFilter === ALL_WORKFLOWS
+        ? listing.items
+        : listing.items.filter((r) => r.workflow_name === workflowFilter)
+      : [];
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1.5">
+        <Select
+          value={workflowFilter}
+          onChange={(e) => setWorkflowFilter(e.target.value)}
+          aria-label="Filter by workflow"
+          disabled={listing?.kind !== "ok" || workflowNames.length === 0}
+          className="min-w-0 max-w-full flex-1 truncate"
+        >
+          <option value={ALL_WORKFLOWS}>All workflows</option>
+          {workflowNames.map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+        </Select>
+        <RefreshButton
+          onClick={() => void fetchRuns()}
+          loading={loading}
+          size={12}
+        />
+      </div>
+      <div className="flex-1 overflow-x-hidden overflow-y-auto">
+        {error ? (
+          <div className="p-3 text-xs text-danger">{error}</div>
+        ) : !listing ? (
+          <PrSkeletonList count={8} />
+        ) : listing.kind === "not_github" ? (
+          <Empty msg="Origin remote is not a GitHub repository." />
+        ) : listing.kind === "no_access" ? (
+          <NoAccessBanner
+            slug={listing.slug}
+            accounts={listing.accounts}
+            repoPath={repoPath}
+          />
+        ) : visibleItems.length === 0 ? (
+          <Empty
+            msg={
+              listing.items.length === 0
+                ? "No workflow runs yet."
+                : "No runs match this filter."
+            }
+          />
+        ) : (
+          <ul className="text-xs">
+            {visibleItems.map((run) => (
+              <WorkflowRunRow
+                key={run.id}
+                run={run}
+                onOpenDetail={() => setDetailRunId(run.id)}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+      <WorkflowRunDetailModal
+        open={detailRunId !== null}
+        repoPath={repoPath}
+        runId={detailRunId}
+        onClose={() => setDetailRunId(null)}
+      />
+    </div>
+  );
+}
+
+function WorkflowRunRow({
+  run,
+  onOpenDetail,
+}: {
+  run: WorkflowRun;
+  onOpenDetail: () => void;
+}) {
+  const updated = toUnixSeconds(run.updated_at);
+  const startedRelative = updated > 0 ? relativeTime(updated) : "";
+  const startedAbsolute = updated > 0 ? absoluteTime(updated) : "";
+  const title =
+    run.display_title.trim().length > 0
+      ? run.display_title
+      : `${run.workflow_name} run`;
+  const branch = run.head_branch?.trim() ?? "";
+
+  return (
+    <li>
+      <button
+        type="button"
+        onDoubleClick={onOpenDetail}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            onOpenDetail();
+          }
+        }}
+        className={cn(
+          "flex w-full items-start gap-2 border-b border-border/40 px-3 py-2 text-left",
+          "transition hover:bg-bg-elevated/60 focus:bg-bg-elevated/60 focus:outline-none",
+        )}
+        title="Double-click to view details"
+      >
+        <span className="mt-0.5 flex shrink-0 items-center">
+          <WorkflowRunStatusIcon
+            status={run.status}
+            conclusion={run.conclusion}
+          />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-fg">{title}</div>
+          <div className="mt-0.5 flex items-center gap-1.5 text-[10px] text-fg-muted">
+            <span className="truncate">{run.workflow_name}</span>
+            <span className="opacity-50">·</span>
+            <span className="truncate">{run.event}</span>
+            {branch ? (
+              <>
+                <span className="opacity-50">·</span>
+                <span className="truncate font-mono">{branch}</span>
+              </>
+            ) : null}
+            {run.attempt > 1 ? (
+              <>
+                <span className="opacity-50">·</span>
+                <span>retry #{run.attempt}</span>
+              </>
+            ) : null}
+          </div>
+        </div>
+        {startedRelative ? (
+          <Tooltip label={startedAbsolute}>
+            <span className="mt-0.5 shrink-0 whitespace-nowrap text-[10px] text-fg-muted">
+              {startedRelative}
+            </span>
+          </Tooltip>
+        ) : null}
+      </button>
+    </li>
+  );
+}
+
+function WorkflowRunDetailModal({
+  open,
+  repoPath,
+  runId,
+  onClose,
+}: {
+  open: boolean;
+  repoPath: string;
+  runId: number | null;
+  onClose: () => void;
+}) {
+  const refreshIntervalMs = useSettings(
+    (s) => s.settings.github.refreshIntervalMs,
+  );
+  const [listing, setListing] = useState<WorkflowRunDetailListing | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || runId == null) {
+      setListing(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    const fetchDetail = (showSpinner: boolean) => {
+      if (showSpinner) setLoading(true);
+      return api
+        .getWorkflowRunDetail(repoPath, runId)
+        .then((result) => {
+          if (cancelled) return result;
+          setListing(result);
+          setError(null);
+          return result;
+        })
+        .catch((e) => {
+          if (cancelled) return null;
+          setError(String(e));
+          return null;
+        })
+        .finally(() => {
+          if (!cancelled && showSpinner) setLoading(false);
+        });
+    };
+
+    setListing(null);
+    setError(null);
+    void fetchDetail(true);
+
+    // Poll while the run is still going. Stops automatically once a
+    // completed status lands so finished runs don't keep hitting `gh`.
+    const handle = window.setInterval(() => {
+      setListing((current) => {
+        const stillRunning =
+          current?.kind !== "ok" ||
+          current.detail.status.toLowerCase() !== "completed";
+        if (stillRunning) void fetchDetail(false);
+        return current;
+      });
+    }, refreshIntervalMs);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(handle);
+    };
+  }, [open, repoPath, runId, refreshIntervalMs]);
+
+  useDialogShortcuts(open, { onCancel: onClose });
+
+  const detail = listing?.kind === "ok" ? listing.detail : null;
+  const title =
+    detail?.display_title.trim().length
+      ? detail.display_title
+      : detail?.workflow_name ?? "Workflow run";
+  const subtitle = detail ? (
+    <span className="flex flex-wrap items-center gap-1.5">
+      <span>{detail.workflow_name}</span>
+      <span className="opacity-50">·</span>
+      <span>{detail.event}</span>
+      {detail.head_branch ? (
+        <>
+          <span className="opacity-50">·</span>
+          <span className="font-mono">{detail.head_branch}</span>
+        </>
+      ) : null}
+      {detail.attempt > 1 ? (
+        <>
+          <span className="opacity-50">·</span>
+          <span>retry #{detail.attempt}</span>
+        </>
+      ) : null}
+    </span>
+  ) : undefined;
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      variant="dialog"
+      size="2xl"
+      className="flex h-[36rem] flex-col"
+    >
+      <ModalHeader
+        title={title}
+        subtitle={subtitle}
+        variant="dialog"
+        icon={
+          <span className="mt-0.5 flex self-start">
+            {detail ? (
+              <WorkflowRunStatusIcon
+                status={detail.status}
+                conclusion={detail.conclusion}
+              />
+            ) : (
+              <Activity size={14} className="text-fg-muted" />
+            )}
+          </span>
+        }
+        actions={
+          detail?.url ? (
+            <button
+              type="button"
+              onClick={() => void openUrl(detail.url)}
+              className="flex items-center gap-1 rounded px-2 py-1 text-[11px] text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
+              title="Open on GitHub"
+            >
+              <ExternalLink size={12} />
+              GitHub
+            </button>
+          ) : null
+        }
+        onClose={onClose}
+      />
+      <div className="flex-1 min-h-0 overflow-y-auto text-xs">
+        <div className="px-4 py-3">
+        {error ? (
+          <div className="p-2 text-danger">{error}</div>
+        ) : loading || !listing ? (
+          <WorkflowRunDetailSkeleton />
+        ) : listing.kind === "not_github" ? (
+          <Empty msg="Origin remote is not a GitHub repository." />
+        ) : listing.kind === "no_access" ? (
+          <NoAccessBanner
+            slug={listing.slug}
+            accounts={listing.accounts}
+            repoPath={repoPath}
+          />
+        ) : (
+          <WorkflowRunDetailBody detail={listing.detail} />
+        )}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function WorkflowRunDetailSkeleton() {
+  return (
+    <div className="space-y-3 animate-pulse">
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[11px]">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="contents">
+            <dt>
+              <span className="block h-3 w-16 rounded bg-border/60" />
+            </dt>
+            <dd>
+              <span
+                className="block h-3 rounded bg-border/40"
+                style={{ width: `${40 + ((i * 37) % 50)}%` }}
+              />
+            </dd>
+          </div>
+        ))}
+      </dl>
+      <div>
+        <span className="mb-1.5 block h-3 w-20 rounded bg-border/60" />
+        <ul className="space-y-1.5">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <li
+              key={i}
+              className="flex items-center gap-2 rounded border border-border/60 bg-bg/40 px-2 py-2"
+            >
+              <span className="h-3.5 w-3.5 shrink-0 rounded-full bg-border/60" />
+              <span
+                className="h-3 rounded bg-border/40"
+                style={{ width: `${50 + ((i * 23) % 30)}%` }}
+              />
+              <span className="ml-auto h-3 w-10 rounded bg-border/40" />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function WorkflowRunDetailBody({ detail }: { detail: WorkflowRunDetail }) {
+  const created = toUnixSeconds(detail.created_at);
+  const updated = toUnixSeconds(detail.updated_at);
+  const totalDuration = formatRunDuration(
+    detail.started_at ?? detail.created_at,
+    detail.status,
+    detail.updated_at,
+  );
+  return (
+    <div className="space-y-3">
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px] text-fg-muted">
+        <dt className="opacity-70">Status</dt>
+        <dd className="text-fg">
+          {detail.status}
+          {detail.conclusion ? ` · ${detail.conclusion}` : ""}
+        </dd>
+        {totalDuration ? (
+          <>
+            <dt className="opacity-70">Total duration</dt>
+            <dd className="text-fg">
+              {totalDuration}
+              {detail.status.toLowerCase() !== "completed" ? (
+                <span className="ml-1 text-fg-muted">(running)</span>
+              ) : null}
+            </dd>
+          </>
+        ) : null}
+        <dt className="opacity-70">Attempt</dt>
+        <dd className="text-fg">
+          #{detail.attempt}
+          {detail.attempt > 1 ? (
+            <span className="ml-1 text-fg-muted">(retried)</span>
+          ) : null}
+        </dd>
+        <dt className="opacity-70">Commit</dt>
+        <dd className="font-mono text-fg">{detail.head_sha.slice(0, 7)}</dd>
+        {created > 0 ? (
+          <>
+            <dt className="opacity-70">Created</dt>
+            <dd className="text-fg">{absoluteTime(created)}</dd>
+          </>
+        ) : null}
+        {updated > 0 ? (
+          <>
+            <dt className="opacity-70">Updated</dt>
+            <dd className="text-fg">{absoluteTime(updated)}</dd>
+          </>
+        ) : null}
+      </dl>
+      <div>
+        <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-fg-muted">
+          Jobs ({detail.jobs.length})
+        </div>
+        {detail.jobs.length === 0 ? (
+          <div className="text-[11px] text-fg-muted">No jobs reported.</div>
+        ) : (
+          <ul className="rounded border border-border/60 divide-y divide-border/40">
+            {detail.jobs.map((job) => (
+              <WorkflowJobRow key={job.id} job={job} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function WorkflowJobRow({ job }: { job: WorkflowJob }) {
+  const [expanded, setExpanded] = useState(false);
+  const duration = formatJobDuration(job.started_at, job.completed_at);
+  return (
+    <li className="bg-bg/40">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className={cn(
+          "flex w-full items-center gap-2 px-2 py-1.5 text-left transition",
+          "sticky top-0 z-10 bg-bg-elevated hover:bg-bg-sidebar",
+          expanded ? "border-b border-border/40" : "",
+        )}
+      >
+        <WorkflowRunStatusIcon
+          status={job.status}
+          conclusion={job.conclusion}
+        />
+        <span className="min-w-0 flex-1 truncate text-xs text-fg">
+          {job.name}
+        </span>
+        {duration ? (
+          <span className="shrink-0 text-[11px] text-fg-muted">{duration}</span>
+        ) : null}
+        {job.url ? (
+          <span
+            role="link"
+            tabIndex={0}
+            onClick={(e) => {
+              e.stopPropagation();
+              void openUrl(job.url);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.stopPropagation();
+                void openUrl(job.url);
+              }
+            }}
+            className="shrink-0 cursor-pointer rounded p-0.5 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
+            title="Open job on GitHub"
+          >
+            <ExternalLink size={11} />
+          </span>
+        ) : null}
+      </button>
+      {expanded && job.steps.length > 0 ? (
+        <ol className="space-y-0.5 px-2 py-1.5 text-xs">
+          {job.steps.map((step) => (
+            <WorkflowStepRow key={`${step.number}-${step.name}`} step={step} />
+          ))}
+        </ol>
+      ) : null}
+    </li>
+  );
+}
+
+function WorkflowStepRow({ step }: { step: WorkflowJobStep }) {
+  return (
+    <li className="flex items-center gap-2">
+      <span className="w-5 shrink-0 text-right font-mono text-[11px] text-fg-muted">
+        {step.number}
+      </span>
+      <WorkflowRunStatusIcon
+        status={step.status}
+        conclusion={step.conclusion}
+      />
+      <span className="min-w-0 flex-1 truncate text-xs text-fg">
+        {step.name}
+      </span>
+    </li>
+  );
+}
+
+function formatRunDuration(
+  startedAt: string,
+  status: string,
+  updatedAt: string,
+): string {
+  const start = toUnixSeconds(startedAt);
+  if (start <= 0) return "";
+  const completed = status.toLowerCase() === "completed";
+  const end = completed
+    ? toUnixSeconds(updatedAt) || Math.floor(Date.now() / 1000)
+    : Math.floor(Date.now() / 1000);
+  return formatDurationSeconds(Math.max(0, end - start));
+}
+
+function formatDurationSeconds(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rem = seconds % 60;
+  if (minutes < 60) return rem === 0 ? `${minutes}m` : `${minutes}m ${rem}s`;
+  const hours = Math.floor(minutes / 60);
+  const minRem = minutes % 60;
+  return minRem === 0 ? `${hours}h` : `${hours}h ${minRem}m`;
+}
+
+function formatJobDuration(
+  startedAt: string | null,
+  completedAt: string | null,
+): string {
+  if (!startedAt) return "";
+  const start = toUnixSeconds(startedAt);
+  if (start <= 0) return "";
+  const end = completedAt ? toUnixSeconds(completedAt) : Math.floor(Date.now() / 1000);
+  return formatDurationSeconds(Math.max(0, end - start));
+}
+
+function WorkflowRunStatusIcon({
+  status,
+  conclusion,
+}: {
+  status: string;
+  conclusion: string | null;
+}) {
+  const s = status.toLowerCase();
+  if (s !== "completed") {
+    if (s === "queued" || s === "pending" || s === "waiting" || s === "requested") {
+      return (
+        <CircleDashed size={14} className="shrink-0 text-fg-muted" />
+      );
+    }
+    // in_progress and anything else still running
+    return (
+      <Loader2
+        size={14}
+        className="shrink-0 animate-spin text-accent"
+      />
+    );
+  }
+  switch ((conclusion ?? "").toLowerCase()) {
+    case "success":
+      return <CircleCheck size={14} className="shrink-0 text-emerald-400" />;
+    case "failure":
+    case "timed_out":
+    case "startup_failure":
+      return <CircleX size={14} className="shrink-0 text-rose-400" />;
+    case "cancelled":
+      return <MinusCircle size={14} className="shrink-0 text-fg-muted" />;
+    case "action_required":
+      return <CircleAlert size={14} className="shrink-0 text-amber-400" />;
+    case "skipped":
+    case "neutral":
+      return <MinusCircle size={14} className="shrink-0 text-fg-muted" />;
+    default:
+      return <CircleDashed size={14} className="shrink-0 text-fg-muted" />;
+  }
+}
+
 function NoAccessBanner({
   slug,
   accounts,
@@ -1669,7 +2301,7 @@ function PrRow({
   /**
    * Render the author's GitHub avatar to the left of the row. Bumps the
    * row's vertical footprint slightly in exchange for at-a-glance author
-   * recognition. Controlled by the `pullRequests.showAvatars` setting.
+   * recognition. Controlled by the `github.showAvatars` setting.
    */
   showAvatar?: boolean;
 }) {
@@ -1785,9 +2417,7 @@ function PullRequestSearchModal({
   onOpenDetail: (number: number) => void;
 }) {
   const repoPath = open?.repoPath ?? null;
-  const showAvatars = useSettings(
-    (s) => s.settings.pullRequests.showAvatars,
-  );
+  const showAvatars = useSettings((s) => s.settings.github.showAvatars);
   const [rawQuery, setRawQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [stateFilter, setStateFilter] = useState<PrStateFilter>("all");

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -38,7 +38,6 @@ import {
   useSettings,
 } from "../lib/settings";
 import { revealThemesFolder, useThemes } from "../lib/themes";
-import type { PrStateFilter } from "../lib/types";
 import {
   CheckboxRow,
   CommandHint,
@@ -56,7 +55,7 @@ type Tab =
   | "terminal"
   | "agents"
   | "sessions"
-  | "pull-requests"
+  | "github"
   | "appearance"
   | "editor"
   | "notifications"
@@ -68,7 +67,7 @@ const TABS: Array<{ id: Tab; label: string }> = [
   { id: "terminal", label: "Terminal" },
   { id: "agents", label: "Agents" },
   { id: "sessions", label: "Sessions" },
-  { id: "pull-requests", label: "Pull Requests" },
+  { id: "github", label: "GitHub" },
   { id: "appearance", label: "Appearance" },
   { id: "editor", label: "Editor" },
   { id: "notifications", label: "Notifications" },
@@ -158,8 +157,8 @@ export function SettingsModal() {
             <AgentSettings />
           ) : tab === "sessions" ? (
             <SessionSettings />
-          ) : tab === "pull-requests" ? (
-            <PullRequestsSettings />
+          ) : tab === "github" ? (
+            <GithubSettings />
           ) : tab === "appearance" ? (
             <AppearanceSettings />
           ) : tab === "editor" ? (
@@ -468,39 +467,20 @@ function ControlSessionInstallSection() {
   );
 }
 
-function PullRequestsSettings() {
+function GithubSettings() {
   const settings = useSettings((s) => s.settings);
-  const patchPullRequests = useSettings((s) => s.patchPullRequests);
+  const patchGithub = useSettings((s) => s.patchGithub);
 
   return (
     <section className="space-y-4">
       <Field
-        label="Default tab"
-        hint="Filter pre-selected when the PRs panel first opens for a repo. Switching tabs by hand still works as before."
-      >
-        <Select
-          value={settings.pullRequests.defaultState}
-          onChange={(e) =>
-            patchPullRequests({
-              defaultState: e.target.value as PrStateFilter,
-            })
-          }
-          className="w-48"
-        >
-          <option value="open">Open</option>
-          <option value="closed">Closed</option>
-          <option value="merged">Merged</option>
-          <option value="all">All</option>
-        </Select>
-      </Field>
-      <Field
         label="Refresh interval"
-        hint="How often the PRs tab auto-refetches from gh. Lower values feel snappier but spend more API budget."
+        hint="How often the PRs and Actions tabs auto-refetch from gh. Lower values feel snappier but spend more API budget."
       >
         <Select
-          value={settings.pullRequests.refreshIntervalMs}
+          value={settings.github.refreshIntervalMs}
           onChange={(e) =>
-            patchPullRequests({
+            patchGithub({
               refreshIntervalMs: Number(e.target.value),
             })
           }
@@ -514,8 +494,8 @@ function PullRequestsSettings() {
         </Select>
       </Field>
       <p className="text-[11px] text-fg-muted">
-        Manual refresh (the icon in the PRs tab) always works regardless of
-        this interval.
+        Manual refresh (the icon in each tab) always works regardless of this
+        interval.
       </p>
       <Field
         label="List density"
@@ -524,8 +504,8 @@ function PullRequestsSettings() {
         <CheckboxRow
           label="Show author avatars"
           description="Render the GitHub avatar next to each PR row."
-          checked={settings.pullRequests.showAvatars}
-          onChange={(v) => patchPullRequests({ showAvatars: v })}
+          checked={settings.github.showAvatars}
+          onChange={(v) => patchGithub({ showAvatars: v })}
         />
       </Field>
     </section>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -15,6 +15,8 @@ import type {
   SessionStatus,
   StagedFile,
   TodoItem,
+  WorkflowRunDetailListing,
+  WorkflowRunsListing,
 } from "./types";
 
 export interface LoadStatus {
@@ -179,6 +181,24 @@ export const api = {
       method,
       command,
       args,
+    });
+  },
+  listWorkflowRuns(
+    repoPath: string,
+    limit = 50,
+  ): Promise<WorkflowRunsListing> {
+    return invoke<WorkflowRunsListing>("list_workflow_runs", {
+      repoPath,
+      limit,
+    });
+  },
+  getWorkflowRunDetail(
+    repoPath: string,
+    runId: number,
+  ): Promise<WorkflowRunDetailListing> {
+    return invoke<WorkflowRunDetailListing>("get_workflow_run_detail", {
+      repoPath,
+      runId,
     });
   },
   getMemoryUsage(): Promise<MemoryUsage> {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -55,7 +55,6 @@ export const AGENT_OPTIONS: ReadonlyArray<{
   },
 ];
 
-import type { PrStateFilter } from "./types";
 
 /**
  * Allowed PRs-tab refresh intervals shown in the Settings UI. Picked to
@@ -216,15 +215,13 @@ export interface AcornSettings {
     showGithubAccount: boolean;
     showMemory: boolean;
   };
-  pullRequests: {
-    /** Tab pre-selected when the PRs panel first mounts for a repo. */
-    defaultState: PrStateFilter;
-    /** Auto-refresh cadence for the PRs tab in milliseconds. */
+  github: {
+    /** Auto-refresh cadence for the PRs and Actions tabs in milliseconds. */
     refreshIntervalMs: number;
     /**
-     * Show the author's GitHub avatar on each PR row. Trades a thicker
-     * row for at-a-glance author recognition, mirroring the PR detail
-     * modal which already shows avatars in its header / conversation.
+     * Show the author's GitHub avatar on PR rows. Trades a thicker row
+     * for at-a-glance author recognition, mirroring the PR detail modal
+     * which already shows avatars in its header / conversation.
      */
     showAvatars: boolean;
   };
@@ -322,8 +319,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     showGithubAccount: true,
     showMemory: true,
   },
-  pullRequests: {
-    defaultState: "open",
+  github: {
     refreshIntervalMs: 60_000,
     showAvatars: true,
   },
@@ -368,13 +364,6 @@ const VALID_AGENTS = new Set<AgentProvider>([
   "ollama",
   "llm",
   "codex",
-]);
-
-const VALID_PR_STATES = new Set<PrStateFilter>([
-  "open",
-  "closed",
-  "merged",
-  "all",
 ]);
 
 const VALID_PR_INTERVALS = new Set<number>(
@@ -441,13 +430,6 @@ function normalizeLineHeight(v: unknown, fallback: number): number {
   return Math.max(1.0, Math.min(2.0, v));
 }
 
-function normalizePrState(v: unknown, fallback: PrStateFilter): PrStateFilter {
-  if (typeof v === "string" && VALID_PR_STATES.has(v as PrStateFilter)) {
-    return v as PrStateFilter;
-  }
-  return fallback;
-}
-
 function normalizePrInterval(v: unknown, fallback: number): number {
   if (typeof v === "number" && VALID_PR_INTERVALS.has(v)) return v;
   return fallback;
@@ -508,13 +490,21 @@ interface LegacyCommitMessage {
   llmModel?: string;
 }
 
+interface LegacyPullRequests {
+  refreshIntervalMs?: number;
+  showAvatars?: boolean;
+}
+
 function loadSettings(): AcornSettings {
   if (typeof localStorage === "undefined") return DEFAULT_SETTINGS;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULT_SETTINGS;
     const parsed = JSON.parse(raw) as
-      | (Partial<AcornSettings> & { commitMessage?: LegacyCommitMessage })
+      | (Partial<AcornSettings> & {
+          commitMessage?: LegacyCommitMessage;
+          pullRequests?: LegacyPullRequests;
+        })
       | null;
     if (!parsed || typeof parsed !== "object") return DEFAULT_SETTINGS;
     const terminalRaw: Partial<AcornSettings["terminal"]> = parsed.terminal ?? {};
@@ -639,19 +629,22 @@ function loadSettings(): AcornSettings {
         ...DEFAULT_SETTINGS.statusBar,
         ...(parsed.statusBar ?? {}),
       },
-      pullRequests: {
-        defaultState: normalizePrState(
-          parsed.pullRequests?.defaultState,
-          DEFAULT_SETTINGS.pullRequests.defaultState,
-        ),
+      github: {
+        // Backwards compat: legacy persisted settings store these fields
+        // under `pullRequests`. Fall through to that key when the new
+        // `github` slot is missing so existing users don't lose their
+        // refresh interval / avatar toggle on first launch after rename.
         refreshIntervalMs: normalizePrInterval(
-          parsed.pullRequests?.refreshIntervalMs,
-          DEFAULT_SETTINGS.pullRequests.refreshIntervalMs,
+          parsed.github?.refreshIntervalMs ??
+            parsed.pullRequests?.refreshIntervalMs,
+          DEFAULT_SETTINGS.github.refreshIntervalMs,
         ),
         showAvatars:
-          typeof parsed.pullRequests?.showAvatars === "boolean"
-            ? parsed.pullRequests.showAvatars
-            : DEFAULT_SETTINGS.pullRequests.showAvatars,
+          typeof parsed.github?.showAvatars === "boolean"
+            ? parsed.github.showAvatars
+            : typeof parsed.pullRequests?.showAvatars === "boolean"
+              ? parsed.pullRequests.showAvatars
+              : DEFAULT_SETTINGS.github.showAvatars,
       },
       sessionDisplay: {
         title: normalizeSessionTitle(
@@ -725,7 +718,7 @@ interface SettingsState {
     },
   ) => void;
   patchStatusBar: (patch: Partial<AcornSettings["statusBar"]>) => void;
-  patchPullRequests: (patch: Partial<AcornSettings["pullRequests"]>) => void;
+  patchGithub: (patch: Partial<AcornSettings["github"]>) => void;
   patchSessionDisplay: (
     patch: Partial<
       Omit<AcornSettings["sessionDisplay"], "metadata" | "icons">
@@ -829,11 +822,11 @@ export const useSettings = create<SettingsState>((set, get) => ({
       persist(next);
       return { settings: next };
     }),
-  patchPullRequests: (patch) =>
+  patchGithub: (patch) =>
     set((s) => {
       const next: AcornSettings = {
         ...s.settings,
-        pullRequests: { ...s.settings.pullRequests, ...patch },
+        github: { ...s.settings.github, ...patch },
       };
       persist(next);
       return { settings: next };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -208,6 +208,71 @@ export type PullRequestDetailListing =
   | { kind: "not_github" }
   | { kind: "no_access"; slug: string; accounts: AccountSummary[] };
 
+export interface WorkflowRun {
+  id: number;
+  /** Commit subject (or dispatch title) gh shows for the run. */
+  display_title: string;
+  /** Human-readable workflow name (e.g. "CI", "Release"). */
+  workflow_name: string;
+  /** queued | in_progress | completed | requested | waiting | pending */
+  status: string;
+  /** success | failure | cancelled | skipped | neutral | timed_out | action_required | startup_failure. null while still running. */
+  conclusion: string | null;
+  /** push | pull_request | workflow_dispatch | schedule | ... */
+  event: string;
+  head_branch: string | null;
+  head_sha: string;
+  url: string;
+  created_at: string;
+  updated_at: string;
+  attempt: number;
+}
+
+export type WorkflowRunsListing =
+  | { kind: "ok"; items: WorkflowRun[]; account: string }
+  | { kind: "not_github" }
+  | { kind: "no_access"; slug: string; accounts: AccountSummary[] };
+
+export interface WorkflowJobStep {
+  name: string;
+  number: number;
+  status: string;
+  conclusion: string | null;
+}
+
+export interface WorkflowJob {
+  id: number;
+  name: string;
+  status: string;
+  conclusion: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  url: string;
+  steps: WorkflowJobStep[];
+}
+
+export interface WorkflowRunDetail {
+  id: number;
+  display_title: string;
+  workflow_name: string;
+  status: string;
+  conclusion: string | null;
+  event: string;
+  head_branch: string | null;
+  head_sha: string;
+  url: string;
+  created_at: string;
+  updated_at: string;
+  started_at: string | null;
+  attempt: number;
+  jobs: WorkflowJob[];
+}
+
+export type WorkflowRunDetailListing =
+  | { kind: "ok"; account: string; detail: WorkflowRunDetail }
+  | { kind: "not_github" }
+  | { kind: "no_access"; slug: string; accounts: AccountSummary[] };
+
 export type MergeMethod = "squash" | "merge" | "rebase";
 
 export interface GeneratedCommitMessage {

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,7 +16,7 @@ import {
   splitPaneInLayout,
 } from "./lib/layout";
 
-type RightTab = "todos" | "commits" | "staged" | "prs";
+type RightTab = "todos" | "commits" | "staged" | "prs" | "actions";
 
 const ROOT_PANE_ID: PaneId = "root";
 

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -42,6 +42,12 @@ export const tauriMockSource = `
     if (cmd === 'list_pull_requests') {
       return Promise.resolve({ items: [], account: null, error: null });
     }
+    if (cmd === 'list_workflow_runs') {
+      return Promise.resolve({ kind: 'not_github' });
+    }
+    if (cmd === 'get_workflow_run_detail') {
+      return Promise.resolve({ kind: 'not_github' });
+    }
     if (cmd === 'staged_diff') return Promise.resolve({ files: [] });
     if (cmd === 'commit_diff') return Promise.resolve({ files: [] });
     if (cmd === 'scrollback_load') return Promise.resolve(null);


### PR DESCRIPTION
## Summary
- 새 **Actions** 탭 (Commits/Staged/PRs 옆): `gh run list` 로 워크플로 런 목록, 상태 아이콘 (success/failure/cancelled/in_progress/queued/action_required), 워크플로 이름 필터.
- 더블 클릭 → **WorkflowRunDetailModal**: `gh run view <id>` 로 잡/스텝 트리, 상태/conclusion, 커밋 SHA, total duration (진행 중이면 `(running)`), attempt 횟수. 잡 헤더는 sticky 로 펼친 스텝 스크롤 중에도 고정. 모달 고정 사이즈 (`h-[36rem]`) + 내부 스크롤.
- 진행 중인 런은 모달도 폴링 (완료되면 자동 중단). 리스트 + 모달 모두 GitHub 설정의 refresh interval 공유.
- Settings: `pullRequests` → `github` 으로 통합 (탭명 "GitHub"), `defaultState` 제거, `refreshIntervalMs` + `showAvatars` 가 PR / Actions 공통. 기존 localStorage 키는 마이그레이션으로 그대로 살아남음.

## Implementation notes
- 백엔드: `pull_requests.rs` 에 `WorkflowRun`, `WorkflowRunDetail`, `WorkflowJob`, `WorkflowJobStep` 추가. 기존 `try_with_account` 다계정 라우팅 재사용 — gh 토큰 / NotGithub / NoAccess 경로 PR 과 동일.
- Tauri commands: `list_workflow_runs`, `get_workflow_run_detail`.
- Sticky 헤더: 처음 `<li>` 에 `overflow-hidden` 을 걸어 sticky 가 동작하지 않던 버그를 잡음 — overflow-hidden 컨테이너는 sticky 의 scroll-ancestor 가 되어버려 무력화됨. `<ul>` 의 `divide-y` 로 외곽 라운드와 행 구분선 유지.
- 모달 body 의 `py-3` 가 sticky `top:0` 윗쪽 영역으로 콘텐츠가 비춰 보이는 문제 → 스크롤 컨테이너에서 padding 분리, 내부 wrapper 로 이동.

## Test plan
- [x] `bun run typecheck` 통과
- [x] `cargo check` 통과
- [x] `tauri dev` 로컬 실행, GitHub 원격 레포에서 Actions 탭 확인 (목록 / 필터 / 더블 클릭 모달 / sticky 헤더 / GitHub 외부 링크)
- [x] Settings 의 "GitHub" 탭 → refresh interval 변경 시 PR + Actions 양쪽 반영
- [ ] 진행 중인 워크플로 런에서 모달 폴링 동작 (완료 시 자동 중단)
- [ ] gh 미인증 / non-GitHub 원격 / no-access 케이스 빈 상태 표시
