### PR TITLE
fix(ipc): stabilize socket path tests and split-crate docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ pnpm run typecheck
 pnpm run build          # tsc + vite build
 ```
 
-`src-tauri/binaries/acorn-ipc-<target-triple>` is `.gitignore`d, so every fresh checkout — including each new `git worktree add` — starts without it, and Tauri's `externalBin` existence check fails the build before anything else runs. Run `pnpm run build:sidecar` once per worktree (and again after any IPC change); plain `cargo build --bin acorn-ipc` is not enough because it skips the target-tripled staging step. See [`docs/CONTROL_SESSIONS.md`](docs/CONTROL_SESSIONS.md#the-acorn-ipc-cli) for details.
+`src-tauri/binaries/acorn-ipc-<target-triple>` is `.gitignore`d, so every fresh checkout — including each new `git worktree add` — starts without it, and Tauri's `externalBin` existence check fails the build before anything else runs. Run `pnpm run build:sidecar` once per worktree (and again after any IPC change); plain `cargo build -p acorn-ipc --bin acorn-ipc` is not enough because it skips the target-tripled staging step. See [`docs/CONTROL_SESSIONS.md`](docs/CONTROL_SESSIONS.md#the-acorn-ipc-cli) for details.
 
 ## Reading webview logs in dev
 

--- a/docs/CONTROL_SESSIONS.md
+++ b/docs/CONTROL_SESSIONS.md
@@ -109,7 +109,7 @@ pnpm run tauri dev
 which both compiles `acorn-ipc` *and* stages it at
 `src-tauri/binaries/acorn-ipc-<target-triple>`, the path Tauri's
 `externalBin` existence check requires before `tauri dev` / `tauri build`
-will even start. Plain `cargo build --bin acorn-ipc` skips the staging
+will even start. Plain `cargo build -p acorn-ipc --bin acorn-ipc` skips the staging
 step, so the build fails with
 `resource path 'binaries/acorn-ipc-...' doesn't exist`.
 
@@ -232,7 +232,7 @@ version `1`. See `src-tauri/src/ipc/proto.rs` for the canonical types.
 
 - **macOS and Linux only.** Both `acorn-ipc` and the in-app server import
   `std::os::unix::net::{UnixListener, UnixStream}` directly (see
-  `src-tauri/src/ipc/server.rs` and `src-tauri/src/bin/acorn-ipc.rs`), so the
+  `src-tauri/src/ipc/server.rs` and `src-tauri/crates/acorn-ipc/src/bin/acorn-ipc.rs`), so the
   crate does not compile on Windows targets at all. Porting would mean
   abstracting the transport — e.g. via the `interprocess` crate, which
   unifies Unix domain sockets and Windows named pipes behind one API — and

--- a/src-tauri/crates/acorn-daemon/src/paths.rs
+++ b/src-tauri/crates/acorn-daemon/src/paths.rs
@@ -35,7 +35,7 @@ use directories::ProjectDirs;
 pub const ENV_DATA_DIR_OVERRIDE: &str = "ACORN_DATA_DIR";
 
 /// Override env var for the daemon control socket. Mirrors the existing
-/// `ACORN_IPC_SOCKET` override pattern used by `crate::ipc::socket_path`
+/// `ACORN_IPC_SOCKET` override pattern used by `acorn_ipc::socket_path`
 /// so the same E2E harness that points the legacy IPC at a tempdir can
 /// also point the daemon at one.
 pub const ENV_DAEMON_SOCKET_OVERRIDE: &str = "ACORN_DAEMON_SOCKET";

--- a/src-tauri/crates/acorn-ipc/src/cli_path.rs
+++ b/src-tauri/crates/acorn-ipc/src/cli_path.rs
@@ -8,9 +8,9 @@
 //! receive this addition — they stay sandboxed from the IPC surface.
 //!
 //! In `tauri dev` the same `current_exe().parent()` resolves to
-//! `src-tauri/target/debug/`, where `cargo build --bin acorn-ipc` writes
-//! the dev binary, so dev and production converge without a code path
-//! split.
+//! `src-tauri/target/debug/`, where
+//! `cargo build -p acorn-ipc --bin acorn-ipc` writes the dev binary, so
+//! dev and production converge without a code path split.
 
 use std::path::{Path, PathBuf};
 

--- a/src-tauri/crates/acorn-ipc/src/socket_path.rs
+++ b/src-tauri/crates/acorn-ipc/src/socket_path.rs
@@ -48,12 +48,14 @@ pub fn resolve() -> Result<PathBuf, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn env_override_takes_precedence() {
-        // SAFETY: tests run on a single thread inside this test process and
-        // we restore the previous value before returning so neighbouring
-        // tests are not perturbed.
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        // SAFETY: serialized via ENV_LOCK and restored before returning.
         let prev = std::env::var(ENV_OVERRIDE).ok();
         unsafe {
             std::env::set_var(ENV_OVERRIDE, "/tmp/acorn-test.sock");
@@ -70,6 +72,7 @@ mod tests {
 
     #[test]
     fn falls_back_to_data_dir() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
         let prev = std::env::var(ENV_OVERRIDE).ok();
         unsafe {
             std::env::remove_var(ENV_OVERRIDE);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -30,7 +30,7 @@ pub struct AcornIpcStatus {
     /// never happen in a packaged build but is handled gracefully for dev.
     pub bundled_path: String,
     /// True when the bundled binary actually exists at `bundled_path`. False
-    /// in dev mode before `cargo build --bin acorn-ipc` has run.
+    /// in dev mode before `cargo build -p acorn-ipc --bin acorn-ipc` has run.
     pub bundled_exists: bool,
     /// Canonical Unix-socket path used by the IPC server.
     pub socket_path: String,


### PR DESCRIPTION
## Summary

Fixes the remaining IPC split follow-ups from review: a flaky env-mutating unit test and stale developer-facing build references.

1. **Socket path test stability**: serialize `ACORN_IPC_SOCKET` mutations inside `acorn-ipc` socket path tests so parallel `cargo test` runs cannot make the override/default cases race.
2. **Split-crate command docs**: replace stale `cargo build --bin acorn-ipc` references with `cargo build -p acorn-ipc --bin acorn-ipc`, and update the moved CLI source path in control-session docs.
3. **Stale module reference**: update a daemon path comment from the old host `crate::ipc::socket_path` location to `acorn_ipc::socket_path`.

## Expected impact

| Area | Impact |
| --- | --- |
| Test reliability | `cargo test -p acorn-ipc socket_path::tests` no longer flakes under parallel test execution. |
| Developer workflow | Docs and inline comments now point at the post-extraction package-qualified build command. |
| Runtime behavior | No runtime behavior change. |

## Design notes

The tests still use process-global env because that is the behavior under test. The mutex keeps the scope narrow and avoids changing production path resolution.

## Test plan

- [x] `for i in {1..100}; do cargo test -p acorn-ipc socket_path::tests --quiet >/tmp/acorn-ipc-socket-test.log 2>&1 || { echo "failed on run $i"; cat /tmp/acorn-ipc-socket-test.log; exit 1; }; done; echo ok`
- [x] `cargo test -p acorn-ipc`
- [x] `cargo check --workspace`
- [x] `cargo fmt -p acorn-ipc --check`
- [x] `git diff --check`

## Notes

`cargo fmt --check` for the full workspace currently reports pre-existing formatting drift outside this PR's edited Rust files, so this PR verifies formatting for the changed `acorn-ipc` package directly.
