### PR TITLE
fix(files): preserve explorer expansion when opening code tabs

### DIFF
--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -792,12 +792,12 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       if (entry.is_dir) return;
       try {
         const store = await import("../store");
-        store.useAppStore.getState().openCodeViewerTab(entry.path);
+        store.useAppStore.getState().openCodeViewerTab(entry.path, rootPath);
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
       }
     },
-    [],
+    [rootPath],
   );
 
   const handleBulkTrash = useCallback(async () => {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -133,17 +133,21 @@ export function RightPanel() {
   const t = useTranslation();
   const sessions = useAppStore((s) => s.sessions);
   const activeSessionId = useAppStore((s) => s.activeSessionId);
+  const activeTabId = useAppStore((s) => s.activeTabId);
   const activeProject = useAppStore((s) => s.activeProject);
+  const workspaceTabs = useAppStore((s) => s.workspaceTabs);
   const rightTab = useAppStore((s) => s.rightTab);
   const setRightTab = useAppStore((s) => s.setRightTab);
   const setRightGroup = useAppStore((s) => s.setRightGroup);
   const active = sessions.find((s) => s.id === activeSessionId);
+  const activeWorkspaceTab = activeTabId ? workspaceTabs[activeTabId] : undefined;
   // The session's recorded worktree path is what we set at spawn time. The
   // PTY child (or any descendant) may have chdir'd since — most notably via
   // `claude --worktree`, which silently moves the running session into a
   // freshly created worktree. `useLiveRepoPath` asks the backend on demand
   // and falls back to the recorded path when there's no live PTY.
-  const fallbackPath = active?.worktree_path ?? activeProject ?? null;
+  const fallbackPath =
+    active?.worktree_path ?? activeWorkspaceTab?.repoPath ?? activeProject ?? null;
   const repoPath = useLiveRepoPath(active?.id ?? null, fallbackPath, rightTab);
   const [expanded, setExpanded] = useState<ExpandedDiff | null>(null);
   const [prDetail, setPrDetail] = useState<{

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -242,7 +242,7 @@ describe("workspace tabs", () => {
 
     useAppStore
       .getState()
-      .openCodeViewerTab(`${s1.worktree_path}/src/App.tsx`);
+      .openCodeViewerTab(`${s1.worktree_path}/src/App.tsx`, s1.worktree_path);
 
     const s = useAppStore.getState();
     expect(s.workspaceTabs[s.activeTabId!]).toMatchObject({

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -234,6 +234,24 @@ describe("workspace tabs", () => {
     });
   });
 
+  it("scopes code viewer tabs to the active session worktree", async () => {
+    const s1 = session("a1", REPO_A, {
+      worktree_path: `${REPO_A}/.worktrees/a1`,
+    });
+    await seed([project(REPO_A, 0)], [s1]);
+
+    useAppStore
+      .getState()
+      .openCodeViewerTab(`${s1.worktree_path}/src/App.tsx`);
+
+    const s = useAppStore.getState();
+    expect(s.workspaceTabs[s.activeTabId!]).toMatchObject({
+      kind: "code",
+      path: `${s1.worktree_path}/src/App.tsx`,
+      repoPath: s1.worktree_path,
+    });
+  });
+
   it("closes the active code viewer instead of requesting session removal", async () => {
     await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
     useAppStore.getState().openCodeViewerTab(`${REPO_A}/src/App.tsx`);

--- a/src/store.ts
+++ b/src/store.ts
@@ -1206,18 +1206,10 @@ export const useAppStore = create<AppStateModel>()(
       const focused = ws.focusedPaneId;
       const pane = ws.panes[focused];
       if (!pane) return s;
-      const activeSessionId = activeSessionIdFromTabId(pane.activeTabId);
-      const activeSession = activeSessionId
-        ? s.sessions.find((session) => session.id === activeSessionId)
-        : null;
       const activeWorkspaceTab = pane.activeTabId
         ? s.workspaceTabs[pane.activeTabId]
         : undefined;
-      const targetRepoPath =
-        repoPath ??
-        activeSession?.worktree_path ??
-        activeWorkspaceTab?.repoPath ??
-        s.activeProject;
+      const targetRepoPath = repoPath ?? activeWorkspaceTab?.repoPath ?? s.activeProject;
       // Reuse an existing code tab for the same path if there is one;
       // this avoids piling up identical tabs when the user double-clicks
       // the same file repeatedly. The reuse cycles focus to the tab.

--- a/src/store.ts
+++ b/src/store.ts
@@ -178,7 +178,7 @@ interface AppStateModel {
   consumePendingTerminalInput: (sessionId: string) => PendingTerminalInput | null;
   toggleMultiInput: () => boolean;
   /** Open a readonly code viewer tab for `path` in the focused pane. */
-  openCodeViewerTab: (path: string) => void;
+  openCodeViewerTab: (path: string, repoPath?: string) => void;
   /** Close any frontend-owned tab and remove it from panes. */
   closeWorkspaceTab: (id: string) => void;
 }
@@ -1198,11 +1198,26 @@ export const useAppStore = create<AppStateModel>()(
     return enabled;
   },
 
-  openCodeViewerTab(path) {
+  openCodeViewerTab(path, repoPath) {
     set((s) => {
       if (!s.activeProject) return s;
       const ws = s.workspaces[s.activeProject];
       if (!ws) return s;
+      const focused = ws.focusedPaneId;
+      const pane = ws.panes[focused];
+      if (!pane) return s;
+      const activeSessionId = activeSessionIdFromTabId(pane.activeTabId);
+      const activeSession = activeSessionId
+        ? s.sessions.find((session) => session.id === activeSessionId)
+        : null;
+      const activeWorkspaceTab = pane.activeTabId
+        ? s.workspaceTabs[pane.activeTabId]
+        : undefined;
+      const targetRepoPath =
+        repoPath ??
+        activeSession?.worktree_path ??
+        activeWorkspaceTab?.repoPath ??
+        s.activeProject;
       // Reuse an existing code tab for the same path if there is one;
       // this avoids piling up identical tabs when the user double-clicks
       // the same file repeatedly. The reuse cycles focus to the tab.
@@ -1210,12 +1225,9 @@ export const useAppStore = create<AppStateModel>()(
         (tab) =>
           tab.kind === "code" &&
           tab.path === path &&
-          tab.repoPath === s.activeProject,
+          tab.repoPath === targetRepoPath,
       );
-      const tab = existing ?? makeCodeWorkspaceTab(path, s.activeProject);
-      const focused = ws.focusedPaneId;
-      const pane = ws.panes[focused];
-      if (!pane) return s;
+      const tab = existing ?? makeCodeWorkspaceTab(path, targetRepoPath);
       const alreadyInPane = pane.tabIds.includes(tab.id);
       const newPane: PaneState = alreadyInPane
         ? { ...pane, activeTabId: tab.id }

--- a/tests/e2e/file-explorer.spec.ts
+++ b/tests/e2e/file-explorer.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from "./support";
+
+test.describe("file explorer", () => {
+  test("keeps expanded worktree folders after opening a file", async ({
+    page,
+    tauri,
+  }) => {
+    const repo = "/tmp/demo";
+    const worktree = "/tmp/demo-worktree";
+    const src = `${worktree}/src`;
+    const file = `${src}/App.tsx`;
+
+    await tauri.respond("list_projects", [
+      {
+        repo_path: repo,
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-1",
+        name: "sess",
+        repo_path: repo,
+        worktree_path: worktree,
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_repo_root", () => "/tmp/demo-worktree");
+    await tauri.handle("fs_list_dir", (args) => {
+      const worktree = "/tmp/demo-worktree";
+      const src = `${worktree}/src`;
+      const file = `${src}/App.tsx`;
+      const { path } = args as { path: string };
+      if (path === worktree) {
+        return {
+          repo_root: worktree,
+          entries: [
+            {
+              name: "src",
+              path: src,
+              is_dir: true,
+              is_symlink: false,
+              size: 0,
+              modified_ms: 0,
+              gitignored: false,
+            },
+          ],
+        };
+      }
+      if (path === src) {
+        return {
+          repo_root: worktree,
+          entries: [
+            {
+              name: "App.tsx",
+              path: file,
+              is_dir: false,
+              is_symlink: false,
+              size: 42,
+              modified_ms: 0,
+              gitignored: false,
+            },
+          ],
+        };
+      }
+      return { repo_root: path, entries: [] };
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Code" }).click();
+    await page.getByRole("button", { name: "Files", exact: true }).click();
+
+    await page.getByRole("button", { name: "src" }).click();
+    await expect(page.getByRole("button", { name: "App.tsx" })).toBeVisible();
+
+    await page.getByRole("button", { name: "App.tsx" }).dblclick();
+
+    await expect(
+      page.getByRole("button", { name: /App\.tsx Close tab/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "App.tsx", exact: true }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
Opening a file from the File Explorer should not reset the tree that the user just navigated.

1. **Preserve explorer scope:** pass the File Explorer root into `openCodeViewerTab` so code tabs opened from worktrees keep the same repo/worktree scope.
2. **Stabilize right-panel fallback:** when a code tab is active, RightPanel now uses that tab's `repoPath` before falling back to the project root, avoiding a `FileExplorer key={repoPath}` remount.
3. **Cover the regression:** add store and E2E coverage for opening a worktree file while keeping expanded folders visible.

## Expected impact
| Area | Impact |
| --- | --- |
| File Explorer UX | Expanded folders stay open after double-clicking a file. |
| Code tabs | Code viewer tabs opened from worktrees remain scoped to the worktree path. |
| Sessions | No change to terminal/session process behavior. |

## Design notes
The bug came from opening a code tab making `activeSessionId` become `null`. RightPanel then fell back from the session worktree path to the project root, changing the FileExplorer key and remounting the tree. The fix keeps the current explorer root attached to the code tab and uses that path while the code tab is active.

## Follow-up (not in this PR)
None.

## Test plan
- [x] `pnpm vitest run src/store.test.ts -t "scopes code viewer tabs"` - passed
- [x] `pnpm test:e2e tests/e2e/file-explorer.spec.ts --project=chromium` - passed

## Notes
The E2E run prints existing mock-environment warnings for `load_status` and user theme loading; they are not caused by this PR and the test passed.
