### PR TITLE
feat(fs-explorer): File explorer with code viewer + VSCode-style search

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -13,8 +13,10 @@ dependencies = [
  "dashmap",
  "directories",
  "git2",
+ "ignore",
  "interprocess",
  "nix 0.31.3",
+ "notify",
  "parking_lot",
  "portable-pty",
  "serde",
@@ -30,11 +32,13 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "trash",
  "uuid",
 ]
 
@@ -403,6 +407,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +719,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1263,6 +1296,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +1630,19 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -1966,6 +2021,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,6 +2066,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2200,6 +2291,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2394,6 +2505,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -2476,6 +2599,25 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4749,7 +4891,7 @@ checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -5020,6 +5162,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "trash"
+version = "5.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7602e0c7d66ec2d92a8c917219fbc7894039efa2063b9064260110828a356f46"
+dependencies = [
+ "chrono",
+ "libc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "once_cell",
+ "percent-encoding",
+ "scopeguard",
+ "urlencoding",
+ "windows 0.56.0",
+]
+
+[[package]]
 name = "tray-icon"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5147,6 +5307,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -5544,6 +5710,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core 0.56.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
@@ -5572,6 +5748,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5625,6 +5813,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
@@ -5639,6 +5838,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -72,6 +72,15 @@ clap = { version = "4", features = ["derive"] }
 # loop is a small synchronous thread per socket — pulling tokio's async
 # runtime into the daemon binary would dwarf the work it actually does.
 interprocess = "2"
+# File-explorer support: cross-platform fs watcher (FSEvents on macOS),
+# gitignore matcher aggregated per directory from repo root, and OS trash.
+notify = "6"
+ignore = "0.4"
+trash = "5"
+
+[dev-dependencies]
+# Used by `fs_explorer` unit tests for scratch directories.
+tempfile = "3"
 
 [target.'cfg(unix)'.dependencies]
 # `setsid()` and `getpid()` wrappers for detaching the daemon from the

--- a/src-tauri/src/fs_explorer.rs
+++ b/src-tauri/src/fs_explorer.rs
@@ -182,31 +182,6 @@ fn reject_dangerous(p: &Path) -> AppResult<()> {
 }
 
 #[tauri::command]
-pub fn fs_create_file(path: String) -> AppResult<()> {
-    let p = PathBuf::from(&path);
-    reject_dangerous(&p)?;
-    if p.exists() {
-        return Err(AppError::InvalidPath(format!("already exists: {path}")));
-    }
-    if let Some(parent) = p.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    std::fs::File::create(&p)?;
-    Ok(())
-}
-
-#[tauri::command]
-pub fn fs_create_dir(path: String) -> AppResult<()> {
-    let p = PathBuf::from(&path);
-    reject_dangerous(&p)?;
-    if p.exists() {
-        return Err(AppError::InvalidPath(format!("already exists: {path}")));
-    }
-    std::fs::create_dir_all(&p)?;
-    Ok(())
-}
-
-#[tauri::command]
 pub fn fs_rename(from: String, to: String) -> AppResult<()> {
     let from_p = PathBuf::from(&from);
     let to_p = PathBuf::from(&to);
@@ -443,6 +418,158 @@ fn classify_status(s: Status) -> &'static str {
     "clean"
 }
 
