### PR TITLE
perf(code-tab): cache commits + staged listings per project

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1344,6 +1344,13 @@ function AgentHistoryTab({
   );
 }
 
+// Per-repo cache for the commits list. Survives remounts so revisiting a
+// project shows its commit log synchronously; the safety interval still kicks
+// off a background refresh on mount to splice newer commits over the cached
+// prefix. Process memory only.
+type CommitsCacheEntry = { commits: CommitInfo[]; hasMore: boolean };
+const commitsCache = new Map<string, CommitsCacheEntry>();
+
 function CommitsTab({
   repoPath,
   invalidateKey,
@@ -1354,18 +1361,22 @@ function CommitsTab({
   onExpand: (e: ExpandedDiff) => void;
 }) {
   const t = useTranslation();
-  const [commits, setCommits] = useState<CommitInfo[]>([]);
+  const cachedCommits = commitsCache.get(repoPath);
+  const [commits, setCommits] = useState<CommitInfo[]>(
+    () => cachedCommits?.commits ?? [],
+  );
   const [commitLogins, setCommitLogins] = useState<
     Record<string, string | null>
   >({});
   const [selected, setSelected] = useState<string | null>(null);
   const [diff, setDiff] = useState<DiffPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [hasMore, setHasMore] = useState(true);
+  const [hasMore, setHasMore] = useState(() => cachedCommits?.hasMore ?? true);
   const [loadingMore, setLoadingMore] = useState(false);
   // Tracks the very first fetch for the current `repoPath` so we can show
-  // skeleton rows instead of a blank panel on project switch.
-  const [loadingFirst, setLoadingFirst] = useState(true);
+  // skeleton rows instead of a blank panel on project switch. Cache hit
+  // skips the skeleton entirely.
+  const [loadingFirst, setLoadingFirst] = useState(!cachedCommits);
   const [menu, setMenu] = useState<{
     x: number;
     y: number;
@@ -1373,7 +1384,9 @@ function CommitsTab({
   } | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const generationRef = useRef(0);
-  const loadedTopRef = useRef(false);
+  // Hydrated cache counts as a successful top-of-history load so a failed
+  // background refresh doesn't replace good data with an error banner.
+  const loadedTopRef = useRef(!!cachedCommits);
 
   const refreshFirstPage = useCallback(async () => {
     const generation = generationRef.current;
@@ -1403,17 +1416,12 @@ function CommitsTab({
 
   const { refreshNow, scheduleRefresh } = useRefreshScheduler(refreshFirstPage);
 
+  // Parent mounts CommitsTab with key={repoPath}, so this effect only fires
+  // on initial mount — useState initializers already seeded the right state
+  // for that mount (cache hit or empty). We only need the cleanup bump so
+  // any in-flight refresh from the previous instance bails on unmount.
   useEffect(() => {
     generationRef.current += 1;
-    loadedTopRef.current = false;
-    setError(null);
-    setSelected(null);
-    setDiff(null);
-    setHasMore(true);
-    setLoadingMore(false);
-    setLoadingFirst(true);
-    setCommits([]);
-    setCommitLogins({});
     return () => {
       generationRef.current += 1;
     };
@@ -1427,6 +1435,15 @@ function CommitsTab({
   useEffect(() => {
     if (invalidateKey > 0) scheduleRefresh();
   }, [invalidateKey, scheduleRefresh]);
+
+  // Mirror local list state into the module-level cache so the next mount of
+  // CommitsTab for this repo hydrates synchronously. Skip the very first
+  // pre-fetch state (empty + loadingFirst) so we don't pollute the cache with
+  // a blank entry that suppresses the skeleton on a true first visit.
+  useEffect(() => {
+    if (loadingFirst) return;
+    commitsCache.set(repoPath, { commits, hasMore });
+  }, [repoPath, commits, hasMore, loadingFirst]);
 
   // Resolve commit author logins via GitHub GraphQL for any sha we don't
   // already have. The backend caches by (slug, sha) so re-fetches across
@@ -1804,6 +1821,11 @@ function absoluteTime(unixSeconds: number): string {
   return new Date(unixSeconds * 1000).toLocaleString();
 }
 
+// Per-repo cache for the staged-files snapshot. Same lifecycle as
+// commitsCache — survives remounts, refreshed on every safety interval mount.
+type StagedCacheEntry = { files: StagedFile[]; diff: DiffPayload | null };
+const stagedCache = new Map<string, StagedCacheEntry>();
+
 function StagedTab({
   repoPath,
   invalidateKey,
@@ -1814,10 +1836,15 @@ function StagedTab({
   onExpand: (e: ExpandedDiff) => void;
 }) {
   const t = useTranslation();
-  const [files, setFiles] = useState<StagedFile[]>([]);
-  const [diff, setDiff] = useState<DiffPayload | null>(null);
+  const cachedStaged = stagedCache.get(repoPath);
+  const [files, setFiles] = useState<StagedFile[]>(
+    () => cachedStaged?.files ?? [],
+  );
+  const [diff, setDiff] = useState<DiffPayload | null>(
+    () => cachedStaged?.diff ?? null,
+  );
   const [error, setError] = useState<string | null>(null);
-  const [loadingFirst, setLoadingFirst] = useState(true);
+  const [loadingFirst, setLoadingFirst] = useState(!cachedStaged);
   const [menu, setMenu] = useState<{
     x: number;
     y: number;
@@ -1846,12 +1873,11 @@ function StagedTab({
 
   const { refreshNow, scheduleRefresh } = useRefreshScheduler(refresh);
 
+  // Same shape as CommitsTab: key={repoPath} on the parent means this only
+  // fires on initial mount, so useState initializers handle the hydration.
+  // Cleanup bump still cancels any in-flight refresh on unmount.
   useEffect(() => {
     generationRef.current += 1;
-    setError(null);
-    setLoadingFirst(true);
-    setFiles([]);
-    setDiff(null);
     return () => {
       generationRef.current += 1;
     };
@@ -1865,6 +1891,12 @@ function StagedTab({
   useEffect(() => {
     if (invalidateKey > 0) scheduleRefresh();
   }, [invalidateKey, scheduleRefresh]);
+
+  // Mirror to module cache so the next mount for this repo hydrates instantly.
+  useEffect(() => {
+    if (loadingFirst) return;
+    stagedCache.set(repoPath, { files, diff });
+  }, [repoPath, files, diff, loadingFirst]);
 
   function isDeleted(file: StagedFile): boolean {
     return file.status.toLowerCase().includes("delete");


### PR DESCRIPTION
## Summary
Same SWR cache pattern as Agents → History (#236) and GitHub PRs/Actions (#237), now applied to the Code group.

- **CommitsTab**: cache keyed by `repoPath`, stores both `commits` and `hasMore` so the "load more" button starts in the right state on remount.
- **StagedTab**: cache keyed by `repoPath`, stores both `files` and the staged `diff` so the right pane doesn't flash either.
- Both: hydrate the initial `useState` from the cache and mirror back via a small `useEffect` on `[repoPath, <data>, loadingFirst]`.
- Both: stripped the mount-time `setFiles([])` / `setLoadingFirst(true)` / etc. reset block. With `key={repoPath}` on the parent the component fully remounts on project switch, so those calls were always dead code — and they were actively clobbering the cache hydration. The cleanup `generationRef` bump that cancels in-flight refreshes on unmount stays.
- `loadedTopRef` in CommitsTab now starts `true` when hydrating from cache so a transient background-refresh failure doesn't replace visible commits with an error banner.

Network / git work still happens on mount via the existing safety interval; the cache just hides the gap while the refresh runs.

## Test plan
- [ ] Open Project A's Code → Commits tab; wait for rows. Switch to Project B (also visited), then back to A — commits render instantly, with a brief refresh in the background.
- [ ] Same flow for Code → Staged.
- [ ] First-time project: skeleton appears, then real data.
- [ ] Modify a file in the repo (or commit something) and verify the safety interval picks up the change and the displayed list updates (cache replaces transparently).
- [ ] CommitsTab: scroll to load more, switch projects, return — first page renders from cache (subsequent pages need re-scroll, that's by design).
- [ ] StagedTab: stage / unstage a file, the FS invalidation triggers a refresh and the cached entry is replaced.
- [ ] `pnpm run typecheck` passes; no backend changes.
