### PR TITLE
fix(resume): suppress modal for live agent sessions

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2122,6 +2122,11 @@ fn agent_is_running_in_session(state: &AppState, session_id: &Uuid, basename: &s
         .stream_registry
         .pid(session_id)
         .or_else(|| state.pty.child_pid(session_id))
+        // On cold app boot with background sessions enabled, the resume
+        // probe can run before `pty_spawn` reattaches the frontend stream.
+        // Ask the daemon directly so live claude/codex processes still
+        // suppress the modal during that attach race.
+        .or_else(|| state.daemon_bridge.session_pid(*session_id))
     else {
         return false;
     };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,7 @@ import { applyTheme, useThemes } from "./lib/themes";
 import { extractTabFromEvent } from "./lib/settings-events";
 import { useAppStore } from "./store";
 import type { TranslationKey, Translator } from "./lib/i18n";
+import type { SessionStatus } from "./lib/types";
 import { useTranslation } from "./lib/useTranslation";
 
 const FOCUSABLE_SELECTOR =
@@ -250,24 +251,46 @@ function App() {
   // `activeSessionId × resumeCandidates`, so dismissal only needs to
   // drop the entry — no separate "currently shown" state to keep in
   // sync.
-  // Probe each session for a "이전 대화" candidate exactly once per
-  // Acorn launch. Per-session ref dedup so the effect re-firing when
+  // Probe each non-busy session for a "이전 대화" candidate exactly once
+  // per Acorn launch. Per-session ref dedup so the effect re-firing when
   // zustand pushes a new `sessions` array reference (boot rehydrate,
-  // reconcile, refresh) does NOT re-probe sessions we already checked.
+  // reconcile, refresh, status polling) does NOT re-probe sessions we
+  // already checked. Busy sessions are marked as checked without hitting
+  // the candidate APIs, because an active claude/codex should never be
+  // interrupted by a resume prompt for the transcript it is already using.
   // That dedup is what holds the "cold boot only" UX promise: after
   // the user finishes a claude run and the persister updates
   // `claude.id`, the in-memory map stays stable, so the modal never
   // pops mid-session.
-  const sessionIds = useMemo(() => sessions.map((s) => s.id), [sessions]);
   const resumeModalEnabled = useSettings(
     (s) => s.settings.experiments.resumeModal,
   );
   const probedSessionsRef = useRef<Set<string>>(new Set());
   useEffect(() => {
     if (!resumeModalEnabled) return;
-    const toProbe = sessionIds.filter(
-      (sid) => !probedSessionsRef.current.has(sid),
+    const activeSessions = sessions.filter((s) =>
+      shouldSkipResumeProbeForStatus(s.status),
     );
+    if (activeSessions.length > 0) {
+      for (const session of activeSessions) {
+        probedSessionsRef.current.add(session.id);
+      }
+      setResumeCandidates((prev) => {
+        let changed = false;
+        const next = new Map(prev);
+        for (const session of activeSessions) {
+          changed = next.delete(session.id) || changed;
+        }
+        return changed ? next : prev;
+      });
+    }
+    const toProbe = sessions
+      .filter(
+        (session) =>
+          !shouldSkipResumeProbeForStatus(session.status) &&
+          !probedSessionsRef.current.has(session.id),
+      )
+      .map((session) => session.id);
     if (toProbe.length === 0) return;
     // Mark *before* the await so a concurrent effect run (caused by
     // the same `sessions` array re-emitting a new reference during
@@ -303,7 +326,7 @@ function App() {
         // Best-effort probe — failures here just mean a session won't
         // surface its modal on this boot. The next launch retries.
       });
-  }, [sessionIds, resumeModalEnabled]);
+  }, [sessions, resumeModalEnabled]);
 
   const resumeCandidate = useMemo(() => {
     if (!activeSessionId) return null;
@@ -1004,6 +1027,10 @@ function pickResumeCandidate(
   if (claude) return { agent: "claude", candidate: claude };
   if (codex) return { agent: "codex", candidate: codex };
   return null;
+}
+
+function shouldSkipResumeProbeForStatus(status: SessionStatus): boolean {
+  return status === "running" || status === "needs_input";
 }
 
 export default App;

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -541,6 +541,7 @@ export function Terminal({
     let liveCwdProbeTimer: number | null = null;
     let agentProbeTimer: number | null = null;
     let restoredDiskScrollback = false;
+    let daemonSessionAliveAtMount = false;
     let codexImagePasteActive = false;
 
     const refreshAgentDetection = () => {
@@ -1366,7 +1367,7 @@ export function Terminal({
           env: {},
           cols: spawnCols,
           rows: spawnRows,
-          replayScrollback: !restoredDiskScrollback,
+          replayScrollback: daemonSessionAliveAtMount || !restoredDiskScrollback,
         });
         if (disposed) {
           // Cleanup ran mid-spawn — the pty just got created has no UI.
@@ -1551,19 +1552,40 @@ export function Terminal({
       });
       unlistenFns.push(() => restartDisposable.dispose());
 
+      // If the daemon already owns a live PTY for this session, its ring
+      // buffer is the freshest representation of the screen. Disk scrollback
+      // is only the last saved frontend snapshot and can be stale after the
+      // app has been closed while Claude/Codex kept running. Replaying that
+      // stale snapshot first leaves xterm's buffer/cursor out of sync with
+      // the next daemon redraw, so live daemon reattach skips disk restore
+      // and asks `pty_spawn` to replay the daemon ring instead.
+      try {
+        const daemonSessions = await api.daemonListSessions();
+        if (disposed) return;
+        daemonSessionAliveAtMount = daemonSessions.some(
+          (session) => session.id === sessionId && session.alive,
+        );
+      } catch {
+        daemonSessionAliveAtMount = false;
+      }
+
       // Restore the xterm-rendered disk snapshot before spawning so the user
-      // sees the previous terminal screen immediately on app restart. If this
-      // succeeds, `spawnPty()` tells the daemon attachment not to replay its
-      // raw PTY ring buffer: raw TUI output contains intermediate Claude
-      // redraw frames, while the disk snapshot is already parsed by xterm.
+      // sees the previous terminal screen immediately on app restart. Dead or
+      // newly spawned sessions can safely use that snapshot; already-live
+      // daemon sessions must use the daemon ring instead so cursor state
+      // matches the running PTY.
       try {
         const saved = await invoke<string | null>("scrollback_load", {
           sessionId,
         });
         if (disposed) return;
-        restoredDiskScrollback = saved !== null;
+        restoredDiskScrollback = !daemonSessionAliveAtMount && saved !== null;
         const restored = saved ? stripRestoreMarkers(saved) : "";
-        if (restored && shouldRestoreScrollback(restored)) {
+        if (
+          !daemonSessionAliveAtMount &&
+          restored &&
+          shouldRestoreScrollback(restored)
+        ) {
           // Each step is awaited individually. Previously the mode
           // resets and marker were fired without awaiting and `spawnPty`
           // was called immediately after, so the new shell's first

--- a/tests/e2e/agent-resume-modal.spec.ts
+++ b/tests/e2e/agent-resume-modal.spec.ts
@@ -20,9 +20,45 @@ const SESSION = {
   last_message: null,
   kind: "regular",
 };
+const RUNNING_SESSION = {
+  ...SESSION,
+  status: "running",
+};
 const CANDIDATE_UUID = "deadbeef-1234-5678-9abc-def012345678";
 
 test.describe("agent resume modal", () => {
+  test("does not pop for a session that is already running", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [RUNNING_SESSION]);
+    await tauri.handle("get_claude_resume_candidate", () => {
+      const w = window as unknown as { __ACORN_RESUME_PROBES__?: number };
+      w.__ACORN_RESUME_PROBES__ = (w.__ACORN_RESUME_PROBES__ ?? 0) + 1;
+      return {
+        uuid: CANDIDATE_UUID,
+        lastActivityUnix: Math.floor(Date.now() / 1000) - 600,
+        preview: "Preview of the previous conversation",
+      };
+    });
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("dialog", { name: /Resume previous conversation/ }),
+    ).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __ACORN_RESUME_PROBES__?: number })
+              .__ACORN_RESUME_PROBES__ ?? 0,
+        ),
+      )
+      .toBe(0);
+  });
+
   test("focusing a session with a claude candidate pops the modal and Resume writes claude --resume", async ({
     page,
     tauri,

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -145,4 +145,78 @@ test.describe("terminal: spawn", () => {
       )
       .toBeGreaterThanOrEqual(1);
   });
+
+  test("reattaching a live daemon session replays daemon scrollback instead of stale disk scrollback", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "running",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("daemon_list_sessions", () => [
+      {
+        id: "s-term",
+        name: "shell",
+        kind: "regular",
+        alive: true,
+        cwd: "/tmp/demo",
+        repo_path: "/tmp/demo",
+        branch: "main",
+        agent_kind: null,
+      },
+    ]);
+    await tauri.handle("scrollback_load", () => "stale disk snapshot\r\n");
+    await tauri.handle("pty_spawn", (args) => {
+      const w = window as unknown as { __ptySpawnCalls?: unknown[] };
+      w.__ptySpawnCalls = w.__ptySpawnCalls ?? [];
+      w.__ptySpawnCalls.push(args);
+      return null;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Running$/ })
+      .click();
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __ptySpawnCalls?: unknown[] })
+                .__ptySpawnCalls?.length ?? 0,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThanOrEqual(1);
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __ptySpawnCalls?: unknown[] }).__ptySpawnCalls,
+    )) as Array<{ replayScrollback: boolean }>;
+
+    expect(calls[0].replayScrollback).toBe(true);
+    await expect(page.locator(".xterm")).not.toContainText(
+      "stale disk snapshot",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Prevents Acorn from interrupting live agent sessions with stale resume or terminal restore state after a cold reattach.

1. **Resume modal guard:** skips resume-candidate probes for sessions currently marked `running` or `needs_input`, and clears any stale in-memory candidate for those sessions.
2. **Daemon liveness fallback:** checks the daemon-owned session pid when the frontend stream has not reattached yet, so cold-boot attach races still suppress redundant resume prompts.
3. **Live terminal reattach:** skips stale disk scrollback for already-live daemon sessions and asks the daemon to replay its fresh ring buffer, keeping xterm cursor state aligned with the running PTY.
4. **Regression coverage:** adds E2E cases for running-session resume suppression and live-daemon terminal reattach replay.

## Expected impact

| Area | Impact |
| --- | --- |
| User-visible behavior | Running Claude/Codex sessions no longer show redundant resume prompts or restore stale terminal cursor state. |
| Reliability | Cold-boot background-session attach races now have daemon-side liveness and scrollback fallbacks. |
| Build/test speed | No expected change. |

## Design notes

- The frontend treats `running` and `needs_input` as busy states because both represent an active or just-finished interaction where a resume prompt would be disruptive.
- The backend still keeps process-tree detection as the source of truth for candidate commands; it now looks through `stream_registry`, in-process PTY, and daemon session pid in that order.
- For live daemon reattach, the daemon ring buffer is fresher than the last saved frontend scrollback snapshot, so replaying the ring avoids applying live TUI redraws on top of stale xterm state.

## Follow-up (not in this PR)

- Consider exposing an explicit backend `session_has_live_agent` command if more UI surfaces need the same guard.

## Test plan

- [x] `pnpm test:e2e tests/e2e/agent-resume-modal.spec.ts tests/e2e/terminal.spec.ts --project=chromium` - 7 passed.
- [x] `pnpm typecheck` - passed.
- [x] `cargo test agent_resume --manifest-path src-tauri/Cargo.toml` - 9 passed.

## Notes

- Playwright emitted existing E2E mock warnings for `load_status` and user theme defaults; they did not fail the suite and are not caused by this PR.