### PR TITLE
fix(sessions): unblock isolated session creation when branch name collides

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1970,6 +1970,12 @@ pub(crate) fn create_unique_worktree(
             match worktree::create_worktree(repo, &candidate) {
                 Ok(path) => return Ok((candidate, path)),
                 Err(AppError::InvalidPath(_)) => {}
+                // libgit2 auto-creates a branch named after the worktree when
+                // no explicit reference is supplied. If a branch with that name
+                // already exists (e.g. a stale leftover or a real branch the
+                // user has been working on), it returns Exists. Treat that as
+                // "this candidate is taken" and bump the suffix.
+                Err(AppError::Git(ref e)) if e.code() == git2::ErrorCode::Exists => {}
                 Err(e) => return Err(e),
             }
         }
@@ -2140,10 +2146,11 @@ pub fn acknowledge_staged_rev_mismatch(state: State<'_, AppState>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        collect_memory_usage_from_roots, font_name_from_path, infer_acornd_root_from_session_pids,
-        memory_root_pids, validate_new_project_name, ProcessMemorySnapshot,
+        collect_memory_usage_from_roots, create_unique_worktree, font_name_from_path,
+        infer_acornd_root_from_session_pids, memory_root_pids, validate_new_project_name,
+        ProcessMemorySnapshot,
     };
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     #[test]
     fn font_name_from_path_strips_compound_style_suffixes() {
@@ -2239,6 +2246,66 @@ mod tests {
         assert_eq!(memory_root_pids(&by_pid, 10, Some(20)), vec![10, 20]);
         assert_eq!(memory_root_pids(&by_pid, 10, Some(30)), vec![10]);
         assert_eq!(memory_root_pids(&by_pid, 10, Some(999)), vec![10]);
+    }
+
+    fn unique_repo_dir(label: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-commands-test-{label}-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    fn init_repo_with_commit(path: &Path) -> git2::Repository {
+        let repo = git2::Repository::init(path).expect("init repo");
+        let sig = git2::Signature::now("acorn-test", "test@acorn").expect("sig");
+        let tree_id = {
+            let mut idx = repo.index().expect("index");
+            idx.write_tree().expect("write tree")
+        };
+        let tree = repo.find_tree(tree_id).expect("find tree");
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .expect("initial commit");
+        drop(tree);
+        repo
+    }
+
+    // Regression: libgit2's default `Repository::worktree(name, path, None)`
+    // auto-creates a branch named after the worktree. When that branch
+    // already exists (e.g. the user's primary branch happens to share the
+    // repo basename), the call returned ErrorCode::Exists and bubbled up to
+    // the user as "failed to write reference 'refs/heads/<name>'". The
+    // retry loop now bumps the suffix on Exists just like it does for
+    // path collisions.
+    #[test]
+    fn create_unique_worktree_bumps_suffix_when_branch_name_taken() {
+        let repo_dir = unique_repo_dir("branch-collision");
+        let repo = init_repo_with_commit(&repo_dir);
+        // Create a branch named after the repo so the libgit2 auto-branch
+        // creation would collide on the first attempt.
+        let head_commit = repo
+            .head()
+            .and_then(|h| h.peel_to_commit())
+            .expect("HEAD commit");
+        repo.branch("acorn", &head_commit, false)
+            .expect("create acorn branch");
+        drop(head_commit);
+        drop(repo);
+
+        let (name, path) =
+            create_unique_worktree(&repo_dir, "acorn").expect("worktree should be created");
+        assert_eq!(
+            name, "acorn-2",
+            "expected suffix bump when `acorn` branch is taken"
+        );
+        assert!(path.exists(), "worktree path should exist on disk");
+
+        std::fs::remove_dir_all(&repo_dir).ok();
     }
 
     #[test]

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -56,6 +56,7 @@ import {
   type ProjectClickPlan,
 } from "../lib/sidebar-actions";
 import type { Project, Session, SessionKind, SessionStatus } from "../lib/types";
+import { suggestSessionName } from "../lib/sessionName";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { NewProjectDialog } from "./NewProjectDialog";
 import { Tooltip } from "./Tooltip";
@@ -234,7 +235,7 @@ export function Sidebar() {
               : sidebarText(t, "sidebar.dialog.selectDirectory"),
         }));
       if (!repoPath || typeof repoPath !== "string") return;
