### PR TITLE
refactor(right-panel): centralize panel cache manager

### DIFF
--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -49,6 +49,7 @@ vi.mock("./FileExplorer", () => ({
 }));
 
 import { api } from "../lib/api";
+import { rightPanelCache } from "../lib/right-panel-cache";
 import { useAppStore } from "../store";
 import { RightPanel } from "./RightPanel";
 
@@ -69,6 +70,7 @@ describe("RightPanel background tab loading", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    rightPanelCache.resetForTests();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -109,6 +111,7 @@ describe("RightPanel background tab loading", () => {
     act(() => root.unmount());
     container.remove();
     vi.clearAllMocks();
+    rightPanelCache.resetForTests();
     vi.useRealTimers();
   });
 

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -44,6 +44,7 @@ import { api, FS_CHANGED_EVENT, type FsChangePayload } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openFileInEditor } from "../lib/editor";
 import { joinPath } from "../lib/paths";
+import { rightPanelCache } from "../lib/right-panel-cache";
 import { classifyRightPanelFsChange } from "../lib/right-panel-invalidation";
 import { useSettings } from "../lib/settings";
 import { useAppStore } from "../store";
@@ -120,7 +121,6 @@ const COMMIT_ROW_HEIGHT = 48;
 const BACKGROUND_LOADED_TABS = new Set<RightTab>(["prs", "actions", "history"]);
 const PROJECT_PREFETCH_START_DELAY_MS = 1_000;
 const PROJECT_PREFETCH_GAP_MS = 250;
-const prefetchedProjectRepos = new Set<string>();
 
 type RightPanelTranslationKey = Extract<TranslationKey, `rightPanel.${string}`>;
 
