### PR TITLE
perf(terminal): reduce output and subscription overhead

### DIFF
--- a/src-tauri/crates/acorn-pty/src/lib.rs
+++ b/src-tauri/crates/acorn-pty/src/lib.rs
@@ -6,9 +6,9 @@
 //!   * a process child handle used to kill the process
 //!   * a stop flag used to signal the reader task to exit cleanly
 //!
-//! Output bytes are read on a blocking thread, base64-encoded, and emitted to
-//! the frontend via Tauri events:
-//!   * `pty:output:{session_id}` — payload `{ "data": "<base64>" }`
+//! Output bytes are read on a blocking thread and forwarded through the
+//! host-provided output sink. The host can send raw bytes through a Tauri
+//! Channel and fall back to legacy events when needed.
 //!   * `pty:exit:{session_id}` — payload `{ "code": Option<i32> }`
 
 use std::collections::VecDeque;
@@ -51,6 +51,7 @@ pub enum PtyError {
 }
 
 pub type PtyResult<T> = Result<T, PtyError>;
+pub type PtyOutputSink = Arc<dyn Fn(&str, &Uuid, &[u8]) + Send + Sync + 'static>;
 
 /// Coarse classification of a shell-mode session's liveness, derived purely
 /// from "does the PTY child have any descendant processes right now?".
