### PR TITLE
feat(pty): spawn user $SHELL as login shell

### DIFF
--- a/src-tauri/shell-init/zlogin
+++ b/src-tauri/shell-init/zlogin
@@ -1,0 +1,20 @@
+# Acorn zsh login init.
+#
+# Login-mode counterpart of the staged `.zprofile`. zsh sources `.zlogin`
+# after `.zshrc` for login shells, and resolves it relative to
+# `$ZDOTDIR` — which Acorn pinned to its staged dir, so without this
+# file the user's real `.zlogin` would never run. Most users keep
+# `.zlogin` empty, but ssh-agent bootstrap and motd-style logic
+# occasionally live here.
+#
+# Same forward pattern as `.zprofile` / `.zshrc`: temporarily point
+# `ZDOTDIR` at the user's dir, source their file, then restore Acorn's
+# staged dir so a later `exec zsh` still resolves stage files
+# correctly.
+
+_acorn_zd_save=$ZDOTDIR
+_acorn_user_zd=${ACORN_USER_ZDOTDIR:-$HOME}
+ZDOTDIR=$_acorn_user_zd
+[ -f "$ZDOTDIR/.zlogin" ] && source "$ZDOTDIR/.zlogin"
+ZDOTDIR=$_acorn_zd_save
+unset _acorn_zd_save _acorn_user_zd

--- a/src-tauri/shell-init/zprofile
+++ b/src-tauri/shell-init/zprofile
@@ -1,0 +1,19 @@
+# Acorn zsh login profile init.
+#
+# Acorn spawns the user's `$SHELL` with `-l` (matching macOS Terminal.app /
+# iTerm2 / VS Code), so zsh runs `.zprofile` before `.zshrc`. Because
+# Acorn redirects `ZDOTDIR` to its staged dir, zsh looks for `.zprofile`
+# there — without this file the user's real `.zprofile` (typically
+# `eval "$(/opt/homebrew/bin/brew shellenv)"`, `nvm`, `rbenv`, manual
+# PATH bootstrapping) would silently be skipped.
+#
+# Source the user's real `.zprofile` with `ZDOTDIR` temporarily pointing
+# at their dir, then restore Acorn's staged dir so subsequent stage
+# files (`.zshrc`, `.zlogin`) keep resolving to our forwarders.
+
+_acorn_zd_save=$ZDOTDIR
+_acorn_user_zd=${ACORN_USER_ZDOTDIR:-$HOME}
+ZDOTDIR=$_acorn_user_zd
+[ -f "$ZDOTDIR/.zprofile" ] && source "$ZDOTDIR/.zprofile"
+ZDOTDIR=$_acorn_zd_save
+unset _acorn_zd_save _acorn_user_zd

--- a/src-tauri/shell-init/zshrc
+++ b/src-tauri/shell-init/zshrc
@@ -14,9 +14,8 @@
 #
 # After the user's rc runs we append an OSC 7 emitter so the host
 # learns the live cwd after every command without polling
-# `proc_pidinfo`, and re-prepend Acorn's shim / IPC CLI directories
-# in case the user's rc reset `$PATH` entirely (`export PATH="…"`
-# patterns).
+# `proc_pidinfo`, and re-prepend Acorn's IPC CLI directory in case
+# the user's rc reset `$PATH` entirely (`export PATH="…"` patterns).
 #
 # OSC 7 (`\e]7;file://<host><pwd>\e\\`) is the de-facto "current
 # directory" protocol shared by iTerm2, GNOME Terminal, Wezterm,
@@ -39,7 +38,6 @@ _acorn_prepend_path() {
         *) PATH=$1${PATH:+:$PATH} ;;
     esac
 }
-[ -n "${ACORN_SHIM_DIR-}" ] && _acorn_prepend_path "$ACORN_SHIM_DIR"
 [ -n "${ACORN_CLI_DIR-}" ] && _acorn_prepend_path "$ACORN_CLI_DIR"
 unset -f _acorn_prepend_path
 export PATH

--- a/src-tauri/shell-init/zshrc
+++ b/src-tauri/shell-init/zshrc
@@ -1,32 +1,59 @@
-# Acorn zsh init.
+# Acorn zsh interactive init.
 #