@@ -145,16 +145,16 @@ function sleep(ms: number): Promise<void> {
 }
 
 async function prefetchProjectPanelData(repoPath: string): Promise<void> {
-  void fetchAgentHistoryCached(repoPath).catch((error) => {
+  void rightPanelCache.fetchAgentHistory(repoPath).catch((error) => {
     console.debug("[RightPanel] agent history prefetch failed", repoPath, error);
   });
   const isGitHub = await prefetchGitHubRepoStatus(repoPath);
   if (!isGitHub) return;
-  await fetchPullRequestsCached(repoPath, "open", PR_PAGE_SIZE);
+  await rightPanelCache.fetchPullRequests(repoPath, "open", PR_PAGE_SIZE);
   for (const filter of PR_BACKGROUND_PREFETCH_STATES) {
-    await fetchPullRequestsCached(repoPath, filter, PR_PAGE_SIZE);
+    await rightPanelCache.fetchPullRequests(repoPath, filter, PR_PAGE_SIZE);
   }
-  await fetchWorkflowRunsCached(repoPath, WORKFLOW_RUNS_LIMIT);
+  await rightPanelCache.fetchWorkflowRuns(repoPath, WORKFLOW_RUNS_LIMIT);
 }
 
 export function RightPanel() {
@@ -235,6 +235,18 @@ export function RightPanel() {
     () => projects.map((project) => project.repo_path).join("\0"),
     [projects],
   );
+  const retainedRepoPaths = useMemo(() => {
+    const repos = new Set<string>();
+    for (const project of projects) repos.add(project.repo_path);
+    for (const session of sessions) {
+      repos.add(session.repo_path);
+      repos.add(session.worktree_path);
+    }
+    for (const tab of Object.values(workspaceTabs)) {
+      if (tab.repoPath) repos.add(tab.repoPath);
+    }
+    return Array.from(repos);
+  }, [projects, sessions, workspaceTabs]);
 
   // If the user is sitting on a tab that just became invisible (Todos emptied,
   // GitHub origin disappeared, etc.), slide them to the nearest visible tab
@@ -254,8 +266,7 @@ export function RightPanel() {
       void (async () => {
         for (const repo of repos) {
           if (cancelled) return;
-          if (prefetchedProjectRepos.has(repo)) continue;
-          prefetchedProjectRepos.add(repo);
+          if (!rightPanelCache.claimProjectPrefetch(repo)) continue;
           await prefetchProjectPanelData(repo).catch((error) => {
             console.debug("[RightPanel] project prefetch failed", repo, error);
           });
@@ -268,6 +279,10 @@ export function RightPanel() {
       window.clearTimeout(handle);
     };
   }, [projectKey, projects]);
+
+  useEffect(() => {
+    rightPanelCache.retainRepos(retainedRepoPaths);
+  }, [retainedRepoPaths]);
 
   return (
     <aside className="flex h-full w-full flex-col bg-bg-sidebar">
@@ -1048,39 +1063,6 @@ function countByStatus(todos: TodoItem[]) {
   return { pending, in_progress, completed };
 }
 
-// Per-project History snapshot kept in module memory so re-opening a project
-// renders its rows synchronously. The accompanying SWR fetch still refreshes
-// in the background to pick up sessions created since the snapshot. Lives in
-// process memory only — wiped on app restart, which is the right TTL for
-// session lists that turn over often.
-const agentHistoryCache = new Map<string, AgentHistoryItem[]>();
-const agentHistoryInFlight = new Map<string, Promise<AgentHistoryItem[]>>();
-
-function cachedAgentHistory(repoPath: string): AgentHistoryItem[] | null {
-  return agentHistoryCache.get(repoPath) ?? null;
-}
-
-function fetchAgentHistoryCached(
-  repoPath: string,
-  options: { force?: boolean } = {},
-): Promise<AgentHistoryItem[]> {
-  const cached = agentHistoryCache.get(repoPath);
-  if (cached && !options.force) return Promise.resolve(cached);
-  const existing = agentHistoryInFlight.get(repoPath);
-  if (existing) return existing;
-  const promise = api
-    .listAgentHistory(repoPath, 100)
-    .then((items) => {
-      agentHistoryCache.set(repoPath, items);
-      return items;
-    })
-    .finally(() => {
-      agentHistoryInFlight.delete(repoPath);
-    });
-  agentHistoryInFlight.set(repoPath, promise);
-  return promise;
-}
-
 function AgentHistoryTab({
   repoPath,
   sessionHostRepoPath,
@@ -1096,7 +1078,7 @@ function AgentHistoryTab({
   // list instantly. The accompanying fetch below still runs (SWR-style)
   // to surface new sessions created since the cached snapshot.
   const [items, setItems] = useState<AgentHistoryItem[] | null>(() =>
-    cachedAgentHistory(repoPath),
+    rightPanelCache.getAgentHistory(repoPath),
   );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -1129,7 +1111,9 @@ function AgentHistoryTab({
     setLoading(true);
     setError(null);
     try {
-      const result = await fetchAgentHistoryCached(repoPath, { force: true });
+      const result = await rightPanelCache.fetchAgentHistory(repoPath, {
+        force: true,
+      });
       if (token !== fetchTokenRef.current) return;
       setItems(result);
     } catch (e) {
@@ -1205,7 +1189,7 @@ function AgentHistoryTab({
             candidate.id !== item.id ||
             candidate.transcript_path !== item.transcript_path,
         );
-        agentHistoryCache.set(repoPath, next);
+        rightPanelCache.setAgentHistory(repoPath, next);
         return next;
       });
       setTrashCandidate(null);
@@ -1446,13 +1430,6 @@ function AgentHistoryTab({
   );
 }
 
-// Per-repo cache for the commits list. Survives remounts so revisiting a
-// project shows its commit log synchronously; the safety interval still kicks
-// off a background refresh on mount to splice newer commits over the cached
-// prefix. Process memory only.
-type CommitsCacheEntry = { commits: CommitInfo[]; hasMore: boolean };
-const commitsCache = new Map<string, CommitsCacheEntry>();
-
 function CommitsTab({
   repoPath,
   invalidateKey,
@@ -1463,7 +1440,7 @@ function CommitsTab({
   onExpand: (e: ExpandedDiff) => void;
 }) {
   const t = useTranslation();
-  const cachedCommits = commitsCache.get(repoPath);
+  const cachedCommits = rightPanelCache.getCommits(repoPath);
   const [commits, setCommits] = useState<CommitInfo[]>(
     () => cachedCommits?.commits ?? [],
   );
@@ -1544,7 +1521,7 @@ function CommitsTab({
   // a blank entry that suppresses the skeleton on a true first visit.
   useEffect(() => {
     if (loadingFirst) return;
-    commitsCache.set(repoPath, { commits, hasMore });
+    rightPanelCache.setCommits(repoPath, { commits, hasMore });
   }, [repoPath, commits, hasMore, loadingFirst]);
 
   // Resolve commit author logins via GitHub GraphQL for any sha we don't
@@ -1923,11 +1900,6 @@ function absoluteTime(unixSeconds: number): string {
   return new Date(unixSeconds * 1000).toLocaleString();
 }
 
-// Per-repo cache for the staged-files snapshot. Same lifecycle as
-// commitsCache — survives remounts, refreshed on every safety interval mount.
-type StagedCacheEntry = { files: StagedFile[]; diff: DiffPayload | null };
-const stagedCache = new Map<string, StagedCacheEntry>();
-
 function StagedTab({
   repoPath,
   invalidateKey,
@@ -1938,7 +1910,7 @@ function StagedTab({
   onExpand: (e: ExpandedDiff) => void;
 }) {
   const t = useTranslation();
-  const cachedStaged = stagedCache.get(repoPath);
+  const cachedStaged = rightPanelCache.getStaged(repoPath);
   const [files, setFiles] = useState<StagedFile[]>(
     () => cachedStaged?.files ?? [],
   );
@@ -1997,7 +1969,7 @@ function StagedTab({
   // Mirror to module cache so the next mount for this repo hydrates instantly.
   useEffect(() => {
     if (loadingFirst) return;
-    stagedCache.set(repoPath, { files, diff });
+    rightPanelCache.setStaged(repoPath, { files, diff });
   }, [repoPath, files, diff, loadingFirst]);
 
   function isDeleted(file: StagedFile): boolean {
@@ -2155,23 +2127,12 @@ interface PrListState {
   limit: number;
 }
 
-const prListCache = new Map<string, PullRequestListing>();
-const prListInFlight = new Map<string, Promise<PullRequestListing>>();
-
-function prListCacheKey(
-  repoPath: string,
-  filter: PrStateFilter,
-  limit: number,
-): string {
-  return JSON.stringify([repoPath, filter, limit]);
-}
-
 function cachedPrListing(
   repoPath: string,
   filter: PrStateFilter,
   limit = PR_PAGE_SIZE,
 ): PullRequestListing | null {
-  return prListCache.get(prListCacheKey(repoPath, filter, limit)) ?? null;
+  return rightPanelCache.getPullRequests(repoPath, filter, limit);
 }
 
 function fetchPullRequestsCached(
@@ -2180,22 +2141,7 @@ function fetchPullRequestsCached(
   limit: number,
   options: { force?: boolean } = {},
 ): Promise<PullRequestListing> {
-  const key = prListCacheKey(repoPath, filter, limit);
-  const cached = prListCache.get(key);
-  if (cached && !options.force) return Promise.resolve(cached);
-  const existing = prListInFlight.get(key);
-  if (existing) return existing;
-  const promise = api
-    .listPullRequests(repoPath, filter, limit)
-    .then((result) => {
-      prListCache.set(key, result);
-      return result;
-    })
-    .finally(() => {
-      prListInFlight.delete(key);
-    });
-  prListInFlight.set(key, promise);
-  return promise;
+  return rightPanelCache.fetchPullRequests(repoPath, filter, limit, options);
 }
 
 function emptyPrListState(): PrListState {
@@ -2658,18 +2604,12 @@ function PullRequestsTab({
 
 const WORKFLOW_RUNS_LIMIT = 50;
 const ALL_WORKFLOWS = "__all__";
-const workflowRunsCache = new Map<string, WorkflowRunsListing>();
-const workflowRunsInFlight = new Map<string, Promise<WorkflowRunsListing>>();
-
-function workflowRunsCacheKey(repoPath: string, limit: number): string {
-  return JSON.stringify([repoPath, limit]);
-}
 
 function cachedWorkflowRuns(
   repoPath: string,
   limit = WORKFLOW_RUNS_LIMIT,
 ): WorkflowRunsListing | null {
-  return workflowRunsCache.get(workflowRunsCacheKey(repoPath, limit)) ?? null;
+  return rightPanelCache.getWorkflowRuns(repoPath, limit);
 }
 
 function fetchWorkflowRunsCached(
@@ -2677,22 +2617,7 @@ function fetchWorkflowRunsCached(
   limit: number,
   options: { force?: boolean } = {},
 ): Promise<WorkflowRunsListing> {
-  const key = workflowRunsCacheKey(repoPath, limit);
-  const cached = workflowRunsCache.get(key);
-  if (cached && !options.force) return Promise.resolve(cached);
-  const existing = workflowRunsInFlight.get(key);
-  if (existing) return existing;
-  const promise = api
-    .listWorkflowRuns(repoPath, limit)
-    .then((result) => {
-      workflowRunsCache.set(key, result);
-      return result;
-    })
-    .finally(() => {
-      workflowRunsInFlight.delete(key);
-    });
-  workflowRunsInFlight.set(key, promise);
-  return promise;
+  return rightPanelCache.fetchWorkflowRuns(repoPath, limit, options);
 }
 
 function ActionsTab({ repoPath }: { repoPath: string }) {

--- a/src/lib/right-panel-cache.test.ts
+++ b/src/lib/right-panel-cache.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  AgentHistoryItem,
+  PullRequestListing,
+  WorkflowRunsListing,
+} from "./types";
+
+vi.mock("./api", () => ({
+  api: {
+    listAgentHistory:
+      vi.fn<(repoPath: string, limit: number) => Promise<AgentHistoryItem[]>>(),
+    listPullRequests:
+      vi.fn<
+        (
+          repoPath: string,
+          state: string,
+          limit: number,
+        ) => Promise<PullRequestListing>
+      >(),
+    listWorkflowRuns:
+      vi.fn<(repoPath: string, limit: number) => Promise<WorkflowRunsListing>>(),
+  },
+}));
+
+import { api } from "./api";
+import { rightPanelCache } from "./right-panel-cache";
+
+const mockApi = vi.mocked(api);
+const REPO = "/tmp/acorn";
+const OTHER_REPO = "/tmp/other";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("rightPanelCache", () => {
+  beforeEach(() => {
+    rightPanelCache.resetForTests();
+    vi.clearAllMocks();
+  });
+
+  it("dedupes in-flight PR fetches and reuses cached results", async () => {
+    const listing: PullRequestListing = {
+      kind: "ok",
+      items: [],
+      account: "tester",
+    };
+    const pending = deferred<PullRequestListing>();
+    mockApi.listPullRequests.mockReturnValueOnce(pending.promise);
+
+    const first = rightPanelCache.fetchPullRequests(REPO, "merged", 50);
+    const second = rightPanelCache.fetchPullRequests(REPO, "merged", 50);
+    expect(first).toBe(second);
+    expect(mockApi.listPullRequests).toHaveBeenCalledTimes(1);
+
+    pending.resolve(listing);
+    await expect(first).resolves.toBe(listing);
+    await expect(
+      rightPanelCache.fetchPullRequests(REPO, "merged", 50),
+    ).resolves.toBe(listing);
+    expect(mockApi.listPullRequests).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks project prefetch once until the repo is pruned", () => {
+    expect(rightPanelCache.claimProjectPrefetch(REPO)).toBe(true);
+    expect(rightPanelCache.claimProjectPrefetch(REPO)).toBe(false);
+
+    rightPanelCache.retainRepos([OTHER_REPO]);
+    expect(rightPanelCache.claimProjectPrefetch(REPO)).toBe(true);
+  });
+
+  it("drops cached repo data when the repo is no longer retained", async () => {
+    const history: AgentHistoryItem[] = [];
+    const workflows: WorkflowRunsListing = {
+      kind: "ok",
+      items: [],
+      account: "tester",
+    };
+    mockApi.listAgentHistory.mockResolvedValue(history);
+    mockApi.listWorkflowRuns.mockResolvedValue(workflows);
+
+    await rightPanelCache.fetchAgentHistory(REPO);
+    await rightPanelCache.fetchWorkflowRuns(REPO, 50);
+    expect(rightPanelCache.getAgentHistory(REPO)).toBe(history);
+    expect(rightPanelCache.getWorkflowRuns(REPO, 50)).toBe(workflows);
+
+    rightPanelCache.retainRepos([OTHER_REPO]);
+    expect(rightPanelCache.getAgentHistory(REPO)).toBeNull();
+    expect(rightPanelCache.getWorkflowRuns(REPO, 50)).toBeNull();
+  });
+
+  it("does not repopulate a pruned repo from a stale in-flight request", async () => {
+    const listing: PullRequestListing = {
+      kind: "ok",
+      items: [],
+      account: "tester",
+    };
+    const pending = deferred<PullRequestListing>();
+    mockApi.listPullRequests.mockReturnValueOnce(pending.promise);
+
+    const request = rightPanelCache.fetchPullRequests(REPO, "open", 50);
+    rightPanelCache.retainRepos([OTHER_REPO]);
+    pending.resolve(listing);
+    await expect(request).resolves.toBe(listing);
+
+    expect(rightPanelCache.getPullRequests(REPO, "open", 50)).toBeNull();
+  });
+});

--- a/src/lib/right-panel-cache.ts
+++ b/src/lib/right-panel-cache.ts
@@ -1,0 +1,289 @@
+import { api } from "./api";
+import type {
+  AgentHistoryItem,
+  CommitInfo,
+  DiffPayload,
+  PrStateFilter,
+  PullRequestListing,
+  StagedFile,
+  WorkflowRunsListing,
+} from "./types";
+
+export type CommitsCacheEntry = { commits: CommitInfo[]; hasMore: boolean };
+export type StagedCacheEntry = { files: StagedFile[]; diff: DiffPayload | null };
+
+interface FetchOptions {
+  force?: boolean;
+}
+
+class RightPanelCacheManager {
+  private retainedRepos: Set<string> | null = null;
+  private repoVersions = new Map<string, number>();
+  private prefetchedProjectRepos = new Set<string>();
+  private agentHistoryCache = new Map<string, AgentHistoryItem[]>();
+  private agentHistoryInFlight = new Map<string, Promise<AgentHistoryItem[]>>();
+  private commitsCache = new Map<string, CommitsCacheEntry>();
+  private stagedCache = new Map<string, StagedCacheEntry>();
+  private prListCache = new Map<string, PullRequestListing>();
+  private prListInFlight = new Map<string, Promise<PullRequestListing>>();
+  private workflowRunsCache = new Map<string, WorkflowRunsListing>();
+  private workflowRunsInFlight = new Map<string, Promise<WorkflowRunsListing>>();
+
+  claimProjectPrefetch(repoPath: string): boolean {
+    if (this.prefetchedProjectRepos.has(repoPath)) return false;
+    this.prefetchedProjectRepos.add(repoPath);
+    return true;
+  }
+
+  retainRepos(repoPaths: Iterable<string>): void {
+    const next = new Set(repoPaths);
+    const removed = new Set<string>();
+    if (this.retainedRepos) {
+      for (const repoPath of this.retainedRepos) {
+        if (!next.has(repoPath)) removed.add(repoPath);
+      }
+    }
+    this.collectRemovedStringKeys(this.agentHistoryCache, next, removed);
+    this.collectRemovedStringKeys(this.agentHistoryInFlight, next, removed);
+    this.collectRemovedStringKeys(this.commitsCache, next, removed);
+    this.collectRemovedStringKeys(this.stagedCache, next, removed);
+    this.collectRemovedStringValues(this.prefetchedProjectRepos, next, removed);
+    this.collectRemovedJsonKeys(this.prListCache, next, removed);
+    this.collectRemovedJsonKeys(this.prListInFlight, next, removed);
+    this.collectRemovedJsonKeys(this.workflowRunsCache, next, removed);
+    this.collectRemovedJsonKeys(this.workflowRunsInFlight, next, removed);
+    for (const repoPath of removed) this.bumpRepoVersion(repoPath);
+
+    this.retainedRepos = next;
+    this.pruneStringKeyedMap(this.agentHistoryCache, next);
+    this.pruneStringKeyedMap(this.agentHistoryInFlight, next);
+    this.pruneStringKeyedMap(this.commitsCache, next);
+    this.pruneStringKeyedMap(this.stagedCache, next);
+    this.pruneStringKeyedSet(this.prefetchedProjectRepos, next);
+    this.pruneJsonKeyedMap(this.prListCache, next);
+    this.pruneJsonKeyedMap(this.prListInFlight, next);
+    this.pruneJsonKeyedMap(this.workflowRunsCache, next);
+    this.pruneJsonKeyedMap(this.workflowRunsInFlight, next);
+  }
+
+  getAgentHistory(repoPath: string): AgentHistoryItem[] | null {
+    return this.agentHistoryCache.get(repoPath) ?? null;
+  }
+
+  setAgentHistory(repoPath: string, items: AgentHistoryItem[]): void {
+    if (!this.canStore(repoPath)) return;
+    this.agentHistoryCache.set(repoPath, items);
+  }
+
+  fetchAgentHistory(
+    repoPath: string,
+    options: FetchOptions = {},
+  ): Promise<AgentHistoryItem[]> {
+    const cached = this.agentHistoryCache.get(repoPath);
+    if (cached && !options.force) return Promise.resolve(cached);
+    const existing = this.agentHistoryInFlight.get(repoPath);
+    if (existing) return existing;
+    const version = this.repoVersion(repoPath);
+    const promise = api
+      .listAgentHistory(repoPath, 100)
+      .then((items) => {
+        if (this.isCurrentRepoVersion(repoPath, version)) {
+          this.agentHistoryCache.set(repoPath, items);
+        }
+        return items;
+      })
+      .finally(() => {
+        this.agentHistoryInFlight.delete(repoPath);
+      });
+    this.agentHistoryInFlight.set(repoPath, promise);
+    return promise;
+  }
+
+  getCommits(repoPath: string): CommitsCacheEntry | null {
+    return this.commitsCache.get(repoPath) ?? null;
+  }
+
+  setCommits(repoPath: string, entry: CommitsCacheEntry): void {
+    if (!this.canStore(repoPath)) return;
+    this.commitsCache.set(repoPath, entry);
+  }
+
+  getStaged(repoPath: string): StagedCacheEntry | null {
+    return this.stagedCache.get(repoPath) ?? null;
+  }
+
+  setStaged(repoPath: string, entry: StagedCacheEntry): void {
+    if (!this.canStore(repoPath)) return;
+    this.stagedCache.set(repoPath, entry);
+  }
+
+  getPullRequests(
+    repoPath: string,
+    filter: PrStateFilter,
+    limit: number,
+  ): PullRequestListing | null {
+    return this.prListCache.get(this.prListKey(repoPath, filter, limit)) ?? null;
+  }
+
+  fetchPullRequests(
+    repoPath: string,
+    filter: PrStateFilter,
+    limit: number,
+    options: FetchOptions = {},
+  ): Promise<PullRequestListing> {
+    const key = this.prListKey(repoPath, filter, limit);
+    const cached = this.prListCache.get(key);
+    if (cached && !options.force) return Promise.resolve(cached);
+    const existing = this.prListInFlight.get(key);
+    if (existing) return existing;
+    const version = this.repoVersion(repoPath);
+    const promise = api
+      .listPullRequests(repoPath, filter, limit)
+      .then((result) => {
+        if (this.isCurrentRepoVersion(repoPath, version)) {
+          this.prListCache.set(key, result);
+        }
+        return result;
+      })
+      .finally(() => {
+        this.prListInFlight.delete(key);
+      });
+    this.prListInFlight.set(key, promise);
+    return promise;
+  }
+
+  getWorkflowRuns(repoPath: string, limit: number): WorkflowRunsListing | null {
+    return this.workflowRunsCache.get(this.workflowRunsKey(repoPath, limit)) ?? null;
+  }
+
+  fetchWorkflowRuns(
+    repoPath: string,
+    limit: number,
+    options: FetchOptions = {},
+  ): Promise<WorkflowRunsListing> {
+    const key = this.workflowRunsKey(repoPath, limit);
+    const cached = this.workflowRunsCache.get(key);
+    if (cached && !options.force) return Promise.resolve(cached);
+    const existing = this.workflowRunsInFlight.get(key);
+    if (existing) return existing;
+    const version = this.repoVersion(repoPath);
+    const promise = api
+      .listWorkflowRuns(repoPath, limit)
+      .then((result) => {
+        if (this.isCurrentRepoVersion(repoPath, version)) {
+          this.workflowRunsCache.set(key, result);
+        }
+        return result;
+      })
+      .finally(() => {
+        this.workflowRunsInFlight.delete(key);
+      });
+    this.workflowRunsInFlight.set(key, promise);
+    return promise;
+  }
+
+  resetForTests(): void {
+    this.retainedRepos = null;
+    this.repoVersions.clear();
+    this.prefetchedProjectRepos.clear();
+    this.agentHistoryCache.clear();
+    this.agentHistoryInFlight.clear();
+    this.commitsCache.clear();
+    this.stagedCache.clear();
+    this.prListCache.clear();
+    this.prListInFlight.clear();
+    this.workflowRunsCache.clear();
+    this.workflowRunsInFlight.clear();
+  }
+
+  private canStore(repoPath: string): boolean {
+    return this.retainedRepos === null || this.retainedRepos.has(repoPath);
+  }
+
+  private repoVersion(repoPath: string): number {
+    return this.repoVersions.get(repoPath) ?? 0;
+  }
+
+  private isCurrentRepoVersion(repoPath: string, version: number): boolean {
+    return this.repoVersion(repoPath) === version;
+  }
+
+  private bumpRepoVersion(repoPath: string): void {
+    this.repoVersions.set(repoPath, this.repoVersion(repoPath) + 1);
+  }
+
+  private prListKey(
+    repoPath: string,
+    filter: PrStateFilter,
+    limit: number,
+  ): string {
+    return JSON.stringify([repoPath, filter, limit]);
+  }
+
+  private workflowRunsKey(repoPath: string, limit: number): string {
+    return JSON.stringify([repoPath, limit]);
+  }
+
+  private pruneStringKeyedMap<T>(map: Map<string, T>, retained: Set<string>): void {
+    for (const key of map.keys()) {
+      if (!retained.has(key)) map.delete(key);
+    }
+  }
+
+  private collectRemovedStringKeys<T>(
+    map: Map<string, T>,
+    retained: Set<string>,
+    removed: Set<string>,
+  ): void {
+    for (const key of map.keys()) {
+      if (!retained.has(key)) removed.add(key);
+    }
+  }
+
+  private pruneStringKeyedSet(set: Set<string>, retained: Set<string>): void {
+    for (const value of set) {
+      if (!retained.has(value)) set.delete(value);
+    }
+  }
+
+  private collectRemovedStringValues(
+    set: Set<string>,
+    retained: Set<string>,
+    removed: Set<string>,
+  ): void {
+    for (const value of set) {
+      if (!retained.has(value)) removed.add(value);
+    }
+  }
+
+  private pruneJsonKeyedMap<T>(map: Map<string, T>, retained: Set<string>): void {
+    for (const key of map.keys()) {
+      if (!retained.has(this.repoFromJsonKey(key))) map.delete(key);
+    }
+  }
+
+  private collectRemovedJsonKeys<T>(
+    map: Map<string, T>,
+    retained: Set<string>,
+    removed: Set<string>,
+  ): void {
+    for (const key of map.keys()) {
+      const repoPath = this.repoFromJsonKey(key);
+      if (repoPath && !retained.has(repoPath)) removed.add(repoPath);
+    }
+  }
+
+  private repoFromJsonKey(key: string): string {
+    try {
+      const parsed = JSON.parse(key) as unknown;
+      if (Array.isArray(parsed) && typeof parsed[0] === "string") {
+        return parsed[0];
+      }
+    } catch {
+      return "";
+    }
+    return "";
+  }
+}
+
+export const rightPanelCache = new RightPanelCacheManager();


### PR DESCRIPTION
## Summary
This PR moves right-panel cache ownership out of `RightPanel.tsx` and into a dedicated cache manager without changing the visible panel behavior.

1. **Centralized cache ownership:** Added `rightPanelCache` for Agent History, Commits, Staged, PR listings, workflow runs, in-flight de-dupe, and one-time project prefetch tracking.
2. **Project-scope pruning:** Added retained-repo tracking so caches for closed projects are removed while active sessions, worktrees, and workspace tabs remain retained.
3. **Stale in-flight guard:** Added repo-version checks so requests that resolve after their repo was pruned do not repopulate stale cache entries.
4. **Focused coverage:** Added cache-manager tests and reset the shared cache in the existing right-panel background loading tests.

## Expected impact

| Area | Impact |
| --- | --- |
| Right-panel behavior | No intended user-visible behavior change. Cached tabs should hydrate as before. |
| Reliability | Closed-project cache cleanup is explicit, and stale in-flight requests cannot re-add pruned entries. |
| Maintainability | Cache policy and in-flight de-dupe now live in one module instead of being spread across `RightPanel.tsx`. |
| Performance | Neutral to slightly improved through the same de-dupe behavior with clearer ownership. |

## Design notes

- The manager remains frontend process-memory only; it does not introduce persistence or a backend cache.
- `RightPanel` still decides which repos are open and when to prefetch. The manager only owns storage, de-dupe, pruning, and stale-result protection.
- Retained repos include open projects plus active session/worktree paths and workspace-tab repos so worktree-backed panels are not pruned just because their path differs from the project root.

## Follow-up (not in this PR)

- Consider exposing lightweight cache metrics for debugging prefetch behavior during project switching.
- Consider moving GitHub-origin cache ownership into the same manager later if we want one right-panel cache surface.

## Test plan

- [x] `pnpm test -- src/lib/right-panel-cache.test.ts src/components/RightPanel.test.tsx`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts --reporter=line`
- [x] `git diff --check`

## Notes

- The Playwright run still prints pre-existing E2E mock warnings for `load_status` and user theme loading; the right-panel tests passed despite that existing noise.
