### PR TITLE
perf(right-panel): unblock tab clicks + cache history per project

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1603,14 +1603,33 @@ fn session_root_pid(state: &State<'_, AppState>, id: &Uuid) -> Option<u32> {
 /// banner appearing inside the panel any time the PTY drifts outside a
 /// repo.
 #[tauri::command]
-pub fn pty_repo_root(state: State<'_, AppState>, session_id: String) -> AppResult<Option<String>> {
-    let Some(cwd) = pty_cwd(state, session_id)? else {
+pub async fn pty_repo_root(
+    state: State<'_, AppState>,
+    session_id: String,
+) -> AppResult<Option<String>> {
+    let id = parse_id(&session_id)?;
+    let Some(root_pid) = session_root_pid(&state, &id) else {
         return Ok(None);
     };
-    let Ok(repo) = git2::Repository::discover(&cwd) else {
-        return Ok(None);
-    };
-    Ok(repo.workdir().map(|p| p.to_string_lossy().into_owned()))
+    tauri::async_runtime::spawn_blocking(move || {
+        let mut sys = System::new_with_specifics(
+            RefreshKind::new().with_processes(ProcessRefreshKind::new()),
+        );
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::All,
+            true,
+            ProcessRefreshKind::new().with_cwd(UpdateKind::Always),
+        );
+        let Some(cwd) = deepest_descendant_cwd(&sys, Pid::from_u32(root_pid)) else {
+            return Ok(None);
+        };
+        let Ok(repo) = git2::Repository::discover(&cwd) else {
+            return Ok(None);
+        };
+        Ok(repo.workdir().map(|p| p.to_string_lossy().into_owned()))
+    })
+    .await
+    .map_err(|e| crate::error::AppError::Other(format!("pty_repo_root join failed: {e}")))?
 }
 
 /// BFS over `sys`, starting at `root`, returning the cwd of the deepest

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -151,7 +151,7 @@ export function RightPanel() {
   // and falls back to the recorded path when there's no live PTY.
   const fallbackPath =
     active?.worktree_path ?? activeWorkspaceTab?.repoPath ?? activeProject ?? null;
-  const repoPath = useLiveRepoPath(active?.id ?? null, fallbackPath, rightTab);
+  const repoPath = useLiveRepoPath(active?.id ?? null, fallbackPath);
   const sessionHostRepoPath =
     active?.repo_path ?? activeWorkspaceTab?.repoPath ?? activeProject ?? repoPath;
   const invalidations = useRightPanelInvalidations(repoPath);
@@ -775,7 +775,6 @@ function useRightPanelInvalidations(
 function useLiveRepoPath(
   sessionId: string | null,
   fallbackPath: string | null,
-  rightTab: string,
 ): string | null {
   const [liveRepo, setLiveRepo] = useState<LiveRepoCache | null>(null);
   const [tick, setTick] = useState(0);
@@ -800,7 +799,7 @@ function useLiveRepoPath(
     return () => {
       cancelled = true;
     };
-  }, [sessionId, fallbackPath, rightTab, tick]);
+  }, [sessionId, fallbackPath, tick]);
 
   // Refocusing the app is a strong signal the user is about to look at the
   // panel — re-resolve so a `claude --worktree` that happened while we were
@@ -972,6 +971,13 @@ function countByStatus(todos: TodoItem[]) {
   return { pending, in_progress, completed };
 }
 
+// Per-project History snapshot kept in module memory so re-opening a project
+// renders its rows synchronously. The accompanying SWR fetch still refreshes
+// in the background to pick up sessions created since the snapshot. Lives in
+// process memory only — wiped on app restart, which is the right TTL for
+// session lists that turn over often.
+const agentHistoryCache = new Map<string, AgentHistoryItem[]>();
+
 function AgentHistoryTab({
   repoPath,
   sessionHostRepoPath,
@@ -983,7 +989,12 @@ function AgentHistoryTab({
   const createSession = useAppStore((s) => s.createSession);
   const adoptSessionWorktree = useAppStore((s) => s.adoptSessionWorktree);
   const setPendingTerminalInput = useAppStore((s) => s.setPendingTerminalInput);
-  const [items, setItems] = useState<AgentHistoryItem[] | null>(null);
+  // Hydrate from the module-level cache so re-opening a project shows its
+  // list instantly. The accompanying fetch below still runs (SWR-style)
+  // to surface new sessions created since the cached snapshot.
+  const [items, setItems] = useState<AgentHistoryItem[] | null>(
+    () => agentHistoryCache.get(repoPath) ?? null,
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [menu, setMenu] = useState<{
@@ -1017,6 +1028,7 @@ function AgentHistoryTab({
     try {
       const result = await api.listAgentHistory(repoPath, 100);
       if (token !== fetchTokenRef.current) return;
+      agentHistoryCache.set(repoPath, result);
       setItems(result);
     } catch (e) {
       if (token !== fetchTokenRef.current) return;
@@ -1024,14 +1036,6 @@ function AgentHistoryTab({
     } finally {
       if (token === fetchTokenRef.current) setLoading(false);
     }
-  }, [repoPath]);
-
-  // Project switch: drop the previous project's items so the skeleton shows
-  // immediately instead of leaving stale data on screen while the scan runs.
-  useEffect(() => {
-    fetchTokenRef.current++;
-    setItems(null);
-    setError(null);
   }, [repoPath]);
 
   useEffect(() => {
@@ -1091,16 +1095,17 @@ function AgentHistoryTab({
     setError(null);
     try {
       await api.trashAgentHistoryTranscript(item);
-      setItems((prev) =>
-        prev
-          ? prev.filter(
-              (candidate) =>
-                candidate.provider !== item.provider ||
-                candidate.id !== item.id ||
-                candidate.transcript_path !== item.transcript_path,
-            )
-          : prev,
-      );
+      setItems((prev) => {
+        if (!prev) return prev;
+        const next = prev.filter(
+          (candidate) =>
+            candidate.provider !== item.provider ||
+            candidate.id !== item.id ||
+            candidate.transcript_path !== item.transcript_path,
+        );
+        agentHistoryCache.set(repoPath, next);
+        return next;
+      });
       setTrashCandidate(null);
     } catch (e) {
       setTrashCandidate(null);


### PR DESCRIPTION
## Summary
Two related symptoms with the same root cause family — sync Tauri commands doing IO on the main thread.

### Tab navigation eaten during skeleton state
`useLiveRepoPath` had `rightTab` in its dep array, so every tab click re-ran `pty_repo_root`. That command was sync: a full process tree scan + `git2::Repository::discover` on the main thread. While it ran, the IPC channel was busy and the next tab click was effectively dropped. The recently-added History skeleton made the loading state visible long enough to make the lost clicks obvious.

Fix:
- Drop `rightTab` from `useLiveRepoPath`'s signature and deps — the session's repo root is determined by `sessionId`, not which tab is active.
- Make `pty_repo_root` `async fn` with `tauri::async_runtime::spawn_blocking` so even when it does fire, the process scan + git2 discover never touches the UI thread.

### Per-project History cache (SWR)
Module-level `Map<repoPath, AgentHistoryItem[]>` hydrates `AgentHistoryTab` on mount, so re-opening a project shows rows synchronously instead of re-scanning thousands of `.jsonl` files under `~/.codex/` / `~/.claude/`. The fetch still runs in the background to surface new sessions; the trash flow keeps the cache in sync after deletion. Cache lives in process memory only — wiped on app restart, which is the right TTL for session lists that turn over often.

## Test plan
- [ ] Open Agents → History on a project, wait for the skeleton to appear, then click another tab (or the Code / Agents group buttons) immediately — the click should register without delay.
- [ ] Switch between two projects you've both visited; the History list should render instantly from cache, and a refresh spinner appears briefly as the background fetch reconciles.
- [ ] Switch to a project you've never opened before — skeleton appears, then real items.
- [ ] Trash a transcript; re-enter the project — the trashed item stays gone (cache was updated).
- [ ] Hit the Refresh button on a populated list; items stay visible while loading and update in place when done.
- [ ] `pnpm run typecheck` and `pnpm run test` pass.
