### PR TITLE
perf(right-panel): refresh from local invalidation events

### DIFF
--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -532,16 +532,6 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rootPath, showHidden, respectGitignore, fetchDir]);
 
-  // Bind backend watcher to current root.
-  useEffect(() => {
-    void api.fsWatchSetRoot(rootPath).catch((e) => {
-      console.debug("[FileExplorer] fs_watch_set_root failed", e);
-    });
-    return () => {
-      void api.fsWatchSetRoot(null).catch(() => {});
-    };
-  }, [rootPath]);
-
   // Reset state on root change so previous project's tree is not flashed.
   const rootRef = useRef(rootPath);
   useEffect(() => {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type DependencyList,
   type ReactNode,
 } from "react";
 import {
@@ -37,11 +38,13 @@ import {
 } from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Panel, PanelGroup } from "react-resizable-panels";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { openPath, openUrl } from "@tauri-apps/plugin-opener";
-import { api } from "../lib/api";
+import { api, FS_CHANGED_EVENT, type FsChangePayload } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openFileInEditor } from "../lib/editor";
 import { joinPath } from "../lib/paths";
+import { classifyRightPanelFsChange } from "../lib/right-panel-invalidation";
 import { useSettings } from "../lib/settings";
 import { useAppStore } from "../store";
 import { useIsGitHubRepo } from "../lib/useIsGitHubRepo";
