### PR TITLE
feat(i18n): localize app shell surfaces

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,8 @@ import { applyBackgroundVars, clearBackgroundVars } from "./lib/background";
 import { applyTheme, useThemes } from "./lib/themes";
 import { extractTabFromEvent } from "./lib/settings-events";
 import { useAppStore } from "./store";
+import type { TranslationKey, Translator } from "./lib/i18n";
+import { useTranslation } from "./lib/useTranslation";
 
 const FOCUSABLE_SELECTOR =
   "textarea, input:not([type='hidden']), button, [tabindex]:not([tabindex='-1']), a[href]";
@@ -69,6 +71,12 @@ const SIDEBAR_DEFAULT_SIZE = 18;
 const SIDEBAR_MIN_SIZE = 12;
 const RIGHT_PANEL_DEFAULT_SIZE = 26;
 const RIGHT_PANEL_MIN_SIZE = 16;
+
+type AppTranslationKey = Extract<TranslationKey, `app.${string}`>;
+
+function appText(t: Translator, key: AppTranslationKey): string {
+  return t(key);
+}
 
 function focusPanel(id: "sidebar" | "main" | "right") {
   const panel = document.querySelector(
@@ -117,6 +125,7 @@ function focusAdjacentPane(direction: "left" | "right" | "up" | "down") {
 }
 
 function App() {
+  const t = useTranslation();
   const refreshAll = useAppStore((s) => s.refreshAll);
   const sessions = useAppStore((s) => s.sessions);
   const projects = useAppStore((s) => s.projects);
@@ -148,8 +157,12 @@ function App() {
     const enabled = useAppStore.getState().toggleMultiInput();
     useToasts
       .getState()
-      .show(enabled ? "Multi-input on." : "Multi-input off.");
-  }, []);
+      .show(
+        enabled
+          ? appText(t, "app.toast.multiInputOn")
+          : appText(t, "app.toast.multiInputOff"),
+      );
+  }, [t]);
   const sidebarPanelRef = useRef<ImperativePanelHandle | null>(null);
   const rightPanelRef = useRef<ImperativePanelHandle | null>(null);
   const themes = useThemes((s) => s.themes);
@@ -840,11 +853,21 @@ function App() {
             // Existing PTY children keep the env they forked with —
             // surfacing this so the user knows why their already-open
             // session didn't change.
-            show("Shell environment reloaded. Open a new session to apply.");
+            show(
+              appText(
+                t,
+                "app.toast.shellEnvironmentReloaded",
+              ),
+            );
           })
           .catch((err: unknown) => {
             console.error("[App] reloadShellEnv failed", err);
-            show("Failed to reload shell environment.");
+            show(
+              appText(
+                t,
+                "app.toast.shellEnvironmentReloadFailed",
+              ),
+            );
           });
       },
       [Hotkeys.closeEmptyPane]: (e: KeyboardEvent) => {
@@ -859,7 +882,7 @@ function App() {
         useAppStore.getState().closePane(focusedPaneId);
       },
     }),
-    [],
+    [t, toggleMultiInput],
   );
 
   useHotkeys(bindings);

--- a/src/components/AgentResumeModal.tsx
+++ b/src/components/AgentResumeModal.tsx
@@ -5,7 +5,9 @@ import {
   type AgentKind,
   type ResumeCandidate,
 } from "../lib/api";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { useToasts } from "../lib/toasts";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal } from "./ui/Modal";
 import { ModalHeader } from "./ui/ModalHeader";
 
@@ -27,21 +29,25 @@ interface AgentResumeModalProps {
 
 interface AgentCopy {
   resumeCommand: (uuid: string) => string;
-  bodyParagraph: string;
+  bodyKey: DialogTranslationKey;
   ariaLabelledBy: string;
+}
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
 }
 
 const COPY: Record<AgentKind, AgentCopy> = {
   claude: {
     resumeCommand: (uuid) => `claude --resume ${uuid}`,
-    bodyParagraph:
-      "There's a Claude conversation that was in progress in this session. You can pick it up where you left off, or just close this dialog to start fresh.",
+    bodyKey: "dialogs.agentResume.bodyClaude",
     ariaLabelledBy: "acorn-claude-resume-title",
   },
   codex: {
     resumeCommand: (uuid) => `codex resume ${uuid}`,
-    bodyParagraph:
-      "There's a Codex conversation that was in progress in this session. You can pick it up where you left off, or just close this dialog to start fresh.",
+    bodyKey: "dialogs.agentResume.bodyCodex",
     ariaLabelledBy: "acorn-codex-resume-title",
   },
 };
