### PR TITLE
feat(ipc): add control session ownership context

### DIFF
--- a/docs/CONTROL_SESSIONS.md
+++ b/docs/CONTROL_SESSIONS.md
@@ -45,11 +45,12 @@ should be able to orchestrate siblings *immediately*, not only after the
 user has explained the protocol. Acorn ships that priming through two
 layers that fire automatically every time a control-session PTY spawns:
 
-1. **PTY environment.** Three pieces of state are injected into the
+1. **PTY environment.** Four pieces of state are injected into the
    control session's PTY before any user code runs:
    - `ACORN_SESSION_ID` — this session's UUID, so `acorn-ipc` knows who
      is asking.
    - `ACORN_IPC_SOCKET` — the canonical IPC socket path.
+   - `ACORN_DAEMON_SOCKET` — the background daemon control socket path.
    - `PATH` — the directory containing the bundled `acorn-ipc` binary is
      prepended (de-duplicated), so the agent can invoke `acorn-ipc` by
      name without the user installing a shim. Regular sessions do not
@@ -63,22 +64,24 @@ layers that fire automatically every time a control-session PTY spawns:
    the protocol — point the agent at it explicitly if it doesn't auto-
    ingest project docs on startup.
 
-The primer text itself is generated server-side and lists every
-`acorn-ipc` subcommand with the current session id and socket path
-pre-substituted, so the agent can copy-paste examples without further
-work.
+The primer text itself is generated server-side and lists the control
+session id, socket paths, natural-language mapping for phrases like "new
+session", the ownership rule for worker sessions, and every `acorn-ipc`
+subcommand with copy-pasteable examples. Agents can also reload the same
+text at any time with `acorn-ipc context`.
 
 ## The `acorn-ipc` CLI
 
-When Acorn spawns a control session it injects two env vars into the PTY:
+When Acorn spawns a control session it injects these env vars into the PTY:
 
 | Env var             | Source                            |
 | ------------------- | --------------------------------- |
 | `ACORN_SESSION_ID`  | The session's UUID                |
 | `ACORN_IPC_SOCKET`  | Path to the in-app IPC socket     |
+| `ACORN_DAEMON_SOCKET` | Path to the daemon control socket |
 
-The `acorn-ipc` binary reads those two vars, so commands run straight from
-the shell without flags.
+The `acorn-ipc` binary reads `ACORN_SESSION_ID` and `ACORN_IPC_SOCKET`, so
+commands run straight from the shell without flags.
 
 ### Install
 
@@ -125,12 +128,13 @@ acorn-ipc --help
 ### Commands
 
 ```text
+acorn-ipc context
 acorn-ipc list-sessions
-acorn-ipc send-keys     -t <uuid> --data "ls\n"          # or --enter
-acorn-ipc read-buffer   -t <uuid> [--max-bytes N]
-acorn-ipc new-session   <name> [--isolated]
-acorn-ipc select-session -t <uuid>
-acorn-ipc kill-session  -t <uuid>
+acorn-ipc new-session   <name> [--isolated] [--owner me|user]
+acorn-ipc send-keys     -t <uuid> --data "ls" --enter [--allow-foreign]
+acorn-ipc read-buffer   -t <uuid> [--max-bytes N] [--allow-foreign]
+acorn-ipc select-session -t <uuid> [--allow-foreign]
+acorn-ipc kill-session  -t <uuid> [--allow-foreign]
 ```
 
 Add `--json` to any command to get machine-readable output. Each command
@@ -143,13 +147,27 @@ exits non-zero with a stable code on error:
 | 4    | Target session belongs to a different project                      |
 | 5    | Invalid request shape / arguments                                  |
 | 6    | Internal — PTY write failed, persistence failed, etc.              |
