### PR TITLE
Fix empty terminal scrollback restore

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -21,6 +21,12 @@ import {
   unpatchTerminalCellMeasurements,
 } from "../lib/terminal-cjk-cell-width-addon";
 import {
+  prepareScrollbackForSave,
+  RESTORE_MARKER_TEXT,
+  shouldRestoreScrollback,
+  stripRestoreMarkers,
+} from "../lib/terminalScrollback";
+import {
   useSettings,
   type TerminalLinkActivation,
 } from "../lib/settings";
@@ -1268,7 +1274,8 @@ export function Terminal({
         });
         if (disposed) return;
         restoredDiskScrollback = saved !== null;
-        if (saved && saved.length > 0) {
+        const restored = saved ? stripRestoreMarkers(saved) : "";
+        if (restored && shouldRestoreScrollback(restored)) {
           // Each step is awaited individually. Previously the mode
           // resets and marker were fired without awaiting and `spawnPty`
           // was called immediately after, so the new shell's first
@@ -1282,7 +1289,7 @@ export function Terminal({
           const writeAndDrain = (data: string): Promise<void> =>
             new Promise<void>((resolve) => term.write(data, resolve));
 
-          await writeAndDrain(saved);
+          await writeAndDrain(restored);
           if (disposed) return;
           // Only exit alt-screen if the snapshot actually left us in it
           // — issuing `\x1b[?1049l` from the normal buffer pushes the
@@ -1316,7 +1323,7 @@ export function Terminal({
           await writeAndDrain(RESETS);
           if (disposed) return;
           await writeAndDrain(
-            `\r\n${ANSI_DIM}— restored from previous session —${ANSI_RESET}\r\n`,
+            `\r\n${ANSI_DIM}${RESTORE_MARKER_TEXT}${ANSI_RESET}\r\n`,
           );
           if (disposed) return;
         }
@@ -1361,7 +1368,10 @@ export function Terminal({
         const data = serializeAddon.serialize({
           scrollback: SCROLLBACK_MAX_ROWS,
         });
-        await invoke("scrollback_save", { sessionId, data });
+        await invoke("scrollback_save", {
+          sessionId,
+          data: prepareScrollbackForSave(data),
+        });
       } catch (err) {
         console.warn("[Terminal] scrollback_save failed", err);
       }

--- a/src/lib/terminalScrollback.test.ts
+++ b/src/lib/terminalScrollback.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  prepareScrollbackForSave,
+  RESTORE_MARKER_TEXT,
+  shouldRestoreScrollback,
+} from "./terminalScrollback";
+
+describe("terminal scrollback restore hygiene", () => {
+  it("does not restore whitespace-only scrollback", () => {
+    expect(shouldRestoreScrollback("\r\n\n   \x1b[0m\r\n")).toBe(false);
+  });
+
+  it("does not restore a shell prompt with no session content", () => {
+    expect(
+      shouldRestoreScrollback(
+        "jthefloor@jthefloorui-MacBookPro acorn %     \r\n",
+      ),
+    ).toBe(false);
+  });
+
+  it("removes Acorn restore markers before saving", () => {
+    const saved = prepareScrollbackForSave(
+      `build ok\r\n\x1b[2m${RESTORE_MARKER_TEXT}\x1b[0m\r\nnext prompt % `,
+    );
+
+    expect(saved).not.toContain(RESTORE_MARKER_TEXT);
+    expect(saved).toContain("build ok");
+  });
+
+  it("keeps real command output restorable", () => {
+    const saved = prepareScrollbackForSave(
+      "jthefloor@host acorn % npm test\r\nPASS src/lib/foo.test.ts\r\njthefloor@host acorn % ",
+    );
+
+    expect(saved).toContain("PASS src/lib/foo.test.ts");
+    expect(shouldRestoreScrollback(saved)).toBe(true);
+  });
+});

--- a/src/lib/terminalScrollback.ts
+++ b/src/lib/terminalScrollback.ts
@@ -1,0 +1,47 @@
+export const RESTORE_MARKER_TEXT = "— restored from previous session —";
+
+const ANSI_ESCAPE_RE =
+  // OSC, CSI, and common one-character escape sequences.
+  /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-_]/g;
+
+const LINE_RE = /[^\r\n]*(?:\r\n|\n|\r|$)/g;
+
+function stripAnsi(input: string): string {
+  return input.replace(ANSI_ESCAPE_RE, "");
+}
+
+function visibleLines(input: string): string[] {
+  return stripRestoreMarkers(input)
+    .replace(/\r/g, "\n")
+    .split("\n")
+    .map((line) => stripAnsi(line).trim())
+    .filter((line) => line.length > 0);
+}
+
+function isLikelyPromptOnlyLine(line: string): boolean {
+  if (/^[#$%>❯]\s*$/u.test(line)) return true;
+  return /^[\w.@:/~+\-()[\]]+(?:\s+[\w.@:/~+\-()[\]]+)*\s+[#$%>❯]\s*$/u.test(
+    line,
+  );
+}
+
+export function stripRestoreMarkers(input: string): string {
+  const chunks = input.match(LINE_RE) ?? [];
+  return chunks
+    .filter((chunk) => {
+      if (chunk.length === 0) return false;
+      return !stripAnsi(chunk).includes(RESTORE_MARKER_TEXT);
+    })
+    .join("");
+}
+
+export function shouldRestoreScrollback(input: string): boolean {
+  const lines = visibleLines(input);
+  if (lines.length === 0) return false;
+  return lines.some((line) => !isLikelyPromptOnlyLine(line));
+}
+
+export function prepareScrollbackForSave(input: string): string {
+  const withoutMarkers = stripRestoreMarkers(input);
+  return shouldRestoreScrollback(withoutMarkers) ? withoutMarkers : "";
+}


### PR DESCRIPTION
## Summary
- skip terminal scrollback restore when the saved buffer is only whitespace or a bare prompt
- strip Acorn restore separator lines before loading/saving scrollback
- add unit coverage for prompt-only and marker-cleanup cases

## Self-review
- checked against latest origin/main after resolving overlap with the terminal redraw/replay change
- confirmed the PR diff only includes the terminal scrollback change and excludes the pre-existing App.tsx whitespace edit

## Tests
- npm test -- src/lib/terminalScrollback.test.ts
- npm run typecheck
- npm test
- npm run build