### PR TITLE
fix(diff): extend row backgrounds across full content width when scrolling

### DIFF
--- a/src/components/DiffSplitView.tsx
+++ b/src/components/DiffSplitView.tsx
@@ -230,9 +230,11 @@ function DiffSplitContent({ entry }: { entry: FileEntry }) {
   }
   return (
     <div className="acorn-selectable min-h-0 flex-1 select-text overflow-auto font-mono text-[11px] leading-5">
-      {entry.lines.map((line, i) => (
-        <DiffLine key={i} line={line} html={highlighted[i] ?? null} />
-      ))}
+      <div className="w-max min-w-full">
+        {entry.lines.map((line, i) => (
+          <DiffLine key={i} line={line} html={highlighted[i] ?? null} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -148,9 +148,11 @@ function DiffFileAccordion({ file, collapsed, onToggle }: DiffFileAccordionProps
           <ImageDiff file={file} />
         ) : (
           <div className="acorn-selectable max-h-80 overflow-auto font-mono text-[11px] leading-5 select-text">
-            {lines.map((line, i) => (
-              <DiffLine key={i} line={line} html={highlighted[i] ?? null} />
-            ))}
+            <div className="w-max min-w-full">
+              {lines.map((line, i) => (
+                <DiffLine key={i} line={line} html={highlighted[i] ?? null} />
+              ))}
+            </div>
           </div>
         )
       ) : null}
@@ -294,14 +296,14 @@ export function DiffLine({
 }) {
   if (line.kind === "hunk") {
     return (
-      <div className="bg-[oklch(28%_0.04_250)] px-3 py-0.5 text-[oklch(70%_0.05_250)]">
+      <div className="bg-[oklch(28%_0.04_250)] px-3 py-0.5 text-[oklch(70%_0.05_250)] whitespace-pre">
         {line.text}
       </div>
     );
   }
   if (line.kind === "meta") {
     return (
-      <div className="bg-bg-elevated/40 px-3 py-0.5 text-fg-muted">
+      <div className="bg-bg-elevated/40 px-3 py-0.5 text-fg-muted whitespace-pre">
         {line.text}
       </div>
     );


### PR DESCRIPTION
## Summary

Diff row backgrounds (add / del / hunk header) stopped at the visible viewport when the diff scroll container had horizontal overflow. Long lines forced horizontal scroll, but shorter rows' background fills only spanned the original viewport — scrolling right exposed an uncolored gap to the right of every short row.

Wrap the row list in a `w-max min-w-full` inner container so the rendered "page" sizes to the widest line. Every row, regardless of its own length, now uniformly fills that width. Hunk and meta lines are also marked `whitespace-pre` so headers stay on a single visual line.

Applies to both inline (`DiffView`) and split (`DiffSplitView`) diff renderers, which means the PR Files tab and the message-board diff view both pick up the fix.

## Test plan

- [x] `pnpm typecheck`
- [x] Open a PR with a file that has lines wider than the diff pane; scroll horizontally; confirm `+` / `-` / hunk backgrounds extend to the longest line's end on every row
