### PR TITLE
perf(github-tab): cache PR + workflow run listings per project

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -2190,6 +2190,14 @@ function usePrRowActions(
   return { openContextMenu, overlays, error };
 }
 
+// Per-(repo, stateFilter) cache for PR listings. Keeps rows on screen across
+// remounts and filter toggles so the user doesn't see a skeleton every time
+// they revisit a project. Process memory only — turns over on app restart.
+const pullRequestsCache = new Map<string, PullRequestListing>();
+function pullRequestsCacheKey(repoPath: string, stateFilter: PrStateFilter) {
+  return `${repoPath} ${stateFilter}`;
+}
+
 function PullRequestsTab({
   repoPath,
   onOpenDetail,
@@ -2208,7 +2216,9 @@ function PullRequestsTab({
   );
   const showAvatars = useSettings((s) => s.settings.github.showAvatars);
   const [stateFilter, setStateFilter] = useState<PrStateFilter>("open");
-  const [listing, setListing] = useState<PullRequestListing | null>(null);
+  const [listing, setListing] = useState<PullRequestListing | null>(
+    () => pullRequestsCache.get(pullRequestsCacheKey(repoPath, "open")) ?? null,
+  );
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   // Grows by PR_PAGE_SIZE each time the user scrolls to the bottom. Resets on
@@ -2222,6 +2232,10 @@ function PullRequestsTab({
       try {
         const result = await api.listPullRequests(repoPath, stateFilter, limit);
         if (signal?.cancelled) return;
+        pullRequestsCache.set(
+          pullRequestsCacheKey(repoPath, stateFilter),
+          result,
+        );
         setListing(result);
         setError(null);
         setPrAccountForRepo(
@@ -2238,11 +2252,14 @@ function PullRequestsTab({
     [repoPath, stateFilter, limit, setPrAccountForRepo],
   );
 
-  // Reset list state on context change (project / filter) but NOT on limit
-  // growth — keeping the existing rows during a "load more" prevents the
-  // skeleton from flashing while the larger page lands.
+  // On filter change, hydrate from the cache for that filter (or show the
+  // skeleton if we've never fetched it). The accompanying fetch below still
+  // runs SWR-style. Limit resets so a fresh filter context starts at one page.
   useEffect(() => {
-    setListing(null);
+    setListing(
+      pullRequestsCache.get(pullRequestsCacheKey(repoPath, stateFilter)) ??
+        null,
+    );
     setError(null);
     setLimit(PR_PAGE_SIZE);
   }, [repoPath, stateFilter]);
@@ -2388,12 +2405,19 @@ function PullRequestsTab({
 const WORKFLOW_RUNS_LIMIT = 50;
 const ALL_WORKFLOWS = "__all__";
 
+// Per-repo cache for workflow runs. Same idea as pullRequestsCache —
+// re-opening a project surfaces its runs synchronously while a background
+// fetch reconciles fresh results.
+const workflowRunsCache = new Map<string, WorkflowRunsListing>();
+
 function ActionsTab({ repoPath }: { repoPath: string }) {
   const t = useTranslation();
   const refreshIntervalMs = useSettings(
     (s) => s.settings.github.refreshIntervalMs,
   );
-  const [listing, setListing] = useState<WorkflowRunsListing | null>(null);
+  const [listing, setListing] = useState<WorkflowRunsListing | null>(
+    () => workflowRunsCache.get(repoPath) ?? null,
+  );
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [workflowFilter, setWorkflowFilter] = useState<string>(ALL_WORKFLOWS);
@@ -2405,6 +2429,7 @@ function ActionsTab({ repoPath }: { repoPath: string }) {
       try {
         const result = await api.listWorkflowRuns(repoPath, WORKFLOW_RUNS_LIMIT);
         if (signal?.cancelled) return;
+        workflowRunsCache.set(repoPath, result);
         setListing(result);
         setError(null);
       } catch (e) {
@@ -2416,13 +2441,6 @@ function ActionsTab({ repoPath }: { repoPath: string }) {
     },
     [repoPath],
   );
-
-  useEffect(() => {
-    setListing(null);
-    setError(null);
-    setWorkflowFilter(ALL_WORKFLOWS);
-    setDetailRunId(null);
-  }, [repoPath]);
 
   useEffect(() => {
     const signal = { cancelled: false };


### PR DESCRIPTION
## Summary
Same SWR pattern that landed for Agents → History, applied to the GitHub group.

- **PullRequestsTab**: cache keyed by `${repoPath}:${stateFilter}`. Re-opening a project — or toggling Open/Closed/Merged — hydrates from the cache instead of flashing a skeleton.
- **ActionsTab**: cache keyed by `repoPath`. Same hydration on remount.
- The periodic poll + manual refresh + post-merge `refreshKey` bump all keep flowing into the cache via the regular fetch path.
- Removed the now-redundant `setListing(null)` effect that was the original cause of the skeleton flash on project / filter change.

Cache lives in process memory only — wiped on app restart, which matches how often PR / CI state actually turns over for a single user.

No backend changes: `list_pull_requests` and `list_workflow_runs` were already `async fn`, so they don't share the main-thread blocking issue that bit `pty_repo_root` and `list_agent_history`.

## Test plan
- [x] Open Project A's GitHub → Pull Requests tab, wait for rows, switch to Project B (also visited before), then back to A — list should appear instantly with a brief refresh spinner instead of a skeleton flash.
- [x] Toggle Open / Closed / Merged filters back and forth on the same project — instant on second visit to each filter.
- [x] Open a project never visited before — skeleton appears, then real rows.
- [x] Merge or close a PR via the detail modal — list reflects the change after the parent's `refreshKey` triggers a refetch.
- [x] Open Project A's GitHub → Actions tab, switch projects, return — same instant render.
- [ ] `pnpm run typecheck` passes (no backend test impact since no Rust changed).
