### PR TITLE
fix(resume): prime live status before resume probes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -146,6 +146,10 @@ function App() {
   const pendingProjectSessions = pendingProject
     ? sessions.filter((s) => s.repo_path === pendingProject.repo_path)
     : [];
+  const sessionIdsKey = useMemo(
+    () => sessions.map((session) => session.id).join("\0"),
+    [sessions],
+  );
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [controlGuideOpen, setControlGuideOpen] = useState(false);
   const activeSessionId = useAppStore((s) => s.activeSessionId);
@@ -265,10 +269,51 @@ function App() {
   const resumeModalEnabled = useSettings(
     (s) => s.settings.experiments.resumeModal,
   );
+  const primedResumeSessionsRef = useRef<Set<string>>(new Set());
+  const [resumePrimeVersion, setResumePrimeVersion] = useState(0);
   const probedSessionsRef = useRef<Set<string>>(new Set());
   useEffect(() => {
+    if (!resumeModalEnabled) {
+      primedResumeSessionsRef.current.clear();
+      setResumePrimeVersion((version) => version + 1);
+      return;
+    }
+    const unprimedIds = sessions
+      .map((session) => session.id)
+      .filter((id) => !primedResumeSessionsRef.current.has(id));
+    if (unprimedIds.length === 0) return;
+    let cancelled = false;
+    void useAppStore
+      .getState()
+      .pollSessionStatuses()
+      .finally(() => {
+        if (cancelled) return;
+        for (const id of unprimedIds) {
+          primedResumeSessionsRef.current.add(id);
+        }
+        setResumePrimeVersion((version) => version + 1);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [resumeModalEnabled, sessionIdsKey]);
+
+  useEffect(() => {
     if (!resumeModalEnabled) return;
-    const activeSessions = sessions.filter((s) =>
+    const latestById = new Map(
+      useAppStore.getState().sessions.map((session) => [session.id, session]),
+    );
+    const effectiveSessions = sessions.map(
+      (session) => latestById.get(session.id) ?? session,
+    );
+    if (
+      effectiveSessions.some(
+        (session) => !primedResumeSessionsRef.current.has(session.id),
+      )
+    ) {
+      return;
+    }
+    const activeSessions = effectiveSessions.filter((s) =>
       shouldSkipResumeProbeForStatus(s.status),
     );
     if (activeSessions.length > 0) {
@@ -284,7 +329,7 @@ function App() {
         return changed ? next : prev;
       });
     }
-    const toProbe = sessions
+    const toProbe = effectiveSessions
       .filter(
         (session) =>
           !shouldSkipResumeProbeForStatus(session.status) &&
@@ -326,7 +371,7 @@ function App() {
         // Best-effort probe — failures here just mean a session won't
         // surface its modal on this boot. The next launch retries.
       });
-  }, [sessions, resumeModalEnabled]);
+  }, [sessions, resumeModalEnabled, resumePrimeVersion]);
 
   const resumeCandidate = useMemo(() => {
     if (!activeSessionId) return null;
@@ -477,9 +522,11 @@ function App() {
   // (idle/running). The Rust side does the file work; this just kicks the tick.
   useEffect(() => {
     const tick = () => useAppStore.getState().pollSessionStatuses();
-    tick();
+    void tick();
     const handle = setInterval(tick, 1000);
-    return () => clearInterval(handle);
+    return () => {
+      clearInterval(handle);
+    };
   }, []);
 
   // Skip the confirmation dialog for non-isolated sessions when the user has

--- a/tests/e2e/agent-resume-modal.spec.ts
+++ b/tests/e2e/agent-resume-modal.spec.ts
@@ -59,6 +59,41 @@ test.describe("agent resume modal", () => {
       .toBe(0);
   });
 
+  test("waits for the first status poll before probing idle persisted sessions", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [SESSION]);
+    await tauri.handle("detect_session_statuses", () => [
+      { id: "s-resume", status: "running", branch: null },
+    ]);
+    await tauri.handle("get_claude_resume_candidate", () => {
+      const w = window as unknown as { __ACORN_RESUME_PROBES__?: number };
+      w.__ACORN_RESUME_PROBES__ = (w.__ACORN_RESUME_PROBES__ ?? 0) + 1;
+      return {
+        uuid: CANDIDATE_UUID,
+        lastActivityUnix: Math.floor(Date.now() / 1000) - 600,
+        preview: "Preview of the previous conversation",
+      };
+    });
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("dialog", { name: /Resume previous conversation/ }),
+    ).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __ACORN_RESUME_PROBES__?: number })
+              .__ACORN_RESUME_PROBES__ ?? 0,
+        ),
+      )
+      .toBe(0);
+  });
+
   test("focusing a session with a claude candidate pops the modal and Resume writes claude --resume", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Prevent stale persisted session state from showing a resume modal before Acorn has checked whether the agent is already live.

1. **Status prime gate**: add a per-session status-prime step so resume candidate probes wait until `pollSessionStatuses()` has run for that session id.
2. **Latest status read**: evaluate resume probes against the latest zustand session state after the prime poll completes, so `running` and `needs_input` sessions are skipped before candidate APIs are called.
3. **Regression coverage**: add an E2E case where a persisted `idle` session becomes `running` on the first status poll and must not open the resume modal or call the resume candidate API.

## Expected impact

| Area | Impact |
| --- | --- |
| Resume modal reliability | Running Claude/Codex sessions no longer get interrupted by a stale resume prompt during app restart. |
| Agent session UX | Users can restart Acorn while agents are live without being offered to resume the transcript already in use. |
| Startup behavior | Resume probing waits for one status poll per session id before checking transcript candidates. |

## Design notes

The prior guard skipped sessions whose in-memory status was already `running` or `needs_input`, but on a cold boot the persisted status can still be `idle` until the first status poll lands. This PR tracks a primed set by session id, calls `pollSessionStatuses()` for unprimed ids, and only then allows resume candidate probing.

The gate is per-session rather than a single boolean so newly loaded sessions cannot inherit a primed state from an earlier empty or different session list.

## Follow-up (not in this PR)

- Keep the backend live-agent candidate suppression from #221 as a second line of defense for direct command calls.

## Test plan

- [x] `pnpm test:e2e tests/e2e/agent-resume-modal.spec.ts --project=chromium -g "waits for the first status poll"` - passed after fix; failed before the implementation because the candidate API was called once.
- [x] `pnpm test:e2e tests/e2e/agent-resume-modal.spec.ts --project=chromium` - 5 passed.
- [x] `pnpm typecheck` - passed.
- [x] `pnpm test` - 30 files passed, 255 passed, 1 skipped.

## Notes

The E2E output still includes existing mocked-RPC warnings for `load_status` and user themes. They are test harness setup warnings and are not introduced by this PR.
