### PR TITLE
feat(right-panel): group tabs into Code / GitHub / Agents

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1656,6 +1656,14 @@ pub async fn commit_web_url(repo_path: String, sha: String) -> AppResult<Option<
     git_ops::web_url_for_commit(&PathBuf::from(repo_path), &sha)
 }
 
+/// `Some("owner/repo")` when the repo's `origin` remote points at GitHub,
+/// `None` otherwise. The frontend uses this to hide the GitHub group of the
+/// right panel for non-GitHub repos. Read-only and cheap — no network calls.
+#[tauri::command]
+pub async fn github_origin_slug(repo_path: String) -> AppResult<Option<String>> {
+    git_ops::github_owner_repo(&PathBuf::from(repo_path))
+}
+
 /// Spawn an external editor on `path`. Used by the "Open in editor" action
 /// when the user has configured a custom editor command in settings.
 ///

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -297,6 +297,7 @@ pub fn run() {
             commands::list_staged,
             commands::commit_diff,
             commands::commit_web_url,
+            commands::github_origin_slug,
             commands::open_in_editor,
             commands::staged_diff,
             commands::list_pull_requests,

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1,8 +1,17 @@
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   Activity,
+  Bot,
   Check,
   CircleAlert,
+  Code2,
   CircleCheck,
   CircleDashed,
   CircleX,
@@ -33,6 +42,14 @@ import { openFileInEditor } from "../lib/editor";
 import { joinPath } from "../lib/paths";
 import { useSettings } from "../lib/settings";
 import { useAppStore } from "../store";
+import { useIsGitHubRepo } from "../lib/useIsGitHubRepo";
+import {
+  RIGHT_GROUPS,
+  groupOfTab,
+  tabsForGroup,
+  type RightGroup,
+  type RightTab,
+} from "../lib/rightPanelGroups";
 import type {
   AccountSummary,
   AgentHistoryItem,
@@ -117,6 +134,7 @@ export function RightPanel() {
   const activeProject = useAppStore((s) => s.activeProject);
   const rightTab = useAppStore((s) => s.rightTab);
   const setRightTab = useAppStore((s) => s.setRightTab);
+  const setRightGroup = useAppStore((s) => s.setRightGroup);
   const active = sessions.find((s) => s.id === activeSessionId);
   // The session's recorded worktree path is what we set at spawn time. The
   // PTY child (or any descendant) may have chdir'd since — most notably via
@@ -146,15 +164,41 @@ export function RightPanel() {
     active?.worktree_path ?? null,
   );
   const showTodos = todosState.todos.length > 0;
+  // null while the first probe is in flight — keep GitHub visible during
+  // that brief window so the bar doesn't flicker on first paint.
+  const isGitHubRepo = useIsGitHubRepo(repoPath);
+  const githubVisible = isGitHubRepo !== false;
 
-  // If the user is sitting on Todos but the underlying list emptied (e.g.
-  // session ended, switched to a session with no todos), fall back rather
-  // than render an empty hidden tab.
+  const visibleTabsByGroup = useMemo<
+    Record<RightGroup, ReadonlyArray<RightTab>>
+  >(
+    () => ({
+      code: tabsForGroup("code"),
+      github: githubVisible ? tabsForGroup("github") : [],
+      agents: showTodos
+        ? tabsForGroup("agents")
+        : tabsForGroup("agents").filter((tab) => tab !== "todos"),
+    }),
+    [githubVisible, showTodos],
+  );
+  const visibleGroups = useMemo(
+    () => RIGHT_GROUPS.filter((g) => visibleTabsByGroup[g].length > 0),
+    [visibleTabsByGroup],
+  );
+  const activeGroup: RightGroup = visibleGroups.includes(groupOfTab(rightTab))
+    ? groupOfTab(rightTab)
+    : (visibleGroups[0] ?? "code");
+  const visibleTabs = visibleTabsByGroup[activeGroup];
+
+  // If the user is sitting on a tab that just became invisible (Todos emptied,
+  // GitHub origin disappeared, etc.), slide them to the nearest visible tab
+  // rather than render the panel against a stale selection.
   useEffect(() => {
-    if (rightTab === "todos" && !showTodos && todosState.loaded) {
-      setRightTab("commits");
+    if (visibleTabs.length === 0) return;
+    if (!visibleTabs.includes(rightTab)) {
+      setRightTab(visibleTabs[0]);
     }
-  }, [rightTab, showTodos, todosState.loaded, setRightTab]);
+  }, [rightTab, visibleTabs, setRightTab]);
 
   return (
     <aside className="flex h-full w-full flex-col bg-bg-sidebar">
@@ -163,53 +207,38 @@ export function RightPanel() {
           "flex shrink-0 overflow-x-auto whitespace-nowrap border-b border-border",
           "[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
         )}
+        aria-label="Right panel group"
       >
-        <TabButton
-          icon={<FolderTree size={14} />}
-          label={rt(t, "rightPanel.tabs.files")}
-          active={rightTab === "files"}
-          onClick={() => setRightTab("files")}
-        />
-        {showTodos ? (
+        {visibleGroups.map((group) => (
           <TabButton
-            icon={<ListTodo size={14} />}
-            label={rt(t, "rightPanel.tabs.todos")}
-            badge={todosState.todos.length}
-            active={rightTab === "todos"}
-            onClick={() => setRightTab("todos")}
+            key={group}
+            icon={groupIcon(group)}
+            label={rt(t, groupLabelKey(group))}
+            active={group === activeGroup}
+            onClick={() => setRightGroup(group)}
           />
-        ) : null}
-        <TabButton
-          icon={<GitCommit size={14} />}
-          label={rt(t, "rightPanel.tabs.commits")}
-          active={rightTab === "commits"}
-          onClick={() => setRightTab("commits")}
-        />
-        <TabButton
-          icon={<FileDiff size={14} />}
-          label={rt(t, "rightPanel.tabs.staged")}
-          active={rightTab === "staged"}
-          onClick={() => setRightTab("staged")}
-        />
-        <TabButton
-          icon={<GitPullRequest size={14} />}
-          label={rt(t, "rightPanel.tabs.prs")}
-          active={rightTab === "prs"}
-          onClick={() => setRightTab("prs")}
-        />
-        <TabButton
-          icon={<History size={14} />}
-          label={rt(t, "rightPanel.tabs.history")}
-          active={rightTab === "history"}
-          onClick={() => setRightTab("history")}
-        />
-        <TabButton
-          icon={<Activity size={14} />}
-          label={rt(t, "rightPanel.tabs.actions")}
-          active={rightTab === "actions"}
-          onClick={() => setRightTab("actions")}
-        />
+        ))}
       </nav>
+      {visibleTabs.length > 0 ? (
+        <nav
+          className={cn(
+            "flex shrink-0 overflow-x-auto whitespace-nowrap border-b border-border bg-bg-elevated/30",
+            "[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+          )}
+          aria-label="Right panel sub-tab"
+        >
+          {visibleTabs.map((tab) => (
+            <SubTabButton
+              key={tab}
+              icon={tabIcon(tab)}
+              label={rt(t, tabLabelKey(tab))}
+              badge={tab === "todos" ? todosState.todos.length : undefined}
+              active={tab === rightTab}
+              onClick={() => setRightTab(tab)}
+            />
+          ))}
+        </nav>
+      ) : null}
       <div className="flex-1 overflow-hidden">
         {rightTab === "todos" ? (
           active && showTodos ? (
@@ -336,6 +365,83 @@ function TabButton({ icon, label, active, onClick, badge, className }: TabButton
       ) : null}
     </button>
   );
+}
+
+// Sub-tabs sit under the group bar with denser padding and a lighter inactive
+// state, so the eye registers "group is primary, sub-tab is secondary".
+function SubTabButton({ icon, label, active, onClick, badge }: TabButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "relative flex shrink-0 items-center justify-center gap-1.5 px-2.5 py-1.5 text-[11px] transition",
+        active
+          ? "text-fg after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-accent/40"
+          : "text-fg-muted/80 hover:text-fg",
+      )}
+    >
+      {icon}
+      {label}
+      {typeof badge === "number" && badge > 0 ? (
+        <span
+          className={cn(
+            "rounded-full px-1 py-px text-[9px] font-medium tabular-nums",
+            active
+              ? "bg-accent/20 text-fg"
+              : "bg-fg-muted/15 text-fg-muted",
+          )}
+        >
+          {badge}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function groupIcon(group: RightGroup): ReactNode {
+  switch (group) {
+    case "code":
+      return <Code2 size={14} />;
+    case "github":
+      return <Globe size={14} />;
+    case "agents":
+      return <Bot size={14} />;
+  }
+}
+
+function groupLabelKey(group: RightGroup): RightPanelTranslationKey {
+  switch (group) {
+    case "code":
+      return "rightPanel.groups.code";
+    case "github":
+      return "rightPanel.groups.github";
+    case "agents":
+      return "rightPanel.groups.agents";
+  }
+}
+
+function tabIcon(tab: RightTab): ReactNode {
+  switch (tab) {
+    case "files":
+      return <FolderTree size={12} />;
+    case "staged":
+      return <FileDiff size={12} />;
+    case "commits":
+      return <GitCommit size={12} />;
+    case "prs":
+      return <GitPullRequest size={12} />;
+    case "actions":
+      return <Activity size={12} />;
+    case "todos":
+      return <ListTodo size={12} />;
+    case "history":
+      return <History size={12} />;
+  }
+}
+
+function tabLabelKey(tab: RightTab): RightPanelTranslationKey {
+  return `rightPanel.tabs.${tab}` as RightPanelTranslationKey;
 }
 
 function Empty({ msg }: { msg: string }) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -100,6 +100,11 @@ export const api = {
   commitWebUrl(repoPath: string, sha: string): Promise<string | null> {
     return invoke<string | null>("commit_web_url", { repoPath, sha });
   },
+  /** Resolve the repo's GitHub `owner/repo` slug, or null when the origin
+   *  remote isn't a GitHub host. Used to conditionally hide GitHub-only UI. */
+  githubOriginSlug(repoPath: string): Promise<string | null> {
+    return invoke<string | null>("github_origin_slug", { repoPath });
+  },
   openInEditor(command: string, args: string[], path: string): Promise<void> {
     return invoke<void>("open_in_editor", { command, args, path });
   },

--- a/src/lib/rightPanelGroups.ts
+++ b/src/lib/rightPanelGroups.ts
@@ -1,0 +1,49 @@
+export type RightGroup = "code" | "github" | "agents";
+
+export type RightTab =
+  | "files"
+  | "staged"
+  | "commits"
+  | "prs"
+  | "actions"
+  | "todos"
+  | "history";
+
+export const RIGHT_GROUPS: ReadonlyArray<RightGroup> = ["code", "github", "agents"];
+
+const TABS_BY_GROUP: Record<RightGroup, ReadonlyArray<RightTab>> = {
+  code: ["files", "staged", "commits"],
+  github: ["prs", "actions"],
+  agents: ["todos", "history"],
+};
+
+export function tabsForGroup(group: RightGroup): ReadonlyArray<RightTab> {
+  return TABS_BY_GROUP[group];
+}
+
+export function groupOfTab(tab: RightTab): RightGroup {
+  for (const group of RIGHT_GROUPS) {
+    if (TABS_BY_GROUP[group].includes(tab)) return group;
+  }
+  return "code";
+}
+
+export function defaultTabForGroup(group: RightGroup): RightTab {
+  return TABS_BY_GROUP[group][0];
+}
+
+export function defaultTabByGroup(): Record<RightGroup, RightTab> {
+  return {
+    code: defaultTabForGroup("code"),
+    github: defaultTabForGroup("github"),
+    agents: defaultTabForGroup("agents"),
+  };
+}
+
+const ALL_TABS = new Set<string>(
+  RIGHT_GROUPS.flatMap((g) => TABS_BY_GROUP[g] as ReadonlyArray<string>),
+);
+
+export function isRightTab(value: unknown): value is RightTab {
+  return typeof value === "string" && ALL_TABS.has(value);
+}

--- a/src/lib/useIsGitHubRepo.ts
+++ b/src/lib/useIsGitHubRepo.ts
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { api } from "./api";
+
+/**
+ * Per-repo cache for the GitHub origin probe. The result rarely changes
+ * during a session (only when the user edits `origin`), so we resolve once
+ * per repoPath and reuse across mounts. Concurrent callers for the same
+ * repoPath share one in-flight promise.
+ */
+const cache = new Map<string, boolean>();
+const inFlight = new Map<string, Promise<boolean>>();
+
+async function probe(repoPath: string): Promise<boolean> {
+  const cached = cache.get(repoPath);
+  if (cached !== undefined) return cached;
+  const existing = inFlight.get(repoPath);
+  if (existing) return existing;
+  const promise = api
+    .githubOriginSlug(repoPath)
+    .then((slug) => {
+      const value = slug !== null;
+      cache.set(repoPath, value);
+      return value;
+    })
+    .catch((error) => {
+      // Treat probe failures as "unknown" → assume GitHub so the user still
+      // sees the GitHub tabs and their built-in error states (rather than
+      // silently hiding navigation). Don't poison the cache.
+      console.warn("[useIsGitHubRepo] probe failed", error);
+      return true;
+    })
+    .finally(() => {
+      inFlight.delete(repoPath);
+    });
+  inFlight.set(repoPath, promise);
+  return promise;
+}
+
+/**
+ * Returns `true` when `repoPath` has a GitHub `origin` remote, `false`
+ * otherwise, or `null` while the first probe is in flight (so callers can
+ * avoid flicker between "show GitHub" and "hide GitHub" on first paint).
+ */
+export function useIsGitHubRepo(repoPath: string | null): boolean | null {
+  const [state, setState] = useState<boolean | null>(() =>
+    repoPath ? (cache.get(repoPath) ?? null) : null,
+  );
+
+  useEffect(() => {
+    if (!repoPath) {
+      setState(null);
+      return;
+    }
+    const cached = cache.get(repoPath);
+    if (cached !== undefined) {
+      setState(cached);
+      return;
+    }
+    setState(null);
+    let cancelled = false;
+    void probe(repoPath).then((value) => {
+      if (cancelled) return;
+      setState(value);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [repoPath]);
+
+  return state;
+}
+
+/** Test-only: clear the module-level cache between cases. */
+export function __resetIsGitHubRepoCacheForTests(): void {
+  cache.clear();
+  inFlight.clear();
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -561,13 +561,18 @@
     }
   },
   "rightPanel": {
+    "groups": {
+      "code": "Code",
+      "github": "GitHub",
+      "agents": "Agents"
+    },
     "tabs": {
       "files": "Files",
       "todos": "Todos",
       "commits": "Commits",
       "staged": "Staged",
       "prs": "PRs",
-      "history": "Sessions",
+      "history": "History",
       "actions": "Actions"
     },
     "empty": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -561,13 +561,18 @@
     }
   },
   "rightPanel": {
+    "groups": {
+      "code": "코드",
+      "github": "GitHub",
+      "agents": "에이전트"
+    },
     "tabs": {
       "files": "파일",
       "todos": "할 일",
       "commits": "커밋",
       "staged": "스테이징",
       "prs": "PR",
-      "history": "세션",
+      "history": "기록",
       "actions": "작업"
     },
     "empty": {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -39,6 +39,7 @@ vi.mock("./lib/api", () => {
 
 import { api } from "./lib/api";
 import { useAppStore } from "./store";
+import { defaultTabByGroup } from "./lib/rightPanelGroups";
 
 const mockApi = vi.mocked(api);
 
@@ -95,6 +96,7 @@ function resetStore(): void {
       activeTabId: null,
       activeSessionId: null,
       rightTab: "commits",
+      rightTabByGroup: defaultTabByGroup(),
       workspaceTabs: {},
       prAccountByRepo: {},
       pendingTerminalInput: {},
@@ -864,5 +866,45 @@ describe("createSession returns the created session", () => {
       .createSession("x", REPO_A);
     expect(result).toBeNull();
     expect(useAppStore.getState().error).toBe("nope");
+  });
+});
+
+describe("right panel groups", () => {
+  it("setRightTab records the tab and assigns it to its group's memory slot", () => {
+    useAppStore.getState().setRightTab("prs");
+    let s = useAppStore.getState();
+    expect(s.rightTab).toBe("prs");
+    expect(s.rightTabByGroup.github).toBe("prs");
+
+    useAppStore.getState().setRightTab("actions");
+    s = useAppStore.getState();
+    expect(s.rightTab).toBe("actions");
+    expect(s.rightTabByGroup.github).toBe("actions");
+    // Other groups untouched.
+    expect(s.rightTabByGroup.code).toBe("files");
+    expect(s.rightTabByGroup.agents).toBe("todos");
+  });
+
+  it("setRightGroup restores the group's last sub-tab", () => {
+    useAppStore.getState().setRightTab("commits");
+    useAppStore.getState().setRightTab("actions");
+    useAppStore.getState().setRightTab("history");
+    expect(useAppStore.getState().rightTab).toBe("history");
+
+    useAppStore.getState().setRightGroup("code");
+    expect(useAppStore.getState().rightTab).toBe("commits");
+
+    useAppStore.getState().setRightGroup("github");
+    expect(useAppStore.getState().rightTab).toBe("actions");
+
+    useAppStore.getState().setRightGroup("agents");
+    expect(useAppStore.getState().rightTab).toBe("history");
+  });
+
+  it("setRightGroup falls back to the group's default tab when no memory exists", () => {
+    // Fresh store — rightTabByGroup is seeded with defaults; switching to a
+    // group whose memory was never written returns the default.
+    useAppStore.getState().setRightGroup("github");
+    expect(useAppStore.getState().rightTab).toBe("prs");
   });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -23,15 +23,16 @@ import {
   makeCodeWorkspaceTab,
   type FrontendWorkspaceTab,
 } from "./lib/workspaceTabs";
+import {
+  defaultTabByGroup,
+  defaultTabForGroup,
+  groupOfTab,
+  isRightTab,
+  type RightGroup,
+  type RightTab,
+} from "./lib/rightPanelGroups";
 
-type RightTab =
-  | "todos"
-  | "commits"
-  | "staged"
-  | "prs"
-  | "history"
-  | "actions"
-  | "files";
+export type { RightGroup, RightTab };
 
 const ROOT_PANE_ID: PaneId = "root";
 
@@ -72,6 +73,12 @@ interface AppStateModel {
   activeSessionId: string | null;
 
   rightTab: RightTab;
+  /**
+   * Last sub-tab selected per group. Lets the user switch groups via the
+   * top-level group bar and return to their previous sub-tab in each group
+   * without re-clicking.
+   */
+  rightTabByGroup: Record<RightGroup, RightTab>;
   /**
    * Frontend-owned tabs such as readonly code viewers. Terminal sessions
    * use their backend session id directly as the tab id and therefore do
@@ -158,6 +165,8 @@ interface AppStateModel {
   requestRemoveProject: (repoPath: string) => void;
   clearPendingRemoveProject: () => void;
   setRightTab: (tab: RightTab) => void;
+  /** Switch to `group` and restore that group's last sub-tab. */
+  setRightGroup: (group: RightGroup) => void;
   setPrAccountForRepo: (repoPath: string, login: string | null) => void;
   /** Queue a command for the next successful `pty_spawn` of `sessionId`. */
   setPendingTerminalInput: (
@@ -430,6 +439,7 @@ export const useAppStore = create<AppStateModel>()(
   activeSessionId: null,
 
   rightTab: "commits",
+  rightTabByGroup: defaultTabByGroup(),
   workspaceTabs: {},
   prAccountByRepo: {},
   pendingTerminalInput: {},
@@ -1117,7 +1127,21 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   setRightTab(tab) {
-    set({ rightTab: tab });
+    set((s) => ({
+      rightTab: tab,
+      rightTabByGroup: {
+        ...s.rightTabByGroup,
+        [groupOfTab(tab)]: tab,
+      },
+    }));
+  },
+
+  setRightGroup(group) {
+    set((s) => {
+      const remembered = s.rightTabByGroup[group] ?? defaultTabForGroup(group);
+      if (s.rightTab === remembered) return s;
+      return { rightTab: remembered };
+    });
   },
 
   setPrAccountForRepo(repoPath, login) {
@@ -1251,17 +1275,38 @@ export const useAppStore = create<AppStateModel>()(
     {
       name: "acorn-workspaces",
       storage: createJSONStorage(() => localStorage),
-      version: 1,
+      version: 2,
       partialize: (state) => ({
         workspaces: state.workspaces,
         activeProject: state.activeProject,
         rightTab: state.rightTab,
+        rightTabByGroup: state.rightTabByGroup,
         workspaceTabs: Object.fromEntries(
           Object.entries(state.workspaceTabs).filter(([, tab]) =>
             isRestorableWorkspaceTab(tab),
           ),
         ),
       }),
+      migrate: (persisted, fromVersion) => {
+        // v1 → v2: rightTabByGroup did not exist. Seed it from the persisted
+        // rightTab so the group bar opens to whatever the user last looked at.
+        // An invalid/unknown persisted rightTab leaves rightTabByGroup at the
+        // defaults; the panel-level visibility guard then slides to the
+        // nearest valid tab on first render.
+        if (
+          persisted &&
+          typeof persisted === "object" &&
+          fromVersion < 2
+        ) {
+          const p = persisted as { rightTab?: unknown };
+          const seeded = defaultTabByGroup();
+          if (isRightTab(p.rightTab)) {
+            seeded[groupOfTab(p.rightTab)] = p.rightTab;
+          }
+          return { ...p, rightTabByGroup: seeded } as typeof persisted;
+        }
+        return persisted as typeof persisted;
+      },
       // Recompute the active-workspace mirror after hydration so consumers
       // see the persisted layout immediately, before the first refreshAll.
       onRehydrateStorage: () => (state) => {

--- a/tests/e2e/command-hint.spec.ts
+++ b/tests/e2e/command-hint.spec.ts
@@ -44,6 +44,9 @@ test.describe("CommandHint via NoAccessBanner", () => {
     await seedNoAccess(tauri);
 
     await page.goto("/");
+    // PRs lives under the GitHub group of the right panel — open the group
+    // first so the sub-tab is in the DOM, then click it.
+    await page.getByRole("button", { name: "GitHub" }).click();
     await page.getByRole("button", { name: "PRs" }).click();
 
     // Banner renders the command as a clickable chip with title attr.
@@ -64,6 +67,9 @@ test.describe("CommandHint via NoAccessBanner", () => {
     await seedNoAccess(tauri);
 
     await page.goto("/");
+    // PRs lives under the GitHub group of the right panel — open the group
+    // first so the sub-tab is in the DOM, then click it.
+    await page.getByRole("button", { name: "GitHub" }).click();
     await page.getByRole("button", { name: "PRs" }).click();
     await page.getByRole("button", { name: /gh auth login/ }).click();
     await page.getByRole("button", { name: /^Cancel$/ }).click();

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -58,6 +58,13 @@ export const tauriMockSource = `
     if (cmd === 'get_workflow_run_detail') {
       return Promise.resolve({ kind: 'not_github' });
     }
+    // Right panel uses this to decide whether to show the GitHub group.
+    // Default to "GitHub repo" so the existing PRs/Actions tabs stay
+    // visible across all E2Es; tests that need the not-github branch
+    // override this via window.__ACORN_MOCK_HANDLERS__.
+    if (cmd === 'github_origin_slug') {
+      return Promise.resolve('acorn/test');
+    }
     if (cmd === 'staged_diff') return Promise.resolve({ files: [] });
     if (cmd === 'commit_diff') return Promise.resolve({ files: [] });
     if (cmd === 'scrollback_load') return Promise.resolve(null);

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -47,11 +47,14 @@ test.describe("right panel: tab switching", () => {
       page.getByText(/No staged or modified files/i),
     ).toBeVisible();
 
+    // PRs lives under the GitHub group — switch group first, then sub-tab.
+    await page.getByRole("button", { name: "GitHub" }).click();
     await page.getByRole("button", { name: "PRs" }).click();
     // PR tab: when remote isn't GitHub OR list is empty, one of these shows.
     // Mock returns an empty list so the empty-list copy wins.
     await expect(page.getByText(/No .* pull requests/i)).toBeVisible();
 
+    await page.getByRole("button", { name: "Code" }).click();
     await page.getByRole("button", { name: "Commits" }).click();
     await expect(page.getByText(/Select a commit to see diff/i)).toBeVisible();
   });
@@ -215,5 +218,73 @@ test.describe("right panel: tab switching", () => {
     });
     // Regression: A's page-1 marker must never appear in B's panel.
     await expect(page.getByText(/leak-marker-AAA/)).toHaveCount(0);
+  });
+});
+
+test.describe("right panel: groups", () => {
+  test("group buttons restore each group's last sub-tab", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    // GitHub group is visible by default in the mock; align Actions so its
+    // empty-state copy matches "ok with no items" rather than "not GitHub".
+    await tauri.handle("list_workflow_runs", () => ({
+      kind: "ok",
+      items: [],
+      account: "test-account",
+    }));
+    await page.goto("/");
+
+    // Pick a non-default sub-tab inside Code so we can prove it's remembered.
+    await page.getByRole("button", { name: "Staged" }).click();
+    await expect(page.getByText(/No staged or modified files/i)).toBeVisible();
+
+    // Hop to GitHub → land on its default sub-tab (PRs).
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await expect(page.getByText(/No .* pull requests/i)).toBeVisible();
+    // Switch to the other GitHub sub-tab.
+    await page.getByRole("button", { name: "Actions" }).click();
+    await expect(page.getByText(/No workflow runs yet/i)).toBeVisible();
+
+    // Hop back to Code — Staged should be restored, not Commits.
+    await page.getByRole("button", { name: "Code" }).click();
+    await expect(page.getByText(/No staged or modified files/i)).toBeVisible();
+
+    // Hop back to GitHub — Actions should be restored, not PRs.
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await expect(page.getByText(/No workflow runs yet/i)).toBeVisible();
+  });
+
+  test("GitHub group is hidden when origin is not GitHub", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    // Override the default mock so the probe reports "not GitHub".
+    await tauri.handle("github_origin_slug", () => null);
+
+    await page.goto("/");
+
+    // Code group is always there; Agents group is too. GitHub must be gone.
+    await expect(page.getByRole("button", { name: "Code" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Agents" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "GitHub" })).toHaveCount(0);
+  });
+
+  test("History sub-tab is labeled 'History' (renamed from 'Sessions')", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Agents" }).click();
+    // The right-panel sub-tab bar surfaces History; scope to it so we don't
+    // collide with the sidebar's session list which previously used the
+    // "Sessions" label.
+    await expect(
+      page.getByRole("button", { name: "History" }),
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Replace the seven flat right-panel tabs with a two-row layout: top-level **Code / GitHub / Agents** group bar plus a sub-tab bar for that group's children.
- Each group remembers its last sub-tab — switching groups returns the user to where they were.
- **GitHub group auto-hides** when the repo's `origin` remote isn't GitHub (new `github_origin_slug` Tauri command, cached by `useIsGitHubRepo`).
- **Sessions → History** sub-tab rename (`Sessions`/`세션` → `History`/`기록`) to stop colliding with the sidebar's session list.

### Group → sub-tab map

| Group   | Sub-tabs                         | Visibility                                             |
|---------|----------------------------------|--------------------------------------------------------|
| Code    | Files · Staged · Commits         | Always (when repo selected)                            |
| GitHub  | PRs · Actions                    | Hidden when origin isn't GitHub                        |
| Agents  | Todos · History                  | Todos sub-tab still auto-hides when session has none   |

### Implementation notes

- New `src/lib/rightPanelGroups.ts` holds the group/tab taxonomy + helpers; `RightTab` / `RightGroup` re-exported via `store.ts`.
- Persist version bumped to 2 — `migrate` seeds `rightTabByGroup` from the legacy single `rightTab` so existing users land on the group containing their last selection.
- `useIsGitHubRepo` caches per-`repoPath` and returns `null` during the first probe to avoid flicker. Probe failures default to "show GitHub" so the tab's own error states still surface.
- E2E mock defaults `github_origin_slug` → `acorn/test` so existing GitHub-bearing tests keep working; the new "hide GitHub" test overrides via `__ACORN_MOCK_HANDLERS__`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 237 pass / 1 skipped (added 3 store cases for group switching, last-tab memory, default fallback)
- [x] `bun run test:e2e` — 61 pass; added three new cases:
  - group buttons restore each group's last sub-tab
  - GitHub group disappears when `github_origin_slug` returns `null`
  - History sub-tab is labeled "History" (rename verification)
- [x] Updated `command-hint.spec.ts` + existing `right-panel.spec.ts` to navigate via the GitHub group before clicking the PRs sub-tab
- [ ] Manual: `bun run tauri dev`, switch through Code/GitHub/Agents, confirm last-sub-tab memory, confirm GitHub group hides on a non-GitHub repo, confirm History label in EN + KO