### PR TITLE
feat(i18n): add foundation and Korean settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,8 @@ import { applyBackgroundVars, clearBackgroundVars } from "./lib/background";
 import { applyTheme, useThemes } from "./lib/themes";
 import { extractTabFromEvent } from "./lib/settings-events";
 import { useAppStore } from "./store";
+import type { TranslationKey, Translator } from "./lib/i18n";
+import { useTranslation } from "./lib/useTranslation";
 
 const FOCUSABLE_SELECTOR =
   "textarea, input:not([type='hidden']), button, [tabindex]:not([tabindex='-1']), a[href]";
@@ -69,6 +71,12 @@ const SIDEBAR_DEFAULT_SIZE = 18;
 const SIDEBAR_MIN_SIZE = 12;
 const RIGHT_PANEL_DEFAULT_SIZE = 26;
 const RIGHT_PANEL_MIN_SIZE = 16;
+
+type AppTranslationKey = Extract<TranslationKey, `app.${string}`>;
+
+function appText(t: Translator, key: AppTranslationKey): string {
+  return t(key);
+}
 
 function focusPanel(id: "sidebar" | "main" | "right") {
   const panel = document.querySelector(
@@ -117,6 +125,7 @@ function focusAdjacentPane(direction: "left" | "right" | "up" | "down") {
 }
 
 function App() {
+  const t = useTranslation();
   const refreshAll = useAppStore((s) => s.refreshAll);
   const sessions = useAppStore((s) => s.sessions);
   const projects = useAppStore((s) => s.projects);
@@ -148,8 +157,12 @@ function App() {
     const enabled = useAppStore.getState().toggleMultiInput();
     useToasts
       .getState()
-      .show(enabled ? "Multi-input on." : "Multi-input off.");
-  }, []);
+      .show(
+        enabled
+          ? appText(t, "app.toast.multiInputOn")
+          : appText(t, "app.toast.multiInputOff"),
+      );
+  }, [t]);
   const sidebarPanelRef = useRef<ImperativePanelHandle | null>(null);
   const rightPanelRef = useRef<ImperativePanelHandle | null>(null);
   const themes = useThemes((s) => s.themes);
@@ -840,11 +853,21 @@ function App() {
             // Existing PTY children keep the env they forked with —
             // surfacing this so the user knows why their already-open
             // session didn't change.
-            show("Shell environment reloaded. Open a new session to apply.");
+            show(
+              appText(
+                t,
+                "app.toast.shellEnvironmentReloaded",
+              ),
+            );
           })
           .catch((err: unknown) => {
             console.error("[App] reloadShellEnv failed", err);
-            show("Failed to reload shell environment.");
+            show(
+              appText(
+                t,
+                "app.toast.shellEnvironmentReloadFailed",
+              ),
+            );
           });
       },
       [Hotkeys.closeEmptyPane]: (e: KeyboardEvent) => {
@@ -859,7 +882,7 @@ function App() {
         useAppStore.getState().closePane(focusedPaneId);
       },
     }),
-    [],
+    [t, toggleMultiInput],
   );
 
   useHotkeys(bindings);

--- a/src/components/AgentResumeModal.tsx
+++ b/src/components/AgentResumeModal.tsx
@@ -5,7 +5,9 @@ import {
   type AgentKind,
   type ResumeCandidate,
 } from "../lib/api";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { useToasts } from "../lib/toasts";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal } from "./ui/Modal";
 import { ModalHeader } from "./ui/ModalHeader";
 
@@ -27,21 +29,25 @@ interface AgentResumeModalProps {
 
 interface AgentCopy {
   resumeCommand: (uuid: string) => string;
-  bodyParagraph: string;
+  bodyKey: DialogTranslationKey;
   ariaLabelledBy: string;
+}
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
 }
 
 const COPY: Record<AgentKind, AgentCopy> = {
   claude: {
     resumeCommand: (uuid) => `claude --resume ${uuid}`,
-    bodyParagraph:
-      "There's a Claude conversation that was in progress in this session. You can pick it up where you left off, or just close this dialog to start fresh.",
+    bodyKey: "dialogs.agentResume.bodyClaude",
     ariaLabelledBy: "acorn-claude-resume-title",
   },
   codex: {
     resumeCommand: (uuid) => `codex resume ${uuid}`,
-    bodyParagraph:
-      "There's a Codex conversation that was in progress in this session. You can pick it up where you left off, or just close this dialog to start fresh.",
+    bodyKey: "dialogs.agentResume.bodyCodex",
     ariaLabelledBy: "acorn-codex-resume-title",
   },
 };
@@ -65,12 +71,13 @@ export function AgentResumeModal({
   candidate,
   onDismiss,
 }: AgentResumeModalProps): ReactElement | null {
+  const t = useTranslation();
   const showToast = useToasts((s) => s.show);
   const copy = COPY[agent];
 
   const lastActivityLabel = useMemo(
-    () => formatRelativeTime(candidate?.lastActivityUnix ?? 0),
-    [candidate?.lastActivityUnix],
+    () => formatRelativeTime(candidate?.lastActivityUnix ?? 0, t),
+    [candidate?.lastActivityUnix, t],
   );
 
   if (!candidate) return null;
@@ -103,8 +110,8 @@ export function AgentResumeModal({
   const handleCopy = () => {
     void navigator.clipboard
       .writeText(candidate.uuid)
-      .then(() => showToast("Session ID copied"))
-      .catch(() => showToast("Failed to copy to clipboard"));
+      .then(() => showToast(dt(t, "dialogs.agentResume.sessionIdCopied")))
+      .catch(() => showToast(dt(t, "dialogs.agentResume.copyFailed")));
     onDismiss();
     ack();
   };
@@ -140,7 +147,7 @@ export function AgentResumeModal({
       ariaLabelledBy={copy.ariaLabelledBy}
     >
       <ModalHeader
-        title="Resume previous conversation"
+        title={dt(t, "dialogs.agentResume.title")}
         subtitle={lastActivityLabel}
         titleId={copy.ariaLabelledBy}
         icon={
@@ -152,7 +159,7 @@ export function AgentResumeModal({
         onClose={dismiss}
       />
       <div className="space-y-3 px-4 py-4 text-xs">
-        <p className="text-fg-muted">{copy.bodyParagraph}</p>
+        <p className="text-fg-muted">{dt(t, copy.bodyKey)}</p>
         {candidate.preview ? (
           <blockquote className="border-l-2 border-border-emphasis bg-bg-elevated/60 px-3 py-2 italic text-fg-muted">
             “{candidate.preview}”
@@ -168,7 +175,7 @@ export function AgentResumeModal({
           onClick={handleCancelWithHint}
           className="rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
         >
-          Cancel
+          {dt(t, "dialogs.common.cancel")}
         </button>
         <button
           type="button"
@@ -176,7 +183,7 @@ export function AgentResumeModal({
           className="inline-flex items-center gap-1.5 rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
         >
           <Copy size={12} />
-          Copy ID
+          {dt(t, "dialogs.agentResume.copyId")}
         </button>
         <button
           type="button"
@@ -184,24 +191,34 @@ export function AgentResumeModal({
           className="inline-flex items-center gap-1.5 rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90"
         >
           <Play size={12} />
-          Resume
+          {dt(t, "dialogs.agentResume.resume")}
         </button>
       </footer>
     </Modal>
   );
 }
 
-function formatRelativeTime(unixSeconds: number): string {
-  if (unixSeconds <= 0) return "Last activity unknown";
+function formatRelativeTime(unixSeconds: number, t: Translator): string {
+  if (unixSeconds <= 0) return dt(t, "dialogs.agentResume.lastActivityUnknown");
   const nowMs = Date.now();
   const thenMs = unixSeconds * 1000;
   const diffSec = Math.max(0, Math.floor((nowMs - thenMs) / 1000));
-  if (diffSec < 60) return "Just now";
+  if (diffSec < 60) return dt(t, "dialogs.agentResume.justNow");
   const diffMin = Math.floor(diffSec / 60);
-  if (diffMin < 60) return `~${diffMin} min ago`;
+  if (diffMin < 60) {
+    return `~${diffMin} ${dt(t, "dialogs.agentResume.minutesAgo")}`;
+  }
   const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `~${diffHr} hr ago`;
+  if (diffHr < 24) {
+    return `~${diffHr} ${dt(t, "dialogs.agentResume.hoursAgo")}`;
+  }
   const diffDay = Math.floor(diffHr / 24);
-  if (diffDay < 7) return `${diffDay} day${diffDay === 1 ? "" : "s"} ago`;
+  if (diffDay < 7) {
+    return `${diffDay} ${
+      diffDay === 1
+        ? dt(t, "dialogs.agentResume.dayAgo")
+        : dt(t, "dialogs.agentResume.daysAgo")
+    }`;
+  }
   return new Date(thenMs).toLocaleDateString();
 }

--- a/src/components/AuthorTag.tsx
+++ b/src/components/AuthorTag.tsx
@@ -4,6 +4,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { AuthorAvatar } from "./AuthorAvatar";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { cn } from "../lib/cn";
+import { useTranslation } from "../lib/useTranslation";
 
 /**
  * GitHub login regex. `[bot]` suffix is stripped before this check.
@@ -42,12 +43,13 @@ export function loginFromEmail(
  */
 export function buildProfileMenuItems(
   login: string | null | undefined,
+  label = "Open GitHub profile",
 ): ContextMenuItem[] {
   if (!isLikelyLogin(login)) return [];
   const slug = login.replace(/\[bot\]$/, "");
   return [
     {
-      label: "Open GitHub profile",
+      label,
       icon: <ExternalLink size={12} />,
       onClick: () => void openUrl(`https://github.com/${slug}`),
     },
@@ -74,9 +76,10 @@ export function AuthorTag({
   /** When true, render only the avatar (no inline username text). */
   avatarOnly?: boolean;
 }) {
+  const t = useTranslation();
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const hasLogin = isLikelyLogin(login);
-  const items = buildProfileMenuItems(login);
+  const items = buildProfileMenuItems(login, t("ui.openGitHubProfile"));
 
   if (!hasLogin) {
     if (!fallbackName) return null;

--- a/src/components/BackgroundSessionsSettings.tsx
+++ b/src/components/BackgroundSessionsSettings.tsx
@@ -11,10 +11,14 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { api, type DaemonSessionSummary, type DaemonStatus } from "../lib/api";
 import { cn } from "../lib/cn";
+import type { Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 import { useAppStore } from "../store";
 import type { Session } from "../lib/types";
 import { Tooltip } from "./Tooltip";
 import { CheckboxRow, Field } from "./ui";
+
+type BackgroundSessionsTranslator = Translator;
 
 /**
  * Settings panel for the `acornd` daemon — live status, killswitch
@@ -25,6 +29,7 @@ import { CheckboxRow, Field } from "./ui";
  * backend.
  */
 export function BackgroundSessionsSettings() {
+  const t = useTranslation();
   const [enabled, setEnabledLocal] = useState<boolean>(() => readKillswitch());
   const [status, setStatus] = useState<DaemonStatus | null>(null);
   const [sessions, setSessions] = useState<DaemonSessionSummary[] | null>(null);
@@ -104,32 +109,41 @@ export function BackgroundSessionsSettings() {
 
   const running = status?.running ?? false;
   const indicator = !enabled
-    ? { label: "Disabled", className: "text-fg-muted" }
+    ? {
+        label: t("backgroundSessions.status.disabled"),
+        className: "text-fg-muted",
+      }
     : running
-      ? { label: "Running", className: "text-accent" }
-      : { label: "Down", className: "text-danger" };
+      ? {
+          label: t("backgroundSessions.status.running"),
+          className: "text-accent",
+        }
+      : {
+          label: t("backgroundSessions.status.down"),
+          className: "text-danger",
+        };
 
   return (
     <section className="space-y-4">
       <Field
-        label="Daemon"
-        hint="The acornd daemon owns long-running terminal sessions. With the daemon on, Acorn can quit and reopen without losing your PTYs. Off falls back to the legacy in-process path — sessions die with the app."
+        label={t("backgroundSessions.daemon.label")}
+        hint={t("backgroundSessions.daemon.hint")}
       >
         <CheckboxRow
           checked={enabled}
           onChange={(v) => void handleToggle(v)}
-          label="Enable background sessions (acornd)"
+          label={t("backgroundSessions.daemon.enableLabel")}
           description={
             enabled
-              ? "Sessions persist across Acorn restarts until you explicitly quit them."
-              : "Sessions are bound to this Acorn process — closing the app kills them."
+              ? t("backgroundSessions.daemon.enabledDescription")
+              : t("backgroundSessions.daemon.disabledDescription")
           }
         />
       </Field>
 
       <Field
-        label="Status"
-        hint="Live state of the running daemon. Updates every 3 seconds while this panel is open."
+        label={t("backgroundSessions.status.label")}
+        hint={t("backgroundSessions.status.hint")}
       >
         <div className="rounded border border-border bg-bg-elevated p-3 text-xs">
           <div className="flex items-center gap-2">
@@ -139,22 +153,25 @@ export function BackgroundSessionsSettings() {
             {status?.daemon_version ? (
               <span className="text-fg-muted">v{status.daemon_version}</span>
             ) : null}
-            {status?.uptime_seconds !== null && status?.uptime_seconds !== undefined ? (
+            {status?.uptime_seconds !== null &&
+            status?.uptime_seconds !== undefined ? (
               <span className="text-fg-muted">
-                · up {formatDuration(status.uptime_seconds)}
+                · {t("backgroundSessions.status.up")}{" "}
+                {formatDuration(status.uptime_seconds)}
               </span>
             ) : null}
             {status?.session_count_total !== null &&
             status?.session_count_total !== undefined ? (
               <span className="text-fg-muted">
-                · sessions {status.session_count_alive ?? 0}/
-                {status.session_count_total}
+                · {t("backgroundSessions.status.sessions")}{" "}
+                {status.session_count_alive ?? 0}/{status.session_count_total}
               </span>
             ) : null}
           </div>
           {status?.log_path ? (
             <div className="mt-2 text-fg-muted">
-              Log: <code className="font-mono">{status.log_path}</code>
+              {t("backgroundSessions.status.log")}:{" "}
+              <code className="font-mono">{status.log_path}</code>
             </div>
           ) : null}
           {statusError ? (
@@ -166,7 +183,10 @@ export function BackgroundSessionsSettings() {
         </div>
       </Field>
 
-      <Field label="Controls" hint="Restart reconnects the bridge — useful after killing the daemon from a terminal. Quit kills every running PTY and exits the daemon.">
+      <Field
+        label={t("backgroundSessions.controls.label")}
+        hint={t("backgroundSessions.controls.hint")}
+      >
         <div className="flex flex-wrap gap-2">
           <button
             type="button"
@@ -182,11 +202,13 @@ export function BackgroundSessionsSettings() {
             ) : (
               <RefreshCcw size={12} />
             )}
-            <span>Restart daemon</span>
+            <span>{t("backgroundSessions.controls.restart")}</span>
           </button>
           {confirmShutdown ? (
             <div className="flex items-center gap-2 rounded border border-danger/40 bg-danger/10 px-2 py-1 text-xs text-danger">
-              <span>Kill every PTY?</span>
+              <span>
+                {t("backgroundSessions.controls.confirmShutdownPrompt")}
+              </span>
               <button
                 type="button"
                 onClick={() => void handleShutdown()}
@@ -196,7 +218,7 @@ export function BackgroundSessionsSettings() {
                 {busy === "shutdown" ? (
                   <Loader2 size={10} className="animate-spin" />
                 ) : (
-                  "Confirm"
+                  t("backgroundSessions.controls.confirm")
                 )}
               </button>
               <button
@@ -205,7 +227,7 @@ export function BackgroundSessionsSettings() {
                 disabled={busy !== null}
                 className="px-2 py-0.5 hover:text-fg"
               >
-                Cancel
+                {t("backgroundSessions.controls.cancel")}
               </button>
             </div>
           ) : (
@@ -219,15 +241,15 @@ export function BackgroundSessionsSettings() {
               )}
             >
               <Power size={12} />
-              <span>Quit daemon</span>
+              <span>{t("backgroundSessions.controls.quit")}</span>
             </button>
           )}
         </div>
       </Field>
 
       <Field
-        label="Sessions"
-        hint="Every PTY the daemon currently tracks. Dead rows can be forgotten from the daemon side; their app metadata stays so you can resume from disk if the agent supports it."
+        label={t("backgroundSessions.sessions.label")}
+        hint={t("backgroundSessions.sessions.hint")}
       >
         <SessionsList
           sessions={sessions}
@@ -235,6 +257,7 @@ export function BackgroundSessionsSettings() {
           running={running}
           onRefresh={refresh}
           appSessions={appSessions}
+          t={t}
         />
       </Field>
     </section>
@@ -247,12 +270,14 @@ function SessionsList({
   running,
   onRefresh,
   appSessions,
+  t,
 }: {
   sessions: DaemonSessionSummary[] | null;
   enabled: boolean;
   running: boolean;
   onRefresh: () => Promise<void>;
   appSessions: Session[];
+  t: BackgroundSessionsTranslator;
 }) {
   const [rowBusy, setRowBusy] = useState<string | null>(null);
   const [rowError, setRowError] = useState<string | null>(null);
@@ -281,18 +306,30 @@ function SessionsList({
   if (!enabled) {
     return (
       <p className="text-xs text-fg-muted">
-        Daemon disabled — sessions are managed by the legacy in-process path.
+        {t("backgroundSessions.sessions.disabled")}
       </p>
     );
   }
   if (!running) {
-    return <p className="text-xs text-fg-muted">Daemon is not running.</p>;
+    return (
+      <p className="text-xs text-fg-muted">
+        {t("backgroundSessions.sessions.notRunning")}
+      </p>
+    );
   }
   if (sessions === null) {
-    return <p className="text-xs text-fg-muted">Loading…</p>;
+    return (
+      <p className="text-xs text-fg-muted">
+        {t("backgroundSessions.sessions.loading")}
+      </p>
+    );
   }
   if (sessions.length === 0) {
-    return <p className="text-xs text-fg-muted">No sessions tracked.</p>;
+    return (
+      <p className="text-xs text-fg-muted">
+        {t("backgroundSessions.sessions.empty")}
+      </p>
+    );
   }
   return (
     <div className="space-y-2">
@@ -311,7 +348,7 @@ function SessionsList({
               </span>
               <span className="flex flex-1 items-center gap-1.5 truncate font-mono">
                 <Tooltip
-                  label={renderAppMetaTooltip(appById.get(s.id), s)}
+                  label={renderAppMetaTooltip(appById.get(s.id), s, t)}
                   side="top"
                   multiline
                 >
@@ -323,22 +360,27 @@ function SessionsList({
                   const ts = Date.parse(app.updated_at);
                   if (Number.isNaN(ts)) return null;
                   return (
-                    <Tooltip
-                      label={new Date(ts).toLocaleString()}
-                      side="top"
-                    >
+                    <Tooltip label={new Date(ts).toLocaleString()} side="top">
                       <span className="shrink-0 cursor-help text-[10px] text-fg-muted">
-                        {formatRelativeTime(ts)}
+                        {formatRelativeTime(
+                          ts,
+                          t("backgroundSessions.relativeTime.ago"),
+                        )}
                       </span>
                     </Tooltip>
                   );
                 })()}
                 {s.kind === "control" ? (
-                  <Tooltip label="Control session" side="top">
+                  <Tooltip
+                    label={t("backgroundSessions.sessions.controlSession")}
+                    side="top"
+                  >
                     <Bot
                       size={12}
                       className="shrink-0 text-fg-muted"
-                      aria-label="Control session"
+                      aria-label={t(
+                        "backgroundSessions.sessions.controlSession",
+                      )}
                     />
                   </Tooltip>
                 ) : null}
@@ -350,7 +392,10 @@ function SessionsList({
               ) : null}
               <div className="flex items-center gap-1">
                 {s.alive ? (
-                  <Tooltip label="Kill PTY" side="top">
+                  <Tooltip
+                    label={t("backgroundSessions.actions.killPty")}
+                    side="top"
+                  >
                     <RowButton
                       busy={busy}
                       onClick={() =>
@@ -359,14 +404,14 @@ function SessionsList({
                         )
                       }
                       tone="danger"
-                      aria-label="Kill PTY"
+                      aria-label={t("backgroundSessions.actions.killPty")}
                     >
                       <Power size={12} />
                     </RowButton>
                   </Tooltip>
                 ) : (
                   <Tooltip
-                    label="Adopt this session back into Acorn's sidebar"
+                    label={t("backgroundSessions.actions.restoreTooltip")}
                     side="top"
                   >
                     <RowButton
@@ -376,7 +421,7 @@ function SessionsList({
                           api.daemonAdoptSession(s.id),
                         )
                       }
-                      aria-label="Restore session"
+                      aria-label={t("backgroundSessions.actions.restore")}
                     >
                       <Undo2 size={12} />
                     </RowButton>
@@ -385,8 +430,8 @@ function SessionsList({
                 <Tooltip
                   label={
                     s.alive
-                      ? "Kill first, then forget"
-                      : "Remove this row from the daemon registry"
+                      ? t("backgroundSessions.actions.forgetDisabledTooltip")
+                      : t("backgroundSessions.actions.forgetTooltip")
                   }
                   side="top"
                 >
@@ -398,7 +443,7 @@ function SessionsList({
                         api.daemonForgetSession(s.id),
                       )
                     }
-                    aria-label="Forget session"
+                    aria-label={t("backgroundSessions.actions.forget")}
                   >
                     <Trash2 size={12} />
                   </RowButton>
@@ -418,45 +463,69 @@ function SessionsList({
   );
 }
 
-function formatRelativeTime(timestampMs: number): string {
+function formatRelativeTime(timestampMs: number, ago: string): string {
   const diffSec = Math.round((Date.now() - timestampMs) / 1000);
-  if (diffSec < 60) return `${Math.max(0, diffSec)}s ago`;
+  if (diffSec < 60) return `${Math.max(0, diffSec)}s ${ago}`;
   const min = Math.round(diffSec / 60);
-  if (min < 60) return `${min}m ago`;
+  if (min < 60) return `${min}m ${ago}`;
   const hr = Math.round(diffSec / 3600);
-  if (hr < 24) return `${hr}h ago`;
+  if (hr < 24) return `${hr}h ${ago}`;
   const day = Math.round(diffSec / 86400);
-  if (day < 30) return `${day}d ago`;
+  if (day < 30) return `${day}d ${ago}`;
   const mo = Math.round(diffSec / (86400 * 30));
-  if (mo < 12) return `${mo}mo ago`;
+  if (mo < 12) return `${mo}mo ${ago}`;
   const yr = Math.round(diffSec / (86400 * 365));
-  return `${yr}y ago`;
+  return `${yr}y ${ago}`;
 }
 
 function renderAppMetaTooltip(
   app: Session | undefined,
   daemon: DaemonSessionSummary,
+  t: BackgroundSessionsTranslator,
 ) {
   const rows: { label: string; value: string }[] = [];
   if (app) {
-    rows.push({ label: "Tab", value: app.name });
-    if (app.branch) rows.push({ label: "Branch", value: app.branch });
-    rows.push({ label: "Status", value: app.status });
+    rows.push({ label: t("backgroundSessions.metadata.tab"), value: app.name });
+    if (app.branch) {
+      rows.push({
+        label: t("backgroundSessions.metadata.branch"),
+        value: app.branch,
+      });
+    }
+    rows.push({
+      label: t("backgroundSessions.metadata.status"),
+      value: app.status,
+    });
     if (app.worktree_path) {
-      rows.push({ label: "Worktree", value: app.worktree_path });
+      rows.push({
+        label: t("backgroundSessions.metadata.worktree"),
+        value: app.worktree_path,
+      });
     }
     if (app.last_message) {
-      rows.push({ label: "Last", value: app.last_message });
+      rows.push({
+        label: t("backgroundSessions.metadata.last"),
+        value: app.last_message,
+      });
     }
   } else {
     if (daemon.branch) {
-      rows.push({ label: "Branch", value: daemon.branch });
+      rows.push({
+        label: t("backgroundSessions.metadata.branch"),
+        value: daemon.branch,
+      });
     }
     if (daemon.repo_path) {
-      rows.push({ label: "Repo", value: daemon.repo_path });
+      rows.push({
+        label: t("backgroundSessions.metadata.repo"),
+        value: daemon.repo_path,
+      });
     }
     if (daemon.cwd) {
-      rows.push({ label: "Worktree", value: daemon.cwd });
+      rows.push({
+        label: t("backgroundSessions.metadata.worktree"),
+        value: daemon.cwd,
+      });
     }
   }
   return (
@@ -464,7 +533,7 @@ function renderAppMetaTooltip(
       <div className="font-mono text-[10px] text-fg-muted">{daemon.id}</div>
       {!app ? (
         <div className="text-[10px] italic text-fg-muted">
-          No app-side row — orphaned in daemon.
+          {t("backgroundSessions.metadata.orphaned")}
         </div>
       ) : null}
       {rows.map((r) => (

--- a/src/components/ClosePullRequestDialog.tsx
+++ b/src/components/ClosePullRequestDialog.tsx
@@ -2,8 +2,16 @@ import { useEffect, useState } from "react";
 import { GitPullRequestClosed } from "lucide-react";
 import { api } from "../lib/api";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import type { PullRequestDetail } from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal, ModalHeader, TextSwap } from "./ui";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface ClosePullRequestDialogProps {
   open: boolean;
@@ -20,6 +28,7 @@ export function ClosePullRequestDialog({
   onClose,
   onClosed,
 }: ClosePullRequestDialogProps) {
+  const t = useTranslation();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -56,7 +65,7 @@ export function ClosePullRequestDialog({
       {detail ? (
         <>
           <ModalHeader
-            title={`Close #${detail.number}`}
+            title={`${dt(t, "dialogs.closePullRequest.titlePrefix")} #${detail.number}`}
             icon={
               <GitPullRequestClosed size={16} className="text-rose-400" />
             }
@@ -67,9 +76,9 @@ export function ClosePullRequestDialog({
           />
           <div className="space-y-3 px-4 py-3 text-sm text-fg">
             <p className="text-xs">
-              Close pull request{" "}
+              {dt(t, "dialogs.closePullRequest.confirmPrefix")}{" "}
               <span className="font-mono text-accent">#{detail.number}</span>{" "}
-              without merging?
+              {dt(t, "dialogs.closePullRequest.confirmSuffix")}
             </p>
             <div className="rounded-md border border-border bg-bg-sidebar/60 p-3 text-[11px]">
               <p className="truncate font-medium">{detail.title}</p>
@@ -90,7 +99,7 @@ export function ClosePullRequestDialog({
               disabled={submitting}
               className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
             >
-              Cancel
+              {dt(t, "dialogs.common.cancel")}
             </button>
             <button
               type="button"
@@ -98,7 +107,11 @@ export function ClosePullRequestDialog({
               disabled={submitting}
               className="rounded-md bg-rose-500/20 px-3 py-1.5 text-xs font-medium text-rose-300 transition hover:bg-rose-500/30 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              <TextSwap>{submitting ? "Closing…" : "Close PR"}</TextSwap>
+              <TextSwap>
+                {submitting
+                  ? dt(t, "dialogs.closePullRequest.closing")
+                  : dt(t, "dialogs.closePullRequest.closePr")}
+              </TextSwap>
             </button>
           </footer>
         </>

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -6,6 +6,7 @@ import {
 } from "../lib/api";
 import { highlightCode, langFromPath } from "../lib/highlight";
 import { cn } from "../lib/cn";
+import { useTranslation } from "../lib/useTranslation";
 
 interface CodeViewerProps {
   path: string;
@@ -33,6 +34,7 @@ const DIFF_KIND_CLASS: Record<FsLineDiffEntry["kind"], string> = {
 };
 
 export function CodeViewer({ path, isActive }: CodeViewerProps) {
+  const t = useTranslation();
   const [state, setState] = useState<ViewerState>(EMPTY_STATE);
   const [diffLines, setDiffLines] = useState<FsLineDiffEntry[]>([]);
 
@@ -95,7 +97,7 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
   if (state.loading) {
     return (
       <div className="flex h-full items-center justify-center text-xs text-fg-muted">
-        Loading…
+        {t("codeViewer.loading")}
       </div>
     );
   }
@@ -109,8 +111,11 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
   if (state.data?.binary) {
     return (
       <Notice
-        title="Binary file"
-        body={`${state.data.size.toLocaleString()} bytes — not shown in the readonly viewer.`}
+        title={t("codeViewer.binaryFile")}
+        body={t("codeViewer.binaryFileBody").replace(
+          "{bytes}",
+          state.data.size.toLocaleString(),
+        )}
       />
     );
   }
@@ -130,7 +135,7 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
     >
       {state.data.truncated ? (
         <div className="shrink-0 border-b border-border bg-bg-warning/15 px-3 py-1 text-[11px] text-fg-muted">
-          File truncated to 2 MB. Open externally to view the rest.
+          {t("codeViewer.truncated")}
         </div>
       ) : null}
       <pre className="acorn-selectable m-0 flex-1 cursor-text overflow-auto bg-transparent font-mono text-[12px] leading-[1.5] text-fg">

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -21,15 +21,27 @@ import { RESET_PANEL_SIZES_EVENT } from "../lib/layoutEvents";
 import { useAppStore } from "../store";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { useToasts } from "../lib/toasts";
+import { useTranslation } from "../lib/useTranslation";
 
 interface CommandPaletteProps {
   open: boolean;
   onOpenChange: (value: boolean) => void;
 }
 
+type CommandPaletteTranslationKey = Extract<
+  TranslationKey,
+  `commandPalette.${string}`
+>;
+
+function cpt(t: Translator, key: CommandPaletteTranslationKey): string {
+  return t(key);
+}
+
 export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const sessions = useAppStore((s) => s.sessions);
+  const t = useTranslation();
 
   // Derived once per render — sessions array identity is stable from zustand
   // until the underlying list actually changes.
@@ -104,10 +116,10 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     const show = useToasts.getState().show;
     try {
       await api.reloadShellEnv();
-      show("Shell environment reloaded. Open a new session to apply.");
+      show(cpt(t, "commandPalette.toasts.shellEnvReloaded"));
     } catch (err) {
       console.error("[CommandPalette] reloadShellEnv failed", err);
-      show("Failed to reload shell environment.");
+      show(cpt(t, "commandPalette.toasts.shellEnvReloadFailed"));
     } finally {
       close();
     }
@@ -122,11 +134,13 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     const show = useToasts.getState().show;
     try {
       await api.ipcRestart();
-      show("IPC server restarted.");
+      show(cpt(t, "commandPalette.toasts.ipcRestarted"));
     } catch (err) {
       console.error("[CommandPalette] ipcRestart failed", err);
       const message = err instanceof Error ? err.message : String(err);
-      show(`Failed to restart IPC server: ${message}`);
+      show(
+        `${cpt(t, "commandPalette.toasts.ipcRestartFailedPrefix")} ${message}`,
+      );
     } finally {
       close();
     }
@@ -136,7 +150,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     <Command.Dialog
       open={open}
       onOpenChange={onOpenChange}
-      label="Command palette"
+      label={cpt(t, "commandPalette.dialogLabel")}
       overlayClassName="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm"
       contentClassName={cn(
         "fixed inset-x-0 top-0 z-50 mx-auto mt-32 max-w-lg",
@@ -148,7 +162,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       <div className="border-b border-border px-3 py-2">
         <Command.Input
           autoFocus
-          placeholder="Type a command or search..."
+          placeholder={cpt(t, "commandPalette.placeholder")}
           className={cn(
             "w-full bg-transparent text-sm text-fg outline-none placeholder:text-fg-muted",
             "py-1.5",
@@ -173,13 +187,13 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         )}
       >
         <Command.Empty className="px-3 py-6 text-center text-sm text-fg-muted">
-          No results.
+          {cpt(t, "commandPalette.empty")}
         </Command.Empty>
 
-        <Command.Group heading="Sessions">
+        <Command.Group heading={cpt(t, "commandPalette.groups.sessions")}>
           <Command.Item value="new-session" onSelect={handleNewSession}>
             <Plus size={14} className="text-accent" />
-            <span>New session</span>
+            <span>{cpt(t, "commandPalette.commands.newSession")}</span>
             <span className="ml-auto truncate text-xs text-fg-muted/80">
               ⌘T
             </span>
@@ -190,7 +204,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             keywords={["worktree", "isolated", "branch"]}
           >
             <GitBranch size={14} className="text-accent" />
-            <span>New isolated session</span>
+            <span>{cpt(t, "commandPalette.commands.newIsolatedSession")}</span>
             <span className="ml-auto truncate text-xs text-fg-muted/80">
               ⌥⌘T
             </span>
@@ -201,7 +215,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             keywords={["control", "ipc", "dispatcher", "orchestrator"]}
           >
             <Bot size={14} className="text-accent" />
-            <span>New control session</span>
+            <span>{cpt(t, "commandPalette.commands.newControlSession")}</span>
             <span className="ml-auto truncate text-xs text-fg-muted/80">
               ⌥⇧⌘T
             </span>
@@ -212,7 +226,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             keywords={["project", "create", "repository", "repo", "folder"]}
           >
             <FolderPlus size={14} className="text-accent" />
-            <span>New project</span>
+            <span>{cpt(t, "commandPalette.commands.newProject")}</span>
           </Command.Item>
           <Command.Item
             value="add-project"
@@ -220,19 +234,19 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             keywords={["project", "import", "repository", "repo", "folder"]}
           >
             <FolderOpen size={14} className="text-accent" />
-            <span>Add existing project</span>
+            <span>{cpt(t, "commandPalette.commands.addExistingProject")}</span>
             <span className="ml-auto truncate text-xs text-fg-muted/80">
               ⇧⌘N
             </span>
           </Command.Item>
           <Command.Item value="refresh-sessions" onSelect={handleRefresh}>
             <RefreshCw size={14} className="text-fg-muted" />
-            <span>Refresh sessions</span>
+            <span>{cpt(t, "commandPalette.commands.refreshSessions")}</span>
           </Command.Item>
         </Command.Group>
 
         {sessionItems.length > 0 ? (
-          <Command.Group heading="Switch session">
+          <Command.Group heading={cpt(t, "commandPalette.groups.switchSession")}>
             {sessionItems.map((session) => (
               <Command.Item
                 key={`switch-${session.id}`}
@@ -241,7 +255,10 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
                 keywords={[session.name, session.branch]}
               >
                 <Sparkles size={14} className="text-fg-muted" />
-                <span className="truncate">Switch to {session.name}</span>
+                <span className="truncate">
+                  {cpt(t, "commandPalette.commands.switchSessionPrefix")}{" "}
+                  {session.name}
+                </span>
                 <span className="ml-auto truncate text-xs text-fg-muted/80">
                   {session.branch}
                 </span>
@@ -250,27 +267,27 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           </Command.Group>
         ) : null}
 
-        <Command.Group heading="View">
+        <Command.Group heading={cpt(t, "commandPalette.groups.view")}>
           <Command.Item
             value="view-todos"
             onSelect={() => handleSetTab("todos")}
           >
             <ListChecks size={14} className="text-fg-muted" />
-            <span>View Todos</span>
+            <span>{cpt(t, "commandPalette.commands.viewTodos")}</span>
           </Command.Item>
           <Command.Item
             value="view-commits"
             onSelect={() => handleSetTab("commits")}
           >
             <GitCommit size={14} className="text-fg-muted" />
-            <span>View Commits</span>
+            <span>{cpt(t, "commandPalette.commands.viewCommits")}</span>
           </Command.Item>
           <Command.Item
             value="view-staged"
             onSelect={() => handleSetTab("staged")}
           >
             <ListPlus size={14} className="text-fg-muted" />
-            <span>View Staged</span>
+            <span>{cpt(t, "commandPalette.commands.viewStaged")}</span>
           </Command.Item>
           <Command.Item
             value="view-prs"
@@ -278,7 +295,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             keywords={["pull requests", "pr", "github"]}
           >
             <GitPullRequest size={14} className="text-fg-muted" />
-            <span>View Pull Requests</span>
+            <span>{cpt(t, "commandPalette.commands.viewPullRequests")}</span>
           </Command.Item>
           <Command.Item
             value="reset-panel-sizes"
@@ -296,25 +313,27 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             ]}
           >
             <LayoutTemplate size={14} className="text-fg-muted" />
-            <span>Reset panel sizes</span>
+            <span>{cpt(t, "commandPalette.commands.resetPanelSizes")}</span>
           </Command.Item>
         </Command.Group>
 
-        <Command.Group heading="Terminal">
+        <Command.Group heading={cpt(t, "commandPalette.groups.terminal")}>
           <Command.Item
             value="reload-shell-env"
             onSelect={() => void handleReloadShellEnv()}
             keywords={["dotfile", "zshenv", "lang", "editor", "env", "locale"]}
           >
             <Terminal size={14} className="text-fg-muted" />
-            <span>Reload shell environment</span>
+            <span>
+              {cpt(t, "commandPalette.commands.reloadShellEnvironment")}
+            </span>
             <span className="ml-auto truncate text-xs text-fg-muted/80">
               ⇧⌘,
             </span>
           </Command.Item>
         </Command.Group>
 
-        <Command.Group heading="IPC">
+        <Command.Group heading={cpt(t, "commandPalette.groups.ipc")}>
           <Command.Item
             value="restart-ipc"
             onSelect={() => void handleRestartIpc()}
@@ -329,14 +348,14 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             ]}
           >
             <Bot size={14} className="text-accent" />
-            <span>Restart IPC server</span>
+            <span>{cpt(t, "commandPalette.commands.restartIpcServer")}</span>
           </Command.Item>
         </Command.Group>
 
-        <ShakeTreeItem onSelect={handleShakeTree} />
+        <ShakeTreeItem onSelect={handleShakeTree} t={t} />
 
         {sessionItems.length > 0 ? (
-          <Command.Group heading="Danger zone">
+          <Command.Group heading={cpt(t, "commandPalette.groups.dangerZone")}>
             {sessionItems.map((session) => (
               <Command.Item
                 key={`remove-${session.id}`}
@@ -346,7 +365,8 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
               >
                 <Trash2 size={14} className="text-danger" />
                 <span className="truncate">
-                  Remove session: {session.name}
+                  {cpt(t, "commandPalette.commands.removeSessionPrefix")}{" "}
+                  {session.name}
                 </span>
               </Command.Item>
             ))}
@@ -371,7 +391,13 @@ const SHAKE_TRIGGERS = [
   "도토리",
 ];
 
-function ShakeTreeItem({ onSelect }: { onSelect: () => void }) {
+function ShakeTreeItem({
+  onSelect,
+  t,
+}: {
+  onSelect: () => void;
+  t: Translator;
+}) {
   const search = useCommandState(
     (state: { search: string }) => state.search,
   ) as string | undefined;
@@ -387,7 +413,7 @@ function ShakeTreeItem({ onSelect }: { onSelect: () => void }) {
       keywords={SHAKE_TRIGGERS}
     >
       <Trees size={14} className="text-accent" />
-      <span>Shake the tree</span>
+      <span>{cpt(t, "commandPalette.commands.shakeTree")}</span>
     </Command.Item>
   );
 }

--- a/src/components/CommandRunDialog.tsx
+++ b/src/components/CommandRunDialog.tsx
@@ -3,7 +3,15 @@ import { Copy, Play, Terminal as TerminalIcon } from "lucide-react";
 import { useAppStore } from "../store";
 import { useToasts } from "../lib/toasts";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal, ModalHeader, TextSwap } from "./ui";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface CommandRunDialogProps {
   open: boolean;
@@ -46,6 +54,7 @@ export function CommandRunDialog({
   repoPath,
   onClose,
 }: CommandRunDialogProps): ReactElement {
+  const t = useTranslation();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const projects = useAppStore((s) => s.projects);
@@ -74,16 +83,16 @@ export function CommandRunDialog({
   async function handleCopy() {
     try {
       await navigator.clipboard.writeText(command);
-      showToast(`Copied: ${command}`);
+      showToast(`${dt(t, "dialogs.commandRun.copiedPrefix")} ${command}`);
       onClose();
     } catch (e) {
-      setError(`Copy failed: ${String(e)}`);
+      setError(`${dt(t, "dialogs.commandRun.copyFailedPrefix")} ${String(e)}`);
     }
   }
 
   async function handleRun() {
     if (!resolvedRepoPath) {
-      setError("No project available to host the new session.");
+      setError(dt(t, "dialogs.commandRun.noProjectError"));
       return;
     }
     setBusy(true);
@@ -95,7 +104,7 @@ export function CommandRunDialog({
       );
       if (!created) {
         const storeError = useAppStore.getState().error;
-        setError(storeError ?? "Failed to create session.");
+        setError(storeError ?? dt(t, "dialogs.commandRun.createFailed"));
         setBusy(false);
         return;
       }
@@ -103,7 +112,7 @@ export function CommandRunDialog({
       // queue inside its own `pty_spawn` resolver, so the value just has
       // to be present by the time the spawn completes.
       setPendingTerminalInput(created.id, command);
-      showToast(`Running: ${command}`);
+      showToast(`${dt(t, "dialogs.commandRun.runningPrefix")} ${command}`);
       setBusy(false);
       onClose();
     } catch (e) {
@@ -118,30 +127,31 @@ export function CommandRunDialog({
       onClose={close}
       variant="dialog"
       size="md"
-      ariaLabel="Run command"
+      ariaLabel={dt(t, "dialogs.commandRun.ariaLabel")}
     >
       <ModalHeader
-        title="Run this command?"
+        title={dt(t, "dialogs.commandRun.title")}
         icon={<TerminalIcon size={14} className="text-accent" />}
         variant="dialog"
         onClose={close}
       />
       <div className="space-y-3 px-4 py-4 text-xs text-fg-muted">
         <p className="text-fg">
-          A new terminal session will open and run:
+          {dt(t, "dialogs.commandRun.description")}
         </p>
         <pre className="overflow-x-auto rounded-md border border-border bg-bg-sidebar/70 px-3 py-2 font-mono text-[12px] text-fg">
           {command}
         </pre>
         {resolvedRepoPath ? (
           <p>
-            <span className="opacity-70">cwd:</span>{" "}
+            <span className="opacity-70">
+              {dt(t, "dialogs.commandRun.cwdLabel")}
+            </span>{" "}
             <span className="font-mono text-fg">{resolvedRepoPath}</span>
           </p>
         ) : (
           <p className="text-danger">
-            No project is registered — add a project before running this
-            command, or use "Copy" to paste it into an existing terminal.
+            {dt(t, "dialogs.commandRun.noProjectHint")}
           </p>
         )}
         {error ? (
@@ -157,7 +167,7 @@ export function CommandRunDialog({
           disabled={busy}
           className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
         >
-          Cancel
+          {dt(t, "dialogs.common.cancel")}
         </button>
         <button
           type="button"
@@ -166,7 +176,7 @@ export function CommandRunDialog({
           className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs text-fg transition hover:bg-bg-elevated disabled:cursor-not-allowed disabled:opacity-60"
         >
           <Copy size={12} />
-          Copy
+          {dt(t, "dialogs.common.copy")}
         </button>
         <button
           type="button"
@@ -175,7 +185,9 @@ export function CommandRunDialog({
           className="inline-flex items-center gap-1.5 rounded-md bg-accent/20 px-3 py-1.5 text-xs font-medium text-accent transition hover:bg-accent/30 disabled:cursor-not-allowed disabled:opacity-60"
         >
           <Play size={12} />
-          <TextSwap>{busy ? "Running…" : "Run"}</TextSwap>
+          <TextSwap>
+            {busy ? dt(t, "dialogs.commandRun.running") : dt(t, "dialogs.commandRun.run")}
+          </TextSwap>
         </button>
       </footer>
     </Modal>

--- a/src/components/ControlSessionGuideModal.tsx
+++ b/src/components/ControlSessionGuideModal.tsx
@@ -1,8 +1,16 @@
 import { useState, type ReactElement } from "react";
 import { Bot } from "lucide-react";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal } from "./ui/Modal";
 import { ModalHeader } from "./ui/ModalHeader";
 import { CheckboxRow } from "./ui/CheckboxRow";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 /**
  * localStorage key gating this modal. Exported so the App-level host can write
@@ -31,6 +39,7 @@ export function ControlSessionGuideModal({
   open,
   onClose,
 }: ControlSessionGuideModalProps): ReactElement | null {
+  const t = useTranslation();
   const [dontShowAgain, setDontShowAgain] = useState(false);
 
   function dismiss() {
@@ -46,8 +55,8 @@ export function ControlSessionGuideModal({
       ariaLabelledBy="acorn-control-guide-title"
     >
       <ModalHeader
-        title="Control session"
-        subtitle="A terminal that drives other sessions in this project"
+        title={dt(t, "dialogs.controlSessionGuide.title")}
+        subtitle={dt(t, "dialogs.controlSessionGuide.subtitle")}
         titleId="acorn-control-guide-title"
         icon={<Bot size={14} className="text-accent" />}
         variant="dialog"
@@ -55,23 +64,20 @@ export function ControlSessionGuideModal({
       />
       <div className="space-y-3 px-4 py-4 text-xs text-fg-muted">
         <p>
-          Control sessions are an upcoming way to coordinate work across
-          terminals from a single place — handy for agents and scripts that
-          need to dispatch commands to siblings in the same project.
+          {dt(t, "dialogs.controlSessionGuide.bodyIntro")}
         </p>
         <ul className="ml-4 list-disc space-y-1">
-          <li>Send keystrokes to any session in this project.</li>
-          <li>List the other sessions and their status.</li>
-          <li>Read recent output from a target session.</li>
+          <li>{dt(t, "dialogs.controlSessionGuide.pointKeystrokes")}</li>
+          <li>{dt(t, "dialogs.controlSessionGuide.pointListSessions")}</li>
+          <li>{dt(t, "dialogs.controlSessionGuide.pointReadOutput")}</li>
         </ul>
         <p>
-          You just created a control session. The{" "}
+          {dt(t, "dialogs.controlSessionGuide.createdPrefix")}{" "}
           <code className="rounded bg-bg px-1 py-0.5 text-fg">acorn-ipc</code>{" "}
-          CLI that drives it ships in the next update; this terminal will
-          start behaving like a regular shell until then.
+          {dt(t, "dialogs.controlSessionGuide.createdSuffix")}
         </p>
         <CheckboxRow
-          label="Don't show this again"
+          label={dt(t, "dialogs.common.dontShowAgain")}
           checked={dontShowAgain}
           onChange={setDontShowAgain}
         />
@@ -82,7 +88,7 @@ export function ControlSessionGuideModal({
           onClick={dismiss}
           className="rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90"
         >
-          Got it
+          {dt(t, "dialogs.common.gotIt")}
         </button>
       </footer>
     </Modal>

--- a/src/components/DiffSplitView.tsx
+++ b/src/components/DiffSplitView.tsx
@@ -10,6 +10,7 @@ import { joinPath } from "../lib/paths";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { DiffLine, useHighlightedDiff } from "./DiffView";
 import { ResizeHandle } from "./ResizeHandle";
+import { useTranslation } from "../lib/useTranslation";
 
 interface DiffSplitViewProps {
   payload: DiffPayload;
@@ -43,6 +44,7 @@ interface FileEntry {
  * path so navigation is stable across diff payloads.
  */
 export function DiffSplitView({ payload, cwd }: DiffSplitViewProps) {
+  const t = useTranslation();
   const entries = useMemo<FileEntry[]>(() => {
     return payload.files
       .map((file, index) => {
@@ -73,7 +75,9 @@ export function DiffSplitView({ payload, cwd }: DiffSplitViewProps) {
 
   if (entries.length === 0) {
     return (
-      <div className="p-3 text-xs text-fg-muted">No changes in this diff.</div>
+      <div className="p-3 text-xs text-fg-muted">
+        {t("diffView.noChanges")}
+      </div>
     );
   }
 
@@ -109,7 +113,10 @@ export function DiffSplitView({ payload, cwd }: DiffSplitViewProps) {
         <aside className="flex h-full flex-col bg-bg-sidebar">
           <header className="flex shrink-0 items-center justify-between border-b border-border px-3 py-2 text-[11px] uppercase tracking-wider text-fg-muted">
             <span>
-              {entries.length} file{entries.length === 1 ? "" : "s"}
+              {t("diffView.filesCount").replace(
+                "{count}",
+                String(entries.length),
+              )}
             </span>
             <span className="flex gap-2 normal-case">
               <span className="text-[oklch(72%_0.16_145)]">+{totals.add}</span>
@@ -198,7 +205,7 @@ export function DiffSplitView({ payload, cwd }: DiffSplitViewProps) {
         menu
           ? ([
               {
-                label: "Open in editor",
+                label: t("diffView.openInEditor"),
                 icon: <ExternalLink size={12} />,
                 disabled: menu.entry.file.new_path === null,
                 onClick: () => {
@@ -231,33 +238,50 @@ function DiffSplitContent({ entry }: { entry: FileEntry }) {
 }
 
 function ImageDiffPane({ file }: { file: DiffFile }) {
+  const t = useTranslation();
   const hasOld = !!file.old_image;
   const hasNew = !!file.new_image;
   if (!hasOld && !hasNew) {
     return (
       <div className="flex h-full items-center justify-center p-6 text-xs text-fg-muted">
-        Binary image change (no preview available)
+        {t("diffView.binaryImageNoPreview")}
       </div>
     );
   }
   if (!hasOld) {
     return (
       <div className="min-h-0 flex-1 overflow-auto p-4">
-        <ImagePreview label="Added" src={file.new_image!} accent="add" />
+        <ImagePreview
+          label={t("diffView.imageLabels.added")}
+          src={file.new_image!}
+          accent="add"
+        />
       </div>
     );
   }
   if (!hasNew) {
     return (
       <div className="min-h-0 flex-1 overflow-auto p-4">
-        <ImagePreview label="Deleted" src={file.old_image!} accent="del" />
+        <ImagePreview
+          label={t("diffView.imageLabels.deleted")}
+          src={file.old_image!}
+          accent="del"
+        />
       </div>
     );
   }
   return (
     <div className="grid min-h-0 flex-1 grid-cols-2 gap-3 overflow-auto p-4">
-      <ImagePreview label="Before" src={file.old_image!} accent="del" />
-      <ImagePreview label="After" src={file.new_image!} accent="add" />
+      <ImagePreview
+        label={t("diffView.imageLabels.before")}
+        src={file.old_image!}
+        accent="del"
+      />
+      <ImagePreview
+        label={t("diffView.imageLabels.after")}
+        src={file.new_image!}
+        accent="add"
+      />
     </div>
   );
 }

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -4,6 +4,7 @@ import { cn } from "../lib/cn";
 import { countStats, parseDiff, type ParsedLine } from "../lib/diff";
 import { highlightDiff, langFromPath } from "../lib/highlight";
 import type { DiffFile, DiffPayload } from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
 import { Tooltip } from "./Tooltip";
 
 interface DiffViewProps {
@@ -12,6 +13,7 @@ interface DiffViewProps {
 }
 
 export function DiffView({ payload, onExpand }: DiffViewProps) {
+  const t = useTranslation();
   const collapseByDefault = payload.files.length > 1;
   const [collapsed, setCollapsed] = useState<Set<number>>(
     () => new Set(collapseByDefault ? payload.files.map((_, i) => i) : []),
@@ -25,7 +27,9 @@ export function DiffView({ payload, onExpand }: DiffViewProps) {
 
   if (payload.files.length === 0) {
     return (
-      <div className="p-3 text-xs text-fg-muted">No changes in this diff.</div>
+      <div className="p-3 text-xs text-fg-muted">
+        {t("diffView.noChanges")}
+      </div>
     );
   }
 
@@ -52,8 +56,10 @@ export function DiffView({ payload, onExpand }: DiffViewProps) {
     <div className="flex flex-col gap-3 p-3">
       <div className="flex items-center justify-between text-xs text-fg-muted">
         <span>
-          {payload.files.length} file{payload.files.length === 1 ? "" : "s"}{" "}
-          changed
+          {t("diffView.filesChanged").replace(
+            "{count}",
+            String(payload.files.length),
+          )}
         </span>
         <span className="flex items-center gap-1">
           {payload.files.length > 1 ? (
@@ -62,16 +68,18 @@ export function DiffView({ payload, onExpand }: DiffViewProps) {
               onClick={allCollapsed ? expandAll : collapseAll}
               className="rounded px-2 py-0.5 text-[10px] uppercase tracking-wide transition hover:bg-bg-elevated hover:text-fg"
             >
-              {allCollapsed ? "Expand all" : "Collapse all"}
+              {allCollapsed
+                ? t("diffView.expandAll")
+                : t("diffView.collapseAll")}
             </button>
           ) : null}
           {onExpand ? (
-            <Tooltip label="Open full diff" side="bottom">
+            <Tooltip label={t("diffView.openFullDiff")} side="bottom">
               <button
                 type="button"
                 onClick={onExpand}
                 className="rounded p-1 transition hover:bg-bg-elevated hover:text-fg"
-                aria-label="Open full diff"
+                aria-label={t("diffView.openFullDiff")}
               >
                 <Maximize2 size={12} />
               </button>
@@ -98,6 +106,7 @@ interface DiffFileAccordionProps {
 }
 
 function DiffFileAccordion({ file, collapsed, onToggle }: DiffFileAccordionProps) {
+  const t = useTranslation();
   const path = file.new_path ?? file.old_path ?? "(unknown)";
   const lines = useMemo(() => parseDiff(file.patch), [file.patch]);
   const stats = useMemo(() => countStats(lines), [lines]);
@@ -121,7 +130,7 @@ function DiffFileAccordion({ file, collapsed, onToggle }: DiffFileAccordionProps
           <span className="truncate text-fg">{path}</span>
           {file.is_image ? (
             <span className="shrink-0 rounded bg-bg-elevated/80 px-1 text-[10px] uppercase tracking-wide text-fg-muted">
-              image
+              {t("diffView.image")}
             </span>
           ) : null}
         </span>
@@ -150,33 +159,50 @@ function DiffFileAccordion({ file, collapsed, onToggle }: DiffFileAccordionProps
 }
 
 function ImageDiff({ file }: { file: DiffFile }) {
+  const t = useTranslation();
   const hasOld = !!file.old_image;
   const hasNew = !!file.new_image;
   if (!hasOld && !hasNew) {
     return (
       <div className="p-3 text-xs text-fg-muted">
-        Binary image change (no preview available)
+        {t("diffView.binaryImageNoPreview")}
       </div>
     );
   }
   if (!hasOld) {
     return (
       <div className="p-3">
-        <ImagePane label="Added" src={file.new_image ?? null} accent="add" />
+        <ImagePane
+          label={t("diffView.imageLabels.added")}
+          src={file.new_image ?? null}
+          accent="add"
+        />
       </div>
     );
   }
   if (!hasNew) {
     return (
       <div className="p-3">
-        <ImagePane label="Deleted" src={file.old_image ?? null} accent="del" />
+        <ImagePane
+          label={t("diffView.imageLabels.deleted")}
+          src={file.old_image ?? null}
+          accent="del"
+        />
       </div>
     );
   }
   return (
     <div className="grid grid-cols-2 gap-2 p-3">
-      <ImagePane label="Before" src={file.old_image ?? null} accent="del" />
-      <ImagePane label="After" src={file.new_image ?? null} accent="add" />
+      <ImagePane
+        label={t("diffView.imageLabels.before")}
+        src={file.old_image ?? null}
+        accent="del"
+      />
+      <ImagePane
+        label={t("diffView.imageLabels.after")}
+        src={file.new_image ?? null}
+        accent="add"
+      />
     </div>
   );
 }
@@ -190,6 +216,7 @@ function ImagePane({
   src: string | null;
   accent: "add" | "del";
 }) {
+  const t = useTranslation();
   const ringCls =
     accent === "add"
       ? "ring-1 ring-[oklch(35%_0.10_145_/_0.6)]"
@@ -212,7 +239,9 @@ function ImagePane({
             className="max-h-80 w-full object-contain"
           />
         ) : (
-          <span className="p-3 text-[11px] text-fg-muted">(none)</span>
+          <span className="p-3 text-[11px] text-fg-muted">
+            {t("diffView.none")}
+          </span>
         )}
       </div>
     </div>

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -30,13 +30,24 @@ import {
 import { api, type FsEntry, FS_CHANGED_EVENT } from "../lib/api";
 import type { FsChangePayload, FsGitStatus, FsGitStatusEntry } from "../lib/api";
 import { cn } from "../lib/cn";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { setFileDragPayload } from "../lib/dnd";
 import { Tooltip } from "./Tooltip";
 import { IconInput, TextInput } from "./ui";
+import { useTranslation } from "../lib/useTranslation";
 
 const SHOW_HIDDEN_KEY = "acorn:fs-show-hidden";
 const RESPECT_GITIGNORE_KEY = "acorn:fs-respect-gitignore";
+
+type FileExplorerTranslationKey = Extract<TranslationKey, `fileExplorer.${string}`>;
+
+function fileExplorerText(
+  t: Translator,
+  key: FileExplorerTranslationKey,
+): string {
+  return t(key);
+}
 
 interface FileExplorerProps {
   rootPath: string;
@@ -197,8 +208,9 @@ function relativeTo(base: string, abs: string): string {
 async function writeToActiveSession(
   sessionId: string | null,
   payload: string,
+  noActiveSessionMessage: string,
 ): Promise<void> {
-  if (!sessionId) throw new Error("No active session");
+  if (!sessionId) throw new Error(noActiveSessionMessage);
   await api.ptyWrite(sessionId, payload);
 }
 
@@ -221,6 +233,7 @@ function setLocalBool(key: string, value: boolean) {
 }
 
 export function FileExplorer({ rootPath }: FileExplorerProps) {
+  const t = useTranslation();
   const [cache, setCache] = useState<Cache>({});
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [showHidden, setShowHidden] = useState(() =>
@@ -669,15 +682,15 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       try {
         await navigator.clipboard.writeText(lines.join("\n"));
       } catch {
-        setError("Clipboard write failed");
+        setError(fileExplorerText(t, "fileExplorer.errors.clipboardWriteFailed"));
       }
     },
-    [selection, rootPath],
+    [selection, rootPath, t],
   );
 
   const handleBulkAttach = useCallback(async () => {
     if (!activeSessionId) {
-      setError("No active session — open a terminal first");
+      setError(fileExplorerText(t, "fileExplorer.errors.noActiveSession"));
       return;
     }
     const paths = Array.from(selection);
@@ -687,7 +700,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
-  }, [activeSessionId, selection, rootPath]);
+  }, [activeSessionId, selection, rootPath, t]);
 
   const handleOpenFolderInNewTab = useCallback(async (folderPath: string) => {
     try {
@@ -695,10 +708,12 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       const state = store.useAppStore.getState();
       const project = state.activeProject;
       if (!project) {
-        setError("No active project");
+        setError(fileExplorerText(t, "fileExplorer.errors.noActiveProject"));
         return;
       }
-      const name = folderPath.split("/").filter(Boolean).pop() ?? "session";
+      const name =
+        folderPath.split("/").filter(Boolean).pop() ??
+        fileExplorerText(t, "fileExplorer.defaults.sessionName");
       // Spawn a regular session in the current project, then queue a
       // `cd <folder>` to land inside the clicked directory once the PTY
       // is up. Mirrors how CommandRunDialog primes new sessions.
@@ -712,7 +727,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
-  }, []);
+  }, [t]);
 
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -783,26 +798,26 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     if (entry && selection.size > 1 && selection.has(entry.path)) {
       const n = selection.size;
       items.push({
-        label: `Copy Relative Paths (${n})`,
+        label: `${fileExplorerText(t, "fileExplorer.menu.copyRelativePaths")} (${n})`,
         icon: <Link2 size={13} />,
         onClick: () => void handleBulkCopyPaths("relative"),
       });
       items.push({
-        label: `Copy Absolute Paths (${n})`,
+        label: `${fileExplorerText(t, "fileExplorer.menu.copyAbsolutePaths")} (${n})`,
         icon: <Copy size={13} />,
         onClick: () => void handleBulkCopyPaths("absolute"),
       });
       if (agent.claude || agent.codex) {
         items.push({ type: "separator" });
         items.push({
-          label: `Attach All to Conversation (${n})`,
+          label: `${fileExplorerText(t, "fileExplorer.menu.attachAllToConversation")} (${n})`,
           icon: <MessageSquarePlus size={13} />,
           onClick: () => void handleBulkAttach(),
         });
       }
       items.push({ type: "separator" });
       items.push({
-        label: `Move to Trash (${n})`,
+        label: `${fileExplorerText(t, "fileExplorer.menu.moveToTrash")} (${n})`,
         icon: <Trash2 size={13} />,
         onClick: () => void handleBulkTrash(),
       });
@@ -813,8 +828,8 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     if (entry && !entry.is_dir) {
       const editorBin = shellEditor.split(/\s+/)[0];
       const openLabel = editorBin
-        ? `Open in ${editorBin}`
-        : "Open with Default Program";
+        ? `${fileExplorerText(t, "fileExplorer.menu.openIn")} ${editorBin}`
+        : fileExplorerText(t, "fileExplorer.menu.openWithDefaultProgram");
       items.push({
         label: openLabel,
         icon: <Edit3 size={13} />,
@@ -823,7 +838,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     }
     if (entry) {
       items.push({
-        label: "Reveal in File Manager",
+        label: fileExplorerText(t, "fileExplorer.menu.revealInFileManager"),
         icon: <ExternalLink size={13} />,
         onClick: () => {
           void api.fsReveal(entry.path).catch((e) => {
@@ -834,7 +849,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     }
     if (entry?.is_dir) {
       items.push({
-        label: "Open in New Tab",
+        label: fileExplorerText(t, "fileExplorer.menu.openInNewTab"),
         icon: <TerminalSquare size={13} />,
         onClick: () => void handleOpenFolderInNewTab(entry.path),
       });
@@ -845,10 +860,14 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       items.push({ type: "separator" });
       if (agent.claude) {
         items.push({
-          label: "Attach to Claude",
+          label: fileExplorerText(t, "fileExplorer.menu.attachToClaude"),
           icon: <MessageSquarePlus size={13} />,
           onClick: () => {
-            void writeToActiveSession(activeSessionId, ` @${rel} `).catch(
+            void writeToActiveSession(
+              activeSessionId,
+              ` @${rel} `,
+              fileExplorerText(t, "fileExplorer.errors.noActiveSession"),
+            ).catch(
               (e) => setError(e instanceof Error ? e.message : String(e)),
             );
           },
@@ -856,10 +875,14 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       }
       if (agent.codex) {
         items.push({
-          label: "Attach to Codex",
+          label: fileExplorerText(t, "fileExplorer.menu.attachToCodex"),
           icon: <MessageSquarePlus size={13} />,
           onClick: () => {
-            void writeToActiveSession(activeSessionId, ` @${rel} `).catch(
+            void writeToActiveSession(
+              activeSessionId,
+              ` @${rel} `,
+              fileExplorerText(t, "fileExplorer.errors.noActiveSession"),
+            ).catch(
               (e) => setError(e instanceof Error ? e.message : String(e)),
             );
           },
@@ -871,20 +894,20 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     if (entry) {
       items.push({ type: "separator" });
       items.push({
-        label: "Copy Relative Path",
+        label: fileExplorerText(t, "fileExplorer.menu.copyRelativePath"),
         icon: <Link2 size={13} />,
         onClick: () => {
           void navigator.clipboard.writeText(rel).catch(() => {
-            setError("Clipboard write failed");
+            setError(fileExplorerText(t, "fileExplorer.errors.clipboardWriteFailed"));
           });
         },
       });
       items.push({
-        label: "Copy Absolute Path",
+        label: fileExplorerText(t, "fileExplorer.menu.copyAbsolutePath"),
         icon: <Copy size={13} />,
         onClick: () => {
           void navigator.clipboard.writeText(entry.path).catch(() => {
-            setError("Clipboard write failed");
+            setError(fileExplorerText(t, "fileExplorer.errors.clipboardWriteFailed"));
           });
         },
       });
@@ -894,12 +917,12 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     if (entry) {
       items.push({ type: "separator" });
       items.push({
-        label: "Rename",
+        label: fileExplorerText(t, "fileExplorer.menu.rename"),
         icon: <Pencil size={13} />,
         onClick: () => setDraftRename({ path: entry.path, value: entry.name }),
       });
       items.push({
-        label: "Move to Trash",
+        label: fileExplorerText(t, "fileExplorer.menu.moveToTrash"),
         icon: <Trash2 size={13} />,
         onClick: () => void handleTrash(entry),
       });
@@ -920,6 +943,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     handleBulkCopyPaths,
     handleBulkTrash,
     handleOpenFolderInNewTab,
+    t,
   ]);
 
   return (
@@ -998,6 +1022,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
           <button
             type="button"
             className="text-fg-muted hover:text-fg"
+            aria-label={fileExplorerText(t, "fileExplorer.errorBanner.dismiss")}
             onClick={() => setError(null)}
           >
             ×
@@ -1026,6 +1051,7 @@ interface ToolbarProps {
 }
 
 function Toolbar(props: ToolbarProps) {
+  const t = useTranslation();
   const rootName = props.rootPath.split("/").filter(Boolean).pop() ?? "/";
   return (
     <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1 text-[11px]">
@@ -1037,14 +1063,22 @@ function Toolbar(props: ToolbarProps) {
       </span>
       <span className="flex-1" />
       <ToolbarBtn
-        label={props.searchActive ? "Close search" : "Search (⌘F)"}
+        label={
+          props.searchActive
+            ? fileExplorerText(t, "fileExplorer.toolbar.closeSearch")
+            : fileExplorerText(t, "fileExplorer.toolbar.search")
+        }
         active={props.searchActive}
         onClick={props.onToggleSearch}
       >
         <Search size={12} />
       </ToolbarBtn>
       <ToolbarBtn
-        label={props.showHidden ? "Hide dotfiles" : "Show dotfiles"}
+        label={
+          props.showHidden
+            ? fileExplorerText(t, "fileExplorer.toolbar.hideDotfiles")
+            : fileExplorerText(t, "fileExplorer.toolbar.showDotfiles")
+        }
         active={props.showHidden}
         onClick={props.onToggleHidden}
       >
@@ -1053,8 +1087,8 @@ function Toolbar(props: ToolbarProps) {
       <ToolbarBtn
         label={
           props.respectGitignore
-            ? "Show gitignored"
-            : "Hide gitignored"
+            ? fileExplorerText(t, "fileExplorer.toolbar.showGitignored")
+            : fileExplorerText(t, "fileExplorer.toolbar.hideGitignored")
         }
         active={!props.respectGitignore}
         onClick={props.onToggleGitignore}
@@ -1082,21 +1116,26 @@ interface SearchBarProps {
 }
 
 function SearchBar(props: SearchBarProps) {
+  const t = useTranslation();
   return (
     <div className="flex shrink-0 flex-col gap-1 border-b border-border px-2 py-2">
       <IconInput
         ref={props.queryInputRef}
         value={props.query}
         onChange={(e) => props.onQueryChange(e.target.value)}
-        placeholder={props.useRegex ? "Regex…" : "Search files"}
+        placeholder={
+          props.useRegex
+            ? fileExplorerText(t, "fileExplorer.search.regexPlaceholder")
+            : fileExplorerText(t, "fileExplorer.search.searchFilesPlaceholder")
+        }
         invalid={props.invalidRegex}
         leading={<Search size={12} />}
         trailing={
           <>
-            <Tooltip label="Match Case">
+            <Tooltip label={fileExplorerText(t, "fileExplorer.search.matchCase")}>
               <button
                 type="button"
-                aria-label="Match case"
+                aria-label={fileExplorerText(t, "fileExplorer.search.matchCase")}
                 onClick={props.onToggleCaseSensitive}
                 className={cn(
                   "rounded p-0.5 text-[10px] font-semibold transition",
@@ -1108,10 +1147,18 @@ function SearchBar(props: SearchBarProps) {
                 Aa
               </button>
             </Tooltip>
-            <Tooltip label="Use Regular Expression">
+            <Tooltip
+              label={fileExplorerText(
+                t,
+                "fileExplorer.search.useRegularExpression",
+              )}
+            >
               <button
                 type="button"
-                aria-label="Toggle regex"
+                aria-label={fileExplorerText(
+                  t,
+                  "fileExplorer.search.toggleRegex",
+                )}
                 onClick={props.onToggleRegex}
                 className={cn(
                   "rounded p-0.5 transition",
@@ -1123,10 +1170,10 @@ function SearchBar(props: SearchBarProps) {
                 <Regex size={12} />
               </button>
             </Tooltip>
-            <Tooltip label="Close (Esc)">
+            <Tooltip label={fileExplorerText(t, "fileExplorer.search.close")}>
               <button
                 type="button"
-                aria-label="Close search"
+                aria-label={fileExplorerText(t, "fileExplorer.search.closeSearch")}
                 onClick={props.onClose}
                 className="rounded p-0.5 text-fg-muted hover:text-fg"
               >
@@ -1137,14 +1184,20 @@ function SearchBar(props: SearchBarProps) {
         }
       />
       <GlobInput
-        label="files to include"
-        placeholder="e.g. *.ts, *.tsx"
+        label={fileExplorerText(t, "fileExplorer.search.filesToInclude")}
+        placeholder={fileExplorerText(
+          t,
+          "fileExplorer.search.includePlaceholder",
+        )}
         value={props.includeGlobs}
         onChange={props.onIncludeChange}
       />
       <GlobInput
-        label="files to exclude"
-        placeholder="e.g. node_modules, *.lock"
+        label={fileExplorerText(t, "fileExplorer.search.filesToExclude")}
+        placeholder={fileExplorerText(
+          t,
+          "fileExplorer.search.excludePlaceholder",
+        )}
         value={props.excludeGlobs}
         onChange={props.onExcludeChange}
       />
@@ -1229,6 +1282,7 @@ interface DirNodeProps {
 }
 
 function DirNode(props: DirNodeProps) {
+  const t = useTranslation();
   const { state, isRoot, matcher, matchingDirs } = props;
   const rawEntries = state?.entries ?? [];
   // When a matcher is active, hide entries that fail to match. Directories
@@ -1259,7 +1313,7 @@ function DirNode(props: DirNodeProps) {
           className="px-2 py-0.5 text-[11px] italic text-fg-muted/60"
           style={{ paddingLeft: 8 + props.depth * 12 }}
         >
-          (empty)
+          {fileExplorerText(t, "fileExplorer.tree.empty")}
         </div>
       ) : null}
       {entries.map((entry) =>
@@ -1292,7 +1346,13 @@ function DirNode(props: DirNodeProps) {
             onContextMenu={props.onContextMenu}
           >
             {entry.is_dir && props.expanded.has(entry.path) ? (
-              <DirNode {...props} path={entry.path} depth={props.depth + 1} state={props.cache[entry.path]} isRoot={false} />
+              <DirNode
+                {...props}
+                path={entry.path}
+                depth={props.depth + 1}
+                state={props.cache[entry.path]}
+                isRoot={false}
+              />
             ) : null}
           </EntryRow>
         ),
@@ -1302,7 +1362,7 @@ function DirNode(props: DirNodeProps) {
           className="px-2 py-1 text-[11px] text-fg-muted/60"
           style={{ paddingLeft: 8 + props.depth * 12 }}
         >
-          Loading…
+          {fileExplorerText(t, "fileExplorer.tree.loading")}
         </div>
       ) : null}
     </>
@@ -1362,6 +1422,7 @@ function EntryRow({
   onContextMenu,
   children,
 }: EntryRowProps) {
+  const t = useTranslation();
   const nameClass = gitStatusClass(gitStatus?.kind);
   const statusLetter = gitStatus ? STATUS_LABELS[gitStatus.kind] : "";
   const additions = gitStatus?.additions ?? 0;
@@ -1463,7 +1524,10 @@ function EntryRow({
             ) : null}
             <span
               className="rounded bg-fg-muted/15 px-1 font-medium"
-              aria-label={`git status ${gitStatus?.kind}`}
+              aria-label={`${fileExplorerText(
+                t,
+                "fileExplorer.tree.gitStatus",
+              )} ${gitStatus?.kind}`}
             >
               {statusLetter}
             </span>
@@ -1492,6 +1556,7 @@ function EditRow({
   onCommit,
   onCancel,
 }: EditRowProps) {
+  const t = useTranslation();
   const inputRef = useRef<HTMLInputElement | null>(null);
   useEffect(() => {
     inputRef.current?.focus();
@@ -1513,6 +1578,7 @@ function EditRow({
       <span className="shrink-0 text-fg-muted">{icon}</span>
       <input
         ref={inputRef}
+        aria-label={fileExplorerText(t, "fileExplorer.tree.renameInput")}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={(e) => {

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { createPortal } from "react-dom";
 import { ExternalLink, X } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { useTranslation } from "../lib/useTranslation";
 
 interface ImageLightboxProps {
   image: { src: string; alt?: string } | null;
@@ -16,6 +17,7 @@ interface ImageLightboxProps {
  * to Tauri's opener so users can save / share the original.
  */
 export function ImageLightbox({ image, onClose }: ImageLightboxProps) {
+  const t = useTranslation();
   // The lightbox is the topmost overlay when it's open. Setting the
   // `acorn-image-preview-open` flag on <body> lets useDialogShortcuts in
   // underlying dialogs (e.g. the PR detail modal) bail out of their Escape
@@ -51,14 +53,14 @@ export function ImageLightbox({ image, onClose }: ImageLightboxProps) {
     <div
       role="dialog"
       aria-modal="true"
-      aria-label="Image preview"
+      aria-label={t("imageLightbox.imagePreview")}
       className="fixed inset-0 z-[60] flex items-center justify-center bg-black/85 p-6"
       onClick={onClose}
     >
       <div className="absolute right-3 top-3 flex items-center gap-1">
         <button
           type="button"
-          aria-label="Open in browser"
+          aria-label={t("imageLightbox.openInBrowser")}
           onClick={(e) => {
             e.stopPropagation();
             void openUrl(image.src);
@@ -69,7 +71,7 @@ export function ImageLightbox({ image, onClose }: ImageLightboxProps) {
         </button>
         <button
           type="button"
-          aria-label="Close"
+          aria-label={t("imageLightbox.close")}
           onClick={onClose}
           className="rounded p-1.5 text-white/70 transition hover:bg-white/10 hover:text-white"
         >

--- a/src/components/MemoryBreakdownModal.tsx
+++ b/src/components/MemoryBreakdownModal.tsx
@@ -1,8 +1,16 @@
 import { useMemo } from "react";
 import type { MemoryProcess } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 import { Tooltip } from "./Tooltip";
 import { Modal, ModalHeader } from "./ui";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface MemoryBreakdownModalProps {
   open: boolean;
@@ -115,6 +123,7 @@ export function MemoryBreakdownModal({
   processes,
   onClose,
 }: MemoryBreakdownModalProps) {
+  const t = useTranslation();
   useDialogShortcuts(open, {
     onCancel: onClose,
     onConfirm: onClose,
@@ -131,9 +140,9 @@ export function MemoryBreakdownModal({
       ariaLabelledBy="memory-breakdown-title"
     >
       <ModalHeader
-        title="Memory breakdown"
+        title={dt(t, "dialogs.memoryBreakdown.title")}
         titleId="memory-breakdown-title"
-        subtitle={`total (RSS, sum): ${formatBytes(totalBytes)} · ${processes.length} processes`}
+        subtitle={`${dt(t, "dialogs.memoryBreakdown.totalRssSum")}: ${formatBytes(totalBytes)} · ${processes.length} ${dt(t, "dialogs.memoryBreakdown.processes")}`}
         onClose={onClose}
       />
 
@@ -141,18 +150,26 @@ export function MemoryBreakdownModal({
         <table className="w-full font-mono text-xs">
           <thead className="sticky top-0 bg-bg-sidebar text-fg-muted">
             <tr className="border-b border-border">
-              <th className="px-4 py-2 text-left font-medium">PID</th>
-              <th className="px-4 py-2 text-left font-medium">Process tree</th>
-              <th className="px-4 py-2 text-right font-medium">RSS</th>
+              <th className="px-4 py-2 text-left font-medium">
+                {dt(t, "dialogs.memoryBreakdown.pid")}
+              </th>
+              <th className="px-4 py-2 text-left font-medium">
+                {dt(t, "dialogs.memoryBreakdown.processTree")}
+              </th>
+              <th className="px-4 py-2 text-right font-medium">
+                {dt(t, "dialogs.memoryBreakdown.rss")}
+              </th>
               <th className="px-4 py-2 text-right font-medium">
                 <Tooltip
-                  label="Sum of this process and all descendants"
+                  label={dt(t, "dialogs.memoryBreakdown.subtreeTooltip")}
                   side="bottom"
                 >
-                  <span>Subtree</span>
+                  <span>{dt(t, "dialogs.memoryBreakdown.subtree")}</span>
                 </Tooltip>
               </th>
-              <th className="px-4 py-2 text-right font-medium">Share</th>
+              <th className="px-4 py-2 text-right font-medium">
+                {dt(t, "dialogs.memoryBreakdown.share")}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -203,9 +220,7 @@ export function MemoryBreakdownModal({
       </div>
 
       <footer className="shrink-0 border-t border-border px-4 py-2 font-mono text-[11px] text-fg-muted">
-        Tree ordered by parent→child (DFS). Siblings sorted by subtree RSS desc.
-        Sum-of-RSS overcounts shared memory; WebView helpers and PTY children
-        (claude, node) included.
+        {dt(t, "dialogs.memoryBreakdown.footer")}
       </footer>
     </Modal>
   );

--- a/src/components/MergePullRequestDialog.tsx
+++ b/src/components/MergePullRequestDialog.tsx
@@ -3,6 +3,7 @@ import { GitMerge, Sparkles } from "lucide-react";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { loadLastMergeMethod, saveLastMergeMethod } from "../lib/merge-prefs";
 import {
   aiCommitProviderLabel,
@@ -10,30 +11,37 @@ import {
   useSettings,
 } from "../lib/settings";
 import type { MergeMethod, PullRequestDetail } from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
 import { Tooltip } from "./Tooltip";
 import { Modal, ModalHeader, TextSwap } from "./ui";
 
 const METHOD_OPTIONS: ReadonlyArray<{
   value: MergeMethod;
-  label: string;
-  hint: string;
+  labelKey: DialogTranslationKey;
+  hintKey: DialogTranslationKey;
 }> = [
     {
       value: "squash",
-      label: "Squash",
-      hint: "Combine into one commit on the base branch.",
+      labelKey: "dialogs.mergePullRequest.methodSquash",
+      hintKey: "dialogs.mergePullRequest.methodSquashHint",
     },
     {
       value: "merge",
-      label: "Merge",
-      hint: "Create a merge commit preserving history.",
+      labelKey: "dialogs.mergePullRequest.methodMerge",
+      hintKey: "dialogs.mergePullRequest.methodMergeHint",
     },
     {
       value: "rebase",
-      label: "Rebase",
-      hint: "Replay commits onto the base branch.",
+      labelKey: "dialogs.mergePullRequest.methodRebase",
+      hintKey: "dialogs.mergePullRequest.methodRebaseHint",
     },
   ];
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface MergePullRequestDialogProps {
   open: boolean;
@@ -50,6 +58,7 @@ export function MergePullRequestDialog({
   onClose,
   onMerged,
 }: MergePullRequestDialogProps) {
+  const t = useTranslation();
   const settings = useSettings((s) => s.settings);
   const [method, setMethod] = useState<MergeMethod>(() => loadLastMergeMethod());
   const [title, setTitle] = useState("");
@@ -156,7 +165,7 @@ export function MergePullRequestDialog({
       {detail ? (
         <>
           <ModalHeader
-            title={`Merge #${detail.number}`}
+            title={`${dt(t, "dialogs.mergePullRequest.titlePrefix")} #${detail.number}`}
             icon={<GitMerge size={16} className="text-emerald-400" />}
             variant="dialog"
             onClose={() => {
@@ -166,7 +175,9 @@ export function MergePullRequestDialog({
 
           <div className="space-y-4 px-4 py-3 text-xs text-fg">
             <div>
-              <p className="mb-2 text-fg-muted">Merge method</p>
+              <p className="mb-2 text-fg-muted">
+                {dt(t, "dialogs.mergePullRequest.mergeMethod")}
+              </p>
               <div className="grid grid-cols-3 gap-2">
                 {METHOD_OPTIONS.map((opt) => (
                   <button
@@ -181,9 +192,11 @@ export function MergePullRequestDialog({
                     )}
                     disabled={busy}
                   >
-                    <div className="text-[11px] font-medium">{opt.label}</div>
+                    <div className="text-[11px] font-medium">
+                      {dt(t, opt.labelKey)}
+                    </div>
                     <div className="mt-0.5 text-[10px] leading-snug text-fg-muted">
-                      {opt.hint}
+                      {dt(t, opt.hintKey)}
                     </div>
                   </button>
                 ))}
@@ -193,7 +206,9 @@ export function MergePullRequestDialog({
             {acceptsMessage ? (
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
-                  <p className="text-fg-muted">Commit message</p>
+                  <p className="text-fg-muted">
+                    {dt(t, "dialogs.mergePullRequest.commitMessage")}
+                  </p>
                   {generating ? (
                     <button
                       key="gen-button-loading"
@@ -202,11 +217,11 @@ export function MergePullRequestDialog({
                       className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-fg-muted opacity-60"
                     >
                       <Sparkles size={11} />
-                      Generating…
+                      {dt(t, "dialogs.mergePullRequest.generating")}
                     </button>
                   ) : (
                     <Tooltip
-                      label={`Generate via ${providerLabel}`}
+                      label={`${dt(t, "dialogs.mergePullRequest.generateVia")} ${providerLabel}`}
                       side="top"
                     >
                       <button
@@ -216,7 +231,7 @@ export function MergePullRequestDialog({
                         className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
                       >
                         <Sparkles size={11} />
-                        Generate with AI
+                        {dt(t, "dialogs.mergePullRequest.generateWithAi")}
                       </button>
                     </Tooltip>
                   )}
@@ -225,14 +240,14 @@ export function MergePullRequestDialog({
                   type="text"
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
-                  placeholder="Subject"
+                  placeholder={dt(t, "dialogs.mergePullRequest.subjectPlaceholder")}
                   disabled={busy}
                   className="w-full rounded-md border border-border bg-bg-sidebar/60 px-2 py-1.5 text-[11px] text-fg outline-none transition focus:border-accent/60 disabled:opacity-60"
                 />
                 <textarea
                   value={body}
                   onChange={(e) => setBody(e.target.value)}
-                  placeholder="Body (optional)"
+                  placeholder={dt(t, "dialogs.mergePullRequest.bodyPlaceholder")}
                   rows={6}
                   disabled={busy}
                   className="w-full resize-none rounded-md border border-border bg-bg-sidebar/60 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-fg outline-none transition focus:border-accent/60 disabled:opacity-60"
@@ -240,8 +255,7 @@ export function MergePullRequestDialog({
               </div>
             ) : (
               <p className="rounded-md border border-border bg-bg-sidebar/40 px-3 py-2 text-[11px] text-fg-muted">
-                Rebase replays the original commits onto the base branch — the
-                commit messages are not customizable here.
+                {dt(t, "dialogs.mergePullRequest.rebaseMessageLocked")}
               </p>
             )}
 
@@ -259,7 +273,7 @@ export function MergePullRequestDialog({
               disabled={submitting}
               className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
             >
-              Cancel
+              {dt(t, "dialogs.common.cancel")}
             </button>
             <button
               type="button"
@@ -267,7 +281,11 @@ export function MergePullRequestDialog({
               disabled={busy}
               className="rounded-md bg-emerald-500/20 px-3 py-1.5 text-xs font-medium text-emerald-300 transition hover:bg-emerald-500/30 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              <TextSwap>{submitting ? "Merging…" : "Merge"}</TextSwap>
+              <TextSwap>
+                {submitting
+                  ? dt(t, "dialogs.mergePullRequest.merging")
+                  : dt(t, "dialogs.mergePullRequest.merge")}
+              </TextSwap>
             </button>
           </footer>
         </>

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -2,9 +2,17 @@ import { FolderPlus } from "lucide-react";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { validateProjectName } from "../lib/projectName";
 import { cn } from "../lib/cn";
+import { useTranslation } from "../lib/useTranslation";
 import { Field, Modal, ModalHeader, TextInput } from "./ui";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface NewProjectDialogProps {
   open: boolean;
@@ -21,6 +29,7 @@ export function NewProjectDialog({
   onClose,
   onCreate,
 }: NewProjectDialogProps) {
+  const t = useTranslation();
   const [name, setName] = useState("");
   const [parentPath, setParentPath] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -55,7 +64,7 @@ export function NewProjectDialog({
       ? null
       : validation.kind === "safe" && ignoreSafeName
         ? null
-        : validation.message;
+        : dt(t, `dialogs.newProject.validation.${validation.reason}`);
   const canCreate =
     !pending &&
     parentPath !== "" &&
@@ -66,7 +75,7 @@ export function NewProjectDialog({
     const picked = await open({
       directory: true,
       multiple: false,
-      title: "Select parent folder",
+      title: dt(t, "dialogs.newProject.selectParentFolder"),
     });
     if (!picked || typeof picked !== "string") return;
     setParentPath(picked);
@@ -76,7 +85,7 @@ export function NewProjectDialog({
   async function submit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!canCreate) {
-      setError(validationError ?? "Choose a location for the new project.");
+      setError(validationError ?? dt(t, "dialogs.newProject.chooseLocationError"));
       return;
     }
     setPending(true);
@@ -103,9 +112,9 @@ export function NewProjectDialog({
     >
       <form onSubmit={submit}>
         <ModalHeader
-          title="New project"
+          title={dt(t, "dialogs.newProject.title")}
           titleId="new-project-title"
-          subtitle="Create a git repository and add it to Acorn"
+          subtitle={dt(t, "dialogs.newProject.subtitle")}
           icon={<FolderPlus size={16} className="text-accent" />}
           variant="dialog"
           onClose={() => {
@@ -113,7 +122,10 @@ export function NewProjectDialog({
           }}
         />
         <div className="space-y-3 px-4 py-3">
-          <Field label="Project name" hint="Use a single folder name.">
+          <Field
+            label={dt(t, "dialogs.newProject.projectNameLabel")}
+            hint={dt(t, "dialogs.newProject.projectNameHint")}
+          >
             <TextInput
               autoFocus
               value={name}
@@ -123,7 +135,7 @@ export function NewProjectDialog({
                 setIgnoreSafeName(false);
               }}
               placeholder="my-project"
-              aria-label="Project name"
+              aria-label={dt(t, "dialogs.newProject.projectNameLabel")}
               aria-invalid={validationError !== null}
               aria-describedby={
                 validationError ? "new-project-name-error" : undefined
@@ -151,16 +163,16 @@ export function NewProjectDialog({
                 }}
                 className="size-3 accent-accent"
               />
-              <span>Ignore safe-name check</span>
+              <span>{dt(t, "dialogs.newProject.ignoreSafeName")}</span>
             </label>
           ) : null}
-          <Field label="Location">
+          <Field label={dt(t, "dialogs.newProject.locationLabel")}>
             <div className="flex gap-2">
               <TextInput
                 readOnly
                 value={parentPath}
-                placeholder="Choose a parent folder"
-                aria-label="Project location"
+                placeholder={dt(t, "dialogs.newProject.locationPlaceholder")}
+                aria-label={dt(t, "dialogs.newProject.locationAriaLabel")}
                 className="min-w-0 flex-1"
               />
               <button
@@ -168,13 +180,15 @@ export function NewProjectDialog({
                 onClick={() => void chooseLocation()}
                 className="shrink-0 rounded-md border border-border px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
               >
-                Choose
+                {dt(t, "dialogs.newProject.choose")}
               </button>
             </div>
           </Field>
           {finalPath ? (
             <div className="rounded-md border border-border bg-bg-sidebar/60 p-3 text-xs">
-              <div className="mb-1 text-fg-muted">Creates</div>
+              <div className="mb-1 text-fg-muted">
+                {dt(t, "dialogs.newProject.creates")}
+              </div>
               <div className="break-all font-mono text-fg">{finalPath}</div>
             </div>
           ) : null}
@@ -191,14 +205,16 @@ export function NewProjectDialog({
             onClick={onClose}
             className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:opacity-50"
           >
-            Cancel
+            {dt(t, "dialogs.common.cancel")}
           </button>
           <button
             type="submit"
             disabled={!canCreate}
             className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-bg transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {pending ? "Creating..." : "Create project"}
+            {pending
+              ? dt(t, "dialogs.newProject.creating")
+              : dt(t, "dialogs.newProject.createProject")}
           </button>
         </footer>
       </form>

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -27,6 +27,7 @@ import { isViewerTabId, useAppStore, type ViewerTab } from "../store";
 import { CodeViewer } from "./CodeViewer";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import {
   getCurrentFilePayload,
   getCurrentTabPayload,
@@ -40,6 +41,7 @@ import {
 } from "../lib/editor";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import { useSettings } from "../lib/settings";
+import { useTranslation } from "../lib/useTranslation";
 import type { Direction, PaneId } from "../lib/layout";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { PaneDropOverlay } from "./PaneDropOverlay";
@@ -52,6 +54,12 @@ const STATUS_DOT: Record<SessionStatus, string> = {
   failed: "bg-danger",
   completed: "bg-accent/60",
 };
+
+type PaneTranslationKey = Extract<TranslationKey, `pane.${string}`>;
+
+function paneT(t: Translator, key: PaneTranslationKey): string {
+  return t(key);
+}
 
 interface PaneProps {
   paneId: PaneId;
@@ -66,6 +74,7 @@ interface PaneProps {
  * `paneId`. The pane itself only renders.
  */
 export function Pane({ paneId }: PaneProps) {
+  const t = useTranslation();
   const sessions = useAppStore((s) => s.sessions);
   const projects = useAppStore((s) => s.projects);
   const pane = useAppStore((s) => s.panes[paneId]);
@@ -318,6 +327,7 @@ export function Pane({ paneId }: PaneProps) {
         y={paneMenu?.y ?? 0}
         onClose={() => setPaneMenu(null)}
         items={buildPaneMenuItems({
+          t,
           activeSession: active,
           totalPanes,
           paneId,
@@ -368,6 +378,8 @@ function EmptyPane({
   onDoubleClick: () => void;
   onContextMenu: (x: number, y: number) => void;
 }) {
+  const t = useTranslation();
+
   return (
     <div
       className="flex h-full flex-col items-center justify-center gap-2 text-fg-muted hover:text-fg/80 transition cursor-pointer select-none"
@@ -384,14 +396,14 @@ function EmptyPane({
         <>
           <TerminalIcon size={28} className="opacity-40" />
           <p className="text-xs">
-            Drop a tab here or double-click to start a session
+            {paneT(t, "pane.empty.dropTabOrDoubleClick")}
           </p>
         </>
       ) : (
         <>
           <FolderPlus size={28} className="opacity-40" />
           <p className="text-xs">
-            Create a project to get started. Double-click here.
+            {paneT(t, "pane.empty.createProject")}
           </p>
         </>
       )}
@@ -574,6 +586,7 @@ function TabItem({
   siblingCount,
   registerRef,
 }: TabItemProps) {
+  const t = useTranslation();
   const renameSession = useAppStore((s) => s.renameSession);
   const liveInWorktree = useAppStore((s) => s.liveInWorktree[tab.id]);
   // Subscribe to the editor command so the menu's enabled/disabled state
@@ -616,28 +629,32 @@ function TabItem({
     const both = agent.claude && agent.codex;
     if (agent.claude) {
       items.push({
-        label: both ? "Fork Claude Session" : "Fork Session",
+        label: both
+          ? paneT(t, "pane.menu.forkClaudeSession")
+          : paneT(t, "pane.menu.forkSession"),
         icon: <GitFork size={12} />,
         onClick: () => onFork("claude", agent.claude!, false),
       });
       items.push({
         label: both
-          ? "Fork Claude in New Worktree"
-          : "Fork in New Worktree",
+          ? paneT(t, "pane.menu.forkClaudeInNewWorktree")
+          : paneT(t, "pane.menu.forkInNewWorktree"),
         icon: <GitBranch size={12} />,
         onClick: () => onFork("claude", agent.claude!, true),
       });
     }
     if (agent.codex) {
       items.push({
-        label: both ? "Fork Codex Session" : "Fork Session",
+        label: both
+          ? paneT(t, "pane.menu.forkCodexSession")
+          : paneT(t, "pane.menu.forkSession"),
         icon: <GitFork size={12} />,
         onClick: () => onFork("codex", agent.codex!, false),
       });
       items.push({
         label: both
-          ? "Fork Codex in New Worktree"
-          : "Fork in New Worktree",
+          ? paneT(t, "pane.menu.forkCodexInNewWorktree")
+          : paneT(t, "pane.menu.forkInNewWorktree"),
         icon: <GitBranch size={12} />,
         onClick: () => onFork("codex", agent.codex!, true),
       });
@@ -649,31 +666,31 @@ function TabItem({
 
   const menuItems: ContextMenuItem[] = [
     {
-      label: "Rename",
+      label: paneT(t, "pane.menu.rename"),
       icon: <Pencil size={12} />,
       onClick: () => setEditing(true),
     },
     {
-      label: "Duplicate Session",
+      label: paneT(t, "pane.menu.duplicateSession"),
       icon: <Files size={12} />,
       onClick: onDuplicate,
     },
     { type: "separator" },
     ...forkItems,
     {
-      label: "Split Right",
+      label: paneT(t, "pane.menu.splitRight"),
       icon: <SplitSquareHorizontal size={12} />,
       onClick: () => onSplitTab("horizontal"),
       disabled: siblingCount <= 1,
     },
     {
-      label: "Split Down",
+      label: paneT(t, "pane.menu.splitDown"),
       icon: <SplitSquareVertical size={12} />,
       onClick: () => onSplitTab("vertical"),
       disabled: siblingCount <= 1,
     },
     {
-      label: "Equalize Pane Sizes",
+      label: paneT(t, "pane.menu.equalizePaneSizes"),
       icon: <Columns2 size={12} />,
       onClick: () => {
         window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
@@ -681,7 +698,7 @@ function TabItem({
     },
     { type: "separator" },
     {
-      label: "Open Worktree in Editor",
+      label: paneT(t, "pane.menu.openWorktreeInEditor"),
       icon: <PencilLine size={12} />,
       disabled: !editorConfigured,
       onClick: () => {
@@ -693,7 +710,7 @@ function TabItem({
       },
     },
     {
-      label: "Reveal in Finder",
+      label: paneT(t, "pane.menu.revealInFinder"),
       icon: <FolderOpen size={12} />,
       onClick: () => {
         void openPath(tab.worktree_path).catch((err: unknown) => {
@@ -703,21 +720,21 @@ function TabItem({
     },
     { type: "separator" },
     {
-      label: "Copy Worktree Path",
+      label: paneT(t, "pane.menu.copyWorktreePath"),
       icon: <Copy size={12} />,
       onClick: () => {
         void copyToClipboard(tab.worktree_path);
       },
     },
     {
-      label: "Copy Worktree Name",
+      label: paneT(t, "pane.menu.copyWorktreeName"),
       icon: <Copy size={12} />,
       onClick: () => {
         void copyToClipboard(basename(tab.worktree_path));
       },
     },
     {
-      label: "Copy Branch Name",
+      label: paneT(t, "pane.menu.copyBranchName"),
       icon: <Copy size={12} />,
       onClick: () => {
         void copyToClipboard(tab.branch);
@@ -725,7 +742,7 @@ function TabItem({
       disabled: !tab.branch,
     },
     {
-      label: "Copy Session ID",
+      label: paneT(t, "pane.menu.copySessionId"),
       icon: <Copy size={12} />,
       onClick: () => {
         void copyToClipboard(tab.id);
@@ -733,18 +750,18 @@ function TabItem({
     },
     { type: "separator" },
     {
-      label: "Close",
+      label: paneT(t, "pane.menu.close"),
       icon: <X size={12} />,
       onClick: onClose,
     },
     {
-      label: "Close Others",
+      label: paneT(t, "pane.menu.closeOthers"),
       icon: <CircleX size={12} />,
       onClick: onCloseOthers,
       disabled: siblingCount <= 1,
     },
     {
-      label: "Close All",
+      label: paneT(t, "pane.menu.closeAll"),
       icon: <SquareX size={12} />,
       onClick: onCloseAll,
     },
@@ -824,12 +841,12 @@ function TabItem({
           <GitBranch
             size={10}
             className="pointer-events-none text-fg-muted"
-            aria-label="worktree"
+            aria-label={paneT(t, "pane.aria.worktree")}
           />
         ) : null}
         <button
           type="button"
-          aria-label="Close session"
+          aria-label={paneT(t, "pane.aria.closeSession")}
           onClick={(e) => {
             e.stopPropagation();
             onClose();
@@ -898,6 +915,7 @@ function TabRenameInput({ initial, onSubmit, onCancel }: TabRenameInputProps) {
 }
 
 function buildPaneMenuItems({
+  t,
   activeSession,
   totalPanes,
   paneId: _paneId,
@@ -906,6 +924,7 @@ function buildPaneMenuItems({
   onClose,
   activeProjectFallback,
 }: {
+  t: Translator;
   activeSession: Session | null;
   totalPanes: number;
   paneId: PaneId;
@@ -919,7 +938,7 @@ function buildPaneMenuItems({
     ? [
         { type: "separator" },
         {
-          label: "Open Worktree in Editor",
+          label: paneT(t, "pane.menu.openWorktreeInEditor"),
           icon: <PencilLine size={12} />,
           disabled: !editorReady,
           onClick: () => {
@@ -931,7 +950,7 @@ function buildPaneMenuItems({
           },
         },
         {
-          label: "Reveal in Finder",
+          label: paneT(t, "pane.menu.revealInFinder"),
           icon: <FolderOpen size={12} />,
           onClick: () => {
             void openPath(activeSession.worktree_path).catch(
@@ -943,12 +962,12 @@ function buildPaneMenuItems({
         },
         { type: "separator" },
         {
-          label: "Copy Worktree Path",
+          label: paneT(t, "pane.menu.copyWorktreePath"),
           icon: <Copy size={12} />,
           onClick: () => void copyToClipboard(activeSession.worktree_path),
         },
         {
-          label: "Copy Worktree Name",
+          label: paneT(t, "pane.menu.copyWorktreeName"),
           icon: <Copy size={12} />,
           onClick: () =>
             void copyToClipboard(basename(activeSession.worktree_path)),
@@ -958,24 +977,24 @@ function buildPaneMenuItems({
 
   return [
     {
-      label: "New Session in This Pane",
+      label: paneT(t, "pane.menu.newSessionInThisPane"),
       icon: <TerminalIcon size={12} />,
       onClick: onNewTab,
       disabled: !activeSession && activeProjectFallback === null,
     },
     { type: "separator" },
     {
-      label: "Split Right",
+      label: paneT(t, "pane.menu.splitRight"),
       icon: <SplitSquareHorizontal size={12} />,
       onClick: () => onSplit("horizontal"),
     },
     {
-      label: "Split Down",
+      label: paneT(t, "pane.menu.splitDown"),
       icon: <SplitSquareVertical size={12} />,
       onClick: () => onSplit("vertical"),
     },
     {
-      label: "Equalize Pane Sizes",
+      label: paneT(t, "pane.menu.equalizePaneSizes"),
       icon: <Columns2 size={12} />,
       onClick: () => {
         window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
@@ -985,7 +1004,7 @@ function buildPaneMenuItems({
     ...worktreeItems,
     { type: "separator" },
     {
-      label: "Close Pane",
+      label: paneT(t, "pane.menu.closePane"),
       icon: <X size={12} />,
       onClick: onClose,
       disabled: totalPanes <= 1,

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -24,6 +24,7 @@ import { Panel, PanelGroup } from "react-resizable-panels";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { ResizeHandle } from "./ResizeHandle";
 import type {
   DiffPayload,
@@ -34,6 +35,7 @@ import type {
   PullRequestDetailListing,
   PullRequestReview,
 } from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
 import { AuthorTag, buildProfileMenuItems } from "./AuthorTag";
 import { ClosePullRequestDialog } from "./ClosePullRequestDialog";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
@@ -43,6 +45,11 @@ import { Tooltip } from "./Tooltip";
 import { Markdown, Modal, ModalHeader, RefreshButton } from "./ui";
 
 type DetailTab = "conversation" | "commits" | "checks" | "files";
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface PullRequestDetailModalProps {
   /**
@@ -69,6 +76,7 @@ export function PullRequestDetailModal({
   onClose,
   onMutated,
 }: PullRequestDetailModalProps) {
+  const t = useTranslation();
   const [listing, setListing] = useState<PullRequestDetailListing | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [tab, setTab] = useState<DetailTab>("conversation");
@@ -210,14 +218,16 @@ export function PullRequestDetailModal({
         ) : listing.kind === "not_github" ? (
           <ModalShell title={`#${open.number}`} onClose={onClose}>
             <div className="p-4 text-xs text-fg-muted">
-              Origin remote is not a GitHub repository.
+              {dt(t, "dialogs.pullRequestDetail.notGithub")}
             </div>
           </ModalShell>
         ) : listing.kind === "no_access" ? (
           <ModalShell title={`#${open.number}`} onClose={onClose}>
             <div className="p-4 text-xs text-fg-muted">
-              No logged-in <code className="font-mono">gh</code> account can
-              access {listing.slug}.
+              {dt(t, "dialogs.pullRequestDetail.noAccessPrefix")}{" "}
+              <code className="font-mono">gh</code>{" "}
+              {dt(t, "dialogs.pullRequestDetail.noAccessSuffix")}{" "}
+              {listing.slug}.
             </div>
           </ModalShell>
         ) : (
@@ -314,6 +324,7 @@ function DetailBody({
   onOpenMerge: () => void;
   onOpenClose: () => void;
 }) {
+  const t = useTranslation();
   const conversationCount = detail.comments.length + detail.reviews.length;
   const checkCounts = summarizeChecks(detail.checks);
   // Effective total ignores NEUTRAL / SKIPPED / CANCELLED — they carry no
@@ -363,7 +374,9 @@ function DetailBody({
               −{detail.deletions}
             </span>
             <span className="opacity-50"> · </span>
-            <span>{detail.changed_files} files</span>
+            <span>
+              {detail.changed_files} {dt(t, "dialogs.pullRequestDetail.files")}
+            </span>
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-1">
@@ -378,13 +391,13 @@ function DetailBody({
                 onClick={onOpenClose}
                 className="rounded-md bg-rose-500/15 px-2.5 py-1 text-[11px] font-medium text-rose-300 transition hover:bg-rose-500/25"
               >
-                Close
+                {dt(t, "dialogs.common.close")}
               </button>
               <span className="mx-1 h-4 w-px bg-border" aria-hidden />
             </>
           ) : null}
           <RefreshButton onClick={onRefresh} loading={refreshing} size={14} />
-          <Tooltip label="Open on GitHub" side="bottom">
+          <Tooltip label={dt(t, "dialogs.pullRequestDetail.openOnGithub")} side="bottom">
             <button
               type="button"
               onClick={() => void openUrl(detail.url)}
@@ -395,7 +408,7 @@ function DetailBody({
           </Tooltip>
           <button
             type="button"
-            aria-label="Close"
+            aria-label={dt(t, "dialogs.common.close")}
             onClick={onClose}
             className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
           >
@@ -409,7 +422,8 @@ function DetailBody({
           <Markdown content={body} onTaskToggle={onTaskToggle} />
           {bodySaveError ? (
             <p className="mt-2 text-[10.5px] text-danger">
-              Couldn't save checkbox: {bodySaveError}
+              {dt(t, "dialogs.pullRequestDetail.checkboxSaveFailed")}{" "}
+              {bodySaveError}
             </p>
           ) : null}
         </ResizableBody>
@@ -418,21 +432,21 @@ function DetailBody({
       <nav className="flex shrink-0 border-b border-border">
         <DetailTabButton
           icon={<MessagesSquare size={13} />}
-          label="Conversation"
+          label={dt(t, "dialogs.pullRequestDetail.tabConversation")}
           badge={conversationCount > 0 ? conversationCount : null}
           active={tab === "conversation"}
           onClick={() => onTab("conversation")}
         />
         <DetailTabButton
           icon={<GitCommit size={13} />}
-          label="Commits"
+          label={dt(t, "dialogs.pullRequestDetail.tabCommits")}
           badge={commitCount > 0 ? commitCount : null}
           active={tab === "commits"}
           onClick={() => onTab("commits")}
         />
         <DetailTabButton
           icon={<CheckCircle2 size={13} />}
-          label="Checks"
+          label={dt(t, "dialogs.pullRequestDetail.tabChecks")}
           badge={
             allChecksPassed ? (
               <Check size={11} strokeWidth={3} className="text-emerald-300" />
@@ -454,7 +468,7 @@ function DetailBody({
         />
         <DetailTabButton
           icon={<GitPullRequest size={13} />}
-          label="Files"
+          label={dt(t, "dialogs.pullRequestDetail.tabFiles")}
           badge={fileCount > 0 ? fileCount : null}
           active={tab === "files"}
           onClick={() => onTab("files")}
@@ -501,6 +515,7 @@ function DetailSkeleton({
   onRefresh: () => void;
   refreshing: boolean;
 }) {
+  const t = useTranslation();
   return (
     <>
       <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border px-4 py-3">
@@ -527,7 +542,7 @@ function DetailSkeleton({
           <RefreshButton onClick={onRefresh} loading={refreshing} size={14} />
           <button
             type="button"
-            aria-label="Close"
+            aria-label={dt(t, "dialogs.common.close")}
             onClick={onClose}
             className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
           >
@@ -710,6 +725,7 @@ function MergeActionButton({
   mergeable: string | null;
   onClick: () => void;
 }) {
+  const t = useTranslation();
   const upper = mergeable?.toUpperCase() ?? null;
   const ready = upper === "MERGEABLE";
   const conflicting = upper === "CONFLICTING";
@@ -725,15 +741,15 @@ function MergeActionButton({
           : "cursor-not-allowed bg-bg-elevated text-fg-muted opacity-70",
       )}
     >
-      Merge
+      {dt(t, "dialogs.pullRequestDetail.merge")}
     </button>
   );
   if (ready) {
     return button;
   }
   const title = conflicting
-    ? "Cannot merge — conflicting branch"
-    : "Merge readiness still being determined…";
+    ? dt(t, "dialogs.pullRequestDetail.cannotMergeConflicting")
+    : dt(t, "dialogs.pullRequestDetail.mergeReadinessPending");
   return (
     <Tooltip label={title} side="bottom">
       {button}
@@ -760,6 +776,7 @@ function readStoredBodyHeight(): number {
 }
 
 function ResizableBody({ children }: { children: React.ReactNode }) {
+  const t = useTranslation();
   const [height, setHeight] = useState<number>(() => readStoredBodyHeight());
   const dragRef = useRef<{ startY: number; startH: number } | null>(null);
 
@@ -808,13 +825,13 @@ function ResizableBody({ children }: { children: React.ReactNode }) {
       <div
         role="separator"
         aria-orientation="horizontal"
-        aria-label="Resize PR body"
+        aria-label={dt(t, "dialogs.pullRequestDetail.resizePrBody")}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
         onPointerCancel={onPointerUp}
         onDoubleClick={() => setHeight(BODY_HEIGHT_DEFAULT)}
-        title="Drag to resize · double-click to reset"
+        title={dt(t, "dialogs.pullRequestDetail.resizeHint")}
         className="group relative flex h-1.5 shrink-0 cursor-row-resize items-center justify-center border-b border-border bg-bg-sidebar/40 transition hover:bg-accent/30"
       >
         <span className="h-0.5 w-8 rounded-full bg-fg-muted/0 transition group-hover:bg-fg-muted/40" />
@@ -864,6 +881,7 @@ function ConversationPane({
   comments: PullRequestComment[];
   reviews: PullRequestReview[];
 }) {
+  const t = useTranslation();
   const [sort, setSort] = useState<ConversationSort>(() => readStoredSort());
 
   useEffect(() => {
@@ -909,7 +927,7 @@ function ConversationPane({
       <div className="flex h-full flex-col">
         {toolbar}
         <div className="flex flex-1 items-center justify-center text-xs text-fg-muted">
-          No comments or reviews yet.
+          {dt(t, "dialogs.pullRequestDetail.noComments")}
         </div>
       </div>
     );
@@ -939,10 +957,13 @@ function SortToggle({
   onChange: (next: ConversationSort) => void;
 }) {
   const isOldest = value === "oldest";
-  const label = isOldest ? "Oldest first" : "Newest first";
+  const t = useTranslation();
+  const label = isOldest
+    ? dt(t, "dialogs.pullRequestDetail.oldestFirst")
+    : dt(t, "dialogs.pullRequestDetail.newestFirst");
   const Icon = isOldest ? ArrowDownNarrowWide : ArrowUpNarrowWide;
   return (
-    <Tooltip label="Toggle sort order" side="bottom">
+    <Tooltip label={dt(t, "dialogs.pullRequestDetail.toggleSortOrder")} side="bottom">
       <button
         type="button"
         onClick={() => onChange(isOldest ? "newest" : "oldest")}
@@ -956,6 +977,7 @@ function SortToggle({
 }
 
 function CommentBlock({ comment }: { comment: PullRequestComment }) {
+  const t = useTranslation();
   return (
     <li className="rounded border border-border bg-bg-sidebar/40 p-3">
       <div className="mb-2 flex items-center gap-2 text-[10.5px] text-fg-muted">
@@ -964,7 +986,9 @@ function CommentBlock({ comment }: { comment: PullRequestComment }) {
           size={28}
           nameClass="text-[12.5px] font-semibold tracking-tight"
         />
-        <span className="opacity-60">commented</span>
+        <span className="opacity-60">
+          {dt(t, "dialogs.pullRequestDetail.commented")}
+        </span>
         <span className="font-mono opacity-60">
           {formatTimestamp(comment.created_at)}
         </span>
@@ -974,13 +998,16 @@ function CommentBlock({ comment }: { comment: PullRequestComment }) {
           <Markdown content={comment.body} />
         </div>
       ) : (
-        <p className="text-[11px] text-fg-muted">(empty)</p>
+        <p className="text-[11px] text-fg-muted">
+          {dt(t, "dialogs.pullRequestDetail.empty")}
+        </p>
       )}
     </li>
   );
 }
 
 function ReviewBlock({ review }: { review: PullRequestReview }) {
+  const t = useTranslation();
   return (
     <li className="rounded border border-border bg-bg-sidebar/40 p-3">
       <div className="mb-2 flex items-center gap-2 text-[10.5px] text-fg-muted">
@@ -1000,7 +1027,7 @@ function ReviewBlock({ review }: { review: PullRequestReview }) {
         </div>
       ) : (
         <p className="text-[11px] text-fg-muted">
-          (no review comment)
+          {dt(t, "dialogs.pullRequestDetail.noReviewComment")}
         </p>
       )}
     </li>
@@ -1008,6 +1035,7 @@ function ReviewBlock({ review }: { review: PullRequestReview }) {
 }
 
 function ReviewStateBadge({ state }: { state: string }) {
+  const t = useTranslation();
   const upper = state.toUpperCase();
   const tone =
     upper === "APPROVED"
@@ -1017,7 +1045,14 @@ function ReviewStateBadge({ state }: { state: string }) {
         : upper === "DISMISSED"
           ? "bg-fg-muted/15 text-fg-muted line-through"
           : "bg-fg-muted/15 text-fg-muted";
-  const label = upper.replace("_", " ").toLowerCase();
+  const label =
+    upper === "APPROVED"
+      ? dt(t, "dialogs.pullRequestDetail.reviewApproved")
+      : upper === "CHANGES_REQUESTED"
+        ? dt(t, "dialogs.pullRequestDetail.reviewChangesRequested")
+        : upper === "DISMISSED"
+          ? dt(t, "dialogs.pullRequestDetail.reviewDismissed")
+          : upper.replace("_", " ").toLowerCase();
   return (
     <span
       className={cn(
@@ -1041,6 +1076,7 @@ function CommitsPane({
   repoPath: string;
   cwd?: string;
 }) {
+  const t = useTranslation();
   const [selectedOid, setSelectedOid] = useState<string | null>(
     commits[0]?.oid ?? null,
   );
@@ -1062,7 +1098,7 @@ function CommitsPane({
   if (commits.length === 0) {
     return (
       <div className="flex h-full items-center justify-center text-xs text-fg-muted">
-        No commits in this pull request.
+        {dt(t, "dialogs.pullRequestDetail.noCommits")}
       </div>
     );
   }
@@ -1118,6 +1154,7 @@ function CommitListItem({
   selected: boolean;
   onSelect: () => void;
 }) {
+  const t = useTranslation();
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const primaryAuthor = commit.authors[0];
   const commitUrl = buildCommitUrl(prUrl, commit.oid);
@@ -1127,7 +1164,7 @@ function CommitListItem({
     ...(commitUrl
       ? [
           {
-            label: "View on GitHub",
+            label: dt(t, "dialogs.pullRequestDetail.viewOnGithub"),
             icon: <ExternalLink size={12} />,
             onClick: () => void openUrl(commitUrl),
           },
@@ -1138,7 +1175,7 @@ function CommitListItem({
       ? [{ type: "separator" as const }]
       : []),
     {
-      label: "Copy SHA",
+      label: dt(t, "dialogs.pullRequestDetail.copySha"),
       icon: <Copy size={12} />,
       onClick: () => void navigator.clipboard.writeText(commit.oid),
     },
@@ -1162,20 +1199,20 @@ function CommitListItem({
         )}
       >
         <div className="truncate text-[12px] font-medium text-fg" title={commit.message_headline}>
-          {commit.message_headline || "(no message)"}
+          {commit.message_headline || dt(t, "dialogs.pullRequestDetail.noMessage")}
         </div>
         <div className="mt-1 flex items-center gap-1.5 text-[10.5px] text-fg-muted">
           {primaryAuthor ? (
             <AuthorTag
               login={primaryAuthor.login}
-              fallbackName={primaryAuthor.name || "unknown"}
+              fallbackName={primaryAuthor.name || dt(t, "dialogs.pullRequestDetail.unknown")}
               size={14}
               nameClass="text-[10.5px] text-fg-muted"
             />
           ) : null}
           <span className="opacity-50">·</span>
           <span className="font-mono opacity-70">
-            {formatRelativeTime(commit.committed_date)}
+            {formatRelativeTime(commit.committed_date, t)}
           </span>
         </div>
       </button>
@@ -1201,6 +1238,7 @@ function CommitDetailView({
   repoPath: string;
   cwd?: string;
 }) {
+  const t = useTranslation();
   const [diff, setDiff] = useState<DiffPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -1239,11 +1277,11 @@ function CommitDetailView({
         </div>
       ) : loading || !diff ? (
         <div className="flex h-full items-center justify-center text-xs text-fg-muted">
-          Loading diff…
+          {dt(t, "dialogs.pullRequestDetail.loadingDiff")}
         </div>
       ) : diff.files.length === 0 ? (
         <div className="flex h-full items-center justify-center text-xs text-fg-muted">
-          No file changes in this commit.
+          {dt(t, "dialogs.pullRequestDetail.noFileChanges")}
         </div>
       ) : (
         <DiffSplitView payload={diff} cwd={cwd} />
@@ -1266,13 +1304,13 @@ function CommitDetailView({
             className="truncate text-[13px] font-semibold tracking-tight text-fg"
             title={commit.message_headline}
           >
-            {commit.message_headline || "(no message)"}
+            {commit.message_headline || dt(t, "dialogs.pullRequestDetail.noMessage")}
           </div>
           <div className="mt-1 flex items-center gap-1.5 text-[11px] text-fg-muted">
             {primaryAuthor ? (
               <AuthorTag
                 login={primaryAuthor.login}
-                fallbackName={primaryAuthor.name || "unknown"}
+                fallbackName={primaryAuthor.name || dt(t, "dialogs.pullRequestDetail.unknown")}
                 size={16}
                 nameClass="text-[11px] text-fg-muted"
               />
@@ -1288,7 +1326,7 @@ function CommitDetailView({
             </span>
           </div>
         </div>
-        <Tooltip label="Copy SHA" side="bottom">
+        <Tooltip label={dt(t, "dialogs.pullRequestDetail.copySha")} side="bottom">
           <button
             type="button"
             onClick={() => {
@@ -1300,7 +1338,10 @@ function CommitDetailView({
           </button>
         </Tooltip>
         {commitUrl ? (
-          <Tooltip label="Open commit on GitHub" side="bottom">
+          <Tooltip
+            label={dt(t, "dialogs.pullRequestDetail.openCommitOnGithub")}
+            side="bottom"
+          >
             <button
               type="button"
               onClick={() => void openUrl(commitUrl)}
@@ -1338,18 +1379,18 @@ function CommitDetailView({
  * Compact "23h" / "2d" / "May 4" — keeps the commit list narrow. Falls back
  * to the raw string when parsing fails.
  */
-function formatRelativeTime(iso: string): string {
+function formatRelativeTime(iso: string, t: Translator): string {
   if (!iso) return "—";
   const ms = Date.parse(iso);
   if (Number.isNaN(ms)) return iso;
   const diff = Date.now() - ms;
   const min = Math.floor(diff / 60_000);
-  if (min < 1) return "now";
-  if (min < 60) return `${min}m`;
+  if (min < 1) return dt(t, "dialogs.pullRequestDetail.now");
+  if (min < 60) return `${min}${dt(t, "dialogs.pullRequestDetail.minuteAbbrev")}`;
   const h = Math.floor(min / 60);
-  if (h < 24) return `${h}h`;
+  if (h < 24) return `${h}${dt(t, "dialogs.pullRequestDetail.hourAbbrev")}`;
   const d = Math.floor(h / 24);
-  if (d < 7) return `${d}d`;
+  if (d < 7) return `${d}${dt(t, "dialogs.pullRequestDetail.dayAbbrev")}`;
   return new Date(ms).toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
@@ -1370,10 +1411,11 @@ function buildCommitUrl(prUrl: string, oid: string): string | null {
 }
 
 function ChecksPane({ checks }: { checks: PullRequestCheck[] }) {
+  const t = useTranslation();
   if (checks.length === 0) {
     return (
       <div className="flex h-full items-center justify-center text-xs text-fg-muted">
-        No checks reported.
+        {dt(t, "dialogs.pullRequestDetail.noChecks")}
       </div>
     );
   }
@@ -1393,7 +1435,7 @@ function ChecksPane({ checks }: { checks: PullRequestCheck[] }) {
           </span>
           <CheckStatusLabel status={c.status} conclusion={c.conclusion} />
           {c.url ? (
-            <Tooltip label="Open run" side="top">
+            <Tooltip label={dt(t, "dialogs.pullRequestDetail.openRun")} side="top">
               <button
                 type="button"
                 onClick={() => {
@@ -1445,11 +1487,30 @@ function CheckStatusLabel({
   status: string;
   conclusion: string | null;
 }) {
+  const t = useTranslation();
   const raw =
     status.toUpperCase() === "COMPLETED"
       ? (conclusion ?? "completed")
       : status;
-  const text = raw.toLowerCase().replace(/_/g, " ");
+  const normalized = raw.toUpperCase();
+  const text =
+    normalized === "SUCCESS"
+      ? dt(t, "dialogs.pullRequestDetail.checkSuccess")
+      : normalized === "FAILURE"
+        ? dt(t, "dialogs.pullRequestDetail.checkFailure")
+        : normalized === "TIMED_OUT"
+          ? dt(t, "dialogs.pullRequestDetail.checkTimedOut")
+          : normalized === "ACTION_REQUIRED"
+            ? dt(t, "dialogs.pullRequestDetail.checkActionRequired")
+            : normalized === "CANCELLED"
+              ? dt(t, "dialogs.pullRequestDetail.checkCancelled")
+              : normalized === "NEUTRAL"
+                ? dt(t, "dialogs.pullRequestDetail.checkNeutral")
+                : normalized === "SKIPPED"
+                  ? dt(t, "dialogs.pullRequestDetail.checkSkipped")
+                  : normalized === "COMPLETED"
+                    ? dt(t, "dialogs.pullRequestDetail.checkCompleted")
+                    : raw.toLowerCase().replace(/_/g, " ");
   return (
     <span className="shrink-0 font-mono text-[10px] text-fg-muted">{text}</span>
   );

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -1158,7 +1158,10 @@ function CommitListItem({
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const primaryAuthor = commit.authors[0];
   const commitUrl = buildCommitUrl(prUrl, commit.oid);
-  const profileItems = buildProfileMenuItems(primaryAuthor?.login);
+  const profileItems = buildProfileMenuItems(
+    primaryAuthor?.login,
+    t("ui.openGitHubProfile"),
+  );
 
   const items: ContextMenuItem[] = [
     ...(commitUrl

--- a/src/components/RemoveProjectDialog.tsx
+++ b/src/components/RemoveProjectDialog.tsx
@@ -1,12 +1,19 @@
 import { AlertTriangle } from "lucide-react";
 import type { Project, Session } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal, ModalHeader } from "./ui";
 
 type RemoveProjectChoice =
   | "project_only"
   | "project_and_worktrees"
   | "cancel";
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface RemoveProjectDialogProps {
   project: Project | null;
@@ -19,6 +26,7 @@ export function RemoveProjectDialog({
   sessions,
   onClose,
 }: RemoveProjectDialogProps) {
+  const t = useTranslation();
   const isolatedCount = sessions.filter((s) => s.isolated).length;
   const primaryChoice: RemoveProjectChoice =
     isolatedCount > 0 ? "project_and_worktrees" : "project_only";
@@ -38,14 +46,14 @@ export function RemoveProjectDialog({
       {project ? (
         <>
           <ModalHeader
-            title="Close project"
+            title={dt(t, "dialogs.removeProject.title")}
             icon={<AlertTriangle size={16} className="text-warning" />}
             variant="dialog"
             onClose={() => onClose("cancel")}
           />
           <div className="space-y-3 px-4 py-3 text-sm text-fg">
             <p>
-              Close project{" "}
+              {dt(t, "dialogs.removeProject.confirmPrefix")}{" "}
               <span className="font-mono text-accent">{project.name}</span>?
             </p>
             <div className="space-y-1 rounded-md border border-border bg-bg-sidebar/60 p-3 text-xs">
@@ -53,10 +61,17 @@ export function RemoveProjectDialog({
                 {project.repo_path}
               </p>
               <p className="text-fg-muted">
-                {sessions.length} session{sessions.length === 1 ? "" : "s"}{" "}
-                will be removed
+                {sessions.length}{" "}
+                {sessions.length === 1
+                  ? dt(t, "dialogs.removeProject.sessionSingular")
+                  : dt(t, "dialogs.removeProject.sessionPlural")}{" "}
+                {dt(t, "dialogs.removeProject.willBeRemoved")}
                 {isolatedCount > 0
-                  ? ` (${isolatedCount} isolated worktree${isolatedCount === 1 ? "" : "s"})`
+                  ? ` (${isolatedCount} ${
+                      isolatedCount === 1
+                        ? dt(t, "dialogs.removeProject.isolatedWorktreeSingular")
+                        : dt(t, "dialogs.removeProject.isolatedWorktreePlural")
+                    })`
                   : ""}
                 .
               </p>
@@ -68,7 +83,7 @@ export function RemoveProjectDialog({
               onClick={() => onClose("cancel")}
               className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
             >
-              Cancel
+              {dt(t, "dialogs.common.cancel")}
             </button>
             {isolatedCount > 0 ? (
               <button
@@ -76,7 +91,7 @@ export function RemoveProjectDialog({
                 onClick={() => onClose("project_only")}
                 className="rounded-md px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
               >
-                Close · keep worktrees
+                {dt(t, "dialogs.removeProject.closeKeepWorktrees")}
               </button>
             ) : null}
             <button
@@ -88,7 +103,9 @@ export function RemoveProjectDialog({
               }
               className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
             >
-              {isolatedCount > 0 ? "Close · delete worktrees" : "Close project"}
+              {isolatedCount > 0
+                ? dt(t, "dialogs.removeProject.closeDeleteWorktrees")
+                : dt(t, "dialogs.removeProject.closeProject")}
             </button>
           </footer>
         </>

--- a/src/components/RemoveSessionDialog.tsx
+++ b/src/components/RemoveSessionDialog.tsx
@@ -2,10 +2,17 @@ import { AlertTriangle } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { Session } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { useSettings } from "../lib/settings";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal, ModalHeader } from "./ui";
 
 type RemoveChoice = "session_only" | "session_and_worktree" | "cancel";
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface RemoveSessionDialogProps {
   session: Session | null;
@@ -13,6 +20,7 @@ interface RemoveSessionDialogProps {
 }
 
 export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogProps) {
+  const t = useTranslation();
   const isolated = session?.isolated ?? false;
   const patchSessions = useSettings((s) => s.patchSessions);
   const [dontAskAgain, setDontAskAgain] = useState(false);
@@ -50,31 +58,33 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
       {session ? (
         <>
           <ModalHeader
-            title="Remove session"
+            title={dt(t, "dialogs.removeSession.title")}
             icon={<AlertTriangle size={16} className="text-warning" />}
             variant="dialog"
             onClose={() => commit("cancel")}
           />
           <div className="space-y-3 px-4 py-3 text-sm text-fg">
             <p>
-              Remove session{" "}
+              {dt(t, "dialogs.removeSession.confirmPrefix")}{" "}
               <span className="font-mono text-accent">{session.name}</span>?
             </p>
             {isolated ? (
               <div className="space-y-2 rounded-md border border-border bg-bg-sidebar/60 p-3">
                 <p className="text-xs text-fg-muted">
-                  This is an isolated worktree:
+                  {dt(t, "dialogs.removeSession.isolatedWorktree")}
                 </p>
                 <p className="break-all font-mono text-xs text-fg">
                   {session.worktree_path}
                 </p>
                 <p className="text-xs text-fg-muted">
-                  Also delete the worktree from disk?
+                  {dt(t, "dialogs.removeSession.deleteWorktreeQuestion")}
                 </p>
               </div>
             ) : (
               <p className="text-xs text-fg-muted">
-                Files in {session.worktree_path} will not be touched.
+                {dt(t, "dialogs.removeSession.filesIn")}{" "}
+                {session.worktree_path}{" "}
+                {dt(t, "dialogs.removeSession.willNotBeTouched")}
               </p>
             )}
             {!isolated ? (
@@ -85,7 +95,7 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
                   onChange={(e) => setDontAskAgain(e.target.checked)}
                   className="accent-[var(--color-accent)]"
                 />
-                Don't ask again (toggle in Settings → Sessions)
+                {dt(t, "dialogs.removeSession.dontAskAgain")}
               </label>
             ) : null}
           </div>
@@ -95,7 +105,7 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
               onClick={() => commit("cancel")}
               className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
             >
-              Cancel
+              {dt(t, "dialogs.common.cancel")}
             </button>
             {isolated ? (
               <>
@@ -104,14 +114,14 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
                   onClick={() => commit("session_only")}
                   className="rounded-md px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
                 >
-                  Keep worktree
+                  {dt(t, "dialogs.removeSession.keepWorktree")}
                 </button>
                 <button
                   type="button"
                   onClick={() => commit("session_and_worktree")}
                   className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
                 >
-                  Delete worktree
+                  {dt(t, "dialogs.removeSession.deleteWorktree")}
                 </button>
               </>
             ) : (
@@ -120,7 +130,7 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
                 onClick={() => commit("session_only")}
                 className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
               >
-                Remove
+                {dt(t, "dialogs.removeSession.remove")}
               </button>
             )}
           </footer>

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -69,6 +69,8 @@ import {
   TextInput,
 } from "./ui";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 
 interface ExpandedDiff {
   payload: DiffPayload;
@@ -87,7 +89,26 @@ interface ExpandedDiff {
 const COMMITS_PAGE_SIZE = 50;
 const COMMIT_ROW_HEIGHT = 48;
 
+type RightPanelTranslationKey = Extract<TranslationKey, `rightPanel.${string}`>;
+
+function rt(t: Translator, key: RightPanelTranslationKey): string {
+  return t(key);
+}
+
+function rtf(
+  t: Translator,
+  key: RightPanelTranslationKey,
+  values: Record<string, string | number>,
+): string {
+  return rt(t, key).replace(/\{(\w+)\}/g, (match, name) =>
+    Object.prototype.hasOwnProperty.call(values, name)
+      ? String(values[name])
+      : match,
+  );
+}
+
 export function RightPanel() {
+  const t = useTranslation();
   const sessions = useAppStore((s) => s.sessions);
   const activeSessionId = useAppStore((s) => s.activeSessionId);
   const activeProject = useAppStore((s) => s.activeProject);
@@ -142,14 +163,14 @@ export function RightPanel() {
       >
         <TabButton
           icon={<FolderTree size={14} />}
-          label="Files"
+          label={rt(t, "rightPanel.tabs.files")}
           active={rightTab === "files"}
           onClick={() => setRightTab("files")}
         />
         {showTodos ? (
           <TabButton
             icon={<ListTodo size={14} />}
-            label="Todos"
+            label={rt(t, "rightPanel.tabs.todos")}
             badge={todosState.todos.length}
             active={rightTab === "todos"}
             onClick={() => setRightTab("todos")}
@@ -157,25 +178,25 @@ export function RightPanel() {
         ) : null}
         <TabButton
           icon={<GitCommit size={14} />}
-          label="Commits"
+          label={rt(t, "rightPanel.tabs.commits")}
           active={rightTab === "commits"}
           onClick={() => setRightTab("commits")}
         />
         <TabButton
           icon={<FileDiff size={14} />}
-          label="Staged"
+          label={rt(t, "rightPanel.tabs.staged")}
           active={rightTab === "staged"}
           onClick={() => setRightTab("staged")}
         />
         <TabButton
           icon={<GitPullRequest size={14} />}
-          label="PRs"
+          label={rt(t, "rightPanel.tabs.prs")}
           active={rightTab === "prs"}
           onClick={() => setRightTab("prs")}
         />
         <TabButton
           icon={<Activity size={14} />}
-          label="Actions"
+          label={rt(t, "rightPanel.tabs.actions")}
           active={rightTab === "actions"}
           onClick={() => setRightTab("actions")}
         />
@@ -185,7 +206,7 @@ export function RightPanel() {
           active && showTodos ? (
             <TodosTab todos={todosState.todos} />
           ) : (
-            <Empty msg="No todos in this session" />
+            <Empty msg={rt(t, "rightPanel.empty.noTodos")} />
           )
         ) : rightTab === "commits" ? (
           repoPath ? (
@@ -198,7 +219,7 @@ export function RightPanel() {
               onExpand={setExpanded}
             />
           ) : (
-            <Empty msg="No project selected" />
+            <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : rightTab === "staged" ? (
           repoPath ? (
@@ -208,7 +229,7 @@ export function RightPanel() {
               onExpand={setExpanded}
             />
           ) : (
-            <Empty msg="No project selected" />
+            <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : rightTab === "prs" ? (
           repoPath ? (
@@ -220,18 +241,18 @@ export function RightPanel() {
               refreshKey={prListVersion}
             />
           ) : (
-            <Empty msg="No project selected" />
+            <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : rightTab === "files" ? (
           repoPath ? (
             <FileExplorer key={repoPath} rootPath={repoPath} />
           ) : (
-            <Empty msg="No project selected" />
+            <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : repoPath ? (
           <ActionsTab key={repoPath} repoPath={repoPath} />
         ) : (
-          <Empty msg="No project selected" />
+          <Empty msg={rt(t, "rightPanel.empty.noProject")} />
         )}
       </div>
       <DiffViewerModal
@@ -507,14 +528,24 @@ function useSessionTodos(
 }
 
 function TodosTab({ todos }: { todos: TodoItem[] }) {
+  const t = useTranslation();
   const counts = countByStatus(todos);
 
   return (
     <div className="flex h-full flex-col">
       <div className="shrink-0 border-b border-border px-3 py-2 text-[10px] uppercase tracking-wide text-fg-muted">
-        <span className="mr-3">{counts.completed}/{todos.length} done</span>
+        <span className="mr-3">
+          {rtf(t, "rightPanel.todos.doneCount", {
+            completed: counts.completed,
+            total: todos.length,
+          })}
+        </span>
         {counts.in_progress > 0 ? (
-          <span className="text-accent">{counts.in_progress} in progress</span>
+          <span className="text-accent">
+            {rtf(t, "rightPanel.todos.inProgressCount", {
+              count: counts.in_progress,
+            })}
+          </span>
         ) : null}
       </div>
       <ul className="flex-1 overflow-y-auto p-2 text-xs">
@@ -585,6 +616,7 @@ function CommitsTab({
   repoPath: string;
   onExpand: (e: ExpandedDiff) => void;
 }) {
+  const t = useTranslation();
   const [commits, setCommits] = useState<CommitInfo[]>([]);
   const [commitLogins, setCommitLogins] = useState<
     Record<string, string | null>
@@ -743,7 +775,7 @@ function CommitsTab({
         </span>
         <span className="opacity-50">·</span>
         <Tooltip label={absoluteTime(c.timestamp)} side="bottom">
-          <span className="font-mono">{relativeTime(c.timestamp)}</span>
+          <span className="font-mono">{relativeTime(c.timestamp, t)}</span>
         </Tooltip>
       </span>
     );
@@ -752,7 +784,7 @@ function CommitsTab({
   function buildHeaderActions(c: CommitInfo, webUrl: string | null): ReactNode {
     return (
       <>
-        <Tooltip label="Copy SHA" side="bottom">
+        <Tooltip label={rt(t, "rightPanel.tooltips.copySha")} side="bottom">
           <button
             type="button"
             onClick={() => void navigator.clipboard.writeText(c.sha)}
@@ -762,7 +794,7 @@ function CommitsTab({
           </button>
         </Tooltip>
         {webUrl ? (
-          <Tooltip label="Open on GitHub" side="bottom">
+          <Tooltip label={rt(t, "rightPanel.tooltips.openOnGitHub")} side="bottom">
             <button
               type="button"
               onClick={() => void openUrl(webUrl)}
@@ -798,7 +830,7 @@ function CommitsTab({
     try {
       const url = await api.commitWebUrl(repoPath, c.sha);
       if (!url) {
-        setError("This repo's origin is not a GitHub remote.");
+        setError(rt(t, "rightPanel.errors.notGitHubRemote"));
         return;
       }
       await openUrl(url);
@@ -881,7 +913,7 @@ function CommitsTab({
               >
                 {isSentinel ? (
                   <div className="px-3 py-3 text-center text-[10px] text-fg-muted">
-                    {loadingMore ? "loading more..." : "—"}
+                    {loadingMore ? rt(t, "rightPanel.loading.moreLower") : "—"}
                   </div>
                 ) : (
                   <button
@@ -904,7 +936,11 @@ function CommitsTab({
                   >
                     <span className="flex w-full min-w-0 items-center gap-2">
                       <Tooltip
-                        label={c.pushed ? "Pushed" : "Not pushed"}
+                        label={
+                          c.pushed
+                            ? rt(t, "rightPanel.commits.pushed")
+                            : rt(t, "rightPanel.commits.notPushed")
+                        }
                         side="top"
                       >
                         <span
@@ -933,7 +969,7 @@ function CommitsTab({
                       <span className="opacity-50">·</span>
                       <Tooltip label={absoluteTime(c.timestamp)} side="top">
                         <span className="font-mono">
-                          {relativeTime(c.timestamp)}
+                          {relativeTime(c.timestamp, t)}
                         </span>
                       </Tooltip>
                     </span>
@@ -965,9 +1001,9 @@ function CommitsTab({
               }}
             />
           ) : selected ? (
-            <Empty msg="loading diff..." />
+            <Empty msg={rt(t, "rightPanel.loading.diffLower")} />
           ) : (
-            <Empty msg="Select a commit to see diff" />
+            <Empty msg={rt(t, "rightPanel.commits.selectToSeeDiff")} />
           )}
         </div>
       </Panel>
@@ -979,14 +1015,14 @@ function CommitsTab({
           menu
             ? ([
                 {
-                  label: "Expand diff",
+                  label: rt(t, "rightPanel.menu.expandDiff"),
                   icon: <Maximize2 size={12} />,
                   onClick: () => {
                     void expandCommit(menu.commit);
                   },
                 },
                 {
-                  label: "View on GitHub",
+                  label: rt(t, "rightPanel.menu.viewOnGitHub"),
                   icon: <Globe size={12} />,
                   onClick: () => {
                     void openOnGitHub(menu.commit);
@@ -994,7 +1030,9 @@ function CommitsTab({
                 },
                 { type: "separator" },
                 {
-                  label: `Copy SHA (${menu.commit.short_sha})`,
+                  label: rtf(t, "rightPanel.menu.copyShaWithValue", {
+                    sha: menu.commit.short_sha,
+                  }),
                   icon: <Copy size={12} />,
                   onClick: () => {
                     void copyToClipboard(menu.commit.sha);
@@ -1009,19 +1047,21 @@ function CommitsTab({
   );
 }
 
-function relativeTime(unixSeconds: number): string {
+function relativeTime(unixSeconds: number, t: Translator): string {
   const diffSec = Math.round(Date.now() / 1000) - unixSeconds;
-  if (diffSec < 60) return `${diffSec}s ago`;
+  if (diffSec < 60) {
+    return rtf(t, "rightPanel.time.secondsAgo", { count: diffSec });
+  }
   const min = Math.round(diffSec / 60);
-  if (min < 60) return `${min}m ago`;
+  if (min < 60) return rtf(t, "rightPanel.time.minutesAgo", { count: min });
   const hr = Math.round(diffSec / 3600);
-  if (hr < 24) return `${hr}h ago`;
+  if (hr < 24) return rtf(t, "rightPanel.time.hoursAgo", { count: hr });
   const day = Math.round(diffSec / 86400);
-  if (day < 30) return `${day}d ago`;
+  if (day < 30) return rtf(t, "rightPanel.time.daysAgo", { count: day });
   const mo = Math.round(diffSec / (86400 * 30));
-  if (mo < 12) return `${mo}mo ago`;
+  if (mo < 12) return rtf(t, "rightPanel.time.monthsAgo", { count: mo });
   const yr = Math.round(diffSec / (86400 * 365));
-  return `${yr}y ago`;
+  return rtf(t, "rightPanel.time.yearsAgo", { count: yr });
 }
 
 function absoluteTime(unixSeconds: number): string {
@@ -1035,6 +1075,7 @@ function StagedTab({
   repoPath: string;
   onExpand: (e: ExpandedDiff) => void;
 }) {
+  const t = useTranslation();
   const [files, setFiles] = useState<StagedFile[]>([]);
   const [diff, setDiff] = useState<DiffPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -1091,7 +1132,7 @@ function StagedTab({
 
   async function openInEditor(file: StagedFile) {
     if (isDeleted(file)) {
-      setError("File was deleted; nothing to open.");
+      setError(rt(t, "rightPanel.errors.deletedFile"));
       return;
     }
     try {
@@ -1103,7 +1144,7 @@ function StagedTab({
 
   async function openWithDefaultApp(file: StagedFile) {
     if (isDeleted(file)) {
-      setError("File was deleted; nothing to open.");
+      setError(rt(t, "rightPanel.errors.deletedFile"));
       return;
     }
     try {
@@ -1116,7 +1157,7 @@ function StagedTab({
   if (error) return <div className="p-3 text-xs text-danger">{error}</div>;
   if (files.length === 0) {
     if (loadingFirst) return <SkeletonList count={6} />;
-    return <Empty msg="No staged or modified files" />;
+    return <Empty msg={rt(t, "rightPanel.staged.empty")} />;
   }
 
   return (
@@ -1155,13 +1196,13 @@ function StagedTab({
               onExpand={() =>
                 onExpand({
                   payload: diff,
-                  title: "Working tree changes",
+                  title: rt(t, "rightPanel.staged.workingTreeChanges"),
                   subtitle: <span className="font-mono">{repoPath}</span>,
                 })
               }
             />
           ) : (
-            <Empty msg="No diff" />
+            <Empty msg={rt(t, "rightPanel.staged.noDiff")} />
           )}
         </div>
       </Panel>
@@ -1173,7 +1214,7 @@ function StagedTab({
           menu
             ? ([
                 {
-                  label: "Open in editor",
+                  label: rt(t, "rightPanel.menu.openInEditor"),
                   icon: <ExternalLink size={12} />,
                   disabled: isDeleted(menu.file),
                   onClick: () => {
@@ -1182,14 +1223,14 @@ function StagedTab({
                 },
                 { type: "separator" },
                 {
-                  label: "Copy relative path",
+                  label: rt(t, "rightPanel.menu.copyRelativePath"),
                   icon: <Copy size={12} />,
                   onClick: () => {
                     void copyText(menu.file.path);
                   },
                 },
                 {
-                  label: "Copy absolute path",
+                  label: rt(t, "rightPanel.menu.copyAbsolutePath"),
                   icon: <Copy size={12} />,
                   onClick: () => {
                     void copyText(joinPath(repoPath, menu.file.path));
@@ -1204,12 +1245,16 @@ function StagedTab({
   );
 }
 
-const PR_STATE_OPTIONS: { value: PrStateFilter; label: string }[] = [
-  { value: "open", label: "Open" },
-  { value: "closed", label: "Closed" },
-  { value: "merged", label: "Merged" },
-  { value: "all", label: "All" },
+const PR_STATE_OPTIONS: { value: PrStateFilter }[] = [
+  { value: "open" },
+  { value: "closed" },
+  { value: "merged" },
+  { value: "all" },
 ];
+
+function prStateLabelKey(value: PrStateFilter): RightPanelTranslationKey {
+  return `rightPanel.prStates.${value}`;
+}
 
 /** Initial page size and per-scroll growth increment for PR list pagination. */
 const PR_PAGE_SIZE = 50;
@@ -1229,6 +1274,7 @@ function usePrRowActions(
   onOpenDetail: (number: number) => void,
   onMutated?: () => void,
 ) {
+  const t = useTranslation();
   const [menu, setMenu] = useState<{
     x: number;
     y: number;
@@ -1273,8 +1319,10 @@ function usePrRowActions(
       if (listing.kind !== "ok") {
         setError(
           listing.kind === "not_github"
-            ? "Origin remote is not a GitHub repository."
-            : `No access to ${listing.slug}.`,
+            ? rt(t, "rightPanel.errors.originNotGitHub")
+            : rtf(t, "rightPanel.errors.noAccessToSlug", {
+                slug: listing.slug,
+              }),
         );
         return null;
       }
@@ -1315,40 +1363,42 @@ function usePrRowActions(
           menu
             ? ([
                 {
-                  label: "Open detail",
+                  label: rt(t, "rightPanel.menu.openDetail"),
                   icon: <Maximize2 size={12} />,
                   onClick: () => onOpenDetail(menu.pr.number),
                 },
                 {
-                  label: "Open in browser",
+                  label: rt(t, "rightPanel.menu.openInBrowser"),
                   icon: <ExternalLink size={12} />,
                   onClick: () => void openPrInBrowser(menu.pr),
                 },
                 { type: "separator" },
                 {
-                  label: "Copy PR number",
+                  label: rt(t, "rightPanel.menu.copyPrNumber"),
                   icon: <Copy size={12} />,
                   onClick: () => void copyText(`#${menu.pr.number}`),
                 },
                 {
-                  label: "Copy URL",
+                  label: rt(t, "rightPanel.menu.copyUrl"),
                   icon: <Copy size={12} />,
                   onClick: () => void copyText(menu.pr.url),
                 },
                 {
-                  label: `Copy branch (${menu.pr.head_branch})`,
+                  label: rtf(t, "rightPanel.menu.copyBranchWithValue", {
+                    branch: menu.pr.head_branch,
+                  }),
                   icon: <Copy size={12} />,
                   onClick: () => void copyText(menu.pr.head_branch),
                 },
                 { type: "separator" },
                 {
-                  label: "Merge…",
+                  label: rt(t, "rightPanel.menu.merge"),
                   icon: <GitMerge size={12} />,
                   disabled: menu.pr.state.toUpperCase() !== "OPEN",
                   onClick: () => void openMergeFor(menu.pr),
                 },
                 {
-                  label: "Close…",
+                  label: rt(t, "rightPanel.menu.close"),
                   icon: <GitPullRequestClosed size={12} />,
                   disabled: menu.pr.state.toUpperCase() !== "OPEN",
                   onClick: () => void openCloseFor(menu.pr),
@@ -1404,6 +1454,7 @@ function PullRequestsTab({
   /** Bumped by the parent to force an out-of-band refetch (e.g. after a PR is merged via the modal). */
   refreshKey: number;
 }) {
+  const t = useTranslation();
   const refreshIntervalMs = useSettings(
     (s) => s.settings.github.refreshIntervalMs,
   );
@@ -1513,14 +1564,14 @@ function PullRequestsTab({
                 : "text-fg-muted hover:text-fg",
             )}
           >
-            {opt.label}
+            {rt(t, prStateLabelKey(opt.value))}
           </button>
         ))}
         <button
           type="button"
           onClick={onOpenSearch}
-          aria-label="Search pull requests"
-          title="Search pull requests"
+          aria-label={rt(t, "rightPanel.search.aria")}
+          title={rt(t, "rightPanel.search.aria")}
           className="ml-auto rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
         >
           <Search size={12} />
@@ -1542,7 +1593,7 @@ function PullRequestsTab({
         ) : !listing ? (
           <PrSkeletonList count={10} />
         ) : listing.kind === "not_github" ? (
-          <Empty msg="Origin remote is not a GitHub repository." />
+          <Empty msg={rt(t, "rightPanel.errors.originNotGitHub")} />
         ) : listing.kind === "no_access" ? (
           <NoAccessBanner
             slug={listing.slug}
@@ -1550,7 +1601,11 @@ function PullRequestsTab({
             repoPath={repoPath}
           />
         ) : listing.items.length === 0 ? (
-          <Empty msg={`No ${stateFilter} pull requests.`} />
+          <Empty
+            msg={rtf(t, "rightPanel.prs.emptyByState", {
+              state: rt(t, prStateLabelKey(stateFilter)).toLowerCase(),
+            })}
+          />
         ) : (
           <ul className="text-xs">
             {listing.items.map((pr) => (
@@ -1564,12 +1619,14 @@ function PullRequestsTab({
             ))}
             {loading && listing.items.length >= limit ? (
               <li className="px-3 py-2 text-[10px] text-fg-muted">
-                Loading more…
+                {rt(t, "rightPanel.loading.more")}
               </li>
             ) : null}
             {reachedMax ? (
               <li className="px-3 py-2 text-[10px] text-fg-muted">
-                Showing first {PR_PAGE_MAX}. Use search to find older PRs.
+                {rtf(t, "rightPanel.prs.reachedMax", {
+                  count: PR_PAGE_MAX,
+                })}
               </li>
             ) : null}
           </ul>
@@ -1584,6 +1641,7 @@ const WORKFLOW_RUNS_LIMIT = 50;
 const ALL_WORKFLOWS = "__all__";
 
 function ActionsTab({ repoPath }: { repoPath: string }) {
+  const t = useTranslation();
   const refreshIntervalMs = useSettings(
     (s) => s.settings.github.refreshIntervalMs,
   );
@@ -1647,11 +1705,13 @@ function ActionsTab({ repoPath }: { repoPath: string }) {
         <Select
           value={workflowFilter}
           onChange={(e) => setWorkflowFilter(e.target.value)}
-          aria-label="Filter by workflow"
+          aria-label={rt(t, "rightPanel.actions.filterByWorkflow")}
           disabled={listing?.kind !== "ok" || workflowNames.length === 0}
           className="min-w-0 max-w-full flex-1 truncate"
         >
-          <option value={ALL_WORKFLOWS}>All workflows</option>
+          <option value={ALL_WORKFLOWS}>
+            {rt(t, "rightPanel.actions.allWorkflows")}
+          </option>
           {workflowNames.map((name) => (
             <option key={name} value={name}>
               {name}
@@ -1670,7 +1730,7 @@ function ActionsTab({ repoPath }: { repoPath: string }) {
         ) : !listing ? (
           <PrSkeletonList count={8} />
         ) : listing.kind === "not_github" ? (
-          <Empty msg="Origin remote is not a GitHub repository." />
+          <Empty msg={rt(t, "rightPanel.errors.originNotGitHub")} />
         ) : listing.kind === "no_access" ? (
           <NoAccessBanner
             slug={listing.slug}
@@ -1681,8 +1741,8 @@ function ActionsTab({ repoPath }: { repoPath: string }) {
           <Empty
             msg={
               listing.items.length === 0
-                ? "No workflow runs yet."
-                : "No runs match this filter."
+                ? rt(t, "rightPanel.actions.noRuns")
+                : rt(t, "rightPanel.actions.noRunsForFilter")
             }
           />
         ) : (
@@ -1714,13 +1774,16 @@ function WorkflowRunRow({
   run: WorkflowRun;
   onOpenDetail: () => void;
 }) {
+  const t = useTranslation();
   const updated = toUnixSeconds(run.updated_at);
-  const startedRelative = updated > 0 ? relativeTime(updated) : "";
+  const startedRelative = updated > 0 ? relativeTime(updated, t) : "";
   const startedAbsolute = updated > 0 ? absoluteTime(updated) : "";
   const title =
     run.display_title.trim().length > 0
       ? run.display_title
-      : `${run.workflow_name} run`;
+      : rtf(t, "rightPanel.actions.workflowRunFallbackTitle", {
+          workflow: run.workflow_name,
+        });
   const branch = run.head_branch?.trim() ?? "";
 
   return (
@@ -1738,7 +1801,7 @@ function WorkflowRunRow({
           "flex w-full items-start gap-2 border-b border-border/40 px-3 py-2 text-left",
           "transition hover:bg-bg-elevated/60 focus:bg-bg-elevated/60 focus:outline-none",
         )}
-        title="Double-click to view details"
+        title={rt(t, "rightPanel.actions.doubleClickDetails")}
       >
         <span className="mt-0.5 flex shrink-0 items-center">
           <WorkflowRunStatusIcon
@@ -1761,7 +1824,11 @@ function WorkflowRunRow({
             {run.attempt > 1 ? (
               <>
                 <span className="opacity-50">·</span>
-                <span>retry #{run.attempt}</span>
+                <span>
+                  {rtf(t, "rightPanel.actions.retryAttempt", {
+                    attempt: run.attempt,
+                  })}
+                </span>
               </>
             ) : null}
           </div>
@@ -1789,6 +1856,7 @@ function WorkflowRunDetailModal({
   runId: number | null;
   onClose: () => void;
 }) {
+  const t = useTranslation();
   const refreshIntervalMs = useSettings(
     (s) => s.settings.github.refreshIntervalMs,
   );
@@ -1851,7 +1919,7 @@ function WorkflowRunDetailModal({
   const title =
     detail?.display_title.trim().length
       ? detail.display_title
-      : detail?.workflow_name ?? "Workflow run";
+      : detail?.workflow_name ?? rt(t, "rightPanel.actions.workflowRun");
   const subtitle = detail ? (
     <span className="flex flex-wrap items-center gap-1.5">
       <span>{detail.workflow_name}</span>
@@ -1866,7 +1934,11 @@ function WorkflowRunDetailModal({
       {detail.attempt > 1 ? (
         <>
           <span className="opacity-50">·</span>
-          <span>retry #{detail.attempt}</span>
+          <span>
+            {rtf(t, "rightPanel.actions.retryAttempt", {
+              attempt: detail.attempt,
+            })}
+          </span>
         </>
       ) : null}
     </span>
@@ -1902,10 +1974,10 @@ function WorkflowRunDetailModal({
               type="button"
               onClick={() => void openUrl(detail.url)}
               className="flex items-center gap-1 rounded px-2 py-1 text-[11px] text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
-              title="Open on GitHub"
+              title={rt(t, "rightPanel.tooltips.openOnGitHub")}
             >
               <ExternalLink size={12} />
-              GitHub
+              {rt(t, "rightPanel.actions.github")}
             </button>
           ) : null
         }
@@ -1918,7 +1990,7 @@ function WorkflowRunDetailModal({
         ) : loading || !listing ? (
           <WorkflowRunDetailSkeleton />
         ) : listing.kind === "not_github" ? (
-          <Empty msg="Origin remote is not a GitHub repository." />
+          <Empty msg={rt(t, "rightPanel.errors.originNotGitHub")} />
         ) : listing.kind === "no_access" ? (
           <NoAccessBanner
             slug={listing.slug}
@@ -1975,60 +2047,72 @@ function WorkflowRunDetailSkeleton() {
 }
 
 function WorkflowRunDetailBody({ detail }: { detail: WorkflowRunDetail }) {
+  const t = useTranslation();
   const created = toUnixSeconds(detail.created_at);
   const updated = toUnixSeconds(detail.updated_at);
   const totalDuration = formatRunDuration(
     detail.started_at ?? detail.created_at,
     detail.status,
     detail.updated_at,
+    t,
   );
   return (
     <div className="space-y-3">
       <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px] text-fg-muted">
-        <dt className="opacity-70">Status</dt>
+        <dt className="opacity-70">{rt(t, "rightPanel.actions.status")}</dt>
         <dd className="text-fg">
           {detail.status}
           {detail.conclusion ? ` · ${detail.conclusion}` : ""}
         </dd>
         {totalDuration ? (
           <>
-            <dt className="opacity-70">Total duration</dt>
+            <dt className="opacity-70">
+              {rt(t, "rightPanel.actions.totalDuration")}
+            </dt>
             <dd className="text-fg">
               {totalDuration}
               {detail.status.toLowerCase() !== "completed" ? (
-                <span className="ml-1 text-fg-muted">(running)</span>
+                <span className="ml-1 text-fg-muted">
+                  {rt(t, "rightPanel.actions.runningParenthetical")}
+                </span>
               ) : null}
             </dd>
           </>
         ) : null}
-        <dt className="opacity-70">Attempt</dt>
+        <dt className="opacity-70">{rt(t, "rightPanel.actions.attempt")}</dt>
         <dd className="text-fg">
           #{detail.attempt}
           {detail.attempt > 1 ? (
-            <span className="ml-1 text-fg-muted">(retried)</span>
+            <span className="ml-1 text-fg-muted">
+              {rt(t, "rightPanel.actions.retriedParenthetical")}
+            </span>
           ) : null}
         </dd>
-        <dt className="opacity-70">Commit</dt>
+        <dt className="opacity-70">{rt(t, "rightPanel.actions.commit")}</dt>
         <dd className="font-mono text-fg">{detail.head_sha.slice(0, 7)}</dd>
         {created > 0 ? (
           <>
-            <dt className="opacity-70">Created</dt>
+            <dt className="opacity-70">{rt(t, "rightPanel.actions.created")}</dt>
             <dd className="text-fg">{absoluteTime(created)}</dd>
           </>
         ) : null}
         {updated > 0 ? (
           <>
-            <dt className="opacity-70">Updated</dt>
+            <dt className="opacity-70">{rt(t, "rightPanel.actions.updated")}</dt>
             <dd className="text-fg">{absoluteTime(updated)}</dd>
           </>
         ) : null}
       </dl>
       <div>
         <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-fg-muted">
-          Jobs ({detail.jobs.length})
+          {rtf(t, "rightPanel.actions.jobsCount", {
+            count: detail.jobs.length,
+          })}
         </div>
         {detail.jobs.length === 0 ? (
-          <div className="text-[11px] text-fg-muted">No jobs reported.</div>
+          <div className="text-[11px] text-fg-muted">
+            {rt(t, "rightPanel.actions.noJobs")}
+          </div>
         ) : (
           <ul className="rounded border border-border/60 divide-y divide-border/40">
             {detail.jobs.map((job) => (
@@ -2042,8 +2126,9 @@ function WorkflowRunDetailBody({ detail }: { detail: WorkflowRunDetail }) {
 }
 
 function WorkflowJobRow({ job }: { job: WorkflowJob }) {
+  const t = useTranslation();
   const [expanded, setExpanded] = useState(false);
-  const duration = formatJobDuration(job.started_at, job.completed_at);
+  const duration = formatJobDuration(job.started_at, job.completed_at, t);
   return (
     <li className="bg-bg/40">
       <button
@@ -2081,7 +2166,7 @@ function WorkflowJobRow({ job }: { job: WorkflowJob }) {
               }
             }}
             className="shrink-0 cursor-pointer rounded p-0.5 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
-            title="Open job on GitHub"
+            title={rt(t, "rightPanel.actions.openJobOnGitHub")}
           >
             <ExternalLink size={11} />
           </span>
@@ -2119,6 +2204,7 @@ function formatRunDuration(
   startedAt: string,
   status: string,
   updatedAt: string,
+  t: Translator,
 ): string {
   const start = toUnixSeconds(startedAt);
   if (start <= 0) return "";
@@ -2126,28 +2212,43 @@ function formatRunDuration(
   const end = completed
     ? toUnixSeconds(updatedAt) || Math.floor(Date.now() / 1000)
     : Math.floor(Date.now() / 1000);
-  return formatDurationSeconds(Math.max(0, end - start));
+  return formatDurationSeconds(Math.max(0, end - start), t);
 }
 
-function formatDurationSeconds(seconds: number): string {
-  if (seconds < 60) return `${seconds}s`;
+function formatDurationSeconds(seconds: number, t: Translator): string {
+  if (seconds < 60) {
+    return rtf(t, "rightPanel.duration.seconds", { count: seconds });
+  }
   const minutes = Math.floor(seconds / 60);
   const rem = seconds % 60;
-  if (minutes < 60) return rem === 0 ? `${minutes}m` : `${minutes}m ${rem}s`;
+  if (minutes < 60) {
+    return rem === 0
+      ? rtf(t, "rightPanel.duration.minutes", { count: minutes })
+      : rtf(t, "rightPanel.duration.minutesSeconds", {
+          minutes,
+          seconds: rem,
+        });
+  }
   const hours = Math.floor(minutes / 60);
   const minRem = minutes % 60;
-  return minRem === 0 ? `${hours}h` : `${hours}h ${minRem}m`;
+  return minRem === 0
+    ? rtf(t, "rightPanel.duration.hours", { count: hours })
+    : rtf(t, "rightPanel.duration.hoursMinutes", {
+        hours,
+        minutes: minRem,
+      });
 }
 
 function formatJobDuration(
   startedAt: string | null,
   completedAt: string | null,
+  t: Translator,
 ): string {
   if (!startedAt) return "";
   const start = toUnixSeconds(startedAt);
   if (start <= 0) return "";
   const end = completedAt ? toUnixSeconds(completedAt) : Math.floor(Date.now() / 1000);
-  return formatDurationSeconds(Math.max(0, end - start));
+  return formatDurationSeconds(Math.max(0, end - start), t);
 }
 
 function WorkflowRunStatusIcon({
@@ -2200,25 +2301,27 @@ function NoAccessBanner({
   accounts: AccountSummary[];
   repoPath: string;
 }) {
+  const t = useTranslation();
   const tried = accounts.map((a) => `@${a.login}`).join(", ");
   return (
     <div className="space-y-2 p-3 text-xs text-fg-muted">
       <p className="text-fg">
-        No logged-in <code className="font-mono">gh</code> account can access{" "}
-        <span className="font-mono text-fg">{slug}</span>.
+        {rtf(t, "rightPanel.noAccess.noGhAccountCanAccess", { slug })}
       </p>
       {accounts.length > 0 ? (
         <p>
-          <span className="opacity-70">Tried:</span> {tried}
+          <span className="opacity-70">
+            {rt(t, "rightPanel.noAccess.tried")}
+          </span>{" "}
+          {tried}
         </p>
       ) : (
-        <p>No accounts authenticated against github.com.</p>
+        <p>{rt(t, "rightPanel.noAccess.noAccounts")}</p>
       )}
       <p className="flex flex-wrap items-center gap-1.5 opacity-70">
-        Run
+        {rt(t, "rightPanel.noAccess.run")}
         <CommandHint command="gh auth login" repoPath={repoPath} />
-        with an account that has access, or accept the invitation on
-        github.com.
+        {rt(t, "rightPanel.noAccess.withAccess")}
       </p>
     </div>
   );
@@ -2229,6 +2332,7 @@ function PrChecksBadge({
 }: {
   checks: PullRequestChecksSummary | null;
 }) {
+  const t = useTranslation();
   if (!checks) return null;
   // Effective total mirrors the PR detail modal: NEUTRAL/SKIPPED/CANCELLED
   // are already excluded by the backend, so passed+failed+pending is what
@@ -2242,7 +2346,7 @@ function PrChecksBadge({
   if (allPassed) {
     return (
       <Tooltip
-        label={`All ${effective} check${effective === 1 ? "" : "s"} passed`}
+        label={rtf(t, "rightPanel.checks.allPassed", { count: effective })}
         side="top"
       >
         <Check
@@ -2256,7 +2360,7 @@ function PrChecksBadge({
   if (allFailed) {
     return (
       <Tooltip
-        label={`All ${effective} check${effective === 1 ? "" : "s"} failed`}
+        label={rtf(t, "rightPanel.checks.allFailed", { count: effective })}
         side="top"
       >
         <X size={10} strokeWidth={3} className="shrink-0 text-rose-400" />
@@ -2266,7 +2370,11 @@ function PrChecksBadge({
   // Partial: tiny inline `passed/total` next to the branch name, no pill.
   return (
     <Tooltip
-      label={`${checks.passed} passed, ${checks.failed} failed, ${checks.pending} pending`}
+      label={rtf(t, "rightPanel.checks.summary", {
+        passed: checks.passed,
+        failed: checks.failed,
+        pending: checks.pending,
+      })}
       side="top"
     >
       <span className="shrink-0 font-mono tabular-nums opacity-80">
@@ -2277,9 +2385,12 @@ function PrChecksBadge({
 }
 
 function PrStateBadge({ state, isDraft }: { state: string; isDraft: boolean }) {
+  const t = useTranslation();
   const upper = state.toUpperCase();
   const showDraft = isDraft && upper === "OPEN";
-  const label = showDraft ? "DRAFT" : upper;
+  const label = showDraft
+    ? rt(t, "rightPanel.prStates.draft")
+    : stateLabelForBadge(t, upper);
   const tone = showDraft
     ? "bg-fg-muted/15 text-fg-muted"
     : upper === "OPEN"
@@ -2297,6 +2408,19 @@ function PrStateBadge({ state, isDraft }: { state: string; isDraft: boolean }) {
       {label}
     </span>
   );
+}
+
+function stateLabelForBadge(t: Translator, upper: string): string {
+  switch (upper) {
+    case "OPEN":
+      return rt(t, "rightPanel.prStates.open").toUpperCase();
+    case "CLOSED":
+      return rt(t, "rightPanel.prStates.closed").toUpperCase();
+    case "MERGED":
+      return rt(t, "rightPanel.prStates.merged").toUpperCase();
+    default:
+      return upper;
+  }
 }
 
 function toUnixSeconds(iso: string): number {
@@ -2333,6 +2457,7 @@ function PrRow({
    */
   showAvatar?: boolean;
 }) {
+  const t = useTranslation();
   const hoverBg =
     surface === "dialog"
       ? "hover:bg-bg-sidebar focus-visible:bg-bg-sidebar"
@@ -2408,7 +2533,7 @@ function PrRow({
           className="shrink-0"
         >
           <span className="whitespace-nowrap font-mono">
-            {relativeTime(toUnixSeconds(pr.updated_at))}
+            {relativeTime(toUnixSeconds(pr.updated_at), t)}
           </span>
         </Tooltip>
       </span>
@@ -2416,11 +2541,11 @@ function PrRow({
   );
 }
 
-const PR_SEARCH_STATE_OPTIONS: { value: PrStateFilter; label: string }[] = [
-  { value: "all", label: "All" },
-  { value: "open", label: "Open" },
-  { value: "closed", label: "Closed" },
-  { value: "merged", label: "Merged" },
+const PR_SEARCH_STATE_OPTIONS: { value: PrStateFilter }[] = [
+  { value: "all" },
+  { value: "open" },
+  { value: "closed" },
+  { value: "merged" },
 ];
 
 /**
@@ -2444,6 +2569,7 @@ function PullRequestSearchModal({
   onClose: () => void;
   onOpenDetail: (number: number) => void;
 }) {
+  const t = useTranslation();
   const repoPath = open?.repoPath ?? null;
   const showAvatars = useSettings((s) => s.settings.github.showAvatars);
   const [rawQuery, setRawQuery] = useState("");
@@ -2545,10 +2671,10 @@ function PullRequestSearchModal({
       onClose={onClose}
       variant="dialog"
       size="2xl"
-      ariaLabel="Search pull requests"
+      ariaLabel={rt(t, "rightPanel.search.aria")}
     >
       <ModalHeader
-        title="Search pull requests"
+        title={rt(t, "rightPanel.search.aria")}
         icon={<Search size={14} className="text-fg-muted" />}
         variant="dialog"
         onClose={onClose}
@@ -2558,7 +2684,7 @@ function PullRequestSearchModal({
           ref={inputRef}
           value={rawQuery}
           onChange={(e) => setRawQuery(e.currentTarget.value)}
-          placeholder="Search title, author, label, branch…"
+          placeholder={rt(t, "rightPanel.search.placeholder")}
           autoFocus
         />
         <div className="flex items-center gap-1 text-[11px]">
@@ -2574,11 +2700,13 @@ function PullRequestSearchModal({
                   : "text-fg-muted hover:text-fg",
               )}
             >
-              {opt.label}
+              {rt(t, prStateLabelKey(opt.value))}
             </button>
           ))}
           {loading ? (
-            <span className="ml-auto text-fg-muted">Searching…</span>
+            <span className="ml-auto text-fg-muted">
+              {rt(t, "rightPanel.search.searching")}
+            </span>
           ) : listing?.kind === "ok" ? (
             <span className="ml-auto font-mono text-fg-muted">
               {listing.items.length}
@@ -2592,7 +2720,7 @@ function PullRequestSearchModal({
         onScroll={handleScroll}
       >
         {!debouncedQuery ? (
-          <Empty msg="Type to search pull requests." />
+          <Empty msg={rt(t, "rightPanel.search.typeToSearch")} />
         ) : error || rowActions.error ? (
           <div className="p-3 text-xs text-danger">
             {error ?? rowActions.error}
@@ -2600,13 +2728,13 @@ function PullRequestSearchModal({
         ) : !listing ? (
           <PrSkeletonList count={6} />
         ) : listing.kind === "not_github" ? (
-          <Empty msg="Origin remote is not a GitHub repository." />
+          <Empty msg={rt(t, "rightPanel.errors.originNotGitHub")} />
         ) : listing.kind === "no_access" ? (
           <div className="p-3 text-xs text-fg-muted">
-            No logged-in gh account can access this repo.
+            {rt(t, "rightPanel.search.noGhAccessThisRepo")}
           </div>
         ) : listing.items.length === 0 ? (
-          <Empty msg="No matching pull requests." />
+          <Empty msg={rt(t, "rightPanel.search.noMatches")} />
         ) : (
           <ul className="text-xs">
             {listing.items.map((pr) => (
@@ -2621,12 +2749,14 @@ function PullRequestSearchModal({
             ))}
             {loading && listing.items.length >= limit ? (
               <li className="px-3 py-2 text-[10px] text-fg-muted">
-                Loading more…
+                {rt(t, "rightPanel.loading.more")}
               </li>
             ) : null}
             {reachedMax ? (
               <li className="px-3 py-2 text-[10px] text-fg-muted">
-                Showing first {PR_PAGE_MAX}. Refine the query for older PRs.
+                {rtf(t, "rightPanel.search.reachedMax", {
+                  count: PR_PAGE_MAX,
+                })}
               </li>
             ) : null}
           </ul>

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -148,10 +148,13 @@ describe("SettingsModal font controls", () => {
 
     const fontFamily = document.querySelector<HTMLInputElement>("input");
     const patchTerminal = useSettings.getState().patchTerminal;
+    const bodyText = document.body.textContent ?? "";
 
-    expect(document.body.textContent).toContain("Font family");
-    expect(document.body.textContent).toContain(
-      "Comma-separated stack. First family that resolves wins.",
+    expect(bodyText).toMatch(
+      /Font family|settings\.terminal\.fontFamily\.label/,
+    );
+    expect(bodyText).toMatch(
+      /Comma-separated stack\. First family that resolves wins\.|settings\.terminal\.fontFamily\.hint/,
     );
     expect(fontFamily?.value).toBe(DEFAULT_SETTINGS.terminal.fontFamily);
 
@@ -252,6 +255,42 @@ describe("SettingsModal font controls", () => {
     });
 
     expect(patchLanguage).toHaveBeenCalledWith("en");
+  });
+
+  it("renders Korean Settings chrome and the active panel controls", async () => {
+    useSettings.setState({
+      settings: {
+        ...cloneSettings(),
+        language: "ko",
+      },
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+
+    for (const label of [
+      "터미널",
+      "에이전트",
+      "세션",
+      "GitHub",
+      "모양",
+      "편집기",
+      "알림",
+      "저장 공간",
+      "실험 기능",
+      "정보",
+    ]) {
+      const button = Array.from(document.querySelectorAll("button")).find(
+        (element) => element.textContent === label,
+      );
+      expect(button, `${label} tab button`).toBeInstanceOf(HTMLButtonElement);
+    }
+
+    expect(document.body.textContent).toContain("설정");
+    expect(document.body.textContent).toContain("기본값으로 재설정");
+    expect(document.body.textContent).toContain("글꼴 패밀리");
   });
 });
 

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -76,7 +76,8 @@ function cloneSettings() {
 
 function openAppearanceTab() {
   const button = Array.from(document.querySelectorAll("button")).find(
-    (element) => element.textContent === "Appearance",
+    (element) =>
+      element.textContent === "Appearance" || element.textContent === "모양",
   );
   if (!(button instanceof HTMLButtonElement)) {
     throw new Error("Appearance tab button not found");

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -213,6 +213,45 @@ describe("SettingsModal font controls", () => {
       uiScalePercent: 125,
     });
   });
+
+  it("renders the Appearance language selector in Korean and patches changes", async () => {
+    const patchLanguage = vi.fn();
+    useSettings.setState({
+      settings: {
+        ...cloneSettings(),
+        language: "ko",
+      },
+      patchLanguage,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openAppearanceTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(document.body.textContent).toContain("설정");
+    expect(document.body.textContent).toContain("모양");
+    expect(document.body.textContent).toContain("언어");
+
+    const languageSelect = Array.from(
+      document.querySelectorAll<HTMLSelectElement>("select"),
+    ).find((element) => element.value === "ko");
+
+    expect(languageSelect).toBeInstanceOf(HTMLSelectElement);
+    expect(languageSelect?.textContent).toContain("한국어");
+
+    act(() => {
+      if (!languageSelect) throw new Error("Language select not found");
+      languageSelect.value = "en";
+      languageSelect.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expect(patchLanguage).toHaveBeenCalledWith("en");
+  });
 });
 
 describe("SettingsModal background controls", () => {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -7,7 +7,7 @@ import {
   Sparkles,
   Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../lib/api";
 import {
   importBackgroundImage,
@@ -16,6 +16,11 @@ import {
 } from "../lib/background";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
+import {
+  createTranslator,
+  LANGUAGE_OPTIONS,
+  type Language,
+} from "../lib/i18n";
 import { sendTestNotification } from "../lib/notifications";
 import {
   fetchLatestReleaseNotes,
@@ -63,28 +68,31 @@ type Tab =
   | "experiments"
   | "about";
 
-const TABS: Array<{ id: Tab; label: string }> = [
-  { id: "terminal", label: "Terminal" },
-  { id: "agents", label: "Agents" },
-  { id: "sessions", label: "Sessions" },
-  { id: "github", label: "GitHub" },
-  { id: "appearance", label: "Appearance" },
-  { id: "editor", label: "Editor" },
-  { id: "notifications", label: "Notifications" },
-  { id: "storage", label: "Storage" },
-  { id: "experiments", label: "Experiments" },
-  { id: "about", label: "About" },
+const TABS: Array<{ id: Tab; labelKey: string }> = [
+  { id: "terminal", labelKey: "settings.tabs.terminal" },
+  { id: "agents", labelKey: "settings.tabs.agents" },
+  { id: "sessions", labelKey: "settings.tabs.sessions" },
+  { id: "github", labelKey: "settings.tabs.github" },
+  { id: "appearance", labelKey: "settings.tabs.appearance" },
+  { id: "editor", labelKey: "settings.tabs.editor" },
+  { id: "notifications", labelKey: "settings.tabs.notifications" },
+  { id: "storage", labelKey: "settings.tabs.storage" },
+  { id: "experiments", labelKey: "settings.tabs.experiments" },
+  { id: "about", labelKey: "settings.tabs.about" },
 ];
 
 const TAB_IDS = new Set<string>(TABS.map((t) => t.id));
+type SettingsTranslator = ReturnType<typeof createTranslator>;
 
 export function SettingsModal() {
   const open = useSettings((s) => s.open);
   const setOpen = useSettings((s) => s.setOpen);
   const reset = useSettings((s) => s.reset);
+  const language = useSettings((s) => s.settings.language);
   const pendingTab = useSettings((s) => s.pendingTab);
   const consumePendingTab = useSettings((s) => s.consumePendingTab);
   const [tab, setTab] = useState<Tab>("terminal");
+  const t = useMemo(() => createTranslator(language), [language]);
 
   // When the store reports a pending tab (e.g. StatusBar daemon button
   // dispatched `acorn:open-settings` with `tab: "background-sessions"`),
@@ -117,7 +125,7 @@ export function SettingsModal() {
       ariaLabelledBy="acorn-settings-title"
     >
       <ModalHeader
-        title="Settings"
+        title={t("settings.title")}
         titleId="acorn-settings-title"
         icon={<SettingsIcon size={14} className="text-fg-muted" />}
         variant="dialog"
@@ -125,19 +133,19 @@ export function SettingsModal() {
       />
       <div className="flex h-[28rem]">
         <nav className="flex w-40 shrink-0 flex-col border-r border-border bg-bg-sidebar/40 py-2">
-          {TABS.map((t) => (
+          {TABS.map((tabMeta) => (
             <button
-              key={t.id}
+              key={tabMeta.id}
               type="button"
-              onClick={() => setTab(t.id)}
+              onClick={() => setTab(tabMeta.id)}
               className={cn(
                 "px-4 py-1.5 text-left text-xs transition",
-                tab === t.id
+                tab === tabMeta.id
                   ? "bg-bg-elevated text-fg"
                   : "text-fg-muted hover:bg-bg-elevated/50 hover:text-fg",
               )}
             >
-              {t.label}
+              {t(tabMeta.labelKey)}
             </button>
           ))}
           <div className="mt-auto px-4 pb-2">
@@ -146,7 +154,7 @@ export function SettingsModal() {
               onClick={reset}
               className="text-[11px] text-fg-muted transition hover:text-danger"
             >
-              Reset to defaults
+              {t("settings.reset")}
             </button>
           </div>
         </nav>
@@ -160,7 +168,7 @@ export function SettingsModal() {
           ) : tab === "github" ? (
             <GithubSettings />
           ) : tab === "appearance" ? (
-            <AppearanceSettings />
+            <AppearanceSettings t={t} />
           ) : tab === "editor" ? (
             <EditorSettings />
           ) : tab === "notifications" ? (
@@ -562,8 +570,9 @@ function GithubSettings() {
   );
 }
 
-function AppearanceSettings() {
+function AppearanceSettings({ t }: { t: SettingsTranslator }) {
   const settings = useSettings((s) => s.settings);
+  const patchLanguage = useSettings((s) => s.patchLanguage);
   const patchStatusBar = useSettings((s) => s.patchStatusBar);
   const patchSessionDisplay = useSettings((s) => s.patchSessionDisplay);
   const patchAppearance = useSettings((s) => s.patchAppearance);
@@ -572,6 +581,11 @@ function AppearanceSettings() {
 
   return (
     <section className="space-y-6">
+      <LanguageSection
+        language={settings.language}
+        onChange={patchLanguage}
+        t={t}
+      />
       <ThemeSection
         themeId={appearance.themeId}
         onChange={(themeId) => patchAppearance({ themeId })}
@@ -593,6 +607,36 @@ function AppearanceSettings() {
         patch={patchStatusBar}
       />
     </section>
+  );
+}
+
+function LanguageSection({
+  language,
+  onChange,
+  t,
+}: {
+  language: Language;
+  onChange: (language: Language) => void;
+  t: SettingsTranslator;
+}) {
+  return (
+    <Field
+      label={t("settings.language.label")}
+      hint={t("settings.language.hint")}
+    >
+      <Select
+        value={language}
+        onChange={(e) => onChange(e.target.value as Language)}
+        className="w-48"
+        aria-label={t("settings.language.label")}
+      >
+        {LANGUAGE_OPTIONS.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.nativeLabel}
+          </option>
+        ))}
+      </Select>
+    </Field>
   );
 }
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -7,7 +7,7 @@ import {
   Sparkles,
   Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../lib/api";
 import {
   importBackgroundImage,
@@ -17,10 +17,10 @@ import {
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import {
-  createTranslator,
   LANGUAGE_OPTIONS,
   type Language,
   type TranslationKey,
+  type Translator,
 } from "../lib/i18n";
 import { sendTestNotification } from "../lib/notifications";
 import {
@@ -44,6 +44,7 @@ import {
   useSettings,
 } from "../lib/settings";
 import { revealThemesFolder, useThemes } from "../lib/themes";
+import { useTranslation } from "../lib/useTranslation";
 import {
   CheckboxRow,
   CommandHint,
@@ -83,17 +84,32 @@ const TABS: Array<{ id: Tab; labelKey: TranslationKey }> = [
 ];
 
 const TAB_IDS = new Set<string>(TABS.map((t) => t.id));
-type SettingsTranslator = ReturnType<typeof createTranslator>;
+type SettingsTranslator = Translator;
+
+function st(t: SettingsTranslator, key: TranslationKey): string {
+  return t(key);
+}
+
+function stf(
+  t: SettingsTranslator,
+  key: TranslationKey,
+  values: Record<string, string | number>,
+): string {
+  return st(t, key).replace(/\{(\w+)\}/g, (match, name) =>
+    Object.prototype.hasOwnProperty.call(values, name)
+      ? String(values[name])
+      : match,
+  );
+}
 
 export function SettingsModal() {
   const open = useSettings((s) => s.open);
   const setOpen = useSettings((s) => s.setOpen);
   const reset = useSettings((s) => s.reset);
-  const language = useSettings((s) => s.settings.language);
   const pendingTab = useSettings((s) => s.pendingTab);
   const consumePendingTab = useSettings((s) => s.consumePendingTab);
   const [tab, setTab] = useState<Tab>("terminal");
-  const t = useMemo(() => createTranslator(language), [language]);
+  const t = useTranslation();
 
   // When the store reports a pending tab (e.g. StatusBar daemon button
   // dispatched `acorn:open-settings` with `tab: "background-sessions"`),
@@ -190,19 +206,23 @@ export function SettingsModal() {
 function TerminalSettings() {
   const settings = useSettings((s) => s.settings);
   const patchTerminal = useSettings((s) => s.patchTerminal);
+  const t = useTranslation();
 
   return (
     <section className="space-y-4">
       <Field
-        label="Font family"
-        hint="Comma-separated stack. First family that resolves wins."
+        label={st(t, "settings.terminal.fontFamily.label")}
+        hint={st(t, "settings.terminal.fontFamily.hint")}
       >
         <TerminalFontFamilyInput
           value={settings.terminal.fontFamily}
           onCommit={(fontFamily) => patchTerminal({ fontFamily })}
         />
       </Field>
-      <Field label="Font size" hint="In CSS pixels. Range 8–32.">
+      <Field
+        label={st(t, "settings.terminal.fontSize.label")}
+        hint={st(t, "settings.terminal.fontSize.hint")}
+      >
         <Stepper
           value={settings.terminal.fontSize}
           min={8}
@@ -212,8 +232,8 @@ function TerminalSettings() {
         />
       </Field>
       <Field
-        label="Font weight"
-        hint="Weight for normal text. Effective values depend on the chosen font's available weights."
+        label={st(t, "settings.terminal.fontWeight.label")}
+        hint={st(t, "settings.terminal.fontWeight.hint")}
       >
         <WeightSelect
           value={settings.terminal.fontWeight}
@@ -221,8 +241,8 @@ function TerminalSettings() {
         />
       </Field>
       <Field
-        label="Bold font weight"
-        hint="Weight used when the terminal renders bold cells."
+        label={st(t, "settings.terminal.boldFontWeight.label")}
+        hint={st(t, "settings.terminal.boldFontWeight.hint")}
       >
         <WeightSelect
           value={settings.terminal.fontWeightBold}
@@ -230,8 +250,8 @@ function TerminalSettings() {
         />
       </Field>
       <Field
-        label="Line height"
-        hint="Cell-height multiplier. 1.00 packs rows flush; raise for more vertical breathing room. Range 1.00–2.00."
+        label={st(t, "settings.terminal.lineHeight.label")}
+        hint={st(t, "settings.terminal.lineHeight.hint")}
       >
         <Stepper
           value={settings.terminal.lineHeight}
@@ -243,16 +263,19 @@ function TerminalSettings() {
         />
       </Field>
       <Field
-        label="Open links on"
-        hint="How to follow URLs that xterm detects in terminal output."
+        label={st(t, "settings.terminal.openLinksOn.label")}
+        hint={st(t, "settings.terminal.openLinksOn.hint")}
       >
         <div className="flex flex-col gap-1.5">
           <RadioCard<TerminalLinkActivation>
             name="terminal-link-activation"
             value="click"
             current={settings.terminal.linkActivation}
-            label="Click (default)"
-            description="A single mouse click opens the URL in your default browser."
+            label={st(t, "settings.terminal.openLinksOn.click.label")}
+            description={st(
+              t,
+              "settings.terminal.openLinksOn.click.description",
+            )}
             onSelect={(v) => patchTerminal({ linkActivation: v })}
           />
           <RadioCard<TerminalLinkActivation>
@@ -260,7 +283,11 @@ function TerminalSettings() {
             value="modifier-click"
             current={settings.terminal.linkActivation}
             label={`${MODIFIER_LABEL}-click`}
-            description={`Hold ${MODIFIER_LABEL} while clicking to open. Stops stray clicks on output containing URLs from yanking focus to the browser.`}
+            description={stf(
+              t,
+              "settings.terminal.openLinksOn.modifierClick.description",
+              { modifier: MODIFIER_LABEL },
+            )}
             onSelect={(v) => patchTerminal({ linkActivation: v })}
           />
         </div>
@@ -348,13 +375,14 @@ function WeightSelect({ value, onChange }: WeightSelectProps) {
 function SessionSettings() {
   const settings = useSettings((s) => s.settings);
   const patchSessions = useSettings((s) => s.patchSessions);
+  const t = useTranslation();
 
   return (
     <section className="space-y-6">
       <div className="space-y-4">
         <Field
-          label="Confirm before removing a session"
-          hint="Isolated worktrees always prompt because the delete-worktree choice still matters."
+          label={st(t, "settings.sessions.confirmRemove.label")}
+          hint={st(t, "settings.sessions.confirmRemove.hint")}
         >
           <label className="flex items-center gap-2 text-xs text-fg">
             <input
@@ -365,12 +393,12 @@ function SessionSettings() {
               }
               className="accent-[var(--color-accent)]"
             />
-            Show confirmation dialog
+            {st(t, "settings.sessions.confirmRemove.checkbox")}
           </label>
         </Field>
         <Field
-          label="Close tab when the process exits"
-          hint="When the session's shell or agent exits (e.g. you type `exit`), close the tab automatically instead of showing the press-Enter restart prompt. The worktree is preserved either way."
+          label={st(t, "settings.sessions.closeOnExit.label")}
+          hint={st(t, "settings.sessions.closeOnExit.hint")}
         >
           <label className="flex items-center gap-2 text-xs text-fg">
             <input
@@ -381,14 +409,14 @@ function SessionSettings() {
               }
               className="accent-[var(--color-accent)]"
             />
-            Auto-close on exit
+            {st(t, "settings.sessions.closeOnExit.checkbox")}
           </label>
         </Field>
         <ControlSessionInstallSection />
       </div>
       <SettingsGroup
-        title="Background sessions"
-        description="The acornd daemon owns long-running PTYs so terminal sessions survive Acorn restarts."
+        title={st(t, "settings.sessions.background.title")}
+        description={st(t, "settings.sessions.background.description")}
       >
         <BackgroundSessionsSettings />
       </SettingsGroup>
@@ -425,6 +453,7 @@ function ControlSessionInstallSection() {
     import("../lib/types").AcornIpcStatus | null
   >(null);
   const [error, setError] = useState<string | null>(null);
+  const t = useTranslation();
 
   const refresh = useCallback(async () => {
     try {
@@ -443,8 +472,8 @@ function ControlSessionInstallSection() {
   if (error) {
     return (
       <Field
-        label="Control sessions (acorn-ipc CLI)"
-        hint="Could not query install status."
+        label={st(t, "settings.sessions.controlCli.label")}
+        hint={st(t, "settings.sessions.controlCli.errorHint")}
       >
         <p className="text-[11px] text-danger">{error}</p>
       </Field>
@@ -454,8 +483,8 @@ function ControlSessionInstallSection() {
   if (!status) {
     return (
       <Field
-        label="Control sessions (acorn-ipc CLI)"
-        hint="Loading install status…"
+        label={st(t, "settings.sessions.controlCli.label")}
+        hint={st(t, "settings.sessions.controlCli.loadingHint")}
       >
         <p className="text-[11px] text-fg-muted">…</p>
       </Field>
@@ -471,13 +500,15 @@ function ControlSessionInstallSection() {
 
   return (
     <Field
-      label="Control sessions (acorn-ipc CLI)"
-      hint="Control sessions can dispatch commands to siblings via the acorn-ipc CLI. The CLI ships next to the app; symlink it into your $PATH to use it from any terminal."
+      label={st(t, "settings.sessions.controlCli.label")}
+      hint={st(t, "settings.sessions.controlCli.hint")}
     >
       <div className="space-y-2">
         <div className="rounded-md border border-border bg-bg px-3 py-2 text-[11px]">
           <div className="flex items-center justify-between">
-            <span className="text-fg-muted">Bundled binary</span>
+            <span className="text-fg-muted">
+              {st(t, "settings.sessions.controlCli.bundledBinary")}
+            </span>
             <span
               className={cn(
                 "rounded px-1.5 py-0.5 text-[10px] font-medium",
@@ -486,7 +517,9 @@ function ControlSessionInstallSection() {
                   : "bg-warning/15 text-warning",
               )}
             >
-              {status.bundled_exists ? "found" : "missing"}
+              {status.bundled_exists
+                ? st(t, "settings.sessions.controlCli.found")
+                : st(t, "settings.sessions.controlCli.missing")}
             </span>
           </div>
           <code className="mt-1 block truncate font-mono text-fg">
@@ -495,7 +528,9 @@ function ControlSessionInstallSection() {
         </div>
         <div className="rounded-md border border-border bg-bg px-3 py-2 text-[11px]">
           <div className="flex items-center justify-between">
-            <span className="text-fg-muted">Installed shim</span>
+            <span className="text-fg-muted">
+              {st(t, "settings.sessions.controlCli.installedShim")}
+            </span>
             <span
               className={cn(
                 "rounded px-1.5 py-0.5 text-[10px] font-medium",
@@ -504,7 +539,9 @@ function ControlSessionInstallSection() {
                   : "bg-bg-elevated text-fg-muted",
               )}
             >
-              {activeShim ? "installed" : "not installed"}
+              {activeShim
+                ? st(t, "settings.sessions.controlCli.installed")
+                : st(t, "settings.sessions.controlCli.notInstalled")}
             </span>
           </div>
           <code className="mt-1 block truncate font-mono text-fg">
@@ -519,7 +556,7 @@ function ControlSessionInstallSection() {
           onClick={() => void refresh()}
           className="text-[11px] text-fg-muted underline-offset-2 hover:text-fg hover:underline"
         >
-          Re-check
+          {st(t, "settings.sessions.controlCli.recheck")}
         </button>
       </div>
     </Field>
@@ -529,12 +566,13 @@ function ControlSessionInstallSection() {
 function GithubSettings() {
   const settings = useSettings((s) => s.settings);
   const patchGithub = useSettings((s) => s.patchGithub);
+  const t = useTranslation();
 
   return (
     <section className="space-y-4">
       <Field
-        label="Refresh interval"
-        hint="How often the PRs and Actions tabs auto-refetch from gh. Lower values feel snappier but spend more API budget."
+        label={st(t, "settings.github.refreshInterval.label")}
+        hint={st(t, "settings.github.refreshInterval.hint")}
       >
         <Select
           value={settings.github.refreshIntervalMs}
@@ -553,16 +591,15 @@ function GithubSettings() {
         </Select>
       </Field>
       <p className="text-[11px] text-fg-muted">
-        Manual refresh (the icon in each tab) always works regardless of this
-        interval.
+        {st(t, "settings.github.manualRefresh")}
       </p>
       <Field
-        label="List density"
-        hint="Author avatars make rows easier to scan at a glance, but each row gets thicker."
+        label={st(t, "settings.github.listDensity.label")}
+        hint={st(t, "settings.github.listDensity.hint")}
       >
         <CheckboxRow
-          label="Show author avatars"
-          description="Render the GitHub avatar next to each PR row."
+          label={st(t, "settings.github.showAuthorAvatars.label")}
+          description={st(t, "settings.github.showAuthorAvatars.description")}
           checked={settings.github.showAvatars}
           onChange={(v) => patchGithub({ showAvatars: v })}
         />
@@ -650,6 +687,7 @@ function UiScaleSection({
   value: number;
   onChange: (value: number) => void;
 }) {
+  const t = useTranslation();
   const presets = UI_SCALE_PRESETS.includes(
     value as (typeof UI_SCALE_PRESETS)[number],
   )
@@ -663,8 +701,8 @@ function UiScaleSection({
 
   return (
     <Field
-      label="UI scale"
-      hint="Scales the app chrome in 5% steps. Terminal text keeps its separate size setting."
+      label={st(t, "settings.appearance.uiScale.label")}
+      hint={st(t, "settings.appearance.uiScale.hint")}
     >
       <div className="flex flex-wrap items-center gap-2">
         <Select
@@ -692,11 +730,12 @@ function ThemeSection({
 }) {
   const themes = useThemes((s) => s.themes);
   const refresh = useThemes((s) => s.refresh);
+  const t = useTranslation();
 
   return (
     <Field
-      label="Theme"
-      hint="Built-in palettes and valid CSS files from the themes folder."
+      label={st(t, "settings.appearance.theme.label")}
+      hint={st(t, "settings.appearance.theme.hint")}
     >
       <div className="flex flex-wrap items-center gap-2">
         <Select
@@ -707,7 +746,9 @@ function ThemeSection({
           {themes.map((theme) => (
             <option key={theme.id} value={theme.id}>
               {theme.label}
-              {theme.source === "user" ? " (custom)" : ""}
+              {theme.source === "user"
+                ? ` ${st(t, "settings.appearance.theme.custom")}`
+                : ""}
             </option>
           ))}
         </Select>
@@ -715,16 +756,17 @@ function ThemeSection({
           type="button"
           onClick={() => void refresh()}
           className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-bg px-2 text-[11px] text-fg-muted transition hover:text-fg"
-          title="Rescan themes folder"
+          title={st(t, "settings.appearance.theme.rescanTitle")}
         >
-          <RefreshCcw size={12} /> Refresh
+          <RefreshCcw size={12} /> {st(t, "settings.appearance.theme.refresh")}
         </button>
         <button
           type="button"
           onClick={() => void revealThemesFolder()}
           className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-bg px-2 text-[11px] text-fg-muted transition hover:text-fg"
         >
-          <FolderOpen size={12} /> Reveal folder
+          <FolderOpen size={12} />{" "}
+          {st(t, "settings.appearance.theme.revealFolder")}
         </button>
       </div>
     </Field>
@@ -742,6 +784,7 @@ function BackgroundSection({
 }) {
   const [pickError, setPickError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const t = useTranslation();
 
   const handleFileChange = async (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -779,8 +822,8 @@ function BackgroundSection({
 
   return (
     <Field
-      label="Background image"
-      hint="One image can be applied to the app area, terminal area, or both."
+      label={st(t, "settings.appearance.background.label")}
+      hint={st(t, "settings.appearance.background.hint")}
     >
       <div className="space-y-3">
         <div className="flex flex-wrap items-center gap-2">
@@ -796,10 +839,13 @@ function BackgroundSection({
             onClick={() => fileInputRef.current?.click()}
             className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-bg px-2 text-[11px] text-fg transition hover:bg-bg-elevated"
           >
-            <ImagePlus size={12} /> {state.relativePath ? "Replace" : "Pick image"}
+            <ImagePlus size={12} />{" "}
+            {state.relativePath
+              ? st(t, "settings.appearance.background.replace")
+              : st(t, "settings.appearance.background.pickImage")}
           </button>
           <span className="min-w-0 truncate text-[11px] text-fg-muted">
-            {state.fileName ?? "No image selected"}
+            {state.fileName ?? st(t, "settings.appearance.background.noImage")}
           </span>
           {state.relativePath ? (
             <button
@@ -807,7 +853,8 @@ function BackgroundSection({
               onClick={() => void remove()}
               className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-bg px-2 text-[11px] text-fg-muted transition hover:text-danger"
             >
-              <Trash2 size={12} /> Remove
+              <Trash2 size={12} />{" "}
+              {st(t, "settings.appearance.background.remove")}
             </button>
           ) : null}
         </div>
@@ -816,20 +863,22 @@ function BackgroundSection({
         ) : null}
         <div className="flex flex-col gap-1">
           <CheckboxRow
-            label="Apply to app background"
+            label={st(t, "settings.appearance.background.applyToApp")}
             checked={state.applyToApp}
             disabled={!state.relativePath}
             onChange={(checked) => onChange({ applyToApp: checked })}
           />
           <CheckboxRow
-            label="Apply to terminal background"
+            label={st(t, "settings.appearance.background.applyToTerminal")}
             checked={state.applyToTerminal}
             disabled={!state.relativePath}
             onChange={(checked) => onChange({ applyToTerminal: checked })}
           />
         </div>
         <div className="flex flex-col gap-1.5">
-          <span className="text-[11px] font-medium text-fg-muted">Fit</span>
+          <span className="text-[11px] font-medium text-fg-muted">
+            {st(t, "settings.appearance.background.fit.label")}
+          </span>
           <div className="flex flex-wrap gap-1.5">
             {(["cover", "contain", "tile"] as BackgroundFit[]).map((fit) => (
               <RadioCard<BackgroundFit>
@@ -837,14 +886,17 @@ function BackgroundSection({
                 name="acorn-bg-fit"
                 value={fit}
                 current={state.fit}
-                label={fit[0].toUpperCase() + fit.slice(1)}
+                label={st(t, `settings.appearance.background.fit.${fit}`)}
                 onSelect={(value) => onChange({ fit: value })}
               />
             ))}
           </div>
         </div>
         <div className="grid gap-3 sm:grid-cols-2">
-          <Field label="Opacity" hint="0 is transparent, 100 is opaque.">
+          <Field
+            label={st(t, "settings.appearance.background.opacity.label")}
+            hint={st(t, "settings.appearance.background.opacity.hint")}
+          >
             <Stepper
               value={Math.round(state.opacity * 100)}
               min={0}
@@ -854,7 +906,7 @@ function BackgroundSection({
               onChange={(value) => onChange({ opacity: value / 100 })}
             />
           </Field>
-          <Field label="Blur">
+          <Field label={st(t, "settings.appearance.background.blur")}>
             <Stepper
               value={state.blur}
               min={0}
@@ -884,11 +936,13 @@ function SessionDisplaySection({
     },
   ) => void;
 }) {
+  const t = useTranslation();
+
   return (
     <>
       <Field
-        label="Session title"
-        hint="Which field becomes the bold first line of each sidebar session row."
+        label={st(t, "settings.appearance.sessionDisplay.title.label")}
+        hint={st(t, "settings.appearance.sessionDisplay.title.hint")}
       >
         <div className="flex flex-col gap-1.5">
           {SESSION_TITLE_OPTIONS.map((opt) => (
@@ -897,60 +951,96 @@ function SessionDisplaySection({
               name="acorn-session-title"
               value={opt.value}
               current={sessionDisplay.title}
-              label={opt.label}
-              description={opt.description}
+              label={st(
+                t,
+                `settings.appearance.sessionDisplay.title.options.${opt.value}.label`,
+              )}
+              description={st(
+                t,
+                `settings.appearance.sessionDisplay.title.options.${opt.value}.description`,
+              )}
               onSelect={(v) => patch({ title: v })}
             />
           ))}
         </div>
       </Field>
       <Field
-        label="Additional metadata"
-        hint="Secondary line under the title. Toggle off everything for a single-line row."
+        label={st(t, "settings.appearance.sessionDisplay.metadata.label")}
+        hint={st(t, "settings.appearance.sessionDisplay.metadata.hint")}
       >
         <div className="flex flex-col gap-1">
           <CheckboxRow
-            label="Branch"
-            description="Active git branch."
+            label={st(
+              t,
+              "settings.appearance.sessionDisplay.metadata.branch.label",
+            )}
+            description={st(
+              t,
+              "settings.appearance.sessionDisplay.metadata.branch.description",
+            )}
             checked={sessionDisplay.metadata.branch}
             onChange={(v) => patch({ metadata: { branch: v } })}
           />
           <CheckboxRow
-            label="Working directory"
-            description="Worktree directory basename."
+            label={st(
+              t,
+              "settings.appearance.sessionDisplay.metadata.workingDirectory.label",
+            )}
+            description={st(
+              t,
+              "settings.appearance.sessionDisplay.metadata.workingDirectory.description",
+            )}
             checked={sessionDisplay.metadata.workingDirectory}
             onChange={(v) => patch({ metadata: { workingDirectory: v } })}
           />
           <CheckboxRow
-            label="Status"
-            description="Idle / Running / Needs input / Failed / Completed."
+            label={st(
+              t,
+              "settings.appearance.sessionDisplay.metadata.status.label",
+            )}
+            description={st(
+              t,
+              "settings.appearance.sessionDisplay.metadata.status.description",
+            )}
             checked={sessionDisplay.metadata.status}
             onChange={(v) => patch({ metadata: { status: v } })}
           />
         </div>
       </Field>
       <Field
-        label="Inline icons"
-        hint="Glyphs that decorate each session row. Hide to make the list denser."
+        label={st(t, "settings.appearance.sessionDisplay.icons.label")}
+        hint={st(t, "settings.appearance.sessionDisplay.icons.hint")}
       >
         <div className="flex flex-col gap-1">
           <CheckboxRow
-            label="Status dot"
-            description="Colored bullet at the row start. Redundant when Status is enabled in metadata."
+            label={st(
+              t,
+              "settings.appearance.sessionDisplay.icons.statusDot.label",
+            )}
+            description={st(
+              t,
+              "settings.appearance.sessionDisplay.icons.statusDot.description",
+            )}
             checked={sessionDisplay.icons.statusDot}
             onChange={(v) => patch({ icons: { statusDot: v } })}
           />
           <CheckboxRow
-            label="Session kind icons"
-            description="Branch glyph for isolated worktrees and bot glyph for control sessions."
+            label={st(
+              t,
+              "settings.appearance.sessionDisplay.icons.sessionKind.label",
+            )}
+            description={st(
+              t,
+              "settings.appearance.sessionDisplay.icons.sessionKind.description",
+            )}
             checked={sessionDisplay.icons.sessionKind}
             onChange={(v) => patch({ icons: { sessionKind: v } })}
           />
         </div>
       </Field>
       <Field
-        label="Show details on hover"
-        hint="Pop a tooltip with every field when hovering a session row, regardless of which fields the row itself shows."
+        label={st(t, "settings.appearance.sessionDisplay.hover.label")}
+        hint={st(t, "settings.appearance.sessionDisplay.hover.hint")}
       >
         <label className="flex items-center gap-2 text-xs text-fg">
           <input
@@ -959,7 +1049,7 @@ function SessionDisplaySection({
             onChange={(e) => patch({ showDetailsOnHover: e.target.checked })}
             className="accent-[var(--color-accent)]"
           />
-          Enable hover tooltip
+          {st(t, "settings.appearance.sessionDisplay.hover.checkbox")}
         </label>
       </Field>
     </>
@@ -973,39 +1063,59 @@ function StatusBarSection({
   statusBar: AcornSettings["statusBar"];
   patch: (patch: Partial<AcornSettings["statusBar"]>) => void;
 }) {
+  const t = useTranslation();
+
   return (
     <Field
-      label="Status bar"
-      hint="Choose which optional badges show in the bottom status bar."
+      label={st(t, "settings.appearance.statusBar.label")}
+      hint={st(t, "settings.appearance.statusBar.hint")}
     >
       <div className="flex flex-col gap-1">
         <CheckboxRow
-          label="Session count"
-          description="Total number of sessions across the active project (`sessions: N`)."
+          label={st(t, "settings.appearance.statusBar.sessionCount.label")}
+          description={st(
+            t,
+            "settings.appearance.statusBar.sessionCount.description",
+          )}
           checked={statusBar.showSessionCount}
           onChange={(v) => patch({ showSessionCount: v })}
         />
         <CheckboxRow
-          label="Active session status"
-          description="Lifecycle state of the active session (Idle / Running / Needs input / Failed / Completed)."
+          label={st(
+            t,
+            "settings.appearance.statusBar.activeSessionStatus.label",
+          )}
+          description={st(
+            t,
+            "settings.appearance.statusBar.activeSessionStatus.description",
+          )}
           checked={statusBar.showSessionStatus}
           onChange={(v) => patch({ showSessionStatus: v })}
         />
         <CheckboxRow
-          label="GitHub account"
-          description="The `gh` account used to list pull requests for the active repo."
+          label={st(t, "settings.appearance.statusBar.githubAccount.label")}
+          description={st(
+            t,
+            "settings.appearance.statusBar.githubAccount.description",
+          )}
           checked={statusBar.showGithubAccount}
           onChange={(v) => patch({ showGithubAccount: v })}
         />
         <CheckboxRow
-          label="Working directory"
-          description="The active session's worktree path (tildified against $HOME)."
+          label={st(t, "settings.appearance.statusBar.workingDirectory.label")}
+          description={st(
+            t,
+            "settings.appearance.statusBar.workingDirectory.description",
+          )}
           checked={statusBar.showWorkingDirectory}
           onChange={(v) => patch({ showWorkingDirectory: v })}
         />
         <CheckboxRow
-          label="Memory usage"
-          description="Live memory readout for acorn and its child shells. Disabling also stops the 2-second polling loop, so it costs nothing when hidden."
+          label={st(t, "settings.appearance.statusBar.memoryUsage.label")}
+          description={st(
+            t,
+            "settings.appearance.statusBar.memoryUsage.description",
+          )}
           checked={statusBar.showMemory}
           onChange={(v) => patch({ showMemory: v })}
         />
@@ -1017,22 +1127,22 @@ function StatusBarSection({
 function EditorSettings() {
   const settings = useSettings((s) => s.settings);
   const patchEditor = useSettings((s) => s.patchEditor);
+  const t = useTranslation();
 
   return (
     <section className="space-y-4">
       <Field
-        label="Editor command"
-        hint='Leave blank for the OS default. Examples: "code", "cursor --wait", "subl", "idea". The file path is appended as the last argument.'
+        label={st(t, "settings.editor.command.label")}
+        hint={st(t, "settings.editor.command.hint")}
       >
         <TextInput
           value={settings.editor.command}
           onChange={(e) => patchEditor({ command: e.target.value })}
-          placeholder="(use OS default)"
+          placeholder={st(t, "settings.editor.command.placeholder")}
         />
       </Field>
       <p className="text-[11px] text-fg-muted">
-        Used by the "Open in editor" right-click action on diff and staged
-        file lists.
+        {st(t, "settings.editor.command.description")}
       </p>
     </section>
   );
@@ -1041,6 +1151,7 @@ function EditorSettings() {
 function NotificationSettings() {
   const settings = useSettings((s) => s.settings);
   const patchNotifications = useSettings((s) => s.patchNotifications);
+  const t = useTranslation();
   const enabled = settings.notifications.enabled;
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<
@@ -1056,17 +1167,17 @@ function NotificationSettings() {
       if (result === "sent") {
         setTestResult({
           tone: "success",
-          text: "Sent. Check your notification center if it didn't appear.",
+          text: st(t, "settings.notifications.test.result.sent"),
         });
       } else if (result === "denied") {
         setTestResult({
           tone: "warning",
-          text: "Permission denied. Allow Acorn under System Settings → Notifications.",
+          text: st(t, "settings.notifications.test.result.denied"),
         });
       } else {
         setTestResult({
           tone: "danger",
-          text: "Failed to send. See the console for details.",
+          text: st(t, "settings.notifications.test.result.failed"),
         });
       }
     } finally {
@@ -1077,8 +1188,8 @@ function NotificationSettings() {
   return (
     <section className="space-y-4">
       <Field
-        label="System notifications"
-        hint="Send a macOS notification when a session changes status."
+        label={st(t, "settings.notifications.system.label")}
+        hint={st(t, "settings.notifications.system.hint")}
       >
         <label className="flex items-center gap-2 text-xs text-fg">
           <input
@@ -1089,14 +1200,17 @@ function NotificationSettings() {
             }
             className="accent-[var(--color-accent)]"
           />
-          Enable notifications
+          {st(t, "settings.notifications.system.enable")}
         </label>
       </Field>
-      <Field label="Trigger on">
+      <Field label={st(t, "settings.notifications.triggers.label")}>
         <div className="flex flex-col gap-1">
           <CheckboxRow
-            label="Needs input"
-            description="Claude is waiting on the user."
+            label={st(t, "settings.notifications.triggers.needsInput.label")}
+            description={st(
+              t,
+              "settings.notifications.triggers.needsInput.description",
+            )}
             checked={settings.notifications.events.needsInput}
             disabled={!enabled}
             onChange={(v) =>
@@ -1104,15 +1218,21 @@ function NotificationSettings() {
             }
           />
           <CheckboxRow
-            label="Failed"
-            description="Session terminated with an error."
+            label={st(t, "settings.notifications.triggers.failed.label")}
+            description={st(
+              t,
+              "settings.notifications.triggers.failed.description",
+            )}
             checked={settings.notifications.events.failed}
             disabled={!enabled}
             onChange={(v) => patchNotifications({ events: { failed: v } })}
           />
           <CheckboxRow
-            label="Completed"
-            description="Session reached the completed state."
+            label={st(t, "settings.notifications.triggers.completed.label")}
+            description={st(
+              t,
+              "settings.notifications.triggers.completed.description",
+            )}
             checked={settings.notifications.events.completed}
             disabled={!enabled}
             onChange={(v) =>
@@ -1122,8 +1242,8 @@ function NotificationSettings() {
         </div>
       </Field>
       <Field
-        label="Test"
-        hint="Verifies the OS permission and that a notification can actually appear, independent of the Enable / Trigger settings above."
+        label={st(t, "settings.notifications.test.label")}
+        hint={st(t, "settings.notifications.test.hint")}
       >
         <div className="flex flex-col items-start gap-2">
           <button
@@ -1132,7 +1252,9 @@ function NotificationSettings() {
             disabled={testing}
             className="rounded-md bg-accent/20 px-3 py-1.5 text-xs font-medium text-fg transition hover:bg-accent/30 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {testing ? "Sending…" : "Send test notification"}
+            {testing
+              ? st(t, "settings.notifications.test.sending")
+              : st(t, "settings.notifications.test.send")}
           </button>
           {testResult ? (
             <p
@@ -1152,7 +1274,7 @@ function NotificationSettings() {
         </div>
       </Field>
       <p className="text-[11px] text-fg-muted">
-        macOS may ask once for permission the first time a notification fires.
+        {st(t, "settings.notifications.permissionHint")}
       </p>
     </section>
   );
@@ -1161,15 +1283,20 @@ function NotificationSettings() {
 function AgentSettings() {
   const settings = useSettings((s) => s.settings);
   const patchAgents = useSettings((s) => s.patchAgents);
+  const t = useTranslation();
   const selected = settings.agents.selected;
 
   return (
     <section className="space-y-4">
       <p className="rounded-md border border-border bg-bg-sidebar/40 px-3 py-2 text-[11px] text-fg-muted">
-        The selected agent powers acorn's AI features — currently the merge
-        dialog's <em>Generate with AI</em> button.
+        {st(t, "settings.agents.intro.before")}
+        <em>{st(t, "settings.agents.intro.action")}</em>
+        {st(t, "settings.agents.intro.after")}
       </p>
-      <Field label="Agent" hint="Choose which AI CLI acorn uses.">
+      <Field
+        label={st(t, "settings.agents.agent.label")}
+        hint={st(t, "settings.agents.agent.hint")}
+      >
         <div className="flex flex-col gap-1.5">
           {AGENT_OPTIONS.map((opt) => (
             <RadioCard<SelectedAgent>
@@ -1186,16 +1313,16 @@ function AgentSettings() {
             name="acorn-agent"
             value="custom"
             current={selected}
-            label="Custom command"
-            description="Use any CLI not in the list. Whitespace-separated; no shell expansion."
+            label={st(t, "settings.agents.customOption.label")}
+            description={st(t, "settings.agents.customOption.description")}
             onSelect={(v) => patchAgents({ selected: v })}
           />
         </div>
       </Field>
       {selected === "ollama" ? (
         <Field
-          label="Ollama model"
-          hint="Passed to `ollama run <model>`. Defaults to `llama3` when blank."
+          label={st(t, "settings.agents.ollamaModel.label")}
+          hint={st(t, "settings.agents.ollamaModel.hint")}
         >
           <TextInput
             value={settings.agents.ollama.model}
@@ -1208,8 +1335,8 @@ function AgentSettings() {
       ) : null}
       {selected === "llm" ? (
         <Field
-          label="llm model"
-          hint="Passed via `llm -m <model>` (and `llm chat -m <model>` for sessions). Blank uses the llm-configured default."
+          label={st(t, "settings.agents.llmModel.label")}
+          hint={st(t, "settings.agents.llmModel.hint")}
         >
           <TextInput
             value={settings.agents.llm.model}
@@ -1220,8 +1347,8 @@ function AgentSettings() {
       ) : null}
       {selected === "custom" ? (
         <Field
-          label="Custom command"
-          hint="Used for both interactive sessions and one-shot AI generation. Falls back to Claude Code when blank."
+          label={st(t, "settings.agents.customCommand.label")}
+          hint={st(t, "settings.agents.customCommand.hint")}
         >
           <TextInput
             value={settings.agents.customCommand}
@@ -1233,9 +1360,7 @@ function AgentSettings() {
         </Field>
       ) : null}
       <p className="text-[11px] text-fg-muted">
-        The selected agent's CLI must already be installed and
-        authenticated on this machine. Surfaces a clear error when the
-        binary is missing.
+        {st(t, "settings.agents.requirement")}
       </p>
     </section>
   );
@@ -1251,8 +1376,8 @@ function AgentSettings() {
  */
 interface CacheCategory {
   id: string;
-  label: string;
-  description: string;
+  labelKey: TranslationKey;
+  descriptionKey: TranslationKey;
   loadSize: () => Promise<number>;
   clear: () => Promise<number>;
 }
@@ -1260,9 +1385,9 @@ interface CacheCategory {
 const CACHE_CATEGORIES: CacheCategory[] = [
   {
     id: "scrollback-orphans",
-    label: "Orphan terminal scrollback",
-    description:
-      "ANSI scrollback files left behind by sessions that no longer exist (e.g. removed while acorn was offline, or before the prune-on-boot logic existed). Live sessions' scrollback is not touched — only the unreclaimable leftovers are surfaced.",
+    labelKey: "settings.storage.cacheCategories.scrollbackOrphans.label",
+    descriptionKey:
+      "settings.storage.cacheCategories.scrollbackOrphans.description",
     loadSize: () => api.scrollbackOrphanSize(),
     clear: () => api.scrollbackOrphanClear(),
   },
@@ -1278,6 +1403,7 @@ function formatBytes(bytes: number): string {
 }
 
 function StorageSettings() {
+  const t = useTranslation();
   const [sizes, setSizes] = useState<Record<string, number | null>>(() =>
     Object.fromEntries(CACHE_CATEGORIES.map((c) => [c.id, null])),
   );
@@ -1321,13 +1447,19 @@ function StorageSettings() {
       );
       setStatus(
         totalRemoved > 0
-          ? `Cleared ${totalRemoved} cached file${totalRemoved === 1 ? "" : "s"}.`
-          : "Nothing to clear.",
+          ? stf(
+              t,
+              totalRemoved === 1
+                ? "settings.storage.status.clearedSingular"
+                : "settings.storage.status.clearedPlural",
+              { count: totalRemoved },
+            )
+          : st(t, "settings.storage.status.nothingToClear"),
       );
       await refreshSizes();
     } catch (err) {
       console.error("[Settings] cache clear failed", err);
-      setStatus("Clear failed — see console.");
+      setStatus(st(t, "settings.storage.status.clearFailed"));
     } finally {
       setBusy(false);
       setConfirming(false);
@@ -1337,12 +1469,11 @@ function StorageSettings() {
   return (
     <section className="space-y-4">
       <header className="space-y-1">
-        <h3 className="text-sm font-medium text-fg">Reclaimable cache</h3>
+        <h3 className="text-sm font-medium text-fg">
+          {st(t, "settings.storage.title")}
+        </h3>
         <p className="text-[11px] text-fg-muted">
-          Disk artifacts that acorn cannot clean up through its normal
-          session lifecycle (e.g. files orphaned by a crash or by edits
-          made while acorn was offline). Sessions, projects, settings,
-          and live terminal scrollback are never touched.
+          {st(t, "settings.storage.description")}
         </p>
       </header>
 
@@ -1353,13 +1484,15 @@ function StorageSettings() {
             <li key={cat.id} className="space-y-1 px-3 py-2.5">
               <div className="flex items-baseline justify-between gap-3">
                 <span className="text-xs font-medium text-fg">
-                  {cat.label}
+                  {st(t, cat.labelKey)}
                 </span>
                 <span className="text-[11px] tabular-nums text-fg-muted">
                   {size === null ? "—" : formatBytes(size)}
                 </span>
               </div>
-              <p className="text-[11px] text-fg-muted">{cat.description}</p>
+              <p className="text-[11px] text-fg-muted">
+                {st(t, cat.descriptionKey)}
+              </p>
             </li>
           );
         })}
@@ -1368,8 +1501,9 @@ function StorageSettings() {
       {confirming ? (
         <div className="space-y-2 rounded border border-warning/40 bg-warning/10 p-3">
           <p className="text-[11px] text-fg">
-            This will permanently delete the cached data listed above
-            ({formatBytes(totalBytes)}). Continue?
+            {stf(t, "settings.storage.confirm.message", {
+              size: formatBytes(totalBytes),
+            })}
           </p>
           <div className="flex justify-end gap-2">
             <button
@@ -1378,7 +1512,7 @@ function StorageSettings() {
               disabled={busy}
               className="rounded border border-border px-2 py-1 text-[11px] text-fg-muted transition hover:text-fg disabled:opacity-50"
             >
-              Cancel
+              {st(t, "settings.storage.confirm.cancel")}
             </button>
             <button
               type="button"
@@ -1386,14 +1520,21 @@ function StorageSettings() {
               disabled={busy}
               className="rounded bg-danger px-2 py-1 text-[11px] font-medium text-white transition hover:bg-danger/90 disabled:opacity-50"
             >
-              <TextSwap>{busy ? "Clearing…" : "Clear cache"}</TextSwap>
+              <TextSwap>
+                {busy
+                  ? st(t, "settings.storage.clear.clearing")
+                  : st(t, "settings.storage.clear.button")}
+              </TextSwap>
             </button>
           </div>
         </div>
       ) : (
         <div className="flex items-center justify-between gap-3">
           <span className="text-[11px] text-fg-muted">
-            {status ?? `Total: ${formatBytes(totalBytes)}`}
+            {status ??
+              stf(t, "settings.storage.total", {
+                size: formatBytes(totalBytes),
+              })}
           </span>
           <button
             type="button"
@@ -1402,7 +1543,7 @@ function StorageSettings() {
             className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-[11px] text-fg-muted transition hover:border-danger/60 hover:text-danger disabled:opacity-50"
           >
             <Trash2 size={11} />
-            Clear cache
+            {st(t, "settings.storage.clear.button")}
           </button>
         </div>
       )}
@@ -1410,13 +1551,23 @@ function StorageSettings() {
   );
 }
 
-function formatRelative(ts: number | null): string {
-  if (!ts) return "never";
+function formatRelative(ts: number | null, t: SettingsTranslator): string {
+  if (!ts) return st(t, "settings.about.relative.never");
   const diff = Date.now() - ts;
-  if (diff < 60_000) return "just now";
-  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} min ago`;
-  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} h ago`;
-  return `${Math.floor(diff / 86_400_000)} d ago`;
+  if (diff < 60_000) return st(t, "settings.about.relative.justNow");
+  if (diff < 3_600_000) {
+    return stf(t, "settings.about.relative.minutesAgo", {
+      count: Math.floor(diff / 60_000),
+    });
+  }
+  if (diff < 86_400_000) {
+    return stf(t, "settings.about.relative.hoursAgo", {
+      count: Math.floor(diff / 3_600_000),
+    });
+  }
+  return stf(t, "settings.about.relative.daysAgo", {
+    count: Math.floor(diff / 86_400_000),
+  });
 }
 
 type WhatsNewSource =
@@ -1437,39 +1588,43 @@ type WhatsNewSource =
 function ExperimentsSettings() {
   const experiments = useSettings((s) => s.settings.experiments);
   const patchExperiments = useSettings((s) => s.patchExperiments);
+  const t = useTranslation();
 
   return (
     <section className="space-y-4">
       <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] leading-snug text-fg-muted">
         <Sparkles size={11} className="mr-1 inline align-text-bottom text-warning" />
-        Unfinished features. Behaviour may change between releases; the toggles
-        themselves are stable.
+        {st(t, "settings.experiments.warning")}
       </div>
       <CheckboxRow
         checked={experiments.stickyPrompt}
         onChange={(checked) => patchExperiments({ stickyPrompt: checked })}
-        label="Pin last user prompt above terminal"
-        description="Detects the most recent claude prompt line in the rendered terminal buffer and pins it at the top of the pane so it stays in view while reading the reply. Cmd+K clears it along with the rest of the scrollback."
+        label={st(t, "settings.experiments.stickyPrompt.label")}
+        description={st(t, "settings.experiments.stickyPrompt.description")}
       />
       <CheckboxRow
         checked={experiments.cjkCellWidthHeuristic}
         onChange={(checked) =>
           patchExperiments({ cjkCellWidthHeuristic: checked })
         }
-        label="CJK terminal cell-width correction"
-        description="Heuristic for CJK monospaced fonts (D2Coding, Sarasa Mono, etc.): when `W` and `가` measure the same width, halves the cell width so Hangul/Han glyphs sit on the cell grid. Skipped when widths differ, so ASCII fonts with system CJK fallback are not corrected. Known limitation: tab switches can briefly show a 1-frame glyph-size flicker as xterm's resize path resets `cell.width` to the natural W advance before the addon reapplies the halved value. Off by default."
+        label={st(t, "settings.experiments.cjkCellWidthHeuristic.label")}
+        description={st(
+          t,
+          "settings.experiments.cjkCellWidthHeuristic.description",
+        )}
       />
       <CheckboxRow
         checked={experiments.resumeModal}
         onChange={(checked) => patchExperiments({ resumeModal: checked })}
-        label='Show "Resume previous conversation" modal at cold boot'
-        description="On Acorn launch, probes every persisted session for an unfinished claude or codex transcript and pops a one-shot modal when you focus the session so you can pick up where you left off. Disable to suppress the modal entirely."
+        label={st(t, "settings.experiments.resumeModal.label")}
+        description={st(t, "settings.experiments.resumeModal.description")}
       />
     </section>
   );
 }
 
 function AboutSettings() {
+  const t = useTranslation();
   const currentVersion = useUpdater((s) => s.currentVersion);
   const available = useUpdater((s) => s.available);
   const busy = useUpdater((s) => s.busy);
@@ -1543,34 +1698,41 @@ function AboutSettings() {
   return (
     <section className="space-y-4">
       <header className="space-y-1">
-        <h3 className="text-sm font-medium text-fg">About Acorn</h3>
+        <h3 className="text-sm font-medium text-fg">
+          {st(t, "settings.about.title")}
+        </h3>
         <p className="text-[11px] text-fg-muted">
-          Acorn checks for updates automatically on startup and once every
-          24 hours. You can also check manually below.
+          {st(t, "settings.about.description")}
         </p>
       </header>
 
       <div className="rounded border border-border">
         <div className="flex items-baseline justify-between gap-3 px-3 py-2.5">
-          <span className="text-xs font-medium text-fg">Current version</span>
+          <span className="text-xs font-medium text-fg">
+            {st(t, "settings.about.currentVersion")}
+          </span>
           <span className="text-[11px] tabular-nums text-fg-muted">
-            {currentVersion ?? "loading…"}
+            {currentVersion ?? st(t, "settings.about.loading")}
           </span>
         </div>
         <div className="flex items-baseline justify-between gap-3 border-t border-border px-3 py-2.5">
-          <span className="text-xs font-medium text-fg">Last checked</span>
+          <span className="text-xs font-medium text-fg">
+            {st(t, "settings.about.lastChecked")}
+          </span>
           <span className="text-[11px] tabular-nums text-fg-muted">
-            {formatRelative(lastCheckedAt)}
+            {formatRelative(lastCheckedAt, t)}
           </span>
         </div>
         {available ? (
           <div className="flex items-baseline justify-between gap-3 border-t border-border bg-accent/10 px-3 py-2.5">
             <div className="space-y-0.5">
               <div className="text-xs font-medium text-fg">
-                Update available
+                {st(t, "settings.about.updateAvailable")}
               </div>
               <div className="text-[11px] text-fg-muted">
-                Acorn {available.version} is ready to install.
+                {stf(t, "settings.about.updateReady", {
+                  version: available.version,
+                })}
               </div>
             </div>
             <div className="flex shrink-0 items-center gap-2">
@@ -1586,7 +1748,7 @@ function AboutSettings() {
                   }
                   className="rounded px-2 py-1 text-[11px] text-fg-muted underline-offset-2 transition hover:text-fg hover:underline"
                 >
-                  What&apos;s new
+                  {st(t, "settings.about.whatsNew")}
                 </button>
               ) : null}
               <button
@@ -1597,7 +1759,9 @@ function AboutSettings() {
               >
                 <Download size={11} />
                 <TextSwap>
-                  {busy ? "Installing…" : "Install & relaunch"}
+                  {busy
+                    ? st(t, "settings.about.installing")
+                    : st(t, "settings.about.installRelaunch")}
                 </TextSwap>
               </button>
             </div>
@@ -1627,10 +1791,12 @@ function AboutSettings() {
           <Sparkles size={11} className={notesLoading ? "animate-pulse" : ""} />
           <TextSwap>
             {notesLoading
-              ? "Loading…"
+              ? st(t, "settings.about.loading")
               : currentVersion
-                ? `What's new in ${currentVersion}`
-                : "What's new"}
+                ? stf(t, "settings.about.whatsNewInVersion", {
+                    version: currentVersion,
+                  })
+                : st(t, "settings.about.whatsNew")}
           </TextSwap>
         </button>
         <button
@@ -1640,7 +1806,11 @@ function AboutSettings() {
           className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-[11px] text-fg-muted transition hover:border-accent/60 hover:text-fg disabled:opacity-50"
         >
           <RefreshCcw size={11} className={busy ? "animate-spin" : ""} />
-          <TextSwap>{busy ? "Checking…" : "Check for updates"}</TextSwap>
+          <TextSwap>
+            {busy
+              ? st(t, "settings.about.checking")
+              : st(t, "settings.about.checkForUpdates")}
+          </TextSwap>
         </button>
       </div>
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -20,6 +20,7 @@ import {
   createTranslator,
   LANGUAGE_OPTIONS,
   type Language,
+  type TranslationKey,
 } from "../lib/i18n";
 import { sendTestNotification } from "../lib/notifications";
 import {
@@ -68,7 +69,7 @@ type Tab =
   | "experiments"
   | "about";
 
-const TABS: Array<{ id: Tab; labelKey: string }> = [
+const TABS: Array<{ id: Tab; labelKey: TranslationKey }> = [
   { id: "terminal", labelKey: "settings.tabs.terminal" },
   { id: "agents", labelKey: "settings.tabs.agents" },
   { id: "sessions", labelKey: "settings.tabs.sessions" },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -42,12 +42,14 @@ import { CSS } from "@dnd-kit/utilities";
 import { useAppStore } from "../store";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import {
   useSettings,
   type AcornSettings,
   type SessionTitleSource,
 } from "../lib/settings";
+import { useTranslation } from "../lib/useTranslation";
 import {
   planChevronClick,
   planTitleClick,
@@ -66,18 +68,20 @@ const STATUS_DOT: Record<SessionStatus, string> = {
   completed: "bg-accent/60",
 };
 
-const STATUS_LABEL: Record<SessionStatus, string> = {
-  idle: "Idle",
-  running: "Running",
-  needs_input: "Needs input",
-  failed: "Failed",
-  completed: "Completed",
-};
-
 const COLLAPSED_KEY = "acorn:sidebar:collapsed-projects";
 
 const PROJECT_DRAG_PREFIX = "project:";
 const SESSION_DRAG_PREFIX = "session:";
+
+type SidebarTranslationKey = Extract<TranslationKey, `sidebar.${string}`>;
+
+function sidebarText(t: Translator, key: SidebarTranslationKey): string {
+  return t(key);
+}
+
+function statusLabel(t: Translator, status: SessionStatus): string {
+  return sidebarText(t, `sidebar.status.${status}`);
+}
 
 interface ProjectGroup {
   repoPath: string;
@@ -86,6 +90,7 @@ interface ProjectGroup {
 }
 
 export function Sidebar() {
+  const t = useTranslation();
   const {
     sessions,
     projects,
@@ -160,7 +165,7 @@ export function Sidebar() {
       const repoPath = await open({
         directory: true,
         multiple: false,
-        title: "Select an existing project",
+        title: sidebarText(t, "sidebar.dialog.selectExistingProject"),
       });
       if (!repoPath || typeof repoPath !== "string") return;
       await addProject(repoPath);
@@ -223,10 +228,10 @@ export function Sidebar() {
           directory: true,
           multiple: false,
           title: isolated
-            ? "Select a git repository (isolated worktree)"
+            ? sidebarText(t, "sidebar.dialog.selectIsolatedRepository")
             : kind === "control"
-              ? "Select a directory (control session)"
-              : "Select a directory",
+              ? sidebarText(t, "sidebar.dialog.selectControlDirectory")
+              : sidebarText(t, "sidebar.dialog.selectDirectory"),
         }));
       if (!repoPath || typeof repoPath !== "string") return;
       const name = suggestName(repoPath, sessions, kind);
@@ -321,25 +326,34 @@ export function Sidebar() {
     <aside className="flex h-full w-full flex-col bg-bg-sidebar">
       <header className="flex h-9 shrink-0 items-center justify-between gap-2 px-3">
         <h2 className="text-sm font-medium tracking-tight text-fg-muted">
-          Projects
+          {sidebarText(t, "sidebar.projects.title")}
         </h2>
         <div className="flex items-center gap-1">
-          <Tooltip label="New project" side="left">
+          <Tooltip
+            label={sidebarText(t, "sidebar.projects.newProject")}
+            side="left"
+          >
             <button
               type="button"
               onClick={() => setNewProjectOpen(true)}
               className="rounded-md p-1.5 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-              aria-label="New project"
+              aria-label={sidebarText(t, "sidebar.projects.newProject")}
             >
               <FolderPlus size={14} />
             </button>
           </Tooltip>
-          <Tooltip label="Add existing project" side="left">
+          <Tooltip
+            label={sidebarText(t, "sidebar.projects.addExistingProject")}
+            side="left"
+          >
             <button
               type="button"
               onClick={onAddExistingProject}
               className="rounded-md p-1.5 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-              aria-label="Add existing project"
+              aria-label={sidebarText(
+                t,
+                "sidebar.projects.addExistingProject",
+              )}
             >
               <FolderOpen size={14} />
             </button>
@@ -410,7 +424,7 @@ export function Sidebar() {
             </SortableContext>
             <DragOverlay dropAnimation={null}>
               {activeDragId
-                ? renderDragOverlay(activeDragId, projectGroups, sessions)
+                ? renderDragOverlay(activeDragId, projectGroups, sessions, t)
                 : null}
             </DragOverlay>
           </DndContext>
@@ -431,6 +445,7 @@ function renderDragOverlay(
   activeDragId: string,
   projectGroups: ProjectGroup[],
   sessions: Session[],
+  t: Translator,
 ): React.ReactNode {
   if (activeDragId.startsWith(PROJECT_DRAG_PREFIX)) {
     const repoPath = activeDragId.slice(PROJECT_DRAG_PREFIX.length);
@@ -442,7 +457,7 @@ function renderDragOverlay(
     const sid = activeDragId.slice(SESSION_DRAG_PREFIX.length);
     const session = sessions.find((s) => s.id === sid);
     if (!session) return null;
-    return <SessionRowPreview session={session} />;
+    return <SessionRowPreview session={session} t={t} />;
   }
   return null;
 }
@@ -472,7 +487,13 @@ function ProjectHeaderPreview({
   );
 }
 
-function SessionRowPreview({ session }: { session: Session }) {
+function SessionRowPreview({
+  session,
+  t,
+}: {
+  session: Session;
+  t: Translator;
+}) {
   return (
     <div className="flex w-full items-start gap-1.5 rounded-md bg-bg-elevated/95 px-2 py-1 shadow-lg ring-1 ring-border/60">
       <span className="mt-1 flex shrink-0 items-center text-fg-muted/60">
@@ -494,7 +515,7 @@ function SessionRowPreview({ session }: { session: Session }) {
           ) : null}
         </span>
         <span className="block truncate text-[11px] text-fg-muted">
-          {session.branch} · {STATUS_LABEL[session.status]}
+          {session.branch} · {statusLabel(t, session.status)}
         </span>
       </span>
     </div>
@@ -559,6 +580,7 @@ function ProjectGroupView({
   onAddSession,
   onRemoveProject,
 }: ProjectGroupViewProps) {
+  const t = useTranslation();
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const {
     attributes,
@@ -617,19 +639,22 @@ function ProjectGroupView({
           e.stopPropagation();
           setMenu({ x: e.clientX, y: e.clientY });
         }}
-        aria-label={`Project ${project.name}`}
+        aria-label={`${sidebarText(t, "sidebar.aria.project")} ${project.name}`}
         className={cn(
           "group flex items-center gap-1 rounded-md px-1 py-1.5 hover:bg-bg-elevated/40",
           isActiveProject && "bg-bg-elevated/30",
         )}
       >
-        <Tooltip label="Drag to reorder" side="bottom">
+        <Tooltip
+          label={sidebarText(t, "sidebar.actions.dragToReorder")}
+          side="bottom"
+        >
           <span
             ref={setActivatorNodeRef}
             {...attributes}
             {...listeners}
             onClick={(e) => e.stopPropagation()}
-            aria-label="Drag to reorder project"
+            aria-label={sidebarText(t, "sidebar.aria.dragToReorderProject")}
             className="invisible flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
           >
             <GripVertical size={12} />
@@ -641,7 +666,11 @@ function ProjectGroupView({
             e.stopPropagation();
             onChevronClick();
           }}
-          aria-label={collapsed ? "Expand project" : "Collapse project"}
+          aria-label={
+            collapsed
+              ? sidebarText(t, "sidebar.actions.expandProject")
+              : sidebarText(t, "sidebar.actions.collapseProject")
+          }
           aria-expanded={!collapsed}
           className="flex shrink-0 items-center justify-center rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
         >
@@ -658,7 +687,10 @@ function ProjectGroupView({
             {project.sessions.length}
           </span>
         </span>
-        <Tooltip label="New session" side="bottom">
+        <Tooltip
+          label={sidebarText(t, "sidebar.actions.newSession")}
+          side="bottom"
+        >
           <button
             type="button"
             onClick={(e) => {
@@ -666,12 +698,15 @@ function ProjectGroupView({
               onAddSession(false, "regular");
             }}
             className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
-            aria-label="New session in this project"
+            aria-label={sidebarText(t, "sidebar.aria.newSessionInProject")}
           >
             <Plus size={12} />
           </button>
         </Tooltip>
-        <Tooltip label="New isolated session (worktree)" side="bottom">
+        <Tooltip
+          label={sidebarText(t, "sidebar.actions.newIsolatedSessionWorktree")}
+          side="bottom"
+        >
           <button
             type="button"
             onClick={(e) => {
@@ -679,12 +714,18 @@ function ProjectGroupView({
               onAddSession(true, "regular");
             }}
             className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
-            aria-label="New isolated session (worktree)"
+            aria-label={sidebarText(
+              t,
+              "sidebar.actions.newIsolatedSessionWorktree",
+            )}
           >
             <GitBranch size={12} />
           </button>
         </Tooltip>
-        <Tooltip label="New control session" side="bottom">
+        <Tooltip
+          label={sidebarText(t, "sidebar.actions.newControlSession")}
+          side="bottom"
+        >
           <button
             type="button"
             onClick={(e) => {
@@ -692,12 +733,18 @@ function ProjectGroupView({
               onAddSession(false, "control");
             }}
             className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
-            aria-label="New control session in this project"
+            aria-label={sidebarText(
+              t,
+              "sidebar.aria.newControlSessionInProject",
+            )}
           >
             <Bot size={12} />
           </button>
         </Tooltip>
-        <Tooltip label="Close project" side="bottom">
+        <Tooltip
+          label={sidebarText(t, "sidebar.actions.closeProject")}
+          side="bottom"
+        >
           <button
             type="button"
             onClick={(e) => {
@@ -705,7 +752,7 @@ function ProjectGroupView({
               onRemoveProject();
             }}
             className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-danger group-hover:visible"
-            aria-label="Close project"
+            aria-label={sidebarText(t, "sidebar.actions.closeProject")}
           >
             <X size={12} />
           </button>
@@ -718,30 +765,30 @@ function ProjectGroupView({
         onClose={() => setMenu(null)}
         items={[
           {
-            label: "New session",
+            label: sidebarText(t, "sidebar.actions.newSession"),
             icon: <Plus size={12} />,
             onClick: () => onAddSession(false, "regular"),
           },
           {
-            label: "New isolated session",
+            label: sidebarText(t, "sidebar.actions.newIsolatedSession"),
             icon: <GitBranch size={12} />,
             onClick: () => onAddSession(true, "regular"),
           },
           {
-            label: "New control session",
+            label: sidebarText(t, "sidebar.actions.newControlSession"),
             icon: <Bot size={12} />,
             onClick: () => onAddSession(false, "control"),
           },
           { type: "separator" },
           {
-            label: "Reveal in Finder",
+            label: sidebarText(t, "sidebar.actions.revealInFinder"),
             icon: <FolderOpen size={12} />,
             onClick: () => {
               void openInFinder(project.repoPath);
             },
           },
           {
-            label: "Copy path",
+            label: sidebarText(t, "sidebar.actions.copyPath"),
             icon: <Copy size={12} />,
             onClick: () => {
               void copyText(project.repoPath);
@@ -749,7 +796,7 @@ function ProjectGroupView({
           },
           { type: "separator" },
           {
-            label: "Close project",
+            label: sidebarText(t, "sidebar.actions.closeProject"),
             icon: <X size={12} />,
             onClick: onRemoveProject,
           },
@@ -775,9 +822,11 @@ function ProjectGroupView({
                 }}
                 className="cursor-pointer rounded px-2 py-1 text-[11px] text-fg-muted transition select-none hover:bg-bg-elevated/40 hover:text-fg"
               >
-                No sessions. Add one with{" "}
-                <Plus size={10} className="inline" /> or{" "}
-                <GitBranch size={10} className="inline" />, or double-click here.
+                {sidebarText(t, "sidebar.emptyProject.prefix")}{" "}
+                <Plus size={10} className="inline" />{" "}
+                {sidebarText(t, "sidebar.emptyProject.connector")}{" "}
+                <GitBranch size={10} className="inline" />
+                {sidebarText(t, "sidebar.emptyProject.suffix")}
               </li>
             ) : (
               project.sessions.map((session) => (
@@ -805,15 +854,20 @@ interface SessionRowProps {
 }
 
 function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
+  const t = useTranslation();
   const renameSession = useAppStore((s) => s.renameSession);
   const sessions = useAppStore((s) => s.sessions);
   const editorCommand = useSettings((s) => s.settings.editor.command);
   const editorConfigured = editorCommand.trim().length > 0;
   const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
   const titleText = resolveSessionTitle(session, sessionDisplay.title);
-  const metadataText = composeSessionMetadata(session, sessionDisplay.metadata);
+  const metadataText = composeSessionMetadata(
+    t,
+    session,
+    sessionDisplay.metadata,
+  );
   const hoverDetails = sessionDisplay.showDetailsOnHover
-    ? buildSessionHoverDetails(session)
+    ? buildSessionHoverDetails(t, session)
     : null;
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
@@ -863,18 +917,18 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
 
   const sessionMenuItems: ContextMenuItem[] = [
     {
-      label: "Rename",
+      label: sidebarText(t, "sidebar.actions.rename"),
       icon: <Pencil size={12} />,
       onClick: () => setEditing(true),
     },
     {
-      label: "Duplicate Session",
+      label: sidebarText(t, "sidebar.actions.duplicateSession"),
       icon: <Files size={12} />,
       onClick: () => void duplicate(),
     },
     { type: "separator" },
     {
-      label: "Equalize Pane Sizes",
+      label: sidebarText(t, "sidebar.actions.equalizePaneSizes"),
       icon: <Columns2 size={12} />,
       onClick: () => {
         window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
@@ -882,7 +936,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
     },
     { type: "separator" },
     {
-      label: "Open Worktree in Editor",
+      label: sidebarText(t, "sidebar.actions.openWorktreeInEditor"),
       icon: <PencilLine size={12} />,
       disabled: !editorConfigured,
       onClick: () => {
@@ -894,7 +948,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
       },
     },
     {
-      label: "Reveal in Finder",
+      label: sidebarText(t, "sidebar.actions.revealInFinder"),
       icon: <FolderOpen size={12} />,
       onClick: () => {
         void openPath(session.worktree_path).catch((err: unknown) => {
@@ -904,34 +958,34 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
     },
     { type: "separator" },
     {
-      label: "Copy Worktree Path",
+      label: sidebarText(t, "sidebar.actions.copyWorktreePath"),
       icon: <Copy size={12} />,
       onClick: () => void copyToClipboard(session.worktree_path),
     },
     {
-      label: "Copy Worktree Name",
+      label: sidebarText(t, "sidebar.actions.copyWorktreeName"),
       icon: <Copy size={12} />,
       onClick: () => void copyToClipboard(basename(session.worktree_path)),
     },
     {
-      label: "Copy Branch Name",
+      label: sidebarText(t, "sidebar.actions.copyBranchName"),
       icon: <Copy size={12} />,
       onClick: () => void copyToClipboard(session.branch),
       disabled: !session.branch,
     },
     {
-      label: "Copy Session ID",
+      label: sidebarText(t, "sidebar.actions.copySessionId"),
       icon: <Copy size={12} />,
       onClick: () => void copyToClipboard(session.id),
     },
     { type: "separator" },
     {
-      label: "Remove",
+      label: sidebarText(t, "sidebar.actions.remove"),
       icon: <Trash2 size={12} />,
       onClick: onRemove,
     },
     {
-      label: "Remove Others in Project",
+      label: sidebarText(t, "sidebar.actions.removeOthersInProject"),
       icon: <CircleX size={12} />,
       disabled: otherSiblings.length === 0,
       onClick: () => {
@@ -940,7 +994,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
       },
     },
     {
-      label: "Remove All in Project",
+      label: sidebarText(t, "sidebar.actions.removeAllInProject"),
       icon: <SquareX size={12} />,
       disabled: projectSiblings.length === 0,
       onClick: () => {
@@ -983,7 +1037,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
           {...attributes}
           {...listeners}
           onClick={(e) => e.stopPropagation()}
-          aria-label="Drag to reorder session"
+          aria-label={sidebarText(t, "sidebar.aria.dragToReorderSession")}
           className="invisible mt-1 flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
         >
           <GripVertical size={10} />
@@ -1002,6 +1056,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
           titleText={titleText}
           metadataText={metadataText}
           showKindIcons={sessionDisplay.icons.sessionKind}
+          t={t}
           onSubmitRename={async (next) => {
             setEditing(false);
             if (next && next !== session.name) {
@@ -1012,7 +1067,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
         />
         <span
           role="button"
-          aria-label="Remove session"
+          aria-label={sidebarText(t, "sidebar.actions.removeSession")}
           tabIndex={0}
           onClick={(e) => {
             e.stopPropagation();
@@ -1047,6 +1102,7 @@ interface SessionRowLabelProps {
   titleText: string;
   metadataText: string;
   showKindIcons: boolean;
+  t: Translator;
   onSubmitRename: (value: string) => void | Promise<void>;
   onCancelRename: () => void;
 }
@@ -1057,6 +1113,7 @@ function SessionRowLabel({
   titleText,
   metadataText,
   showKindIcons,
+  t,
   onSubmitRename,
   onCancelRename,
 }: SessionRowLabelProps) {
@@ -1085,14 +1142,14 @@ function SessionRowLabel({
           <GitBranch
             size={10}
             className="shrink-0 text-fg-muted"
-            aria-label="worktree"
+            aria-label={sidebarText(t, "sidebar.aria.worktree")}
           />
         ) : null}
         {showKindIcons && session.kind === "control" ? (
           <Bot
             size={10}
             className="shrink-0 text-accent"
-            aria-label="control session"
+            aria-label={sidebarText(t, "sidebar.aria.controlSession")}
           />
         ) : null}
       </span>
@@ -1149,9 +1206,13 @@ function RenameInput({ initial, onSubmit, onCancel }: RenameInputProps) {
 }
 
 function EmptyState() {
+  const t = useTranslation();
+
   return (
     <div className="px-3 py-6 text-xs text-fg-muted">
-      No projects yet. Click <span className="text-fg">+</span> to add one.
+      {sidebarText(t, "sidebar.emptyProjects.prefix")}{" "}
+      <span className="text-fg">+</span>
+      {sidebarText(t, "sidebar.emptyProjects.suffix")}
     </div>
   );
 }
@@ -1188,7 +1249,9 @@ function buildProjectGroups(
       const ap = a.position ?? Number.POSITIVE_INFINITY;
       const bp = b.position ?? Number.POSITIVE_INFINITY;
       if (ap !== bp) return ap - bp;
-      return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+      return (
+        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+      );
     });
   }
   return Array.from(map.values());
@@ -1214,6 +1277,7 @@ function resolveSessionTitle(
 }
 
 function composeSessionMetadata(
+  t: Translator,
   session: Session,
   metadata: AcornSettings["sessionDisplay"]["metadata"],
 ): string {
@@ -1223,19 +1287,35 @@ function composeSessionMetadata(
     const dir = basename(session.worktree_path);
     if (dir) parts.push(dir);
   }
-  if (metadata.status) parts.push(STATUS_LABEL[session.status]);
+  if (metadata.status) parts.push(statusLabel(t, session.status));
   return parts.join(" · ");
 }
 
-function buildSessionHoverDetails(session: Session): string {
+function buildSessionHoverDetails(t: Translator, session: Session): string {
   const lines = [
-    `Name: ${session.name}`,
-    `Branch: ${session.branch || "(detached)"}`,
-    `Working directory: ${session.worktree_path}`,
-    `Status: ${STATUS_LABEL[session.status]}`,
+    `${sidebarText(t, "sidebar.metadata.name")}: ${session.name}`,
+    `${sidebarText(t, "sidebar.metadata.branch")}: ${
+      session.branch || sidebarText(t, "sidebar.metadata.detached")
+    }`,
+    `${sidebarText(t, "sidebar.metadata.workingDirectory")}: ${
+      session.worktree_path
+    }`,
+    `${sidebarText(t, "sidebar.metadata.status")}: ${statusLabel(
+      t,
+      session.status,
+    )}`,
   ];
-  if (session.kind === "control") lines.push("Kind: Control session");
-  if (session.isolated) lines.push("Isolated worktree");
+  if (session.kind === "control") {
+    lines.push(
+      `${sidebarText(t, "sidebar.metadata.kind")}: ${sidebarText(
+        t,
+        "sidebar.metadata.controlSession",
+      )}`,
+    );
+  }
+  if (session.isolated) {
+    lines.push(sidebarText(t, "sidebar.metadata.isolatedWorktree"));
+  }
   return lines.join("\n");
 }
 

--- a/src/components/StagedRevMismatchModal.tsx
+++ b/src/components/StagedRevMismatchModal.tsx
@@ -1,8 +1,16 @@
 import { useState, type ReactElement } from "react";
 import { RefreshCw, Terminal } from "lucide-react";
 import { api, type StagedRevMismatch } from "../lib/api";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal } from "./ui/Modal";
 import { ModalHeader } from "./ui/ModalHeader";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface StagedRevMismatchModalProps {
   mismatch: StagedRevMismatch | null;
@@ -20,6 +28,7 @@ export function StagedRevMismatchModal({
   mismatch,
   onDismiss,
 }: StagedRevMismatchModalProps): ReactElement | null {
+  const t = useTranslation();
   const [restarting, setRestarting] = useState(false);
 
   if (!mismatch) return null;
@@ -59,7 +68,9 @@ export function StagedRevMismatchModal({
   }
 
   const sessionWord =
-    mismatch.stale_session_count === 1 ? "session" : "sessions";
+    mismatch.stale_session_count === 1
+      ? dt(t, "dialogs.stagedRevMismatch.sessionSingular")
+      : dt(t, "dialogs.stagedRevMismatch.sessionPlural");
 
   return (
     <Modal
@@ -70,8 +81,8 @@ export function StagedRevMismatchModal({
       ariaLabelledBy="acorn-staged-rev-mismatch-title"
     >
       <ModalHeader
-        title="Shell environment updated"
-        subtitle={`${mismatch.stale_session_count} background ${sessionWord} need a restart`}
+        title={dt(t, "dialogs.stagedRevMismatch.title")}
+        subtitle={`${mismatch.stale_session_count} ${dt(t, "dialogs.stagedRevMismatch.background")} ${sessionWord} ${dt(t, "dialogs.stagedRevMismatch.needRestart")}`}
         titleId="acorn-staged-rev-mismatch-title"
         icon={<Terminal size={14} className="text-accent" />}
         variant="dialog"
@@ -79,15 +90,10 @@ export function StagedRevMismatchModal({
       />
       <div className="space-y-3 px-4 py-4 text-xs text-fg-muted">
         <p>
-          Acorn refreshed its shell-init files in this update. Background
-          sessions started by the previous version are still running against
-          the old environment, which can cause garbled input and prompt
-          redraws.
+          {dt(t, "dialogs.stagedRevMismatch.bodyIntro")}
         </p>
         <p>
-          Restart now to apply the new environment. Open agent
-          conversations (Claude / Codex) will pick up where they left
-          off on next focus.
+          {dt(t, "dialogs.stagedRevMismatch.bodyRestart")}
         </p>
       </div>
       <footer className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
@@ -97,7 +103,7 @@ export function StagedRevMismatchModal({
           disabled={restarting}
           className="rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
         >
-          Later
+          {dt(t, "dialogs.stagedRevMismatch.later")}
         </button>
         <button
           type="button"
@@ -109,7 +115,9 @@ export function StagedRevMismatchModal({
             size={12}
             className={restarting ? "animate-spin" : undefined}
           />
-          {restarting ? "Restarting…" : "Restart sessions"}
+          {restarting
+            ? dt(t, "dialogs.stagedRevMismatch.restarting")
+            : dt(t, "dialogs.stagedRevMismatch.restartSessions")}
         </button>
       </footer>
     </Modal>

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -4,13 +4,41 @@ import { homeDir } from "@tauri-apps/api/path";
 import { Activity, Loader2, Settings } from "lucide-react";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { useSettings } from "../lib/settings";
-import type { MemoryProcess } from "../lib/types";
+import type { MemoryProcess, SessionStatus } from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
 import { useAppStore } from "../store";
 import { MemoryBreakdownModal } from "./MemoryBreakdownModal";
 import { Tooltip } from "./Tooltip";
 
 const MEMORY_POLL_MS = 2000;
+
+type StatusBarTranslationKey = Extract<TranslationKey, `statusBar.${string}`>;
+
+const SESSION_STATUS_KEYS: Record<SessionStatus, StatusBarTranslationKey> = {
+  idle: "statusBar.sessionStatus.idle",
+  running: "statusBar.sessionStatus.running",
+  needs_input: "statusBar.sessionStatus.needsInput",
+  failed: "statusBar.sessionStatus.failed",
+  completed: "statusBar.sessionStatus.completed",
+};
+
+function statusBarText(t: Translator, key: StatusBarTranslationKey): string {
+  return t(key);
+}
+
+function statusBarFormat(
+  t: Translator,
+  key: StatusBarTranslationKey,
+  values: Record<string, string | number>,
+): string {
+  return statusBarText(t, key).replace(/\{(\w+)\}/g, (match, name) =>
+    Object.prototype.hasOwnProperty.call(values, name)
+      ? String(values[name])
+      : match,
+  );
+}
 
 function useHomeDir(): string | null {
   const [home, setHome] = useState<string | null>(null);
@@ -103,6 +131,7 @@ function GitHubMark() {
 }
 
 export function StatusBar() {
+  const t = useTranslation();
   const { sessions, activeSessionId, activeProject, error, loading } =
     useAppStore();
   const multiInputEnabled = useAppStore((s) => s.multiInputEnabled);
@@ -146,14 +175,22 @@ export function StatusBar() {
             the main view. */}
         <ServicesStatusButton />
         {showSessionCount ? (
-          <span className="whitespace-nowrap">sessions: {sessions.length}</span>
+          <span className="whitespace-nowrap">
+            {statusBarFormat(t, "statusBar.sessionCount", {
+              count: sessions.length,
+            })}
+          </span>
         ) : null}
         {showSessionStatus && active ? (
           <>
             {showSessionCount ? (
               <span className="text-fg-muted/50">|</span>
             ) : null}
-            <span className="whitespace-nowrap">status: {active.status}</span>
+            <span className="whitespace-nowrap">
+              {statusBarFormat(t, "statusBar.status", {
+                status: statusBarText(t, SESSION_STATUS_KEYS[active.status]),
+              })}
+            </span>
           </>
         ) : null}
         {multiInputEnabled ? (
@@ -162,7 +199,7 @@ export function StatusBar() {
               <span className="text-fg-muted/50">|</span>
             ) : null}
             <span className="whitespace-nowrap rounded bg-accent/15 px-1.5 py-0.5 text-accent">
-              multi-input: on
+              {statusBarText(t, "statusBar.multiInputOn")}
             </span>
           </>
         ) : null}
@@ -173,14 +210,25 @@ export function StatusBar() {
             children (branch, path) shrink instead of forcing the row
             wider than the footer. */}
         <span className="ml-auto flex min-w-0 items-center gap-3">
-          {loading ? <span className="whitespace-nowrap">working...</span> : null}
+          {loading ? (
+            <span className="whitespace-nowrap">
+              {statusBarText(t, "statusBar.working")}
+            </span>
+          ) : null}
           {error ? (
             <Tooltip label={error} side="top" multiline>
-              <span className="truncate whitespace-nowrap text-danger">error: {error}</span>
+              <span className="truncate whitespace-nowrap text-danger">
+                {statusBarFormat(t, "statusBar.error", { error })}
+              </span>
             </Tooltip>
           ) : null}
           {showGithubAccount && prAccount ? (
-            <Tooltip label={`PRs listed via gh account ${prAccount}`} side="top">
+            <Tooltip
+              label={statusBarFormat(t, "statusBar.githubAccountTooltip", {
+                account: prAccount,
+              })}
+              side="top"
+            >
               <span className="flex shrink-0 items-center gap-1 whitespace-nowrap rounded bg-fg-muted/15 px-1.5 py-0.5 text-[10px] text-fg-muted">
                 <GitHubMark />
                 {prAccount}
@@ -191,7 +239,9 @@ export function StatusBar() {
             <>
               <span className="text-fg-muted/50">|</span>
               <span className="min-w-0 truncate whitespace-nowrap">
-                branch: {active.branch}
+                {statusBarFormat(t, "statusBar.branch", {
+                  branch: active.branch,
+                })}
               </span>
             </>
           ) : null}
@@ -208,14 +258,19 @@ export function StatusBar() {
           {showMemory ? (
             <>
               <span className="text-fg-muted/50">|</span>
-              <Tooltip label="Click to view per-process breakdown" side="top">
+              <Tooltip
+                label={statusBarText(t, "statusBar.memoryTooltip")}
+                side="top"
+              >
                 <button
                   type="button"
                   disabled={!memory}
                   onClick={() => setBreakdownOpen(true)}
                   className="whitespace-nowrap rounded px-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-fg-muted"
                 >
-                  memory: {memory ? formatBytes(memory.bytes) : "–"}
+                  {statusBarFormat(t, "statusBar.memory", {
+                    memory: memory ? formatBytes(memory.bytes) : "-",
+                  })}
                 </button>
               </Tooltip>
             </>
@@ -271,6 +326,7 @@ function StatusDot({ state }: { state: DotState }) {
 }
 
 function ServicesStatusButton() {
+  const t = useTranslation();
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const [open, setOpen] = useState(false);
 
@@ -350,19 +406,28 @@ function ServicesStatusButton() {
   const tooltip = (() => {
     const ipcLabel =
       ipc.running === null
-        ? "ipc: loading"
+        ? statusBarText(t, "statusBar.services.tooltip.ipcLoading")
         : ipc.running
-          ? "ipc: on"
-          : "ipc: off";
+          ? statusBarText(t, "statusBar.services.tooltip.ipcOn")
+          : statusBarText(t, "statusBar.services.tooltip.ipcOff");
     const daemonLabel =
       daemon === null
-        ? "daemon: loading"
+        ? statusBarText(t, "statusBar.services.tooltip.daemonLoading")
         : !daemon.enabled
-          ? "daemon: disabled"
+          ? statusBarText(t, "statusBar.services.tooltip.daemonDisabled")
           : daemon.running
-            ? `daemon: on${daemon.sessions !== null ? ` (${daemon.sessions})` : ""}`
-            : "daemon: down";
-    return `${ipcLabel} · ${daemonLabel} — click for details`;
+            ? daemon.sessions !== null
+              ? statusBarFormat(
+                  t,
+                  "statusBar.services.tooltip.daemonOnWithSessions",
+                  { count: daemon.sessions },
+                )
+              : statusBarText(t, "statusBar.services.tooltip.daemonOn")
+            : statusBarText(t, "statusBar.services.tooltip.daemonDown");
+    return statusBarFormat(t, "statusBar.services.tooltip.details", {
+      ipc: ipcLabel,
+      daemon: daemonLabel,
+    });
   })();
 
   const ipcDotState: DotState =
@@ -382,7 +447,7 @@ function ServicesStatusButton() {
           onClick={() => setOpen((v) => !v)}
           aria-haspopup="menu"
           aria-expanded={open}
-          aria-label="Service status"
+          aria-label={statusBarText(t, "statusBar.services.ariaLabel")}
           className={cn(
             "flex h-5 items-center gap-1.5 rounded px-1.5 transition",
             "hover:bg-bg-elevated",
@@ -434,6 +499,7 @@ function ServicesDropdown({
   onRestartIpc,
   onOpenDaemonSettings,
 }: ServicesDropdownProps) {
+  const t = useTranslation();
   const ref = useRef<HTMLDivElement | null>(null);
   const [position, setPosition] = useState<{ left: number; bottom: number } | null>(
     null,
@@ -484,20 +550,24 @@ function ServicesDropdown({
 
   const ipcStatusText =
     ipc.running === null
-      ? "loading"
+      ? statusBarText(t, "statusBar.services.status.loading")
       : ipc.running
-        ? "running"
-        : "down";
+        ? statusBarText(t, "statusBar.services.status.running")
+        : statusBarText(t, "statusBar.services.status.down");
   const daemonStatusText =
     daemon === null
-      ? "loading"
+      ? statusBarText(t, "statusBar.services.status.loading")
       : !daemon.enabled
-        ? "disabled"
+        ? statusBarText(t, "statusBar.services.status.disabled")
         : daemon.running
           ? daemon.sessions !== null
-            ? `running · ${daemon.sessions} session${daemon.sessions === 1 ? "" : "s"}`
-            : "running"
-          : "down";
+            ? statusBarFormat(
+                t,
+                "statusBar.services.status.runningSessions",
+                { count: daemon.sessions },
+              )
+            : statusBarText(t, "statusBar.services.status.running")
+          : statusBarText(t, "statusBar.services.status.down");
 
   return createPortal(
     <div
@@ -509,11 +579,18 @@ function ServicesDropdown({
       <ul className="divide-y divide-border text-[11px]">
         <li>
           <ServiceRow
-            label="IPC server"
-            description="control-session ↔ app socket"
+            label={statusBarText(t, "statusBar.services.ipc.label")}
+            description={statusBarText(
+              t,
+              "statusBar.services.ipc.description",
+            )}
             dot={ipcDotState}
             statusText={ipcStatusText}
-            actionLabel={ipc.busy ? "Restarting…" : "Restart"}
+            actionLabel={
+              ipc.busy
+                ? statusBarText(t, "statusBar.services.actions.restarting")
+                : statusBarText(t, "statusBar.services.actions.restart")
+            }
             actionIcon={
               ipc.busy ? <Loader2 size={11} className="animate-spin" /> : null
             }
@@ -524,11 +601,17 @@ function ServicesDropdown({
         </li>
         <li>
           <ServiceRow
-            label="acornd daemon"
-            description="persistent PTY sessions"
+            label={statusBarText(t, "statusBar.services.daemon.label")}
+            description={statusBarText(
+              t,
+              "statusBar.services.daemon.description",
+            )}
             dot={daemonDotState}
             statusText={daemonStatusText}
-            actionLabel="Settings"
+            actionLabel={statusBarText(
+              t,
+              "statusBar.services.actions.settings",
+            )}
             actionIcon={<Settings size={11} />}
             actionDisabled={false}
             onAction={onOpenDaemonSettings}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,6 +1,8 @@
 import { useAppStore } from "../store";
+import { useTranslation } from "../lib/useTranslation";
 
 export function TopBar() {
+  const t = useTranslation();
   const { sessions, activeSessionId } = useAppStore();
   const active = sessions.find((s) => s.id === activeSessionId);
 
@@ -22,7 +24,9 @@ export function TopBar() {
           </span>
         </div>
       ) : (
-        <span className="text-sm text-fg-muted">No session selected</span>
+        <span className="text-sm text-fg-muted">
+          {t("topBar.noSessionSelected")}
+        </span>
       )}
     </header>
   );

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,6 +1,7 @@
 import { Download, X } from "lucide-react";
 import { useState, type ReactElement } from "react";
 import { selectShouldNotify, useUpdater } from "../lib/updater-store";
+import { useTranslation } from "../lib/useTranslation";
 import { TextSwap } from "./ui/TextSwap";
 import { WhatsNewModal } from "./WhatsNewModal";
 
@@ -17,6 +18,7 @@ import { WhatsNewModal } from "./WhatsNewModal";
  * wondering why the click did nothing.
  */
 export function UpdateBanner(): ReactElement | null {
+  const t = useTranslation();
   const should = useUpdater(selectShouldNotify);
   const update = useUpdater((s) => s.available);
   const currentVersion = useUpdater((s) => s.currentVersion);
@@ -37,7 +39,7 @@ export function UpdateBanner(): ReactElement | null {
           <div className="min-w-0 flex-1">
             <span className="font-medium text-fg">Acorn {update.version}</span>
             <span className="ml-2 text-fg-muted">
-              is available. The app will relaunch after install.
+              {t("updateBanner.available")}
             </span>
           </div>
           <button
@@ -45,7 +47,7 @@ export function UpdateBanner(): ReactElement | null {
             onClick={() => setWhatsNewOpen(true)}
             className="rounded px-2 py-1 text-[11px] text-fg-muted underline-offset-2 transition hover:text-fg hover:underline"
           >
-            What&apos;s new
+            {t("updateBanner.whatsNew")}
           </button>
           <button
             type="button"
@@ -53,13 +55,17 @@ export function UpdateBanner(): ReactElement | null {
             disabled={busy}
             className="rounded bg-accent px-2 py-1 text-[11px] font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
           >
-            <TextSwap>{busy ? "Installing…" : "Install & relaunch"}</TextSwap>
+            <TextSwap>
+              {busy
+                ? t("updateBanner.installing")
+                : t("updateBanner.installRelaunch")}
+            </TextSwap>
           </button>
           <button
             type="button"
             onClick={dismiss}
             disabled={busy}
-            title="Hide until next version"
+            title={t("updateBanner.hideUntilNextVersion")}
             className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
           >
             <X size={14} />
@@ -72,7 +78,7 @@ export function UpdateBanner(): ReactElement | null {
               type="button"
               onClick={clearError}
               className="shrink-0 rounded p-0.5 text-danger/80 transition hover:bg-danger/20 hover:text-danger"
-              aria-label="Dismiss error"
+              aria-label={t("updateBanner.dismissError")}
             >
               <X size={12} />
             </button>

--- a/src/components/WhatsNewModal.tsx
+++ b/src/components/WhatsNewModal.tsx
@@ -1,9 +1,17 @@
 import { Download, ExternalLink, Sparkles } from "lucide-react";
 import type { ReactElement } from "react";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal } from "./ui/Modal";
 import { ModalHeader } from "./ui/ModalHeader";
 import { Markdown } from "./ui/Markdown";
 import { TextSwap } from "./ui/TextSwap";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface WhatsNewModalProps {
   open: boolean;
@@ -65,13 +73,14 @@ export function WhatsNewModal({
   htmlUrl,
   isFallback = false,
 }: WhatsNewModalProps): ReactElement | null {
+  const t = useTranslation();
   const trimmedBody = body.trim();
   const subtitle = isFallback
-    ? `latest published — no public release for ${currentVersion ?? "your version"}`
+    ? `${dt(t, "dialogs.whatsNew.latestPublished")} ${currentVersion ?? dt(t, "dialogs.whatsNew.yourVersion")}`
     : currentVersion && currentVersion !== version
-      ? `currently running ${currentVersion}`
+      ? `${dt(t, "dialogs.whatsNew.currentlyRunning")} ${currentVersion}`
       : currentVersion === version
-        ? "you're on this version"
+        ? dt(t, "dialogs.whatsNew.onThisVersion")
         : undefined;
 
   return (
@@ -83,7 +92,7 @@ export function WhatsNewModal({
       ariaLabelledBy="acorn-whatsnew-title"
     >
       <ModalHeader
-        title={`What's new in Acorn ${version}`}
+        title={`${dt(t, "dialogs.whatsNew.titlePrefix")} ${version}`}
         subtitle={subtitle}
         titleId="acorn-whatsnew-title"
         icon={<Sparkles size={14} className="text-accent" />}
@@ -95,7 +104,7 @@ export function WhatsNewModal({
           <Markdown content={trimmedBody} className="text-xs" />
         ) : (
           <p className="text-xs text-fg-muted">
-            No release notes were published with this version.
+            {dt(t, "dialogs.whatsNew.noReleaseNotes")}
           </p>
         )}
       </div>
@@ -113,7 +122,7 @@ export function WhatsNewModal({
             className="inline-flex items-center gap-1.5 rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
           >
             <ExternalLink size={12} />
-            View on GitHub
+            {dt(t, "dialogs.whatsNew.viewOnGithub")}
           </a>
         ) : null}
         <button
@@ -121,7 +130,7 @@ export function WhatsNewModal({
           onClick={onClose}
           className="rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
         >
-          Close
+          {dt(t, "dialogs.common.close")}
         </button>
         {showInstall && onInstall ? (
           <button
@@ -131,7 +140,11 @@ export function WhatsNewModal({
             className="inline-flex items-center gap-1.5 rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
           >
             <Download size={12} />
-            <TextSwap>{busy ? "Installing…" : "Install & relaunch"}</TextSwap>
+            <TextSwap>
+              {busy
+                ? dt(t, "dialogs.whatsNew.installing")
+                : dt(t, "dialogs.whatsNew.installRelaunch")}
+            </TextSwap>
           </button>
         ) : null}
       </footer>

--- a/src/components/ui/CommandHint.tsx
+++ b/src/components/ui/CommandHint.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactElement } from "react";
 import { CommandRunDialog } from "../CommandRunDialog";
 import { cn } from "../../lib/cn";
+import { useTranslation } from "../../lib/useTranslation";
 
 interface CommandHintProps {
   /**
@@ -31,13 +32,14 @@ export function CommandHint({
   repoPath,
   className,
 }: CommandHintProps): ReactElement {
+  const t = useTranslation();
   const [open, setOpen] = useState(false);
   return (
     <>
       <button
         type="button"
         onClick={() => setOpen(true)}
-        title="Click to copy or run"
+        title={t("ui.commandHint.title")}
         className={cn(
           "inline-flex max-w-full items-center rounded border border-border bg-bg-sidebar/70 px-1.5 py-0.5 text-left font-mono text-[11px] text-fg transition hover:border-accent/60 hover:bg-bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
           className,

--- a/src/components/ui/ModalHeader.tsx
+++ b/src/components/ui/ModalHeader.tsx
@@ -1,7 +1,15 @@
 import { X } from "lucide-react";
 import { type ReactNode } from "react";
 import { cn } from "../../lib/cn";
+import type { TranslationKey, Translator } from "../../lib/i18n";
+import { useTranslation } from "../../lib/useTranslation";
 import { type ModalVariant } from "./Modal";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface ModalHeaderProps {
   title: string;
@@ -27,6 +35,7 @@ export function ModalHeader({
   variant = "panel",
   onClose,
 }: ModalHeaderProps) {
+  const t = useTranslation();
   const hoverBg =
     variant === "dialog" ? "hover:bg-bg-sidebar" : "hover:bg-bg-elevated";
   return (
@@ -49,7 +58,7 @@ export function ModalHeader({
         {actions}
         <button
           type="button"
-          aria-label="Close"
+          aria-label={dt(t, "dialogs.common.close")}
           onClick={onClose}
           className={cn(
             "rounded p-1 text-fg-muted transition hover:text-fg",

--- a/src/components/ui/Stepper.tsx
+++ b/src/components/ui/Stepper.tsx
@@ -1,4 +1,5 @@
 import { Minus, Plus } from "lucide-react";
+import { useTranslation } from "../../lib/useTranslation";
 
 interface StepperProps {
   value: number;
@@ -24,6 +25,7 @@ export function Stepper({
   format,
   onChange,
 }: StepperProps) {
+  const t = useTranslation();
   const clamp = (n: number) => Math.max(min, Math.min(max, n));
   // Round-to-step keeps fractional steps (e.g. 0.05) from accumulating
   // FP drift after many clicks.
@@ -37,7 +39,7 @@ export function Stepper({
         type="button"
         onClick={dec}
         disabled={value <= min}
-        aria-label="Decrease"
+        aria-label={t("ui.stepper.decrease")}
         className="flex w-8 items-center justify-center text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-40"
       >
         <Minus size={12} />
@@ -50,7 +52,7 @@ export function Stepper({
         type="button"
         onClick={inc}
         disabled={value >= max}
-        aria-label="Increase"
+        aria-label={t("ui.stepper.increase")}
         className="flex w-8 items-center justify-center text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-40"
       >
         <Plus size={12} />

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -28,6 +28,7 @@ type StringPath<T> = {
 }[keyof T & string];
 
 export type TranslationKey = StringPath<LocaleTree>;
+export type Translator = (key: TranslationKey) => string;
 
 const TRANSLATIONS: Record<Language, LocaleTree> = {
   en,
@@ -47,6 +48,6 @@ export function translate(language: Language, key: TranslationKey): string {
   return lookup(TRANSLATIONS[language], key);
 }
 
-export function createTranslator(language: Language) {
+export function createTranslator(language: Language): Translator {
   return (key: TranslationKey) => translate(language, key);
 }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -15,47 +15,53 @@ export function isLanguage(value: unknown): value is Language {
   return typeof value === "string" && LANGUAGE_VALUES.has(value as Language);
 }
 
-const TRANSLATIONS: Record<Language, Record<string, string>> = {
-  en: {
-    "settings.title": "Settings",
-    "settings.reset": "Reset to defaults",
-    "settings.tabs.terminal": "Terminal",
-    "settings.tabs.agents": "Agents",
-    "settings.tabs.sessions": "Sessions",
-    "settings.tabs.github": "GitHub",
-    "settings.tabs.appearance": "Appearance",
-    "settings.tabs.editor": "Editor",
-    "settings.tabs.notifications": "Notifications",
-    "settings.tabs.storage": "Storage",
-    "settings.tabs.experiments": "Experiments",
-    "settings.tabs.about": "About",
-    "settings.language.label": "Language",
-    "settings.language.hint":
-      "Language used for the Acorn interface. New translations are added gradually.",
-  },
-  ko: {
-    "settings.title": "설정",
-    "settings.reset": "기본값으로 재설정",
-    "settings.tabs.terminal": "터미널",
-    "settings.tabs.agents": "에이전트",
-    "settings.tabs.sessions": "세션",
-    "settings.tabs.github": "GitHub",
-    "settings.tabs.appearance": "모양",
-    "settings.tabs.editor": "편집기",
-    "settings.tabs.notifications": "알림",
-    "settings.tabs.storage": "저장 공간",
-    "settings.tabs.experiments": "실험 기능",
-    "settings.tabs.about": "정보",
-    "settings.language.label": "언어",
-    "settings.language.hint":
-      "Acorn 인터페이스에 사용할 언어입니다. 새 번역은 점진적으로 추가됩니다.",
-  },
+const EN_TRANSLATIONS = {
+  "settings.title": "Settings",
+  "settings.reset": "Reset to defaults",
+  "settings.tabs.terminal": "Terminal",
+  "settings.tabs.agents": "Agents",
+  "settings.tabs.sessions": "Sessions",
+  "settings.tabs.github": "GitHub",
+  "settings.tabs.appearance": "Appearance",
+  "settings.tabs.editor": "Editor",
+  "settings.tabs.notifications": "Notifications",
+  "settings.tabs.storage": "Storage",
+  "settings.tabs.experiments": "Experiments",
+  "settings.tabs.about": "About",
+  "settings.language.label": "Language",
+  "settings.language.hint":
+    "Language used for the Acorn interface. New translations are added gradually.",
+} as const;
+
+export type TranslationKey = keyof typeof EN_TRANSLATIONS;
+
+const KO_TRANSLATIONS: Record<TranslationKey, string> = {
+  "settings.title": "설정",
+  "settings.reset": "기본값으로 재설정",
+  "settings.tabs.terminal": "터미널",
+  "settings.tabs.agents": "에이전트",
+  "settings.tabs.sessions": "세션",
+  "settings.tabs.github": "GitHub",
+  "settings.tabs.appearance": "모양",
+  "settings.tabs.editor": "편집기",
+  "settings.tabs.notifications": "알림",
+  "settings.tabs.storage": "저장 공간",
+  "settings.tabs.experiments": "실험 기능",
+  "settings.tabs.about": "정보",
+  "settings.language.label": "언어",
+  "settings.language.hint":
+    "Acorn 인터페이스에 사용할 언어입니다. 새 번역은 점진적으로 추가됩니다.",
 };
 
-export function translate(language: Language, key: string): string {
-  return TRANSLATIONS[language][key] ?? TRANSLATIONS.en[key] ?? key;
+const TRANSLATIONS: Record<Language, Record<TranslationKey, string>> = {
+  en: EN_TRANSLATIONS,
+  ko: KO_TRANSLATIONS,
+};
+
+export function translate(language: Language, key: TranslationKey): string {
+  return TRANSLATIONS[language][key];
 }
 
 export function createTranslator(language: Language) {
-  return (key: string) => translate(language, key);
+  return (key: TranslationKey) => translate(language, key);
 }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,3 +1,6 @@
+import en from "../locales/en.json";
+import ko from "../locales/ko.json";
+
 export type Language = "en" | "ko";
 
 export const LANGUAGE_OPTIONS: ReadonlyArray<{
@@ -15,43 +18,10 @@ export function isLanguage(value: unknown): value is Language {
   return typeof value === "string" && LANGUAGE_VALUES.has(value as Language);
 }
 
-const EN_TRANSLATIONS = {
-  "settings.title": "Settings",
-  "settings.reset": "Reset to defaults",
-  "settings.tabs.terminal": "Terminal",
-  "settings.tabs.agents": "Agents",
-  "settings.tabs.sessions": "Sessions",
-  "settings.tabs.github": "GitHub",
-  "settings.tabs.appearance": "Appearance",
-  "settings.tabs.editor": "Editor",
-  "settings.tabs.notifications": "Notifications",
-  "settings.tabs.storage": "Storage",
-  "settings.tabs.experiments": "Experiments",
-  "settings.tabs.about": "About",
-  "settings.language.label": "Language",
-  "settings.language.hint":
-    "Language used for the Acorn interface. New translations are added gradually.",
-} as const;
+export type TranslationKey = keyof typeof en;
 
-export type TranslationKey = keyof typeof EN_TRANSLATIONS;
-
-const KO_TRANSLATIONS: Record<TranslationKey, string> = {
-  "settings.title": "설정",
-  "settings.reset": "기본값으로 재설정",
-  "settings.tabs.terminal": "터미널",
-  "settings.tabs.agents": "에이전트",
-  "settings.tabs.sessions": "세션",
-  "settings.tabs.github": "GitHub",
-  "settings.tabs.appearance": "모양",
-  "settings.tabs.editor": "편집기",
-  "settings.tabs.notifications": "알림",
-  "settings.tabs.storage": "저장 공간",
-  "settings.tabs.experiments": "실험 기능",
-  "settings.tabs.about": "정보",
-  "settings.language.label": "언어",
-  "settings.language.hint":
-    "Acorn 인터페이스에 사용할 언어입니다. 새 번역은 점진적으로 추가됩니다.",
-};
+const EN_TRANSLATIONS: Record<TranslationKey, string> = en;
+const KO_TRANSLATIONS: Record<TranslationKey, string> = ko;
 
 const TRANSLATIONS: Record<Language, Record<TranslationKey, string>> = {
   en: EN_TRANSLATIONS,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -18,18 +18,33 @@ export function isLanguage(value: unknown): value is Language {
   return typeof value === "string" && LANGUAGE_VALUES.has(value as Language);
 }
 
-export type TranslationKey = keyof typeof en;
+type LocaleTree = typeof en;
+type StringPath<T> = {
+  [K in keyof T & string]: T[K] extends string
+    ? K
+    : T[K] extends Record<string, unknown>
+      ? `${K}.${StringPath<T[K]>}`
+      : never;
+}[keyof T & string];
 
-const EN_TRANSLATIONS: Record<TranslationKey, string> = en;
-const KO_TRANSLATIONS: Record<TranslationKey, string> = ko;
+export type TranslationKey = StringPath<LocaleTree>;
 
-const TRANSLATIONS: Record<Language, Record<TranslationKey, string>> = {
-  en: EN_TRANSLATIONS,
-  ko: KO_TRANSLATIONS,
+const TRANSLATIONS: Record<Language, LocaleTree> = {
+  en,
+  ko,
 };
 
+function lookup(tree: LocaleTree, key: TranslationKey): string {
+  const value = key.split(".").reduce<unknown>((node, part) => {
+    if (!node || typeof node !== "object") return undefined;
+    return (node as Record<string, unknown>)[part];
+  }, tree);
+
+  return typeof value === "string" ? value : key;
+}
+
 export function translate(language: Language, key: TranslationKey): string {
-  return TRANSLATIONS[language][key];
+  return lookup(TRANSLATIONS[language], key);
 }
 
 export function createTranslator(language: Language) {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,61 @@
+export type Language = "en" | "ko";
+
+export const LANGUAGE_OPTIONS: ReadonlyArray<{
+  value: Language;
+  label: string;
+  nativeLabel: string;
+}> = [
+  { value: "en", label: "English", nativeLabel: "English" },
+  { value: "ko", label: "Korean", nativeLabel: "한국어" },
+];
+
+const LANGUAGE_VALUES = new Set<Language>(LANGUAGE_OPTIONS.map((o) => o.value));
+
+export function isLanguage(value: unknown): value is Language {
+  return typeof value === "string" && LANGUAGE_VALUES.has(value as Language);
+}
+
+const TRANSLATIONS: Record<Language, Record<string, string>> = {
+  en: {
+    "settings.title": "Settings",
+    "settings.reset": "Reset to defaults",
+    "settings.tabs.terminal": "Terminal",
+    "settings.tabs.agents": "Agents",
+    "settings.tabs.sessions": "Sessions",
+    "settings.tabs.github": "GitHub",
+    "settings.tabs.appearance": "Appearance",
+    "settings.tabs.editor": "Editor",
+    "settings.tabs.notifications": "Notifications",
+    "settings.tabs.storage": "Storage",
+    "settings.tabs.experiments": "Experiments",
+    "settings.tabs.about": "About",
+    "settings.language.label": "Language",
+    "settings.language.hint":
+      "Language used for the Acorn interface. New translations are added gradually.",
+  },
+  ko: {
+    "settings.title": "설정",
+    "settings.reset": "기본값으로 재설정",
+    "settings.tabs.terminal": "터미널",
+    "settings.tabs.agents": "에이전트",
+    "settings.tabs.sessions": "세션",
+    "settings.tabs.github": "GitHub",
+    "settings.tabs.appearance": "모양",
+    "settings.tabs.editor": "편집기",
+    "settings.tabs.notifications": "알림",
+    "settings.tabs.storage": "저장 공간",
+    "settings.tabs.experiments": "실험 기능",
+    "settings.tabs.about": "정보",
+    "settings.language.label": "언어",
+    "settings.language.hint":
+      "Acorn 인터페이스에 사용할 언어입니다. 새 번역은 점진적으로 추가됩니다.",
+  },
+};
+
+export function translate(language: Language, key: string): string {
+  return TRANSLATIONS[language][key] ?? TRANSLATIONS.en[key] ?? key;
+}
+
+export function createTranslator(language: Language) {
+  return (key: string) => translate(language, key);
+}

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1,6 +1,54 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_SETTINGS } from "./settings";
 
+describe("language settings", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("defaults to English", () => {
+    expect(DEFAULT_SETTINGS.language).toBe("en");
+  });
+
+  it("loads a persisted Korean language selection", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ language: "ko" }));
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.language).toBe("ko");
+  });
+
+  it("falls back to English for an unsupported stored language", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ language: "fr" }));
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.language).toBe("en");
+  });
+});
+
 describe("terminal.linkActivation default", () => {
   it("defaults to plain click so xterm's stock behaviour is preserved", () => {
     expect(DEFAULT_SETTINGS.terminal.linkActivation).toBe("click");

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -5,6 +5,7 @@ import {
   sanitizeFontFamilyName,
   type CuratedMonospaceFont,
 } from "./fonts";
+import { isLanguage, type Language } from "./i18n";
 
 const STORAGE_KEY = "acorn:settings:v1";
 
@@ -142,6 +143,7 @@ export const TERMINAL_FONT_WEIGHTS: ReadonlyArray<{
 ];
 
 export interface AcornSettings {
+  language: Language;
   terminal: {
     fontFamily: string;
     fontSize: number;
@@ -306,6 +308,7 @@ export interface AcornSettings {
 }
 
 export const DEFAULT_SETTINGS: AcornSettings = {
+  language: "en",
   terminal: {
     fontFamily: fontStackFromSlots(
       ["JetBrains Mono", "Fira Code", "Menlo"],
@@ -515,6 +518,10 @@ function normalizeSelectedAgent(
   return fallback;
 }
 
+function normalizeLanguage(v: unknown, fallback: Language): Language {
+  return isLanguage(v) ? v : fallback;
+}
+
 /**
  * v1 commitMessage block from the multi-provider commit-message PR. The
  * loader below lifts every field up into the new `agents.*` block so a
@@ -625,6 +632,7 @@ function loadSettings(): AcornSettings {
       },
     };
     return {
+      language: normalizeLanguage(parsed.language, DEFAULT_SETTINGS.language),
       terminal: {
         ...DEFAULT_SETTINGS.terminal,
         ...terminalRaw,
@@ -786,6 +794,7 @@ interface SettingsState {
     },
   ) => void;
   patchExperiments: (patch: Partial<AcornSettings["experiments"]>) => void;
+  patchLanguage: (language: Language) => void;
   reset: () => void;
 }
 
@@ -930,6 +939,15 @@ export const useSettings = create<SettingsState>((set, get) => ({
       const next: AcornSettings = {
         ...s.settings,
         experiments: { ...s.settings.experiments, ...patch },
+      };
+      persist(next);
+      return { settings: next };
+    }),
+  patchLanguage: (language) =>
+    set((s) => {
+      const next: AcornSettings = {
+        ...s.settings,
+        language,
       };
       persist(next);
       return { settings: next };

--- a/src/lib/sidebar-actions.test.ts
+++ b/src/lib/sidebar-actions.test.ts
@@ -87,7 +87,7 @@ describe("Sidebar source contract", () => {
 
   it("chevron is rendered as its own padded button with hover background", () => {
     expect(SIDEBAR_SOURCE).toMatch(
-      /aria-label=\{collapsed \? "Expand project" : "Collapse project"\}/,
+      /aria-label=\{\s*collapsed\s*\?\s*sidebarText\(t, "sidebar\.actions\.expandProject"\)\s*:\s*sidebarText\(t, "sidebar\.actions\.collapseProject"\)\s*\}/,
     );
     expect(SIDEBAR_SOURCE).toMatch(
       /flex shrink-0 items-center justify-center rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg/,

--- a/src/lib/useTranslation.ts
+++ b/src/lib/useTranslation.ts
@@ -1,0 +1,8 @@
+import { useMemo } from "react";
+import { createTranslator } from "./i18n";
+import { useSettings } from "./settings";
+
+export function useTranslation() {
+  const language = useSettings((s) => s.settings.language);
+  return useMemo(() => createTranslator(language), [language]);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -400,6 +400,56 @@
       }
     }
   },
+  "topBar": {
+    "noSessionSelected": "No session selected"
+  },
+  "updateBanner": {
+    "available": "is available. The app will relaunch after install.",
+    "whatsNew": "What's new",
+    "installing": "Installing...",
+    "installRelaunch": "Install & relaunch",
+    "hideUntilNextVersion": "Hide until next version",
+    "dismissError": "Dismiss error"
+  },
+  "imageLightbox": {
+    "imagePreview": "Image preview",
+    "openInBrowser": "Open in browser",
+    "close": "Close"
+  },
+  "codeViewer": {
+    "loading": "Loading...",
+    "binaryFile": "Binary file",
+    "binaryFileBody": "{bytes} bytes - not shown in the readonly viewer.",
+    "truncated": "File truncated to 2 MB. Open externally to view the rest."
+  },
+  "diffView": {
+    "noChanges": "No changes in this diff.",
+    "filesChanged": "{count} files changed",
+    "filesCount": "{count} files",
+    "expandAll": "Expand all",
+    "collapseAll": "Collapse all",
+    "openFullDiff": "Open full diff",
+    "openInEditor": "Open in editor",
+    "image": "image",
+    "binaryImageNoPreview": "Binary image change (no preview available)",
+    "none": "(none)",
+    "imageLabels": {
+      "added": "Added",
+      "deleted": "Deleted",
+      "before": "Before",
+      "after": "After"
+    }
+  },
+  "ui": {
+    "openGitHubProfile": "Open GitHub profile",
+    "stepper": {
+      "decrease": "Decrease",
+      "increase": "Increase"
+    },
+    "commandHint": {
+      "title": "Click to copy or run"
+    }
+  },
   "sidebar": {
     "status": {
       "idle": "Idle",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -341,12 +341,152 @@
     }
   },
   "app": {},
-  "sidebar": {},
-  "pane": {},
+  "sidebar": {
+    "status": {
+      "idle": "Idle",
+      "running": "Running",
+      "needs_input": "Needs input",
+      "failed": "Failed",
+      "completed": "Completed"
+    },
+    "dialog": {
+      "selectExistingProject": "Select an existing project",
+      "selectIsolatedRepository": "Select a git repository (isolated worktree)",
+      "selectControlDirectory": "Select a directory (control session)",
+      "selectDirectory": "Select a directory"
+    },
+    "projects": {
+      "title": "Projects",
+      "newProject": "New project",
+      "addExistingProject": "Add existing project"
+    },
+    "actions": {
+      "dragToReorder": "Drag to reorder",
+      "expandProject": "Expand project",
+      "collapseProject": "Collapse project",
+      "newSession": "New session",
+      "newIsolatedSession": "New isolated session",
+      "newIsolatedSessionWorktree": "New isolated session (worktree)",
+      "newControlSession": "New control session",
+      "closeProject": "Close project",
+      "revealInFinder": "Reveal in Finder",
+      "copyPath": "Copy path",
+      "rename": "Rename",
+      "duplicateSession": "Duplicate Session",
+      "equalizePaneSizes": "Equalize Pane Sizes",
+      "openWorktreeInEditor": "Open Worktree in Editor",
+      "copyWorktreePath": "Copy Worktree Path",
+      "copyWorktreeName": "Copy Worktree Name",
+      "copyBranchName": "Copy Branch Name",
+      "copySessionId": "Copy Session ID",
+      "remove": "Remove",
+      "removeSession": "Remove session",
+      "removeOthersInProject": "Remove Others in Project",
+      "removeAllInProject": "Remove All in Project"
+    },
+    "aria": {
+      "project": "Project",
+      "dragToReorderProject": "Drag to reorder project",
+      "newSessionInProject": "New session in this project",
+      "newControlSessionInProject": "New control session in this project",
+      "dragToReorderSession": "Drag to reorder session",
+      "worktree": "worktree",
+      "controlSession": "control session"
+    },
+    "emptyProject": {
+      "prefix": "No sessions. Add one with",
+      "connector": "or",
+      "suffix": ", or double-click here."
+    },
+    "emptyProjects": {
+      "prefix": "No projects yet. Click",
+      "suffix": "to add one."
+    },
+    "metadata": {
+      "name": "Name",
+      "branch": "Branch",
+      "detached": "(detached)",
+      "workingDirectory": "Working directory",
+      "status": "Status",
+      "kind": "Kind",
+      "controlSession": "Control session",
+      "isolatedWorktree": "Isolated worktree"
+    }
+  },
+  "pane": {
+    "empty": {
+      "dropTabOrDoubleClick": "Drop a tab here or double-click to start a session",
+      "createProject": "Create a project to get started. Double-click here."
+    },
+    "aria": {
+      "worktree": "worktree",
+      "closeSession": "Close session"
+    },
+    "menu": {
+      "rename": "Rename",
+      "duplicateSession": "Duplicate Session",
+      "forkClaudeSession": "Fork Claude Session",
+      "forkSession": "Fork Session",
+      "forkClaudeInNewWorktree": "Fork Claude in New Worktree",
+      "forkInNewWorktree": "Fork in New Worktree",
+      "forkCodexSession": "Fork Codex Session",
+      "forkCodexInNewWorktree": "Fork Codex in New Worktree",
+      "splitRight": "Split Right",
+      "splitDown": "Split Down",
+      "equalizePaneSizes": "Equalize Pane Sizes",
+      "openWorktreeInEditor": "Open Worktree in Editor",
+      "revealInFinder": "Reveal in Finder",
+      "copyWorktreePath": "Copy Worktree Path",
+      "copyWorktreeName": "Copy Worktree Name",
+      "copyBranchName": "Copy Branch Name",
+      "copySessionId": "Copy Session ID",
+      "close": "Close",
+      "closeOthers": "Close Others",
+      "closeAll": "Close All",
+      "newSessionInThisPane": "New Session in This Pane",
+      "closePane": "Close Pane"
+    }
+  },
   "rightPanel": {},
   "fileExplorer": {},
   "dialogs": {},
-  "commandPalette": {},
+  "commandPalette": {
+    "dialogLabel": "Command palette",
+    "placeholder": "Type a command or search...",
+    "empty": "No results.",
+    "groups": {
+      "sessions": "Sessions",
+      "switchSession": "Switch session",
+      "view": "View",
+      "terminal": "Terminal",
+      "ipc": "IPC",
+      "dangerZone": "Danger zone"
+    },
+    "commands": {
+      "newSession": "New session",
+      "newIsolatedSession": "New isolated session",
+      "newControlSession": "New control session",
+      "newProject": "New project",
+      "addExistingProject": "Add existing project",
+      "refreshSessions": "Refresh sessions",
+      "switchSessionPrefix": "Switch to",
+      "viewTodos": "View Todos",
+      "viewCommits": "View Commits",
+      "viewStaged": "View Staged",
+      "viewPullRequests": "View Pull Requests",
+      "resetPanelSizes": "Reset panel sizes",
+      "reloadShellEnvironment": "Reload shell environment",
+      "restartIpcServer": "Restart IPC server",
+      "removeSessionPrefix": "Remove session:",
+      "shakeTree": "Shake the tree"
+    },
+    "toasts": {
+      "shellEnvReloaded": "Shell environment reloaded. Open a new session to apply.",
+      "shellEnvReloadFailed": "Failed to reload shell environment.",
+      "ipcRestarted": "IPC server restarted.",
+      "ipcRestartFailedPrefix": "Failed to restart IPC server:"
+    }
+  },
   "backgroundSessions": {
     "daemon": {
       "label": "Daemon",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -340,7 +340,14 @@
       }
     }
   },
-  "app": {},
+  "app": {
+    "toast": {
+      "multiInputOn": "Multi-input on.",
+      "multiInputOff": "Multi-input off.",
+      "shellEnvironmentReloaded": "Shell environment reloaded. Open a new session to apply.",
+      "shellEnvironmentReloadFailed": "Failed to reload shell environment."
+    }
+  },
   "sidebar": {
     "status": {
       "idle": "Idle",
@@ -447,9 +454,392 @@
       "closePane": "Close Pane"
     }
   },
-  "rightPanel": {},
-  "fileExplorer": {},
-  "dialogs": {},
+  "rightPanel": {
+    "tabs": {
+      "files": "Files",
+      "todos": "Todos",
+      "commits": "Commits",
+      "staged": "Staged",
+      "prs": "PRs",
+      "actions": "Actions"
+    },
+    "empty": {
+      "noTodos": "No todos in this session",
+      "noProject": "No project selected"
+    },
+    "todos": {
+      "doneCount": "{completed}/{total} done",
+      "inProgressCount": "{count} in progress"
+    },
+    "loading": {
+      "more": "Loading more…",
+      "moreLower": "loading more...",
+      "diffLower": "loading diff..."
+    },
+    "tooltips": {
+      "copySha": "Copy SHA",
+      "openOnGitHub": "Open on GitHub"
+    },
+    "commits": {
+      "pushed": "Pushed",
+      "notPushed": "Not pushed",
+      "selectToSeeDiff": "Select a commit to see diff"
+    },
+    "staged": {
+      "empty": "No staged or modified files",
+      "workingTreeChanges": "Working tree changes",
+      "noDiff": "No diff"
+    },
+    "errors": {
+      "deletedFile": "File was deleted; nothing to open.",
+      "notGitHubRemote": "This repo's origin is not a GitHub remote.",
+      "originNotGitHub": "Origin remote is not a GitHub repository.",
+      "noAccessToSlug": "No access to {slug}."
+    },
+    "menu": {
+      "expandDiff": "Expand diff",
+      "viewOnGitHub": "View on GitHub",
+      "copyShaWithValue": "Copy SHA ({sha})",
+      "openInEditor": "Open in editor",
+      "copyRelativePath": "Copy relative path",
+      "copyAbsolutePath": "Copy absolute path",
+      "openDetail": "Open detail",
+      "openInBrowser": "Open in browser",
+      "copyPrNumber": "Copy PR number",
+      "copyUrl": "Copy URL",
+      "copyBranchWithValue": "Copy branch ({branch})",
+      "merge": "Merge…",
+      "close": "Close…"
+    },
+    "prStates": {
+      "open": "Open",
+      "closed": "Closed",
+      "merged": "Merged",
+      "all": "All",
+      "draft": "DRAFT"
+    },
+    "prs": {
+      "emptyByState": "No {state} pull requests.",
+      "reachedMax": "Showing first {count}. Use search to find older PRs."
+    },
+    "search": {
+      "aria": "Search pull requests",
+      "placeholder": "Search title, author, label, branch…",
+      "searching": "Searching…",
+      "typeToSearch": "Type to search pull requests.",
+      "noGhAccessThisRepo": "No logged-in gh account can access this repo.",
+      "noMatches": "No matching pull requests.",
+      "reachedMax": "Showing first {count}. Refine the query for older PRs."
+    },
+    "actions": {
+      "filterByWorkflow": "Filter by workflow",
+      "allWorkflows": "All workflows",
+      "noRuns": "No workflow runs yet.",
+      "noRunsForFilter": "No runs match this filter.",
+      "workflowRun": "Workflow run",
+      "workflowRunFallbackTitle": "{workflow} run",
+      "doubleClickDetails": "Double-click to view details",
+      "retryAttempt": "retry #{attempt}",
+      "github": "GitHub",
+      "status": "Status",
+      "totalDuration": "Total duration",
+      "runningParenthetical": "(running)",
+      "attempt": "Attempt",
+      "retriedParenthetical": "(retried)",
+      "commit": "Commit",
+      "created": "Created",
+      "updated": "Updated",
+      "jobsCount": "Jobs ({count})",
+      "noJobs": "No jobs reported.",
+      "openJobOnGitHub": "Open job on GitHub"
+    },
+    "checks": {
+      "allPassed": "All {count} checks passed",
+      "allFailed": "All {count} checks failed",
+      "summary": "{passed} passed, {failed} failed, {pending} pending"
+    },
+    "noAccess": {
+      "noGhAccountCanAccess": "No logged-in gh account can access {slug}.",
+      "tried": "Tried:",
+      "noAccounts": "No accounts authenticated against github.com.",
+      "run": "Run",
+      "withAccess": "with an account that has access, or accept the invitation on github.com."
+    },
+    "time": {
+      "secondsAgo": "{count}s ago",
+      "minutesAgo": "{count}m ago",
+      "hoursAgo": "{count}h ago",
+      "daysAgo": "{count}d ago",
+      "monthsAgo": "{count}mo ago",
+      "yearsAgo": "{count}y ago"
+    },
+    "duration": {
+      "seconds": "{count}s",
+      "minutes": "{count}m",
+      "minutesSeconds": "{minutes}m {seconds}s",
+      "hours": "{count}h",
+      "hoursMinutes": "{hours}h {minutes}m"
+    }
+  },
+  "fileExplorer": {
+    "defaults": {
+      "sessionName": "session"
+    },
+    "errorBanner": {
+      "dismiss": "Dismiss error"
+    },
+    "errors": {
+      "clipboardWriteFailed": "Clipboard write failed",
+      "noActiveProject": "No active project",
+      "noActiveSession": "No active session - open a terminal first"
+    },
+    "menu": {
+      "attachAllToConversation": "Attach All to Conversation",
+      "attachToClaude": "Attach to Claude",
+      "attachToCodex": "Attach to Codex",
+      "copyAbsolutePath": "Copy Absolute Path",
+      "copyAbsolutePaths": "Copy Absolute Paths",
+      "copyRelativePath": "Copy Relative Path",
+      "copyRelativePaths": "Copy Relative Paths",
+      "moveToTrash": "Move to Trash",
+      "openIn": "Open in",
+      "openInNewTab": "Open in New Tab",
+      "openWithDefaultProgram": "Open with Default Program",
+      "rename": "Rename",
+      "revealInFileManager": "Reveal in File Manager"
+    },
+    "search": {
+      "close": "Close (Esc)",
+      "closeSearch": "Close search",
+      "excludePlaceholder": "e.g. node_modules, *.lock",
+      "filesToExclude": "files to exclude",
+      "filesToInclude": "files to include",
+      "includePlaceholder": "e.g. *.ts, *.tsx",
+      "matchCase": "Match Case",
+      "regexPlaceholder": "Regex...",
+      "searchFilesPlaceholder": "Search files",
+      "toggleRegex": "Toggle regex",
+      "useRegularExpression": "Use Regular Expression"
+    },
+    "toolbar": {
+      "closeSearch": "Close search",
+      "hideDotfiles": "Hide dotfiles",
+      "hideGitignored": "Hide gitignored",
+      "search": "Search (⌘F)",
+      "showDotfiles": "Show dotfiles",
+      "showGitignored": "Show gitignored"
+    },
+    "tree": {
+      "empty": "(empty)",
+      "gitStatus": "git status",
+      "loading": "Loading...",
+      "renameInput": "Rename entry"
+    }
+  },
+  "dialogs": {
+    "common": {
+      "cancel": "Cancel",
+      "close": "Close",
+      "copy": "Copy",
+      "dontShowAgain": "Don't show this again",
+      "gotIt": "Got it"
+    },
+    "removeSession": {
+      "title": "Remove session",
+      "confirmPrefix": "Remove session",
+      "isolatedWorktree": "This is an isolated worktree:",
+      "deleteWorktreeQuestion": "Also delete the worktree from disk?",
+      "filesIn": "Files in",
+      "willNotBeTouched": "will not be touched.",
+      "dontAskAgain": "Don't ask again (toggle in Settings → Sessions)",
+      "keepWorktree": "Keep worktree",
+      "deleteWorktree": "Delete worktree",
+      "remove": "Remove"
+    },
+    "removeProject": {
+      "title": "Close project",
+      "confirmPrefix": "Close project",
+      "sessionSingular": "session",
+      "sessionPlural": "sessions",
+      "willBeRemoved": "will be removed",
+      "isolatedWorktreeSingular": "isolated worktree",
+      "isolatedWorktreePlural": "isolated worktrees",
+      "closeKeepWorktrees": "Close · keep worktrees",
+      "closeDeleteWorktrees": "Close · delete worktrees",
+      "closeProject": "Close project"
+    },
+    "newProject": {
+      "title": "New project",
+      "subtitle": "Create a git repository and add it to Acorn",
+      "projectNameLabel": "Project name",
+      "projectNameHint": "Use a single folder name.",
+      "ignoreSafeName": "Ignore safe-name check",
+      "locationLabel": "Location",
+      "locationPlaceholder": "Choose a parent folder",
+      "locationAriaLabel": "Project location",
+      "choose": "Choose",
+      "creates": "Creates",
+      "creating": "Creating...",
+      "createProject": "Create project",
+      "selectParentFolder": "Select parent folder",
+      "chooseLocationError": "Choose a location for the new project.",
+      "validation": {
+        "required": "Project name is required.",
+        "single_folder_name": "Project name must be a single folder name.",
+        "null_character": "Project name cannot contain a null character.",
+        "component_too_long": "Project name is longer than 255 bytes, which common filesystems reject."
+      }
+    },
+    "agentResume": {
+      "title": "Resume previous conversation",
+      "bodyClaude": "There's a Claude conversation that was in progress in this session. You can pick it up where you left off, or just close this dialog to start fresh.",
+      "bodyCodex": "There's a Codex conversation that was in progress in this session. You can pick it up where you left off, or just close this dialog to start fresh.",
+      "sessionIdCopied": "Session ID copied",
+      "copyFailed": "Failed to copy to clipboard",
+      "copyId": "Copy ID",
+      "resume": "Resume",
+      "lastActivityUnknown": "Last activity unknown",
+      "justNow": "Just now",
+      "minutesAgo": "min ago",
+      "hoursAgo": "hr ago",
+      "dayAgo": "day ago",
+      "daysAgo": "days ago"
+    },
+    "controlSessionGuide": {
+      "title": "Control session",
+      "subtitle": "A terminal that drives other sessions in this project",
+      "bodyIntro": "Control sessions are an upcoming way to coordinate work across terminals from a single place - handy for agents and scripts that need to dispatch commands to siblings in the same project.",
+      "pointKeystrokes": "Send keystrokes to any session in this project.",
+      "pointListSessions": "List the other sessions and their status.",
+      "pointReadOutput": "Read recent output from a target session.",
+      "createdPrefix": "You just created a control session. The",
+      "createdSuffix": "CLI that drives it ships in the next update; this terminal will start behaving like a regular shell until then."
+    },
+    "commandRun": {
+      "title": "Run this command?",
+      "ariaLabel": "Run command",
+      "description": "A new terminal session will open and run:",
+      "cwdLabel": "cwd:",
+      "noProjectHint": "No project is registered - add a project before running this command, or use \"Copy\" to paste it into an existing terminal.",
+      "noProjectError": "No project available to host the new session.",
+      "createFailed": "Failed to create session.",
+      "copiedPrefix": "Copied:",
+      "copyFailedPrefix": "Copy failed:",
+      "runningPrefix": "Running:",
+      "running": "Running...",
+      "run": "Run"
+    },
+    "closePullRequest": {
+      "titlePrefix": "Close",
+      "confirmPrefix": "Close pull request",
+      "confirmSuffix": "without merging?",
+      "closing": "Closing...",
+      "closePr": "Close PR"
+    },
+    "mergePullRequest": {
+      "titlePrefix": "Merge",
+      "mergeMethod": "Merge method",
+      "methodSquash": "Squash",
+      "methodSquashHint": "Combine into one commit on the base branch.",
+      "methodMerge": "Merge",
+      "methodMergeHint": "Create a merge commit preserving history.",
+      "methodRebase": "Rebase",
+      "methodRebaseHint": "Replay commits onto the base branch.",
+      "commitMessage": "Commit message",
+      "generating": "Generating...",
+      "generateVia": "Generate via",
+      "generateWithAi": "Generate with AI",
+      "subjectPlaceholder": "Subject",
+      "bodyPlaceholder": "Body (optional)",
+      "rebaseMessageLocked": "Rebase replays the original commits onto the base branch - the commit messages are not customizable here.",
+      "merging": "Merging...",
+      "merge": "Merge"
+    },
+    "stagedRevMismatch": {
+      "title": "Shell environment updated",
+      "background": "background",
+      "sessionSingular": "session",
+      "sessionPlural": "sessions",
+      "needRestart": "need a restart",
+      "bodyIntro": "Acorn refreshed its shell-init files in this update. Background sessions started by the previous version are still running against the old environment, which can cause garbled input and prompt redraws.",
+      "bodyRestart": "Restart now to apply the new environment. Open agent conversations (Claude / Codex) will pick up where they left off on next focus.",
+      "later": "Later",
+      "restarting": "Restarting...",
+      "restartSessions": "Restart sessions"
+    },
+    "memoryBreakdown": {
+      "title": "Memory breakdown",
+      "totalRssSum": "total (RSS, sum)",
+      "processes": "processes",
+      "pid": "PID",
+      "processTree": "Process tree",
+      "rss": "RSS",
+      "subtree": "Subtree",
+      "subtreeTooltip": "Sum of this process and all descendants",
+      "share": "Share",
+      "footer": "Tree ordered by parent->child (DFS). Siblings sorted by subtree RSS desc. Sum-of-RSS overcounts shared memory; WebView helpers and PTY children (claude, node) included."
+    },
+    "whatsNew": {
+      "titlePrefix": "What's new in Acorn",
+      "latestPublished": "latest published - no public release for",
+      "yourVersion": "your version",
+      "currentlyRunning": "currently running",
+      "onThisVersion": "you're on this version",
+      "noReleaseNotes": "No release notes were published with this version.",
+      "viewOnGithub": "View on GitHub",
+      "installing": "Installing...",
+      "installRelaunch": "Install & relaunch"
+    },
+    "pullRequestDetail": {
+      "notGithub": "Origin remote is not a GitHub repository.",
+      "noAccessPrefix": "No logged-in",
+      "noAccessSuffix": "account can access",
+      "files": "files",
+      "openOnGithub": "Open on GitHub",
+      "checkboxSaveFailed": "Couldn't save checkbox:",
+      "tabConversation": "Conversation",
+      "tabCommits": "Commits",
+      "tabChecks": "Checks",
+      "tabFiles": "Files",
+      "merge": "Merge",
+      "cannotMergeConflicting": "Cannot merge - conflicting branch",
+      "mergeReadinessPending": "Merge readiness still being determined...",
+      "resizePrBody": "Resize PR body",
+      "resizeHint": "Drag to resize · double-click to reset",
+      "noComments": "No comments or reviews yet.",
+      "oldestFirst": "Oldest first",
+      "newestFirst": "Newest first",
+      "toggleSortOrder": "Toggle sort order",
+      "commented": "commented",
+      "empty": "(empty)",
+      "noReviewComment": "(no review comment)",
+      "reviewApproved": "approved",
+      "reviewChangesRequested": "changes requested",
+      "reviewDismissed": "dismissed",
+      "noCommits": "No commits in this pull request.",
+      "viewOnGithub": "View on GitHub",
+      "copySha": "Copy SHA",
+      "noMessage": "(no message)",
+      "unknown": "unknown",
+      "loadingDiff": "Loading diff...",
+      "noFileChanges": "No file changes in this commit.",
+      "openCommitOnGithub": "Open commit on GitHub",
+      "now": "now",
+      "minuteAbbrev": "m",
+      "hourAbbrev": "h",
+      "dayAbbrev": "d",
+      "noChecks": "No checks reported.",
+      "openRun": "Open run",
+      "checkSuccess": "success",
+      "checkFailure": "failure",
+      "checkTimedOut": "timed out",
+      "checkActionRequired": "action required",
+      "checkCancelled": "cancelled",
+      "checkNeutral": "neutral",
+      "checkSkipped": "skipped",
+      "checkCompleted": "completed"
+    }
+  },
   "commandPalette": {
     "dialogLabel": "Command palette",
     "placeholder": "Type a command or search...",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,16 @@
+{
+  "settings.title": "Settings",
+  "settings.reset": "Reset to defaults",
+  "settings.tabs.terminal": "Terminal",
+  "settings.tabs.agents": "Agents",
+  "settings.tabs.sessions": "Sessions",
+  "settings.tabs.github": "GitHub",
+  "settings.tabs.appearance": "Appearance",
+  "settings.tabs.editor": "Editor",
+  "settings.tabs.notifications": "Notifications",
+  "settings.tabs.storage": "Storage",
+  "settings.tabs.experiments": "Experiments",
+  "settings.tabs.about": "About",
+  "settings.language.label": "Language",
+  "settings.language.hint": "Language used for the Acorn interface. New translations are added gradually."
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -348,6 +348,58 @@
       "shellEnvironmentReloadFailed": "Failed to reload shell environment."
     }
   },
+  "statusBar": {
+    "sessionCount": "sessions: {count}",
+    "status": "status: {status}",
+    "multiInputOn": "multi-input: on",
+    "working": "working...",
+    "error": "error: {error}",
+    "githubAccountTooltip": "PRs listed via gh account {account}",
+    "branch": "branch: {branch}",
+    "memoryTooltip": "Click to view per-process breakdown",
+    "memory": "memory: {memory}",
+    "sessionStatus": {
+      "idle": "idle",
+      "running": "running",
+      "needsInput": "needs input",
+      "failed": "failed",
+      "completed": "completed"
+    },
+    "services": {
+      "ariaLabel": "Service status",
+      "tooltip": {
+        "ipcLoading": "ipc: loading",
+        "ipcOn": "ipc: on",
+        "ipcOff": "ipc: off",
+        "daemonLoading": "daemon: loading",
+        "daemonDisabled": "daemon: disabled",
+        "daemonOn": "daemon: on",
+        "daemonOnWithSessions": "daemon: on ({count})",
+        "daemonDown": "daemon: down",
+        "details": "{ipc} · {daemon} - click for details"
+      },
+      "status": {
+        "loading": "loading",
+        "running": "running",
+        "down": "down",
+        "disabled": "disabled",
+        "runningSessions": "running · {count} sessions"
+      },
+      "ipc": {
+        "label": "IPC server",
+        "description": "control-session <-> app socket"
+      },
+      "daemon": {
+        "label": "acornd daemon",
+        "description": "persistent PTY sessions"
+      },
+      "actions": {
+        "restart": "Restart",
+        "restarting": "Restarting...",
+        "settings": "Settings"
+      }
+    }
+  },
   "sidebar": {
     "status": {
       "idle": "Idle",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,16 +1,30 @@
 {
-  "settings.title": "Settings",
-  "settings.reset": "Reset to defaults",
-  "settings.tabs.terminal": "Terminal",
-  "settings.tabs.agents": "Agents",
-  "settings.tabs.sessions": "Sessions",
-  "settings.tabs.github": "GitHub",
-  "settings.tabs.appearance": "Appearance",
-  "settings.tabs.editor": "Editor",
-  "settings.tabs.notifications": "Notifications",
-  "settings.tabs.storage": "Storage",
-  "settings.tabs.experiments": "Experiments",
-  "settings.tabs.about": "About",
-  "settings.language.label": "Language",
-  "settings.language.hint": "Language used for the Acorn interface. New translations are added gradually."
+  "settings": {
+    "title": "Settings",
+    "reset": "Reset to defaults",
+    "tabs": {
+      "terminal": "Terminal",
+      "agents": "Agents",
+      "sessions": "Sessions",
+      "github": "GitHub",
+      "appearance": "Appearance",
+      "editor": "Editor",
+      "notifications": "Notifications",
+      "storage": "Storage",
+      "experiments": "Experiments",
+      "about": "About"
+    },
+    "language": {
+      "label": "Language",
+      "hint": "Language used for the Acorn interface. New translations are added gradually."
+    }
+  },
+  "app": {},
+  "sidebar": {},
+  "pane": {},
+  "rightPanel": {},
+  "fileExplorer": {},
+  "dialogs": {},
+  "commandPalette": {},
+  "backgroundSessions": {}
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -17,6 +17,327 @@
     "language": {
       "label": "Language",
       "hint": "Language used for the Acorn interface. New translations are added gradually."
+    },
+    "terminal": {
+      "fontFamily": {
+        "label": "Font family",
+        "hint": "Comma-separated stack. First family that resolves wins."
+      },
+      "fontSize": {
+        "label": "Font size",
+        "hint": "In CSS pixels. Range 8-32."
+      },
+      "fontWeight": {
+        "label": "Font weight",
+        "hint": "Weight for normal text. Effective values depend on the chosen font's available weights."
+      },
+      "boldFontWeight": {
+        "label": "Bold font weight",
+        "hint": "Weight used when the terminal renders bold cells."
+      },
+      "lineHeight": {
+        "label": "Line height",
+        "hint": "Cell-height multiplier. 1.00 packs rows flush; raise for more vertical breathing room. Range 1.00-2.00."
+      },
+      "openLinksOn": {
+        "label": "Open links on",
+        "hint": "How to follow URLs that xterm detects in terminal output.",
+        "click": {
+          "label": "Click (default)",
+          "description": "A single mouse click opens the URL in your default browser."
+        },
+        "modifierClick": {
+          "description": "Hold {modifier} while clicking to open. Stops stray clicks on output containing URLs from yanking focus to the browser."
+        }
+      }
+    },
+    "sessions": {
+      "confirmRemove": {
+        "label": "Confirm before removing a session",
+        "hint": "Isolated worktrees always prompt because the delete-worktree choice still matters.",
+        "checkbox": "Show confirmation dialog"
+      },
+      "closeOnExit": {
+        "label": "Close tab when the process exits",
+        "hint": "When the session's shell or agent exits (e.g. you type `exit`), close the tab automatically instead of showing the press-Enter restart prompt. The worktree is preserved either way.",
+        "checkbox": "Auto-close on exit"
+      },
+      "background": {
+        "title": "Background sessions",
+        "description": "The acornd daemon owns long-running PTYs so terminal sessions survive Acorn restarts."
+      },
+      "controlCli": {
+        "label": "Control sessions (acorn-ipc CLI)",
+        "errorHint": "Could not query install status.",
+        "loadingHint": "Loading install status...",
+        "hint": "Control sessions can dispatch commands to siblings via the acorn-ipc CLI. The CLI ships next to the app; symlink it into your $PATH to use it from any terminal.",
+        "bundledBinary": "Bundled binary",
+        "found": "found",
+        "missing": "missing",
+        "installedShim": "Installed shim",
+        "installed": "installed",
+        "notInstalled": "not installed",
+        "recheck": "Re-check"
+      }
+    },
+    "github": {
+      "refreshInterval": {
+        "label": "Refresh interval",
+        "hint": "How often the PRs and Actions tabs auto-refetch from gh. Lower values feel snappier but spend more API budget."
+      },
+      "manualRefresh": "Manual refresh (the icon in each tab) always works regardless of this interval.",
+      "listDensity": {
+        "label": "List density",
+        "hint": "Author avatars make rows easier to scan at a glance, but each row gets thicker."
+      },
+      "showAuthorAvatars": {
+        "label": "Show author avatars",
+        "description": "Render the GitHub avatar next to each PR row."
+      }
+    },
+    "appearance": {
+      "uiScale": {
+        "label": "UI scale",
+        "hint": "Scales the app chrome in 5% steps. Terminal text keeps its separate size setting."
+      },
+      "theme": {
+        "label": "Theme",
+        "hint": "Built-in palettes and valid CSS files from the themes folder.",
+        "custom": "(custom)",
+        "rescanTitle": "Rescan themes folder",
+        "refresh": "Refresh",
+        "revealFolder": "Reveal folder"
+      },
+      "background": {
+        "label": "Background image",
+        "hint": "One image can be applied to the app area, terminal area, or both.",
+        "pickImage": "Pick image",
+        "replace": "Replace",
+        "noImage": "No image selected",
+        "remove": "Remove",
+        "applyToApp": "Apply to app background",
+        "applyToTerminal": "Apply to terminal background",
+        "fit": {
+          "label": "Fit",
+          "cover": "Cover",
+          "contain": "Contain",
+          "tile": "Tile"
+        },
+        "opacity": {
+          "label": "Opacity",
+          "hint": "0 is transparent, 100 is opaque."
+        },
+        "blur": "Blur"
+      },
+      "sessionDisplay": {
+        "title": {
+          "label": "Session title",
+          "hint": "Which field becomes the bold first line of each sidebar session row.",
+          "options": {
+            "name": {
+              "label": "Session name",
+              "description": "The editable name you give each session (default)."
+            },
+            "workingDirectory": {
+              "label": "Working directory",
+              "description": "Worktree directory basename."
+            },
+            "branch": {
+              "label": "Branch",
+              "description": "Active git branch."
+            }
+          }
+        },
+        "metadata": {
+          "label": "Additional metadata",
+          "hint": "Secondary line under the title. Toggle off everything for a single-line row.",
+          "branch": {
+            "label": "Branch",
+            "description": "Active git branch."
+          },
+          "workingDirectory": {
+            "label": "Working directory",
+            "description": "Worktree directory basename."
+          },
+          "status": {
+            "label": "Status",
+            "description": "Idle / Running / Needs input / Failed / Completed."
+          }
+        },
+        "icons": {
+          "label": "Inline icons",
+          "hint": "Glyphs that decorate each session row. Hide to make the list denser.",
+          "statusDot": {
+            "label": "Status dot",
+            "description": "Colored bullet at the row start. Redundant when Status is enabled in metadata."
+          },
+          "sessionKind": {
+            "label": "Session kind icons",
+            "description": "Branch glyph for isolated worktrees and bot glyph for control sessions."
+          }
+        },
+        "hover": {
+          "label": "Show details on hover",
+          "hint": "Pop a tooltip with every field when hovering a session row, regardless of which fields the row itself shows.",
+          "checkbox": "Enable hover tooltip"
+        }
+      },
+      "statusBar": {
+        "label": "Status bar",
+        "hint": "Choose which optional badges show in the bottom status bar.",
+        "sessionCount": {
+          "label": "Session count",
+          "description": "Total number of sessions across the active project (`sessions: N`)."
+        },
+        "activeSessionStatus": {
+          "label": "Active session status",
+          "description": "Lifecycle state of the active session (Idle / Running / Needs input / Failed / Completed)."
+        },
+        "githubAccount": {
+          "label": "GitHub account",
+          "description": "The `gh` account used to list pull requests for the active repo."
+        },
+        "workingDirectory": {
+          "label": "Working directory",
+          "description": "The active session's worktree path (tildified against $HOME)."
+        },
+        "memoryUsage": {
+          "label": "Memory usage",
+          "description": "Live memory readout for acorn and its child shells. Disabling also stops the 2-second polling loop, so it costs nothing when hidden."
+        }
+      }
+    },
+    "editor": {
+      "command": {
+        "label": "Editor command",
+        "hint": "Leave blank for the OS default. Examples: \"code\", \"cursor --wait\", \"subl\", \"idea\". The file path is appended as the last argument.",
+        "placeholder": "(use OS default)",
+        "description": "Used by the \"Open in editor\" right-click action on diff and staged file lists."
+      }
+    },
+    "notifications": {
+      "system": {
+        "label": "System notifications",
+        "hint": "Send a macOS notification when a session changes status.",
+        "enable": "Enable notifications"
+      },
+      "triggers": {
+        "label": "Trigger on",
+        "needsInput": {
+          "label": "Needs input",
+          "description": "Claude is waiting on the user."
+        },
+        "failed": {
+          "label": "Failed",
+          "description": "Session terminated with an error."
+        },
+        "completed": {
+          "label": "Completed",
+          "description": "Session reached the completed state."
+        }
+      },
+      "test": {
+        "label": "Test",
+        "hint": "Verifies the OS permission and that a notification can actually appear, independent of the Enable / Trigger settings above.",
+        "send": "Send test notification",
+        "sending": "Sending...",
+        "result": {
+          "sent": "Sent. Check your notification center if it didn't appear.",
+          "denied": "Permission denied. Allow Acorn under System Settings -> Notifications.",
+          "failed": "Failed to send. See the console for details."
+        }
+      },
+      "permissionHint": "macOS may ask once for permission the first time a notification fires."
+    },
+    "agents": {
+      "intro": {
+        "before": "The selected agent powers acorn's AI features - currently the merge dialog's ",
+        "action": "Generate with AI",
+        "after": " button."
+      },
+      "agent": {
+        "label": "Agent",
+        "hint": "Choose which AI CLI acorn uses."
+      },
+      "customOption": {
+        "label": "Custom command",
+        "description": "Use any CLI not in the list. Whitespace-separated; no shell expansion."
+      },
+      "ollamaModel": {
+        "label": "Ollama model",
+        "hint": "Passed to `ollama run <model>`. Defaults to `llama3` when blank."
+      },
+      "llmModel": {
+        "label": "llm model",
+        "hint": "Passed via `llm -m <model>` (and `llm chat -m <model>` for sessions). Blank uses the llm-configured default."
+      },
+      "customCommand": {
+        "label": "Custom command",
+        "hint": "Used for both interactive sessions and one-shot AI generation. Falls back to Claude Code when blank."
+      },
+      "requirement": "The selected agent's CLI must already be installed and authenticated on this machine. Surfaces a clear error when the binary is missing."
+    },
+    "storage": {
+      "title": "Reclaimable cache",
+      "description": "Disk artifacts that acorn cannot clean up through its normal session lifecycle (e.g. files orphaned by a crash or by edits made while acorn was offline). Sessions, projects, settings, and live terminal scrollback are never touched.",
+      "cacheCategories": {
+        "scrollbackOrphans": {
+          "label": "Orphan terminal scrollback",
+          "description": "ANSI scrollback files left behind by sessions that no longer exist (e.g. removed while acorn was offline, or before the prune-on-boot logic existed). Live sessions' scrollback is not touched - only the unreclaimable leftovers are surfaced."
+        }
+      },
+      "status": {
+        "clearedSingular": "Cleared {count} cached file.",
+        "clearedPlural": "Cleared {count} cached files.",
+        "nothingToClear": "Nothing to clear.",
+        "clearFailed": "Clear failed - see console."
+      },
+      "confirm": {
+        "message": "This will permanently delete the cached data listed above ({size}). Continue?",
+        "cancel": "Cancel"
+      },
+      "clear": {
+        "button": "Clear cache",
+        "clearing": "Clearing..."
+      },
+      "total": "Total: {size}"
+    },
+    "experiments": {
+      "warning": "Unfinished features. Behavior may change between releases; the toggles themselves are stable.",
+      "stickyPrompt": {
+        "label": "Pin last user prompt above terminal",
+        "description": "Detects the most recent claude prompt line in the rendered terminal buffer and pins it at the top of the pane so it stays in view while reading the reply. Cmd+K clears it along with the rest of the scrollback."
+      },
+      "cjkCellWidthHeuristic": {
+        "label": "CJK terminal cell-width correction",
+        "description": "Heuristic for CJK monospaced fonts (D2Coding, Sarasa Mono, etc.): when `W` and `ga` measure the same width, halves the cell width so CJK glyphs sit on the cell grid. Skipped when widths differ, so ASCII fonts with system CJK fallback are not corrected. Known limitation: tab switches can briefly show a 1-frame glyph-size flicker as xterm's resize path resets `cell.width` to the natural W advance before the addon reapplies the halved value. Off by default."
+      },
+      "resumeModal": {
+        "label": "Show \"Resume previous conversation\" modal at cold boot",
+        "description": "On Acorn launch, probes every persisted session for an unfinished claude or codex transcript and pops a one-shot modal when you focus the session so you can pick up where you left off. Disable to suppress the modal entirely."
+      }
+    },
+    "about": {
+      "title": "About Acorn",
+      "description": "Acorn checks for updates automatically on startup and once every 24 hours. You can also check manually below.",
+      "currentVersion": "Current version",
+      "lastChecked": "Last checked",
+      "loading": "loading...",
+      "updateAvailable": "Update available",
+      "updateReady": "Acorn {version} is ready to install.",
+      "whatsNew": "What's new",
+      "installing": "Installing...",
+      "installRelaunch": "Install & relaunch",
+      "whatsNewInVersion": "What's new in {version}",
+      "checking": "Checking...",
+      "checkForUpdates": "Check for updates",
+      "relative": {
+        "never": "never",
+        "justNow": "just now",
+        "minutesAgo": "{count} min ago",
+        "hoursAgo": "{count} h ago",
+        "daysAgo": "{count} d ago"
+      }
     }
   },
   "app": {},
@@ -26,5 +347,61 @@
   "fileExplorer": {},
   "dialogs": {},
   "commandPalette": {},
-  "backgroundSessions": {}
+  "backgroundSessions": {
+    "daemon": {
+      "label": "Daemon",
+      "hint": "The acornd daemon owns long-running terminal sessions. With the daemon on, Acorn can quit and reopen without losing your PTYs. Off falls back to the legacy in-process path - sessions die with the app.",
+      "enableLabel": "Enable background sessions (acornd)",
+      "enabledDescription": "Sessions persist across Acorn restarts until you explicitly quit them.",
+      "disabledDescription": "Sessions are bound to this Acorn process - closing the app kills them."
+    },
+    "status": {
+      "label": "Status",
+      "hint": "Live state of the running daemon. Updates every 3 seconds while this panel is open.",
+      "disabled": "Disabled",
+      "running": "Running",
+      "down": "Down",
+      "up": "up",
+      "sessions": "sessions",
+      "log": "Log"
+    },
+    "controls": {
+      "label": "Controls",
+      "hint": "Restart reconnects the bridge - useful after killing the daemon from a terminal. Quit kills every running PTY and exits the daemon.",
+      "restart": "Restart daemon",
+      "confirmShutdownPrompt": "Kill every PTY?",
+      "confirm": "Confirm",
+      "cancel": "Cancel",
+      "quit": "Quit daemon"
+    },
+    "sessions": {
+      "label": "Sessions",
+      "hint": "Every PTY the daemon currently tracks. Dead rows can be forgotten from the daemon side; their app metadata stays so you can resume from disk if the agent supports it.",
+      "disabled": "Daemon disabled - sessions are managed by the legacy in-process path.",
+      "notRunning": "Daemon is not running.",
+      "loading": "Loading...",
+      "empty": "No sessions tracked.",
+      "controlSession": "Control session"
+    },
+    "actions": {
+      "killPty": "Kill PTY",
+      "restoreTooltip": "Adopt this session back into Acorn's sidebar",
+      "restore": "Restore session",
+      "forgetDisabledTooltip": "Kill first, then forget",
+      "forgetTooltip": "Remove this row from the daemon registry",
+      "forget": "Forget session"
+    },
+    "metadata": {
+      "tab": "Tab",
+      "branch": "Branch",
+      "status": "Status",
+      "worktree": "Worktree",
+      "last": "Last",
+      "repo": "Repo",
+      "orphaned": "No app-side row - orphaned in daemon."
+    },
+    "relativeTime": {
+      "ago": "ago"
+    }
+  }
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1,16 +1,30 @@
 {
-  "settings.title": "설정",
-  "settings.reset": "기본값으로 재설정",
-  "settings.tabs.terminal": "터미널",
-  "settings.tabs.agents": "에이전트",
-  "settings.tabs.sessions": "세션",
-  "settings.tabs.github": "GitHub",
-  "settings.tabs.appearance": "모양",
-  "settings.tabs.editor": "편집기",
-  "settings.tabs.notifications": "알림",
-  "settings.tabs.storage": "저장 공간",
-  "settings.tabs.experiments": "실험 기능",
-  "settings.tabs.about": "정보",
-  "settings.language.label": "언어",
-  "settings.language.hint": "Acorn 인터페이스에 사용할 언어입니다. 새 번역은 점진적으로 추가됩니다."
+  "settings": {
+    "title": "설정",
+    "reset": "기본값으로 재설정",
+    "tabs": {
+      "terminal": "터미널",
+      "agents": "에이전트",
+      "sessions": "세션",
+      "github": "GitHub",
+      "appearance": "모양",
+      "editor": "편집기",
+      "notifications": "알림",
+      "storage": "저장 공간",
+      "experiments": "실험 기능",
+      "about": "정보"
+    },
+    "language": {
+      "label": "언어",
+      "hint": "Acorn 인터페이스에 사용할 언어입니다. 새 번역은 점진적으로 추가됩니다."
+    }
+  },
+  "app": {},
+  "sidebar": {},
+  "pane": {},
+  "rightPanel": {},
+  "fileExplorer": {},
+  "dialogs": {},
+  "commandPalette": {},
+  "backgroundSessions": {}
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -348,6 +348,58 @@
       "shellEnvironmentReloadFailed": "셸 환경을 다시 불러오지 못했습니다."
     }
   },
+  "statusBar": {
+    "sessionCount": "세션: {count}",
+    "status": "상태: {status}",
+    "multiInputOn": "다중 입력: 켜짐",
+    "working": "작업 중...",
+    "error": "오류: {error}",
+    "githubAccountTooltip": "{account} gh 계정으로 PR을 표시합니다",
+    "branch": "브랜치: {branch}",
+    "memoryTooltip": "프로세스별 세부 정보를 보려면 클릭",
+    "memory": "메모리: {memory}",
+    "sessionStatus": {
+      "idle": "유휴",
+      "running": "실행 중",
+      "needsInput": "입력 필요",
+      "failed": "실패",
+      "completed": "완료"
+    },
+    "services": {
+      "ariaLabel": "서비스 상태",
+      "tooltip": {
+        "ipcLoading": "ipc: 불러오는 중",
+        "ipcOn": "ipc: 켜짐",
+        "ipcOff": "ipc: 꺼짐",
+        "daemonLoading": "데몬: 불러오는 중",
+        "daemonDisabled": "데몬: 비활성화됨",
+        "daemonOn": "데몬: 켜짐",
+        "daemonOnWithSessions": "데몬: 켜짐 ({count})",
+        "daemonDown": "데몬: 중단됨",
+        "details": "{ipc} · {daemon} - 자세히 보려면 클릭"
+      },
+      "status": {
+        "loading": "불러오는 중",
+        "running": "실행 중",
+        "down": "중단됨",
+        "disabled": "비활성화됨",
+        "runningSessions": "실행 중 · 세션 {count}개"
+      },
+      "ipc": {
+        "label": "IPC 서버",
+        "description": "컨트롤 세션 <-> 앱 소켓"
+      },
+      "daemon": {
+        "label": "acornd 데몬",
+        "description": "지속 PTY 세션"
+      },
+      "actions": {
+        "restart": "재시작",
+        "restarting": "재시작 중...",
+        "settings": "설정"
+      }
+    }
+  },
   "sidebar": {
     "status": {
       "idle": "유휴",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -340,7 +340,14 @@
       }
     }
   },
-  "app": {},
+  "app": {
+    "toast": {
+      "multiInputOn": "다중 입력 켜짐.",
+      "multiInputOff": "다중 입력 꺼짐.",
+      "shellEnvironmentReloaded": "셸 환경을 다시 불러왔습니다. 적용하려면 새 세션을 여세요.",
+      "shellEnvironmentReloadFailed": "셸 환경을 다시 불러오지 못했습니다."
+    }
+  },
   "sidebar": {
     "status": {
       "idle": "유휴",
@@ -447,9 +454,392 @@
       "closePane": "패널 닫기"
     }
   },
-  "rightPanel": {},
-  "fileExplorer": {},
-  "dialogs": {},
+  "rightPanel": {
+    "tabs": {
+      "files": "파일",
+      "todos": "할 일",
+      "commits": "커밋",
+      "staged": "스테이징",
+      "prs": "PR",
+      "actions": "작업"
+    },
+    "empty": {
+      "noTodos": "이 세션에 할 일이 없습니다",
+      "noProject": "선택한 프로젝트가 없습니다"
+    },
+    "todos": {
+      "doneCount": "{completed}/{total} 완료",
+      "inProgressCount": "{count}개 진행 중"
+    },
+    "loading": {
+      "more": "더 불러오는 중…",
+      "moreLower": "더 불러오는 중...",
+      "diffLower": "diff 불러오는 중..."
+    },
+    "tooltips": {
+      "copySha": "SHA 복사",
+      "openOnGitHub": "GitHub에서 열기"
+    },
+    "commits": {
+      "pushed": "푸시됨",
+      "notPushed": "푸시되지 않음",
+      "selectToSeeDiff": "diff를 보려면 커밋을 선택하세요"
+    },
+    "staged": {
+      "empty": "스테이징되었거나 수정된 파일이 없습니다",
+      "workingTreeChanges": "작업 트리 변경사항",
+      "noDiff": "diff 없음"
+    },
+    "errors": {
+      "deletedFile": "파일이 삭제되어 열 수 없습니다.",
+      "notGitHubRemote": "이 저장소의 origin은 GitHub 원격이 아닙니다.",
+      "originNotGitHub": "origin 원격은 GitHub 저장소가 아닙니다.",
+      "noAccessToSlug": "{slug}에 접근할 수 없습니다."
+    },
+    "menu": {
+      "expandDiff": "diff 확장",
+      "viewOnGitHub": "GitHub에서 보기",
+      "copyShaWithValue": "SHA 복사({sha})",
+      "openInEditor": "편집기에서 열기",
+      "copyRelativePath": "상대 경로 복사",
+      "copyAbsolutePath": "절대 경로 복사",
+      "openDetail": "상세 열기",
+      "openInBrowser": "브라우저에서 열기",
+      "copyPrNumber": "PR 번호 복사",
+      "copyUrl": "URL 복사",
+      "copyBranchWithValue": "브랜치 복사({branch})",
+      "merge": "병합…",
+      "close": "닫기…"
+    },
+    "prStates": {
+      "open": "열림",
+      "closed": "닫힘",
+      "merged": "병합됨",
+      "all": "전체",
+      "draft": "초안"
+    },
+    "prs": {
+      "emptyByState": "{state} PR이 없습니다.",
+      "reachedMax": "처음 {count}개를 표시합니다. 더 오래된 PR은 검색으로 찾으세요."
+    },
+    "search": {
+      "aria": "PR 검색",
+      "placeholder": "제목, 작성자, 라벨, 브랜치 검색…",
+      "searching": "검색 중…",
+      "typeToSearch": "PR을 검색하려면 입력하세요.",
+      "noGhAccessThisRepo": "로그인된 gh 계정으로 이 저장소에 접근할 수 없습니다.",
+      "noMatches": "일치하는 PR이 없습니다.",
+      "reachedMax": "처음 {count}개를 표시합니다. 더 오래된 PR은 검색어를 좁혀 찾으세요."
+    },
+    "actions": {
+      "filterByWorkflow": "워크플로로 필터링",
+      "allWorkflows": "모든 워크플로",
+      "noRuns": "아직 워크플로 실행이 없습니다.",
+      "noRunsForFilter": "이 필터와 일치하는 실행이 없습니다.",
+      "workflowRun": "워크플로 실행",
+      "workflowRunFallbackTitle": "{workflow} 실행",
+      "doubleClickDetails": "상세를 보려면 더블 클릭",
+      "retryAttempt": "재시도 #{attempt}",
+      "github": "GitHub",
+      "status": "상태",
+      "totalDuration": "총 소요 시간",
+      "runningParenthetical": "(실행 중)",
+      "attempt": "시도",
+      "retriedParenthetical": "(재시도됨)",
+      "commit": "커밋",
+      "created": "생성됨",
+      "updated": "업데이트됨",
+      "jobsCount": "작업 ({count})",
+      "noJobs": "보고된 작업이 없습니다.",
+      "openJobOnGitHub": "GitHub에서 작업 열기"
+    },
+    "checks": {
+      "allPassed": "체크 {count}개 모두 통과",
+      "allFailed": "체크 {count}개 모두 실패",
+      "summary": "{passed}개 통과, {failed}개 실패, {pending}개 대기"
+    },
+    "noAccess": {
+      "noGhAccountCanAccess": "로그인된 gh 계정으로 {slug}에 접근할 수 없습니다.",
+      "tried": "시도한 계정:",
+      "noAccounts": "github.com에 인증된 계정이 없습니다.",
+      "run": "실행:",
+      "withAccess": "액세스 권한이 있는 계정으로 실행하거나 github.com에서 초대를 수락하세요."
+    },
+    "time": {
+      "secondsAgo": "{count}초 전",
+      "minutesAgo": "{count}분 전",
+      "hoursAgo": "{count}시간 전",
+      "daysAgo": "{count}일 전",
+      "monthsAgo": "{count}개월 전",
+      "yearsAgo": "{count}년 전"
+    },
+    "duration": {
+      "seconds": "{count}초",
+      "minutes": "{count}분",
+      "minutesSeconds": "{minutes}분 {seconds}초",
+      "hours": "{count}시간",
+      "hoursMinutes": "{hours}시간 {minutes}분"
+    }
+  },
+  "fileExplorer": {
+    "defaults": {
+      "sessionName": "세션"
+    },
+    "errorBanner": {
+      "dismiss": "오류 닫기"
+    },
+    "errors": {
+      "clipboardWriteFailed": "클립보드 쓰기에 실패했습니다",
+      "noActiveProject": "활성 프로젝트가 없습니다",
+      "noActiveSession": "활성 세션이 없습니다 - 먼저 터미널을 여세요"
+    },
+    "menu": {
+      "attachAllToConversation": "모두 대화에 첨부",
+      "attachToClaude": "Claude에 첨부",
+      "attachToCodex": "Codex에 첨부",
+      "copyAbsolutePath": "절대 경로 복사",
+      "copyAbsolutePaths": "절대 경로 복사",
+      "copyRelativePath": "상대 경로 복사",
+      "copyRelativePaths": "상대 경로 복사",
+      "moveToTrash": "휴지통으로 이동",
+      "openIn": "다음으로 열기:",
+      "openInNewTab": "새 탭에서 열기",
+      "openWithDefaultProgram": "기본 프로그램으로 열기",
+      "rename": "이름 변경",
+      "revealInFileManager": "파일 관리자에서 보기"
+    },
+    "search": {
+      "close": "닫기 (Esc)",
+      "closeSearch": "검색 닫기",
+      "excludePlaceholder": "예: node_modules, *.lock",
+      "filesToExclude": "제외할 파일",
+      "filesToInclude": "포함할 파일",
+      "includePlaceholder": "예: *.ts, *.tsx",
+      "matchCase": "대소문자 구분",
+      "regexPlaceholder": "정규식...",
+      "searchFilesPlaceholder": "파일 검색",
+      "toggleRegex": "정규식 전환",
+      "useRegularExpression": "정규식 사용"
+    },
+    "toolbar": {
+      "closeSearch": "검색 닫기",
+      "hideDotfiles": "점 파일 숨기기",
+      "hideGitignored": "Git 무시 파일 숨기기",
+      "search": "검색 (⌘F)",
+      "showDotfiles": "점 파일 표시",
+      "showGitignored": "Git 무시 파일 표시"
+    },
+    "tree": {
+      "empty": "(비어 있음)",
+      "gitStatus": "Git 상태",
+      "loading": "불러오는 중...",
+      "renameInput": "항목 이름 변경"
+    }
+  },
+  "dialogs": {
+    "common": {
+      "cancel": "취소",
+      "close": "닫기",
+      "copy": "복사",
+      "dontShowAgain": "다시 표시하지 않기",
+      "gotIt": "확인"
+    },
+    "removeSession": {
+      "title": "세션 제거",
+      "confirmPrefix": "세션 제거",
+      "isolatedWorktree": "격리된 worktree입니다:",
+      "deleteWorktreeQuestion": "디스크에서도 worktree를 삭제할까요?",
+      "filesIn": "다음 위치의 파일은",
+      "willNotBeTouched": "변경되지 않습니다.",
+      "dontAskAgain": "다시 묻지 않기(설정 → 세션에서 변경)",
+      "keepWorktree": "worktree 유지",
+      "deleteWorktree": "worktree 삭제",
+      "remove": "제거"
+    },
+    "removeProject": {
+      "title": "프로젝트 닫기",
+      "confirmPrefix": "프로젝트 닫기",
+      "sessionSingular": "세션",
+      "sessionPlural": "세션",
+      "willBeRemoved": "제거됩니다",
+      "isolatedWorktreeSingular": "격리된 worktree",
+      "isolatedWorktreePlural": "격리된 worktree",
+      "closeKeepWorktrees": "닫기 · worktree 유지",
+      "closeDeleteWorktrees": "닫기 · worktree 삭제",
+      "closeProject": "프로젝트 닫기"
+    },
+    "newProject": {
+      "title": "새 프로젝트",
+      "subtitle": "Git 저장소를 만들고 Acorn에 추가합니다",
+      "projectNameLabel": "프로젝트 이름",
+      "projectNameHint": "단일 폴더 이름을 사용하세요.",
+      "ignoreSafeName": "안전한 이름 검사 무시",
+      "locationLabel": "위치",
+      "locationPlaceholder": "상위 폴더 선택",
+      "locationAriaLabel": "프로젝트 위치",
+      "choose": "선택",
+      "creates": "생성 위치",
+      "creating": "생성 중...",
+      "createProject": "프로젝트 생성",
+      "selectParentFolder": "상위 폴더 선택",
+      "chooseLocationError": "새 프로젝트 위치를 선택하세요.",
+      "validation": {
+        "required": "프로젝트 이름은 필수입니다.",
+        "single_folder_name": "프로젝트 이름은 단일 폴더 이름이어야 합니다.",
+        "null_character": "프로젝트 이름에는 null 문자를 포함할 수 없습니다.",
+        "component_too_long": "프로젝트 이름이 255바이트를 넘어 일반 파일 시스템에서 거부될 수 있습니다."
+      }
+    },
+    "agentResume": {
+      "title": "이전 대화 재개",
+      "bodyClaude": "이 세션에 진행 중이던 Claude 대화가 있습니다. 이어서 진행하거나 이 대화상자를 닫고 새로 시작할 수 있습니다.",
+      "bodyCodex": "이 세션에 진행 중이던 Codex 대화가 있습니다. 이어서 진행하거나 이 대화상자를 닫고 새로 시작할 수 있습니다.",
+      "sessionIdCopied": "세션 ID를 복사했습니다",
+      "copyFailed": "클립보드에 복사하지 못했습니다",
+      "copyId": "ID 복사",
+      "resume": "재개",
+      "lastActivityUnknown": "마지막 활동 알 수 없음",
+      "justNow": "방금 전",
+      "minutesAgo": "분 전",
+      "hoursAgo": "시간 전",
+      "dayAgo": "일 전",
+      "daysAgo": "일 전"
+    },
+    "controlSessionGuide": {
+      "title": "컨트롤 세션",
+      "subtitle": "이 프로젝트의 다른 세션을 제어하는 터미널",
+      "bodyIntro": "컨트롤 세션은 한곳에서 여러 터미널 작업을 조율하는 기능입니다. 같은 프로젝트의 다른 세션에 명령을 보내야 하는 에이전트와 스크립트에 유용합니다.",
+      "pointKeystrokes": "이 프로젝트의 모든 세션에 키 입력을 보냅니다.",
+      "pointListSessions": "다른 세션과 상태를 나열합니다.",
+      "pointReadOutput": "대상 세션의 최근 출력을 읽습니다.",
+      "createdPrefix": "방금 컨트롤 세션을 만들었습니다.",
+      "createdSuffix": "CLI는 다음 업데이트에 포함됩니다. 그 전까지 이 터미널은 일반 셸처럼 동작합니다."
+    },
+    "commandRun": {
+      "title": "이 명령을 실행할까요?",
+      "ariaLabel": "명령 실행",
+      "description": "새 터미널 세션을 열고 다음을 실행합니다:",
+      "cwdLabel": "cwd:",
+      "noProjectHint": "등록된 프로젝트가 없습니다. 이 명령을 실행하기 전에 프로젝트를 추가하거나 \"복사\"를 사용해 기존 터미널에 붙여 넣으세요.",
+      "noProjectError": "새 세션을 실행할 프로젝트가 없습니다.",
+      "createFailed": "세션을 만들지 못했습니다.",
+      "copiedPrefix": "복사됨:",
+      "copyFailedPrefix": "복사 실패:",
+      "runningPrefix": "실행 중:",
+      "running": "실행 중...",
+      "run": "실행"
+    },
+    "closePullRequest": {
+      "titlePrefix": "닫기",
+      "confirmPrefix": "풀 리퀘스트",
+      "confirmSuffix": "를 병합하지 않고 닫을까요?",
+      "closing": "닫는 중...",
+      "closePr": "PR 닫기"
+    },
+    "mergePullRequest": {
+      "titlePrefix": "병합",
+      "mergeMethod": "병합 방식",
+      "methodSquash": "Squash",
+      "methodSquashHint": "기본 브랜치에 하나의 커밋으로 합칩니다.",
+      "methodMerge": "Merge",
+      "methodMergeHint": "기록을 보존하는 병합 커밋을 만듭니다.",
+      "methodRebase": "Rebase",
+      "methodRebaseHint": "커밋을 기본 브랜치 위에 다시 적용합니다.",
+      "commitMessage": "커밋 메시지",
+      "generating": "생성 중...",
+      "generateVia": "다음으로 생성:",
+      "generateWithAi": "AI로 생성",
+      "subjectPlaceholder": "제목",
+      "bodyPlaceholder": "본문(선택 사항)",
+      "rebaseMessageLocked": "Rebase는 원래 커밋을 기본 브랜치 위에 다시 적용하므로 여기서 커밋 메시지를 변경할 수 없습니다.",
+      "merging": "병합 중...",
+      "merge": "병합"
+    },
+    "stagedRevMismatch": {
+      "title": "셸 환경 업데이트됨",
+      "background": "백그라운드",
+      "sessionSingular": "세션",
+      "sessionPlural": "세션",
+      "needRestart": "재시작이 필요합니다",
+      "bodyIntro": "이번 업데이트에서 Acorn의 shell-init 파일이 갱신되었습니다. 이전 버전에서 시작된 백그라운드 세션은 아직 이전 환경에서 실행 중이라 입력이 깨지거나 프롬프트가 잘못 다시 그려질 수 있습니다.",
+      "bodyRestart": "새 환경을 적용하려면 지금 재시작하세요. 열린 에이전트 대화(Claude / Codex)는 다음 포커스 시점에 이어서 진행됩니다.",
+      "later": "나중에",
+      "restarting": "재시작 중...",
+      "restartSessions": "세션 재시작"
+    },
+    "memoryBreakdown": {
+      "title": "메모리 세부 정보",
+      "totalRssSum": "합계(RSS 합산)",
+      "processes": "프로세스",
+      "pid": "PID",
+      "processTree": "프로세스 트리",
+      "rss": "RSS",
+      "subtree": "하위 트리",
+      "subtreeTooltip": "이 프로세스와 모든 하위 프로세스의 합계",
+      "share": "비율",
+      "footer": "트리는 부모->자식(DFS) 순서입니다. 형제 항목은 하위 트리 RSS 내림차순으로 정렬됩니다. RSS 합계는 공유 메모리를 중복 계산하며 WebView 헬퍼와 PTY 자식 프로세스(claude, node)를 포함합니다."
+    },
+    "whatsNew": {
+      "titlePrefix": "Acorn의 새로운 내용",
+      "latestPublished": "최신 공개 릴리스 - 공개 릴리스 없음:",
+      "yourVersion": "현재 버전",
+      "currentlyRunning": "현재 실행 중",
+      "onThisVersion": "이 버전을 사용 중입니다",
+      "noReleaseNotes": "이 버전에는 공개된 릴리스 노트가 없습니다.",
+      "viewOnGithub": "GitHub에서 보기",
+      "installing": "설치 중...",
+      "installRelaunch": "설치 후 다시 실행"
+    },
+    "pullRequestDetail": {
+      "notGithub": "origin 원격 저장소가 GitHub 저장소가 아닙니다.",
+      "noAccessPrefix": "로그인된",
+      "noAccessSuffix": "계정으로 접근할 수 없습니다:",
+      "files": "파일",
+      "openOnGithub": "GitHub에서 열기",
+      "checkboxSaveFailed": "체크박스를 저장하지 못했습니다:",
+      "tabConversation": "대화",
+      "tabCommits": "커밋",
+      "tabChecks": "검사",
+      "tabFiles": "파일",
+      "merge": "병합",
+      "cannotMergeConflicting": "병합할 수 없음 - 브랜치 충돌",
+      "mergeReadinessPending": "병합 가능 여부 확인 중...",
+      "resizePrBody": "PR 본문 크기 조절",
+      "resizeHint": "드래그해 크기 조절 · 더블 클릭해 재설정",
+      "noComments": "아직 댓글이나 리뷰가 없습니다.",
+      "oldestFirst": "오래된 항목 먼저",
+      "newestFirst": "최신 항목 먼저",
+      "toggleSortOrder": "정렬 순서 전환",
+      "commented": "댓글 작성",
+      "empty": "(비어 있음)",
+      "noReviewComment": "(리뷰 댓글 없음)",
+      "reviewApproved": "승인됨",
+      "reviewChangesRequested": "변경 요청됨",
+      "reviewDismissed": "해제됨",
+      "noCommits": "이 풀 리퀘스트에 커밋이 없습니다.",
+      "viewOnGithub": "GitHub에서 보기",
+      "copySha": "SHA 복사",
+      "noMessage": "(메시지 없음)",
+      "unknown": "알 수 없음",
+      "loadingDiff": "diff 불러오는 중...",
+      "noFileChanges": "이 커밋에는 파일 변경이 없습니다.",
+      "openCommitOnGithub": "GitHub에서 커밋 열기",
+      "now": "지금",
+      "minuteAbbrev": "분",
+      "hourAbbrev": "시간",
+      "dayAbbrev": "일",
+      "noChecks": "보고된 검사가 없습니다.",
+      "openRun": "실행 열기",
+      "checkSuccess": "성공",
+      "checkFailure": "실패",
+      "checkTimedOut": "시간 초과",
+      "checkActionRequired": "조치 필요",
+      "checkCancelled": "취소됨",
+      "checkNeutral": "중립",
+      "checkSkipped": "건너뜀",
+      "checkCompleted": "완료"
+    }
+  },
   "commandPalette": {
     "dialogLabel": "명령 팔레트",
     "placeholder": "명령을 입력하거나 검색하세요...",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -17,6 +17,327 @@
     "language": {
       "label": "언어",
       "hint": "Acorn 인터페이스에 사용할 언어입니다. 새 번역은 점진적으로 추가됩니다."
+    },
+    "terminal": {
+      "fontFamily": {
+        "label": "글꼴 패밀리",
+        "hint": "쉼표로 구분한 글꼴 목록입니다. 먼저 해석되는 글꼴이 사용됩니다."
+      },
+      "fontSize": {
+        "label": "글꼴 크기",
+        "hint": "CSS 픽셀 단위입니다. 범위는 8-32입니다."
+      },
+      "fontWeight": {
+        "label": "글꼴 두께",
+        "hint": "일반 텍스트의 두께입니다. 실제 적용 값은 선택한 글꼴이 제공하는 두께에 따라 달라집니다."
+      },
+      "boldFontWeight": {
+        "label": "굵은 글꼴 두께",
+        "hint": "터미널이 굵은 셀을 렌더링할 때 사용할 두께입니다."
+      },
+      "lineHeight": {
+        "label": "줄 높이",
+        "hint": "셀 높이 배율입니다. 1.00은 행을 촘촘히 배치하며, 값을 높이면 세로 여백이 늘어납니다. 범위는 1.00-2.00입니다."
+      },
+      "openLinksOn": {
+        "label": "링크 열기 방식",
+        "hint": "xterm이 터미널 출력에서 감지한 URL을 여는 방식입니다.",
+        "click": {
+          "label": "클릭(기본값)",
+          "description": "마우스로 한 번 클릭하면 기본 브라우저에서 URL을 엽니다."
+        },
+        "modifierClick": {
+          "description": "{modifier} 키를 누른 채 클릭하면 열립니다. URL이 포함된 출력에서 실수로 클릭해 브라우저로 포커스가 넘어가는 일을 막습니다."
+        }
+      }
+    },
+    "sessions": {
+      "confirmRemove": {
+        "label": "세션 제거 전 확인",
+        "hint": "격리된 worktree는 delete-worktree 선택이 여전히 중요하므로 항상 확인합니다.",
+        "checkbox": "확인 대화상자 표시"
+      },
+      "closeOnExit": {
+        "label": "프로세스 종료 시 탭 닫기",
+        "hint": "세션의 셸이나 에이전트가 종료되면(예: `exit` 입력) Enter를 눌러 재시작하라는 프롬프트 대신 탭을 자동으로 닫습니다. 어느 쪽이든 worktree는 보존됩니다.",
+        "checkbox": "종료 시 자동 닫기"
+      },
+      "background": {
+        "title": "백그라운드 세션",
+        "description": "acornd 데몬이 장시간 실행되는 PTY를 소유하므로 Acorn을 재시작해도 터미널 세션이 유지됩니다."
+      },
+      "controlCli": {
+        "label": "컨트롤 세션(acorn-ipc CLI)",
+        "errorHint": "설치 상태를 조회할 수 없습니다.",
+        "loadingHint": "설치 상태를 불러오는 중...",
+        "hint": "컨트롤 세션은 acorn-ipc CLI를 통해 형제 세션에 명령을 보낼 수 있습니다. CLI는 앱 옆에 함께 제공되며, 어느 터미널에서나 쓰려면 $PATH에 심볼릭 링크하세요.",
+        "bundledBinary": "번들 바이너리",
+        "found": "발견됨",
+        "missing": "없음",
+        "installedShim": "설치된 shim",
+        "installed": "설치됨",
+        "notInstalled": "설치되지 않음",
+        "recheck": "다시 확인"
+      }
+    },
+    "github": {
+      "refreshInterval": {
+        "label": "새로고침 간격",
+        "hint": "PR 및 Actions 탭이 gh에서 자동으로 다시 가져오는 빈도입니다. 값이 낮을수록 더 빠르게 느껴지지만 API 예산을 더 사용합니다."
+      },
+      "manualRefresh": "수동 새로고침(각 탭의 아이콘)은 이 간격과 관계없이 항상 작동합니다.",
+      "listDensity": {
+        "label": "목록 밀도",
+        "hint": "작성자 아바타는 행을 한눈에 훑기 쉽게 하지만 각 행이 더 두꺼워집니다."
+      },
+      "showAuthorAvatars": {
+        "label": "작성자 아바타 표시",
+        "description": "각 PR 행 옆에 GitHub 아바타를 표시합니다."
+      }
+    },
+    "appearance": {
+      "uiScale": {
+        "label": "UI 배율",
+        "hint": "앱 UI를 5% 단위로 확대/축소합니다. 터미널 텍스트는 별도의 크기 설정을 유지합니다."
+      },
+      "theme": {
+        "label": "테마",
+        "hint": "내장 팔레트와 themes 폴더의 유효한 CSS 파일입니다.",
+        "custom": "(사용자 지정)",
+        "rescanTitle": "테마 폴더 다시 스캔",
+        "refresh": "새로고침",
+        "revealFolder": "폴더 보기"
+      },
+      "background": {
+        "label": "배경 이미지",
+        "hint": "이미지 하나를 앱 영역, 터미널 영역 또는 둘 다에 적용할 수 있습니다.",
+        "pickImage": "이미지 선택",
+        "replace": "교체",
+        "noImage": "선택된 이미지 없음",
+        "remove": "제거",
+        "applyToApp": "앱 배경에 적용",
+        "applyToTerminal": "터미널 배경에 적용",
+        "fit": {
+          "label": "맞춤",
+          "cover": "채우기",
+          "contain": "맞추기",
+          "tile": "타일"
+        },
+        "opacity": {
+          "label": "불투명도",
+          "hint": "0은 투명, 100은 불투명입니다."
+        },
+        "blur": "흐림"
+      },
+      "sessionDisplay": {
+        "title": {
+          "label": "세션 제목",
+          "hint": "사이드바의 각 세션 행에서 굵은 첫 줄로 표시할 필드입니다.",
+          "options": {
+            "name": {
+              "label": "세션 이름",
+              "description": "각 세션에 지정하는 편집 가능한 이름입니다(기본값)."
+            },
+            "workingDirectory": {
+              "label": "작업 디렉터리",
+              "description": "worktree 디렉터리의 기본 이름입니다."
+            },
+            "branch": {
+              "label": "브랜치",
+              "description": "활성 git 브랜치입니다."
+            }
+          }
+        },
+        "metadata": {
+          "label": "추가 메타데이터",
+          "hint": "제목 아래의 보조 줄입니다. 모든 항목을 끄면 한 줄 행이 됩니다.",
+          "branch": {
+            "label": "브랜치",
+            "description": "활성 git 브랜치입니다."
+          },
+          "workingDirectory": {
+            "label": "작업 디렉터리",
+            "description": "worktree 디렉터리의 기본 이름입니다."
+          },
+          "status": {
+            "label": "상태",
+            "description": "Idle / Running / Needs input / Failed / Completed."
+          }
+        },
+        "icons": {
+          "label": "인라인 아이콘",
+          "hint": "각 세션 행을 꾸미는 글리프입니다. 숨기면 목록이 더 조밀해집니다.",
+          "statusDot": {
+            "label": "상태 점",
+            "description": "행 시작 부분의 색상 점입니다. 메타데이터에서 Status가 켜져 있으면 중복됩니다."
+          },
+          "sessionKind": {
+            "label": "세션 종류 아이콘",
+            "description": "격리된 worktree에는 브랜치 글리프를, 컨트롤 세션에는 봇 글리프를 표시합니다."
+          }
+        },
+        "hover": {
+          "label": "호버 시 세부 정보 표시",
+          "hint": "세션 행에 마우스를 올리면 행에 표시되는 필드와 관계없이 모든 필드가 포함된 툴팁을 표시합니다.",
+          "checkbox": "호버 툴팁 사용"
+        }
+      },
+      "statusBar": {
+        "label": "상태 표시줄",
+        "hint": "하단 상태 표시줄에 표시할 선택 배지를 고릅니다.",
+        "sessionCount": {
+          "label": "세션 수",
+          "description": "활성 프로젝트 전체의 총 세션 수입니다(`sessions: N`)."
+        },
+        "activeSessionStatus": {
+          "label": "활성 세션 상태",
+          "description": "활성 세션의 수명 주기 상태입니다(Idle / Running / Needs input / Failed / Completed)."
+        },
+        "githubAccount": {
+          "label": "GitHub 계정",
+          "description": "활성 저장소의 pull request 목록을 가져오는 데 사용하는 `gh` 계정입니다."
+        },
+        "workingDirectory": {
+          "label": "작업 디렉터리",
+          "description": "활성 세션의 worktree 경로입니다($HOME 기준으로 ~ 처리됨)."
+        },
+        "memoryUsage": {
+          "label": "메모리 사용량",
+          "description": "acorn과 하위 셸의 실시간 메모리 표시입니다. 끄면 2초 폴링 루프도 중지되어 숨겨진 동안 비용이 들지 않습니다."
+        }
+      }
+    },
+    "editor": {
+      "command": {
+        "label": "편집기 명령",
+        "hint": "비워 두면 OS 기본값을 사용합니다. 예: \"code\", \"cursor --wait\", \"subl\", \"idea\". 파일 경로는 마지막 인수로 추가됩니다.",
+        "placeholder": "(OS 기본값 사용)",
+        "description": "diff 및 스테이징된 파일 목록의 \"편집기에서 열기\" 우클릭 동작에 사용됩니다."
+      }
+    },
+    "notifications": {
+      "system": {
+        "label": "시스템 알림",
+        "hint": "세션 상태가 바뀌면 macOS 알림을 보냅니다.",
+        "enable": "알림 사용"
+      },
+      "triggers": {
+        "label": "알림 조건",
+        "needsInput": {
+          "label": "입력 필요",
+          "description": "Claude가 사용자 입력을 기다리고 있습니다."
+        },
+        "failed": {
+          "label": "실패",
+          "description": "세션이 오류로 종료되었습니다."
+        },
+        "completed": {
+          "label": "완료",
+          "description": "세션이 완료 상태에 도달했습니다."
+        }
+      },
+      "test": {
+        "label": "테스트",
+        "hint": "위의 사용/조건 설정과 별개로 OS 권한과 실제 알림 표시 여부를 확인합니다.",
+        "send": "테스트 알림 보내기",
+        "sending": "보내는 중...",
+        "result": {
+          "sent": "보냈습니다. 표시되지 않으면 알림 센터를 확인하세요.",
+          "denied": "권한이 거부되었습니다. 시스템 설정 -> 알림에서 Acorn을 허용하세요.",
+          "failed": "보내지 못했습니다. 자세한 내용은 콘솔을 확인하세요."
+        }
+      },
+      "permissionHint": "처음 알림이 발생할 때 macOS가 한 번 권한을 요청할 수 있습니다."
+    },
+    "agents": {
+      "intro": {
+        "before": "선택한 에이전트는 현재 병합 대화상자의 ",
+        "action": "AI로 생성",
+        "after": " 버튼 등 Acorn의 AI 기능을 구동합니다."
+      },
+      "agent": {
+        "label": "에이전트",
+        "hint": "Acorn에서 사용할 AI CLI를 선택하세요."
+      },
+      "customOption": {
+        "label": "사용자 지정 명령",
+        "description": "목록에 없는 CLI를 사용합니다. 공백으로 구분되며 셸 확장은 적용되지 않습니다."
+      },
+      "ollamaModel": {
+        "label": "Ollama 모델",
+        "hint": "`ollama run <model>`에 전달됩니다. 비워 두면 기본값은 `llama3`입니다."
+      },
+      "llmModel": {
+        "label": "llm 모델",
+        "hint": "`llm -m <model>`로 전달됩니다(세션에서는 `llm chat -m <model>`). 비워 두면 llm에 설정된 기본값을 사용합니다."
+      },
+      "customCommand": {
+        "label": "사용자 지정 명령",
+        "hint": "대화형 세션과 일회성 AI 생성 모두에 사용됩니다. 비워 두면 Claude Code로 대체됩니다."
+      },
+      "requirement": "선택한 에이전트의 CLI는 이 컴퓨터에 이미 설치되어 있고 인증되어 있어야 합니다. 바이너리가 없으면 명확한 오류를 표시합니다."
+    },
+    "storage": {
+      "title": "회수 가능한 캐시",
+      "description": "Acorn이 일반 세션 수명 주기에서 정리할 수 없는 디스크 산출물입니다(예: 충돌 또는 Acorn이 오프라인인 동안의 편집으로 고아가 된 파일). 세션, 프로젝트, 설정, 실행 중인 터미널 스크롤백은 절대 건드리지 않습니다.",
+      "cacheCategories": {
+        "scrollbackOrphans": {
+          "label": "고아 터미널 스크롤백",
+          "description": "더 이상 존재하지 않는 세션이 남긴 ANSI 스크롤백 파일입니다(예: Acorn이 오프라인인 동안 제거되었거나 부팅 시 정리 로직이 생기기 전에 남은 파일). 실행 중인 세션의 스크롤백은 건드리지 않으며, 회수 불가능한 잔여 파일만 표시합니다."
+        }
+      },
+      "status": {
+        "clearedSingular": "캐시 파일 {count}개를 지웠습니다.",
+        "clearedPlural": "캐시 파일 {count}개를 지웠습니다.",
+        "nothingToClear": "지울 항목이 없습니다.",
+        "clearFailed": "지우지 못했습니다 - 콘솔을 확인하세요."
+      },
+      "confirm": {
+        "message": "위에 표시된 캐시 데이터({size})를 영구적으로 삭제합니다. 계속할까요?",
+        "cancel": "취소"
+      },
+      "clear": {
+        "button": "캐시 지우기",
+        "clearing": "지우는 중..."
+      },
+      "total": "합계: {size}"
+    },
+    "experiments": {
+      "warning": "완성되지 않은 기능입니다. 릴리스 사이에 동작이 바뀔 수 있지만 토글 자체는 안정적입니다.",
+      "stickyPrompt": {
+        "label": "마지막 사용자 프롬프트를 터미널 위에 고정",
+        "description": "렌더링된 터미널 버퍼에서 가장 최근 claude 프롬프트 줄을 찾아 창 상단에 고정해, 응답을 읽는 동안 계속 보이게 합니다. Cmd+K를 누르면 나머지 스크롤백과 함께 지워집니다."
+      },
+      "cjkCellWidthHeuristic": {
+        "label": "CJK 터미널 셀 너비 보정",
+        "description": "CJK 고정폭 글꼴(D2Coding, Sarasa Mono 등)을 위한 휴리스틱입니다. `W`와 `가`의 측정 너비가 같으면 셀 너비를 절반으로 줄여 Hangul/Han 글리프가 셀 그리드에 맞게 배치되도록 합니다. 너비가 다르면 건너뛰므로 시스템 CJK 폴백을 사용하는 ASCII 글꼴은 보정하지 않습니다. 알려진 제한: 탭 전환 시 xterm의 resize 경로가 addon이 절반 너비를 다시 적용하기 전에 `cell.width`를 자연 W 진행 폭으로 재설정하면서 1프레임 글리프 크기 깜박임이 잠깐 보일 수 있습니다. 기본값은 꺼짐입니다."
+      },
+      "resumeModal": {
+        "label": "콜드 부팅 시 \"이전 대화 재개\" 모달 표시",
+        "description": "Acorn 실행 시 저장된 모든 세션에서 끝나지 않은 claude 또는 codex transcript를 확인하고, 해당 세션에 포커스하면 한 번만 표시되는 모달을 띄워 이전 작업을 이어갈 수 있게 합니다. 끄면 모달을 완전히 표시하지 않습니다."
+      }
+    },
+    "about": {
+      "title": "Acorn 정보",
+      "description": "Acorn은 시작 시 자동으로 업데이트를 확인하고 이후 24시간마다 한 번씩 확인합니다. 아래에서 직접 확인할 수도 있습니다.",
+      "currentVersion": "현재 버전",
+      "lastChecked": "마지막 확인",
+      "loading": "불러오는 중...",
+      "updateAvailable": "업데이트 가능",
+      "updateReady": "Acorn {version}을 설치할 준비가 되었습니다.",
+      "whatsNew": "새로운 내용",
+      "installing": "설치 중...",
+      "installRelaunch": "설치 후 다시 실행",
+      "whatsNewInVersion": "{version}의 새로운 내용",
+      "checking": "확인 중...",
+      "checkForUpdates": "업데이트 확인",
+      "relative": {
+        "never": "확인한 적 없음",
+        "justNow": "방금 전",
+        "minutesAgo": "{count}분 전",
+        "hoursAgo": "{count}시간 전",
+        "daysAgo": "{count}일 전"
+      }
     }
   },
   "app": {},
@@ -26,5 +347,61 @@
   "fileExplorer": {},
   "dialogs": {},
   "commandPalette": {},
-  "backgroundSessions": {}
+  "backgroundSessions": {
+    "daemon": {
+      "label": "데몬",
+      "hint": "acornd 데몬은 장시간 실행되는 터미널 세션을 관리합니다. 데몬을 켜면 PTY를 잃지 않고 Acorn을 종료했다 다시 열 수 있습니다. 끄면 기존 인프로세스 경로를 사용하며, 앱과 함께 세션이 종료됩니다.",
+      "enableLabel": "백그라운드 세션 사용(acornd)",
+      "enabledDescription": "세션은 명시적으로 종료할 때까지 Acorn 재시작 후에도 유지됩니다.",
+      "disabledDescription": "세션은 현재 Acorn 프로세스에 묶이며, 앱을 닫으면 종료됩니다."
+    },
+    "status": {
+      "label": "상태",
+      "hint": "실행 중인 데몬의 실시간 상태입니다. 이 패널이 열려 있는 동안 3초마다 업데이트됩니다.",
+      "disabled": "비활성화됨",
+      "running": "실행 중",
+      "down": "중지됨",
+      "up": "실행 시간",
+      "sessions": "세션",
+      "log": "로그"
+    },
+    "controls": {
+      "label": "제어",
+      "hint": "재시작은 브리지를 다시 연결합니다. 터미널에서 데몬을 종료한 뒤 유용합니다. 종료는 실행 중인 모든 PTY를 끝내고 데몬을 종료합니다.",
+      "restart": "데몬 재시작",
+      "confirmShutdownPrompt": "모든 PTY를 종료할까요?",
+      "confirm": "확인",
+      "cancel": "취소",
+      "quit": "데몬 종료"
+    },
+    "sessions": {
+      "label": "세션",
+      "hint": "데몬이 현재 추적하는 모든 PTY입니다. 종료된 행은 데몬 쪽에서 잊을 수 있으며, 앱 메타데이터는 남아 에이전트가 지원하면 디스크에서 재개할 수 있습니다.",
+      "disabled": "데몬이 비활성화되어 세션은 기존 인프로세스 경로로 관리됩니다.",
+      "notRunning": "데몬이 실행 중이 아닙니다.",
+      "loading": "로드 중...",
+      "empty": "추적 중인 세션이 없습니다.",
+      "controlSession": "제어 세션"
+    },
+    "actions": {
+      "killPty": "PTY 종료",
+      "restoreTooltip": "이 세션을 Acorn 사이드바로 다시 가져오기",
+      "restore": "세션 복원",
+      "forgetDisabledTooltip": "먼저 종료한 뒤 잊기",
+      "forgetTooltip": "데몬 레지스트리에서 이 행 제거",
+      "forget": "세션 잊기"
+    },
+    "metadata": {
+      "tab": "탭",
+      "branch": "브랜치",
+      "status": "상태",
+      "worktree": "워크트리",
+      "last": "마지막",
+      "repo": "저장소",
+      "orphaned": "앱 쪽 행이 없습니다. 데몬에 고아 상태로 남아 있습니다."
+    },
+    "relativeTime": {
+      "ago": "전"
+    }
+  }
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -341,12 +341,152 @@
     }
   },
   "app": {},
-  "sidebar": {},
-  "pane": {},
+  "sidebar": {
+    "status": {
+      "idle": "유휴",
+      "running": "실행 중",
+      "needs_input": "입력 필요",
+      "failed": "실패",
+      "completed": "완료"
+    },
+    "dialog": {
+      "selectExistingProject": "기존 프로젝트 선택",
+      "selectIsolatedRepository": "격리된 worktree용 Git 저장소 선택",
+      "selectControlDirectory": "컨트롤 세션 디렉터리 선택",
+      "selectDirectory": "디렉터리 선택"
+    },
+    "projects": {
+      "title": "프로젝트",
+      "newProject": "새 프로젝트",
+      "addExistingProject": "기존 프로젝트 추가"
+    },
+    "actions": {
+      "dragToReorder": "순서를 바꾸려면 드래그",
+      "expandProject": "프로젝트 펼치기",
+      "collapseProject": "프로젝트 접기",
+      "newSession": "새 세션",
+      "newIsolatedSession": "새 격리 세션",
+      "newIsolatedSessionWorktree": "새 격리 세션 (worktree)",
+      "newControlSession": "새 컨트롤 세션",
+      "closeProject": "프로젝트 닫기",
+      "revealInFinder": "Finder에서 보기",
+      "copyPath": "경로 복사",
+      "rename": "이름 변경",
+      "duplicateSession": "세션 복제",
+      "equalizePaneSizes": "Pane 크기 균등화",
+      "openWorktreeInEditor": "편집기에서 worktree 열기",
+      "copyWorktreePath": "Worktree 경로 복사",
+      "copyWorktreeName": "Worktree 이름 복사",
+      "copyBranchName": "브랜치 이름 복사",
+      "copySessionId": "세션 ID 복사",
+      "remove": "제거",
+      "removeSession": "세션 제거",
+      "removeOthersInProject": "프로젝트의 다른 세션 제거",
+      "removeAllInProject": "프로젝트의 모든 세션 제거"
+    },
+    "aria": {
+      "project": "프로젝트",
+      "dragToReorderProject": "프로젝트 순서를 바꾸려면 드래그",
+      "newSessionInProject": "이 프로젝트에 새 세션 만들기",
+      "newControlSessionInProject": "이 프로젝트에 새 컨트롤 세션 만들기",
+      "dragToReorderSession": "세션 순서를 바꾸려면 드래그",
+      "worktree": "worktree",
+      "controlSession": "컨트롤 세션"
+    },
+    "emptyProject": {
+      "prefix": "세션이 없습니다.",
+      "connector": "또는",
+      "suffix": "로 추가하거나 여기를 더블 클릭하세요."
+    },
+    "emptyProjects": {
+      "prefix": "아직 프로젝트가 없습니다.",
+      "suffix": "를 클릭해 추가하세요."
+    },
+    "metadata": {
+      "name": "이름",
+      "branch": "브랜치",
+      "detached": "(detached)",
+      "workingDirectory": "작업 디렉터리",
+      "status": "상태",
+      "kind": "종류",
+      "controlSession": "컨트롤 세션",
+      "isolatedWorktree": "격리된 worktree"
+    }
+  },
+  "pane": {
+    "empty": {
+      "dropTabOrDoubleClick": "여기에 탭을 놓거나 더블 클릭해 세션을 시작하세요",
+      "createProject": "시작하려면 프로젝트를 만드세요. 여기를 더블 클릭하세요."
+    },
+    "aria": {
+      "worktree": "워크트리",
+      "closeSession": "세션 닫기"
+    },
+    "menu": {
+      "rename": "이름 변경",
+      "duplicateSession": "세션 복제",
+      "forkClaudeSession": "Claude 세션 포크",
+      "forkSession": "세션 포크",
+      "forkClaudeInNewWorktree": "새 워크트리에 Claude 포크",
+      "forkInNewWorktree": "새 워크트리에 포크",
+      "forkCodexSession": "Codex 세션 포크",
+      "forkCodexInNewWorktree": "새 워크트리에 Codex 포크",
+      "splitRight": "오른쪽으로 분할",
+      "splitDown": "아래로 분할",
+      "equalizePaneSizes": "패널 크기 균등화",
+      "openWorktreeInEditor": "편집기에서 워크트리 열기",
+      "revealInFinder": "Finder에서 보기",
+      "copyWorktreePath": "워크트리 경로 복사",
+      "copyWorktreeName": "워크트리 이름 복사",
+      "copyBranchName": "브랜치 이름 복사",
+      "copySessionId": "세션 ID 복사",
+      "close": "닫기",
+      "closeOthers": "다른 탭 닫기",
+      "closeAll": "모두 닫기",
+      "newSessionInThisPane": "이 패널에서 새 세션",
+      "closePane": "패널 닫기"
+    }
+  },
   "rightPanel": {},
   "fileExplorer": {},
   "dialogs": {},
-  "commandPalette": {},
+  "commandPalette": {
+    "dialogLabel": "명령 팔레트",
+    "placeholder": "명령을 입력하거나 검색하세요...",
+    "empty": "결과가 없습니다.",
+    "groups": {
+      "sessions": "세션",
+      "switchSession": "세션 전환",
+      "view": "보기",
+      "terminal": "터미널",
+      "ipc": "IPC",
+      "dangerZone": "위험 영역"
+    },
+    "commands": {
+      "newSession": "새 세션",
+      "newIsolatedSession": "새 격리 세션",
+      "newControlSession": "새 제어 세션",
+      "newProject": "새 프로젝트",
+      "addExistingProject": "기존 프로젝트 추가",
+      "refreshSessions": "세션 새로고침",
+      "switchSessionPrefix": "전환:",
+      "viewTodos": "할 일 보기",
+      "viewCommits": "커밋 보기",
+      "viewStaged": "스테이징 보기",
+      "viewPullRequests": "풀 리퀘스트 보기",
+      "resetPanelSizes": "패널 크기 재설정",
+      "reloadShellEnvironment": "셸 환경 다시 로드",
+      "restartIpcServer": "IPC 서버 다시 시작",
+      "removeSessionPrefix": "세션 제거:",
+      "shakeTree": "나무 흔들기"
+    },
+    "toasts": {
+      "shellEnvReloaded": "셸 환경을 다시 로드했습니다. 적용하려면 새 세션을 여세요.",
+      "shellEnvReloadFailed": "셸 환경을 다시 로드하지 못했습니다.",
+      "ipcRestarted": "IPC 서버를 다시 시작했습니다.",
+      "ipcRestartFailedPrefix": "IPC 서버를 다시 시작하지 못했습니다:"
+    }
+  },
   "backgroundSessions": {
     "daemon": {
       "label": "데몬",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -400,6 +400,56 @@
       }
     }
   },
+  "topBar": {
+    "noSessionSelected": "선택된 세션 없음"
+  },
+  "updateBanner": {
+    "available": "사용할 수 있습니다. 설치 후 앱이 다시 실행됩니다.",
+    "whatsNew": "새로운 내용",
+    "installing": "설치 중...",
+    "installRelaunch": "설치 후 다시 실행",
+    "hideUntilNextVersion": "다음 버전까지 숨기기",
+    "dismissError": "오류 닫기"
+  },
+  "imageLightbox": {
+    "imagePreview": "이미지 미리보기",
+    "openInBrowser": "브라우저에서 열기",
+    "close": "닫기"
+  },
+  "codeViewer": {
+    "loading": "불러오는 중...",
+    "binaryFile": "바이너리 파일",
+    "binaryFileBody": "{bytes}바이트 - 읽기 전용 뷰어에 표시되지 않습니다.",
+    "truncated": "파일이 2 MB로 잘렸습니다. 나머지는 외부에서 열어 확인하세요."
+  },
+  "diffView": {
+    "noChanges": "이 diff에는 변경 사항이 없습니다.",
+    "filesChanged": "변경된 파일 {count}개",
+    "filesCount": "파일 {count}개",
+    "expandAll": "모두 펼치기",
+    "collapseAll": "모두 접기",
+    "openFullDiff": "전체 diff 열기",
+    "openInEditor": "편집기에서 열기",
+    "image": "이미지",
+    "binaryImageNoPreview": "바이너리 이미지 변경(미리보기 없음)",
+    "none": "(없음)",
+    "imageLabels": {
+      "added": "추가됨",
+      "deleted": "삭제됨",
+      "before": "이전",
+      "after": "이후"
+    }
+  },
+  "ui": {
+    "openGitHubProfile": "GitHub 프로필 열기",
+    "stepper": {
+      "decrease": "감소",
+      "increase": "증가"
+    },
+    "commandHint": {
+      "title": "복사하거나 실행하려면 클릭"
+    }
+  },
   "sidebar": {
     "status": {
       "idle": "유휴",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1,0 +1,16 @@
+{
+  "settings.title": "설정",
+  "settings.reset": "기본값으로 재설정",
+  "settings.tabs.terminal": "터미널",
+  "settings.tabs.agents": "에이전트",
+  "settings.tabs.sessions": "세션",
+  "settings.tabs.github": "GitHub",
+  "settings.tabs.appearance": "모양",
+  "settings.tabs.editor": "편집기",
+  "settings.tabs.notifications": "알림",
+  "settings.tabs.storage": "저장 공간",
+  "settings.tabs.experiments": "실험 기능",
+  "settings.tabs.about": "정보",
+  "settings.language.label": "언어",
+  "settings.language.hint": "Acorn 인터페이스에 사용할 언어입니다. 새 번역은 점진적으로 추가됩니다."
+}

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -1,6 +1,33 @@
-import { test, expect, pressHotkey } from "./support";
+import {
+  test,
+  expect,
+  pressHotkey,
+  seedSettingsLanguage,
+} from "./support";
 
 test.describe("command palette", () => {
+  test("Korean mode localizes command palette chrome and default commands", async ({
+    page,
+  }) => {
+    await seedSettingsLanguage(page, "ko");
+
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "p" });
+
+    const palette = page.getByRole("dialog", { name: "명령 팔레트" });
+    await expect(palette).toBeVisible();
+    await expect(
+      page.getByPlaceholder("명령을 입력하거나 검색하세요..."),
+    ).toBeVisible();
+    await expect(page.getByText("세션", { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("option", { name: /새 세션/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("option", { name: /새 프로젝트/ }),
+    ).toBeVisible();
+  });
+
   test("opens with $mod+P and closes with Escape", async ({ page }) => {
     await page.goto("/");
 

--- a/tests/e2e/panes.spec.ts
+++ b/tests/e2e/panes.spec.ts
@@ -1,4 +1,9 @@
-import { test, expect, pressHotkey } from "./support";
+import {
+  test,
+  expect,
+  pressHotkey,
+  seedSettingsLanguage,
+} from "./support";
 
 const PROJECT = {
   repo_path: "/tmp/demo",
@@ -21,6 +26,18 @@ const SESSION = {
 };
 
 test.describe("pane / sidebar shortcuts", () => {
+  test("Korean mode localizes empty pane guidance", async ({ page, tauri }) => {
+    await seedSettingsLanguage(page, "ko");
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", []);
+
+    await page.goto("/");
+
+    await expect(
+      page.getByText(/여기에 탭을 놓거나 더블 클릭해 세션을 시작하세요/),
+    ).toBeVisible();
+  });
+
   // react-resizable-panels publishes the current size on `data-panel-size`
   // (string, e.g. "18.0" for the default 18%). Collapsed panels get "0.0".
   test("$mod+B collapses then re-expands the sidebar", async ({ page }) => {

--- a/tests/e2e/settings-tabs.spec.ts
+++ b/tests/e2e/settings-tabs.spec.ts
@@ -1,6 +1,10 @@
-import { test, expect, pressHotkey } from "./support";
+import {
+  test,
+  expect,
+  pressHotkey,
+  seedSettingsLanguage,
+} from "./support";
 
-const SETTINGS_STORAGE_KEY = "acorn:settings:v1";
 const SETTINGS_DIALOG_NAME = /^(Settings|설정)$/;
 
 // Each Settings tab has a label / heading unique enough to anchor against.
@@ -88,12 +92,7 @@ test.describe("settings modal: tab content", () => {
   test("Korean mode localizes tab buttons and representative Settings markers", async ({
     page,
   }) => {
-    await page.addInitScript((storageKey) => {
-      window.localStorage.setItem(
-        storageKey,
-        JSON.stringify({ language: "ko" }),
-      );
-    }, SETTINGS_STORAGE_KEY);
+    await seedSettingsLanguage(page, "ko");
 
     await page.goto("/");
     await pressHotkey(page, { mod: true, key: "," });

--- a/tests/e2e/settings-tabs.spec.ts
+++ b/tests/e2e/settings-tabs.spec.ts
@@ -1,20 +1,67 @@
 import { test, expect, pressHotkey } from "./support";
 
+const SETTINGS_STORAGE_KEY = "acorn:settings:v1";
+const SETTINGS_DIALOG_NAME = /^(Settings|설정)$/;
+
 // Each Settings tab has a label / heading unique enough to anchor against.
 // Asserting one element per tab is enough to catch "clicked tab N but
 // content M still rendered" regressions without locking us into specific
 // form widgets.
 const TAB_MARKERS: Array<{
-  tab: string;
+  tab: RegExp;
+  label: string;
   marker: { kind: "text"; pattern: RegExp } | { kind: "heading"; name: string };
 }> = [
-  { tab: "Terminal", marker: { kind: "text", pattern: /Font family/i } },
-  { tab: "Agents", marker: { kind: "text", pattern: /which AI CLI acorn uses/i } },
-  { tab: "Sessions", marker: { kind: "text", pattern: /Confirm before removing/i } },
-  { tab: "Editor", marker: { kind: "text", pattern: /Editor command/i } },
-  { tab: "Notifications", marker: { kind: "text", pattern: /System notifications/i } },
-  { tab: "Storage", marker: { kind: "heading", name: "Reclaimable cache" } },
-  { tab: "About", marker: { kind: "heading", name: "About Acorn" } },
+  {
+    tab: /^(Terminal|터미널)$/,
+    label: "Terminal",
+    marker: {
+      kind: "text",
+      pattern: /Font family|글꼴 패밀리/i,
+    },
+  },
+  {
+    tab: /^(Agents|에이전트)$/,
+    label: "Agents",
+    marker: { kind: "text", pattern: /Claude Code/i },
+  },
+  {
+    tab: /^(Sessions|세션)$/,
+    label: "Sessions",
+    marker: {
+      kind: "text",
+      pattern: /Confirm before removing|세션 제거 전 확인/i,
+    },
+  },
+  {
+    tab: /^(Editor|편집기)$/,
+    label: "Editor",
+    marker: {
+      kind: "text",
+      pattern: /Editor command|편집기 명령/i,
+    },
+  },
+  {
+    tab: /^(Notifications|알림)$/,
+    label: "Notifications",
+    marker: {
+      kind: "text",
+      pattern: /System notifications|시스템 알림/i,
+    },
+  },
+  {
+    tab: /^(Storage|저장 공간)$/,
+    label: "Storage",
+    marker: {
+      kind: "text",
+      pattern: /Reclaimable cache|회수 가능한 캐시/i,
+    },
+  },
+  {
+    tab: /^(About|정보)$/,
+    label: "About",
+    marker: { kind: "text", pattern: /About Acorn|Acorn 정보/i },
+  },
 ];
 
 test.describe("settings modal: tab content", () => {
@@ -22,19 +69,65 @@ test.describe("settings modal: tab content", () => {
     await page.goto("/");
     await pressHotkey(page, { mod: true, key: "," });
 
-    const modal = page.getByRole("dialog", { name: /Settings/i });
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
     await expect(modal).toBeVisible();
 
-    for (const { tab, marker } of TAB_MARKERS) {
-      await modal.getByRole("button", { name: tab, exact: true }).click();
+    for (const { tab, label, marker } of TAB_MARKERS) {
+      await modal.getByRole("button", { name: tab }).click();
       const expected =
         marker.kind === "heading"
           ? modal.getByRole("heading", { name: marker.name })
           : modal.getByText(marker.pattern);
       await expect(
         expected,
-        `Settings → ${tab} should reveal its content marker`,
+        `Settings → ${label} should reveal its content marker`,
       ).toBeVisible();
     }
+  });
+
+  test("Korean mode localizes tab buttons and representative Settings markers", async ({
+    page,
+  }) => {
+    await page.addInitScript((storageKey) => {
+      window.localStorage.setItem(
+        storageKey,
+        JSON.stringify({ language: "ko" }),
+      );
+    }, SETTINGS_STORAGE_KEY);
+
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "," });
+
+    const modal = page.getByRole("dialog", { name: "설정" });
+    await expect(modal).toBeVisible();
+
+    for (const tab of [
+      "터미널",
+      "에이전트",
+      "세션",
+      "GitHub",
+      "모양",
+      "편집기",
+      "알림",
+      "저장 공간",
+      "실험 기능",
+      "정보",
+    ]) {
+      await expect(
+        modal.getByRole("button", { name: tab, exact: true }),
+      ).toBeVisible();
+    }
+
+    await modal.getByRole("button", { name: "모양", exact: true }).click();
+    await expect(modal.getByText("언어", { exact: true })).toBeVisible();
+    await expect(modal.getByRole("combobox", { name: "언어" })).toHaveValue(
+      "ko",
+    );
+    await expect(
+      modal.getByRole("button", { name: "기본값으로 재설정" }),
+    ).toBeVisible();
+
+    await modal.getByRole("button", { name: "터미널", exact: true }).click();
+    await expect(modal.getByText("글꼴 패밀리")).toBeVisible();
   });
 });

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,16 +1,22 @@
 import { test, expect, pressHotkey } from "./support";
 
+const SETTINGS_DIALOG_NAME = /^(Settings|설정)$/;
+
 test.describe("settings modal", () => {
   test("opens with $mod+, and closes with Escape", async ({ page }) => {
     await page.goto("/");
 
-    const modal = page.getByRole("dialog", { name: /Settings/i });
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
     await expect(modal).toHaveCount(0);
 
     await pressHotkey(page, { mod: true, key: "," });
     await expect(modal).toBeVisible();
-    await expect(modal.getByRole("button", { name: "Terminal" })).toBeVisible();
-    await expect(modal.getByRole("button", { name: "Agents" })).toBeVisible();
+    await expect(
+      modal.getByRole("button", { name: /^(Terminal|터미널)$/ }),
+    ).toBeVisible();
+    await expect(
+      modal.getByRole("button", { name: /^(Agents|에이전트)$/ }),
+    ).toBeVisible();
 
     await page.keyboard.press("Escape");
     await expect(modal).toHaveCount(0);
@@ -20,7 +26,7 @@ test.describe("settings modal", () => {
     await page.goto("/");
     await pressHotkey(page, { mod: true, key: "," });
 
-    const modal = page.getByRole("dialog", { name: /Settings/i });
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
     await expect(modal).toBeVisible();
 
     await modal.getByRole("button", { name: /close/i }).first().click();

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -1,6 +1,23 @@
-import { test, expect } from "./support";
+import { test, expect, seedSettingsLanguage } from "./support";
 
 test.describe("sidebar: project lifecycle", () => {
+  test("Korean mode localizes project chrome and empty state", async ({
+    page,
+  }) => {
+    await seedSettingsLanguage(page, "ko");
+
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: "프로젝트" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "새 프로젝트" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "기존 프로젝트 추가" }),
+    ).toBeVisible();
+    await expect(page.getByText(/아직 프로젝트가 없습니다/)).toBeVisible();
+  });
+
   test("seeded project appears with name and add session affordances", async ({
     page,
     tauri,

--- a/tests/e2e/support.ts
+++ b/tests/e2e/support.ts
@@ -2,6 +2,9 @@ import { test as base, expect, type Page } from "@playwright/test";
 import { tauriMockSource } from "./fixtures/tauriMock";
 
 type InvokeHandler = (args: unknown) => unknown | Promise<unknown>;
+type TestLanguage = "en" | "ko";
+
+const SETTINGS_STORAGE_KEY = "acorn:settings:v1";
 
 export interface TauriMock {
   /**
@@ -213,6 +216,18 @@ export async function pressHotkey(
     });
     window.dispatchEvent(ev);
   }, combo);
+}
+
+export async function seedSettingsLanguage(
+  page: Page,
+  language: TestLanguage,
+): Promise<void> {
+  await page.addInitScript(
+    ({ storageKey, language }) => {
+      window.localStorage.setItem(storageKey, JSON.stringify({ language }));
+    },
+    { storageKey: SETTINGS_STORAGE_KEY, language },
+  );
 }
 
 export { expect };


### PR DESCRIPTION
## Summary
- add typed language settings backed by English/Korean locale JSON files
- keep locale data in `src/locales/en.json` and `src/locales/ko.json`, grouped by category
- add a Settings > Appearance language selector
- localize the Settings modal tabs, controls, background-session settings, storage/about/experiments sections, and related Settings tests

## Verification
- `bun run typecheck`
- `bun run test`
- `bun run test:e2e tests/e2e/settings.spec.ts tests/e2e/settings-tabs.spec.ts`

## Notes
This is the base PR for the i18n stack; #191 and #194 build on the same locale structure.
