### PR TITLE
fix(codex): support exec and transcript previews

### DIFF
--- a/src-tauri/src/agent_resume.rs
+++ b/src-tauri/src/agent_resume.rs
@@ -319,6 +319,22 @@ fn extract_codex_preview(path: &Path) -> io::Result<Option<String>> {
         }
         let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) else { continue };
 
+        if v.pointer("/payload/role").and_then(|r| r.as_str()) == Some("assistant") {
+            if let Some(content) = v.pointer("/payload/content").and_then(|c| c.as_array()) {
+                for item in content.iter().rev() {
+                    let text = item
+                        .get("text")
+                        .or_else(|| item.get("output_text"))
+                        .and_then(|t| t.as_str());
+                    if let Some(text) = text {
+                        if let Some(p) = collapse_preview(text) {
+                            return Ok(Some(p));
+                        }
+                    }
+                }
+            }
+        }
+
         if let Some(msg) = v
             .pointer("/payload/message")
             .and_then(|m| m.as_str())
@@ -456,6 +472,21 @@ mod tests {
         .unwrap();
         let candidate = result.expect("rotated UUID must re-surface");
         assert_eq!(candidate.uuid, "22222222-2222-2222-2222-222222222222");
+    }
+
+    #[test]
+    fn codex_preview_reads_response_item_output_text() {
+        let base = ScratchDir::new("codex-preview");
+        let path = base.path().join("rollout.jsonl");
+        fs::write(
+            &path,
+            r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Here is the latest Codex answer."}]}}"#,
+        )
+        .unwrap();
+
+        let preview = extract_codex_preview(&path).unwrap();
+
+        assert_eq!(preview.as_deref(), Some("Here is the latest Codex answer."));
     }
 
     #[test]

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1,9 +1,30 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_SETTINGS } from "./settings";
+import {
+  AGENT_OPTIONS,
+  DEFAULT_SETTINGS,
+  resolveAiCommitCommand,
+} from "./settings";
 
 describe("terminal.linkActivation default", () => {
   it("defaults to plain click so xterm's stock behaviour is preserved", () => {
     expect(DEFAULT_SETTINGS.terminal.linkActivation).toBe("click");
+  });
+});
+
+describe("AI commit command resolution", () => {
+  it("runs Codex through non-interactive exec mode", () => {
+    expect(
+      resolveAiCommitCommand({
+        ...DEFAULT_SETTINGS,
+        agents: { ...DEFAULT_SETTINGS.agents, selected: "codex" },
+      }),
+    ).toEqual({ command: "codex", args: ["exec"] });
+  });
+
+  it("describes the Codex one-shot invocation in settings", () => {
+    expect(AGENT_OPTIONS.find((o) => o.value === "codex")?.oneshotHint).toBe(
+      "codex exec",
+    );
   });
 });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -51,7 +51,7 @@ export const AGENT_OPTIONS: ReadonlyArray<{
   {
     value: "codex",
     label: "OpenAI Codex CLI",
-    oneshotHint: "codex (interactive only)",
+    oneshotHint: "codex exec",
   },
 ];
 
@@ -947,9 +947,7 @@ interface ResolvedCommand {
 
 /**
  * One-shot stdin → stdout invocation for an agent. Used by the merge
- * dialog's "Generate with AI" action. Codex has no documented headless
- * mode here, so users who need codex specifically should select Custom
- * and supply their own one-shot incantation.
+ * dialog's "Generate with AI" action.
  */
 function agentOneshotCommand(
   agent: AgentProvider,
@@ -961,7 +959,7 @@ function agentOneshotCommand(
     case "gemini":
       return { command: "gemini", args: ["-p"] };
     case "codex":
-      return { command: "codex", args: [] };
+      return { command: "codex", args: ["exec"] };
     case "ollama": {
       const model = agents.ollama.model.trim() || "llama3";
       return { command: "ollama", args: ["run", model] };


### PR DESCRIPTION
## Summary
- run the Codex provider through `codex exec` for non-interactive AI commit-message generation
- update the Settings hint so Codex no longer appears interactive-only
- parse current Codex `response_item` transcript entries for resume modal previews

## Verification
- `bun run test`
- `bun run typecheck`
- `cargo test agent_resume`

## Notes
Full `cargo test` was attempted, but the existing `daemon::ring_buffer::tests::newline_indices_stay_coherent_across_byte_eviction` test hung for more than 2 minutes. The targeted checks above passed.