### PR TITLE
feat(agent-history): add project history panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Acorn은 여러 AI 코딩 에이전트(Claude Code / Codex / Gemini / Ollama / l
 - Acorn 세션에서 `claude` / `codex`를 띄운 뒤 앱을 껐다 켜도 **이전 대화 그대로 이어서** 사용 가능
 - 별도 설정 / 설치 단계 없음 — 그냥 `claude` 또는 `codex` 치면 자동 적용
 - 사용자가 직접 옵션이나 서브커맨드를 지정한 호출은 그대로 통과
+- 우측 **Sessions** 패널에서 프로젝트별 Claude / Codex transcript 히스토리를 확인하고, 더블 클릭으로 새 터미널에서 이어서 실행
 
 ### 🛏️ Background sessions
 - Acorn 앱을 종료·재시작해도 **PTY 세션이 그대로 살아 있음** — 다시 열면 화면도 복원
@@ -99,6 +100,9 @@ Acorn은 여러 AI 코딩 에이전트(Claude Code / Codex / Gemini / Ollama / l
   - Conversation / Commits / Checks / Files 탭
   - PR 본문의 task checkbox 토글
   - 머지 메시지를 설치된 AI CLI(`claude` / `codex` / `gemini` / `ollama` / `llm`)로 자동 생성
+- **Sessions** — 선택한 프로젝트의 Claude / Codex JSONL transcript 히스토리, 미리보기, cwd, 최근 활동 시간 표시
+  - 더블 클릭으로 resume 명령을 새 터미널에서 실행
+  - 우클릭 메뉴에서 resume 명령 복사 또는 transcript 열기
 - **Actions** — GitHub Actions 실행 목록, workflow 필터, run 상세 보기
 
 ### 🔍 Diff 뷰어

--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -1,0 +1,413 @@
+use std::fs;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::error::{AppError, AppResult};
+
+const MAX_SCAN_FILES_PER_PROVIDER: usize = 5_000;
+const DEFAULT_LIMIT: usize = 100;
+const MAX_LIMIT: usize = 500;
+const READ_HEAD_INITIAL_BYTES: u64 = 256 * 1024;
+const READ_HEAD_MAX_BYTES: u64 = 2 * 1024 * 1024;
+const READ_TAIL_BYTES: u64 = 256 * 1024;
+const PREVIEW_CHARS: usize = 160;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentHistoryProvider {
+    Claude,
+    Codex,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentHistoryItem {
+    pub provider: AgentHistoryProvider,
+    pub id: String,
+    pub title: String,
+    pub preview: Option<String>,
+    pub cwd: Option<String>,
+    pub transcript_path: String,
+    pub updated_at: u64,
+    pub resume_command: Option<String>,
+}
+
+pub fn list_agent_history(
+    repo_path: PathBuf,
+    limit: Option<usize>,
+) -> AppResult<Vec<AgentHistoryItem>> {
+    let repo = normalize_path(&repo_path);
+    if repo.as_os_str().is_empty() {
+        return Err(AppError::InvalidPath(repo_path.display().to_string()));
+    }
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+
+    let mut items = Vec::new();
+    items.extend(scan_codex(&repo));
+    items.extend(scan_claude(&repo));
+    items.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    items.truncate(limit);
+    Ok(items)
+}
+
+fn scan_codex(repo: &Path) -> Vec<AgentHistoryItem> {
+    let Some(root) = codex_sessions_root() else {
+        return Vec::new();
+    };
+    let files = collect_files(&root, |path| {
+        path.extension().and_then(|s| s.to_str()) == Some("jsonl")
+            && path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(|name| name.starts_with("rollout-"))
+                .unwrap_or(false)
+    });
+    files
+        .into_iter()
+        .filter_map(|path| parse_codex_file(&path, repo))
+        .collect()
+}
+
+fn scan_claude(repo: &Path) -> Vec<AgentHistoryItem> {
+    let Some(root) = home_dir().map(|home| home.join(".claude")) else {
+        return Vec::new();
+    };
+    let files = collect_files(&root, |path| {
+        path.extension().and_then(|s| s.to_str()) == Some("jsonl")
+    });
+    files
+        .into_iter()
+        .filter_map(|path| parse_claude_file(&path, repo))
+        .collect()
+}
+
+fn collect_files(root: &Path, accept: impl Fn(&Path) -> bool) -> Vec<PathBuf> {
+    if !root.is_dir() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(path);
+            } else if file_type.is_file() && accept(&path) {
+                out.push(path);
+            }
+        }
+    }
+
+    out.sort_by(|a, b| file_updated_at(b).cmp(&file_updated_at(a)));
+    out.truncate(MAX_SCAN_FILES_PER_PROVIDER);
+    out
+}
+
+fn parse_codex_file(path: &Path, repo: &Path) -> Option<AgentHistoryItem> {
+    let mut state = ParsedAgentFile::default();
+    for line in sample_lines(path).ok()? {
+        let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
+            continue;
+        };
+        let payload = value.get("payload");
+
+        if state.id.is_none() {
+            state.id = string_at(payload, "id")
+                .or_else(|| string_at(payload, "session_id"))
+                .or_else(|| string_at(Some(&value), "session_id"));
+        }
+        if state.cwd.is_none() {
+            state.cwd = string_at(payload, "cwd")
+                .or_else(|| string_at(Some(&value), "cwd"))
+                .or_else(|| extract_cwd_from_text(&value_texts(&value)));
+        }
+
+        let role = string_at(payload, "role");
+        let text = first_text(&value_texts(&value));
+        if state.title.is_none() && role.as_deref() == Some("user") {
+            state.title = text.clone();
+        }
+        if role.as_deref() == Some("assistant") {
+            state.preview = text.clone().or(state.preview);
+        }
+        if state.preview.is_none() {
+            state.preview = response_text(&value).or(state.preview);
+        }
+    }
+
+    let cwd = state.cwd.clone()?;
+    if !path_is_within(&cwd, repo) {
+        return None;
+    }
+    let id = state.id.or_else(|| codex_id_from_filename(path))?;
+    let title = state
+        .title
+        .or_else(|| state.preview.clone())
+        .unwrap_or_else(|| "Codex session".to_string());
+    Some(AgentHistoryItem {
+        provider: AgentHistoryProvider::Codex,
+        resume_command: Some(format!("codex resume {id}")),
+        id,
+        title: collapse_preview(&title, PREVIEW_CHARS)
+            .unwrap_or_else(|| "Codex session".to_string()),
+        preview: state
+            .preview
+            .and_then(|s| collapse_preview(&s, PREVIEW_CHARS)),
+        cwd: Some(cwd),
+        transcript_path: path.display().to_string(),
+        updated_at: file_updated_at(path),
+    })
+}
+
+fn parse_claude_file(path: &Path, repo: &Path) -> Option<AgentHistoryItem> {
+    let mut state = ParsedAgentFile::default();
+    for line in sample_lines(path).ok()? {
+        let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
+            continue;
+        };
+        if state.id.is_none() {
+            state.id = string_at(Some(&value), "sessionId");
+        }
+        if state.cwd.is_none() {
+            state.cwd =
+                string_at(Some(&value), "cwd").or_else(|| string_at(Some(&value), "project"));
+        }
+        let ty = string_at(Some(&value), "type");
+        let text = first_text(&value_texts(&value));
+        if state.title.is_none() && ty.as_deref() == Some("user") {
+            state.title = text.clone();
+        }
+        if ty.as_deref() == Some("assistant") {
+            state.preview = text.clone().or(state.preview);
+        }
+    }
+
+    let cwd = state.cwd.clone()?;
+    if !path_is_within(&cwd, repo) {
+        return None;
+    }
+    let id = state.id.or_else(|| {
+        path.file_stem()
+            .and_then(|s| s.to_str())
+            .map(str::to_string)
+    })?;
+    let title = state
+        .title
+        .or_else(|| state.preview.clone())
+        .unwrap_or_else(|| "Claude session".to_string());
+    Some(AgentHistoryItem {
+        provider: AgentHistoryProvider::Claude,
+        resume_command: Some(format!("claude --resume {id}")),
+        id,
+        title: collapse_preview(&title, PREVIEW_CHARS)
+            .unwrap_or_else(|| "Claude session".to_string()),
+        preview: state
+            .preview
+            .and_then(|s| collapse_preview(&s, PREVIEW_CHARS)),
+        cwd: Some(cwd),
+        transcript_path: path.display().to_string(),
+        updated_at: file_updated_at(path),
+    })
+}
+
+#[derive(Default)]
+struct ParsedAgentFile {
+    id: Option<String>,
+    title: Option<String>,
+    preview: Option<String>,
+    cwd: Option<String>,
+}
+
+fn sample_lines(path: &Path) -> std::io::Result<Vec<String>> {
+    let mut file = fs::File::open(path)?;
+    let len = file.metadata()?.len();
+    let mut bytes = Vec::new();
+    let head_max = READ_HEAD_MAX_BYTES.min(len);
+    let mut read = 0_u64;
+    let mut saw_newline = false;
+    while read < head_max {
+        let chunk_len = (64 * 1024).min(head_max - read);
+        let mut chunk = vec![0; chunk_len as usize];
+        file.read_exact(&mut chunk)?;
+        saw_newline = saw_newline || chunk.contains(&b'\n');
+        bytes.extend(chunk);
+        read += chunk_len;
+        if read >= READ_HEAD_INITIAL_BYTES && saw_newline {
+            break;
+        }
+    }
+
+    if len > read {
+        let tail_start = len.saturating_sub(READ_TAIL_BYTES);
+        file.seek(SeekFrom::Start(tail_start))?;
+        let mut tail = Vec::new();
+        file.read_to_end(&mut tail)?;
+        bytes.push(b'\n');
+        bytes.extend(tail);
+    }
+
+    Ok(String::from_utf8_lossy(&bytes)
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with('{'))
+        .map(str::to_string)
+        .collect())
+}
+
+fn value_texts(value: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    collect_texts(value.get("message").unwrap_or(value), &mut out);
+    if let Some(payload) = value.get("payload") {
+        collect_texts(payload, &mut out);
+    }
+    out
+}
+
+fn collect_texts(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::String(s) => {
+            if !s.trim().is_empty() {
+                out.push(s.clone());
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_texts(item, out);
+            }
+        }
+        Value::Object(map) => {
+            for key in ["text", "output_text", "message", "content"] {
+                if let Some(child) = map.get(key) {
+                    collect_texts(child, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn first_text(texts: &[String]) -> Option<String> {
+    texts
+        .iter()
+        .map(|s| s.trim())
+        .find(|s| !s.is_empty() && !looks_like_context_block(s))
+        .map(str::to_string)
+}
+
+fn response_text(value: &Value) -> Option<String> {
+    for pointer in [
+        "/payload/response/output",
+        "/response_payload/output",
+        "/payload/output",
+    ] {
+        if let Some(v) = value.pointer(pointer) {
+            let texts = value_texts(v);
+            if let Some(text) = first_text(&texts) {
+                return Some(text);
+            }
+        }
+    }
+    None
+}
+
+fn looks_like_context_block(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("<environment_context>")
+        || lower.contains("<cwd>")
+        || lower.contains("# agents.md")
+        || lower.contains("<instructions>")
+}
+
+fn extract_cwd_from_text(texts: &[String]) -> Option<String> {
+    for text in texts {
+        let Some(start) = text.find("<cwd>") else {
+            continue;
+        };
+        let after = start + "<cwd>".len();
+        let Some(end) = text[after..].find("</cwd>") else {
+            continue;
+        };
+        let cwd = text[after..after + end].trim();
+        if !cwd.is_empty() {
+            return Some(cwd.to_string());
+        }
+    }
+    None
+}
+
+fn string_at(value: Option<&Value>, key: &str) -> Option<String> {
+    value?
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+fn codex_id_from_filename(path: &Path) -> Option<String> {
+    let stem = path.file_stem()?.to_str()?;
+    stem.rsplit('-').next().map(str::to_string)
+}
+
+fn collapse_preview(s: &str, max_chars: usize) -> Option<String> {
+    let collapsed = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() {
+        return None;
+    }
+    let mut out = collapsed.chars().take(max_chars).collect::<String>();
+    if collapsed.chars().count() > max_chars {
+        out.push('…');
+    }
+    Some(out)
+}
+
+fn path_is_within(cwd: &str, repo: &Path) -> bool {
+    let cwd = normalize_path(Path::new(cwd));
+    cwd == repo || cwd.starts_with(repo)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| {
+        let mut out = PathBuf::new();
+        for component in path.components() {
+            match component {
+                std::path::Component::CurDir => {}
+                std::path::Component::ParentDir => {
+                    out.pop();
+                }
+                other => out.push(other.as_os_str()),
+            }
+        }
+        out
+    })
+}
+
+fn file_updated_at(path: &Path) -> u64 {
+    fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn codex_sessions_root() -> Option<PathBuf> {
+    std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .or_else(|| home_dir().map(|home| home.join(".codex")))
+        .map(|root| root.join("sessions"))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    directories::UserDirs::new().map(|dirs| dirs.home_dir().to_path_buf())
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,6 +5,7 @@ use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System, U
 use tauri::{AppHandle, Runtime, State};
 use uuid::Uuid;
 
+use crate::agent_history::{self, AgentHistoryItem};
 use crate::agent_resume;
 use crate::error::{AppError, AppResult};
 use crate::git_ops::{self, CommitInfo, DiffPayload, StagedFile};
@@ -101,6 +102,14 @@ pub fn list_system_fonts() -> Vec<String> {
     }
 
     fonts.into_iter().collect()
+}
+
+#[tauri::command]
+pub fn list_agent_history(
+    repo_path: String,
+    limit: Option<usize>,
+) -> AppResult<Vec<AgentHistoryItem>> {
+    agent_history::list_agent_history(PathBuf::from(repo_path), limit)
 }
 
 /// Stop the running IPC listener (if any) and spawn a fresh one. Used by

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod agent_history;
 mod agent_resume;
 mod agent_resume_persister;
 mod claude_util;
@@ -333,6 +334,7 @@ pub fn run() {
             commands::get_acorn_ipc_status,
             commands::ipc_restart,
             commands::list_system_fonts,
+            commands::list_agent_history,
             commands::get_claude_resume_candidate,
             commands::acknowledge_claude_resume,
             commands::get_codex_resume_candidate,

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -691,7 +691,7 @@ function AgentHistoryTab({ repoPath }: { repoPath: string }) {
                       "mt-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide",
                       item.provider === "codex"
                         ? "bg-accent/15 text-accent"
-                        : "bg-fg-muted/15 text-fg-muted",
+                        : "bg-warning/15 text-warning",
                     )}
                   >
                     {item.provider}

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -15,6 +15,7 @@ import {
   GitPullRequest,
   GitPullRequestClosed,
   Globe,
+  History,
   Loader2,
   ListTodo,
   Maximize2,
@@ -33,6 +34,7 @@ import { useSettings } from "../lib/settings";
 import { useAppStore } from "../store";
 import type {
   AccountSummary,
+  AgentHistoryItem,
   CommitInfo,
   DiffPayload,
   PrStateFilter,
@@ -195,6 +197,12 @@ export function RightPanel() {
           onClick={() => setRightTab("prs")}
         />
         <TabButton
+          icon={<History size={14} />}
+          label={rt(t, "rightPanel.tabs.history")}
+          active={rightTab === "history"}
+          onClick={() => setRightTab("history")}
+        />
+        <TabButton
           icon={<Activity size={14} />}
           label={rt(t, "rightPanel.tabs.actions")}
           active={rightTab === "actions"}
@@ -246,6 +254,12 @@ export function RightPanel() {
         ) : rightTab === "files" ? (
           repoPath ? (
             <FileExplorer key={repoPath} rootPath={repoPath} />
+          ) : (
+            <Empty msg={rt(t, "rightPanel.empty.noProject")} />
+          )
+        ) : rightTab === "history" ? (
+          repoPath ? (
+            <AgentHistoryTab key={repoPath} repoPath={repoPath} />
           ) : (
             <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
@@ -607,6 +621,140 @@ function countByStatus(todos: TodoItem[]) {
     else pending++;
   }
   return { pending, in_progress, completed };
+}
+
+function AgentHistoryTab({ repoPath }: { repoPath: string }) {
+  const t = useTranslation();
+  const [items, setItems] = useState<AgentHistoryItem[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchHistory = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setItems(await api.listAgentHistory(repoPath, 100));
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [repoPath]);
+
+  useEffect(() => {
+    void fetchHistory();
+  }, [fetchHistory]);
+
+  async function copy(text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-2 py-1.5">
+        <div className="min-w-0 flex-1 truncate text-[11px] text-fg-muted">
+          {items
+            ? rtf(t, "rightPanel.history.count", { count: items.length })
+            : rt(t, "rightPanel.history.loading")}
+        </div>
+        <RefreshButton
+          onClick={() => void fetchHistory()}
+          loading={loading}
+          size={12}
+        />
+      </div>
+      <div className="flex-1 overflow-x-hidden overflow-y-auto">
+        {error ? (
+          <div className="p-3 text-xs text-danger">{error}</div>
+        ) : !items ? (
+          <div>
+            {Array.from({ length: 8 }).map((_, i) => (
+              <SkeletonRow key={i} pulseDelayMs={i * 70} />
+            ))}
+          </div>
+        ) : items.length === 0 ? (
+          <Empty msg={rt(t, "rightPanel.history.empty")} />
+        ) : (
+          <div className="divide-y divide-border/50">
+            {items.map((item) => (
+              <div
+                key={`${item.provider}:${item.id}:${item.transcript_path}`}
+                className="group px-3 py-2.5 hover:bg-bg-elevated/60"
+              >
+                <div className="flex items-start gap-2">
+                  <span
+                    className={cn(
+                      "mt-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+                      item.provider === "codex"
+                        ? "bg-accent/15 text-accent"
+                        : "bg-fg-muted/15 text-fg-muted",
+                    )}
+                  >
+                    {item.provider}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-xs font-medium text-fg">
+                      {item.title}
+                    </div>
+                    {item.preview ? (
+                      <div className="mt-1 max-h-8 overflow-hidden text-[11px] leading-4 text-fg-muted">
+                        {item.preview}
+                      </div>
+                    ) : null}
+                    <div className="mt-1 flex min-w-0 items-center gap-2 text-[10.5px] text-fg-muted/80">
+                      <Tooltip label={absoluteTime(item.updated_at)} side="bottom">
+                        <span className="shrink-0 font-mono">
+                          {relativeTime(item.updated_at, t)}
+                        </span>
+                      </Tooltip>
+                      {item.cwd ? (
+                        <>
+                          <span className="shrink-0 opacity-50">·</span>
+                          <span className="truncate font-mono">{item.cwd}</span>
+                        </>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1 opacity-0 transition group-hover:opacity-100">
+                    {item.resume_command ? (
+                      <Tooltip
+                        label={rt(t, "rightPanel.history.copyResume")}
+                        side="bottom"
+                      >
+                        <button
+                          type="button"
+                          onClick={() => void copy(item.resume_command ?? "")}
+                          className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+                        >
+                          <Copy size={12} />
+                        </button>
+                      </Tooltip>
+                    ) : null}
+                    <Tooltip
+                      label={rt(t, "rightPanel.history.openTranscript")}
+                      side="bottom"
+                    >
+                      <button
+                        type="button"
+                        onClick={() => void openPath(item.transcript_path)}
+                        className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+                      >
+                        <ExternalLink size={12} />
+                      </button>
+                    </Tooltip>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }
 
 function CommitsTab({

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -725,7 +725,7 @@ function AgentHistoryTab({ repoPath }: { repoPath: string }) {
                       "mt-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide",
                       item.provider === "codex"
                         ? "bg-[#3867ff]/15 text-[#5f7dff]"
-                        : "bg-warning/15 text-warning",
+                        : "bg-[#de7356]/15 text-[#de7356]",
                     )}
                   >
                     {item.provider}

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -724,7 +724,7 @@ function AgentHistoryTab({ repoPath }: { repoPath: string }) {
                     className={cn(
                       "mt-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide",
                       item.provider === "codex"
-                        ? "bg-accent/15 text-accent"
+                        ? "bg-[#3867ff]/15 text-[#5f7dff]"
                         : "bg-warning/15 text-warning",
                     )}
                   >

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -20,6 +20,7 @@ import {
   ListTodo,
   Maximize2,
   MinusCircle,
+  Play,
   Search,
   X,
 } from "lucide-react";
@@ -625,9 +626,16 @@ function countByStatus(todos: TodoItem[]) {
 
 function AgentHistoryTab({ repoPath }: { repoPath: string }) {
   const t = useTranslation();
+  const createSession = useAppStore((s) => s.createSession);
+  const setPendingTerminalInput = useAppStore((s) => s.setPendingTerminalInput);
   const [items, setItems] = useState<AgentHistoryItem[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [menu, setMenu] = useState<{
+    x: number;
+    y: number;
+    item: AgentHistoryItem;
+  } | null>(null);
 
   const fetchHistory = useCallback(async () => {
     setLoading(true);
@@ -648,6 +656,27 @@ function AgentHistoryTab({ repoPath }: { repoPath: string }) {
   async function copy(text: string) {
     try {
       await navigator.clipboard.writeText(text);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function runSession(item: AgentHistoryItem) {
+    if (!item.resume_command) return;
+    setError(null);
+    try {
+      const created = await createSession(
+        `${item.provider} ${rt(t, "rightPanel.history.resumeSessionName")}`,
+        repoPath,
+      );
+      if (!created) {
+        setError(
+          useAppStore.getState().error ??
+            rt(t, "rightPanel.history.createFailed"),
+        );
+        return;
+      }
+      setPendingTerminalInput(created.id, item.resume_command);
     } catch (e) {
       setError(String(e));
     }
@@ -683,7 +712,12 @@ function AgentHistoryTab({ repoPath }: { repoPath: string }) {
             {items.map((item) => (
               <div
                 key={`${item.provider}:${item.id}:${item.transcript_path}`}
-                className="group px-3 py-2.5 hover:bg-bg-elevated/60"
+                className="group cursor-default px-3 py-2.5 hover:bg-bg-elevated/60"
+                onDoubleClick={() => void runSession(item)}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  setMenu({ x: e.clientX, y: e.clientY, item });
+                }}
               >
                 <div className="flex items-start gap-2">
                   <span
@@ -719,40 +753,41 @@ function AgentHistoryTab({ repoPath }: { repoPath: string }) {
                       ) : null}
                     </div>
                   </div>
-                  <div className="flex shrink-0 items-center gap-1 opacity-0 transition group-hover:opacity-100">
-                    {item.resume_command ? (
-                      <Tooltip
-                        label={rt(t, "rightPanel.history.copyResume")}
-                        side="bottom"
-                      >
-                        <button
-                          type="button"
-                          onClick={() => void copy(item.resume_command ?? "")}
-                          className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-                        >
-                          <Copy size={12} />
-                        </button>
-                      </Tooltip>
-                    ) : null}
-                    <Tooltip
-                      label={rt(t, "rightPanel.history.openTranscript")}
-                      side="bottom"
-                    >
-                      <button
-                        type="button"
-                        onClick={() => void openPath(item.transcript_path)}
-                        className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-                      >
-                        <ExternalLink size={12} />
-                      </button>
-                    </Tooltip>
-                  </div>
                 </div>
               </div>
             ))}
           </div>
         )}
       </div>
+      <ContextMenu
+        open={menu !== null}
+        x={menu?.x ?? 0}
+        y={menu?.y ?? 0}
+        onClose={() => setMenu(null)}
+        items={
+          menu
+            ? ([
+                {
+                  label: rt(t, "rightPanel.history.runSession"),
+                  icon: <Play size={12} />,
+                  disabled: !menu.item.resume_command,
+                  onClick: () => void runSession(menu.item),
+                },
+                {
+                  label: rt(t, "rightPanel.history.copyResume"),
+                  icon: <Copy size={12} />,
+                  disabled: !menu.item.resume_command,
+                  onClick: () => void copy(menu.item.resume_command ?? ""),
+                },
+                {
+                  label: rt(t, "rightPanel.history.openTranscript"),
+                  icon: <ExternalLink size={12} />,
+                  onClick: () => void openPath(menu.item.transcript_path),
+                },
+              ] satisfies ContextMenuItem[])
+            : []
+        }
+      />
     </div>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
   AcornIpcStatus,
+  AgentHistoryItem,
   CommitInfo,
   DiffPayload,
   GeneratedCommitMessage,
@@ -235,6 +236,12 @@ export const api = {
   },
   listSystemFonts(): Promise<string[]> {
     return invoke<string[]>("list_system_fonts");
+  },
+  listAgentHistory(repoPath: string, limit = 100): Promise<AgentHistoryItem[]> {
+    return invoke<AgentHistoryItem[]>("list_agent_history", {
+      repoPath,
+      limit,
+    });
   },
   readSessionTodos(sessionId: string, cwd: string): Promise<TodoItem[]> {
     return invoke<TodoItem[]>("read_session_todos", { sessionId, cwd });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,6 +44,19 @@ export interface Project {
   position: number;
 }
 
+export type AgentHistoryProvider = "claude" | "codex";
+
+export interface AgentHistoryItem {
+  provider: AgentHistoryProvider;
+  id: string;
+  title: string;
+  preview: string | null;
+  cwd: string | null;
+  transcript_path: string;
+  updated_at: number;
+  resume_command: string | null;
+}
+
 export interface CommitInfo {
   sha: string;
   short_sha: string;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -596,8 +596,11 @@
       "loading": "Scanning agent sessions…",
       "count": "{count} agent sessions",
       "empty": "No Claude or Codex sessions found for this project",
+      "runSession": "Run in new terminal",
       "copyResume": "Copy resume command",
-      "openTranscript": "Open transcript"
+      "openTranscript": "Open transcript",
+      "resumeSessionName": "resume",
+      "createFailed": "Failed to create terminal session"
     },
     "staged": {
       "empty": "No staged or modified files",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -567,6 +567,7 @@
       "commits": "Commits",
       "staged": "Staged",
       "prs": "PRs",
+      "history": "History",
       "actions": "Actions"
     },
     "empty": {
@@ -590,6 +591,13 @@
       "pushed": "Pushed",
       "notPushed": "Not pushed",
       "selectToSeeDiff": "Select a commit to see diff"
+    },
+    "history": {
+      "loading": "Scanning agent sessions…",
+      "count": "{count} agent sessions",
+      "empty": "No Claude or Codex sessions found for this project",
+      "copyResume": "Copy resume command",
+      "openTranscript": "Open transcript"
     },
     "staged": {
       "empty": "No staged or modified files",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -567,7 +567,7 @@
       "commits": "Commits",
       "staged": "Staged",
       "prs": "PRs",
-      "history": "History",
+      "history": "Sessions",
       "actions": "Actions"
     },
     "empty": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -567,6 +567,7 @@
       "commits": "커밋",
       "staged": "스테이징",
       "prs": "PR",
+      "history": "히스토리",
       "actions": "작업"
     },
     "empty": {
@@ -590,6 +591,13 @@
       "pushed": "푸시됨",
       "notPushed": "푸시되지 않음",
       "selectToSeeDiff": "diff를 보려면 커밋을 선택하세요"
+    },
+    "history": {
+      "loading": "agent 세션을 스캔하는 중…",
+      "count": "agent 세션 {count}개",
+      "empty": "이 프로젝트의 Claude 또는 Codex 세션을 찾지 못했습니다",
+      "copyResume": "resume 명령 복사",
+      "openTranscript": "transcript 열기"
     },
     "staged": {
       "empty": "스테이징되었거나 수정된 파일이 없습니다",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -567,7 +567,7 @@
       "commits": "커밋",
       "staged": "스테이징",
       "prs": "PR",
-      "history": "히스토리",
+      "history": "세션",
       "actions": "작업"
     },
     "empty": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -596,8 +596,11 @@
       "loading": "agent 세션을 스캔하는 중…",
       "count": "agent 세션 {count}개",
       "empty": "이 프로젝트의 Claude 또는 Codex 세션을 찾지 못했습니다",
+      "runSession": "새 터미널에서 실행",
       "copyResume": "resume 명령 복사",
-      "openTranscript": "transcript 열기"
+      "openTranscript": "transcript 열기",
+      "resumeSessionName": "resume",
+      "createFailed": "터미널 세션을 만들지 못했습니다"
     },
     "staged": {
       "empty": "스테이징되었거나 수정된 파일이 없습니다",

--- a/src/store.ts
+++ b/src/store.ts
@@ -29,6 +29,7 @@ type RightTab =
   | "commits"
   | "staged"
   | "prs"
+  | "history"
   | "actions"
   | "files";
 


### PR DESCRIPTION
## Summary
- add a backend `list_agent_history` command that scans local Claude and Codex JSONL transcripts, extracts lightweight cwd/title/preview metadata, and filters sessions to the selected repo path
- add a right-panel History tab that lists matched agent sessions with provider, preview, cwd, relative activity time, transcript open action, and copy-resume command
- wire the new API/types/store tab state and English/Korean copy for the History panel

## Tests
- ./node_modules/.bin/tsc --noEmit
- ./src-tauri/scripts/build-sidecar.sh
- cargo check
- git diff --check