### PR TITLE
feat(github): show PR labels in row and detail modal

### DIFF
--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -61,6 +61,13 @@ impl PrStateFilter {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct PullRequestLabel {
+    pub name: String,
+    /// Hex color without the leading `#`, as returned by gh.
+    pub color: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct PullRequestInfo {
     pub number: u64,
     pub title: String,
@@ -76,6 +83,7 @@ pub struct PullRequestInfo {
     /// Aggregate of status checks on the head sha, mirroring the detail
     /// modal's badge logic. `None` when gh returned no rollup entries.
     pub checks: Option<ChecksSummary>,
+    pub labels: Vec<PullRequestLabel>,
 }
 
 /// Pass / fail / pending counts derived from `statusCheckRollup`. NEUTRAL,
@@ -116,6 +124,16 @@ struct GhPullRequest {
     is_draft: bool,
     #[serde(rename = "statusCheckRollup", default)]
     status_check_rollup: Option<Vec<GhCheck>>,
+    #[serde(default)]
+    labels: Vec<GhLabel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhLabel {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    color: String,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -306,7 +324,7 @@ fn run_pr_list(
                 &limit_s,
                 "--json",
                 "number,title,state,author,headRefName,baseRefName,url,updatedAt,\
-                 isDraft,statusCheckRollup",
+                 isDraft,statusCheckRollup,labels",
             ]);
         if let Some(q) = query {
             cmd.args(["--search", q]);
@@ -347,6 +365,14 @@ fn run_pr_list(
                 updated_at: pr.updated_at,
                 is_draft: pr.is_draft,
                 checks,
+                labels: pr
+                    .labels
+                    .into_iter()
+                    .map(|l| PullRequestLabel {
+                        name: l.name,
+                        color: l.color,
+                    })
+                    .collect(),
             }
         })
         .collect())
@@ -692,6 +718,7 @@ pub struct PullRequestDetail {
     /// by `gh pr view --json mergeable`. The frontend uses this to decide
     /// whether to enable the merge button.
     pub mergeable: Option<String>,
+    pub labels: Vec<PullRequestLabel>,
     pub comments: Vec<PullRequestComment>,
     pub reviews: Vec<PullRequestReview>,
     pub checks: Vec<PullRequestCheck>,
@@ -865,6 +892,14 @@ fn build_detail(number: u64, view: GhPullRequestView, diff_text: String) -> Pull
         deletions: view.deletions.unwrap_or(0),
         changed_files: view.changed_files.unwrap_or(0),
         mergeable: view.mergeable,
+        labels: view
+            .labels
+            .into_iter()
+            .map(|l| PullRequestLabel {
+                name: l.name,
+                color: l.color,
+            })
+            .collect(),
         comments,
         reviews,
         checks,
@@ -885,7 +920,7 @@ fn run_pr_view(slug: &str, number: u64, token: &str) -> AppResult<GhPullRequestV
             "--json",
             "number,title,body,state,isDraft,author,headRefName,baseRefName,url,\
                  createdAt,updatedAt,mergedAt,additions,deletions,changedFiles,\
-                 mergeable,comments,reviews,statusCheckRollup,commits",
+                 mergeable,labels,comments,reviews,statusCheckRollup,commits",
         ]);
     })?;
 
