### PR TITLE
fix(sessions): reconcile stale worktree paths on list

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -328,12 +328,45 @@ pub fn load_status(state: State<'_, AppState>) -> LoadStatus {
 
 #[tauri::command]
 pub fn list_sessions(state: State<'_, AppState>) -> Vec<Session> {
+    reconcile_stale_worktrees(&state);
     state
         .sessions
         .list()
         .into_iter()
         .map(enrich_session)
         .collect()
+}
+
+/// Sweep sessions whose linked worktree directory has vanished (e.g. the
+/// agent pruned its worktree on exit) and re-point them at the project's
+/// main repo. Without this, every subsequent git op (`list_commits`,
+/// `list_staged`, `diff_*`) for that session bubbles a raw `ensure_repo`
+/// failure ("could not find git repository from '<missing-path>'") into
+/// the UI. Only touches sessions where the parent project still exists,
+/// so a temporarily unmounted repo doesn't trip the cleanup.
+fn reconcile_stale_worktrees(state: &AppState) {
+    let mut dirty = false;
+    for session in state.sessions.list() {
+        if session.worktree_path == session.repo_path {
+            continue;
+        }
+        if !session.repo_path.exists() {
+            continue;
+        }
+        if session.worktree_path.exists() {
+            continue;
+        }
+        if state
+            .sessions
+            .reconcile_missing_worktree(&session.id)
+            .is_ok()
+        {
+            dirty = true;
+        }
+    }
+    if dirty {
+        persist(state);
+    }
 }
 
 /// Attach derived fields (`branch`, `in_worktree`) computed from the

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -367,6 +367,23 @@ impl SessionStore {
         Ok(entry.clone())
     }
 
+    /// Re-point a session at its main repo and clear `isolated` when the
+    /// linked worktree has disappeared from disk (typically: agent exit
+    /// pruned the worktree but the session row still references it). Keeps
+    /// the session row alive so PTY/agent history stays addressable;
+    /// downstream git ops resolve against the main repo instead of erroring
+    /// on a missing path.
+    pub fn reconcile_missing_worktree(&self, id: &Uuid) -> AppResult<Session> {
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
+        entry.worktree_path = entry.repo_path.clone();
+        entry.isolated = false;
+        entry.updated_at = Utc::now();
+        Ok(entry.clone())
+    }
+
     pub fn remove(&self, id: &Uuid) -> AppResult<Session> {
         self.inner
             .remove(id)
@@ -409,5 +426,47 @@ impl SessionStore {
                 pos += 1;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_session(repo: &str, worktree: &str, isolated: bool) -> Session {
+        Session::new(
+            "test".to_string(),
+            PathBuf::from(repo),
+            PathBuf::from(worktree),
+            "main".to_string(),
+            isolated,
+            SessionKind::Regular,
+        )
+    }
+
+    #[test]
+    fn reconcile_missing_worktree_resets_path_and_isolation() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session(
+            "/tmp/acorn-repo",
+            "/tmp/acorn-repo/.acorn/worktrees/gone",
+            true,
+        ));
+
+        let reconciled = store
+            .reconcile_missing_worktree(&session.id)
+            .expect("session exists");
+
+        assert_eq!(reconciled.worktree_path, PathBuf::from("/tmp/acorn-repo"));
+        assert!(!reconciled.isolated);
+        assert_eq!(reconciled.id, session.id);
+        assert_eq!(reconciled.name, session.name);
+    }
+
+    #[test]
+    fn reconcile_missing_worktree_errors_for_unknown_session() {
+        let store = SessionStore::new();
+        let result = store.reconcile_missing_worktree(&Uuid::new_v4());
+        assert!(matches!(result, Err(AppError::SessionNotFound(_))));
     }
 }

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -12,13 +12,35 @@ pub fn ensure_repo(path: &Path) -> AppResult<Repository> {
     // can pass any subdirectory (e.g. a session's PTY cwd that drifted into
     // `<repo>/src-tauri`) without the open failing. Also handles linked
     // worktrees, where `.git` is a file pointing at the parent repo.
-    Repository::discover(path).map_err(|e| {
+    //
+    // If `path` itself no longer exists (typical when a linked worktree was
+    // pruned externally — e.g. `claude -w` cleaning up on exit — but the
+    // session row in our store still references it), libgit2 refuses to
+    // resolve the path and `discover` returns "failed to resolve path".
+    // Walk up to the nearest existing ancestor first so the call survives
+    // until the persistent reconcile sweep in `list_sessions` rewrites the
+    // session's `worktree_path` back to the main repo. Without this layer,
+    // any UI poll (`list_commits`, `list_staged`, `diff_*`) racing the
+    // sweep still bubbles the raw git error into the right panel.
+    let start = walk_to_existing_ancestor(path);
+    Repository::discover(&start).map_err(|e| {
         AppError::Other(format!(
             "could not find git repository from '{}': {}",
             path.display(),
             e.message()
         ))
     })
+}
+
+fn walk_to_existing_ancestor(path: &Path) -> PathBuf {
+    let mut probe = path.to_path_buf();
+    while !probe.exists() {
+        match probe.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => probe = parent.to_path_buf(),
+            _ => return path.to_path_buf(),
+        }
+    }
+    probe
 }
 
 pub fn worktree_root(repo_path: &Path) -> PathBuf {
@@ -167,6 +189,25 @@ mod tests {
             msg.contains("could not find git repository from"),
             "unexpected error message: {msg}"
         );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn ensure_repo_walks_up_when_path_missing() {
+        let root = unique_temp_dir("pruned");
+        Repository::init(&root).expect("init repo");
+        // Simulate a pruned linked worktree path that no longer exists, sitting
+        // under the still-present repo root.
+        let pruned = root.join(".acorn").join("worktrees").join("gone");
+        assert!(!pruned.exists());
+
+        let opened = ensure_repo(&pruned).expect("walk up to repo root");
+        let workdir = opened.workdir().expect("workdir present");
+        assert_eq!(
+            workdir.canonicalize().unwrap(),
+            root.canonicalize().unwrap(),
+        );
+
         std::fs::remove_dir_all(&root).ok();
     }
 }


### PR DESCRIPTION
## Summary

When a session's linked worktree is pruned externally (agent exit removing its worktree, manual `git worktree remove`, hand-deletion of the directory), the session row in Acorn's store still references the now-missing path. Every downstream git op against that path bubbles a raw `ensure_repo` failure into the UI:

```
could not find git repository from '<path>': failed to resolve path '<path>': No such file or directory
```

Two complementary layers fix this:

**Layer 1 — persistent reconcile sweep.** `list_sessions` now sweeps sessions whose `worktree_path` no longer exists on disk (with `repo_path` still present, so a temporarily unmounted volume isn't mistaken for a pruned worktree), re-points them at the main repo, and clears `isolated`. The session row stays alive — UUID, PTY binding, agent resume token, kind, ordering all preserved — so the user lands in the main repo on next focus.

**Layer 2 — resilient `ensure_repo`.** The sweep only cleans state on the next `list_sessions` call; an in-flight UI poll (`list_commits`, `list_staged`, `diff_*`) racing the sweep still hands the stale path to libgit2. `ensure_repo` now walks up to the nearest existing ancestor before calling `Repository::discover`, so pruned linked worktrees under `.acorn/worktrees/` or `.claude/worktrees/` resolve to the main repo until the sweep catches up.

## Why

Reproducible whenever a worktree disappears while a session still references it; visible to users as a red toast / inline error on the right panel. Bringing the session back into a consistent state without a modal keeps the UX recoverable without requiring user permission for what is essentially a cleanup of state Acorn already owns.

## Changes

- `SessionStore::reconcile_missing_worktree(id)` — resets `worktree_path` to `repo_path` and clears `isolated`. Keeps the rest of session identity intact; `branch` is re-derived by the existing `enrich_session` pass after the sweep.
- `list_sessions` — calls `reconcile_stale_worktrees` before enrichment, persists once if anything changed.
- `ensure_repo` — walks up to the nearest existing ancestor before `Repository::discover`, preserving the original error message and path in the fallback failure case.
- Unit tests for the store mutator (happy + `SessionNotFound`) and the ancestor walk.

## Test plan

- [x] `cargo test --lib session::tests` — both new tests pass
- [x] `cargo test --lib worktree::tests` — 3 tests pass (including new `ensure_repo_walks_up_when_path_missing`)
- [x] `cargo test --lib` full suite — 148 pass, 1 pre-existing flaky `daemon::lifecycle::tests::pid_lock_reclaims_stale_file` (passes in isolation on this branch and on `main`)
- [x] `cargo check --lib` clean
- [x] `cargo fmt --check` clean
- [x] Manual: `claude -w` in an Acorn session → `/exit` prunes the worktree → focusing the surviving session no longer surfaces `could not find git repository`; session shows as non-isolated, focused on main repo.
