### PR TITLE
fix(terminal): prevent Claude redraw artifacts

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -895,6 +895,7 @@ pub async fn pty_spawn<R: Runtime>(
     env: Option<HashMap<String, String>>,
     cols: Option<u16>,
     rows: Option<u16>,
+    replay_scrollback: Option<bool>,
 ) -> AppResult<()> {
     let id = parse_id(&session_id)?;
     let cwd = PathBuf::from(cwd);
@@ -1065,6 +1066,7 @@ pub async fn pty_spawn<R: Runtime>(
             &effective_env,
             cols.unwrap_or(0),
             rows.unwrap_or(0),
+            replay_scrollback.unwrap_or(true),
         ) {
             Ok(()) => return Ok(()),
             Err(err) => {
@@ -1090,8 +1092,9 @@ pub async fn pty_spawn<R: Runtime>(
 /// 1. **Already attached** — short-circuit; redundant guard catches
 ///    races where two callers hit this helper concurrently.
 /// 2. **Daemon already has an alive session** under this UUID (Acorn
-///    just restarted) — skip spawn, open a stream attachment with
-///    scrollback replay so the user sees the daemon's last screen.
+///    just restarted) — skip spawn, open a stream attachment. The frontend
+///    decides whether to replay the daemon's raw ring buffer based on whether
+///    it already restored an xterm-rendered disk snapshot.
 /// 3. **No live session** — fresh daemon spawn, attach the stream,
 ///    persist `daemon_session_id` so the next restart hits case 2.
 fn spawn_via_daemon<R: Runtime>(
@@ -1104,6 +1107,7 @@ fn spawn_via_daemon<R: Runtime>(
     env: &HashMap<String, String>,
     cols: u16,
     rows: u16,
+    replay_scrollback: bool,
 ) -> Result<(), String> {
     let bridge = &state.daemon_bridge;
     let registry = state.stream_registry.clone();
@@ -1142,7 +1146,7 @@ fn spawn_via_daemon<R: Runtime>(
     // tree to walk without an extra round-trip on every poll.
     if bridge.is_alive(id) {
         let pid = bridge.session_pid(id);
-        crate::daemon_stream::attach(app.clone(), registry.clone(), id, pid, true)
+        crate::daemon_stream::attach(app.clone(), registry.clone(), id, pid, replay_scrollback)
             .map_err(|e| format!("daemon stream attach failed: {e}"))?;
         return Ok(());
     }
@@ -1178,7 +1182,7 @@ fn spawn_via_daemon<R: Runtime>(
     }
     persist(state);
 
-    crate::daemon_stream::attach(app.clone(), registry, id, outcome.pid, true)
+    crate::daemon_stream::attach(app.clone(), registry, id, outcome.pid, replay_scrollback)
         .map_err(|e| format!("daemon stream attach failed: {e}"))
 }
 

--- a/src-tauri/src/pty_env.rs
+++ b/src-tauri/src/pty_env.rs
@@ -21,6 +21,17 @@ use portable_pty::CommandBuilder;
 pub const RENDER_CAPABILITY: &[(&str, &str)] =
     &[("TERM", "xterm-256color"), ("COLORTERM", "truecolor")];
 
+const HOST_TERMINAL_ENV: &[&str] = &[
+    "TERM_PROGRAM",
+    "TERM_PROGRAM_VERSION",
+    "TERM_SESSION_ID",
+    "LC_TERMINAL",
+    "LC_TERMINAL_VERSION",
+    "ITERM_SESSION_ID",
+    "WT_SESSION",
+    "VTE_VERSION",
+];
+
 /// Apply layered env to `cmd`, lowest-to-highest priority:
 ///   * (A) Render capability — TERM / COLORTERM defaults.
 ///   * (B) System locale — LANG default.
@@ -49,6 +60,18 @@ pub fn apply_layered_env(cmd: &mut CommandBuilder, env: HashMap<String, String>)
 
     let shell_env = crate::shell_env::resolve();
     let mut applied: HashSet<String> = env.keys().cloned().collect();
+
+    // `CommandBuilder::new` starts from Acorn's own environment. If Acorn
+    // was launched from Terminal.app/iTerm/VS Code, those host terminal
+    // fingerprints leak into the embedded xterm.js PTY. TUIs such as Claude
+    // can special-case `TERM_PROGRAM` / friends and emit redraw behaviour for
+    // a terminal Acorn is not actually running. Strip inherited fingerprints;
+    // explicit caller env below can still opt back in for tests/tools.
+    for k in HOST_TERMINAL_ENV {
+        if !applied.contains(*k) {
+            cmd.env_remove(k);
+        }
+    }
 
     // (A) Render capability — TERM advertises what xterm.js renders, so
     // zsh's terminfo lookups (used by zsh-autosuggestions for cursor
@@ -79,6 +102,9 @@ pub fn apply_layered_env(cmd: &mut CommandBuilder, env: HashMap<String, String>)
     // user explicitly exported — LANG, EDITOR, PAGER, TZ, etc. —
     // without acorn having to know each shell's rc-file conventions.
     for (k, v) in &shell_env {
+        if HOST_TERMINAL_ENV.contains(&k.as_str()) && !applied.contains(k) {
+            continue;
+        }
         if !applied.contains(k) {
             cmd.env(k, v);
             applied.insert(k.clone());
@@ -166,6 +192,30 @@ mod tests {
         assert_eq!(
             cmd.get_env("COLORTERM").and_then(|s| s.to_str()),
             Some("24bit"),
+        );
+    }
+
+    #[test]
+    fn layered_env_removes_inherited_host_terminal_fingerprints() {
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.env_clear();
+        cmd.env("TERM_PROGRAM", "Apple_Terminal");
+        cmd.env("TERM_SESSION_ID", "abc123");
+        apply_layered_env(&mut cmd, HashMap::new());
+        assert_eq!(cmd.get_env("TERM_PROGRAM"), None);
+        assert_eq!(cmd.get_env("TERM_SESSION_ID"), None);
+    }
+
+    #[test]
+    fn layered_env_preserves_explicit_host_terminal_override() {
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.env_clear();
+        let mut env = HashMap::new();
+        env.insert("TERM_PROGRAM".to_string(), "AcornTest".to_string());
+        apply_layered_env(&mut cmd, env);
+        assert_eq!(
+            cmd.get_env("TERM_PROGRAM").and_then(|s| s.to_str()),
+            Some("AcornTest"),
         );
     }
 }

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -335,6 +335,7 @@ export function Terminal({
     const unlistenFns: UnlistenFn[] = [];
     let observedLinkedWorktreePath: string | null = null;
     let liveCwdProbeTimer: number | null = null;
+    let restoredDiskScrollback = false;
 
     const rememberLinkedWorktreeCwd = (path: string, source: string) => {
       void api
@@ -478,39 +479,48 @@ export function Terminal({
       }, SCROLLBACK_SAVE_DEBOUNCE_MS);
     };
 
-    // Force a viewport repaint shortly after a PTY output burst goes idle.
+    // Force viewport repaints around PTY output bursts.
     //
     // xterm's DOM renderer reuses per-row DOM elements and incrementally
     // patches glyphs as the buffer changes. When a streaming TUI (Claude
-    // CLI, `htop`, `claude --print`) is interrupted mid-redraw — user
-    // presses Esc/Ctrl+C, or the stream simply stops — the parser settles
-    // but the last set of cell-diffs may never trigger a paint that
-    // overwrites stale glyphs left by an earlier wider line. The xterm
-    // buffer is correct (copy-to-clipboard yields clean text); only the
-    // DOM rendition is stale. Forcing `refresh(0, rows-1)` rebuilds every
-    // visible row from the buffer, which clears the leftover characters.
+    // CLI, `htop`, `claude --print`) is mid-redraw — or interrupted by
+    // Esc/Ctrl+C — the parser can settle with stale cursor/cell DOM left
+    // from an earlier frame. The xterm buffer is correct
+    // (copy-to-clipboard yields clean text); only the DOM rendition is
+    // stale. Forcing `refresh(0, rows-1)` rebuilds every visible row from
+    // the buffer, which clears leftover characters and cursor blocks.
     //
-    // Mid-burst paints already happen naturally as each chunk lands, so
-    // we only fire this when the stream goes quiet. 120ms after the last
-    // chunk: short enough that the stale frame is rarely visible, long
-    // enough to coalesce a Claude-CLI streaming burst (where natural
-    // gaps run ~10-60ms) into one refresh instead of one per chunk.
+    // We run one rAF-throttled refresh after each parsed write for live
+    // interactive redraws (notably Claude's slash-command picker), plus
+    // an idle refresh after the burst goes quiet to catch interrupted
+    // final frames.
     const VIEWPORT_REPAINT_IDLE_MS = 120;
     let viewportRepaintTimer: number | null = null;
-    const scheduleViewportRepaint = () => {
+    let viewportRepaintFrame: number | null = null;
+    const repaintViewport = () => {
+      if (disposed) return;
+      try {
+        term.refresh(0, term.rows - 1);
+      } catch {
+        // ignore — terminal may have been disposed between scheduling
+        // and reaching the call.
+      }
+    };
+    const scheduleViewportFrameRepaint = () => {
+      if (disposed || viewportRepaintFrame !== null) return;
+      viewportRepaintFrame = requestAnimationFrame(() => {
+        viewportRepaintFrame = null;
+        repaintViewport();
+      });
+    };
+    const scheduleViewportIdleRepaint = () => {
       if (disposed) return;
       if (viewportRepaintTimer !== null) {
         window.clearTimeout(viewportRepaintTimer);
       }
       viewportRepaintTimer = window.setTimeout(() => {
         viewportRepaintTimer = null;
-        if (disposed) return;
-        try {
-          term.refresh(0, term.rows - 1);
-        } catch {
-          // ignore — terminal may have been disposed between the timer
-          // firing and reaching the call.
-        }
+        repaintViewport();
       }, VIEWPORT_REPAINT_IDLE_MS);
     };
 
@@ -1069,6 +1079,7 @@ export function Terminal({
           env: {},
           cols: term.cols,
           rows: term.rows,
+          replayScrollback: !restoredDiskScrollback,
         });
         if (disposed) {
           // Cleanup ran mid-spawn — the pty just got created has no UI.
@@ -1127,18 +1138,25 @@ export function Terminal({
             if (disposed) return;
             try {
               const bytes = decodeBase64ToBytes(event.payload.data);
-              term.write(bytes);
-              // Output landed in the buffer — schedule a debounced save
+              term.write(bytes, () => {
+                if (disposed) return;
+                // The parser has drained this chunk. Force a frame-bound
+                // refresh so fast cursor-move/erase TUIs do not leave stale
+                // DOM cursor blocks or cells behind.
+                scheduleViewportFrameRepaint();
+                // Also schedule a viewport repaint once the burst goes
+                // quiet, so a TUI redraw interrupted mid-stream doesn't
+                // leave stale glyphs from a wider previous line painted on
+                // screen.
+                scheduleViewportIdleRepaint();
+                // A new prompt row may have just been rendered. Rescan the
+                // buffer so the sticky banner picks it up in the same frame
+                // (instead of waiting for the user's next scroll).
+                scheduleContextDispatch();
+              });
+              // Output will land in the buffer — schedule a debounced save
               // so the new content reaches disk ~1s after activity ends.
               scheduleScrollbackSave();
-              // Also schedule a viewport repaint once the burst goes quiet,
-              // so a TUI redraw interrupted mid-stream doesn't leave stale
-              // glyphs from a wider previous line painted on screen.
-              scheduleViewportRepaint();
-              // A new prompt row may have just been rendered. Rescan the
-              // buffer so the sticky banner picks it up in the same frame
-              // (instead of waiting for the user's next scroll).
-              scheduleContextDispatch();
               // Agents can create a worktree and chdir a descendant process
               // without triggering our shell's OSC 7 prompt hook. Probe the
               // live descendant cwd on output bursts so exit adoption can
@@ -1239,14 +1257,17 @@ export function Terminal({
       });
       unlistenFns.push(() => restartDisposable.dispose());
 
-      // Restore prior scrollback before spawning so the user sees the
-      // previous session's output immediately on app restart. The dim
-      // separator marks where the live PTY output begins.
+      // Restore the xterm-rendered disk snapshot before spawning so the user
+      // sees the previous terminal screen immediately on app restart. If this
+      // succeeds, `spawnPty()` tells the daemon attachment not to replay its
+      // raw PTY ring buffer: raw TUI output contains intermediate Claude
+      // redraw frames, while the disk snapshot is already parsed by xterm.
       try {
         const saved = await invoke<string | null>("scrollback_load", {
           sessionId,
         });
         if (disposed) return;
+        restoredDiskScrollback = saved !== null;
         if (saved && saved.length > 0) {
           // Each step is awaited individually. Previously the mode
           // resets and marker were fired without awaiting and `spawnPty`
@@ -1365,6 +1386,10 @@ export function Terminal({
       if (viewportRepaintTimer !== null) {
         window.clearTimeout(viewportRepaintTimer);
         viewportRepaintTimer = null;
+      }
+      if (viewportRepaintFrame !== null) {
+        cancelAnimationFrame(viewportRepaintFrame);
+        viewportRepaintFrame = null;
       }
       // No cleanup-time save: under React.StrictMode the cleanup of the
       // first dev mount fires while the buffer is still empty (load


### PR DESCRIPTION
## Summary

Fixes terminal rendering and persistence issues seen with Claude Code inside Acorn's xterm.js terminal.

### 1. Prefer xterm snapshots over daemon raw replay

Background sessions can restore history from two places:

- the frontend disk snapshot saved from xterm's already-parsed buffer
- the daemon raw PTY ring buffer replayed on stream attach

Claude's TUI emits intermediate cursor-move and erase frames while redrawing. Those bytes are fine live, but replaying the daemon raw ring later turns those intermediate frames into real scrollback rows. That is what caused repeated Claude headers and duplicated prompts after reconnect/resume.

The fix restores the disk snapshot first. If a snapshot exists, `Terminal.tsx` passes `replayScrollback: false` to `pty_spawn`, so daemon attach skips historical raw replay and only streams new live output.

### 2. Repaint after parsed PTY writes

The xterm DOM renderer can leave stale cursor blocks/cells during fast TUI redraws, especially in Claude slash-command/search UIs. The PTY output path now uses `term.write(bytes, callback)` and schedules a frame-bound `term.refresh(0, rows - 1)` only after xterm has parsed the chunk. The idle refresh remains as a final cleanup for interrupted redraws.

### 3. Strip inherited host-terminal fingerprints

When Acorn is launched from Terminal.app, iTerm, VS Code, etc., env vars like `TERM_PROGRAM`, `TERM_SESSION_ID`, `ITERM_SESSION_ID`, or `VTE_VERSION` can leak into Acorn's embedded PTY. That can make TUIs choose behavior for a terminal Acorn is not actually running. The PTY env layer now strips inherited host-terminal fingerprints while preserving explicit caller overrides.

## Verification

- `bun run typecheck`
- `cargo test --manifest-path src-tauri/Cargo.toml pty_env --lib`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- Manual local Tauri dev test on port 1430 with Claude resume/replay behavior
- GitHub checks: `Frontend` pass, `E2E` pass