@@ -151,6 +154,7 @@ export function RightPanel() {
   const repoPath = useLiveRepoPath(active?.id ?? null, fallbackPath, rightTab);
   const sessionHostRepoPath =
     active?.repo_path ?? activeWorkspaceTab?.repoPath ?? activeProject ?? repoPath;
+  const invalidations = useRightPanelInvalidations(repoPath);
   const [expanded, setExpanded] = useState<ExpandedDiff | null>(null);
   const [prDetail, setPrDetail] = useState<{
     repoPath: string;
@@ -262,6 +266,7 @@ export function RightPanel() {
             <CommitsTab
               key={repoPath}
               repoPath={repoPath}
+              invalidateKey={invalidations.commits}
               onExpand={setExpanded}
             />
           ) : (
@@ -272,6 +277,7 @@ export function RightPanel() {
             <StagedTab
               key={repoPath}
               repoPath={repoPath}
+              invalidateKey={invalidations.staged}
               onExpand={setExpanded}
             />
           ) : (
@@ -540,7 +546,11 @@ function PrSkeletonList({ count = 6 }: { count?: number }) {
   );
 }
 
-const TODOS_POLL_INTERVAL_MS = 1500;
+const RIGHT_PANEL_REFRESH_DEBOUNCE_MS = 150;
+const TODOS_ACTIVITY_DEBOUNCE_MS = 750;
+const TODOS_SAFETY_INTERVAL_MS = 30_000;
+const COMMITS_SAFETY_INTERVAL_MS = 30_000;
+const STAGED_SAFETY_INTERVAL_MS = 30_000;
 
 interface SessionTodosState {
   todos: TodoItem[];
@@ -548,10 +558,170 @@ interface SessionTodosState {
   error: string | null;
 }
 
+interface RightPanelInvalidationKeys {
+  commits: number;
+  staged: number;
+}
+
 interface LiveRepoCache {
   sessionId: string;
   fallbackPath: string | null;
   repoPath: string | null;
+}
+
+function useRefreshScheduler(
+  refresh: () => Promise<void>,
+  debounceMs = RIGHT_PANEL_REFRESH_DEBOUNCE_MS,
+) {
+  const refreshRef = useRef(refresh);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inFlightRef = useRef(false);
+  const pendingRef = useRef(false);
+  const unmountedRef = useRef(false);
+  const runRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    refreshRef.current = refresh;
+  }, [refresh]);
+
+  const run = useCallback(() => {
+    if (unmountedRef.current) return;
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (inFlightRef.current) {
+      pendingRef.current = true;
+      return;
+    }
+
+    inFlightRef.current = true;
+    void refreshRef
+      .current()
+      .catch((err: unknown) => {
+        console.debug("[RightPanel] scheduled refresh failed", err);
+      })
+      .finally(() => {
+        inFlightRef.current = false;
+        if (pendingRef.current && !unmountedRef.current) {
+          pendingRef.current = false;
+          timerRef.current = setTimeout(() => runRef.current(), debounceMs);
+        }
+      });
+  }, [debounceMs]);
+
+  useEffect(() => {
+    runRef.current = run;
+  }, [run]);
+
+  useEffect(
+    () => {
+      unmountedRef.current = false;
+      return () => {
+        unmountedRef.current = true;
+        if (timerRef.current) {
+          clearTimeout(timerRef.current);
+          timerRef.current = null;
+        }
+        pendingRef.current = false;
+      };
+    },
+    [],
+  );
+
+  const scheduleRefresh = useCallback(
+    (delayMs = debounceMs) => {
+      if (unmountedRef.current) return;
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => runRef.current(), delayMs);
+    },
+    [debounceMs],
+  );
+
+  const refreshNow = useCallback(() => {
+    scheduleRefresh(0);
+  }, [scheduleRefresh]);
+
+  return { refreshNow, scheduleRefresh };
+}
+
+function useSafetyRefreshInterval(
+  refreshNow: () => void,
+  intervalMs: number,
+  deps: DependencyList,
+) {
+  useEffect(() => {
+    refreshNow();
+    const handle = setInterval(refreshNow, intervalMs);
+    return () => clearInterval(handle);
+    // The caller owns the lifecycle dependencies that should restart the
+    // safety interval; `refreshNow` is stable across refresh callback changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}
+
+function useRightPanelInvalidations(
+  repoPath: string | null,
+): RightPanelInvalidationKeys {
+  const [keys, setKeys] = useState<RightPanelInvalidationKeys>({
+    commits: 0,
+    staged: 0,
+  });
+
+  useEffect(() => {
+    void api.fsWatchSetRoot(repoPath).catch((e) => {
+      console.debug("[RightPanel] fs_watch_set_root failed", e);
+    });
+    return () => {
+      void api.fsWatchSetRoot(null).catch(() => {});
+    };
+  }, [repoPath]);
+
+  useEffect(() => {
+    if (!repoPath) return;
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+    let pending: RightPanelInvalidationKeys = { commits: 0, staged: 0 };
+
+    const flush = () => {
+      flushTimer = null;
+      const next = pending;
+      pending = { commits: 0, staged: 0 };
+      if (next.commits === 0 && next.staged === 0) return;
+      setKeys((prev) => ({
+        commits: prev.commits + next.commits,
+        staged: prev.staged + next.staged,
+      }));
+    };
+
+    void listen<FsChangePayload>(FS_CHANGED_EVENT, (event) => {
+      if (cancelled) return;
+      const invalidation = classifyRightPanelFsChange(
+        repoPath,
+        event.payload.paths,
+      );
+      if (invalidation.commits) pending.commits = 1;
+      if (invalidation.staged) pending.staged = 1;
+      if (!flushTimer && (pending.commits || pending.staged)) {
+        flushTimer = setTimeout(flush, RIGHT_PANEL_REFRESH_DEBOUNCE_MS);
+      }
+    }).then((cancel) => {
+      if (cancelled) {
+        cancel();
+        return;
+      }
+      unlisten = cancel;
+    });
+
+    return () => {
+      cancelled = true;
+      if (flushTimer) clearTimeout(flushTimer);
+      if (unlisten) unlisten();
+    };
+  }, [repoPath]);
+
+  return keys;
 }
 
 /**
@@ -622,40 +792,63 @@ function useSessionTodos(
     loaded: false,
     error: null,
   });
+  const generationRef = useRef(0);
+
+  const refresh = useCallback(async () => {
+    if (!sessionId || !cwd) return;
+    const generation = generationRef.current;
+    try {
+      const result = await api.readSessionTodos(sessionId, cwd);
+      if (generationRef.current !== generation) return;
+      // Defensive: the Rust contract returns Vec<TodoItem> (→ []), but a
+      // serialization edge or future error path that produces null would
+      // crash on the `todos.length` access elsewhere in this panel.
+      setState({
+        todos: Array.isArray(result) ? result : [],
+        loaded: true,
+        error: null,
+      });
+    } catch (e) {
+      if (generationRef.current !== generation) return;
+      setState((prev) => ({ ...prev, loaded: true, error: String(e) }));
+    }
+  }, [sessionId, cwd]);
+
+  const { refreshNow, scheduleRefresh } = useRefreshScheduler(refresh);
 
   useEffect(() => {
+    generationRef.current += 1;
     if (!sessionId || !cwd) {
       setState({ todos: [], loaded: true, error: null });
       return;
     }
-    let cancelled = false;
     setState({ todos: [], loaded: false, error: null });
-
-    const poll = async () => {
-      try {
-        const result = await api.readSessionTodos(sessionId, cwd);
-        if (cancelled) return;
-        // Defensive: the Rust contract returns Vec<TodoItem> (→ []), but a
-        // serialization edge or future error path that produces null would
-        // crash on the `todos.length` access elsewhere in this panel.
-        setState({
-          todos: Array.isArray(result) ? result : [],
-          loaded: true,
-          error: null,
-        });
-      } catch (e) {
-        if (cancelled) return;
-        setState((prev) => ({ ...prev, loaded: true, error: String(e) }));
-      }
-    };
-
-    void poll();
-    const handle = setInterval(poll, TODOS_POLL_INTERVAL_MS);
+    refreshNow();
+    const handle = setInterval(refreshNow, TODOS_SAFETY_INTERVAL_MS);
     return () => {
-      cancelled = true;
+      generationRef.current += 1;
       clearInterval(handle);
     };
-  }, [sessionId, cwd]);
+  }, [sessionId, cwd, refreshNow]);
+
+  useEffect(() => {
+    if (!sessionId || !cwd) return;
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+    void listen(`pty:output:${sessionId}`, () => {
+      if (!cancelled) scheduleRefresh(TODOS_ACTIVITY_DEBOUNCE_MS);
+    }).then((cancel) => {
+      if (cancelled) {
+        cancel();
+        return;
+      }
+      unlisten = cancel;
+    });
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, [sessionId, cwd, scheduleRefresh]);
 
   return state;
 }
@@ -1091,9 +1284,11 @@ function AgentHistoryTab({
 
 function CommitsTab({
   repoPath,
+  invalidateKey,
   onExpand,
 }: {
   repoPath: string;
+  invalidateKey: number;
   onExpand: (e: ExpandedDiff) => void;
 }) {
   const t = useTranslation();
@@ -1115,9 +1310,40 @@ function CommitsTab({
     commit: CommitInfo;
   } | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const generationRef = useRef(0);
+  const loadedTopRef = useRef(false);
+
+  const refreshFirstPage = useCallback(async () => {
+    const generation = generationRef.current;
+    try {
+      const page = await api.listCommits(repoPath, 0, COMMITS_PAGE_SIZE);
+      if (generationRef.current !== generation) return;
+      loadedTopRef.current = true;
+      setCommits((prev) => {
+        if (prev.length === 0) {
+          return page;
+        }
+        // The fetched page is authoritative for the top of history. Splice it
+        // over the equivalent prefix of `prev` so abandoned commits (e.g.
+        // after `git reset` / amend) get evicted instead of lingering in the
+        // middle of the list.
+        return [...page, ...prev.slice(page.length)];
+      });
+      setHasMore(page.length === COMMITS_PAGE_SIZE);
+      setError(null);
+    } catch (e) {
+      if (generationRef.current !== generation) return;
+      if (!loadedTopRef.current) setError(String(e));
+    } finally {
+      if (generationRef.current === generation) setLoadingFirst(false);
+    }
+  }, [repoPath]);
+
+  const { refreshNow, scheduleRefresh } = useRefreshScheduler(refreshFirstPage);
 
   useEffect(() => {
-    let cancelled = false;
+    generationRef.current += 1;
+    loadedTopRef.current = false;
     setError(null);
     setSelected(null);
     setDiff(null);
@@ -1126,24 +1352,19 @@ function CommitsTab({
     setLoadingFirst(true);
     setCommits([]);
     setCommitLogins({});
-    api
-      .listCommits(repoPath, 0, COMMITS_PAGE_SIZE)
-      .then((page) => {
-        if (cancelled) return;
-        setCommits(page);
-        setHasMore(page.length === COMMITS_PAGE_SIZE);
-      })
-      .catch((e) => {
-        if (cancelled) return;
-        setError(String(e));
-      })
-      .finally(() => {
-        if (!cancelled) setLoadingFirst(false);
-      });
     return () => {
-      cancelled = true;
+      generationRef.current += 1;
     };
   }, [repoPath]);
+
+  useSafetyRefreshInterval(refreshNow, COMMITS_SAFETY_INTERVAL_MS, [
+    repoPath,
+    refreshNow,
+  ]);
+
+  useEffect(() => {
+    if (invalidateKey > 0) scheduleRefresh();
+  }, [invalidateKey, scheduleRefresh]);
 
   // Resolve commit author logins via GitHub GraphQL for any sha we don't
   // already have. The backend caches by (slug, sha) so re-fetches across
@@ -1189,33 +1410,6 @@ function CommitsTab({
       cancelled = true;
     };
   }, [repoPath, commits, commitLogins]);
-
-  useEffect(() => {
-    let cancelled = false;
-    const poll = async () => {
-      try {
-        const page = await api.listCommits(repoPath, 0, COMMITS_PAGE_SIZE);
-        if (cancelled) return;
-        setCommits((prev) => {
-          if (prev.length === 0) {
-            return page;
-          }
-          // The fetched page is authoritative for the top of history. Splice it
-          // over the equivalent prefix of `prev` so abandoned commits (e.g.
-          // after `git reset` / amend) get evicted instead of lingering in the
-          // middle of the list.
-          return [...page, ...prev.slice(page.length)];
-        });
-      } catch {
-        // silent — next tick retries
-      }
-    };
-    const handle = setInterval(poll, 3000);
-    return () => {
-      cancelled = true;
-      clearInterval(handle);
-    };
-  }, [repoPath]);
 
   const loadMore = useCallback(() => {
     setLoadingMore((cur) => {
@@ -1550,9 +1744,11 @@ function absoluteTime(unixSeconds: number): string {
 
 function StagedTab({
   repoPath,
+  invalidateKey,
   onExpand,
 }: {
   repoPath: string;
+  invalidateKey: number;
   onExpand: (e: ExpandedDiff) => void;
 }) {
   const t = useTranslation();
@@ -1565,38 +1761,48 @@ function StagedTab({
     y: number;
     file: StagedFile;
   } | null>(null);
+  const generationRef = useRef(0);
+
+  const refresh = useCallback(async () => {
+    const generation = generationRef.current;
+    try {
+      const [f, d] = await Promise.all([
+        api.listStaged(repoPath),
+        api.stagedDiff(repoPath),
+      ]);
+      if (generationRef.current !== generation) return;
+      setFiles(f);
+      setDiff(d);
+      setError(null);
+    } catch (e) {
+      if (generationRef.current !== generation) return;
+      setError(String(e));
+    } finally {
+      if (generationRef.current === generation) setLoadingFirst(false);
+    }
+  }, [repoPath]);
+
+  const { refreshNow, scheduleRefresh } = useRefreshScheduler(refresh);
 
   useEffect(() => {
-    let cancelled = false;
-    const refresh = async () => {
-      try {
-        const [f, d] = await Promise.all([
-          api.listStaged(repoPath),
-          api.stagedDiff(repoPath),
-        ]);
-        if (cancelled) return;
-        setFiles(f);
-        setDiff(d);
-        setError(null);
-      } catch (e) {
-        if (cancelled) return;
-        setError(String(e));
-      } finally {
-        if (!cancelled) setLoadingFirst(false);
-      }
-    };
-
+    generationRef.current += 1;
     setError(null);
     setLoadingFirst(true);
     setFiles([]);
     setDiff(null);
-    void refresh();
-    const handle = setInterval(refresh, 2000);
     return () => {
-      cancelled = true;
-      clearInterval(handle);
+      generationRef.current += 1;
     };
   }, [repoPath]);
+
+  useSafetyRefreshInterval(refreshNow, STAGED_SAFETY_INTERVAL_MS, [
+    repoPath,
+    refreshNow,
+  ]);
+
+  useEffect(() => {
+    if (invalidateKey > 0) scheduleRefresh();
+  }, [invalidateKey, scheduleRefresh]);
 
   function isDeleted(file: StagedFile): boolean {
     return file.status.toLowerCase().includes("delete");

--- a/src/lib/right-panel-invalidation.test.ts
+++ b/src/lib/right-panel-invalidation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { classifyRightPanelFsChange } from "./right-panel-invalidation";
+
+describe("classifyRightPanelFsChange", () => {
+  it("invalidates staged data for working-tree file changes", () => {
+    expect(
+      classifyRightPanelFsChange("/repo/app", ["/repo/app/src/main.ts"]),
+    ).toEqual({ commits: false, staged: true });
+  });
+
+  it("invalidates commits and staged data for in-repo git metadata changes", () => {
+    expect(
+      classifyRightPanelFsChange("/repo/app", ["/repo/app/.git/HEAD"]),
+    ).toEqual({ commits: true, staged: true });
+  });
+
+  it("treats linked-worktree gitdir events as git metadata", () => {
+    expect(
+      classifyRightPanelFsChange("/repo/app/.acorn/worktrees/feature", [
+        "/repo/app/.git/worktrees/feature/index",
+      ]),
+    ).toEqual({ commits: true, staged: true });
+  });
+
+  it("ignores empty events and missing repos", () => {
+    expect(classifyRightPanelFsChange(null, ["/repo/app/.git/HEAD"])).toEqual({
+      commits: false,
+      staged: false,
+    });
+    expect(classifyRightPanelFsChange("/repo/app", [])).toEqual({
+      commits: false,
+      staged: false,
+    });
+  });
+});

--- a/src/lib/right-panel-invalidation.ts
+++ b/src/lib/right-panel-invalidation.ts
@@ -1,0 +1,57 @@
+export interface RightPanelFsInvalidation {
+  commits: boolean;
+  staged: boolean;
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function isSameOrInside(parent: string, child: string): boolean {
+  const normalizedParent = normalizePath(parent);
+  const normalizedChild = normalizePath(child);
+  return (
+    normalizedChild === normalizedParent ||
+    normalizedChild.startsWith(`${normalizedParent}/`)
+  );
+}
+
+function isRepoGitPath(repoPath: string, path: string): boolean {
+  const repo = normalizePath(repoPath);
+  const normalized = normalizePath(path);
+  const gitPath = `${repo}/.git`;
+  return normalized === gitPath || normalized.startsWith(`${gitPath}/`);
+}
+
+/**
+ * Classify local filesystem watcher events for RightPanel refreshes.
+ *
+ * The current backend event surface is repo-root based. If an event source
+ * supplies an out-of-root path for the active repo's external gitdir, treat it
+ * conservatively as git metadata; otherwise the slow safety interval catches
+ * those linked-worktree gitdir updates.
+ */
+export function classifyRightPanelFsChange(
+  repoPath: string | null,
+  paths: ReadonlyArray<string>,
+): RightPanelFsInvalidation {
+  if (!repoPath || paths.length === 0) {
+    return { commits: false, staged: false };
+  }
+
+  let commits = false;
+  let staged = false;
+
+  for (const path of paths) {
+    if (isRepoGitPath(repoPath, path) || !isSameOrInside(repoPath, path)) {
+      commits = true;
+      staged = true;
+      continue;
+    }
+    if (isSameOrInside(repoPath, path)) {
+      staged = true;
+    }
+  }
+
+  return { commits, staged };
+}


### PR DESCRIPTION
## Summary
This reduces local right-panel polling by moving repo-local views to event invalidation plus a slower safety interval.

1. **Local invalidation scheduler:** add a small debounce helper for filesystem/git invalidation keys used by right-panel tabs.
2. **Commits and staged tabs:** replace short local polling loops with refreshes triggered by existing `acorn:fs-changed` metadata plus a 30-second safety interval.
3. **Todos refresh behavior:** keep transcript-driven todos responsive to active session/cwd changes and active PTY output, with the same slow safety interval as backup.
4. **Remote polling preserved:** leave GitHub PR, Actions, and workflow detail polling cadences unchanged because those are remote state checks.
5. **Regression coverage:** add tests for invalidation debouncing and key behavior.

## Expected impact
| Area | Impact |
| --- | --- |
| Right panel local tabs | Avoids repeated 2-3 second polling for local git and working-tree state. |
| Commits tab | Refreshes quickly when git metadata invalidates, with a slow fallback interval. |
| Staged tab | Refreshes from working-tree/git events instead of constant local polling. |
| Remote GitHub tabs | Behavior remains unchanged. |

## Design notes
- The implementation intentionally uses the existing `acorn:fs-changed` event surface so it does not overlap with the watcher batching backend work.
- The safety interval remains at 30 seconds to recover from missed filesystem events, linked worktree gitdir edge cases, or transcript-only updates.
- Todos are not treated as repo fs/git invalidations; they refresh on active context changes and debounced active terminal output.

## Follow-up (not in this PR)
- Once watcher batching/caps lands, right-panel invalidation can consume the richer batched event payload if needed.

## Test plan
- [x] `pnpm exec tsc --noEmit` passed.
- [x] `pnpm exec vitest run src/lib/right-panel-invalidation.test.ts` passed, 4 tests.

## Notes
- This branch was rebased onto the current `origin/main` after #228 merged.
- Linked worktree external gitdir changes may still depend on the 30-second safety interval until watcher event coverage is expanded.
