### PR TITLE
fix(pr-detail): render GitHub App conversation avatars

### DIFF
--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -650,6 +650,7 @@ fn git_user_email(repo_path: &Path) -> Option<String> {
 #[derive(Debug, Clone, Serialize)]
 pub struct PullRequestComment {
     pub author: String,
+    pub author_avatar_url: Option<String>,
     pub body: String,
     pub created_at: String,
 }
@@ -657,6 +658,7 @@ pub struct PullRequestComment {
 #[derive(Debug, Clone, Serialize)]
 pub struct PullRequestReview {
     pub author: String,
+    pub author_avatar_url: Option<String>,
     /// Review state from GitHub: `APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` / `DISMISSED` / `PENDING`.
     pub state: String,
     pub body: String,
@@ -801,14 +803,23 @@ fn enrich_image_previews_against_refs(
 }
 
 fn build_detail(number: u64, view: GhPullRequestView, diff_text: String) -> PullRequestDetail {
+    let actor_avatars = view
+        .actor_avatars
+        .as_ref()
+        .map(|avatars| avatars.by_login.clone())
+        .unwrap_or_default();
     let comments = view
         .comments
         .unwrap_or_default()
         .into_iter()
-        .map(|c| PullRequestComment {
-            author: c.author.login.unwrap_or_else(|| "unknown".to_string()),
-            body: c.body.unwrap_or_default(),
-            created_at: c.created_at.unwrap_or_default(),
+        .map(|c| {
+            let author = c.author.login.unwrap_or_else(|| "unknown".to_string());
+            PullRequestComment {
+                author_avatar_url: actor_avatars.get(&author).cloned(),
+                author,
+                body: c.body.unwrap_or_default(),
+                created_at: c.created_at.unwrap_or_default(),
+            }
         })
         .collect();
 
@@ -826,11 +837,15 @@ fn build_detail(number: u64, view: GhPullRequestView, diff_text: String) -> Pull
                     .map(|s| s == "APPROVED" || s == "CHANGES_REQUESTED" || s == "DISMISSED")
                     .unwrap_or(false)
         })
-        .map(|r| PullRequestReview {
-            author: r.author.login.unwrap_or_else(|| "unknown".to_string()),
-            state: r.state.unwrap_or_default(),
-            body: r.body.unwrap_or_default(),
-            submitted_at: r.submitted_at.unwrap_or_default(),
+        .map(|r| {
+            let author = r.author.login.unwrap_or_else(|| "unknown".to_string());
+            PullRequestReview {
+                author_avatar_url: actor_avatars.get(&author).cloned(),
+                author,
+                state: r.state.unwrap_or_default(),
+                body: r.body.unwrap_or_default(),
+                submitted_at: r.submitted_at.unwrap_or_default(),
+            }
         })
         .collect();
 
@@ -934,8 +949,85 @@ fn run_pr_view(slug: &str, number: u64, token: &str) -> AppResult<GhPullRequestV
         return Err(AppError::Other(msg));
     }
 
+    let mut view: GhPullRequestView = serde_json::from_slice(&output.stdout)
+        .map_err(|e| AppError::Other(format!("failed to parse gh output: {e}")))?;
+    view.actor_avatars = Some(resolve_pr_actor_avatars(&view, token));
+    Ok(view)
+}
+
+#[derive(Debug, Default, Clone)]
+struct PrActorAvatars {
+    by_login: HashMap<String, String>,
+}
+
+fn resolve_pr_actor_avatars(view: &GhPullRequestView, token: &str) -> PrActorAvatars {
+    let mut logins = Vec::new();
+    for comment in view.comments.as_deref().unwrap_or(&[]) {
+        if let Some(login) = comment.author.login.as_deref() {
+            logins.push(login.to_string());
+        }
+    }
+    for review in view.reviews.as_deref().unwrap_or(&[]) {
+        if let Some(login) = review.author.login.as_deref() {
+            logins.push(login.to_string());
+        }
+    }
+    logins.sort();
+    logins.dedup();
+
+    let mut by_login = HashMap::new();
+    for login in logins {
+        if let Some(url) = resolve_actor_avatar_url(&login, token) {
+            by_login.insert(login, url);
+        }
+    }
+    PrActorAvatars { by_login }
+}
+
+fn resolve_actor_avatar_url(login: &str, token: &str) -> Option<String> {
+    let user_endpoint = format!("users/{login}");
+    if let Some(url) = gh_api_json::<GhRestUser>(&user_endpoint, token)
+        .ok()
+        .and_then(|u| u.avatar_url)
+    {
+        return Some(url);
+    }
+
+    let app_endpoint = format!("apps/{login}");
+    gh_api_json::<GhRestApp>(&app_endpoint, token)
+        .ok()
+        .map(|app| format!("https://avatars.githubusercontent.com/in/{}?v=4", app.id))
+}
+
+fn gh_api_json<T: serde::de::DeserializeOwned>(endpoint: &str, token: &str) -> AppResult<T> {
+    let output = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token)
+            .env("GH_HOST", GH_HOST)
+            .args(["api", endpoint]);
+    })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("gh api {endpoint} exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+
     serde_json::from_slice(&output.stdout)
-        .map_err(|e| AppError::Other(format!("failed to parse gh output: {e}")))
+        .map_err(|e| AppError::Other(format!("failed to parse gh api output: {e}")))
+}
+
+#[derive(Debug, Deserialize)]
+struct GhRestUser {
+    #[serde(rename = "avatar_url")]
+    avatar_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhRestApp {
+    id: u64,
 }
 
 pub fn get_pull_request_commit_diff(repo_path: &Path, sha: &str) -> AppResult<DiffPayload> {
@@ -1198,6 +1290,8 @@ struct GhPullRequestView {
     #[serde(rename = "statusCheckRollup")]
     status_check_rollup: Option<Vec<GhCheck>>,
     commits: Option<Vec<GhCommit>>,
+    #[serde(skip)]
+    actor_avatars: Option<PrActorAvatars>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/components/AuthorAvatar.tsx
+++ b/src/components/AuthorAvatar.tsx
@@ -1,18 +1,20 @@
 import { cn } from "../lib/cn";
 
 /**
- * Inline GitHub avatar. Uses the public `github.com/{login}.png` endpoint
- * so no API token is needed and `[bot]` accounts still resolve once the
- * suffix is stripped. Renders nothing when `login` is null, empty, or
- * doesn't look like a GitHub handle (e.g. a git author name with spaces),
- * so callers can pass nullable values without guarding.
+ * Inline GitHub avatar. Uses an API-provided avatar URL when one is available,
+ * and falls back to the public `github.com/{login}.png` endpoint so no API
+ * token is needed for simple callers. Renders nothing when `login` is null,
+ * empty, or doesn't look like a GitHub handle (e.g. a git author name with
+ * spaces), so callers can pass nullable values without guarding.
  */
 export function AuthorAvatar({
   login,
+  avatarUrl,
   size = 24,
   className,
 }: {
   login: string | null | undefined;
+  avatarUrl?: string | null;
   size?: number;
   className?: string;
 }) {
@@ -20,9 +22,12 @@ export function AuthorAvatar({
   const slug = login.replace(/\[bot\]$/, "");
   if (!/^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){0,38}$/i.test(slug)) return null;
   const pixelSize = Math.max(40, size * 2);
+  const src = avatarUrl
+    ? withAvatarSize(avatarUrl, pixelSize)
+    : `https://github.com/${encodeURIComponent(slug)}.png?size=${pixelSize}`;
   return (
     <img
-      src={`https://github.com/${encodeURIComponent(slug)}.png?size=${pixelSize}`}
+      src={src}
       alt=""
       title={login}
       width={size}
@@ -35,4 +40,14 @@ export function AuthorAvatar({
       )}
     />
   );
+}
+
+function withAvatarSize(src: string, size: number): string {
+  try {
+    const url = new URL(src);
+    url.searchParams.set("s", String(size));
+    return url.toString();
+  } catch {
+    return src;
+  }
 }

--- a/src/components/AuthorTag.tsx
+++ b/src/components/AuthorTag.tsx
@@ -63,12 +63,14 @@ export function buildProfileMenuItems(
  */
 export function AuthorTag({
   login,
+  avatarUrl,
   fallbackName,
   size = 24,
   nameClass,
   avatarOnly = false,
 }: {
   login: string | null | undefined;
+  avatarUrl?: string | null;
   /** Plain-text name shown when `login` isn't a resolvable GitHub handle. */
   fallbackName?: string;
   size?: number;
@@ -98,7 +100,7 @@ export function AuthorTag({
         }}
         className="inline-flex shrink-0 items-center gap-1.5 align-middle"
       >
-        <AuthorAvatar login={login} size={size} />
+        <AuthorAvatar login={login} avatarUrl={avatarUrl} size={size} />
         {avatarOnly ? null : (
           <span className={cn("font-mono text-fg", nameClass)}>{login}</span>
         )}

--- a/src/components/PullRequestDetailModal.modal.test.tsx
+++ b/src/components/PullRequestDetailModal.modal.test.tsx
@@ -135,6 +135,41 @@ describe("PullRequestDetailModal — body checkbox toggle", () => {
     expect(updated[1]?.checked).toBe(true);
   });
 
+  it("uses the API-provided conversation author avatar URL", async () => {
+    const detail = fakeDetail("");
+    detail.comments = [
+      {
+        author: "linear-code",
+        author_avatar_url:
+          "https://avatars.githubusercontent.com/in/1658531?s=80&v=4",
+        body: "Figma parity note",
+        created_at: "2026-05-19T02:00:00Z",
+      },
+    ];
+    mockApi.getPullRequestDetail.mockResolvedValueOnce({
+      kind: "ok",
+      account: "tester",
+      detail,
+    });
+
+    await act(async () => {
+      root.render(
+        <PullRequestDetailModal
+          open={{ repoPath: "/r", number: 999 }}
+          onClose={() => {}}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const img = document.body.querySelector<HTMLImageElement>(
+      'img[title="linear-code"]',
+    );
+    expect(img?.src).toBe(
+      "https://avatars.githubusercontent.com/in/1658531?s=56&v=4",
+    );
+  });
+
   it("reverts and surfaces an error when updatePullRequestBody rejects", async () => {
     mockApi.getPullRequestDetail.mockResolvedValueOnce({
       kind: "ok",

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -1024,6 +1024,7 @@ function CommentBlock({ comment }: { comment: PullRequestComment }) {
       <div className="mb-2 flex items-center gap-2 text-[10.5px] text-fg-muted">
         <AuthorTag
           login={comment.author}
+          avatarUrl={comment.author_avatar_url}
           size={28}
           nameClass="text-[12.5px] font-semibold tracking-tight"
         />
@@ -1054,6 +1055,7 @@ function ReviewBlock({ review }: { review: PullRequestReview }) {
       <div className="mb-2 flex items-center gap-2 text-[10.5px] text-fg-muted">
         <AuthorTag
           login={review.author}
+          avatarUrl={review.author_avatar_url}
           size={28}
           nameClass="text-[12.5px] font-semibold tracking-tight"
         />

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -170,12 +170,14 @@ export type PullRequestListing =
 
 export interface PullRequestComment {
   author: string;
+  author_avatar_url: string | null;
   body: string;
   created_at: string;
 }
 
 export interface PullRequestReview {
   author: string;
+  author_avatar_url: string | null;
   /** APPROVED | CHANGES_REQUESTED | COMMENTED | DISMISSED | PENDING */
   state: string;
   body: string;


### PR DESCRIPTION
## Summary
PR detail conversation avatars now use GitHub-provided actor avatar URLs instead of relying only on `github.com/{login}.png`.

1. **Conversation actor data**: add `author_avatar_url` to PR comments and reviews returned by the Tauri PR detail API.
2. **GitHub App fallback**: resolve normal users through `gh api users/{login}` and GitHub Apps through `gh api apps/{slug}`, producing `/in/{id}` avatar URLs for app actors such as `linear-code`.
3. **UI rendering**: pass explicit avatar URLs through `AuthorTag` / `AuthorAvatar`, while preserving the existing login-derived fallback for callers without backend avatar data.
4. **Regression coverage**: add a PR detail modal test that verifies `linear-code` renders the provided `avatars.githubusercontent.com/in/1658531` URL.

## Expected impact

| Area | Impact |
| --- | --- |
| User-visible behavior | GitHub App/bot comments in the PR detail Conversation tab show their real avatar instead of the broken/fallback image. |
| Reliability | Avatar rendering no longer depends on `github.com/{login}.png` existing for app actors. |
| Performance | PR detail fetch performs best-effort avatar lookup for unique conversation actors; failures are non-blocking and fall back to the prior behavior. |

## Design notes

- `gh pr view --json comments,reviews` only exposes author login for conversation actors, so the backend enriches the existing detail payload after parsing the `gh` result.
- User actors prefer the REST `avatar_url`; app actors use the GitHub App id to build the same `/in/{id}` avatar URL shape GitHub serves for app avatars.
- The frontend keeps `login` validation and profile-menu behavior unchanged; explicit avatar URLs only affect the image source.

## Test plan

- [x] `pnpm test` — 36 files passed, 295 tests passed, 1 skipped.
- [x] `pnpm typecheck` — passed.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — passed.
- [x] `git diff --check` — passed.
- [ ] `cargo fmt --manifest-path src-tauri/Cargo.toml --check` — fails on pre-existing unrelated Rust formatting diffs outside this PR.

## Notes

- `cargo fmt --check` reports existing formatting churn in files such as `src-tauri/src/commands.rs`, `src-tauri/src/fs_explorer.rs`, `src-tauri/src/git_ops.rs`, `src-tauri/src/ipc/server.rs`, and `src-tauri/src/pty_env.rs`; this PR does not touch those files.