-# Sourced because Acorn sets `ZDOTDIR` to its own staged dir before spawning
-# the PTY. This file restores the user's real `ZDOTDIR`, sources their
-# `.zshrc` so their configuration still runs, then appends an OSC 7
-# emitter so the terminal learns the live cwd after every command without
-# the host having to poll `proc_pidinfo`.
+# Sourced because Acorn sets `ZDOTDIR` to its own staged dir before
+# spawning the PTY. zsh resolves `.zshrc` (and `.zprofile` / `.zlogin`)
+# off `$ZDOTDIR`, so without this file the user's real `.zshrc` would
+# be skipped.
 #
-# OSC 7 (`\e]7;file://<host><pwd>\e\\`) is the de-facto "current directory"
-# protocol shared by iTerm2, GNOME Terminal, Wezterm, Kitty, VS Code, etc.
-# Acorn's xterm.js handler treats every emit as the new live cwd for the
-# session and updates the worktree-icon condition in O(1) — no system scan.
+# Source the user's real `.zshrc` with `ZDOTDIR` temporarily pointing
+# at their dir (so any `$ZDOTDIR`-relative paths inside their rc keep
+# working), then restore Acorn's staged dir. `ACORN_USER_ZDOTDIR` is
+# preserved across this file because the staged `.zlogin` reads it
+# too; the `.zshenv` forwarder is the only place we permanently
+# rebase `ZDOTDIR`.
+#
+# After the user's rc runs we append an OSC 7 emitter so the host
+# learns the live cwd after every command without polling
+# `proc_pidinfo`, and re-prepend Acorn's shim / IPC CLI directories
+# in case the user's rc reset `$PATH` entirely (`export PATH="…"`
+# patterns).
+#
+# OSC 7 (`\e]7;file://<host><pwd>\e\\`) is the de-facto "current
+# directory" protocol shared by iTerm2, GNOME Terminal, Wezterm,
+# Kitty, VS Code, etc. Acorn's xterm.js handler treats every emit as
+# the new live cwd for the session and updates the worktree-icon
+# condition in O(1) — no system scan.
 
-if [ -n "${ACORN_USER_ZDOTDIR-}" ]; then
-    ZDOTDIR=$ACORN_USER_ZDOTDIR
-else
-    ZDOTDIR=$HOME
-fi
-unset ACORN_USER_ZDOTDIR
+_acorn_zd_save=$ZDOTDIR
+_acorn_user_zd=${ACORN_USER_ZDOTDIR:-$HOME}
+ZDOTDIR=$_acorn_user_zd
 [ -f "$ZDOTDIR/.zshrc" ] && source "$ZDOTDIR/.zshrc"
+ZDOTDIR=$_acorn_zd_save
+unset _acorn_zd_save _acorn_user_zd
+
+# Re-prepend Acorn-managed PATH entries if the user's rc replaced
+# PATH wholesale. Idempotent — duplicate entries are skipped.
+_acorn_prepend_path() {
+    case ":$PATH:" in
+        *":$1:"*) ;;
+        *) PATH=$1${PATH:+:$PATH} ;;
+    esac
+}
+[ -n "${ACORN_SHIM_DIR-}" ] && _acorn_prepend_path "$ACORN_SHIM_DIR"
+[ -n "${ACORN_CLI_DIR-}" ] && _acorn_prepend_path "$ACORN_CLI_DIR"
+unset -f _acorn_prepend_path
+export PATH
 
 _acorn_osc7() {
     printf '\e]7;file://%s%s\e\\' "${HOST:-${HOSTNAME-localhost}}" "$PWD"
 }
-# precmd_functions is the canonical "run before each prompt" hook list in
-# zsh. typeset -gaU keeps it global, array-typed, and dedup'd so a repeated
-# `source` of this file (e.g. `exec zsh`) doesn't stack duplicate emitters.
+# precmd_functions is the canonical "run before each prompt" hook list
+# in zsh. `typeset -gaU` keeps it global, array-typed, and dedup'd so
+# a repeated `source` of this file (e.g. `exec zsh`) doesn't stack
+# duplicate emitters.
 typeset -gaU precmd_functions
 precmd_functions+=(_acorn_osc7)
