### PR TITLE
chore(release): v1.0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.15",
+  "version": "1.0.16",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.15"
+version = "1.0.16"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
Bump package.json, Cargo.toml/Cargo.lock, and tauri.conf.json to 1.0.16.

## Changes since v1.0.15

- feat(right-panel): group tabs into Code / GitHub / Agents (#203)
- build: switch package manager to pnpm (#202)
- test(e2e): scope command palette assertions (#201)
- feat(agent-history): add project history panel + run-from-context-menu (#200)
- fix(daemon): treat recycled PID as stale lock (#199)
- fix(file-explorer): reduce git status refresh cost
- docs(readme): document new product features (#197)

## Test plan

- [x] All four version files bumped to 1.0.16
- [x] CI green on PRs merged since v1.0.15
- [ ] After merge: tag `v1.0.16` on the resulting commit; the release workflow builds + signs both macOS targets and publishes the GitHub release