### PR TITLE
fix(file-explorer): reduce git status refresh cost

### DIFF
--- a/src-tauri/src/fs_explorer.rs
+++ b/src-tauri/src/fs_explorer.rs
@@ -7,7 +7,7 @@ use git2::{Repository, Status, StatusOptions};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use parking_lot::Mutex;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Runtime, State};
 
 use crate::error::{AppError, AppResult};
@@ -291,9 +291,11 @@ pub struct GitStatusEntry {
 }
 
 /// Per-path git status, mapped to a small set of buckets the frontend
-/// uses to pick a color, plus diff line counts (vs HEAD) so the entry
-/// can render a `+n -n` badge. Paths are absolute strings keyed by full
-/// path so the FileExplorer's flat lookup matches its entry paths.
+/// uses to pick a color. Diff line counts are intentionally omitted here
+/// because computing them requires extra per-path IO/diff work.
+///
+/// Paths are absolute strings keyed by full path so the FileExplorer's
+/// flat lookup matches its entry paths.
 #[tauri::command]
 pub fn fs_git_status(repo_root: String) -> AppResult<HashMap<String, GitStatusEntry>> {
     let root = PathBuf::from(&repo_root);
@@ -327,11 +329,60 @@ pub fn fs_git_status(repo_root: String) -> AppResult<HashMap<String, GitStatusEn
         let abs_str = abs.to_string_lossy().into_owned();
         let s = entry.status();
         let kind = classify_status(s);
-        let (additions, deletions) = file_diff_stats(&repo, &workdir, rel, kind);
         out.insert(
             abs_str,
             GitStatusEntry {
                 kind: kind.into(),
+                additions: 0,
+                deletions: 0,
+            },
+        );
+    }
+    Ok(out)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GitDiffStatsRequest {
+    pub path: String,
+    pub kind: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GitDiffStatsEntry {
+    pub additions: u32,
+    pub deletions: u32,
+}
+
+#[tauri::command]
+pub fn fs_git_diff_stats(
+    repo_root: String,
+    entries: Vec<GitDiffStatsRequest>,
+) -> AppResult<HashMap<String, GitDiffStatsEntry>> {
+    let root = PathBuf::from(&repo_root);
+    if !root.exists() {
+        return Err(AppError::InvalidPath(format!("missing: {repo_root}")));
+    }
+    let repo = match Repository::discover(&root) {
+        Ok(r) => r,
+        Err(_) => return Ok(HashMap::new()),
+    };
+    let workdir = match repo.workdir() {
+        Some(p) => p.to_path_buf(),
+        None => return Ok(HashMap::new()),
+    };
+
+    let mut out = HashMap::with_capacity(entries.len());
+    for entry in entries {
+        let path = PathBuf::from(&entry.path);
+        reject_dangerous(&path)?;
+        let Ok(rel_path) = path.strip_prefix(&workdir) else {
+            continue;
+        };
+        let rel = rel_path.to_string_lossy();
+        let (additions, deletions) = file_diff_stats(&repo, &workdir, &rel, &entry.kind);
+        out.insert(
+            path.to_string_lossy().into_owned(),
+            GitDiffStatsEntry {
                 additions,
                 deletions,
             },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -359,6 +359,7 @@ pub fn run() {
             fs_explorer::fs_git_status,
             fs_explorer::fs_git_branch,
             fs_explorer::fs_read_file,
+            fs_explorer::fs_git_diff_stats,
             fs_explorer::fs_git_diff_lines,
             fs_explorer::fs_watch_set_root,
         ])

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -186,6 +186,27 @@ function buildDirtyAncestors(
   return out;
 }
 
+function collectVisiblePaths(
+  cache: Cache,
+  expanded: Set<string>,
+  rootPath: string,
+): Set<string> {
+  const out = new Set<string>();
+
+  const walk = (dir: string) => {
+    const entries = cache[dir]?.entries ?? [];
+    for (const entry of entries) {
+      out.add(entry.path);
+      if (entry.is_dir && expanded.has(entry.path)) {
+        walk(entry.path);
+      }
+    }
+  };
+
+  walk(rootPath);
+  return out;
+}
+
 /**
  * POSIX shell-quote a path with single quotes. Inside `'…'` every byte
  * except `'` is literal — even newlines, `!`, `$`, backticks. The only
@@ -276,10 +297,20 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     claude: string | null;
     codex: string | null;
   }>({ claude: null, codex: null });
+  const gitStatsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const gitStatusRef = useRef<Record<string, FsGitStatusEntry>>({});
+  const visiblePathsRef = useRef<Set<string>>(new Set());
+  const changedPathsRef = useRef<Set<string>>(new Set());
+  const statusInFlightRef = useRef<Promise<void> | null>(null);
+  const statusRefreshPendingRef = useRef(false);
   // Tracks the focused session id so the menu can write into the right
   // PTY without re-importing the store at every click.
   const [activeSessionId, setActiveSessionIdLocal] = useState<string | null>(
     null,
+  );
+  const visiblePaths = useMemo(
+    () => collectVisiblePaths(cache, expanded, rootPath),
+    [cache, expanded, rootPath],
   );
 
   useEffect(() => {
@@ -295,18 +326,125 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     };
   }, []);
 
+  useEffect(() => {
+    gitStatusRef.current = gitStatus;
+  }, [gitStatus]);
+
+  useEffect(() => {
+    visiblePathsRef.current = visiblePaths;
+  }, [visiblePaths]);
+
   const refreshGitStatus = useCallback(async () => {
-    try {
-      const map = await api.fsGitStatus(rootPath);
-      setGitStatus(map);
-    } catch {
-      setGitStatus({});
+    if (statusInFlightRef.current) {
+      statusRefreshPendingRef.current = true;
+      return statusInFlightRef.current;
     }
+
+    const run = async () => {
+      try {
+        const map = await api.fsGitStatus(rootPath);
+        setGitStatus((prev) => {
+          const next: Record<string, FsGitStatusEntry> = {};
+          for (const [path, entry] of Object.entries(map)) {
+            const previous = prev[path];
+            next[path] =
+              previous && previous.kind === entry.kind
+                ? {
+                    ...entry,
+                    additions: previous.additions,
+                    deletions: previous.deletions,
+                  }
+                : entry;
+          }
+          gitStatusRef.current = next;
+          return next;
+        });
+      } catch {
+        gitStatusRef.current = {};
+        setGitStatus({});
+      }
+    };
+
+    const promise = run().finally(() => {
+      statusInFlightRef.current = null;
+      if (statusRefreshPendingRef.current) {
+        statusRefreshPendingRef.current = false;
+        void refreshGitStatus();
+      }
+    });
+    statusInFlightRef.current = promise;
+    return promise;
   }, [rootPath]);
+
+  const scheduleGitDiffStats = useCallback(() => {
+    if (gitStatsTimerRef.current) {
+      clearTimeout(gitStatsTimerRef.current);
+    }
+    gitStatsTimerRef.current = setTimeout(() => {
+      gitStatsTimerRef.current = null;
+      const targetPaths = new Set([
+        ...visiblePathsRef.current,
+        ...changedPathsRef.current,
+      ]);
+      changedPathsRef.current.clear();
+      const entries = Object.entries(gitStatusRef.current)
+        .filter(([path]) => targetPaths.has(path))
+        .map(([path, status]) => ({ path, kind: status.kind }));
+      if (entries.length === 0) return;
+
+      void api
+        .fsGitDiffStats(rootPath, entries)
+        .then((stats) => {
+          const requestedKinds = new Map(entries.map((e) => [e.path, e.kind]));
+          setGitStatus((prev) => {
+            let changed = false;
+            const next = { ...prev };
+            for (const [path, stat] of Object.entries(stats)) {
+              const current = next[path];
+              if (!current || current.kind !== requestedKinds.get(path)) continue;
+              if (
+                current.additions === stat.additions &&
+                current.deletions === stat.deletions
+              ) {
+                continue;
+              }
+              next[path] = { ...current, ...stat };
+              changed = true;
+            }
+            if (changed) gitStatusRef.current = next;
+            return changed ? next : prev;
+          });
+        })
+        .catch(() => {});
+    }, 1200);
+  }, [rootPath]);
+
+  const gitStatusKindFingerprint = useMemo(
+    () =>
+      Object.entries(gitStatus)
+        .map(([path, status]) => `${path}:${status.kind}`)
+        .join("\0"),
+    [gitStatus],
+  );
 
   useEffect(() => {
     void refreshGitStatus();
-  }, [refreshGitStatus]);
+    scheduleGitDiffStats();
+    return () => {
+      if (gitStatsTimerRef.current) {
+        clearTimeout(gitStatsTimerRef.current);
+        gitStatsTimerRef.current = null;
+      }
+    };
+  }, [refreshGitStatus, scheduleGitDiffStats]);
+
+  useEffect(() => {
+    scheduleGitDiffStats();
+  }, [visiblePaths, scheduleGitDiffStats]);
+
+  useEffect(() => {
+    scheduleGitDiffStats();
+  }, [gitStatusKindFingerprint, scheduleGitDiffStats]);
 
   // Subscribe to focused-session changes via the store so the menu
   // always reflects the agent state of whichever PTY would receive the
@@ -444,9 +582,11 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
         }
       }
       void refreshGitStatus();
+      scheduleGitDiffStats();
     };
     void listen<FsChangePayload>(FS_CHANGED_EVENT, (event) => {
       for (const p of event.payload.paths) {
+        changedPathsRef.current.add(p);
         pending.add(parentOf(p));
       }
       if (!flushTimer) flushTimer = setTimeout(flush, 100);
@@ -457,7 +597,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       if (flushTimer) clearTimeout(flushTimer);
       if (cancel) cancel();
     };
-  }, [rootPath, fetchDir, refreshGitStatus]);
+  }, [rootPath, fetchDir, refreshGitStatus, scheduleGitDiffStats]);
 
   const toggleDir = useCallback(
     (path: string) => {
@@ -670,8 +810,10 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       }
     }
     setSelection(new Set());
+    for (const p of paths) changedPathsRef.current.add(p);
     void refreshGitStatus();
-  }, [selection, refreshGitStatus]);
+    scheduleGitDiffStats();
+  }, [selection, refreshGitStatus, scheduleGitDiffStats]);
 
   const handleBulkCopyPaths = useCallback(
     async (mode: "relative" | "absolute") => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -525,6 +525,15 @@ export const api = {
       repoRoot,
     });
   },
+  fsGitDiffStats(
+    repoRoot: string,
+    entries: FsGitDiffStatsRequest[],
+  ): Promise<Record<string, FsGitDiffStatsEntry>> {
+    return invoke<Record<string, FsGitDiffStatsEntry>>("fs_git_diff_stats", {
+      repoRoot,
+      entries,
+    });
+  },
   fsGitBranch(repoRoot: string): Promise<string> {
     return invoke<string>("fs_git_branch", { repoRoot });
   },
@@ -575,6 +584,16 @@ export type FsGitStatus =
 /** Mirror of `crate::fs_explorer::GitStatusEntry`. */
 export interface FsGitStatusEntry {
   kind: FsGitStatus;
+  additions: number;
+  deletions: number;
+}
+
+export interface FsGitDiffStatsRequest {
+  path: string;
+  kind: FsGitStatus;
+}
+
+export interface FsGitDiffStatsEntry {
   additions: number;
   deletions: number;
 }


### PR DESCRIPTION
## Summary
- split file explorer git status refresh into fast status-only updates and deferred diff stats
- add a targeted fs_git_diff_stats command so +/- line counts are calculated only for visible or recently changed paths
- dedupe in-flight status refreshes so watcher bursts do not stack concurrent git status work

## Tests
- bun run typecheck
- TAURI_SIDECAR_PROFILE=debug ./src-tauri/scripts/build-sidecar.sh
- cargo check
- cargo test fs_explorer
- git diff --check