### PR TITLE
fix(agents): stabilize history resume and transcript trash

### DIFF
--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -94,7 +94,7 @@ pub fn trash_agent_history_transcript(
                     path.display()
                 )));
             }
-            if codex_id_from_filename(&path).as_deref() != Some(id.as_str()) {
+            if !codex_transcript_matches_id(&path, &id) {
                 return Err(AppError::InvalidPath(
                     "transcript id does not match selected Codex session".to_string(),
                 ));
@@ -434,6 +434,27 @@ fn codex_id_from_filename(path: &Path) -> Option<String> {
     stem.rsplit('-').next().map(str::to_string)
 }
 
+fn codex_id_from_transcript(path: &Path) -> Option<String> {
+    for line in sample_lines(path).ok()? {
+        let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
+            continue;
+        };
+        let payload = value.get("payload");
+        if let Some(id) = string_at(payload, "id")
+            .or_else(|| string_at(payload, "session_id"))
+            .or_else(|| string_at(Some(&value), "session_id"))
+        {
+            return Some(id);
+        }
+    }
+    None
+}
+
+fn codex_transcript_matches_id(path: &Path, id: &str) -> bool {
+    codex_id_from_filename(path).as_deref() == Some(id)
+        || codex_id_from_transcript(path).as_deref() == Some(id)
+}
+
 fn collapse_preview(s: &str, max_chars: usize) -> Option<String> {
     let collapsed = s.split_whitespace().collect::<Vec<_>>().join(" ");
     if collapsed.is_empty() {
@@ -582,4 +603,26 @@ fn codex_sessions_root() -> Option<PathBuf> {
 
 fn home_dir() -> Option<PathBuf> {
     directories::UserDirs::new().map(|dirs| dirs.home_dir().to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn codex_transcript_match_accepts_payload_id_when_filename_differs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir
+            .path()
+            .join("rollout-2026-05-18T00-00-00-000Z-filename-id.jsonl");
+        let mut file = fs::File::create(&path).unwrap();
+        writeln!(
+            file,
+            r#"{{"payload":{{"id":"payload-id","cwd":"/tmp/demo"}}}}"#
+        )
+        .unwrap();
+
+        assert!(codex_transcript_matches_id(&path, "payload-id"));
+    }
 }

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -149,6 +149,8 @@ export function RightPanel() {
   const fallbackPath =
     active?.worktree_path ?? activeWorkspaceTab?.repoPath ?? activeProject ?? null;
   const repoPath = useLiveRepoPath(active?.id ?? null, fallbackPath, rightTab);
+  const sessionHostRepoPath =
+    active?.repo_path ?? activeWorkspaceTab?.repoPath ?? activeProject ?? repoPath;
   const [expanded, setExpanded] = useState<ExpandedDiff | null>(null);
   const [prDetail, setPrDetail] = useState<{
     repoPath: string;
@@ -295,7 +297,11 @@ export function RightPanel() {
           )
         ) : rightTab === "history" ? (
           repoPath ? (
-            <AgentHistoryTab key={repoPath} repoPath={repoPath} />
+            <AgentHistoryTab
+              key={repoPath}
+              repoPath={repoPath}
+              sessionHostRepoPath={sessionHostRepoPath ?? repoPath}
+            />
           ) : (
             <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
@@ -736,7 +742,13 @@ function countByStatus(todos: TodoItem[]) {
   return { pending, in_progress, completed };
 }
 
-function AgentHistoryTab({ repoPath }: { repoPath: string }) {
+function AgentHistoryTab({
+  repoPath,
+  sessionHostRepoPath,
+}: {
+  repoPath: string;
+  sessionHostRepoPath: string;
+}) {
   const t = useTranslation();
   const createSession = useAppStore((s) => s.createSession);
   const adoptSessionWorktree = useAppStore((s) => s.adoptSessionWorktree);
@@ -802,7 +814,7 @@ function AgentHistoryTab({ repoPath }: { repoPath: string }) {
     try {
       const created = await createSession(
         `${item.provider} ${rt(t, "rightPanel.history.resumeSessionName")}`,
-        repoPath,
+        sessionHostRepoPath,
       );
       if (!created) {
         setError(

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -30,6 +30,33 @@ async function seedActiveSession(
   ]);
 }
 
+async function seedActiveWorktreeSession(
+  tauri: { handle: (cmd: string, fn: (args: unknown) => unknown) => Promise<void> },
+) {
+  await tauri.handle("list_projects", () => [
+    {
+      repo_path: "/tmp/demo",
+      name: "demo",
+      created_at: "2026-01-01T00:00:00Z",
+      position: 0,
+    },
+  ]);
+  await tauri.handle("list_sessions", () => [
+    {
+      id: "s-1",
+      name: "sess",
+      repo_path: "/tmp/demo",
+      worktree_path: "/tmp/demo/.acorn/worktrees/demo-1",
+      branch: "main",
+      isolated: true,
+      status: "idle",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:05Z",
+      last_message: null,
+    },
+  ]);
+}
+
 test.describe("right panel: tab switching", () => {
   test("each tab shows its own empty placeholder when seeded with a project", async ({
     page,
@@ -407,6 +434,74 @@ test.describe("right panel: groups", () => {
     await expect(
       page.getByRole("dialog", { name: "Running in worktree" }),
     ).toBeVisible();
+  });
+
+  test("History run in new terminal hosts resumed sessions in the project root", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveWorktreeSession(tauri);
+    await tauri.handle("list_agent_history", () => [
+      {
+        provider: "codex",
+        id: "codex-root",
+        title: "Resume without project duplication",
+        preview: null,
+        cwd: "/tmp/demo/.acorn/worktrees/demo-1",
+        worktree: {
+          name: "demo-1",
+          path: "/tmp/demo/.acorn/worktrees/demo-1",
+          exists: true,
+        },
+        transcript_path: "/tmp/codex-root.jsonl",
+        updated_at: 1770000000,
+        resume_command: "codex resume codex-root",
+      },
+    ]);
+    await tauri.handle("create_session", (args) => {
+      const w = window as unknown as { __createSessionCalls?: unknown[] };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(args);
+      return {
+        id: "created-root",
+        name: (args as { name: string }).name,
+        repo_path: (args as { repoPath: string }).repoPath,
+        worktree_path: (args as { repoPath: string }).repoPath,
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      };
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Agents" }).click();
+    await page.getByRole("button", { name: "History" }).click();
+    await page.getByText("Resume without project duplication").click({
+      button: "right",
+    });
+    await page.getByRole("menuitem", { name: "Run in new terminal" }).click();
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __createSessionCalls?: unknown[] })
+                .__createSessionCalls?.length ?? 0,
+          ),
+        { timeout: 3_000 },
+      )
+      .toBe(1);
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __createSessionCalls?: unknown[] })
+          .__createSessionCalls,
+    )) as Array<{ repoPath: string }>;
+    expect(calls[0].repoPath).toBe("/tmp/demo");
   });
 
   test("History context menu can explicitly resume in a worktree", async ({


### PR DESCRIPTION
## Summary
This fixes two Agents History regressions around resumed terminal placement and transcript removal.

1. **History terminal host project:** keep History scanning scoped to the live repo/worktree path, but create resumed terminals under the recorded project root so the sidebar does not create a duplicate project for the worktree path.
2. **Codex transcript trash validation:** accept Codex transcript ids read from the JSONL payload as well as ids derived from the rollout filename, matching how History rows choose their resume id.
3. **Regression coverage:** add E2E coverage for History `Run in new terminal` from an active worktree session and a Rust unit test for Codex payload-id transcript matching.

## Expected impact
| Area | Impact |
| --- | --- |
| Agents History | `Run in new terminal` no longer creates a duplicate project when the active session is inside a worktree. |
| Transcript cleanup | Moving Codex transcripts to Trash no longer fails when the transcript payload id differs from the rollout filename suffix. |
| Existing worktree flow | Explicit `Run in worktree` behavior remains unchanged. |

## Design notes
- `AgentHistoryTab` now receives separate paths for reading history and for hosting newly created sessions. The history path can still be a live worktree repo, while the session host path prefers `active.repo_path`.
- Codex transcript deletion still validates extension, root containment, and selected id; it now checks the same payload id fields used during History parsing before falling back to filename-derived ids.

## Follow-up (not in this PR)
- The E2E Tauri mock still logs unrelated `load_status` and user theme warnings during right-panel tests; this PR does not change that mock surface.

## Test plan
- [x] `pnpm typecheck` passed.
- [x] `pnpm test:e2e tests/e2e/right-panel.spec.ts` passed, 12 tests.
- [x] `cargo test agent_history` passed.

## Notes
- The Playwright run still emits pre-existing mock warnings for `load_status` and user themes. The right-panel tests passed, and those warnings are not caused by this PR.
