### PR TITLE
feat(projects): add new project creation flow

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeSet, HashMap};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System, UpdateKind};
 use tauri::{AppHandle, Runtime, State};
@@ -484,6 +484,56 @@ pub fn add_project(state: State<'_, AppState>, repo_path: String) -> AppResult<P
     let project = state.projects.ensure(path.clone(), project_basename(&path));
     persist(&state);
     Ok(project)
+}
+
+#[tauri::command]
+pub fn create_new_project(
+    state: State<'_, AppState>,
+    parent_path: String,
+    name: String,
+) -> AppResult<Project> {
+    let name = validate_new_project_name(&name)?;
+    let parent = PathBuf::from(&parent_path);
+    if !parent.is_dir() {
+        return Err(AppError::InvalidPath(parent_path));
+    }
+    let parent = parent.canonicalize()?;
+    let target = parent.join(name);
+    if target.exists() {
+        return Err(AppError::Other(format!(
+            "project directory already exists: {}",
+            target.display()
+        )));
+    }
+
+    std::fs::create_dir(&target)?;
+    if let Err(err) = git2::Repository::init(&target) {
+        let _ = std::fs::remove_dir(&target);
+        return Err(AppError::Git(err));
+    }
+
+    let project = state.projects.ensure(target.clone(), project_basename(&target));
+    persist(&state);
+    Ok(project)
+}
+
+fn validate_new_project_name(name: &str) -> AppResult<&str> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::Other("project name is required".into()));
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(AppError::Other(
+            "project name must be a single folder name".into(),
+        ));
+    }
+    let mut components = Path::new(trimmed).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(trimmed),
+        _ => Err(AppError::Other(
+            "project name must be a single folder name".into(),
+        )),
+    }
 }
 
 #[tauri::command]