@@ -65,12 +71,13 @@ export function AgentResumeModal({
   candidate,
   onDismiss,
 }: AgentResumeModalProps): ReactElement | null {
+  const t = useTranslation();
   const showToast = useToasts((s) => s.show);
   const copy = COPY[agent];
 
   const lastActivityLabel = useMemo(
-    () => formatRelativeTime(candidate?.lastActivityUnix ?? 0),
-    [candidate?.lastActivityUnix],
+    () => formatRelativeTime(candidate?.lastActivityUnix ?? 0, t),
+    [candidate?.lastActivityUnix, t],
   );
 
   if (!candidate) return null;
@@ -103,8 +110,8 @@ export function AgentResumeModal({
   const handleCopy = () => {
     void navigator.clipboard
       .writeText(candidate.uuid)
-      .then(() => showToast("Session ID copied"))
-      .catch(() => showToast("Failed to copy to clipboard"));
+      .then(() => showToast(dt(t, "dialogs.agentResume.sessionIdCopied")))
+      .catch(() => showToast(dt(t, "dialogs.agentResume.copyFailed")));
     onDismiss();
     ack();
   };
@@ -140,7 +147,7 @@ export function AgentResumeModal({
       ariaLabelledBy={copy.ariaLabelledBy}
     >
       <ModalHeader
-        title="Resume previous conversation"
+        title={dt(t, "dialogs.agentResume.title")}
         subtitle={lastActivityLabel}
         titleId={copy.ariaLabelledBy}
         icon={
@@ -152,7 +159,7 @@ export function AgentResumeModal({
         onClose={dismiss}
       />
       <div className="space-y-3 px-4 py-4 text-xs">
-        <p className="text-fg-muted">{copy.bodyParagraph}</p>
+        <p className="text-fg-muted">{dt(t, copy.bodyKey)}</p>
         {candidate.preview ? (
           <blockquote className="border-l-2 border-border-emphasis bg-bg-elevated/60 px-3 py-2 italic text-fg-muted">
             “{candidate.preview}”
@@ -168,7 +175,7 @@ export function AgentResumeModal({
           onClick={handleCancelWithHint}
           className="rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
         >
-          Cancel
+          {dt(t, "dialogs.common.cancel")}
         </button>
         <button
           type="button"
@@ -176,7 +183,7 @@ export function AgentResumeModal({
           className="inline-flex items-center gap-1.5 rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
         >
           <Copy size={12} />
-          Copy ID
+          {dt(t, "dialogs.agentResume.copyId")}
         </button>
         <button
           type="button"
@@ -184,24 +191,34 @@ export function AgentResumeModal({
           className="inline-flex items-center gap-1.5 rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90"
         >
           <Play size={12} />
-          Resume
+          {dt(t, "dialogs.agentResume.resume")}
         </button>
       </footer>
     </Modal>
   );
 }
 
-function formatRelativeTime(unixSeconds: number): string {
-  if (unixSeconds <= 0) return "Last activity unknown";
+function formatRelativeTime(unixSeconds: number, t: Translator): string {
+  if (unixSeconds <= 0) return dt(t, "dialogs.agentResume.lastActivityUnknown");
   const nowMs = Date.now();
   const thenMs = unixSeconds * 1000;
   const diffSec = Math.max(0, Math.floor((nowMs - thenMs) / 1000));
-  if (diffSec < 60) return "Just now";
+  if (diffSec < 60) return dt(t, "dialogs.agentResume.justNow");
   const diffMin = Math.floor(diffSec / 60);
-  if (diffMin < 60) return `~${diffMin} min ago`;
+  if (diffMin < 60) {
+    return `~${diffMin} ${dt(t, "dialogs.agentResume.minutesAgo")}`;
+  }
   const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `~${diffHr} hr ago`;
+  if (diffHr < 24) {
+    return `~${diffHr} ${dt(t, "dialogs.agentResume.hoursAgo")}`;
+  }
   const diffDay = Math.floor(diffHr / 24);
-  if (diffDay < 7) return `${diffDay} day${diffDay === 1 ? "" : "s"} ago`;
+  if (diffDay < 7) {
+    return `${diffDay} ${
+      diffDay === 1
+        ? dt(t, "dialogs.agentResume.dayAgo")
+        : dt(t, "dialogs.agentResume.daysAgo")
+    }`;
+  }
   return new Date(thenMs).toLocaleDateString();
 }

--- a/src/components/ClosePullRequestDialog.tsx
+++ b/src/components/ClosePullRequestDialog.tsx
@@ -2,8 +2,16 @@ import { useEffect, useState } from "react";
 import { GitPullRequestClosed } from "lucide-react";
 import { api } from "../lib/api";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import type { PullRequestDetail } from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal, ModalHeader, TextSwap } from "./ui";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface ClosePullRequestDialogProps {
   open: boolean;
@@ -20,6 +28,7 @@ export function ClosePullRequestDialog({
   onClose,
   onClosed,
 }: ClosePullRequestDialogProps) {
+  const t = useTranslation();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -56,7 +65,7 @@ export function ClosePullRequestDialog({
       {detail ? (
         <>
           <ModalHeader
-            title={`Close #${detail.number}`}
+            title={`${dt(t, "dialogs.closePullRequest.titlePrefix")} #${detail.number}`}
             icon={
               <GitPullRequestClosed size={16} className="text-rose-400" />
             }
@@ -67,9 +76,9 @@ export function ClosePullRequestDialog({
           />
           <div className="space-y-3 px-4 py-3 text-sm text-fg">
             <p className="text-xs">
-              Close pull request{" "}
+              {dt(t, "dialogs.closePullRequest.confirmPrefix")}{" "}
               <span className="font-mono text-accent">#{detail.number}</span>{" "}
-              without merging?
+              {dt(t, "dialogs.closePullRequest.confirmSuffix")}
             </p>
             <div className="rounded-md border border-border bg-bg-sidebar/60 p-3 text-[11px]">
               <p className="truncate font-medium">{detail.title}</p>
@@ -90,7 +99,7 @@ export function ClosePullRequestDialog({
               disabled={submitting}
               className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
             >
-              Cancel
+              {dt(t, "dialogs.common.cancel")}
             </button>
             <button
               type="button"
@@ -98,7 +107,11 @@ export function ClosePullRequestDialog({
               disabled={submitting}
               className="rounded-md bg-rose-500/20 px-3 py-1.5 text-xs font-medium text-rose-300 transition hover:bg-rose-500/30 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              <TextSwap>{submitting ? "Closing…" : "Close PR"}</TextSwap>
+              <TextSwap>
+                {submitting
+                  ? dt(t, "dialogs.closePullRequest.closing")
+                  : dt(t, "dialogs.closePullRequest.closePr")}
+              </TextSwap>
             </button>
           </footer>
         </>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -21,15 +21,27 @@ import { RESET_PANEL_SIZES_EVENT } from "../lib/layoutEvents";
 import { useAppStore } from "../store";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { useToasts } from "../lib/toasts";
+import { useTranslation } from "../lib/useTranslation";
 
 interface CommandPaletteProps {
   open: boolean;
   onOpenChange: (value: boolean) => void;
 }
 
+type CommandPaletteTranslationKey = Extract<
+  TranslationKey,
+  `commandPalette.${string}`
+>;
+
+function cpt(t: Translator, key: CommandPaletteTranslationKey): string {
+  return t(key);
+}
+
 export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const sessions = useAppStore((s) => s.sessions);
+  const t = useTranslation();
 
   // Derived once per render — sessions array identity is stable from zustand
   // until the underlying list actually changes.
@@ -104,10 +116,10 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     const show = useToasts.getState().show;
     try {
       await api.reloadShellEnv();
-      show("Shell environment reloaded. Open a new session to apply.");
+      show(cpt(t, "commandPalette.toasts.shellEnvReloaded"));
     } catch (err) {
       console.error("[CommandPalette] reloadShellEnv failed", err);
-      show("Failed to reload shell environment.");
+      show(cpt(t, "commandPalette.toasts.shellEnvReloadFailed"));
     } finally {
       close();
     }
@@ -122,11 +134,13 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     const show = useToasts.getState().show;
     try {
       await api.ipcRestart();
-      show("IPC server restarted.");
+      show(cpt(t, "commandPalette.toasts.ipcRestarted"));
     } catch (err) {
       console.error("[CommandPalette] ipcRestart failed", err);
       const message = err instanceof Error ? err.message : String(err);
-      show(`Failed to restart IPC server: ${message}`);
+      show(
+        `${cpt(t, "commandPalette.toasts.ipcRestartFailedPrefix")} ${message}`,
+      );
     } finally {
       close();
     }
@@ -136,7 +150,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     <Command.Dialog
       open={open}
       onOpenChange={onOpenChange}
-      label="Command palette"
+      label={cpt(t, "commandPalette.dialogLabel")}
       overlayClassName="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm"
       contentClassName={cn(
         "fixed inset-x-0 top-0 z-50 mx-auto mt-32 max-w-lg",
@@ -148,7 +162,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       <div className="border-b border-border px-3 py-2">
         <Command.Input
           autoFocus
-          placeholder="Type a command or search..."
+          placeholder={cpt(t, "commandPalette.placeholder")}
           className={cn(
             "w-full bg-transparent text-sm text-fg outline-none placeholder:text-fg-muted",
             "py-1.5",
@@ -173,13 +187,13 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         )}
       >
         <Command.Empty className="px-3 py-6 text-center text-sm text-fg-muted">
-          No results.
+          {cpt(t, "commandPalette.empty")}
         </Command.Empty>
 
-        <Command.Group heading="Sessions">
+        <Command.Group heading={cpt(t, "commandPalette.groups.sessions")}>
           <Command.Item value="new-session" onSelect={handleNewSession}>
             <Plus size={14} className="text-accent" />
-            <span>New session</span>
+            <span>{cpt(t, "commandPalette.commands.newSession")}</span>
             <span className="ml-auto truncate text-xs text-fg-muted/80">
               ⌘T
             </span>
@@ -190,7 +204,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             keywords={["worktree", "isolated", "branch"]}
           >
             <GitBranch size={14} className="text-accent" />
-            <span>New isolated session</span>
+            <span>{cpt(t, "commandPalette.commands.newIsolatedSession")}</span>
             <span className="ml-auto truncate text-xs text-fg-muted/80">
               ⌥⌘T
             </span>
@@ -201,7 +215,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             keywords={["control", "ipc", "dispatcher", "orchestrator"]}
           >
             <Bot size={14} className="text-accent" />
-            <span>New control session</span>
+            <span>{cpt(t, "commandPalette.commands.newControlSession")}</span>
             <span className="ml-auto truncate text-xs text-fg-muted/80">
               ⌥⇧⌘T
             </span>
@@ -212,7 +226,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             keywords={["project", "create", "repository", "repo", "folder"]}
           >
             <FolderPlus size={14} className="text-accent" />
-            <span>New project</span>
+            <span>{cpt(t, "commandPalette.commands.newProject")}</span>
           </Command.Item>
           <Command.Item
             value="add-project"
@@ -220,19 +234,19 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             keywords={["project", "import", "repository", "repo", "folder"]}
           >
             <FolderOpen size={14} className="text-accent" />
-            <span>Add existing project</span>
+            <span>{cpt(t, "commandPalette.commands.addExistingProject")}</span>
             <span className="ml-auto truncate text-xs text-fg-muted/80">
               ⇧⌘N
             </span>
           </Command.Item>
           <Command.Item value="refresh-sessions" onSelect={handleRefresh}>
             <RefreshCw size={14} className="text-fg-muted" />
-            <span>Refresh sessions</span>
+            <span>{cpt(t, "commandPalette.commands.refreshSessions")}</span>
           </Command.Item>
         </Command.Group>
 
         {sessionItems.length > 0 ? (
-          <Command.Group heading="Switch session">
+          <Command.Group heading={cpt(t, "commandPalette.groups.switchSession")}>
             {sessionItems.map((session) => (
               <Command.Item
                 key={`switch-${session.id}`}
@@ -241,7 +255,10 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
                 keywords={[session.name, session.branch]}
               >
                 <Sparkles size={14} className="text-fg-muted" />
-                <span className="truncate">Switch to {session.name}</span>
+                <span className="truncate">
+                  {cpt(t, "commandPalette.commands.switchSessionPrefix")}{" "}
+                  {session.name}
+                </span>
                 <span className="ml-auto truncate text-xs text-fg-muted/80">
                   {session.branch}
                 </span>
@@ -250,27 +267,27 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           </Command.Group>
         ) : null}
 
-        <Command.Group heading="View">
+        <Command.Group heading={cpt(t, "commandPalette.groups.view")}>
           <Command.Item
             value="view-todos"
             onSelect={() => handleSetTab("todos")}
           >
             <ListChecks size={14} className="text-fg-muted" />
-            <span>View Todos</span>
+            <span>{cpt(t, "commandPalette.commands.viewTodos")}</span>
           </Command.Item>
           <Command.Item
             value="view-commits"
             onSelect={() => handleSetTab("commits")}
           >
             <GitCommit size={14} className="text-fg-muted" />
-            <span>View Commits</span>
+            <span>{cpt(t, "commandPalette.commands.viewCommits")}</span>
           </Command.Item>
           <Command.Item
             value="view-staged"
             onSelect={() => handleSetTab("staged")}
           >
             <ListPlus size={14} className="text-fg-muted" />
-            <span>View Staged</span>
+            <span>{cpt(t, "commandPalette.commands.viewStaged")}</span>
           </Command.Item>
           <Command.Item
             value="view-prs"
@@ -278,7 +295,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             keywords={["pull requests", "pr", "github"]}
           >
             <GitPullRequest size={14} className="text-fg-muted" />
-            <span>View Pull Requests</span>
+            <span>{cpt(t, "commandPalette.commands.viewPullRequests")}</span>
           </Command.Item>
           <Command.Item
             value="reset-panel-sizes"
@@ -296,25 +313,27 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             ]}
           >
             <LayoutTemplate size={14} className="text-fg-muted" />
-            <span>Reset panel sizes</span>
+            <span>{cpt(t, "commandPalette.commands.resetPanelSizes")}</span>
           </Command.Item>
         </Command.Group>
 
-        <Command.Group heading="Terminal">
+        <Command.Group heading={cpt(t, "commandPalette.groups.terminal")}>
           <Command.Item
             value="reload-shell-env"
             onSelect={() => void handleReloadShellEnv()}
             keywords={["dotfile", "zshenv", "lang", "editor", "env", "locale"]}
           >
             <Terminal size={14} className="text-fg-muted" />
-            <span>Reload shell environment</span>
+            <span>
+              {cpt(t, "commandPalette.commands.reloadShellEnvironment")}
+            </span>
             <span className="ml-auto truncate text-xs text-fg-muted/80">
               ⇧⌘,
             </span>
           </Command.Item>
         </Command.Group>
 
-        <Command.Group heading="IPC">
+        <Command.Group heading={cpt(t, "commandPalette.groups.ipc")}>
           <Command.Item
             value="restart-ipc"
             onSelect={() => void handleRestartIpc()}
@@ -329,14 +348,14 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             ]}
           >
             <Bot size={14} className="text-accent" />
-            <span>Restart IPC server</span>
+            <span>{cpt(t, "commandPalette.commands.restartIpcServer")}</span>
           </Command.Item>
         </Command.Group>
 
-        <ShakeTreeItem onSelect={handleShakeTree} />
+        <ShakeTreeItem onSelect={handleShakeTree} t={t} />
 
         {sessionItems.length > 0 ? (
-          <Command.Group heading="Danger zone">
+          <Command.Group heading={cpt(t, "commandPalette.groups.dangerZone")}>
             {sessionItems.map((session) => (
               <Command.Item
                 key={`remove-${session.id}`}
@@ -346,7 +365,8 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
               >
                 <Trash2 size={14} className="text-danger" />
                 <span className="truncate">
-                  Remove session: {session.name}
+                  {cpt(t, "commandPalette.commands.removeSessionPrefix")}{" "}
+                  {session.name}
                 </span>
               </Command.Item>
             ))}
@@ -371,7 +391,13 @@ const SHAKE_TRIGGERS = [
   "도토리",
 ];
 
-function ShakeTreeItem({ onSelect }: { onSelect: () => void }) {
+function ShakeTreeItem({
+  onSelect,
+  t,
+}: {
+  onSelect: () => void;
+  t: Translator;
+}) {
   const search = useCommandState(
     (state: { search: string }) => state.search,
   ) as string | undefined;
@@ -387,7 +413,7 @@ function ShakeTreeItem({ onSelect }: { onSelect: () => void }) {
       keywords={SHAKE_TRIGGERS}
     >
       <Trees size={14} className="text-accent" />
-      <span>Shake the tree</span>
+      <span>{cpt(t, "commandPalette.commands.shakeTree")}</span>
     </Command.Item>
   );
 }

--- a/src/components/CommandRunDialog.tsx
+++ b/src/components/CommandRunDialog.tsx
@@ -3,7 +3,15 @@ import { Copy, Play, Terminal as TerminalIcon } from "lucide-react";
 import { useAppStore } from "../store";
 import { useToasts } from "../lib/toasts";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal, ModalHeader, TextSwap } from "./ui";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface CommandRunDialogProps {
   open: boolean;
@@ -46,6 +54,7 @@ export function CommandRunDialog({
   repoPath,
   onClose,
 }: CommandRunDialogProps): ReactElement {
+  const t = useTranslation();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const projects = useAppStore((s) => s.projects);
@@ -74,16 +83,16 @@ export function CommandRunDialog({
   async function handleCopy() {
     try {
       await navigator.clipboard.writeText(command);
-      showToast(`Copied: ${command}`);
+      showToast(`${dt(t, "dialogs.commandRun.copiedPrefix")} ${command}`);
       onClose();
     } catch (e) {
-      setError(`Copy failed: ${String(e)}`);
+      setError(`${dt(t, "dialogs.commandRun.copyFailedPrefix")} ${String(e)}`);
     }
   }
 
   async function handleRun() {
     if (!resolvedRepoPath) {
-      setError("No project available to host the new session.");
+      setError(dt(t, "dialogs.commandRun.noProjectError"));
       return;
     }
     setBusy(true);
@@ -95,7 +104,7 @@ export function CommandRunDialog({
       );
       if (!created) {
         const storeError = useAppStore.getState().error;
-        setError(storeError ?? "Failed to create session.");
+        setError(storeError ?? dt(t, "dialogs.commandRun.createFailed"));
         setBusy(false);
         return;
       }
@@ -103,7 +112,7 @@ export function CommandRunDialog({
       // queue inside its own `pty_spawn` resolver, so the value just has
       // to be present by the time the spawn completes.
       setPendingTerminalInput(created.id, command);
-      showToast(`Running: ${command}`);
+      showToast(`${dt(t, "dialogs.commandRun.runningPrefix")} ${command}`);
       setBusy(false);
       onClose();
     } catch (e) {
@@ -118,30 +127,31 @@ export function CommandRunDialog({
       onClose={close}
       variant="dialog"
       size="md"
-      ariaLabel="Run command"
+      ariaLabel={dt(t, "dialogs.commandRun.ariaLabel")}
     >
       <ModalHeader
-        title="Run this command?"
+        title={dt(t, "dialogs.commandRun.title")}
         icon={<TerminalIcon size={14} className="text-accent" />}
         variant="dialog"
         onClose={close}
       />
       <div className="space-y-3 px-4 py-4 text-xs text-fg-muted">
         <p className="text-fg">
-          A new terminal session will open and run:
+          {dt(t, "dialogs.commandRun.description")}
         </p>
         <pre className="overflow-x-auto rounded-md border border-border bg-bg-sidebar/70 px-3 py-2 font-mono text-[12px] text-fg">
           {command}
         </pre>
         {resolvedRepoPath ? (
           <p>
-            <span className="opacity-70">cwd:</span>{" "}
+            <span className="opacity-70">
+              {dt(t, "dialogs.commandRun.cwdLabel")}
+            </span>{" "}
             <span className="font-mono text-fg">{resolvedRepoPath}</span>
           </p>
         ) : (
           <p className="text-danger">
-            No project is registered — add a project before running this
-            command, or use "Copy" to paste it into an existing terminal.
+            {dt(t, "dialogs.commandRun.noProjectHint")}
           </p>
         )}
         {error ? (
@@ -157,7 +167,7 @@ export function CommandRunDialog({
           disabled={busy}
           className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
         >
-          Cancel
+          {dt(t, "dialogs.common.cancel")}
         </button>
         <button
           type="button"
@@ -166,7 +176,7 @@ export function CommandRunDialog({
           className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs text-fg transition hover:bg-bg-elevated disabled:cursor-not-allowed disabled:opacity-60"
         >
           <Copy size={12} />
-          Copy
+          {dt(t, "dialogs.common.copy")}
         </button>
         <button
           type="button"
@@ -175,7 +185,9 @@ export function CommandRunDialog({
           className="inline-flex items-center gap-1.5 rounded-md bg-accent/20 px-3 py-1.5 text-xs font-medium text-accent transition hover:bg-accent/30 disabled:cursor-not-allowed disabled:opacity-60"
         >
           <Play size={12} />
-          <TextSwap>{busy ? "Running…" : "Run"}</TextSwap>
+          <TextSwap>
+            {busy ? dt(t, "dialogs.commandRun.running") : dt(t, "dialogs.commandRun.run")}
+          </TextSwap>
         </button>
       </footer>
     </Modal>

--- a/src/components/ControlSessionGuideModal.tsx
+++ b/src/components/ControlSessionGuideModal.tsx
@@ -1,8 +1,16 @@
 import { useState, type ReactElement } from "react";
 import { Bot } from "lucide-react";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal } from "./ui/Modal";
 import { ModalHeader } from "./ui/ModalHeader";
 import { CheckboxRow } from "./ui/CheckboxRow";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 /**
  * localStorage key gating this modal. Exported so the App-level host can write
@@ -31,6 +39,7 @@ export function ControlSessionGuideModal({
   open,
   onClose,
 }: ControlSessionGuideModalProps): ReactElement | null {
+  const t = useTranslation();
   const [dontShowAgain, setDontShowAgain] = useState(false);
 
   function dismiss() {
@@ -46,8 +55,8 @@ export function ControlSessionGuideModal({
       ariaLabelledBy="acorn-control-guide-title"
     >
       <ModalHeader
-        title="Control session"
-        subtitle="A terminal that drives other sessions in this project"
+        title={dt(t, "dialogs.controlSessionGuide.title")}
+        subtitle={dt(t, "dialogs.controlSessionGuide.subtitle")}
         titleId="acorn-control-guide-title"
         icon={<Bot size={14} className="text-accent" />}
         variant="dialog"
@@ -55,23 +64,20 @@ export function ControlSessionGuideModal({
       />
       <div className="space-y-3 px-4 py-4 text-xs text-fg-muted">
         <p>
-          Control sessions are an upcoming way to coordinate work across
-          terminals from a single place — handy for agents and scripts that
-          need to dispatch commands to siblings in the same project.
+          {dt(t, "dialogs.controlSessionGuide.bodyIntro")}
         </p>
         <ul className="ml-4 list-disc space-y-1">
-          <li>Send keystrokes to any session in this project.</li>
-          <li>List the other sessions and their status.</li>
-          <li>Read recent output from a target session.</li>
+          <li>{dt(t, "dialogs.controlSessionGuide.pointKeystrokes")}</li>
+          <li>{dt(t, "dialogs.controlSessionGuide.pointListSessions")}</li>
+          <li>{dt(t, "dialogs.controlSessionGuide.pointReadOutput")}</li>
         </ul>
         <p>
-          You just created a control session. The{" "}
+          {dt(t, "dialogs.controlSessionGuide.createdPrefix")}{" "}
           <code className="rounded bg-bg px-1 py-0.5 text-fg">acorn-ipc</code>{" "}
-          CLI that drives it ships in the next update; this terminal will
-          start behaving like a regular shell until then.
+          {dt(t, "dialogs.controlSessionGuide.createdSuffix")}
         </p>
         <CheckboxRow
-          label="Don't show this again"
+          label={dt(t, "dialogs.common.dontShowAgain")}
           checked={dontShowAgain}
           onChange={setDontShowAgain}
         />
@@ -82,7 +88,7 @@ export function ControlSessionGuideModal({
           onClick={dismiss}
           className="rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90"
         >
-          Got it
+          {dt(t, "dialogs.common.gotIt")}
         </button>
       </footer>
     </Modal>

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -30,13 +30,24 @@ import {
 import { api, type FsEntry, FS_CHANGED_EVENT } from "../lib/api";
 import type { FsChangePayload, FsGitStatus, FsGitStatusEntry } from "../lib/api";
 import { cn } from "../lib/cn";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { setFileDragPayload } from "../lib/dnd";
 import { Tooltip } from "./Tooltip";
 import { IconInput, TextInput } from "./ui";
+import { useTranslation } from "../lib/useTranslation";
 
 const SHOW_HIDDEN_KEY = "acorn:fs-show-hidden";
 const RESPECT_GITIGNORE_KEY = "acorn:fs-respect-gitignore";
+
+type FileExplorerTranslationKey = Extract<TranslationKey, `fileExplorer.${string}`>;
+
+function fileExplorerText(
+  t: Translator,
+  key: FileExplorerTranslationKey,
+): string {
+  return t(key);
+}
 
 interface FileExplorerProps {
   rootPath: string;
@@ -197,8 +208,9 @@ function relativeTo(base: string, abs: string): string {
 async function writeToActiveSession(
   sessionId: string | null,
   payload: string,
+  noActiveSessionMessage: string,
 ): Promise<void> {
-  if (!sessionId) throw new Error("No active session");
+  if (!sessionId) throw new Error(noActiveSessionMessage);
   await api.ptyWrite(sessionId, payload);
 }
 
@@ -221,6 +233,7 @@ function setLocalBool(key: string, value: boolean) {
 }
 
 export function FileExplorer({ rootPath }: FileExplorerProps) {
+  const t = useTranslation();
   const [cache, setCache] = useState<Cache>({});
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [showHidden, setShowHidden] = useState(() =>
@@ -669,15 +682,15 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       try {
         await navigator.clipboard.writeText(lines.join("\n"));
       } catch {
-        setError("Clipboard write failed");
+        setError(fileExplorerText(t, "fileExplorer.errors.clipboardWriteFailed"));
       }
     },
-    [selection, rootPath],
+    [selection, rootPath, t],
   );
 
   const handleBulkAttach = useCallback(async () => {
     if (!activeSessionId) {
-      setError("No active session — open a terminal first");
+      setError(fileExplorerText(t, "fileExplorer.errors.noActiveSession"));
       return;
     }
     const paths = Array.from(selection);
@@ -687,7 +700,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
-  }, [activeSessionId, selection, rootPath]);
+  }, [activeSessionId, selection, rootPath, t]);
 
   const handleOpenFolderInNewTab = useCallback(async (folderPath: string) => {
     try {
@@ -695,10 +708,12 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       const state = store.useAppStore.getState();
       const project = state.activeProject;
       if (!project) {
-        setError("No active project");
+        setError(fileExplorerText(t, "fileExplorer.errors.noActiveProject"));
         return;
       }
-      const name = folderPath.split("/").filter(Boolean).pop() ?? "session";
+      const name =
+        folderPath.split("/").filter(Boolean).pop() ??
+        fileExplorerText(t, "fileExplorer.defaults.sessionName");
       // Spawn a regular session in the current project, then queue a
       // `cd <folder>` to land inside the clicked directory once the PTY
       // is up. Mirrors how CommandRunDialog primes new sessions.
@@ -712,7 +727,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     }
-  }, []);
+  }, [t]);
 
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -783,26 +798,26 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     if (entry && selection.size > 1 && selection.has(entry.path)) {
       const n = selection.size;
       items.push({
-        label: `Copy Relative Paths (${n})`,
+        label: `${fileExplorerText(t, "fileExplorer.menu.copyRelativePaths")} (${n})`,
         icon: <Link2 size={13} />,
         onClick: () => void handleBulkCopyPaths("relative"),
       });
       items.push({
-        label: `Copy Absolute Paths (${n})`,
+        label: `${fileExplorerText(t, "fileExplorer.menu.copyAbsolutePaths")} (${n})`,
         icon: <Copy size={13} />,
         onClick: () => void handleBulkCopyPaths("absolute"),
       });
       if (agent.claude || agent.codex) {
         items.push({ type: "separator" });
         items.push({
-          label: `Attach All to Conversation (${n})`,
+          label: `${fileExplorerText(t, "fileExplorer.menu.attachAllToConversation")} (${n})`,
           icon: <MessageSquarePlus size={13} />,
           onClick: () => void handleBulkAttach(),
         });
       }
       items.push({ type: "separator" });
       items.push({
-        label: `Move to Trash (${n})`,
+        label: `${fileExplorerText(t, "fileExplorer.menu.moveToTrash")} (${n})`,
         icon: <Trash2 size={13} />,
         onClick: () => void handleBulkTrash(),
       });
@@ -813,8 +828,8 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     if (entry && !entry.is_dir) {
       const editorBin = shellEditor.split(/\s+/)[0];
       const openLabel = editorBin
-        ? `Open in ${editorBin}`
-        : "Open with Default Program";
+        ? `${fileExplorerText(t, "fileExplorer.menu.openIn")} ${editorBin}`
+        : fileExplorerText(t, "fileExplorer.menu.openWithDefaultProgram");
       items.push({
         label: openLabel,
         icon: <Edit3 size={13} />,
@@ -823,7 +838,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     }
     if (entry) {
       items.push({
-        label: "Reveal in File Manager",
+        label: fileExplorerText(t, "fileExplorer.menu.revealInFileManager"),
         icon: <ExternalLink size={13} />,
         onClick: () => {
           void api.fsReveal(entry.path).catch((e) => {
@@ -834,7 +849,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     }
     if (entry?.is_dir) {
       items.push({
-        label: "Open in New Tab",
+        label: fileExplorerText(t, "fileExplorer.menu.openInNewTab"),
         icon: <TerminalSquare size={13} />,
         onClick: () => void handleOpenFolderInNewTab(entry.path),
       });
@@ -845,10 +860,14 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       items.push({ type: "separator" });
       if (agent.claude) {
         items.push({
-          label: "Attach to Claude",
+          label: fileExplorerText(t, "fileExplorer.menu.attachToClaude"),
           icon: <MessageSquarePlus size={13} />,
           onClick: () => {
-            void writeToActiveSession(activeSessionId, ` @${rel} `).catch(
+            void writeToActiveSession(
+              activeSessionId,
+              ` @${rel} `,
+              fileExplorerText(t, "fileExplorer.errors.noActiveSession"),
+            ).catch(
               (e) => setError(e instanceof Error ? e.message : String(e)),
             );
           },
@@ -856,10 +875,14 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       }
       if (agent.codex) {
         items.push({
-          label: "Attach to Codex",
+          label: fileExplorerText(t, "fileExplorer.menu.attachToCodex"),
           icon: <MessageSquarePlus size={13} />,
           onClick: () => {
-            void writeToActiveSession(activeSessionId, ` @${rel} `).catch(
+            void writeToActiveSession(
+              activeSessionId,
+              ` @${rel} `,
+              fileExplorerText(t, "fileExplorer.errors.noActiveSession"),
+            ).catch(
               (e) => setError(e instanceof Error ? e.message : String(e)),
             );
           },
@@ -871,20 +894,20 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     if (entry) {
       items.push({ type: "separator" });
       items.push({
-        label: "Copy Relative Path",
+        label: fileExplorerText(t, "fileExplorer.menu.copyRelativePath"),
         icon: <Link2 size={13} />,
         onClick: () => {
           void navigator.clipboard.writeText(rel).catch(() => {
-            setError("Clipboard write failed");
+            setError(fileExplorerText(t, "fileExplorer.errors.clipboardWriteFailed"));
           });
         },
       });
       items.push({
-        label: "Copy Absolute Path",
+        label: fileExplorerText(t, "fileExplorer.menu.copyAbsolutePath"),
         icon: <Copy size={13} />,
         onClick: () => {
           void navigator.clipboard.writeText(entry.path).catch(() => {
-            setError("Clipboard write failed");
+            setError(fileExplorerText(t, "fileExplorer.errors.clipboardWriteFailed"));
           });
         },
       });
@@ -894,12 +917,12 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     if (entry) {
       items.push({ type: "separator" });
       items.push({
-        label: "Rename",
+        label: fileExplorerText(t, "fileExplorer.menu.rename"),
         icon: <Pencil size={13} />,
         onClick: () => setDraftRename({ path: entry.path, value: entry.name }),
       });
       items.push({
-        label: "Move to Trash",
+        label: fileExplorerText(t, "fileExplorer.menu.moveToTrash"),
         icon: <Trash2 size={13} />,
         onClick: () => void handleTrash(entry),
       });
@@ -920,6 +943,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     handleBulkCopyPaths,
     handleBulkTrash,
     handleOpenFolderInNewTab,
+    t,
   ]);
 
   return (
@@ -998,6 +1022,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
           <button
             type="button"
             className="text-fg-muted hover:text-fg"
+            aria-label={fileExplorerText(t, "fileExplorer.errorBanner.dismiss")}
             onClick={() => setError(null)}
           >
             ×
@@ -1026,6 +1051,7 @@ interface ToolbarProps {
 }
 
 function Toolbar(props: ToolbarProps) {
+  const t = useTranslation();
   const rootName = props.rootPath.split("/").filter(Boolean).pop() ?? "/";
   return (
     <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1 text-[11px]">
@@ -1037,14 +1063,22 @@ function Toolbar(props: ToolbarProps) {
       </span>
       <span className="flex-1" />
       <ToolbarBtn
-        label={props.searchActive ? "Close search" : "Search (⌘F)"}
+        label={
+          props.searchActive
+            ? fileExplorerText(t, "fileExplorer.toolbar.closeSearch")
+            : fileExplorerText(t, "fileExplorer.toolbar.search")
+        }
         active={props.searchActive}
         onClick={props.onToggleSearch}
       >
         <Search size={12} />
       </ToolbarBtn>
       <ToolbarBtn
-        label={props.showHidden ? "Hide dotfiles" : "Show dotfiles"}
+        label={
+          props.showHidden
+            ? fileExplorerText(t, "fileExplorer.toolbar.hideDotfiles")
+            : fileExplorerText(t, "fileExplorer.toolbar.showDotfiles")
+        }
         active={props.showHidden}
         onClick={props.onToggleHidden}
       >
@@ -1053,8 +1087,8 @@ function Toolbar(props: ToolbarProps) {
       <ToolbarBtn
         label={
           props.respectGitignore
-            ? "Show gitignored"
-            : "Hide gitignored"
+            ? fileExplorerText(t, "fileExplorer.toolbar.showGitignored")
+            : fileExplorerText(t, "fileExplorer.toolbar.hideGitignored")
         }
         active={!props.respectGitignore}
         onClick={props.onToggleGitignore}
@@ -1082,21 +1116,26 @@ interface SearchBarProps {
 }
 
 function SearchBar(props: SearchBarProps) {
+  const t = useTranslation();
   return (
     <div className="flex shrink-0 flex-col gap-1 border-b border-border px-2 py-2">
       <IconInput
         ref={props.queryInputRef}
         value={props.query}
         onChange={(e) => props.onQueryChange(e.target.value)}
-        placeholder={props.useRegex ? "Regex…" : "Search files"}
+        placeholder={
+          props.useRegex
+            ? fileExplorerText(t, "fileExplorer.search.regexPlaceholder")
+            : fileExplorerText(t, "fileExplorer.search.searchFilesPlaceholder")
+        }
         invalid={props.invalidRegex}
         leading={<Search size={12} />}
         trailing={
           <>
-            <Tooltip label="Match Case">
+            <Tooltip label={fileExplorerText(t, "fileExplorer.search.matchCase")}>
               <button
                 type="button"
-                aria-label="Match case"
+                aria-label={fileExplorerText(t, "fileExplorer.search.matchCase")}
                 onClick={props.onToggleCaseSensitive}
                 className={cn(
                   "rounded p-0.5 text-[10px] font-semibold transition",
@@ -1108,10 +1147,18 @@ function SearchBar(props: SearchBarProps) {
                 Aa
               </button>
             </Tooltip>
-            <Tooltip label="Use Regular Expression">
+            <Tooltip
+              label={fileExplorerText(
+                t,
+                "fileExplorer.search.useRegularExpression",
+              )}
+            >
               <button
                 type="button"
-                aria-label="Toggle regex"
+                aria-label={fileExplorerText(
+                  t,
+                  "fileExplorer.search.toggleRegex",
+                )}
                 onClick={props.onToggleRegex}
                 className={cn(
                   "rounded p-0.5 transition",
@@ -1123,10 +1170,10 @@ function SearchBar(props: SearchBarProps) {
                 <Regex size={12} />
               </button>
             </Tooltip>
-            <Tooltip label="Close (Esc)">
+            <Tooltip label={fileExplorerText(t, "fileExplorer.search.close")}>
               <button
                 type="button"
-                aria-label="Close search"
+                aria-label={fileExplorerText(t, "fileExplorer.search.closeSearch")}
                 onClick={props.onClose}
                 className="rounded p-0.5 text-fg-muted hover:text-fg"
               >
@@ -1137,14 +1184,20 @@ function SearchBar(props: SearchBarProps) {
         }
       />
       <GlobInput
-        label="files to include"
-        placeholder="e.g. *.ts, *.tsx"
+        label={fileExplorerText(t, "fileExplorer.search.filesToInclude")}
+        placeholder={fileExplorerText(
+          t,
+          "fileExplorer.search.includePlaceholder",
+        )}
         value={props.includeGlobs}
         onChange={props.onIncludeChange}
       />
       <GlobInput
-        label="files to exclude"
-        placeholder="e.g. node_modules, *.lock"
+        label={fileExplorerText(t, "fileExplorer.search.filesToExclude")}
+        placeholder={fileExplorerText(
+          t,
+          "fileExplorer.search.excludePlaceholder",
+        )}
         value={props.excludeGlobs}
         onChange={props.onExcludeChange}
       />
@@ -1229,6 +1282,7 @@ interface DirNodeProps {
 }
 
 function DirNode(props: DirNodeProps) {
+  const t = useTranslation();
   const { state, isRoot, matcher, matchingDirs } = props;
   const rawEntries = state?.entries ?? [];
   // When a matcher is active, hide entries that fail to match. Directories
@@ -1259,7 +1313,7 @@ function DirNode(props: DirNodeProps) {
           className="px-2 py-0.5 text-[11px] italic text-fg-muted/60"
           style={{ paddingLeft: 8 + props.depth * 12 }}
         >
-          (empty)
+          {fileExplorerText(t, "fileExplorer.tree.empty")}
         </div>
       ) : null}
       {entries.map((entry) =>
@@ -1292,7 +1346,13 @@ function DirNode(props: DirNodeProps) {
             onContextMenu={props.onContextMenu}
           >
             {entry.is_dir && props.expanded.has(entry.path) ? (
-              <DirNode {...props} path={entry.path} depth={props.depth + 1} state={props.cache[entry.path]} isRoot={false} />
+              <DirNode
+                {...props}
+                path={entry.path}
+                depth={props.depth + 1}
+                state={props.cache[entry.path]}
+                isRoot={false}
+              />
             ) : null}
           </EntryRow>
         ),
@@ -1302,7 +1362,7 @@ function DirNode(props: DirNodeProps) {
           className="px-2 py-1 text-[11px] text-fg-muted/60"
           style={{ paddingLeft: 8 + props.depth * 12 }}
         >
-          Loading…
+          {fileExplorerText(t, "fileExplorer.tree.loading")}
         </div>
       ) : null}
     </>
@@ -1362,6 +1422,7 @@ function EntryRow({
   onContextMenu,
   children,
 }: EntryRowProps) {
+  const t = useTranslation();
   const nameClass = gitStatusClass(gitStatus?.kind);
   const statusLetter = gitStatus ? STATUS_LABELS[gitStatus.kind] : "";
   const additions = gitStatus?.additions ?? 0;
@@ -1463,7 +1524,10 @@ function EntryRow({
             ) : null}
             <span
               className="rounded bg-fg-muted/15 px-1 font-medium"
-              aria-label={`git status ${gitStatus?.kind}`}
+              aria-label={`${fileExplorerText(
+                t,
+                "fileExplorer.tree.gitStatus",
+              )} ${gitStatus?.kind}`}
             >
               {statusLetter}
             </span>
@@ -1492,6 +1556,7 @@ function EditRow({
   onCommit,
   onCancel,
 }: EditRowProps) {
+  const t = useTranslation();
   const inputRef = useRef<HTMLInputElement | null>(null);
   useEffect(() => {
     inputRef.current?.focus();
@@ -1513,6 +1578,7 @@ function EditRow({
       <span className="shrink-0 text-fg-muted">{icon}</span>
       <input
         ref={inputRef}
+        aria-label={fileExplorerText(t, "fileExplorer.tree.renameInput")}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={(e) => {

--- a/src/components/MemoryBreakdownModal.tsx
+++ b/src/components/MemoryBreakdownModal.tsx
@@ -1,8 +1,16 @@
 import { useMemo } from "react";
 import type { MemoryProcess } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 import { Tooltip } from "./Tooltip";
 import { Modal, ModalHeader } from "./ui";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface MemoryBreakdownModalProps {
   open: boolean;
@@ -115,6 +123,7 @@ export function MemoryBreakdownModal({
   processes,
   onClose,
 }: MemoryBreakdownModalProps) {
+  const t = useTranslation();
   useDialogShortcuts(open, {
     onCancel: onClose,
     onConfirm: onClose,
@@ -131,9 +140,9 @@ export function MemoryBreakdownModal({
       ariaLabelledBy="memory-breakdown-title"
     >
       <ModalHeader
-        title="Memory breakdown"
+        title={dt(t, "dialogs.memoryBreakdown.title")}
         titleId="memory-breakdown-title"
-        subtitle={`total (RSS, sum): ${formatBytes(totalBytes)} · ${processes.length} processes`}
+        subtitle={`${dt(t, "dialogs.memoryBreakdown.totalRssSum")}: ${formatBytes(totalBytes)} · ${processes.length} ${dt(t, "dialogs.memoryBreakdown.processes")}`}
         onClose={onClose}
       />
 
@@ -141,18 +150,26 @@ export function MemoryBreakdownModal({
         <table className="w-full font-mono text-xs">
           <thead className="sticky top-0 bg-bg-sidebar text-fg-muted">
             <tr className="border-b border-border">
-              <th className="px-4 py-2 text-left font-medium">PID</th>
-              <th className="px-4 py-2 text-left font-medium">Process tree</th>
-              <th className="px-4 py-2 text-right font-medium">RSS</th>
+              <th className="px-4 py-2 text-left font-medium">
+                {dt(t, "dialogs.memoryBreakdown.pid")}
+              </th>
+              <th className="px-4 py-2 text-left font-medium">
+                {dt(t, "dialogs.memoryBreakdown.processTree")}
+              </th>
+              <th className="px-4 py-2 text-right font-medium">
+                {dt(t, "dialogs.memoryBreakdown.rss")}
+              </th>
               <th className="px-4 py-2 text-right font-medium">
                 <Tooltip
-                  label="Sum of this process and all descendants"
+                  label={dt(t, "dialogs.memoryBreakdown.subtreeTooltip")}
                   side="bottom"
                 >
-                  <span>Subtree</span>
+                  <span>{dt(t, "dialogs.memoryBreakdown.subtree")}</span>
                 </Tooltip>
               </th>
-              <th className="px-4 py-2 text-right font-medium">Share</th>
+              <th className="px-4 py-2 text-right font-medium">
+                {dt(t, "dialogs.memoryBreakdown.share")}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -203,9 +220,7 @@ export function MemoryBreakdownModal({
       </div>
 
       <footer className="shrink-0 border-t border-border px-4 py-2 font-mono text-[11px] text-fg-muted">
-        Tree ordered by parent→child (DFS). Siblings sorted by subtree RSS desc.
-        Sum-of-RSS overcounts shared memory; WebView helpers and PTY children
-        (claude, node) included.
+        {dt(t, "dialogs.memoryBreakdown.footer")}
       </footer>
     </Modal>
   );

--- a/src/components/MergePullRequestDialog.tsx
+++ b/src/components/MergePullRequestDialog.tsx
@@ -3,6 +3,7 @@ import { GitMerge, Sparkles } from "lucide-react";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { loadLastMergeMethod, saveLastMergeMethod } from "../lib/merge-prefs";
 import {
   aiCommitProviderLabel,
@@ -10,30 +11,37 @@ import {
   useSettings,
 } from "../lib/settings";
 import type { MergeMethod, PullRequestDetail } from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
 import { Tooltip } from "./Tooltip";
 import { Modal, ModalHeader, TextSwap } from "./ui";
 
 const METHOD_OPTIONS: ReadonlyArray<{
   value: MergeMethod;
-  label: string;
-  hint: string;
+  labelKey: DialogTranslationKey;
+  hintKey: DialogTranslationKey;
 }> = [
     {
       value: "squash",
-      label: "Squash",
-      hint: "Combine into one commit on the base branch.",
+      labelKey: "dialogs.mergePullRequest.methodSquash",
+      hintKey: "dialogs.mergePullRequest.methodSquashHint",
     },
     {
       value: "merge",
-      label: "Merge",
-      hint: "Create a merge commit preserving history.",
+      labelKey: "dialogs.mergePullRequest.methodMerge",
+      hintKey: "dialogs.mergePullRequest.methodMergeHint",
     },
     {
       value: "rebase",
-      label: "Rebase",
-      hint: "Replay commits onto the base branch.",
+      labelKey: "dialogs.mergePullRequest.methodRebase",
+      hintKey: "dialogs.mergePullRequest.methodRebaseHint",
     },
   ];
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface MergePullRequestDialogProps {
   open: boolean;
@@ -50,6 +58,7 @@ export function MergePullRequestDialog({
   onClose,
   onMerged,
 }: MergePullRequestDialogProps) {
+  const t = useTranslation();
   const settings = useSettings((s) => s.settings);
   const [method, setMethod] = useState<MergeMethod>(() => loadLastMergeMethod());
   const [title, setTitle] = useState("");
@@ -156,7 +165,7 @@ export function MergePullRequestDialog({
       {detail ? (
         <>
           <ModalHeader
-            title={`Merge #${detail.number}`}
+            title={`${dt(t, "dialogs.mergePullRequest.titlePrefix")} #${detail.number}`}
             icon={<GitMerge size={16} className="text-emerald-400" />}
             variant="dialog"
             onClose={() => {
@@ -166,7 +175,9 @@ export function MergePullRequestDialog({
 
           <div className="space-y-4 px-4 py-3 text-xs text-fg">
             <div>
-              <p className="mb-2 text-fg-muted">Merge method</p>
+              <p className="mb-2 text-fg-muted">
+                {dt(t, "dialogs.mergePullRequest.mergeMethod")}
+              </p>
               <div className="grid grid-cols-3 gap-2">
                 {METHOD_OPTIONS.map((opt) => (
                   <button
@@ -181,9 +192,11 @@ export function MergePullRequestDialog({
                     )}
                     disabled={busy}
                   >
-                    <div className="text-[11px] font-medium">{opt.label}</div>
+                    <div className="text-[11px] font-medium">
+                      {dt(t, opt.labelKey)}
+                    </div>
                     <div className="mt-0.5 text-[10px] leading-snug text-fg-muted">
-                      {opt.hint}
+                      {dt(t, opt.hintKey)}
                     </div>
                   </button>
                 ))}
@@ -193,7 +206,9 @@ export function MergePullRequestDialog({
             {acceptsMessage ? (
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
-                  <p className="text-fg-muted">Commit message</p>
+                  <p className="text-fg-muted">
+                    {dt(t, "dialogs.mergePullRequest.commitMessage")}
+                  </p>
                   {generating ? (
                     <button
                       key="gen-button-loading"
@@ -202,11 +217,11 @@ export function MergePullRequestDialog({
                       className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-fg-muted opacity-60"
                     >
                       <Sparkles size={11} />
-                      Generating…
+                      {dt(t, "dialogs.mergePullRequest.generating")}
                     </button>
                   ) : (
                     <Tooltip
-                      label={`Generate via ${providerLabel}`}
+                      label={`${dt(t, "dialogs.mergePullRequest.generateVia")} ${providerLabel}`}
                       side="top"
                     >
                       <button
@@ -216,7 +231,7 @@ export function MergePullRequestDialog({
                         className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
                       >
                         <Sparkles size={11} />
-                        Generate with AI
+                        {dt(t, "dialogs.mergePullRequest.generateWithAi")}
                       </button>
                     </Tooltip>
                   )}
@@ -225,14 +240,14 @@ export function MergePullRequestDialog({
                   type="text"
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
-                  placeholder="Subject"
+                  placeholder={dt(t, "dialogs.mergePullRequest.subjectPlaceholder")}
                   disabled={busy}
                   className="w-full rounded-md border border-border bg-bg-sidebar/60 px-2 py-1.5 text-[11px] text-fg outline-none transition focus:border-accent/60 disabled:opacity-60"
                 />
                 <textarea
                   value={body}
                   onChange={(e) => setBody(e.target.value)}
-                  placeholder="Body (optional)"
+                  placeholder={dt(t, "dialogs.mergePullRequest.bodyPlaceholder")}
                   rows={6}
                   disabled={busy}
                   className="w-full resize-none rounded-md border border-border bg-bg-sidebar/60 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-fg outline-none transition focus:border-accent/60 disabled:opacity-60"
@@ -240,8 +255,7 @@ export function MergePullRequestDialog({
               </div>
             ) : (
               <p className="rounded-md border border-border bg-bg-sidebar/40 px-3 py-2 text-[11px] text-fg-muted">
-                Rebase replays the original commits onto the base branch — the
-                commit messages are not customizable here.
+                {dt(t, "dialogs.mergePullRequest.rebaseMessageLocked")}
               </p>
             )}
 
@@ -259,7 +273,7 @@ export function MergePullRequestDialog({
               disabled={submitting}
               className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
             >
-              Cancel
+              {dt(t, "dialogs.common.cancel")}
             </button>
             <button
               type="button"
@@ -267,7 +281,11 @@ export function MergePullRequestDialog({
               disabled={busy}
               className="rounded-md bg-emerald-500/20 px-3 py-1.5 text-xs font-medium text-emerald-300 transition hover:bg-emerald-500/30 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              <TextSwap>{submitting ? "Merging…" : "Merge"}</TextSwap>
+              <TextSwap>
+                {submitting
+                  ? dt(t, "dialogs.mergePullRequest.merging")
+                  : dt(t, "dialogs.mergePullRequest.merge")}
+              </TextSwap>
             </button>
           </footer>
         </>

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -2,9 +2,17 @@ import { FolderPlus } from "lucide-react";
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { validateProjectName } from "../lib/projectName";
 import { cn } from "../lib/cn";
+import { useTranslation } from "../lib/useTranslation";
 import { Field, Modal, ModalHeader, TextInput } from "./ui";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface NewProjectDialogProps {
   open: boolean;
@@ -21,6 +29,7 @@ export function NewProjectDialog({
   onClose,
   onCreate,
 }: NewProjectDialogProps) {
+  const t = useTranslation();
   const [name, setName] = useState("");
   const [parentPath, setParentPath] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -55,7 +64,7 @@ export function NewProjectDialog({
       ? null
       : validation.kind === "safe" && ignoreSafeName
         ? null
-        : validation.message;
+        : dt(t, `dialogs.newProject.validation.${validation.reason}`);
   const canCreate =
     !pending &&
     parentPath !== "" &&
@@ -66,7 +75,7 @@ export function NewProjectDialog({
     const picked = await open({
       directory: true,
       multiple: false,
-      title: "Select parent folder",
+      title: dt(t, "dialogs.newProject.selectParentFolder"),
     });
     if (!picked || typeof picked !== "string") return;
     setParentPath(picked);
@@ -76,7 +85,7 @@ export function NewProjectDialog({
   async function submit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!canCreate) {
-      setError(validationError ?? "Choose a location for the new project.");
+      setError(validationError ?? dt(t, "dialogs.newProject.chooseLocationError"));
       return;
     }
     setPending(true);
@@ -103,9 +112,9 @@ export function NewProjectDialog({
     >
       <form onSubmit={submit}>
         <ModalHeader
-          title="New project"
+          title={dt(t, "dialogs.newProject.title")}
           titleId="new-project-title"
-          subtitle="Create a git repository and add it to Acorn"
+          subtitle={dt(t, "dialogs.newProject.subtitle")}
           icon={<FolderPlus size={16} className="text-accent" />}
           variant="dialog"
           onClose={() => {
@@ -113,7 +122,10 @@ export function NewProjectDialog({
           }}
         />
         <div className="space-y-3 px-4 py-3">
-          <Field label="Project name" hint="Use a single folder name.">
+          <Field
+            label={dt(t, "dialogs.newProject.projectNameLabel")}
+            hint={dt(t, "dialogs.newProject.projectNameHint")}
+          >
             <TextInput
               autoFocus
               value={name}
@@ -123,7 +135,7 @@ export function NewProjectDialog({
                 setIgnoreSafeName(false);
               }}
               placeholder="my-project"
-              aria-label="Project name"
+              aria-label={dt(t, "dialogs.newProject.projectNameLabel")}
               aria-invalid={validationError !== null}
               aria-describedby={
                 validationError ? "new-project-name-error" : undefined
@@ -151,16 +163,16 @@ export function NewProjectDialog({
                 }}
                 className="size-3 accent-accent"
               />
-              <span>Ignore safe-name check</span>
+              <span>{dt(t, "dialogs.newProject.ignoreSafeName")}</span>
             </label>
           ) : null}
-          <Field label="Location">
+          <Field label={dt(t, "dialogs.newProject.locationLabel")}>
             <div className="flex gap-2">
               <TextInput
                 readOnly
                 value={parentPath}
-                placeholder="Choose a parent folder"
-                aria-label="Project location"
+                placeholder={dt(t, "dialogs.newProject.locationPlaceholder")}
+                aria-label={dt(t, "dialogs.newProject.locationAriaLabel")}
                 className="min-w-0 flex-1"
               />
               <button
@@ -168,13 +180,15 @@ export function NewProjectDialog({
                 onClick={() => void chooseLocation()}
                 className="shrink-0 rounded-md border border-border px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
               >
-                Choose
+                {dt(t, "dialogs.newProject.choose")}
               </button>
             </div>
           </Field>
           {finalPath ? (
             <div className="rounded-md border border-border bg-bg-sidebar/60 p-3 text-xs">
-              <div className="mb-1 text-fg-muted">Creates</div>
+              <div className="mb-1 text-fg-muted">
+                {dt(t, "dialogs.newProject.creates")}
+              </div>
               <div className="break-all font-mono text-fg">{finalPath}</div>
             </div>
           ) : null}
@@ -191,14 +205,16 @@ export function NewProjectDialog({
             onClick={onClose}
             className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:opacity-50"
           >
-            Cancel
+            {dt(t, "dialogs.common.cancel")}
           </button>
           <button
             type="submit"
             disabled={!canCreate}
             className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-bg transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {pending ? "Creating..." : "Create project"}
+            {pending
+              ? dt(t, "dialogs.newProject.creating")
+              : dt(t, "dialogs.newProject.createProject")}
           </button>
         </footer>
       </form>

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -27,6 +27,7 @@ import { isViewerTabId, useAppStore, type ViewerTab } from "../store";
 import { CodeViewer } from "./CodeViewer";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import {
   getCurrentFilePayload,
   getCurrentTabPayload,
@@ -40,6 +41,7 @@ import {
 } from "../lib/editor";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import { useSettings } from "../lib/settings";
+import { useTranslation } from "../lib/useTranslation";
 import type { Direction, PaneId } from "../lib/layout";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { PaneDropOverlay } from "./PaneDropOverlay";
@@ -52,6 +54,12 @@ const STATUS_DOT: Record<SessionStatus, string> = {
   failed: "bg-danger",
   completed: "bg-accent/60",
 };
+
+type PaneTranslationKey = Extract<TranslationKey, `pane.${string}`>;
+
+function paneT(t: Translator, key: PaneTranslationKey): string {
+  return t(key);
+}
 
 interface PaneProps {
   paneId: PaneId;
@@ -66,6 +74,7 @@ interface PaneProps {
  * `paneId`. The pane itself only renders.
  */
 export function Pane({ paneId }: PaneProps) {
+  const t = useTranslation();
   const sessions = useAppStore((s) => s.sessions);
   const projects = useAppStore((s) => s.projects);
   const pane = useAppStore((s) => s.panes[paneId]);
@@ -318,6 +327,7 @@ export function Pane({ paneId }: PaneProps) {
         y={paneMenu?.y ?? 0}
         onClose={() => setPaneMenu(null)}
         items={buildPaneMenuItems({
+          t,
           activeSession: active,
           totalPanes,
           paneId,
@@ -368,6 +378,8 @@ function EmptyPane({
   onDoubleClick: () => void;
   onContextMenu: (x: number, y: number) => void;
 }) {
+  const t = useTranslation();
+
   return (
     <div
       className="flex h-full flex-col items-center justify-center gap-2 text-fg-muted hover:text-fg/80 transition cursor-pointer select-none"
@@ -384,14 +396,14 @@ function EmptyPane({
         <>
           <TerminalIcon size={28} className="opacity-40" />
           <p className="text-xs">
-            Drop a tab here or double-click to start a session
+            {paneT(t, "pane.empty.dropTabOrDoubleClick")}
           </p>
         </>
       ) : (
         <>
           <FolderPlus size={28} className="opacity-40" />
           <p className="text-xs">
-            Create a project to get started. Double-click here.
+            {paneT(t, "pane.empty.createProject")}
           </p>
         </>
       )}
@@ -574,6 +586,7 @@ function TabItem({
   siblingCount,
   registerRef,
 }: TabItemProps) {
+  const t = useTranslation();
   const renameSession = useAppStore((s) => s.renameSession);
   const liveInWorktree = useAppStore((s) => s.liveInWorktree[tab.id]);
   // Subscribe to the editor command so the menu's enabled/disabled state
@@ -616,28 +629,32 @@ function TabItem({
     const both = agent.claude && agent.codex;
     if (agent.claude) {
       items.push({
-        label: both ? "Fork Claude Session" : "Fork Session",
+        label: both
+          ? paneT(t, "pane.menu.forkClaudeSession")
+          : paneT(t, "pane.menu.forkSession"),
         icon: <GitFork size={12} />,
         onClick: () => onFork("claude", agent.claude!, false),
       });
       items.push({
         label: both
-          ? "Fork Claude in New Worktree"
-          : "Fork in New Worktree",
+          ? paneT(t, "pane.menu.forkClaudeInNewWorktree")
+          : paneT(t, "pane.menu.forkInNewWorktree"),
         icon: <GitBranch size={12} />,
         onClick: () => onFork("claude", agent.claude!, true),
       });
     }
     if (agent.codex) {
       items.push({
-        label: both ? "Fork Codex Session" : "Fork Session",
+        label: both
+          ? paneT(t, "pane.menu.forkCodexSession")
+          : paneT(t, "pane.menu.forkSession"),
         icon: <GitFork size={12} />,
         onClick: () => onFork("codex", agent.codex!, false),
       });
       items.push({
         label: both
-          ? "Fork Codex in New Worktree"
-          : "Fork in New Worktree",
+          ? paneT(t, "pane.menu.forkCodexInNewWorktree")
+          : paneT(t, "pane.menu.forkInNewWorktree"),
         icon: <GitBranch size={12} />,
         onClick: () => onFork("codex", agent.codex!, true),
       });
@@ -649,31 +666,31 @@ function TabItem({
 
   const menuItems: ContextMenuItem[] = [
     {
-      label: "Rename",
+      label: paneT(t, "pane.menu.rename"),
       icon: <Pencil size={12} />,
       onClick: () => setEditing(true),
     },
     {
-      label: "Duplicate Session",
+      label: paneT(t, "pane.menu.duplicateSession"),
       icon: <Files size={12} />,
       onClick: onDuplicate,
     },
     { type: "separator" },
     ...forkItems,
     {
-      label: "Split Right",
+      label: paneT(t, "pane.menu.splitRight"),
       icon: <SplitSquareHorizontal size={12} />,
       onClick: () => onSplitTab("horizontal"),
       disabled: siblingCount <= 1,
     },
     {
-      label: "Split Down",
+      label: paneT(t, "pane.menu.splitDown"),
       icon: <SplitSquareVertical size={12} />,
       onClick: () => onSplitTab("vertical"),
       disabled: siblingCount <= 1,
     },
     {
-      label: "Equalize Pane Sizes",
+      label: paneT(t, "pane.menu.equalizePaneSizes"),
       icon: <Columns2 size={12} />,
       onClick: () => {
         window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
@@ -681,7 +698,7 @@ function TabItem({
     },
     { type: "separator" },
     {
-      label: "Open Worktree in Editor",
+      label: paneT(t, "pane.menu.openWorktreeInEditor"),
       icon: <PencilLine size={12} />,
       disabled: !editorConfigured,
       onClick: () => {
@@ -693,7 +710,7 @@ function TabItem({
       },
     },
     {
-      label: "Reveal in Finder",
+      label: paneT(t, "pane.menu.revealInFinder"),
       icon: <FolderOpen size={12} />,
       onClick: () => {
         void openPath(tab.worktree_path).catch((err: unknown) => {
@@ -703,21 +720,21 @@ function TabItem({
     },
     { type: "separator" },
     {
-      label: "Copy Worktree Path",
+      label: paneT(t, "pane.menu.copyWorktreePath"),
       icon: <Copy size={12} />,
       onClick: () => {
         void copyToClipboard(tab.worktree_path);
       },
     },
     {
-      label: "Copy Worktree Name",
+      label: paneT(t, "pane.menu.copyWorktreeName"),
       icon: <Copy size={12} />,
       onClick: () => {
         void copyToClipboard(basename(tab.worktree_path));
       },
     },
     {
-      label: "Copy Branch Name",
+      label: paneT(t, "pane.menu.copyBranchName"),
       icon: <Copy size={12} />,
       onClick: () => {
         void copyToClipboard(tab.branch);
@@ -725,7 +742,7 @@ function TabItem({
       disabled: !tab.branch,
     },
     {
-      label: "Copy Session ID",
+      label: paneT(t, "pane.menu.copySessionId"),
       icon: <Copy size={12} />,
       onClick: () => {
         void copyToClipboard(tab.id);
@@ -733,18 +750,18 @@ function TabItem({
     },
     { type: "separator" },
     {
-      label: "Close",
+      label: paneT(t, "pane.menu.close"),
       icon: <X size={12} />,
       onClick: onClose,
     },
     {
-      label: "Close Others",
+      label: paneT(t, "pane.menu.closeOthers"),
       icon: <CircleX size={12} />,
       onClick: onCloseOthers,
       disabled: siblingCount <= 1,
     },
     {
-      label: "Close All",
+      label: paneT(t, "pane.menu.closeAll"),
       icon: <SquareX size={12} />,
       onClick: onCloseAll,
     },
@@ -824,12 +841,12 @@ function TabItem({
           <GitBranch
             size={10}
             className="pointer-events-none text-fg-muted"
-            aria-label="worktree"
+            aria-label={paneT(t, "pane.aria.worktree")}
           />
         ) : null}
         <button
           type="button"
-          aria-label="Close session"
+          aria-label={paneT(t, "pane.aria.closeSession")}
           onClick={(e) => {
             e.stopPropagation();
             onClose();
@@ -898,6 +915,7 @@ function TabRenameInput({ initial, onSubmit, onCancel }: TabRenameInputProps) {
 }
 
 function buildPaneMenuItems({
+  t,
   activeSession,
   totalPanes,
   paneId: _paneId,
@@ -906,6 +924,7 @@ function buildPaneMenuItems({
   onClose,
   activeProjectFallback,
 }: {
+  t: Translator;
   activeSession: Session | null;
   totalPanes: number;
   paneId: PaneId;
@@ -919,7 +938,7 @@ function buildPaneMenuItems({
     ? [
         { type: "separator" },
         {
-          label: "Open Worktree in Editor",
+          label: paneT(t, "pane.menu.openWorktreeInEditor"),
           icon: <PencilLine size={12} />,
           disabled: !editorReady,
           onClick: () => {
@@ -931,7 +950,7 @@ function buildPaneMenuItems({
           },
         },
         {
-          label: "Reveal in Finder",
+          label: paneT(t, "pane.menu.revealInFinder"),
           icon: <FolderOpen size={12} />,
           onClick: () => {
             void openPath(activeSession.worktree_path).catch(
@@ -943,12 +962,12 @@ function buildPaneMenuItems({
         },
         { type: "separator" },
         {
-          label: "Copy Worktree Path",
+          label: paneT(t, "pane.menu.copyWorktreePath"),
           icon: <Copy size={12} />,
           onClick: () => void copyToClipboard(activeSession.worktree_path),
         },
         {
-          label: "Copy Worktree Name",
+          label: paneT(t, "pane.menu.copyWorktreeName"),
           icon: <Copy size={12} />,
           onClick: () =>
             void copyToClipboard(basename(activeSession.worktree_path)),
@@ -958,24 +977,24 @@ function buildPaneMenuItems({
 
   return [
     {
-      label: "New Session in This Pane",
+      label: paneT(t, "pane.menu.newSessionInThisPane"),
       icon: <TerminalIcon size={12} />,
       onClick: onNewTab,
       disabled: !activeSession && activeProjectFallback === null,
     },
     { type: "separator" },
     {
-      label: "Split Right",
+      label: paneT(t, "pane.menu.splitRight"),
       icon: <SplitSquareHorizontal size={12} />,
       onClick: () => onSplit("horizontal"),
     },
     {
-      label: "Split Down",
+      label: paneT(t, "pane.menu.splitDown"),
       icon: <SplitSquareVertical size={12} />,
       onClick: () => onSplit("vertical"),
     },
     {
-      label: "Equalize Pane Sizes",
+      label: paneT(t, "pane.menu.equalizePaneSizes"),
       icon: <Columns2 size={12} />,
       onClick: () => {
         window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
@@ -985,7 +1004,7 @@ function buildPaneMenuItems({
     ...worktreeItems,
     { type: "separator" },
     {
-      label: "Close Pane",
+      label: paneT(t, "pane.menu.closePane"),
       icon: <X size={12} />,
       onClick: onClose,
       disabled: totalPanes <= 1,

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -24,6 +24,7 @@ import { Panel, PanelGroup } from "react-resizable-panels";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { ResizeHandle } from "./ResizeHandle";
 import type {
   DiffPayload,
@@ -34,6 +35,7 @@ import type {
   PullRequestDetailListing,
   PullRequestReview,
 } from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
 import { AuthorTag, buildProfileMenuItems } from "./AuthorTag";
 import { ClosePullRequestDialog } from "./ClosePullRequestDialog";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
@@ -43,6 +45,11 @@ import { Tooltip } from "./Tooltip";
 import { Markdown, Modal, ModalHeader, RefreshButton } from "./ui";
 
 type DetailTab = "conversation" | "commits" | "checks" | "files";
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface PullRequestDetailModalProps {
   /**
@@ -69,6 +76,7 @@ export function PullRequestDetailModal({
   onClose,
   onMutated,
 }: PullRequestDetailModalProps) {
+  const t = useTranslation();
   const [listing, setListing] = useState<PullRequestDetailListing | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [tab, setTab] = useState<DetailTab>("conversation");
@@ -210,14 +218,16 @@ export function PullRequestDetailModal({
         ) : listing.kind === "not_github" ? (
           <ModalShell title={`#${open.number}`} onClose={onClose}>
             <div className="p-4 text-xs text-fg-muted">
-              Origin remote is not a GitHub repository.
+              {dt(t, "dialogs.pullRequestDetail.notGithub")}
             </div>
           </ModalShell>
         ) : listing.kind === "no_access" ? (
           <ModalShell title={`#${open.number}`} onClose={onClose}>
             <div className="p-4 text-xs text-fg-muted">
-              No logged-in <code className="font-mono">gh</code> account can
-              access {listing.slug}.
+              {dt(t, "dialogs.pullRequestDetail.noAccessPrefix")}{" "}
+              <code className="font-mono">gh</code>{" "}
+              {dt(t, "dialogs.pullRequestDetail.noAccessSuffix")}{" "}
+              {listing.slug}.
             </div>
           </ModalShell>
         ) : (
@@ -314,6 +324,7 @@ function DetailBody({
   onOpenMerge: () => void;
   onOpenClose: () => void;
 }) {
+  const t = useTranslation();
   const conversationCount = detail.comments.length + detail.reviews.length;
   const checkCounts = summarizeChecks(detail.checks);
   // Effective total ignores NEUTRAL / SKIPPED / CANCELLED — they carry no
@@ -363,7 +374,9 @@ function DetailBody({
               −{detail.deletions}
             </span>
             <span className="opacity-50"> · </span>
-            <span>{detail.changed_files} files</span>
+            <span>
+              {detail.changed_files} {dt(t, "dialogs.pullRequestDetail.files")}
+            </span>
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-1">
@@ -378,13 +391,13 @@ function DetailBody({
                 onClick={onOpenClose}
                 className="rounded-md bg-rose-500/15 px-2.5 py-1 text-[11px] font-medium text-rose-300 transition hover:bg-rose-500/25"
               >
-                Close
+                {dt(t, "dialogs.common.close")}
               </button>
               <span className="mx-1 h-4 w-px bg-border" aria-hidden />
             </>
           ) : null}
           <RefreshButton onClick={onRefresh} loading={refreshing} size={14} />
-          <Tooltip label="Open on GitHub" side="bottom">
+          <Tooltip label={dt(t, "dialogs.pullRequestDetail.openOnGithub")} side="bottom">
             <button
               type="button"
               onClick={() => void openUrl(detail.url)}
@@ -395,7 +408,7 @@ function DetailBody({
           </Tooltip>
           <button
             type="button"
-            aria-label="Close"
+            aria-label={dt(t, "dialogs.common.close")}
             onClick={onClose}
             className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
           >
@@ -409,7 +422,8 @@ function DetailBody({
           <Markdown content={body} onTaskToggle={onTaskToggle} />
           {bodySaveError ? (
             <p className="mt-2 text-[10.5px] text-danger">
-              Couldn't save checkbox: {bodySaveError}
+              {dt(t, "dialogs.pullRequestDetail.checkboxSaveFailed")}{" "}
+              {bodySaveError}
             </p>
           ) : null}
         </ResizableBody>
@@ -418,21 +432,21 @@ function DetailBody({
       <nav className="flex shrink-0 border-b border-border">
         <DetailTabButton
           icon={<MessagesSquare size={13} />}
-          label="Conversation"
+          label={dt(t, "dialogs.pullRequestDetail.tabConversation")}
           badge={conversationCount > 0 ? conversationCount : null}
           active={tab === "conversation"}
           onClick={() => onTab("conversation")}
         />
         <DetailTabButton
           icon={<GitCommit size={13} />}
-          label="Commits"
+          label={dt(t, "dialogs.pullRequestDetail.tabCommits")}
           badge={commitCount > 0 ? commitCount : null}
           active={tab === "commits"}
           onClick={() => onTab("commits")}
         />
         <DetailTabButton
           icon={<CheckCircle2 size={13} />}
-          label="Checks"
+          label={dt(t, "dialogs.pullRequestDetail.tabChecks")}
           badge={
             allChecksPassed ? (
               <Check size={11} strokeWidth={3} className="text-emerald-300" />
@@ -454,7 +468,7 @@ function DetailBody({
         />
         <DetailTabButton
           icon={<GitPullRequest size={13} />}
-          label="Files"
+          label={dt(t, "dialogs.pullRequestDetail.tabFiles")}
           badge={fileCount > 0 ? fileCount : null}
           active={tab === "files"}
           onClick={() => onTab("files")}
@@ -501,6 +515,7 @@ function DetailSkeleton({
   onRefresh: () => void;
   refreshing: boolean;
 }) {
+  const t = useTranslation();
   return (
     <>
       <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border px-4 py-3">
@@ -527,7 +542,7 @@ function DetailSkeleton({
           <RefreshButton onClick={onRefresh} loading={refreshing} size={14} />
           <button
             type="button"
-            aria-label="Close"
+            aria-label={dt(t, "dialogs.common.close")}
             onClick={onClose}
             className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
           >
@@ -710,6 +725,7 @@ function MergeActionButton({
   mergeable: string | null;
   onClick: () => void;
 }) {
+  const t = useTranslation();
   const upper = mergeable?.toUpperCase() ?? null;
   const ready = upper === "MERGEABLE";
   const conflicting = upper === "CONFLICTING";
@@ -725,15 +741,15 @@ function MergeActionButton({
           : "cursor-not-allowed bg-bg-elevated text-fg-muted opacity-70",
       )}
     >
-      Merge
+      {dt(t, "dialogs.pullRequestDetail.merge")}
     </button>
   );
   if (ready) {
     return button;
   }
   const title = conflicting
-    ? "Cannot merge — conflicting branch"
-    : "Merge readiness still being determined…";
+    ? dt(t, "dialogs.pullRequestDetail.cannotMergeConflicting")
+    : dt(t, "dialogs.pullRequestDetail.mergeReadinessPending");
   return (
     <Tooltip label={title} side="bottom">
       {button}
@@ -760,6 +776,7 @@ function readStoredBodyHeight(): number {
 }
 
 function ResizableBody({ children }: { children: React.ReactNode }) {
+  const t = useTranslation();
   const [height, setHeight] = useState<number>(() => readStoredBodyHeight());
   const dragRef = useRef<{ startY: number; startH: number } | null>(null);
 
@@ -808,13 +825,13 @@ function ResizableBody({ children }: { children: React.ReactNode }) {
       <div
         role="separator"
         aria-orientation="horizontal"
-        aria-label="Resize PR body"
+        aria-label={dt(t, "dialogs.pullRequestDetail.resizePrBody")}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
         onPointerCancel={onPointerUp}
         onDoubleClick={() => setHeight(BODY_HEIGHT_DEFAULT)}
-        title="Drag to resize · double-click to reset"
+        title={dt(t, "dialogs.pullRequestDetail.resizeHint")}
         className="group relative flex h-1.5 shrink-0 cursor-row-resize items-center justify-center border-b border-border bg-bg-sidebar/40 transition hover:bg-accent/30"
       >
         <span className="h-0.5 w-8 rounded-full bg-fg-muted/0 transition group-hover:bg-fg-muted/40" />
@@ -864,6 +881,7 @@ function ConversationPane({
   comments: PullRequestComment[];
   reviews: PullRequestReview[];
 }) {
+  const t = useTranslation();
   const [sort, setSort] = useState<ConversationSort>(() => readStoredSort());
 
   useEffect(() => {
@@ -909,7 +927,7 @@ function ConversationPane({
       <div className="flex h-full flex-col">
         {toolbar}
         <div className="flex flex-1 items-center justify-center text-xs text-fg-muted">
-          No comments or reviews yet.
+          {dt(t, "dialogs.pullRequestDetail.noComments")}
         </div>
       </div>
     );
@@ -939,10 +957,13 @@ function SortToggle({
   onChange: (next: ConversationSort) => void;
 }) {
   const isOldest = value === "oldest";
-  const label = isOldest ? "Oldest first" : "Newest first";
+  const t = useTranslation();
+  const label = isOldest
+    ? dt(t, "dialogs.pullRequestDetail.oldestFirst")
+    : dt(t, "dialogs.pullRequestDetail.newestFirst");
   const Icon = isOldest ? ArrowDownNarrowWide : ArrowUpNarrowWide;
   return (
-    <Tooltip label="Toggle sort order" side="bottom">
+    <Tooltip label={dt(t, "dialogs.pullRequestDetail.toggleSortOrder")} side="bottom">
       <button
         type="button"
         onClick={() => onChange(isOldest ? "newest" : "oldest")}
@@ -956,6 +977,7 @@ function SortToggle({
 }
 
 function CommentBlock({ comment }: { comment: PullRequestComment }) {
+  const t = useTranslation();
   return (
     <li className="rounded border border-border bg-bg-sidebar/40 p-3">
       <div className="mb-2 flex items-center gap-2 text-[10.5px] text-fg-muted">
@@ -964,7 +986,9 @@ function CommentBlock({ comment }: { comment: PullRequestComment }) {
           size={28}
           nameClass="text-[12.5px] font-semibold tracking-tight"
         />
-        <span className="opacity-60">commented</span>
+        <span className="opacity-60">
+          {dt(t, "dialogs.pullRequestDetail.commented")}
+        </span>
         <span className="font-mono opacity-60">
           {formatTimestamp(comment.created_at)}
         </span>
@@ -974,13 +998,16 @@ function CommentBlock({ comment }: { comment: PullRequestComment }) {
           <Markdown content={comment.body} />
         </div>
       ) : (
-        <p className="text-[11px] text-fg-muted">(empty)</p>
+        <p className="text-[11px] text-fg-muted">
+          {dt(t, "dialogs.pullRequestDetail.empty")}
+        </p>
       )}
     </li>
   );
 }
 
 function ReviewBlock({ review }: { review: PullRequestReview }) {
+  const t = useTranslation();
   return (
     <li className="rounded border border-border bg-bg-sidebar/40 p-3">
       <div className="mb-2 flex items-center gap-2 text-[10.5px] text-fg-muted">
@@ -1000,7 +1027,7 @@ function ReviewBlock({ review }: { review: PullRequestReview }) {
         </div>
       ) : (
         <p className="text-[11px] text-fg-muted">
-          (no review comment)
+          {dt(t, "dialogs.pullRequestDetail.noReviewComment")}
         </p>
       )}
     </li>
@@ -1008,6 +1035,7 @@ function ReviewBlock({ review }: { review: PullRequestReview }) {
 }
 
 function ReviewStateBadge({ state }: { state: string }) {
+  const t = useTranslation();
   const upper = state.toUpperCase();
   const tone =
     upper === "APPROVED"
@@ -1017,7 +1045,14 @@ function ReviewStateBadge({ state }: { state: string }) {
         : upper === "DISMISSED"
           ? "bg-fg-muted/15 text-fg-muted line-through"
           : "bg-fg-muted/15 text-fg-muted";
-  const label = upper.replace("_", " ").toLowerCase();
+  const label =
+    upper === "APPROVED"
+      ? dt(t, "dialogs.pullRequestDetail.reviewApproved")
+      : upper === "CHANGES_REQUESTED"
+        ? dt(t, "dialogs.pullRequestDetail.reviewChangesRequested")
+        : upper === "DISMISSED"
+          ? dt(t, "dialogs.pullRequestDetail.reviewDismissed")
+          : upper.replace("_", " ").toLowerCase();
   return (
     <span
       className={cn(
@@ -1041,6 +1076,7 @@ function CommitsPane({
   repoPath: string;
   cwd?: string;
 }) {
+  const t = useTranslation();
   const [selectedOid, setSelectedOid] = useState<string | null>(
     commits[0]?.oid ?? null,
   );
@@ -1062,7 +1098,7 @@ function CommitsPane({
   if (commits.length === 0) {
     return (
       <div className="flex h-full items-center justify-center text-xs text-fg-muted">
-        No commits in this pull request.
+        {dt(t, "dialogs.pullRequestDetail.noCommits")}
       </div>
     );
   }
@@ -1118,6 +1154,7 @@ function CommitListItem({
   selected: boolean;
   onSelect: () => void;
 }) {
+  const t = useTranslation();
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const primaryAuthor = commit.authors[0];
   const commitUrl = buildCommitUrl(prUrl, commit.oid);
@@ -1127,7 +1164,7 @@ function CommitListItem({
     ...(commitUrl
       ? [
           {
-            label: "View on GitHub",
+            label: dt(t, "dialogs.pullRequestDetail.viewOnGithub"),
             icon: <ExternalLink size={12} />,
             onClick: () => void openUrl(commitUrl),
           },
@@ -1138,7 +1175,7 @@ function CommitListItem({
       ? [{ type: "separator" as const }]
       : []),
     {
-      label: "Copy SHA",
+      label: dt(t, "dialogs.pullRequestDetail.copySha"),
       icon: <Copy size={12} />,
       onClick: () => void navigator.clipboard.writeText(commit.oid),
     },
@@ -1162,20 +1199,20 @@ function CommitListItem({
         )}
       >
         <div className="truncate text-[12px] font-medium text-fg" title={commit.message_headline}>
-          {commit.message_headline || "(no message)"}
+          {commit.message_headline || dt(t, "dialogs.pullRequestDetail.noMessage")}
         </div>
         <div className="mt-1 flex items-center gap-1.5 text-[10.5px] text-fg-muted">
           {primaryAuthor ? (
             <AuthorTag
               login={primaryAuthor.login}
-              fallbackName={primaryAuthor.name || "unknown"}
+              fallbackName={primaryAuthor.name || dt(t, "dialogs.pullRequestDetail.unknown")}
               size={14}
               nameClass="text-[10.5px] text-fg-muted"
             />
           ) : null}
           <span className="opacity-50">·</span>
           <span className="font-mono opacity-70">
-            {formatRelativeTime(commit.committed_date)}
+            {formatRelativeTime(commit.committed_date, t)}
           </span>
         </div>
       </button>
@@ -1201,6 +1238,7 @@ function CommitDetailView({
   repoPath: string;
   cwd?: string;
 }) {
+  const t = useTranslation();
   const [diff, setDiff] = useState<DiffPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -1239,11 +1277,11 @@ function CommitDetailView({
         </div>
       ) : loading || !diff ? (
         <div className="flex h-full items-center justify-center text-xs text-fg-muted">
-          Loading diff…
+          {dt(t, "dialogs.pullRequestDetail.loadingDiff")}
         </div>
       ) : diff.files.length === 0 ? (
         <div className="flex h-full items-center justify-center text-xs text-fg-muted">
-          No file changes in this commit.
+          {dt(t, "dialogs.pullRequestDetail.noFileChanges")}
         </div>
       ) : (
         <DiffSplitView payload={diff} cwd={cwd} />
@@ -1266,13 +1304,13 @@ function CommitDetailView({
             className="truncate text-[13px] font-semibold tracking-tight text-fg"
             title={commit.message_headline}
           >
-            {commit.message_headline || "(no message)"}
+            {commit.message_headline || dt(t, "dialogs.pullRequestDetail.noMessage")}
           </div>
           <div className="mt-1 flex items-center gap-1.5 text-[11px] text-fg-muted">
             {primaryAuthor ? (
               <AuthorTag
                 login={primaryAuthor.login}
-                fallbackName={primaryAuthor.name || "unknown"}
+                fallbackName={primaryAuthor.name || dt(t, "dialogs.pullRequestDetail.unknown")}
                 size={16}
                 nameClass="text-[11px] text-fg-muted"
               />
@@ -1288,7 +1326,7 @@ function CommitDetailView({
             </span>
           </div>
         </div>
-        <Tooltip label="Copy SHA" side="bottom">
+        <Tooltip label={dt(t, "dialogs.pullRequestDetail.copySha")} side="bottom">
           <button
             type="button"
             onClick={() => {
@@ -1300,7 +1338,10 @@ function CommitDetailView({
           </button>
         </Tooltip>
         {commitUrl ? (
-          <Tooltip label="Open commit on GitHub" side="bottom">
+          <Tooltip
+            label={dt(t, "dialogs.pullRequestDetail.openCommitOnGithub")}
+            side="bottom"
+          >
             <button
               type="button"
               onClick={() => void openUrl(commitUrl)}
@@ -1338,18 +1379,18 @@ function CommitDetailView({
  * Compact "23h" / "2d" / "May 4" — keeps the commit list narrow. Falls back
  * to the raw string when parsing fails.
  */
-function formatRelativeTime(iso: string): string {
+function formatRelativeTime(iso: string, t: Translator): string {
   if (!iso) return "—";
   const ms = Date.parse(iso);
   if (Number.isNaN(ms)) return iso;
   const diff = Date.now() - ms;
   const min = Math.floor(diff / 60_000);
-  if (min < 1) return "now";
-  if (min < 60) return `${min}m`;
+  if (min < 1) return dt(t, "dialogs.pullRequestDetail.now");
+  if (min < 60) return `${min}${dt(t, "dialogs.pullRequestDetail.minuteAbbrev")}`;
   const h = Math.floor(min / 60);
-  if (h < 24) return `${h}h`;
+  if (h < 24) return `${h}${dt(t, "dialogs.pullRequestDetail.hourAbbrev")}`;
   const d = Math.floor(h / 24);
-  if (d < 7) return `${d}d`;
+  if (d < 7) return `${d}${dt(t, "dialogs.pullRequestDetail.dayAbbrev")}`;
   return new Date(ms).toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
@@ -1370,10 +1411,11 @@ function buildCommitUrl(prUrl: string, oid: string): string | null {
 }
 
 function ChecksPane({ checks }: { checks: PullRequestCheck[] }) {
+  const t = useTranslation();
   if (checks.length === 0) {
     return (
       <div className="flex h-full items-center justify-center text-xs text-fg-muted">
-        No checks reported.
+        {dt(t, "dialogs.pullRequestDetail.noChecks")}
       </div>
     );
   }
@@ -1393,7 +1435,7 @@ function ChecksPane({ checks }: { checks: PullRequestCheck[] }) {
           </span>
           <CheckStatusLabel status={c.status} conclusion={c.conclusion} />
           {c.url ? (
-            <Tooltip label="Open run" side="top">
+            <Tooltip label={dt(t, "dialogs.pullRequestDetail.openRun")} side="top">
               <button
                 type="button"
                 onClick={() => {
@@ -1445,11 +1487,30 @@ function CheckStatusLabel({
   status: string;
   conclusion: string | null;
 }) {
+  const t = useTranslation();
   const raw =
     status.toUpperCase() === "COMPLETED"
       ? (conclusion ?? "completed")
       : status;
-  const text = raw.toLowerCase().replace(/_/g, " ");
+  const normalized = raw.toUpperCase();
+  const text =
+    normalized === "SUCCESS"
+      ? dt(t, "dialogs.pullRequestDetail.checkSuccess")
+      : normalized === "FAILURE"
+        ? dt(t, "dialogs.pullRequestDetail.checkFailure")
+        : normalized === "TIMED_OUT"
+          ? dt(t, "dialogs.pullRequestDetail.checkTimedOut")
+          : normalized === "ACTION_REQUIRED"
+            ? dt(t, "dialogs.pullRequestDetail.checkActionRequired")
+            : normalized === "CANCELLED"
+              ? dt(t, "dialogs.pullRequestDetail.checkCancelled")
+              : normalized === "NEUTRAL"
+                ? dt(t, "dialogs.pullRequestDetail.checkNeutral")
+                : normalized === "SKIPPED"
+                  ? dt(t, "dialogs.pullRequestDetail.checkSkipped")
+                  : normalized === "COMPLETED"
+                    ? dt(t, "dialogs.pullRequestDetail.checkCompleted")
+                    : raw.toLowerCase().replace(/_/g, " ");
   return (
     <span className="shrink-0 font-mono text-[10px] text-fg-muted">{text}</span>
   );

--- a/src/components/RemoveProjectDialog.tsx
+++ b/src/components/RemoveProjectDialog.tsx
@@ -1,12 +1,19 @@
 import { AlertTriangle } from "lucide-react";
 import type { Project, Session } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal, ModalHeader } from "./ui";
 
 type RemoveProjectChoice =
   | "project_only"
   | "project_and_worktrees"
   | "cancel";
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface RemoveProjectDialogProps {
   project: Project | null;
@@ -19,6 +26,7 @@ export function RemoveProjectDialog({
   sessions,
   onClose,
 }: RemoveProjectDialogProps) {
+  const t = useTranslation();
   const isolatedCount = sessions.filter((s) => s.isolated).length;
   const primaryChoice: RemoveProjectChoice =
     isolatedCount > 0 ? "project_and_worktrees" : "project_only";
@@ -38,14 +46,14 @@ export function RemoveProjectDialog({
       {project ? (
         <>
           <ModalHeader
-            title="Close project"
+            title={dt(t, "dialogs.removeProject.title")}
             icon={<AlertTriangle size={16} className="text-warning" />}
             variant="dialog"
             onClose={() => onClose("cancel")}
           />
           <div className="space-y-3 px-4 py-3 text-sm text-fg">
             <p>
-              Close project{" "}
+              {dt(t, "dialogs.removeProject.confirmPrefix")}{" "}
               <span className="font-mono text-accent">{project.name}</span>?
             </p>
             <div className="space-y-1 rounded-md border border-border bg-bg-sidebar/60 p-3 text-xs">
@@ -53,10 +61,17 @@ export function RemoveProjectDialog({
                 {project.repo_path}
               </p>
               <p className="text-fg-muted">
-                {sessions.length} session{sessions.length === 1 ? "" : "s"}{" "}
-                will be removed
+                {sessions.length}{" "}
+                {sessions.length === 1
+                  ? dt(t, "dialogs.removeProject.sessionSingular")
+                  : dt(t, "dialogs.removeProject.sessionPlural")}{" "}
+                {dt(t, "dialogs.removeProject.willBeRemoved")}
                 {isolatedCount > 0
-                  ? ` (${isolatedCount} isolated worktree${isolatedCount === 1 ? "" : "s"})`
+                  ? ` (${isolatedCount} ${
+                      isolatedCount === 1
+                        ? dt(t, "dialogs.removeProject.isolatedWorktreeSingular")
+                        : dt(t, "dialogs.removeProject.isolatedWorktreePlural")
+                    })`
                   : ""}
                 .
               </p>
@@ -68,7 +83,7 @@ export function RemoveProjectDialog({
               onClick={() => onClose("cancel")}
               className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
             >
-              Cancel
+              {dt(t, "dialogs.common.cancel")}
             </button>
             {isolatedCount > 0 ? (
               <button
@@ -76,7 +91,7 @@ export function RemoveProjectDialog({
                 onClick={() => onClose("project_only")}
                 className="rounded-md px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
               >
-                Close · keep worktrees
+                {dt(t, "dialogs.removeProject.closeKeepWorktrees")}
               </button>
             ) : null}
             <button
@@ -88,7 +103,9 @@ export function RemoveProjectDialog({
               }
               className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
             >
-              {isolatedCount > 0 ? "Close · delete worktrees" : "Close project"}
+              {isolatedCount > 0
+                ? dt(t, "dialogs.removeProject.closeDeleteWorktrees")
+                : dt(t, "dialogs.removeProject.closeProject")}
             </button>
           </footer>
         </>

--- a/src/components/RemoveSessionDialog.tsx
+++ b/src/components/RemoveSessionDialog.tsx
@@ -2,10 +2,17 @@ import { AlertTriangle } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { Session } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { useSettings } from "../lib/settings";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal, ModalHeader } from "./ui";
 
 type RemoveChoice = "session_only" | "session_and_worktree" | "cancel";
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface RemoveSessionDialogProps {
   session: Session | null;
@@ -13,6 +20,7 @@ interface RemoveSessionDialogProps {
 }
 
 export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogProps) {
+  const t = useTranslation();
   const isolated = session?.isolated ?? false;
   const patchSessions = useSettings((s) => s.patchSessions);
   const [dontAskAgain, setDontAskAgain] = useState(false);
@@ -50,31 +58,33 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
       {session ? (
         <>
           <ModalHeader
-            title="Remove session"
+            title={dt(t, "dialogs.removeSession.title")}
             icon={<AlertTriangle size={16} className="text-warning" />}
             variant="dialog"
             onClose={() => commit("cancel")}
           />
           <div className="space-y-3 px-4 py-3 text-sm text-fg">
             <p>
-              Remove session{" "}
+              {dt(t, "dialogs.removeSession.confirmPrefix")}{" "}
               <span className="font-mono text-accent">{session.name}</span>?
             </p>
             {isolated ? (
               <div className="space-y-2 rounded-md border border-border bg-bg-sidebar/60 p-3">
                 <p className="text-xs text-fg-muted">
-                  This is an isolated worktree:
+                  {dt(t, "dialogs.removeSession.isolatedWorktree")}
                 </p>
                 <p className="break-all font-mono text-xs text-fg">
                   {session.worktree_path}
                 </p>
                 <p className="text-xs text-fg-muted">
-                  Also delete the worktree from disk?
+                  {dt(t, "dialogs.removeSession.deleteWorktreeQuestion")}
                 </p>
               </div>
             ) : (
               <p className="text-xs text-fg-muted">
-                Files in {session.worktree_path} will not be touched.
+                {dt(t, "dialogs.removeSession.filesIn")}{" "}
+                {session.worktree_path}{" "}
+                {dt(t, "dialogs.removeSession.willNotBeTouched")}
               </p>
             )}
             {!isolated ? (
@@ -85,7 +95,7 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
                   onChange={(e) => setDontAskAgain(e.target.checked)}
                   className="accent-[var(--color-accent)]"
                 />
-                Don't ask again (toggle in Settings → Sessions)
+                {dt(t, "dialogs.removeSession.dontAskAgain")}
               </label>
             ) : null}
           </div>
@@ -95,7 +105,7 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
               onClick={() => commit("cancel")}
               className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
             >
-              Cancel
+              {dt(t, "dialogs.common.cancel")}
             </button>
             {isolated ? (
               <>
@@ -104,14 +114,14 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
                   onClick={() => commit("session_only")}
                   className="rounded-md px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
                 >
-                  Keep worktree
+                  {dt(t, "dialogs.removeSession.keepWorktree")}
                 </button>
                 <button
                   type="button"
                   onClick={() => commit("session_and_worktree")}
                   className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
                 >
-                  Delete worktree
+                  {dt(t, "dialogs.removeSession.deleteWorktree")}
                 </button>
               </>
             ) : (
@@ -120,7 +130,7 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
                 onClick={() => commit("session_only")}
                 className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
               >
-                Remove
+                {dt(t, "dialogs.removeSession.remove")}
               </button>
             )}
           </footer>

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -69,6 +69,8 @@ import {
   TextInput,
 } from "./ui";
 import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 
 interface ExpandedDiff {
   payload: DiffPayload;
@@ -87,7 +89,26 @@ interface ExpandedDiff {
 const COMMITS_PAGE_SIZE = 50;
 const COMMIT_ROW_HEIGHT = 48;
 
+type RightPanelTranslationKey = Extract<TranslationKey, `rightPanel.${string}`>;
+
+function rt(t: Translator, key: RightPanelTranslationKey): string {
+  return t(key);
+}
+
+function rtf(
+  t: Translator,
+  key: RightPanelTranslationKey,
+  values: Record<string, string | number>,
+): string {
+  return rt(t, key).replace(/\{(\w+)\}/g, (match, name) =>
+    Object.prototype.hasOwnProperty.call(values, name)
+      ? String(values[name])
+      : match,
+  );
+}
+
 export function RightPanel() {
+  const t = useTranslation();
   const sessions = useAppStore((s) => s.sessions);
   const activeSessionId = useAppStore((s) => s.activeSessionId);
   const activeProject = useAppStore((s) => s.activeProject);
@@ -142,14 +163,14 @@ export function RightPanel() {
       >
         <TabButton
           icon={<FolderTree size={14} />}
-          label="Files"
+          label={rt(t, "rightPanel.tabs.files")}
           active={rightTab === "files"}
           onClick={() => setRightTab("files")}
         />
         {showTodos ? (
           <TabButton
             icon={<ListTodo size={14} />}
-            label="Todos"
+            label={rt(t, "rightPanel.tabs.todos")}
             badge={todosState.todos.length}
             active={rightTab === "todos"}
             onClick={() => setRightTab("todos")}
@@ -157,25 +178,25 @@ export function RightPanel() {
         ) : null}
         <TabButton
           icon={<GitCommit size={14} />}
-          label="Commits"
+          label={rt(t, "rightPanel.tabs.commits")}
           active={rightTab === "commits"}
           onClick={() => setRightTab("commits")}
         />
         <TabButton
           icon={<FileDiff size={14} />}
-          label="Staged"
+          label={rt(t, "rightPanel.tabs.staged")}
           active={rightTab === "staged"}
           onClick={() => setRightTab("staged")}
         />
         <TabButton
           icon={<GitPullRequest size={14} />}
-          label="PRs"
+          label={rt(t, "rightPanel.tabs.prs")}
           active={rightTab === "prs"}
           onClick={() => setRightTab("prs")}
         />
         <TabButton
           icon={<Activity size={14} />}
-          label="Actions"
+          label={rt(t, "rightPanel.tabs.actions")}
           active={rightTab === "actions"}
           onClick={() => setRightTab("actions")}
         />
@@ -185,7 +206,7 @@ export function RightPanel() {
           active && showTodos ? (
             <TodosTab todos={todosState.todos} />
           ) : (
-            <Empty msg="No todos in this session" />
+            <Empty msg={rt(t, "rightPanel.empty.noTodos")} />
           )
         ) : rightTab === "commits" ? (
           repoPath ? (
@@ -198,7 +219,7 @@ export function RightPanel() {
               onExpand={setExpanded}
             />
           ) : (
-            <Empty msg="No project selected" />
+            <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : rightTab === "staged" ? (
           repoPath ? (
@@ -208,7 +229,7 @@ export function RightPanel() {
               onExpand={setExpanded}
             />
           ) : (
-            <Empty msg="No project selected" />
+            <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : rightTab === "prs" ? (
           repoPath ? (
@@ -220,18 +241,18 @@ export function RightPanel() {
               refreshKey={prListVersion}
             />
           ) : (
-            <Empty msg="No project selected" />
+            <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : rightTab === "files" ? (
           repoPath ? (
             <FileExplorer key={repoPath} rootPath={repoPath} />
           ) : (
-            <Empty msg="No project selected" />
+            <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : repoPath ? (
           <ActionsTab key={repoPath} repoPath={repoPath} />
         ) : (
-          <Empty msg="No project selected" />
+          <Empty msg={rt(t, "rightPanel.empty.noProject")} />
         )}
       </div>
       <DiffViewerModal
@@ -507,14 +528,24 @@ function useSessionTodos(
 }
 
 function TodosTab({ todos }: { todos: TodoItem[] }) {
+  const t = useTranslation();
   const counts = countByStatus(todos);
 
   return (
     <div className="flex h-full flex-col">
       <div className="shrink-0 border-b border-border px-3 py-2 text-[10px] uppercase tracking-wide text-fg-muted">
-        <span className="mr-3">{counts.completed}/{todos.length} done</span>
+        <span className="mr-3">
+          {rtf(t, "rightPanel.todos.doneCount", {
+            completed: counts.completed,
+            total: todos.length,
+          })}
+        </span>
         {counts.in_progress > 0 ? (
-          <span className="text-accent">{counts.in_progress} in progress</span>
+          <span className="text-accent">
+            {rtf(t, "rightPanel.todos.inProgressCount", {
+              count: counts.in_progress,
+            })}
+          </span>
         ) : null}
       </div>
       <ul className="flex-1 overflow-y-auto p-2 text-xs">
@@ -585,6 +616,7 @@ function CommitsTab({
   repoPath: string;
   onExpand: (e: ExpandedDiff) => void;
 }) {
+  const t = useTranslation();
   const [commits, setCommits] = useState<CommitInfo[]>([]);
   const [commitLogins, setCommitLogins] = useState<
     Record<string, string | null>
@@ -743,7 +775,7 @@ function CommitsTab({
         </span>
         <span className="opacity-50">·</span>
         <Tooltip label={absoluteTime(c.timestamp)} side="bottom">
-          <span className="font-mono">{relativeTime(c.timestamp)}</span>
+          <span className="font-mono">{relativeTime(c.timestamp, t)}</span>
         </Tooltip>
       </span>
     );
@@ -752,7 +784,7 @@ function CommitsTab({
   function buildHeaderActions(c: CommitInfo, webUrl: string | null): ReactNode {
     return (
       <>
-        <Tooltip label="Copy SHA" side="bottom">
+        <Tooltip label={rt(t, "rightPanel.tooltips.copySha")} side="bottom">
           <button
             type="button"
             onClick={() => void navigator.clipboard.writeText(c.sha)}
@@ -762,7 +794,7 @@ function CommitsTab({
           </button>
         </Tooltip>
         {webUrl ? (
-          <Tooltip label="Open on GitHub" side="bottom">
+          <Tooltip label={rt(t, "rightPanel.tooltips.openOnGitHub")} side="bottom">
             <button
               type="button"
               onClick={() => void openUrl(webUrl)}
@@ -798,7 +830,7 @@ function CommitsTab({
     try {
       const url = await api.commitWebUrl(repoPath, c.sha);
       if (!url) {
-        setError("This repo's origin is not a GitHub remote.");
+        setError(rt(t, "rightPanel.errors.notGitHubRemote"));
         return;
       }
       await openUrl(url);
@@ -881,7 +913,7 @@ function CommitsTab({
               >
                 {isSentinel ? (
                   <div className="px-3 py-3 text-center text-[10px] text-fg-muted">
-                    {loadingMore ? "loading more..." : "—"}
+                    {loadingMore ? rt(t, "rightPanel.loading.moreLower") : "—"}
                   </div>
                 ) : (
                   <button
@@ -904,7 +936,11 @@ function CommitsTab({
                   >
                     <span className="flex w-full min-w-0 items-center gap-2">
                       <Tooltip
-                        label={c.pushed ? "Pushed" : "Not pushed"}
+                        label={
+                          c.pushed
+                            ? rt(t, "rightPanel.commits.pushed")
+                            : rt(t, "rightPanel.commits.notPushed")
+                        }
                         side="top"
                       >
                         <span
@@ -933,7 +969,7 @@ function CommitsTab({
                       <span className="opacity-50">·</span>
                       <Tooltip label={absoluteTime(c.timestamp)} side="top">
                         <span className="font-mono">
-                          {relativeTime(c.timestamp)}
+                          {relativeTime(c.timestamp, t)}
                         </span>
                       </Tooltip>
                     </span>
@@ -965,9 +1001,9 @@ function CommitsTab({
               }}
             />
           ) : selected ? (
-            <Empty msg="loading diff..." />
+            <Empty msg={rt(t, "rightPanel.loading.diffLower")} />
           ) : (
-            <Empty msg="Select a commit to see diff" />
+            <Empty msg={rt(t, "rightPanel.commits.selectToSeeDiff")} />
           )}
         </div>
       </Panel>
@@ -979,14 +1015,14 @@ function CommitsTab({
           menu
             ? ([
                 {
-                  label: "Expand diff",
+                  label: rt(t, "rightPanel.menu.expandDiff"),
                   icon: <Maximize2 size={12} />,
                   onClick: () => {
                     void expandCommit(menu.commit);
                   },
                 },
                 {
-                  label: "View on GitHub",
+                  label: rt(t, "rightPanel.menu.viewOnGitHub"),
                   icon: <Globe size={12} />,
                   onClick: () => {
                     void openOnGitHub(menu.commit);
@@ -994,7 +1030,9 @@ function CommitsTab({
                 },
                 { type: "separator" },
                 {
-                  label: `Copy SHA (${menu.commit.short_sha})`,
+                  label: rtf(t, "rightPanel.menu.copyShaWithValue", {
+                    sha: menu.commit.short_sha,
+                  }),
                   icon: <Copy size={12} />,
                   onClick: () => {
                     void copyToClipboard(menu.commit.sha);
@@ -1009,19 +1047,21 @@ function CommitsTab({
   );
 }
 
-function relativeTime(unixSeconds: number): string {
+function relativeTime(unixSeconds: number, t: Translator): string {
   const diffSec = Math.round(Date.now() / 1000) - unixSeconds;
-  if (diffSec < 60) return `${diffSec}s ago`;
+  if (diffSec < 60) {
+    return rtf(t, "rightPanel.time.secondsAgo", { count: diffSec });
+  }
   const min = Math.round(diffSec / 60);
-  if (min < 60) return `${min}m ago`;
+  if (min < 60) return rtf(t, "rightPanel.time.minutesAgo", { count: min });
   const hr = Math.round(diffSec / 3600);
-  if (hr < 24) return `${hr}h ago`;
+  if (hr < 24) return rtf(t, "rightPanel.time.hoursAgo", { count: hr });
   const day = Math.round(diffSec / 86400);
-  if (day < 30) return `${day}d ago`;
+  if (day < 30) return rtf(t, "rightPanel.time.daysAgo", { count: day });
   const mo = Math.round(diffSec / (86400 * 30));
-  if (mo < 12) return `${mo}mo ago`;
+  if (mo < 12) return rtf(t, "rightPanel.time.monthsAgo", { count: mo });
   const yr = Math.round(diffSec / (86400 * 365));
-  return `${yr}y ago`;
+  return rtf(t, "rightPanel.time.yearsAgo", { count: yr });
 }
 
 function absoluteTime(unixSeconds: number): string {
@@ -1035,6 +1075,7 @@ function StagedTab({
   repoPath: string;
   onExpand: (e: ExpandedDiff) => void;
 }) {
+  const t = useTranslation();
   const [files, setFiles] = useState<StagedFile[]>([]);
   const [diff, setDiff] = useState<DiffPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -1091,7 +1132,7 @@ function StagedTab({
 
   async function openInEditor(file: StagedFile) {
     if (isDeleted(file)) {
-      setError("File was deleted; nothing to open.");
+      setError(rt(t, "rightPanel.errors.deletedFile"));
       return;
     }
     try {
@@ -1103,7 +1144,7 @@ function StagedTab({
 
   async function openWithDefaultApp(file: StagedFile) {
     if (isDeleted(file)) {
-      setError("File was deleted; nothing to open.");
+      setError(rt(t, "rightPanel.errors.deletedFile"));
       return;
     }
     try {
@@ -1116,7 +1157,7 @@ function StagedTab({
   if (error) return <div className="p-3 text-xs text-danger">{error}</div>;
   if (files.length === 0) {
     if (loadingFirst) return <SkeletonList count={6} />;
-    return <Empty msg="No staged or modified files" />;
+    return <Empty msg={rt(t, "rightPanel.staged.empty")} />;
   }
 
   return (
@@ -1155,13 +1196,13 @@ function StagedTab({
               onExpand={() =>
                 onExpand({
                   payload: diff,
-                  title: "Working tree changes",
+                  title: rt(t, "rightPanel.staged.workingTreeChanges"),
                   subtitle: <span className="font-mono">{repoPath}</span>,
                 })
               }
             />
           ) : (
-            <Empty msg="No diff" />
+            <Empty msg={rt(t, "rightPanel.staged.noDiff")} />
           )}
         </div>
       </Panel>
@@ -1173,7 +1214,7 @@ function StagedTab({
           menu
             ? ([
                 {
-                  label: "Open in editor",
+                  label: rt(t, "rightPanel.menu.openInEditor"),
                   icon: <ExternalLink size={12} />,
                   disabled: isDeleted(menu.file),
                   onClick: () => {
@@ -1182,14 +1223,14 @@ function StagedTab({
                 },
                 { type: "separator" },
                 {
-                  label: "Copy relative path",
+                  label: rt(t, "rightPanel.menu.copyRelativePath"),
                   icon: <Copy size={12} />,
                   onClick: () => {
                     void copyText(menu.file.path);
                   },
                 },
                 {
-                  label: "Copy absolute path",
+                  label: rt(t, "rightPanel.menu.copyAbsolutePath"),
                   icon: <Copy size={12} />,
                   onClick: () => {
                     void copyText(joinPath(repoPath, menu.file.path));
@@ -1204,12 +1245,16 @@ function StagedTab({
   );
 }
 
-const PR_STATE_OPTIONS: { value: PrStateFilter; label: string }[] = [
-  { value: "open", label: "Open" },
-  { value: "closed", label: "Closed" },
-  { value: "merged", label: "Merged" },
-  { value: "all", label: "All" },
+const PR_STATE_OPTIONS: { value: PrStateFilter }[] = [
+  { value: "open" },
+  { value: "closed" },
+  { value: "merged" },
+  { value: "all" },
 ];
+
+function prStateLabelKey(value: PrStateFilter): RightPanelTranslationKey {
+  return `rightPanel.prStates.${value}`;
+}
 
 /** Initial page size and per-scroll growth increment for PR list pagination. */
 const PR_PAGE_SIZE = 50;
@@ -1229,6 +1274,7 @@ function usePrRowActions(
   onOpenDetail: (number: number) => void,
   onMutated?: () => void,
 ) {
+  const t = useTranslation();
   const [menu, setMenu] = useState<{
     x: number;
     y: number;
@@ -1273,8 +1319,10 @@ function usePrRowActions(
       if (listing.kind !== "ok") {
         setError(
           listing.kind === "not_github"
-            ? "Origin remote is not a GitHub repository."
-            : `No access to ${listing.slug}.`,
+            ? rt(t, "rightPanel.errors.originNotGitHub")
+            : rtf(t, "rightPanel.errors.noAccessToSlug", {
+                slug: listing.slug,
+              }),
         );
         return null;
       }
@@ -1315,40 +1363,42 @@ function usePrRowActions(
           menu
             ? ([
                 {
-                  label: "Open detail",
+                  label: rt(t, "rightPanel.menu.openDetail"),
                   icon: <Maximize2 size={12} />,
                   onClick: () => onOpenDetail(menu.pr.number),
                 },
                 {
-                  label: "Open in browser",
+                  label: rt(t, "rightPanel.menu.openInBrowser"),
                   icon: <ExternalLink size={12} />,
                   onClick: () => void openPrInBrowser(menu.pr),
                 },
                 { type: "separator" },
                 {
-                  label: "Copy PR number",
+                  label: rt(t, "rightPanel.menu.copyPrNumber"),
                   icon: <Copy size={12} />,
                   onClick: () => void copyText(`#${menu.pr.number}`),
                 },
                 {
-                  label: "Copy URL",
+                  label: rt(t, "rightPanel.menu.copyUrl"),
                   icon: <Copy size={12} />,
                   onClick: () => void copyText(menu.pr.url),
                 },
                 {
-                  label: `Copy branch (${menu.pr.head_branch})`,
+                  label: rtf(t, "rightPanel.menu.copyBranchWithValue", {
+                    branch: menu.pr.head_branch,
+                  }),
                   icon: <Copy size={12} />,
                   onClick: () => void copyText(menu.pr.head_branch),
                 },
                 { type: "separator" },
                 {
-                  label: "Merge…",
+                  label: rt(t, "rightPanel.menu.merge"),
                   icon: <GitMerge size={12} />,
                   disabled: menu.pr.state.toUpperCase() !== "OPEN",
                   onClick: () => void openMergeFor(menu.pr),
                 },
                 {
-                  label: "Close…",
+                  label: rt(t, "rightPanel.menu.close"),
                   icon: <GitPullRequestClosed size={12} />,
                   disabled: menu.pr.state.toUpperCase() !== "OPEN",
                   onClick: () => void openCloseFor(menu.pr),
@@ -1404,6 +1454,7 @@ function PullRequestsTab({
   /** Bumped by the parent to force an out-of-band refetch (e.g. after a PR is merged via the modal). */
   refreshKey: number;
 }) {
+  const t = useTranslation();
   const refreshIntervalMs = useSettings(
     (s) => s.settings.github.refreshIntervalMs,
   );
@@ -1513,14 +1564,14 @@ function PullRequestsTab({
                 : "text-fg-muted hover:text-fg",
             )}
           >
-            {opt.label}
+            {rt(t, prStateLabelKey(opt.value))}
           </button>
         ))}
         <button
           type="button"
           onClick={onOpenSearch}
-          aria-label="Search pull requests"
-          title="Search pull requests"
+          aria-label={rt(t, "rightPanel.search.aria")}
+          title={rt(t, "rightPanel.search.aria")}
           className="ml-auto rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
         >
           <Search size={12} />
@@ -1542,7 +1593,7 @@ function PullRequestsTab({
         ) : !listing ? (
           <PrSkeletonList count={10} />
         ) : listing.kind === "not_github" ? (
-          <Empty msg="Origin remote is not a GitHub repository." />
+          <Empty msg={rt(t, "rightPanel.errors.originNotGitHub")} />
         ) : listing.kind === "no_access" ? (
           <NoAccessBanner
             slug={listing.slug}
@@ -1550,7 +1601,11 @@ function PullRequestsTab({
             repoPath={repoPath}
           />
         ) : listing.items.length === 0 ? (
-          <Empty msg={`No ${stateFilter} pull requests.`} />
+          <Empty
+            msg={rtf(t, "rightPanel.prs.emptyByState", {
+              state: rt(t, prStateLabelKey(stateFilter)).toLowerCase(),
+            })}
+          />
         ) : (
           <ul className="text-xs">
             {listing.items.map((pr) => (
@@ -1564,12 +1619,14 @@ function PullRequestsTab({
             ))}
             {loading && listing.items.length >= limit ? (
               <li className="px-3 py-2 text-[10px] text-fg-muted">
-                Loading more…
+                {rt(t, "rightPanel.loading.more")}
               </li>
             ) : null}
             {reachedMax ? (
               <li className="px-3 py-2 text-[10px] text-fg-muted">
-                Showing first {PR_PAGE_MAX}. Use search to find older PRs.
+                {rtf(t, "rightPanel.prs.reachedMax", {
+                  count: PR_PAGE_MAX,
+                })}
               </li>
             ) : null}
           </ul>
@@ -1584,6 +1641,7 @@ const WORKFLOW_RUNS_LIMIT = 50;
 const ALL_WORKFLOWS = "__all__";
 
 function ActionsTab({ repoPath }: { repoPath: string }) {
+  const t = useTranslation();
   const refreshIntervalMs = useSettings(
     (s) => s.settings.github.refreshIntervalMs,
   );
@@ -1647,11 +1705,13 @@ function ActionsTab({ repoPath }: { repoPath: string }) {
         <Select
           value={workflowFilter}
           onChange={(e) => setWorkflowFilter(e.target.value)}
-          aria-label="Filter by workflow"
+          aria-label={rt(t, "rightPanel.actions.filterByWorkflow")}
           disabled={listing?.kind !== "ok" || workflowNames.length === 0}
           className="min-w-0 max-w-full flex-1 truncate"
         >
-          <option value={ALL_WORKFLOWS}>All workflows</option>
+          <option value={ALL_WORKFLOWS}>
+            {rt(t, "rightPanel.actions.allWorkflows")}
+          </option>
           {workflowNames.map((name) => (
             <option key={name} value={name}>
               {name}
@@ -1670,7 +1730,7 @@ function ActionsTab({ repoPath }: { repoPath: string }) {
         ) : !listing ? (
           <PrSkeletonList count={8} />
         ) : listing.kind === "not_github" ? (
-          <Empty msg="Origin remote is not a GitHub repository." />
+          <Empty msg={rt(t, "rightPanel.errors.originNotGitHub")} />
         ) : listing.kind === "no_access" ? (
           <NoAccessBanner
             slug={listing.slug}
@@ -1681,8 +1741,8 @@ function ActionsTab({ repoPath }: { repoPath: string }) {
           <Empty
             msg={
               listing.items.length === 0
-                ? "No workflow runs yet."
-                : "No runs match this filter."
+                ? rt(t, "rightPanel.actions.noRuns")
+                : rt(t, "rightPanel.actions.noRunsForFilter")
             }
           />
         ) : (
@@ -1714,13 +1774,16 @@ function WorkflowRunRow({
   run: WorkflowRun;
   onOpenDetail: () => void;
 }) {
+  const t = useTranslation();
   const updated = toUnixSeconds(run.updated_at);
-  const startedRelative = updated > 0 ? relativeTime(updated) : "";
+  const startedRelative = updated > 0 ? relativeTime(updated, t) : "";
   const startedAbsolute = updated > 0 ? absoluteTime(updated) : "";
   const title =
     run.display_title.trim().length > 0
       ? run.display_title
-      : `${run.workflow_name} run`;
+      : rtf(t, "rightPanel.actions.workflowRunFallbackTitle", {
+          workflow: run.workflow_name,
+        });
   const branch = run.head_branch?.trim() ?? "";
 
   return (
@@ -1738,7 +1801,7 @@ function WorkflowRunRow({
           "flex w-full items-start gap-2 border-b border-border/40 px-3 py-2 text-left",
           "transition hover:bg-bg-elevated/60 focus:bg-bg-elevated/60 focus:outline-none",
         )}
-        title="Double-click to view details"
+        title={rt(t, "rightPanel.actions.doubleClickDetails")}
       >
         <span className="mt-0.5 flex shrink-0 items-center">
           <WorkflowRunStatusIcon
@@ -1761,7 +1824,11 @@ function WorkflowRunRow({
             {run.attempt > 1 ? (
               <>
                 <span className="opacity-50">·</span>
-                <span>retry #{run.attempt}</span>
+                <span>
+                  {rtf(t, "rightPanel.actions.retryAttempt", {
+                    attempt: run.attempt,
+                  })}
+                </span>
               </>
             ) : null}
           </div>
@@ -1789,6 +1856,7 @@ function WorkflowRunDetailModal({
   runId: number | null;
   onClose: () => void;
 }) {
+  const t = useTranslation();
   const refreshIntervalMs = useSettings(
     (s) => s.settings.github.refreshIntervalMs,
   );
@@ -1851,7 +1919,7 @@ function WorkflowRunDetailModal({
   const title =
     detail?.display_title.trim().length
       ? detail.display_title
-      : detail?.workflow_name ?? "Workflow run";
+      : detail?.workflow_name ?? rt(t, "rightPanel.actions.workflowRun");
   const subtitle = detail ? (
     <span className="flex flex-wrap items-center gap-1.5">
       <span>{detail.workflow_name}</span>
@@ -1866,7 +1934,11 @@ function WorkflowRunDetailModal({
       {detail.attempt > 1 ? (
         <>
           <span className="opacity-50">·</span>
-          <span>retry #{detail.attempt}</span>
+          <span>
+            {rtf(t, "rightPanel.actions.retryAttempt", {
+              attempt: detail.attempt,
+            })}
+          </span>
         </>
       ) : null}
     </span>
@@ -1902,10 +1974,10 @@ function WorkflowRunDetailModal({
               type="button"
               onClick={() => void openUrl(detail.url)}
               className="flex items-center gap-1 rounded px-2 py-1 text-[11px] text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
-              title="Open on GitHub"
+              title={rt(t, "rightPanel.tooltips.openOnGitHub")}
             >
               <ExternalLink size={12} />
-              GitHub
+              {rt(t, "rightPanel.actions.github")}
             </button>
           ) : null
         }
@@ -1918,7 +1990,7 @@ function WorkflowRunDetailModal({
         ) : loading || !listing ? (
           <WorkflowRunDetailSkeleton />
         ) : listing.kind === "not_github" ? (
-          <Empty msg="Origin remote is not a GitHub repository." />
+          <Empty msg={rt(t, "rightPanel.errors.originNotGitHub")} />
         ) : listing.kind === "no_access" ? (
           <NoAccessBanner
             slug={listing.slug}
@@ -1975,60 +2047,72 @@ function WorkflowRunDetailSkeleton() {
 }
 
 function WorkflowRunDetailBody({ detail }: { detail: WorkflowRunDetail }) {
+  const t = useTranslation();
   const created = toUnixSeconds(detail.created_at);
   const updated = toUnixSeconds(detail.updated_at);
   const totalDuration = formatRunDuration(
     detail.started_at ?? detail.created_at,
     detail.status,
     detail.updated_at,
+    t,
   );
   return (
     <div className="space-y-3">
       <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px] text-fg-muted">
-        <dt className="opacity-70">Status</dt>
+        <dt className="opacity-70">{rt(t, "rightPanel.actions.status")}</dt>
         <dd className="text-fg">
           {detail.status}
           {detail.conclusion ? ` · ${detail.conclusion}` : ""}
         </dd>
         {totalDuration ? (
           <>
-            <dt className="opacity-70">Total duration</dt>
+            <dt className="opacity-70">
+              {rt(t, "rightPanel.actions.totalDuration")}
+            </dt>
             <dd className="text-fg">
               {totalDuration}
               {detail.status.toLowerCase() !== "completed" ? (
-                <span className="ml-1 text-fg-muted">(running)</span>
+                <span className="ml-1 text-fg-muted">
+                  {rt(t, "rightPanel.actions.runningParenthetical")}
+                </span>
               ) : null}
             </dd>
           </>
         ) : null}
-        <dt className="opacity-70">Attempt</dt>
+        <dt className="opacity-70">{rt(t, "rightPanel.actions.attempt")}</dt>
         <dd className="text-fg">
           #{detail.attempt}
           {detail.attempt > 1 ? (
-            <span className="ml-1 text-fg-muted">(retried)</span>
+            <span className="ml-1 text-fg-muted">
+              {rt(t, "rightPanel.actions.retriedParenthetical")}
+            </span>
           ) : null}
         </dd>
-        <dt className="opacity-70">Commit</dt>
+        <dt className="opacity-70">{rt(t, "rightPanel.actions.commit")}</dt>
         <dd className="font-mono text-fg">{detail.head_sha.slice(0, 7)}</dd>
         {created > 0 ? (
           <>
-            <dt className="opacity-70">Created</dt>
+            <dt className="opacity-70">{rt(t, "rightPanel.actions.created")}</dt>
             <dd className="text-fg">{absoluteTime(created)}</dd>
           </>
         ) : null}
         {updated > 0 ? (
           <>
-            <dt className="opacity-70">Updated</dt>
+            <dt className="opacity-70">{rt(t, "rightPanel.actions.updated")}</dt>
             <dd className="text-fg">{absoluteTime(updated)}</dd>
           </>
         ) : null}
       </dl>
       <div>
         <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-fg-muted">
-          Jobs ({detail.jobs.length})
+          {rtf(t, "rightPanel.actions.jobsCount", {
+            count: detail.jobs.length,
+          })}
         </div>
         {detail.jobs.length === 0 ? (
-          <div className="text-[11px] text-fg-muted">No jobs reported.</div>
+          <div className="text-[11px] text-fg-muted">
+            {rt(t, "rightPanel.actions.noJobs")}
+          </div>
         ) : (
           <ul className="rounded border border-border/60 divide-y divide-border/40">
             {detail.jobs.map((job) => (
@@ -2042,8 +2126,9 @@ function WorkflowRunDetailBody({ detail }: { detail: WorkflowRunDetail }) {
 }
 
 function WorkflowJobRow({ job }: { job: WorkflowJob }) {
+  const t = useTranslation();
   const [expanded, setExpanded] = useState(false);
-  const duration = formatJobDuration(job.started_at, job.completed_at);
+  const duration = formatJobDuration(job.started_at, job.completed_at, t);
   return (
     <li className="bg-bg/40">
       <button
@@ -2081,7 +2166,7 @@ function WorkflowJobRow({ job }: { job: WorkflowJob }) {
               }
             }}
             className="shrink-0 cursor-pointer rounded p-0.5 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
-            title="Open job on GitHub"
+            title={rt(t, "rightPanel.actions.openJobOnGitHub")}
           >
             <ExternalLink size={11} />
           </span>
@@ -2119,6 +2204,7 @@ function formatRunDuration(
   startedAt: string,
   status: string,
   updatedAt: string,
+  t: Translator,
 ): string {
   const start = toUnixSeconds(startedAt);
   if (start <= 0) return "";
@@ -2126,28 +2212,43 @@ function formatRunDuration(
   const end = completed
     ? toUnixSeconds(updatedAt) || Math.floor(Date.now() / 1000)
     : Math.floor(Date.now() / 1000);
-  return formatDurationSeconds(Math.max(0, end - start));
+  return formatDurationSeconds(Math.max(0, end - start), t);
 }
 
-function formatDurationSeconds(seconds: number): string {
-  if (seconds < 60) return `${seconds}s`;
+function formatDurationSeconds(seconds: number, t: Translator): string {
+  if (seconds < 60) {
+    return rtf(t, "rightPanel.duration.seconds", { count: seconds });
+  }
   const minutes = Math.floor(seconds / 60);
   const rem = seconds % 60;
-  if (minutes < 60) return rem === 0 ? `${minutes}m` : `${minutes}m ${rem}s`;
+  if (minutes < 60) {
+    return rem === 0
+      ? rtf(t, "rightPanel.duration.minutes", { count: minutes })
+      : rtf(t, "rightPanel.duration.minutesSeconds", {
+          minutes,
+          seconds: rem,
+        });
+  }
   const hours = Math.floor(minutes / 60);
   const minRem = minutes % 60;
-  return minRem === 0 ? `${hours}h` : `${hours}h ${minRem}m`;
+  return minRem === 0
+    ? rtf(t, "rightPanel.duration.hours", { count: hours })
+    : rtf(t, "rightPanel.duration.hoursMinutes", {
+        hours,
+        minutes: minRem,
+      });
 }
 
 function formatJobDuration(
   startedAt: string | null,
   completedAt: string | null,
+  t: Translator,
 ): string {
   if (!startedAt) return "";
   const start = toUnixSeconds(startedAt);
   if (start <= 0) return "";
   const end = completedAt ? toUnixSeconds(completedAt) : Math.floor(Date.now() / 1000);
-  return formatDurationSeconds(Math.max(0, end - start));
+  return formatDurationSeconds(Math.max(0, end - start), t);
 }
 
 function WorkflowRunStatusIcon({
@@ -2200,25 +2301,27 @@ function NoAccessBanner({
   accounts: AccountSummary[];
   repoPath: string;
 }) {
+  const t = useTranslation();
   const tried = accounts.map((a) => `@${a.login}`).join(", ");
   return (
     <div className="space-y-2 p-3 text-xs text-fg-muted">
       <p className="text-fg">
-        No logged-in <code className="font-mono">gh</code> account can access{" "}
-        <span className="font-mono text-fg">{slug}</span>.
+        {rtf(t, "rightPanel.noAccess.noGhAccountCanAccess", { slug })}
       </p>
       {accounts.length > 0 ? (
         <p>
-          <span className="opacity-70">Tried:</span> {tried}
+          <span className="opacity-70">
+            {rt(t, "rightPanel.noAccess.tried")}
+          </span>{" "}
+          {tried}
         </p>
       ) : (
-        <p>No accounts authenticated against github.com.</p>
+        <p>{rt(t, "rightPanel.noAccess.noAccounts")}</p>
       )}
       <p className="flex flex-wrap items-center gap-1.5 opacity-70">
-        Run
+        {rt(t, "rightPanel.noAccess.run")}
         <CommandHint command="gh auth login" repoPath={repoPath} />
-        with an account that has access, or accept the invitation on
-        github.com.
+        {rt(t, "rightPanel.noAccess.withAccess")}
       </p>
     </div>
   );
@@ -2229,6 +2332,7 @@ function PrChecksBadge({
 }: {
   checks: PullRequestChecksSummary | null;
 }) {
+  const t = useTranslation();
   if (!checks) return null;
   // Effective total mirrors the PR detail modal: NEUTRAL/SKIPPED/CANCELLED
   // are already excluded by the backend, so passed+failed+pending is what
@@ -2242,7 +2346,7 @@ function PrChecksBadge({
   if (allPassed) {
     return (
       <Tooltip
-        label={`All ${effective} check${effective === 1 ? "" : "s"} passed`}
+        label={rtf(t, "rightPanel.checks.allPassed", { count: effective })}
         side="top"
       >
         <Check
@@ -2256,7 +2360,7 @@ function PrChecksBadge({
   if (allFailed) {
     return (
       <Tooltip
-        label={`All ${effective} check${effective === 1 ? "" : "s"} failed`}
+        label={rtf(t, "rightPanel.checks.allFailed", { count: effective })}
         side="top"
       >
         <X size={10} strokeWidth={3} className="shrink-0 text-rose-400" />
@@ -2266,7 +2370,11 @@ function PrChecksBadge({
   // Partial: tiny inline `passed/total` next to the branch name, no pill.
   return (
     <Tooltip
-      label={`${checks.passed} passed, ${checks.failed} failed, ${checks.pending} pending`}
+      label={rtf(t, "rightPanel.checks.summary", {
+        passed: checks.passed,
+        failed: checks.failed,
+        pending: checks.pending,
+      })}
       side="top"
     >
       <span className="shrink-0 font-mono tabular-nums opacity-80">
@@ -2277,9 +2385,12 @@ function PrChecksBadge({
 }
 
 function PrStateBadge({ state, isDraft }: { state: string; isDraft: boolean }) {
+  const t = useTranslation();
   const upper = state.toUpperCase();
   const showDraft = isDraft && upper === "OPEN";
-  const label = showDraft ? "DRAFT" : upper;
+  const label = showDraft
+    ? rt(t, "rightPanel.prStates.draft")
+    : stateLabelForBadge(t, upper);
   const tone = showDraft
     ? "bg-fg-muted/15 text-fg-muted"
     : upper === "OPEN"
@@ -2297,6 +2408,19 @@ function PrStateBadge({ state, isDraft }: { state: string; isDraft: boolean }) {
       {label}
     </span>
   );
+}
+
+function stateLabelForBadge(t: Translator, upper: string): string {
+  switch (upper) {
+    case "OPEN":
+      return rt(t, "rightPanel.prStates.open").toUpperCase();
+    case "CLOSED":
+      return rt(t, "rightPanel.prStates.closed").toUpperCase();
+    case "MERGED":
+      return rt(t, "rightPanel.prStates.merged").toUpperCase();
+    default:
+      return upper;
+  }
 }
 
 function toUnixSeconds(iso: string): number {
@@ -2333,6 +2457,7 @@ function PrRow({
    */
   showAvatar?: boolean;
 }) {
+  const t = useTranslation();
   const hoverBg =
     surface === "dialog"
       ? "hover:bg-bg-sidebar focus-visible:bg-bg-sidebar"
@@ -2408,7 +2533,7 @@ function PrRow({
           className="shrink-0"
         >
           <span className="whitespace-nowrap font-mono">
-            {relativeTime(toUnixSeconds(pr.updated_at))}
+            {relativeTime(toUnixSeconds(pr.updated_at), t)}
           </span>
         </Tooltip>
       </span>
@@ -2416,11 +2541,11 @@ function PrRow({
   );
 }
 
-const PR_SEARCH_STATE_OPTIONS: { value: PrStateFilter; label: string }[] = [
-  { value: "all", label: "All" },
-  { value: "open", label: "Open" },
-  { value: "closed", label: "Closed" },
-  { value: "merged", label: "Merged" },
+const PR_SEARCH_STATE_OPTIONS: { value: PrStateFilter }[] = [
+  { value: "all" },
+  { value: "open" },
+  { value: "closed" },
+  { value: "merged" },
 ];
 
 /**
@@ -2444,6 +2569,7 @@ function PullRequestSearchModal({
   onClose: () => void;
   onOpenDetail: (number: number) => void;
 }) {
+  const t = useTranslation();
   const repoPath = open?.repoPath ?? null;
   const showAvatars = useSettings((s) => s.settings.github.showAvatars);
   const [rawQuery, setRawQuery] = useState("");
@@ -2545,10 +2671,10 @@ function PullRequestSearchModal({
       onClose={onClose}
       variant="dialog"
       size="2xl"
-      ariaLabel="Search pull requests"
+      ariaLabel={rt(t, "rightPanel.search.aria")}
     >
       <ModalHeader
-        title="Search pull requests"
+        title={rt(t, "rightPanel.search.aria")}
         icon={<Search size={14} className="text-fg-muted" />}
         variant="dialog"
         onClose={onClose}
@@ -2558,7 +2684,7 @@ function PullRequestSearchModal({
           ref={inputRef}
           value={rawQuery}
           onChange={(e) => setRawQuery(e.currentTarget.value)}
-          placeholder="Search title, author, label, branch…"
+          placeholder={rt(t, "rightPanel.search.placeholder")}
           autoFocus
         />
         <div className="flex items-center gap-1 text-[11px]">
@@ -2574,11 +2700,13 @@ function PullRequestSearchModal({
                   : "text-fg-muted hover:text-fg",
               )}
             >
-              {opt.label}
+              {rt(t, prStateLabelKey(opt.value))}
             </button>
           ))}
           {loading ? (
-            <span className="ml-auto text-fg-muted">Searching…</span>
+            <span className="ml-auto text-fg-muted">
+              {rt(t, "rightPanel.search.searching")}
+            </span>
           ) : listing?.kind === "ok" ? (
             <span className="ml-auto font-mono text-fg-muted">
               {listing.items.length}
@@ -2592,7 +2720,7 @@ function PullRequestSearchModal({
         onScroll={handleScroll}
       >
         {!debouncedQuery ? (
-          <Empty msg="Type to search pull requests." />
+          <Empty msg={rt(t, "rightPanel.search.typeToSearch")} />
         ) : error || rowActions.error ? (
           <div className="p-3 text-xs text-danger">
             {error ?? rowActions.error}
@@ -2600,13 +2728,13 @@ function PullRequestSearchModal({
         ) : !listing ? (
           <PrSkeletonList count={6} />
         ) : listing.kind === "not_github" ? (
-          <Empty msg="Origin remote is not a GitHub repository." />
+          <Empty msg={rt(t, "rightPanel.errors.originNotGitHub")} />
         ) : listing.kind === "no_access" ? (
           <div className="p-3 text-xs text-fg-muted">
-            No logged-in gh account can access this repo.
+            {rt(t, "rightPanel.search.noGhAccessThisRepo")}
           </div>
         ) : listing.items.length === 0 ? (
-          <Empty msg="No matching pull requests." />
+          <Empty msg={rt(t, "rightPanel.search.noMatches")} />
         ) : (
           <ul className="text-xs">
             {listing.items.map((pr) => (
@@ -2621,12 +2749,14 @@ function PullRequestSearchModal({
             ))}
             {loading && listing.items.length >= limit ? (
               <li className="px-3 py-2 text-[10px] text-fg-muted">
-                Loading more…
+                {rt(t, "rightPanel.loading.more")}
               </li>
             ) : null}
             {reachedMax ? (
               <li className="px-3 py-2 text-[10px] text-fg-muted">
-                Showing first {PR_PAGE_MAX}. Refine the query for older PRs.
+                {rtf(t, "rightPanel.search.reachedMax", {
+                  count: PR_PAGE_MAX,
+                })}
               </li>
             ) : null}
           </ul>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -42,12 +42,14 @@ import { CSS } from "@dnd-kit/utilities";
 import { useAppStore } from "../store";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
+import type { TranslationKey, Translator } from "../lib/i18n";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import {
   useSettings,
   type AcornSettings,
   type SessionTitleSource,
 } from "../lib/settings";
+import { useTranslation } from "../lib/useTranslation";
 import {
   planChevronClick,
   planTitleClick,
@@ -66,18 +68,20 @@ const STATUS_DOT: Record<SessionStatus, string> = {
   completed: "bg-accent/60",
 };
 
-const STATUS_LABEL: Record<SessionStatus, string> = {
-  idle: "Idle",
-  running: "Running",
-  needs_input: "Needs input",
-  failed: "Failed",
-  completed: "Completed",
-};
-
 const COLLAPSED_KEY = "acorn:sidebar:collapsed-projects";
 
 const PROJECT_DRAG_PREFIX = "project:";
 const SESSION_DRAG_PREFIX = "session:";
+
+type SidebarTranslationKey = Extract<TranslationKey, `sidebar.${string}`>;
+
+function sidebarText(t: Translator, key: SidebarTranslationKey): string {
+  return t(key);
+}
+
+function statusLabel(t: Translator, status: SessionStatus): string {
+  return sidebarText(t, `sidebar.status.${status}`);
+}
 
 interface ProjectGroup {
   repoPath: string;
@@ -86,6 +90,7 @@ interface ProjectGroup {
 }
 
 export function Sidebar() {
+  const t = useTranslation();
   const {
     sessions,
     projects,
@@ -160,7 +165,7 @@ export function Sidebar() {
       const repoPath = await open({
         directory: true,
         multiple: false,
-        title: "Select an existing project",
+        title: sidebarText(t, "sidebar.dialog.selectExistingProject"),
       });
       if (!repoPath || typeof repoPath !== "string") return;
       await addProject(repoPath);
@@ -223,10 +228,10 @@ export function Sidebar() {
           directory: true,
           multiple: false,
           title: isolated
-            ? "Select a git repository (isolated worktree)"
+            ? sidebarText(t, "sidebar.dialog.selectIsolatedRepository")
             : kind === "control"
-              ? "Select a directory (control session)"
-              : "Select a directory",
+              ? sidebarText(t, "sidebar.dialog.selectControlDirectory")
+              : sidebarText(t, "sidebar.dialog.selectDirectory"),
         }));
       if (!repoPath || typeof repoPath !== "string") return;
       const name = suggestName(repoPath, sessions, kind);
@@ -321,25 +326,34 @@ export function Sidebar() {
     <aside className="flex h-full w-full flex-col bg-bg-sidebar">
       <header className="flex h-9 shrink-0 items-center justify-between gap-2 px-3">
         <h2 className="text-sm font-medium tracking-tight text-fg-muted">
-          Projects
+          {sidebarText(t, "sidebar.projects.title")}
         </h2>
         <div className="flex items-center gap-1">
-          <Tooltip label="New project" side="left">
+          <Tooltip
+            label={sidebarText(t, "sidebar.projects.newProject")}
+            side="left"
+          >
             <button
               type="button"
               onClick={() => setNewProjectOpen(true)}
               className="rounded-md p-1.5 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-              aria-label="New project"
+              aria-label={sidebarText(t, "sidebar.projects.newProject")}
             >
               <FolderPlus size={14} />
             </button>
           </Tooltip>
-          <Tooltip label="Add existing project" side="left">
+          <Tooltip
+            label={sidebarText(t, "sidebar.projects.addExistingProject")}
+            side="left"
+          >
             <button
               type="button"
               onClick={onAddExistingProject}
               className="rounded-md p-1.5 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-              aria-label="Add existing project"
+              aria-label={sidebarText(
+                t,
+                "sidebar.projects.addExistingProject",
+              )}
             >
               <FolderOpen size={14} />
             </button>
@@ -410,7 +424,7 @@ export function Sidebar() {
             </SortableContext>
             <DragOverlay dropAnimation={null}>
               {activeDragId
-                ? renderDragOverlay(activeDragId, projectGroups, sessions)
+                ? renderDragOverlay(activeDragId, projectGroups, sessions, t)
                 : null}
             </DragOverlay>
           </DndContext>
@@ -431,6 +445,7 @@ function renderDragOverlay(
   activeDragId: string,
   projectGroups: ProjectGroup[],
   sessions: Session[],
+  t: Translator,
 ): React.ReactNode {
   if (activeDragId.startsWith(PROJECT_DRAG_PREFIX)) {
     const repoPath = activeDragId.slice(PROJECT_DRAG_PREFIX.length);
@@ -442,7 +457,7 @@ function renderDragOverlay(
     const sid = activeDragId.slice(SESSION_DRAG_PREFIX.length);
     const session = sessions.find((s) => s.id === sid);
     if (!session) return null;
-    return <SessionRowPreview session={session} />;
+    return <SessionRowPreview session={session} t={t} />;
   }
   return null;
 }
@@ -472,7 +487,13 @@ function ProjectHeaderPreview({
   );
 }
 
-function SessionRowPreview({ session }: { session: Session }) {
+function SessionRowPreview({
+  session,
+  t,
+}: {
+  session: Session;
+  t: Translator;
+}) {
   return (
     <div className="flex w-full items-start gap-1.5 rounded-md bg-bg-elevated/95 px-2 py-1 shadow-lg ring-1 ring-border/60">
       <span className="mt-1 flex shrink-0 items-center text-fg-muted/60">
@@ -494,7 +515,7 @@ function SessionRowPreview({ session }: { session: Session }) {
           ) : null}
         </span>
         <span className="block truncate text-[11px] text-fg-muted">
-          {session.branch} · {STATUS_LABEL[session.status]}
+          {session.branch} · {statusLabel(t, session.status)}
         </span>
       </span>
     </div>
@@ -559,6 +580,7 @@ function ProjectGroupView({
   onAddSession,
   onRemoveProject,
 }: ProjectGroupViewProps) {
+  const t = useTranslation();
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const {
     attributes,
@@ -617,19 +639,22 @@ function ProjectGroupView({
           e.stopPropagation();
           setMenu({ x: e.clientX, y: e.clientY });
         }}
-        aria-label={`Project ${project.name}`}
+        aria-label={`${sidebarText(t, "sidebar.aria.project")} ${project.name}`}
         className={cn(
           "group flex items-center gap-1 rounded-md px-1 py-1.5 hover:bg-bg-elevated/40",
           isActiveProject && "bg-bg-elevated/30",
         )}
       >
-        <Tooltip label="Drag to reorder" side="bottom">
+        <Tooltip
+          label={sidebarText(t, "sidebar.actions.dragToReorder")}
+          side="bottom"
+        >
           <span
             ref={setActivatorNodeRef}
             {...attributes}
             {...listeners}
             onClick={(e) => e.stopPropagation()}
-            aria-label="Drag to reorder project"
+            aria-label={sidebarText(t, "sidebar.aria.dragToReorderProject")}
             className="invisible flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
           >
             <GripVertical size={12} />
@@ -641,7 +666,11 @@ function ProjectGroupView({
             e.stopPropagation();
             onChevronClick();
           }}
-          aria-label={collapsed ? "Expand project" : "Collapse project"}
+          aria-label={
+            collapsed
+              ? sidebarText(t, "sidebar.actions.expandProject")
+              : sidebarText(t, "sidebar.actions.collapseProject")
+          }
           aria-expanded={!collapsed}
           className="flex shrink-0 items-center justify-center rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
         >
@@ -658,7 +687,10 @@ function ProjectGroupView({
             {project.sessions.length}
           </span>
         </span>
-        <Tooltip label="New session" side="bottom">
+        <Tooltip
+          label={sidebarText(t, "sidebar.actions.newSession")}
+          side="bottom"
+        >
           <button
             type="button"
             onClick={(e) => {
@@ -666,12 +698,15 @@ function ProjectGroupView({
               onAddSession(false, "regular");
             }}
             className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
-            aria-label="New session in this project"
+            aria-label={sidebarText(t, "sidebar.aria.newSessionInProject")}
           >
             <Plus size={12} />
           </button>
         </Tooltip>
-        <Tooltip label="New isolated session (worktree)" side="bottom">
+        <Tooltip
+          label={sidebarText(t, "sidebar.actions.newIsolatedSessionWorktree")}
+          side="bottom"
+        >
           <button
             type="button"
             onClick={(e) => {
@@ -679,12 +714,18 @@ function ProjectGroupView({
               onAddSession(true, "regular");
             }}
             className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
-            aria-label="New isolated session (worktree)"
+            aria-label={sidebarText(
+              t,
+              "sidebar.actions.newIsolatedSessionWorktree",
+            )}
           >
             <GitBranch size={12} />
           </button>
         </Tooltip>
-        <Tooltip label="New control session" side="bottom">
+        <Tooltip
+          label={sidebarText(t, "sidebar.actions.newControlSession")}
+          side="bottom"
+        >
           <button
             type="button"
             onClick={(e) => {
@@ -692,12 +733,18 @@ function ProjectGroupView({
               onAddSession(false, "control");
             }}
             className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
-            aria-label="New control session in this project"
+            aria-label={sidebarText(
+              t,
+              "sidebar.aria.newControlSessionInProject",
+            )}
           >
             <Bot size={12} />
           </button>
         </Tooltip>
-        <Tooltip label="Close project" side="bottom">
+        <Tooltip
+          label={sidebarText(t, "sidebar.actions.closeProject")}
+          side="bottom"
+        >
           <button
             type="button"
             onClick={(e) => {
@@ -705,7 +752,7 @@ function ProjectGroupView({
               onRemoveProject();
             }}
             className="invisible rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-danger group-hover:visible"
-            aria-label="Close project"
+            aria-label={sidebarText(t, "sidebar.actions.closeProject")}
           >
             <X size={12} />
           </button>
@@ -718,30 +765,30 @@ function ProjectGroupView({
         onClose={() => setMenu(null)}
         items={[
           {
-            label: "New session",
+            label: sidebarText(t, "sidebar.actions.newSession"),
             icon: <Plus size={12} />,
             onClick: () => onAddSession(false, "regular"),
           },
           {
-            label: "New isolated session",
+            label: sidebarText(t, "sidebar.actions.newIsolatedSession"),
             icon: <GitBranch size={12} />,
             onClick: () => onAddSession(true, "regular"),
           },
           {
-            label: "New control session",
+            label: sidebarText(t, "sidebar.actions.newControlSession"),
             icon: <Bot size={12} />,
             onClick: () => onAddSession(false, "control"),
           },
           { type: "separator" },
           {
-            label: "Reveal in Finder",
+            label: sidebarText(t, "sidebar.actions.revealInFinder"),
             icon: <FolderOpen size={12} />,
             onClick: () => {
               void openInFinder(project.repoPath);
             },
           },
           {
-            label: "Copy path",
+            label: sidebarText(t, "sidebar.actions.copyPath"),
             icon: <Copy size={12} />,
             onClick: () => {
               void copyText(project.repoPath);
@@ -749,7 +796,7 @@ function ProjectGroupView({
           },
           { type: "separator" },
           {
-            label: "Close project",
+            label: sidebarText(t, "sidebar.actions.closeProject"),
             icon: <X size={12} />,
             onClick: onRemoveProject,
           },
@@ -775,9 +822,11 @@ function ProjectGroupView({
                 }}
                 className="cursor-pointer rounded px-2 py-1 text-[11px] text-fg-muted transition select-none hover:bg-bg-elevated/40 hover:text-fg"
               >
-                No sessions. Add one with{" "}
-                <Plus size={10} className="inline" /> or{" "}
-                <GitBranch size={10} className="inline" />, or double-click here.
+                {sidebarText(t, "sidebar.emptyProject.prefix")}{" "}
+                <Plus size={10} className="inline" />{" "}
+                {sidebarText(t, "sidebar.emptyProject.connector")}{" "}
+                <GitBranch size={10} className="inline" />
+                {sidebarText(t, "sidebar.emptyProject.suffix")}
               </li>
             ) : (
               project.sessions.map((session) => (
@@ -805,15 +854,20 @@ interface SessionRowProps {
 }
 
 function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
+  const t = useTranslation();
   const renameSession = useAppStore((s) => s.renameSession);
   const sessions = useAppStore((s) => s.sessions);
   const editorCommand = useSettings((s) => s.settings.editor.command);
   const editorConfigured = editorCommand.trim().length > 0;
   const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
   const titleText = resolveSessionTitle(session, sessionDisplay.title);
-  const metadataText = composeSessionMetadata(session, sessionDisplay.metadata);
+  const metadataText = composeSessionMetadata(
+    t,
+    session,
+    sessionDisplay.metadata,
+  );
   const hoverDetails = sessionDisplay.showDetailsOnHover
-    ? buildSessionHoverDetails(session)
+    ? buildSessionHoverDetails(t, session)
     : null;
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
@@ -863,18 +917,18 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
 
   const sessionMenuItems: ContextMenuItem[] = [
     {
-      label: "Rename",
+      label: sidebarText(t, "sidebar.actions.rename"),
       icon: <Pencil size={12} />,
       onClick: () => setEditing(true),
     },
     {
-      label: "Duplicate Session",
+      label: sidebarText(t, "sidebar.actions.duplicateSession"),
       icon: <Files size={12} />,
       onClick: () => void duplicate(),
     },
     { type: "separator" },
     {
-      label: "Equalize Pane Sizes",
+      label: sidebarText(t, "sidebar.actions.equalizePaneSizes"),
       icon: <Columns2 size={12} />,
       onClick: () => {
         window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
@@ -882,7 +936,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
     },
     { type: "separator" },
     {
-      label: "Open Worktree in Editor",
+      label: sidebarText(t, "sidebar.actions.openWorktreeInEditor"),
       icon: <PencilLine size={12} />,
       disabled: !editorConfigured,
       onClick: () => {
@@ -894,7 +948,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
       },
     },
     {
-      label: "Reveal in Finder",
+      label: sidebarText(t, "sidebar.actions.revealInFinder"),
       icon: <FolderOpen size={12} />,
       onClick: () => {
         void openPath(session.worktree_path).catch((err: unknown) => {
@@ -904,34 +958,34 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
     },
     { type: "separator" },
     {
-      label: "Copy Worktree Path",
+      label: sidebarText(t, "sidebar.actions.copyWorktreePath"),
       icon: <Copy size={12} />,
       onClick: () => void copyToClipboard(session.worktree_path),
     },
     {
-      label: "Copy Worktree Name",
+      label: sidebarText(t, "sidebar.actions.copyWorktreeName"),
       icon: <Copy size={12} />,
       onClick: () => void copyToClipboard(basename(session.worktree_path)),
     },
     {
-      label: "Copy Branch Name",
+      label: sidebarText(t, "sidebar.actions.copyBranchName"),
       icon: <Copy size={12} />,
       onClick: () => void copyToClipboard(session.branch),
       disabled: !session.branch,
     },
     {
-      label: "Copy Session ID",
+      label: sidebarText(t, "sidebar.actions.copySessionId"),
       icon: <Copy size={12} />,
       onClick: () => void copyToClipboard(session.id),
     },
     { type: "separator" },
     {
-      label: "Remove",
+      label: sidebarText(t, "sidebar.actions.remove"),
       icon: <Trash2 size={12} />,
       onClick: onRemove,
     },
     {
-      label: "Remove Others in Project",
+      label: sidebarText(t, "sidebar.actions.removeOthersInProject"),
       icon: <CircleX size={12} />,
       disabled: otherSiblings.length === 0,
       onClick: () => {
@@ -940,7 +994,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
       },
     },
     {
-      label: "Remove All in Project",
+      label: sidebarText(t, "sidebar.actions.removeAllInProject"),
       icon: <SquareX size={12} />,
       disabled: projectSiblings.length === 0,
       onClick: () => {
@@ -983,7 +1037,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
           {...attributes}
           {...listeners}
           onClick={(e) => e.stopPropagation()}
-          aria-label="Drag to reorder session"
+          aria-label={sidebarText(t, "sidebar.aria.dragToReorderSession")}
           className="invisible mt-1 flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
         >
           <GripVertical size={10} />
@@ -1002,6 +1056,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
           titleText={titleText}
           metadataText={metadataText}
           showKindIcons={sessionDisplay.icons.sessionKind}
+          t={t}
           onSubmitRename={async (next) => {
             setEditing(false);
             if (next && next !== session.name) {
@@ -1012,7 +1067,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
         />
         <span
           role="button"
-          aria-label="Remove session"
+          aria-label={sidebarText(t, "sidebar.actions.removeSession")}
           tabIndex={0}
           onClick={(e) => {
             e.stopPropagation();
@@ -1047,6 +1102,7 @@ interface SessionRowLabelProps {
   titleText: string;
   metadataText: string;
   showKindIcons: boolean;
+  t: Translator;
   onSubmitRename: (value: string) => void | Promise<void>;
   onCancelRename: () => void;
 }
@@ -1057,6 +1113,7 @@ function SessionRowLabel({
   titleText,
   metadataText,
   showKindIcons,
+  t,
   onSubmitRename,
   onCancelRename,
 }: SessionRowLabelProps) {
@@ -1085,14 +1142,14 @@ function SessionRowLabel({
           <GitBranch
             size={10}
             className="shrink-0 text-fg-muted"
-            aria-label="worktree"
+            aria-label={sidebarText(t, "sidebar.aria.worktree")}
           />
         ) : null}
         {showKindIcons && session.kind === "control" ? (
           <Bot
             size={10}
             className="shrink-0 text-accent"
-            aria-label="control session"
+            aria-label={sidebarText(t, "sidebar.aria.controlSession")}
           />
         ) : null}
       </span>
@@ -1149,9 +1206,13 @@ function RenameInput({ initial, onSubmit, onCancel }: RenameInputProps) {
 }
 
 function EmptyState() {
+  const t = useTranslation();
+
   return (
     <div className="px-3 py-6 text-xs text-fg-muted">
-      No projects yet. Click <span className="text-fg">+</span> to add one.
+      {sidebarText(t, "sidebar.emptyProjects.prefix")}{" "}
+      <span className="text-fg">+</span>
+      {sidebarText(t, "sidebar.emptyProjects.suffix")}
     </div>
   );
 }
@@ -1188,7 +1249,9 @@ function buildProjectGroups(
       const ap = a.position ?? Number.POSITIVE_INFINITY;
       const bp = b.position ?? Number.POSITIVE_INFINITY;
       if (ap !== bp) return ap - bp;
-      return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+      return (
+        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+      );
     });
   }
   return Array.from(map.values());
@@ -1214,6 +1277,7 @@ function resolveSessionTitle(
 }
 
 function composeSessionMetadata(
+  t: Translator,
   session: Session,
   metadata: AcornSettings["sessionDisplay"]["metadata"],
 ): string {
@@ -1223,19 +1287,35 @@ function composeSessionMetadata(
     const dir = basename(session.worktree_path);
     if (dir) parts.push(dir);
   }
-  if (metadata.status) parts.push(STATUS_LABEL[session.status]);
+  if (metadata.status) parts.push(statusLabel(t, session.status));
   return parts.join(" · ");
 }
 
-function buildSessionHoverDetails(session: Session): string {
+function buildSessionHoverDetails(t: Translator, session: Session): string {
   const lines = [
-    `Name: ${session.name}`,
-    `Branch: ${session.branch || "(detached)"}`,
-    `Working directory: ${session.worktree_path}`,
-    `Status: ${STATUS_LABEL[session.status]}`,
+    `${sidebarText(t, "sidebar.metadata.name")}: ${session.name}`,
+    `${sidebarText(t, "sidebar.metadata.branch")}: ${
+      session.branch || sidebarText(t, "sidebar.metadata.detached")
+    }`,
+    `${sidebarText(t, "sidebar.metadata.workingDirectory")}: ${
+      session.worktree_path
+    }`,
+    `${sidebarText(t, "sidebar.metadata.status")}: ${statusLabel(
+      t,
+      session.status,
+    )}`,
   ];
-  if (session.kind === "control") lines.push("Kind: Control session");
-  if (session.isolated) lines.push("Isolated worktree");
+  if (session.kind === "control") {
+    lines.push(
+      `${sidebarText(t, "sidebar.metadata.kind")}: ${sidebarText(
+        t,
+        "sidebar.metadata.controlSession",
+      )}`,
+    );
+  }
+  if (session.isolated) {
+    lines.push(sidebarText(t, "sidebar.metadata.isolatedWorktree"));
+  }
   return lines.join("\n");
 }
 

--- a/src/components/StagedRevMismatchModal.tsx
+++ b/src/components/StagedRevMismatchModal.tsx
@@ -1,8 +1,16 @@
 import { useState, type ReactElement } from "react";
 import { RefreshCw, Terminal } from "lucide-react";
 import { api, type StagedRevMismatch } from "../lib/api";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal } from "./ui/Modal";
 import { ModalHeader } from "./ui/ModalHeader";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface StagedRevMismatchModalProps {
   mismatch: StagedRevMismatch | null;
@@ -20,6 +28,7 @@ export function StagedRevMismatchModal({
   mismatch,
   onDismiss,
 }: StagedRevMismatchModalProps): ReactElement | null {
+  const t = useTranslation();
   const [restarting, setRestarting] = useState(false);
 
   if (!mismatch) return null;
@@ -59,7 +68,9 @@ export function StagedRevMismatchModal({
   }
 
   const sessionWord =
-    mismatch.stale_session_count === 1 ? "session" : "sessions";
+    mismatch.stale_session_count === 1
+      ? dt(t, "dialogs.stagedRevMismatch.sessionSingular")
+      : dt(t, "dialogs.stagedRevMismatch.sessionPlural");
 
   return (
     <Modal
@@ -70,8 +81,8 @@ export function StagedRevMismatchModal({
       ariaLabelledBy="acorn-staged-rev-mismatch-title"
     >
       <ModalHeader
-        title="Shell environment updated"
-        subtitle={`${mismatch.stale_session_count} background ${sessionWord} need a restart`}
+        title={dt(t, "dialogs.stagedRevMismatch.title")}
+        subtitle={`${mismatch.stale_session_count} ${dt(t, "dialogs.stagedRevMismatch.background")} ${sessionWord} ${dt(t, "dialogs.stagedRevMismatch.needRestart")}`}
         titleId="acorn-staged-rev-mismatch-title"
         icon={<Terminal size={14} className="text-accent" />}
         variant="dialog"
@@ -79,15 +90,10 @@ export function StagedRevMismatchModal({
       />
       <div className="space-y-3 px-4 py-4 text-xs text-fg-muted">
         <p>
-          Acorn refreshed its shell-init files in this update. Background
-          sessions started by the previous version are still running against
-          the old environment, which can cause garbled input and prompt
-          redraws.
+          {dt(t, "dialogs.stagedRevMismatch.bodyIntro")}
         </p>
         <p>
-          Restart now to apply the new environment. Open agent
-          conversations (Claude / Codex) will pick up where they left
-          off on next focus.
+          {dt(t, "dialogs.stagedRevMismatch.bodyRestart")}
         </p>
       </div>
       <footer className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
@@ -97,7 +103,7 @@ export function StagedRevMismatchModal({
           disabled={restarting}
           className="rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
         >
-          Later
+          {dt(t, "dialogs.stagedRevMismatch.later")}
         </button>
         <button
           type="button"
@@ -109,7 +115,9 @@ export function StagedRevMismatchModal({
             size={12}
             className={restarting ? "animate-spin" : undefined}
           />
-          {restarting ? "Restarting…" : "Restart sessions"}
+          {restarting
+            ? dt(t, "dialogs.stagedRevMismatch.restarting")
+            : dt(t, "dialogs.stagedRevMismatch.restartSessions")}
         </button>
       </footer>
     </Modal>

--- a/src/components/WhatsNewModal.tsx
+++ b/src/components/WhatsNewModal.tsx
@@ -1,9 +1,17 @@
 import { Download, ExternalLink, Sparkles } from "lucide-react";
 import type { ReactElement } from "react";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
 import { Modal } from "./ui/Modal";
 import { ModalHeader } from "./ui/ModalHeader";
 import { Markdown } from "./ui/Markdown";
 import { TextSwap } from "./ui/TextSwap";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface WhatsNewModalProps {
   open: boolean;
@@ -65,13 +73,14 @@ export function WhatsNewModal({
   htmlUrl,
   isFallback = false,
 }: WhatsNewModalProps): ReactElement | null {
+  const t = useTranslation();
   const trimmedBody = body.trim();
   const subtitle = isFallback
-    ? `latest published — no public release for ${currentVersion ?? "your version"}`
+    ? `${dt(t, "dialogs.whatsNew.latestPublished")} ${currentVersion ?? dt(t, "dialogs.whatsNew.yourVersion")}`
     : currentVersion && currentVersion !== version
-      ? `currently running ${currentVersion}`
+      ? `${dt(t, "dialogs.whatsNew.currentlyRunning")} ${currentVersion}`
       : currentVersion === version
-        ? "you're on this version"
+        ? dt(t, "dialogs.whatsNew.onThisVersion")
         : undefined;
 
   return (
@@ -83,7 +92,7 @@ export function WhatsNewModal({
       ariaLabelledBy="acorn-whatsnew-title"
     >
       <ModalHeader
-        title={`What's new in Acorn ${version}`}
+        title={`${dt(t, "dialogs.whatsNew.titlePrefix")} ${version}`}
         subtitle={subtitle}
         titleId="acorn-whatsnew-title"
         icon={<Sparkles size={14} className="text-accent" />}
@@ -95,7 +104,7 @@ export function WhatsNewModal({
           <Markdown content={trimmedBody} className="text-xs" />
         ) : (
           <p className="text-xs text-fg-muted">
-            No release notes were published with this version.
+            {dt(t, "dialogs.whatsNew.noReleaseNotes")}
           </p>
         )}
       </div>
@@ -113,7 +122,7 @@ export function WhatsNewModal({
             className="inline-flex items-center gap-1.5 rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
           >
             <ExternalLink size={12} />
-            View on GitHub
+            {dt(t, "dialogs.whatsNew.viewOnGithub")}
           </a>
         ) : null}
         <button
@@ -121,7 +130,7 @@ export function WhatsNewModal({
           onClick={onClose}
           className="rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
         >
-          Close
+          {dt(t, "dialogs.common.close")}
         </button>
         {showInstall && onInstall ? (
           <button
@@ -131,7 +140,11 @@ export function WhatsNewModal({
             className="inline-flex items-center gap-1.5 rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
           >
             <Download size={12} />
-            <TextSwap>{busy ? "Installing…" : "Install & relaunch"}</TextSwap>
+            <TextSwap>
+              {busy
+                ? dt(t, "dialogs.whatsNew.installing")
+                : dt(t, "dialogs.whatsNew.installRelaunch")}
+            </TextSwap>
           </button>
         ) : null}
       </footer>

--- a/src/components/ui/ModalHeader.tsx
+++ b/src/components/ui/ModalHeader.tsx
@@ -1,7 +1,15 @@
 import { X } from "lucide-react";
 import { type ReactNode } from "react";
 import { cn } from "../../lib/cn";
+import type { TranslationKey, Translator } from "../../lib/i18n";
+import { useTranslation } from "../../lib/useTranslation";
 import { type ModalVariant } from "./Modal";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
 
 interface ModalHeaderProps {
   title: string;
@@ -27,6 +35,7 @@ export function ModalHeader({
   variant = "panel",
   onClose,
 }: ModalHeaderProps) {
+  const t = useTranslation();
   const hoverBg =
     variant === "dialog" ? "hover:bg-bg-sidebar" : "hover:bg-bg-elevated";
   return (
@@ -49,7 +58,7 @@ export function ModalHeader({
         {actions}
         <button
           type="button"
-          aria-label="Close"
+          aria-label={dt(t, "dialogs.common.close")}
           onClick={onClose}
           className={cn(
             "rounded p-1 text-fg-muted transition hover:text-fg",

--- a/src/lib/sidebar-actions.test.ts
+++ b/src/lib/sidebar-actions.test.ts
@@ -87,7 +87,7 @@ describe("Sidebar source contract", () => {
 
   it("chevron is rendered as its own padded button with hover background", () => {
     expect(SIDEBAR_SOURCE).toMatch(
-      /aria-label=\{collapsed \? "Expand project" : "Collapse project"\}/,
+      /aria-label=\{\s*collapsed\s*\?\s*sidebarText\(t, "sidebar\.actions\.expandProject"\)\s*:\s*sidebarText\(t, "sidebar\.actions\.collapseProject"\)\s*\}/,
     );
     expect(SIDEBAR_SOURCE).toMatch(
       /flex shrink-0 items-center justify-center rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg/,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -341,12 +341,152 @@
     }
   },
   "app": {},
-  "sidebar": {},
-  "pane": {},
+  "sidebar": {
+    "status": {
+      "idle": "Idle",
+      "running": "Running",
+      "needs_input": "Needs input",
+      "failed": "Failed",
+      "completed": "Completed"
+    },
+    "dialog": {
+      "selectExistingProject": "Select an existing project",
+      "selectIsolatedRepository": "Select a git repository (isolated worktree)",
+      "selectControlDirectory": "Select a directory (control session)",
+      "selectDirectory": "Select a directory"
+    },
+    "projects": {
+      "title": "Projects",
+      "newProject": "New project",
+      "addExistingProject": "Add existing project"
+    },
+    "actions": {
+      "dragToReorder": "Drag to reorder",
+      "expandProject": "Expand project",
+      "collapseProject": "Collapse project",
+      "newSession": "New session",
+      "newIsolatedSession": "New isolated session",
+      "newIsolatedSessionWorktree": "New isolated session (worktree)",
+      "newControlSession": "New control session",
+      "closeProject": "Close project",
+      "revealInFinder": "Reveal in Finder",
+      "copyPath": "Copy path",
+      "rename": "Rename",
+      "duplicateSession": "Duplicate Session",
+      "equalizePaneSizes": "Equalize Pane Sizes",
+      "openWorktreeInEditor": "Open Worktree in Editor",
+      "copyWorktreePath": "Copy Worktree Path",
+      "copyWorktreeName": "Copy Worktree Name",
+      "copyBranchName": "Copy Branch Name",
+      "copySessionId": "Copy Session ID",
+      "remove": "Remove",
+      "removeSession": "Remove session",
+      "removeOthersInProject": "Remove Others in Project",
+      "removeAllInProject": "Remove All in Project"
+    },
+    "aria": {
+      "project": "Project",
+      "dragToReorderProject": "Drag to reorder project",
+      "newSessionInProject": "New session in this project",
+      "newControlSessionInProject": "New control session in this project",
+      "dragToReorderSession": "Drag to reorder session",
+      "worktree": "worktree",
+      "controlSession": "control session"
+    },
+    "emptyProject": {
+      "prefix": "No sessions. Add one with",
+      "connector": "or",
+      "suffix": ", or double-click here."
+    },
+    "emptyProjects": {
+      "prefix": "No projects yet. Click",
+      "suffix": "to add one."
+    },
+    "metadata": {
+      "name": "Name",
+      "branch": "Branch",
+      "detached": "(detached)",
+      "workingDirectory": "Working directory",
+      "status": "Status",
+      "kind": "Kind",
+      "controlSession": "Control session",
+      "isolatedWorktree": "Isolated worktree"
+    }
+  },
+  "pane": {
+    "empty": {
+      "dropTabOrDoubleClick": "Drop a tab here or double-click to start a session",
+      "createProject": "Create a project to get started. Double-click here."
+    },
+    "aria": {
+      "worktree": "worktree",
+      "closeSession": "Close session"
+    },
+    "menu": {
+      "rename": "Rename",
+      "duplicateSession": "Duplicate Session",
+      "forkClaudeSession": "Fork Claude Session",
+      "forkSession": "Fork Session",
+      "forkClaudeInNewWorktree": "Fork Claude in New Worktree",
+      "forkInNewWorktree": "Fork in New Worktree",
+      "forkCodexSession": "Fork Codex Session",
+      "forkCodexInNewWorktree": "Fork Codex in New Worktree",
+      "splitRight": "Split Right",
+      "splitDown": "Split Down",
+      "equalizePaneSizes": "Equalize Pane Sizes",
+      "openWorktreeInEditor": "Open Worktree in Editor",
+      "revealInFinder": "Reveal in Finder",
+      "copyWorktreePath": "Copy Worktree Path",
+      "copyWorktreeName": "Copy Worktree Name",
+      "copyBranchName": "Copy Branch Name",
+      "copySessionId": "Copy Session ID",
+      "close": "Close",
+      "closeOthers": "Close Others",
+      "closeAll": "Close All",
+      "newSessionInThisPane": "New Session in This Pane",
+      "closePane": "Close Pane"
+    }
+  },
   "rightPanel": {},
   "fileExplorer": {},
   "dialogs": {},
-  "commandPalette": {},
+  "commandPalette": {
+    "dialogLabel": "Command palette",
+    "placeholder": "Type a command or search...",
+    "empty": "No results.",
+    "groups": {
+      "sessions": "Sessions",
+      "switchSession": "Switch session",
+      "view": "View",
+      "terminal": "Terminal",
+      "ipc": "IPC",
+      "dangerZone": "Danger zone"
+    },
+    "commands": {
+      "newSession": "New session",
+      "newIsolatedSession": "New isolated session",
+      "newControlSession": "New control session",
+      "newProject": "New project",
+      "addExistingProject": "Add existing project",
+      "refreshSessions": "Refresh sessions",
+      "switchSessionPrefix": "Switch to",
+      "viewTodos": "View Todos",
+      "viewCommits": "View Commits",
+      "viewStaged": "View Staged",
+      "viewPullRequests": "View Pull Requests",
+      "resetPanelSizes": "Reset panel sizes",
+      "reloadShellEnvironment": "Reload shell environment",
+      "restartIpcServer": "Restart IPC server",
+      "removeSessionPrefix": "Remove session:",
+      "shakeTree": "Shake the tree"
+    },
+    "toasts": {
+      "shellEnvReloaded": "Shell environment reloaded. Open a new session to apply.",
+      "shellEnvReloadFailed": "Failed to reload shell environment.",
+      "ipcRestarted": "IPC server restarted.",
+      "ipcRestartFailedPrefix": "Failed to restart IPC server:"
+    }
+  },
   "backgroundSessions": {
     "daemon": {
       "label": "Daemon",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -340,7 +340,14 @@
       }
     }
   },
-  "app": {},
+  "app": {
+    "toast": {
+      "multiInputOn": "Multi-input on.",
+      "multiInputOff": "Multi-input off.",
+      "shellEnvironmentReloaded": "Shell environment reloaded. Open a new session to apply.",
+      "shellEnvironmentReloadFailed": "Failed to reload shell environment."
+    }
+  },
   "sidebar": {
     "status": {
       "idle": "Idle",
@@ -447,9 +454,392 @@
       "closePane": "Close Pane"
     }
   },
-  "rightPanel": {},
-  "fileExplorer": {},
-  "dialogs": {},
+  "rightPanel": {
+    "tabs": {
+      "files": "Files",
+      "todos": "Todos",
+      "commits": "Commits",
+      "staged": "Staged",
+      "prs": "PRs",
+      "actions": "Actions"
+    },
+    "empty": {
+      "noTodos": "No todos in this session",
+      "noProject": "No project selected"
+    },
+    "todos": {
+      "doneCount": "{completed}/{total} done",
+      "inProgressCount": "{count} in progress"
+    },
+    "loading": {
+      "more": "Loading more…",
+      "moreLower": "loading more...",
+      "diffLower": "loading diff..."
+    },
+    "tooltips": {
+      "copySha": "Copy SHA",
+      "openOnGitHub": "Open on GitHub"
+    },
+    "commits": {
+      "pushed": "Pushed",
+      "notPushed": "Not pushed",
+      "selectToSeeDiff": "Select a commit to see diff"
+    },
+    "staged": {
+      "empty": "No staged or modified files",
+      "workingTreeChanges": "Working tree changes",
+      "noDiff": "No diff"
+    },
+    "errors": {
+      "deletedFile": "File was deleted; nothing to open.",
+      "notGitHubRemote": "This repo's origin is not a GitHub remote.",
+      "originNotGitHub": "Origin remote is not a GitHub repository.",
+      "noAccessToSlug": "No access to {slug}."
+    },
+    "menu": {
+      "expandDiff": "Expand diff",
+      "viewOnGitHub": "View on GitHub",
+      "copyShaWithValue": "Copy SHA ({sha})",
+      "openInEditor": "Open in editor",
+      "copyRelativePath": "Copy relative path",
+      "copyAbsolutePath": "Copy absolute path",
+      "openDetail": "Open detail",
+      "openInBrowser": "Open in browser",
+      "copyPrNumber": "Copy PR number",
+      "copyUrl": "Copy URL",
+      "copyBranchWithValue": "Copy branch ({branch})",
+      "merge": "Merge…",
+      "close": "Close…"
+    },
+    "prStates": {
+      "open": "Open",
+      "closed": "Closed",
+      "merged": "Merged",
+      "all": "All",
+      "draft": "DRAFT"
+    },
+    "prs": {
+      "emptyByState": "No {state} pull requests.",
+      "reachedMax": "Showing first {count}. Use search to find older PRs."
+    },
+    "search": {
+      "aria": "Search pull requests",
+      "placeholder": "Search title, author, label, branch…",
+      "searching": "Searching…",
+      "typeToSearch": "Type to search pull requests.",
+      "noGhAccessThisRepo": "No logged-in gh account can access this repo.",
+      "noMatches": "No matching pull requests.",
+      "reachedMax": "Showing first {count}. Refine the query for older PRs."
+    },
+    "actions": {
+      "filterByWorkflow": "Filter by workflow",
+      "allWorkflows": "All workflows",
+      "noRuns": "No workflow runs yet.",
+      "noRunsForFilter": "No runs match this filter.",
+      "workflowRun": "Workflow run",
+      "workflowRunFallbackTitle": "{workflow} run",
+      "doubleClickDetails": "Double-click to view details",
+      "retryAttempt": "retry #{attempt}",
+      "github": "GitHub",
+      "status": "Status",
+      "totalDuration": "Total duration",
+      "runningParenthetical": "(running)",
+      "attempt": "Attempt",
+      "retriedParenthetical": "(retried)",
+      "commit": "Commit",
+      "created": "Created",
+      "updated": "Updated",
+      "jobsCount": "Jobs ({count})",
+      "noJobs": "No jobs reported.",
+      "openJobOnGitHub": "Open job on GitHub"
+    },
+    "checks": {
+      "allPassed": "All {count} checks passed",
+      "allFailed": "All {count} checks failed",
+      "summary": "{passed} passed, {failed} failed, {pending} pending"
+    },
+    "noAccess": {
+      "noGhAccountCanAccess": "No logged-in gh account can access {slug}.",
+      "tried": "Tried:",
+      "noAccounts": "No accounts authenticated against github.com.",
+      "run": "Run",
+      "withAccess": "with an account that has access, or accept the invitation on github.com."
+    },
+    "time": {
+      "secondsAgo": "{count}s ago",
+      "minutesAgo": "{count}m ago",
+      "hoursAgo": "{count}h ago",
+      "daysAgo": "{count}d ago",
+      "monthsAgo": "{count}mo ago",
+      "yearsAgo": "{count}y ago"
+    },
+    "duration": {
+      "seconds": "{count}s",
+      "minutes": "{count}m",
+      "minutesSeconds": "{minutes}m {seconds}s",
+      "hours": "{count}h",
+      "hoursMinutes": "{hours}h {minutes}m"
+    }
+  },
+  "fileExplorer": {
+    "defaults": {
+      "sessionName": "session"
+    },
+    "errorBanner": {
+      "dismiss": "Dismiss error"
+    },
+    "errors": {
+      "clipboardWriteFailed": "Clipboard write failed",
+      "noActiveProject": "No active project",
+      "noActiveSession": "No active session - open a terminal first"
+    },
+    "menu": {
+      "attachAllToConversation": "Attach All to Conversation",
+      "attachToClaude": "Attach to Claude",
+      "attachToCodex": "Attach to Codex",
+      "copyAbsolutePath": "Copy Absolute Path",
+      "copyAbsolutePaths": "Copy Absolute Paths",
+      "copyRelativePath": "Copy Relative Path",
+      "copyRelativePaths": "Copy Relative Paths",
+      "moveToTrash": "Move to Trash",
+      "openIn": "Open in",
+      "openInNewTab": "Open in New Tab",
+      "openWithDefaultProgram": "Open with Default Program",
+      "rename": "Rename",
+      "revealInFileManager": "Reveal in File Manager"
+    },
+    "search": {
+      "close": "Close (Esc)",
+      "closeSearch": "Close search",
+      "excludePlaceholder": "e.g. node_modules, *.lock",
+      "filesToExclude": "files to exclude",
+      "filesToInclude": "files to include",
+      "includePlaceholder": "e.g. *.ts, *.tsx",
+      "matchCase": "Match Case",
+      "regexPlaceholder": "Regex...",
+      "searchFilesPlaceholder": "Search files",
+      "toggleRegex": "Toggle regex",
+      "useRegularExpression": "Use Regular Expression"
+    },
+    "toolbar": {
+      "closeSearch": "Close search",
+      "hideDotfiles": "Hide dotfiles",
+      "hideGitignored": "Hide gitignored",
+      "search": "Search (⌘F)",
+      "showDotfiles": "Show dotfiles",
+      "showGitignored": "Show gitignored"
+    },
+    "tree": {
+      "empty": "(empty)",
+      "gitStatus": "git status",
+      "loading": "Loading...",
+      "renameInput": "Rename entry"
+    }
+  },
+  "dialogs": {
+    "common": {
+      "cancel": "Cancel",
+      "close": "Close",
+      "copy": "Copy",
+      "dontShowAgain": "Don't show this again",
+      "gotIt": "Got it"
+    },
+    "removeSession": {
+      "title": "Remove session",
+      "confirmPrefix": "Remove session",
+      "isolatedWorktree": "This is an isolated worktree:",
+      "deleteWorktreeQuestion": "Also delete the worktree from disk?",
+      "filesIn": "Files in",
+      "willNotBeTouched": "will not be touched.",
+      "dontAskAgain": "Don't ask again (toggle in Settings → Sessions)",
+      "keepWorktree": "Keep worktree",
+      "deleteWorktree": "Delete worktree",
+      "remove": "Remove"
+    },
+    "removeProject": {
+      "title": "Close project",
+      "confirmPrefix": "Close project",
+      "sessionSingular": "session",
+      "sessionPlural": "sessions",
+      "willBeRemoved": "will be removed",
+      "isolatedWorktreeSingular": "isolated worktree",
+      "isolatedWorktreePlural": "isolated worktrees",
+      "closeKeepWorktrees": "Close · keep worktrees",
+      "closeDeleteWorktrees": "Close · delete worktrees",
+      "closeProject": "Close project"
+    },
+    "newProject": {
+      "title": "New project",
+      "subtitle": "Create a git repository and add it to Acorn",
+      "projectNameLabel": "Project name",
+      "projectNameHint": "Use a single folder name.",
+      "ignoreSafeName": "Ignore safe-name check",
+      "locationLabel": "Location",
+      "locationPlaceholder": "Choose a parent folder",
+      "locationAriaLabel": "Project location",
+      "choose": "Choose",
+      "creates": "Creates",
+      "creating": "Creating...",
+      "createProject": "Create project",
+      "selectParentFolder": "Select parent folder",
+      "chooseLocationError": "Choose a location for the new project.",
+      "validation": {
+        "required": "Project name is required.",
+        "single_folder_name": "Project name must be a single folder name.",
+        "null_character": "Project name cannot contain a null character.",
+        "component_too_long": "Project name is longer than 255 bytes, which common filesystems reject."
+      }
+    },
+    "agentResume": {
+      "title": "Resume previous conversation",
+      "bodyClaude": "There's a Claude conversation that was in progress in this session. You can pick it up where you left off, or just close this dialog to start fresh.",
+      "bodyCodex": "There's a Codex conversation that was in progress in this session. You can pick it up where you left off, or just close this dialog to start fresh.",
+      "sessionIdCopied": "Session ID copied",
+      "copyFailed": "Failed to copy to clipboard",
+      "copyId": "Copy ID",
+      "resume": "Resume",
+      "lastActivityUnknown": "Last activity unknown",
+      "justNow": "Just now",
+      "minutesAgo": "min ago",
+      "hoursAgo": "hr ago",
+      "dayAgo": "day ago",
+      "daysAgo": "days ago"
+    },
+    "controlSessionGuide": {
+      "title": "Control session",
+      "subtitle": "A terminal that drives other sessions in this project",
+      "bodyIntro": "Control sessions are an upcoming way to coordinate work across terminals from a single place - handy for agents and scripts that need to dispatch commands to siblings in the same project.",
+      "pointKeystrokes": "Send keystrokes to any session in this project.",
+      "pointListSessions": "List the other sessions and their status.",
+      "pointReadOutput": "Read recent output from a target session.",
+      "createdPrefix": "You just created a control session. The",
+      "createdSuffix": "CLI that drives it ships in the next update; this terminal will start behaving like a regular shell until then."
+    },
+    "commandRun": {
+      "title": "Run this command?",
+      "ariaLabel": "Run command",
+      "description": "A new terminal session will open and run:",
+      "cwdLabel": "cwd:",
+      "noProjectHint": "No project is registered - add a project before running this command, or use \"Copy\" to paste it into an existing terminal.",
+      "noProjectError": "No project available to host the new session.",
+      "createFailed": "Failed to create session.",
+      "copiedPrefix": "Copied:",
+      "copyFailedPrefix": "Copy failed:",
+      "runningPrefix": "Running:",
+      "running": "Running...",
+      "run": "Run"
+    },
+    "closePullRequest": {
+      "titlePrefix": "Close",
+      "confirmPrefix": "Close pull request",
+      "confirmSuffix": "without merging?",
+      "closing": "Closing...",
+      "closePr": "Close PR"
+    },
+    "mergePullRequest": {
+      "titlePrefix": "Merge",
+      "mergeMethod": "Merge method",
+      "methodSquash": "Squash",
+      "methodSquashHint": "Combine into one commit on the base branch.",
+      "methodMerge": "Merge",
+      "methodMergeHint": "Create a merge commit preserving history.",
+      "methodRebase": "Rebase",
+      "methodRebaseHint": "Replay commits onto the base branch.",
+      "commitMessage": "Commit message",
+      "generating": "Generating...",
+      "generateVia": "Generate via",
+      "generateWithAi": "Generate with AI",
+      "subjectPlaceholder": "Subject",
+      "bodyPlaceholder": "Body (optional)",
+      "rebaseMessageLocked": "Rebase replays the original commits onto the base branch - the commit messages are not customizable here.",
+      "merging": "Merging...",
+      "merge": "Merge"
+    },
+    "stagedRevMismatch": {
+      "title": "Shell environment updated",
+      "background": "background",
+      "sessionSingular": "session",
+      "sessionPlural": "sessions",
+      "needRestart": "need a restart",
+      "bodyIntro": "Acorn refreshed its shell-init files in this update. Background sessions started by the previous version are still running against the old environment, which can cause garbled input and prompt redraws.",
+      "bodyRestart": "Restart now to apply the new environment. Open agent conversations (Claude / Codex) will pick up where they left off on next focus.",
+      "later": "Later",
+      "restarting": "Restarting...",
+      "restartSessions": "Restart sessions"
+    },
+    "memoryBreakdown": {
+      "title": "Memory breakdown",
+      "totalRssSum": "total (RSS, sum)",
+      "processes": "processes",
+      "pid": "PID",
+      "processTree": "Process tree",
+      "rss": "RSS",
+      "subtree": "Subtree",
+      "subtreeTooltip": "Sum of this process and all descendants",
+      "share": "Share",
+      "footer": "Tree ordered by parent->child (DFS). Siblings sorted by subtree RSS desc. Sum-of-RSS overcounts shared memory; WebView helpers and PTY children (claude, node) included."
+    },
+    "whatsNew": {
+      "titlePrefix": "What's new in Acorn",
+      "latestPublished": "latest published - no public release for",
+      "yourVersion": "your version",
+      "currentlyRunning": "currently running",
+      "onThisVersion": "you're on this version",
+      "noReleaseNotes": "No release notes were published with this version.",
+      "viewOnGithub": "View on GitHub",
+      "installing": "Installing...",
+      "installRelaunch": "Install & relaunch"
+    },
+    "pullRequestDetail": {
+      "notGithub": "Origin remote is not a GitHub repository.",
+      "noAccessPrefix": "No logged-in",
+      "noAccessSuffix": "account can access",
+      "files": "files",
+      "openOnGithub": "Open on GitHub",
+      "checkboxSaveFailed": "Couldn't save checkbox:",
+      "tabConversation": "Conversation",
+      "tabCommits": "Commits",
+      "tabChecks": "Checks",
+      "tabFiles": "Files",
+      "merge": "Merge",
+      "cannotMergeConflicting": "Cannot merge - conflicting branch",
+      "mergeReadinessPending": "Merge readiness still being determined...",
+      "resizePrBody": "Resize PR body",
+      "resizeHint": "Drag to resize · double-click to reset",
+      "noComments": "No comments or reviews yet.",
+      "oldestFirst": "Oldest first",
+      "newestFirst": "Newest first",
+      "toggleSortOrder": "Toggle sort order",
+      "commented": "commented",
+      "empty": "(empty)",
+      "noReviewComment": "(no review comment)",
+      "reviewApproved": "approved",
+      "reviewChangesRequested": "changes requested",
+      "reviewDismissed": "dismissed",
+      "noCommits": "No commits in this pull request.",
+      "viewOnGithub": "View on GitHub",
+      "copySha": "Copy SHA",
+      "noMessage": "(no message)",
+      "unknown": "unknown",
+      "loadingDiff": "Loading diff...",
+      "noFileChanges": "No file changes in this commit.",
+      "openCommitOnGithub": "Open commit on GitHub",
+      "now": "now",
+      "minuteAbbrev": "m",
+      "hourAbbrev": "h",
+      "dayAbbrev": "d",
+      "noChecks": "No checks reported.",
+      "openRun": "Open run",
+      "checkSuccess": "success",
+      "checkFailure": "failure",
+      "checkTimedOut": "timed out",
+      "checkActionRequired": "action required",
+      "checkCancelled": "cancelled",
+      "checkNeutral": "neutral",
+      "checkSkipped": "skipped",
+      "checkCompleted": "completed"
+    }
+  },
   "commandPalette": {
     "dialogLabel": "Command palette",
     "placeholder": "Type a command or search...",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -340,7 +340,14 @@
       }
     }
   },
-  "app": {},
+  "app": {
+    "toast": {
+      "multiInputOn": "다중 입력 켜짐.",
+      "multiInputOff": "다중 입력 꺼짐.",
+      "shellEnvironmentReloaded": "셸 환경을 다시 불러왔습니다. 적용하려면 새 세션을 여세요.",
+      "shellEnvironmentReloadFailed": "셸 환경을 다시 불러오지 못했습니다."
+    }
+  },
   "sidebar": {
     "status": {
       "idle": "유휴",
@@ -447,9 +454,392 @@
       "closePane": "패널 닫기"
     }
   },
-  "rightPanel": {},
-  "fileExplorer": {},
-  "dialogs": {},
+  "rightPanel": {
+    "tabs": {
+      "files": "파일",
+      "todos": "할 일",
+      "commits": "커밋",
+      "staged": "스테이징",
+      "prs": "PR",
+      "actions": "작업"
+    },
+    "empty": {
+      "noTodos": "이 세션에 할 일이 없습니다",
+      "noProject": "선택한 프로젝트가 없습니다"
+    },
+    "todos": {
+      "doneCount": "{completed}/{total} 완료",
+      "inProgressCount": "{count}개 진행 중"
+    },
+    "loading": {
+      "more": "더 불러오는 중…",
+      "moreLower": "더 불러오는 중...",
+      "diffLower": "diff 불러오는 중..."
+    },
+    "tooltips": {
+      "copySha": "SHA 복사",
+      "openOnGitHub": "GitHub에서 열기"
+    },
+    "commits": {
+      "pushed": "푸시됨",
+      "notPushed": "푸시되지 않음",
+      "selectToSeeDiff": "diff를 보려면 커밋을 선택하세요"
+    },
+    "staged": {
+      "empty": "스테이징되었거나 수정된 파일이 없습니다",
+      "workingTreeChanges": "작업 트리 변경사항",
+      "noDiff": "diff 없음"
+    },
+    "errors": {
+      "deletedFile": "파일이 삭제되어 열 수 없습니다.",
+      "notGitHubRemote": "이 저장소의 origin은 GitHub 원격이 아닙니다.",
+      "originNotGitHub": "origin 원격은 GitHub 저장소가 아닙니다.",
+      "noAccessToSlug": "{slug}에 접근할 수 없습니다."
+    },
+    "menu": {
+      "expandDiff": "diff 확장",
+      "viewOnGitHub": "GitHub에서 보기",
+      "copyShaWithValue": "SHA 복사({sha})",
+      "openInEditor": "편집기에서 열기",
+      "copyRelativePath": "상대 경로 복사",
+      "copyAbsolutePath": "절대 경로 복사",
+      "openDetail": "상세 열기",
+      "openInBrowser": "브라우저에서 열기",
+      "copyPrNumber": "PR 번호 복사",
+      "copyUrl": "URL 복사",
+      "copyBranchWithValue": "브랜치 복사({branch})",
+      "merge": "병합…",
+      "close": "닫기…"
+    },
+    "prStates": {
+      "open": "열림",
+      "closed": "닫힘",
+      "merged": "병합됨",
+      "all": "전체",
+      "draft": "초안"
+    },
+    "prs": {
+      "emptyByState": "{state} PR이 없습니다.",
+      "reachedMax": "처음 {count}개를 표시합니다. 더 오래된 PR은 검색으로 찾으세요."
+    },
+    "search": {
+      "aria": "PR 검색",
+      "placeholder": "제목, 작성자, 라벨, 브랜치 검색…",
+      "searching": "검색 중…",
+      "typeToSearch": "PR을 검색하려면 입력하세요.",
+      "noGhAccessThisRepo": "로그인된 gh 계정으로 이 저장소에 접근할 수 없습니다.",
+      "noMatches": "일치하는 PR이 없습니다.",
+      "reachedMax": "처음 {count}개를 표시합니다. 더 오래된 PR은 검색어를 좁혀 찾으세요."
+    },
+    "actions": {
+      "filterByWorkflow": "워크플로로 필터링",
+      "allWorkflows": "모든 워크플로",
+      "noRuns": "아직 워크플로 실행이 없습니다.",
+      "noRunsForFilter": "이 필터와 일치하는 실행이 없습니다.",
+      "workflowRun": "워크플로 실행",
+      "workflowRunFallbackTitle": "{workflow} 실행",
+      "doubleClickDetails": "상세를 보려면 더블 클릭",
+      "retryAttempt": "재시도 #{attempt}",
+      "github": "GitHub",
+      "status": "상태",
+      "totalDuration": "총 소요 시간",
+      "runningParenthetical": "(실행 중)",
+      "attempt": "시도",
+      "retriedParenthetical": "(재시도됨)",
+      "commit": "커밋",
+      "created": "생성됨",
+      "updated": "업데이트됨",
+      "jobsCount": "작업 ({count})",
+      "noJobs": "보고된 작업이 없습니다.",
+      "openJobOnGitHub": "GitHub에서 작업 열기"
+    },
+    "checks": {
+      "allPassed": "체크 {count}개 모두 통과",
+      "allFailed": "체크 {count}개 모두 실패",
+      "summary": "{passed}개 통과, {failed}개 실패, {pending}개 대기"
+    },
+    "noAccess": {
+      "noGhAccountCanAccess": "로그인된 gh 계정으로 {slug}에 접근할 수 없습니다.",
+      "tried": "시도한 계정:",
+      "noAccounts": "github.com에 인증된 계정이 없습니다.",
+      "run": "실행:",
+      "withAccess": "액세스 권한이 있는 계정으로 실행하거나 github.com에서 초대를 수락하세요."
+    },
+    "time": {
+      "secondsAgo": "{count}초 전",
+      "minutesAgo": "{count}분 전",
+      "hoursAgo": "{count}시간 전",
+      "daysAgo": "{count}일 전",
+      "monthsAgo": "{count}개월 전",
+      "yearsAgo": "{count}년 전"
+    },
+    "duration": {
+      "seconds": "{count}초",
+      "minutes": "{count}분",
+      "minutesSeconds": "{minutes}분 {seconds}초",
+      "hours": "{count}시간",
+      "hoursMinutes": "{hours}시간 {minutes}분"
+    }
+  },
+  "fileExplorer": {
+    "defaults": {
+      "sessionName": "세션"
+    },
+    "errorBanner": {
+      "dismiss": "오류 닫기"
+    },
+    "errors": {
+      "clipboardWriteFailed": "클립보드 쓰기에 실패했습니다",
+      "noActiveProject": "활성 프로젝트가 없습니다",
+      "noActiveSession": "활성 세션이 없습니다 - 먼저 터미널을 여세요"
+    },
+    "menu": {
+      "attachAllToConversation": "모두 대화에 첨부",
+      "attachToClaude": "Claude에 첨부",
+      "attachToCodex": "Codex에 첨부",
+      "copyAbsolutePath": "절대 경로 복사",
+      "copyAbsolutePaths": "절대 경로 복사",
+      "copyRelativePath": "상대 경로 복사",
+      "copyRelativePaths": "상대 경로 복사",
+      "moveToTrash": "휴지통으로 이동",
+      "openIn": "다음으로 열기:",
+      "openInNewTab": "새 탭에서 열기",
+      "openWithDefaultProgram": "기본 프로그램으로 열기",
+      "rename": "이름 변경",
+      "revealInFileManager": "파일 관리자에서 보기"
+    },
+    "search": {
+      "close": "닫기 (Esc)",
+      "closeSearch": "검색 닫기",
+      "excludePlaceholder": "예: node_modules, *.lock",
+      "filesToExclude": "제외할 파일",
+      "filesToInclude": "포함할 파일",
+      "includePlaceholder": "예: *.ts, *.tsx",
+      "matchCase": "대소문자 구분",
+      "regexPlaceholder": "정규식...",
+      "searchFilesPlaceholder": "파일 검색",
+      "toggleRegex": "정규식 전환",
+      "useRegularExpression": "정규식 사용"
+    },
+    "toolbar": {
+      "closeSearch": "검색 닫기",
+      "hideDotfiles": "점 파일 숨기기",
+      "hideGitignored": "Git 무시 파일 숨기기",
+      "search": "검색 (⌘F)",
+      "showDotfiles": "점 파일 표시",
+      "showGitignored": "Git 무시 파일 표시"
+    },
+    "tree": {
+      "empty": "(비어 있음)",
+      "gitStatus": "Git 상태",
+      "loading": "불러오는 중...",
+      "renameInput": "항목 이름 변경"
+    }
+  },
+  "dialogs": {
+    "common": {
+      "cancel": "취소",
+      "close": "닫기",
+      "copy": "복사",
+      "dontShowAgain": "다시 표시하지 않기",
+      "gotIt": "확인"
+    },
+    "removeSession": {
+      "title": "세션 제거",
+      "confirmPrefix": "세션 제거",
+      "isolatedWorktree": "격리된 worktree입니다:",
+      "deleteWorktreeQuestion": "디스크에서도 worktree를 삭제할까요?",
+      "filesIn": "다음 위치의 파일은",
+      "willNotBeTouched": "변경되지 않습니다.",
+      "dontAskAgain": "다시 묻지 않기(설정 → 세션에서 변경)",
+      "keepWorktree": "worktree 유지",
+      "deleteWorktree": "worktree 삭제",
+      "remove": "제거"
+    },
+    "removeProject": {
+      "title": "프로젝트 닫기",
+      "confirmPrefix": "프로젝트 닫기",
+      "sessionSingular": "세션",
+      "sessionPlural": "세션",
+      "willBeRemoved": "제거됩니다",
+      "isolatedWorktreeSingular": "격리된 worktree",
+      "isolatedWorktreePlural": "격리된 worktree",
+      "closeKeepWorktrees": "닫기 · worktree 유지",
+      "closeDeleteWorktrees": "닫기 · worktree 삭제",
+      "closeProject": "프로젝트 닫기"
+    },
+    "newProject": {
+      "title": "새 프로젝트",
+      "subtitle": "Git 저장소를 만들고 Acorn에 추가합니다",
+      "projectNameLabel": "프로젝트 이름",
+      "projectNameHint": "단일 폴더 이름을 사용하세요.",
+      "ignoreSafeName": "안전한 이름 검사 무시",
+      "locationLabel": "위치",
+      "locationPlaceholder": "상위 폴더 선택",
+      "locationAriaLabel": "프로젝트 위치",
+      "choose": "선택",
+      "creates": "생성 위치",
+      "creating": "생성 중...",
+      "createProject": "프로젝트 생성",
+      "selectParentFolder": "상위 폴더 선택",
+      "chooseLocationError": "새 프로젝트 위치를 선택하세요.",
+      "validation": {
+        "required": "프로젝트 이름은 필수입니다.",
+        "single_folder_name": "프로젝트 이름은 단일 폴더 이름이어야 합니다.",
+        "null_character": "프로젝트 이름에는 null 문자를 포함할 수 없습니다.",
+        "component_too_long": "프로젝트 이름이 255바이트를 넘어 일반 파일 시스템에서 거부될 수 있습니다."
+      }
+    },
+    "agentResume": {
+      "title": "이전 대화 재개",
+      "bodyClaude": "이 세션에 진행 중이던 Claude 대화가 있습니다. 이어서 진행하거나 이 대화상자를 닫고 새로 시작할 수 있습니다.",
+      "bodyCodex": "이 세션에 진행 중이던 Codex 대화가 있습니다. 이어서 진행하거나 이 대화상자를 닫고 새로 시작할 수 있습니다.",
+      "sessionIdCopied": "세션 ID를 복사했습니다",
+      "copyFailed": "클립보드에 복사하지 못했습니다",
+      "copyId": "ID 복사",
+      "resume": "재개",
+      "lastActivityUnknown": "마지막 활동 알 수 없음",
+      "justNow": "방금 전",
+      "minutesAgo": "분 전",
+      "hoursAgo": "시간 전",
+      "dayAgo": "일 전",
+      "daysAgo": "일 전"
+    },
+    "controlSessionGuide": {
+      "title": "컨트롤 세션",
+      "subtitle": "이 프로젝트의 다른 세션을 제어하는 터미널",
+      "bodyIntro": "컨트롤 세션은 한곳에서 여러 터미널 작업을 조율하는 기능입니다. 같은 프로젝트의 다른 세션에 명령을 보내야 하는 에이전트와 스크립트에 유용합니다.",
+      "pointKeystrokes": "이 프로젝트의 모든 세션에 키 입력을 보냅니다.",
+      "pointListSessions": "다른 세션과 상태를 나열합니다.",
+      "pointReadOutput": "대상 세션의 최근 출력을 읽습니다.",
+      "createdPrefix": "방금 컨트롤 세션을 만들었습니다.",
+      "createdSuffix": "CLI는 다음 업데이트에 포함됩니다. 그 전까지 이 터미널은 일반 셸처럼 동작합니다."
+    },
+    "commandRun": {
+      "title": "이 명령을 실행할까요?",
+      "ariaLabel": "명령 실행",
+      "description": "새 터미널 세션을 열고 다음을 실행합니다:",
+      "cwdLabel": "cwd:",
+      "noProjectHint": "등록된 프로젝트가 없습니다. 이 명령을 실행하기 전에 프로젝트를 추가하거나 \"복사\"를 사용해 기존 터미널에 붙여 넣으세요.",
+      "noProjectError": "새 세션을 실행할 프로젝트가 없습니다.",
+      "createFailed": "세션을 만들지 못했습니다.",
+      "copiedPrefix": "복사됨:",
+      "copyFailedPrefix": "복사 실패:",
+      "runningPrefix": "실행 중:",
+      "running": "실행 중...",
+      "run": "실행"
+    },
+    "closePullRequest": {
+      "titlePrefix": "닫기",
+      "confirmPrefix": "풀 리퀘스트",
+      "confirmSuffix": "를 병합하지 않고 닫을까요?",
+      "closing": "닫는 중...",
+      "closePr": "PR 닫기"
+    },
+    "mergePullRequest": {
+      "titlePrefix": "병합",
+      "mergeMethod": "병합 방식",
+      "methodSquash": "Squash",
+      "methodSquashHint": "기본 브랜치에 하나의 커밋으로 합칩니다.",
+      "methodMerge": "Merge",
+      "methodMergeHint": "기록을 보존하는 병합 커밋을 만듭니다.",
+      "methodRebase": "Rebase",
+      "methodRebaseHint": "커밋을 기본 브랜치 위에 다시 적용합니다.",
+      "commitMessage": "커밋 메시지",
+      "generating": "생성 중...",
+      "generateVia": "다음으로 생성:",
+      "generateWithAi": "AI로 생성",
+      "subjectPlaceholder": "제목",
+      "bodyPlaceholder": "본문(선택 사항)",
+      "rebaseMessageLocked": "Rebase는 원래 커밋을 기본 브랜치 위에 다시 적용하므로 여기서 커밋 메시지를 변경할 수 없습니다.",
+      "merging": "병합 중...",
+      "merge": "병합"
+    },
+    "stagedRevMismatch": {
+      "title": "셸 환경 업데이트됨",
+      "background": "백그라운드",
+      "sessionSingular": "세션",
+      "sessionPlural": "세션",
+      "needRestart": "재시작이 필요합니다",
+      "bodyIntro": "이번 업데이트에서 Acorn의 shell-init 파일이 갱신되었습니다. 이전 버전에서 시작된 백그라운드 세션은 아직 이전 환경에서 실행 중이라 입력이 깨지거나 프롬프트가 잘못 다시 그려질 수 있습니다.",
+      "bodyRestart": "새 환경을 적용하려면 지금 재시작하세요. 열린 에이전트 대화(Claude / Codex)는 다음 포커스 시점에 이어서 진행됩니다.",
+      "later": "나중에",
+      "restarting": "재시작 중...",
+      "restartSessions": "세션 재시작"
+    },
+    "memoryBreakdown": {
+      "title": "메모리 세부 정보",
+      "totalRssSum": "합계(RSS 합산)",
+      "processes": "프로세스",
+      "pid": "PID",
+      "processTree": "프로세스 트리",
+      "rss": "RSS",
+      "subtree": "하위 트리",
+      "subtreeTooltip": "이 프로세스와 모든 하위 프로세스의 합계",
+      "share": "비율",
+      "footer": "트리는 부모->자식(DFS) 순서입니다. 형제 항목은 하위 트리 RSS 내림차순으로 정렬됩니다. RSS 합계는 공유 메모리를 중복 계산하며 WebView 헬퍼와 PTY 자식 프로세스(claude, node)를 포함합니다."
+    },
+    "whatsNew": {
+      "titlePrefix": "Acorn의 새로운 내용",
+      "latestPublished": "최신 공개 릴리스 - 공개 릴리스 없음:",
+      "yourVersion": "현재 버전",
+      "currentlyRunning": "현재 실행 중",
+      "onThisVersion": "이 버전을 사용 중입니다",
+      "noReleaseNotes": "이 버전에는 공개된 릴리스 노트가 없습니다.",
+      "viewOnGithub": "GitHub에서 보기",
+      "installing": "설치 중...",
+      "installRelaunch": "설치 후 다시 실행"
+    },
+    "pullRequestDetail": {
+      "notGithub": "origin 원격 저장소가 GitHub 저장소가 아닙니다.",
+      "noAccessPrefix": "로그인된",
+      "noAccessSuffix": "계정으로 접근할 수 없습니다:",
+      "files": "파일",
+      "openOnGithub": "GitHub에서 열기",
+      "checkboxSaveFailed": "체크박스를 저장하지 못했습니다:",
+      "tabConversation": "대화",
+      "tabCommits": "커밋",
+      "tabChecks": "검사",
+      "tabFiles": "파일",
+      "merge": "병합",
+      "cannotMergeConflicting": "병합할 수 없음 - 브랜치 충돌",
+      "mergeReadinessPending": "병합 가능 여부 확인 중...",
+      "resizePrBody": "PR 본문 크기 조절",
+      "resizeHint": "드래그해 크기 조절 · 더블 클릭해 재설정",
+      "noComments": "아직 댓글이나 리뷰가 없습니다.",
+      "oldestFirst": "오래된 항목 먼저",
+      "newestFirst": "최신 항목 먼저",
+      "toggleSortOrder": "정렬 순서 전환",
+      "commented": "댓글 작성",
+      "empty": "(비어 있음)",
+      "noReviewComment": "(리뷰 댓글 없음)",
+      "reviewApproved": "승인됨",
+      "reviewChangesRequested": "변경 요청됨",
+      "reviewDismissed": "해제됨",
+      "noCommits": "이 풀 리퀘스트에 커밋이 없습니다.",
+      "viewOnGithub": "GitHub에서 보기",
+      "copySha": "SHA 복사",
+      "noMessage": "(메시지 없음)",
+      "unknown": "알 수 없음",
+      "loadingDiff": "diff 불러오는 중...",
+      "noFileChanges": "이 커밋에는 파일 변경이 없습니다.",
+      "openCommitOnGithub": "GitHub에서 커밋 열기",
+      "now": "지금",
+      "minuteAbbrev": "분",
+      "hourAbbrev": "시간",
+      "dayAbbrev": "일",
+      "noChecks": "보고된 검사가 없습니다.",
+      "openRun": "실행 열기",
+      "checkSuccess": "성공",
+      "checkFailure": "실패",
+      "checkTimedOut": "시간 초과",
+      "checkActionRequired": "조치 필요",
+      "checkCancelled": "취소됨",
+      "checkNeutral": "중립",
+      "checkSkipped": "건너뜀",
+      "checkCompleted": "완료"
+    }
+  },
   "commandPalette": {
     "dialogLabel": "명령 팔레트",
     "placeholder": "명령을 입력하거나 검색하세요...",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -341,12 +341,152 @@
     }
   },
   "app": {},
-  "sidebar": {},
-  "pane": {},
+  "sidebar": {
+    "status": {
+      "idle": "유휴",
+      "running": "실행 중",
+      "needs_input": "입력 필요",
+      "failed": "실패",
+      "completed": "완료"
+    },
+    "dialog": {
+      "selectExistingProject": "기존 프로젝트 선택",
+      "selectIsolatedRepository": "격리된 worktree용 Git 저장소 선택",
+      "selectControlDirectory": "컨트롤 세션 디렉터리 선택",
+      "selectDirectory": "디렉터리 선택"
+    },
+    "projects": {
+      "title": "프로젝트",
+      "newProject": "새 프로젝트",
+      "addExistingProject": "기존 프로젝트 추가"
+    },
+    "actions": {
+      "dragToReorder": "순서를 바꾸려면 드래그",
+      "expandProject": "프로젝트 펼치기",
+      "collapseProject": "프로젝트 접기",
+      "newSession": "새 세션",
+      "newIsolatedSession": "새 격리 세션",
+      "newIsolatedSessionWorktree": "새 격리 세션 (worktree)",
+      "newControlSession": "새 컨트롤 세션",
+      "closeProject": "프로젝트 닫기",
+      "revealInFinder": "Finder에서 보기",
+      "copyPath": "경로 복사",
+      "rename": "이름 변경",
+      "duplicateSession": "세션 복제",
+      "equalizePaneSizes": "Pane 크기 균등화",
+      "openWorktreeInEditor": "편집기에서 worktree 열기",
+      "copyWorktreePath": "Worktree 경로 복사",
+      "copyWorktreeName": "Worktree 이름 복사",
+      "copyBranchName": "브랜치 이름 복사",
+      "copySessionId": "세션 ID 복사",
+      "remove": "제거",
+      "removeSession": "세션 제거",
+      "removeOthersInProject": "프로젝트의 다른 세션 제거",
+      "removeAllInProject": "프로젝트의 모든 세션 제거"
+    },
+    "aria": {
+      "project": "프로젝트",
+      "dragToReorderProject": "프로젝트 순서를 바꾸려면 드래그",
+      "newSessionInProject": "이 프로젝트에 새 세션 만들기",
+      "newControlSessionInProject": "이 프로젝트에 새 컨트롤 세션 만들기",
+      "dragToReorderSession": "세션 순서를 바꾸려면 드래그",
+      "worktree": "worktree",
+      "controlSession": "컨트롤 세션"
+    },
+    "emptyProject": {
+      "prefix": "세션이 없습니다.",
+      "connector": "또는",
+      "suffix": "로 추가하거나 여기를 더블 클릭하세요."
+    },
+    "emptyProjects": {
+      "prefix": "아직 프로젝트가 없습니다.",
+      "suffix": "를 클릭해 추가하세요."
+    },
+    "metadata": {
+      "name": "이름",
+      "branch": "브랜치",
+      "detached": "(detached)",
+      "workingDirectory": "작업 디렉터리",
+      "status": "상태",
+      "kind": "종류",
+      "controlSession": "컨트롤 세션",
+      "isolatedWorktree": "격리된 worktree"
+    }
+  },
+  "pane": {
+    "empty": {
+      "dropTabOrDoubleClick": "여기에 탭을 놓거나 더블 클릭해 세션을 시작하세요",
+      "createProject": "시작하려면 프로젝트를 만드세요. 여기를 더블 클릭하세요."
+    },
+    "aria": {
+      "worktree": "워크트리",
+      "closeSession": "세션 닫기"
+    },
+    "menu": {
+      "rename": "이름 변경",
+      "duplicateSession": "세션 복제",
+      "forkClaudeSession": "Claude 세션 포크",
+      "forkSession": "세션 포크",
+      "forkClaudeInNewWorktree": "새 워크트리에 Claude 포크",
+      "forkInNewWorktree": "새 워크트리에 포크",
+      "forkCodexSession": "Codex 세션 포크",
+      "forkCodexInNewWorktree": "새 워크트리에 Codex 포크",
+      "splitRight": "오른쪽으로 분할",
+      "splitDown": "아래로 분할",
+      "equalizePaneSizes": "패널 크기 균등화",
+      "openWorktreeInEditor": "편집기에서 워크트리 열기",
+      "revealInFinder": "Finder에서 보기",
+      "copyWorktreePath": "워크트리 경로 복사",
+      "copyWorktreeName": "워크트리 이름 복사",
+      "copyBranchName": "브랜치 이름 복사",
+      "copySessionId": "세션 ID 복사",
+      "close": "닫기",
+      "closeOthers": "다른 탭 닫기",
+      "closeAll": "모두 닫기",
+      "newSessionInThisPane": "이 패널에서 새 세션",
+      "closePane": "패널 닫기"
+    }
+  },
   "rightPanel": {},
   "fileExplorer": {},
   "dialogs": {},
-  "commandPalette": {},
+  "commandPalette": {
+    "dialogLabel": "명령 팔레트",
+    "placeholder": "명령을 입력하거나 검색하세요...",
+    "empty": "결과가 없습니다.",
+    "groups": {
+      "sessions": "세션",
+      "switchSession": "세션 전환",
+      "view": "보기",
+      "terminal": "터미널",
+      "ipc": "IPC",
+      "dangerZone": "위험 영역"
+    },
+    "commands": {
+      "newSession": "새 세션",
+      "newIsolatedSession": "새 격리 세션",
+      "newControlSession": "새 제어 세션",
+      "newProject": "새 프로젝트",
+      "addExistingProject": "기존 프로젝트 추가",
+      "refreshSessions": "세션 새로고침",
+      "switchSessionPrefix": "전환:",
+      "viewTodos": "할 일 보기",
+      "viewCommits": "커밋 보기",
+      "viewStaged": "스테이징 보기",
+      "viewPullRequests": "풀 리퀘스트 보기",
+      "resetPanelSizes": "패널 크기 재설정",
+      "reloadShellEnvironment": "셸 환경 다시 로드",
+      "restartIpcServer": "IPC 서버 다시 시작",
+      "removeSessionPrefix": "세션 제거:",
+      "shakeTree": "나무 흔들기"
+    },
+    "toasts": {
+      "shellEnvReloaded": "셸 환경을 다시 로드했습니다. 적용하려면 새 세션을 여세요.",
+      "shellEnvReloadFailed": "셸 환경을 다시 로드하지 못했습니다.",
+      "ipcRestarted": "IPC 서버를 다시 시작했습니다.",
+      "ipcRestartFailedPrefix": "IPC 서버를 다시 시작하지 못했습니다:"
+    }
+  },
   "backgroundSessions": {
     "daemon": {
       "label": "데몬",

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -1,6 +1,33 @@
-import { test, expect, pressHotkey } from "./support";
+import {
+  test,
+  expect,
+  pressHotkey,
+  seedSettingsLanguage,
+} from "./support";
 
 test.describe("command palette", () => {
+  test("Korean mode localizes command palette chrome and default commands", async ({
+    page,
+  }) => {
+    await seedSettingsLanguage(page, "ko");
+
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "p" });
+
+    const palette = page.getByRole("dialog", { name: "명령 팔레트" });
+    await expect(palette).toBeVisible();
+    await expect(
+      page.getByPlaceholder("명령을 입력하거나 검색하세요..."),
+    ).toBeVisible();
+    await expect(page.getByText("세션", { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("option", { name: /새 세션/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("option", { name: /새 프로젝트/ }),
+    ).toBeVisible();
+  });
+
   test("opens with $mod+P and closes with Escape", async ({ page }) => {
     await page.goto("/");
 

--- a/tests/e2e/panes.spec.ts
+++ b/tests/e2e/panes.spec.ts
@@ -1,4 +1,9 @@
-import { test, expect, pressHotkey } from "./support";
+import {
+  test,
+  expect,
+  pressHotkey,
+  seedSettingsLanguage,
+} from "./support";
 
 const PROJECT = {
   repo_path: "/tmp/demo",
@@ -21,6 +26,18 @@ const SESSION = {
 };
 
 test.describe("pane / sidebar shortcuts", () => {
+  test("Korean mode localizes empty pane guidance", async ({ page, tauri }) => {
+    await seedSettingsLanguage(page, "ko");
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", []);
+
+    await page.goto("/");
+
+    await expect(
+      page.getByText(/여기에 탭을 놓거나 더블 클릭해 세션을 시작하세요/),
+    ).toBeVisible();
+  });
+
   // react-resizable-panels publishes the current size on `data-panel-size`
   // (string, e.g. "18.0" for the default 18%). Collapsed panels get "0.0".
   test("$mod+B collapses then re-expands the sidebar", async ({ page }) => {

--- a/tests/e2e/settings-tabs.spec.ts
+++ b/tests/e2e/settings-tabs.spec.ts
@@ -1,6 +1,10 @@
-import { test, expect, pressHotkey } from "./support";
+import {
+  test,
+  expect,
+  pressHotkey,
+  seedSettingsLanguage,
+} from "./support";
 
-const SETTINGS_STORAGE_KEY = "acorn:settings:v1";
 const SETTINGS_DIALOG_NAME = /^(Settings|설정)$/;
 
 // Each Settings tab has a label / heading unique enough to anchor against.
@@ -88,12 +92,7 @@ test.describe("settings modal: tab content", () => {
   test("Korean mode localizes tab buttons and representative Settings markers", async ({
     page,
   }) => {
-    await page.addInitScript((storageKey) => {
-      window.localStorage.setItem(
-        storageKey,
-        JSON.stringify({ language: "ko" }),
-      );
-    }, SETTINGS_STORAGE_KEY);
+    await seedSettingsLanguage(page, "ko");
 
     await page.goto("/");
     await pressHotkey(page, { mod: true, key: "," });

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -1,6 +1,23 @@
-import { test, expect } from "./support";
+import { test, expect, seedSettingsLanguage } from "./support";
 
 test.describe("sidebar: project lifecycle", () => {
+  test("Korean mode localizes project chrome and empty state", async ({
+    page,
+  }) => {
+    await seedSettingsLanguage(page, "ko");
+
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: "프로젝트" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "새 프로젝트" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "기존 프로젝트 추가" }),
+    ).toBeVisible();
+    await expect(page.getByText(/아직 프로젝트가 없습니다/)).toBeVisible();
+  });
+
   test("seeded project appears with name and add session affordances", async ({
     page,
     tauri,

--- a/tests/e2e/support.ts
+++ b/tests/e2e/support.ts
@@ -2,6 +2,9 @@ import { test as base, expect, type Page } from "@playwright/test";
 import { tauriMockSource } from "./fixtures/tauriMock";
 
 type InvokeHandler = (args: unknown) => unknown | Promise<unknown>;
+type TestLanguage = "en" | "ko";
+
+const SETTINGS_STORAGE_KEY = "acorn:settings:v1";
 
 export interface TauriMock {
   /**
@@ -213,6 +216,18 @@ export async function pressHotkey(
     });
     window.dispatchEvent(ev);
   }, combo);
+}
+
+export async function seedSettingsLanguage(
+  page: Page,
+  language: TestLanguage,
+): Promise<void> {
+  await page.addInitScript(
+    ({ storageKey, language }) => {
+      window.localStorage.setItem(storageKey, JSON.stringify({ language }));
+    },
+    { storageKey: SETTINGS_STORAGE_KEY, language },
+  );
 }
 
 export { expect };


### PR DESCRIPTION
Stacked on #189.

## Summary
- localize Sidebar, Pane, and CommandPalette chrome through the existing translation hook
- fill `sidebar`, `pane`, and `commandPalette` sections in `locales/en.json` and `locales/ko.json`
- add Korean-mode e2e smoke coverage for the app shell surfaces

## Verification
- `bun run typecheck`
- `bun run test`
- `bun run test:e2e tests/e2e/sidebar.spec.ts tests/e2e/panes.spec.ts tests/e2e/command-palette.spec.ts`
