### PR TITLE
feat(pr-detail): require admin override to merge when checks block

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2128,6 +2128,7 @@ pub async fn merge_pull_request(
     method: MergeMethod,
     commit_title: Option<String>,
     commit_body: Option<String>,
+    admin: Option<bool>,
 ) -> AppResult<()> {
     pull_requests::merge_pull_request(
         &PathBuf::from(repo_path),
@@ -2135,6 +2136,7 @@ pub async fn merge_pull_request(
         method,
         commit_title,
         commit_body,
+        admin.unwrap_or(false),
     )
 }
 

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -1259,6 +1259,7 @@ pub fn merge_pull_request(
     method: MergeMethod,
     commit_title: Option<String>,
     commit_body: Option<String>,
+    admin: bool,
 ) -> AppResult<()> {
     let Some(slug) = github_owner_repo(repo_path)? else {
         return Err(AppError::Other(
@@ -1274,6 +1275,7 @@ pub fn merge_pull_request(
             method,
             commit_title.as_deref(),
             commit_body.as_deref(),
+            admin,
         )
     })? {
         AccountOutcome::Ok { value, .. } => Ok(value),
@@ -1322,6 +1324,7 @@ fn run_pr_merge(
     method: MergeMethod,
     commit_title: Option<&str>,
     commit_body: Option<&str>,
+    admin: bool,
 ) -> AppResult<()> {
     use std::io::Write;
     use std::process::Stdio;
@@ -1340,6 +1343,13 @@ fn run_pr_merge(
         slug,
         method.flag(),
     ]);
+
+    // `--admin` instructs gh to use admin privileges to override branch
+    // protection rules. Required when checks are failing or pending but the
+    // user has the role to force-merge against repo policy.
+    if admin {
+        cmd.arg("--admin");
+    }
 
     if method.accepts_message_override() {
         if let Some(title) = commit_title {

--- a/src/components/MergePullRequestDialog.tsx
+++ b/src/components/MergePullRequestDialog.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from "react";
-import { GitMerge, Sparkles } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AlertTriangle, GitMerge, ShieldAlert, Sparkles } from "lucide-react";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
@@ -10,7 +10,11 @@ import {
   resolveAiCommitCommand,
   useSettings,
 } from "../lib/settings";
-import type { MergeMethod, PullRequestDetail } from "../lib/types";
+import type {
+  MergeMethod,
+  PullRequestCheck,
+  PullRequestDetail,
+} from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
 import { Tooltip } from "./Tooltip";
 import { Modal, ModalHeader, TextSwap } from "./ui";
@@ -43,6 +47,37 @@ function dt(t: Translator, key: DialogTranslationKey): string {
   return t(key);
 }
 
+interface ChecksBlock {
+  blocked: boolean;
+  failed: number;
+  pending: number;
+}
+
+function summarizeBlockingChecks(checks: PullRequestCheck[]): ChecksBlock {
+  let failed = 0;
+  let pending = 0;
+  for (const c of checks) {
+    if (c.status.toUpperCase() !== "COMPLETED") {
+      pending += 1;
+      continue;
+    }
+    switch ((c.conclusion ?? "").toUpperCase()) {
+      case "FAILURE":
+      case "TIMED_OUT":
+      case "ACTION_REQUIRED":
+        failed += 1;
+        break;
+      default:
+        break;
+    }
+  }
+  return { blocked: failed > 0 || pending > 0, failed, pending };
+}
+
+function formatCount(template: string, count: number): string {
+  return template.replace("{count}", String(count));
+}
+
 interface MergePullRequestDialogProps {
   open: boolean;
   repoPath: string;
@@ -66,6 +101,12 @@ export function MergePullRequestDialog({
   const [submitting, setSubmitting] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [adminMerge, setAdminMerge] = useState(false);
+
+  const checksBlock = useMemo<ChecksBlock>(
+    () => summarizeBlockingChecks(detail?.checks ?? []),
+    [detail?.checks],
+  );
 
   // Monotonic counter that bumps on every open/close so in-flight AI
   // generation calls can detect that the dialog was reset under them. The
@@ -86,6 +127,7 @@ export function MergePullRequestDialog({
     setError(null);
     setSubmitting(false);
     setGenerating(false);
+    setAdminMerge(false);
   }, [open, detail]);
 
   // Close also bumps the epoch — a generate kicked off right before the
@@ -121,6 +163,7 @@ export function MergePullRequestDialog({
         method,
         acceptsMessage ? title : null,
         acceptsMessage ? body : null,
+        checksBlock.blocked && adminMerge,
       );
       onMerged();
     } catch (e) {
@@ -159,6 +202,7 @@ export function MergePullRequestDialog({
 
   const providerLabel = aiCommitProviderLabel(settings);
   const busy = submitting || generating;
+  const mergeBlocked = checksBlock.blocked && !adminMerge;
 
   return (
     <Modal open={open} onClose={onClose} variant="dialog" size="lg">
@@ -259,6 +303,53 @@ export function MergePullRequestDialog({
               </p>
             )}
 
+            {checksBlock.blocked ? (
+              <div className="space-y-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-200">
+                <div className="flex items-start gap-2">
+                  <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                  <div className="space-y-0.5">
+                    {checksBlock.failed > 0 ? (
+                      <p>
+                        {formatCount(
+                          dt(t, "dialogs.mergePullRequest.checksFailing"),
+                          checksBlock.failed,
+                        )}
+                      </p>
+                    ) : null}
+                    {checksBlock.pending > 0 ? (
+                      <p>
+                        {formatCount(
+                          dt(t, "dialogs.mergePullRequest.checksPending"),
+                          checksBlock.pending,
+                        )}
+                      </p>
+                    ) : null}
+                    <p className="text-amber-200/80">
+                      {dt(t, "dialogs.mergePullRequest.checksBlocking")}
+                    </p>
+                  </div>
+                </div>
+                <label className="flex cursor-pointer items-start gap-2 rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1.5 text-amber-100 transition hover:bg-amber-500/15">
+                  <input
+                    type="checkbox"
+                    checked={adminMerge}
+                    onChange={(e) => setAdminMerge(e.target.checked)}
+                    disabled={busy}
+                    className="mt-0.5 h-3 w-3 cursor-pointer accent-amber-400"
+                  />
+                  <span className="flex flex-col gap-0.5">
+                    <span className="flex items-center gap-1 font-medium">
+                      <ShieldAlert size={11} />
+                      {dt(t, "dialogs.mergePullRequest.adminMerge")}
+                    </span>
+                    <span className="text-[10px] leading-snug text-amber-200/80">
+                      {dt(t, "dialogs.mergePullRequest.adminMergeHint")}
+                    </span>
+                  </span>
+                </label>
+              </div>
+            ) : null}
+
             {error ? (
               <p className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-[11px] text-danger">
                 {error}
@@ -278,8 +369,13 @@ export function MergePullRequestDialog({
             <button
               type="button"
               onClick={() => void handleMerge()}
-              disabled={busy}
-              className="rounded-md bg-emerald-500/20 px-3 py-1.5 text-xs font-medium text-emerald-300 transition hover:bg-emerald-500/30 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={busy || mergeBlocked}
+              className={cn(
+                "rounded-md px-3 py-1.5 text-xs font-medium transition disabled:cursor-not-allowed disabled:opacity-60",
+                checksBlock.blocked && adminMerge
+                  ? "bg-amber-500/25 text-amber-100 hover:bg-amber-500/35"
+                  : "bg-emerald-500/20 text-emerald-300 hover:bg-emerald-500/30",
+              )}
             >
               <TextSwap>
                 {submitting

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -162,6 +162,7 @@ export const api = {
     method: MergeMethod,
     commitTitle: string | null,
     commitBody: string | null,
+    admin: boolean = false,
   ): Promise<void> {
     return invoke<void>("merge_pull_request", {
       repoPath,
@@ -169,6 +170,7 @@ export const api = {
       method,
       commitTitle,
       commitBody,
+      admin,
     });
   },
   closePullRequest(repoPath: string, number: number): Promise<void> {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -887,7 +887,12 @@
       "bodyPlaceholder": "Body (optional)",
       "rebaseMessageLocked": "Rebase replays the original commits onto the base branch - the commit messages are not customizable here.",
       "merging": "Merging...",
-      "merge": "Merge"
+      "merge": "Merge",
+      "checksFailing": "{count} check(s) failing on the head ref.",
+      "checksPending": "{count} check(s) still running on the head ref.",
+      "checksBlocking": "Merge is blocked by branch protection until checks finish or pass.",
+      "adminMerge": "Admin merge (override branch protection)",
+      "adminMergeHint": "Forces the merge by passing --admin to gh. Use only when repo policy permits and you accept overriding required checks."
     },
     "stagedRevMismatch": {
       "title": "Shell environment updated",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -887,7 +887,12 @@
       "bodyPlaceholder": "본문(선택 사항)",
       "rebaseMessageLocked": "Rebase는 원래 커밋을 기본 브랜치 위에 다시 적용하므로 여기서 커밋 메시지를 변경할 수 없습니다.",
       "merging": "병합 중...",
-      "merge": "병합"
+      "merge": "병합",
+      "checksFailing": "head 커밋의 체크 {count}개가 실패했습니다.",
+      "checksPending": "head 커밋의 체크 {count}개가 아직 진행 중입니다.",
+      "checksBlocking": "브랜치 보호 정책에 따라 체크가 완료/통과될 때까지 머지가 차단됩니다.",
+      "adminMerge": "관리자 머지 (브랜치 보호 무시)",
+      "adminMergeHint": "gh에 --admin 옵션을 전달해 강제로 머지합니다. 저장소 정책상 허용되며 필수 체크를 무시해도 되는 경우에만 사용하세요."
     },
     "stagedRevMismatch": {
       "title": "셸 환경 업데이트됨",


### PR DESCRIPTION
## Summary
- Gate the PR detail merge dialog when head-ref checks are failing or pending: the green merge button is disabled and an explicit "Admin merge" checkbox is required to proceed.
- Opting in forwards `--admin` to `gh pr merge` so branch-protection rules are overridden through gh's policy path rather than silently bypassed.
- Backend `merge_pull_request` gains an optional `admin: bool` parameter; the frontend API wrapper defaults to `false` so existing call sites are unaffected.

## Behavior
- Checks classified as **blocking** = any check whose `status` is non-`COMPLETED` (pending) or whose `conclusion` is `FAILURE` / `TIMED_OUT` / `ACTION_REQUIRED`. `NEUTRAL` / `SKIPPED` / `CANCELLED` carry no signal, matching the existing checks summary.
- When blocking: amber warning banner shows failing/pending counts, plus a checkbox `Admin merge (override branch protection)`. The merge button stays disabled until checked.
- When not blocking (passing, or repo has no checks): unchanged green merge flow.

## Test plan
- [ ] Open PR detail modal with a PR where CI is **pending** → open merge dialog → see warning + disabled merge button → tick admin merge → button enables (amber) → merge succeeds via `--admin`.
- [ ] Open PR detail modal with a PR where CI **failed** → see failure count + admin checkbox → merge with admin → succeeds.
- [ ] Open PR detail modal with a PR where CI **passed** → no warning, normal green merge flow → merges without `--admin`.
- [ ] Closing and reopening the dialog resets the admin checkbox to off.
- [ ] `pnpm run typecheck`, `pnpm run test`, and `cargo check --lib` pass.