### PR TITLE
chore(release): v1.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.13",
+  "version": "1.0.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.13"
+version = "1.0.14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.13"
+version = "1.0.14"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "bun run dev:sidecar && bun run dev",


### PR DESCRIPTION
## Summary
Bump version to 1.0.14.

Includes since v1.0.13:
- 앱 UI 배율 조절 기능 추가 (UI scale: Cmd+-/+/0, 75–150% range)
- fix(status-bar): clamp footer to a single row at narrow widths (#169)
- feat(appearance): toggle working-directory readout in the status bar (#170)
- fix(daemon-pty): apply render-capability env layering on daemon path (#171)
- feat(actions): add GitHub Actions tab with run detail modal (#172)
- feat: rebuild resize handle UX with collapse tooltip and reset command (#173)
- refactor(agent-resume): replace shim with filesystem watcher (#174)
- test(e2e): Resume button no longer acks (Resume signals keep-going) (#176)
- feat(daemon-sessions): per-row Kill / Restore / Forget actions (#177)
- 터미널 CJK 셀 폭 렌더링 수정 (#164)

## Test plan
- [x] `bun run typecheck`
- [ ] CI green
