### PR TITLE
perf(diff): virtualize large code and diff views

### DIFF
--- a/src/components/CodeDiffVirtualization.test.tsx
+++ b/src/components/CodeDiffVirtualization.test.tsx
@@ -1,0 +1,174 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FsLineDiffEntry, FsReadFileResult } from "../lib/api";
+import type { ParsedLine } from "../lib/diff";
+import type { DiffPayload } from "../lib/types";
+
+vi.mock("../lib/highlight", () => ({
+  langFromPath: vi.fn(() => null),
+  highlightCode: vi.fn(async (content: string) =>
+    content.split("\n").map(() => null),
+  ),
+  highlightDiff: vi.fn(async (lines: ParsedLine[]) => lines.map(() => null)),
+}));
+
+vi.mock("../lib/api", () => ({
+  api: {
+    fsReadFile: vi.fn<(path: string) => Promise<FsReadFileResult>>(),
+    fsGitDiffLines: vi.fn<(path: string) => Promise<FsLineDiffEntry[]>>(),
+  },
+}));
+
+import { api } from "../lib/api";
+import { CodeViewer } from "./CodeViewer";
+import { DiffView } from "./DiffView";
+import {
+  lineIndexProps,
+  lineTextContentProps,
+  VirtualizedLineList,
+  VIRTUALIZED_LINE_THRESHOLD,
+} from "./VirtualizedLines";
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function makePatch(lineCount: number): string {
+  return Array.from({ length: lineCount }, (_, index) => `+line-${index}`).join(
+    "\n",
+  );
+}
+
+function makePayload(lineCount: number): DiffPayload {
+  return {
+    files: [
+      {
+        old_path: "src/big.txt",
+        new_path: "src/big.txt",
+        patch: makePatch(lineCount),
+        is_image: false,
+      },
+    ],
+  };
+}
+
+describe("virtualized code and diff rendering", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.mocked(api.fsReadFile).mockReset();
+    vi.mocked(api.fsGitDiffLines).mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("keeps small diffs fully rendered", () => {
+    act(() => {
+      root.render(<DiffView payload={makePayload(4)} />);
+    });
+
+    expect(
+      container.querySelector('[data-virtualized="false"]'),
+    ).not.toBeNull();
+    expect(container.querySelectorAll("[data-line-index]")).toHaveLength(4);
+  });
+
+  it("renders only a window of large diff lines", () => {
+    const lineCount = VIRTUALIZED_LINE_THRESHOLD + 300;
+    act(() => {
+      root.render(<DiffView payload={makePayload(lineCount)} />);
+    });
+
+    const renderedLines = container.querySelectorAll("[data-line-index]");
+    expect(container.querySelector('[data-virtualized="true"]')).not.toBeNull();
+    expect(renderedLines.length).toBeGreaterThan(0);
+    expect(renderedLines.length).toBeLessThan(lineCount);
+    expect(container.textContent).toContain(`+${lineCount}`);
+  });
+
+  it("renders only a window of large code files", async () => {
+    const lineCount = VIRTUALIZED_LINE_THRESHOLD + 400;
+    const content = Array.from(
+      { length: lineCount },
+      (_, index) => `const line${index} = ${index};`,
+    ).join("\n");
+    vi.mocked(api.fsReadFile).mockResolvedValueOnce({
+      content,
+      size: content.length,
+      truncated: false,
+      binary: false,
+    });
+    vi.mocked(api.fsGitDiffLines).mockResolvedValueOnce([
+      { line: 2, kind: "modified" },
+    ]);
+
+    await act(async () => {
+      root.render(<CodeViewer path="/repo/src/big.ts" isActive />);
+    });
+    await flushPromises();
+
+    const renderedLines = container.querySelectorAll("[data-line-index]");
+    expect(container.querySelector("pre")?.dataset.virtualized).toBe("true");
+    expect(renderedLines.length).toBeGreaterThan(0);
+    expect(renderedLines.length).toBeLessThan(lineCount);
+    expect(container.textContent).toContain("const line0 = 0;");
+  });
+
+  it("copies selected text by source line in virtualized lists", () => {
+    const lineCount = VIRTUALIZED_LINE_THRESHOLD + 1;
+    act(() => {
+      root.render(
+        <VirtualizedLineList
+          count={lineCount}
+          className="overflow-auto"
+          estimateSize={() => 20}
+          getLineText={(index) => `line-${index}`}
+          renderLine={(index) => (
+            <div key={index} {...lineIndexProps(index)}>
+              <span {...lineTextContentProps()}>{`line-${index}`}</span>
+            </div>
+          )}
+        />,
+      );
+    });
+
+    const content = container.querySelectorAll("[data-line-content]");
+    const range = document.createRange();
+    range.setStart(content[1]!.firstChild!, 0);
+    range.setEnd(content[3]!.firstChild!, content[3]!.textContent!.length);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    const clipboard = createClipboardData();
+    const event = new Event("copy", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", { value: clipboard });
+    container.querySelector('[data-virtualized="true"]')!.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(clipboard.getData("text/plain")).toBe("line-1\nline-2\nline-3");
+  });
+});
+
+function createClipboardData() {
+  const data = new Map<string, string>();
+  return {
+    setData(type: string, value: string) {
+      data.set(type, value);
+    },
+    getData(type: string) {
+      return data.get(type) ?? "";
+    },
+  };
+}

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -7,6 +7,12 @@ import {
 import { highlightCode, langFromPath } from "../lib/highlight";
 import { cn } from "../lib/cn";
 import { useTranslation } from "../lib/useTranslation";
+import {
+  estimateMaxLineWidthCh,
+  lineIndexProps,
+  lineTextContentProps,
+  VirtualizedLineList,
+} from "./VirtualizedLines";
 
 interface CodeViewerProps {
   path: string;
@@ -32,6 +38,8 @@ const DIFF_KIND_CLASS: Record<FsLineDiffEntry["kind"], string> = {
   modified: "bg-amber-400",
   deleted: "bg-rose-400",
 };
+
+const CODE_LINE_HEIGHT = 18;
 
 export function CodeViewer({ path, isActive }: CodeViewerProps) {
   const t = useTranslation();
@@ -93,6 +101,20 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
     for (const d of diffLines) map.set(d.line, d.kind);
     return map;
   }, [diffLines]);
+  const sourceLines = useMemo(
+    () =>
+      state.data && !state.data.binary ? state.data.content.split("\n") : [],
+    [state.data],
+  );
+  const plainHighlightedLines = useMemo(
+    () => sourceLines.map(() => null),
+    [sourceLines],
+  );
+  const gutterWidth = String(Math.max(1, sourceLines.length)).length;
+  const minWidthCh = useMemo(
+    () => estimateMaxLineWidthCh(sourceLines, gutterWidth + 7),
+    [gutterWidth, sourceLines],
+  );
 
   if (state.loading) {
     return (
@@ -121,10 +143,7 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
   }
   if (!state.data) return null;
 
-  const sourceLines = state.data.content.split("\n");
-  const lines =
-    state.highlightedLines ?? sourceLines.map(() => null);
-  const gutterWidth = String(sourceLines.length).length;
+  const lines = state.highlightedLines ?? plainHighlightedLines;
 
   return (
     <div
@@ -138,37 +157,65 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
           {t("codeViewer.truncated")}
         </div>
       ) : null}
-      <pre className="acorn-selectable m-0 flex-1 cursor-text overflow-auto bg-transparent font-mono text-[12px] leading-[1.5] text-fg">
-        {sourceLines.map((rawText, i) => {
-          const tokens = lines[i];
-          const diff = diffByLine.get(i + 1);
-          return (
-            <div key={i} className="flex whitespace-pre">
-              <span
-                aria-hidden
-                className={cn(
-                  "shrink-0 self-stretch",
-                  diff ? DIFF_KIND_CLASS[diff] : "bg-transparent",
-                )}
-                style={{ width: 3 }}
-              />
-              <span
-                aria-hidden
-                className="select-none shrink-0 pl-2 pr-3 text-right text-fg-muted/60 tabular-nums"
-                style={{ minWidth: `${gutterWidth + 3}ch` }}
-              >
-                {i + 1}
-              </span>
-              <span
-                className="grow"
-                {...(tokens
-                  ? { dangerouslySetInnerHTML: { __html: tokens } }
-                  : { children: rawText })}
-              />
-            </div>
-          );
-        })}
-      </pre>
+      <VirtualizedLineList
+        as="pre"
+        count={sourceLines.length}
+        className="acorn-selectable m-0 flex-1 cursor-text overflow-auto bg-transparent font-mono text-[12px] leading-[1.5] text-fg"
+        estimateSize={() => CODE_LINE_HEIGHT}
+        getLineText={(index) => sourceLines[index] ?? ""}
+        minWidthCh={minWidthCh}
+        renderLine={(index) => (
+          <CodeLine
+            key={index}
+            index={index}
+            rawText={sourceLines[index] ?? ""}
+            tokens={lines[index] ?? null}
+            diff={diffByLine.get(index + 1)}
+            gutterWidth={gutterWidth}
+          />
+        )}
+      />
+    </div>
+  );
+}
+
+function CodeLine({
+  index,
+  rawText,
+  tokens,
+  diff,
+  gutterWidth,
+}: {
+  index: number;
+  rawText: string;
+  tokens: string | null;
+  diff?: FsLineDiffEntry["kind"];
+  gutterWidth: number;
+}) {
+  return (
+    <div className="flex whitespace-pre" {...lineIndexProps(index)}>
+      <span
+        aria-hidden
+        className={cn(
+          "shrink-0 self-stretch",
+          diff ? DIFF_KIND_CLASS[diff] : "bg-transparent",
+        )}
+        style={{ width: 3 }}
+      />
+      <span
+        aria-hidden
+        className="select-none shrink-0 pl-2 pr-3 text-right text-fg-muted/60 tabular-nums"
+        style={{ minWidth: `${gutterWidth + 3}ch` }}
+      >
+        {index + 1}
+      </span>
+      <span
+        {...lineTextContentProps()}
+        className="grow"
+        {...(tokens
+          ? { dangerouslySetInnerHTML: { __html: tokens } }
+          : { children: rawText })}
+      />
     </div>
   );
 }