@@ -1156,6 +1191,8 @@ struct GhPullRequestView {
     #[serde(rename = "changedFiles")]
     changed_files: Option<u64>,
     mergeable: Option<String>,
+    #[serde(default)]
+    labels: Vec<GhLabel>,
     comments: Option<Vec<GhComment>>,
     reviews: Option<Vec<GhReview>>,
     #[serde(rename = "statusCheckRollup")]

--- a/src/components/PullRequestDetailModal.modal.test.tsx
+++ b/src/components/PullRequestDetailModal.modal.test.tsx
@@ -51,6 +51,7 @@ function fakeDetail(body: string): PullRequestDetail {
     deletions: 0,
     changed_files: 0,
     mergeable: "MERGEABLE",
+    labels: [],
     comments: [],
     reviews: [],
     checks: [],

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -349,45 +349,61 @@ function DetailBody({
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 items-center gap-2">
             <PrStateGlyph state={detail.state} isDraft={detail.is_draft} />
-            <span className="shrink-0 font-mono text-xs text-fg-muted">
+            <span
+              className={cn(
+                "shrink-0 font-mono text-xs leading-5",
+                detail.is_draft && detail.state.toUpperCase() === "OPEN"
+                  ? "text-fg-muted"
+                  : detail.state.toUpperCase() === "OPEN"
+                    ? "text-emerald-400"
+                    : detail.state.toUpperCase() === "MERGED"
+                      ? "text-purple-400"
+                      : "text-rose-400",
+              )}
+            >
               #{detail.number}
             </span>
-            <Tooltip label={detail.title} side="bottom" multiline className="min-w-0 flex-1">
-              <h3 className="truncate text-sm font-semibold tracking-tight text-fg">
+            <Tooltip
+              label={detail.title}
+              side="bottom"
+              multiline
+              className="min-w-0 flex-1"
+            >
+              <h3 className="truncate text-sm font-semibold leading-5 tracking-tight text-fg">
                 {detail.title}
               </h3>
             </Tooltip>
-            {detail.labels.length > 0 ? (
-              <span className="flex shrink-0 items-center gap-1">
-                {detail.labels.map((label) => (
-                  <PrDetailLabelChip key={label.name} label={label} />
-                ))}
-              </span>
-            ) : null}
           </div>
-          <p className="mt-1 truncate text-[11px] text-fg-muted">
+          <div className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-fg-muted">
             <AuthorTag
               login={detail.author}
               size={16}
               nameClass="text-[11px] text-fg-muted"
             />
-            <span className="opacity-50"> · </span>
+            <span className="opacity-50">·</span>
             <span className="font-mono">
               {detail.head_branch} → {detail.base_branch}
             </span>
-            <span className="opacity-50"> · </span>
+            <span className="opacity-50">·</span>
             <span className="font-mono text-emerald-400">
               +{detail.additions}
             </span>
-            <span className="opacity-50"> </span>
             <span className="font-mono text-rose-400">
               −{detail.deletions}
             </span>
-            <span className="opacity-50"> · </span>
+            <span className="opacity-50">·</span>
             <span>
               {detail.changed_files} {dt(t, "dialogs.pullRequestDetail.files")}
             </span>
-          </p>
+            {detail.labels.length > 0 ? (
+              <>
+                <span className="opacity-50">·</span>
+                {detail.labels.map((label) => (
+                  <PrDetailLabelChip key={label.name} label={label} />
+                ))}
+              </>
+            ) : null}
+          </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
           {detail.state.toUpperCase() === "OPEN" ? (

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -347,14 +347,23 @@ function DetailBody({
     <>
       <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border px-4 py-3">
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
+          <div className="flex min-w-0 items-center gap-2">
             <PrStateGlyph state={detail.state} isDraft={detail.is_draft} />
-            <span className="font-mono text-xs text-fg-muted">
+            <span className="shrink-0 font-mono text-xs text-fg-muted">
               #{detail.number}
             </span>
-            <h3 className="truncate text-sm font-semibold tracking-tight text-fg">
-              {detail.title}
-            </h3>
+            <Tooltip label={detail.title} side="bottom" multiline className="min-w-0 flex-1">
+              <h3 className="truncate text-sm font-semibold tracking-tight text-fg">
+                {detail.title}
+              </h3>
+            </Tooltip>
+            {detail.labels.length > 0 ? (
+              <span className="flex shrink-0 items-center gap-1">
+                {detail.labels.map((label) => (
+                  <PrDetailLabelChip key={label.name} label={label} />
+                ))}
+              </span>
+            ) : null}
           </div>
           <p className="mt-1 truncate text-[11px] text-fg-muted">
             <AuthorTag
@@ -379,13 +388,6 @@ function DetailBody({
               {detail.changed_files} {dt(t, "dialogs.pullRequestDetail.files")}
             </span>
           </p>
-          {detail.labels.length > 0 ? (
-            <div className="mt-1.5 flex flex-wrap gap-1">
-              {detail.labels.map((label) => (
-                <PrDetailLabelChip key={label.name} label={label} />
-              ))}
-            </div>
-          ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-1">
           {detail.state.toUpperCase() === "OPEN" ? (

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -850,15 +850,13 @@ function ResizableBody({ children }: { children: React.ReactNode }) {
 
 function PrDetailLabelChip({ label }: { label: PullRequestLabel }) {
   const hex = label.color.replace(/^#/, "");
-  const r = parseInt(hex.slice(0, 2), 16);
-  const g = parseInt(hex.slice(2, 4), 16);
-  const b = parseInt(hex.slice(4, 6), 16);
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  const textColor = luminance > 0.5 ? "#000000" : "#ffffff";
   return (
     <span
-      className="rounded px-1.5 py-0.5 text-[10px] font-medium leading-tight"
-      style={{ backgroundColor: `#${hex}`, color: textColor }}
+      className="rounded px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide"
+      style={{
+        backgroundColor: `#${hex}26`,
+        color: `#${hex}`,
+      }}
     >
       {label.name}
     </span>

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -33,6 +33,7 @@ import type {
   PullRequestCommit,
   PullRequestDetail,
   PullRequestDetailListing,
+  PullRequestLabel,
   PullRequestReview,
 } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
@@ -378,6 +379,13 @@ function DetailBody({
               {detail.changed_files} {dt(t, "dialogs.pullRequestDetail.files")}
             </span>
           </p>
+          {detail.labels.length > 0 ? (
+            <div className="mt-1.5 flex flex-wrap gap-1">
+              {detail.labels.map((label) => (
+                <PrDetailLabelChip key={label.name} label={label} />
+              ))}
+            </div>
+          ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-1">
           {detail.state.toUpperCase() === "OPEN" ? (
@@ -837,6 +845,23 @@ function ResizableBody({ children }: { children: React.ReactNode }) {
         <span className="h-0.5 w-8 rounded-full bg-fg-muted/0 transition group-hover:bg-fg-muted/40" />
       </div>
     </>
+  );
+}
+
+function PrDetailLabelChip({ label }: { label: PullRequestLabel }) {
+  const hex = label.color.replace(/^#/, "");
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  const textColor = luminance > 0.5 ? "#000000" : "#ffffff";
+  return (
+    <span
+      className="rounded px-1.5 py-0.5 text-[10px] font-medium leading-tight"
+      style={{ backgroundColor: `#${hex}`, color: textColor }}
+    >
+      {label.name}
+    </span>
   );
 }
 

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -3127,17 +3127,14 @@ function NoAccessBanner({
 }
 
 function PrLabelChip({ label }: { label: PullRequestLabel }) {
-  const hex = label.color.replace(/^#/, "");
-  const r = parseInt(hex.slice(0, 2), 16);
-  const g = parseInt(hex.slice(2, 4), 16);
-  const b = parseInt(hex.slice(4, 6), 16);
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  const textColor = luminance > 0.5 ? "#000000" : "#ffffff";
   return (
     <Tooltip label={label.name} side="top">
       <span
-        className="shrink-0 rounded px-1.5 py-px text-[9px] font-medium leading-tight"
-        style={{ backgroundColor: `#${hex}`, color: textColor }}
+        className="shrink-0 rounded px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide"
+        style={{
+          backgroundColor: `#${label.color.replace(/^#/, "")}26`,
+          color: `#${label.color.replace(/^#/, "")}`,
+        }}
       >
         {label.name}
       </span>
@@ -3202,44 +3199,6 @@ function PrChecksBadge({
   );
 }
 
-function PrStateBadge({ state, isDraft }: { state: string; isDraft: boolean }) {
-  const t = useTranslation();
-  const upper = state.toUpperCase();
-  const showDraft = isDraft && upper === "OPEN";
-  const label = showDraft
-    ? rt(t, "rightPanel.prStates.draft")
-    : stateLabelForBadge(t, upper);
-  const tone = showDraft
-    ? "bg-fg-muted/15 text-fg-muted"
-    : upper === "OPEN"
-      ? "bg-emerald-500/15 text-emerald-400"
-      : upper === "MERGED"
-        ? "bg-purple-500/15 text-purple-400"
-        : "bg-rose-500/15 text-rose-400";
-  return (
-    <span
-      className={cn(
-        "shrink-0 rounded px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide",
-        tone,
-      )}
-    >
-      {label}
-    </span>
-  );
-}
-
-function stateLabelForBadge(t: Translator, upper: string): string {
-  switch (upper) {
-    case "OPEN":
-      return rt(t, "rightPanel.prStates.open").toUpperCase();
-    case "CLOSED":
-      return rt(t, "rightPanel.prStates.closed").toUpperCase();
-    case "MERGED":
-      return rt(t, "rightPanel.prStates.merged").toUpperCase();
-    default:
-      return upper;
-  }
-}
 
 function toUnixSeconds(iso: string): number {
   const ms = Date.parse(iso);
@@ -3284,6 +3243,15 @@ function PrRow({
   // doesn't dominate visually. Plain rows stay compact at the prior size.
   const titleSize = showAvatar ? "text-[13px]" : "text-xs";
   const metaSize = showAvatar ? "text-[11px]" : "text-[10px]";
+  const upper = pr.state.toUpperCase();
+  const isDraft = pr.is_draft && upper === "OPEN";
+  const numberColor = isDraft
+    ? "text-fg-muted"
+    : upper === "OPEN"
+      ? "text-emerald-400"
+      : upper === "MERGED"
+        ? "text-purple-400"
+        : "text-rose-400";
   return (
     <li
       role="button"
@@ -3307,8 +3275,7 @@ function PrRow({
           titleSize,
         )}
       >
-        <span className="shrink-0 font-mono text-fg-muted">#{pr.number}</span>
-        <PrStateBadge state={pr.state} isDraft={pr.is_draft} />
+        <span className={cn("shrink-0 font-mono", numberColor)}>#{pr.number}</span>
         <Tooltip
           label={pr.title}
           side="top"

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -64,6 +64,7 @@ import type {
   PullRequestChecksSummary,
   PullRequestDetail,
   PullRequestInfo,
+  PullRequestLabel,
   PullRequestListing,
   StagedFile,
   TodoItem,
@@ -3125,6 +3126,25 @@ function NoAccessBanner({
   );
 }
 
+function PrLabelChip({ label }: { label: PullRequestLabel }) {
+  const hex = label.color.replace(/^#/, "");
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  const textColor = luminance > 0.5 ? "#000000" : "#ffffff";
+  return (
+    <Tooltip label={label.name} side="top">
+      <span
+        className="shrink-0 rounded px-1.5 py-px text-[9px] font-medium leading-tight"
+        style={{ backgroundColor: `#${hex}`, color: textColor }}
+      >
+        {label.name}
+      </span>
+    </Tooltip>
+  );
+}
+
 function PrChecksBadge({
   checks,
 }: {
@@ -3297,6 +3317,16 @@ function PrRow({
         >
           <span className="min-w-0 flex-1 truncate text-fg">{pr.title}</span>
         </Tooltip>
+        {pr.labels.length > 0 ? (
+          <span className="flex shrink-0 items-center gap-1">
+            {pr.labels.slice(0, 3).map((label) => (
+              <PrLabelChip key={label.name} label={label} />
+            ))}
+            {pr.labels.length > 3 ? (
+              <span className="text-[9px] text-fg-muted">+{pr.labels.length - 3}</span>
+            ) : null}
+          </span>
+        ) : null}
       </span>
       <span
         className={cn(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -131,6 +131,12 @@ export interface TodoItem {
 
 export type PrStateFilter = "open" | "closed" | "merged" | "all";
 
+export interface PullRequestLabel {
+  name: string;
+  /** Hex color without the leading `#`, as returned by gh. */
+  color: string;
+}
+
 export interface PullRequestChecksSummary {
   passed: number;
   failed: number;
@@ -149,6 +155,7 @@ export interface PullRequestInfo {
   is_draft: boolean;
   /** Aggregate of head-sha checks. null when gh returned no rollup entries. */
   checks: PullRequestChecksSummary | null;
+  labels: PullRequestLabel[];
 }
 
 export interface AccountSummary {
@@ -221,6 +228,7 @@ export interface PullRequestDetail {
   changed_files: number;
   /** "MERGEABLE" | "CONFLICTING" | "UNKNOWN" — null when gh omits the field. */
   mergeable: string | null;
+  labels: PullRequestLabel[];
   comments: PullRequestComment[];
   reviews: PullRequestReview[];
   checks: PullRequestCheck[];


### PR DESCRIPTION
## Summary

- Adds `PullRequestLabel { name, color }` struct to the Rust backend and extends `gh pr list` / `gh pr view` JSON requests to include the `labels` field
- Propagates labels through `PullRequestInfo` and `PullRequestDetail` (Rust → TypeScript types)
- **PrRow** (right panel list): renders up to 3 colored label chips in the title line with a `+N` overflow indicator
- **PullRequestDetailModal** header: renders all label chips below the author/branch/stats meta line, with GitHub-accurate foreground color computed from the label's luminance

## Test plan

- [ ] Open a GitHub repo that has PRs with labels attached
- [ ] Confirm labels appear as colored chips in the PR row (right panel → PRs tab)
- [ ] Confirm that PRs with more than 3 labels show a `+N` indicator
- [ ] Open a PR detail modal and confirm labels appear below the branch/stat meta line
- [ ] Confirm label text color is legible on both light and dark background labels
- [ ] Confirm PRs with no labels show no extra UI elements
- [ ] `pnpm run typecheck` passes (no new type errors)