-# Emit once immediately so the host gets the spawn cwd before the user runs
-# anything — without this, the icon waits for the first prompt.
+# Emit once immediately so the host gets the spawn cwd before the
+# user runs anything — without this, the icon waits for the first
+# prompt.
 _acorn_osc7

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -837,15 +837,33 @@ pub async fn pty_spawn<R: Runtime>(
     if state.pty.contains(&id) || state.stream_registry.contains(&id) {
         return Ok(());
     }
-    // Sessions always spawn the user's interactive `$SHELL`.
+    // Sessions always spawn the user's interactive `$SHELL` in login
+    // mode so `.zprofile` / `.bash_profile` / `.profile` run — matches
+    // macOS Terminal.app / iTerm2 / VS Code so the PTY feels identical
+    // to opening the user's native terminal.
     let resolved_command = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
-    let resolved_args: Vec<String> = Vec::new();
+    let resolved_args: Vec<String> = crate::shell_args::login_args_for(&resolved_command);
     // Inject IPC env vars for control sessions so the user's shell (and any
     // agent it launches) can address the running app via the `acorn-ipc`
     // CLI without per-session configuration. Only control sessions get the
     // env; regular sessions stay sandboxed from the IPC surface.
     let mut effective_env = env.unwrap_or_default();
     let mut primed_args = resolved_args;
+
+    // PTY children get the same SHELL/HOME their dotfiles expect to
+    // see. portable-pty inherits these from Acorn's own env in
+    // practice, but being explicit prevents drift when Acorn is
+    // launched by launchd (which sanitises HOME) or via a wrapper
+    // that overrode SHELL — both manifest as zsh refusing to honor
+    // `~` expansion or `$SHELL`-gated logic in user dotfiles.
+    effective_env
+        .entry("SHELL".to_string())
+        .or_insert_with(|| resolved_command.clone());
+    if let Some(home) = std::env::var_os("HOME") {
+        effective_env
+            .entry("HOME".to_string())
+            .or_insert_with(|| home.to_string_lossy().into_owned());
+    }
 
     // `ACORN_RESUME_TOKEN` carries the Acorn session UUID. Older builds
     // used the value inside a PATH-based shim to auto-inject claude's
@@ -927,6 +945,13 @@ pub async fn pty_spawn<R: Runtime>(
                     "PATH".to_string(),
                     crate::ipc::cli_path::prepend_to_path(&bin_dir, &existing),
                 );
+                // Expose the dir so the staged `.zshrc` can re-prepend
+                // the IPC CLI entry after the user's rc runs — covers
+                // `export PATH="…"` patterns that wipe Acorn's earlier
+                // prepend.
+                effective_env
+                    .entry("ACORN_CLI_DIR".to_string())
+                    .or_insert_with(|| bin_dir.display().to_string());
             }
             // Drop the primer in a worktree-local marker file so whichever
             // agent the user invokes inside the shell can read the IPC

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod pull_requests;
 mod scrollback;
 mod session;
 mod session_status;
+mod shell_args;
 mod shell_env;
 mod shell_init;
 mod shell_util;