-      const name = suggestName(repoPath, sessions, kind);
+      const name = suggestSessionName(repoPath, sessions, kind, isolated);
       await createSession(name, repoPath, isolated, kind);
       setCollapsed((prev) => {
         if (!prev.has(repoPath)) return prev;
@@ -1317,24 +1318,6 @@ function buildSessionHoverDetails(t: Translator, session: Session): string {
     lines.push(sidebarText(t, "sidebar.metadata.isolatedWorktree"));
   }
   return lines.join("\n");
-}
-
-function suggestName(
-  repoPath: string,
-  existing: Session[],
-  kind: SessionKind = "regular",
-): string {
-  // Control sessions get a "control-" prefix so they sort into a clearly
-  // distinct namespace at-a-glance, mirroring how `tmux` users name dedicated
-  // controller panes.
-  const base = kind === "control" ? `control-${basename(repoPath)}` : basename(repoPath);
-  let candidate = base;
-  let n = 2;
-  const taken = new Set(existing.map((s) => s.name));
-  while (taken.has(candidate)) {
-    candidate = `${base}-${n++}`;
-  }
-  return candidate;
 }
 
 function loadCollapsed(): Set<string> {

--- a/src/lib/sessionName.test.ts
+++ b/src/lib/sessionName.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { Session } from "./types";
+import { suggestSessionName } from "./sessionName";
+
+function session(name: string): Session {
+  return {
+    id: name,
+    name,
+    repo_path: "/repo",
+    worktree_path: "/repo",
+    branch: "main",
+    isolated: false,
+    status: "idle",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: null,
+  } as Session;
+}
+
+describe("suggestSessionName", () => {
+  it("uses repo basename for a fresh regular session", () => {
+    expect(suggestSessionName("/Users/x/acorn", [])).toBe("acorn");
+  });
+
+  it("bumps numeric suffix on collision for regular sessions", () => {
+    const existing = [session("acorn")];
+    expect(suggestSessionName("/Users/x/acorn", existing)).toBe("acorn-2");
+  });
+
+  it("walks past multiple existing collisions", () => {
+    const existing = [session("acorn"), session("acorn-2"), session("acorn-3")];
+    expect(suggestSessionName("/Users/x/acorn", existing)).toBe("acorn-4");
+  });
+
+  it("prefixes control sessions to keep them in their own namespace", () => {
+    expect(suggestSessionName("/Users/x/acorn", [], "control")).toBe(
+      "control-acorn",
+    );
+  });
+
+  // Regression: isolated sessions used to inherit the same naming as regular
+  // ones (`acorn`), which collided with the existing `acorn` branch the
+  // moment libgit2 tried to auto-create a worktree branch — see
+  // `create_unique_worktree` in src-tauri/src/commands.rs.
+  it("uses `{repo}-worktree-{n}` for the first isolated session", () => {
+    expect(suggestSessionName("/Users/x/acorn", [], "regular", true)).toBe(
+      "acorn-worktree-1",
+    );
+  });
+
+  it("bumps the worktree suffix on collision for isolated sessions", () => {
+    const existing = [session("acorn-worktree-1"), session("acorn-worktree-2")];
+    expect(suggestSessionName("/Users/x/acorn", existing, "regular", true)).toBe(
+      "acorn-worktree-3",
+    );
+  });
+
+  it("isolated naming ignores regular-session collisions in the same repo", () => {
+    // A regular session named `acorn` should not consume the
+    // `acorn-worktree-1` slot — the two namespaces are independent.
+    const existing = [session("acorn"), session("acorn-2")];
+    expect(suggestSessionName("/Users/x/acorn", existing, "regular", true)).toBe(
+      "acorn-worktree-1",
+    );
+  });
+
+  it("strips trailing separators when computing basename", () => {
+    expect(suggestSessionName("/Users/x/acorn/", [])).toBe("acorn");
+    expect(suggestSessionName("/Users/x/acorn/", [], "regular", true)).toBe(
+      "acorn-worktree-1",
+    );
+  });
+});

--- a/src/lib/sessionName.ts
+++ b/src/lib/sessionName.ts
@@ -1,0 +1,45 @@
+import type { Session, SessionKind } from "./types";
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
+}
+
+/**
+ * Pick a session name that doesn't collide with any name in `existing`.
+ *
+ * Isolated sessions follow a `{repo}-worktree-{n}` convention (n starts at 1)
+ * because each one maps to a linked git worktree at
+ * `.acorn/worktrees/<name>/`, and matching the directory grouping in the
+ * sidebar makes "which worktree is this?" obvious. Control sessions get a
+ * `control-` prefix so they sort into their own namespace. Regular sessions
+ * use the bare repo basename and only get a numeric suffix on collision.
+ *
+ * The numeric suffix is purely a frontend-side hint — the Rust backend's
+ * `create_unique_worktree` still re-suffixes on its own if the candidate
+ * collides with an existing branch or worktree, so a stale state where the
+ * frontend's `existing` snapshot lags reality still produces a valid result.
+ */
+export function suggestSessionName(
+  repoPath: string,
+  existing: Session[],
+  kind: SessionKind = "regular",
+  isolated: boolean = false,
+): string {
+  const taken = new Set(existing.map((s) => s.name));
+  if (isolated) {
+    const base = `${basename(repoPath)}-worktree`;
+    let n = 1;
+    while (taken.has(`${base}-${n}`)) n++;
+    return `${base}-${n}`;
+  }
+  const base =
+    kind === "control"
+      ? `control-${basename(repoPath)}`
+      : basename(repoPath);
+  let candidate = base;
+  let n = 2;
+  while (taken.has(candidate)) {
+    candidate = `${base}-${n++}`;
+  }
+  return candidate;
+}


### PR DESCRIPTION
## Summary

Creating an isolated session failed when the auto-suggested name (the repo basename, e.g. `acorn`) already existed as a branch in the parent repo. libgit2's `Repository::worktree(name, path, None)` auto-creates a branch matching the worktree name when no explicit reference is given, so the call returned `code=Exists (-4)` and surfaced as `git error: failed to write reference 'refs/heads/acorn': a reference with that name already exists`.

This is the second report of the same bug, so the fix lands two independent layers so a regression in one still leaves the other catching the user.

## Changes

**Backend (`src-tauri/src/commands.rs`)** — `create_unique_worktree` now treats `git2::ErrorCode::Exists` the same way it treats `InvalidPath` (path-on-disk collision): bump the candidate suffix and try again, up to the existing 100-iteration cap. Covers every caller — frontend `create_session`, IPC `handle_new_session`, daemon — so any unique-name skew between frontend snapshot and reality still produces a valid worktree.

**Frontend (`src/lib/sessionName.ts`)** — `suggestSessionName` (extracted from `Sidebar.tsx::suggestName` so it's unit-testable) now applies the `{repo}-worktree-{n}` convention for isolated sessions, starting at n=1. Regular and control sessions keep their existing naming. The convention was agreed in an earlier conversation but never landed in code.

| Case | Before | After |
| --- | --- | --- |
| First isolated session in `acorn` repo | `acorn` (collides with existing `acorn` branch → bug) | `acorn-worktree-1` |
| Second isolated session | `acorn-2` | `acorn-worktree-2` |
| Regular session | `acorn` / `acorn-2` | unchanged |
| Control session | `control-acorn` | unchanged |

## Tests

- `commands::tests::create_unique_worktree_bumps_suffix_when_branch_name_taken` — spins up a real repo, pre-creates the colliding `acorn` branch, asserts `create_unique_worktree(repo, "acorn")` returns `("acorn-2", path)` and the path exists on disk.
- `src/lib/sessionName.test.ts` — 8 cases covering all four naming branches (regular, control, isolated, multi-collision), namespace independence between regular and isolated, and trailing-slash basename handling.

## Test plan

- [x] `cargo test --lib commands::tests::create_unique_worktree_bumps_suffix_when_branch_name_taken` — 1 passed
- [x] `pnpm exec vitest run` — 29 files / 245 passed / 1 skipped (full suite)
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] Manual: create isolated session in `acorn` repo via "+" button — verify name lands as `acorn-worktree-1`, worktree at `.acorn/worktrees/acorn-worktree-1/`, branch `acorn-worktree-1` checked out
- [ ] Manual: create second isolated session in same repo — verify `acorn-worktree-2`
