### PR TITLE
fix(terminal): stabilize repaint and spawn sizing

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -22,6 +22,10 @@ import {
   unpatchTerminalCellMeasurements,
 } from "../lib/terminal-cjk-cell-width-addon";
 import {
+  createTerminalRepaintScheduler,
+  repaintTerminalViewport,
+} from "../lib/terminalRepaint";
+import {
   prepareScrollbackForSave,
   RESTORE_MARKER_TEXT,
   shouldRestoreScrollback,
@@ -386,6 +390,7 @@ export function Terminal({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<XTerm | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
+  const fitTerminalRef = useRef<(() => void) | null>(null);
   const [linkTooltip, setLinkTooltip] = useState<{
     anchorRect: TooltipAnchorRect;
   } | null>(null);
@@ -502,6 +507,7 @@ export function Terminal({
       fitAddon.fit();
       if (cjkEnabled) patchTerminalCellMeasurements(term);
     };
+    fitTerminalRef.current = fitWithCellMeasurements;
     try {
       fitWithCellMeasurements();
     } catch {
@@ -1669,6 +1675,7 @@ export function Terminal({
       term.dispose();
       termRef.current = null;
       fitRef.current = null;
+      fitTerminalRef.current = null;
     };
   }, [sessionId, cwd]);
 
@@ -1711,38 +1718,51 @@ export function Terminal({
   // each refresh so xterm's row geometry is up to date.
   useEffect(() => {
     if (!isActive) return;
-    const term = termRef.current;
-    const fit = fitRef.current;
-    const container = containerRef.current;
-    if (!term || !fit || !container) return;
-
     const refresh = () => {
-      // Force layout reflow so any pending visibility/size changes commit
-      // before xterm queries its container dimensions.
-      void container.offsetHeight;
-      try {
-        fit.fit();
-      } catch {
-        // ignore
-      }
-      try {
-        term.refresh(0, term.rows - 1);
-      } catch {
-        // ignore
-      }
-      try {
-        term.scrollToBottom();
-      } catch {
-        // ignore
-      }
+      const term = termRef.current;
+      const fit = fitTerminalRef.current;
+      const container = containerRef.current;
+      if (!term || !fit || !container) return;
+      repaintTerminalViewport({
+        container,
+        fit,
+        term,
+        scrollToBottom: true,
+      });
     };
 
-    refresh();
-    const raf = requestAnimationFrame(refresh);
-    const timeout = window.setTimeout(refresh, 50);
+    const scheduler = createTerminalRepaintScheduler(refresh);
+    scheduler.schedule();
+    return scheduler.dispose;
+  }, [isActive]);
+
+  // WKWebView can defer paints while the app window is not focused. PTY
+  // output still reaches xterm's buffer, but the DOM renderer may return with
+  // stale row elements until another terminal event happens. On focus/visible
+  // return, force the same layout + full-row repaint used for tab activation,
+  // without scrolling the user's viewport.
+  useEffect(() => {
+    if (!isActive) return;
+
+    const refresh = () => {
+      const term = termRef.current;
+      const fit = fitTerminalRef.current;
+      const container = containerRef.current;
+      if (!term || !fit || !container) return;
+      repaintTerminalViewport({ container, fit, term });
+    };
+    const scheduler = createTerminalRepaintScheduler(refresh);
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") return;
+      scheduler.schedule();
+    };
+
+    window.addEventListener("focus", scheduler.schedule);
+    document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
-      cancelAnimationFrame(raf);
-      window.clearTimeout(timeout);
+      window.removeEventListener("focus", scheduler.schedule);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      scheduler.dispose();
     };
   }, [isActive]);
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1136,8 +1136,61 @@ export function Terminal({
     container.addEventListener("compositionupdate", swallowComposition, true);
     container.addEventListener("compositionend", swallowComposition, true);
 
+    let ptyReady = false;
+    let lastPtyResize:
+      | {
+          cols: number;
+          rows: number;
+        }
+      | null = null;
+    const sendPtyResize = (
+      force = false,
+      size: { cols: number; rows: number } = {
+        cols: term.cols,
+        rows: term.rows,
+      },
+    ) => {
+      if (!ptyReady || size.cols <= 0 || size.rows <= 0) return;
+      if (
+        !force &&
+        lastPtyResize?.cols === size.cols &&
+        lastPtyResize.rows === size.rows
+      ) {
+        return;
+      }
+      lastPtyResize = { cols: size.cols, rows: size.rows };
+      invoke("pty_resize", {
+        sessionId,
+        cols: size.cols,
+        rows: size.rows,
+      }).catch((err: unknown) => {
+        if (
+          lastPtyResize?.cols === size.cols &&
+          lastPtyResize.rows === size.rows
+        ) {
+          lastPtyResize = null;
+        }
+        console.error("[Terminal] pty_resize failed", err);
+      });
+    };
+    const syncViewportAndPtySize = () => {
+      const fit = fitTerminalRef.current;
+      if (!fit) return;
+      repaintTerminalViewport({ container, fit, term });
+      // Even when xterm's cols/rows are unchanged, force a backend resize so
+      // TUIs launched from an already-open shell observe the current pane size.
+      sendPtyResize(true);
+    };
+    const commandSizeSyncScheduler = createTerminalRepaintScheduler(
+      syncViewportAndPtySize,
+      120,
+    );
+
     const inputDisposable = term.onData((data: string) => {
       sendUserInputToPty(data);
+      if (data.includes("\r") || data.includes("\n")) {
+        commandSizeSyncScheduler.schedule();
+      }
     });
 
     // Re-anchor the composition preview to the cursor on every xterm render.
@@ -1240,9 +1293,7 @@ export function Terminal({
     window.addEventListener("acorn:terminal-clear", onClearRequested);
 
     const resizeDisposable = term.onResize(({ cols, rows }) => {
-      invoke("pty_resize", { sessionId, cols, rows }).catch((err: unknown) => {
-        console.error("[Terminal] pty_resize failed", err);
-      });
+      sendPtyResize(false, { cols, rows });
     });
 
     // Debounce resize-driven `fit()` + SIGWINCH. Without this, dragging the
@@ -1281,6 +1332,8 @@ export function Terminal({
     async function spawnPty() {
       if (disposed) return;
       try {
+        ptyReady = false;
+        lastPtyResize = null;
         observedLinkedWorktreePath = null;
         worktreeAdoptionIntent = { kind: "none" };
         worktreeSnapshot = null;
@@ -1305,12 +1358,14 @@ export function Terminal({
         // "no pty for session".
         //
         // Sessions always drop into $SHELL on the backend.
+        const spawnCols = term.cols;
+        const spawnRows = term.rows;
         await invoke("pty_spawn", {
           sessionId,
           cwd,
           env: {},
-          cols: term.cols,
-          rows: term.rows,
+          cols: spawnCols,
+          rows: spawnRows,
           replayScrollback: !restoredDiskScrollback,
         });
         if (disposed) {
@@ -1321,6 +1376,9 @@ export function Terminal({
           });
           return;
         }
+        ptyReady = true;
+        lastPtyResize = { cols: spawnCols, rows: spawnRows };
+        commandSizeSyncScheduler.schedule();
         exited = false;
         // CommandRunDialog may have queued a one-shot command for this
         // session (e.g. `gh auth login` launched from the NoAccessBanner).
@@ -1408,6 +1466,8 @@ export function Terminal({
 
         const unlistenExit = await listen(`pty:exit:${sessionId}`, () => {
           if (disposed) return;
+          ptyReady = false;
+          lastPtyResize = null;
           codexImagePasteActive = false;
           // Adopt only when Acorn queued an explicit worktree command, or
           // when this terminal itself was observed running inside a fresh
@@ -1643,6 +1703,7 @@ export function Terminal({
         resizeTimer = null;
       }
       resizeObserver.disconnect();
+      commandSizeSyncScheduler.dispose();
       container.removeEventListener("input", onInput, true);
       container.removeEventListener("keydown", onKeydown, true);
       container.removeEventListener("paste", onPaste, true);

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { getTerminalLimbo } from "../lib/terminalLimbo";
 import { isSessionInFocusedPane } from "../lib/multiInput";
@@ -64,45 +64,33 @@ function PortaledTerminal({ session }: { session: Session }) {
     isSessionInFocusedPane(session.id, state.panes, state.focusedPaneId),
   );
 
-  // Park the target in limbo immediately on mount so React's createPortal
-  // has a connected DOM node to render into; full unmount returns it to
-  // the document tree so we don't leak the orphaned subtree.
+  // Full unmount removes the stable portal target so we do not leak an
+  // orphaned terminal subtree.
   useEffect(() => {
     const target = targetRef.current;
     if (!target) return;
-    if (!target.isConnected) {
-      getTerminalLimbo().appendChild(target);
-    }
     return () => {
       target.remove();
     };
   }, []);
 
   // Whenever the visible pane changes, move our target div into that pane's
-  // body (or back to limbo). Use rAF so we move after React commits any
-  // pending pane mounts, ensuring `[data-pane-body]` is in the DOM.
-  useEffect(() => {
+  // body (or back to limbo). This must run as a layout effect: Terminal's
+  // passive mount effect opens xterm and spawns the PTY with the current
+  // measured cols/rows, so the target needs to be in its real pane before
+  // that effect runs. Waiting for rAF leaves the first spawn fitted against
+  // the off-screen limbo size, which narrow panes and agent TUIs expose as
+  // stale wrapping/paint until the next resize or tab refit.
+  useLayoutEffect(() => {
     const target = targetRef.current;
     if (!target) return;
-    let cancelled = false;
-    const id = requestAnimationFrame(() => {
-      if (cancelled) return;
-      const dest = visiblePaneId
-        ? (document.querySelector(
-            `[data-pane-body="${cssEscape(visiblePaneId)}"]`,
-          ) as HTMLElement | null)
-        : null;
-      if (dest) {
-        if (target.parentElement !== dest) dest.appendChild(target);
-      } else {
-        const limbo = getTerminalLimbo();
-        if (target.parentElement !== limbo) limbo.appendChild(target);
-      }
-    });
-    return () => {
-      cancelled = true;
-      cancelAnimationFrame(id);
-    };
+    const dest = visiblePaneId
+      ? (document.querySelector(
+          `[data-pane-body="${cssEscape(visiblePaneId)}"]`,
+        ) as HTMLElement | null)
+      : null;
+    const nextParent = dest ?? getTerminalLimbo();
+    if (target.parentElement !== nextParent) nextParent.appendChild(target);
   }, [visiblePaneId, layoutRef]);
 
   return createPortal(

--- a/src/lib/terminalRepaint.test.ts
+++ b/src/lib/terminalRepaint.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createTerminalRepaintScheduler,
+  repaintTerminalViewport,
+} from "./terminalRepaint";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("repaintTerminalViewport", () => {
+  it("forces layout, fits, and refreshes the visible xterm rows", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "offsetHeight", {
+      configurable: true,
+      get: vi.fn(() => 240),
+    });
+    const fit = vi.fn();
+    const term = {
+      rows: 24,
+      refresh: vi.fn(),
+      scrollToBottom: vi.fn(),
+    };
+
+    repaintTerminalViewport({ container, fit, term, scrollToBottom: true });
+
+    expect(fit).toHaveBeenCalledTimes(1);
+    expect(term.refresh).toHaveBeenCalledWith(0, 23);
+    expect(term.scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not scroll when repainting after a window focus return", () => {
+    const container = document.createElement("div");
+    const fit = vi.fn();
+    const term = {
+      rows: 10,
+      refresh: vi.fn(),
+      scrollToBottom: vi.fn(),
+    };
+
+    repaintTerminalViewport({ container, fit, term });
+
+    expect(term.refresh).toHaveBeenCalledWith(0, 9);
+    expect(term.scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it("still refreshes when fit fails during a focus-return repaint", () => {
+    const container = document.createElement("div");
+    const fit = vi.fn(() => {
+      throw new Error("zero-sized terminal");
+    });
+    const term = {
+      rows: 8,
+      refresh: vi.fn(),
+    };
+
+    repaintTerminalViewport({ container, fit, term });
+
+    expect(term.refresh).toHaveBeenCalledWith(0, 7);
+  });
+});
+
+describe("createTerminalRepaintScheduler", () => {
+  it("runs repaint immediately, on the next frame, and after the delay", () => {
+    vi.useFakeTimers();
+    const frames = new Map<number, FrameRequestCallback>();
+    let nextFrame = 1;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      const id = nextFrame++;
+      frames.set(id, cb);
+      return id;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+      frames.delete(id);
+    });
+    const repaint = vi.fn();
+    const scheduler = createTerminalRepaintScheduler(repaint);
+
+    scheduler.schedule();
+
+    expect(repaint).toHaveBeenCalledTimes(1);
+    frames.get(1)?.(0);
+    expect(repaint).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(50);
+    expect(repaint).toHaveBeenCalledTimes(3);
+  });
+
+  it("cancels pending frame and timeout work when disposed", () => {
+    vi.useFakeTimers();
+    const frames = new Map<number, FrameRequestCallback>();
+    let nextFrame = 1;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      const id = nextFrame++;
+      frames.set(id, cb);
+      return id;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+      frames.delete(id);
+    });
+    const repaint = vi.fn();
+    const scheduler = createTerminalRepaintScheduler(repaint);
+
+    scheduler.schedule();
+    scheduler.dispose();
+    frames.get(1)?.(0);
+    vi.advanceTimersByTime(50);
+
+    expect(repaint).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/terminalRepaint.ts
+++ b/src/lib/terminalRepaint.ts
@@ -1,0 +1,73 @@
+interface RepaintTerminal {
+  rows: number;
+  refresh(start: number, end: number): void;
+  scrollToBottom?(): void;
+}
+
+export function repaintTerminalViewport({
+  container,
+  fit,
+  term,
+  scrollToBottom = false,
+}: {
+  container: HTMLElement;
+  fit: () => void;
+  term: RepaintTerminal;
+  scrollToBottom?: boolean;
+}): void {
+  // Force layout reflow so pending visibility/size changes commit before
+  // xterm queries container dimensions or rebuilds visible rows.
+  void container.offsetHeight;
+  try {
+    fit();
+  } catch {
+    // A hidden or zero-sized terminal can make FitAddon throw. The buffer can
+    // still be repainted, so do not let a fit miss block the refresh.
+  }
+  try {
+    term.refresh(0, Math.max(0, term.rows - 1));
+  } catch {
+    // Terminal may be disposed between scheduling and execution.
+  }
+  if (scrollToBottom) {
+    try {
+      term.scrollToBottom?.();
+    } catch {
+      // Best-effort; repaint is the important part.
+    }
+  }
+}
+
+export function createTerminalRepaintScheduler(
+  repaint: () => void,
+  delayMs = 50,
+): { schedule: () => void; dispose: () => void } {
+  let raf: number | null = null;
+  let timeout: number | null = null;
+
+  const dispose = () => {
+    if (raf !== null) {
+      cancelAnimationFrame(raf);
+      raf = null;
+    }
+    if (timeout !== null) {
+      window.clearTimeout(timeout);
+      timeout = null;
+    }
+  };
+
+  const schedule = () => {
+    dispose();
+    repaint();
+    raf = requestAnimationFrame(() => {
+      raf = null;
+      repaint();
+    });
+    timeout = window.setTimeout(() => {
+      timeout = null;
+      repaint();
+    }, delayMs);
+  };
+
+  return { schedule, dispose };
+}

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -33,9 +33,17 @@ test.describe("terminal: spawn", () => {
     // Record every pty_spawn invocation on `window` so the test can read it
     // back via page.evaluate.
     await tauri.handle("pty_spawn", (args) => {
+      const slot = document.querySelector<HTMLElement>(
+        '[data-acorn-terminal-slot="s-term"]',
+      );
+      const parent = slot?.parentElement ?? null;
       const w = window as unknown as { __ptySpawnCalls?: unknown[] };
       w.__ptySpawnCalls = w.__ptySpawnCalls ?? [];
-      w.__ptySpawnCalls.push(args);
+      w.__ptySpawnCalls.push({
+        ...(args as Record<string, unknown>),
+        parentPane: parent?.getAttribute("data-pane-body") ?? null,
+        parentLimbo: parent?.getAttribute("data-acorn-terminal-limbo") ?? null,
+      });
       return null;
     });
 
@@ -68,5 +76,7 @@ test.describe("terminal: spawn", () => {
     const first = calls[0];
     expect(first.sessionId).toBe("s-term");
     expect(first.cwd).toBe("/tmp/demo");
+    expect(first.parentPane).not.toBeNull();
+    expect(first.parentLimbo).toBeNull();
   });
 });

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -46,6 +46,12 @@ test.describe("terminal: spawn", () => {
       });
       return null;
     });
+    await tauri.handle("pty_resize", (args) => {
+      const w = window as unknown as { __ptyResizeCalls?: unknown[] };
+      w.__ptyResizeCalls = w.__ptyResizeCalls ?? [];
+      w.__ptyResizeCalls.push(args);
+      return null;
+    });
 
     await page.goto("/");
 
@@ -78,5 +84,65 @@ test.describe("terminal: spawn", () => {
     expect(first.cwd).toBe("/tmp/demo");
     expect(first.parentPane).not.toBeNull();
     expect(first.parentLimbo).toBeNull();
+  });
+
+  test("submitting a command resyncs the PTY size for agent TUIs", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_resize", (args) => {
+      const w = window as unknown as { __ptyResizeCalls?: unknown[] };
+      w.__ptyResizeCalls = w.__ptyResizeCalls ?? [];
+      w.__ptyResizeCalls.push(args);
+      return null;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await page.waitForTimeout(150);
+    await page.evaluate(() => {
+      (window as unknown as { __ptyResizeCalls?: unknown[] })
+        .__ptyResizeCalls = [];
+    });
+    await page.locator(".xterm-helper-textarea").focus();
+    await page.keyboard.press("Enter");
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __ptyResizeCalls?: unknown[] })
+                .__ptyResizeCalls?.length ?? 0,
+          ),
+        { timeout: 1_000 },
+      )
+      .toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## Summary

This fixes terminal paint artifacts that can appear when output arrives while Acorn is unfocused, when agent TUIs start before the terminal has been measured in its real pane, or when an already-open shell launches Claude/Codex from a narrow pane.

1. **Focus-return repaint:** Repaint the active terminal when the window regains focus or the document becomes visible again.
2. **Spawn-size correctness:** Attach the terminal portal target during layout before xterm opens and `pty_spawn` reads cols/rows, so narrow panes do not start agents against the off-screen limbo size.
3. **Command-submit size sync:** When the user submits a shell command, refit/repaint and force a PTY resize so newly launched TUIs observe the current pane size.
4. **Shared repaint helper:** Centralize terminal viewport repainting and the immediate/frame/delayed scheduling pattern used for paint race windows.
5. **CJK-aware fit path:** Reuse the terminal's existing cell-measurement-aware fit function so focus-return, tab-return, and command-submit repaints stay aligned with the CJK cell-width heuristic.
6. **Regression coverage:** Add unit coverage for repaint behavior and E2E coverage for pane attachment before spawn plus command-submit PTY size sync.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Terminal reliability | Reduces stale glyph/cursor artifacts after background output and agent TUI redraws in narrow panes. |
| Initial agent layout | Claude/Codex sessions start with pane-sized cols/rows instead of the off-screen limbo dimensions. |
| Existing shell agent launch | Claude/Codex launched from an already-open terminal receives a fresh pane-size resize signal on command submit. |
| User scroll position | Focus-return repaint refreshes visible rows without forcing scroll-to-bottom. |
| CJK terminal rendering | Repaint-triggered fits use the same CJK-aware measurement path as resize/initial fit. |
| Performance | Minimal; active terminals schedule bounded repaint/resize passes on focus return, tab return, spawn, and command submit. |

## Design notes

- The repaint path uses public xterm operations (`refresh`) plus the existing FitAddon path; it does not mutate xterm internals or row DOM.
- Tab activation still scrolls to bottom, matching the previous behavior. Window focus return deliberately does not scroll so reading scrollback is preserved.
- `fit()` failures are isolated from `refresh()` so a transient zero-sized container cannot prevent the buffer-backed repaint.
- TerminalHost now moves portal targets in a layout effect instead of waiting for rAF. That keeps `pty_spawn` dimensions tied to the real pane before agent TUIs render their first frame.
- PTY resize calls are gated until spawn succeeds; resize state resets on process exit to avoid sending stale resizes to a dead PTY.

## Test plan

- [x] `pnpm vitest run src/lib/terminalRepaint.test.ts` - 5 tests passed.
- [x] `pnpm playwright test tests/e2e/terminal.spec.ts` - 2 tests passed.
- [x] `pnpm typecheck` - passed.
- [x] `pnpm test` - 30 files passed, 255 tests passed, 1 skipped.

## Notes

- Full native paint timing still depends on WKWebView and user shell plugins, but this PR covers the deterministic causes: stale focus-return repaint scheduling, first-spawn measurement against the wrong container, and missing PTY size sync at command submit.