### PR TITLE
feat: auto-reconcile stale daemon sessions on staged-dotfile updates

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,37 @@
+use std::fs;
+use std::path::Path;
+
+// Dotfiles materialised by `shell_init::ensure_shell_init_dir`. Each
+// child PTY env carries `ACORN_STAGED_REV = hash(of these files)` so
+// the app can detect a stale daemon session (spawned by an older
+// build with different dotfile bodies) on boot and force-respawn it.
+//
+// FNV-1a 64-bit chosen over sha2 to avoid adding a build-dependency;
+// collision risk is negligible for the small input set and the
+// downstream check only needs equality.
+const STAGED_DOTFILES: &[&str] = &[
+    "shell-init/zshenv",
+    "shell-init/zprofile",
+    "shell-init/zshrc",
+    "shell-init/zlogin",
+];
+
 fn main() {
-    tauri_build::build()
+    let mut hash: u64 = 0xcbf29ce4_84222325;
+    for path in STAGED_DOTFILES {
+        println!("cargo:rerun-if-changed={path}");
+        let bytes = fs::read(Path::new(path))
+            .unwrap_or_else(|e| panic!("read {path}: {e}"));
+        for b in bytes {
+            hash ^= b as u64;
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        // Inter-file separator so reordering bytes across files does
+        // not collide with a contiguous-bytes input.
+        hash ^= 0xff;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    println!("cargo:rustc-env=ACORN_STAGED_REV={hash:016x}");
+
+    tauri_build::build();
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -865,13 +865,10 @@ pub async fn pty_spawn<R: Runtime>(
             .or_insert_with(|| home.to_string_lossy().into_owned());
     }
 
-    // Stamp every PTY child with the staged-dotfile fingerprint. The
-    // daemon stores this on its `DaemonSession` row and surfaces it
-    // back via `ListSessions`, so a reboot-time reconcile can spot a
-    // session that survived from an older build (different staged rc
-    // bodies) and force-respawn it before the user types into a ZLE
-    // that has stale dotfile state. Always overwritten — callers do
-    // not get to forge a stale rev.
+    // Stamp the staged-dotfile fingerprint so the daemon can store
+    // it per session and the app's boot reconcile can spot sessions
+    // that survived from an older build. Always overwrites — callers
+    // do not get to forge a stale rev.
     effective_env.insert(
         "ACORN_STAGED_REV".to_string(),
         crate::shell_init::STAGED_REV.to_string(),

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1855,6 +1855,27 @@ pub(crate) fn sanitize_worktree_name(name: &str) -> String {
         .to_string()
 }
 
+/// Returns the cached boot-time staged-rev reconcile result. `Some` if
+/// the daemon still holds PTYs spawned by an older build with different
+/// staged dotfile bodies; `None` when reconcile found everything in
+/// sync (or hasn't run yet because the daemon is disabled or
+/// unreachable). The frontend polls this at mount so the prompt
+/// survives a listener-mount-after-emit race.
+#[tauri::command]
+pub fn staged_rev_mismatch_status(
+    state: State<'_, AppState>,
+) -> Option<crate::staged_rev_reconcile::StagedRevMismatch> {
+    state.staged_rev_mismatch.lock().clone()
+}
+
+/// Clear the cached staged-rev mismatch so the prompt does not re-show
+/// when the user dismisses it or after they trigger the "restart
+/// daemon" flow. Idempotent.
+#[tauri::command]
+pub fn acknowledge_staged_rev_mismatch(state: State<'_, AppState>) {
+    *state.staged_rev_mismatch.lock() = None;
+}
+
 #[cfg(test)]
 mod tests {
     use super::font_name_from_path;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -865,6 +865,18 @@ pub async fn pty_spawn<R: Runtime>(
             .or_insert_with(|| home.to_string_lossy().into_owned());
     }
 
+    // Stamp every PTY child with the staged-dotfile fingerprint. The
+    // daemon stores this on its `DaemonSession` row and surfaces it
+    // back via `ListSessions`, so a reboot-time reconcile can spot a
+    // session that survived from an older build (different staged rc
+    // bodies) and force-respawn it before the user types into a ZLE
+    // that has stale dotfile state. Always overwritten — callers do
+    // not get to forge a stale rev.
+    effective_env.insert(
+        "ACORN_STAGED_REV".to_string(),
+        crate::shell_init::STAGED_REV.to_string(),
+    );
+
     // `ACORN_RESUME_TOKEN` carries the Acorn session UUID. Older builds
     // used the value inside a PATH-based shim to auto-inject claude's
     // `--session-id`; the shim is gone (filesystem-watcher persister

--- a/src-tauri/src/daemon/protocol.rs
+++ b/src-tauri/src/daemon/protocol.rs
@@ -324,6 +324,15 @@ pub struct SessionSummary {
     /// session being described — the CLI uses this to render a marker.
     #[serde(default)]
     pub is_source: bool,
+    /// Fingerprint of the staged zsh dotfile bodies the session was
+    /// spawned against (see `shell_init::STAGED_REV`). `None` for
+    /// sessions spawned by builds that pre-date the fingerprint, or
+    /// when the spawn caller did not pass `ACORN_STAGED_REV` in
+    /// `SpawnSpec.env`. The app reconcile compares this against its
+    /// own `STAGED_REV` on boot — a mismatch means the live PTY is
+    /// running against stale rc bodies and should be force-respawned.
+    #[serde(default)]
+    pub staged_rev: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src-tauri/src/daemon/protocol.rs
+++ b/src-tauri/src/daemon/protocol.rs
@@ -326,11 +326,8 @@ pub struct SessionSummary {
     pub is_source: bool,
     /// Fingerprint of the staged zsh dotfile bodies the session was
     /// spawned against (see `shell_init::STAGED_REV`). `None` for
-    /// sessions spawned by builds that pre-date the fingerprint, or
-    /// when the spawn caller did not pass `ACORN_STAGED_REV` in
-    /// `SpawnSpec.env`. The app reconcile compares this against its
-    /// own `STAGED_REV` on boot — a mismatch means the live PTY is
-    /// running against stale rc bodies and should be force-respawned.
+    /// sessions spawned by builds that pre-date the fingerprint —
+    /// treated as stale by the app reconcile.
     #[serde(default)]
     pub staged_rev: Option<String>,
 }

--- a/src-tauri/src/daemon/pty.rs
+++ b/src-tauri/src/daemon/pty.rs
@@ -183,6 +183,10 @@ impl PtyManager {
         session.agent_resume_token = spec.agent_resume_token.clone();
         session.scrollback = Arc::clone(&scrollback);
         session.pid = pid;
+        // Capture the staged-dotfile fingerprint from caller env so the
+        // app can detect, on boot, that this session was spawned by an
+        // older build with different rc bodies and force-respawn it.
+        session.staged_rev = spec.env.get("ACORN_STAGED_REV").cloned();
         registry.insert(session);
 
         let stop_reader = stop.clone();

--- a/src-tauri/src/daemon/server.rs
+++ b/src-tauri/src/daemon/server.rs
@@ -261,6 +261,7 @@ impl Daemon {
                         branch: s.branch,
                         agent_kind: s.agent_kind,
                         pid: s.pid,
+                        staged_rev: s.staged_rev,
                     })
                     .collect(),
             },

--- a/src-tauri/src/daemon/session.rs
+++ b/src-tauri/src/daemon/session.rs
@@ -71,6 +71,11 @@ pub struct DaemonSession {
     /// Daemon-local creation time. Useful for "Background sessions"
     /// status panel ordering and for telemetry on long-lived sessions.
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Fingerprint of the staged dotfile bodies the PTY was spawned
+    /// against. `None` for legacy sessions whose spawner did not pass
+    /// `ACORN_STAGED_REV` in `SpawnSpec.env`. Surfaced back via
+    /// `SessionSummary.staged_rev` so the app can reconcile on boot.
+    pub staged_rev: Option<String>,
 }
 
 impl DaemonSession {
@@ -89,6 +94,7 @@ impl DaemonSession {
             alive: true,
             exit_code: None,
             created_at: chrono::Utc::now(),
+            staged_rev: None,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -259,14 +259,10 @@ pub fn run() {
                         tracing::warn!(error = %err, "daemon boot spawn failed");
                         return;
                     }
-                    // The daemon may still hold PTYs spawned by an
-                    // older Acorn build with different staged
-                    // dotfile bodies; reattaching would let the user
-                    // type into a ZLE wired against stale rc files.
-                    // Cache the result on AppState so the frontend
-                    // pull (`staged_rev_mismatch_status`) wins even
-                    // when the matching listener mounts after the
-                    // emit.
+                    // Detect stale daemon sessions (older `shell-init/`
+                    // bodies); the reconcile caches its verdict on
+                    // AppState so the frontend prompt survives a
+                    // listener-mount-after-emit race.
                     staged_rev_reconcile::reconcile(
                         &app_for_boot,
                         &state_for_boot,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ mod shell_args;
 mod shell_env;
 mod shell_init;
 mod shell_util;
+mod staged_rev_reconcile;
 mod state;
 mod todos;
 mod transcript_watcher;
@@ -246,6 +247,8 @@ pub fn run() {
             // killswitch UI surfaces the same error if the user opens
             // the Background sessions tab.
             let bridge_for_boot = state.daemon_bridge.clone();
+            let state_for_boot = state.inner().clone();
+            let app_for_boot = app.handle().clone();
             std::thread::Builder::new()
                 .name("acorn-daemon-boot".into())
                 .spawn(move || {
@@ -254,7 +257,21 @@ pub fn run() {
                     }
                     if let Err(err) = bridge_for_boot.ensure_connection() {
                         tracing::warn!(error = %err, "daemon boot spawn failed");
+                        return;
                     }
+                    // The daemon may still hold PTYs spawned by an
+                    // older Acorn build with different staged
+                    // dotfile bodies; reattaching would let the user
+                    // type into a ZLE wired against stale rc files.
+                    // Cache the result on AppState so the frontend
+                    // pull (`staged_rev_mismatch_status`) wins even
+                    // when the matching listener mounts after the
+                    // emit.
+                    staged_rev_reconcile::reconcile(
+                        &app_for_boot,
+                        &state_for_boot,
+                        &bridge_for_boot,
+                    );
                 })
                 .ok();
 
@@ -321,6 +338,8 @@ pub fn run() {
             commands::acknowledge_claude_resume,
             commands::get_codex_resume_candidate,
             commands::acknowledge_codex_resume,
+            commands::staged_rev_mismatch_status,
+            commands::acknowledge_staged_rev_mismatch,
             daemon_commands::daemon_status,
             daemon_commands::daemon_set_enabled,
             daemon_commands::daemon_restart,

--- a/src-tauri/src/shell_init.rs
+++ b/src-tauri/src/shell_init.rs
@@ -34,6 +34,15 @@ const ZPROFILE_BODY: &str = include_str!("../shell-init/zprofile");
 const ZSHRC_BODY: &str = include_str!("../shell-init/zshrc");
 const ZLOGIN_BODY: &str = include_str!("../shell-init/zlogin");
 
+/// Fingerprint of the staged dotfile bodies, computed at build time by
+/// `build.rs` (FNV-1a over the four files in declaration order). Used
+/// as the value of the `ACORN_STAGED_REV` env stamped into every PTY
+/// child env, so a boot-time reconcile can detect a daemon session
+/// spawned against an older build's dotfile bodies and force-respawn
+/// it before the user's ZLE state collides with the new staged
+/// `.zshrc` / `.zprofile` / `.zlogin`.
+pub const STAGED_REV: &str = env!("ACORN_STAGED_REV");
+
 /// Materialise the shell-init dir under Acorn's data dir, returning the
 /// path callers should hand to `ZDOTDIR` on PTY spawn. Idempotent — the
 /// body is rewritten every call so a shipped fix lands without a data
@@ -135,5 +144,18 @@ mod tests {
         let a = ensure_shell_init_dir_at(base.path()).unwrap();
         let b = ensure_shell_init_dir_at(base.path()).unwrap();
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn staged_rev_is_nonempty_hex() {
+        // build.rs stamps `ACORN_STAGED_REV` as a 16-char hex FNV-1a
+        // digest. Both length and charset are part of the contract —
+        // reconcile code grep-matches on this format.
+        assert_eq!(STAGED_REV.len(), 16, "expected 16-char hex, got {:?}", STAGED_REV);
+        assert!(
+            STAGED_REV.chars().all(|c| c.is_ascii_hexdigit()),
+            "expected hex chars only, got {:?}",
+            STAGED_REV,
+        );
     }
 }

--- a/src-tauri/src/shell_init.rs
+++ b/src-tauri/src/shell_init.rs
@@ -148,9 +148,7 @@ mod tests {
 
     #[test]
     fn staged_rev_is_nonempty_hex() {
-        // build.rs stamps `ACORN_STAGED_REV` as a 16-char hex FNV-1a
-        // digest. Both length and charset are part of the contract —
-        // reconcile code grep-matches on this format.
+        // 16-char lowercase hex — the format `build.rs` commits to.
         assert_eq!(STAGED_REV.len(), 16, "expected 16-char hex, got {:?}", STAGED_REV);
         assert!(
             STAGED_REV.chars().all(|c| c.is_ascii_hexdigit()),

--- a/src-tauri/src/staged_rev_reconcile.rs
+++ b/src-tauri/src/staged_rev_reconcile.rs
@@ -1,21 +1,17 @@
 //! Boot-time staged-dotfile reconcile.
 //!
-//! `acornd` may still own PTY sessions spawned by an older Acorn build
-//! whose staged zsh dotfiles were different. Reattaching to those PTYs
-//! leaves the user typing into a ZLE wired up against the old `.zshrc`
-//! while the new body is materialised on disk — surfaces as duplicated
+//! `acornd` outlives the Acorn app, so a pulled-in update with a new
+//! `shell-init/` body leaves the daemon attached to PTYs running
+//! against the previous `.zshrc`. The user types into a ZLE that
+//! disagrees with the on-disk dotfile — surfaces as duplicated
 //! keystrokes / broken prompt redraws.
 //!
 //! Compare each alive daemon session's `staged_rev` against the
-//! current [`shell_init::STAGED_REV`](crate::shell_init::STAGED_REV).
-//! Any mismatch emits an `acorn:staged-rev-mismatch` event the
-//! frontend prompts on; the user-confirmed restart path is
-//! `daemon_restart` (which respawns every session against the new
-//! dotfiles).
-//!
-//! Sessions with `staged_rev == None` are also treated as stale —
-//! they were spawned by a build that pre-dates the fingerprint and
-//! therefore can't be proven up-to-date.
+//! build's [`shell_init::STAGED_REV`](crate::shell_init::STAGED_REV);
+//! any mismatch (including legacy `staged_rev == None` from
+//! pre-fingerprint builds) emits `acorn:staged-rev-mismatch` and
+//! caches the result on `AppState` so the frontend prompt can pull
+//! it at mount.
 
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Runtime};
@@ -32,14 +28,11 @@ pub struct StagedRevMismatch {
 }
 
 /// Compare the daemon's session staged-revs against the build's
-/// `STAGED_REV`. On mismatch, both store the result in `state` (so
-/// the frontend can pull it via `commands::staged_rev_mismatch_status`
-/// at mount — defeating the listener-mount race) and emit
-/// [`EVENT_STAGED_REV_MISMATCH`] for already-mounted listeners.
-///
-/// Always overwrites `state.staged_rev_mismatch` — clearing it back
-/// to `None` when reconcile finds nothing stale, so a `daemon_restart`
-/// followed by a re-reconcile correctly retracts an earlier prompt.
+/// `STAGED_REV`. Store the result on `state` (pulled at mount via
+/// `commands::staged_rev_mismatch_status` — defeats the listener
+/// race) and emit [`EVENT_STAGED_REV_MISMATCH`] for already-mounted
+/// listeners. Both branches overwrite the cache, so a re-reconcile
+/// that finds nothing stale correctly retracts an earlier prompt.
 pub fn reconcile<R: Runtime>(app: &AppHandle<R>, state: &AppState, bridge: &DaemonBridge) {
     if !bridge.is_enabled() {
         *state.staged_rev_mismatch.lock() = None;

--- a/src-tauri/src/staged_rev_reconcile.rs
+++ b/src-tauri/src/staged_rev_reconcile.rs
@@ -1,0 +1,78 @@
+//! Boot-time staged-dotfile reconcile.
+//!
+//! `acornd` may still own PTY sessions spawned by an older Acorn build
+//! whose staged zsh dotfiles were different. Reattaching to those PTYs
+//! leaves the user typing into a ZLE wired up against the old `.zshrc`
+//! while the new body is materialised on disk — surfaces as duplicated
+//! keystrokes / broken prompt redraws.
+//!
+//! Compare each alive daemon session's `staged_rev` against the
+//! current [`shell_init::STAGED_REV`](crate::shell_init::STAGED_REV).
+//! Any mismatch emits an `acorn:staged-rev-mismatch` event the
+//! frontend prompts on; the user-confirmed restart path is
+//! `daemon_restart` (which respawns every session against the new
+//! dotfiles).
+//!
+//! Sessions with `staged_rev == None` are also treated as stale —
+//! they were spawned by a build that pre-dates the fingerprint and
+//! therefore can't be proven up-to-date.
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Runtime};
+
+use crate::daemon_bridge::DaemonBridge;
+use crate::state::AppState;
+
+pub const EVENT_STAGED_REV_MISMATCH: &str = "acorn:staged-rev-mismatch";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StagedRevMismatch {
+    pub current_rev: String,
+    pub stale_session_count: usize,
+}
+
+/// Compare the daemon's session staged-revs against the build's
+/// `STAGED_REV`. On mismatch, both store the result in `state` (so
+/// the frontend can pull it via `commands::staged_rev_mismatch_status`
+/// at mount — defeating the listener-mount race) and emit
+/// [`EVENT_STAGED_REV_MISMATCH`] for already-mounted listeners.
+///
+/// Always overwrites `state.staged_rev_mismatch` — clearing it back
+/// to `None` when reconcile finds nothing stale, so a `daemon_restart`
+/// followed by a re-reconcile correctly retracts an earlier prompt.
+pub fn reconcile<R: Runtime>(app: &AppHandle<R>, state: &AppState, bridge: &DaemonBridge) {
+    if !bridge.is_enabled() {
+        *state.staged_rev_mismatch.lock() = None;
+        return;
+    }
+    let sessions = match bridge.list_sessions() {
+        Ok(s) => s,
+        Err(err) => {
+            tracing::warn!(error = %err, "staged-rev reconcile: list_sessions failed");
+            return;
+        }
+    };
+    let current = crate::shell_init::STAGED_REV;
+    let stale = sessions
+        .iter()
+        .filter(|s| s.alive)
+        .filter(|s| s.staged_rev.as_deref() != Some(current))
+        .count();
+    if stale == 0 {
+        *state.staged_rev_mismatch.lock() = None;
+        return;
+    }
+    let payload = StagedRevMismatch {
+        current_rev: current.to_string(),
+        stale_session_count: stale,
+    };
+    *state.staged_rev_mismatch.lock() = Some(payload.clone());
+    match app.emit(EVENT_STAGED_REV_MISMATCH, payload) {
+        Ok(()) => tracing::info!(
+            stale_count = stale,
+            current_rev = current,
+            "staged-rev mismatch detected; user prompted to restart daemon",
+        ),
+        Err(err) => tracing::warn!(error = %err, "staged-rev reconcile: emit failed"),
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -38,12 +38,9 @@ pub struct AppState {
     /// in-process routing on subsequent calls.
     pub stream_registry: Arc<StreamRegistry>,
     /// Result of the boot-time staged-dotfile reconcile. `Some` when
-    /// the daemon held PTYs from an older build with different rc
-    /// bodies, `None` when everything was in sync (or reconcile did
-    /// not run yet). Frontend pulls this via `staged_rev_mismatch_status`
-    /// at mount; the same `acorn:staged-rev-mismatch` event is also
-    /// emitted at the end of reconcile but the pull is what's
-    /// authoritative, so a listener registered after the emit still
+    /// the daemon owns PTYs spawned against older rc bodies; `None`
+    /// when in sync or reconcile has not run. Frontend pulls this at
+    /// mount so a listener registered after the matching emit still
     /// sees the prompt.
     pub staged_rev_mismatch: Arc<Mutex<Option<StagedRevMismatch>>>,
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8,6 +8,7 @@ use crate::daemon_stream::StreamRegistry;
 use crate::ipc::server::IpcServerHandle;
 use crate::pty::PtyManager;
 use crate::session::{ProjectStore, SessionStore};
+use crate::staged_rev_reconcile::StagedRevMismatch;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -36,6 +37,15 @@ pub struct AppState {
     /// check the dispatch helpers use to decide between daemon and
     /// in-process routing on subsequent calls.
     pub stream_registry: Arc<StreamRegistry>,
+    /// Result of the boot-time staged-dotfile reconcile. `Some` when
+    /// the daemon held PTYs from an older build with different rc
+    /// bodies, `None` when everything was in sync (or reconcile did
+    /// not run yet). Frontend pulls this via `staged_rev_mismatch_status`
+    /// at mount; the same `acorn:staged-rev-mismatch` event is also
+    /// emitted at the end of reconcile but the pull is what's
+    /// authoritative, so a listener registered after the emit still
+    /// sees the prompt.
+    pub staged_rev_mismatch: Arc<Mutex<Option<StagedRevMismatch>>>,
 }
 
 impl AppState {
@@ -49,6 +59,7 @@ impl AppState {
             ipc_handle: Arc::new(Mutex::new(None)),
             daemon_bridge: DaemonBridge::new(),
             stream_registry: StreamRegistry::new(),
+            staged_rev_mismatch: Arc::new(Mutex::new(None)),
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,13 +161,10 @@ function App() {
   }, [refreshThemes]);
 
   useEffect(() => {
-    // Boot-time reconcile result lands in two places: a one-shot
-    // emit (caught by the listener below) and the AppState cache
-    // (pulled here at mount). The cache makes us race-proof — if
-    // the daemon boot thread emits before this listener attaches,
-    // the pull still finds the stored result. Each subsequent
-    // reconcile (e.g. after `daemon_restart`) updates the cache
-    // and re-emits, so both paths converge.
+    // Pull at mount + listen. The pull defeats a listener-mount-
+    // after-emit race: if the daemon boot thread reconciled before
+    // this effect attached, the AppState cache still holds the
+    // result.
     let cancelled = false;
     let unlisten: UnlistenFn | null = null;
     void api

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { RightPanel } from "./components/RightPanel";
 import { ResizeHandle } from "./components/ResizeHandle";
 import { AcornRain } from "./components/AcornRain";
 import { AgentResumeModal } from "./components/AgentResumeModal";
+import { StagedRevMismatchModal } from "./components/StagedRevMismatchModal";
 import { CommandPalette } from "./components/CommandPalette";
 import {
   ControlSessionGuideModal,
@@ -25,7 +26,13 @@ import { SettingsModal } from "./components/SettingsModal";
 import { TerminalHost } from "./components/TerminalHost";
 import { ToastHost } from "./components/ToastHost";
 import { UpdateBanner } from "./components/UpdateBanner";
-import { api, type AgentKind, type ResumeCandidate } from "./lib/api";
+import {
+  api,
+  STAGED_REV_MISMATCH_EVENT,
+  type AgentKind,
+  type ResumeCandidate,
+  type StagedRevMismatch,
+} from "./lib/api";
 import {
   Hotkeys,
   shouldUseTinykeysToggleMultiInputFallback,
@@ -134,6 +141,8 @@ function App() {
   const [resumeCandidates, setResumeCandidates] = useState<
     Map<string, { agent: AgentKind; candidate: ResumeCandidate }>
   >(new Map());
+  const [stagedRevMismatch, setStagedRevMismatch] =
+    useState<StagedRevMismatch | null>(null);
 
   const toggleMultiInput = useCallback(() => {
     const enabled = useAppStore.getState().toggleMultiInput();
@@ -150,6 +159,49 @@ function App() {
   useEffect(() => {
     void refreshThemes();
   }, [refreshThemes]);
+
+  useEffect(() => {
+    // Boot-time reconcile result lands in two places: a one-shot
+    // emit (caught by the listener below) and the AppState cache
+    // (pulled here at mount). The cache makes us race-proof — if
+    // the daemon boot thread emits before this listener attaches,
+    // the pull still finds the stored result. Each subsequent
+    // reconcile (e.g. after `daemon_restart`) updates the cache
+    // and re-emits, so both paths converge.
+    let cancelled = false;
+    let unlisten: UnlistenFn | null = null;
+    void api
+      .stagedRevMismatchStatus()
+      .then((m) => {
+        if (!cancelled && m) setStagedRevMismatch(m);
+      })
+      .catch((err) => {
+        console.error(
+          "[App] staged_rev_mismatch_status pull failed",
+          err,
+        );
+      });
+    listen<StagedRevMismatch>(STAGED_REV_MISMATCH_EVENT, (event) => {
+      if (!cancelled) setStagedRevMismatch(event.payload);
+    })
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      })
+      .catch((err) => {
+        console.error(
+          "[App] staged-rev-mismatch listener attach failed",
+          err,
+        );
+      });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
 
   useEffect(() => {
     const theme = themes.find((t) => t.id === appearance.themeId) ?? themes[0];
@@ -854,6 +906,10 @@ function App() {
         }}
       />
       <SettingsModal />
+      <StagedRevMismatchModal
+        mismatch={stagedRevMismatch}
+        onDismiss={() => setStagedRevMismatch(null)}
+      />
       <AgentResumeModal
         sessionId={resumeCandidate?.sessionId ?? ""}
         agent={resumeCandidate?.agent ?? "claude"}

--- a/src/components/StagedRevMismatchModal.tsx
+++ b/src/components/StagedRevMismatchModal.tsx
@@ -10,22 +10,11 @@ interface StagedRevMismatchModalProps {
 }
 
 /**
- * Boot-time prompt shown when `acornd` still owns PTY sessions that
- * were spawned against a different staged-dotfile revision than the
- * running build (typically: user pulled a new Acorn build whose
- * `shell-init/` rc bodies differ, but the daemon survived the app
- * update). Reattaching to those PTYs leaves the user typing into a
- * ZLE wired up against the old `.zshrc`, surfacing as duplicated
+ * Boot-time prompt shown when `acornd` still owns PTY sessions
+ * spawned against an older `shell-init/` revision than the running
+ * build. Reattaching to those PTYs leaves the user typing into a
+ * ZLE wired up against the old `.zshrc` — surfaces as duplicated
  * keystrokes / broken prompt redraws.
- *
- * Two paths out:
- *
- * - **Restart sessions**: ask the daemon to shut down (kills every
- *   stale PTY) then reload the webview so Terminal components
- *   re-mount and re-spawn against the new dotfiles via the freshly
- *   started daemon.
- * - **Later**: acknowledge so the prompt does not re-pop within
- *   the session; the same check fires on next app boot.
  */
 export function StagedRevMismatchModal({
   mismatch,

--- a/src/components/StagedRevMismatchModal.tsx
+++ b/src/components/StagedRevMismatchModal.tsx
@@ -1,0 +1,128 @@
+import { useState, type ReactElement } from "react";
+import { RefreshCw, Terminal } from "lucide-react";
+import { api, type StagedRevMismatch } from "../lib/api";
+import { Modal } from "./ui/Modal";
+import { ModalHeader } from "./ui/ModalHeader";
+
+interface StagedRevMismatchModalProps {
+  mismatch: StagedRevMismatch | null;
+  onDismiss: () => void;
+}
+
+/**
+ * Boot-time prompt shown when `acornd` still owns PTY sessions that
+ * were spawned against a different staged-dotfile revision than the
+ * running build (typically: user pulled a new Acorn build whose
+ * `shell-init/` rc bodies differ, but the daemon survived the app
+ * update). Reattaching to those PTYs leaves the user typing into a
+ * ZLE wired up against the old `.zshrc`, surfacing as duplicated
+ * keystrokes / broken prompt redraws.
+ *
+ * Two paths out:
+ *
+ * - **Restart sessions**: ask the daemon to shut down (kills every
+ *   stale PTY) then reload the webview so Terminal components
+ *   re-mount and re-spawn against the new dotfiles via the freshly
+ *   started daemon.
+ * - **Later**: acknowledge so the prompt does not re-pop within
+ *   the session; the same check fires on next app boot.
+ */
+export function StagedRevMismatchModal({
+  mismatch,
+  onDismiss,
+}: StagedRevMismatchModalProps): ReactElement | null {
+  const [restarting, setRestarting] = useState(false);
+
+  if (!mismatch) return null;
+
+  async function handleRestart() {
+    setRestarting(true);
+    try {
+      await api.daemonShutdown();
+    } catch (err) {
+      console.error("[StagedRevMismatchModal] daemon_shutdown failed", err);
+    }
+    try {
+      await api.acknowledgeStagedRevMismatch();
+    } catch (err) {
+      console.error(
+        "[StagedRevMismatchModal] acknowledge_staged_rev_mismatch failed",
+        err,
+      );
+    }
+    // Webview reload re-runs the app setup. The daemon boot thread
+    // will spawn a fresh `acornd` process whose registry is empty, so
+    // the next reconcile finds nothing stale and the prompt does not
+    // reappear.
+    window.location.reload();
+  }
+
+  async function handleLater() {
+    try {
+      await api.acknowledgeStagedRevMismatch();
+    } catch (err) {
+      console.error(
+        "[StagedRevMismatchModal] acknowledge_staged_rev_mismatch failed",
+        err,
+      );
+    }
+    onDismiss();
+  }
+
+  const sessionWord =
+    mismatch.stale_session_count === 1 ? "session" : "sessions";
+
+  return (
+    <Modal
+      open={true}
+      onClose={handleLater}
+      variant="dialog"
+      size="md"
+      ariaLabelledBy="acorn-staged-rev-mismatch-title"
+    >
+      <ModalHeader
+        title="Shell environment updated"
+        subtitle={`${mismatch.stale_session_count} background ${sessionWord} need a restart`}
+        titleId="acorn-staged-rev-mismatch-title"
+        icon={<Terminal size={14} className="text-accent" />}
+        variant="dialog"
+        onClose={handleLater}
+      />
+      <div className="space-y-3 px-4 py-4 text-xs text-fg-muted">
+        <p>
+          Acorn refreshed its shell-init files in this update. Background
+          sessions started by the previous version are still running against
+          the old environment, which can cause garbled input and prompt
+          redraws.
+        </p>
+        <p>
+          Restart now to apply the new environment. Open agent
+          conversations (Claude / Codex) will pick up where they left
+          off on next focus.
+        </p>
+      </div>
+      <footer className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+        <button
+          type="button"
+          onClick={handleLater}
+          disabled={restarting}
+          className="rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
+        >
+          Later
+        </button>
+        <button
+          type="button"
+          onClick={handleRestart}
+          disabled={restarting}
+          className="inline-flex items-center gap-1.5 rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
+        >
+          <RefreshCw
+            size={12}
+            className={restarting ? "animate-spin" : undefined}
+          />
+          {restarting ? "Restarting…" : "Restart sessions"}
+        </button>
+      </footer>
+    </Modal>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -341,6 +341,25 @@ export const api = {
     return invoke<DaemonStatus>("daemon_status");
   },
   /**
+   * Pull the cached boot-time staged-rev reconcile result. `null` when
+   * either reconcile has not run, the daemon is disabled, or every
+   * alive daemon session was spawned against the same staged dotfile
+   * bodies as the current build. Frontend calls this at mount so a
+   * listener registered after the matching emit still sees the
+   * prompt.
+   */
+  stagedRevMismatchStatus(): Promise<StagedRevMismatch | null> {
+    return invoke<StagedRevMismatch | null>("staged_rev_mismatch_status");
+  },
+  /**
+   * Drop the cached staged-rev mismatch so the prompt does not re-show
+   * after the user dismisses it or after the daemon-restart flow that
+   * resolves it.
+   */
+  acknowledgeStagedRevMismatch(): Promise<void> {
+    return invoke<void>("acknowledge_staged_rev_mismatch");
+  },
+  /**
    * Flip the daemon killswitch. Persistence (so the setting survives a
    * restart) is the caller's responsibility — stash to `localStorage`
    * under `acorn:daemon-enabled`.
@@ -496,3 +515,15 @@ export interface DaemonSessionSummary {
   branch: string | null;
   agent_kind: string | null;
 }
+
+/**
+ * Mirror of `crate::staged_rev_reconcile::StagedRevMismatch`. Returned
+ * when the daemon still owns PTYs spawned against a different
+ * staged-dotfile revision than the running build.
+ */
+export interface StagedRevMismatch {
+  current_rev: string;
+  stale_session_count: number;
+}
+
+export const STAGED_REV_MISMATCH_EVENT = "acorn:staged-rev-mismatch";

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -111,6 +111,12 @@ export const tauriMockSource = `
     if (cmd === 'get_codex_resume_candidate') return Promise.resolve(null);
     if (cmd === 'acknowledge_claude_resume') return Promise.resolve(undefined);
     if (cmd === 'acknowledge_codex_resume') return Promise.resolve(undefined);
+    // Staged-rev mismatch is the daemon-stale prompt at boot. Default to
+    // "no mismatch" so non-related E2Es never see the modal; tests that
+    // exercise it override via __ACORN_MOCK_HANDLERS__.
+    if (cmd === 'staged_rev_mismatch_status') return Promise.resolve(null);
+    if (cmd === 'acknowledge_staged_rev_mismatch')
+      return Promise.resolve(undefined);
     if (cmd === 'pty_write') return Promise.resolve(undefined);
     if (cmd && cmd.startsWith('list_')) return Promise.resolve([]);
     return Promise.resolve(null);


### PR DESCRIPTION
## Summary

Follow-up to #180. That PR opted Acorn's PTY shells into login mode and reworked the staged ZDOTDIR forwarders; everything works for fresh `acornd` spawns, but `acornd` is a long-lived daemon that can outlive the Acorn app. After pulling, users with a previous-version `acornd` still running saw garbled input / prompt redraws on their already-running background sessions — the daemon was attaching to PTYs spawned against the old staged `.zshrc` while the new `.zshrc` body is what's materialised on disk now. Manually restarting the daemon fixed it, but the user had no way to know that was required.

This PR detects the mismatch automatically and prompts the user to restart on next app boot.

### How it works

1. **Fingerprint stamping** — `build.rs` hashes the four staged dotfile bodies (`shell-init/{zshenv,zprofile,zshrc,zlogin}`) with FNV-1a at compile time and exposes the result as `shell_init::STAGED_REV`. Every PTY spawn injects `ACORN_STAGED_REV = STAGED_REV` into the child env (so the daemon's `SpawnSpec.env` carries it).

2. **Daemon-side capture** — `DaemonSession.staged_rev` stores whatever value arrived in `SpawnSpec.env`, and `SessionSummary.staged_rev` surfaces it back via `ListSessions`. Both fields are `Option<String>` with `#[serde(default)]` so older daemons / clients deserialize cleanly.

3. **Boot reconcile** — when the app's daemon boot thread finishes `ensure_connection`, it walks `ListSessions` and counts alive sessions whose `staged_rev` doesn't match the current `STAGED_REV` (pre-stamp `None` is also treated as stale). On any mismatch the result is cached on `AppState.staged_rev_mismatch` **and** emitted as `acorn:staged-rev-mismatch`.

4. **Race-proof frontend wiring** — `App.tsx` both attaches a `listen()` and calls the new `staged_rev_mismatch_status` Tauri command at mount. The cache makes us race-proof even if the listener attaches after the emit. `StagedRevMismatchModal` renders when the value is non-null with two paths:
   - **Restart sessions** → `daemon_shutdown` (kills every stale PTY) → `acknowledge_staged_rev_mismatch` → `window.location.reload()`. Reload re-runs the app boot, the daemon boot thread spawns a fresh `acornd` against the new dotfiles, and the next reconcile finds nothing stale.
   - **Later** → `acknowledge_staged_rev_mismatch` only; same check fires on next boot.

### Why FNV-1a, why not sha2?

The fingerprint is only checked for equality and the input set is tiny. FNV-1a is a single-file 64-bit hash with no extra build dependency; sha2 would have meant adding a `[build-dependencies]` block and a third-party crate to the build-graph just to gain bits we don't need.

### Files

- `src-tauri/build.rs` — FNV-1a digest emitted as `cargo:rustc-env=ACORN_STAGED_REV`.
- `src-tauri/src/shell_init.rs` — `pub const STAGED_REV` + a test asserting the hex format.
- `src-tauri/src/commands.rs` — `effective_env.insert("ACORN_STAGED_REV", …)` in `pty_spawn`; new `staged_rev_mismatch_status` and `acknowledge_staged_rev_mismatch` commands.
- `src-tauri/src/daemon/{protocol,session,pty,server}.rs` — new `staged_rev` field on session/summary + capture in `daemon::pty::PtyManager::spawn`.
- `src-tauri/src/staged_rev_reconcile.rs` — boot-time comparison; emits `acorn:staged-rev-mismatch` and caches on `AppState`.
- `src-tauri/src/state.rs` — `staged_rev_mismatch: Arc<Mutex<Option<StagedRevMismatch>>>`.
- `src-tauri/src/lib.rs` — wires the reconcile call into the existing daemon boot thread and registers the new Tauri commands.
- `src/lib/api.ts` — new wrappers + types + `STAGED_REV_MISMATCH_EVENT` constant.
- `src/components/StagedRevMismatchModal.tsx` — the prompt.
- `src/App.tsx` — pull-at-mount + listen + modal host.
- `tests/e2e/fixtures/tauriMock.ts` — `null` default for the new pull command so existing E2Es never see the modal.

## Test plan

Automated:

- [x] `cargo build --bins` — clean (acorn + acornd both rebuild).
- [x] `cargo test --lib shell_init` — 6/6 (the new hex-format assertion plus the four forwarder tests + idempotency).
- [x] `cargo test --lib` — 131 passed (the previously-flaky `pid_lock_reclaims_stale_file` passed cleanly this run).
- [x] `bun run typecheck` — clean.
- [x] `bun run test` — 202 passed / 1 skipped.
- [x] `bun run test:e2e` — 52/52 passed, no regression.

Manual (please run after pulling, since you'll be in exactly the scenario this PR addresses — `acornd` from #180 still alive with old staged rev):

- [ ] Pull this branch, `bun install` if needed, `bun run tauri dev`.
- [ ] On first boot the modal "Shell environment updated" should appear, citing the stale session count.
- [ ] Click **Restart sessions** — the app reloads and on next boot the modal must NOT reappear (`acornd` is fresh, every session was respawned against the current `STAGED_REV`).
- [ ] Open a fresh terminal in Acorn after reload — input echo is clean, prompt redraws normally.
- [ ] Edit any of `src-tauri/shell-init/*` (e.g. add a blank line to `zshrc`), `bun run tauri dev` again — the modal should reappear because the new build's `STAGED_REV` no longer matches the stamp on running daemon sessions. **Revert the edit afterwards.**
- [ ] Dismiss the modal with **Later** — the prompt should not return until the next app launch.
