### PR TITLE
fix(diff): show old/new line-number gutter in code diff views

### DIFF
--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -351,7 +351,16 @@ fn collect_diff(repo: &Repository, diff: &git2::Diff) -> AppResult<DiffPayload> 
             true
         },
         None,
-        None,
+        Some(&mut |_delta, hunk| {
+            // Without this callback the patch stream contains only +/-/space
+            // body lines, so the renderer has no per-line numbering anchor.
+            // libgit2's `header()` already includes the trailing newline.
+            if let Some(f) = current.borrow_mut().as_mut() {
+                let header = std::str::from_utf8(hunk.header()).unwrap_or("");
+                f.patch.push_str(header);
+            }
+            true
+        }),
         Some(&mut |_delta, _hunk, line| {
             if let Some(f) = current.borrow_mut().as_mut() {
                 let origin = line.origin();
@@ -437,4 +446,71 @@ fn image_data_uri_workdir(repo: &Repository, oid: git2::Oid, path: Option<&str>)
     let abs = workdir.join(path);
     let bytes = std::fs::read(abs).ok()?;
     Some(encode_data_uri(&bytes, path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-git-ops-test-{label}-{}-{nanos}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    fn commit_file(
+        repo: &git2::Repository,
+        rel: &str,
+        contents: &str,
+        message: &str,
+        parents: &[&git2::Commit<'_>],
+    ) -> git2::Oid {
+        let workdir = repo.workdir().expect("workdir");
+        let path = workdir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).ok();
+        }
+        fs::write(&path, contents).expect("write file");
+        let mut idx = repo.index().expect("index");
+        idx.add_path(std::path::Path::new(rel)).expect("add");
+        idx.write().expect("write index");
+        let tree_id = idx.write_tree().expect("write tree");
+        let tree = repo.find_tree(tree_id).expect("tree");
+        let sig = git2::Signature::now("test", "t@example").expect("sig");
+        repo.commit(Some("HEAD"), &sig, &sig, message, &tree, parents)
+            .expect("commit")
+    }
+
+    #[test]
+    fn diff_for_commit_includes_hunk_headers() {
+        let root = unique_temp_dir("hunk-headers");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        let v1 = "alpha\nbeta\ngamma\ndelta\nepsilon\n";
+        let first_oid = commit_file(&repo, "a.txt", v1, "init", &[]);
+        let first = repo.find_commit(first_oid).expect("first commit");
+        let v2 = "alpha\nbeta\nGAMMA\ndelta\nepsilon\n";
+        let second_oid = commit_file(&repo, "a.txt", v2, "mutate", &[&first]);
+        drop(first);
+        drop(repo);
+
+        let payload = diff_for_commit(&root, &second_oid.to_string())
+            .expect("diff for second commit");
+        assert_eq!(payload.files.len(), 1);
+        let patch = &payload.files[0].patch;
+        assert!(
+            patch.lines().any(|l| l.starts_with("@@")),
+            "patch should contain at least one hunk header, got: {patch:?}",
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
 }

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -1,7 +1,12 @@
 import { ChevronRight, Maximize2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { cn } from "../lib/cn";
-import { countStats, parseDiff, type ParsedLine } from "../lib/diff";
+import {
+  countStats,
+  diffGutterWidth,
+  parseDiff,
+  type ParsedLine,
+} from "../lib/diff";
 import { highlightDiff, langFromPath } from "../lib/highlight";
 import type { DiffFile, DiffPayload } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
@@ -295,10 +300,12 @@ export function DiffLine({
   line,
   html,
   index,
+  gutterWidth = 1,
 }: {
   line: ParsedLine;
   html?: string | null;
   index?: number;
+  gutterWidth?: number;
 }) {
   if (line.kind === "hunk") {
     return (
@@ -334,8 +341,23 @@ export function DiffLine({
         : "text-fg-muted";
   const marker =
     line.kind === "add" ? "+" : line.kind === "del" ? "-" : " ";
+  const gutterStyle = { minWidth: `${Math.max(1, gutterWidth)}ch` };
   return (
     <div className={`flex gap-2 px-2 py-0 ${cls}`} {...lineDataProps(index)}>
+      <span
+        aria-hidden
+        className="select-none shrink-0 text-right tabular-nums text-fg-muted/55"
+        style={gutterStyle}
+      >
+        {line.oldLine ?? ""}
+      </span>
+      <span
+        aria-hidden
+        className="select-none shrink-0 text-right tabular-nums text-fg-muted/55"
+        style={gutterStyle}
+      >
+        {line.newLine ?? ""}
+      </span>
       <span className="select-none w-3 shrink-0 text-center opacity-70">
         {marker}
       </span>
@@ -367,9 +389,10 @@ export function DiffLineList({
   className: string;
 }) {
   const lineTexts = useMemo(() => lines.map(diffLineCopyText), [lines]);
+  const gutterWidth = useMemo(() => diffGutterWidth(lines), [lines]);
   const minWidthCh = useMemo(
-    () => estimateMaxLineWidthCh(lineTexts, 5),
-    [lineTexts],
+    () => estimateMaxLineWidthCh(lineTexts, gutterWidth * 2 + 7),
+    [lineTexts, gutterWidth],
   );
 
   return (
@@ -386,6 +409,7 @@ export function DiffLineList({
           index={index}
           line={lines[index]}
           html={highlighted[index] ?? null}
+          gutterWidth={gutterWidth}
         />
       )}
     />

--- a/src/lib/diff.test.ts
+++ b/src/lib/diff.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { countStats, parseDiff } from "./diff";
+import { countStats, diffGutterWidth, parseDiff } from "./diff";
 
 describe("parseDiff", () => {
   it("classifies hunk headers", () => {
     expect(parseDiff("@@ -1,3 +1,4 @@")).toEqual([
-      { kind: "hunk", prefix: "@@", text: "@@ -1,3 +1,4 @@" },
+      {
+        kind: "hunk",
+        prefix: "@@",
+        text: "@@ -1,3 +1,4 @@",
+        oldLine: null,
+        newLine: null,
+      },
     ]);
   });
 
@@ -27,20 +33,73 @@ describe("parseDiff", () => {
   it("strips +/-/space prefix and tags add/del/ctx", () => {
     const patch = "+added\n-removed\n unchanged";
     expect(parseDiff(patch)).toEqual([
-      { kind: "add", prefix: "+", text: "added" },
-      { kind: "del", prefix: "-", text: "removed" },
-      { kind: "ctx", prefix: " ", text: "unchanged" },
+      { kind: "add", prefix: "+", text: "added", oldLine: null, newLine: null },
+      {
+        kind: "del",
+        prefix: "-",
+        text: "removed",
+        oldLine: null,
+        newLine: null,
+      },
+      {
+        kind: "ctx",
+        prefix: " ",
+        text: "unchanged",
+        oldLine: null,
+        newLine: null,
+      },
     ]);
   });
 
   it("treats prefix-less lines as ctx with empty prefix", () => {
     expect(parseDiff("bare")).toEqual([
-      { kind: "ctx", prefix: "", text: "bare" },
+      { kind: "ctx", prefix: "", text: "bare", oldLine: null, newLine: null },
     ]);
   });
 
   it("preserves an empty trailing line from a trailing newline", () => {
     expect(parseDiff("+a\n")).toHaveLength(2);
+  });
+
+  it("tracks old and new line numbers across hunks", () => {
+    const patch = [
+      "@@ -10,3 +20,4 @@",
+      " ctx-a",
+      "-removed",
+      "+added-1",
+      "+added-2",
+      "@@ -100,2 +200,2 @@",
+      " ctx-b",
+      "-gone",
+    ].join("\n");
+    const lines = parseDiff(patch);
+    expect(lines.map((l) => [l.kind, l.oldLine, l.newLine])).toEqual([
+      ["hunk", null, null],
+      ["ctx", 10, 20],
+      ["del", 11, null],
+      ["add", null, 21],
+      ["add", null, 22],
+      ["hunk", null, null],
+      ["ctx", 100, 200],
+      ["del", 101, null],
+    ]);
+  });
+
+  it("falls back to null cursors when the hunk header is malformed", () => {
+    const patch = ["@@ broken header @@", "+x"].join("\n");
+    const lines = parseDiff(patch);
+    expect(lines[1]).toMatchObject({ kind: "add", oldLine: null, newLine: null });
+  });
+});
+
+describe("diffGutterWidth", () => {
+  it("returns 1 when no line numbers are known", () => {
+    expect(diffGutterWidth(parseDiff("+a\n-b"))).toBe(1);
+  });
+
+  it("returns the digit count of the largest tracked line number", () => {
+    const patch = ["@@ -1,2 +98,3 @@", " a", " b", "+c"].join("\n");
+    expect(diffGutterWidth(parseDiff(patch))).toBe(3);
   });
 });
 

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -12,6 +12,8 @@ export interface ParsedLine {
   kind: LineKind;
   prefix: string;
   text: string;
+  oldLine: number | null;
+  newLine: number | null;
 }
 
 export interface DiffStats {
@@ -19,10 +21,28 @@ export interface DiffStats {
   del: number;
 }
 
+const HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
 export function parseDiff(patch: string): ParsedLine[] {
-  return patch.split("\n").map((raw) => {
+  let oldCursor: number | null = null;
+  let newCursor: number | null = null;
+  return patch.split("\n").map((raw): ParsedLine => {
     if (raw.startsWith("@@")) {
-      return { kind: "hunk" as const, prefix: "@@", text: raw };
+      const match = HUNK_HEADER.exec(raw);
+      if (match) {
+        oldCursor = Number(match[1]);
+        newCursor = Number(match[2]);
+      } else {
+        oldCursor = null;
+        newCursor = null;
+      }
+      return {
+        kind: "hunk",
+        prefix: "@@",
+        text: raw,
+        oldLine: null,
+        newLine: null,
+      };
     }
     if (
       raw.startsWith("diff ") ||
@@ -34,19 +54,66 @@ export function parseDiff(patch: string): ParsedLine[] {
       raw.startsWith("similarity index") ||
       raw.startsWith("rename ")
     ) {
-      return { kind: "meta" as const, prefix: "", text: raw };
+      return {
+        kind: "meta",
+        prefix: "",
+        text: raw,
+        oldLine: null,
+        newLine: null,
+      };
     }
     if (raw.startsWith("+")) {
-      return { kind: "add" as const, prefix: "+", text: raw.slice(1) };
+      const newLine = newCursor;
+      if (newCursor !== null) newCursor += 1;
+      return {
+        kind: "add",
+        prefix: "+",
+        text: raw.slice(1),
+        oldLine: null,
+        newLine,
+      };
     }
     if (raw.startsWith("-")) {
-      return { kind: "del" as const, prefix: "-", text: raw.slice(1) };
+      const oldLine = oldCursor;
+      if (oldCursor !== null) oldCursor += 1;
+      return {
+        kind: "del",
+        prefix: "-",
+        text: raw.slice(1),
+        oldLine,
+        newLine: null,
+      };
     }
     if (raw.startsWith(" ")) {
-      return { kind: "ctx" as const, prefix: " ", text: raw.slice(1) };
+      const oldLine = oldCursor;
+      const newLine = newCursor;
+      if (oldCursor !== null) oldCursor += 1;
+      if (newCursor !== null) newCursor += 1;
+      return {
+        kind: "ctx",
+        prefix: " ",
+        text: raw.slice(1),
+        oldLine,
+        newLine,
+      };
     }
-    return { kind: "ctx" as const, prefix: "", text: raw };
+    return {
+      kind: "ctx",
+      prefix: "",
+      text: raw,
+      oldLine: null,
+      newLine: null,
+    };
   });
+}
+
+export function diffGutterWidth(lines: readonly ParsedLine[]): number {
+  let max = 0;
+  for (const l of lines) {
+    if (l.oldLine !== null && l.oldLine > max) max = l.oldLine;
+    if (l.newLine !== null && l.newLine > max) max = l.newLine;
+  }
+  return max > 0 ? String(max).length : 1;
 }
 
 export function countStats(lines: ParsedLine[]): DiffStats {


### PR DESCRIPTION
## Summary
- `DiffView` / `DiffSplitView` (right-panel code diff, PR diff modal, staged diff) rendered only a `+/-` marker column — no line numbers were visible anywhere.
- `parseDiff` in `src/lib/diff.ts` now reads `@@ -X,Y +A,B @@` hunk headers, advances per-line cursors for `add` / `del` / `ctx`, and exposes `oldLine` / `newLine` on each `ParsedLine`. Falls back to `null` if the hunk header is malformed or if a line lives outside any hunk.
- `DiffLine` now renders two right-aligned `tabular-nums` gutters before the marker. Width is computed once per file via the new `diffGutterWidth(lines)` helper and threaded down to every row + into the virtualized `minWidthCh` calculation. Hunk / meta rows keep their existing full-width treatment.
- Gutters use `select-none aria-hidden`, and the virtualized copy path keeps using `getLineText` (line text only), so line numbers don't leak into the clipboard or screen readers.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 277 passed (incl. new `parseDiff` line-number tracking + `diffGutterWidth` cases, and updated `ParsedLine` shape expectations)
- [ ] `pnpm run tauri dev` — open a session, switch to the Code tab → commit diff shows old/new line gutters; PR detail modal split diff shows gutters; staged diff shows gutters; large diffs still virtualize correctly
- [ ] Verify selecting and copying multiple diff lines copies only the code text (no line numbers in clipboard)