### PR TITLE
fix(projects): validate macOS/Linux project names

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -491,8 +491,9 @@ pub fn create_new_project(
     state: State<'_, AppState>,
     parent_path: String,
     name: String,
+    ignore_safe_name: Option<bool>,
 ) -> AppResult<Project> {
-    let name = validate_new_project_name(&name)?;
+    let name = validate_new_project_name(&name, ignore_safe_name.unwrap_or(false))?;
     let parent = PathBuf::from(&parent_path);
     if !parent.is_dir() {
         return Err(AppError::InvalidPath(parent_path));
@@ -517,23 +518,42 @@ pub fn create_new_project(
     Ok(project)
 }
 
-fn validate_new_project_name(name: &str) -> AppResult<&str> {
+fn validate_new_project_name(name: &str, ignore_safe_name: bool) -> AppResult<&str> {
     let trimmed = name.trim();
     if trimmed.is_empty() {
         return Err(AppError::Other("project name is required".into()));
     }
-    if trimmed.contains('/') || trimmed.contains('\\') {
+    if trimmed.contains('\0') {
+        return Err(AppError::Other(
+            "project name cannot contain a null character".into(),
+        ));
+    }
+    if trimmed.contains('/') {
         return Err(AppError::Other(
             "project name must be a single folder name".into(),
         ));
     }
     let mut components = Path::new(trimmed).components();
     match (components.next(), components.next()) {
-        (Some(Component::Normal(_)), None) => Ok(trimmed),
+        (Some(Component::Normal(_)), None) => {
+            if !ignore_safe_name {
+                if let Some(message) = safe_project_name_error(trimmed) {
+                    return Err(AppError::Other(message));
+                }
+            }
+            Ok(trimmed)
+        }
         _ => Err(AppError::Other(
             "project name must be a single folder name".into(),
         )),
     }
+}
+
+fn safe_project_name_error(name: &str) -> Option<String> {
+    if name.as_bytes().len() > 255 {
+        return Some("project name is longer than 255 bytes, which common filesystems reject".into());
+    }
+    None
 }
 
 #[tauri::command]
@@ -1916,15 +1936,39 @@ mod tests {
 
     #[test]
     fn validate_new_project_name_accepts_single_folder_name() {
-        assert_eq!(validate_new_project_name(" fresh-app ").unwrap(), "fresh-app");
+        assert_eq!(
+            validate_new_project_name(" fresh-app ", false).unwrap(),
+            "fresh-app"
+        );
     }
 
     #[test]
     fn validate_new_project_name_rejects_path_like_names() {
-        assert!(validate_new_project_name("").is_err());
-        assert!(validate_new_project_name("../fresh-app").is_err());
-        assert!(validate_new_project_name("parent/fresh-app").is_err());
-        assert!(validate_new_project_name("parent\\fresh-app").is_err());
-        assert!(validate_new_project_name(".").is_err());
+        assert!(validate_new_project_name("", false).is_err());
+        assert!(validate_new_project_name("../fresh-app", false).is_err());
+        assert!(validate_new_project_name("parent/fresh-app", false).is_err());
+        assert!(validate_new_project_name(".", false).is_err());
+    }
+
+    #[test]
+    fn validate_new_project_name_rejects_long_names_unless_overridden() {
+        let long = "a".repeat(256);
+        assert!(validate_new_project_name(&long, false).is_err());
+        assert_eq!(validate_new_project_name(&long, true).unwrap(), long);
+    }
+
+    #[test]
+    fn validate_new_project_name_allows_macos_linux_valid_names() {
+        assert_eq!(validate_new_project_name("CON", false).unwrap(), "CON");
+        assert_eq!(validate_new_project_name("nul.txt", false).unwrap(), "nul.txt");
+        assert_eq!(
+            validate_new_project_name("foo:bar", false).unwrap(),
+            "foo:bar"
+        );
+        assert_eq!(validate_new_project_name("name.", false).unwrap(), "name.");
+        assert_eq!(
+            validate_new_project_name("parent\\fresh-app", false).unwrap(),
+            "parent\\fresh-app"
+        );
     }
 }

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -2,12 +2,18 @@ import { FolderPlus } from "lucide-react";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useDialogShortcuts } from "../lib/dialog";
+import { validateProjectName } from "../lib/projectName";
+import { cn } from "../lib/cn";
 import { Field, Modal, ModalHeader, TextInput } from "./ui";
 
 interface NewProjectDialogProps {
   open: boolean;
   onClose: () => void;
-  onCreate: (parentPath: string, name: string) => Promise<void>;
+  onCreate: (
+    parentPath: string,
+    name: string,
+    ignoreSafeName: boolean,
+  ) => Promise<void>;
 }
 
 export function NewProjectDialog({
@@ -18,6 +24,7 @@ export function NewProjectDialog({
   const [name, setName] = useState("");
   const [parentPath, setParentPath] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [ignoreSafeName, setIgnoreSafeName] = useState(false);
   const [pending, setPending] = useState(false);
 
   useEffect(() => {
@@ -25,6 +32,7 @@ export function NewProjectDialog({
     setName("");
     setParentPath("");
     setError(null);
+    setIgnoreSafeName(false);
     setPending(false);
   }, [isOpen]);
 
@@ -40,8 +48,19 @@ export function NewProjectDialog({
     return `${parentPath.replace(/\/+$/, "")}/${trimmedName}`;
   }, [parentPath, trimmedName]);
 
-  const validationError = validateProjectName(trimmedName);
-  const canCreate = !pending && parentPath !== "" && validationError === null;
+  const validation = validateProjectName(trimmedName);
+  const canOverrideSafeName = validation.kind === "safe";
+  const validationError =
+    validation.kind === "ok"
+      ? null
+      : validation.kind === "safe" && ignoreSafeName
+        ? null
+        : validation.message;
+  const canCreate =
+    !pending &&
+    parentPath !== "" &&
+    (validation.kind === "ok" ||
+      (validation.kind === "safe" && ignoreSafeName));
 
   async function chooseLocation() {
     const picked = await open({
@@ -63,7 +82,7 @@ export function NewProjectDialog({
     setPending(true);
     setError(null);
     try {
-      await onCreate(parentPath, trimmedName);
+      await onCreate(parentPath, trimmedName, ignoreSafeName);
       onClose();
     } catch (err) {
       setError(errorMessage(err));
@@ -101,11 +120,40 @@ export function NewProjectDialog({
               onChange={(e) => {
                 setName(e.target.value);
                 setError(null);
+                setIgnoreSafeName(false);
               }}
               placeholder="my-project"
               aria-label="Project name"
+              aria-invalid={validationError !== null}
+              aria-describedby={
+                validationError ? "new-project-name-error" : undefined
+              }
+              className={cn(validationError ? "border-danger" : null)}
             />
+            {validationError ? (
+              <span
+                id="new-project-name-error"
+                role="alert"
+                className="text-[11px] text-danger"
+              >
+                {validationError}
+              </span>
+            ) : null}
           </Field>
+          {canOverrideSafeName ? (
+            <label className="flex items-center gap-2 text-xs text-fg-muted">
+              <input
+                type="checkbox"
+                checked={ignoreSafeName}
+                onChange={(e) => {
+                  setIgnoreSafeName(e.target.checked);
+                  setError(null);
+                }}
+                className="size-3 accent-accent"
+              />
+              <span>Ignore safe-name check</span>
+            </label>
+          ) : null}
           <Field label="Location">
             <div className="flex gap-2">
               <TextInput
@@ -156,14 +204,6 @@ export function NewProjectDialog({
       </form>
     </Modal>
   );
-}
-
-function validateProjectName(name: string): string | null {
-  if (!name) return "Project name is required.";
-  if (name === "." || name === "..") return "Project name is not valid.";
-  if (name.includes("/") || name.includes("\\"))
-    return "Project name must be a single folder name.";
-  return null;
 }
 
 function errorMessage(e: unknown): string {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -419,8 +419,8 @@ export function Sidebar() {
       <NewProjectDialog
         open={newProjectOpen}
         onClose={() => setNewProjectOpen(false)}
-        onCreate={async (parentPath, name) => {
-          await createNewProject(parentPath, name);
+        onCreate={async (parentPath, name, ignoreSafeName) => {
+          await createNewProject(parentPath, name, ignoreSafeName);
         }}
       />
     </aside>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -59,8 +59,16 @@ export const api = {
   addProject(repoPath: string): Promise<Project> {
     return invoke<Project>("add_project", { repoPath });
   },
-  createNewProject(parentPath: string, name: string): Promise<Project> {
-    return invoke<Project>("create_new_project", { parentPath, name });
+  createNewProject(
+    parentPath: string,
+    name: string,
+    ignoreSafeName = false,
+  ): Promise<Project> {
+    return invoke<Project>("create_new_project", {
+      parentPath,
+      name,
+      ignoreSafeName,
+    });
   },
   removeProject(
     repoPath: string,

--- a/src/lib/projectName.test.ts
+++ b/src/lib/projectName.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { validateProjectName } from "./projectName";
+
+describe("validateProjectName", () => {
+  it("rejects names that are not a single folder component", () => {
+    expect(validateProjectName("").kind).toBe("hard");
+    expect(validateProjectName(".").kind).toBe("hard");
+    expect(validateProjectName("..").kind).toBe("hard");
+    expect(validateProjectName("parent/app").kind).toBe("hard");
+  });
+
+  it("warns for names likely to exceed common macOS/Linux component limits", () => {
+    expect(validateProjectName("a".repeat(256))).toMatchObject({
+      kind: "safe",
+      reason: "component_too_long",
+    });
+  });
+
+  it("accepts ordinary macOS/Linux folder names", () => {
+    expect(validateProjectName("fresh-app")).toEqual({ kind: "ok" });
+    expect(validateProjectName("Fresh_App 2")).toEqual({ kind: "ok" });
+    expect(validateProjectName("CON")).toEqual({ kind: "ok" });
+    expect(validateProjectName("foo:bar")).toEqual({ kind: "ok" });
+    expect(validateProjectName("name.")).toEqual({ kind: "ok" });
+    expect(validateProjectName("parent\\app")).toEqual({ kind: "ok" });
+  });
+});

--- a/src/lib/projectName.ts
+++ b/src/lib/projectName.ts
@@ -1,0 +1,62 @@
+export type ProjectNameValidationReason =
+  | "required"
+  | "single_folder_name"
+  | "null_character"
+  | "component_too_long";
+
+export type ProjectNameValidation =
+  | { kind: "ok" }
+  | {
+      kind: "hard" | "safe";
+      reason: ProjectNameValidationReason;
+      message: string;
+    };
+
+export function validateProjectName(name: string): ProjectNameValidation {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return {
+      kind: "hard",
+      reason: "required",
+      message: "Project name is required.",
+    };
+  }
+  if (trimmed.includes("\0")) {
+    return {
+      kind: "hard",
+      reason: "null_character",
+      message: "Project name cannot contain a null character.",
+    };
+  }
+  if (trimmed === "." || trimmed === "..") {
+    return {
+      kind: "hard",
+      reason: "single_folder_name",
+      message: "Project name must be a single folder name.",
+    };
+  }
+  if (trimmed.includes("/")) {
+    return {
+      kind: "hard",
+      reason: "single_folder_name",
+      message: "Project name must be a single folder name.",
+    };
+  }
+
+  const safe = validateProjectNameSafety(trimmed);
+  return safe ?? { kind: "ok" };
+}
+
+function validateProjectNameSafety(
+  name: string,
+): Exclude<ProjectNameValidation, { kind: "ok" }> | null {
+  if (new TextEncoder().encode(name).length > 255) {
+    return {
+      kind: "safe",
+      reason: "component_too_long",
+      message:
+        "Project name is longer than 255 bytes, which common filesystems reject.",
+    };
+  }
+  return null;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -124,7 +124,11 @@ interface AppStateModel {
   cycleTab: (direction: 1 | -1) => void;
   cycleProject: (direction: 1 | -1) => void;
   addProject: (repoPath: string) => Promise<void>;
-  createNewProject: (parentPath: string, name: string) => Promise<Project>;
+  createNewProject: (
+    parentPath: string,
+    name: string,
+    ignoreSafeName?: boolean,
+  ) => Promise<Project>;
   removeProject: (repoPath: string, removeWorktrees?: boolean) => Promise<void>;
   reorderProjects: (orderedRepoPaths: string[]) => Promise<void>;
   reorderSessions: (repoPath: string, orderedIds: string[]) => Promise<void>;
@@ -921,9 +925,13 @@ export const useAppStore = create<AppStateModel>()(
     }
   },
 
-  async createNewProject(parentPath, name) {
+  async createNewProject(parentPath, name, ignoreSafeName = false) {
     try {
-      const project = await api.createNewProject(parentPath, name);
+      const project = await api.createNewProject(
+        parentPath,
+        name,
+        ignoreSafeName,
+      );
       await get().refreshProjects();
       get().setActiveProject(project.repo_path);
       set({ error: null });

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -27,13 +27,15 @@ export const tauriMockSource = `
     return undefined;
   }
 
-  function appDefault(cmd) {
+  function appDefault(cmd, args) {
     if (cmd === 'list_sessions') return Promise.resolve([]);
     if (cmd === 'list_projects') return Promise.resolve([]);
     if (cmd === 'create_new_project') {
+      const name = args && typeof args.name === 'string' ? args.name : 'new-project';
+      const parentPath = args && typeof args.parentPath === 'string' ? args.parentPath : '/tmp';
       return Promise.resolve({
-        repo_path: '/tmp/new-project',
-        name: 'new-project',
+        repo_path: parentPath + '/' + name,
+        name,
         created_at: '2026-01-01T00:00:00Z',
         position: 0,
       });
@@ -154,7 +156,7 @@ export const tauriMockSource = `
       }
       const plugin = pluginDefault(cmd);
       if (plugin !== undefined) return plugin;
-      return appDefault(cmd);
+      return appDefault(cmd, args);
     },
   };
 

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -123,6 +123,74 @@ test.describe("sidebar: project lifecycle", () => {
     expect(calls[0]).toEqual({
       parentPath: "/tmp/parent",
       name: "fresh-app",
+      ignoreSafeName: false,
+    });
+  });
+
+  test("New project can override long-name safe warnings", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("plugin:dialog|open", () => "/tmp/parent");
+    await tauri.handle("create_new_project", (args) => {
+      const w = window as unknown as {
+        __newProjectCalls?: unknown[];
+        __projectCreated?: boolean;
+      };
+      w.__newProjectCalls = w.__newProjectCalls ?? [];
+      w.__newProjectCalls.push(args);
+      w.__projectCreated = true;
+      const a = args as { parentPath: string; name: string };
+      return {
+        repo_path: `${a.parentPath}/${a.name}`,
+        name: a.name,
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      };
+    });
+    await tauri.handle("list_projects", () => {
+      const w = window as unknown as { __projectCreated?: boolean };
+      return w.__projectCreated
+        ? [
+            {
+              repo_path: `/tmp/parent/${"a".repeat(256)}`,
+              name: "a".repeat(256),
+              created_at: "2026-01-01T00:00:00Z",
+              position: 0,
+            },
+          ]
+        : [];
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "New project" }).click();
+    await page.getByLabel("Project name").fill("a".repeat(256));
+    await page.getByRole("button", { name: "Choose" }).click();
+
+    await expect(page.getByRole("alert")).toContainText(
+      "longer than 255 bytes",
+    );
+    await expect(
+      page.getByRole("button", { name: "Create project" }),
+    ).toBeDisabled();
+
+    await page.getByLabel("Ignore safe-name check").check();
+    await page.getByRole("button", { name: "Create project" }).click();
+
+    await expect(
+      page.getByRole("listitem").filter({ hasText: "a".repeat(256) }),
+    ).toBeVisible();
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __newProjectCalls?: unknown[] })
+          .__newProjectCalls,
+    )) as Array<{ parentPath: string; name: string; ignoreSafeName: boolean }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      parentPath: "/tmp/parent",
+      name: "a".repeat(256),
+      ignoreSafeName: true,
     });
   });
 


### PR DESCRIPTION
## Summary
- follow-up to #181 after the new project creation flow landed
- add macOS/Linux-oriented project-name validation for new projects
- show inline input errors and an explicit ignore-safe-name checkbox for 255-byte component warnings
- enforce the same validation in the Tauri command unless the override flag is set

## Validation
- bun run test
- bun run test -- src/lib/projectName.test.ts
- bun run typecheck
- cargo test --manifest-path src-tauri/Cargo.toml validate_new_project_name
- bun run test:e2e tests/e2e/sidebar.spec.ts
- bun run build
- git diff --check