--- a/src-tauri/src/shell_args.rs
+++ b/src-tauri/src/shell_args.rs
@@ -1,0 +1,82 @@
+//! Map a resolved shell path to the argv that makes it behave like a
+//! native terminal session — login + interactive — whenever the shell
+//! understands `-l`.
+//!
+//! macOS Terminal.app, iTerm2, WezTerm and VS Code all spawn the user's
+//! `$SHELL` as a login shell so `~/.zprofile` / `~/.bash_profile` /
+//! `~/.profile` run and version managers, `brew shellenv`, `nvm`, etc.
+//! see their normal startup path. Acorn matches that contract: any
+//! recognised POSIX-style shell gets `-l`. Unrecognised binaries
+//! (pwsh, nushell, xonsh, custom wrappers) get no extra args so we
+//! don't pass a flag they may reject.
+//!
+//! PTY children inherit a tty on stdin, which is the trigger every
+//! supported shell uses to flip itself into interactive mode — so we
+//! deliberately omit `-i`. zsh in particular emits a noisy warning if
+//! `-i` is passed without an attached tty and the cost of guessing
+//! wrong is higher than the cost of letting the shell decide.
+
+use std::path::Path;
+
+/// Returns argv flags to pass after the shell binary so it starts in
+/// login mode. Empty vec means "no extra args" — used for unknown
+/// shells we don't want to risk misconfiguring.
+pub fn login_args_for(shell_path: &str) -> Vec<String> {
+    let basename = Path::new(shell_path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(shell_path);
+
+    match basename {
+        "sh" | "bash" | "zsh" | "dash" | "ash" | "ksh" | "mksh" | "fish" => {
+            vec!["-l".to_string()]
+        }
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn login_flag_for_known_posix_shells() {
+        for path in [
+            "/bin/zsh",
+            "/bin/bash",
+            "/bin/sh",
+            "/bin/dash",
+            "/usr/local/bin/fish",
+            "/opt/homebrew/bin/zsh",
+            "zsh",
+            "bash",
+            "/usr/bin/ksh",
+            "/usr/local/bin/mksh",
+        ] {
+            assert_eq!(
+                login_args_for(path),
+                vec!["-l".to_string()],
+                "expected -l for {path}",
+            );
+        }
+    }
+
+    #[test]
+    fn no_args_for_unknown_shells() {
+        for path in [
+            "/usr/local/bin/pwsh",
+            "pwsh",
+            "/usr/local/bin/nu",
+            "nu",
+            "xonsh",
+            "/some/custom/wrapper",
+            "",
+        ] {
+            assert_eq!(
+                login_args_for(path),
+                Vec::<String>::new(),
+                "expected empty args for {path}",
+            );
+        }
+    }
+}

--- a/src-tauri/src/shell_init.rs
+++ b/src-tauri/src/shell_init.rs
@@ -1,17 +1,23 @@
 //! Acorn-managed shell rc files materialised under the data dir.
 //!
-//! Set `ZDOTDIR` on PTY spawn to point zsh at our staged `.zshenv` +
-//! `.zshrc`. The `.zshrc` registers an OSC 7 emitter so the host learns
-//! the live cwd every prompt without polling, and the `.zshenv` forwards
-//! to the user's real `.zshenv` so rustup / asdf style env bootstrap
-//! still runs (zsh resolves both files via `$ZDOTDIR`, not `$HOME`).
-//! The same pattern iTerm2 / Wezterm / VS Code use; `ZDOTDIR` is the
-//! only env handle zsh provides for "load an extra interactive rc
-//! before the user's".
+//! Acorn spawns the user's `$SHELL` with `-l` (matching macOS
+//! Terminal.app / iTerm2 / VS Code) and points `ZDOTDIR` at this
+//! staged dir so zsh sees all four rc files we own (`.zshenv`,
+//! `.zprofile`, `.zshrc`, `.zlogin`). Each forwarder sources the
+//! user's real counterpart so version managers, `brew shellenv`,
+//! `nvm`, ssh-agent bootstrap, etc. run normally; `.zshrc`
+//! additionally installs an OSC 7 emitter so the host learns the
+//! live cwd every prompt without polling, and re-prepends Acorn's
+//! shim / IPC CLI dirs if the user's rc reset PATH.
 //!
-//! bash and fish are out of scope today — bash supports `PROMPT_COMMAND`
-//! from the env directly, and fish emits OSC 7 by default. zsh is the
-//! macOS default and the only shell that needs file-side help.
+//! `ZDOTDIR` is the only env handle zsh provides for "load an extra
+//! interactive rc before the user's" — same pattern iTerm2 / Wezterm
+//! / VS Code use.
+//!
+//! bash and fish are out of scope today. bash handles its own
+//! `.bash_profile` / `.bashrc` resolution off `$HOME` and we already
+//! pass `-l` so login mode runs. fish emits OSC 7 by default. zsh is
+//! the macOS default and the only shell that needs file-side help.
 
 use std::fs;
 use std::io;
@@ -19,10 +25,14 @@ use std::path::{Path, PathBuf};
 
 const SHELL_INIT_DIR_NAME: &str = "shell-init";
 const ZSHENV_NAME: &str = ".zshenv";
+const ZPROFILE_NAME: &str = ".zprofile";
 const ZSHRC_NAME: &str = ".zshrc";
+const ZLOGIN_NAME: &str = ".zlogin";
 
 const ZSHENV_BODY: &str = include_str!("../shell-init/zshenv");
+const ZPROFILE_BODY: &str = include_str!("../shell-init/zprofile");
 const ZSHRC_BODY: &str = include_str!("../shell-init/zshrc");
+const ZLOGIN_BODY: &str = include_str!("../shell-init/zlogin");
 
 /// Materialise the shell-init dir under Acorn's data dir, returning the
 /// path callers should hand to `ZDOTDIR` on PTY spawn. Idempotent — the
@@ -36,7 +46,9 @@ fn ensure_shell_init_dir_at(base: &Path) -> io::Result<PathBuf> {
     let dir = base.join(SHELL_INIT_DIR_NAME);
     fs::create_dir_all(&dir)?;
     fs::write(dir.join(ZSHENV_NAME), ZSHENV_BODY)?;
+    fs::write(dir.join(ZPROFILE_NAME), ZPROFILE_BODY)?;
     fs::write(dir.join(ZSHRC_NAME), ZSHRC_BODY)?;
+    fs::write(dir.join(ZLOGIN_NAME), ZLOGIN_BODY)?;
     Ok(dir)
 }
 
@@ -65,7 +77,7 @@ mod tests {
     }
 
     #[test]
-    fn writes_zshrc_with_osc7_emitter() {
+    fn writes_zshrc_with_osc7_emitter_and_path_guard() {
         let base = ScratchDir::new("zshrc");
         let dir = ensure_shell_init_dir_at(base.path()).unwrap();
         let zshrc = dir.join(ZSHRC_NAME);
@@ -74,6 +86,11 @@ mod tests {
         assert!(body.contains("_acorn_osc7"));
         assert!(body.contains("precmd_functions"));
         assert!(body.contains("ACORN_USER_ZDOTDIR"));
+        assert!(body.contains("ACORN_SHIM_DIR"));
+        assert!(body.contains("ACORN_CLI_DIR"));
+        // Restore ZDOTDIR before .zlogin runs (otherwise the staged
+        // .zlogin would resolve to the user's dir on its own).
+        assert!(body.contains("_acorn_zd_save"));
     }
 
     #[test]
@@ -86,6 +103,31 @@ mod tests {
         assert!(body.contains("ACORN_USER_ZDOTDIR"));
         assert!(body.contains(".zshenv"));
         assert!(body.contains("ZDOTDIR=$_acorn_zd"));
+    }
+
+    #[test]
+    fn writes_zprofile_forwarding_to_user() {
+        let base = ScratchDir::new("zprofile");
+        let dir = ensure_shell_init_dir_at(base.path()).unwrap();
+        let zprofile = dir.join(ZPROFILE_NAME);
+        assert!(zprofile.exists());
+        let body = fs::read_to_string(&zprofile).unwrap();
+        assert!(body.contains("ACORN_USER_ZDOTDIR"));
+        assert!(body.contains(".zprofile"));
+        // Restore ZDOTDIR so subsequent stage files keep resolving to
+        // our forwarders.
+        assert!(body.contains("_acorn_zd_save"));
+    }
+
+    #[test]
+    fn writes_zlogin_forwarding_to_user() {
+        let base = ScratchDir::new("zlogin");
+        let dir = ensure_shell_init_dir_at(base.path()).unwrap();
+        let zlogin = dir.join(ZLOGIN_NAME);
+        assert!(zlogin.exists());
+        let body = fs::read_to_string(&zlogin).unwrap();
+        assert!(body.contains("ACORN_USER_ZDOTDIR"));
+        assert!(body.contains(".zlogin"));
     }
 
     #[test]

--- a/src-tauri/src/shell_init.rs
+++ b/src-tauri/src/shell_init.rs
@@ -86,7 +86,6 @@ mod tests {
         assert!(body.contains("_acorn_osc7"));
         assert!(body.contains("precmd_functions"));
         assert!(body.contains("ACORN_USER_ZDOTDIR"));
-        assert!(body.contains("ACORN_SHIM_DIR"));
         assert!(body.contains("ACORN_CLI_DIR"));
         // Restore ZDOTDIR before .zlogin runs (otherwise the staged
         // .zlogin would resolve to the user's dir on its own).


### PR DESCRIPTION
## Summary

Acorn was spawning the user's `$SHELL` with no extra args, so zsh and bash started as interactive-but-not-login PTYs. Login-only rc files (`~/.zprofile`, `~/.bash_profile`, `~/.profile`, `~/.zlogin`) never ran, which silently dropped a chunk of every user's environment: `brew shellenv`, version managers, ssh-agent bootstrap, custom aliases / functions / PATH that live in `.zprofile`. macOS Terminal.app, iTerm2, WezTerm, and VS Code all spawn `$SHELL -l`; Acorn now matches that contract.

The fix has two halves:

1. **PTY spawn passes `-l`.** A new `shell_args::login_args_for(&shell_path)` helper resolves the right argv based on the shell binary's basename. POSIX-style shells (zsh / bash / sh / dash / ash / ksh / mksh / fish) get `-l`. Unrecognised binaries (pwsh / nushell / xonsh / custom wrappers) get no extra args so a wrong flag can't crash the spawn. The PTY children also get `SHELL` and `HOME` injected explicitly so launchd-sanitised environments don't leave them unset.

2. **Staged ZDOTDIR forwards every zsh rc file, not just `.zshrc`.** Acorn already pinned `ZDOTDIR` to a staged dir so its `.zshrc` could install the OSC 7 emitter. Now that zsh runs in login mode, it also looks for `.zprofile` / `.zlogin` under that staged dir — so the staged dir now ships forwarders for both. The staged `.zshrc` was reworked to (a) preserve `ACORN_USER_ZDOTDIR` across the file so `.zlogin` can still find it, and (b) re-prepend `ACORN_CLI_DIR` to PATH if the user's rc replaced PATH wholesale (`export PATH="…"` patterns wipe Acorn's IPC CLI prepend).

bash and fish are unaffected by the ZDOTDIR plumbing — their dotfile resolution is `$HOME`-based, so login mode alone is enough.

### New env vars exposed to PTY children

* `ACORN_CLI_DIR` — directory containing `acorn-ipc` / `acornd` bundled CLIs (control sessions only).

Existing env vars (`ACORN_SESSION_ID`, `ACORN_IPC_SOCKET`, `ACORN_DAEMON_SOCKET`, `ACORN_RESUME_TOKEN`, `ACORN_AGENT_STATE_DIR`, `ACORN_USER_ZDOTDIR`) are untouched.

### Known side effect: stale daemon sessions

A one-time follow-up is needed after pulling. Acorn's `acornd` daemon holds PTY sessions across app restarts; sessions spawned by a pre-PR build are non-login and were attached to an older staged dotfile snapshot. When the new build reattaches to them the staged `.zshrc` swap collides with the running ZLE state, which surfaces as duplicated keystrokes / garbled prompt redraws.

Reproduce + recover with one of the following after pulling:

* Open the Daemon panel and `Restart` — kills the daemon, fresh sessions spawn login-mode against the new dotfiles.
* Toggle the daemon killswitch off then on in Settings.
* Or kill the daemon manually: `pkill -f acornd && acorn` (or relaunch from Finder).

Automatic reconciliation (boot-time hash compare → force-respawn with one-click UI) is filed as a follow-up so this PR stays focused. Issue tracking that work belongs in a separate PR.

## Test plan

Automated:

- [x] `cargo build --bin acorn` — clean.
- [x] `cargo test --lib shell_args` — 2/2 pass.
- [x] `cargo test --lib shell_init` — 5/5 pass, covers all four forwarders + idempotency + PATH guard.
- [x] `cargo test --lib` — 130 pass, 1 known-flaky `pid_lock_reclaims_stale_file` (unrelated to this PR, passes on rerun).

Manual:

- [x] `bun run tauri dev`, open a fresh terminal (after daemon restart on first pull).
- [x] `echo $-` → contains `l` (login mode confirmed).
- [x] `echo $HOMEBREW_PREFIX` → `/opt/homebrew` (user `.zprofile` ran).
- [ ] `which acorn-ipc` inside a control session — should resolve to `ACORN_CLI_DIR`.
- [ ] Confirm OSC 7 cwd tracking still works — `cd` somewhere and the worktree icon in the sidebar should update without polling.
- [ ] Sentinel test: add `export ACORN_TEST_MARKER=hello` to `.zprofile`, open a new terminal, `echo $ACORN_TEST_MARKER` → `hello`, remove sentinel after.