--- a/src/components/DiffSplitView.tsx
+++ b/src/components/DiffSplitView.tsx
@@ -8,7 +8,7 @@ import type { DiffFile, DiffPayload } from "../lib/types";
 import { Tooltip } from "./Tooltip";
 import { joinPath } from "../lib/paths";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
-import { DiffLine, useHighlightedDiff } from "./DiffView";
+import { DiffLineList, useHighlightedDiff } from "./DiffView";
 import { ResizeHandle } from "./ResizeHandle";
 import { useTranslation } from "../lib/useTranslation";
 
@@ -229,13 +229,11 @@ function DiffSplitContent({ entry }: { entry: FileEntry }) {
     return <ImageDiffPane file={entry.file} />;
   }
   return (
-    <div className="acorn-selectable min-h-0 flex-1 select-text overflow-auto font-mono text-[11px] leading-5">
-      <div className="w-max min-w-full">
-        {entry.lines.map((line, i) => (
-          <DiffLine key={i} line={line} html={highlighted[i] ?? null} />
-        ))}
-      </div>
-    </div>
+    <DiffLineList
+      lines={entry.lines}
+      highlighted={highlighted}
+      className="acorn-selectable min-h-0 flex-1 select-text overflow-auto font-mono text-[11px] leading-5"
+    />
   );
 }
 

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -6,6 +6,12 @@ import { highlightDiff, langFromPath } from "../lib/highlight";
 import type { DiffFile, DiffPayload } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
 import { Tooltip } from "./Tooltip";
