### PR TITLE
perf(status): adapt session polling cadence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,11 @@ import {
 import { applyBackgroundVars, clearBackgroundVars } from "./lib/background";
 import { applyTheme, useThemes } from "./lib/themes";
 import { extractTabFromEvent } from "./lib/settings-events";
+import {
+  nextSessionStatusPollDelayMs,
+  selectDueSessionStatusPollIds,
+  selectImmediateSessionStatusPollIds,
+} from "./lib/sessionStatusPolling";
 import { useAppStore } from "./store";
 import type { TranslationKey, Translator } from "./lib/i18n";
 import type { SessionStatus } from "./lib/types";
@@ -171,6 +176,7 @@ function App() {
   }, [t]);
   const sidebarPanelRef = useRef<ImperativePanelHandle | null>(null);
   const rightPanelRef = useRef<ImperativePanelHandle | null>(null);
+  const statusPollLastPolledAtRef = useRef<Map<string, number>>(new Map());
   const themes = useThemes((s) => s.themes);
   const refreshThemes = useThemes((s) => s.refresh);
   const appearance = useSettings((s) => s.settings.appearance);
@@ -518,16 +524,142 @@ function App() {
     };
   }, []);
 
-  // Periodically probe each session's transcript JSONL to infer live status
-  // (idle/running). The Rust side does the file work; this just kicks the tick.
+  // Probe session status adaptively: active tabs stay fresh, volatile sessions
+  // get a moderate cadence, and stable sessions fall back to a slow safety
+  // sweep. The Rust side accepts an id subset, so each tick sends only ids
+  // whose cadence has elapsed.
   useEffect(() => {
-    const tick = () => useAppStore.getState().pollSessionStatuses();
-    void tick();
-    const handle = setInterval(tick, 1000);
-    return () => {
-      clearInterval(handle);
+    const lastPolledAt = statusPollLastPolledAtRef.current;
+    const currentSessions = useAppStore.getState().sessions;
+    const currentIds = new Set(currentSessions.map((session) => session.id));
+    for (const id of Array.from(lastPolledAt.keys())) {
+      if (!currentIds.has(id)) lastPolledAt.delete(id);
+    }
+
+    let cancelled = false;
+    let inFlight = false;
+    let windowFocused =
+      typeof document === "undefined" ||
+      typeof document.hasFocus !== "function" ||
+      document.hasFocus();
+    let timer: ReturnType<typeof window.setTimeout> | null = null;
+    const pendingImmediateIds = new Set(
+      selectImmediateSessionStatusPollIds({
+        sessions: currentSessions,
+        activeSessionId: useAppStore.getState().activeSessionId,
+        lastPolledAt,
+      }),
+    );
+
+    const isForeground = () =>
+      windowFocused &&
+      (typeof document === "undefined" || document.visibilityState !== "hidden");
+
+    const clearTimer = () => {
+      if (timer === null) return;
+      window.clearTimeout(timer);
+      timer = null;
     };
-  }, []);
+
+    const scheduleNext = (delay?: number) => {
+      clearTimer();
+      if (cancelled || !isForeground()) return;
+      const state = useAppStore.getState();
+      const nextDelay =
+        delay ??
+        nextSessionStatusPollDelayMs({
+          sessions: state.sessions,
+          activeSessionId: state.activeSessionId,
+          lastPolledAt,
+          now: Date.now(),
+        });
+      if (nextDelay === null) return;
+      timer = window.setTimeout(() => {
+        void runPoll();
+      }, nextDelay);
+    };
+
+    const enqueueImmediate = (ids: string[]) => {
+      for (const id of ids) pendingImmediateIds.add(id);
+      scheduleNext(0);
+    };
+
+    const runPoll = async () => {
+      clearTimer();
+      if (cancelled || !isForeground()) return;
+      if (inFlight) return;
+
+      const state = useAppStore.getState();
+      const existingIds = new Set(state.sessions.map((session) => session.id));
+      const immediateIds = Array.from(pendingImmediateIds).filter((id) =>
+        existingIds.has(id),
+      );
+      pendingImmediateIds.clear();
+      const dueIds =
+        immediateIds.length > 0
+          ? immediateIds
+          : selectDueSessionStatusPollIds({
+              sessions: state.sessions,
+              activeSessionId: state.activeSessionId,
+              lastPolledAt,
+              now: Date.now(),
+            });
+
+      if (dueIds.length === 0) {
+        scheduleNext();
+        return;
+      }
+
+      inFlight = true;
+      try {
+        await useAppStore.getState().pollSessionStatuses(dueIds);
+      } finally {
+        const completedAt = Date.now();
+        for (const id of dueIds) lastPolledAt.set(id, completedAt);
+        inFlight = false;
+        scheduleNext(pendingImmediateIds.size > 0 ? 0 : undefined);
+      }
+    };
+
+    const foregroundImmediateIds = () => {
+      const state = useAppStore.getState();
+      return selectImmediateSessionStatusPollIds({
+        sessions: state.sessions,
+        activeSessionId: state.activeSessionId,
+        lastPolledAt,
+        includeVolatile: true,
+      });
+    };
+
+    const onFocus = () => {
+      windowFocused = true;
+      enqueueImmediate(foregroundImmediateIds());
+    };
+    const onBlur = () => {
+      windowFocused = false;
+      clearTimer();
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        clearTimer();
+      } else {
+        enqueueImmediate(foregroundImmediateIds());
+      }
+    };
+
+    window.addEventListener("focus", onFocus);
+    window.addEventListener("blur", onBlur);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    scheduleNext(0);
+
+    return () => {
+      cancelled = true;
+      clearTimer();
+      window.removeEventListener("focus", onFocus);
+      window.removeEventListener("blur", onBlur);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [activeSessionId, sessionIdsKey]);
 
   // Skip the confirmation dialog for non-isolated sessions when the user has
   // opted out via Settings. Isolated worktrees always prompt because the

