### PR TITLE
fix(terminal): stop link tooltip flicker on output

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1854,6 +1854,7 @@ export function Terminal({
         anchorRect={linkTooltip?.anchorRect ?? null}
         side="top"
         overlayClassName="xterm-hover"
+        dismissOnScroll={false}
       />
       {/* Pinned-prompt overlay. */}
       <StickyUserPrompt sessionId={sessionId} />

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -46,6 +46,15 @@ interface FloatingTooltipProps {
   multiline?: boolean;
   portalTarget?: HTMLElement | null;
   overlayClassName?: string;
+  /**
+   * Auto-dismiss when any ancestor scrolls. Default `true` matches the
+   * common case (anchor lives inside scrollable list / page). Set `false`
+   * for callers whose anchor sits inside a high-frequency internal
+   * scroller (e.g. xterm.js viewport) where bubbled scroll events from
+   * normal output would otherwise flicker the tooltip; those callers must
+   * drive show/hide themselves.
+   */
+  dismissOnScroll?: boolean;
 }
 
 interface TooltipPosition {
@@ -96,6 +105,7 @@ export function FloatingTooltip({
   multiline = false,
   portalTarget,
   overlayClassName,
+  dismissOnScroll = true,
 }: FloatingTooltipProps) {
   const tooltipRef = useRef<HTMLSpanElement>(null);
   const [position, setPosition] = useState<TooltipPosition | null>(null);
@@ -111,13 +121,17 @@ export function FloatingTooltip({
   useEffect(() => {
     if (position === null) return;
     const onMove = () => setPosition(null);
-    window.addEventListener("scroll", onMove, true);
+    if (dismissOnScroll) {
+      window.addEventListener("scroll", onMove, true);
+    }
     window.addEventListener("resize", onMove);
     return () => {
-      window.removeEventListener("scroll", onMove, true);
+      if (dismissOnScroll) {
+        window.removeEventListener("scroll", onMove, true);
+      }
       window.removeEventListener("resize", onMove);
     };
-  }, [position]);
+  }, [position, dismissOnScroll]);
 
   // Clamp the tooltip into the viewport AFTER it has been measured. The
   // initial `computePosition` anchors at the trigger center, which can


### PR DESCRIPTION
## Summary

Link tooltips inside the terminal (the "Cmd-click to open link" hint shown when hovering a URL with link-activation set to `modifier-click`) flickered on every redraw whenever the shell wrote output. `FloatingTooltip` registered a capture-phase `scroll` listener on `window` and dismissed the tooltip on any scroll event. xterm.js scrolls its viewport on each output write, that scroll bubbled up through capture, and the tooltip cleared — only to be re-shown a moment later when the linkifier re-fired `hover` on the next render.

## Fix

- `FloatingTooltip` now accepts an opt-out `dismissOnScroll` prop (default `true`, existing behavior preserved).
- The Terminal's link tooltip passes `dismissOnScroll={false}`. It already drives its own show/hide via xterm's `hover` / `leave` callbacks, so the global scroll-dismiss was redundant and harmful for that anchor.

## Test plan

- [ ] Hover a URL in a terminal session with `linkActivation = modifier-click` while output is actively streaming — tooltip stays put instead of flickering.
- [ ] Move mouse off link → tooltip dismisses immediately.
- [ ] Existing `Tooltip` callers (sidebar, status bar, etc.) still dismiss on page scroll — `dismissOnScroll` defaults to `true`.
- [ ] Window resize still dismisses.
