### PR TITLE
fix(github): refresh repo probe on git metadata changes

### DIFF
--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -50,12 +50,14 @@ vi.mock("./FileExplorer", () => ({
 }));
 
 import { api } from "../lib/api";
+import { listen } from "@tauri-apps/api/event";
 import { rightPanelCache } from "../lib/right-panel-cache";
 import { __resetIsGitHubRepoCacheForTests } from "../lib/useIsGitHubRepo";
 import { useAppStore } from "../store";
 import { RightPanel } from "./RightPanel";
 
 const mockApi = vi.mocked(api);
+const mockListen = vi.mocked(listen);
 const REPO = "/tmp/acorn-test-repo";
 const REPO_B = "/tmp/acorn-other-repo";
 
@@ -63,6 +65,19 @@ async function flushPromises() {
   await act(async () => {
     await Promise.resolve();
     await Promise.resolve();
+  });
+}
+
+function emitFsChanged(payload: {
+  paths: string[];
+  dotgit_changed: boolean;
+}) {
+  const listener = mockListen.mock.calls[mockListen.mock.calls.length - 1]?.[1];
+  if (!listener) throw new Error("fs listener not registered");
+  listener({
+    event: "fs-changed",
+    id: 1,
+    payload,
   });
 }
 
@@ -200,5 +215,44 @@ describe("RightPanel background tab loading", () => {
     expect(mockApi.githubOriginSlug).not.toHaveBeenCalled();
     expect(mockApi.listPullRequests).not.toHaveBeenCalled();
     expect(mockApi.listWorkflowRuns).not.toHaveBeenCalled();
+  });
+
+  it("reprobes GitHub visibility when git metadata changes", async () => {
+    mockApi.isGitRepository.mockResolvedValueOnce(false);
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+    expect(container.textContent).not.toContain("GitHub");
+    expect(mockApi.githubOriginSlug).not.toHaveBeenCalled();
+
+    mockApi.isGitRepository.mockResolvedValueOnce(true);
+    mockApi.githubOriginSlug.mockResolvedValueOnce("im-ian/acorn");
+    await act(async () => {
+      emitFsChanged({ paths: [], dotgit_changed: true });
+    });
+    await flushPromises();
+
+    expect(mockApi.isGitRepository).toHaveBeenCalledTimes(2);
+    expect(mockApi.githubOriginSlug).toHaveBeenCalledWith(REPO);
+    expect(container.textContent).toContain("GitHub");
+  });
+
+  it("hides GitHub tabs when git metadata is removed", async () => {
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+    expect(container.textContent).toContain("GitHub");
+
+    mockApi.isGitRepository.mockResolvedValueOnce(false);
+    await act(async () => {
+      emitFsChanged({ paths: [], dotgit_changed: true });
+    });
+    await flushPromises();
+
+    expect(mockApi.isGitRepository).toHaveBeenCalledTimes(2);
+    expect(container.textContent).not.toContain("GitHub");
   });
 });

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -49,6 +49,7 @@ import { classifyRightPanelFsChange } from "../lib/right-panel-invalidation";
 import { useSettings } from "../lib/settings";
 import { useAppStore } from "../store";
 import {
+  invalidateGitHubRepoStatus,
   prefetchGitHubRepoStatus,
   useIsGitHubRepo,
 } from "../lib/useIsGitHubRepo";