--- a/src/lib/sessionStatusPolling.test.ts
+++ b/src/lib/sessionStatusPolling.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import type { Session, SessionStatus } from "./types";
+import {
+  ACTIVE_SESSION_STATUS_POLL_INTERVAL_MS,
+  STABLE_SESSION_STATUS_POLL_INTERVAL_MS,
+  VOLATILE_SESSION_STATUS_POLL_INTERVAL_MS,
+  nextSessionStatusPollDelayMs,
+  selectDueSessionStatusPollIds,
+  selectImmediateSessionStatusPollIds,
+  sessionStatusPollIntervalMs,
+} from "./sessionStatusPolling";
+
+const REPO = "/Users/me/repo";
+
+function session(id: string, status: SessionStatus): Session {
+  return {
+    id,
+    name: id,
+    repo_path: REPO,
+    worktree_path: `${REPO}/.worktrees/${id}`,
+    branch: `feat/${id}`,
+    isolated: false,
+    status,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: null,
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: false,
+  };
+}
+
+describe("session status polling schedule", () => {
+  it("uses fast active, medium volatile, and slow stable intervals", () => {
+    expect(sessionStatusPollIntervalMs(session("a", "idle"), "a")).toBe(
+      ACTIVE_SESSION_STATUS_POLL_INTERVAL_MS,
+    );
+    expect(sessionStatusPollIntervalMs(session("b", "running"), "a")).toBe(
+      VOLATILE_SESSION_STATUS_POLL_INTERVAL_MS,
+    );
+    expect(sessionStatusPollIntervalMs(session("c", "needs_input"), "a")).toBe(
+      VOLATILE_SESSION_STATUS_POLL_INTERVAL_MS,
+    );
+    expect(sessionStatusPollIntervalMs(session("d", "completed"), "a")).toBe(
+      STABLE_SESSION_STATUS_POLL_INTERVAL_MS,
+    );
+  });
+
+  it("selects only sessions whose adaptive interval has elapsed", () => {
+    const now = 60_000;
+    const sessions = [
+      session("active", "idle"),
+      session("running", "running"),
+      session("needs", "needs_input"),
+      session("idle", "idle"),
+      session("failed", "failed"),
+    ];
+    const lastPolledAt = new Map([
+      ["active", now - ACTIVE_SESSION_STATUS_POLL_INTERVAL_MS],
+      ["running", now - VOLATILE_SESSION_STATUS_POLL_INTERVAL_MS + 1],
+      ["needs", now - VOLATILE_SESSION_STATUS_POLL_INTERVAL_MS],
+      ["idle", now - STABLE_SESSION_STATUS_POLL_INTERVAL_MS + 1],
+      ["failed", now - STABLE_SESSION_STATUS_POLL_INTERVAL_MS],
+    ]);
+
+    expect(
+      selectDueSessionStatusPollIds({
+        sessions,
+        activeSessionId: "active",
+        lastPolledAt,
+        now,
+      }),
+    ).toEqual(["active", "needs", "failed"]);
+  });
+
+  it("prioritizes active and newly seen sessions for immediate polling", () => {
+    const sessions = [
+      session("active", "idle"),
+      session("running", "running"),
+      session("new", "idle"),
+      session("stable", "completed"),
+    ];
+    const lastPolledAt = new Map([
+      ["active", 100],
+      ["running", 100],
+      ["stable", 100],
+    ]);
+
+    expect(
+      selectImmediateSessionStatusPollIds({
+        sessions,
+        activeSessionId: "active",
+        lastPolledAt,
+      }),
+    ).toEqual(["active", "new"]);
+    expect(
+      selectImmediateSessionStatusPollIds({
+        sessions,
+        activeSessionId: "active",
+        lastPolledAt,
+        includeVolatile: true,
+      }),
+    ).toEqual(["active", "running", "new"]);
+  });
+
+  it("returns the delay until the next session becomes due", () => {
+    const now = 60_000;
+    const sessions = [
+      session("active", "idle"),
+      session("running", "running"),
+      session("idle", "idle"),
+    ];
+    const lastPolledAt = new Map([
+      ["active", now - 250],
+      ["running", now - 4500],
+      ["idle", now - 1000],
+    ]);
+
+    expect(
+      nextSessionStatusPollDelayMs({
+        sessions,
+        activeSessionId: "active",
+        lastPolledAt,
+        now,
+      }),
+    ).toBe(500);
+  });
+});

