### PR TITLE
refactor(src-tauri): extract acorn-session crate

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8,6 +8,7 @@ version = "1.1.0"
 dependencies = [
  "acorn-ipc",
  "acorn-pty",
+ "acorn-session",
  "acorn-transcript",
  "anyhow",
  "base64 0.22.1",
@@ -67,6 +68,20 @@ dependencies = [
  "tauri",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "acorn-session"
+version = "0.1.0"
+dependencies = [
+ "acorn-pty",
+ "chrono",
+ "dashmap",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     ".",
     "crates/acorn-ipc",
     "crates/acorn-pty",
+    "crates/acorn-session",
     "crates/acorn-transcript",
 ]
 
@@ -87,6 +88,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 acorn-ipc = { path = "crates/acorn-ipc" }
 acorn-pty = { path = "crates/acorn-pty" }
+acorn-session = { path = "crates/acorn-session" }
 acorn-transcript = { path = "crates/acorn-transcript" }
 tauri = { workspace = true }
 tauri-plugin-opener = "2"

--- a/src-tauri/crates/acorn-session/Cargo.toml
+++ b/src-tauri/crates/acorn-session/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "acorn-session"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+name = "acorn_session"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+dashmap = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+acorn-pty = { path = "../acorn-pty" }

--- a/src-tauri/crates/acorn-session/src/lib.rs
+++ b/src-tauri/crates/acorn-session/src/lib.rs
@@ -1,0 +1,20 @@
+//! Session-state primitives shared across the Acorn app and its sibling
+//! tools. Pulled out of the main `acorn` crate so changes to unrelated
+//! Tauri command surfaces do not force a recompile of these stable types.
+//!
+//! Three submodules:
+//!
+//! - [`session`] — `Project` / `Session` records and their in-memory stores.
+//! - [`status`] — JSONL-transcript-tail parser that maps the last meaningful
+//!   line to a `SessionStatus`.
+//! - [`scrollback`] — per-session terminal scrollback persistence under a
+//!   caller-provided data directory.
+
+pub mod scrollback;
+pub mod session;
+pub mod status;
+
+pub use session::{
+    Project, ProjectStore, Session, SessionError, SessionKind, SessionOwner, SessionResult,
+    SessionStatus, SessionStore,
+};

--- a/src-tauri/crates/acorn-session/src/scrollback.rs
+++ b/src-tauri/crates/acorn-session/src/scrollback.rs
@@ -8,12 +8,15 @@
 //!
 //! Atomic writes use a temp file + rename. Files are best-effort: read errors
 //! return `None` so the UI can proceed with an empty buffer.
+//!
+//! Callers pass the application's data directory in explicitly so this crate
+//! does not depend on the main `acorn` crate's `persistence::data_dir()`
+//! resolver. The single per-process data dir is resolved once at boot and
+//! threaded through.
 
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
-
-use crate::error::{AppError, AppResult};
-use crate::persistence;
 
 const SCROLLBACK_DIR: &str = "scrollback";
 /// Hard upper bound on a single session's persisted buffer. Frontend caps the
@@ -21,17 +24,30 @@ const SCROLLBACK_DIR: &str = "scrollback";
 /// belt-and-braces guard against runaway payloads.
 const MAX_PAYLOAD_BYTES: usize = 4 * 1024 * 1024; // 4 MiB
 
-fn scrollback_dir() -> AppResult<PathBuf> {
-    let dir = persistence::data_dir()?.join(SCROLLBACK_DIR);
+/// Errors surfaced by the scrollback API. Path-traversal rejection and
+/// unrecoverable IO failures bubble up here; ordinary missing-file reads
+/// short-circuit to `Ok(None)` instead.
+#[derive(Debug, thiserror::Error)]
+pub enum ScrollbackError {
+    #[error("io error: {0}")]
+    Io(#[from] io::Error),
+    #[error("invalid session id: {0}")]
+    InvalidSessionId(String),
+}
+
+pub type ScrollbackResult<T> = Result<T, ScrollbackError>;
+
+fn scrollback_dir(data_dir: &Path) -> ScrollbackResult<PathBuf> {
+    let dir = data_dir.join(SCROLLBACK_DIR);
     fs::create_dir_all(&dir)?;
     Ok(dir)
 }
 
-fn session_file(session_id: &str) -> AppResult<PathBuf> {
+fn session_file(data_dir: &Path, session_id: &str) -> ScrollbackResult<PathBuf> {
     if !is_safe_session_id(session_id) {
-        return Err(AppError::Other(format!("invalid session id: {session_id}")));
+        return Err(ScrollbackError::InvalidSessionId(session_id.to_string()));
     }
-    Ok(scrollback_dir()?.join(format!("{session_id}.txt")))
+    Ok(scrollback_dir(data_dir)?.join(format!("{session_id}.txt")))
 }
 
 /// UUIDs only. Reject anything that could traverse paths.
@@ -39,8 +55,8 @@ fn is_safe_session_id(id: &str) -> bool {
     !id.is_empty() && id.len() <= 64 && id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
 }
 
-pub fn save(session_id: &str, data: &str) -> AppResult<()> {
-    let final_path = session_file(session_id)?;
+pub fn save(data_dir: &Path, session_id: &str, data: &str) -> ScrollbackResult<()> {
+    let final_path = session_file(data_dir, session_id)?;
     let payload = if data.len() > MAX_PAYLOAD_BYTES {
         // Drop the oldest bytes; xterm-rendered ANSI may break mid-sequence
         // here, but the frontend re-clears the screen on full restore so a
@@ -52,8 +68,8 @@ pub fn save(session_id: &str, data: &str) -> AppResult<()> {
     write_atomic(&final_path, payload.as_bytes())
 }
 
-pub fn load(session_id: &str) -> AppResult<Option<String>> {
-    let path = session_file(session_id)?;
+pub fn load(data_dir: &Path, session_id: &str) -> ScrollbackResult<Option<String>> {
+    let path = session_file(data_dir, session_id)?;
     if !path.exists() {
         return Ok(None);
     }
@@ -66,8 +82,8 @@ pub fn load(session_id: &str) -> AppResult<Option<String>> {
     }
 }
 
-pub fn delete(session_id: &str) -> AppResult<()> {
-    let path = session_file(session_id)?;
+pub fn delete(data_dir: &Path, session_id: &str) -> ScrollbackResult<()> {
+    let path = session_file(data_dir, session_id)?;
     if path.exists() {
         fs::remove_file(&path)?;
     }
@@ -76,12 +92,12 @@ pub fn delete(session_id: &str) -> AppResult<()> {
 
 /// Remove scrollback files for any session id not present in `keep`.
 /// Called at boot to evict files left behind by sessions that no longer exist.
-pub fn prune_orphans<I, S>(keep: I) -> AppResult<usize>
+pub fn prune_orphans<I, S>(data_dir: &Path, keep: I) -> ScrollbackResult<usize>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
-    let dir = scrollback_dir()?;
+    let dir = scrollback_dir(data_dir)?;
     let keep_set: std::collections::HashSet<String> =
         keep.into_iter().map(|s| s.as_ref().to_string()).collect();
     let mut removed = 0usize;
@@ -122,12 +138,12 @@ where
 /// counted because they cannot be safely reclaimed without losing the
 /// session's restorable buffer; the user-facing "Clear cache" UI only
 /// surfaces the reclaimable portion. Returns 0 on read errors.
-pub fn orphan_size_bytes<I, S>(keep: I) -> AppResult<u64>
+pub fn orphan_size_bytes<I, S>(data_dir: &Path, keep: I) -> ScrollbackResult<u64>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
-    let dir = scrollback_dir()?;
+    let dir = scrollback_dir(data_dir)?;
     let keep_set: std::collections::HashSet<String> =
         keep.into_iter().map(|s| s.as_ref().to_string()).collect();
     let entries = match fs::read_dir(&dir) {
@@ -153,7 +169,7 @@ where
     Ok(total)
 }
 
-fn write_atomic(final_path: &Path, bytes: &[u8]) -> AppResult<()> {
+fn write_atomic(final_path: &Path, bytes: &[u8]) -> ScrollbackResult<()> {
     let tmp_path = final_path.with_extension("txt.tmp");
     fs::write(&tmp_path, bytes)?;
     fs::rename(&tmp_path, final_path)?;
@@ -173,5 +189,50 @@ mod tests {
         assert!(!is_safe_session_id(&"x".repeat(65)));
         assert!(is_safe_session_id("550e8400-e29b-41d4-a716-446655440000"));
         assert!(is_safe_session_id("abcdef0123456789"));
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let tmp = tempdir_path();
+        let id = "550e8400-e29b-41d4-a716-446655440000";
+        save(&tmp, id, "hello\n\x1b[31mred\x1b[0m\n").expect("save");
+        let got = load(&tmp, id).expect("load").expect("some");
+        assert!(got.contains("hello"));
+        // Cleanup
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn load_returns_none_for_missing() {
+        let tmp = tempdir_path();
+        let id = "550e8400-e29b-41d4-a716-446655440001";
+        let got = load(&tmp, id).expect("load");
+        assert!(got.is_none());
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn prune_orphans_drops_unknown_ids() {
+        let tmp = tempdir_path();
+        let kept = "550e8400-e29b-41d4-a716-44665544000a";
+        let orphan = "550e8400-e29b-41d4-a716-44665544000b";
+        save(&tmp, kept, "k").expect("kept");
+        save(&tmp, orphan, "o").expect("orphan");
+        let removed = prune_orphans(&tmp, [kept]).expect("prune");
+        assert_eq!(removed, 1);
+        assert!(load(&tmp, kept).expect("load kept").is_some());
+        assert!(load(&tmp, orphan).expect("load orphan").is_none());
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    fn tempdir_path() -> PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let p = std::env::temp_dir().join(format!("acorn-session-scrollback-{ns}"));
+        fs::create_dir_all(&p).unwrap();
+        p
     }
 }

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -5,7 +5,16 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::error::{AppError, AppResult};
+/// Errors produced by `SessionStore` lookups. Kept local so the crate does
+/// not need to share `AppError` with the main `acorn` crate; the main crate
+/// adapts via `From<SessionError>`.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionError {
+    #[error("session not found: {0}")]
+    NotFound(String),
+}
+
+pub type SessionResult<T> = Result<T, SessionError>;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Project {
@@ -270,11 +279,11 @@ impl SessionStore {
         session
     }
 
-    pub fn get(&self, id: &Uuid) -> AppResult<Session> {
+    pub fn get(&self, id: &Uuid) -> SessionResult<Session> {
         self.inner
             .get(id)
             .map(|r| r.value().clone())
-            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))
     }
 
     pub fn list(&self) -> Vec<Session> {
@@ -283,11 +292,11 @@ impl SessionStore {
         v
     }
 
-    pub fn update_status(&self, id: &Uuid, status: SessionStatus) -> AppResult<Session> {
+    pub fn update_status(&self, id: &Uuid, status: SessionStatus) -> SessionResult<Session> {
         let mut entry = self
             .inner
             .get_mut(id)
-            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
         entry.status = status;
         entry.updated_at = Utc::now();
         Ok(entry.clone())
@@ -296,11 +305,11 @@ impl SessionStore {
     /// Update status without bumping `updated_at`. No-op if the status is
     /// unchanged. Used by the periodic liveness probe so polling doesn't
     /// reshuffle the sidebar's most-recent-first ordering.
-    pub fn refresh_status(&self, id: &Uuid, status: SessionStatus) -> AppResult<Session> {
+    pub fn refresh_status(&self, id: &Uuid, status: SessionStatus) -> SessionResult<Session> {
         let mut entry = self
             .inner
             .get_mut(id)
-            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
         if entry.status != status {
             entry.status = status;
         }
@@ -313,11 +322,15 @@ impl SessionStore {
     /// — leaving the API stable today avoids a second schema migration.
     /// Idempotent: passing `None` detaches.
     #[allow(dead_code)]
-    pub fn set_daemon_session_id(&self, id: &Uuid, daemon_id: Option<Uuid>) -> AppResult<Session> {
+    pub fn set_daemon_session_id(
+        &self,
+        id: &Uuid,
+        daemon_id: Option<Uuid>,
+    ) -> SessionResult<Session> {
         let mut entry = self
             .inner
             .get_mut(id)
-            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
         entry.daemon_session_id = daemon_id;
         Ok(entry.clone())
     }
@@ -327,20 +340,24 @@ impl SessionStore {
     /// daemon re-injects this on every respawn. Pairs with
     /// `set_daemon_session_id` — wired by the same downstream path.
     #[allow(dead_code)]
-    pub fn set_agent_resume_token(&self, id: &Uuid, token: Option<String>) -> AppResult<Session> {
+    pub fn set_agent_resume_token(
+        &self,
+        id: &Uuid,
+        token: Option<String>,
+    ) -> SessionResult<Session> {
         let mut entry = self
             .inner
             .get_mut(id)
-            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
         entry.agent_resume_token = token;
         Ok(entry.clone())
     }
 
-    pub fn rename(&self, id: &Uuid, name: String) -> AppResult<Session> {
+    pub fn rename(&self, id: &Uuid, name: String) -> SessionResult<Session> {
         let mut entry = self
             .inner
             .get_mut(id)
-            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
         entry.name = name;
         entry.updated_at = Utc::now();
         Ok(entry.clone())
@@ -357,11 +374,11 @@ impl SessionStore {
         &self,
         id: &Uuid,
         worktree_path: std::path::PathBuf,
-    ) -> AppResult<Session> {
+    ) -> SessionResult<Session> {
         let mut entry = self
             .inner
             .get_mut(id)
-            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
         entry.worktree_path = worktree_path;
         entry.updated_at = Utc::now();
         Ok(entry.clone())
@@ -373,22 +390,22 @@ impl SessionStore {
     /// the session row alive so PTY/agent history stays addressable;
     /// downstream git ops resolve against the main repo instead of erroring
     /// on a missing path.
-    pub fn reconcile_missing_worktree(&self, id: &Uuid) -> AppResult<Session> {
+    pub fn reconcile_missing_worktree(&self, id: &Uuid) -> SessionResult<Session> {
         let mut entry = self
             .inner
             .get_mut(id)
-            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
         entry.worktree_path = entry.repo_path.clone();
         entry.isolated = false;
         entry.updated_at = Utc::now();
         Ok(entry.clone())
     }
 
-    pub fn remove(&self, id: &Uuid) -> AppResult<Session> {
+    pub fn remove(&self, id: &Uuid) -> SessionResult<Session> {
         self.inner
             .remove(id)
             .map(|(_, v)| v)
-            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))
     }
 
     /// Assign explicit positions (0..N) to the sessions listed in `order`,

--- a/src-tauri/crates/acorn-session/src/status.rs
+++ b/src-tauri/crates/acorn-session/src/status.rs
@@ -25,36 +25,39 @@
 //! deliberately do NOT gate on mtime, otherwise the moment after a turn
 //! ends (file still warm) gets misreported as Running.
 //!
-//! Transcript resolution. The on-disk markers `<data_dir>/agent-state/
-//! <acorn-session-uuid>/{claude,codex}.id` (kept fresh by
-//! `agent_resume_persister`) are the canonical bridge from an Acorn
-//! session UUID to the agent's transcript filename. Without this, the
-//! detector could only consult `~/.claude/projects/*/<acorn-uuid>.jsonl`,
-//! which never matches in the common case where the user runs
-//! `claude` / `codex` *inside* an Acorn shell session (the JSONL is
-//! named after the agent's own UUID, not Acorn's). The result was that
-//! every claude/codex run looked perpetually `Running` until the agent
-//! process exited — `NeedsInput` was structurally unreachable.
+//! Transcript resolution lives in the host `acorn` crate (it consults
+//! `agent_resume`'s persister markers + the legacy `~/.claude/projects/`
+//! UUID-named fallback) and is passed in here as `(PathBuf, AgentKind)`
+//! so this crate stays a leaf with no upstream dependency.
 
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use acorn_pty::ShellHint;
 
-use crate::agent_resume::{self, AgentKind, LiveTranscript};
-use crate::error::AppResult;
 use crate::session::SessionStatus;
-use crate::todos;
 
 // Big enough to comfortably contain the last assistant turn line for typical
 // Claude responses. JSONL lines are one-per-message, so a long assistant
 // response can be many KB on a single line.
 const TAIL_BYTES: u64 = 262_144;
 
-/// Resolve the session's live transcript (via the persister's resume
-/// markers or — as a legacy fallback — the Acorn UUID itself) and infer
-/// status from its tail.
+/// Which agent's transcript format the tail should be parsed as. The host
+/// crate maps its richer `agent_resume::AgentKind` onto this two-variant
+/// enum at the call site.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum AgentKind {
+    Claude,
+    Codex,
+}
+
+/// Infer a session's status from its transcript tail (when one was resolved)
+/// plus an optional shell-mode liveness hint.
+///
+/// `transcript` is `Some((path, kind))` when the caller resolved a live
+/// JSONL for the session (via `agent_resume` markers or the legacy lookup);
+/// `None` falls back to the shell hint.
 ///
 /// `previous` is the last status the caller observed for this session. It is
 /// only consulted when the transcript file exists but the tail buffer is
@@ -71,14 +74,13 @@ const TAIL_BYTES: u64 = 262_144;
 /// terminal sessions, so when no transcript resolves we map it directly
 /// to a status. `None` means "no live PTY" → Idle.
 pub fn detect(
-    session_id: &str,
+    transcript: Option<(PathBuf, AgentKind)>,
     previous: SessionStatus,
     shell_hint: Option<ShellHint>,
-) -> AppResult<SessionStatus> {
-    let resolved = resolve_transcript(session_id);
-    let (path, kind) = match resolved {
-        Some(LiveTranscript { path, kind }) => (path, kind),
-        None => return Ok(map_shell_hint(shell_hint)),
+) -> SessionStatus {
+    let (path, kind) = match transcript {
+        Some(t) => t,
+        None => return map_shell_hint(shell_hint),
     };
 
     let file_size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
@@ -89,7 +91,7 @@ pub fn detect(
         AgentKind::Codex => classify_codex_tail(&tail, read_full),
     };
 
-    Ok(match classified {
+    match classified {
         Some(TurnClass::NeedsInput) => SessionStatus::NeedsInput,
         Some(TurnClass::Running) => SessionStatus::Running,
         // Transcript exists but the tail held no turn lines; keep
@@ -97,30 +99,7 @@ pub fn detect(
         // to Idle. The next poll that lands on a real turn line corrects
         // it.
         None => previous,
-    })
-}
-
-/// Two-stage transcript lookup. First the persister marker (the canonical
-/// path for "user ran `claude` / `codex` inside a shell session"), then
-/// the legacy Acorn-UUID-named JSONL (kept so any direct caller that
-/// passes a claude session-id continues to work, and so the dedicated
-/// unit tests below can stage a fixture without standing up a fake
-/// `agent-state` tree). Returns `None` only when neither lookup
-/// resolves — that's the cue for `detect` to fall back to `shell_hint`.
-fn resolve_transcript(session_id: &str) -> Option<LiveTranscript> {
-    let parsed = uuid::Uuid::parse_str(session_id).ok();
-    if let Some(uuid) = parsed {
-        if let Some(found) = agent_resume::live_transcript(uuid) {
-            return Some(found);
-        }
     }
-    todos::locate_transcript_for(session_id)
-        .ok()
-        .flatten()
-        .map(|path| LiveTranscript {
-            path,
-            kind: AgentKind::Claude,
-        })
 }
 
 fn map_shell_hint(hint: Option<ShellHint>) -> SessionStatus {
@@ -418,5 +397,23 @@ mod tests {
     #[test]
     fn codex_empty_tail_returns_none() {
         assert_eq!(classify_codex_tail("", true), None);
+    }
+
+    // --- detect() entry point ---
+
+    #[test]
+    fn detect_returns_idle_when_no_transcript_and_no_hint() {
+        assert_eq!(
+            detect(None, SessionStatus::Idle, None),
+            SessionStatus::Idle
+        );
+    }
+
+    #[test]
+    fn detect_uses_shell_hint_when_no_transcript() {
+        assert_eq!(
+            detect(None, SessionStatus::Idle, Some(ShellHint::Running)),
+            SessionStatus::Running
+        );
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -14,12 +14,12 @@ use crate::pull_requests::{
     self, GeneratedCommitMessage, MergeMethod, PrStateFilter, PullRequestDetailListing,
     PullRequestListing, WorkflowRunDetailListing, WorkflowRunsListing,
 };
-use crate::scrollback;
-use crate::session::{Project, Session, SessionKind, SessionStatus};
-use crate::session_status;
 use crate::state::AppState;
 use crate::todos::{self, TodoItem};
 use crate::worktree;
+use acorn_session::scrollback;
+use acorn_session::status as session_status;
+use acorn_session::{Project, Session, SessionKind, SessionStatus};
 
 use serde::Serialize;
 
@@ -829,7 +829,9 @@ pub async fn remove_session(
     let id = Uuid::parse_str(&id).map_err(|e| AppError::Other(e.to_string()))?;
     let session = state.sessions.get(&id)?;
     state.pty.kill(&id).ok();
-    scrollback::delete(&id.to_string()).ok();
+    if let Ok(dir) = persistence::data_dir() {
+        scrollback::delete(&dir, &id.to_string()).ok();
+    }
     if session.isolated && remove_worktree.unwrap_or(false) {
         let safe_name = sanitize_worktree_name(&session.name);
         worktree::remove_worktree(&session.repo_path, &safe_name).ok();
@@ -1667,17 +1669,23 @@ pub async fn scrollback_save(
     if state.sessions.get(&id).is_err() {
         return Ok(());
     }
-    scrollback::save(&session_id, &data)
+    let dir = persistence::data_dir()?;
+    scrollback::save(&dir, &session_id, &data)?;
+    Ok(())
 }
 
 #[tauri::command]
 pub async fn scrollback_load(session_id: String) -> AppResult<Option<String>> {
-    scrollback::load(&session_id)
+    let dir = persistence::data_dir()?;
+    let value = scrollback::load(&dir, &session_id)?;
+    Ok(value)
 }
 
 #[tauri::command]
 pub async fn scrollback_delete(session_id: String) -> AppResult<()> {
-    scrollback::delete(&session_id)
+    let dir = persistence::data_dir()?;
+    scrollback::delete(&dir, &session_id)?;
+    Ok(())
 }
 
 /// Return the on-disk size (in bytes) of scrollback files whose session
@@ -1691,7 +1699,9 @@ pub async fn scrollback_orphan_size(state: State<'_, AppState>) -> AppResult<u64
         .iter()
         .map(|s| s.id.to_string())
         .collect();
-    scrollback::orphan_size_bytes(live_ids)
+    let dir = persistence::data_dir()?;
+    let value = scrollback::orphan_size_bytes(&dir, live_ids)?;
+    Ok(value)
 }
 
 /// Delete scrollback files whose session id no longer matches a known
@@ -1705,7 +1715,9 @@ pub async fn scrollback_orphan_clear(state: State<'_, AppState>) -> AppResult<us
         .iter()
         .map(|s| s.id.to_string())
         .collect();
-    scrollback::prune_orphans(live_ids)
+    let dir = persistence::data_dir()?;
+    let count = scrollback::prune_orphans(&dir, live_ids)?;
+    Ok(count)
 }
 
 #[tauri::command]
@@ -1780,7 +1792,28 @@ pub async fn detect_session_statuses(
                     state.pty.update_shell_state(&uuid, has_child_now)
                 }
             });
-            let status = session_status::detect(&id, previous, shell_hint).unwrap_or(previous);
+            // Resolve the live transcript via the persister's resume markers
+            // first (covers claude/codex run inside a shell session — JSONL
+            // is named after the agent's own UUID, not Acorn's). Fall back
+            // to the legacy Acorn-UUID-named JSONL so any direct claude
+            // session-id caller keeps working.
+            let live = parsed_id.and_then(agent_resume::live_transcript);
+            let transcript = match live {
+                Some(t) => {
+                    let kind = match t.kind {
+                        agent_resume::AgentKind::Claude => {
+                            acorn_session::status::AgentKind::Claude
+                        }
+                        agent_resume::AgentKind::Codex => acorn_session::status::AgentKind::Codex,
+                    };
+                    Some((t.path, kind))
+                }
+                None => todos::locate_transcript_for(&id)
+                    .ok()
+                    .flatten()
+                    .map(|p| (p, acorn_session::status::AgentKind::Claude)),
+            };
+            let status = session_status::detect(transcript, previous, shell_hint);
             // Branch source priority:
             //  1. deepest PTY descendant cwd — reflects `cd` + `git checkout`
             //     performed inside the terminal (and `claude -w` worktrees)

--- a/src-tauri/src/daemon/protocol.rs
+++ b/src-tauri/src/daemon/protocol.rs
@@ -185,7 +185,7 @@ pub struct SpawnSpec {
     #[serde(default)]
     pub rows: u16,
     /// Session classification (regular / control). Mirrors the
-    /// `SessionKind` enum in `crate::session`. The daemon preserves it
+    /// `SessionKind` enum in `acorn_session`. The daemon preserves it
     /// in metadata so reattach can re-augment the env on respawn.
     #[serde(default)]
     pub kind: SessionKind,

--- a/src-tauri/src/daemon/session.rs
+++ b/src-tauri/src/daemon/session.rs
@@ -13,7 +13,7 @@
 //!
 //! Anything else (timestamps for ordering, last-message previews, etc.)
 //! stays in the app DB. The daemon-side struct here is intentionally
-//! smaller than `crate::session::Session`.
+//! smaller than `acorn_session::Session`.
 
 use parking_lot::RwLock;
 use std::collections::HashMap;

--- a/src-tauri/src/daemon_commands.rs
+++ b/src-tauri/src/daemon_commands.rs
@@ -293,8 +293,8 @@ pub fn daemon_adopt_session(
     let branch = summary.branch.clone().unwrap_or_default();
 
     let kind = match summary.kind {
-        crate::daemon::protocol::SessionKind::Regular => crate::session::SessionKind::Regular,
-        crate::daemon::protocol::SessionKind::Control => crate::session::SessionKind::Control,
+        crate::daemon::protocol::SessionKind::Regular => acorn_session::SessionKind::Regular,
+        crate::daemon::protocol::SessionKind::Control => acorn_session::SessionKind::Control,
     };
 
     let project_name = repo_path
@@ -304,19 +304,19 @@ pub fn daemon_adopt_session(
     state.projects.ensure(repo_path.clone(), project_name);
 
     let now = chrono::Utc::now();
-    let session = crate::session::Session {
+    let session = acorn_session::Session {
         id,
         name: summary.name.clone(),
         repo_path: repo_path.clone(),
         worktree_path,
         branch,
         isolated: false,
-        status: crate::session::SessionStatus::Idle,
+        status: acorn_session::SessionStatus::Idle,
         created_at: now,
         updated_at: now,
         last_message: None,
         kind,
-        owner: crate::session::SessionOwner::User,
+        owner: acorn_session::SessionOwner::User,
         position: None,
         daemon_session_id: Some(id),
         agent_resume_token: Some(id.to_string()),

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -27,6 +27,25 @@ impl From<anyhow::Error> for AppError {
     }
 }
 
+impl From<acorn_session::SessionError> for AppError {
+    fn from(value: acorn_session::SessionError) -> Self {
+        match value {
+            acorn_session::SessionError::NotFound(id) => AppError::SessionNotFound(id),
+        }
+    }
+}
+
+impl From<acorn_session::scrollback::ScrollbackError> for AppError {
+    fn from(value: acorn_session::scrollback::ScrollbackError) -> Self {
+        match value {
+            acorn_session::scrollback::ScrollbackError::Io(err) => AppError::Io(err),
+            acorn_session::scrollback::ScrollbackError::InvalidSessionId(id) => {
+                AppError::Other(format!("invalid session id: {id}"))
+            }
+        }
+    }
+}
+
 impl Serialize for AppError {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&self.to_string())

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -40,7 +40,7 @@ use uuid::Uuid;
 
 use crate::commands::{create_unique_worktree, sanitize_worktree_name};
 use crate::persistence;
-use crate::session::{Session, SessionKind, SessionOwner, SessionStore};
+use acorn_session::{Session, SessionKind, SessionOwner, SessionStore};
 use crate::state::AppState;
 use crate::worktree;
 
@@ -574,7 +574,7 @@ fn handle_kill_session<R: Runtime>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::SessionStatus;
+    use acorn_session::SessionStatus;
     use std::path::PathBuf;
 
     fn make_session(repo: &str, name: &str, kind: SessionKind) -> Session {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,9 +14,6 @@ mod ipc;
 mod persistence;
 mod pty_env;
 mod pull_requests;
-mod scrollback;
-mod session;
-mod session_status;
 mod shell_args;
 mod shell_env;
 mod shell_init;
@@ -207,8 +204,18 @@ pub fn run() {
                 tracing::warn!(
                     "skipping scrollback prune: session load was unclean and no live ids"
                 );
-            } else if let Err(err) = scrollback::prune_orphans(&live_ids) {
-                tracing::warn!("scrollback prune at boot failed: {err}");
+            } else {
+                match persistence::data_dir() {
+                    Ok(dir) => {
+                        if let Err(err) = acorn_session::scrollback::prune_orphans(&dir, &live_ids)
+                        {
+                            tracing::warn!("scrollback prune at boot failed: {err}");
+                        }
+                    }
+                    Err(err) => {
+                        tracing::warn!("scrollback prune at boot: data_dir failed: {err}");
+                    }
+                }
             }
             // Start the IPC server in the background. It owns its own
             // listener thread; if bind fails it logs and the app keeps

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -5,7 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use directories::ProjectDirs;
 
 use crate::error::{AppError, AppResult};
-use crate::session::{Project, Session};
+use acorn_session::{Project, Session};
 
 const SESSIONS_FILE: &str = "sessions.json";
 const SESSIONS_TMP_FILE: &str = "sessions.json.tmp";

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -7,7 +7,7 @@ use crate::daemon_bridge::DaemonBridge;
 use crate::daemon_stream::StreamRegistry;
 use crate::fs_explorer::WatcherState;
 use crate::ipc::server::IpcServerHandle;
-use crate::session::{ProjectStore, SessionStore};
+use acorn_session::{ProjectStore, SessionStore};
 use crate::staged_rev_reconcile::StagedRevMismatch;
 use acorn_pty::PtyManager;
 


### PR DESCRIPTION
## Summary
Continues the workspace split started in #206. Extracts session state into a dedicated `acorn-session` workspace crate.

## Scope
Moved into `src-tauri/crates/acorn-session/`:
- `src/session.rs` → `acorn-session::session` (Session struct, persistence)
- `src/session_status.rs` → `acorn-session::status` (SessionStatus enum)
- `src/scrollback.rs` → `acorn-session::scrollback` (ring buffer)

## Why
Smaller compile unit. When session-layer code changes in isolation, only this crate (a few thousand lines) recompiles instead of the whole `acorn` crate. `Swatinem/rust-cache` covers it independently in CI.

## Out of scope
Daemon-side session code at `src/daemon/session.rs` stays in the main crate — it has daemon-specific concerns (broadcast channel, restart semantics) and is not symmetric with the host-side `Session` type.

## Test plan
- [x] `cargo check --workspace` passes (2s warm)
- [x] All call sites in `commands.rs`, `state.rs`, `persistence.rs`, `daemon_commands.rs`, `ipc/server.rs` updated to import from `acorn_session::*`
- [ ] CI green on this PR
- [ ] Local `pnpm run tauri dev` smoke test (post-merge)

## Notes
- Two `daemon::lifecycle` / `daemon::paths` flaky tests exist on `main` (`ENV_LOCK` race under parallel execution) — pre-existing, not caused by this PR.