+| 7    | Foreign session — target is user-owned or owned by another control |
+
+### Ownership
+
+Sessions created from the UI are owned by `user`. Sessions created through
+`acorn-ipc new-session` are owned by the source control session by default
+(`control:<ACORN_SESSION_ID>`), unless the caller passes `--owner user`.
+
+`list-sessions` shows each session's owner and whether it is owned by the
+current controller. By default, `send-keys`, `read-buffer`, `select-session`,
+and `kill-session` only operate on sessions owned by the current controller
+or on the source control session itself. Passing `--allow-foreign` is the
+explicit escape hatch for a direct user request to touch a user-owned session
+or a session owned by another control session.
 
 ### Examples
 
 Send a command to every regular sibling and wait for output:
 
 ```sh
-for id in $(acorn-ipc list-sessions --json | jq -r '.sessions[] | select(.kind == "regular") | .id'); do
+for id in $(acorn-ipc list-sessions --json | jq -r '.sessions[] | select(.owned_by_me and .kind == "regular") | .id'); do
   acorn-ipc send-keys -t "$id" --data "git status" --enter
   sleep 1
   acorn-ipc read-buffer -t "$id" --max-bytes 4096

--- a/src-tauri/shell-init/zshrc
+++ b/src-tauri/shell-init/zshrc
@@ -42,6 +42,14 @@ _acorn_prepend_path() {
 unset -f _acorn_prepend_path
 export PATH
 
+if [ -n "${ACORN_SESSION_ID-}" ] && [ -z "${ACORN_CONTROL_BANNER_SHOWN-}" ]; then
+    export ACORN_CONTROL_BANNER_SHOWN=1
+    printf '%s\n' \
+        'Acorn control session ready.' \
+        'Agents can run: acorn-ipc context' \
+        '"new session" means an Acorn sibling terminal session.'
+fi
+
 _acorn_osc7() {
     printf '\e]7;file://%s%s\e\\' "${HOST:-${HOSTNAME-localhost}}" "$PWD"
 }

--- a/src-tauri/src/bin/acorn-ipc.rs
+++ b/src-tauri/src/bin/acorn-ipc.rs
@@ -22,7 +22,9 @@ mod proto;
 #[path = "../ipc/socket_path.rs"]
 mod socket_path;
 
-use proto::{Envelope, ErrorCode, Request, Response, SessionSummary, PROTOCOL_VERSION};
+use proto::{
+    Envelope, ErrorCode, NewSessionOwner, Request, Response, SessionSummary, PROTOCOL_VERSION,
+};
 
 const ENV_SESSION_ID: &str = "ACORN_SESSION_ID";
 
@@ -57,6 +59,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// Print the Acorn control-session context an agent should load.
+    Context,
     /// List the sessions in your project, including this control session.
     ListSessions,
     /// Send raw keys to a target session. `<DATA>` is forwarded verbatim;
@@ -85,6 +89,10 @@ enum Command {
         /// command across two lines and never run it.
         #[arg(long)]
         enter: bool,
+        /// Allow touching a user-owned session or one owned by another control
+        /// session. Use only for direct user requests.
+        #[arg(long = "allow-foreign")]
+        allow_foreign: bool,
     },
     /// Print the recent output of a target session.
     ReadBuffer {
@@ -94,6 +102,10 @@ enum Command {
         /// Max bytes to fetch from the session's tail buffer (server cap: 4 MiB).
         #[arg(long, default_value_t = 65_536)]
         max_bytes: usize,
+        /// Allow reading a user-owned session or one owned by another control
+        /// session. Use only for direct user requests.
+        #[arg(long = "allow-foreign")]
+        allow_foreign: bool,
     },
     /// Create a new regular session in this project.
     NewSession {
@@ -102,18 +114,30 @@ enum Command {
         /// Create the session inside a fresh git worktree.
         #[arg(long)]
         isolated: bool,
+        /// Assign ownership for the created session: `me` (default) marks it as
+        /// this controller's worker; `user` opts out of controller ownership.
+        #[arg(long, value_parser = ["me", "user"])]
+        owner: Option<String>,
     },
     /// Focus a session in the app UI.
     SelectSession {
         /// UUID of the target session.
         #[arg(short = 't', long = "target")]
         target: String,
+        /// Allow focusing a user-owned session or one owned by another control
+        /// session. Use only for direct user requests.
+        #[arg(long = "allow-foreign")]
+        allow_foreign: bool,
     },
     /// Kill a session (close the PTY, drop the session from state).
     KillSession {
         /// UUID of the target session.
         #[arg(short = 't', long = "target")]
         target: String,
+        /// Allow killing a user-owned session or one owned by another control
+        /// session. Use only for direct user requests.
+        #[arg(long = "allow-foreign")]
+        allow_foreign: bool,
     },
     /// Report IPC reachability: socket path, file presence, and whether
     /// the in-app server accepts connections. No `ACORN_SESSION_ID`
@@ -188,12 +212,14 @@ fn main() -> ExitCode {
 
 fn build_request(cmd: &Command) -> Result<Request, String> {
     Ok(match cmd {
+        Command::Context => Request::Context,
         Command::ListSessions => Request::ListSessions,
         Command::SendKeys {
             target,
             data,
             raw_base64,
             enter,
+            allow_foreign,
         } => {
             let data_b64 = match (raw_base64, data) {
                 (Some(b64), _) => b64.clone(),
@@ -208,30 +234,51 @@ fn build_request(cmd: &Command) -> Result<Request, String> {
                     if *enter {
                         base64::engine::general_purpose::STANDARD.encode(b"\r")
                     } else {
-                        return Err(
-                            "send-keys needs --data, --raw-base64, or --enter".to_string()
-                        );
+                        return Err("send-keys needs --data, --raw-base64, or --enter".to_string());
                     }
                 }
             };
             Request::SendKeys {
                 target_session_id: target.clone(),
                 data_b64,
+                allow_foreign: *allow_foreign,
             }
         }
-        Command::ReadBuffer { target, max_bytes } => Request::ReadBuffer {
+        Command::ReadBuffer {
+            target,
+            max_bytes,
+            allow_foreign,
+        } => Request::ReadBuffer {
             target_session_id: target.clone(),
             max_bytes: Some(*max_bytes),
+            allow_foreign: *allow_foreign,
         },
-        Command::NewSession { name, isolated } => Request::NewSession {
+        Command::NewSession {
+            name,
+            isolated,
+            owner,
+        } => Request::NewSession {
             name: name.clone(),
             isolated: *isolated,
+            owner: match owner.as_deref() {
+                Some("user") => Some(NewSessionOwner::User),
+                Some("me") | None => None,
+                Some(other) => return Err(format!("unsupported --owner value: {other}")),
+            },
         },
-        Command::SelectSession { target } => Request::SelectSession {
+        Command::SelectSession {
+            target,
+            allow_foreign,
+        } => Request::SelectSession {
             target_session_id: target.clone(),
+            allow_foreign: *allow_foreign,
         },
-        Command::KillSession { target } => Request::KillSession {
+        Command::KillSession {
+            target,
+            allow_foreign,
+        } => Request::KillSession {
             target_session_id: target.clone(),
+            allow_foreign: *allow_foreign,
         },
         Command::Status => {
             // Routed before `build_request` in `main`. Reaching here means
@@ -276,7 +323,10 @@ fn run_status(socket_path: &Path, json: bool) -> ExitCode {
         return ExitCode::SUCCESS;
     }
     println!("socket:           {}", socket_path.display());
-    println!("socket file:      {}", if exists { "present" } else { "missing" });
+    println!(
+        "socket file:      {}",
+        if exists { "present" } else { "missing" }
+    );
     if reachable {
         println!("reachable:        yes");
     } else {
@@ -292,15 +342,18 @@ fn run_status(socket_path: &Path, json: bool) -> ExitCode {
 }
 
 fn send(path: &std::path::Path, envelope: &Envelope) -> Result<Response, String> {
-    let mut stream =
-        UnixStream::connect(path).map_err(|e| format!("connect: {e}"))?;
+    let mut stream = UnixStream::connect(path).map_err(|e| format!("connect: {e}"))?;
     let mut payload = serde_json::to_vec(envelope).map_err(|e| format!("encode: {e}"))?;
     payload.push(b'\n');
-    stream.write_all(&payload).map_err(|e| format!("write: {e}"))?;
+    stream
+        .write_all(&payload)
+        .map_err(|e| format!("write: {e}"))?;
     stream.flush().map_err(|e| format!("flush: {e}"))?;
     let mut reader = BufReader::new(stream);
     let mut line = String::new();
-    reader.read_line(&mut line).map_err(|e| format!("read: {e}"))?;
+    reader
+        .read_line(&mut line)
+        .map_err(|e| format!("read: {e}"))?;
     serde_json::from_str(line.trim_end()).map_err(|e| format!("decode: {e}"))
 }
 
@@ -319,12 +372,19 @@ fn render(response: &Response, json: bool) -> ExitCode {
         };
     }
     match response {
+        Response::Context { text } => {
+            println!("{text}");
+            ExitCode::SUCCESS
+        }
         Response::Sessions { sessions } => {
             print_sessions(sessions);
             ExitCode::SUCCESS
         }
         Response::Ack => ExitCode::SUCCESS,
-        Response::Buffer { data_b64, truncated } => {
+        Response::Buffer {
+            data_b64,
+            truncated,
+        } => {
             match base64::engine::general_purpose::STANDARD.decode(data_b64) {
                 Ok(bytes) => {
                     let _ = std::io::stdout().write_all(&bytes);
@@ -356,13 +416,24 @@ fn print_sessions(sessions: &[SessionSummary]) {
         return;
     }
     let id_w = sessions.iter().map(|s| s.id.len()).max().unwrap_or(8);
-    let name_w = sessions.iter().map(|s| s.name.len()).max().unwrap_or(8).max(4);
+    let name_w = sessions
+        .iter()
+        .map(|s| s.name.len())
+        .max()
+        .unwrap_or(8)
+        .max(4);
     let kind_w = sessions
         .iter()
         .map(|s| s.kind.len())
         .max()
         .unwrap_or(7)
         .max(4);
+    let owner_w = sessions
+        .iter()
+        .map(|s| s.owner.len())
+        .max()
+        .unwrap_or(5)
+        .max(5);
     let status_w = sessions
         .iter()
         .map(|s| s.status.len())
@@ -370,21 +441,26 @@ fn print_sessions(sessions: &[SessionSummary]) {
         .unwrap_or(6)
         .max(6);
     println!(
-        "{marker} {id:<id_w$}  {name:<name_w$}  {kind:<kind_w$}  {status:<status_w$}  branch",
+        "{marker} {mine:<4}  {id:<id_w$}  {name:<name_w$}  {kind:<kind_w$}  {owner:<owner_w$}  {status:<status_w$}  branch",
         marker = " ",
+        mine = "MINE",
         id = "ID",
         name = "NAME",
         kind = "KIND",
+        owner = "OWNER",
         status = "STATUS",
     );
     for s in sessions {
         let marker = if s.is_source { "*" } else { " " };
+        let mine = if s.owned_by_me { "yes" } else { "no" };
         println!(
-            "{marker} {id:<id_w$}  {name:<name_w$}  {kind:<kind_w$}  {status:<status_w$}  {branch}",
+            "{marker} {mine:<4}  {id:<id_w$}  {name:<name_w$}  {kind:<kind_w$}  {owner:<owner_w$}  {status:<status_w$}  {branch}",
             marker = marker,
+            mine = mine,
             id = s.id,
             name = s.name,
             kind = s.kind,
+            owner = s.owner,
             status = s.status,
             branch = s.branch,
         );
@@ -400,6 +476,7 @@ fn map_error_exit(code: ErrorCode) -> u8 {
         ErrorCode::OutOfScope => 4,
         ErrorCode::Invalid => 5,
         ErrorCode::Internal => 6,
+        ErrorCode::ForeignSession => 7,
     }
 }
 
@@ -422,6 +499,7 @@ mod tests {
             data: data.map(str::to_string),
             raw_base64: raw_base64.map(str::to_string),
             enter,
+            allow_foreign: false,
         })
     }
 
@@ -481,5 +559,42 @@ mod tests {
         assert!(msg.contains("--data"), "error should mention --data");
         assert!(msg.contains("--enter"), "error should mention --enter");
     }
-}
 
+    #[test]
+    fn context_command_builds_context_request() {
+        let req = build_request(&Command::Context).expect("build");
+        assert!(matches!(req, Request::Context));
+    }
+
+    #[test]
+    fn new_session_owner_user_is_forwarded() {
+        let req = build_request(&Command::NewSession {
+            name: "worker".to_string(),
+            isolated: false,
+            owner: Some("user".to_string()),
+        })
+        .expect("build");
+        match req {
+            Request::NewSession { owner, .. } => {
+                assert_eq!(owner, Some(NewSessionOwner::User));
+            }
+            other => panic!("expected new-session, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn send_keys_allow_foreign_is_forwarded() {
+        let req = build_request(&Command::SendKeys {
+            target: "00000000-0000-0000-0000-000000000001".to_string(),
+            data: Some("ls".to_string()),
+            raw_base64: None,
+            enter: true,
+            allow_foreign: true,
+        })
+        .expect("build");
+        match req {
+            Request::SendKeys { allow_foreign, .. } => assert!(allow_foreign),
+            other => panic!("expected send-keys, got {other:?}"),
+        }
+    }
+}

--- a/src-tauri/src/daemon_commands.rs
+++ b/src-tauri/src/daemon_commands.rs
@@ -323,6 +323,7 @@ pub fn daemon_adopt_session(
         updated_at: now,
         last_message: None,
         kind,
+        owner: crate::session::SessionOwner::User,
         position: None,
         daemon_session_id: Some(id),
         agent_resume_token: Some(id.to_string()),

--- a/src-tauri/src/ipc/primer.rs
+++ b/src-tauri/src/ipc/primer.rs
@@ -55,20 +55,35 @@ pub fn primer_for(session: &Session, socket_path: &Path) -> String {
     format!(
         "You are running inside an Acorn \"control session\". You can orchestrate \
          other terminal sessions in the same project ({repo}) via the `acorn-ipc` \
-         CLI.\n\
+         CLI. The user does not need to know that `acorn-ipc` exists; treat it as \
+         your local control tool.\n\
          \n\
          Your session id: {session_id}\n\
          IPC socket:      {socket}\n\
          Daemon socket:   {daemon}\n\
+         Context command: acorn-ipc context\n\
+         \n\
+         Natural-language mapping:\n\
+         - If the user asks you to create, open, spawn, or use a \"new session\", \
+         interpret that as a new Acorn sibling terminal session in this project \
+         unless they clearly mean a new chat conversation.\n\
+         - Sessions you create with `acorn-ipc new-session` are owned by this \
+         controller by default. Only operate on sessions where `list-sessions` \
+         shows MINE=yes unless the user explicitly asks you to touch another \
+         session.\n\
+         - Do not repurpose, send input to, read from, focus, or kill user-owned \
+         sessions or sessions owned by another control session unless the user \
+         made that direct request; then pass `--allow-foreign`.\n\
          \n\
          Available commands (project-scoped — other projects are not reachable):\n\
          \n\
+           acorn-ipc context                             # print this context\n\
            acorn-ipc list-sessions                       # see siblings + self\n\
-           acorn-ipc send-keys     -t <uuid> --data '…' --enter\n\
-           acorn-ipc read-buffer   -t <uuid> [--max-bytes N]\n\
-           acorn-ipc new-session   <name> [--isolated]   # prints the new uuid\n\
-           acorn-ipc select-session -t <uuid>            # focus a tab in the UI\n\
-           acorn-ipc kill-session  -t <uuid>             # destructive — last resort\n\
+           acorn-ipc new-session   <name> [--isolated] [--owner me|user]\n\
+           acorn-ipc send-keys     -t <uuid> --data '…' --enter [--allow-foreign]\n\
+           acorn-ipc read-buffer   -t <uuid> [--max-bytes N] [--allow-foreign]\n\
+           acorn-ipc select-session -t <uuid> [--allow-foreign]\n\
+           acorn-ipc kill-session  -t <uuid> [--allow-foreign]\n\
          \n\
          The newer `acornd` CLI talks to the same project graph via the\n\
          background daemon (currently rolling out). `acornd list-sessions`,\n\

--- a/src-tauri/src/ipc/proto.rs
+++ b/src-tauri/src/ipc/proto.rs
@@ -31,6 +31,9 @@ pub struct Envelope {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum Request {
+    /// Return the control-session context primer the agent should load before
+    /// interpreting natural-language requests like "new session".
+    Context,
     /// List sessions visible to the source — i.e. sessions in the same
     /// project (`repo_path`) as the calling control session.
     ListSessions,
@@ -40,6 +43,8 @@ pub enum Request {
     SendKeys {
         target_session_id: String,
         data_b64: String,
+        #[serde(default)]
+        allow_foreign: bool,
     },
     /// Read the tail of a target session's PTY output ring buffer. Returns
     /// up to `max_bytes`; `truncated = true` indicates the buffer had more
@@ -47,6 +52,8 @@ pub enum Request {
     ReadBuffer {
         target_session_id: String,
         max_bytes: Option<usize>,
+        #[serde(default)]
+        allow_foreign: bool,
     },
     /// Create a new (non-control) regular session in the same project as the
     /// source. Returns the new session's id. The frontend's `pty_spawn`
@@ -56,22 +63,40 @@ pub enum Request {
     NewSession {
         name: String,
         isolated: bool,
+        #[serde(default)]
+        owner: Option<NewSessionOwner>,
     },
     /// Ask the app to focus the given session in its pane. Emits a Tauri
     /// event the frontend reacts to.
     SelectSession {
         target_session_id: String,
+        #[serde(default)]
+        allow_foreign: bool,
     },
     /// Tear down a target session (kill its PTY, remove it from state).
     /// Destructive — the server logs every invocation to the audit log.
     KillSession {
         target_session_id: String,
+        #[serde(default)]
+        allow_foreign: bool,
     },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum NewSessionOwner {
+    /// Default for `acorn-ipc new-session`: owned by the source control session.
+    SourceControl,
+    /// Explicit opt-out for sessions that should behave like user-created tabs.
+    User,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum Response {
+    Context {
+        text: String,
+    },
     Sessions {
         sessions: Vec<SessionSummary>,
     },
@@ -108,6 +133,9 @@ pub enum ErrorCode {
     OutOfScope,
     /// Request shape was unrecognized or its arguments were invalid.
     Invalid,
+    /// Target exists in the same project but is owned by the user or by another
+    /// control session. Callers must opt in explicitly for these operations.
+    ForeignSession,
     /// Catch-all for server-side failures (PTY write errors, persistence
     /// errors, etc.). The `message` carries the underlying cause.
     Internal,
@@ -120,7 +148,9 @@ pub struct SessionSummary {
     pub repo_path: String,
     pub branch: String,
     pub kind: String,
+    pub owner: String,
     pub status: String,
+    pub owned_by_me: bool,
     /// True when the source session itself is the one being described —
     /// the CLI uses this to render an arrow / current-session marker.
     pub is_source: bool,
@@ -138,6 +168,7 @@ mod tests {
             request: Request::SendKeys {
                 target_session_id: "00000000-0000-0000-0000-000000000002".to_string(),
                 data_b64: "aGVsbG8=".to_string(),
+                allow_foreign: false,
             },
         };
         let encoded = serde_json::to_string(&env).expect("encode");
@@ -160,7 +191,8 @@ mod tests {
 
     #[test]
     fn unknown_request_kind_rejected() {
-        let bad = r#"{"protocol_version":1,"source_session_id":"x","request":{"kind":"frobnicate"}}"#;
+        let bad =
+            r#"{"protocol_version":1,"source_session_id":"x","request":{"kind":"frobnicate"}}"#;
         let parsed: Result<Envelope, _> = serde_json::from_str(bad);
         assert!(parsed.is_err());
     }

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -35,11 +35,11 @@ use uuid::Uuid;
 
 use crate::commands::{create_unique_worktree, sanitize_worktree_name};
 use crate::ipc::proto::{
-    Envelope, ErrorCode, Request, Response, SessionSummary, PROTOCOL_VERSION,
+    Envelope, ErrorCode, NewSessionOwner, Request, Response, SessionSummary, PROTOCOL_VERSION,
 };
 use crate::ipc::socket_path;
 use crate::persistence;
-use crate::session::{Session, SessionKind, SessionStore};
+use crate::session::{Session, SessionKind, SessionOwner, SessionStore};
 use crate::state::AppState;
 use crate::worktree;
 
@@ -222,11 +222,7 @@ fn handle_connection<R: Runtime>(
 /// Top-level request dispatch. Resolves the source session and enforces the
 /// "must be Control" gate before invoking command-specific handlers, so
 /// each handler can assume `source` is a live, authorized session.
-fn dispatch<R: Runtime>(
-    envelope: Envelope,
-    app: &AppHandle<R>,
-    state: &AppState,
-) -> Response {
+fn dispatch<R: Runtime>(envelope: Envelope, app: &AppHandle<R>, state: &AppState) -> Response {
     if envelope.protocol_version != PROTOCOL_VERSION {
         return Response::Error {
             code: ErrorCode::Invalid,
@@ -247,29 +243,37 @@ fn dispatch<R: Runtime>(
         "ipc: dispatch",
     );
     match envelope.request {
+        Request::Context => handle_context(&source),
         Request::ListSessions => handle_list_sessions(&source, &state.sessions),
         Request::SendKeys {
             target_session_id,
             data_b64,
-        } => handle_send_keys(&source, &target_session_id, &data_b64, state),
+            allow_foreign,
+        } => handle_send_keys(&source, &target_session_id, &data_b64, allow_foreign, state),
         Request::ReadBuffer {
             target_session_id,
             max_bytes,
-        } => handle_read_buffer(&source, &target_session_id, max_bytes, state),
-        Request::NewSession { name, isolated } => {
-            handle_new_session(&source, name, isolated, app, state)
-        }
-        Request::SelectSession { target_session_id } => {
-            handle_select_session(&source, &target_session_id, app, state)
-        }
-        Request::KillSession { target_session_id } => {
-            handle_kill_session(&source, &target_session_id, app, state)
-        }
+            allow_foreign,
+        } => handle_read_buffer(&source, &target_session_id, max_bytes, allow_foreign, state),
+        Request::NewSession {
+            name,
+            isolated,
+            owner,
+        } => handle_new_session(&source, name, isolated, owner, app, state),
+        Request::SelectSession {
+            target_session_id,
+            allow_foreign,
+        } => handle_select_session(&source, &target_session_id, allow_foreign, app, state),
+        Request::KillSession {
+            target_session_id,
+            allow_foreign,
+        } => handle_kill_session(&source, &target_session_id, allow_foreign, app, state),
     }
 }
 
 fn request_label(req: &Request) -> &'static str {
     match req {
+        Request::Context => "context",
         Request::ListSessions => "list-sessions",
         Request::SendKeys { .. } => "send-keys",
         Request::ReadBuffer { .. } => "read-buffer",
@@ -324,22 +328,57 @@ fn resolve_target(
     Ok(target)
 }
 
+fn is_owned_by_source(source: &Session, target: &Session) -> bool {
+    target.id == source.id || target.owner.is_control_owner(source.id)
+}
+
+fn resolve_action_target(
+    source: &Session,
+    raw_id: &str,
+    sessions: &SessionStore,
+    allow_foreign: bool,
+) -> Result<Session, Response> {
+    let target = resolve_target(source, raw_id, sessions)?;
+    if !allow_foreign && !is_owned_by_source(source, &target) {
+        return Err(Response::Error {
+            code: ErrorCode::ForeignSession,
+            message: format!(
+                "target session is owned by {}; pass --allow-foreign only when the user explicitly asked you to touch it",
+                target.owner.label()
+            ),
+        });
+    }
+    Ok(target)
+}
+
+fn handle_context(source: &Session) -> Response {
+    let socket = socket_path::resolve().unwrap_or_default();
+    Response::Context {
+        text: crate::ipc::primer::primer_for(source, &socket),
+    }
+}
+
 fn handle_list_sessions(source: &Session, sessions: &SessionStore) -> Response {
     let summaries: Vec<SessionSummary> = sessions
         .list()
         .into_iter()
         .filter(|s| s.repo_path == source.repo_path)
-        .map(|s| SessionSummary {
-            is_source: s.id == source.id,
-            id: s.id.to_string(),
-            name: s.name,
-            repo_path: s.repo_path.display().to_string(),
-            branch: s.branch,
-            kind: match s.kind {
-                SessionKind::Regular => "regular".to_string(),
-                SessionKind::Control => "control".to_string(),
-            },
-            status: format!("{:?}", s.status).to_lowercase(),
+        .map(|s| {
+            let owned_by_me = is_owned_by_source(source, &s);
+            SessionSummary {
+                is_source: s.id == source.id,
+                id: s.id.to_string(),
+                name: s.name,
+                repo_path: s.repo_path.display().to_string(),
+                branch: s.branch,
+                kind: match s.kind {
+                    SessionKind::Regular => "regular".to_string(),
+                    SessionKind::Control => "control".to_string(),
+                },
+                owner: s.owner.label(),
+                status: format!("{:?}", s.status).to_lowercase(),
+                owned_by_me,
+            }
         })
         .collect();
     Response::Sessions {
@@ -351,9 +390,10 @@ fn handle_send_keys(
     source: &Session,
     target_id: &str,
     data_b64: &str,
+    allow_foreign: bool,
     state: &AppState,
 ) -> Response {
-    let target = match resolve_target(source, target_id, &state.sessions) {
+    let target = match resolve_action_target(source, target_id, &state.sessions, allow_foreign) {
         Ok(t) => t,
         Err(err) => return err,
     };
@@ -379,9 +419,10 @@ fn handle_read_buffer(
     source: &Session,
     target_id: &str,
     max_bytes: Option<usize>,
+    allow_foreign: bool,
     state: &AppState,
 ) -> Response {
-    let target = match resolve_target(source, target_id, &state.sessions) {
+    let target = match resolve_action_target(source, target_id, &state.sessions, allow_foreign) {
         Ok(t) => t,
         Err(err) => return err,
     };
@@ -402,6 +443,7 @@ fn handle_new_session<R: Runtime>(
     source: &Session,
     name: String,
     isolated: bool,
+    owner: Option<NewSessionOwner>,
     app: &AppHandle<R>,
     state: &AppState,
 ) -> Response {
@@ -426,9 +468,8 @@ fn handle_new_session<R: Runtime>(
     } else {
         repo.clone()
     };
-    let branch =
-        worktree::current_branch(&worktree_path).unwrap_or_else(|_| "HEAD".to_string());
-    let session = Session::new(
+    let branch = worktree::current_branch(&worktree_path).unwrap_or_else(|_| "HEAD".to_string());
+    let mut session = Session::new(
         name,
         repo.clone(),
         worktree_path,
@@ -436,6 +477,10 @@ fn handle_new_session<R: Runtime>(
         isolated,
         SessionKind::Regular,
     );
+    session.owner = match owner.unwrap_or(NewSessionOwner::SourceControl) {
+        NewSessionOwner::SourceControl => SessionOwner::control(source.id),
+        NewSessionOwner::User => SessionOwner::User,
+    };
     let inserted = state.sessions.insert(session);
     let basename = repo
         .file_name()
@@ -465,10 +510,11 @@ fn handle_new_session<R: Runtime>(
 fn handle_select_session<R: Runtime>(
     source: &Session,
     target_id: &str,
+    allow_foreign: bool,
     app: &AppHandle<R>,
     state: &AppState,
 ) -> Response {
-    let target = match resolve_target(source, target_id, &state.sessions) {
+    let target = match resolve_action_target(source, target_id, &state.sessions, allow_foreign) {
         Ok(t) => t,
         Err(err) => return err,
     };
@@ -484,10 +530,11 @@ fn handle_select_session<R: Runtime>(
 fn handle_kill_session<R: Runtime>(
     source: &Session,
     target_id: &str,
+    allow_foreign: bool,
     app: &AppHandle<R>,
     state: &AppState,
 ) -> Response {
-    let target = match resolve_target(source, target_id, &state.sessions) {
+    let target = match resolve_action_target(source, target_id, &state.sessions, allow_foreign) {
         Ok(t) => t,
         Err(err) => return err,
     };
@@ -517,18 +564,13 @@ fn handle_kill_session<R: Runtime>(
     Response::Ack
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::session::SessionStatus;
     use std::path::PathBuf;
 
-    fn make_session(
-        repo: &str,
-        name: &str,
-        kind: SessionKind,
-    ) -> Session {
+    fn make_session(repo: &str, name: &str, kind: SessionKind) -> Session {
         let mut s = Session::new(
             name.to_string(),
             PathBuf::from(repo),
@@ -580,14 +622,22 @@ mod tests {
     fn list_sessions_filters_by_project() {
         let store = SessionStore::new();
         let ctl = store.insert(make_session("/tmp/A", "ctl", SessionKind::Control));
-        let _peer = store.insert(make_session("/tmp/A", "peer", SessionKind::Regular));
+        let mut peer = make_session("/tmp/A", "peer", SessionKind::Regular);
+        peer.owner = SessionOwner::control(ctl.id);
+        let _peer = store.insert(peer);
         let _other = store.insert(make_session("/tmp/B", "other", SessionKind::Regular));
         match handle_list_sessions(&ctl, &store) {
             Response::Sessions { sessions } => {
                 assert_eq!(sessions.len(), 2, "should see ctl + peer, not other");
                 assert!(sessions.iter().all(|s| s.repo_path == "/tmp/A"));
-                let source = sessions.iter().find(|s| s.is_source).expect("source marked");
+                let source = sessions
+                    .iter()
+                    .find(|s| s.is_source)
+                    .expect("source marked");
                 assert_eq!(source.id, ctl.id.to_string());
+                let worker = sessions.iter().find(|s| s.name == "peer").expect("worker");
+                assert_eq!(worker.owner, format!("control:{}", ctl.id));
+                assert!(worker.owned_by_me);
             }
             other => panic!("expected sessions response, got {other:?}"),
         }
@@ -606,5 +656,40 @@ mod tests {
             }) => {}
             other => panic!("expected out-of-scope, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn action_target_rejects_foreign_owner_by_default() {
+        let store = SessionStore::new();
+        let ctl = store.insert(make_session("/tmp/A", "ctl", SessionKind::Control));
+        let target = store.insert(make_session("/tmp/A", "user", SessionKind::Regular));
+        let res = resolve_action_target(&ctl, &target.id.to_string(), &store, false);
+        match res {
+            Err(Response::Error {
+                code: ErrorCode::ForeignSession,
+                ..
+            }) => {}
+            other => panic!("expected foreign-session, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn action_target_accepts_source_owned_session() {
+        let store = SessionStore::new();
+        let ctl = store.insert(make_session("/tmp/A", "ctl", SessionKind::Control));
+        let mut target = make_session("/tmp/A", "worker", SessionKind::Regular);
+        target.owner = SessionOwner::control(ctl.id);
+        let target = store.insert(target);
+        let res = resolve_action_target(&ctl, &target.id.to_string(), &store, false);
+        assert!(res.is_ok(), "source-owned worker should be allowed");
+    }
+
+    #[test]
+    fn action_target_allows_foreign_owner_when_explicit() {
+        let store = SessionStore::new();
+        let ctl = store.insert(make_session("/tmp/A", "ctl", SessionKind::Control));
+        let target = store.insert(make_session("/tmp/A", "user", SessionKind::Regular));
+        let res = resolve_action_target(&ctl, &target.id.to_string(), &store, true);
+        assert!(res.is_ok(), "allow_foreign should bypass owner guard");
     }
 }

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -133,6 +133,39 @@ pub enum SessionKind {
     Control,
 }
 
+/// Ownership boundary for control-session-created worker sessions.
+///
+/// User-created and legacy sessions default to `User`. Sessions created through
+/// `acorn-ipc new-session` are owned by the source control session so agents can
+/// distinguish their own workers from user terminals or workers created by
+/// another controller.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum SessionOwner {
+    #[default]
+    User,
+    Control {
+        session_id: Uuid,
+    },
+}
+
+impl SessionOwner {
+    pub fn control(session_id: Uuid) -> Self {
+        Self::Control { session_id }
+    }
+
+    pub fn is_control_owner(&self, source_session_id: Uuid) -> bool {
+        matches!(self, Self::Control { session_id } if *session_id == source_session_id)
+    }
+
+    pub fn label(&self) -> String {
+        match self {
+            Self::User => "user".to_string(),
+            Self::Control { session_id } => format!("control:{session_id}"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     pub id: Uuid,
@@ -148,6 +181,8 @@ pub struct Session {
     pub last_message: Option<String>,
     #[serde(default)]
     pub kind: SessionKind,
+    #[serde(default)]
+    pub owner: SessionOwner,
     /// User-defined display order within the project group. `None` means the
     /// session has never been reordered — the frontend falls back to
     /// `updated_at DESC` for these. Once any session in a project is dragged,
@@ -206,6 +241,7 @@ impl Session {
             updated_at: now,
             last_message: None,
             kind,
+            owner: SessionOwner::User,
             position: None,
             daemon_session_id: None,
             agent_resume_token: None,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,6 +13,10 @@ export type SessionStatus =
  */
 export type SessionKind = "regular" | "control";
 
+export type SessionOwner =
+  | { kind: "user" }
+  | { kind: "control"; session_id: string };
+
 export interface Session {
   id: string;
   name: string;
@@ -25,6 +29,7 @@ export interface Session {
   updated_at: string;
   last_message: string | null;
   kind: SessionKind;
+  owner: SessionOwner;
   position: number | null;
   /** Derived backend-side from `worktree_path`'s `.git` being a file (linked
    * worktree marker). Surfaces the worktree icon regardless of whether Acorn,

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -71,6 +71,7 @@ function session(
     updated_at: "2026-01-01T00:00:00Z",
     last_message: null,
     kind: "regular",
+    owner: { kind: "user" },
     position: null,
     in_worktree: false,
     ...overrides,


### PR DESCRIPTION
## Summary
- Add `acorn-ipc context` and strengthen the control-session primer so agents understand Acorn session identity, "new session" requests, and worker ownership.
- Track session ownership so controller-created workers are marked as owned by the source control session, while UI/adopted sessions remain user-owned.
- Gate `send-keys`, `read-buffer`, `select-session`, and `kill-session` to controller-owned sessions by default, with `--allow-foreign` for direct user requests.

## Verification
- `npm run typecheck`
- `npm test -- src/store.test.ts`
- `cargo check`
- `cargo test ipc::`
- `cargo test --bin acorn-ipc`

## Notes
Full `cargo test` was attempted, but the existing `daemon::ring_buffer::tests::newline_indices_stay_coherent_across_byte_eviction` test hung for more than 60 seconds. The targeted checks above passed.
