### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.0.16",
+  "version": "1.1.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.0.16"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acorn"
-version = "1.0.16"
+version = "1.1.0"
 description = "Acorn — orchestrate parallel Claude Code sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.0.16",
+  "version": "1.1.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
Bump package.json, Cargo.toml/Cargo.lock, and tauri.conf.json to 1.1.0.

## Why the version jump

Earlier releases applied SemVer incorrectly: patch bumps were used even for releases that introduced user-visible features — e.g. the right-panel Code/GitHub/Agents grouping (#203), the agent history / sessions panel (#200), the pnpm package-manager migration (#202), the UI scale + GitHub Actions tab work in v1.0.14 — all of which by SemVer rules should have been minor bumps, not patches.

This release course-corrects by jumping straight from 1.0.16 to 1.1.0 to reflect the accumulated feature additions. Going forward, releases will follow MAJOR.MINOR.PATCH = breaking / feature / fix properly.

## Changes since v1.0.16

- Version label only — no code changes beyond the four version strings in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json`.

## Test plan

- [x] All four version files bumped to 1.1.0 (`package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`)
- [x] Branch is one commit ahead of `origin/main`, fast-forwardable
- [x] CI green on this PR
- [ ] After merge: tag `v1.1.0` on the resulting commit; the release workflow builds + signs both macOS targets and publishes the GitHub release
- [ ] In-app updater banner surfaces on a running v1.0.16 install