### PR TITLE
fix(status): clear stale needs-input transcript markers

### DIFF
--- a/src-tauri/crates/acorn-session/src/status.rs
+++ b/src-tauri/crates/acorn-session/src/status.rs
@@ -69,15 +69,22 @@ pub enum AgentKind {
 /// dot stuck at Idle until the agent emits another turn line within the
 /// tail window — which for long sessions can be never.
 ///
-/// `shell_hint` carries the descendant-process snapshot for shell-mode
-/// sessions (no transcript on disk). It is the only signal we have for
-/// terminal sessions, so when no transcript resolves we map it directly
-/// to a status. `None` means "no live PTY" → Idle.
+/// `shell_hint` carries the descendant-process snapshot for the session's
+/// PTY. It also guards transcript markers from becoming sticky state:
+/// resume markers are durable, so an old transcript can still end in
+/// `NeedsInput` long after the agent process exited. When the PTY is idle
+/// (or gone), the durable marker is stale for status purposes and the
+/// session should be Idle. When a live descendant exists, the transcript
+/// tail refines that live process into Running vs NeedsInput.
 pub fn detect(
     transcript: Option<(PathBuf, AgentKind)>,
     previous: SessionStatus,
     shell_hint: Option<ShellHint>,
 ) -> SessionStatus {
+    if matches!(shell_hint, Some(ShellHint::Idle) | None) {
+        return SessionStatus::Idle;
+    }
+
     let (path, kind) = match transcript {
         Some(t) => t,
         None => return map_shell_hint(shell_hint),
@@ -415,5 +422,56 @@ mod tests {
             detect(None, SessionStatus::Idle, Some(ShellHint::Running)),
             SessionStatus::Running
         );
+    }
+
+    #[test]
+    fn detect_ignores_stale_needs_input_transcript_when_shell_is_idle() {
+        let path = write_status_transcript(&assistant("end_turn"));
+
+        assert_eq!(
+            detect(
+                Some((path, AgentKind::Claude)),
+                SessionStatus::NeedsInput,
+                Some(ShellHint::Idle),
+            ),
+            SessionStatus::Idle,
+        );
+    }
+
+    #[test]
+    fn detect_ignores_stale_needs_input_transcript_without_live_pty() {
+        let path = write_status_transcript(&assistant("end_turn"));
+
+        assert_eq!(
+            detect(
+                Some((path, AgentKind::Claude)),
+                SessionStatus::NeedsInput,
+                None,
+            ),
+            SessionStatus::Idle,
+        );
+    }
+
+    #[test]
+    fn detect_uses_needs_input_transcript_while_shell_has_live_child() {
+        let path = write_status_transcript(&assistant("end_turn"));
+
+        assert_eq!(
+            detect(
+                Some((path, AgentKind::Claude)),
+                SessionStatus::Running,
+                Some(ShellHint::Running),
+            ),
+            SessionStatus::NeedsInput,
+        );
+    }
+
+    fn write_status_transcript(body: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "acorn-status-test-{}.jsonl",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&path, body).expect("write status transcript");
+        path
     }
 }


### PR DESCRIPTION
## Summary
Agent transcript markers should refine live sessions, not keep old sessions permanently stuck in `NeedsInput`.

1. **Gate transcript classification on PTY liveness:** `status::detect` now treats durable resume markers as stale when the PTY is idle or gone, returning `Idle` instead of replaying an old `end_turn` / `task_complete` forever.
2. **Keep live agent behavior:** when the shell hint reports a live descendant, the transcript tail still distinguishes `Running` from `NeedsInput`.
3. **Cover stale-marker regressions:** add Rust tests for idle shell, missing PTY, and live-child transcript classification.

## Expected impact
| Area | Impact |
| --- | --- |
| Session status | Sessions no longer remain stuck as `NeedsInput` after the agent process exits or the PTY is idle. |
| Live agent status | Active agent sessions still surface `NeedsInput` when the live transcript says the turn is complete. |
| Resume markers | Existing marker files remain durable for resume, but no longer act as a live status signal by themselves. |

## Design notes
PR #210 correctly moved agent status toward transcript-aware classification, but it reused durable resume markers as if they were live-process evidence. This PR keeps the transcript parser, but makes the shell liveness hint the guardrail: no live PTY child means the marker is stale for status purposes.

## Follow-up (not in this PR)
None.

## Test plan
- [x] `cargo test -p acorn-session status --manifest-path src-tauri/Cargo.toml` - 25 passed

## Notes
This is scoped to status classification only; it does not change resume modal candidate persistence.
