### PR TITLE
refactor(tabs): introduce workspace tab lifecycles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import {
   startSessionNotificationWatcher,
 } from "./lib/notifications";
 import { findFocusedSessionId } from "./lib/focus";
+import { isSessionTabId } from "./lib/workspaceTabs";
 import { flushAllScrollbacks } from "./lib/scrollback-coordinator";
 import { useToasts } from "./lib/toasts";
 import { useUpdater } from "./lib/updater-store";
@@ -69,6 +70,7 @@ const SIDEBAR_DEFAULT_SIZE = 18;
 const SIDEBAR_MIN_SIZE = 12;
 const RIGHT_PANEL_DEFAULT_SIZE = 26;
 const RIGHT_PANEL_MIN_SIZE = 16;
+
 
 function focusPanel(id: "sidebar" | "main" | "right") {
   const panel = document.querySelector(
@@ -333,7 +335,7 @@ function App() {
       const ws = state.workspaces[state.activeProject];
       if (!ws) return;
       for (const [pid, pane] of Object.entries(ws.panes)) {
-        if (pane.sessionIds.includes(sid)) {
+        if (pane.tabIds.includes(sid)) {
           if (ws.focusedPaneId !== pid) state.setFocusedPane(pid);
           return;
         }
@@ -705,8 +707,8 @@ function App() {
             const ws = s.workspaces[s.activeProject];
             if (ws) {
               for (const pane of Object.values(ws.panes)) {
-                if (pane.activeSessionId) {
-                  sessionId = pane.activeSessionId;
+                if (pane.activeTabId && isSessionTabId(pane.activeTabId)) {
+                  sessionId = pane.activeTabId;
                   break;
                 }
               }
@@ -852,7 +854,7 @@ function App() {
         // available for inputs, dialogs, and the command palette.
         const { focusedPaneId, panes } = useAppStore.getState();
         const pane = panes[focusedPaneId];
-        if (!pane || pane.sessionIds.length > 0) return;
+        if (!pane || pane.tabIds.length > 0) return;
         const total = Object.keys(panes).length;
         if (total <= 1) return;
         e.preventDefault();

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -639,7 +639,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       if (entry.is_dir) return;
       try {
         const store = await import("../store");
-        store.useAppStore.getState().openViewerTab(entry.path);
+        store.useAppStore.getState().openCodeViewerTab(entry.path);
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
       }

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -23,7 +23,7 @@ import {
   type CSSProperties,
 } from "react";
 import { openPath } from "@tauri-apps/plugin-opener";
-import { isViewerTabId, useAppStore, type ViewerTab } from "../store";
+import { useAppStore } from "../store";
 import { CodeViewer } from "./CodeViewer";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
@@ -44,6 +44,11 @@ import type { Direction, PaneId } from "../lib/layout";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { PaneDropOverlay } from "./PaneDropOverlay";
 import type { Session, SessionKind, SessionStatus } from "../lib/types";
+import {
+  makeSessionWorkspaceTab,
+  type CodeWorkspaceTab,
+  type SessionWorkspaceTab,
+} from "../lib/workspaceTabs";
 
 const STATUS_DOT: Record<SessionStatus, string> = {
   idle: "bg-fg-muted",
@@ -56,6 +61,10 @@ const STATUS_DOT: Record<SessionStatus, string> = {
 interface PaneProps {
   paneId: PaneId;
 }
+
+type PaneTab =
+  | (SessionWorkspaceTab & { session: Session })
+  | CodeWorkspaceTab;
 
 /**
  * A single workspace pane. Hosts a tab strip and a body with the active
@@ -72,9 +81,10 @@ export function Pane({ paneId }: PaneProps) {
   const totalPanes = useAppStore((s) => Object.keys(s.panes).length);
   const focusedPaneId = useAppStore((s) => s.focusedPaneId);
   const setFocusedPane = useAppStore((s) => s.setFocusedPane);
-  const selectSession = useAppStore((s) => s.selectSession);
+  const selectTab = useAppStore((s) => s.selectTab);
   const createSession = useAppStore((s) => s.createSession);
   const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
+  const closeWorkspaceTab = useAppStore((s) => s.closeWorkspaceTab);
   const moveTab = useAppStore((s) => s.moveTab);
   const splitFocusedPane = useAppStore((s) => s.splitFocusedPane);
   const closePane = useAppStore((s) => s.closePane);
@@ -98,29 +108,42 @@ export function Pane({ paneId }: PaneProps) {
     return () => node.removeEventListener("mousedown", handler);
   }, [paneId, setFocusedPane]);
 
-  const viewerTabs = useAppStore((s) => s.viewerTabs);
-  const closeViewerTab = useAppStore((s) => s.closeViewerTab);
-  const tabs = useMemo<Session[]>(() => {
+  const workspaceTabs = useAppStore((s) => s.workspaceTabs);
+  const tabs = useMemo<PaneTab[]>(() => {
     if (!pane) return [];
     const lookup = new Map(sessions.map((s) => [s.id, s] as const));
-    const ordered: Session[] = [];
-    for (const id of pane.sessionIds) {
+    const ordered: PaneTab[] = [];
+    for (const id of pane.tabIds) {
       const s = lookup.get(id);
       if (s) {
-        ordered.push(s);
+        ordered.push({
+          ...makeSessionWorkspaceTab({
+            id: s.id,
+            title: s.name,
+            repoPath: s.repo_path,
+          }),
+          session: s,
+        });
         continue;
       }
-      if (isViewerTabId(id)) {
-        const v = viewerTabs[id];
-        if (v) ordered.push(viewerToSession(v));
+      const workspaceTab = workspaceTabs[id];
+      if (workspaceTab?.kind === "code") {
+        ordered.push({
+          kind: "code",
+          id: workspaceTab.id,
+          title: workspaceTab.title,
+          repoPath: workspaceTab.repoPath,
+          lifecycle: workspaceTab.lifecycle,
+          path: workspaceTab.path,
+        });
       }
     }
     return ordered;
-  }, [pane, sessions, viewerTabs]);
+  }, [pane, sessions, workspaceTabs]);
 
-  const active = useMemo<Session | null>(() => {
-    if (!pane?.activeSessionId) return null;
-    return tabs.find((t) => t.id === pane.activeSessionId) ?? null;
+  const active = useMemo<PaneTab | null>(() => {
+    if (!pane?.activeTabId) return null;
+    return tabs.find((t) => t.id === pane.activeTabId) ?? null;
   }, [pane, tabs]);
 
   const isFocused = focusedPaneId === paneId;
@@ -192,7 +215,7 @@ export function Pane({ paneId }: PaneProps) {
           : `codex fork ${parentAgentId}`;
       useAppStore.getState().setPendingTerminalInput(created.id, command);
       await useAppStore.getState().refreshAll();
-      selectSession(created.id);
+      selectTab(created.id);
     } catch (err) {
       console.error("[Pane] fork session failed", err);
     }
@@ -200,14 +223,14 @@ export function Pane({ paneId }: PaneProps) {
 
   async function handleNewTabFromStrip() {
     if (tabs.length === 0) return;
-    await spawnSession(tabs[0].repo_path);
+    await spawnSession(tabs[0].repoPath);
   }
 
   async function handleNewTabFromEmpty() {
     // Prefer the pane's project if any tabs exist (shouldn't here), else use
     // the globally active project. With no project at all, do nothing.
     const repoPath =
-      tabs[0]?.repo_path ??
+      tabs[0]?.repoPath ??
       useAppStore.getState().activeProject ??
       null;
     if (!repoPath) return;
@@ -230,27 +253,28 @@ export function Pane({ paneId }: PaneProps) {
           activeId={active?.id ?? null}
           onSelect={(id) => {
             setFocusedPane(paneId);
-            selectSession(id);
+            selectTab(id);
           }}
           onClose={(id) => {
-            if (isViewerTabId(id)) closeViewerTab(id);
-            else requestRemoveSession(id);
+            const tab = tabs.find((t) => t.id === id);
+            if (tab?.kind === "session") requestRemoveSession(id);
+            else closeWorkspaceTab(id);
           }}
           onDropReorder={(payload, toIndex) => {
             moveTab({
-              sessionId: payload.sessionId,
+              tabId: payload.tabId,
               fromPaneId: payload.fromPaneId,
               toPaneId: paneId,
               toIndex,
             });
           }}
           onNewTab={handleNewTabFromStrip}
-          onSplitTab={(sessionId, direction) => {
+          onSplitTab={(tabId, direction) => {
             // Move the tab into a fresh pane created on the right (horizontal)
             // or below (vertical) the current pane. Mirrors VS Code's
             // "Split Right / Split Down" command on a tab.
             moveTab({
-              sessionId,
+              tabId,
               fromPaneId: paneId,
               toPaneId: paneId,
               splitDirection: direction,
@@ -287,11 +311,11 @@ export function Pane({ paneId }: PaneProps) {
           gets `appendChild`-moved into this pane body when this session is
           active. We render only an EmptyPane fallback here for the
           no-active-session case — or a CodeViewer when the active tab is
-          a frontend-only readonly viewer instead of a PTY session.
+          a frontend-owned code tab instead of a PTY session.
         */}
-        {active && active.kind === "viewer" && viewerTabs[active.id] ? (
+        {active?.kind === "code" ? (
           <CodeViewer
-            path={viewerTabs[active.id].path}
+            path={active.path}
             isActive={isFocused}
           />
         ) : null}
@@ -318,7 +342,7 @@ export function Pane({ paneId }: PaneProps) {
         y={paneMenu?.y ?? 0}
         onClose={() => setPaneMenu(null)}
         items={buildPaneMenuItems({
-          activeSession: active,
+          activeSession: active?.kind === "session" ? active.session : null,
           totalPanes,
           paneId,
           onNewTab: () => void handleNewTabFromEmpty(),
@@ -329,24 +353,6 @@ export function Pane({ paneId }: PaneProps) {
       />
     </div>
   );
-}
-
-function viewerToSession(v: ViewerTab): Session {
-  return {
-    id: v.id,
-    name: v.name,
-    repo_path: v.repoPath,
-    worktree_path: v.repoPath,
-    branch: "",
-    isolated: false,
-    status: "idle",
-    created_at: "",
-    updated_at: "",
-    last_message: null,
-    kind: "viewer",
-    position: null,
-    in_worktree: false,
-  };
 }
 
 function suggestSessionName(repoPath: string, existing: Session[]): string {
@@ -401,16 +407,16 @@ function EmptyPane({
 
 interface TabStripProps {
   paneId: PaneId;
-  tabs: Session[];
+  tabs: PaneTab[];
   activeId: string | null;
   onSelect: (id: string) => void;
   onClose: (id: string) => void;
   onDropReorder: (
-    payload: { sessionId: string; fromPaneId: PaneId },
+    payload: { tabId: string; fromPaneId: PaneId },
     toIndex: number,
   ) => void;
   onNewTab: () => void;
-  onSplitTab: (sessionId: string, direction: Direction) => void;
+  onSplitTab: (tabId: string, direction: Direction) => void;
   onDuplicate: (repoPath: string, kind: SessionKind) => void;
   onFork: (
     parent: Session,
@@ -476,14 +482,14 @@ function TabStrip({
         const filePayload = getCurrentFilePayload();
         if (filePayload) {
           useAppStore.getState().setFocusedPane(paneId);
-          useAppStore.getState().openViewerTab(filePayload.path);
+          useAppStore.getState().openCodeViewerTab(filePayload.path);
           return;
         }
         const payload = getCurrentTabPayload();
         if (!payload) return;
         // No-op: dropping onto the same pane at the same position.
         if (payload.fromPaneId === paneId) {
-          const currentIdx = tabs.findIndex((t) => t.id === payload.sessionId);
+          const currentIdx = tabs.findIndex((t) => t.id === payload.tabId);
           if (currentIdx === idx || currentIdx + 1 === idx) return;
         }
         onDropReorder(payload, idx);
@@ -507,9 +513,16 @@ function TabStrip({
             for (const t of tabs) onClose(t.id);
           }}
           onSplitTab={(direction) => onSplitTab(tab.id, direction)}
-          onDuplicate={() => onDuplicate(tab.repo_path, tab.kind)}
-          onFork={(kind, parentAgentId, isolated) =>
-            onFork(tab, kind, parentAgentId, isolated)
+          onDuplicate={
+            tab.kind === "session"
+              ? () => onDuplicate(tab.session.repo_path, tab.session.kind)
+              : undefined
+          }
+          onFork={
+            tab.kind === "session"
+              ? (kind, parentAgentId, isolated) =>
+                  onFork(tab.session, kind, parentAgentId, isolated)
+              : undefined
           }
           siblingCount={tabs.length}
           registerRef={(el) => {
@@ -540,7 +553,7 @@ function TabStrip({
 }
 
 interface TabItemProps {
-  tab: Session;
+  tab: PaneTab;
   paneId: PaneId;
   active: boolean;
   insertBefore: boolean;
@@ -549,8 +562,8 @@ interface TabItemProps {
   onCloseOthers: () => void;
   onCloseAll: () => void;
   onSplitTab: (direction: Direction) => void;
-  onDuplicate: () => void;
-  onFork: (
+  onDuplicate?: () => void;
+  onFork?: (
     kind: "claude" | "codex",
     parentAgentId: string,
     isolated: boolean,
@@ -575,7 +588,11 @@ function TabItem({
   registerRef,
 }: TabItemProps) {
   const renameSession = useAppStore((s) => s.renameSession);
-  const liveInWorktree = useAppStore((s) => s.liveInWorktree[tab.id]);
+  const session = tab.kind === "session" ? tab.session : null;
+  const tabPath = tab.kind === "session" ? tab.session.worktree_path : tab.path;
+  const liveInWorktree = useAppStore((s) =>
+    session ? s.liveInWorktree[session.id] : false,
+  );
   // Subscribe to the editor command so the menu's enabled/disabled state
   // updates immediately when the user configures an editor in Settings.
   const editorCommand = useSettings(
@@ -593,25 +610,28 @@ function TabItem({
   } | null>(null);
 
   useEffect(() => {
-    if (!menu) return;
+    if (!menu || !session) return;
     setAgent(null);
     let cancelled = false;
     api
-      .detectSessionAgent(tab.id)
+      .detectSessionAgent(session.id)
       .then((res) => {
         if (!cancelled) setAgent(res);
       })
       .catch((err) => {
-        console.error("[Pane.Fork] detect failed", { sessionId: tab.id, err });
+        console.error("[Pane.Fork] detect failed", {
+          sessionId: session.id,
+          err,
+        });
         if (!cancelled) setAgent({ claude: null, codex: null });
       });
     return () => {
       cancelled = true;
     };
-  }, [menu, tab.id]);
+  }, [menu, session]);
 
   const forkItems: ContextMenuItem[] = (() => {
-    if (!agent) return [];
+    if (!agent || !onFork) return [];
     const items: ContextMenuItem[] = [];
     const both = agent.claude && agent.codex;
     if (agent.claude) {
@@ -652,11 +672,13 @@ function TabItem({
       label: "Rename",
       icon: <Pencil size={12} />,
       onClick: () => setEditing(true),
+      disabled: !session,
     },
     {
       label: "Duplicate Session",
       icon: <Files size={12} />,
-      onClick: onDuplicate,
+      onClick: () => onDuplicate?.(),
+      disabled: !onDuplicate,
     },
     { type: "separator" },
     ...forkItems,
@@ -681,11 +703,11 @@ function TabItem({
     },
     { type: "separator" },
     {
-      label: "Open Worktree in Editor",
+      label: session ? "Open Worktree in Editor" : "Open File in Editor",
       icon: <PencilLine size={12} />,
       disabled: !editorConfigured,
       onClick: () => {
-        void openInConfiguredEditor(tab.worktree_path).catch(
+        void openInConfiguredEditor(tabPath).catch(
           (err: unknown) => {
             console.error("[Pane] open in editor failed", err);
           },
@@ -696,33 +718,33 @@ function TabItem({
       label: "Reveal in Finder",
       icon: <FolderOpen size={12} />,
       onClick: () => {
-        void openPath(tab.worktree_path).catch((err: unknown) => {
+        void openPath(tabPath).catch((err: unknown) => {
           console.error("[Pane] reveal in finder failed", err);
         });
       },
     },
     { type: "separator" },
     {
-      label: "Copy Worktree Path",
+      label: session ? "Copy Worktree Path" : "Copy File Path",
       icon: <Copy size={12} />,
       onClick: () => {
-        void copyToClipboard(tab.worktree_path);
+        void copyToClipboard(tabPath);
       },
     },
     {
-      label: "Copy Worktree Name",
+      label: session ? "Copy Worktree Name" : "Copy File Name",
       icon: <Copy size={12} />,
       onClick: () => {
-        void copyToClipboard(basename(tab.worktree_path));
+        void copyToClipboard(basename(tabPath));
       },
     },
     {
       label: "Copy Branch Name",
       icon: <Copy size={12} />,
       onClick: () => {
-        void copyToClipboard(tab.branch);
+        if (session) void copyToClipboard(session.branch);
       },
-      disabled: !tab.branch,
+      disabled: !session?.branch,
     },
     {
       label: "Copy Session ID",
@@ -730,6 +752,7 @@ function TabItem({
       onClick: () => {
         void copyToClipboard(tab.id);
       },
+      disabled: !session,
     },
     { type: "separator" },
     {
@@ -766,12 +789,12 @@ function TabItem({
             : undefined
         }
         onDragStart={(e) => {
-          setTabDragPayload(e, { sessionId: tab.id, fromPaneId: paneId });
+          setTabDragPayload(e, { tabId: tab.id, fromPaneId: paneId });
         }}
         onClick={editing ? undefined : onSelect}
         onDoubleClick={(e) => {
           e.stopPropagation();
-          setEditing(true);
+          if (session) setEditing(true);
         }}
         onContextMenu={(e) => {
           e.preventDefault();
@@ -788,7 +811,7 @@ function TabItem({
             onSelect();
           } else if (e.key === "F2") {
             e.preventDefault();
-            setEditing(true);
+            if (session) setEditing(true);
           }
         }}
         className={cn(
@@ -801,26 +824,27 @@ function TabItem({
         <span
           className={cn(
             "pointer-events-none size-1.5 rounded-full",
-            STATUS_DOT[tab.status],
+            session ? STATUS_DOT[session.status] : "bg-fg-muted/50",
           )}
         />
         {editing ? (
           <TabRenameInput
-            initial={tab.name}
+            initial={tab.title}
             onSubmit={async (next) => {
               setEditing(false);
-              if (next && next !== tab.name) {
-                await renameSession(tab.id, next);
+              if (session && next && next !== session.name) {
+                await renameSession(session.id, next);
               }
             }}
             onCancel={() => setEditing(false)}
           />
         ) : (
           <span className="pointer-events-none max-w-[12rem] truncate">
-            {tab.name}
+            {tab.title}
           </span>
         )}
-        {(liveInWorktree ?? (tab.isolated || tab.in_worktree)) ? (
+        {session &&
+        (liveInWorktree ?? (session.isolated || session.in_worktree)) ? (
           <GitBranch
             size={10}
             className="pointer-events-none text-fg-muted"
@@ -829,7 +853,7 @@ function TabItem({
         ) : null}
         <button
           type="button"
-          aria-label="Close session"
+          aria-label="Close tab"
           onClick={(e) => {
             e.stopPropagation();
             onClose();

--- a/src/components/PaneDropOverlay.tsx
+++ b/src/components/PaneDropOverlay.tsx
@@ -24,7 +24,7 @@ interface PaneDropOverlayProps {
 export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
   const dragging = useAcornDragInProgress();
   const moveTab = useAppStore((s) => s.moveTab);
-  const openViewerTab = useAppStore((s) => s.openViewerTab);
+  const openCodeViewerTab = useAppStore((s) => s.openCodeViewerTab);
   const setFocusedPane = useAppStore((s) => s.setFocusedPane);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [zone, setZone] = useState<DropZone | null>(null);
@@ -90,12 +90,12 @@ export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
         if (!target) return;
         const filePayload = getCurrentFilePayload();
         if (filePayload) {
-          // For now ignore edge zones for file drops — viewer tabs land
+          // For now ignore edge zones for file drops — code tabs land
           // inside the target pane regardless of which edge the user hit.
-          // Splitting a pane to host a viewer can be a follow-up if it
+          // Splitting a pane to host a code tab can be a follow-up if it
           // turns out to be common.
           setFocusedPane(paneId);
-          openViewerTab(filePayload.path);
+          openCodeViewerTab(filePayload.path);
           return;
         }
         const payload = getCurrentTabPayload();
@@ -103,7 +103,7 @@ export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
         if (target.kind === "center") {
           if (payload.fromPaneId === paneId) return;
           moveTab({
-            sessionId: payload.sessionId,
+            tabId: payload.tabId,
             fromPaneId: payload.fromPaneId,
             toPaneId: paneId,
           });
@@ -113,10 +113,10 @@ export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
         // dragged tab — the source would immediately collapse.
         if (payload.fromPaneId === paneId) {
           const fromPane = useAppStore.getState().panes[paneId];
-          if (fromPane && fromPane.sessionIds.length <= 1) return;
+          if (fromPane && fromPane.tabIds.length <= 1) return;
         }
         moveTab({
-          sessionId: payload.sessionId,
+          tabId: payload.tabId,
           fromPaneId: payload.fromPaneId,
           toPaneId: paneId,
           splitDirection: target.direction,

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -46,7 +46,7 @@ function PortaledTerminal({ session }: { session: Session }) {
     const ws = state.workspaces[state.activeProject];
     if (!ws) return null;
     for (const pane of Object.values(ws.panes)) {
-      if (pane.activeSessionId === session.id) return pane.id;
+      if (pane.activeTabId === session.id) return pane.id;
     }
     return null;
   });

--- a/src/lib/dnd.ts
+++ b/src/lib/dnd.ts
@@ -1,5 +1,5 @@
 /**
- * Drag-and-drop helpers for moving session tabs between panes.
+ * Drag-and-drop helpers for moving workspace tabs between panes.
  *
  * The browser's `DataTransfer` is unreliable for custom MIME types in some
  * webviews (notably WKWebView used by Tauri on macOS): the `types` list and
@@ -13,7 +13,7 @@ import type { Direction, PaneId, SplitSide } from "./layout";
 
 export interface TabDragPayload {
   kind: "tab";
-  sessionId: string;
+  tabId: string;
   fromPaneId: PaneId;
 }
 
@@ -33,11 +33,11 @@ function notify(): void {
 
 export function setTabDragPayload(
   e: React.DragEvent,
-  payload: { sessionId: string; fromPaneId: PaneId },
+  payload: { tabId: string; fromPaneId: PaneId },
 ): void {
   currentDrag = { kind: "tab", ...payload };
   try {
-    e.dataTransfer.setData("text/plain", payload.sessionId);
+    e.dataTransfer.setData("text/plain", payload.tabId);
   } catch {
     // ignore
   }

--- a/src/lib/multiInput.test.ts
+++ b/src/lib/multiInput.test.ts
@@ -8,8 +8,8 @@ describe("visibleMultiInputSessionIds", () => {
   it("returns the active session from each visible pane", () => {
     expect(
       visibleMultiInputSessionIds({
-        left: { activeSessionId: "s1" },
-        right: { activeSessionId: "s2" },
+        left: { activeTabId: "s1" },
+        right: { activeTabId: "s2" },
       }),
     ).toEqual(["s1", "s2"]);
   });
@@ -17,9 +17,18 @@ describe("visibleMultiInputSessionIds", () => {
   it("skips empty panes and de-duplicates sessions", () => {
     expect(
       visibleMultiInputSessionIds({
-        left: { activeSessionId: "s1" },
-        middle: { activeSessionId: null },
-        right: { activeSessionId: "s1" },
+        left: { activeTabId: "s1" },
+        middle: { activeTabId: null },
+        right: { activeTabId: "s1" },
+      }),
+    ).toEqual(["s1"]);
+  });
+
+  it("skips frontend-owned tabs", () => {
+    expect(
+      visibleMultiInputSessionIds({
+        left: { activeTabId: "s1" },
+        right: { activeTabId: "code-viewer:abc" },
       }),
     ).toEqual(["s1"]);
   });
@@ -28,8 +37,8 @@ describe("visibleMultiInputSessionIds", () => {
 describe("isSessionInFocusedPane", () => {
   it("returns true only for the active session in the focused pane", () => {
     const panes = {
-      left: { activeSessionId: "s1" },
-      right: { activeSessionId: "s2" },
+      left: { activeTabId: "s1" },
+      right: { activeTabId: "s2" },
     };
 
     expect(isSessionInFocusedPane("s1", panes, "left")).toBe(true);

--- a/src/lib/multiInput.ts
+++ b/src/lib/multiInput.ts
@@ -1,5 +1,7 @@
+import { isSessionTabId } from "./workspaceTabs";
+
 interface PaneLike {
-  activeSessionId: string | null;
+  activeTabId: string | null;
 }
 
 export function visibleMultiInputSessionIds(
@@ -8,8 +10,8 @@ export function visibleMultiInputSessionIds(
   const ids: string[] = [];
   const seen = new Set<string>();
   for (const pane of Object.values(panes)) {
-    const id = pane.activeSessionId;
-    if (!id || seen.has(id)) continue;
+    const id = pane.activeTabId;
+    if (!id || !isSessionTabId(id) || seen.has(id)) continue;
     seen.add(id);
     ids.push(id);
   }
@@ -21,5 +23,5 @@ export function isSessionInFocusedPane(
   panes: Record<string, PaneLike>,
   focusedPaneId: string,
 ): boolean {
-  return panes[focusedPaneId]?.activeSessionId === sessionId;
+  return panes[focusedPaneId]?.activeTabId === sessionId;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,7 +11,7 @@ export type SessionStatus =
  * dispatch commands to other sessions in the same project. Persisted
  * sessions without this field load as `"regular"` from the backend.
  */
-export type SessionKind = "regular" | "control" | "viewer";
+export type SessionKind = "regular" | "control";
 
 export interface Session {
   id: string;

--- a/src/lib/workspaceTabs.test.ts
+++ b/src/lib/workspaceTabs.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  activeSessionIdFromTabId,
+  isProcessBackedWorkspaceTab,
+  isRestorableWorkspaceTab,
+  isSessionTabId,
+  isWorkspaceTabId,
+  makeCodeWorkspaceTab,
+  makeSessionWorkspaceTab,
+} from "./workspaceTabs";
+
+describe("workspace tab identity", () => {
+  it("treats session ids as process-backed tab ids", () => {
+    expect(isSessionTabId("session-1")).toBe(true);
+    expect(isWorkspaceTabId("session-1")).toBe(false);
+    expect(activeSessionIdFromTabId("session-1")).toBe("session-1");
+  });
+
+  it("treats code-viewer ids as frontend-owned workspace tab ids", () => {
+    expect(isSessionTabId("code-viewer:abc")).toBe(false);
+    expect(isWorkspaceTabId("code-viewer:abc")).toBe(true);
+    expect(activeSessionIdFromTabId("code-viewer:abc")).toBeNull();
+  });
+});
+
+describe("workspace tab lifecycle", () => {
+  it("creates session tab descriptors as process-backed", () => {
+    const tab = makeSessionWorkspaceTab({
+      id: "s1",
+      title: "main",
+      repoPath: "/repo",
+    });
+
+    expect(tab).toMatchObject({
+      id: "s1",
+      kind: "session",
+      lifecycle: "process-backed",
+      sessionId: "s1",
+      repoPath: "/repo",
+      title: "main",
+    });
+    expect(isProcessBackedWorkspaceTab(tab)).toBe(true);
+  });
+
+  it("creates code tabs as ephemeral by default and allows restorable descriptors", () => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000000",
+    );
+
+    const ephemeral = makeCodeWorkspaceTab("/repo/src/App.tsx", "/repo");
+    const restorable = makeCodeWorkspaceTab(
+      "/repo/src/store.ts",
+      "/repo",
+      "restorable",
+    );
+
+    expect(ephemeral).toMatchObject({
+      id: "code-viewer:00000000-0000-4000-8000-000000000000",
+      kind: "code",
+      lifecycle: "ephemeral",
+      title: "App.tsx",
+    });
+    expect(isRestorableWorkspaceTab(ephemeral)).toBe(false);
+    expect(isRestorableWorkspaceTab(restorable)).toBe(true);
+  });
+});

--- a/src/lib/workspaceTabs.ts
+++ b/src/lib/workspaceTabs.ts
@@ -1,0 +1,103 @@
+export type WorkspaceTabId = string;
+export type WorkspaceTabKind = "session" | "code";
+export type WorkspaceTabLifecycle =
+  | "ephemeral"
+  | "restorable"
+  | "process-backed";
+
+interface WorkspaceTabBase<
+  Kind extends WorkspaceTabKind,
+  Lifecycle extends WorkspaceTabLifecycle,
+> {
+  id: WorkspaceTabId;
+  kind: Kind;
+  lifecycle: Lifecycle;
+  title: string;
+  repoPath: string;
+}
+
+export interface SessionWorkspaceTab
+  extends WorkspaceTabBase<"session", "process-backed"> {
+  sessionId: string;
+}
+
+export interface CodeWorkspaceTab
+  extends WorkspaceTabBase<"code", "ephemeral" | "restorable"> {
+  path: string;
+}
+
+export type WorkspaceTab = SessionWorkspaceTab | CodeWorkspaceTab;
+export type FrontendWorkspaceTab = CodeWorkspaceTab;
+export type RestorableWorkspaceTab = Extract<
+  WorkspaceTab,
+  { lifecycle: "restorable" }
+>;
+export type ProcessBackedWorkspaceTab = Extract<
+  WorkspaceTab,
+  { lifecycle: "process-backed" }
+>;
+
+export const CODE_VIEWER_TAB_PREFIX = "code-viewer:";
+const LEGACY_VIEWER_TAB_PREFIX = "viewer:";
+
+export function isWorkspaceTabId(id: string): boolean {
+  return (
+    id.startsWith(CODE_VIEWER_TAB_PREFIX) ||
+    id.startsWith(LEGACY_VIEWER_TAB_PREFIX)
+  );
+}
+
+export function isSessionTabId(id: string): boolean {
+  return !isWorkspaceTabId(id);
+}
+
+export function activeSessionIdFromTabId(id: string | null): string | null {
+  return id && isSessionTabId(id) ? id : null;
+}
+
+export function makeSessionWorkspaceTab(input: {
+  id: string;
+  title: string;
+  repoPath: string;
+}): SessionWorkspaceTab {
+  return {
+    id: input.id,
+    kind: "session",
+    lifecycle: "process-backed",
+    sessionId: input.id,
+    title: input.title,
+    repoPath: input.repoPath,
+  };
+}
+
+export function makeCodeWorkspaceTab(
+  path: string,
+  repoPath: string,
+  lifecycle: CodeWorkspaceTab["lifecycle"] = "ephemeral",
+): CodeWorkspaceTab {
+  return {
+    id: `${CODE_VIEWER_TAB_PREFIX}${crypto.randomUUID()}`,
+    kind: "code",
+    lifecycle,
+    path,
+    repoPath,
+    title: basename(path),
+  };
+}
+
+export function isRestorableWorkspaceTab(
+  tab: WorkspaceTab,
+): tab is RestorableWorkspaceTab {
+  return tab.lifecycle === "restorable";
+}
+
+export function isProcessBackedWorkspaceTab(
+  tab: WorkspaceTab,
+): tab is ProcessBackedWorkspaceTab {
+  return tab.lifecycle === "process-backed";
+}
+
+export function basename(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] ?? path;
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -16,6 +16,7 @@ vi.mock("./lib/api", () => {
         async (_ids: string[]) =>
           [] as { id: string; status: SessionStatus }[],
       ),
+      ptyInWorktreeAll: vi.fn(async () => ({} as Record<string, boolean>)),
       createSession: vi.fn(async () => ({}) as Session),
       removeSession: vi.fn(async () => undefined),
       renameSession: vi.fn(async () => ({}) as Session),
@@ -88,10 +89,12 @@ function resetStore(): void {
       workspaces: {},
       activeProject: null,
       layout: { kind: "pane", id: "root" },
-      panes: { root: { id: "root", sessionIds: [], activeSessionId: null } },
+      panes: { root: { id: "root", tabIds: [], activeTabId: null } },
       focusedPaneId: "root",
+      activeTabId: null,
       activeSessionId: null,
       rightTab: "commits",
+      workspaceTabs: {},
       prAccountByRepo: {},
       pendingTerminalInput: {},
       multiInputEnabled: false,
@@ -100,6 +103,7 @@ function resetStore(): void {
       pendingRemoveId: null,
       pendingRemoveProject: null,
       sessionsLoadedCleanly: true,
+      liveInWorktree: {},
     },
     false,
   );
@@ -204,6 +208,45 @@ describe("selectSession", () => {
   });
 });
 
+describe("workspace tabs", () => {
+  it("opens a code viewer as a workspace tab without making it the active session", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+
+    useAppStore.getState().openCodeViewerTab(`${REPO_A}/src/App.tsx`);
+
+    const s = useAppStore.getState();
+    expect(s.activeSessionId).toBeNull();
+    expect(s.activeTabId).toMatch(/^code-viewer:/);
+    expect(s.sessions.map((x) => x.id)).toEqual(["a1"]);
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual([
+      "a1",
+      s.activeTabId,
+    ]);
+    expect(s.workspaceTabs[s.activeTabId!]).toMatchObject({
+      kind: "code",
+      lifecycle: "ephemeral",
+      path: `${REPO_A}/src/App.tsx`,
+      repoPath: REPO_A,
+      title: "App.tsx",
+    });
+  });
+
+  it("closes the active code viewer instead of requesting session removal", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+    useAppStore.getState().openCodeViewerTab(`${REPO_A}/src/App.tsx`);
+    const tabId = useAppStore.getState().activeTabId!;
+
+    useAppStore.getState().closeFocusedTab();
+
+    const s = useAppStore.getState();
+    expect(s.pendingRemoveId).toBeNull();
+    expect(s.workspaceTabs[tabId]).toBeUndefined();
+    expect(s.activeTabId).toBe("a1");
+    expect(s.activeSessionId).toBe("a1");
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1"]);
+  });
+});
+
 describe("splitFocusedPane", () => {
   it("creates a new pane and focuses it; layout becomes a split", async () => {
     await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
@@ -213,7 +256,7 @@ describe("splitFocusedPane", () => {
     const s = useAppStore.getState();
     expect(s.layout.kind).toBe("split");
     expect(Object.keys(s.panes)).toHaveLength(2);
-    expect(s.panes[s.focusedPaneId].sessionIds).toEqual([]);
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual([]);
     expect(s.activeSessionId).toBeNull();
   });
 
@@ -241,20 +284,20 @@ describe("moveTab", () => {
     );
     useAppStore.getState().splitFocusedPane("horizontal");
     const fromPaneId = Object.keys(useAppStore.getState().panes).find(
-      (pid) => useAppStore.getState().panes[pid].sessionIds.length === 2,
+      (pid) => useAppStore.getState().panes[pid].tabIds.length === 2,
     )!;
     const toPaneId = useAppStore.getState().focusedPaneId;
     expect(fromPaneId).not.toBe(toPaneId);
 
     useAppStore.getState().moveTab({
-      sessionId: "a1",
+      tabId: "a1",
       fromPaneId,
       toPaneId,
     });
 
     const s = useAppStore.getState();
-    expect(s.panes[fromPaneId].sessionIds).toEqual(["a2"]);
-    expect(s.panes[toPaneId].sessionIds).toEqual(["a1"]);
+    expect(s.panes[fromPaneId].tabIds).toEqual(["a2"]);
+    expect(s.panes[toPaneId].tabIds).toEqual(["a1"]);
     expect(s.focusedPaneId).toBe(toPaneId);
     expect(s.activeSessionId).toBe("a1");
   });
@@ -269,7 +312,7 @@ describe("moveTab", () => {
     )!;
 
     useAppStore.getState().moveTab({
-      sessionId: "a1",
+      tabId: "a1",
       fromPaneId: sourcePaneId,
       toPaneId: focusedAfterSplit,
     });
@@ -277,7 +320,7 @@ describe("moveTab", () => {
     const s = useAppStore.getState();
     expect(s.layout.kind).toBe("pane");
     expect(Object.keys(s.panes)).toHaveLength(1);
-    expect(s.panes[s.focusedPaneId].sessionIds).toEqual(["a1"]);
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1"]);
   });
 
   it("creates a new pane when splitDirection/splitSide are provided; empty source collapses", async () => {
@@ -285,7 +328,7 @@ describe("moveTab", () => {
     const fromPaneId = useAppStore.getState().focusedPaneId;
 
     useAppStore.getState().moveTab({
-      sessionId: "a1",
+      tabId: "a1",
       fromPaneId,
       toPaneId: fromPaneId,
       splitDirection: "horizontal",
@@ -296,7 +339,7 @@ describe("moveTab", () => {
     // Splitting then immediately collapsing the empty source leaves a single pane.
     expect(s.layout.kind).toBe("pane");
     expect(Object.keys(s.panes)).toHaveLength(1);
-    expect(s.panes[s.focusedPaneId].sessionIds).toEqual(["a1"]);
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1"]);
     expect(s.activeSessionId).toBe("a1");
   });
 
@@ -308,7 +351,7 @@ describe("moveTab", () => {
     const fromPaneId = useAppStore.getState().focusedPaneId;
 
     useAppStore.getState().moveTab({
-      sessionId: "a1",
+      tabId: "a1",
       fromPaneId,
       toPaneId: fromPaneId,
       splitDirection: "horizontal",
@@ -318,7 +361,7 @@ describe("moveTab", () => {
     const s = useAppStore.getState();
     expect(s.layout.kind).toBe("split");
     expect(Object.keys(s.panes)).toHaveLength(2);
-    expect(s.panes[s.focusedPaneId].sessionIds).toEqual(["a1"]);
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1"]);
   });
 });
 
@@ -335,7 +378,7 @@ describe("closePane", () => {
     )!;
     // Move a2 to the new (focused) pane so both panes hold sessions.
     useAppStore.getState().moveTab({
-      sessionId: "a2",
+      tabId: "a2",
       fromPaneId: otherPaneId,
       toPaneId: focusedAfterSplit,
     });
@@ -345,7 +388,7 @@ describe("closePane", () => {
     expect(s.layout.kind).toBe("pane");
     expect(Object.keys(s.panes)).toHaveLength(1);
     const surviving = s.panes[s.focusedPaneId];
-    expect(surviving.sessionIds.sort()).toEqual(["a1", "a2"]);
+    expect(surviving.tabIds.sort()).toEqual(["a1", "a2"]);
   });
 
   it("is a no-op when only one pane exists", async () => {
@@ -413,7 +456,7 @@ describe("reconcile via refreshSessions", () => {
       [project(REPO_A, 0)],
       [session("a1", REPO_A), session("a2", REPO_A)],
     );
-    expect(useAppStore.getState().panes[useAppStore.getState().focusedPaneId].sessionIds.sort()).toEqual([
+    expect(useAppStore.getState().panes[useAppStore.getState().focusedPaneId].tabIds.sort()).toEqual([
       "a1",
       "a2",
     ]);
@@ -423,7 +466,7 @@ describe("reconcile via refreshSessions", () => {
 
     const s = useAppStore.getState();
     expect(s.sessions.map((x) => x.id)).toEqual(["a1"]);
-    expect(s.panes[s.focusedPaneId].sessionIds).toEqual(["a1"]);
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1"]);
   });
 
   // TODO(acorn-tests): cross-pane collapse on session removal reproduces
@@ -443,7 +486,7 @@ describe("reconcile via refreshSessions", () => {
       (pid) => pid !== focusedAfterSplit,
     )!;
     useAppStore.getState().moveTab({
-      sessionId: "a2",
+      tabId: "a2",
       fromPaneId: otherPaneId,
       toPaneId: focusedAfterSplit,
     });
@@ -452,7 +495,7 @@ describe("reconcile via refreshSessions", () => {
 
     const s = useAppStore.getState();
     expect(Object.keys(s.panes)).toHaveLength(1);
-    expect(Object.values(s.panes)[0].sessionIds).toEqual(["a1"]);
+    expect(Object.values(s.panes)[0].tabIds).toEqual(["a1"]);
   });
 
   it("places newly seen sessions in the focused pane", async () => {
@@ -463,10 +506,10 @@ describe("reconcile via refreshSessions", () => {
     ]);
     await useAppStore.getState().refreshSessions();
     const s = useAppStore.getState();
-    expect(s.panes[s.focusedPaneId].sessionIds.sort()).toEqual(["a1", "a2"]);
+    expect(s.panes[s.focusedPaneId].tabIds.sort()).toEqual(["a1", "a2"]);
   });
 
-  it("does NOT wipe persisted sessionIds when load_status reports unclean", async () => {
+  it("does NOT wipe persisted tabIds when load_status reports unclean", async () => {
     // Seed: persisted layout with two sessions in one pane.
     await seed(
       [project(REPO_A, 0)],
@@ -474,7 +517,7 @@ describe("reconcile via refreshSessions", () => {
     );
     expect(
       useAppStore.getState().panes[useAppStore.getState().focusedPaneId]
-        .sessionIds.sort(),
+        .tabIds.sort(),
     ).toEqual(["a1", "a2"]);
 
     // Simulate boot-time corruption: backend returns empty + reports unclean.
@@ -490,7 +533,7 @@ describe("reconcile via refreshSessions", () => {
     const s = useAppStore.getState();
     expect(s.sessions).toEqual([]);
     expect(s.sessionsLoadedCleanly).toBe(false);
-    expect(s.panes[s.focusedPaneId].sessionIds.sort()).toEqual(["a1", "a2"]);
+    expect(s.panes[s.focusedPaneId].tabIds.sort()).toEqual(["a1", "a2"]);
   });
 
   it("clears the wipe guard once backend returns at least one session", async () => {
@@ -683,7 +726,7 @@ describe("createSession", () => {
     await useAppStore.getState().createSession("new", REPO_A);
 
     const s = useAppStore.getState();
-    expect(s.panes[s.focusedPaneId].sessionIds).toEqual([
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual([
       "a1",
       "a2",
       "a4",
@@ -701,7 +744,7 @@ describe("createSession", () => {
     await useAppStore.getState().createSession("first", REPO_A);
 
     const s = useAppStore.getState();
-    expect(s.panes[s.focusedPaneId].sessionIds).toEqual(["first"]);
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual(["first"]);
     expect(s.activeSessionId).toBe("first");
   });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,6 +16,13 @@ import {
   removePaneFromLayout,
   splitPaneInLayout,
 } from "./lib/layout";
+import {
+  activeSessionIdFromTabId,
+  isRestorableWorkspaceTab,
+  isWorkspaceTabId,
+  makeCodeWorkspaceTab,
+  type FrontendWorkspaceTab,
+} from "./lib/workspaceTabs";
 
 type RightTab =
   | "todos"
@@ -29,8 +36,8 @@ const ROOT_PANE_ID: PaneId = "root";
 
 export interface PaneState {
   id: PaneId;
-  sessionIds: string[];
-  activeSessionId: string | null;
+  tabIds: string[];
+  activeTabId: string | null;
 }
 
 export interface ProjectWorkspace {
@@ -40,7 +47,7 @@ export interface ProjectWorkspace {
 }
 
 export interface MoveTabArgs {
-  sessionId: string;
+  tabId: string;
   fromPaneId: PaneId;
   toPaneId: PaneId;
   toIndex?: number;
@@ -60,16 +67,16 @@ interface AppStateModel {
   layout: LayoutNode;
   panes: Record<PaneId, PaneState>;
   focusedPaneId: PaneId;
+  activeTabId: string | null;
   activeSessionId: string | null;
 
   rightTab: RightTab;
   /**
-   * Readonly code viewer tabs. Each entry id is also referenced by a
-   * pane's `sessionIds` so the tab strip can render it alongside real
-   * PTY sessions. Frontend-only — not persisted across app restarts,
-   * never round-tripped through the backend.
+   * Frontend-owned tabs such as readonly code viewers. Terminal sessions
+   * use their backend session id directly as the tab id and therefore do
+   * not appear in this map.
    */
-  viewerTabs: Record<string, ViewerTab>;
+  workspaceTabs: Record<string, FrontendWorkspaceTab>;
   /** gh login most recently resolved as having access to a given repo, keyed
    *  by repo path. Populated by the PRs tab; consumed by the StatusBar to
    *  surface "which identity am I acting as for this repo". In-memory only. */
@@ -91,7 +98,7 @@ interface AppStateModel {
   /**
    * Set to false at boot if the backend reports that `sessions.json` failed
    * to load (file existed but could not be read or parsed). When false,
-   * `reconcileWorkspace` refuses to wipe a pane's `sessionIds` on the basis
+   * `reconcileWorkspace` refuses to wipe a pane's `tabIds` on the basis
    * of an empty backend list — protecting layouts from being destroyed by a
    * transient disk failure or a schema-incompatible build run from another
    * worktree. Cleared (set back to true) once the user takes any action that
@@ -116,6 +123,7 @@ interface AppStateModel {
   /** Probe session liveness via JSONL transcripts; updates session statuses
    *  in place without touching `updated_at`. */
   pollSessionStatuses: () => Promise<void>;
+  selectTab: (id: string | null) => void;
   selectSession: (id: string | null) => void;
   setActiveProject: (repoPath: string) => void;
   setFocusedPane: (paneId: PaneId) => void;
@@ -159,27 +167,10 @@ interface AppStateModel {
   /** Atomically read and remove the queued command for `sessionId`. */
   consumePendingTerminalInput: (sessionId: string) => PendingTerminalInput | null;
   toggleMultiInput: () => boolean;
-  /** Open a readonly viewer tab for `path` in the focused pane. */
-  openViewerTab: (path: string) => void;
-  /** Close a viewer tab and remove it from any pane it lives in. */
-  closeViewerTab: (id: string) => void;
-}
-
-export interface ViewerTab {
-  id: string;
-  path: string;
-  name: string;
-  /** Workspace this viewer belongs to. Pane code reads this to set the
-   * synthetic session's `repo_path` to the project root rather than the
-   * file path — otherwise "new tab" double-click would spawn a session
-   * against the file path and land in the wrong (or no) project. */
-  repoPath: string;
-}
-
-export const VIEWER_TAB_PREFIX = "viewer:";
-
-export function isViewerTabId(id: string): boolean {
-  return id.startsWith(VIEWER_TAB_PREFIX);
+  /** Open a readonly code viewer tab for `path` in the focused pane. */
+  openCodeViewerTab: (path: string) => void;
+  /** Close any frontend-owned tab and remove it from panes. */
+  closeWorkspaceTab: (id: string) => void;
 }
 
 export interface PendingTerminalInput {
@@ -203,7 +194,30 @@ function nextSplitId(): string {
 }
 
 function emptyPane(id: PaneId): PaneState {
-  return { id, sessionIds: [], activeSessionId: null };
+  return { id, tabIds: [], activeTabId: null };
+}
+
+type PersistedPaneState = Partial<PaneState> & {
+  sessionIds?: string[];
+  activeSessionId?: string | null;
+};
+
+function normalizePaneState(
+  pane: PersistedPaneState | undefined,
+  id: PaneId,
+): PaneState {
+  const tabIds = Array.isArray(pane?.tabIds)
+    ? pane.tabIds
+    : Array.isArray(pane?.sessionIds)
+      ? pane.sessionIds
+      : [];
+  const activeTabId =
+    pane?.activeTabId !== undefined
+      ? pane.activeTabId
+      : pane?.activeSessionId !== undefined
+        ? pane.activeSessionId
+        : null;
+  return { id, tabIds, activeTabId };
 }
 
 function emptyWorkspace(): ProjectWorkspace {
@@ -215,6 +229,7 @@ function emptyWorkspace(): ProjectWorkspace {
 }
 
 function fallbackEmptyMirror() {
+  const activeTabId = null as string | null;
   return {
     layout: makePaneNode(ROOT_PANE_ID),
     panes: { [ROOT_PANE_ID]: emptyPane(ROOT_PANE_ID) } as Record<
@@ -222,7 +237,8 @@ function fallbackEmptyMirror() {
       PaneState
     >,
     focusedPaneId: ROOT_PANE_ID as PaneId,
-    activeSessionId: null as string | null,
+    activeTabId,
+    activeSessionId: activeSessionIdFromTabId(activeTabId),
   };
 }
 
@@ -233,11 +249,13 @@ function mirrorActive(
   if (!activeProject) return fallbackEmptyMirror();
   const ws = workspaces[activeProject];
   if (!ws) return fallbackEmptyMirror();
+  const activeTabId = ws.panes[ws.focusedPaneId]?.activeTabId ?? null;
   return {
     layout: ws.layout,
     panes: ws.panes,
     focusedPaneId: ws.focusedPaneId,
-    activeSessionId: ws.panes[ws.focusedPaneId]?.activeSessionId ?? null,
+    activeTabId,
+    activeSessionId: activeSessionIdFromTabId(activeTabId),
   };
 }
 
@@ -249,7 +267,7 @@ function mirrorActive(
  * `allowEmptyWipe` is the safety knob for the boot-time disk-corruption
  * scenario. When `false` and `sessions` is empty *while the workspace still
  * remembers session ids*, this function returns the workspace unchanged
- * rather than zeroing every pane's `sessionIds`. This avoids the cascade
+ * rather than zeroing every pane's `tabIds`. This avoids the cascade
  * where a transient `sessions.json` read failure (or a schema-incompatible
  * build from another worktree) erases the persisted layout permanently.
  */
@@ -261,7 +279,7 @@ function reconcileWorkspace(
   if (
     !allowEmptyWipe &&
     sessions.length === 0 &&
-    Object.values(ws.panes).some((p) => p.sessionIds.length > 0)
+    Object.values(ws.panes).some((p) => p.tabIds.length > 0)
   ) {
     return ws;
   }
@@ -270,27 +288,27 @@ function reconcileWorkspace(
 
   let newPanes: Record<PaneId, PaneState> = {};
   for (const pid of validPaneIds) {
-    const existing = ws.panes[pid] ?? emptyPane(pid);
-    // Viewer-tab ids live alongside session ids in the same array but
-    // are not tracked by the backend, so the session-list filter must
+    const existing = normalizePaneState(ws.panes[pid], pid);
+    // Frontend-owned tab ids live alongside session ids in the same array
+    // but are not tracked by the backend, so the session-list filter must
     // preserve them explicitly.
-    const filtered = existing.sessionIds.filter(
-      (id) => knownIds.has(id) || isViewerTabId(id),
+    const filtered = existing.tabIds.filter(
+      (id) => knownIds.has(id) || isWorkspaceTabId(id),
     );
     const active =
-      existing.activeSessionId && filtered.includes(existing.activeSessionId)
-        ? existing.activeSessionId
+      existing.activeTabId && filtered.includes(existing.activeTabId)
+        ? existing.activeTabId
         : filtered[filtered.length - 1] ?? null;
     newPanes[pid] = {
       id: pid,
-      sessionIds: filtered,
-      activeSessionId: active,
+      tabIds: filtered,
+      activeTabId: active,
     };
   }
 
   const assigned = new Set<string>();
   for (const p of Object.values(newPanes)) {
-    for (const id of p.sessionIds) assigned.add(id);
+    for (const id of p.tabIds) assigned.add(id);
   }
   let target = newPanes[ws.focusedPaneId] ? ws.focusedPaneId : ROOT_PANE_ID;
   if (!newPanes[target]) {
@@ -302,8 +320,8 @@ function reconcileWorkspace(
       const pane = newPanes[target];
       newPanes[target] = {
         ...pane,
-        sessionIds: [...pane.sessionIds, s.id],
-        activeSessionId: pane.activeSessionId ?? s.id,
+        tabIds: [...pane.tabIds, s.id],
+        activeTabId: pane.activeTabId ?? s.id,
       };
       assigned.add(s.id);
     }
@@ -369,12 +387,12 @@ function reconcileWorkspaces(
   return { workspaces: newWorkspaces, activeProject: newActive };
 }
 
-function findPaneContainingSession(
+function findPaneContainingTab(
   panes: Record<PaneId, PaneState>,
-  sessionId: string,
+  tabId: string,
 ): PaneId | null {
   for (const [pid, p] of Object.entries(panes)) {
-    if (p.sessionIds.includes(sessionId)) return pid;
+    if (p.tabIds.includes(tabId)) return pid;
   }
   return null;
 }
@@ -407,10 +425,11 @@ export const useAppStore = create<AppStateModel>()(
   layout: makePaneNode(ROOT_PANE_ID),
   panes: { [ROOT_PANE_ID]: emptyPane(ROOT_PANE_ID) },
   focusedPaneId: ROOT_PANE_ID,
+  activeTabId: null,
   activeSessionId: null,
 
   rightTab: "commits",
-  viewerTabs: {},
+  workspaceTabs: {},
   prAccountByRepo: {},
   pendingTerminalInput: {},
   multiInputEnabled: false,
@@ -539,7 +558,7 @@ export const useAppStore = create<AppStateModel>()(
     }
   },
 
-  selectSession(id) {
+  selectTab(id) {
     set((s) => {
       // Clear within active workspace
       if (id === null) {
@@ -550,35 +569,40 @@ export const useAppStore = create<AppStateModel>()(
             ...ws,
             panes: {
               ...ws.panes,
-              [ws.focusedPaneId]: { ...pane, activeSessionId: null },
+              [ws.focusedPaneId]: { ...pane, activeTabId: null },
             },
           };
         });
         return patch ?? s;
       }
 
-      // Viewer tabs are workspace-local — they live in whichever
-      // workspace the user opened them from. Resolve via current active
-      // project rather than session lookup (no backend Session exists).
-      if (isViewerTabId(id)) {
-        const patch = updateActiveWorkspace(s, (ws) => {
-          const containing = findPaneContainingSession(ws.panes, id);
-          if (!containing) return ws;
-          const pane = ws.panes[containing];
-          if (!pane) return ws;
-          return {
-            ...ws,
-            panes: {
-              ...ws.panes,
-              [containing]: { ...pane, activeSessionId: id },
-            },
-            focusedPaneId: containing,
-          };
-        });
-        return patch ?? s;
+      if (isWorkspaceTabId(id)) {
+        const tab = s.workspaceTabs[id];
+        const targetProject = tab?.repoPath ?? s.activeProject;
+        if (!targetProject) return s;
+        const ws = s.workspaces[targetProject];
+        if (!ws) return s;
+        const containing = findPaneContainingTab(ws.panes, id);
+        if (!containing) return s;
+        const pane = ws.panes[containing];
+        if (!pane) return s;
+        const nextWs: ProjectWorkspace = {
+          ...ws,
+          panes: {
+            ...ws.panes,
+            [containing]: { ...pane, activeTabId: id },
+          },
+          focusedPaneId: containing,
+        };
+        const workspaces = { ...s.workspaces, [targetProject]: nextWs };
+        return {
+          workspaces,
+          activeProject: targetProject,
+          ...mirrorActive(workspaces, targetProject),
+        };
       }
 
-      // Find session, switch active project to its repo, set active in pane
+      // Find session, switch active project to its repo, set active in pane.
       const session = s.sessions.find((x) => x.id === id);
       if (!session) return s;
 
@@ -586,21 +610,21 @@ export const useAppStore = create<AppStateModel>()(
       const ws = s.workspaces[targetProject];
       if (!ws) return s;
 
-      const containing = findPaneContainingSession(ws.panes, id);
+      const containing = findPaneContainingTab(ws.panes, id);
       const targetPaneId = containing ?? ws.focusedPaneId;
       const pane =
         ws.panes[targetPaneId] ?? emptyPane(targetPaneId);
-      const sessionIds = pane.sessionIds.includes(id)
-        ? pane.sessionIds
-        : [...pane.sessionIds, id];
+      const tabIds = pane.tabIds.includes(id)
+        ? pane.tabIds
+        : [...pane.tabIds, id];
       const newWs: ProjectWorkspace = {
         ...ws,
         panes: {
           ...ws.panes,
           [targetPaneId]: {
             ...pane,
-            sessionIds,
-            activeSessionId: id,
+            tabIds,
+            activeTabId: id,
           },
         },
         focusedPaneId: targetPaneId,
@@ -612,6 +636,10 @@ export const useAppStore = create<AppStateModel>()(
         ...mirrorActive(workspaces, targetProject),
       };
     });
+  },
+
+  selectSession(id) {
+    get().selectTab(id);
   },
 
   setActiveProject(repoPath) {
@@ -679,10 +707,10 @@ export const useAppStore = create<AppStateModel>()(
     set((s) => {
       const patch = updateActiveWorkspace(s, (ws) => {
         const pane = ws.panes[ws.focusedPaneId];
-        if (!pane || pane.sessionIds.length === 0) return ws;
-        const ids = pane.sessionIds;
-        const currentIdx = pane.activeSessionId
-          ? ids.indexOf(pane.activeSessionId)
+        if (!pane || pane.tabIds.length === 0) return ws;
+        const ids = pane.tabIds;
+        const currentIdx = pane.activeTabId
+          ? ids.indexOf(pane.activeTabId)
           : -1;
         const nextIdx =
           currentIdx < 0
@@ -691,12 +719,12 @@ export const useAppStore = create<AppStateModel>()(
               : ids.length - 1
             : (currentIdx + direction + ids.length) % ids.length;
         const nextId = ids[nextIdx];
-        if (nextId === pane.activeSessionId) return ws;
+        if (nextId === pane.activeTabId) return ws;
         return {
           ...ws,
           panes: {
             ...ws.panes,
-            [ws.focusedPaneId]: { ...pane, activeSessionId: nextId },
+            [ws.focusedPaneId]: { ...pane, activeTabId: nextId },
           },
         };
       });
@@ -721,9 +749,13 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   closeFocusedTab() {
-    const { activeSessionId } = get();
-    if (!activeSessionId) return;
-    get().requestRemoveSession(activeSessionId);
+    const { activeTabId } = get();
+    if (!activeTabId) return;
+    if (isWorkspaceTabId(activeTabId)) {
+      get().closeWorkspaceTab(activeTabId);
+      return;
+    }
+    get().requestRemoveSession(activeTabId);
   },
 
   closePane(paneId) {
@@ -739,12 +771,12 @@ export const useAppStore = create<AppStateModel>()(
         delete newPanes[paneId];
         const surviving = listPaneIds(collapsed);
         const fallback = surviving[0] ?? ROOT_PANE_ID;
-        if (newPanes[fallback] && pane.sessionIds.length > 0) {
+        if (newPanes[fallback] && pane.tabIds.length > 0) {
           const target = newPanes[fallback];
           newPanes[fallback] = {
             ...target,
-            sessionIds: [...target.sessionIds, ...pane.sessionIds],
-            activeSessionId: target.activeSessionId ?? pane.activeSessionId,
+            tabIds: [...target.tabIds, ...pane.tabIds],
+            activeTabId: target.activeTabId ?? pane.activeTabId,
           };
         }
         return {
@@ -762,22 +794,22 @@ export const useAppStore = create<AppStateModel>()(
       // moveTab is intra-workspace only — tabs can't cross projects.
       const patch = updateActiveWorkspace(s, (ws) => {
         const fromPane = ws.panes[args.fromPaneId];
-        if (!fromPane || !fromPane.sessionIds.includes(args.sessionId))
+        if (!fromPane || !fromPane.tabIds.includes(args.tabId))
           return ws;
 
-        const srcSessionIds = fromPane.sessionIds.filter(
-          (id) => id !== args.sessionId,
+        const srcTabIds = fromPane.tabIds.filter(
+          (id) => id !== args.tabId,
         );
         const srcActive =
-          fromPane.activeSessionId === args.sessionId
-            ? srcSessionIds[srcSessionIds.length - 1] ?? null
-            : fromPane.activeSessionId;
+          fromPane.activeTabId === args.tabId
+            ? srcTabIds[srcTabIds.length - 1] ?? null
+            : fromPane.activeTabId;
         let newPanes: Record<PaneId, PaneState> = {
           ...ws.panes,
           [args.fromPaneId]: {
             ...fromPane,
-            sessionIds: srcSessionIds,
-            activeSessionId: srcActive,
+            tabIds: srcTabIds,
+            activeTabId: srcActive,
           },
         };
 
@@ -803,19 +835,19 @@ export const useAppStore = create<AppStateModel>()(
 
         const safeIndex =
           typeof args.toIndex === "number"
-            ? Math.max(0, Math.min(args.toIndex, toPane.sessionIds.length))
-            : toPane.sessionIds.length;
-        const targetIds = [...toPane.sessionIds];
-        targetIds.splice(safeIndex, 0, args.sessionId);
+            ? Math.max(0, Math.min(args.toIndex, toPane.tabIds.length))
+            : toPane.tabIds.length;
+        const targetIds = [...toPane.tabIds];
+        targetIds.splice(safeIndex, 0, args.tabId);
         newPanes[toPaneId] = {
           ...toPane,
-          sessionIds: targetIds,
-          activeSessionId: args.sessionId,
+          tabIds: targetIds,
+          activeTabId: args.tabId,
         };
 
         const totalPanes = Object.keys(newPanes).length;
         if (
-          srcSessionIds.length === 0 &&
+          srcTabIds.length === 0 &&
           totalPanes > 1 &&
           args.fromPaneId !== toPaneId
         ) {
@@ -850,8 +882,8 @@ export const useAppStore = create<AppStateModel>()(
         if (!ws) return null;
         const paneId = ws.focusedPaneId;
         const pane = ws.panes[paneId];
-        if (!pane?.activeSessionId) return null;
-        const idx = pane.sessionIds.indexOf(pane.activeSessionId);
+        if (!pane?.activeTabId) return null;
+        const idx = pane.tabIds.indexOf(pane.activeTabId);
         return idx >= 0 ? { paneId, idx } : null;
       })();
 
@@ -860,7 +892,7 @@ export const useAppStore = create<AppStateModel>()(
 
       // Reorder so the new tab sits immediately after the previously-active
       // tab in the same pane. `reconcileWorkspace` always appends new
-      // sessions at the end of `focusedPaneId.sessionIds`; this step
+      // sessions at the end of `focusedPaneId.tabIds`; this step
       // converts that to "next to active" without changing reconcile's
       // boot-time behavior.
       if (beforeSnap) {
@@ -869,16 +901,16 @@ export const useAppStore = create<AppStateModel>()(
           if (!ws) return s;
           const pane = ws.panes[beforeSnap.paneId];
           if (!pane) return s;
-          const currentIdx = pane.sessionIds.indexOf(created.id);
+          const currentIdx = pane.tabIds.indexOf(created.id);
           if (currentIdx < 0) return s;
           const targetIdx = Math.min(
             beforeSnap.idx + 1,
-            pane.sessionIds.length - 1,
+            pane.tabIds.length - 1,
           );
           if (currentIdx === targetIdx) return s;
-          const ids = pane.sessionIds.filter((id) => id !== created.id);
+          const ids = pane.tabIds.filter((id) => id !== created.id);
           ids.splice(targetIdx, 0, created.id);
-          const newPane = { ...pane, sessionIds: ids };
+          const newPane = { ...pane, tabIds: ids };
           const newWs = {
             ...ws,
             panes: { ...ws.panes, [beforeSnap.paneId]: newPane },
@@ -936,7 +968,7 @@ export const useAppStore = create<AppStateModel>()(
       let owning: { repoPath: string; paneId: PaneId } | null = null;
       for (const [repoPath, ws] of Object.entries(before.workspaces)) {
         for (const [pid, p] of Object.entries(ws.panes)) {
-          if (p.sessionIds.includes(id)) {
+          if (p.tabIds.includes(id)) {
             owning = { repoPath, paneId: pid as PaneId };
             break;
           }
@@ -953,7 +985,7 @@ export const useAppStore = create<AppStateModel>()(
       if (!ws) return;
       const pane = ws.panes[owning.paneId];
       if (!pane) return;
-      if (pane.sessionIds.length > 0) return;
+      if (pane.tabIds.length > 0) return;
       if (Object.keys(ws.panes).length <= 1) return;
       // Only auto-collapse for the currently active workspace's panes —
       // closePane operates on the active workspace, so applying it to a
@@ -1141,33 +1173,31 @@ export const useAppStore = create<AppStateModel>()(
     return enabled;
   },
 
-  openViewerTab(path) {
+  openCodeViewerTab(path) {
     set((s) => {
       if (!s.activeProject) return s;
       const ws = s.workspaces[s.activeProject];
       if (!ws) return s;
-      // Reuse an existing viewer tab for the same path if there is one;
+      // Reuse an existing code tab for the same path if there is one;
       // this avoids piling up identical tabs when the user double-clicks
       // the same file repeatedly. The reuse cycles focus to the tab.
-      const existing = Object.values(s.viewerTabs).find(
-        (v) => v.path === path && v.repoPath === s.activeProject,
+      const existing = Object.values(s.workspaceTabs).find(
+        (tab) =>
+          tab.kind === "code" &&
+          tab.path === path &&
+          tab.repoPath === s.activeProject,
       );
-      const tab: ViewerTab = existing ?? {
-        id: `${VIEWER_TAB_PREFIX}${crypto.randomUUID()}`,
-        path,
-        name: path.split("/").filter(Boolean).pop() ?? path,
-        repoPath: s.activeProject,
-      };
+      const tab = existing ?? makeCodeWorkspaceTab(path, s.activeProject);
       const focused = ws.focusedPaneId;
       const pane = ws.panes[focused];
       if (!pane) return s;
-      const alreadyInPane = pane.sessionIds.includes(tab.id);
+      const alreadyInPane = pane.tabIds.includes(tab.id);
       const newPane: PaneState = alreadyInPane
-        ? { ...pane, activeSessionId: tab.id }
+        ? { ...pane, activeTabId: tab.id }
         : {
             ...pane,
-            sessionIds: [...pane.sessionIds, tab.id],
-            activeSessionId: tab.id,
+            tabIds: [...pane.tabIds, tab.id],
+            activeTabId: tab.id,
           };
       const newWs: ProjectWorkspace = {
         ...ws,
@@ -1178,41 +1208,44 @@ export const useAppStore = create<AppStateModel>()(
         [s.activeProject]: newWs,
       };
       return {
-        viewerTabs: existing ? s.viewerTabs : { ...s.viewerTabs, [tab.id]: tab },
+        workspaceTabs: existing
+          ? s.workspaceTabs
+          : { ...s.workspaceTabs, [tab.id]: tab },
         workspaces: newWorkspaces,
         ...mirrorActive(newWorkspaces, s.activeProject),
       };
     });
   },
 
-  closeViewerTab(id) {
+  closeWorkspaceTab(id) {
     set((s) => {
-      if (!isViewerTabId(id)) return s;
-      const { [id]: _, ...rest } = s.viewerTabs;
+      if (!isWorkspaceTabId(id)) return s;
+      const { [id]: _, ...rest } = s.workspaceTabs;
       const newWorkspaces: Record<string, ProjectWorkspace> = {};
       for (const [key, ws] of Object.entries(s.workspaces)) {
         const newPanes: Record<PaneId, PaneState> = {};
         for (const [pid, pane] of Object.entries(ws.panes)) {
-          const ids = pane.sessionIds.filter((sid) => sid !== id);
+          const ids = pane.tabIds.filter((sid) => sid !== id);
           const nextActive =
-            pane.activeSessionId === id
+            pane.activeTabId === id
               ? ids[ids.length - 1] ?? null
-              : pane.activeSessionId;
+              : pane.activeTabId;
           newPanes[pid as PaneId] = {
             ...pane,
-            sessionIds: ids,
-            activeSessionId: nextActive,
+            tabIds: ids,
+            activeTabId: nextActive,
           };
         }
         newWorkspaces[key] = { ...ws, panes: newPanes };
       }
       return {
-        viewerTabs: rest,
+        workspaceTabs: rest,
         workspaces: newWorkspaces,
         ...mirrorActive(newWorkspaces, s.activeProject),
       };
     });
   },
+
     }),
     {
       name: "acorn-workspaces",
@@ -1222,35 +1255,51 @@ export const useAppStore = create<AppStateModel>()(
         workspaces: state.workspaces,
         activeProject: state.activeProject,
         rightTab: state.rightTab,
+        workspaceTabs: Object.fromEntries(
+          Object.entries(state.workspaceTabs).filter(([, tab]) =>
+            isRestorableWorkspaceTab(tab),
+          ),
+        ),
       }),
       // Recompute the active-workspace mirror after hydration so consumers
       // see the persisted layout immediately, before the first refreshAll.
       onRehydrateStorage: () => (state) => {
         if (!state) return;
-        // Viewer tabs are frontend-only and not persisted, so any
-        // viewer ids in the persisted workspace are stale. Strip them
-        // from pane sessionIds + activeSessionId before the layout
-        // mirror computes, otherwise the empty-pane fallback never
-        // shows and the tab strip points at a dead id.
+        // Only restorable frontend-owned tabs survive rehydrate. Ephemeral
+        // tabs, plus stale ids whose descriptors are gone, are stripped
+        // before the layout mirror computes.
+        const restoredTabs = Object.fromEntries(
+          Object.entries(state.workspaceTabs ?? {}).filter(([, tab]) =>
+            isRestorableWorkspaceTab(tab),
+          ),
+        );
         const sanitized: Record<string, ProjectWorkspace> = {};
         for (const [key, ws] of Object.entries(state.workspaces ?? {})) {
           const newPanes: Record<PaneId, PaneState> = {};
           for (const [pid, pane] of Object.entries(ws.panes ?? {})) {
-            const ids = pane.sessionIds.filter((id) => !isViewerTabId(id));
+            const normalized = normalizePaneState(
+              pane as PersistedPaneState,
+              pid as PaneId,
+            );
+            const ids = normalized.tabIds.filter(
+              (id) => !isWorkspaceTabId(id) || restoredTabs[id],
+            );
             const active =
-              pane.activeSessionId && !isViewerTabId(pane.activeSessionId)
-                ? pane.activeSessionId
+              normalized.activeTabId &&
+              (!isWorkspaceTabId(normalized.activeTabId) ||
+                restoredTabs[normalized.activeTabId])
+                ? normalized.activeTabId
                 : ids[ids.length - 1] ?? null;
             newPanes[pid as PaneId] = {
-              ...pane,
-              sessionIds: ids,
-              activeSessionId: active,
+              ...normalized,
+              tabIds: ids,
+              activeTabId: active,
             };
           }
           sanitized[key] = { ...ws, panes: newPanes };
         }
         state.workspaces = sanitized;
-        state.viewerTabs = {};
+        state.workspaceTabs = restoredTabs;
         Object.assign(
           state,
           mirrorActive(state.workspaces, state.activeProject),


### PR DESCRIPTION
## Summary
- introduce explicit workspace tab `kind` and `lifecycle` descriptors (`ephemeral`, `restorable`, `process-backed`)
- keep regular/control terminal sessions process-backed while code viewer tabs stay ephemeral by default
- migrate pane/store/dnd state from session-only tab fields to generic `tabIds` / `activeTabId` fields
- preserve compatibility for persisted `sessionIds` / `activeSessionId` layouts while scrubbing stale viewer tab ids on rehydrate

## Verification
- npm test
- npm run build