### PR TITLE
perf(agent-history): unblock UI on project switch + skeleton polish

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -107,11 +107,15 @@ pub fn list_system_fonts() -> Vec<String> {
 }
 
 #[tauri::command]
-pub fn list_agent_history(
+pub async fn list_agent_history(
     repo_path: String,
     limit: Option<usize>,
 ) -> AppResult<Vec<AgentHistoryItem>> {
-    agent_history::list_agent_history(PathBuf::from(repo_path), limit)
+    tauri::async_runtime::spawn_blocking(move || {
+        agent_history::list_agent_history(PathBuf::from(repo_path), limit)
+    })
+    .await
+    .map_err(|e| crate::error::AppError::Other(format!("history scan join failed: {e}")))?
 }
 
 #[tauri::command]

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -546,6 +546,42 @@ function PrSkeletonList({ count = 6 }: { count?: number }) {
   );
 }
 
+/**
+ * Shaped placeholder for an Agents History row. Mirrors the real row's
+ * structure — provider badge on the left, then title / preview / worktree /
+ * timestamp stacked on the right — so the panel doesn't reflow when items
+ * arrive. Some rows skip the worktree bar to look like a real mixed list.
+ */
+function HistorySkeletonRow({ index }: { index: number }) {
+  const titleWidths = ["68%", "82%", "54%", "74%", "60%", "88%"];
+  const previewWidths = ["92%", "76%", "60%", "84%"];
+  const titleW = titleWidths[index % titleWidths.length];
+  const previewW = previewWidths[index % previewWidths.length];
+  const showWorktree = index % 3 !== 1;
+  return (
+    <div
+      className="flex items-start gap-2 border-b border-border/40 px-3 py-2.5"
+      style={{ animationDelay: `${index * 60}ms` }}
+    >
+      <span className="mt-0.5 h-4 w-12 shrink-0 animate-pulse rounded bg-fg-muted/15" />
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <span
+          className="block h-3 animate-pulse rounded bg-fg-muted/15"
+          style={{ width: titleW }}
+        />
+        <span
+          className="block h-2.5 animate-pulse rounded bg-fg-muted/10"
+          style={{ width: previewW }}
+        />
+        {showWorktree ? (
+          <span className="block h-2.5 w-24 animate-pulse rounded bg-fg-muted/10" />
+        ) : null}
+        <span className="block h-2 w-12 animate-pulse rounded bg-fg-muted/10" />
+      </div>
+    </div>
+  );
+}
+
 const RIGHT_PANEL_REFRESH_DEBOUNCE_MS = 150;
 const TODOS_ACTIVITY_DEBOUNCE_MS = 750;
 const TODOS_SAFETY_INTERVAL_MS = 30_000;
@@ -968,16 +1004,33 @@ function AgentHistoryTab({
     onCancel: () => setTrashCandidate(null),
   });
 