@@ -1820,7 +1870,7 @@ pub(crate) fn sanitize_worktree_name(name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::font_name_from_path;
+    use super::{font_name_from_path, validate_new_project_name};
     use std::path::Path;
 
     #[test]
@@ -1837,5 +1887,19 @@ mod tests {
             font_name_from_path(Path::new("/tmp/GeistMono-ThinItalic.ttf")),
             Some("GeistMono".to_string())
         );
+    }
+
+    #[test]
+    fn validate_new_project_name_accepts_single_folder_name() {
+        assert_eq!(validate_new_project_name(" fresh-app ").unwrap(), "fresh-app");
+    }
+
+    #[test]
+    fn validate_new_project_name_rejects_path_like_names() {
+        assert!(validate_new_project_name("").is_err());
+        assert!(validate_new_project_name("../fresh-app").is_err());
+        assert!(validate_new_project_name("parent/fresh-app").is_err());
+        assert!(validate_new_project_name("parent\\fresh-app").is_err());
+        assert!(validate_new_project_name(".").is_err());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -273,6 +273,7 @@ pub fn run() {
             commands::rename_session,
             commands::list_projects,
             commands::add_project,
+            commands::create_new_project,
             commands::remove_project,
             commands::reorder_projects,
             commands::reorder_sessions,

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Command, useCommandState } from "cmdk";
 import {
   Bot,
+  FolderOpen,
   FolderPlus,
   GitBranch,
   GitCommit,
@@ -60,6 +61,11 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 
   function handleAddProject() {
     window.dispatchEvent(new CustomEvent("acorn:add-project"));
+    close();
+  }
+
+  function handleNewProject() {
+    window.dispatchEvent(new CustomEvent("acorn:new-project"));
     close();
   }
 
@@ -201,12 +207,20 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             </span>
           </Command.Item>
           <Command.Item
+            value="new-project"
+            onSelect={handleNewProject}
+            keywords={["project", "create", "repository", "repo", "folder"]}
+          >
+            <FolderPlus size={14} className="text-accent" />
+            <span>New project</span>
+          </Command.Item>
+          <Command.Item
             value="add-project"
             onSelect={handleAddProject}
             keywords={["project", "import", "repository", "repo", "folder"]}
           >
-            <FolderPlus size={14} className="text-accent" />
-            <span>Add project</span>
+            <FolderOpen size={14} className="text-accent" />
+            <span>Add existing project</span>
             <span className="ml-auto truncate text-xs text-fg-muted/80">
               ⇧⌘N
             </span>

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -1,0 +1,173 @@
+import { FolderPlus } from "lucide-react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { useDialogShortcuts } from "../lib/dialog";
+import { Field, Modal, ModalHeader, TextInput } from "./ui";
+
+interface NewProjectDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (parentPath: string, name: string) => Promise<void>;
+}
+
+export function NewProjectDialog({
+  open: isOpen,
+  onClose,
+  onCreate,
+}: NewProjectDialogProps) {
+  const [name, setName] = useState("");
+  const [parentPath, setParentPath] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setName("");
+    setParentPath("");
+    setError(null);
+    setPending(false);
+  }, [isOpen]);
+
+  useDialogShortcuts(isOpen, {
+    onCancel: () => {
+      if (!pending) onClose();
+    },
+  });
+
+  const trimmedName = name.trim();
+  const finalPath = useMemo(() => {
+    if (!parentPath || !trimmedName) return "";
+    return `${parentPath.replace(/\/+$/, "")}/${trimmedName}`;
+  }, [parentPath, trimmedName]);
+
+  const validationError = validateProjectName(trimmedName);
+  const canCreate = !pending && parentPath !== "" && validationError === null;
+
+  async function chooseLocation() {
+    const picked = await open({
+      directory: true,
+      multiple: false,
+      title: "Select parent folder",
+    });
+    if (!picked || typeof picked !== "string") return;
+    setParentPath(picked);
+    setError(null);
+  }
+
+  async function submit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!canCreate) {
+      setError(validationError ?? "Choose a location for the new project.");
+      return;
+    }
+    setPending(true);
+    setError(null);
+    try {
+      await onCreate(parentPath, trimmedName);
+      onClose();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={() => {
+        if (!pending) onClose();
+      }}
+      variant="dialog"
+      size="md"
+      ariaLabelledBy="new-project-title"
+    >
+      <form onSubmit={submit}>
+        <ModalHeader
+          title="New project"
+          titleId="new-project-title"
+          subtitle="Create a git repository and add it to Acorn"
+          icon={<FolderPlus size={16} className="text-accent" />}
+          variant="dialog"
+          onClose={() => {
+            if (!pending) onClose();
+          }}
+        />
+        <div className="space-y-3 px-4 py-3">
+          <Field label="Project name" hint="Use a single folder name.">
+            <TextInput
+              autoFocus
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setError(null);
+              }}
+              placeholder="my-project"
+              aria-label="Project name"
+            />
+          </Field>
+          <Field label="Location">
+            <div className="flex gap-2">
+              <TextInput
+                readOnly
+                value={parentPath}
+                placeholder="Choose a parent folder"
+                aria-label="Project location"
+                className="min-w-0 flex-1"
+              />
+              <button
+                type="button"
+                onClick={() => void chooseLocation()}
+                className="shrink-0 rounded-md border border-border px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
+              >
+                Choose
+              </button>
+            </div>
+          </Field>
+          {finalPath ? (
+            <div className="rounded-md border border-border bg-bg-sidebar/60 p-3 text-xs">
+              <div className="mb-1 text-fg-muted">Creates</div>
+              <div className="break-all font-mono text-fg">{finalPath}</div>
+            </div>
+          ) : null}
+          {error ? (
+            <div role="alert" className="text-xs text-danger">
+              {error}
+            </div>
+          ) : null}
+        </div>
+        <footer className="flex items-center justify-end gap-2 border-t border-border bg-bg-sidebar/40 px-4 py-3">
+          <button
+            type="button"
+            disabled={pending}
+            onClick={onClose}
+            className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canCreate}
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-bg transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {pending ? "Creating..." : "Create project"}
+          </button>
+        </footer>
+      </form>
+    </Modal>
+  );
+}
+
+function validateProjectName(name: string): string | null {
+  if (!name) return "Project name is required.";
+  if (name === "." || name === "..") return "Project name is not valid.";
+  if (name.includes("/") || name.includes("\\"))
+    return "Project name must be a single folder name.";
+  return null;
+}
+
+function errorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === "string") return e;
+  return JSON.stringify(e);
+}

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -280,7 +280,7 @@ export function Pane({ paneId }: PaneProps) {
               hasProjects
                 ? handleNewTabFromEmpty
                 : () =>
-                    window.dispatchEvent(new CustomEvent("acorn:add-project"))
+                    window.dispatchEvent(new CustomEvent("acorn:new-project"))
             }
             onContextMenu={(x, y) => {
               setFocusedPane(paneId);
@@ -351,7 +351,7 @@ function EmptyPane({
         <>
           <FolderPlus size={28} className="opacity-40" />
           <p className="text-xs">
-            Add a project to get started. Double-click here.
+            Create a project to get started. Double-click here.
           </p>
         </>
       )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -55,6 +55,7 @@ import {
 } from "../lib/sidebar-actions";
 import type { Project, Session, SessionKind, SessionStatus } from "../lib/types";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
+import { NewProjectDialog } from "./NewProjectDialog";
 import { Tooltip } from "./Tooltip";
 
 const STATUS_DOT: Record<SessionStatus, string> = {
@@ -96,11 +97,13 @@ export function Sidebar() {
     requestRemoveSession,
     requestRemoveProject,
     addProject,
+    createNewProject,
     reorderProjects,
     reorderSessions,
   } = useAppStore();
   const [collapsed, setCollapsed] = useState<Set<string>>(() => loadCollapsed());
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  const [newProjectOpen, setNewProjectOpen] = useState(false);
 
   useEffect(() => {
     saveCollapsed(collapsed);
@@ -152,12 +155,12 @@ export function Sidebar() {
     }
   }
 
-  async function onAddProject() {
+  async function onAddExistingProject() {
     try {
       const repoPath = await open({
         directory: true,
         multiple: false,
-        title: "Select a directory",
+        title: "Select an existing project",
       });
       if (!repoPath || typeof repoPath !== "string") return;
       await addProject(repoPath);
@@ -188,17 +191,22 @@ export function Sidebar() {
       const project = useAppStore.getState().activeProject;
       void onNewSessionRef.current(false, "control", project ?? undefined);
     };
+    const newProject = () => {
+      setNewProjectOpen(true);
+    };
     const addProj = () => {
       void onAddProjectRef.current();
     };
     window.addEventListener("acorn:new-session", newSession);
     window.addEventListener("acorn:new-isolated-session", newIsolated);
     window.addEventListener("acorn:new-control-session", newControl);
+    window.addEventListener("acorn:new-project", newProject);
     window.addEventListener("acorn:add-project", addProj);
     return () => {
       window.removeEventListener("acorn:new-session", newSession);
       window.removeEventListener("acorn:new-isolated-session", newIsolated);
       window.removeEventListener("acorn:new-control-session", newControl);
+      window.removeEventListener("acorn:new-project", newProject);
       window.removeEventListener("acorn:add-project", addProj);
     };
   }, []);
@@ -235,7 +243,7 @@ export function Sidebar() {
   }
 
   onNewSessionRef.current = onNewSession;
-  onAddProjectRef.current = onAddProject;
+  onAddProjectRef.current = onAddExistingProject;
 
   const projectIds = useMemo(
     () => projectGroups.map((p) => projectDragId(p.repoPath)),
@@ -315,16 +323,28 @@ export function Sidebar() {
         <h2 className="text-sm font-medium tracking-tight text-fg-muted">
           Projects
         </h2>
-        <Tooltip label="Add project" side="left">
-          <button
-            type="button"
-            onClick={onAddProject}
-            className="rounded-md p-1.5 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-            aria-label="Add project"
-          >
-            <FolderPlus size={14} />
-          </button>
-        </Tooltip>
+        <div className="flex items-center gap-1">
+          <Tooltip label="New project" side="left">
+            <button
+              type="button"
+              onClick={() => setNewProjectOpen(true)}
+              className="rounded-md p-1.5 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+              aria-label="New project"
+            >
+              <FolderPlus size={14} />
+            </button>
+          </Tooltip>
+          <Tooltip label="Add existing project" side="left">
+            <button
+              type="button"
+              onClick={onAddExistingProject}
+              className="rounded-md p-1.5 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+              aria-label="Add existing project"
+            >
+              <FolderOpen size={14} />
+            </button>
+          </Tooltip>
+        </div>
       </header>
       <div className="flex-1 overflow-y-auto px-1 pb-2">
         {projectGroups.length === 0 ? (
@@ -396,6 +416,13 @@ export function Sidebar() {
           </DndContext>
         )}
       </div>
+      <NewProjectDialog
+        open={newProjectOpen}
+        onClose={() => setNewProjectOpen(false)}
+        onCreate={async (parentPath, name) => {
+          await createNewProject(parentPath, name);
+        }}
+      />
     </aside>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -59,6 +59,9 @@ export const api = {
   addProject(repoPath: string): Promise<Project> {
     return invoke<Project>("add_project", { repoPath });
   },
+  createNewProject(parentPath: string, name: string): Promise<Project> {
+    return invoke<Project>("create_new_project", { parentPath, name });
+  },
   removeProject(
     repoPath: string,
     removeSessions = true,

--- a/src/store.ts
+++ b/src/store.ts
@@ -124,6 +124,7 @@ interface AppStateModel {
   cycleTab: (direction: 1 | -1) => void;
   cycleProject: (direction: 1 | -1) => void;
   addProject: (repoPath: string) => Promise<void>;
+  createNewProject: (parentPath: string, name: string) => Promise<Project>;
   removeProject: (repoPath: string, removeWorktrees?: boolean) => Promise<void>;
   reorderProjects: (orderedRepoPaths: string[]) => Promise<void>;
   reorderSessions: (repoPath: string, orderedIds: string[]) => Promise<void>;
@@ -917,6 +918,19 @@ export const useAppStore = create<AppStateModel>()(
       await get().refreshProjects();
     } catch (e) {
       set({ error: errorMessage(e) });
+    }
+  },
+
+  async createNewProject(parentPath, name) {
+    try {
+      const project = await api.createNewProject(parentPath, name);
+      await get().refreshProjects();
+      get().setActiveProject(project.repo_path);
+      set({ error: null });
+      return project;
+    } catch (e) {
+      set({ error: errorMessage(e) });
+      throw e;
     }
   },
 

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -30,6 +30,14 @@ export const tauriMockSource = `
   function appDefault(cmd) {
     if (cmd === 'list_sessions') return Promise.resolve([]);
     if (cmd === 'list_projects') return Promise.resolve([]);
+    if (cmd === 'create_new_project') {
+      return Promise.resolve({
+        repo_path: '/tmp/new-project',
+        name: 'new-project',
+        created_at: '2026-01-01T00:00:00Z',
+        position: 0,
+      });
+    }
     if (cmd === 'detect_session_statuses') return Promise.resolve([]);
     if (cmd === 'detect_session_agent') {
       return Promise.resolve({ claude: null, codex: null });

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -24,7 +24,7 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(page.getByText(/No sessions\./i)).toBeVisible();
   });
 
-  test("Add Project invokes add_project with the picked path", async ({
+  test("Add existing project invokes add_project with the picked path", async ({
     page,
     tauri,
   }) => {
@@ -53,7 +53,7 @@ test.describe("sidebar: project lifecycle", () => {
     ]);
 
     await page.goto("/");
-    await page.getByRole("button", { name: "Add project" }).click();
+    await page.getByRole("button", { name: "Add existing project" }).click();
 
     await expect(
       page.getByRole("listitem").filter({ hasText: "picked" }),
@@ -66,6 +66,64 @@ test.describe("sidebar: project lifecycle", () => {
     )) as Array<{ repoPath: string }>;
     expect(calls).toHaveLength(1);
     expect(calls[0].repoPath).toBe("/tmp/picked");
+  });
+
+  test("New project creates a git-backed project under the selected parent", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("plugin:dialog|open", () => "/tmp/parent");
+    await tauri.handle("create_new_project", (args) => {
+      const w = window as unknown as {
+        __newProjectCalls?: unknown[];
+        __projectCreated?: boolean;
+      };
+      w.__newProjectCalls = w.__newProjectCalls ?? [];
+      w.__newProjectCalls.push(args);
+      w.__projectCreated = true;
+      const a = args as { parentPath: string; name: string };
+      return {
+        repo_path: `${a.parentPath}/${a.name}`,
+        name: a.name,
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      };
+    });
+    await tauri.handle("list_projects", () => {
+      const w = window as unknown as { __projectCreated?: boolean };
+      return w.__projectCreated
+        ? [
+            {
+              repo_path: "/tmp/parent/fresh-app",
+              name: "fresh-app",
+              created_at: "2026-01-01T00:00:00Z",
+              position: 0,
+            },
+          ]
+        : [];
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "New project" }).click();
+    await page.getByLabel("Project name").fill("fresh-app");
+    await page.getByRole("button", { name: "Choose" }).click();
+    await expect(page.getByText("/tmp/parent/fresh-app")).toBeVisible();
+    await page.getByRole("button", { name: "Create project" }).click();
+
+    await expect(
+      page.getByRole("listitem").filter({ hasText: "fresh-app" }),
+    ).toBeVisible();
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __newProjectCalls?: unknown[] })
+          .__newProjectCalls,
+    )) as Array<{ parentPath: string; name: string }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      parentPath: "/tmp/parent",
+      name: "fresh-app",
+    });
   });
 
   test("Close project removes the project after confirming", async ({

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -10,7 +10,10 @@ test.describe("smoke: app boots in mocked browser", () => {
 
     await expect(page.getByRole("heading", { name: "Projects" })).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Add project" }),
+      page.getByRole("button", { name: "New project" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Add existing project" }),
     ).toBeVisible();
     await expect(page.getByText(/No projects yet/i)).toBeVisible();
     await expect(page.getByText(/update available/i)).toHaveCount(0);


### PR DESCRIPTION
## Summary
- add a New project flow that creates a folder, initializes git, and registers it as an Acorn project
- split sidebar and command palette actions between New project and Add existing project
- cover the flow with E2E mock/default updates and sidebar smoke coverage

## Verification
- git diff --check main