### PR TITLE
fix(terminal): gate worktree adoption on explicit intent

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1373,13 +1373,18 @@ fn deepest_descendant_cwd(sys: &System, root: Pid) -> Option<String> {
 /// touching the system process table.
 #[tauri::command]
 pub fn is_path_linked_worktree(path: String) -> bool {
+    linked_worktree_root(path).is_some()
+}
+
+#[tauri::command]
+pub fn linked_worktree_root(path: String) -> Option<String> {
     let p = PathBuf::from(&path);
     let Ok(repo) = git2::Repository::discover(&p) else {
-        return false;
+        return None;
     };
     repo.workdir()
-        .map(worktree::is_linked_worktree_root)
-        .unwrap_or(false)
+        .filter(|workdir| worktree::is_linked_worktree_root(workdir))
+        .map(|workdir| workdir.to_string_lossy().into_owned())
 }
 
 /// Batched live-cwd → "is linked worktree" probe for every session that has

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1283,7 +1283,7 @@ pub fn pty_reload_shell_env() {
 #[tauri::command]
 pub fn pty_cwd(state: State<'_, AppState>, session_id: String) -> AppResult<Option<String>> {
     let id = parse_id(&session_id)?;
-    let Some(root_pid) = state.pty.child_pid(&id) else {
+    let Some(root_pid) = session_root_pid(&state, &id) else {
         return Ok(None);
     };
 
@@ -1297,6 +1297,13 @@ pub fn pty_cwd(state: State<'_, AppState>, session_id: String) -> AppResult<Opti
     );
 
     Ok(deepest_descendant_cwd(&sys, Pid::from_u32(root_pid)))
+}
+
+fn session_root_pid(state: &State<'_, AppState>, id: &Uuid) -> Option<u32> {
+    state
+        .stream_registry
+        .pid(id)
+        .or_else(|| state.pty.child_pid(id))
 }
 
 /// Like [`pty_cwd`], but resolves the cwd to its enclosing git repository's
@@ -1392,7 +1399,7 @@ pub fn pty_in_worktree_all(state: State<'_, AppState>) -> HashMap<String, bool> 
     let sessions = state.sessions.list();
     let pids: Vec<(Uuid, u32)> = sessions
         .iter()
-        .filter_map(|s| state.pty.child_pid(&s.id).map(|pid| (s.id, pid)))
+        .filter_map(|s| session_root_pid(&state, &s.id).map(|pid| (s.id, pid)))
         .collect();
     if pids.is_empty() {
         return HashMap::new();

--- a/src-tauri/src/daemon/protocol.rs
+++ b/src-tauri/src/daemon/protocol.rs
@@ -311,6 +311,11 @@ pub struct SessionSummary {
     /// `true` while the PTY child is alive; `false` once it has exited.
     /// Dead sessions remain in metadata until `ForgetSession`.
     pub alive: bool,
+    /// Working directory the PTY child was spawned in. The app uses this
+    /// when reconstructing a daemon-owned session row so linked-worktree
+    /// sessions do not collapse back to the project root.
+    #[serde(default)]
+    pub cwd: Option<std::path::PathBuf>,
     pub repo_path: Option<std::path::PathBuf>,
     pub branch: Option<String>,
     pub agent_kind: Option<AgentKind>,
@@ -427,6 +432,27 @@ mod tests {
         let s = serde_json::to_string(&f).unwrap();
         let parsed: StreamFrame = serde_json::from_str(&s).unwrap();
         assert_eq!(parsed, f);
+    }
+
+    #[test]
+    fn session_summary_roundtrips_spawn_cwd() {
+        let summary = SessionSummary {
+            id: Uuid::new_v4(),
+            name: "shell".into(),
+            kind: SessionKind::Regular,
+            alive: true,
+            repo_path: Some("/repo".into()),
+            cwd: Some("/repo/.acorn/worktrees/feature".into()),
+            branch: Some("feature".into()),
+            agent_kind: None,
+            pid: Some(1234),
+            is_source: false,
+            staged_rev: Some("abc123".into()),
+        };
+
+        let s = serde_json::to_string(&summary).unwrap();
+        let parsed: SessionSummary = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed.cwd, summary.cwd);
     }
 
     #[test]

--- a/src-tauri/src/daemon/server.rs
+++ b/src-tauri/src/daemon/server.rs
@@ -257,6 +257,7 @@ impl Daemon {
                         name: s.name,
                         kind: s.kind,
                         alive: s.alive,
+                        cwd: Some(s.cwd),
                         repo_path: s.repo_path,
                         branch: s.branch,
                         agent_kind: s.agent_kind,

--- a/src-tauri/src/daemon_commands.rs
+++ b/src-tauri/src/daemon_commands.rs
@@ -131,6 +131,7 @@ pub struct DaemonSessionSummary {
     pub name: String,
     pub kind: String,
     pub alive: bool,
+    pub cwd: Option<String>,
     pub repo_path: Option<String>,
     pub branch: Option<String>,
     pub agent_kind: Option<String>,
@@ -154,6 +155,7 @@ pub fn daemon_list_sessions(
                 SessionKind::Control => "control".into(),
             },
             alive: s.alive,
+            cwd: s.cwd.map(|p| p.display().to_string()),
             repo_path: s.repo_path.map(|p| p.display().to_string()),
             branch: s.branch,
             agent_kind: s.agent_kind.map(agent_kind_to_str),
@@ -262,7 +264,7 @@ pub fn daemon_forget_session(
 /// the daemon kept the PTY). Idempotent — if the app already has a row
 /// for this id, returns it untouched.
 ///
-/// Pulls metadata (name, kind, repo_path, branch) straight from the
+/// Pulls metadata (name, kind, repo_path, cwd, branch) straight from the
 /// daemon's `SessionSummary`. The daemon must still know this id; pass
 /// `force` semantics through by always querying `list_sessions` first.
 #[tauri::command]
@@ -289,6 +291,7 @@ pub fn daemon_adopt_session(
         .repo_path
         .clone()
         .ok_or_else(|| "daemon session has no repo_path — cannot adopt".to_string())?;
+    let worktree_path = summary.cwd.clone().unwrap_or_else(|| repo_path.clone());
     // Branch is informational — leave empty when the daemon never knew
     // it. Synthesizing "main" would silently lie for repos on master /
     // trunk / detached HEAD; UI tolerates the empty string.
@@ -312,11 +315,7 @@ pub fn daemon_adopt_session(
         id,
         name: summary.name.clone(),
         repo_path: repo_path.clone(),
-        // No way to recover the original worktree path from daemon
-        // metadata. Fall back to repo_path; the user can `cd` inside the
-        // attached PTY if needed. `in_worktree` is recomputed at list
-        // time so it self-corrects if repo_path is itself a worktree.
-        worktree_path: repo_path,
+        worktree_path,
         branch,
         isolated: false,
         status: crate::session::SessionStatus::Idle,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -316,6 +316,7 @@ pub fn run() {
             commands::pty_repo_root,
             commands::pty_in_worktree_all,
             commands::is_path_linked_worktree,
+            commands::linked_worktree_root,
             commands::update_session_worktree,
             commands::git_worktrees,
             commands::scrollback_save,

--- a/src/components/BackgroundSessionsSettings.tsx
+++ b/src/components/BackgroundSessionsSettings.tsx
@@ -455,6 +455,9 @@ function renderAppMetaTooltip(
     if (daemon.repo_path) {
       rows.push({ label: "Repo", value: daemon.repo_path });
     }
+    if (daemon.cwd) {
+      rows.push({ label: "Worktree", value: daemon.cwd });
+    }
   }
   return (
     <div className="flex flex-col gap-0.5 text-left">

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -27,6 +27,10 @@ import {
 import { buildXtermTheme } from "../lib/terminalTheme";
 import { useThemes, type ThemeMode } from "../lib/themes";
 import { useToasts } from "../lib/toasts";
+import {
+  chooseWorktreeToAdoptAfterExit,
+  type WorktreeAdoptionIntent,
+} from "../lib/worktreeAdoption";
 import { useAppStore } from "../store";
 import { StickyUserPrompt } from "./StickyUserPrompt";
 
@@ -995,11 +999,12 @@ export function Terminal({
 
     let exited = false;
     // Snapshot of linked worktrees taken right before each PTY spawn. On exit
-    // we re-fetch and compare; a fresh entry means the just-exited child
-    // (most often `claude --worktree`) added a worktree, and we adopt it as
-    // this session's new home instead of letting the user fall into the
-    // "press Enter to respawn in the same old cwd" dead end.
+    // we re-fetch and compare only when this spawn cycle carried an explicit
+    // adoption intent. A repo-global "new worktree appeared" diff is not
+    // enough evidence: another tab, agent, or external terminal may have
+    // created it while this shell was idle.
     let worktreeSnapshot: Set<string> = new Set();
+    let worktreeAdoptionIntent: WorktreeAdoptionIntent = { kind: "none" };
 
     async function spawnPty() {
       if (disposed) return;
@@ -1053,7 +1058,10 @@ export function Terminal({
         // mount/cleanup/mount sequence. Re-check `disposed` so we do not
         // pty_write into a session whose PTY has already been killed.
         if (queued && !disposed) {
-          const payload = encodeStringToBase64(queued + "\r");
+          if (queued.adoptWorktreeOnExit) {
+            worktreeAdoptionIntent = { kind: "after-exit" };
+          }
+          const payload = encodeStringToBase64(queued.command + "\r");
           invoke("pty_write", { sessionId, data: payload }).catch(
             (err: unknown) => {
               console.error("[Terminal] pending pty_write failed", err);
@@ -1111,25 +1119,20 @@ export function Terminal({
 
         const unlistenExit = await listen(`pty:exit:${sessionId}`, () => {
           if (disposed) return;
-          // Did the just-exited child add a new worktree? Most common cause:
-          // user ran `claude --worktree` (or typed `claude -w`), which on
-          // its own *creates the worktree and exits without putting you
-          // inside it*. Without this branch the user sees a silent exit
-          // and ends up trapped at the press-Enter prompt in the original
-          // cwd, defeating the point. Adopt the new worktree so the next
-          // spawn — triggered by the cwd-prop change after the store update
-          // — lands inside it.
+          // If Acorn queued a command that explicitly asked for worktree
+          // adoption, check whether that spawn cycle produced a new linked
+          // worktree. Plain user `exit` must not adopt unrelated worktrees
+          // created elsewhere in the same repo.
           void (async () => {
             let adoptedPath: string | null = null;
             try {
               const current = await api.gitWorktrees(cwd);
               if (disposed) return;
-              const fresh = current.filter((p) => !worktreeSnapshot.has(p));
-              if (fresh.length > 0) {
-                // Pick the last (most recently appended in libgit2's
-                // enumeration) when the child added several in one run.
-                adoptedPath = fresh[fresh.length - 1];
-              }
+              adoptedPath = chooseWorktreeToAdoptAfterExit({
+                before: [...worktreeSnapshot],
+                after: current,
+                intent: worktreeAdoptionIntent,
+              });
             } catch (err) {
               console.warn(
                 "[Terminal] worktree adoption check failed",
@@ -1137,6 +1140,7 @@ export function Terminal({
               );
             }
             if (disposed) return;
+            worktreeAdoptionIntent = { kind: "none" };
             if (adoptedPath) {
               const name = adoptedPath.split("/").pop() || adoptedPath;
               useToasts.getState().show(`Adopted new worktree: ${name}`);

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -331,12 +331,53 @@ export function Terminal({
     };
     scheduleThemeRefresh();
 
+    let disposed = false;
+    const unlistenFns: UnlistenFn[] = [];
+    let observedLinkedWorktreePath: string | null = null;
+    let liveCwdProbeTimer: number | null = null;
+
+    const rememberLinkedWorktreeCwd = (path: string, source: string) => {
+      void api
+        .linkedWorktreeRoot(path)
+        .then((root) => {
+          if (disposed) return;
+          useAppStore.setState((s) => ({
+            liveInWorktree: { ...s.liveInWorktree, [sessionId]: Boolean(root) },
+          }));
+          if (root) {
+            observedLinkedWorktreePath = root;
+          }
+        })
+        .catch((err: unknown) => {
+          console.debug(`[Terminal] ${source} linked-worktree probe failed`, err);
+        });
+    };
+
+    const scheduleLiveCwdProbe = () => {
+      if (disposed || liveCwdProbeTimer !== null) return;
+      liveCwdProbeTimer = window.setTimeout(() => {
+        liveCwdProbeTimer = null;
+        if (disposed) return;
+        void api
+          .ptyCwd(sessionId)
+          .then((liveCwd) => {
+            if (liveCwd && !disposed) {
+              rememberLinkedWorktreeCwd(liveCwd, "pty-cwd");
+            }
+          })
+          .catch((err: unknown) => {
+            console.debug("[Terminal] pty_cwd probe failed", err);
+          });
+      }, 500);
+    };
+
     // OSC 7 cwd tracking. The shell rc we inject via ZDOTDIR emits
     // `\e]7;file://<host><pwd>\e\\` on every prompt. xterm's parser hands
     // us the inner payload (everything between `\e]7;` and the terminator)
-    // — strip the `file://[host]` prefix, percent-decode, classify via the
-    // backend, and update the live-cwd store entry for this session. Each
-    // emit is one cheap stat through libgit2; no polling, no system scan.
+    // — strip the `file://[host]` prefix, percent-decode, resolve linked
+    // worktree roots via the backend, and update the live-cwd store entry
+    // for this session. A resolved root is also remembered as an adoption
+    // candidate for commands that created and entered a fresh worktree.
     // Returning `true` claims the sequence so xterm doesn't echo it.
     term.parser.registerOscHandler(7, (data) => {
       const match = /^file:\/\/[^/]*(\/.*)$/.exec(data);
@@ -347,16 +388,7 @@ export function Terminal({
       } catch {
         return false;
       }
-      void api
-        .isPathLinkedWorktree(path)
-        .then((flag) => {
-          useAppStore.setState((s) => ({
-            liveInWorktree: { ...s.liveInWorktree, [sessionId]: flag },
-          }));
-        })
-        .catch((err: unknown) => {
-          console.debug("[Terminal] osc7 classify failed", err);
-        });
+      rememberLinkedWorktreeCwd(path, "osc7");
       return true;
     });
 
@@ -416,9 +448,6 @@ export function Terminal({
         }
       }
     });
-
-    let disposed = false;
-    const unlistenFns: UnlistenFn[] = [];
 
     // `scrollback_load` must finish before any save is allowed. Without
     // this gate, React.StrictMode's mount → cleanup → mount cycle in dev
@@ -999,16 +1028,20 @@ export function Terminal({
 
     let exited = false;
     // Snapshot of linked worktrees taken right before each PTY spawn. On exit
-    // we re-fetch and compare only when this spawn cycle carried an explicit
-    // adoption intent. A repo-global "new worktree appeared" diff is not
-    // enough evidence: another tab, agent, or external terminal may have
+    // we re-fetch and compare when this spawn cycle carried an explicit
+    // adoption intent, or when this session's own live cwd was observed inside
+    // a fresh linked worktree. A repo-global "new worktree appeared" diff is
+    // not enough evidence: another tab, agent, or external terminal may have
     // created it while this shell was idle.
-    let worktreeSnapshot: Set<string> = new Set();
+    let worktreeSnapshot: Set<string> | null = null;
     let worktreeAdoptionIntent: WorktreeAdoptionIntent = { kind: "none" };
 
     async function spawnPty() {
       if (disposed) return;
       try {
+        observedLinkedWorktreePath = null;
+        worktreeAdoptionIntent = { kind: "none" };
+        worktreeSnapshot = null;
         // Capture the worktree set *before* the child can mutate it.
         // Failure here is non-fatal — without a snapshot we just lose
         // the adoption shortcut for this spawn cycle, and the press-Enter
@@ -1106,6 +1139,11 @@ export function Terminal({
               // buffer so the sticky banner picks it up in the same frame
               // (instead of waiting for the user's next scroll).
               scheduleContextDispatch();
+              // Agents can create a worktree and chdir a descendant process
+              // without triggering our shell's OSC 7 prompt hook. Probe the
+              // live descendant cwd on output bursts so exit adoption can
+              // remain tied to this session rather than a repo-global diff.
+              scheduleLiveCwdProbe();
             } catch (err) {
               console.error("[Terminal] decode payload failed", err);
             }
@@ -1119,20 +1157,23 @@ export function Terminal({
 
         const unlistenExit = await listen(`pty:exit:${sessionId}`, () => {
           if (disposed) return;
-          // If Acorn queued a command that explicitly asked for worktree
-          // adoption, check whether that spawn cycle produced a new linked
-          // worktree. Plain user `exit` must not adopt unrelated worktrees
-          // created elsewhere in the same repo.
+          // Adopt only when Acorn queued an explicit worktree command, or
+          // when this terminal itself was observed running inside a fresh
+          // linked worktree. Plain user `exit` must not adopt unrelated
+          // worktrees created elsewhere in the same repo.
           void (async () => {
             let adoptedPath: string | null = null;
             try {
               const current = await api.gitWorktrees(cwd);
               if (disposed) return;
-              adoptedPath = chooseWorktreeToAdoptAfterExit({
-                before: [...worktreeSnapshot],
-                after: current,
-                intent: worktreeAdoptionIntent,
-              });
+              if (worktreeSnapshot) {
+                adoptedPath = chooseWorktreeToAdoptAfterExit({
+                  before: [...worktreeSnapshot],
+                  after: current,
+                  intent: worktreeAdoptionIntent,
+                  observedLinkedWorktreePath,
+                });
+              }
             } catch (err) {
               console.warn(
                 "[Terminal] worktree adoption check failed",
@@ -1352,6 +1393,9 @@ export function Terminal({
       contextScrollDisposable.dispose();
       unsubStickyToggle();
       resizeDisposable.dispose();
+      if (liveCwdProbeTimer !== null) {
+        window.clearTimeout(liveCwdProbeTimer);
+      }
       for (const off of unlistenFns) {
         try { off(); } catch { /* ignore */ }
       }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -326,6 +326,15 @@ export const api = {
     return invoke<boolean>("is_path_linked_worktree", { path });
   },
   /**
+   * Resolve an arbitrary path to the root of its enclosing linked git
+   * worktree. Returns null when the path is outside git or belongs to the
+   * main checkout. Used to remember a session-specific adoption candidate
+   * without relying on repo-global worktree diffs alone.
+   */
+  linkedWorktreeRoot(path: string): Promise<string | null> {
+    return invoke<string | null>("linked_worktree_root", { path });
+  },
+  /**
    * Re-point a session at a different worktree directory. Used after an
    * in-PTY command creates a worktree and exits — adopting it lets the next
    * spawn land inside the new worktree instead of the original cwd.

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -522,6 +522,7 @@ export interface DaemonSessionSummary {
   name: string;
   kind: "regular" | "control";
   alive: boolean;
+  cwd: string | null;
   repo_path: string | null;
   branch: string | null;
   agent_kind: string | null;

--- a/src/lib/worktreeAdoption.test.ts
+++ b/src/lib/worktreeAdoption.test.ts
@@ -43,6 +43,28 @@ describe("chooseWorktreeToAdoptAfterExit", () => {
       }),
     ).toBeNull();
   });
+
+  it("adopts a fresh worktree observed as this session's live cwd", () => {
+    expect(
+      chooseWorktreeToAdoptAfterExit({
+        before,
+        after,
+        intent: { kind: "none" },
+        observedLinkedWorktreePath: "/repo/.claude/worktrees/fresh",
+      }),
+    ).toBe("/repo/.claude/worktrees/fresh");
+  });
+
+  it("does not adopt an unobserved fresh worktree", () => {
+    expect(
+      chooseWorktreeToAdoptAfterExit({
+        before,
+        after,
+        intent: { kind: "none" },
+        observedLinkedWorktreePath: "/repo/.claude/worktrees/other",
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("commandRequestsWorktreeAdoption", () => {

--- a/src/lib/worktreeAdoption.test.ts
+++ b/src/lib/worktreeAdoption.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  chooseWorktreeToAdoptAfterExit,
+  commandRequestsWorktreeAdoption,
+  type WorktreeAdoptionIntent,
+} from "./worktreeAdoption";
+
+describe("chooseWorktreeToAdoptAfterExit", () => {
+  const before = ["/repo/.acorn/worktrees/existing"];
+  const after = [
+    "/repo/.acorn/worktrees/existing",
+    "/repo/.claude/worktrees/fresh",
+  ];
+
+  it("does not adopt a repo-global fresh worktree without an explicit intent", () => {
+    expect(
+      chooseWorktreeToAdoptAfterExit({
+        before,
+        after,
+        intent: { kind: "none" },
+      }),
+    ).toBeNull();
+  });
+
+  it("adopts the fresh worktree only when this spawn cycle requested adoption", () => {
+    expect(
+      chooseWorktreeToAdoptAfterExit({
+        before,
+        after,
+        intent: { kind: "after-exit" },
+      }),
+    ).toBe("/repo/.claude/worktrees/fresh");
+  });
+
+  it("keeps adoption disabled after the one-shot intent is consumed", () => {
+    const consumed: WorktreeAdoptionIntent = { kind: "none" };
+
+    expect(
+      chooseWorktreeToAdoptAfterExit({
+        before,
+        after,
+        intent: consumed,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("commandRequestsWorktreeAdoption", () => {
+  it("recognizes explicit claude worktree commands", () => {
+    expect(commandRequestsWorktreeAdoption("claude --worktree")).toBe(true);
+    expect(commandRequestsWorktreeAdoption("claude -w")).toBe(true);
+  });
+
+  it("does not infer adoption from unrelated commands", () => {
+    expect(commandRequestsWorktreeAdoption("exit")).toBe(false);
+    expect(commandRequestsWorktreeAdoption("git worktree add ../x")).toBe(false);
+    expect(commandRequestsWorktreeAdoption("codex -w")).toBe(false);
+  });
+});

--- a/src/lib/worktreeAdoption.ts
+++ b/src/lib/worktreeAdoption.ts
@@ -1,0 +1,26 @@
+export type WorktreeAdoptionIntent = { kind: "none" } | { kind: "after-exit" };
+
+export interface WorktreeAdoptionChoiceInput {
+  before: readonly string[];
+  after: readonly string[];
+  intent: WorktreeAdoptionIntent;
+}
+
+export function chooseWorktreeToAdoptAfterExit({
+  before,
+  after,
+  intent,
+}: WorktreeAdoptionChoiceInput): string | null {
+  if (intent.kind !== "after-exit") return null;
+
+  const known = new Set(before);
+  const fresh = after.filter((path) => !known.has(path));
+  return fresh[fresh.length - 1] ?? null;
+}
+
+export function commandRequestsWorktreeAdoption(command: string): boolean {
+  const tokens = command.trim().split(/\s+/);
+  if (tokens.length < 2) return false;
+  if (tokens[0] !== "claude") return false;
+  return tokens.slice(1).some((token) => token === "--worktree" || token === "-w");
+}

--- a/src/lib/worktreeAdoption.ts
+++ b/src/lib/worktreeAdoption.ts
@@ -4,18 +4,27 @@ export interface WorktreeAdoptionChoiceInput {
   before: readonly string[];
   after: readonly string[];
   intent: WorktreeAdoptionIntent;
+  observedLinkedWorktreePath?: string | null;
 }
 
 export function chooseWorktreeToAdoptAfterExit({
   before,
   after,
   intent,
+  observedLinkedWorktreePath,
 }: WorktreeAdoptionChoiceInput): string | null {
-  if (intent.kind !== "after-exit") return null;
-
   const known = new Set(before);
   const fresh = after.filter((path) => !known.has(path));
-  return fresh[fresh.length - 1] ?? null;
+  if (intent.kind === "after-exit") {
+    return fresh[fresh.length - 1] ?? null;
+  }
+  if (
+    observedLinkedWorktreePath &&
+    fresh.includes(observedLinkedWorktreePath)
+  ) {
+    return observedLinkedWorktreePath;
+  }
+  return null;
 }
 
 export function commandRequestsWorktreeAdoption(command: string): boolean {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -744,11 +744,15 @@ describe("pendingTerminalInput", () => {
     const { setPendingTerminalInput, consumePendingTerminalInput } =
       useAppStore.getState();
     setPendingTerminalInput("sess-1", "gh auth login");
-    expect(useAppStore.getState().pendingTerminalInput["sess-1"]).toBe(
-      "gh auth login",
-    );
+    expect(useAppStore.getState().pendingTerminalInput["sess-1"]).toEqual({
+      command: "gh auth login",
+      adoptWorktreeOnExit: false,
+    });
     const consumed = consumePendingTerminalInput("sess-1");
-    expect(consumed).toBe("gh auth login");
+    expect(consumed).toEqual({
+      command: "gh auth login",
+      adoptWorktreeOnExit: false,
+    });
     expect(useAppStore.getState().pendingTerminalInput["sess-1"]).toBeUndefined();
   });
 
@@ -764,7 +768,10 @@ describe("pendingTerminalInput", () => {
       useAppStore.getState();
     setPendingTerminalInput("sess-1", "first");
     setPendingTerminalInput("sess-1", "second");
-    expect(consumePendingTerminalInput("sess-1")).toBe("second");
+    expect(consumePendingTerminalInput("sess-1")).toEqual({
+      command: "second",
+      adoptWorktreeOnExit: false,
+    });
   });
 
   it("does not cross-contaminate session ids", () => {
@@ -772,8 +779,24 @@ describe("pendingTerminalInput", () => {
       useAppStore.getState();
     setPendingTerminalInput("sess-1", "one");
     setPendingTerminalInput("sess-2", "two");
-    expect(consumePendingTerminalInput("sess-1")).toBe("one");
-    expect(useAppStore.getState().pendingTerminalInput["sess-2"]).toBe("two");
+    expect(consumePendingTerminalInput("sess-1")).toEqual({
+      command: "one",
+      adoptWorktreeOnExit: false,
+    });
+    expect(useAppStore.getState().pendingTerminalInput["sess-2"]).toEqual({
+      command: "two",
+      adoptWorktreeOnExit: false,
+    });
+  });
+
+  it("marks explicit claude worktree commands for after-exit adoption", () => {
+    const { setPendingTerminalInput, consumePendingTerminalInput } =
+      useAppStore.getState();
+    setPendingTerminalInput("sess-1", "claude --worktree");
+    expect(consumePendingTerminalInput("sess-1")).toEqual({
+      command: "claude --worktree",
+      adoptWorktreeOnExit: true,
+    });
   });
 });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { api } from "./lib/api";
 import type { Project, Session, SessionKind } from "./lib/types";
+import { commandRequestsWorktreeAdoption } from "./lib/worktreeAdoption";
 import { CONTROL_GUIDE_DISMISSED_KEY } from "./components/ControlSessionGuideModal";
 import {
   type Direction,
@@ -61,13 +62,13 @@ interface AppStateModel {
    *  surface "which identity am I acting as for this repo". In-memory only. */
   prAccountByRepo: Record<string, string>;
   /**
-   * One-shot command to write into a session's PTY immediately after its
-   * shell finishes spawning. Used by `CommandRunDialog` to launch a freshly
-   * created session that then executes a fixed command (e.g. `gh auth login`).
-   * Terminal.tsx consumes and clears the entry inside the `pty_spawn`
+   * One-shot command metadata to write into a session's PTY immediately after
+   * its shell finishes spawning. Used by `CommandRunDialog` to launch a
+   * freshly created session that then executes a fixed command (e.g. `gh auth
+   * login`). Terminal.tsx consumes and clears the entry inside the `pty_spawn`
    * resolver, so the value is in-memory only and never persisted.
    */
-  pendingTerminalInput: Record<string, string>;
+  pendingTerminalInput: Record<string, PendingTerminalInput>;
   multiInputEnabled: boolean;
   loading: boolean;
   error: string | null;
@@ -137,10 +138,23 @@ interface AppStateModel {
   setRightTab: (tab: RightTab) => void;
   setPrAccountForRepo: (repoPath: string, login: string | null) => void;
   /** Queue a command for the next successful `pty_spawn` of `sessionId`. */
-  setPendingTerminalInput: (sessionId: string, command: string) => void;
+  setPendingTerminalInput: (
+    sessionId: string,
+    command: string,
+    options?: PendingTerminalInputOptions,
+  ) => void;
   /** Atomically read and remove the queued command for `sessionId`. */
-  consumePendingTerminalInput: (sessionId: string) => string | null;
+  consumePendingTerminalInput: (sessionId: string) => PendingTerminalInput | null;
   toggleMultiInput: () => boolean;
+}
+
+export interface PendingTerminalInput {
+  command: string;
+  adoptWorktreeOnExit: boolean;
+}
+
+export interface PendingTerminalInputOptions {
+  adoptWorktreeOnExit?: boolean;
 }
 
 let paneCounter = 0;
@@ -1027,11 +1041,16 @@ export const useAppStore = create<AppStateModel>()(
     });
   },
 
-  setPendingTerminalInput(sessionId, command) {
+  setPendingTerminalInput(sessionId, command, options) {
     set((s) => ({
       pendingTerminalInput: {
         ...s.pendingTerminalInput,
-        [sessionId]: command,
+        [sessionId]: {
+          command,
+          adoptWorktreeOnExit:
+            options?.adoptWorktreeOnExit ??
+            commandRequestsWorktreeAdoption(command),
+        },
       },
     }));
   },
@@ -1041,7 +1060,7 @@ export const useAppStore = create<AppStateModel>()(
     // observe the same value before either of them clears it. Captures the
     // resolved value via closure rather than as the `set` return so the
     // function can still surface it to its caller.
-    let consumed: string | null = null;
+    let consumed: PendingTerminalInput | null = null;
     set((s) => {
       const queued = s.pendingTerminalInput[sessionId];
       if (!queued) return s;


### PR DESCRIPTION
## Summary
- Gate post-exit worktree adoption behind an explicit queued-command intent instead of repo-global worktree diffs
- Preserve daemon session spawn cwd through summaries/adoption so worktree sessions restore to the right cwd
- Make live cwd probes daemon-aware for pty_cwd and pty_in_worktree_all

## Verification
- npx tsc --noEmit
- npx vitest run
- cargo check
- cargo test session_summary_roundtrips_spawn_cwd
- cargo test -- --skip daemon::ring_buffer::tests::newline_indices_stay_coherent_across_byte_eviction

Note: full cargo test was previously observed to hang in daemon::ring_buffer::tests::newline_indices_stay_coherent_across_byte_eviction, so the final Rust suite was run with that existing long-running test skipped.