+  // Stale responses from a previous repoPath (or an earlier in-flight call)
+  // must not overwrite newer results. Each fetch claims a token; only the
+  // latest token is allowed to commit.
+  const fetchTokenRef = useRef(0);
+
   const fetchHistory = useCallback(async () => {
+    const token = ++fetchTokenRef.current;
     setLoading(true);
     setError(null);
     try {
-      setItems(await api.listAgentHistory(repoPath, 100));
+      const result = await api.listAgentHistory(repoPath, 100);
+      if (token !== fetchTokenRef.current) return;
+      setItems(result);
     } catch (e) {
+      if (token !== fetchTokenRef.current) return;
       setError(String(e));
     } finally {
-      setLoading(false);
+      if (token === fetchTokenRef.current) setLoading(false);
     }
+  }, [repoPath]);
+
+  // Project switch: drop the previous project's items so the skeleton shows
+  // immediately instead of leaving stale data on screen while the scan runs.
+  useEffect(() => {
+    fetchTokenRef.current++;
+    setItems(null);
+    setError(null);
   }, [repoPath]);
 
   useEffect(() => {
@@ -1074,7 +1127,7 @@ function AgentHistoryTab({
         ) : !items ? (
           <div>
             {Array.from({ length: 8 }).map((_, i) => (
-              <SkeletonRow key={i} pulseDelayMs={i * 70} />
+              <HistorySkeletonRow key={i} index={i} />
             ))}
           </div>
         ) : items.length === 0 ? (
@@ -1129,7 +1182,12 @@ function AgentHistoryTab({
                           )}
                         >
                           <GitBranch size={11} className="shrink-0" />
-                          <span className="truncate">
+                          <span
+                            className={cn(
+                              "truncate",
+                              item.worktree.exists ? null : "line-through",
+                            )}
+                          >
                             {item.worktree.name}
                           </span>
                         </div>
@@ -1182,12 +1240,6 @@ function AgentHistoryTab({
                   icon: <GitBranch size={12} />,
                   disabled: !menu.item.worktree,
                   onClick: () => void copy(menu.item.worktree?.path ?? ""),
-                },
-                { type: "separator" },
-                {
-                  label: rt(t, "rightPanel.history.openTranscript"),
-                  icon: <ExternalLink size={12} />,
-                  onClick: () => void openPath(menu.item.transcript_path),
                 },
                 { type: "separator" },
                 {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -560,6 +560,7 @@ function HistorySkeletonRow({ index }: { index: number }) {
   const showWorktree = index % 3 !== 1;
   return (
     <div
+      aria-hidden="true"
       className="flex items-start gap-2 border-b border-border/40 px-3 py-2.5"
       style={{ animationDelay: `${index * 60}ms` }}
     >
@@ -1125,7 +1126,11 @@ function AgentHistoryTab({
         {error ? (
           <div className="p-3 text-xs text-danger">{error}</div>
         ) : !items ? (
-          <div>
+          <div
+            role="status"
+            aria-busy="true"
+            aria-label={rt(t, "rightPanel.history.loading")}
+          >
             {Array.from({ length: 8 }).map((_, i) => (
               <HistorySkeletonRow key={i} index={i} />
             ))}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -605,7 +605,6 @@
       "runInWorktree": "Run in worktree",
       "copyResume": "Copy resume command",
       "copyWorktreePath": "Copy worktree path",
-      "openTranscript": "Open transcript",
       "moveTranscriptToTrash": "Move transcript to Trash...",
       "worktreeMissing": "missing",
       "worktreeUnavailable": "That worktree is no longer available.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -605,7 +605,6 @@
       "runInWorktree": "워크트리에서 실행",
       "copyResume": "resume 명령 복사",
       "copyWorktreePath": "워크트리 경로 복사",
-      "openTranscript": "transcript 열기",
       "moveTranscriptToTrash": "transcript를 휴지통으로 이동...",
       "worktreeMissing": "없음",
       "worktreeUnavailable": "해당 워크트리를 더 이상 사용할 수 없습니다.",

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -565,7 +565,7 @@ test.describe("right panel: groups", () => {
 
     await expect(
       page.getByRole("menu").getByRole("separator"),
-    ).toHaveCount(3);
+    ).toHaveCount(2);
     await page.getByRole("menuitem", { name: "Run in worktree" }).click();
 
     await expect


### PR DESCRIPTION
## Summary
- Make `list_agent_history` async via `tauri::async_runtime::spawn_blocking` so the multi-thousand-file fs + git2 scan no longer runs on the Tauri main thread. Switching projects with the Agents → History tab open used to freeze the whole window for several seconds.
- Reset `items` to null when `repoPath` changes so the skeleton shows immediately instead of leaving the previous project's data on screen during the new scan.
- Race-safe SWR via a fetch token — rapid project switches can't let an older fetch overwrite a newer one.
- New `HistorySkeletonRow` mirrors the real row layout (provider badge + title + preview + worktree + timestamp) so the panel doesn't reflow when items land. Wrapper exposes `role=status` + `aria-busy="true"`; rows are `aria-hidden`.
- Strikethrough on the worktree name when `worktree.exists === false`.
- Remove the "Open transcript" context menu item (+ unused i18n keys). macOS has no default app for `.jsonl`, so clicking it silently did nothing.

## Test plan
- [ ] Open Acorn, focus Agents → History on a project with many sessions.
- [ ] Switch rapidly between several projects; verify no UI freeze, skeleton appears immediately on switch, and final list matches the active project (no stale rows from a previous switch).
- [ ] Manually click the Refresh button on a populated list; verify items stay visible while loading and update in place.
- [ ] Force a missing worktree (delete a session's worktree folder) and confirm its name renders with a strikethrough in the row.
- [ ] Right-click a history row; confirm the "Open transcript" item is gone and the remaining menu items (Run, Copy resume, Copy worktree path, Move to Trash) still work.
- [ ] Run `pnpm run typecheck` and `pnpm run test` — both should pass.