@@ -88,8 +89,8 @@ struct PtyHandle {
     /// deadline passes.
     needs_input_until: Mutex<Option<Instant>>,
     /// Rolling tail of raw PTY output bytes. Appended by `read_loop` before
-    /// the bytes are base64-encoded and emitted to the frontend; consumed
-    /// out of band by `tail_bytes` for the IPC `read-buffer` command.
+    /// the bytes are forwarded through the host output sink; consumed out of
+    /// band by `tail_bytes` for the IPC `read-buffer` command.
     /// Capped at `TAIL_BUFFER_CAP` — older bytes are dropped from the
     /// front when the cap is hit.
     tail_buf: Mutex<VecDeque<u8>>,
@@ -99,11 +100,6 @@ struct PtyHandle {
 #[derive(Default)]
 pub struct PtyManager {
     handles: Arc<DashMap<Uuid, Arc<PtyHandle>>>,
-}
-
-#[derive(Serialize, Clone)]
-struct OutputPayload {
-    data: String,
 }
 
 #[derive(Serialize, Clone)]
@@ -129,6 +125,7 @@ impl PtyManager {
     pub fn spawn<R, F>(
         &self,
         app: AppHandle<R>,
+        output_sink: PtyOutputSink,
         session_id: Uuid,
         cwd: PathBuf,
         command: String,
@@ -199,18 +196,17 @@ impl PtyManager {
 
         self.handles.insert(session_id, Arc::clone(&handle));
 
-        let app_for_reader = app.clone();
         let stop_for_reader = stop.clone();
         let handle_for_reader = Arc::clone(&handle);
         std::thread::Builder::new()
             .name(format!("acorn-pty-read-{session_id}"))
             .spawn(move || {
                 read_loop(
-                    app_for_reader,
                     session_id,
                     reader,
                     stop_for_reader,
                     handle_for_reader,
+                    output_sink,
                 );
             })
             .map_err(|e| PtyError::Other(format!("spawn reader thread: {e}")))?;
@@ -360,12 +356,12 @@ impl PtyManager {
     }
 }
 
-fn read_loop<R: Runtime>(
-    app: AppHandle<R>,
+fn read_loop(
     session_id: Uuid,
     mut reader: Box<dyn Read + Send>,
     stop: Arc<AtomicBool>,
     handle: Arc<PtyHandle>,
+    output_sink: PtyOutputSink,
 ) {
     let event = format!("pty:output:{session_id}");
     let mut buf = [0u8; READ_BUFFER_SIZE];
@@ -377,12 +373,7 @@ fn read_loop<R: Runtime>(
             Ok(0) => break, // EOF — child closed the slave
             Ok(n) => {
                 push_tail(&handle.tail_buf, &buf[..n]);
-                let payload = OutputPayload {
-                    data: base64_encode(&buf[..n]),
-                };
-                if let Err(e) = app.emit(&event, payload) {
-                    tracing::warn!(%session_id, error = %e, "failed to emit pty output");
-                }
+                output_sink(&event, &session_id, &buf[..n]);
             }
             Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
             Err(e) => {
@@ -434,76 +425,10 @@ fn wait_loop<R: Runtime>(
     }
 }
 
-/// Minimal RFC 4648 base64 encoder. Avoids pulling in a runtime dep purely
-/// for transport encoding of PTY chunks.
-fn base64_encode(input: &[u8]) -> String {
-    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut out = String::with_capacity((input.len() + 2) / 3 * 4);
-    let mut chunks = input.chunks_exact(3);
-    for chunk in &mut chunks {
-        let n = (u32::from(chunk[0]) << 16) | (u32::from(chunk[1]) << 8) | u32::from(chunk[2]);
-        out.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
-        out.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
-        out.push(ALPHABET[((n >> 6) & 0x3f) as usize] as char);
-        out.push(ALPHABET[(n & 0x3f) as usize] as char);
-    }
-    let rem = chunks.remainder();
-    match rem.len() {
-        0 => {}
-        1 => {
-            let n = u32::from(rem[0]) << 16;
-            out.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
-            out.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
-            out.push('=');
-            out.push('=');
-        }
-        2 => {
-            let n = (u32::from(rem[0]) << 16) | (u32::from(rem[1]) << 8);
-            out.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
-            out.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
-            out.push(ALPHABET[((n >> 6) & 0x3f) as usize] as char);
-            out.push('=');
-        }
-        _ => unreachable!(),
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn base64_encodes_empty_input() {
-        assert_eq!(base64_encode(&[]), "");
-    }
-
-    #[test]
-    fn base64_encodes_single_byte() {
-        assert_eq!(base64_encode(b"f"), "Zg==");
-    }
-
-    #[test]
-    fn base64_encodes_two_bytes() {
-        assert_eq!(base64_encode(b"fo"), "Zm8=");
-    }
-
-    #[test]
-    fn base64_encodes_three_bytes() {
-        assert_eq!(base64_encode(b"foo"), "Zm9v");
-    }
-
-    #[test]
-    fn base64_encodes_classic_man() {
-        assert_eq!(base64_encode(b"Man"), "TWFu");
-    }
-
-    #[test]
-    fn base64_encodes_long_input() {
-        assert_eq!(base64_encode(b"hello world"), "aGVsbG8gd29ybGQ=");
-    }
-
-    #[test]
     fn push_tail_keeps_recent_bytes_when_cap_exceeded() {
         let tail: Mutex<VecDeque<u8>> = Mutex::new(VecDeque::new());
         // Push twice the cap; expect exactly TAIL_BUFFER_CAP bytes left,

--- a/src-tauri/shell-init/zlogin
+++ b/src-tauri/shell-init/zlogin
@@ -14,12 +14,19 @@
 
 _acorn_zd_save=$ZDOTDIR
 _acorn_user_zd=${ACORN_USER_ZDOTDIR:-$HOME}
-if [ "$_acorn_user_zd" = "$_acorn_zd_save" ]; then
+_acorn_realpath() {
+    (cd -P -- "$1" 2>/dev/null && pwd -P)
+}
+_acorn_zd_real=$(_acorn_realpath "$_acorn_zd_save")
+_acorn_user_zd_real=$(_acorn_realpath "$_acorn_user_zd")
+if [ -n "$_acorn_zd_real" ] && [ "$_acorn_user_zd_real" = "$_acorn_zd_real" ]; then
     _acorn_user_zd=$HOME
+    _acorn_user_zd_real=$(_acorn_realpath "$_acorn_user_zd")
 fi
-if [ "$_acorn_user_zd" != "$_acorn_zd_save" ]; then
+if [ -n "$_acorn_user_zd_real" ] && [ "$_acorn_user_zd_real" != "$_acorn_zd_real" ]; then
     ZDOTDIR=$_acorn_user_zd
     [ -f "$ZDOTDIR/.zlogin" ] && source "$ZDOTDIR/.zlogin"
 fi
 ZDOTDIR=$_acorn_zd_save
-unset _acorn_zd_save _acorn_user_zd
+unset -f _acorn_realpath
+unset _acorn_zd_save _acorn_user_zd _acorn_zd_real _acorn_user_zd_real

--- a/src-tauri/shell-init/zlogin
+++ b/src-tauri/shell-init/zlogin
@@ -14,7 +14,12 @@
 
 _acorn_zd_save=$ZDOTDIR
 _acorn_user_zd=${ACORN_USER_ZDOTDIR:-$HOME}
-ZDOTDIR=$_acorn_user_zd
-[ -f "$ZDOTDIR/.zlogin" ] && source "$ZDOTDIR/.zlogin"
+if [ "$_acorn_user_zd" = "$_acorn_zd_save" ]; then
+    _acorn_user_zd=$HOME
+fi
+if [ "$_acorn_user_zd" != "$_acorn_zd_save" ]; then
+    ZDOTDIR=$_acorn_user_zd
+    [ -f "$ZDOTDIR/.zlogin" ] && source "$ZDOTDIR/.zlogin"
+fi
 ZDOTDIR=$_acorn_zd_save
 unset _acorn_zd_save _acorn_user_zd

--- a/src-tauri/shell-init/zprofile
+++ b/src-tauri/shell-init/zprofile
@@ -13,7 +13,12 @@
 
 _acorn_zd_save=$ZDOTDIR
 _acorn_user_zd=${ACORN_USER_ZDOTDIR:-$HOME}
-ZDOTDIR=$_acorn_user_zd
-[ -f "$ZDOTDIR/.zprofile" ] && source "$ZDOTDIR/.zprofile"
+if [ "$_acorn_user_zd" = "$_acorn_zd_save" ]; then
+    _acorn_user_zd=$HOME
+fi
+if [ "$_acorn_user_zd" != "$_acorn_zd_save" ]; then
+    ZDOTDIR=$_acorn_user_zd
+    [ -f "$ZDOTDIR/.zprofile" ] && source "$ZDOTDIR/.zprofile"
+fi
 ZDOTDIR=$_acorn_zd_save
 unset _acorn_zd_save _acorn_user_zd

--- a/src-tauri/shell-init/zprofile
+++ b/src-tauri/shell-init/zprofile
@@ -13,12 +13,19 @@
 
 _acorn_zd_save=$ZDOTDIR
 _acorn_user_zd=${ACORN_USER_ZDOTDIR:-$HOME}
-if [ "$_acorn_user_zd" = "$_acorn_zd_save" ]; then
+_acorn_realpath() {
+    (cd -P -- "$1" 2>/dev/null && pwd -P)
+}
+_acorn_zd_real=$(_acorn_realpath "$_acorn_zd_save")
+_acorn_user_zd_real=$(_acorn_realpath "$_acorn_user_zd")
+if [ -n "$_acorn_zd_real" ] && [ "$_acorn_user_zd_real" = "$_acorn_zd_real" ]; then
     _acorn_user_zd=$HOME
+    _acorn_user_zd_real=$(_acorn_realpath "$_acorn_user_zd")
 fi
-if [ "$_acorn_user_zd" != "$_acorn_zd_save" ]; then
+if [ -n "$_acorn_user_zd_real" ] && [ "$_acorn_user_zd_real" != "$_acorn_zd_real" ]; then
     ZDOTDIR=$_acorn_user_zd
     [ -f "$ZDOTDIR/.zprofile" ] && source "$ZDOTDIR/.zprofile"
 fi
 ZDOTDIR=$_acorn_zd_save
-unset _acorn_zd_save _acorn_user_zd
+unset -f _acorn_realpath
+unset _acorn_zd_save _acorn_user_zd _acorn_zd_real _acorn_user_zd_real

--- a/src-tauri/shell-init/zshenv
+++ b/src-tauri/shell-init/zshenv
@@ -14,15 +14,19 @@
 # source the user's real rc.
 
 _acorn_zd=$ZDOTDIR
-if [ -n "${ACORN_USER_ZDOTDIR-}" ]; then
-    [ -f "$ACORN_USER_ZDOTDIR/.zshenv" ] && . "$ACORN_USER_ZDOTDIR/.zshenv"
-elif [ -f "$HOME/.zshenv" ]; then
-    . "$HOME/.zshenv"
+_acorn_user_zd=${ACORN_USER_ZDOTDIR:-$HOME}
+if [ "$_acorn_user_zd" = "$_acorn_zd" ]; then
+    _acorn_user_zd=$HOME
+fi
+if [ "$_acorn_user_zd" != "$_acorn_zd" ] && [ -f "$_acorn_user_zd/.zshenv" ]; then
+    . "$_acorn_user_zd/.zshenv"
 fi
 # If user .zshenv reset ZDOTDIR, treat that as their real rc dir for
 # .zshrc lookup. Otherwise keep whatever Acorn injected.
 if [ "$ZDOTDIR" != "$_acorn_zd" ]; then
     ACORN_USER_ZDOTDIR=$ZDOTDIR
+else
+    ACORN_USER_ZDOTDIR=$_acorn_user_zd
 fi
 ZDOTDIR=$_acorn_zd
-unset _acorn_zd
+unset _acorn_zd _acorn_user_zd

--- a/src-tauri/shell-init/zshenv
+++ b/src-tauri/shell-init/zshenv
@@ -15,18 +15,26 @@
 
 _acorn_zd=$ZDOTDIR
 _acorn_user_zd=${ACORN_USER_ZDOTDIR:-$HOME}
-if [ "$_acorn_user_zd" = "$_acorn_zd" ]; then
+_acorn_realpath() {
+    (cd -P -- "$1" 2>/dev/null && pwd -P)
+}
+_acorn_zd_real=$(_acorn_realpath "$_acorn_zd")
+_acorn_user_zd_real=$(_acorn_realpath "$_acorn_user_zd")
+if [ -n "$_acorn_zd_real" ] && [ "$_acorn_user_zd_real" = "$_acorn_zd_real" ]; then
     _acorn_user_zd=$HOME
+    _acorn_user_zd_real=$(_acorn_realpath "$_acorn_user_zd")
 fi
-if [ "$_acorn_user_zd" != "$_acorn_zd" ] && [ -f "$_acorn_user_zd/.zshenv" ]; then
+if [ -n "$_acorn_user_zd_real" ] && [ "$_acorn_user_zd_real" != "$_acorn_zd_real" ] && [ -f "$_acorn_user_zd/.zshenv" ]; then
     . "$_acorn_user_zd/.zshenv"
 fi
 # If user .zshenv reset ZDOTDIR, treat that as their real rc dir for
 # .zshrc lookup. Otherwise keep whatever Acorn injected.
-if [ "$ZDOTDIR" != "$_acorn_zd" ]; then
+_acorn_new_zd_real=$(_acorn_realpath "$ZDOTDIR")
+if [ -n "$_acorn_zd_real" ] && [ -n "$_acorn_new_zd_real" ] && [ "$_acorn_new_zd_real" != "$_acorn_zd_real" ]; then
     ACORN_USER_ZDOTDIR=$ZDOTDIR
 else
     ACORN_USER_ZDOTDIR=$_acorn_user_zd
 fi
 ZDOTDIR=$_acorn_zd
-unset _acorn_zd _acorn_user_zd
+unset -f _acorn_realpath
+unset _acorn_zd _acorn_user_zd _acorn_zd_real _acorn_user_zd_real _acorn_new_zd_real

--- a/src-tauri/shell-init/zshrc
+++ b/src-tauri/shell-init/zshrc
@@ -25,15 +25,22 @@
 
 _acorn_zd_save=$ZDOTDIR
 _acorn_user_zd=${ACORN_USER_ZDOTDIR:-$HOME}
-if [ "$_acorn_user_zd" = "$_acorn_zd_save" ]; then
+_acorn_realpath() {
+    (cd -P -- "$1" 2>/dev/null && pwd -P)
+}
+_acorn_zd_real=$(_acorn_realpath "$_acorn_zd_save")
+_acorn_user_zd_real=$(_acorn_realpath "$_acorn_user_zd")
+if [ -n "$_acorn_zd_real" ] && [ "$_acorn_user_zd_real" = "$_acorn_zd_real" ]; then
     _acorn_user_zd=$HOME
+    _acorn_user_zd_real=$(_acorn_realpath "$_acorn_user_zd")
 fi
-if [ "$_acorn_user_zd" != "$_acorn_zd_save" ]; then
+if [ -n "$_acorn_user_zd_real" ] && [ "$_acorn_user_zd_real" != "$_acorn_zd_real" ]; then
     ZDOTDIR=$_acorn_user_zd
     [ -f "$ZDOTDIR/.zshrc" ] && source "$ZDOTDIR/.zshrc"
 fi
 ZDOTDIR=$_acorn_zd_save
-unset _acorn_zd_save _acorn_user_zd
+unset -f _acorn_realpath
+unset _acorn_zd_save _acorn_user_zd _acorn_zd_real _acorn_user_zd_real
 
 # Re-prepend Acorn-managed PATH entries if the user's rc replaced
 # PATH wholesale. Idempotent — duplicate entries are skipped.

--- a/src-tauri/shell-init/zshrc
+++ b/src-tauri/shell-init/zshrc
@@ -25,8 +25,13 @@
 
 _acorn_zd_save=$ZDOTDIR
 _acorn_user_zd=${ACORN_USER_ZDOTDIR:-$HOME}
-ZDOTDIR=$_acorn_user_zd
-[ -f "$ZDOTDIR/.zshrc" ] && source "$ZDOTDIR/.zshrc"
+if [ "$_acorn_user_zd" = "$_acorn_zd_save" ]; then
+    _acorn_user_zd=$HOME
+fi
+if [ "$_acorn_user_zd" != "$_acorn_zd_save" ]; then
+    ZDOTDIR=$_acorn_user_zd
+    [ -f "$ZDOTDIR/.zshrc" ] && source "$ZDOTDIR/.zshrc"
+fi
 ZDOTDIR=$_acorn_zd_save
 unset _acorn_zd_save _acorn_user_zd
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1188,8 +1188,17 @@ pub async fn pty_spawn<R: Runtime>(
             .cloned()
             .or_else(|| std::env::var("ZDOTDIR").ok())
             .unwrap_or_default();
-        if user_zdotdir.is_empty() || user_zdotdir == dir.display().to_string() {
-            user_zdotdir = std::env::var("HOME").unwrap_or_default();
+        let shell_init_dir = dir.canonicalize().unwrap_or_else(|_| dir.clone());
+        let points_at_shell_init = Path::new(&user_zdotdir)
+            .canonicalize()
+            .map(|path| path == shell_init_dir)
+            .unwrap_or(false);
+        if user_zdotdir.is_empty() || points_at_shell_init {
+            user_zdotdir = effective_env
+                .get("HOME")
+                .cloned()
+                .or_else(|| std::env::var("HOME").ok())
+                .unwrap_or_default();
         }
         effective_env.insert("ACORN_USER_ZDOTDIR".to_string(), user_zdotdir);
         effective_env.insert("ZDOTDIR".to_string(), dir.display().to_string());

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1183,11 +1183,14 @@ pub async fn pty_spawn<R: Runtime>(
     // forwards to the user's `$HOME/.zshenv` (rustup, asdf etc. live there
     // and break without it) before pinning `ZDOTDIR` back to ours.
     if let Ok(dir) = crate::shell_init::ensure_shell_init_dir() {
-        let user_zdotdir = effective_env
+        let mut user_zdotdir = effective_env
             .get("ZDOTDIR")
             .cloned()
             .or_else(|| std::env::var("ZDOTDIR").ok())
             .unwrap_or_default();
+        if user_zdotdir.is_empty() || user_zdotdir == dir.display().to_string() {
+            user_zdotdir = std::env::var("HOME").unwrap_or_default();
+        }
         effective_env.insert("ACORN_USER_ZDOTDIR".to_string(), user_zdotdir);
         effective_env.insert("ZDOTDIR".to_string(), dir.display().to_string());
     } else {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System, UpdateKind};
+use tauri::ipc::{Channel, Response};
 use tauri::{AppHandle, Runtime, State};
 use uuid::Uuid;
 
@@ -1285,10 +1286,17 @@ pub async fn pty_spawn<R: Runtime>(
         }
     }
 
+    let output_router = state.pty_output.clone();
+    let app_for_output = app.clone();
+    let output_sink: acorn_pty::PtyOutputSink = Arc::new(move |event, session_id, bytes| {
+        output_router.send_or_emit(&app_for_output, event, session_id, bytes);
+    });
+
     state
         .pty
         .spawn(
             app,
+            output_sink,
             id,
             cwd,
             resolved_command,
@@ -1359,8 +1367,15 @@ fn spawn_via_daemon<R: Runtime>(
     // tree to walk without an extra round-trip on every poll.
     if bridge.is_alive(id) {
         let pid = bridge.session_pid(id);
-        crate::daemon_stream::attach(app.clone(), registry.clone(), id, pid, replay_scrollback)
-            .map_err(|e| format!("daemon stream attach failed: {e}"))?;
+        crate::daemon_stream::attach(
+            app.clone(),
+            registry.clone(),
+            state.pty_output.clone(),
+            id,
+            pid,
+            replay_scrollback,
+        )
+        .map_err(|e| format!("daemon stream attach failed: {e}"))?;
         return Ok(());
     }
 
@@ -1395,8 +1410,15 @@ fn spawn_via_daemon<R: Runtime>(
     }
     persist(state);
 
-    crate::daemon_stream::attach(app.clone(), registry, id, outcome.pid, replay_scrollback)
-        .map_err(|e| format!("daemon stream attach failed: {e}"))
+    crate::daemon_stream::attach(
+        app.clone(),
+        registry,
+        state.pty_output.clone(),
+        id,
+        outcome.pid,
+        replay_scrollback,
+    )
+    .map_err(|e| format!("daemon stream attach failed: {e}"))
 }
 
 /// Drop a `<cwd>/.acorn-control.md` marker every time a control session
@@ -1419,6 +1441,27 @@ fn write_control_marker(cwd: &std::path::Path, primer: &str) {
             "failed to write .acorn-control.md marker",
         );
     }
+}
+
+#[tauri::command]
+pub fn pty_subscribe_output(
+    state: State<'_, AppState>,
+    session_id: String,
+    channel: Channel<Response>,
+) -> AppResult<u64> {
+    let id = parse_id(&session_id)?;
+    Ok(state.pty_output.subscribe(id, channel))
+}
+
+#[tauri::command]
+pub fn pty_unsubscribe_output(
+    state: State<'_, AppState>,
+    session_id: String,
+    token: u64,
+) -> AppResult<()> {
+    let id = parse_id(&session_id)?;
+    state.pty_output.unsubscribe(&id, token);
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/daemon_stream.rs
+++ b/src-tauri/src/daemon_stream.rs
@@ -1,17 +1,16 @@
 //! App-side stream attachment to a daemon-managed PTY.
 //!
-//! Bridges the daemon's per-session stream socket to the Tauri event bus
-//! the frontend already listens on (`pty:output:{uuid}` / `pty:exit:{uuid}`),
-//! so `commands::pty_spawn` can route through the daemon without the
-//! frontend `Terminal.tsx` knowing whether a session is daemon-managed
-//! or in-process.
+//! Bridges the daemon's per-session stream socket to the same output router
+//! used by in-process PTYs, so renderer terminals receive raw bytes through
+//! a Tauri Channel when subscribed and fall back to the legacy event bus when
+//! needed.
 //!
 //! Each attach owns one background thread that reads `StreamFrame`s
-//! line-by-line, re-emits the byte chunks as Tauri events, and exits on
-//! a clean `Exit` frame or socket close. A second thread (input/resize)
-//! is intentionally NOT spawned — keystrokes and resizes go through the
-//! control socket via `daemon_bridge::send_input` / `resize`, which is a
-//! single short RPC round-trip per event and avoids managing two
+//! line-by-line, routes output chunks through the shared output router, and
+//! exits on a clean `Exit` frame or socket close. A second thread
+//! (input/resize) is intentionally NOT spawned — keystrokes and resizes go
+//! through the control socket via `daemon_bridge::send_input` / `resize`,
+//! which is a single short RPC round-trip per event and avoids managing two
 //! per-session sockets on the app side.
 
 use std::io::{BufRead, BufReader, Write};
@@ -26,6 +25,7 @@ use serde::Serialize;
 use tauri::{AppHandle, Emitter, Runtime};
 use uuid::Uuid;
 
+use crate::pty_output::{self, PtyOutputRouter};
 use acorn_daemon::protocol::{ClientRole, Hello, StreamAttach, StreamFrame};
 use acorn_daemon::socket;
 
@@ -135,15 +135,6 @@ impl StreamRegistry {
     }
 }
 
-/// Payload shape the frontend Terminal listens for on `pty:output:{uuid}`.
-/// Matches `crate::pty::OutputPayload` (private to that module, hence
-/// duplicated here — same key name `data`, same base64 value, so a
-/// daemon-attached terminal is byte-equivalent to an in-process one).
-#[derive(Serialize, Clone)]
-struct OutputPayload {
-    data: String,
-}
-
 #[derive(Serialize, Clone)]
 struct ExitPayload {
     code: Option<i32>,
@@ -158,6 +149,7 @@ struct ExitPayload {
 pub fn attach<R: Runtime>(
     app: AppHandle<R>,
     registry: Arc<StreamRegistry>,
+    output_router: Arc<PtyOutputRouter>,
     session_id: Uuid,
     pid: Option<u32>,
     replay_scrollback: bool,
@@ -206,7 +198,14 @@ pub fn attach<R: Runtime>(
     std::thread::Builder::new()
         .name(format!("acorn-daemon-stream-{session_id}"))
         .spawn(move || {
-            pump_loop(app, registry_for_thread, session_id, reader, stop);
+            pump_loop(
+                app,
+                registry_for_thread,
+                output_router,
+                session_id,
+                reader,
+                stop,
+            );
         })?;
     Ok(())
 }
@@ -214,6 +213,7 @@ pub fn attach<R: Runtime>(
 fn pump_loop<R: Runtime>(
     app: AppHandle<R>,
     registry: Arc<StreamRegistry>,
+    output_router: Arc<PtyOutputRouter>,
     session_id: Uuid,
     mut reader: BufReader<Stream>,
     stop: Arc<AtomicBool>,
@@ -252,8 +252,12 @@ fn pump_loop<R: Runtime>(
         };
         match frame {
             StreamFrame::Output { data_b64 } => {
-                if let Err(err) = app.emit(&out_event, OutputPayload { data: data_b64 }) {
-                    tracing::warn!(%session_id, error = %err, "failed to emit pty output");
+                if let Some(bytes) = pty_output::base64_decode(&data_b64) {
+                    output_router.send_or_emit(&app, &out_event, &session_id, &bytes);
+                } else if let Err(err) =
+                    app.emit(&out_event, pty_output::OutputPayload { data: data_b64 })
+                {
+                    tracing::warn!(%session_id, error = %err, "failed to emit invalid pty output fallback");
                 }
             }
             StreamFrame::Exit { code } => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod git_ops;
 mod ipc;
 mod persistence;
 pub mod pty_env;
+mod pty_output;
 mod pull_requests;
 mod shell_args;
 mod shell_env;
@@ -314,6 +315,8 @@ pub fn run() {
             commands::list_workflow_runs,
             commands::get_workflow_run_detail,
             commands::pty_spawn,
+            commands::pty_subscribe_output,
+            commands::pty_unsubscribe_output,
             commands::pty_write,
             commands::pty_resize,
             commands::pty_kill,

--- a/src-tauri/src/pty_env.rs
+++ b/src-tauri/src/pty_env.rs
@@ -32,6 +32,13 @@ const HOST_TERMINAL_ENV: &[&str] = &[
     "VTE_VERSION",
 ];
 
+const HOST_COLOR_POLICY_ENV: &[&str] = &[
+    "NO_COLOR",
+    "FORCE_COLOR",
+    "CLICOLOR",
+    "CLICOLOR_FORCE",
+];
+
 /// Apply layered env to `cmd`, lowest-to-highest priority:
 ///   * (A) Render capability — TERM / COLORTERM defaults.
 ///   * (B) System locale — LANG default.
@@ -68,6 +75,17 @@ pub fn apply_layered_env(cmd: &mut CommandBuilder, env: HashMap<String, String>)
     // a terminal Acorn is not actually running. Strip inherited fingerprints;
     // explicit caller env below can still opt back in for tests/tools.
     for k in HOST_TERMINAL_ENV {
+        if !applied.contains(*k) {
+            cmd.env_remove(k);
+        }
+    }
+
+    // These are process-output policy hints for the environment that launched
+    // Acorn, not terminal capabilities. If the app inherits `NO_COLOR=1`
+    // from a test runner or parent shell, color-aware CLIs inside Acorn
+    // (Claude, chalk-based tools, etc.) suppress ANSI even though xterm.js can
+    // render it. Keep only explicit per-session overrides.
+    for k in HOST_COLOR_POLICY_ENV {
         if !applied.contains(*k) {
             cmd.env_remove(k);
         }
@@ -216,6 +234,35 @@ mod tests {
         assert_eq!(
             cmd.get_env("TERM_PROGRAM").and_then(|s| s.to_str()),
             Some("AcornTest"),
+        );
+    }
+
+    #[test]
+    fn layered_env_removes_inherited_color_policy() {
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.env_clear();
+        cmd.env("NO_COLOR", "1");
+        cmd.env("FORCE_COLOR", "0");
+        cmd.env("CLICOLOR", "0");
+        cmd.env("CLICOLOR_FORCE", "0");
+        apply_layered_env(&mut cmd, HashMap::new());
+        assert_eq!(cmd.get_env("NO_COLOR"), None);
+        assert_eq!(cmd.get_env("FORCE_COLOR"), None);
+        assert_eq!(cmd.get_env("CLICOLOR"), None);
+        assert_eq!(cmd.get_env("CLICOLOR_FORCE"), None);
+    }
+
+    #[test]
+    fn layered_env_preserves_explicit_color_policy_override() {
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.env_clear();
+        cmd.env("NO_COLOR", "0");
+        let mut env = HashMap::new();
+        env.insert("NO_COLOR".to_string(), "1".to_string());
+        apply_layered_env(&mut cmd, env);
+        assert_eq!(
+            cmd.get_env("NO_COLOR").and_then(|s| s.to_str()),
+            Some("1"),
         );
     }
 }

--- a/src-tauri/src/pty_output.rs
+++ b/src-tauri/src/pty_output.rs
@@ -1,0 +1,186 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use dashmap::DashMap;
+use serde::Serialize;
+use tauri::ipc::{Channel, Response};
+use tauri::{AppHandle, Emitter, Runtime};
+use uuid::Uuid;
+
+#[derive(Serialize, Clone)]
+pub struct OutputPayload {
+    pub data: String,
+}
+
+#[derive(Clone)]
+struct OutputSubscription {
+    token: u64,
+    channel: Channel<Response>,
+}
+
+#[derive(Default)]
+pub struct PtyOutputRouter {
+    next_token: AtomicU64,
+    channels: DashMap<Uuid, OutputSubscription>,
+}
+
+impl PtyOutputRouter {
+    pub fn subscribe(&self, session_id: Uuid, channel: Channel<Response>) -> u64 {
+        let token = self.next_token.fetch_add(1, Ordering::Relaxed) + 1;
+        self.channels
+            .insert(session_id, OutputSubscription { token, channel });
+        token
+    }
+
+    pub fn unsubscribe(&self, session_id: &Uuid, token: u64) {
+        let should_remove = self
+            .channels
+            .get(session_id)
+            .map(|entry| entry.token == token)
+            .unwrap_or(false);
+        if should_remove {
+            self.channels.remove(session_id);
+        }
+    }
+
+    pub fn send_or_emit<R: Runtime>(
+        &self,
+        app: &AppHandle<R>,
+        event: &str,
+        session_id: &Uuid,
+        bytes: &[u8],
+    ) {
+        if let Some(entry) = self.channels.get(session_id) {
+            let token = entry.token;
+            let channel = entry.channel.clone();
+            drop(entry);
+
+            if channel.send(Response::new(bytes.to_vec())).is_ok() {
+                return;
+            }
+
+            self.unsubscribe(session_id, token);
+        }
+
+        let payload = OutputPayload {
+            data: base64_encode(bytes),
+        };
+        if let Err(err) = app.emit(event, payload) {
+            tracing::warn!(%session_id, error = %err, "failed to emit pty output");
+        }
+    }
+}
+
+/// Minimal RFC 4648 base64 encoder. Kept local so fallback event delivery
+/// stays dependency-free on the hot PTY output path.
+pub fn base64_encode(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity((input.len() + 2) / 3 * 4);
+    let mut chunks = input.chunks_exact(3);
+    for chunk in &mut chunks {
+        let n = (u32::from(chunk[0]) << 16) | (u32::from(chunk[1]) << 8) | u32::from(chunk[2]);
+        out.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+        out.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+        out.push(ALPHABET[((n >> 6) & 0x3f) as usize] as char);
+        out.push(ALPHABET[(n & 0x3f) as usize] as char);
+    }
+    let rem = chunks.remainder();
+    match rem.len() {
+        0 => {}
+        1 => {
+            let n = u32::from(rem[0]) << 16;
+            out.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+            out.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+            out.push('=');
+            out.push('=');
+        }
+        2 => {
+            let n = (u32::from(rem[0]) << 16) | (u32::from(rem[1]) << 8);
+            out.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+            out.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+            out.push(ALPHABET[((n >> 6) & 0x3f) as usize] as char);
+            out.push('=');
+        }
+        _ => unreachable!(),
+    }
+    out
+}
+
+pub fn base64_decode(input: &str) -> Option<Vec<u8>> {
+    fn val(b: u8) -> Option<u8> {
+        match b {
+            b'A'..=b'Z' => Some(b - b'A'),
+            b'a'..=b'z' => Some(b - b'a' + 26),
+            b'0'..=b'9' => Some(b - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            b'=' => Some(64),
+            _ => None,
+        }
+    }
+
+    let bytes = input.as_bytes();
+    if bytes.len() % 4 != 0 {
+        return None;
+    }
+    let mut out = Vec::with_capacity(bytes.len() / 4 * 3);
+    for chunk in bytes.chunks_exact(4) {
+        let a = val(chunk[0])?;
+        let b = val(chunk[1])?;
+        let c = val(chunk[2])?;
+        let d = val(chunk[3])?;
+        if a >= 64 || b >= 64 {
+            return None;
+        }
+        out.push((a << 2) | (b >> 4));
+        if c == 64 {
+            if d != 64 {
+                return None;
+            }
+            continue;
+        }
+        if c > 64 {
+            return None;
+        }
+        out.push(((b & 0x0f) << 4) | (c >> 2));
+        if d == 64 {
+            continue;
+        }
+        if d > 64 {
+            return None;
+        }
+        out.push(((c & 0x03) << 6) | d);
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_encodes_known_vectors() {
+        assert_eq!(base64_encode(&[]), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"Man"), "TWFu");
+        assert_eq!(base64_encode(b"hello world"), "aGVsbG8gd29ybGQ=");
+    }
+
+    #[test]
+    fn base64_decodes_known_vectors() {
+        assert_eq!(base64_decode("").unwrap(), b"");
+        assert_eq!(base64_decode("Zg==").unwrap(), b"f");
+        assert_eq!(base64_decode("Zm8=").unwrap(), b"fo");
+        assert_eq!(base64_decode("Zm9v").unwrap(), b"foo");
+        assert_eq!(base64_decode("TWFu").unwrap(), b"Man");
+        assert_eq!(base64_decode("aGVsbG8gd29ybGQ=").unwrap(), b"hello world");
+    }
+
+    #[test]
+    fn base64_rejects_bad_padding() {
+        assert!(base64_decode("Zg=A").is_none());
+        assert!(base64_decode("Zg=").is_none());
+        assert!(base64_decode("not!").is_none());
+    }
+}

--- a/src-tauri/src/shell_init.rs
+++ b/src-tauri/src/shell_init.rs
@@ -124,6 +124,7 @@ mod tests {
         let body = fs::read_to_string(&zprofile).unwrap();
         assert!(body.contains("ACORN_USER_ZDOTDIR"));
         assert!(body.contains(".zprofile"));
+        assert!(body.contains("[ \"$_acorn_user_zd\" != \"$_acorn_zd_save\" ]"));
         // Restore ZDOTDIR so subsequent stage files keep resolving to
         // our forwarders.
         assert!(body.contains("_acorn_zd_save"));

--- a/src-tauri/src/shell_init.rs
+++ b/src-tauri/src/shell_init.rs
@@ -95,6 +95,8 @@ mod tests {
         assert!(body.contains("_acorn_osc7"));
         assert!(body.contains("precmd_functions"));
         assert!(body.contains("ACORN_USER_ZDOTDIR"));
+        assert!(body.contains("_acorn_realpath"));
+        assert!(body.contains("_acorn_user_zd_real"));
         assert!(body.contains("ACORN_CLI_DIR"));
         // Restore ZDOTDIR before .zlogin runs (otherwise the staged
         // .zlogin would resolve to the user's dir on its own).
@@ -111,7 +113,8 @@ mod tests {
         assert!(body.contains("ACORN_USER_ZDOTDIR"));
         assert!(body.contains(".zshenv"));
         assert!(body.contains("_acorn_user_zd=$HOME"));
-        assert!(body.contains("[ \"$_acorn_user_zd\" != \"$_acorn_zd\" ]"));
+        assert!(body.contains("_acorn_realpath"));
+        assert!(body.contains("_acorn_user_zd_real"));
         assert!(body.contains("ZDOTDIR=$_acorn_zd"));
     }
 
@@ -124,7 +127,8 @@ mod tests {
         let body = fs::read_to_string(&zprofile).unwrap();
         assert!(body.contains("ACORN_USER_ZDOTDIR"));
         assert!(body.contains(".zprofile"));
-        assert!(body.contains("[ \"$_acorn_user_zd\" != \"$_acorn_zd_save\" ]"));
+        assert!(body.contains("_acorn_realpath"));
+        assert!(body.contains("_acorn_user_zd_real"));
         // Restore ZDOTDIR so subsequent stage files keep resolving to
         // our forwarders.
         assert!(body.contains("_acorn_zd_save"));
@@ -139,6 +143,8 @@ mod tests {
         let body = fs::read_to_string(&zlogin).unwrap();
         assert!(body.contains("ACORN_USER_ZDOTDIR"));
         assert!(body.contains(".zlogin"));
+        assert!(body.contains("_acorn_realpath"));
+        assert!(body.contains("_acorn_user_zd_real"));
     }
 
     #[test]

--- a/src-tauri/src/shell_init.rs
+++ b/src-tauri/src/shell_init.rs
@@ -110,6 +110,8 @@ mod tests {
         let body = fs::read_to_string(&zshenv).unwrap();
         assert!(body.contains("ACORN_USER_ZDOTDIR"));
         assert!(body.contains(".zshenv"));
+        assert!(body.contains("_acorn_user_zd=$HOME"));
+        assert!(body.contains("[ \"$_acorn_user_zd\" != \"$_acorn_zd\" ]"));
         assert!(body.contains("ZDOTDIR=$_acorn_zd"));
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -7,15 +7,19 @@ use crate::daemon_bridge::DaemonBridge;
 use crate::daemon_stream::StreamRegistry;
 use crate::fs_explorer::WatcherState;
 use crate::ipc::server::IpcServerHandle;
-use acorn_session::{ProjectStore, SessionStore};
+use crate::pty_output::PtyOutputRouter;
 use crate::staged_rev_reconcile::StagedRevMismatch;
 use acorn_pty::PtyManager;
+use acorn_session::{ProjectStore, SessionStore};
 
 #[derive(Clone)]
 pub struct AppState {
     pub sessions: Arc<SessionStore>,
     pub projects: Arc<ProjectStore>,
     pub pty: Arc<PtyManager>,
+    /// Raw-byte output channels registered by renderer terminals. PTY output
+    /// falls back to the legacy base64 event path when no channel is active.
+    pub pty_output: Arc<PtyOutputRouter>,
     /// Set to false at boot if `persistence::load_sessions_with_status`
     /// reported a recoverable load failure (file existed but could not be
     /// read or parsed). Frontend reads this via `load_status` and skips the
@@ -56,6 +60,7 @@ impl AppState {
             sessions: SessionStore::new(),
             projects: ProjectStore::new(),
             pty: PtyManager::new(),
+            pty_output: Arc::new(PtyOutputRouter::default()),
             sessions_loaded_cleanly: Arc::new(AtomicBool::new(true)),
             projects_loaded_cleanly: Arc::new(AtomicBool::new(true)),
             ipc_handle: Arc::new(Mutex::new(None)),

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -23,7 +23,7 @@ import {
   type CSSProperties,
 } from "react";
 import { openPath } from "@tauri-apps/plugin-opener";
-import { useAppStore } from "../store";
+import { selectSessionsById, useAppStore } from "../store";
 import { CodeViewer } from "./CodeViewer";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
@@ -98,6 +98,7 @@ export function Pane({ paneId }: PaneProps) {
   const moveTab = useAppStore((s) => s.moveTab);
   const splitFocusedPane = useAppStore((s) => s.splitFocusedPane);
   const closePane = useAppStore((s) => s.closePane);
+  const sessionsById = useAppStore(selectSessionsById);
   const [paneMenu, setPaneMenu] = useState<{ x: number; y: number } | null>(
     null,
   );
@@ -121,10 +122,9 @@ export function Pane({ paneId }: PaneProps) {
   const workspaceTabs = useAppStore((s) => s.workspaceTabs);
   const tabs = useMemo<PaneTab[]>(() => {
     if (!pane) return [];
-    const lookup = new Map(sessions.map((s) => [s.id, s] as const));
     const ordered: PaneTab[] = [];
     for (const id of pane.tabIds) {
-      const s = lookup.get(id);
+      const s = sessionsById.get(id);
       if (s) {
         ordered.push({
           ...makeSessionWorkspaceTab({
@@ -149,7 +149,7 @@ export function Pane({ paneId }: PaneProps) {
       }
     }
     return ordered;
-  }, [pane, sessions, workspaceTabs]);
+  }, [pane, sessionsById, workspaceTabs]);
 
   const active = useMemo<PaneTab | null>(() => {
     if (!pane?.activeTabId) return null;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -93,21 +93,19 @@ interface ProjectGroup {
 
 export function Sidebar() {
   const t = useTranslation();
-  const {
-    sessions,
-    projects,
-    activeSessionId,
-    activeProject,
-    selectSession,
-    setActiveProject,
-    createSession,
-    requestRemoveSession,
-    requestRemoveProject,
-    addProject,
-    createNewProject,
-    reorderProjects,
-    reorderSessions,
-  } = useAppStore();
+  const sessions = useAppStore((s) => s.sessions);
+  const projects = useAppStore((s) => s.projects);
+  const activeSessionId = useAppStore((s) => s.activeSessionId);
+  const activeProject = useAppStore((s) => s.activeProject);
+  const selectSession = useAppStore((s) => s.selectSession);
+  const setActiveProject = useAppStore((s) => s.setActiveProject);
+  const createSession = useAppStore((s) => s.createSession);
+  const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
+  const requestRemoveProject = useAppStore((s) => s.requestRemoveProject);
+  const addProject = useAppStore((s) => s.addProject);
+  const createNewProject = useAppStore((s) => s.createNewProject);
+  const reorderProjects = useAppStore((s) => s.reorderProjects);
+  const reorderSessions = useAppStore((s) => s.reorderSessions);
   const [collapsed, setCollapsed] = useState<Set<string>>(() => loadCollapsed());
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
@@ -835,6 +833,7 @@ function ProjectGroupView({
                 <SessionRow
                   key={session.id}
                   session={session}
+                  projectSessions={project.sessions}
                   active={session.id === activeSessionId}
                   onSelect={() => onSelectSession(session.id)}
                   onRemove={() => onRemoveSession(session)}
@@ -850,15 +849,21 @@ function ProjectGroupView({
 
 interface SessionRowProps {
   session: Session;
+  projectSessions: Session[];
   active: boolean;
   onSelect: () => void;
   onRemove: () => void;
 }
 
-function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
+function SessionRow({
+  session,
+  projectSessions,
+  active,
+  onSelect,
+  onRemove,
+}: SessionRowProps) {
   const t = useTranslation();
   const renameSession = useAppStore((s) => s.renameSession);
-  const sessions = useAppStore((s) => s.sessions);
   const editorCommand = useSettings((s) => s.settings.editor.command);
   const editorConfigured = editorCommand.trim().length > 0;
   const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
@@ -890,7 +895,7 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
 
   async function duplicate() {
     const base = session.name;
-    const taken = new Set(sessions.map((s) => s.name));
+    const taken = new Set(useAppStore.getState().sessions.map((s) => s.name));
     let next = `${base}-copy`;
     let n = 2;
     while (taken.has(next)) {
@@ -911,11 +916,10 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
     }
   }
 
-  const projectSiblings = useMemo(
-    () => sessions.filter((s) => s.repo_path === session.repo_path),
-    [sessions, session.repo_path],
+  const otherSiblings = useMemo(
+    () => projectSessions.filter((s) => s.id !== session.id),
+    [projectSessions, session.id],
   );
-  const otherSiblings = projectSiblings.filter((s) => s.id !== session.id);
 
   const sessionMenuItems: ContextMenuItem[] = [
     {
@@ -999,10 +1003,10 @@ function SessionRow({ session, active, onSelect, onRemove }: SessionRowProps) {
     {
       label: sidebarText(t, "sidebar.actions.removeAllInProject"),
       icon: <SquareX size={12} />,
-      disabled: projectSiblings.length === 0,
+      disabled: projectSessions.length === 0,
       onClick: () => {
         const request = useAppStore.getState().requestRemoveSession;
-        for (const s of projectSiblings) request(s.id);
+        for (const s of projectSessions) request(s.id);
       },
     },
   ];

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -9,7 +9,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
-import { invoke } from "@tauri-apps/api/core";
+import { Channel, invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import "@xterm/xterm/css/xterm.css";
@@ -369,6 +369,39 @@ function decodeBase64ToBytes(b64: string): Uint8Array {
     bytes[i] = binary.charCodeAt(i);
   }
   return bytes;
+}
+
+function decodePtyChannelPayload(payload: unknown): Uint8Array {
+  if (payload instanceof ArrayBuffer) {
+    return new Uint8Array(payload);
+  }
+  if (ArrayBuffer.isView(payload)) {
+    return new Uint8Array(payload.buffer, payload.byteOffset, payload.byteLength);
+  }
+  if (Array.isArray(payload)) {
+    return new Uint8Array(payload);
+  }
+  if (typeof payload === "string") {
+    return decodeBase64ToBytes(payload);
+  }
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "data" in payload &&
+    typeof (payload as { data?: unknown }).data === "string"
+  ) {
+    return decodeBase64ToBytes((payload as { data: string }).data);
+  }
+  throw new Error("unsupported pty output payload");
+}
+
+function unregisterTauriChannel(channel: Channel<unknown>) {
+  const internals = (
+    window as typeof window & {
+      __TAURI_INTERNALS__?: { unregisterCallback?: (id: number) => void };
+    }
+  ).__TAURI_INTERNALS__;
+  internals?.unregisterCallback?.(channel.id);
 }
 
 function encodeStringToBase64(input: string): string {
@@ -1421,39 +1454,76 @@ export function Terminal({
     // collision then orphans one PTY, which exits and triggers the second
     // PTY to also exit (zsh prints "Saving session..." twice). Guard every
     // await resumption point so a disposed mount short-circuits cleanly.
+    const handlePtyOutput = (bytes: Uint8Array) => {
+      term.write(bytes, () => {
+        if (disposed) return;
+        // The parser has drained this chunk. Force a frame-bound
+        // refresh so fast cursor-move/erase TUIs do not leave stale
+        // DOM cursor blocks or cells behind.
+        scheduleViewportFrameRepaint();
+        // Also schedule a viewport repaint once the burst goes quiet,
+        // so a TUI redraw interrupted mid-stream doesn't leave stale
+        // glyphs from a wider previous line painted on screen.
+        scheduleViewportIdleRepaint();
+        // A new prompt row may have just been rendered. Rescan the
+        // buffer so the sticky banner picks it up in the same frame
+        // instead of waiting for the user's next scroll.
+        scheduleContextDispatch();
+      });
+      // Output will land in the buffer — schedule a debounced save so the
+      // new content reaches disk ~1s after activity ends.
+      scheduleScrollbackSave();
+      // Agents can create a worktree and chdir a descendant process without
+      // triggering our shell's OSC 7 prompt hook. Probe the live descendant
+      // cwd on output bursts so exit adoption stays tied to this session.
+      scheduleLiveCwdProbe();
+      scheduleAgentDetection();
+    };
+
     (async () => {
+      let outputChannel: Channel<unknown> | null = null;
       try {
+        outputChannel = new Channel<unknown>((payload) => {
+          if (disposed) return;
+          try {
+            handlePtyOutput(decodePtyChannelPayload(payload));
+          } catch (err) {
+            console.error("[Terminal] decode channel payload failed", err);
+          }
+        });
+        const outputToken = await invoke<number>("pty_subscribe_output", {
+          sessionId,
+          channel: outputChannel,
+        });
+        const subscribedOutputChannel = outputChannel;
+        if (disposed) {
+          invoke("pty_unsubscribe_output", {
+            sessionId,
+            token: outputToken,
+          })
+            .catch(() => {
+              // best effort
+            })
+            .finally(() => unregisterTauriChannel(subscribedOutputChannel));
+          return;
+        }
+        unlistenFns.push(() => {
+          invoke("pty_unsubscribe_output", {
+            sessionId,
+            token: outputToken,
+          })
+            .catch(() => {
+              // best effort
+            })
+            .finally(() => unregisterTauriChannel(subscribedOutputChannel));
+        });
+
         const unlistenOutput = await listen<PtyOutputPayload>(
           `pty:output:${sessionId}`,
           (event) => {
             if (disposed) return;
             try {
-              const bytes = decodeBase64ToBytes(event.payload.data);
-              term.write(bytes, () => {
-                if (disposed) return;
-                // The parser has drained this chunk. Force a frame-bound
-                // refresh so fast cursor-move/erase TUIs do not leave stale
-                // DOM cursor blocks or cells behind.
-                scheduleViewportFrameRepaint();
-                // Also schedule a viewport repaint once the burst goes
-                // quiet, so a TUI redraw interrupted mid-stream doesn't
-                // leave stale glyphs from a wider previous line painted on
-                // screen.
-                scheduleViewportIdleRepaint();
-                // A new prompt row may have just been rendered. Rescan the
-                // buffer so the sticky banner picks it up in the same frame
-                // (instead of waiting for the user's next scroll).
-                scheduleContextDispatch();
-              });
-              // Output will land in the buffer — schedule a debounced save
-              // so the new content reaches disk ~1s after activity ends.
-              scheduleScrollbackSave();
-              // Agents can create a worktree and chdir a descendant process
-              // without triggering our shell's OSC 7 prompt hook. Probe the
-              // live descendant cwd on output bursts so exit adoption can
-              // remain tied to this session rather than a repo-global diff.
-              scheduleLiveCwdProbe();
-              scheduleAgentDetection();
+              handlePtyOutput(decodeBase64ToBytes(event.payload.data));
             } catch (err) {
               console.error("[Terminal] decode payload failed", err);
             }
@@ -1529,6 +1599,9 @@ export function Terminal({
         }
         unlistenFns.push(unlistenExit);
       } catch (err) {
+        if (outputChannel) {
+          unregisterTauriChannel(outputChannel);
+        }
         if (!disposed) {
           term.write(
             `\r\n${ANSI_RED}[acorn] Failed to attach pty listeners: ${formatError(err)}${ANSI_RESET}\r\n`,

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,10 +1,11 @@
-import { useAppStore } from "../store";
+import { selectSessionsById, useAppStore } from "../store";
 import { useTranslation } from "../lib/useTranslation";
 
 export function TopBar() {
   const t = useTranslation();
-  const { sessions, activeSessionId } = useAppStore();
-  const active = sessions.find((s) => s.id === activeSessionId);
+  const activeSessionId = useAppStore((s) => s.activeSessionId);
+  const sessionsById = useAppStore(selectSessionsById);
+  const active = activeSessionId ? sessionsById.get(activeSessionId) : null;
 
   return (
     <header className="flex h-11 shrink-0 items-center gap-3 border-b border-border bg-bg-elevated px-4">

--- a/src/store.ts
+++ b/src/store.ts
@@ -238,6 +238,21 @@ function emptyWorkspace(): ProjectWorkspace {
   };
 }
 
+let indexedSessions: Session[] | null = null;
+let indexedSessionsById: ReadonlyMap<string, Session> = new Map();
+
+export function selectSessionsById(state: {
+  sessions: Session[];
+}): ReadonlyMap<string, Session> {
+  if (state.sessions !== indexedSessions) {
+    indexedSessions = state.sessions;
+    indexedSessionsById = new Map(
+      state.sessions.map((session) => [session.id, session]),
+    );
+  }
+  return indexedSessionsById;
+}
+
 function fallbackEmptyMirror() {
   const activeTabId = null as string | null;
   return {


### PR DESCRIPTION
## Summary
This reduces terminal output hot-path overhead and narrows React store subscriptions that were causing unnecessary UI work.

1. **PTY output transport:** route terminal bytes through a raw-byte Tauri Channel, while keeping the legacy base64 event path as a fallback.
2. **Daemon session parity:** apply the same output router to daemon-managed sessions and keep the PTY crate transport-agnostic through a host-provided sink.
3. **Store subscription scope:** replace broad session subscriptions in Pane, Sidebar, and TopBar with narrower selectors and a memoized session-id map.
4. **Terminal environment resilience:** strip inherited host color-policy env from PTY children and guard staged zsh forwarders against self-source recursion, including trailing-slash and symlink cases.
5. **Regression coverage:** add Rust and frontend coverage for the output router, terminal env handling, shell-init generation, and store selectors.

## Expected impact
| Area | Impact |
| --- | --- |
| Terminal output | Avoids base64 decode and global event fan-out on the normal PTY output path. |
| Daemon sessions | Uses the same output delivery behavior as local PTY sessions, with fallback compatibility preserved. |
| React rendering | Sidebar, Pane, and TopBar avoid re-rendering from unrelated session store updates. |
| Terminal colors | New PTY sessions ignore inherited `NO_COLOR`/color-force policy unless explicitly provided. |
| Dev shell startup | Staged zsh forwarders no longer recurse when `ACORN_USER_ZDOTDIR` resolves back to Acorn shell-init. |

## Design notes
- `pty_output` owns Channel subscribers per session and falls back to the legacy base64 event path when a raw subscriber is unavailable.
- `Terminal.tsx` subscribes with a Tauri Channel, decodes raw output first, keeps the legacy listener as compatibility fallback, and disables stale callbacks on unsubscribe.
- The PTY crate receives a host-provided output sink instead of knowing about Tauri transport details.
- `pty_env` drops inherited color-policy variables from the app host process while preserving explicitly supplied session env values.
- Shell-init staging now compares normalized/canonical zsh paths before sourcing user dotfiles so dev-generated App Support files do not self-source.

## Follow-up (not in this PR)
- Adaptive status polling, virtualized code/diff rendering, right-panel event invalidation, and watcher batching are being handled as separate branches/worktrees.

## Test plan
- [x] `pnpm test` passed.
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts tests/e2e/panes.spec.ts tests/e2e/smoke.spec.ts` passed.
- [x] `pnpm run build` passed.
- [x] `cargo check` passed.
- [x] `cargo test pty_output` passed.
- [x] `cargo test push_tail` passed.
- [x] `cargo test pty_env` passed.
- [x] `cargo test shell_init` passed.
- [x] Manual zsh self-source reproductions with trailing-slash and symlink `ACORN_USER_ZDOTDIR` passed.

## Notes
- `pnpm run build` still reports the existing Vite dynamic-import and large-chunk warnings.
- Manual `pnpm run tauri dev` launched locally; ANSI RED/GREEN terminal color output rendered correctly after inherited `NO_COLOR` was stripped.
- The production app bundle was not replaced while addressing the dev-only zsh recursion issue.