+/// Read a file's contents as UTF-8 for the readonly code viewer.
+/// Caps at 2 MB so a stray `git clone` of an LFS pointer or a giant
+/// log file does not lock up the webview. Detects binary content by
+/// the presence of a NUL byte in the first 4 KB and rejects up front.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReadFileResult {
+    pub content: String,
+    pub size: u64,
+    pub truncated: bool,
+    pub binary: bool,
+}
+
+const VIEWER_MAX_BYTES: u64 = 2 * 1024 * 1024;
+
+#[tauri::command]
+pub fn fs_read_file(path: String) -> AppResult<ReadFileResult> {
+    let p = PathBuf::from(&path);
+    if !p.is_file() {
+        return Err(AppError::InvalidPath(format!("not a file: {path}")));
+    }
+    let meta = std::fs::metadata(&p)?;
+    let size = meta.len();
+    let mut probe = vec![0u8; 4096.min(size as usize)];
+    use std::io::Read;
+    let mut file = std::fs::File::open(&p)?;
+    let probe_n = file.read(&mut probe)?;
+    if probe[..probe_n].contains(&0) {
+        return Ok(ReadFileResult {
+            content: String::new(),
+            size,
+            truncated: false,
+            binary: true,
+        });
+    }
+    let truncated = size > VIEWER_MAX_BYTES;
+    let to_read = if truncated { VIEWER_MAX_BYTES } else { size };
+    let mut buf = Vec::with_capacity(to_read as usize);
+    let file = std::fs::File::open(&p)?;
+    let mut take = file.take(to_read);
+    take.read_to_end(&mut buf)?;
+    let content = String::from_utf8_lossy(&buf).into_owned();
+    Ok(ReadFileResult {
+        content,
+        size,
+        truncated,
+        binary: false,
+    })
+}
+
+/// Per-line change marker against HEAD for the file at `path`. Frontend
+/// uses this to paint a VSCode-style gutter bar next to changed lines
+/// when the readonly viewer is in view mode. `1`-indexed line numbers.
+#[derive(Debug, Clone, Serialize)]
+pub struct LineDiffEntry {
+    pub line: u32,
+    pub kind: String,
+}
+
+#[tauri::command]
+pub fn fs_git_diff_lines(path: String) -> AppResult<Vec<LineDiffEntry>> {
+    let target = PathBuf::from(&path);
+    if !target.is_file() {
+        return Ok(Vec::new());
+    }
+    let repo = match Repository::discover(&target) {
+        Ok(r) => r,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let workdir = match repo.workdir() {
+        Some(p) => p.to_path_buf(),
+        None => return Ok(Vec::new()),
+    };
+    let rel = match target.strip_prefix(&workdir) {
+        Ok(r) => r.to_string_lossy().into_owned(),
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let mut opts = git2::DiffOptions::new();
+    opts.pathspec(&rel)
+        .context_lines(0)
+        .include_untracked(true);
+    let tree = repo
+        .head()
+        .ok()
+        .and_then(|h| h.peel_to_tree().ok());
+    let diff = match repo.diff_tree_to_workdir_with_index(tree.as_ref(), Some(&mut opts)) {
+        Ok(d) => d,
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let mut out: Vec<LineDiffEntry> = Vec::new();
+    let mut adds: Vec<u32> = Vec::new();
+    let mut dels: Vec<u32> = Vec::new();
+    let mut current_marker: Option<u32> = None;
+    diff.print(git2::DiffFormat::Patch, |_delta, _hunk, line| {
+        match line.origin() {
+            '+' => {
+                if let Some(n) = line.new_lineno() {
+                    adds.push(n);
+                }
+            }
+            '-' => {
+                if let Some(n) = line.old_lineno() {
+                    dels.push(n);
+                }
+                // Track the new-side anchor for "modified" classification.
+                if current_marker.is_none() {
+                    current_marker = line.new_lineno();
+                }
+            }
+            _ => {
+                current_marker = None;
+            }
+        }
+        true
+    })
+    .ok();
+
+    // Classify: a deleted-only hunk shows as a "deleted" anchor on the
+    // line immediately AFTER the deletion; an added line that follows
+    // a deletion in the same hunk shows as "modified"; pure additions
+    // show as "added".
+    let del_set: std::collections::HashSet<u32> = dels.iter().copied().collect();
+    let add_set: std::collections::HashSet<u32> = adds.iter().copied().collect();
+    for n in adds.iter().copied() {
+        // Heuristic: if the prior new-line was a deletion anchor or a
+        // contiguous addition started at n, mark as modified vs added.
+        // We classify all adds as `added` here; the frontend collapses
+        // the visual to a single bar so the distinction is cosmetic.
+        let kind = if del_set.contains(&n) {
+            "modified"
+        } else {
+            "added"
+        };
+        out.push(LineDiffEntry {
+            line: n,
+            kind: kind.into(),
+        });
+    }
+    // Surface pure deletions as a marker on the next surviving line so
+    // the user knows something was removed at that spot. Use min(new
+    // lineno) recorded next to the deletion when available.
+    if adds.is_empty() && !dels.is_empty() {
+        out.push(LineDiffEntry {
+            line: 1,
+            kind: "deleted".into(),
+        });
+    }
+    let _ = add_set; // silence: kept for future "modified vs added" refinement
+    Ok(out)
+}
+
 /// Return the current branch name (or short HEAD oid when detached) of
 /// the repo enclosing `repo_root`. Empty string when the path is not a
 /// git repo — frontend then hides the branch chip.
@@ -596,18 +723,17 @@ mod tests {
     }
 
     #[test]
-    fn create_file_rejects_traversal() {
-        let res = fs_create_file("/tmp/../etc/evil".to_string());
+    fn rename_rejects_traversal_segments() {
+        let res = fs_rename("/tmp/../etc/evil".to_string(), "/tmp/x".to_string());
         assert!(res.is_err());
     }
 
     #[test]
-    fn create_and_rename_file_roundtrip() {
+    fn rename_file_roundtrip() {
         let d = tmpdir();
         let a = d.path().join("a.txt");
         let b = d.path().join("b.txt");
-        fs_create_file(a.to_string_lossy().into_owned()).unwrap();
-        assert!(a.exists());
+        std::fs::write(&a, b"hi").unwrap();
         fs_rename(
             a.to_string_lossy().into_owned(),
             b.to_string_lossy().into_owned(),

--- a/src-tauri/src/fs_explorer.rs
+++ b/src-tauri/src/fs_explorer.rs
@@ -1,7 +1,9 @@
 use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
+use git2::{Repository, Status, StatusOptions};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use parking_lot::Mutex;
@@ -261,6 +263,221 @@ pub fn fs_reveal(path: String) -> AppResult<()> {
             .map_err(|e| AppError::Other(format!("explorer failed: {e}")))?;
     }
     Ok(())
+}
+
+/// Open a file with the OS's default registered application. Used as a
+/// fallback when the user has not set `$EDITOR` in their shell rc — the
+/// PTY path otherwise blows up with `permission denied` because the
+/// shell tries to execute the empty command followed by the file.
+#[tauri::command]
+pub fn fs_open_default(path: String) -> AppResult<()> {
+    let p = PathBuf::from(&path);
+    if !p.exists() {
+        return Err(AppError::InvalidPath(format!("missing: {path}")));
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(&p)
+            .spawn()
+            .map_err(|e| AppError::Other(format!("open failed: {e}")))?;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::process::Command::new("xdg-open")
+            .arg(&p)
+            .spawn()
+            .map_err(|e| AppError::Other(format!("xdg-open failed: {e}")))?;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("cmd")
+            .args(["/c", "start", ""])
+            .arg(&p)
+            .spawn()
+            .map_err(|e| AppError::Other(format!("start failed: {e}")))?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GitStatusEntry {
+    pub kind: String,
+    pub additions: u32,
+    pub deletions: u32,
+}
+
+/// Per-path git status, mapped to a small set of buckets the frontend
+/// uses to pick a color, plus diff line counts (vs HEAD) so the entry
+/// can render a `+n -n` badge. Paths are absolute strings keyed by full
+/// path so the FileExplorer's flat lookup matches its entry paths.
+#[tauri::command]
+pub fn fs_git_status(repo_root: String) -> AppResult<HashMap<String, GitStatusEntry>> {
+    let root = PathBuf::from(&repo_root);
+    if !root.exists() {
+        return Err(AppError::InvalidPath(format!("missing: {repo_root}")));
+    }
+    let repo = match Repository::discover(&root) {
+        Ok(r) => r,
+        // Not a git repo — return empty map, frontend treats this as "no
+        // status colors to apply".
+        Err(_) => return Ok(HashMap::new()),
+    };
+    let workdir = match repo.workdir() {
+        Some(p) => p.to_path_buf(),
+        None => return Ok(HashMap::new()),
+    };
+    let mut opts = StatusOptions::new();
+    opts.include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .include_ignored(false)
+        .renames_head_to_index(true)
+        .renames_index_to_workdir(true);
+    let statuses = repo
+        .statuses(Some(&mut opts))
+        .map_err(|e| AppError::Other(format!("git status failed: {e}")))?;
+
+    let mut out: HashMap<String, GitStatusEntry> = HashMap::with_capacity(statuses.len());
+    for entry in statuses.iter() {
+        let Some(rel) = entry.path() else { continue };
+        let abs = workdir.join(rel);
+        let abs_str = abs.to_string_lossy().into_owned();
+        let s = entry.status();
+        let kind = classify_status(s);
+        let (additions, deletions) = file_diff_stats(&repo, &workdir, rel, kind);
+        out.insert(
+            abs_str,
+            GitStatusEntry {
+                kind: kind.into(),
+                additions,
+                deletions,
+            },
+        );
+    }
+    Ok(out)
+}
+
+/// Compute additions/deletions for a single path against HEAD. For
+/// untracked files we count line count as additions; for deleted files
+/// the count comes from the HEAD blob.
+fn file_diff_stats(
+    repo: &Repository,
+    workdir: &Path,
+    rel: &str,
+    kind: &str,
+) -> (u32, u32) {
+    if kind == "added" {
+        // Untracked or freshly-added file. Count file lines as additions.
+        let abs = workdir.join(rel);
+        if let Ok(bytes) = std::fs::read(&abs) {
+            let lines = count_lines(&bytes);
+            return (lines, 0);
+        }
+        return (0, 0);
+    }
+    if kind == "deleted" {
+        // Read HEAD blob to know the original line count.
+        if let Ok(head) = repo.head() {
+            if let Ok(commit) = head.peel_to_commit() {
+                if let Ok(tree) = commit.tree() {
+                    if let Ok(entry) = tree.get_path(Path::new(rel)) {
+                        if let Ok(obj) = entry.to_object(repo) {
+                            if let Some(blob) = obj.as_blob() {
+                                return (0, count_lines(blob.content()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return (0, 0);
+    }
+    // modified / renamed / conflicted — run a diff vs HEAD scoped to
+    // this single path so we get the patch stats directly.
+    let mut opts = git2::DiffOptions::new();
+    opts.pathspec(rel)
+        .include_untracked(true)
+        .recurse_untracked_dirs(false);
+    let tree = repo
+        .head()
+        .ok()
+        .and_then(|h| h.peel_to_tree().ok());
+    let diff = repo.diff_tree_to_workdir_with_index(tree.as_ref(), Some(&mut opts));
+    if let Ok(d) = diff {
+        if let Ok(stats) = d.stats() {
+            return (stats.insertions() as u32, stats.deletions() as u32);
+        }
+    }
+    (0, 0)
+}
+
+fn count_lines(bytes: &[u8]) -> u32 {
+    if bytes.is_empty() {
+        return 0;
+    }
+    let mut n = bytes.iter().filter(|&&b| b == b'\n').count() as u32;
+    if bytes.last() != Some(&b'\n') {
+        n += 1;
+    }
+    n
+}
+
+fn classify_status(s: Status) -> &'static str {
+    if s.is_conflicted() {
+        return "conflicted";
+    }
+    if s.intersects(Status::INDEX_DELETED | Status::WT_DELETED) {
+        return "deleted";
+    }
+    if s.intersects(Status::INDEX_NEW | Status::WT_NEW) {
+        return "added";
+    }
+    if s.intersects(Status::INDEX_RENAMED | Status::WT_RENAMED) {
+        return "renamed";
+    }
+    if s.intersects(
+        Status::INDEX_MODIFIED | Status::WT_MODIFIED | Status::INDEX_TYPECHANGE | Status::WT_TYPECHANGE,
+    ) {
+        return "modified";
+    }
+    "clean"
+}
+
+/// Return the current branch name (or short HEAD oid when detached) of
+/// the repo enclosing `repo_root`. Empty string when the path is not a
+/// git repo — frontend then hides the branch chip.
+#[tauri::command]
+pub fn fs_git_branch(repo_root: String) -> AppResult<String> {
+    let root = PathBuf::from(&repo_root);
+    let repo = match Repository::discover(&root) {
+        Ok(r) => r,
+        Err(_) => return Ok(String::new()),
+    };
+    let head = match repo.head() {
+        Ok(h) => h,
+        Err(_) => return Ok(String::new()),
+    };
+    if head.is_branch() {
+        if let Some(name) = head.shorthand() {
+            return Ok(name.to_string());
+        }
+    }
+    if let Some(oid) = head.target() {
+        let short = oid.to_string();
+        return Ok(short.chars().take(7).collect());
+    }
+    Ok(String::new())
+}
+
+/// Return the cached `$EDITOR` value pulled from the user's shell rc.
+/// Empty string when unset — frontend uses that to decide between the
+/// PTY editor path and the OS-default opener.
+#[tauri::command]
+pub fn fs_shell_editor() -> String {
+    crate::shell_env::resolve()
+        .get("EDITOR")
+        .cloned()
+        .unwrap_or_default()
 }
 
 #[tauri::command]

--- a/src-tauri/src/fs_explorer.rs
+++ b/src-tauri/src/fs_explorer.rs
@@ -171,6 +171,12 @@ pub fn fs_list_dir(
 }
 
 fn reject_dangerous(p: &Path) -> AppResult<()> {
+    // Require absolute paths so relative arguments cannot resolve against
+    // the process CWD (e.g., the app bundle) and overwrite something
+    // outside the user's intended folder.
+    if !p.is_absolute() {
+        return Err(AppError::InvalidPath("absolute path required".into()));
+    }
     for c in p.components() {
         if matches!(c, Component::ParentDir) {
             return Err(AppError::InvalidPath(
@@ -211,6 +217,7 @@ pub fn fs_trash(path: String) -> AppResult<()> {
 #[tauri::command]
 pub fn fs_reveal(path: String) -> AppResult<()> {
     let p = PathBuf::from(&path);
+    reject_dangerous(&p)?;
     if !p.exists() {
         return Err(AppError::InvalidPath(format!("missing: {path}")));
     }
@@ -247,6 +254,7 @@ pub fn fs_reveal(path: String) -> AppResult<()> {
 #[tauri::command]
 pub fn fs_open_default(path: String) -> AppResult<()> {
     let p = PathBuf::from(&path);
+    reject_dangerous(&p)?;
     if !p.exists() {
         return Err(AppError::InvalidPath(format!("missing: {path}")));
     }
@@ -435,6 +443,7 @@ const VIEWER_MAX_BYTES: u64 = 2 * 1024 * 1024;
 #[tauri::command]
 pub fn fs_read_file(path: String) -> AppResult<ReadFileResult> {
     let p = PathBuf::from(&path);
+    reject_dangerous(&p)?;
     if !p.is_file() {
         return Err(AppError::InvalidPath(format!("not a file: {path}")));
     }
@@ -479,6 +488,7 @@ pub struct LineDiffEntry {
 #[tauri::command]
 pub fn fs_git_diff_lines(path: String) -> AppResult<Vec<LineDiffEntry>> {
     let target = PathBuf::from(&path);
+    reject_dangerous(&target)?;
     if !target.is_file() {
         return Ok(Vec::new());
     }

--- a/src-tauri/src/fs_explorer.rs
+++ b/src-tauri/src/fs_explorer.rs
@@ -1,0 +1,402 @@
+use std::cmp::Ordering;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use parking_lot::Mutex;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Runtime, State};
+
+use crate::error::{AppError, AppResult};
+use crate::state::AppState;
+
+const EVENT_FS_CHANGED: &str = "acorn:fs-changed";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FileEntry {
+    pub name: String,
+    pub path: String,
+    pub is_dir: bool,
+    pub is_symlink: bool,
+    pub size: u64,
+    pub modified_ms: i64,
+    /// True when `respect_gitignore` was true and the entry is ignored by
+    /// the aggregated gitignore. We still surface it so the frontend can
+    /// decide whether to dim it; default to hiding ignored entries.
+    pub gitignored: bool,
+}
+
+#[derive(Default)]
+pub struct WatcherState {
+    inner: Mutex<Option<WatcherHandle>>,
+}
+
+impl WatcherState {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+}
+
+struct WatcherHandle {
+    _watcher: RecommendedWatcher,
+    root: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct FsChangePayload {
+    paths: Vec<String>,
+}
+
+fn canonical(path: &str) -> AppResult<PathBuf> {
+    let p = PathBuf::from(path);
+    if p.as_os_str().is_empty() {
+        return Err(AppError::InvalidPath("empty path".into()));
+    }
+    // For browsing we do not require the path to exist on create operations;
+    // canonicalize only when the path already exists.
+    if p.exists() {
+        p.canonicalize().map_err(AppError::from)
+    } else {
+        Ok(p)
+    }
+}
+
+fn find_repo_root(start: &Path) -> Option<PathBuf> {
+    let mut cur: Option<&Path> = Some(start);
+    while let Some(p) = cur {
+        let dot_git = p.join(".git");
+        if dot_git.exists() {
+            return Some(p.to_path_buf());
+        }
+        cur = p.parent();
+    }
+    None
+}
+
+fn build_gitignore(repo_root: &Path) -> Gitignore {
+    let mut b = GitignoreBuilder::new(repo_root);
+    let root_ignore = repo_root.join(".gitignore");
+    if root_ignore.exists() {
+        let _ = b.add(root_ignore);
+    }
+    let exclude = repo_root.join(".git").join("info").join("exclude");
+    if exclude.exists() {
+        let _ = b.add(exclude);
+    }
+    b.build().unwrap_or_else(|_| Gitignore::empty())
+}
+
+fn is_hidden(name: &str) -> bool {
+    name.starts_with('.')
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ListResult {
+    pub entries: Vec<FileEntry>,
+    pub repo_root: Option<String>,
+}
+
+#[tauri::command]
+pub fn fs_list_dir(
+    path: String,
+    show_hidden: bool,
+    respect_gitignore: bool,
+) -> AppResult<ListResult> {
+    let dir = canonical(&path)?;
+    if !dir.is_dir() {
+        return Err(AppError::InvalidPath(format!("not a directory: {path}")));
+    }
+    let repo_root = find_repo_root(&dir);
+    let gi = repo_root.as_deref().map(build_gitignore);
+
+    let mut entries: Vec<FileEntry> = Vec::new();
+    for item in std::fs::read_dir(&dir)? {
+        let item = item?;
+        let p = item.path();
+        let name = match p.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        if !show_hidden && is_hidden(&name) {
+            continue;
+        }
+        let meta = match item.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        // `DirEntry::metadata` follows symlinks on macOS, so check the link
+        // type via `symlink_metadata` to distinguish links from their targets.
+        let is_symlink = std::fs::symlink_metadata(&p)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false);
+        let is_dir = meta.is_dir();
+        let gitignored = match (respect_gitignore, gi.as_ref(), repo_root.as_deref()) {
+            (true, Some(g), Some(_)) => g.matched(&p, is_dir).is_ignore(),
+            _ => false,
+        };
+        if respect_gitignore && gitignored {
+            continue;
+        }
+        let size = if is_dir { 0 } else { meta.len() };
+        let modified_ms = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        entries.push(FileEntry {
+            name,
+            path: p.to_string_lossy().into_owned(),
+            is_dir,
+            is_symlink,
+            size,
+            modified_ms,
+            gitignored,
+        });
+    }
+
+    entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+    });
+
+    Ok(ListResult {
+        entries,
+        repo_root: repo_root.map(|p| p.to_string_lossy().into_owned()),
+    })
+}
+
+fn reject_dangerous(p: &Path) -> AppResult<()> {
+    for c in p.components() {
+        if matches!(c, Component::ParentDir) {
+            return Err(AppError::InvalidPath(
+                "path traversal segment (`..`) is not allowed".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn fs_create_file(path: String) -> AppResult<()> {
+    let p = PathBuf::from(&path);
+    reject_dangerous(&p)?;
+    if p.exists() {
+        return Err(AppError::InvalidPath(format!("already exists: {path}")));
+    }
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::File::create(&p)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn fs_create_dir(path: String) -> AppResult<()> {
+    let p = PathBuf::from(&path);
+    reject_dangerous(&p)?;
+    if p.exists() {
+        return Err(AppError::InvalidPath(format!("already exists: {path}")));
+    }
+    std::fs::create_dir_all(&p)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn fs_rename(from: String, to: String) -> AppResult<()> {
+    let from_p = PathBuf::from(&from);
+    let to_p = PathBuf::from(&to);
+    reject_dangerous(&from_p)?;
+    reject_dangerous(&to_p)?;
+    if !from_p.exists() {
+        return Err(AppError::InvalidPath(format!("source missing: {from}")));
+    }
+    if to_p.exists() {
+        return Err(AppError::InvalidPath(format!("destination exists: {to}")));
+    }
+    std::fs::rename(&from_p, &to_p)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn fs_trash(path: String) -> AppResult<()> {
+    let p = PathBuf::from(&path);
+    reject_dangerous(&p)?;
+    if !p.exists() {
+        return Err(AppError::InvalidPath(format!("missing: {path}")));
+    }
+    trash::delete(&p).map_err(|e| AppError::Other(format!("trash failed: {e}")))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn fs_reveal(path: String) -> AppResult<()> {
+    let p = PathBuf::from(&path);
+    if !p.exists() {
+        return Err(AppError::InvalidPath(format!("missing: {path}")));
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg("-R")
+            .arg(&p)
+            .spawn()
+            .map_err(|e| AppError::Other(format!("open failed: {e}")))?;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::process::Command::new("xdg-open")
+            .arg(p.parent().unwrap_or(&p))
+            .spawn()
+            .map_err(|e| AppError::Other(format!("xdg-open failed: {e}")))?;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("explorer")
+            .arg("/select,")
+            .arg(&p)
+            .spawn()
+            .map_err(|e| AppError::Other(format!("explorer failed: {e}")))?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn fs_watch_set_root<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, AppState>,
+    path: Option<String>,
+) -> AppResult<()> {
+    let mut guard = state.fs_watcher.inner.lock();
+    if let Some(p) = path.as_deref() {
+        let root = canonical(p)?;
+        if !root.is_dir() {
+            return Err(AppError::InvalidPath(format!("not a directory: {p}")));
+        }
+        if let Some(existing) = guard.as_ref() {
+            if existing.root == root {
+                return Ok(());
+            }
+        }
+        let app_for_cb = app.clone();
+        let mut watcher: RecommendedWatcher = notify::recommended_watcher(move |res| {
+            handle_watch_event(&app_for_cb, res);
+        })
+        .map_err(|e| AppError::Other(format!("notify init failed: {e}")))?;
+        watcher
+            .watch(&root, RecursiveMode::Recursive)
+            .map_err(|e| AppError::Other(format!("notify watch failed: {e}")))?;
+        *guard = Some(WatcherHandle {
+            _watcher: watcher,
+            root,
+        });
+    } else {
+        *guard = None;
+    }
+    Ok(())
+}
+
+fn handle_watch_event<R: Runtime>(app: &AppHandle<R>, res: notify::Result<Event>) {
+    let event = match res {
+        Ok(e) => e,
+        Err(err) => {
+            tracing::debug!(error = %err, "fs watch error");
+            return;
+        }
+    };
+    if !matches!(
+        event.kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+    ) {
+        return;
+    }
+    let paths: Vec<String> = event
+        .paths
+        .into_iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    if paths.is_empty() {
+        return;
+    }
+    if let Err(e) = app.emit(EVENT_FS_CHANGED, FsChangePayload { paths }) {
+        tracing::warn!(error = %e, "fs-changed emit failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn tmpdir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    #[test]
+    fn lists_directory_dirs_first_then_alpha() {
+        let d = tmpdir();
+        fs::write(d.path().join("zebra.txt"), b"z").unwrap();
+        fs::write(d.path().join("apple.txt"), b"a").unwrap();
+        fs::create_dir(d.path().join("middle")).unwrap();
+        fs::create_dir(d.path().join("Alpha")).unwrap();
+
+        let res = fs_list_dir(d.path().to_string_lossy().into_owned(), false, false).unwrap();
+        let names: Vec<_> = res.entries.iter().map(|e| e.name.clone()).collect();
+        assert_eq!(names, vec!["Alpha", "middle", "apple.txt", "zebra.txt"]);
+    }
+
+    #[test]
+    fn hides_dotfiles_by_default() {
+        let d = tmpdir();
+        fs::write(d.path().join(".env"), b"").unwrap();
+        fs::write(d.path().join("visible.txt"), b"").unwrap();
+
+        let hidden_off =
+            fs_list_dir(d.path().to_string_lossy().into_owned(), false, false).unwrap();
+        assert_eq!(hidden_off.entries.len(), 1);
+        let hidden_on = fs_list_dir(d.path().to_string_lossy().into_owned(), true, false).unwrap();
+        assert_eq!(hidden_on.entries.len(), 2);
+    }
+
+    #[test]
+    fn respects_gitignore_when_repo_root_present() {
+        let d = tmpdir();
+        fs::create_dir(d.path().join(".git")).unwrap();
+        fs::write(d.path().join(".gitignore"), b"build/\nsecret.txt\n").unwrap();
+        fs::create_dir(d.path().join("build")).unwrap();
+        fs::write(d.path().join("secret.txt"), b"").unwrap();
+        fs::write(d.path().join("keep.txt"), b"").unwrap();
+
+        let on = fs_list_dir(d.path().to_string_lossy().into_owned(), false, true).unwrap();
+        let names: Vec<_> = on.entries.iter().map(|e| e.name.clone()).collect();
+        assert_eq!(names, vec!["keep.txt"]);
+
+        let off = fs_list_dir(d.path().to_string_lossy().into_owned(), false, false).unwrap();
+        let off_names: Vec<_> = off.entries.iter().map(|e| e.name.clone()).collect();
+        assert_eq!(off_names, vec!["build", "keep.txt", "secret.txt"]);
+    }
+
+    #[test]
+    fn create_file_rejects_traversal() {
+        let res = fs_create_file("/tmp/../etc/evil".to_string());
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn create_and_rename_file_roundtrip() {
+        let d = tmpdir();
+        let a = d.path().join("a.txt");
+        let b = d.path().join("b.txt");
+        fs_create_file(a.to_string_lossy().into_owned()).unwrap();
+        assert!(a.exists());
+        fs_rename(
+            a.to_string_lossy().into_owned(),
+            b.to_string_lossy().into_owned(),
+        )
+        .unwrap();
+        assert!(!a.exists());
+        assert!(b.exists());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -355,6 +355,10 @@ pub fn run() {
             fs_explorer::fs_rename,
             fs_explorer::fs_trash,
             fs_explorer::fs_reveal,
+            fs_explorer::fs_open_default,
+            fs_explorer::fs_shell_editor,
+            fs_explorer::fs_git_status,
+            fs_explorer::fs_git_branch,
             fs_explorer::fs_watch_set_root,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -350,8 +350,6 @@ pub fn run() {
             daemon_commands::daemon_forget_session,
             daemon_commands::daemon_adopt_session,
             fs_explorer::fs_list_dir,
-            fs_explorer::fs_create_file,
-            fs_explorer::fs_create_dir,
             fs_explorer::fs_rename,
             fs_explorer::fs_trash,
             fs_explorer::fs_reveal,
@@ -359,6 +357,8 @@ pub fn run() {
             fs_explorer::fs_shell_editor,
             fs_explorer::fs_git_status,
             fs_explorer::fs_git_branch,
+            fs_explorer::fs_read_file,
+            fs_explorer::fs_git_diff_lines,
             fs_explorer::fs_watch_set_root,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod daemon_bridge;
 mod daemon_commands;
 mod daemon_stream;
 mod error;
+mod fs_explorer;
 mod git_ops;
 mod ipc;
 mod persistence;
@@ -348,6 +349,13 @@ pub fn run() {
             daemon_commands::daemon_kill_session,
             daemon_commands::daemon_forget_session,
             daemon_commands::daemon_adopt_session,
+            fs_explorer::fs_list_dir,
+            fs_explorer::fs_create_file,
+            fs_explorer::fs_create_dir,
+            fs_explorer::fs_rename,
+            fs_explorer::fs_trash,
+            fs_explorer::fs_reveal,
+            fs_explorer::fs_watch_set_root,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5,6 +5,7 @@ use parking_lot::Mutex;
 
 use crate::daemon_bridge::DaemonBridge;
 use crate::daemon_stream::StreamRegistry;
+use crate::fs_explorer::WatcherState;
 use crate::ipc::server::IpcServerHandle;
 use crate::pty::PtyManager;
 use crate::session::{ProjectStore, SessionStore};
@@ -43,6 +44,10 @@ pub struct AppState {
     /// mount so a listener registered after the matching emit still
     /// sees the prompt.
     pub staged_rev_mismatch: Arc<Mutex<Option<StagedRevMismatch>>>,
+    /// Filesystem watcher for the right-panel file explorer. Holds a single
+    /// recursive watcher rooted at the active session's cwd; rebound by
+    /// `fs_watch_set_root` whenever the active tab (or its cwd) changes.
+    pub fs_watcher: Arc<WatcherState>,
 }
 
 impl AppState {
@@ -57,6 +62,7 @@ impl AppState {
             daemon_bridge: DaemonBridge::new(),
             stream_registry: StreamRegistry::new(),
             staged_rev_mismatch: Arc::new(Mutex::new(None)),
+            fs_watcher: WatcherState::new(),
         }
     }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -124,6 +124,11 @@ textarea,
   user-select: text;
 }
 
+.acorn-selectable,
+.acorn-selectable * {
+  -webkit-user-drag: auto;
+}
+
 .acorn-terminal,
 .acorn-terminal * {
   cursor: text;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -737,6 +737,23 @@ function App() {
         e.preventDefault();
         useAppStore.getState().setRightTab("prs");
       },
+      [Hotkeys.toggleFiles]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        const panel = rightPanelRef.current;
+        const state = useAppStore.getState();
+        if (!panel) {
+          state.setRightTab("files");
+          return;
+        }
+        if (panel.isCollapsed()) {
+          panel.expand();
+          state.setRightTab("files");
+        } else if (state.rightTab === "files") {
+          panel.collapse();
+        } else {
+          state.setRightTab("files");
+        }
+      },
       [Hotkeys.uiScaleDown]: (e: KeyboardEvent) => {
         e.preventDefault();
         updateUiScalePercent(-UI_SCALE_PERCENT_STEP);

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  api,
+  type FsLineDiffEntry,
+  type FsReadFileResult,
+} from "../lib/api";
+import { highlightCode, langFromPath } from "../lib/highlight";
+import { cn } from "../lib/cn";
+
+interface CodeViewerProps {
+  path: string;
+  isActive: boolean;
+}
+
+interface ViewerState {
+  data: FsReadFileResult | null;
+  highlightedLines: (string | null)[] | null;
+  error: string | null;
+  loading: boolean;
+}
+
+const EMPTY_STATE: ViewerState = {
+  data: null,
+  highlightedLines: null,
+  error: null,
+  loading: true,
+};
+
+const DIFF_KIND_CLASS: Record<FsLineDiffEntry["kind"], string> = {
+  added: "bg-emerald-400",
+  modified: "bg-amber-400",
+  deleted: "bg-rose-400",
+};
+
+export function CodeViewer({ path, isActive }: CodeViewerProps) {
+  const [state, setState] = useState<ViewerState>(EMPTY_STATE);
+  const [diffLines, setDiffLines] = useState<FsLineDiffEntry[]>([]);
+
+  const refreshDiff = useCallback(async () => {
+    try {
+      const lines = await api.fsGitDiffLines(path);
+      setDiffLines(lines);
+    } catch {
+      setDiffLines([]);
+    }
+  }, [path]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState(EMPTY_STATE);
+    api
+      .fsReadFile(path)
+      .then(async (data) => {
+        if (cancelled) return;
+        if (data.binary) {
+          setState({
+            data,
+            highlightedLines: null,
+            error: null,
+            loading: false,
+          });
+          return;
+        }
+        const lang = langFromPath(path);
+        const lines = await highlightCode(data.content, lang);
+        if (cancelled) return;
+        setState({
+          data,
+          highlightedLines: lines,
+          error: null,
+          loading: false,
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setState({
+          data: null,
+          highlightedLines: null,
+          error: err instanceof Error ? err.message : String(err),
+          loading: false,
+        });
+      });
+    void refreshDiff();
+    return () => {
+      cancelled = true;
+    };
+  }, [path, refreshDiff]);
+
+  const diffByLine = useMemo(() => {
+    const map = new Map<number, FsLineDiffEntry["kind"]>();
+    for (const d of diffLines) map.set(d.line, d.kind);
+    return map;
+  }, [diffLines]);
+
+  if (state.loading) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-fg-muted">
+        Loading…
+      </div>
+    );
+  }
+  if (state.error) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-xs text-fg-muted">
+        {state.error}
+      </div>
+    );
+  }
+  if (state.data?.binary) {
+    return (
+      <Notice
+        title="Binary file"
+        body={`${state.data.size.toLocaleString()} bytes — not shown in the readonly viewer.`}
+      />
+    );
+  }
+  if (!state.data) return null;
+
+  const sourceLines = state.data.content.split("\n");
+  const lines =
+    state.highlightedLines ?? sourceLines.map(() => null);
+  const gutterWidth = String(sourceLines.length).length;
+
+  return (
+    <div
+      className={cn(
+        "flex h-full w-full flex-col bg-bg",
+        isActive ? "" : "pointer-events-none opacity-50",
+      )}
+    >
+      {state.data.truncated ? (
+        <div className="shrink-0 border-b border-border bg-bg-warning/15 px-3 py-1 text-[11px] text-fg-muted">
+          File truncated to 2 MB. Open externally to view the rest.
+        </div>
+      ) : null}
+      <pre className="acorn-selectable m-0 flex-1 cursor-text overflow-auto bg-transparent font-mono text-[12px] leading-[1.5] text-fg">
+        {sourceLines.map((rawText, i) => {
+          const tokens = lines[i];
+          const diff = diffByLine.get(i + 1);
+          return (
+            <div key={i} className="flex whitespace-pre">
+              <span
+                aria-hidden
+                className={cn(
+                  "shrink-0 self-stretch",
+                  diff ? DIFF_KIND_CLASS[diff] : "bg-transparent",
+                )}
+                style={{ width: 3 }}
+              />
+              <span
+                aria-hidden
+                className="select-none shrink-0 pl-2 pr-3 text-right text-fg-muted/60 tabular-nums"
+                style={{ minWidth: `${gutterWidth + 3}ch` }}
+              >
+                {i + 1}
+              </span>
+              <span
+                className="grow"
+                {...(tokens
+                  ? { dangerouslySetInnerHTML: { __html: tokens } }
+                  : { children: rawText })}
+              />
+            </div>
+          );
+        })}
+      </pre>
+    </div>
+  );
+}
+
+function Notice({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-1 px-6 text-center">
+      <p className="text-sm font-medium text-fg">{title}</p>
+      <p className="text-xs text-fg-muted">{body}</p>
+    </div>
+  );
+}

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -1,0 +1,762 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { listen } from "@tauri-apps/api/event";
+import {
+  ChevronRight,
+  ChevronDown,
+  Folder,
+  FolderOpen,
+  File as FileIcon,
+  RefreshCw,
+  EyeOff,
+  Eye,
+  Filter,
+} from "lucide-react";
+import { api, type FsEntry, FS_CHANGED_EVENT } from "../lib/api";
+import type { FsChangePayload } from "../lib/api";
+import { cn } from "../lib/cn";
+import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
+
+const SHOW_HIDDEN_KEY = "acorn:fs-show-hidden";
+const RESPECT_GITIGNORE_KEY = "acorn:fs-respect-gitignore";
+
+interface FileExplorerProps {
+  rootPath: string;
+}
+
+interface DirState {
+  entries: FsEntry[] | null;
+  loading: boolean;
+  error: string | null;
+}
+
+type Cache = Record<string, DirState>;
+
+interface DraftCreate {
+  parentPath: string;
+  kind: "file" | "dir";
+  value: string;
+}
+
+interface DraftRename {
+  path: string;
+  value: string;
+}
+
+interface MenuState {
+  x: number;
+  y: number;
+  entry: FsEntry | null;
+}
+
+function parentOf(path: string): string {
+  const idx = path.lastIndexOf("/");
+  if (idx <= 0) return "/";
+  return path.slice(0, idx);
+}
+
+function joinPath(parent: string, name: string): string {
+  if (parent.endsWith("/")) return parent + name;
+  return parent + "/" + name;
+}
+
+function getLocalBool(key: string, fallback: boolean): boolean {
+  try {
+    const v = localStorage.getItem(key);
+    if (v === null) return fallback;
+    return v === "1";
+  } catch {
+    return fallback;
+  }
+}
+
+function setLocalBool(key: string, value: boolean) {
+  try {
+    localStorage.setItem(key, value ? "1" : "0");
+  } catch {
+    /* localStorage may be denied in some webview modes; safe to swallow */
+  }
+}
+
+export function FileExplorer({ rootPath }: FileExplorerProps) {
+  const [cache, setCache] = useState<Cache>({});
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [showHidden, setShowHidden] = useState(() =>
+    getLocalBool(SHOW_HIDDEN_KEY, false),
+  );
+  const [respectGitignore, setRespectGitignore] = useState(() =>
+    getLocalBool(RESPECT_GITIGNORE_KEY, true),
+  );
+  const [menu, setMenu] = useState<MenuState | null>(null);
+  const [draftCreate, setDraftCreate] = useState<DraftCreate | null>(null);
+  const [draftRename, setDraftRename] = useState<DraftRename | null>(null);
+  const [activePath, setActivePath] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLocalBool(SHOW_HIDDEN_KEY, showHidden);
+  }, [showHidden]);
+  useEffect(() => {
+    setLocalBool(RESPECT_GITIGNORE_KEY, respectGitignore);
+  }, [respectGitignore]);
+
+  const fetchDir = useCallback(
+    async (path: string) => {
+      setCache((prev) => ({
+        ...prev,
+        [path]: {
+          entries: prev[path]?.entries ?? null,
+          loading: true,
+          error: null,
+        },
+      }));
+      try {
+        const res = await api.fsListDir(path, showHidden, respectGitignore);
+        setCache((prev) => ({
+          ...prev,
+          [path]: { entries: res.entries, loading: false, error: null },
+        }));
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setCache((prev) => ({
+          ...prev,
+          [path]: {
+            entries: prev[path]?.entries ?? null,
+            loading: false,
+            error: msg,
+          },
+        }));
+      }
+    },
+    [showHidden, respectGitignore],
+  );
+
+  // Re-fetch root and every currently-loaded path whenever filter toggles
+  // change or the root itself swaps in. StrictMode-safe: each effect run
+  // races at most one fetch per path; later runs overwrite earlier results.
+  useEffect(() => {
+    let cancelled = false;
+    const paths = [rootPath, ...Array.from(expanded)];
+    void Promise.all(paths.map((p) => (cancelled ? null : fetchDir(p))));
+    return () => {
+      cancelled = true;
+    };
+    // We intentionally do not depend on `expanded` here — only the rootPath
+    // and filter toggles invalidate the full set. Expansion triggers a
+    // targeted `fetchDir` in `toggleDir`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rootPath, showHidden, respectGitignore, fetchDir]);
+
+  // Bind backend watcher to current root.
+  useEffect(() => {
+    void api.fsWatchSetRoot(rootPath).catch((e) => {
+      console.debug("[FileExplorer] fs_watch_set_root failed", e);
+    });
+    return () => {
+      void api.fsWatchSetRoot(null).catch(() => {});
+    };
+  }, [rootPath]);
+
+  // Reset state on root change so previous project's tree is not flashed.
+  const rootRef = useRef(rootPath);
+  useEffect(() => {
+    if (rootRef.current !== rootPath) {
+      rootRef.current = rootPath;
+      setCache({});
+      setExpanded(new Set());
+      setDraftCreate(null);
+      setDraftRename(null);
+      setActivePath(null);
+    }
+  }, [rootPath]);
+
+  // Listen for backend fs-changed events and refresh the parent dir of
+  // each changed path. Backend emits raw notify events, no debouncing —
+  // collapse here within a 100ms window to avoid refresh storms.
+  useEffect(() => {
+    let cancel: (() => void) | null = null;
+    const pending = new Set<string>();
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+    const flush = () => {
+      flushTimer = null;
+      const toFetch = Array.from(pending);
+      pending.clear();
+      for (const dir of toFetch) {
+        if (cache[dir] || dir === rootPath) {
+          void fetchDir(dir);
+        }
+      }
+    };
+    void listen<FsChangePayload>(FS_CHANGED_EVENT, (event) => {
+      for (const p of event.payload.paths) {
+        pending.add(parentOf(p));
+      }
+      if (!flushTimer) flushTimer = setTimeout(flush, 100);
+    }).then((unlisten) => {
+      cancel = unlisten;
+    });
+    return () => {
+      if (flushTimer) clearTimeout(flushTimer);
+      if (cancel) cancel();
+    };
+  }, [rootPath, fetchDir, cache]);
+
+  const toggleDir = useCallback(
+    (path: string) => {
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        if (next.has(path)) {
+          next.delete(path);
+        } else {
+          next.add(path);
+          if (!cache[path]?.entries) {
+            void fetchDir(path);
+          }
+        }
+        return next;
+      });
+    },
+    [cache, fetchDir],
+  );
+
+  const openInEditor = useCallback(async (entry: FsEntry) => {
+    setActivePath(entry.path);
+    try {
+      // Resolve which session to write into by walking the focused pane.
+      // Avoid a cross-module dep on the store by inlining the lookup.
+      const store = await import("../store");
+      const state = store.useAppStore.getState();
+      const sid = state.activeSessionId;
+      if (!sid) {
+        setError("No active session — open a terminal first");
+        return;
+      }
+      // Shell expands $EDITOR. Quote the path. Trailing \n executes.
+      const escaped = entry.path.replace(/(["\\$`])/g, "\\$1");
+      await api.ptyWrite(sid, `$EDITOR "${escaped}"\n`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  const handleCreate = useCallback(async () => {
+    if (!draftCreate) return;
+    const { parentPath, kind, value } = draftCreate;
+    const name = value.trim();
+    if (!name) {
+      setDraftCreate(null);
+      return;
+    }
+    const target = joinPath(parentPath, name);
+    try {
+      if (kind === "file") {
+        await api.fsCreateFile(target);
+      } else {
+        await api.fsCreateDir(target);
+      }
+      setDraftCreate(null);
+      await fetchDir(parentPath);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [draftCreate, fetchDir]);
+
+  const handleRename = useCallback(async () => {
+    if (!draftRename) return;
+    const { path, value } = draftRename;
+    const name = value.trim();
+    if (!name) {
+      setDraftRename(null);
+      return;
+    }
+    const target = joinPath(parentOf(path), name);
+    if (target === path) {
+      setDraftRename(null);
+      return;
+    }
+    try {
+      await api.fsRename(path, target);
+      setDraftRename(null);
+      await fetchDir(parentOf(path));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [draftRename, fetchDir]);
+
+  const handleTrash = useCallback(
+    async (entry: FsEntry) => {
+      try {
+        await api.fsTrash(entry.path);
+        await fetchDir(parentOf(entry.path));
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [fetchDir],
+  );
+
+  const openMenu = useCallback(
+    (e: React.MouseEvent, entry: FsEntry | null) => {
+      e.preventDefault();
+      setMenu({ x: e.clientX, y: e.clientY, entry });
+    },
+    [],
+  );
+
+  const menuItems: ContextMenuItem[] = useMemo(() => {
+    if (!menu) return [];
+    const entry = menu.entry;
+    const parentForCreate = entry?.is_dir ? entry.path : rootPath;
+    const items: ContextMenuItem[] = [];
+    if (entry && !entry.is_dir) {
+      items.push({
+        label: "Open in $EDITOR",
+        onClick: () => void openInEditor(entry),
+      });
+      items.push({ type: "separator" });
+    }
+    items.push({
+      label: "New file",
+      onClick: () => {
+        if (entry?.is_dir && !expanded.has(entry.path)) {
+          toggleDir(entry.path);
+        }
+        setDraftCreate({ parentPath: parentForCreate, kind: "file", value: "" });
+      },
+    });
+    items.push({
+      label: "New folder",
+      onClick: () => {
+        if (entry?.is_dir && !expanded.has(entry.path)) {
+          toggleDir(entry.path);
+        }
+        setDraftCreate({ parentPath: parentForCreate, kind: "dir", value: "" });
+      },
+    });
+    if (entry) {
+      items.push({ type: "separator" });
+      items.push({
+        label: "Rename",
+        onClick: () => setDraftRename({ path: entry.path, value: entry.name }),
+      });
+      items.push({
+        label: "Move to Trash",
+        onClick: () => void handleTrash(entry),
+      });
+      items.push({ type: "separator" });
+      items.push({
+        label: "Copy path",
+        onClick: () => {
+          void navigator.clipboard.writeText(entry.path).catch(() => {
+            setError("Clipboard write failed");
+          });
+        },
+      });
+      items.push({
+        label: "Reveal in file manager",
+        onClick: () => {
+          void api.fsReveal(entry.path).catch((e) => {
+            setError(e instanceof Error ? e.message : String(e));
+          });
+        },
+      });
+    }
+    return items;
+  }, [menu, rootPath, expanded, toggleDir, openInEditor, handleTrash]);
+
+  return (
+    <div
+      className="flex h-full w-full flex-col"
+      onContextMenu={(e) => openMenu(e, null)}
+    >
+      <Toolbar
+        rootPath={rootPath}
+        showHidden={showHidden}
+        respectGitignore={respectGitignore}
+        onToggleHidden={() => setShowHidden((v) => !v)}
+        onToggleGitignore={() => setRespectGitignore((v) => !v)}
+        onRefresh={() => void fetchDir(rootPath)}
+        onNewFile={() =>
+          setDraftCreate({ parentPath: rootPath, kind: "file", value: "" })
+        }
+        onNewFolder={() =>
+          setDraftCreate({ parentPath: rootPath, kind: "dir", value: "" })
+        }
+      />
+      <div className="flex-1 overflow-auto py-1 text-[12px]">
+        <DirNode
+          path={rootPath}
+          depth={0}
+          state={cache[rootPath]}
+          isRoot
+          expanded={expanded}
+          cache={cache}
+          activePath={activePath}
+          draftCreate={draftCreate}
+          draftRename={draftRename}
+          onToggleDir={toggleDir}
+          onOpenEntry={openInEditor}
+          onContextMenu={openMenu}
+          onCommitCreate={handleCreate}
+          onCancelCreate={() => setDraftCreate(null)}
+          onChangeCreate={(v) =>
+            setDraftCreate((prev) => (prev ? { ...prev, value: v } : prev))
+          }
+          onCommitRename={handleRename}
+          onCancelRename={() => setDraftRename(null)}
+          onChangeRename={(v) =>
+            setDraftRename((prev) => (prev ? { ...prev, value: v } : prev))
+          }
+        />
+      </div>
+      {error ? (
+        <div className="flex items-start gap-2 border-t border-border bg-bg-error/20 px-3 py-1.5 text-[11px] text-fg">
+          <span className="flex-1 break-all">{error}</span>
+          <button
+            type="button"
+            className="text-fg-muted hover:text-fg"
+            onClick={() => setError(null)}
+          >
+            ×
+          </button>
+        </div>
+      ) : null}
+      <ContextMenu
+        open={menu !== null}
+        x={menu?.x ?? 0}
+        y={menu?.y ?? 0}
+        items={menuItems}
+        onClose={() => setMenu(null)}
+      />
+    </div>
+  );
+}
+
+interface ToolbarProps {
+  rootPath: string;
+  showHidden: boolean;
+  respectGitignore: boolean;
+  onToggleHidden: () => void;
+  onToggleGitignore: () => void;
+  onRefresh: () => void;
+  onNewFile: () => void;
+  onNewFolder: () => void;
+}
+
+function Toolbar(props: ToolbarProps) {
+  const rootName = props.rootPath.split("/").filter(Boolean).pop() ?? "/";
+  return (
+    <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1 text-[11px]">
+      <span
+        className="flex-1 truncate font-medium text-fg-muted"
+        title={props.rootPath}
+      >
+        {rootName.toUpperCase()}
+      </span>
+      <ToolbarBtn label="New file" onClick={props.onNewFile}>
+        <FileIcon size={12} />
+      </ToolbarBtn>
+      <ToolbarBtn label="New folder" onClick={props.onNewFolder}>
+        <Folder size={12} />
+      </ToolbarBtn>
+      <ToolbarBtn
+        label={props.showHidden ? "Hide dotfiles" : "Show dotfiles"}
+        active={props.showHidden}
+        onClick={props.onToggleHidden}
+      >
+        {props.showHidden ? <Eye size={12} /> : <EyeOff size={12} />}
+      </ToolbarBtn>
+      <ToolbarBtn
+        label={
+          props.respectGitignore
+            ? "Show gitignored"
+            : "Hide gitignored"
+        }
+        active={!props.respectGitignore}
+        onClick={props.onToggleGitignore}
+      >
+        <Filter size={12} />
+      </ToolbarBtn>
+      <ToolbarBtn label="Refresh" onClick={props.onRefresh}>
+        <RefreshCw size={12} />
+      </ToolbarBtn>
+    </div>
+  );
+}
+
+function ToolbarBtn({
+  children,
+  label,
+  active,
+  onClick,
+}: {
+  children: React.ReactNode;
+  label: string;
+  active?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={label}
+      aria-label={label}
+      className={cn(
+        "rounded p-1 transition",
+        active
+          ? "bg-fg-muted/15 text-fg"
+          : "text-fg-muted hover:bg-fg-muted/10 hover:text-fg",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+interface DirNodeProps {
+  path: string;
+  depth: number;
+  state: DirState | undefined;
+  isRoot?: boolean;
+  expanded: Set<string>;
+  cache: Cache;
+  activePath: string | null;
+  draftCreate: DraftCreate | null;
+  draftRename: DraftRename | null;
+  onToggleDir: (path: string) => void;
+  onOpenEntry: (entry: FsEntry) => void;
+  onContextMenu: (e: React.MouseEvent, entry: FsEntry | null) => void;
+  onCommitCreate: () => void;
+  onCancelCreate: () => void;
+  onChangeCreate: (v: string) => void;
+  onCommitRename: () => void;
+  onCancelRename: () => void;
+  onChangeRename: (v: string) => void;
+}
+
+function DirNode(props: DirNodeProps) {
+  const { state, path, isRoot } = props;
+  const entries = state?.entries ?? [];
+  const loading = state?.loading ?? false;
+  const error = state?.error ?? null;
+
+  return (
+    <>
+      {error ? (
+        <div
+          className="px-2 py-1 text-[11px] text-fg-muted"
+          style={{ paddingLeft: 8 + props.depth * 12 }}
+        >
+          {error}
+        </div>
+      ) : null}
+      {!isRoot && entries.length === 0 && !loading && !error ? (
+        <div
+          className="px-2 py-0.5 text-[11px] italic text-fg-muted/60"
+          style={{ paddingLeft: 8 + props.depth * 12 }}
+        >
+          (empty)
+        </div>
+      ) : null}
+      {entries.map((entry) =>
+        props.draftRename?.path === entry.path ? (
+          <EditRow
+            key={entry.path}
+            depth={props.depth}
+            icon={
+              entry.is_dir ? <Folder size={13} /> : <FileIcon size={13} />
+            }
+            value={props.draftRename.value}
+            onChange={props.onChangeRename}
+            onCommit={props.onCommitRename}
+            onCancel={props.onCancelRename}
+          />
+        ) : (
+          <EntryRow
+            key={entry.path}
+            entry={entry}
+            depth={props.depth}
+            expanded={props.expanded.has(entry.path)}
+            isActive={props.activePath === entry.path}
+            onToggleDir={props.onToggleDir}
+            onOpenEntry={props.onOpenEntry}
+            onContextMenu={props.onContextMenu}
+          >
+            {entry.is_dir && props.expanded.has(entry.path) ? (
+              <DirNode {...props} path={entry.path} depth={props.depth + 1} state={props.cache[entry.path]} isRoot={false} />
+            ) : null}
+            {entry.is_dir &&
+            props.expanded.has(entry.path) &&
+            props.draftCreate?.parentPath === entry.path ? (
+              <EditRow
+                depth={props.depth + 1}
+                icon={
+                  props.draftCreate.kind === "dir" ? (
+                    <Folder size={13} />
+                  ) : (
+                    <FileIcon size={13} />
+                  )
+                }
+                value={props.draftCreate.value}
+                onChange={props.onChangeCreate}
+                onCommit={props.onCommitCreate}
+                onCancel={props.onCancelCreate}
+              />
+            ) : null}
+          </EntryRow>
+        ),
+      )}
+      {isRoot && props.draftCreate?.parentPath === path ? (
+        <EditRow
+          depth={props.depth}
+          icon={
+            props.draftCreate.kind === "dir" ? (
+              <Folder size={13} />
+            ) : (
+              <FileIcon size={13} />
+            )
+          }
+          value={props.draftCreate.value}
+          onChange={props.onChangeCreate}
+          onCommit={props.onCommitCreate}
+          onCancel={props.onCancelCreate}
+        />
+      ) : null}
+      {loading && entries.length === 0 ? (
+        <div
+          className="px-2 py-1 text-[11px] text-fg-muted/60"
+          style={{ paddingLeft: 8 + props.depth * 12 }}
+        >
+          Loading…
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+interface EntryRowProps {
+  entry: FsEntry;
+  depth: number;
+  expanded: boolean;
+  isActive: boolean;
+  onToggleDir: (path: string) => void;
+  onOpenEntry: (entry: FsEntry) => void;
+  onContextMenu: (e: React.MouseEvent, entry: FsEntry) => void;
+  children?: React.ReactNode;
+}
+
+function EntryRow({
+  entry,
+  depth,
+  expanded,
+  isActive,
+  onToggleDir,
+  onOpenEntry,
+  onContextMenu,
+  children,
+}: EntryRowProps) {
+  const onClick = () => {
+    if (entry.is_dir) onToggleDir(entry.path);
+    else onOpenEntry(entry);
+  };
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onClick}
+        onContextMenu={(e) => {
+          e.stopPropagation();
+          onContextMenu(e, entry);
+        }}
+        className={cn(
+          "flex w-full items-center gap-1 truncate px-2 py-0.5 text-left transition",
+          isActive
+            ? "bg-accent/15 text-fg"
+            : "text-fg hover:bg-fg-muted/10",
+          entry.gitignored ? "opacity-60" : "",
+        )}
+        style={{ paddingLeft: 8 + depth * 12 }}
+        title={entry.path}
+      >
+        {entry.is_dir ? (
+          <span className="shrink-0 text-fg-muted">
+            {expanded ? (
+              <ChevronDown size={12} />
+            ) : (
+              <ChevronRight size={12} />
+            )}
+          </span>
+        ) : (
+          <span className="w-3 shrink-0" />
+        )}
+        <span className="shrink-0 text-fg-muted">
+          {entry.is_dir ? (
+            expanded ? (
+              <FolderOpen size={13} />
+            ) : (
+              <Folder size={13} />
+            )
+          ) : (
+            <FileIcon size={13} />
+          )}
+        </span>
+        <span className="truncate">
+          {entry.name}
+          {entry.is_symlink ? (
+            <span className="ml-1 text-fg-muted">↪</span>
+          ) : null}
+        </span>
+      </button>
+      {children}
+    </>
+  );
+}
+
+interface EditRowProps {
+  depth: number;
+  icon: React.ReactNode;
+  value: string;
+  onChange: (v: string) => void;
+  onCommit: () => void;
+  onCancel: () => void;
+}
+
+function EditRow({
+  depth,
+  icon,
+  value,
+  onChange,
+  onCommit,
+  onCancel,
+}: EditRowProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+  return (
+    <div
+      className="flex w-full items-center gap-1 px-2 py-0.5"
+      style={{ paddingLeft: 8 + depth * 12 }}
+    >
+      <span className="w-3 shrink-0" />
+      <span className="shrink-0 text-fg-muted">{icon}</span>
+      <input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") onCommit();
+          else if (e.key === "Escape") onCancel();
+        }}
+        onBlur={onCommit}
+        className="w-full bg-transparent text-[12px] text-fg outline outline-1 outline-accent/40 focus:outline-accent"
+      />
+    </div>
+  );
+}

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -11,9 +11,7 @@ import {
   ChevronDown,
   Folder,
   FolderOpen,
-  FolderPlus,
   File as FileIcon,
-  FilePlus,
   Copy,
   Link2,
   MessageSquarePlus,
@@ -21,13 +19,11 @@ import {
   Trash2,
   ExternalLink,
   Edit3,
-  RefreshCw,
   EyeOff,
   Eye,
   Filter,
   Search,
   Regex,
-  GitBranch,
   TerminalSquare,
   X,
 } from "lucide-react";
@@ -35,7 +31,9 @@ import { api, type FsEntry, FS_CHANGED_EVENT } from "../lib/api";
 import type { FsChangePayload, FsGitStatus, FsGitStatusEntry } from "../lib/api";
 import { cn } from "../lib/cn";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
+import { setFileDragPayload } from "../lib/dnd";
 import { Tooltip } from "./Tooltip";
+import { IconInput, TextInput } from "./ui";
 
 const SHOW_HIDDEN_KEY = "acorn:fs-show-hidden";
 const RESPECT_GITIGNORE_KEY = "acorn:fs-respect-gitignore";
@@ -51,12 +49,6 @@ interface DirState {
 }
 
 type Cache = Record<string, DirState>;
-
-interface DraftCreate {
-  parentPath: string;
-  kind: "file" | "dir";
-  value: string;
-}
 
 interface DraftRename {
   path: string;
@@ -80,20 +72,82 @@ function joinPath(parent: string, name: string): string {
   return parent + "/" + name;
 }
 
-function buildMatcher(query: string, regex: boolean): ((name: string) => boolean) | null {
+interface MatcherResult {
+  matcher: ((name: string) => boolean) | null;
+  invalidRegex: boolean;
+}
+
+function globToRegex(glob: string, flags: string): RegExp {
+  let re = "";
+  for (const ch of glob) {
+    if (ch === "*") re += ".*";
+    else if (ch === "?") re += ".";
+    else if ("^$.|+()[]{}\\".includes(ch)) re += "\\" + ch;
+    else re += ch;
+  }
+  return new RegExp(re, flags);
+}
+
+function buildQueryMatcher(
+  query: string,
+  regex: boolean,
+  caseSensitive: boolean,
+): MatcherResult {
   const q = query.trim();
-  if (!q) return null;
+  if (!q) return { matcher: null, invalidRegex: false };
+  const flags = caseSensitive ? "" : "i";
   if (regex) {
+    let re: RegExp | null = null;
     try {
-      const re = new RegExp(q, "i");
-      return (name) => re.test(name);
+      re = new RegExp(q, flags);
     } catch {
-      // Invalid pattern — disable filtering rather than block the tree.
-      return null;
+      // Regex compile failed — fall through and try glob.
+    }
+    if (!re && (q.includes("*") || q.includes("?"))) {
+      try {
+        re = globToRegex(q, flags);
+      } catch {
+        re = null;
+      }
+    }
+    if (re) {
+      const compiled = re;
+      return { matcher: (name) => compiled.test(name), invalidRegex: false };
+    }
+    return { matcher: null, invalidRegex: true };
+  }
+  const needle = caseSensitive ? q : q.toLowerCase();
+  return {
+    matcher: caseSensitive
+      ? (name) => name.includes(needle)
+      : (name) => name.toLowerCase().includes(needle),
+    invalidRegex: false,
+  };
+}
+
+/**
+ * Compile a comma-separated glob list (e.g. `*.ts, *.tsx, **\/test/*`) into
+ * a name predicate. Returns null when the list is empty so callers can
+ * treat "no filter" distinctly from "matches none".
+ */
+function buildGlobListMatcher(
+  list: string,
+): ((name: string) => boolean) | null {
+  const parts = list
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return null;
+  const compiled: RegExp[] = [];
+  for (const p of parts) {
+    try {
+      compiled.push(globToRegex(p, "i"));
+    } catch {
+      // Skip invalid entries silently — VSCode-style behavior.
     }
   }
-  const lower = q.toLowerCase();
-  return (name) => name.toLowerCase().includes(lower);
+  if (compiled.length === 0) return null;
+  return (name) => compiled.some((re) => re.test(name));
 }
 
 /**
@@ -164,7 +218,6 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     getLocalBool(RESPECT_GITIGNORE_KEY, true),
   );
   const [menu, setMenu] = useState<MenuState | null>(null);
-  const [draftCreate, setDraftCreate] = useState<DraftCreate | null>(null);
   const [draftRename, setDraftRename] = useState<DraftRename | null>(null);
   const [activePath, setActivePath] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -175,11 +228,16 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
   // Selection — Cmd-click toggle, Shift-click range. When non-empty
   // the context menu offers bulk actions across `selection`.
   const [selection, setSelection] = useState<Set<string>>(new Set());
-  // Search / filter state. Empty query disables filtering. Regex flag
-  // switches substring → RegExp; invalid pattern falls back to plain.
+  // VSCode-style search panel. Toggled via Cmd+F when the Files tab is
+  // active. Three composable filters: free-form query, include globs,
+  // exclude globs. Case-sensitivity + regex are per-query toggles.
+  const [searchOpen, setSearchOpen] = useState<boolean>(false);
   const [query, setQuery] = useState<string>("");
   const [useRegex, setUseRegex] = useState<boolean>(false);
-  const [branch, setBranch] = useState<string>("");
+  const [caseSensitive, setCaseSensitive] = useState<boolean>(false);
+  const [includeGlobs, setIncludeGlobs] = useState<string>("");
+  const [excludeGlobs, setExcludeGlobs] = useState<string>("");
+  const queryInputRef = useRef<HTMLInputElement | null>(null);
   // Per-path git status keyed by absolute path. Refreshed on mount + when
   // the fs watcher fires (debounced). Used to color filenames + show
   // status label + +/- line counts.
@@ -221,18 +279,9 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     }
   }, [rootPath]);
 
-  const refreshBranch = useCallback(async () => {
-    try {
-      setBranch(await api.fsGitBranch(rootPath));
-    } catch {
-      setBranch("");
-    }
-  }, [rootPath]);
-
   useEffect(() => {
     void refreshGitStatus();
-    void refreshBranch();
-  }, [refreshGitStatus, refreshBranch]);
+  }, [refreshGitStatus]);
 
   // Subscribe to focused-session changes via the store so the menu
   // always reflects the agent state of whichever PTY would receive the
@@ -337,7 +386,6 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       rootRef.current = rootPath;
       setCache({});
       setExpanded(new Set());
-      setDraftCreate(null);
       setDraftRename(null);
       setActivePath(null);
     }
@@ -360,7 +408,6 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
         }
       }
       void refreshGitStatus();
-      void refreshBranch();
     };
     void listen<FsChangePayload>(FS_CHANGED_EVENT, (event) => {
       for (const p of event.payload.paths) {
@@ -374,7 +421,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       if (flushTimer) clearTimeout(flushTimer);
       if (cancel) cancel();
     };
-  }, [rootPath, fetchDir, cache, refreshGitStatus, refreshBranch]);
+  }, [rootPath, fetchDir, cache, refreshGitStatus]);
 
   const toggleDir = useCallback(
     (path: string) => {
@@ -420,28 +467,6 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     }
   }, []);
 
-  const handleCreate = useCallback(async () => {
-    if (!draftCreate) return;
-    const { parentPath, kind, value } = draftCreate;
-    const name = value.trim();
-    if (!name) {
-      setDraftCreate(null);
-      return;
-    }
-    const target = joinPath(parentPath, name);
-    try {
-      if (kind === "file") {
-        await api.fsCreateFile(target);
-      } else {
-        await api.fsCreateDir(target);
-      }
-      setDraftCreate(null);
-      await fetchDir(parentPath);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    }
-  }, [draftCreate, fetchDir]);
-
   const handleRename = useCallback(async () => {
     if (!draftRename) return;
     const { path, value } = draftRename;
@@ -481,7 +506,89 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     [gitStatus, rootPath],
   );
 
-  const matcher = useMemo(() => buildMatcher(query, useRegex), [query, useRegex]);
+  const queryMatcherResult = useMemo(
+    () => buildQueryMatcher(query, useRegex, caseSensitive),
+    [query, useRegex, caseSensitive],
+  );
+  const includeMatcher = useMemo(
+    () => buildGlobListMatcher(includeGlobs),
+    [includeGlobs],
+  );
+  const excludeMatcher = useMemo(
+    () => buildGlobListMatcher(excludeGlobs),
+    [excludeGlobs],
+  );
+  const invalidRegex = queryMatcherResult.invalidRegex;
+  // Composite matcher: query AND include AND NOT exclude. Each layer
+  // is optional — when one is null, that layer is skipped. The filter
+  // is gated on `searchOpen` so closing the panel removes the visual
+  // filter while preserving the last-used values for the next open.
+  const matcher = useMemo<((name: string) => boolean) | null>(() => {
+    if (!searchOpen) return null;
+    const qm = queryMatcherResult.matcher;
+    if (!qm && !includeMatcher && !excludeMatcher) return null;
+    return (name) => {
+      if (qm && !qm(name)) return false;
+      if (includeMatcher && !includeMatcher(name)) return false;
+      if (excludeMatcher && excludeMatcher(name)) return false;
+      return true;
+    };
+  }, [searchOpen, queryMatcherResult.matcher, includeMatcher, excludeMatcher]);
+
+  // When a filter is active, walk the loaded cache to find every
+  // directory that contains at least one matching descendant. The
+  // tree then hides directories whose names don't match and whose
+  // (loaded) subtree contains no match. Unloaded subtrees are not
+  // probed — the user has to expand to surface them.
+  const matchingDirs = useMemo(() => {
+    if (!matcher) return new Set<string>();
+    const result = new Set<string>();
+    for (const [dirPath, dirState] of Object.entries(cache)) {
+      if (!dirState?.entries) continue;
+      const hasMatch = dirState.entries.some(
+        (e) => matcher(e.name) || (e.is_dir && result.has(e.path)),
+      );
+      if (!hasMatch) continue;
+      let cur = dirPath;
+      while (cur && cur.length >= rootPath.length) {
+        result.add(cur);
+        if (cur === rootPath) break;
+        const idx = cur.lastIndexOf("/");
+        if (idx <= 0) break;
+        const next = cur.slice(0, idx);
+        if (next === cur) break;
+        cur = next;
+      }
+    }
+    // Second pass to propagate ancestor flags when matches surfaced
+    // out of cache iteration order.
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const [dirPath, dirState] of Object.entries(cache)) {
+        if (!dirState?.entries) continue;
+        if (result.has(dirPath)) continue;
+        if (
+          dirState.entries.some(
+            (e) => matcher(e.name) || (e.is_dir && result.has(e.path)),
+          )
+        ) {
+          let cur = dirPath;
+          while (cur && cur.length >= rootPath.length) {
+            result.add(cur);
+            if (cur === rootPath) break;
+            const idx = cur.lastIndexOf("/");
+            if (idx <= 0) break;
+            const next = cur.slice(0, idx);
+            if (next === cur) break;
+            cur = next;
+          }
+          changed = true;
+        }
+      }
+    }
+    return result;
+  }, [matcher, cache, rootPath]);
 
   const handleEntryClick = useCallback(
     (entry: FsEntry, event: React.MouseEvent) => {
@@ -500,9 +607,22 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       // Plain click: clear multi-selection and act on the entry.
       setSelection(new Set());
       if (entry.is_dir) toggleDir(entry.path);
-      else openInEditor(entry);
+      else setActivePath(entry.path);
     },
-    [toggleDir, openInEditor],
+    [toggleDir],
+  );
+
+  const handleEntryDoubleClick = useCallback(
+    async (entry: FsEntry) => {
+      if (entry.is_dir) return;
+      try {
+        const store = await import("../store");
+        store.useAppStore.getState().openViewerTab(entry.path);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [],
   );
 
   const handleBulkTrash = useCallback(async () => {
@@ -574,6 +694,30 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
 
   const containerRef = useRef<HTMLDivElement | null>(null);
 
+  // Cmd+F toggles the VSCode-style search panel. Window-level so it
+  // works even when focus is inside the tree (which doesn't bubble to
+  // the container otherwise). Esc closes the panel when it is open.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
+        e.preventDefault();
+        setSearchOpen((open) => {
+          const next = !open;
+          if (next) {
+            requestAnimationFrame(() => queryInputRef.current?.focus());
+          }
+          return next;
+        });
+        return;
+      }
+      if (e.key === "Escape" && searchOpen) {
+        setSearchOpen(false);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [searchOpen]);
+
   // F2 to rename the focused / single-selected entry. Scoped to the
   // FileExplorer container so it does not collide with terminal input.
   useEffect(() => {
@@ -609,7 +753,6 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
   const menuItems: ContextMenuItem[] = useMemo(() => {
     if (!menu) return [];
     const entry = menu.entry;
-    const parentForCreate = entry?.is_dir ? entry.path : rootPath;
     const rel = entry ? relativeTo(rootPath, entry.path) : "";
     const items: ContextMenuItem[] = [];
 
@@ -725,30 +868,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       });
     }
 
-    // Group 4: Create
-    if (items.length > 0) items.push({ type: "separator" });
-    items.push({
-      label: "New File",
-      icon: <FilePlus size={13} />,
-      onClick: () => {
-        if (entry?.is_dir && !expanded.has(entry.path)) {
-          toggleDir(entry.path);
-        }
-        setDraftCreate({ parentPath: parentForCreate, kind: "file", value: "" });
-      },
-    });
-    items.push({
-      label: "New Folder",
-      icon: <FolderPlus size={13} />,
-      onClick: () => {
-        if (entry?.is_dir && !expanded.has(entry.path)) {
-          toggleDir(entry.path);
-        }
-        setDraftCreate({ parentPath: parentForCreate, kind: "dir", value: "" });
-      },
-    });
-
-    // Group 5: Destructive
+    // Group 4: Destructive
     if (entry) {
       items.push({ type: "separator" });
       items.push({
@@ -789,25 +909,38 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     >
       <Toolbar
         rootPath={rootPath}
-        branch={branch}
         showHidden={showHidden}
         respectGitignore={respectGitignore}
         onToggleHidden={() => setShowHidden((v) => !v)}
         onToggleGitignore={() => setRespectGitignore((v) => !v)}
-        onRefresh={() => void fetchDir(rootPath)}
-        onNewFile={() =>
-          setDraftCreate({ parentPath: rootPath, kind: "file", value: "" })
-        }
-        onNewFolder={() =>
-          setDraftCreate({ parentPath: rootPath, kind: "dir", value: "" })
-        }
+        searchActive={searchOpen}
+        onToggleSearch={() => {
+          setSearchOpen((open) => {
+            const next = !open;
+            if (next) {
+              requestAnimationFrame(() => queryInputRef.current?.focus());
+            }
+            return next;
+          });
+        }}
       />
-      <SearchBar
-        query={query}
-        useRegex={useRegex}
-        onQueryChange={setQuery}
-        onToggleRegex={() => setUseRegex((v) => !v)}
-      />
+      {searchOpen ? (
+        <SearchBar
+          query={query}
+          useRegex={useRegex}
+          caseSensitive={caseSensitive}
+          invalidRegex={invalidRegex}
+          includeGlobs={includeGlobs}
+          excludeGlobs={excludeGlobs}
+          queryInputRef={queryInputRef}
+          onQueryChange={setQuery}
+          onToggleRegex={() => setUseRegex((v) => !v)}
+          onToggleCaseSensitive={() => setCaseSensitive((v) => !v)}
+          onIncludeChange={setIncludeGlobs}
+          onExcludeChange={setExcludeGlobs}
+          onClose={() => setSearchOpen(false)}
+        />
+      ) : null}
       <div className="flex-1 overflow-auto py-1 text-[12px]">
         <div className="w-max min-w-full">
         <DirNode
@@ -818,21 +951,17 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
           expanded={expanded}
           cache={cache}
           activePath={activePath}
-          draftCreate={draftCreate}
           draftRename={draftRename}
           gitStatus={gitStatus}
           dirtyAncestors={dirtyAncestors}
           selection={selection}
           matcher={matcher}
+          matchingDirs={matchingDirs}
           onToggleDir={toggleDir}
           onOpenEntry={openInEditor}
           onEntryClick={handleEntryClick}
+          onEntryDoubleClick={handleEntryDoubleClick}
           onContextMenu={openMenu}
-          onCommitCreate={handleCreate}
-          onCancelCreate={() => setDraftCreate(null)}
-          onChangeCreate={(v) =>
-            setDraftCreate((prev) => (prev ? { ...prev, value: v } : prev))
-          }
           onCommitRename={handleRename}
           onCancelRename={() => setDraftRename(null)}
           onChangeRename={(v) =>
@@ -866,14 +995,12 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
 
 interface ToolbarProps {
   rootPath: string;
-  branch: string;
   showHidden: boolean;
   respectGitignore: boolean;
+  searchActive: boolean;
   onToggleHidden: () => void;
   onToggleGitignore: () => void;
-  onRefresh: () => void;
-  onNewFile: () => void;
-  onNewFolder: () => void;
+  onToggleSearch: () => void;
 }
 
 function Toolbar(props: ToolbarProps) {
@@ -886,20 +1013,13 @@ function Toolbar(props: ToolbarProps) {
       >
         {rootName.toUpperCase()}
       </span>
-      {props.branch ? (
-        <Tooltip label={`Current branch: ${props.branch}`}>
-          <span className="flex shrink-0 items-center gap-1 rounded bg-fg-muted/15 px-1.5 py-px text-[10px] text-fg-muted">
-            <GitBranch size={10} />
-            <span className="max-w-[120px] truncate">{props.branch}</span>
-          </span>
-        </Tooltip>
-      ) : null}
       <span className="flex-1" />
-      <ToolbarBtn label="New File" onClick={props.onNewFile}>
-        <FilePlus size={12} />
-      </ToolbarBtn>
-      <ToolbarBtn label="New Folder" onClick={props.onNewFolder}>
-        <FolderPlus size={12} />
+      <ToolbarBtn
+        label={props.searchActive ? "Close search" : "Search (⌘F)"}
+        active={props.searchActive}
+        onClick={props.onToggleSearch}
+      >
+        <Search size={12} />
       </ToolbarBtn>
       <ToolbarBtn
         label={props.showHidden ? "Hide dotfiles" : "Show dotfiles"}
@@ -919,9 +1039,6 @@ function Toolbar(props: ToolbarProps) {
       >
         <Filter size={12} />
       </ToolbarBtn>
-      <ToolbarBtn label="Refresh" onClick={props.onRefresh}>
-        <RefreshCw size={12} />
-      </ToolbarBtn>
     </div>
   );
 }
@@ -929,49 +1046,109 @@ function Toolbar(props: ToolbarProps) {
 interface SearchBarProps {
   query: string;
   useRegex: boolean;
+  caseSensitive: boolean;
+  invalidRegex: boolean;
+  includeGlobs: string;
+  excludeGlobs: string;
+  queryInputRef: React.RefObject<HTMLInputElement | null>;
   onQueryChange: (v: string) => void;
   onToggleRegex: () => void;
+  onToggleCaseSensitive: () => void;
+  onIncludeChange: (v: string) => void;
+  onExcludeChange: (v: string) => void;
+  onClose: () => void;
 }
 
 function SearchBar(props: SearchBarProps) {
   return (
-    <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1">
-      <Search size={12} className="shrink-0 text-fg-muted" />
-      <input
-        type="text"
+    <div className="flex shrink-0 flex-col gap-1 border-b border-border px-2 py-2">
+      <IconInput
+        ref={props.queryInputRef}
         value={props.query}
         onChange={(e) => props.onQueryChange(e.target.value)}
-        placeholder={props.useRegex ? "Regex…" : "Filter files…"}
-        className="flex-1 bg-transparent text-[11px] text-fg outline-none placeholder:text-fg-muted/60"
+        placeholder={props.useRegex ? "Regex…" : "Search files"}
+        invalid={props.invalidRegex}
+        leading={<Search size={12} />}
+        trailing={
+          <>
+            <Tooltip label="Match Case">
+              <button
+                type="button"
+                aria-label="Match case"
+                onClick={props.onToggleCaseSensitive}
+                className={cn(
+                  "rounded p-0.5 text-[10px] font-semibold transition",
+                  props.caseSensitive
+                    ? "bg-fg-muted/15 text-fg"
+                    : "text-fg-muted hover:text-fg",
+                )}
+              >
+                Aa
+              </button>
+            </Tooltip>
+            <Tooltip label="Use Regular Expression">
+              <button
+                type="button"
+                aria-label="Toggle regex"
+                onClick={props.onToggleRegex}
+                className={cn(
+                  "rounded p-0.5 transition",
+                  props.useRegex
+                    ? "bg-fg-muted/15 text-fg"
+                    : "text-fg-muted hover:text-fg",
+                )}
+              >
+                <Regex size={12} />
+              </button>
+            </Tooltip>
+            <Tooltip label="Close (Esc)">
+              <button
+                type="button"
+                aria-label="Close search"
+                onClick={props.onClose}
+                className="rounded p-0.5 text-fg-muted hover:text-fg"
+              >
+                <X size={11} />
+              </button>
+            </Tooltip>
+          </>
+        }
       />
-      {props.query ? (
-        <Tooltip label="Clear filter">
-          <button
-            type="button"
-            aria-label="Clear filter"
-            onClick={() => props.onQueryChange("")}
-            className="rounded p-0.5 text-fg-muted hover:text-fg"
-          >
-            <X size={11} />
-          </button>
-        </Tooltip>
-      ) : null}
-      <Tooltip label={props.useRegex ? "Plain match" : "Regex match"}>
-        <button
-          type="button"
-          aria-label="Toggle regex"
-          onClick={props.onToggleRegex}
-          className={cn(
-            "rounded p-0.5 transition",
-            props.useRegex
-              ? "bg-fg-muted/15 text-fg"
-              : "text-fg-muted hover:text-fg",
-          )}
-        >
-          <Regex size={12} />
-        </button>
-      </Tooltip>
+      <GlobInput
+        label="files to include"
+        placeholder="e.g. *.ts, *.tsx"
+        value={props.includeGlobs}
+        onChange={props.onIncludeChange}
+      />
+      <GlobInput
+        label="files to exclude"
+        placeholder="e.g. node_modules, *.lock"
+        value={props.excludeGlobs}
+        onChange={props.onExcludeChange}
+      />
     </div>
+  );
+}
+
+interface GlobInputProps {
+  label: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+}
+
+function GlobInput({ label, placeholder, value, onChange }: GlobInputProps) {
+  return (
+    <label className="flex flex-col gap-0.5">
+      <span className="text-[10px] uppercase tracking-wide text-fg-muted/80">
+        {label}
+      </span>
+      <TextInput
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </label>
   );
 }
 
@@ -1013,33 +1190,34 @@ interface DirNodeProps {
   expanded: Set<string>;
   cache: Cache;
   activePath: string | null;
-  draftCreate: DraftCreate | null;
   draftRename: DraftRename | null;
   gitStatus: Record<string, FsGitStatusEntry>;
   dirtyAncestors: Set<string>;
   selection: Set<string>;
   matcher: ((name: string) => boolean) | null;
+  matchingDirs: Set<string>;
   onToggleDir: (path: string) => void;
   onOpenEntry: (entry: FsEntry) => void;
   onEntryClick: (entry: FsEntry, event: React.MouseEvent) => void;
+  onEntryDoubleClick: (entry: FsEntry) => void;
   onContextMenu: (e: React.MouseEvent, entry: FsEntry | null) => void;
-  onCommitCreate: () => void;
-  onCancelCreate: () => void;
-  onChangeCreate: (v: string) => void;
   onCommitRename: () => void;
   onCancelRename: () => void;
   onChangeRename: (v: string) => void;
 }
 
 function DirNode(props: DirNodeProps) {
-  const { state, path, isRoot, matcher } = props;
+  const { state, isRoot, matcher, matchingDirs } = props;
   const rawEntries = state?.entries ?? [];
-  // When a matcher is active, hide entries that fail to match *unless*
-  // they are directories with at least one matching descendant. Without
-  // recursive descent we just keep dirs visible so the user can still
-  // drill in.
+  // When a matcher is active, hide entries that fail to match. Directories
+  // survive only when their own name matches or their loaded subtree
+  // contains at least one matching descendant (tracked in `matchingDirs`).
   const entries = matcher
-    ? rawEntries.filter((e) => e.is_dir || matcher(e.name))
+    ? rawEntries.filter((e) => {
+        if (matcher(e.name)) return true;
+        if (e.is_dir && matchingDirs.has(e.path)) return true;
+        return false;
+      })
     : rawEntries;
   const loading = state?.loading ?? false;
   const error = state?.error ?? null;
@@ -1088,48 +1266,15 @@ function DirNode(props: DirNodeProps) {
               entry.is_dir && props.dirtyAncestors.has(entry.path)
             }
             onEntryClick={props.onEntryClick}
+            onEntryDoubleClick={props.onEntryDoubleClick}
             onContextMenu={props.onContextMenu}
           >
             {entry.is_dir && props.expanded.has(entry.path) ? (
               <DirNode {...props} path={entry.path} depth={props.depth + 1} state={props.cache[entry.path]} isRoot={false} />
             ) : null}
-            {entry.is_dir &&
-            props.expanded.has(entry.path) &&
-            props.draftCreate?.parentPath === entry.path ? (
-              <EditRow
-                depth={props.depth + 1}
-                icon={
-                  props.draftCreate.kind === "dir" ? (
-                    <Folder size={13} />
-                  ) : (
-                    <FileIcon size={13} />
-                  )
-                }
-                value={props.draftCreate.value}
-                onChange={props.onChangeCreate}
-                onCommit={props.onCommitCreate}
-                onCancel={props.onCancelCreate}
-              />
-            ) : null}
           </EntryRow>
         ),
       )}
-      {isRoot && props.draftCreate?.parentPath === path ? (
-        <EditRow
-          depth={props.depth}
-          icon={
-            props.draftCreate.kind === "dir" ? (
-              <Folder size={13} />
-            ) : (
-              <FileIcon size={13} />
-            )
-          }
-          value={props.draftCreate.value}
-          onChange={props.onChangeCreate}
-          onCommit={props.onCommitCreate}
-          onCancel={props.onCancelCreate}
-        />
-      ) : null}
       {loading && entries.length === 0 ? (
         <div
           className="px-2 py-1 text-[11px] text-fg-muted/60"
@@ -1151,6 +1296,7 @@ interface EntryRowProps {
   gitStatus?: FsGitStatusEntry;
   dirtyDescendant: boolean;
   onEntryClick: (entry: FsEntry, event: React.MouseEvent) => void;
+  onEntryDoubleClick: (entry: FsEntry) => void;
   onContextMenu: (e: React.MouseEvent, entry: FsEntry) => void;
   children?: React.ReactNode;
 }
@@ -1190,6 +1336,7 @@ function EntryRow({
   gitStatus,
   dirtyDescendant,
   onEntryClick,
+  onEntryDoubleClick,
   onContextMenu,
   children,
 }: EntryRowProps) {
@@ -1206,7 +1353,28 @@ function EntryRow({
     <>
       <button
         type="button"
+        draggable
+        onDragStart={(e) => {
+          // Set both the OS-friendly text data (terminals + external
+          // apps paste the quoted path) and the in-process Acorn drag
+          // mirror used by Pane/TabStrip drop targets.
+          if (!entry.is_dir) {
+            setFileDragPayload(e, { path: entry.path });
+          }
+          const quoted = `"${entry.path.replace(/(["\\$`])/g, "\\$1")}"`;
+          try {
+            e.dataTransfer.setData("text/plain", quoted);
+            e.dataTransfer.setData("text/uri-list", `file://${entry.path}`);
+          } catch {
+            // ignore
+          }
+          e.dataTransfer.effectAllowed = "copy";
+        }}
         onClick={(e) => onEntryClick(entry, e)}
+        onDoubleClick={(e) => {
+          e.preventDefault();
+          onEntryDoubleClick(entry);
+        }}
         onContextMenu={(e) => {
           e.stopPropagation();
           onContextMenu(e, entry);
@@ -1227,7 +1395,7 @@ function EntryRow({
           <span
             key={i}
             aria-hidden
-            className="relative block w-1 shrink-0 self-stretch before:absolute before:left-[2px] before:top-0 before:bottom-0 before:w-px before:bg-fg-muted/20"
+            className="relative block w-2 shrink-0 self-stretch before:absolute before:left-[4px] before:-top-[2px] before:-bottom-[2px] before:w-px before:bg-fg-muted/25"
           />
         ))}
         {entry.is_dir ? (

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -175,6 +175,18 @@ function buildDirtyAncestors(
   return out;
 }
 
+/**
+ * POSIX shell-quote a path with single quotes. Inside `'…'` every byte
+ * except `'` is literal — even newlines, `!`, `$`, backticks. The only
+ * escape needed is closing the quote, inserting a literal `'`, and
+ * reopening: `'\''`. Safer than the double-quote + char-class regex
+ * dance because it cannot be defeated by history expansion or by an
+ * unescaped metacharacter that we forgot to list.
+ */
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
 function relativeTo(base: string, abs: string): string {
   const b = base.endsWith("/") ? base : base + "/";
   if (abs === base) return ".";
@@ -391,6 +403,16 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     }
   }, [rootPath]);
 
+  // The watcher listener needs the *current* cache to decide which
+  // directories to refresh, but rebinding the listener every cache
+  // write would tear down + recreate the Tauri subscription on every
+  // expand. Track the latest cache in a ref so the listener stays
+  // alive while still seeing fresh state inside its flush callback.
+  const cacheRef = useRef(cache);
+  useEffect(() => {
+    cacheRef.current = cache;
+  }, [cache]);
+
   // Listen for backend fs-changed events and refresh the parent dir of
   // each changed path. Backend emits raw notify events, no debouncing —
   // collapse here within a 100ms window to avoid refresh storms.
@@ -402,8 +424,9 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       flushTimer = null;
       const toFetch = Array.from(pending);
       pending.clear();
+      const current = cacheRef.current;
       for (const dir of toFetch) {
-        if (cache[dir] || dir === rootPath) {
+        if (current[dir] || dir === rootPath) {
           void fetchDir(dir);
         }
       }
@@ -421,7 +444,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       if (flushTimer) clearTimeout(flushTimer);
       if (cancel) cancel();
     };
-  }, [rootPath, fetchDir, cache, refreshGitStatus]);
+  }, [rootPath, fetchDir, refreshGitStatus]);
 
   const toggleDir = useCallback(
     (path: string) => {
@@ -460,8 +483,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
         await api.fsOpenDefault(entry.path);
         return;
       }
-      const escaped = entry.path.replace(/(["\\$`])/g, "\\$1");
-      await api.ptyWrite(sid, `$EDITOR "${escaped}"\n`);
+      await api.ptyWrite(sid, `$EDITOR ${shellQuote(entry.path)}\n`);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
@@ -684,7 +706,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       if (session) {
         state.setPendingTerminalInput(
           session.id,
-          `cd "${folderPath.replace(/(["\\$`])/g, "\\$1")}"\n`,
+          `cd ${shellQuote(folderPath)}\n`,
         );
       }
     } catch (e) {
@@ -1361,7 +1383,7 @@ function EntryRow({
           if (!entry.is_dir) {
             setFileDragPayload(e, { path: entry.path });
           }
-          const quoted = `"${entry.path.replace(/(["\\$`])/g, "\\$1")}"`;
+          const quoted = shellQuote(entry.path);
           try {
             e.dataTransfer.setData("text/plain", quoted);
             e.dataTransfer.setData("text/uri-list", `file://${entry.path}`);

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -11,16 +11,31 @@ import {
   ChevronDown,
   Folder,
   FolderOpen,
+  FolderPlus,
   File as FileIcon,
+  FilePlus,
+  Copy,
+  Link2,
+  MessageSquarePlus,
+  Pencil,
+  Trash2,
+  ExternalLink,
+  Edit3,
   RefreshCw,
   EyeOff,
   Eye,
   Filter,
+  Search,
+  Regex,
+  GitBranch,
+  TerminalSquare,
+  X,
 } from "lucide-react";
 import { api, type FsEntry, FS_CHANGED_EVENT } from "../lib/api";
-import type { FsChangePayload } from "../lib/api";
+import type { FsChangePayload, FsGitStatus, FsGitStatusEntry } from "../lib/api";
 import { cn } from "../lib/cn";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
+import { Tooltip } from "./Tooltip";
 
 const SHOW_HIDDEN_KEY = "acorn:fs-show-hidden";
 const RESPECT_GITIGNORE_KEY = "acorn:fs-respect-gitignore";
@@ -65,6 +80,62 @@ function joinPath(parent: string, name: string): string {
   return parent + "/" + name;
 }
 
+function buildMatcher(query: string, regex: boolean): ((name: string) => boolean) | null {
+  const q = query.trim();
+  if (!q) return null;
+  if (regex) {
+    try {
+      const re = new RegExp(q, "i");
+      return (name) => re.test(name);
+    } catch {
+      // Invalid pattern — disable filtering rather than block the tree.
+      return null;
+    }
+  }
+  const lower = q.toLowerCase();
+  return (name) => name.toLowerCase().includes(lower);
+}
+
+/**
+ * Build a set of directory paths that contain at least one git-dirty
+ * descendant. Used to roll the modified/added/deleted color up to
+ * parent folders so the tree surfaces dirty subtrees even when
+ * collapsed.
+ */
+function buildDirtyAncestors(
+  status: Record<string, FsGitStatusEntry>,
+  rootPath: string,
+): Set<string> {
+  const out = new Set<string>();
+  for (const p of Object.keys(status)) {
+    let cur = p;
+    while (true) {
+      const idx = cur.lastIndexOf("/");
+      if (idx <= 0) break;
+      const parent = cur.slice(0, idx);
+      if (parent === rootPath || !parent.startsWith(rootPath)) break;
+      out.add(parent);
+      cur = parent;
+    }
+  }
+  return out;
+}
+
+function relativeTo(base: string, abs: string): string {
+  const b = base.endsWith("/") ? base : base + "/";
+  if (abs === base) return ".";
+  if (abs.startsWith(b)) return abs.slice(b.length);
+  return abs;
+}
+
+async function writeToActiveSession(
+  sessionId: string | null,
+  payload: string,
+): Promise<void> {
+  if (!sessionId) throw new Error("No active session");
+  await api.ptyWrite(sessionId, payload);
+}
+
 function getLocalBool(key: string, fallback: boolean): boolean {
   try {
     const v = localStorage.getItem(key);
@@ -97,6 +168,103 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
   const [draftRename, setDraftRename] = useState<DraftRename | null>(null);
   const [activePath, setActivePath] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Cached `$EDITOR` value from the user's shell rc. Empty string means
+  // the user did not set one, in which case the open action falls back
+  // to the OS default app and the menu label reflects that.
+  const [shellEditor, setShellEditor] = useState<string>("");
+  // Selection — Cmd-click toggle, Shift-click range. When non-empty
+  // the context menu offers bulk actions across `selection`.
+  const [selection, setSelection] = useState<Set<string>>(new Set());
+  // Search / filter state. Empty query disables filtering. Regex flag
+  // switches substring → RegExp; invalid pattern falls back to plain.
+  const [query, setQuery] = useState<string>("");
+  const [useRegex, setUseRegex] = useState<boolean>(false);
+  const [branch, setBranch] = useState<string>("");
+  // Per-path git status keyed by absolute path. Refreshed on mount + when
+  // the fs watcher fires (debounced). Used to color filenames + show
+  // status label + +/- line counts.
+  const [gitStatus, setGitStatus] = useState<Record<string, FsGitStatusEntry>>(
+    {},
+  );
+  // Which agent (if any) is currently running in the focused session.
+  // Drives the "Attach to Conversation" context-menu entries — null
+  // values mean no live process found for that agent kind.
+  const [agent, setAgent] = useState<{
+    claude: string | null;
+    codex: string | null;
+  }>({ claude: null, codex: null });
+  // Tracks the focused session id so the menu can write into the right
+  // PTY without re-importing the store at every click.
+  const [activeSessionId, setActiveSessionIdLocal] = useState<string | null>(
+    null,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .fsShellEditor()
+      .then((v) => {
+        if (!cancelled) setShellEditor(v.trim());
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const refreshGitStatus = useCallback(async () => {
+    try {
+      const map = await api.fsGitStatus(rootPath);
+      setGitStatus(map);
+    } catch {
+      setGitStatus({});
+    }
+  }, [rootPath]);
+
+  const refreshBranch = useCallback(async () => {
+    try {
+      setBranch(await api.fsGitBranch(rootPath));
+    } catch {
+      setBranch("");
+    }
+  }, [rootPath]);
+
+  useEffect(() => {
+    void refreshGitStatus();
+    void refreshBranch();
+  }, [refreshGitStatus, refreshBranch]);
+
+  // Subscribe to focused-session changes via the store so the menu
+  // always reflects the agent state of whichever PTY would receive the
+  // attached path.
+  useEffect(() => {
+    let cancelled = false;
+    let unsub: (() => void) | null = null;
+    void import("../store").then(({ useAppStore }) => {
+      if (cancelled) return;
+      const sync = (sid: string | null) => {
+        setActiveSessionIdLocal(sid);
+        if (!sid) {
+          setAgent({ claude: null, codex: null });
+          return;
+        }
+        api
+          .detectSessionAgent(sid)
+          .then((res) => {
+            if (!cancelled) setAgent(res);
+          })
+          .catch(() => {});
+      };
+      sync(useAppStore.getState().activeSessionId);
+      unsub = useAppStore.subscribe((s) => {
+        sync(s.activeSessionId);
+      });
+    });
+    return () => {
+      cancelled = true;
+      if (unsub) unsub();
+    };
+  }, []);
 
   useEffect(() => {
     setLocalBool(SHOW_HIDDEN_KEY, showHidden);
@@ -191,6 +359,8 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
           void fetchDir(dir);
         }
       }
+      void refreshGitStatus();
+      void refreshBranch();
     };
     void listen<FsChangePayload>(FS_CHANGED_EVENT, (event) => {
       for (const p of event.payload.paths) {
@@ -204,7 +374,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       if (flushTimer) clearTimeout(flushTimer);
       if (cancel) cancel();
     };
-  }, [rootPath, fetchDir, cache]);
+  }, [rootPath, fetchDir, cache, refreshGitStatus, refreshBranch]);
 
   const toggleDir = useCallback(
     (path: string) => {
@@ -227,16 +397,22 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
   const openInEditor = useCallback(async (entry: FsEntry) => {
     setActivePath(entry.path);
     try {
-      // Resolve which session to write into by walking the focused pane.
-      // Avoid a cross-module dep on the store by inlining the lookup.
-      const store = await import("../store");
-      const state = store.useAppStore.getState();
-      const sid = state.activeSessionId;
-      if (!sid) {
-        setError("No active session — open a terminal first");
+      // Probe `$EDITOR` from cached shell env. Empty means the user has
+      // not configured one — fall back to the OS default app for the
+      // file type. Without this fallback the PTY path becomes
+      // `"<path>"` after the shell expands an empty `$EDITOR`, which
+      // zsh tries to execute and rejects with "permission denied".
+      const editor = (await api.fsShellEditor()).trim();
+      if (!editor) {
+        await api.fsOpenDefault(entry.path);
         return;
       }
-      // Shell expands $EDITOR. Quote the path. Trailing \n executes.
+      const store = await import("../store");
+      const sid = store.useAppStore.getState().activeSessionId;
+      if (!sid) {
+        await api.fsOpenDefault(entry.path);
+        return;
+      }
       const escaped = entry.path.replace(/(["\\$`])/g, "\\$1");
       await api.ptyWrite(sid, `$EDITOR "${escaped}"\n`);
     } catch (e) {
@@ -300,6 +476,128 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     [fetchDir],
   );
 
+  const dirtyAncestors = useMemo(
+    () => buildDirtyAncestors(gitStatus, rootPath),
+    [gitStatus, rootPath],
+  );
+
+  const matcher = useMemo(() => buildMatcher(query, useRegex), [query, useRegex]);
+
+  const handleEntryClick = useCallback(
+    (entry: FsEntry, event: React.MouseEvent) => {
+      const meta = event.metaKey || event.ctrlKey;
+      const shift = event.shiftKey;
+      if (meta || shift) {
+        event.preventDefault();
+        setSelection((prev) => {
+          const next = new Set(prev);
+          if (next.has(entry.path)) next.delete(entry.path);
+          else next.add(entry.path);
+          return next;
+        });
+        return;
+      }
+      // Plain click: clear multi-selection and act on the entry.
+      setSelection(new Set());
+      if (entry.is_dir) toggleDir(entry.path);
+      else openInEditor(entry);
+    },
+    [toggleDir, openInEditor],
+  );
+
+  const handleBulkTrash = useCallback(async () => {
+    const paths = Array.from(selection);
+    for (const p of paths) {
+      try {
+        await api.fsTrash(p);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    }
+    setSelection(new Set());
+    void refreshGitStatus();
+  }, [selection, refreshGitStatus]);
+
+  const handleBulkCopyPaths = useCallback(
+    async (mode: "relative" | "absolute") => {
+      const paths = Array.from(selection);
+      const lines = paths.map((p) =>
+        mode === "absolute" ? p : relativeTo(rootPath, p),
+      );
+      try {
+        await navigator.clipboard.writeText(lines.join("\n"));
+      } catch {
+        setError("Clipboard write failed");
+      }
+    },
+    [selection, rootPath],
+  );
+
+  const handleBulkAttach = useCallback(async () => {
+    if (!activeSessionId) {
+      setError("No active session — open a terminal first");
+      return;
+    }
+    const paths = Array.from(selection);
+    const rels = paths.map((p) => `@${relativeTo(rootPath, p)}`).join(" ");
+    try {
+      await api.ptyWrite(activeSessionId, ` ${rels} `);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [activeSessionId, selection, rootPath]);
+
+  const handleOpenFolderInNewTab = useCallback(async (folderPath: string) => {
+    try {
+      const store = await import("../store");
+      const state = store.useAppStore.getState();
+      const project = state.activeProject;
+      if (!project) {
+        setError("No active project");
+        return;
+      }
+      const name = folderPath.split("/").filter(Boolean).pop() ?? "session";
+      // Spawn a regular session in the current project, then queue a
+      // `cd <folder>` to land inside the clicked directory once the PTY
+      // is up. Mirrors how CommandRunDialog primes new sessions.
+      const session = await state.createSession(name, project, false);
+      if (session) {
+        state.setPendingTerminalInput(
+          session.id,
+          `cd "${folderPath.replace(/(["\\$`])/g, "\\$1")}"\n`,
+        );
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // F2 to rename the focused / single-selected entry. Scoped to the
+  // FileExplorer container so it does not collide with terminal input.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "F2") return;
+      if (selection.size === 1) {
+        const path = Array.from(selection)[0];
+        const name = path.split("/").pop() ?? "";
+        setDraftRename({ path, value: name });
+        e.preventDefault();
+        return;
+      }
+      if (activePath) {
+        const name = activePath.split("/").pop() ?? "";
+        setDraftRename({ path: activePath, value: name });
+        e.preventDefault();
+      }
+    };
+    el.addEventListener("keydown", handler);
+    return () => el.removeEventListener("keydown", handler);
+  }, [selection, activePath]);
+
   const openMenu = useCallback(
     (e: React.MouseEvent, entry: FsEntry | null) => {
       e.preventDefault();
@@ -312,16 +610,126 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     if (!menu) return [];
     const entry = menu.entry;
     const parentForCreate = entry?.is_dir ? entry.path : rootPath;
+    const rel = entry ? relativeTo(rootPath, entry.path) : "";
     const items: ContextMenuItem[] = [];
-    if (entry && !entry.is_dir) {
+
+    // Bulk-action mode: ≥2 entries selected (and the right-clicked
+    // entry is among them) — show actions that apply to the whole set.
+    if (entry && selection.size > 1 && selection.has(entry.path)) {
+      const n = selection.size;
       items.push({
-        label: "Open in $EDITOR",
+        label: `Copy Relative Paths (${n})`,
+        icon: <Link2 size={13} />,
+        onClick: () => void handleBulkCopyPaths("relative"),
+      });
+      items.push({
+        label: `Copy Absolute Paths (${n})`,
+        icon: <Copy size={13} />,
+        onClick: () => void handleBulkCopyPaths("absolute"),
+      });
+      if (agent.claude || agent.codex) {
+        items.push({ type: "separator" });
+        items.push({
+          label: `Attach All to Conversation (${n})`,
+          icon: <MessageSquarePlus size={13} />,
+          onClick: () => void handleBulkAttach(),
+        });
+      }
+      items.push({ type: "separator" });
+      items.push({
+        label: `Move to Trash (${n})`,
+        icon: <Trash2 size={13} />,
+        onClick: () => void handleBulkTrash(),
+      });
+      return items;
+    }
+
+    // Group 1: Open actions
+    if (entry && !entry.is_dir) {
+      const editorBin = shellEditor.split(/\s+/)[0];
+      const openLabel = editorBin
+        ? `Open in ${editorBin}`
+        : "Open with Default Program";
+      items.push({
+        label: openLabel,
+        icon: <Edit3 size={13} />,
         onClick: () => void openInEditor(entry),
       });
-      items.push({ type: "separator" });
     }
+    if (entry) {
+      items.push({
+        label: "Reveal in File Manager",
+        icon: <ExternalLink size={13} />,
+        onClick: () => {
+          void api.fsReveal(entry.path).catch((e) => {
+            setError(e instanceof Error ? e.message : String(e));
+          });
+        },
+      });
+    }
+    if (entry?.is_dir) {
+      items.push({
+        label: "Open in New Tab",
+        icon: <TerminalSquare size={13} />,
+        onClick: () => void handleOpenFolderInNewTab(entry.path),
+      });
+    }
+
+    // Group 2: Agent attach (only when an agent is live)
+    if (entry && (agent.claude || agent.codex)) {
+      items.push({ type: "separator" });
+      if (agent.claude) {
+        items.push({
+          label: "Attach to Claude",
+          icon: <MessageSquarePlus size={13} />,
+          onClick: () => {
+            void writeToActiveSession(activeSessionId, ` @${rel} `).catch(
+              (e) => setError(e instanceof Error ? e.message : String(e)),
+            );
+          },
+        });
+      }
+      if (agent.codex) {
+        items.push({
+          label: "Attach to Codex",
+          icon: <MessageSquarePlus size={13} />,
+          onClick: () => {
+            void writeToActiveSession(activeSessionId, ` @${rel} `).catch(
+              (e) => setError(e instanceof Error ? e.message : String(e)),
+            );
+          },
+        });
+      }
+    }
+
+    // Group 3: Path copy
+    if (entry) {
+      items.push({ type: "separator" });
+      items.push({
+        label: "Copy Relative Path",
+        icon: <Link2 size={13} />,
+        onClick: () => {
+          void navigator.clipboard.writeText(rel).catch(() => {
+            setError("Clipboard write failed");
+          });
+        },
+      });
+      items.push({
+        label: "Copy Absolute Path",
+        icon: <Copy size={13} />,
+        onClick: () => {
+          void navigator.clipboard.writeText(entry.path).catch(() => {
+            setError("Clipboard write failed");
+          });
+        },
+      });
+    }
+
+    // Group 4: Create
+    if (items.length > 0) items.push({ type: "separator" });
     items.push({
-      label: "New file",
+      label: "New File",
+      icon: <FilePlus size={13} />,
       onClick: () => {
         if (entry?.is_dir && !expanded.has(entry.path)) {
           toggleDir(entry.path);
@@ -330,7 +738,8 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       },
     });
     items.push({
-      label: "New folder",
+      label: "New Folder",
+      icon: <FolderPlus size={13} />,
       onClick: () => {
         if (entry?.is_dir && !expanded.has(entry.path)) {
           toggleDir(entry.path);
@@ -338,44 +747,49 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
         setDraftCreate({ parentPath: parentForCreate, kind: "dir", value: "" });
       },
     });
+
+    // Group 5: Destructive
     if (entry) {
       items.push({ type: "separator" });
       items.push({
         label: "Rename",
+        icon: <Pencil size={13} />,
         onClick: () => setDraftRename({ path: entry.path, value: entry.name }),
       });
       items.push({
         label: "Move to Trash",
+        icon: <Trash2 size={13} />,
         onClick: () => void handleTrash(entry),
-      });
-      items.push({ type: "separator" });
-      items.push({
-        label: "Copy path",
-        onClick: () => {
-          void navigator.clipboard.writeText(entry.path).catch(() => {
-            setError("Clipboard write failed");
-          });
-        },
-      });
-      items.push({
-        label: "Reveal in file manager",
-        onClick: () => {
-          void api.fsReveal(entry.path).catch((e) => {
-            setError(e instanceof Error ? e.message : String(e));
-          });
-        },
       });
     }
     return items;
-  }, [menu, rootPath, expanded, toggleDir, openInEditor, handleTrash]);
+  }, [
+    menu,
+    rootPath,
+    expanded,
+    toggleDir,
+    openInEditor,
+    handleTrash,
+    shellEditor,
+    agent,
+    activeSessionId,
+    selection,
+    handleBulkAttach,
+    handleBulkCopyPaths,
+    handleBulkTrash,
+    handleOpenFolderInNewTab,
+  ]);
 
   return (
     <div
-      className="flex h-full w-full flex-col"
+      ref={containerRef}
+      tabIndex={0}
+      className="flex h-full w-full flex-col outline-none"
       onContextMenu={(e) => openMenu(e, null)}
     >
       <Toolbar
         rootPath={rootPath}
+        branch={branch}
         showHidden={showHidden}
         respectGitignore={respectGitignore}
         onToggleHidden={() => setShowHidden((v) => !v)}
@@ -388,7 +802,14 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
           setDraftCreate({ parentPath: rootPath, kind: "dir", value: "" })
         }
       />
+      <SearchBar
+        query={query}
+        useRegex={useRegex}
+        onQueryChange={setQuery}
+        onToggleRegex={() => setUseRegex((v) => !v)}
+      />
       <div className="flex-1 overflow-auto py-1 text-[12px]">
+        <div className="w-max min-w-full">
         <DirNode
           path={rootPath}
           depth={0}
@@ -399,8 +820,13 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
           activePath={activePath}
           draftCreate={draftCreate}
           draftRename={draftRename}
+          gitStatus={gitStatus}
+          dirtyAncestors={dirtyAncestors}
+          selection={selection}
+          matcher={matcher}
           onToggleDir={toggleDir}
           onOpenEntry={openInEditor}
+          onEntryClick={handleEntryClick}
           onContextMenu={openMenu}
           onCommitCreate={handleCreate}
           onCancelCreate={() => setDraftCreate(null)}
@@ -413,6 +839,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
             setDraftRename((prev) => (prev ? { ...prev, value: v } : prev))
           }
         />
+        </div>
       </div>
       {error ? (
         <div className="flex items-start gap-2 border-t border-border bg-bg-error/20 px-3 py-1.5 text-[11px] text-fg">
@@ -439,6 +866,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
 
 interface ToolbarProps {
   rootPath: string;
+  branch: string;
   showHidden: boolean;
   respectGitignore: boolean;
   onToggleHidden: () => void;
@@ -453,16 +881,25 @@ function Toolbar(props: ToolbarProps) {
   return (
     <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1 text-[11px]">
       <span
-        className="flex-1 truncate font-medium text-fg-muted"
+        className="truncate font-medium text-fg-muted"
         title={props.rootPath}
       >
         {rootName.toUpperCase()}
       </span>
-      <ToolbarBtn label="New file" onClick={props.onNewFile}>
-        <FileIcon size={12} />
+      {props.branch ? (
+        <Tooltip label={`Current branch: ${props.branch}`}>
+          <span className="flex shrink-0 items-center gap-1 rounded bg-fg-muted/15 px-1.5 py-px text-[10px] text-fg-muted">
+            <GitBranch size={10} />
+            <span className="max-w-[120px] truncate">{props.branch}</span>
+          </span>
+        </Tooltip>
+      ) : null}
+      <span className="flex-1" />
+      <ToolbarBtn label="New File" onClick={props.onNewFile}>
+        <FilePlus size={12} />
       </ToolbarBtn>
-      <ToolbarBtn label="New folder" onClick={props.onNewFolder}>
-        <Folder size={12} />
+      <ToolbarBtn label="New Folder" onClick={props.onNewFolder}>
+        <FolderPlus size={12} />
       </ToolbarBtn>
       <ToolbarBtn
         label={props.showHidden ? "Hide dotfiles" : "Show dotfiles"}
@@ -489,6 +926,55 @@ function Toolbar(props: ToolbarProps) {
   );
 }
 
+interface SearchBarProps {
+  query: string;
+  useRegex: boolean;
+  onQueryChange: (v: string) => void;
+  onToggleRegex: () => void;
+}
+
+function SearchBar(props: SearchBarProps) {
+  return (
+    <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1">
+      <Search size={12} className="shrink-0 text-fg-muted" />
+      <input
+        type="text"
+        value={props.query}
+        onChange={(e) => props.onQueryChange(e.target.value)}
+        placeholder={props.useRegex ? "Regex…" : "Filter files…"}
+        className="flex-1 bg-transparent text-[11px] text-fg outline-none placeholder:text-fg-muted/60"
+      />
+      {props.query ? (
+        <Tooltip label="Clear filter">
+          <button
+            type="button"
+            aria-label="Clear filter"
+            onClick={() => props.onQueryChange("")}
+            className="rounded p-0.5 text-fg-muted hover:text-fg"
+          >
+            <X size={11} />
+          </button>
+        </Tooltip>
+      ) : null}
+      <Tooltip label={props.useRegex ? "Plain match" : "Regex match"}>
+        <button
+          type="button"
+          aria-label="Toggle regex"
+          onClick={props.onToggleRegex}
+          className={cn(
+            "rounded p-0.5 transition",
+            props.useRegex
+              ? "bg-fg-muted/15 text-fg"
+              : "text-fg-muted hover:text-fg",
+          )}
+        >
+          <Regex size={12} />
+        </button>
+      </Tooltip>
+    </div>
+  );
+}
+
 function ToolbarBtn({
   children,
   label,
@@ -501,20 +987,21 @@ function ToolbarBtn({
   onClick: () => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={label}
-      aria-label={label}
-      className={cn(
-        "rounded p-1 transition",
-        active
-          ? "bg-fg-muted/15 text-fg"
-          : "text-fg-muted hover:bg-fg-muted/10 hover:text-fg",
-      )}
-    >
-      {children}
-    </button>
+    <Tooltip label={label}>
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={label}
+        className={cn(
+          "rounded p-1 transition",
+          active
+            ? "bg-fg-muted/15 text-fg"
+            : "text-fg-muted hover:bg-fg-muted/10 hover:text-fg",
+        )}
+      >
+        {children}
+      </button>
+    </Tooltip>
   );
 }
 
@@ -528,8 +1015,13 @@ interface DirNodeProps {
   activePath: string | null;
   draftCreate: DraftCreate | null;
   draftRename: DraftRename | null;
+  gitStatus: Record<string, FsGitStatusEntry>;
+  dirtyAncestors: Set<string>;
+  selection: Set<string>;
+  matcher: ((name: string) => boolean) | null;
   onToggleDir: (path: string) => void;
   onOpenEntry: (entry: FsEntry) => void;
+  onEntryClick: (entry: FsEntry, event: React.MouseEvent) => void;
   onContextMenu: (e: React.MouseEvent, entry: FsEntry | null) => void;
   onCommitCreate: () => void;
   onCancelCreate: () => void;
@@ -540,8 +1032,15 @@ interface DirNodeProps {
 }
 
 function DirNode(props: DirNodeProps) {
-  const { state, path, isRoot } = props;
-  const entries = state?.entries ?? [];
+  const { state, path, isRoot, matcher } = props;
+  const rawEntries = state?.entries ?? [];
+  // When a matcher is active, hide entries that fail to match *unless*
+  // they are directories with at least one matching descendant. Without
+  // recursive descent we just keep dirs visible so the user can still
+  // drill in.
+  const entries = matcher
+    ? rawEntries.filter((e) => e.is_dir || matcher(e.name))
+    : rawEntries;
   const loading = state?.loading ?? false;
   const error = state?.error ?? null;
 
@@ -583,8 +1082,12 @@ function DirNode(props: DirNodeProps) {
             depth={props.depth}
             expanded={props.expanded.has(entry.path)}
             isActive={props.activePath === entry.path}
-            onToggleDir={props.onToggleDir}
-            onOpenEntry={props.onOpenEntry}
+            isSelected={props.selection.has(entry.path)}
+            gitStatus={props.gitStatus[entry.path]}
+            dirtyDescendant={
+              entry.is_dir && props.dirtyAncestors.has(entry.path)
+            }
+            onEntryClick={props.onEntryClick}
             onContextMenu={props.onContextMenu}
           >
             {entry.is_dir && props.expanded.has(entry.path) ? (
@@ -644,10 +1147,38 @@ interface EntryRowProps {
   depth: number;
   expanded: boolean;
   isActive: boolean;
-  onToggleDir: (path: string) => void;
-  onOpenEntry: (entry: FsEntry) => void;
+  isSelected: boolean;
+  gitStatus?: FsGitStatusEntry;
+  dirtyDescendant: boolean;
+  onEntryClick: (entry: FsEntry, event: React.MouseEvent) => void;
   onContextMenu: (e: React.MouseEvent, entry: FsEntry) => void;
   children?: React.ReactNode;
+}
+
+const STATUS_LABELS: Record<FsGitStatus, string> = {
+  modified: "M",
+  added: "A",
+  deleted: "D",
+  renamed: "R",
+  conflicted: "C",
+  clean: "",
+};
+
+function gitStatusClass(status: FsGitStatus | undefined): string {
+  switch (status) {
+    case "modified":
+      return "text-amber-400";
+    case "added":
+      return "text-emerald-400";
+    case "deleted":
+      return "text-rose-400 line-through";
+    case "renamed":
+      return "text-sky-400";
+    case "conflicted":
+      return "text-orange-400";
+    default:
+      return "";
+  }
 }
 
 function EntryRow({
@@ -655,34 +1186,50 @@ function EntryRow({
   depth,
   expanded,
   isActive,
-  onToggleDir,
-  onOpenEntry,
+  isSelected,
+  gitStatus,
+  dirtyDescendant,
+  onEntryClick,
   onContextMenu,
   children,
 }: EntryRowProps) {
-  const onClick = () => {
-    if (entry.is_dir) onToggleDir(entry.path);
-    else onOpenEntry(entry);
-  };
+  const nameClass = gitStatusClass(gitStatus?.kind);
+  const statusLetter = gitStatus ? STATUS_LABELS[gitStatus.kind] : "";
+  const additions = gitStatus?.additions ?? 0;
+  const deletions = gitStatus?.deletions ?? 0;
+  // Folder rollup: when a directory itself has no status entry but
+  // contains at least one dirty descendant, tint the name amber so the
+  // user sees there's something to look at inside.
+  const folderRollupClass =
+    !gitStatus && dirtyDescendant ? "text-amber-400/70" : "";
   return (
     <>
       <button
         type="button"
-        onClick={onClick}
+        onClick={(e) => onEntryClick(entry, e)}
         onContextMenu={(e) => {
           e.stopPropagation();
           onContextMenu(e, entry);
         }}
         className={cn(
-          "flex w-full items-center gap-1 truncate px-2 py-0.5 text-left transition",
-          isActive
+          "flex w-full items-center gap-1 whitespace-nowrap py-0.5 pr-2 text-left transition",
+          isSelected
+            ? "bg-accent/25 text-fg"
+            : isActive
             ? "bg-accent/15 text-fg"
             : "text-fg hover:bg-fg-muted/10",
           entry.gitignored ? "opacity-60" : "",
         )}
-        style={{ paddingLeft: 8 + depth * 12 }}
+        style={{ paddingLeft: 8 }}
         title={entry.path}
       >
+        {Array.from({ length: depth }).map((_, i) => (
+          <span
+            key={i}
+            aria-hidden
+            className="relative block w-1 shrink-0 self-stretch before:absolute before:left-[2px] before:top-0 before:bottom-0 before:w-px before:bg-fg-muted/20"
+          />
+        ))}
         {entry.is_dir ? (
           <span className="shrink-0 text-fg-muted">
             {expanded ? (
@@ -705,12 +1252,33 @@ function EntryRow({
             <FileIcon size={13} />
           )}
         </span>
-        <span className="truncate">
+        <span className={cn("whitespace-nowrap", nameClass, folderRollupClass)}>
           {entry.name}
           {entry.is_symlink ? (
             <span className="ml-1 text-fg-muted">↪</span>
           ) : null}
         </span>
+        {statusLetter ? (
+          <span
+            className={cn(
+              "ml-auto flex shrink-0 items-center gap-1 pl-2 text-[10px] tabular-nums",
+              nameClass,
+            )}
+          >
+            {additions > 0 ? (
+              <span className="text-emerald-400">+{additions}</span>
+            ) : null}
+            {deletions > 0 ? (
+              <span className="text-rose-400">-{deletions}</span>
+            ) : null}
+            <span
+              className="rounded bg-fg-muted/15 px-1 font-medium"
+              aria-label={`git status ${gitStatus?.kind}`}
+            >
+              {statusLetter}
+            </span>
+          </span>
+        ) : null}
       </button>
       {children}
     </>
@@ -741,9 +1309,16 @@ function EditRow({
   }, []);
   return (
     <div
-      className="flex w-full items-center gap-1 px-2 py-0.5"
-      style={{ paddingLeft: 8 + depth * 12 }}
+      className="flex w-full items-center gap-1 py-0.5 pr-2"
+      style={{ paddingLeft: 8 }}
     >
+      {Array.from({ length: depth }).map((_, i) => (
+        <span
+          key={i}
+          aria-hidden
+          className="block w-3 shrink-0 self-stretch border-l border-fg-muted/20"
+        />
+      ))}
       <span className="w-3 shrink-0" />
       <span className="shrink-0 text-fg-muted">{icon}</span>
       <input

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -23,11 +23,14 @@ import {
   type CSSProperties,
 } from "react";
 import { openPath } from "@tauri-apps/plugin-opener";
-import { useAppStore } from "../store";
+import { isViewerTabId, useAppStore, type ViewerTab } from "../store";
+import { CodeViewer } from "./CodeViewer";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import {
-  getCurrentDragPayload,
+  getCurrentFilePayload,
+  getCurrentTabPayload,
+  isAcornDrag,
   isTabDrag,
   setTabDragPayload,
 } from "../lib/dnd";
@@ -95,16 +98,25 @@ export function Pane({ paneId }: PaneProps) {
     return () => node.removeEventListener("mousedown", handler);
   }, [paneId, setFocusedPane]);
 
+  const viewerTabs = useAppStore((s) => s.viewerTabs);
+  const closeViewerTab = useAppStore((s) => s.closeViewerTab);
   const tabs = useMemo<Session[]>(() => {
     if (!pane) return [];
     const lookup = new Map(sessions.map((s) => [s.id, s] as const));
     const ordered: Session[] = [];
     for (const id of pane.sessionIds) {
       const s = lookup.get(id);
-      if (s) ordered.push(s);
+      if (s) {
+        ordered.push(s);
+        continue;
+      }
+      if (isViewerTabId(id)) {
+        const v = viewerTabs[id];
+        if (v) ordered.push(viewerToSession(v));
+      }
     }
     return ordered;
-  }, [pane, sessions]);
+  }, [pane, sessions, viewerTabs]);
 
   const active = useMemo<Session | null>(() => {
     if (!pane?.activeSessionId) return null;
@@ -220,7 +232,10 @@ export function Pane({ paneId }: PaneProps) {
             setFocusedPane(paneId);
             selectSession(id);
           }}
-          onClose={(id) => requestRemoveSession(id)}
+          onClose={(id) => {
+            if (isViewerTabId(id)) closeViewerTab(id);
+            else requestRemoveSession(id);
+          }}
           onDropReorder={(payload, toIndex) => {
             moveTab({
               sessionId: payload.sessionId,
@@ -271,8 +286,15 @@ export function Pane({ paneId }: PaneProps) {
           at App level. It is portaled into a per-session target div which
           gets `appendChild`-moved into this pane body when this session is
           active. We render only an EmptyPane fallback here for the
-          no-active-session case.
+          no-active-session case — or a CodeViewer when the active tab is
+          a frontend-only readonly viewer instead of a PTY session.
         */}
+        {active && active.kind === "viewer" && viewerTabs[active.id] ? (
+          <CodeViewer
+            path={viewerTabs[active.id].path}
+            isActive={isFocused}
+          />
+        ) : null}
         {active ? null : (
           <EmptyPane
             hasProjects={hasProjects}
@@ -307,6 +329,24 @@ export function Pane({ paneId }: PaneProps) {
       />
     </div>
   );
+}
+
+function viewerToSession(v: ViewerTab): Session {
+  return {
+    id: v.id,
+    name: v.name,
+    repo_path: v.repoPath,
+    worktree_path: v.repoPath,
+    branch: "",
+    isolated: false,
+    status: "idle",
+    created_at: "",
+    updated_at: "",
+    last_message: null,
+    kind: "viewer",
+    position: null,
+    in_worktree: false,
+  };
 }
 
 function suggestSessionName(repoPath: string, existing: Session[]): string {
@@ -415,25 +455,31 @@ function TabStrip({
       ref={stripRef}
       className="relative flex h-9 shrink-0 items-stretch overflow-x-auto border-b border-border"
       onDragEnter={(e) => {
-        if (!isTabDrag(e)) return;
+        if (!isAcornDrag(e)) return;
         e.preventDefault();
         setInsertIndex(computeInsertIndex(e.clientX));
       }}
       onDragOver={(e) => {
-        if (!isTabDrag(e)) return;
+        if (!isAcornDrag(e)) return;
         e.preventDefault();
-        e.dataTransfer.dropEffect = "move";
+        e.dataTransfer.dropEffect = isTabDrag(e) ? "move" : "copy";
         setInsertIndex(computeInsertIndex(e.clientX));
       }}
       onDragLeave={(e) => {
         if (e.currentTarget === e.target) setInsertIndex(null);
       }}
       onDrop={(e) => {
-        if (!isTabDrag(e)) return;
+        if (!isAcornDrag(e)) return;
         e.preventDefault();
-        const payload = getCurrentDragPayload();
         const idx = computeInsertIndex(e.clientX);
         setInsertIndex(null);
+        const filePayload = getCurrentFilePayload();
+        if (filePayload) {
+          useAppStore.getState().setFocusedPane(paneId);
+          useAppStore.getState().openViewerTab(filePayload.path);
+          return;
+        }
+        const payload = getCurrentTabPayload();
         if (!payload) return;
         // No-op: dropping onto the same pane at the same position.
         if (payload.fromPaneId === paneId) {

--- a/src/components/PaneDropOverlay.tsx
+++ b/src/components/PaneDropOverlay.tsx
@@ -3,9 +3,10 @@ import { cn } from "../lib/cn";
 import {
   classifyDropZone,
   type DropZone,
-  getCurrentDragPayload,
-  isTabDrag,
-  useTabDragInProgress,
+  getCurrentFilePayload,
+  getCurrentTabPayload,
+  isAcornDrag,
+  useAcornDragInProgress,
 } from "../lib/dnd";
 import { useAppStore } from "../store";
 import type { PaneId } from "../lib/layout";
@@ -21,8 +22,10 @@ interface PaneDropOverlayProps {
  * append the moved tab into this pane.
  */
 export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
-  const dragging = useTabDragInProgress();
+  const dragging = useAcornDragInProgress();
   const moveTab = useAppStore((s) => s.moveTab);
+  const openViewerTab = useAppStore((s) => s.openViewerTab);
+  const setFocusedPane = useAppStore((s) => s.setFocusedPane);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [zone, setZone] = useState<DropZone | null>(null);
 
@@ -54,14 +57,15 @@ export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
           : "pointer-events-none absolute inset-0 z-20"
       }
       onDragEnter={(e) => {
-        if (!isTabDrag(e)) return;
+        if (!isAcornDrag(e)) return;
         e.preventDefault();
         setZone(computeZone(e));
       }}
       onDragOver={(e) => {
-        if (!isTabDrag(e)) return;
+        if (!isAcornDrag(e)) return;
         e.preventDefault();
-        e.dataTransfer.dropEffect = "move";
+        e.dataTransfer.dropEffect =
+          getCurrentTabPayload() !== null ? "move" : "copy";
         const next = computeZone(e);
         if (
           !zone ||
@@ -79,12 +83,23 @@ export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
         if (e.currentTarget === e.target) setZone(null);
       }}
       onDrop={(e) => {
-        if (!isTabDrag(e)) return;
+        if (!isAcornDrag(e)) return;
         e.preventDefault();
-        const payload = getCurrentDragPayload();
         const target = computeZone(e);
         setZone(null);
-        if (!payload || !target) return;
+        if (!target) return;
+        const filePayload = getCurrentFilePayload();
+        if (filePayload) {
+          // For now ignore edge zones for file drops — viewer tabs land
+          // inside the target pane regardless of which edge the user hit.
+          // Splitting a pane to host a viewer can be a follow-up if it
+          // turns out to be common.
+          setFocusedPane(paneId);
+          openViewerTab(filePayload.path);
+          return;
+        }
+        const payload = getCurrentTabPayload();
+        if (!payload) return;
         if (target.kind === "center") {
           if (payload.fromPaneId === paneId) return;
           moveTab({

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -140,6 +140,12 @@ export function RightPanel() {
           "[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
         )}
       >
+        <TabButton
+          icon={<FolderTree size={14} />}
+          label="Files"
+          active={rightTab === "files"}
+          onClick={() => setRightTab("files")}
+        />
         {showTodos ? (
           <TabButton
             icon={<ListTodo size={14} />}
@@ -172,12 +178,6 @@ export function RightPanel() {
           label="Actions"
           active={rightTab === "actions"}
           onClick={() => setRightTab("actions")}
-        />
-        <TabButton
-          icon={<FolderTree size={14} />}
-          label="Files"
-          active={rightTab === "files"}
-          onClick={() => setRightTab("files")}
         />
       </nav>
       <div className="flex-1 overflow-hidden">
@@ -268,9 +268,10 @@ interface TabButtonProps {
   active: boolean;
   onClick: () => void;
   badge?: number;
+  className?: string;
 }
 
-function TabButton({ icon, label, active, onClick, badge }: TabButtonProps) {
+function TabButton({ icon, label, active, onClick, badge, className }: TabButtonProps) {
   return (
     <button
       type="button"
@@ -280,6 +281,7 @@ function TabButton({ icon, label, active, onClick, badge }: TabButtonProps) {
         active
           ? "text-fg after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-accent/30"
           : "text-fg-muted hover:text-fg",
+        className,
       )}
     >
       {icon}

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -9,6 +9,7 @@ import {
   Copy,
   ExternalLink,
   FileDiff,
+  FolderTree,
   GitCommit,
   GitMerge,
   GitPullRequest,
@@ -54,6 +55,7 @@ import { ClosePullRequestDialog } from "./ClosePullRequestDialog";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { DiffView } from "./DiffView";
 import { DiffViewerModal } from "./DiffViewerModal";
+import { FileExplorer } from "./FileExplorer";
 import { MergePullRequestDialog } from "./MergePullRequestDialog";
 import { PullRequestDetailModal } from "./PullRequestDetailModal";
 import { ResizeHandle } from "./ResizeHandle";
@@ -171,6 +173,12 @@ export function RightPanel() {
           active={rightTab === "actions"}
           onClick={() => setRightTab("actions")}
         />
+        <TabButton
+          icon={<FolderTree size={14} />}
+          label="Files"
+          active={rightTab === "files"}
+          onClick={() => setRightTab("files")}
+        />
       </nav>
       <div className="flex-1 overflow-hidden">
         {rightTab === "todos" ? (
@@ -211,6 +219,12 @@ export function RightPanel() {
               onOpenSearch={() => setPrSearch({ repoPath })}
               refreshKey={prListVersion}
             />
+          ) : (
+            <Empty msg="No project selected" />
+          )
+        ) : rightTab === "files" ? (
+          repoPath ? (
+            <FileExplorer key={repoPath} rootPath={repoPath} />
           ) : (
             <Empty msg="No project selected" />
           )

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, type ReactElement } from "react";
+import { useEffect, useRef, useState, type ReactElement } from "react";
 import {
   Terminal as XTerm,
   type IBuffer,
   type ITheme,
+  type IViewportRange,
 } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
@@ -29,6 +30,7 @@ import { useThemes, type ThemeMode } from "../lib/themes";
 import { useToasts } from "../lib/toasts";
 import { useAppStore } from "../store";
 import { StickyUserPrompt } from "./StickyUserPrompt";
+import { FloatingTooltip, type TooltipAnchorRect } from "./Tooltip";
 
 interface TerminalProps {
   sessionId: string;
@@ -188,9 +190,161 @@ function scanForContextPrompt(buf: IBuffer, startY: number): string | null {
 const IS_MAC =
   typeof navigator !== "undefined" &&
   /Mac|iP(hone|od|ad)/.test(navigator.platform);
+const MODIFIER_LINK_LABEL = IS_MAC ? "Command-click" : "Ctrl-click";
+
+interface TerminalRenderInternals {
+  _core?: {
+    _renderService?: {
+      dimensions?: {
+        css?: {
+          cell?: {
+            width: number;
+            height: number;
+          };
+        };
+      };
+    };
+  };
+}
 
 function modifierHeld(event: MouseEvent): boolean {
   return IS_MAC ? event.metaKey : event.ctrlKey;
+}
+
+function terminalCellDims(term: XTerm): { width: number; height: number } | null {
+  const core = (term as unknown as TerminalRenderInternals)._core;
+  const cell = core?._renderService?.dimensions?.css?.cell;
+  return cell ? { width: cell.width, height: cell.height } : null;
+}
+
+function textRangeRectForColumns(
+  rowElement: HTMLElement,
+  startCol: number,
+  endCol: number,
+): DOMRect | null {
+  const doc = rowElement.ownerDocument;
+  const walker = doc.createTreeWalker(rowElement, NodeFilter.SHOW_TEXT);
+  const range = doc.createRange();
+  let offset = 0;
+  let startSet = false;
+  let endSet = false;
+
+  for (
+    let node = walker.nextNode() as Text | null;
+    node;
+    node = walker.nextNode() as Text | null
+  ) {
+    const textLength = node.textContent?.length ?? 0;
+    const nextOffset = offset + textLength;
+    if (!startSet && startCol <= nextOffset) {
+      range.setStart(node, Math.max(0, startCol - offset));
+      startSet = true;
+    }
+    if (startSet && endCol <= nextOffset) {
+      range.setEnd(node, Math.max(0, endCol - offset));
+      endSet = true;
+      break;
+    }
+    offset = nextOffset;
+  }
+
+  if (!startSet || !endSet) {
+    range.detach();
+    return null;
+  }
+
+  const rect = range.getBoundingClientRect();
+  range.detach();
+  if (rect.width <= 0 || rect.height <= 0) return null;
+  return rect;
+}
+
+function unionRects(rects: DOMRect[]): TooltipAnchorRect | null {
+  if (rects.length === 0) return null;
+  const left = Math.min(...rects.map((r) => r.left));
+  const top = Math.min(...rects.map((r) => r.top));
+  const right = Math.max(...rects.map((r) => r.right));
+  const bottom = Math.max(...rects.map((r) => r.bottom));
+  return {
+    top,
+    bottom,
+    left,
+    right,
+    width: right - left,
+    height: bottom - top,
+  };
+}
+
+function hoveredLinkAnchorRect(container: HTMLElement): TooltipAnchorRect | null {
+  const rects = Array.from(
+    container.querySelectorAll<HTMLElement>(".xterm-rows span"),
+  )
+    .filter((el) => {
+      const style = getComputedStyle(el);
+      return style.textDecorationLine.includes("underline");
+    })
+    .map((el) => el.getBoundingClientRect())
+    .filter((rect) => rect.width > 0 && rect.height > 0);
+  return unionRects(rects);
+}
+
+function linkRangeAnchorRect(
+  container: HTMLElement,
+  term: XTerm,
+  range: IViewportRange,
+): TooltipAnchorRect | null {
+  const cell = terminalCellDims(term);
+  if (!cell) return null;
+  const viewportY = term.buffer.active.viewportY;
+
+  const startViewportY = range.start.y - viewportY - 1;
+  const endViewportY = range.end.y - viewportY - 1;
+  if (endViewportY < 0 || startViewportY >= term.rows) return null;
+
+  const row = Math.max(0, Math.min(term.rows - 1, startViewportY));
+  const rowElements = Array.from(
+    container.querySelectorAll<HTMLElement>(".xterm-rows > div"),
+  );
+  const textRects: DOMRect[] = [];
+  const firstVisibleRow = Math.max(0, startViewportY);
+  const lastVisibleRow = Math.min(term.rows - 1, endViewportY);
+  for (let y = firstVisibleRow; y <= lastVisibleRow; y++) {
+    const rowElement = rowElements[y];
+    if (!rowElement) continue;
+    const startCol = y === startViewportY ? Math.max(0, range.start.x - 1) : 0;
+    const endCol =
+      y === endViewportY
+        ? Math.max(startCol + 1, Math.min(term.cols, range.end.x))
+        : term.cols;
+    const rect = textRangeRectForColumns(rowElement, startCol, endCol);
+    if (rect) textRects.push(rect);
+  }
+  const textRect = unionRects(textRects);
+  if (textRect) return textRect;
+
+  const rowElement = rowElements[row];
+  const rowRect =
+    rowElement?.getBoundingClientRect() ??
+    (
+      container.querySelector<HTMLElement>(".xterm-screen") ?? container
+    ).getBoundingClientRect();
+  const startX = startViewportY < 0 ? 0 : Math.max(0, range.start.x - 1);
+  const endX =
+    row === endViewportY
+      ? Math.max(startX + 1, Math.min(term.cols, range.end.x))
+      : term.cols;
+  const left = rowRect.left + startX * cell.width;
+  const top = rowElement ? rowRect.top : rowRect.top + row * cell.height;
+  const right = rowRect.left + endX * cell.width;
+  const bottom = rowElement ? rowRect.bottom : top + cell.height;
+  return {
+    top,
+    bottom,
+    left,
+    right,
+    width: right - left,
+    height: bottom - top,
+  };
 }
 
 function decodeBase64ToBytes(b64: string): Uint8Array {
@@ -221,6 +375,9 @@ export function Terminal({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<XTerm | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
+  const [linkTooltip, setLinkTooltip] = useState<{
+    anchorRect: TooltipAnchorRect;
+  } | null>(null);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -266,13 +423,47 @@ export function Terminal({
     // app's CSP and would either fail or replace the app shell). When the user
     // opts into modifier-click activation, plain clicks are swallowed so a
     // stray click on a URL in shell output doesn't steal focus.
-    const webLinksAddon = new WebLinksAddon((event, uri) => {
-      event.preventDefault();
-      if (linkActivation === "modifier-click" && !modifierHeld(event)) return;
-      void openUrl(uri).catch((err: unknown) => {
-        console.error("failed to open terminal link", uri, err);
+    let linkTooltipFrame: number | null = null;
+    const showLinkTooltip = (range: IViewportRange) => {
+      if (linkTooltipFrame !== null) {
+        cancelAnimationFrame(linkTooltipFrame);
+      }
+      linkTooltipFrame = requestAnimationFrame(() => {
+        linkTooltipFrame = null;
+        if (linkActivation !== "modifier-click") return;
+        const anchorRect =
+          hoveredLinkAnchorRect(container) ??
+          linkRangeAnchorRect(container, term, range);
+        if (!anchorRect) return;
+        setLinkTooltip({ anchorRect });
       });
-    });
+    };
+    const hideLinkTooltip = () => {
+      if (linkTooltipFrame !== null) {
+        cancelAnimationFrame(linkTooltipFrame);
+        linkTooltipFrame = null;
+      }
+      setLinkTooltip(null);
+    };
+    const webLinksAddon = new WebLinksAddon(
+      (event, uri) => {
+        event.preventDefault();
+        hideLinkTooltip();
+        if (linkActivation === "modifier-click" && !modifierHeld(event)) return;
+        void openUrl(uri).catch((err: unknown) => {
+          console.error("failed to open terminal link", uri, err);
+        });
+      },
+      {
+        hover: (_event, _uri, range) => {
+          if (linkActivation !== "modifier-click") return;
+          showLinkTooltip(range);
+        },
+        leave: () => {
+          hideLinkTooltip();
+        },
+      },
+    );
     const serializeAddon = new SerializeAddon();
     const unicode11Addon = new Unicode11Addon();
     term.loadAddon(fitAddon);
@@ -383,6 +574,9 @@ export function Terminal({
       }
       if (next.linkActivation !== previous.linkActivation) {
         linkActivation = next.linkActivation;
+        if (next.linkActivation !== "modifier-click") {
+          setLinkTooltip(null);
+        }
       }
       if (state.settings.appearance.themeId !== prev.settings.appearance.themeId) {
         scheduleThemeRefresh();
@@ -1308,6 +1502,7 @@ export function Terminal({
     return () => {
       disposed = true;
       unsubSettings();
+      hideLinkTooltip();
       if (themeFrame !== null) {
         cancelAnimationFrame(themeFrame);
         themeFrame = null;
@@ -1458,6 +1653,12 @@ export function Terminal({
         className={`acorn-terminal relative z-10 h-full w-full ${
           isFocusedPane ? "" : "acorn-terminal-inactive"
         }`}
+      />
+      <FloatingTooltip
+        label={`${MODIFIER_LINK_LABEL} to open link`}
+        anchorRect={linkTooltip?.anchorRect ?? null}
+        side="top"
+        overlayClassName="xterm-hover"
       />
       {/* Pinned-prompt overlay. */}
       <StickyUserPrompt sessionId={sessionId} />

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -30,6 +30,24 @@ interface TooltipProps {
   className?: string;
 }
 
+export interface TooltipAnchorRect {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+  width: number;
+  height: number;
+}
+
+interface FloatingTooltipProps {
+  label: ReactNode;
+  anchorRect: TooltipAnchorRect | null;
+  side?: TooltipProps["side"];
+  multiline?: boolean;
+  portalTarget?: HTMLElement | null;
+  overlayClassName?: string;
+}
+
 interface TooltipPosition {
   top: number;
   left: number;
@@ -39,7 +57,7 @@ interface TooltipPosition {
 const GAP = 6;
 
 function computePosition(
-  rect: DOMRect,
+  rect: TooltipAnchorRect,
   side: NonNullable<TooltipProps["side"]>,
 ): TooltipPosition {
   switch (side) {
@@ -71,63 +89,35 @@ function computePosition(
   }
 }
 
-/**
- * Tooltip rendered through a portal so it escapes ancestor `overflow:auto`
- * clipping and z-index stacking contexts. Visibility is driven by explicit
- * pointer events on the trigger, not Tailwind `group-hover`, to avoid
- * cross-talk when nested inside other `group` containers.
- */
-export function Tooltip({
+export function FloatingTooltip({
   label,
+  anchorRect,
   side = "bottom",
-  delay = 250,
   multiline = false,
-  children,
-  className,
-}: TooltipProps) {
-  const triggerRef = useRef<HTMLSpanElement>(null);
+  portalTarget,
+  overlayClassName,
+}: FloatingTooltipProps) {
   const tooltipRef = useRef<HTMLSpanElement>(null);
-  const showTimer = useRef<number | null>(null);
   const [position, setPosition] = useState<TooltipPosition | null>(null);
 
-  const clearTimer = useCallback(() => {
-    if (showTimer.current !== null) {
-      window.clearTimeout(showTimer.current);
-      showTimer.current = null;
+  useEffect(() => {
+    if (anchorRect === null) {
+      setPosition(null);
+      return;
     }
-  }, []);
-
-  const show = useCallback(() => {
-    clearTimer();
-    showTimer.current = window.setTimeout(() => {
-      const el = triggerRef.current;
-      if (!el) return;
-      // Use the inner trigger (first child element) for accurate
-      // anchoring; falls back to the wrapper rect.
-      const target =
-        (el.firstElementChild as HTMLElement | null) ?? el;
-      setPosition(computePosition(target.getBoundingClientRect(), side));
-    }, delay);
-  }, [clearTimer, delay, side]);
-
-  const hide = useCallback(() => {
-    clearTimer();
-    setPosition(null);
-  }, [clearTimer]);
+    setPosition(computePosition(anchorRect, side));
+  }, [anchorRect, side]);
 
   useEffect(() => {
     if (position === null) return;
-    // Hide on scroll/resize so the tooltip never sits at a stale anchor.
-    const onMove = () => hide();
+    const onMove = () => setPosition(null);
     window.addEventListener("scroll", onMove, true);
     window.addEventListener("resize", onMove);
     return () => {
       window.removeEventListener("scroll", onMove, true);
       window.removeEventListener("resize", onMove);
     };
-  }, [position, hide]);
-
-  useEffect(() => () => clearTimer(), [clearTimer]);
+  }, [position]);
 
   // Clamp the tooltip into the viewport AFTER it has been measured. The
   // initial `computePosition` anchors at the trigger center, which can
@@ -156,6 +146,76 @@ export function Tooltip({
     }
   }, [position]);
 
+  if (position === null) return null;
+
+  return createPortal(
+    <span
+      ref={tooltipRef}
+      role="tooltip"
+      style={{
+        position: "fixed",
+        top: position.top,
+        left: position.left,
+        transform: position.transform,
+        zIndex: 9999,
+      }}
+      className={`${
+        multiline
+          ? "pointer-events-none max-w-xs whitespace-pre-line break-words rounded border border-border bg-bg-elevated px-2 py-1 text-[11px] font-normal leading-snug text-fg shadow-md"
+          : "pointer-events-none whitespace-nowrap rounded border border-border bg-bg-elevated px-2 py-0.5 text-[11px] font-normal text-fg shadow-md"
+      } ${overlayClassName ?? ""}`}
+    >
+      {label}
+    </span>,
+    portalTarget ?? document.body,
+  );
+}
+
+/**
+ * Tooltip rendered through a portal so it escapes ancestor `overflow:auto`
+ * clipping and z-index stacking contexts. Visibility is driven by explicit
+ * pointer events on the trigger, not Tailwind `group-hover`, to avoid
+ * cross-talk when nested inside other `group` containers.
+ */
+export function Tooltip({
+  label,
+  side = "bottom",
+  delay = 250,
+  multiline = false,
+  children,
+  className,
+}: TooltipProps) {
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const showTimer = useRef<number | null>(null);
+  const [anchorRect, setAnchorRect] = useState<TooltipAnchorRect | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (showTimer.current !== null) {
+      window.clearTimeout(showTimer.current);
+      showTimer.current = null;
+    }
+  }, []);
+
+  const show = useCallback(() => {
+    clearTimer();
+    showTimer.current = window.setTimeout(() => {
+      const el = triggerRef.current;
+      if (!el) return;
+      // Use the inner trigger (first child element) for accurate
+      // anchoring; falls back to the wrapper rect.
+      const target =
+        (el.firstElementChild as HTMLElement | null) ?? el;
+      setAnchorRect(target.getBoundingClientRect());
+    }, delay);
+  }, [clearTimer, delay]);
+
+  const hide = useCallback(() => {
+    clearTimer();
+    setAnchorRect(null);
+  }, [clearTimer]);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
   return (
     <>
       <span
@@ -169,29 +229,12 @@ export function Tooltip({
       >
         {children}
       </span>
-      {position !== null
-        ? createPortal(
-            <span
-              ref={tooltipRef}
-              role="tooltip"
-              style={{
-                position: "fixed",
-                top: position.top,
-                left: position.left,
-                transform: position.transform,
-                zIndex: 9999,
-              }}
-              className={
-                multiline
-                  ? "pointer-events-none max-w-xs whitespace-pre-line break-words rounded border border-border bg-bg-elevated px-2 py-1 text-[11px] font-normal leading-snug text-fg shadow-md"
-                  : "pointer-events-none whitespace-nowrap rounded border border-border bg-bg-elevated px-2 py-0.5 text-[11px] font-normal text-fg shadow-md"
-              }
-            >
-              {label}
-            </span>,
-            document.body,
-          )
-        : null}
+      <FloatingTooltip
+        label={label}
+        anchorRect={anchorRect}
+        side={side}
+        multiline={multiline}
+      />
     </>
   );
 }

--- a/src/components/ui/IconInput.tsx
+++ b/src/components/ui/IconInput.tsx
@@ -1,0 +1,52 @@
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from "react";
+import { cn } from "../../lib/cn";
+
+interface IconInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
+  /** Optional leading adornment (e.g. a `<Search />` icon). */
+  leading?: ReactNode;
+  /** Optional trailing adornment (toggle buttons, clear button, …). */
+  trailing?: ReactNode;
+  /** Adds a danger-colored border + input text to signal an error. */
+  invalid?: boolean;
+}
+
+/**
+ * Shared input shell that wraps a bare `<input>` with optional leading
+ * and trailing adornments. Visual baseline (height, radius, border,
+ * background, focus ring) matches `TextInput` so search/filter rows in
+ * sidebar-style surfaces stay consistent with form rows in dialogs.
+ */
+export const IconInput = forwardRef<HTMLInputElement, IconInputProps>(
+  function IconInput(
+    { leading, trailing, invalid, className, type = "text", spellCheck = false, ...rest },
+    ref,
+  ) {
+    return (
+      <div
+        className={cn(
+          "flex h-7 items-center gap-1 rounded-md border bg-bg px-2 focus-within:border-accent",
+          invalid ? "border-rose-500/60" : "border-border",
+          className,
+        )}
+      >
+        {leading ? (
+          <span className="shrink-0 text-fg-muted">{leading}</span>
+        ) : null}
+        <input
+          ref={ref}
+          type={type}
+          spellCheck={spellCheck}
+          className={cn(
+            "flex-1 bg-transparent font-mono text-xs outline-none placeholder:text-fg-muted/60",
+            invalid ? "text-rose-400" : "text-fg",
+          )}
+          {...rest}
+        />
+        {trailing ? (
+          <span className="flex shrink-0 items-center gap-1">{trailing}</span>
+        ) : null}
+      </div>
+    );
+  },
+);

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -2,6 +2,7 @@ export { Modal, type ModalSize, type ModalVariant } from "./Modal";
 export { ModalHeader } from "./ModalHeader";
 export { Field } from "./Field";
 export { TextInput, TEXT_INPUT_CLASS } from "./TextInput";
+export { IconInput } from "./IconInput";
 export { Select, SELECT_CLASS } from "./Select";
 export { Stepper } from "./Stepper";
 export { CheckboxRow } from "./CheckboxRow";

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -483,7 +483,60 @@ export const api = {
     const encoded = encodeStringToBase64(data);
     return invoke<void>("pty_write", { sessionId, data: encoded });
   },
+  fsListDir(
+    path: string,
+    showHidden: boolean,
+    respectGitignore: boolean,
+  ): Promise<FsListResult> {
+    return invoke<FsListResult>("fs_list_dir", {
+      path,
+      showHidden,
+      respectGitignore,
+    });
+  },
+  fsCreateFile(path: string): Promise<void> {
+    return invoke<void>("fs_create_file", { path });
+  },
+  fsCreateDir(path: string): Promise<void> {
+    return invoke<void>("fs_create_dir", { path });
+  },
+  fsRename(from: string, to: string): Promise<void> {
+    return invoke<void>("fs_rename", { from, to });
+  },
+  fsTrash(path: string): Promise<void> {
+    return invoke<void>("fs_trash", { path });
+  },
+  fsReveal(path: string): Promise<void> {
+    return invoke<void>("fs_reveal", { path });
+  },
+  fsWatchSetRoot(path: string | null): Promise<void> {
+    return invoke<void>("fs_watch_set_root", { path });
+  },
 };
+
+/** Mirror of `crate::fs_explorer::FileEntry`. */
+export interface FsEntry {
+  name: string;
+  path: string;
+  is_dir: boolean;
+  is_symlink: boolean;
+  size: number;
+  modified_ms: number;
+  gitignored: boolean;
+}
+
+/** Mirror of `crate::fs_explorer::ListResult`. */
+export interface FsListResult {
+  entries: FsEntry[];
+  repo_root: string | null;
+}
+
+/** Event payload from the backend fs watcher. */
+export interface FsChangePayload {
+  paths: string[];
+}
+
+export const FS_CHANGED_EVENT = "acorn:fs-changed";
 
 function encodeStringToBase64(input: string): string {
   const bytes = new TextEncoder().encode(input);
@@ -522,6 +575,7 @@ export interface DaemonSessionSummary {
   name: string;
   kind: "regular" | "control";
   alive: boolean;
+  cwd: string | null;
   repo_path: string | null;
   branch: string | null;
   agent_kind: string | null;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -509,6 +509,22 @@ export const api = {
   fsReveal(path: string): Promise<void> {
     return invoke<void>("fs_reveal", { path });
   },
+  fsOpenDefault(path: string): Promise<void> {
+    return invoke<void>("fs_open_default", { path });
+  },
+  fsShellEditor(): Promise<string> {
+    return invoke<string>("fs_shell_editor");
+  },
+  fsGitStatus(
+    repoRoot: string,
+  ): Promise<Record<string, FsGitStatusEntry>> {
+    return invoke<Record<string, FsGitStatusEntry>>("fs_git_status", {
+      repoRoot,
+    });
+  },
+  fsGitBranch(repoRoot: string): Promise<string> {
+    return invoke<string>("fs_git_branch", { repoRoot });
+  },
   fsWatchSetRoot(path: string | null): Promise<void> {
     return invoke<void>("fs_watch_set_root", { path });
   },
@@ -537,6 +553,22 @@ export interface FsChangePayload {
 }
 
 export const FS_CHANGED_EVENT = "acorn:fs-changed";
+
+/** Per-path git status bucket. Mirrors `crate::fs_explorer::classify_status`. */
+export type FsGitStatus =
+  | "modified"
+  | "added"
+  | "deleted"
+  | "renamed"
+  | "conflicted"
+  | "clean";
+
+/** Mirror of `crate::fs_explorer::GitStatusEntry`. */
+export interface FsGitStatusEntry {
+  kind: FsGitStatus;
+  additions: number;
+  deletions: number;
+}
 
 function encodeStringToBase64(input: string): string {
   const bytes = new TextEncoder().encode(input);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -494,12 +494,6 @@ export const api = {
       respectGitignore,
     });
   },
-  fsCreateFile(path: string): Promise<void> {
-    return invoke<void>("fs_create_file", { path });
-  },
-  fsCreateDir(path: string): Promise<void> {
-    return invoke<void>("fs_create_dir", { path });
-  },
   fsRename(from: string, to: string): Promise<void> {
     return invoke<void>("fs_rename", { from, to });
   },
@@ -524,6 +518,12 @@ export const api = {
   },
   fsGitBranch(repoRoot: string): Promise<string> {
     return invoke<string>("fs_git_branch", { repoRoot });
+  },
+  fsReadFile(path: string): Promise<FsReadFileResult> {
+    return invoke<FsReadFileResult>("fs_read_file", { path });
+  },
+  fsGitDiffLines(path: string): Promise<FsLineDiffEntry[]> {
+    return invoke<FsLineDiffEntry[]>("fs_git_diff_lines", { path });
   },
   fsWatchSetRoot(path: string | null): Promise<void> {
     return invoke<void>("fs_watch_set_root", { path });
@@ -568,6 +568,20 @@ export interface FsGitStatusEntry {
   kind: FsGitStatus;
   additions: number;
   deletions: number;
+}
+
+/** Mirror of `crate::fs_explorer::ReadFileResult`. */
+export interface FsReadFileResult {
+  content: string;
+  size: number;
+  truncated: boolean;
+  binary: boolean;
+}
+
+/** Mirror of `crate::fs_explorer::LineDiffEntry`. */
+export interface FsLineDiffEntry {
+  line: number;
+  kind: "added" | "modified" | "deleted";
 }
 
 function encodeStringToBase64(input: string): string {

--- a/src/lib/dnd.ts
+++ b/src/lib/dnd.ts
@@ -12,11 +12,19 @@ import { useEffect, useState } from "react";
 import type { Direction, PaneId, SplitSide } from "./layout";
 
 export interface TabDragPayload {
+  kind: "tab";
   sessionId: string;
   fromPaneId: PaneId;
 }
 
-let currentDrag: TabDragPayload | null = null;
+export interface FileDragPayload {
+  kind: "file";
+  path: string;
+}
+
+export type DragPayload = TabDragPayload | FileDragPayload;
+
+let currentDrag: DragPayload | null = null;
 const listeners = new Set<() => void>();
 
 function notify(): void {
@@ -25,11 +33,9 @@ function notify(): void {
 
 export function setTabDragPayload(
   e: React.DragEvent,
-  payload: TabDragPayload,
+  payload: { sessionId: string; fromPaneId: PaneId },
 ): void {
-  currentDrag = payload;
-  // Some webviews refuse `setData` during dragstart; guard so the drag
-  // still works via the module-level mirror even if this fails.
+  currentDrag = { kind: "tab", ...payload };
   try {
     e.dataTransfer.setData("text/plain", payload.sessionId);
   } catch {
@@ -39,8 +45,25 @@ export function setTabDragPayload(
   notify();
 }
 
-export function getCurrentDragPayload(): TabDragPayload | null {
+export function setFileDragPayload(
+  e: React.DragEvent,
+  payload: { path: string },
+): void {
+  currentDrag = { kind: "file", path: payload.path };
+  e.dataTransfer.effectAllowed = "copy";
+  notify();
+}
+
+export function getCurrentDragPayload(): DragPayload | null {
   return currentDrag;
+}
+
+export function getCurrentTabPayload(): TabDragPayload | null {
+  return currentDrag?.kind === "tab" ? currentDrag : null;
+}
+
+export function getCurrentFilePayload(): FileDragPayload | null {
+  return currentDrag?.kind === "file" ? currentDrag : null;
 }
 
 export function clearTabDragPayload(): void {
@@ -50,6 +73,14 @@ export function clearTabDragPayload(): void {
 }
 
 export function isTabDrag(_e: React.DragEvent): boolean {
+  return currentDrag?.kind === "tab";
+}
+
+export function isFileDrag(_e: React.DragEvent): boolean {
+  return currentDrag?.kind === "file";
+}
+
+export function isAcornDrag(_e: React.DragEvent): boolean {
   return currentDrag !== null;
 }
 
@@ -59,12 +90,37 @@ export function isTabDrag(_e: React.DragEvent): boolean {
  * an active drag. Backed by a module-level signal updated synchronously
  * inside `setTabDragPayload` and on window-level dragend / drop.
  */
-export function useTabDragInProgress(): boolean {
+export function useAcornDragInProgress(): boolean {
   const [active, setActive] = useState<boolean>(() => currentDrag !== null);
 
   useEffect(() => {
     function onChange() {
       setActive(currentDrag !== null);
+    }
+    listeners.add(onChange);
+    function onEnd() {
+      clearTabDragPayload();
+    }
+    window.addEventListener("dragend", onEnd);
+    window.addEventListener("drop", onEnd);
+    return () => {
+      listeners.delete(onChange);
+      window.removeEventListener("dragend", onEnd);
+      window.removeEventListener("drop", onEnd);
+    };
+  }, []);
+
+  return active;
+}
+
+export function useTabDragInProgress(): boolean {
+  const [active, setActive] = useState<boolean>(
+    () => currentDrag?.kind === "tab",
+  );
+
+  useEffect(() => {
+    function onChange() {
+      setActive(currentDrag?.kind === "tab");
     }
     listeners.add(onChange);
     function onEnd() {

--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -141,6 +141,21 @@ async function renderLines(
 }
 
 /**
+ * Highlight full file content as token-painted HTML lines. Returns one
+ * entry per source line — null when the language is unknown / failed to
+ * load, in which case the caller should render plain text.
+ */
+export async function highlightCode(
+  content: string,
+  lang: BundledLanguage | null,
+): Promise<(string | null)[]> {
+  const lines = content.split("\n");
+  if (!lang) return lines.map(() => null);
+  const out = await renderLines(lines, lang);
+  return out;
+}
+
+/**
  * Highlight a parsed diff. Splits into the new-side (ctx + add) and old-side
  * (ctx + del) virtual files so the lexer keeps coherent state per side, then
  * maps tokens back to the original line order.

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -39,6 +39,7 @@ export const Hotkeys = {
   toggleCommits: "$mod+Shift+c",
   toggleStaged: "$mod+Shift+s",
   togglePrs: "$mod+Shift+p",
+  toggleFiles: "$mod+Shift+e",
   uiScaleDown: "$mod+-",
   uiScaleDownShift: "$mod+Shift+Minus",
   uiScaleUp: "$mod+=",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,7 +11,7 @@ export type SessionStatus =
  * dispatch commands to other sessions in the same project. Persisted
  * sessions without this field load as `"regular"` from the backend.
  */
-export type SessionKind = "regular" | "control";
+export type SessionKind = "regular" | "control" | "viewer";
 
 export interface Session {
   id: string;

--- a/src/store.ts
+++ b/src/store.ts
@@ -62,6 +62,13 @@ interface AppStateModel {
   activeSessionId: string | null;
 
   rightTab: RightTab;
+  /**
+   * Readonly code viewer tabs. Each entry id is also referenced by a
+   * pane's `sessionIds` so the tab strip can render it alongside real
+   * PTY sessions. Frontend-only — not persisted across app restarts,
+   * never round-tripped through the backend.
+   */
+  viewerTabs: Record<string, ViewerTab>;
   /** gh login most recently resolved as having access to a given repo, keyed
    *  by repo path. Populated by the PRs tab; consumed by the StatusBar to
    *  surface "which identity am I acting as for this repo". In-memory only. */
@@ -147,6 +154,27 @@ interface AppStateModel {
   /** Atomically read and remove the queued command for `sessionId`. */
   consumePendingTerminalInput: (sessionId: string) => string | null;
   toggleMultiInput: () => boolean;
+  /** Open a readonly viewer tab for `path` in the focused pane. */
+  openViewerTab: (path: string) => void;
+  /** Close a viewer tab and remove it from any pane it lives in. */
+  closeViewerTab: (id: string) => void;
+}
+
+export interface ViewerTab {
+  id: string;
+  path: string;
+  name: string;
+  /** Workspace this viewer belongs to. Pane code reads this to set the
+   * synthetic session's `repo_path` to the project root rather than the
+   * file path — otherwise "new tab" double-click would spawn a session
+   * against the file path and land in the wrong (or no) project. */
+  repoPath: string;
+}
+
+export const VIEWER_TAB_PREFIX = "viewer:";
+
+export function isViewerTabId(id: string): boolean {
+  return id.startsWith(VIEWER_TAB_PREFIX);
 }
 
 let paneCounter = 0;
@@ -229,7 +257,12 @@ function reconcileWorkspace(
   let newPanes: Record<PaneId, PaneState> = {};
   for (const pid of validPaneIds) {
     const existing = ws.panes[pid] ?? emptyPane(pid);
-    const filtered = existing.sessionIds.filter((id) => knownIds.has(id));
+    // Viewer-tab ids live alongside session ids in the same array but
+    // are not tracked by the backend, so the session-list filter must
+    // preserve them explicitly.
+    const filtered = existing.sessionIds.filter(
+      (id) => knownIds.has(id) || isViewerTabId(id),
+    );
     const active =
       existing.activeSessionId && filtered.includes(existing.activeSessionId)
         ? existing.activeSessionId
@@ -363,6 +396,7 @@ export const useAppStore = create<AppStateModel>()(
   activeSessionId: null,
 
   rightTab: "commits",
+  viewerTabs: {},
   prAccountByRepo: {},
   pendingTerminalInput: {},
   multiInputEnabled: false,
@@ -504,6 +538,27 @@ export const useAppStore = create<AppStateModel>()(
               ...ws.panes,
               [ws.focusedPaneId]: { ...pane, activeSessionId: null },
             },
+          };
+        });
+        return patch ?? s;
+      }
+
+      // Viewer tabs are workspace-local — they live in whichever
+      // workspace the user opened them from. Resolve via current active
+      // project rather than session lookup (no backend Session exists).
+      if (isViewerTabId(id)) {
+        const patch = updateActiveWorkspace(s, (ws) => {
+          const containing = findPaneContainingSession(ws.panes, id);
+          if (!containing) return ws;
+          const pane = ws.panes[containing];
+          if (!pane) return ws;
+          return {
+            ...ws,
+            panes: {
+              ...ws.panes,
+              [containing]: { ...pane, activeSessionId: id },
+            },
+            focusedPaneId: containing,
           };
         });
         return patch ?? s;
@@ -1066,6 +1121,79 @@ export const useAppStore = create<AppStateModel>()(
     });
     return enabled;
   },
+
+  openViewerTab(path) {
+    set((s) => {
+      if (!s.activeProject) return s;
+      const ws = s.workspaces[s.activeProject];
+      if (!ws) return s;
+      // Reuse an existing viewer tab for the same path if there is one;
+      // this avoids piling up identical tabs when the user double-clicks
+      // the same file repeatedly. The reuse cycles focus to the tab.
+      const existing = Object.values(s.viewerTabs).find(
+        (v) => v.path === path && v.repoPath === s.activeProject,
+      );
+      const tab: ViewerTab = existing ?? {
+        id: `${VIEWER_TAB_PREFIX}${crypto.randomUUID()}`,
+        path,
+        name: path.split("/").filter(Boolean).pop() ?? path,
+        repoPath: s.activeProject,
+      };
+      const focused = ws.focusedPaneId;
+      const pane = ws.panes[focused];
+      if (!pane) return s;
+      const alreadyInPane = pane.sessionIds.includes(tab.id);
+      const newPane: PaneState = alreadyInPane
+        ? { ...pane, activeSessionId: tab.id }
+        : {
+            ...pane,
+            sessionIds: [...pane.sessionIds, tab.id],
+            activeSessionId: tab.id,
+          };
+      const newWs: ProjectWorkspace = {
+        ...ws,
+        panes: { ...ws.panes, [focused]: newPane },
+      };
+      const newWorkspaces = {
+        ...s.workspaces,
+        [s.activeProject]: newWs,
+      };
+      return {
+        viewerTabs: existing ? s.viewerTabs : { ...s.viewerTabs, [tab.id]: tab },
+        workspaces: newWorkspaces,
+        ...mirrorActive(newWorkspaces, s.activeProject),
+      };
+    });
+  },
+
+  closeViewerTab(id) {
+    set((s) => {
+      if (!isViewerTabId(id)) return s;
+      const { [id]: _, ...rest } = s.viewerTabs;
+      const newWorkspaces: Record<string, ProjectWorkspace> = {};
+      for (const [key, ws] of Object.entries(s.workspaces)) {
+        const newPanes: Record<PaneId, PaneState> = {};
+        for (const [pid, pane] of Object.entries(ws.panes)) {
+          const ids = pane.sessionIds.filter((sid) => sid !== id);
+          const nextActive =
+            pane.activeSessionId === id
+              ? ids[ids.length - 1] ?? null
+              : pane.activeSessionId;
+          newPanes[pid as PaneId] = {
+            ...pane,
+            sessionIds: ids,
+            activeSessionId: nextActive,
+          };
+        }
+        newWorkspaces[key] = { ...ws, panes: newPanes };
+      }
+      return {
+        viewerTabs: rest,
+        workspaces: newWorkspaces,
+        ...mirrorActive(newWorkspaces, s.activeProject),
+      };
+    });
+  },
     }),
     {
       name: "acorn-workspaces",
@@ -1080,6 +1208,30 @@ export const useAppStore = create<AppStateModel>()(
       // see the persisted layout immediately, before the first refreshAll.
       onRehydrateStorage: () => (state) => {
         if (!state) return;
+        // Viewer tabs are frontend-only and not persisted, so any
+        // viewer ids in the persisted workspace are stale. Strip them
+        // from pane sessionIds + activeSessionId before the layout
+        // mirror computes, otherwise the empty-pane fallback never
+        // shows and the tab strip points at a dead id.
+        const sanitized: Record<string, ProjectWorkspace> = {};
+        for (const [key, ws] of Object.entries(state.workspaces ?? {})) {
+          const newPanes: Record<PaneId, PaneState> = {};
+          for (const [pid, pane] of Object.entries(ws.panes ?? {})) {
+            const ids = pane.sessionIds.filter((id) => !isViewerTabId(id));
+            const active =
+              pane.activeSessionId && !isViewerTabId(pane.activeSessionId)
+                ? pane.activeSessionId
+                : ids[ids.length - 1] ?? null;
+            newPanes[pid as PaneId] = {
+              ...pane,
+              sessionIds: ids,
+              activeSessionId: active,
+            };
+          }
+          sanitized[key] = { ...ws, panes: newPanes };
+        }
+        state.workspaces = sanitized;
+        state.viewerTabs = {};
         Object.assign(
           state,
           mirrorActive(state.workspaces, state.activeProject),

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,7 +16,13 @@ import {
   splitPaneInLayout,
 } from "./lib/layout";
 
-type RightTab = "todos" | "commits" | "staged" | "prs" | "actions";
+type RightTab =
+  | "todos"
+  | "commits"
+  | "staged"
+  | "prs"
+  | "actions"
+  | "files";
 
 const ROOT_PANE_ID: PaneId = "root";
 

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -134,8 +134,6 @@ export const tauriMockSource = `
     if (cmd === 'fs_list_dir') {
       return Promise.resolve({ entries: [], repo_root: null });
     }
-    if (cmd === 'fs_create_file') return Promise.resolve(undefined);
-    if (cmd === 'fs_create_dir') return Promise.resolve(undefined);
     if (cmd === 'fs_rename') return Promise.resolve(undefined);
     if (cmd === 'fs_trash') return Promise.resolve(undefined);
     if (cmd === 'fs_reveal') return Promise.resolve(undefined);
@@ -143,6 +141,10 @@ export const tauriMockSource = `
     if (cmd === 'fs_shell_editor') return Promise.resolve('');
     if (cmd === 'fs_git_status') return Promise.resolve({});
     if (cmd === 'fs_git_branch') return Promise.resolve('');
+    if (cmd === 'fs_read_file') {
+      return Promise.resolve({ content: '', size: 0, truncated: false, binary: false });
+    }
+    if (cmd === 'fs_git_diff_lines') return Promise.resolve([]);
     if (cmd === 'fs_watch_set_root') return Promise.resolve(undefined);
     if (cmd && cmd.startsWith('list_')) return Promise.resolve([]);
     return Promise.resolve(null);

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -128,6 +128,18 @@ export const tauriMockSource = `
     if (cmd === 'acknowledge_staged_rev_mismatch')
       return Promise.resolve(undefined);
     if (cmd === 'pty_write') return Promise.resolve(undefined);
+    // File explorer. No real fs in E2E — default to an empty listing so
+    // the panel renders without errors. Tests that need real entries
+    // override these via window.__ACORN_MOCK_HANDLERS__.
+    if (cmd === 'fs_list_dir') {
+      return Promise.resolve({ entries: [], repo_root: null });
+    }
+    if (cmd === 'fs_create_file') return Promise.resolve(undefined);
+    if (cmd === 'fs_create_dir') return Promise.resolve(undefined);
+    if (cmd === 'fs_rename') return Promise.resolve(undefined);
+    if (cmd === 'fs_trash') return Promise.resolve(undefined);
+    if (cmd === 'fs_reveal') return Promise.resolve(undefined);
+    if (cmd === 'fs_watch_set_root') return Promise.resolve(undefined);
     if (cmd && cmd.startsWith('list_')) return Promise.resolve([]);
     return Promise.resolve(null);
   }

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -139,6 +139,10 @@ export const tauriMockSource = `
     if (cmd === 'fs_rename') return Promise.resolve(undefined);
     if (cmd === 'fs_trash') return Promise.resolve(undefined);
     if (cmd === 'fs_reveal') return Promise.resolve(undefined);
+    if (cmd === 'fs_open_default') return Promise.resolve(undefined);
+    if (cmd === 'fs_shell_editor') return Promise.resolve('');
+    if (cmd === 'fs_git_status') return Promise.resolve({});
+    if (cmd === 'fs_git_branch') return Promise.resolve('');
     if (cmd === 'fs_watch_set_root') return Promise.resolve(undefined);
     if (cmd && cmd.startsWith('list_')) return Promise.resolve([]);
     return Promise.resolve(null);


### PR DESCRIPTION
## Summary

Adds a VSCode-style file explorer to the right panel, rooted at the active session's live repo path. Includes:

- **Lazy-loaded tree** with per-depth indent guides, status colors and `+n -n` line counts from git, folder dirty-rollup, drag-out to terminals or other Acorn surfaces, and Cmd/Shift-click multi-select for bulk attach / copy / trash.
- **Context menu**: open in `$EDITOR` (falls back to the OS default app via `fs_open_default` when `$EDITOR` is unset), reveal in file manager, Open in New Tab (spawns a session in the chosen folder), Attach to Claude / Codex (live agent only), Copy Relative / Absolute Path, Rename (with F2 hotkey), Move to Trash. Bulk variants replace the menu when ≥2 entries are selected.
- **Code viewer tab**: double-click a file (or drag it onto a pane / tab strip) to open a readonly Shiki-highlighted tab. The viewer ships a git-diff gutter, line numbers, selectable text, binary detection, and a 2 MB truncation guard. Viewer tabs are workspace-local, support tab drag, and are scrubbed on app restart so the layout never reopens to a stale viewer.
- **VSCode-style search**: Cmd+F (or toolbar Search) opens a panel with main query, `files to include`, and `files to exclude`. Toggles for case sensitivity and regex sit inline; regex falls back to glob (`*.json` → `.*\.json`) and the input goes rose for invalid patterns. Closing the panel removes the visual filter while preserving values.

The toolbar also wires the existing left-side hotkey `$mod+Shift+e` (VSCode parity) to toggle the right panel between collapsed and the Files tab.

## Backend (`src-tauri/src/fs_explorer.rs`)

- `fs_list_dir` — dirs-first sort, hidden + gitignore filters aggregated from the nearest `.git`.
- `fs_rename`, `fs_trash` (via `trash` crate), `fs_reveal`, `fs_open_default`, `fs_shell_editor`.
- `fs_git_status` — modified / added / deleted / renamed / conflicted buckets with per-file `+n -n` counts vs HEAD.
- `fs_git_branch` (used elsewhere) and `fs_read_file` + `fs_git_diff_lines` for the viewer.
- `fs_watch_set_root` — recursive `notify` watcher emitting `acorn:fs-changed`; frontend debounces 100 ms.

## Test plan

- [ ] Toggle Files tab via `⌘+Shift+E`. Tree renders under the active session's repo root.
- [ ] Toggle hidden / gitignored / refresh-by-watcher all work; modify a file outside Acorn → tree updates within ~100 ms.
- [ ] Right-click a file → Open in `$EDITOR`; with `$EDITOR` unset, label switches to "Open with Default Program" and `open` runs.
- [ ] Right-click a folder → Open in New Tab spawns a session that ends up in the chosen folder.
- [ ] Live agent → Attach to Claude / Codex writes ` @<rel-path> ` to the active PTY.
- [ ] Cmd/Shift-click multi-select → bulk Copy Paths / Attach All / Move to Trash menu appears.
- [ ] Cmd+F opens search; type `*.json` (regex on) → tree filters; close → tree restored.
- [ ] Double-click a file → viewer tab opens with syntax highlight + diff bar; drag a file onto another pane → viewer opens there.
- [ ] Quit and reopen Acorn → if the last active tab was a viewer, the pane no longer renders "Drop a tab here…".
- [ ] `bun run typecheck`, `bun run test`, `cargo test fs_explorer` clean.