@@ -180,7 +181,16 @@ export function RightPanel() {
   const repoPath = useLiveRepoPath(active?.id ?? null, fallbackPath);
   const sessionHostRepoPath =
     active?.repo_path ?? activeWorkspaceTab?.repoPath ?? activeProject ?? repoPath;
-  const invalidations = useRightPanelInvalidations(repoPath);
+  const [githubRepoProbeVersion, setGithubRepoProbeVersion] = useState(0);
+  const invalidateGitHubProbe = useCallback(() => {
+    if (!repoPath) return;
+    invalidateGitHubRepoStatus(repoPath);
+    setGithubRepoProbeVersion((version) => version + 1);
+  }, [repoPath]);
+  const invalidations = useRightPanelInvalidations(
+    repoPath,
+    invalidateGitHubProbe,
+  );
   const [expanded, setExpanded] = useState<ExpandedDiff | null>(null);
   const [prDetail, setPrDetail] = useState<{
     repoPath: string;
@@ -205,7 +215,7 @@ export function RightPanel() {
   // null while the first probe is in flight. Keep GitHub hidden until we know
   // the path is a git repo with a GitHub origin so non-git projects never show
   // GitHub-only actions.
-  const isGitHubRepo = useIsGitHubRepo(repoPath);
+  const isGitHubRepo = useIsGitHubRepo(repoPath, githubRepoProbeVersion);
   const githubVisible = isGitHubRepo === true;
 
   const visibleTabsByGroup = useMemo<
@@ -791,6 +801,7 @@ function useSafetyRefreshInterval(
 
 function useRightPanelInvalidations(
   repoPath: string | null,
+  onGitMetadataChanged?: () => void,
 ): RightPanelInvalidationKeys {
   const [keys, setKeys] = useState<RightPanelInvalidationKeys>({
     commits: 0,
@@ -826,6 +837,9 @@ function useRightPanelInvalidations(
 
     void listen<FsChangePayload>(FS_CHANGED_EVENT, (event) => {
       if (cancelled) return;
+      if (event.payload.dotgit_changed) {
+        onGitMetadataChanged?.();
+      }
       const invalidation = classifyRightPanelFsChange(
         repoPath,
         event.payload.paths,
@@ -848,7 +862,7 @@ function useRightPanelInvalidations(
       if (flushTimer) clearTimeout(flushTimer);
       if (unlisten) unlisten();
     };
-  }, [repoPath]);
+  }, [onGitMetadataChanged, repoPath]);
 
   return keys;
 }

--- a/src/lib/useIsGitHubRepo.ts
+++ b/src/lib/useIsGitHubRepo.ts
@@ -9,22 +9,33 @@ import { api } from "./api";
  */
 const cache = new Map<string, boolean>();
 const inFlight = new Map<string, Promise<boolean>>();
+const generations = new Map<string, number>();
+
+function generationOf(repoPath: string): number {
+  return generations.get(repoPath) ?? 0;
+}
 
 async function probe(repoPath: string): Promise<boolean> {
   const cached = cache.get(repoPath);
   if (cached !== undefined) return cached;
   const existing = inFlight.get(repoPath);
   if (existing) return existing;
+  const generation = generationOf(repoPath);
   const promise = api
     .isGitRepository(repoPath)
     .then(async (isGitRepo) => {
       if (!isGitRepo) {
-        cache.set(repoPath, false);
+        if (generationOf(repoPath) === generation) {
+          cache.set(repoPath, false);
+        }
         return false;
       }
       const slug = await api.githubOriginSlug(repoPath);
       const value = slug !== null;
-      cache.set(repoPath, value);
+      if (generationOf(repoPath) === generation) {
+        cache.set(repoPath, value);
+      }
+      if (generationOf(repoPath) !== generation) return false;
       return value;
     })
     .catch((error) => {
@@ -34,7 +45,9 @@ async function probe(repoPath: string): Promise<boolean> {
       return false;
     })
     .finally(() => {
-      inFlight.delete(repoPath);
+      if (inFlight.get(repoPath) === promise) {
+        inFlight.delete(repoPath);
+      }
     });
   inFlight.set(repoPath, promise);
   return promise;
@@ -44,11 +57,20 @@ export function prefetchGitHubRepoStatus(repoPath: string): Promise<boolean> {
   return probe(repoPath);
 }
 
+export function invalidateGitHubRepoStatus(repoPath: string): void {
+  cache.delete(repoPath);
+  inFlight.delete(repoPath);
+  generations.set(repoPath, generationOf(repoPath) + 1);
+}
+
 /**
  * Returns `true` when `repoPath` is inside a git repo with a GitHub `origin`
  * remote, `false` otherwise, or `null` while the first probe is in flight.
  */
-export function useIsGitHubRepo(repoPath: string | null): boolean | null {
+export function useIsGitHubRepo(
+  repoPath: string | null,
+  refreshKey = 0,
+): boolean | null {
   const [state, setState] = useState<boolean | null>(() =>
     repoPath ? (cache.get(repoPath) ?? null) : null,
   );
@@ -72,7 +94,7 @@ export function useIsGitHubRepo(repoPath: string | null): boolean | null {
     return () => {
       cancelled = true;
     };
-  }, [repoPath]);
+  }, [refreshKey, repoPath]);
 
   return state;
 }
@@ -81,4 +103,5 @@ export function useIsGitHubRepo(repoPath: string | null): boolean | null {
 export function __resetIsGitHubRepoCacheForTests(): void {
   cache.clear();
   inFlight.clear();
+  generations.clear();
 }


### PR DESCRIPTION
## Summary
This PR makes the right-panel GitHub visibility probe respond to runtime git metadata changes, so `git init`, origin edits, and `.git` removal are reflected without restarting Acorn.

1. **Probe invalidation:** Added `invalidateGitHubRepoStatus(repoPath)` and generation guards so cached/in-flight GitHub repo probes can be safely invalidated.
2. **Watcher integration:** Wired `dotgit_changed` filesystem events from the existing right-panel watcher to invalidate and re-run the active repo GitHub probe.
3. **Runtime behavior:** A project becomes GitHub-enabled only after it is a git repo and has a GitHub `origin`; removing `.git` or changing/removing origin hides the GitHub group after the watcher event.
4. **Coverage:** Added unit coverage for non-git → GitHub repo activation and GitHub repo → non-git deactivation through watcher events.

## Expected impact

| Area | Impact |
| --- | --- |
| GitHub group visibility | Updates during the running app when `.git` metadata changes. |
| `git init` flow | `git init` alone keeps GitHub hidden; adding a GitHub origin enables it. |
| `.git` removal | GitHub group is hidden after the watcher reports git metadata removal. |
| Performance | No new polling; reuse existing watcher events and cached probes. |

## Design notes

- The activation condition remains strict: git repo + GitHub origin. This PR only makes that condition re-evaluate after git metadata changes.
- Generation guards prevent stale in-flight probes from repopulating the cache after invalidation.
- The existing watcher already emits `dotgit_changed`; this PR only connects that signal to the GitHub probe cache.

## Test plan

- [x] `pnpm test -- src/components/RightPanel.test.tsx`
- [x] `pnpm typecheck`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts --reporter=line`
- [x] `pnpm test`
- [x] `git diff --check`

## Notes

- E2E still prints existing mock warnings around `load_status` and theme loading, but the right-panel tests passed.
