### PR TITLE
fix(github): hide panel actions outside git repos

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2088,6 +2088,16 @@ pub async fn github_origin_slug(repo_path: String) -> AppResult<Option<String>> 
     .await
 }
 
+/// True when `repo_path` is inside a git repository. The frontend uses this
+/// to avoid showing GitHub-only UI for projects that have not run `git init`.
+#[tauri::command]
+pub async fn is_git_repository(repo_path: String) -> AppResult<bool> {
+    run_blocking("is_git_repository", move || {
+        Ok(git_ops::is_git_repository(&PathBuf::from(repo_path)))
+    })
+    .await
+}
+
 /// Spawn an external editor on `path`. Used by the "Open in editor" action
 /// when the user has configured a custom editor command in settings.
 ///

--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -73,6 +73,10 @@ pub fn github_owner_repo(repo_path: &Path) -> AppResult<Option<String>> {
     Ok(parse_github_owner_repo(url))
 }
 
+pub fn is_git_repository(repo_path: &Path) -> bool {
+    Repository::discover(repo_path).is_ok()
+}
+
 fn parse_github_owner_repo(remote: &str) -> Option<String> {
     let trimmed = remote.trim();
     // Pull "host" + "owner/repo[.git]" out of any of the three common URL

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -302,6 +302,7 @@ pub fn run() {
             commands::commit_diff,
             commands::commit_web_url,
             commands::github_origin_slug,
+            commands::is_git_repository,
             commands::open_in_editor,
             commands::staged_diff,
             commands::list_pull_requests,

--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -19,6 +19,7 @@ vi.mock("../lib/api", () => ({
   api: {
     fsWatchSetRoot: vi.fn<() => Promise<void>>(),
     githubOriginSlug: vi.fn<() => Promise<string | null>>(),
+    isGitRepository: vi.fn<() => Promise<boolean>>(),
     listPullRequests:
       vi.fn<
         (
@@ -50,6 +51,7 @@ vi.mock("./FileExplorer", () => ({
 
 import { api } from "../lib/api";
 import { rightPanelCache } from "../lib/right-panel-cache";
+import { __resetIsGitHubRepoCacheForTests } from "../lib/useIsGitHubRepo";
 import { useAppStore } from "../store";
 import { RightPanel } from "./RightPanel";
 
@@ -71,10 +73,12 @@ describe("RightPanel background tab loading", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     rightPanelCache.resetForTests();
+    __resetIsGitHubRepoCacheForTests();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
     mockApi.githubOriginSlug.mockResolvedValue("im-ian/acorn");
+    mockApi.isGitRepository.mockResolvedValue(true);
     mockApi.fsWatchSetRoot.mockResolvedValue();
     mockApi.listPullRequests.mockResolvedValue({
       kind: "ok",
@@ -112,6 +116,7 @@ describe("RightPanel background tab loading", () => {
     container.remove();
     vi.clearAllMocks();
     rightPanelCache.resetForTests();
+    __resetIsGitHubRepoCacheForTests();
     vi.useRealTimers();
   });
 
@@ -181,5 +186,19 @@ describe("RightPanel background tab loading", () => {
     expect(mockApi.listPullRequests).toHaveBeenCalledWith(REPO_B, "closed", 50);
     expect(mockApi.listPullRequests).toHaveBeenCalledWith(REPO_B, "all", 50);
     expect(mockApi.listWorkflowRuns).toHaveBeenCalledWith(REPO_B, 50);
+  });
+
+  it("hides GitHub tabs for projects that are not git repositories", async () => {
+    mockApi.isGitRepository.mockResolvedValue(false);
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+
+    expect(container.textContent).not.toContain("GitHub");
+    expect(mockApi.githubOriginSlug).not.toHaveBeenCalled();
+    expect(mockApi.listPullRequests).not.toHaveBeenCalled();
+    expect(mockApi.listWorkflowRuns).not.toHaveBeenCalled();
   });
 });

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -202,10 +202,11 @@ export function RightPanel() {
     active?.worktree_path ?? null,
   );
   const showTodos = todosState.todos.length > 0;
-  // null while the first probe is in flight — keep GitHub visible during
-  // that brief window so the bar doesn't flicker on first paint.
+  // null while the first probe is in flight. Keep GitHub hidden until we know
+  // the path is a git repo with a GitHub origin so non-git projects never show
+  // GitHub-only actions.
   const isGitHubRepo = useIsGitHubRepo(repoPath);
-  const githubVisible = isGitHubRepo !== false;
+  const githubVisible = isGitHubRepo === true;
 
   const visibleTabsByGroup = useMemo<
     Record<RightGroup, ReadonlyArray<RightTab>>
@@ -228,9 +229,7 @@ export function RightPanel() {
     : (visibleGroups[0] ?? "code");
   const visibleTabs = visibleTabsByGroup[activeGroup];
   const shouldLoadGitHubTabs =
-    repoPath !== null &&
-    (isGitHubRepo === true ||
-      (isGitHubRepo === null && activeGroup === "github"));
+    repoPath !== null && isGitHubRepo === true;
   const projectKey = useMemo(
     () => projects.map((project) => project.repo_path).join("\0"),
     [projects],
@@ -254,9 +253,10 @@ export function RightPanel() {
   useEffect(() => {
     if (visibleTabs.length === 0) return;
     if (!visibleTabs.includes(rightTab)) {
+      if (isGitHubRepo === null && groupOfTab(rightTab) === "github") return;
       setRightTab(visibleTabs[0]);
     }
-  }, [rightTab, visibleTabs, setRightTab]);
+  }, [isGitHubRepo, rightTab, visibleTabs, setRightTab]);
 
   useEffect(() => {
     if (projects.length === 0) return;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -105,6 +105,10 @@ export const api = {
   githubOriginSlug(repoPath: string): Promise<string | null> {
     return invoke<string | null>("github_origin_slug", { repoPath });
   },
+  /** True when the path is inside a git repository. */
+  isGitRepository(repoPath: string): Promise<boolean> {
+    return invoke<boolean>("is_git_repository", { repoPath });
+  },
   openInEditor(command: string, args: string[], path: string): Promise<void> {
     return invoke<void>("open_in_editor", { command, args, path });
   },

--- a/src/lib/useIsGitHubRepo.ts
+++ b/src/lib/useIsGitHubRepo.ts
@@ -2,10 +2,10 @@ import { useEffect, useState } from "react";
 import { api } from "./api";
 
 /**
- * Per-repo cache for the GitHub origin probe. The result rarely changes
- * during a session (only when the user edits `origin`), so we resolve once
- * per repoPath and reuse across mounts. Concurrent callers for the same
- * repoPath share one in-flight promise.
+ * Per-repo cache for the git-repo + GitHub origin probe. The result rarely
+ * changes during a session (only when the user runs `git init` or edits
+ * `origin`), so we resolve once per repoPath and reuse across mounts.
+ * Concurrent callers for the same repoPath share one in-flight promise.
  */
 const cache = new Map<string, boolean>();
 const inFlight = new Map<string, Promise<boolean>>();
@@ -16,18 +16,22 @@ async function probe(repoPath: string): Promise<boolean> {
   const existing = inFlight.get(repoPath);
   if (existing) return existing;
   const promise = api
-    .githubOriginSlug(repoPath)
-    .then((slug) => {
+    .isGitRepository(repoPath)
+    .then(async (isGitRepo) => {
+      if (!isGitRepo) {
+        cache.set(repoPath, false);
+        return false;
+      }
+      const slug = await api.githubOriginSlug(repoPath);
       const value = slug !== null;
       cache.set(repoPath, value);
       return value;
     })
     .catch((error) => {
-      // Treat probe failures as "unknown" → assume GitHub so the user still
-      // sees the GitHub tabs and their built-in error states (rather than
-      // silently hiding navigation). Don't poison the cache.
+      // Hide GitHub-only UI when the repo probe itself fails. This avoids
+      // surfacing PR/Actions controls for paths that may not be git repos.
       console.warn("[useIsGitHubRepo] probe failed", error);
-      return true;
+      return false;
     })
     .finally(() => {
       inFlight.delete(repoPath);
@@ -41,9 +45,8 @@ export function prefetchGitHubRepoStatus(repoPath: string): Promise<boolean> {
 }
 
 /**
- * Returns `true` when `repoPath` has a GitHub `origin` remote, `false`
- * otherwise, or `null` while the first probe is in flight (so callers can
- * avoid flicker between "show GitHub" and "hide GitHub" on first paint).
+ * Returns `true` when `repoPath` is inside a git repo with a GitHub `origin`
+ * remote, `false` otherwise, or `null` while the first probe is in flight.
  */
 export function useIsGitHubRepo(repoPath: string | null): boolean | null {
   const [state, setState] = useState<boolean | null>(() =>

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -65,6 +65,9 @@ export const tauriMockSource = `
     if (cmd === 'github_origin_slug') {
       return Promise.resolve('acorn/test');
     }
+    if (cmd === 'is_git_repository') {
+      return Promise.resolve(true);
+    }
     if (cmd === 'staged_diff') return Promise.resolve({ files: [] });
     if (cmd === 'commit_diff') return Promise.resolve({ files: [] });
     if (cmd === 'scrollback_load') return Promise.resolve(null);

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -299,6 +299,20 @@ test.describe("right panel: groups", () => {
     await expect(page.getByRole("button", { name: "GitHub" })).toHaveCount(0);
   });
 
+  test("GitHub group is hidden when project is not a git repository", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    await tauri.handle("is_git_repository", () => false);
+
+    await page.goto("/");
+
+    await expect(page.getByRole("button", { name: "Code" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Agents" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "GitHub" })).toHaveCount(0);
+  });
+
   test("History sub-tab is labeled 'History' (renamed from 'Sessions')", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
This PR makes the right-panel GitHub group appear only when the active project path is inside a git repository with a GitHub origin.

1. **Git repo gate:** Added a backend `is_git_repository` command backed by libgit2 discovery and exposed it through the frontend API.
2. **GitHub visibility probe:** Updated `useIsGitHubRepo` to check git repo status before calling `github_origin_slug`; non-git paths now resolve false and skip GitHub prefetch/list calls.
3. **Right-panel rendering:** Changed GitHub group/background tab loading to render only after the probe is positively true, while preserving pending GitHub tab selection during the async probe.
4. **Coverage:** Added unit and E2E coverage for non-git projects hiding the GitHub group.

## Expected impact

| Area | Impact |
| --- | --- |
| Right-panel behavior | Non-git projects no longer show GitHub tabs/actions. |
| GitHub prefetch | Non-git projects skip GitHub origin, PR, and workflow prefetch work. |
| Project switching | GitHub tabs still appear for git repos with GitHub origins after the async probe resolves. |
| Reliability | Probe failures now hide GitHub-only UI instead of exposing unavailable controls. |

## Design notes

- The new backend probe uses `Repository::discover`, so subdirectories and linked worktrees still count as git repositories.
- Existing behavior for git repos without a GitHub origin remains unchanged: the GitHub group is hidden.
- The right-tab correction effect pauses while a persisted GitHub tab is still being probed, so a valid GitHub repo does not immediately lose its saved GitHub tab selection during startup.

## Test plan

- [x] `pnpm test -- src/components/RightPanel.test.tsx`
- [x] `pnpm typecheck`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts --reporter=line`
- [x] `pnpm test`
- [x] `git diff --check`

## Notes

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` still reports pre-existing formatting diffs in unrelated Rust files; the changed code compiles with `cargo check`.