--- a/src/lib/sessionStatusPolling.ts
+++ b/src/lib/sessionStatusPolling.ts
@@ -1,0 +1,85 @@
+import type { Session, SessionStatus } from "./types";
+
+export const ACTIVE_SESSION_STATUS_POLL_INTERVAL_MS = 1000;
+export const VOLATILE_SESSION_STATUS_POLL_INTERVAL_MS = 5000;
+export const STABLE_SESSION_STATUS_POLL_INTERVAL_MS = 30000;
+
+type PollScheduleArgs = {
+  sessions: Session[];
+  activeSessionId: string | null;
+  lastPolledAt: ReadonlyMap<string, number>;
+  now: number;
+};
+
+type ImmediatePollArgs = Omit<PollScheduleArgs, "now"> & {
+  includeVolatile?: boolean;
+};
+
+export function isVolatileSessionStatus(status: SessionStatus): boolean {
+  return status === "running" || status === "needs_input";
+}
+
+export function sessionStatusPollIntervalMs(
+  session: Pick<Session, "id" | "status">,
+  activeSessionId: string | null,
+): number {
+  if (session.id === activeSessionId) {
+    return ACTIVE_SESSION_STATUS_POLL_INTERVAL_MS;
+  }
+  if (isVolatileSessionStatus(session.status)) {
+    return VOLATILE_SESSION_STATUS_POLL_INTERVAL_MS;
+  }
+  return STABLE_SESSION_STATUS_POLL_INTERVAL_MS;
+}
+
+export function selectDueSessionStatusPollIds({
+  sessions,
+  activeSessionId,
+  lastPolledAt,
+  now,
+}: PollScheduleArgs): string[] {
+  return sessions
+    .filter((session) => {
+      const last = lastPolledAt.get(session.id);
+      if (last === undefined) return true;
+      const interval = sessionStatusPollIntervalMs(session, activeSessionId);
+      return now - last >= interval;
+    })
+    .map((session) => session.id);
+}
+
+export function selectImmediateSessionStatusPollIds({
+  sessions,
+  activeSessionId,
+  lastPolledAt,
+  includeVolatile = false,
+}: ImmediatePollArgs): string[] {
+  return sessions
+    .filter(
+      (session) =>
+        session.id === activeSessionId ||
+        !lastPolledAt.has(session.id) ||
+        (includeVolatile && isVolatileSessionStatus(session.status)),
+    )
+    .map((session) => session.id);
+}
+
+export function nextSessionStatusPollDelayMs({
+  sessions,
+  activeSessionId,
+  lastPolledAt,
+  now,
+}: PollScheduleArgs): number | null {
+  if (sessions.length === 0) return null;
+
+  let nextDelay = STABLE_SESSION_STATUS_POLL_INTERVAL_MS;
+  for (const session of sessions) {
+    const last = lastPolledAt.get(session.id);
+    if (last === undefined) return 0;
+
+    const interval = sessionStatusPollIntervalMs(session, activeSessionId);
+    const remaining = Math.max(0, interval - (now - last));
+    nextDelay = Math.min(nextDelay, remaining);
+  }
+  return nextDelay;
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -589,6 +589,136 @@ describe("pollSessionStatuses", () => {
     expect(sessions.find((s) => s.id === "a2")?.status).toBe("running");
   });
 
+  it("polls only the requested existing session ids", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A), session("a2", REPO_A)],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      { id: "a2", status: "running", branch: "feat/a2-live" },
+    ]);
+
+    await useAppStore
+      .getState()
+      .pollSessionStatuses(["a2", "missing", "a2"]);
+
+    expect(mockApi.detectSessionStatuses).toHaveBeenCalledWith(["a2"]);
+    const sessions = useAppStore.getState().sessions;
+    expect(sessions.find((s) => s.id === "a1")?.status).toBe("idle");
+    expect(sessions.find((s) => s.id === "a2")?.status).toBe("running");
+    expect(sessions.find((s) => s.id === "a2")?.branch).toBe("feat/a2-live");
+  });
+
+  it("does not call the backend when the requested ids are absent", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+
+    await useAppStore.getState().pollSessionStatuses(["missing"]);
+
+    expect(mockApi.detectSessionStatuses).not.toHaveBeenCalled();
+  });
+
+  it("serializes overlapping polls and runs queued subsets afterward", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A), session("a2", REPO_A)],
+    );
+    let releaseFirst!: () => void;
+    const firstBlocker = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    mockApi.detectSessionStatuses
+      .mockImplementationOnce(async () => {
+        await firstBlocker;
+        return [{ id: "a1", status: "running", branch: null }];
+      })
+      .mockResolvedValueOnce([
+        { id: "a2", status: "needs_input", branch: null },
+      ]);
+
+    const first = useAppStore.getState().pollSessionStatuses(["a1"]);
+    const second = useAppStore.getState().pollSessionStatuses(["a2"]);
+
+    expect(mockApi.detectSessionStatuses).toHaveBeenCalledTimes(1);
+    expect(mockApi.detectSessionStatuses).toHaveBeenNthCalledWith(1, ["a1"]);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(mockApi.detectSessionStatuses).toHaveBeenCalledTimes(2);
+    expect(mockApi.detectSessionStatuses).toHaveBeenNthCalledWith(2, ["a2"]);
+    const sessions = useAppStore.getState().sessions;
+    expect(sessions.find((s) => s.id === "a1")?.status).toBe("running");
+    expect(sessions.find((s) => s.id === "a2")?.status).toBe("needs_input");
+  });
+
+  it("coalesces subset requests covered by an active full poll", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A), session("a2", REPO_A)],
+    );
+    let releaseFull!: () => void;
+    const fullBlocker = new Promise<void>((resolve) => {
+      releaseFull = resolve;
+    });
+    mockApi.detectSessionStatuses.mockImplementationOnce(async () => {
+      await fullBlocker;
+      return [
+        { id: "a1", status: "running", branch: null },
+        { id: "a2", status: "needs_input", branch: null },
+      ];
+    });
+
+    const full = useAppStore.getState().pollSessionStatuses();
+    const subset = useAppStore.getState().pollSessionStatuses(["a2"]);
+
+    expect(mockApi.detectSessionStatuses).toHaveBeenCalledTimes(1);
+    expect(mockApi.detectSessionStatuses).toHaveBeenCalledWith(["a1", "a2"]);
+
+    releaseFull();
+    await Promise.all([full, subset]);
+
+    expect(mockApi.detectSessionStatuses).toHaveBeenCalledTimes(1);
+    const sessions = useAppStore.getState().sessions;
+    expect(sessions.find((s) => s.id === "a1")?.status).toBe("running");
+    expect(sessions.find((s) => s.id === "a2")?.status).toBe("needs_input");
+  });
+
+  it("queues new session ids that appear during an active full poll", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+    let releaseFull!: () => void;
+    const fullBlocker = new Promise<void>((resolve) => {
+      releaseFull = resolve;
+    });
+    mockApi.detectSessionStatuses
+      .mockImplementationOnce(async () => {
+        await fullBlocker;
+        return [{ id: "a1", status: "running", branch: null }];
+      })
+      .mockResolvedValueOnce([
+        { id: "a2", status: "needs_input", branch: null },
+      ]);
+
+    const full = useAppStore.getState().pollSessionStatuses();
+    useAppStore.setState((s) => ({
+      sessions: [...s.sessions, session("a2", REPO_A)],
+    }));
+    const newSessionPoll = useAppStore
+      .getState()
+      .pollSessionStatuses(["a2"]);
+
+    expect(mockApi.detectSessionStatuses).toHaveBeenCalledTimes(1);
+    expect(mockApi.detectSessionStatuses).toHaveBeenCalledWith(["a1"]);
+
+    releaseFull();
+    await Promise.all([full, newSessionPoll]);
+
+    expect(mockApi.detectSessionStatuses).toHaveBeenCalledTimes(2);
+    expect(mockApi.detectSessionStatuses).toHaveBeenNthCalledWith(2, ["a2"]);
+    const sessions = useAppStore.getState().sessions;
+    expect(sessions.find((s) => s.id === "a1")?.status).toBe("running");
+    expect(sessions.find((s) => s.id === "a2")?.status).toBe("needs_input");
+  });
+
   it("is a no-op when there are no sessions to poll", async () => {
     await useAppStore.getState().pollSessionStatuses();
     expect(mockApi.detectSessionStatuses).not.toHaveBeenCalled();

--- a/src/store.ts
+++ b/src/store.ts
@@ -36,6 +36,13 @@ export type { RightGroup, RightTab };
 
 const ROOT_PANE_ID: PaneId = "root";
 
+let statusPollRunning = false;
+let statusPollChain: Promise<void> | null = null;
+let pendingStatusPollAll = false;
+let pendingStatusPollIds = new Set<string>();
+let activeStatusPollAll = false;
+let activeStatusPollIds = new Set<string>();
+
 export interface PaneState {
   id: PaneId;
   tabIds: string[];
@@ -129,8 +136,9 @@ interface AppStateModel {
   refreshProjects: () => Promise<void>;
   refreshAll: () => Promise<void>;
   /** Probe session liveness via JSONL transcripts; updates session statuses
-   *  in place without touching `updated_at`. */
-  pollSessionStatuses: () => Promise<void>;
+   *  in place without touching `updated_at`. When `ids` is provided, only
+   *  the requested subset is sent to the backend. */
+  pollSessionStatuses: (ids?: string[]) => Promise<void>;
   selectTab: (id: string | null) => void;
   selectSession: (id: string | null) => void;
   setActiveProject: (repoPath: string) => void;
@@ -557,31 +565,84 @@ export const useAppStore = create<AppStateModel>()(
     await Promise.all([get().refreshSessions(), get().refreshProjects()]);
   },
 
-  async pollSessionStatuses() {
-    const ids = get().sessions.map((s) => s.id);
-    if (ids.length === 0) return;
-    try {
-      const updates = await api.detectSessionStatuses(ids);
-      const map = new Map(updates.map((u) => [u.id, u]));
-      set((s) => {
-        let changed = false;
-        const nextSessions = s.sessions.map((sess) => {
-          const update = map.get(sess.id);
-          if (!update) return sess;
-          const nextStatus = update.status;
-          const nextBranch = update.branch ?? sess.branch;
-          if (nextStatus !== sess.status || nextBranch !== sess.branch) {
-            changed = true;
-            return { ...sess, status: nextStatus, branch: nextBranch };
-          }
-          return sess;
-        });
-        return changed ? { sessions: nextSessions } : s;
-      });
-    } catch (e) {
-      // Polling errors are non-fatal: log and move on.
-      console.warn("[acorn] pollSessionStatuses failed", e);
+  async pollSessionStatuses(ids) {
+    const requestedIds =
+      ids === undefined
+        ? undefined
+        : Array.from(new Set(ids)).filter((id) =>
+            get().sessions.some((session) => session.id === id),
+          );
+    if (requestedIds !== undefined && requestedIds.length === 0) return;
+
+    if (requestedIds === undefined) {
+      const currentIds = get().sessions.map((session) => session.id);
+      const activePollCoversAll =
+        activeStatusPollAll &&
+        currentIds.every((id) => activeStatusPollIds.has(id));
+      if (!activePollCoversAll && !pendingStatusPollAll) {
+        pendingStatusPollAll = true;
+        pendingStatusPollIds.clear();
+      }
+    } else if (!pendingStatusPollAll) {
+      for (const id of requestedIds) {
+        if (!activeStatusPollIds.has(id)) pendingStatusPollIds.add(id);
+      }
     }
+
+    if (!statusPollRunning) {
+      statusPollRunning = true;
+      statusPollChain = (async () => {
+        while (pendingStatusPollAll || pendingStatusPollIds.size > 0) {
+          const pollAll = pendingStatusPollAll;
+          const queuedIds = pollAll
+            ? undefined
+            : Array.from(pendingStatusPollIds);
+          pendingStatusPollAll = false;
+          pendingStatusPollIds.clear();
+
+          const sessionIds = new Set(get().sessions.map((s) => s.id));
+          const idsToPoll = Array.from(
+            new Set(queuedIds ?? get().sessions.map((s) => s.id)),
+          ).filter((id) => sessionIds.has(id));
+          if (idsToPoll.length === 0) continue;
+
+          activeStatusPollAll = pollAll;
+          activeStatusPollIds = new Set(idsToPoll);
+          try {
+            const updates = await api.detectSessionStatuses(idsToPoll);
+            const map = new Map(updates.map((u) => [u.id, u]));
+            set((s) => {
+              let changed = false;
+              const nextSessions = s.sessions.map((sess) => {
+                const update = map.get(sess.id);
+                if (!update) return sess;
+                const nextStatus = update.status;
+                const nextBranch = update.branch ?? sess.branch;
+                if (nextStatus !== sess.status || nextBranch !== sess.branch) {
+                  changed = true;
+                  return { ...sess, status: nextStatus, branch: nextBranch };
+                }
+                return sess;
+              });
+              return changed ? { sessions: nextSessions } : s;
+            });
+          } catch (e) {
+            // Polling errors are non-fatal: log and move on.
+            console.warn("[acorn] pollSessionStatuses failed", e);
+          } finally {
+            activeStatusPollAll = false;
+            activeStatusPollIds.clear();
+          }
+        }
+      })().finally(() => {
+        statusPollRunning = false;
+        statusPollChain = null;
+        activeStatusPollAll = false;
+        activeStatusPollIds.clear();
+      });
+    }
+
+    await statusPollChain;
   },
 
   selectTab(id) {


### PR DESCRIPTION
## Summary
This replaces the 1-second global session-status poll with an adaptive scheduler that focuses work on sessions likely to change.

1. **Adaptive status scheduler:** poll the active session fastest, keep running/needs-input sessions on a moderate cadence, and move stable sessions to a slower safety interval.
2. **Subset status polling:** allow `pollSessionStatuses` to probe specific session ids instead of always scanning every session.
3. **Overlap control:** serialize status probes and coalesce queued requests so focus/session changes do not create overlapping backend work.
4. **Visibility and focus behavior:** pause while the document is hidden and trigger immediate checks when focus returns, the active session changes, or new sessions appear.
5. **Regression coverage:** add focused tests for interval decisions, subset polling, coalescing, and new-session queueing.

## Expected impact
| Area | Impact |
| --- | --- |
| Session status polling | Avoids a full session scan every second during normal use. |
| Active session feedback | Keeps the foreground session responsive with shorter adaptive intervals. |
| Background sessions | Keeps running sessions fresh while reducing work for idle/completed sessions. |
| UI/background load | Reduces repeated backend probes and React store writes from status polling. |

## Design notes
- `sessionStatusPolling` centralizes interval and due-session decisions so the scheduler stays testable outside React.
- `pollSessionStatuses(ids?)` still supports full polling when no ids are passed, preserving existing call sites.
- In-flight polling is serialized; new requests queue and coalesce instead of racing.
- The scheduler performs one immediate startup probe, then switches to adaptive subset probes.

## Follow-up (not in this PR)
- Runtime validation in a real Tauri window should confirm focus and document visibility transitions behave as expected across macOS app activation states.

## Test plan
- [x] `pnpm exec tsc --noEmit` passed.
- [x] `pnpm exec vitest run src/store.test.ts src/lib/sessionStatusPolling.test.ts` passed, 58 tests passed and 1 skipped.

## Notes
- This branch was rebased onto the current `origin/main` after #228 merged.
- The initial app load can still probe existing sessions once immediately; subsequent checks use adaptive subset polling.