+import {
+  estimateMaxLineWidthCh,
+  lineIndexProps,
+  lineTextContentProps,
+  VirtualizedLineList,
+} from "./VirtualizedLines";
 
 interface DiffViewProps {
   payload: DiffPayload;
@@ -147,13 +153,11 @@ function DiffFileAccordion({ file, collapsed, onToggle }: DiffFileAccordionProps
         file.is_image ? (
           <ImageDiff file={file} />
         ) : (
-          <div className="acorn-selectable max-h-80 overflow-auto font-mono text-[11px] leading-5 select-text">
-            <div className="w-max min-w-full">
-              {lines.map((line, i) => (
-                <DiffLine key={i} line={line} html={highlighted[i] ?? null} />
-              ))}
-            </div>
-          </div>
+          <DiffLineList
+            lines={lines}
+            highlighted={highlighted}
+            className="acorn-selectable max-h-80 overflow-auto font-mono text-[11px] leading-5 select-text"
+          />
         )
       ) : null}
     </div>
@@ -290,21 +294,29 @@ export function useHighlightedDiff(
 export function DiffLine({
   line,
   html,
+  index,
 }: {
   line: ParsedLine;
   html?: string | null;
+  index?: number;
 }) {
   if (line.kind === "hunk") {
     return (
-      <div className="bg-[oklch(28%_0.04_250)] px-3 py-0.5 text-[oklch(70%_0.05_250)] whitespace-pre">
-        {line.text}
+      <div
+        className="bg-[oklch(28%_0.04_250)] px-3 py-0.5 text-[oklch(70%_0.05_250)] whitespace-pre"
+        {...lineDataProps(index)}
+      >
+        <span {...lineTextContentProps()}>{line.text}</span>
       </div>
     );
   }
   if (line.kind === "meta") {
     return (
-      <div className="bg-bg-elevated/40 px-3 py-0.5 text-fg-muted whitespace-pre">
-        {line.text}
+      <div
+        className="bg-bg-elevated/40 px-3 py-0.5 text-fg-muted whitespace-pre"
+        {...lineDataProps(index)}
+      >
+        <span {...lineTextContentProps()}>{line.text}</span>
       </div>
     );
   }
@@ -323,20 +335,71 @@ export function DiffLine({
   const marker =
     line.kind === "add" ? "+" : line.kind === "del" ? "-" : " ";
   return (
-    <div className={`flex gap-2 px-2 py-0 ${cls}`}>
+    <div className={`flex gap-2 px-2 py-0 ${cls}`} {...lineDataProps(index)}>
       <span className="select-none w-3 shrink-0 text-center opacity-70">
         {marker}
       </span>
       {html ? (
         <span
+          {...lineTextContentProps()}
           className="whitespace-pre"
           dangerouslySetInnerHTML={{ __html: html || "&nbsp;" }}
         />
       ) : (
-        <span className={`whitespace-pre ${fallbackText}`}>
+        <span
+          {...lineTextContentProps()}
+          className={`whitespace-pre ${fallbackText}`}
+        >
           {line.text || " "}
         </span>
       )}
     </div>
   );
+}
+
+export function DiffLineList({
+  lines,
+  highlighted,
+  className,
+}: {
+  lines: ParsedLine[];
+  highlighted: (string | null)[];
+  className: string;
+}) {
+  const lineTexts = useMemo(() => lines.map(diffLineCopyText), [lines]);
+  const minWidthCh = useMemo(
+    () => estimateMaxLineWidthCh(lineTexts, 5),
+    [lineTexts],
+  );
+
+  return (
+    <VirtualizedLineList
+      count={lines.length}
+      className={className}
+      innerClassName="w-max min-w-full"
+      estimateSize={(index) => estimateDiffLineHeight(lines[index])}
+      getLineText={(index) => lineTexts[index] ?? ""}
+      minWidthCh={minWidthCh}
+      renderLine={(index) => (
+        <DiffLine
+          key={index}
+          index={index}
+          line={lines[index]}
+          html={highlighted[index] ?? null}
+        />
+      )}
+    />
+  );
+}
+
+function lineDataProps(index: number | undefined) {
+  return index === undefined ? {} : lineIndexProps(index);
+}
+
+function diffLineCopyText(line: ParsedLine): string {
+  return line.text;
+}
+
+function estimateDiffLineHeight(line: ParsedLine | undefined): number {
+  return line?.kind === "hunk" || line?.kind === "meta" ? 24 : 20;
 }

--- a/src/components/VirtualizedLines.tsx
+++ b/src/components/VirtualizedLines.tsx
@@ -1,0 +1,343 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  type ClipboardEvent,
+  type Key,
+  type RefObject,
+  type ReactNode,
+} from "react";
+
+export const VIRTUALIZED_LINE_THRESHOLD = 500;
+
+const DEFAULT_OVERSCAN = 12;
+const INITIAL_VIEWPORT_ROWS = 36;
+const SHOW_TEXT = 4;
+const ELEMENT_NODE = 1;
+
+interface VirtualizedLineListProps {
+  as?: "div" | "pre";
+  count: number;
+  className?: string;
+  innerClassName?: string;
+  estimateSize: (index: number) => number;
+  getLineText: (index: number) => string;
+  renderLine: (index: number) => ReactNode;
+  minWidthCh?: number;
+  overscan?: number;
+  threshold?: number;
+}
+
+interface SelectionEndpoint {
+  index: number;
+  offset: number;
+  insideContent: boolean;
+}
+
+interface RenderedVirtualItem {
+  key: Key;
+  index: number;
+  start: number;
+  size: number;
+}
+
+export function VirtualizedLineList({
+  as = "div",
+  count,
+  className,
+  innerClassName,
+  estimateSize,
+  getLineText,
+  renderLine,
+  minWidthCh,
+  overscan = DEFAULT_OVERSCAN,
+  threshold = VIRTUALIZED_LINE_THRESHOLD,
+}: VirtualizedLineListProps) {
+  const scrollRef = useRef<HTMLElement | null>(null);
+  const virtualized = count > threshold;
+  const averageInitialSize = useMemo(() => {
+    if (count === 0) return 1;
+    const sample = Math.min(count, INITIAL_VIEWPORT_ROWS);
+    let total = 0;
+    for (let i = 0; i < sample; i++) total += estimateSize(i);
+    return Math.max(1, total / sample);
+  }, [count, estimateSize]);
+  const estimatedTotalSize = useMemo(() => {
+    let total = 0;
+    for (let i = 0; i < count; i++) total += estimateSize(i);
+    return total;
+  }, [count, estimateSize]);
+  const fallbackItems = useMemo(
+    () =>
+      buildFallbackItems(count, estimateSize, INITIAL_VIEWPORT_ROWS + overscan),
+    [count, estimateSize, overscan],
+  );
+
+  const virtualizer = useVirtualizer({
+    count,
+    getScrollElement: () => scrollRef.current,
+    estimateSize,
+    overscan,
+    initialRect: {
+      width: 0,
+      height: averageInitialSize * INITIAL_VIEWPORT_ROWS,
+    },
+  });
+  const virtualItems = virtualizer.getVirtualItems();
+  const renderedItems: RenderedVirtualItem[] =
+    virtualItems.length > 0 ? virtualItems : fallbackItems;
+
+  const setScrollRef = useCallback((node: HTMLElement | null) => {
+    scrollRef.current = node;
+  }, []);
+
+  const onCopy = useVirtualizedCopy({
+    enabled: virtualized,
+    scrollRef,
+    getLineText,
+  });
+
+  const props = {
+    ref: setScrollRef,
+    className,
+    onCopy,
+    "data-virtualized": virtualized ? "true" : "false",
+  };
+
+  const content = virtualized ? (
+    <div
+      className={innerClassName}
+      style={{
+        height: virtualizer.getTotalSize() || estimatedTotalSize,
+        minWidth:
+          minWidthCh === undefined ? undefined : `max(100%, ${minWidthCh}ch)`,
+        position: "relative",
+      }}
+    >
+      {renderedItems.map((item) => (
+        <div
+          key={item.key}
+          data-index={item.index}
+          style={{
+            height: item.size,
+            left: 0,
+            position: "absolute",
+            right: 0,
+            top: 0,
+            transform: `translateY(${item.start}px)`,
+          }}
+        >
+          {renderLine(item.index)}
+        </div>
+      ))}
+    </div>
+  ) : (
+    <div className={innerClassName}>
+      {Array.from({ length: count }, (_, index) => renderLine(index))}
+    </div>
+  );
+
+  return as === "pre" ? (
+    <pre {...props}>{content}</pre>
+  ) : (
+    <div {...props}>{content}</div>
+  );
+}
+
+function buildFallbackItems(
+  count: number,
+  estimateSize: (index: number) => number,
+  visibleCount: number,
+): RenderedVirtualItem[] {
+  const items: RenderedVirtualItem[] = [];
+  let start = 0;
+  const limit = Math.min(count, visibleCount);
+  for (let index = 0; index < limit; index++) {
+    const size = estimateSize(index);
+    items.push({ key: index, index, start, size });
+    start += size;
+  }
+  return items;
+}
+
+export function lineIndexProps(index: number) {
+  return {
+    "data-line-index": index,
+  };
+}
+
+export function lineTextContentProps() {
+  return {
+    "data-line-content": "true",
+  };
+}
+
+export function estimateMonospaceWidthCh(text: string): number {
+  let width = 0;
+  for (const char of text) {
+    if (char === "\t") {
+      width += 8 - (width % 8);
+    } else {
+      width += 1;
+    }
+  }
+  return width;
+}
+
+export function estimateMaxLineWidthCh(
+  lines: readonly string[],
+  extraCh = 0,
+): number {
+  let max = 0;
+  for (const line of lines) {
+    max = Math.max(max, estimateMonospaceWidthCh(line));
+  }
+  return max + extraCh;
+}
+
+function useVirtualizedCopy({
+  enabled,
+  scrollRef,
+  getLineText,
+}: {
+  enabled: boolean;
+  scrollRef: RefObject<HTMLElement | null>;
+  getLineText: (index: number) => string;
+}) {
+  return useCallback(
+    (event: ClipboardEvent<HTMLElement>) => {
+      if (!enabled) return;
+      const root = scrollRef.current;
+      const selection = root?.ownerDocument.getSelection();
+      if (
+        !root ||
+        !selection ||
+        selection.isCollapsed ||
+        selection.rangeCount === 0
+      ) {
+        return;
+      }
+      const range = selection.getRangeAt(0);
+
+      const rawStart = resolveEndpoint(
+        root,
+        range.startContainer,
+        range.startOffset,
+        getLineText,
+      );
+      const rawEnd = resolveEndpoint(
+        root,
+        range.endContainer,
+        range.endOffset,
+        getLineText,
+      );
+      if (!rawStart || !rawEnd) return;
+      if (rawStart.index === rawEnd.index) return;
+
+      const start = rawStart.insideContent
+        ? rawStart
+        : { ...rawStart, offset: 0 };
+      const end = rawEnd.insideContent
+        ? rawEnd
+        : { ...rawEnd, offset: getLineText(rawEnd.index).length };
+      event.clipboardData.setData(
+        "text/plain",
+        selectedLineText(start, end, getLineText),
+      );
+      event.preventDefault();
+    },
+    [enabled, getLineText, scrollRef],
+  );
+}
+
+function resolveEndpoint(
+  root: HTMLElement,
+  node: Node | null,
+  offset: number,
+  getLineText: (index: number) => string,
+): SelectionEndpoint | null {
+  if (!node) return null;
+  const element =
+    node.nodeType === ELEMENT_NODE ? (node as Element) : node.parentElement;
+  const line = element?.closest<HTMLElement>("[data-line-index]");
+  if (!line || !root.contains(line)) return null;
+  const rawIndex = line.dataset.lineIndex;
+  if (rawIndex === undefined) return null;
+  const index = Number(rawIndex);
+  if (!Number.isInteger(index) || index < 0) return null;
+
+  const lineText = getLineText(index);
+  const content = line.querySelector<HTMLElement>("[data-line-content]");
+  const insideContent = content ? nodeWithin(content, node) : false;
+  const textOffset = content
+    ? offsetWithinContent(content, node, offset, 0)
+    : 0;
+  return {
+    index,
+    offset: clamp(textOffset, 0, lineText.length),
+    insideContent,
+  };
+}
+
+function offsetWithinContent(
+  content: HTMLElement,
+  node: Node,
+  offset: number,
+  fallback: number,
+): number {
+  if (!nodeWithin(content, node)) return fallback;
+  if (node === content && node.nodeType === ELEMENT_NODE) {
+    let total = 0;
+    const childNodes = Array.from(node.childNodes);
+    for (let i = 0; i < Math.min(offset, childNodes.length); i++) {
+      total += childNodes[i]?.textContent?.length ?? 0;
+    }
+    return total;
+  }
+
+  const walker = content.ownerDocument.createTreeWalker(content, SHOW_TEXT);
+  let total = 0;
+  let current = walker.nextNode();
+  while (current) {
+    const text = current.textContent ?? "";
+    if (current === node) {
+      return total + Math.min(offset, text.length);
+    }
+    total += text.length;
+    current = walker.nextNode();
+  }
+  return fallback;
+}
+
+function nodeWithin(parent: Node, node: Node): boolean {
+  let current: Node | null = node;
+  while (current) {
+    if (current === parent) return true;
+    current = current.parentNode;
+  }
+  return false;
+}
+
+function selectedLineText(
+  start: SelectionEndpoint,
+  end: SelectionEndpoint,
+  getLineText: (index: number) => string,
+): string {
+  const parts: string[] = [];
+  for (let index = start.index; index <= end.index; index++) {
+    const line = getLineText(index);
+    if (index === start.index) {
+      parts.push(line.slice(start.offset));
+    } else if (index === end.index) {
+      parts.push(line.slice(0, end.offset));
+    } else {
+      parts.push(line);
+    }
+  }
+  return parts.join("\n");
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(value, max));
+}


### PR DESCRIPTION
## Summary
This switches large code and diff views to windowed rendering while preserving the existing full-render path for small files.

1. **Shared virtual line renderer:** add a `VirtualizedLines` component backed by `@tanstack/react-virtual` for large line-oriented views.
2. **Code viewer virtualization:** render large files through the virtualized path while keeping line numbers, highlighted HTML, and horizontal sizing behavior.
3. **Diff view virtualization:** virtualize large unified/split diff line lists while preserving markers, line numbers, and highlight output.
4. **Small file compatibility:** keep the existing non-virtualized rendering path below the line threshold to avoid unnecessary complexity for normal files.
5. **Regression coverage:** add tests for virtualized code/diff rendering and preserve existing PR detail/diff test coverage.

## Expected impact
| Area | Impact |
| --- | --- |
| CodeViewer | Reduces DOM nodes and render work for large files. |
| DiffView | Reduces DOM pressure when opening large diffs. |
| DiffSplitView | Inherits virtualization without changing modal wiring. |
| Small files | Behavior remains on the existing full-render path. |

## Design notes
- Virtualization starts above 500 lines so small files keep their simpler current markup.
- Syntax highlighting still runs against loaded content before rendering; this PR targets DOM/render cost rather than highlighter CPU cost.
- The shared virtual renderer keeps line height stable and preserves horizontal overflow width for copy/selection behavior.

## Follow-up (not in this PR)
- Very large highlighted files may still spend CPU time before render; incremental or worker-based highlighting would be a separate optimization.

## Test plan
- [x] `pnpm exec tsc --noEmit` passed.
- [x] `pnpm exec vitest run src/components/CodeDiffVirtualization.test.tsx src/components/PullRequestDetailModal.test.ts src/components/PullRequestDetailModal.modal.test.tsx src/lib/diff.test.ts` passed, 20 tests.

## Notes
- This branch was rebased onto the current `origin/main` after #228 merged.
- `DiffViewerModal` was not changed directly; it receives the behavior through `DiffSplitView`.
