### PR TITLE
test(e2e): align resume-modal spec with no-ack-on-Resume

### DIFF
--- a/tests/e2e/agent-resume-modal.spec.ts
+++ b/tests/e2e/agent-resume-modal.spec.ts
@@ -97,7 +97,10 @@ test.describe("agent resume modal", () => {
         (window as unknown as { __ACORN_ACKED__?: string[] }).__ACORN_ACKED__ ??
         [],
     );
-    expect(acked).toContain(SESSION.id);
+    // Resume is the one button that does NOT ack — the user signalled
+    // they want to keep working with this conversation, so subsequent
+    // exits should re-offer the modal at the next cold boot.
+    expect(acked).not.toContain(SESSION.id);
   });
 
   test("focusing a session with a codex candidate dispatches `codex resume`", async ({
@@ -162,7 +165,8 @@ test.describe("agent resume modal", () => {
         (window as unknown as { __ACORN_CODEX_ACKED__?: string[] })
           .__ACORN_CODEX_ACKED__ ?? [],
     );
-    expect(acked).toContain(SESSION.id);
+    // Same rule as the claude case: Resume must not ack.
+    expect(acked).not.toContain(SESSION.id);
   });
 
   test("Cancel writes a shell-comment hint with the resume command", async ({


### PR DESCRIPTION
The agent-resume-modal E2E spec was asserting that clicking Resume calls `acknowledge*Resume`, but the production code (from #174) deliberately does NOT ack on Resume — that is how the modal re-pops after the next exit. Flip the two affected assertions to `not.toContain`.

CI on #174 surfaced the mismatch (Frontend green, E2E red); merging this lands `bun run test:e2e` back to green on main.
