### PR TITLE
fix(right-panel): hide git tabs outside repositories

### DIFF
--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -120,7 +120,7 @@ describe("RightPanel background tab loading", () => {
       activeProject: REPO,
       activeSessionId: null,
       activeTabId: null,
-      rightTab: "history",
+      rightTab: "commits",
       workspaceTabs: {},
       prAccountByRepo: {},
     });
@@ -203,7 +203,7 @@ describe("RightPanel background tab loading", () => {
     expect(mockApi.listWorkflowRuns).toHaveBeenCalledWith(REPO_B, 50);
   });
 
-  it("hides GitHub tabs for projects that are not git repositories", async () => {
+  it("hides git-backed tabs for projects that are not git repositories", async () => {
     mockApi.isGitRepository.mockResolvedValue(false);
 
     await act(async () => {
@@ -211,8 +211,28 @@ describe("RightPanel background tab loading", () => {
     });
     await flushPromises();
 
+    expect(container.textContent).toContain("Files");
+    expect(container.textContent).not.toContain("Staged");
+    expect(container.textContent).not.toContain("Commits");
     expect(container.textContent).not.toContain("GitHub");
     expect(mockApi.githubOriginSlug).not.toHaveBeenCalled();
+    expect(mockApi.listPullRequests).not.toHaveBeenCalled();
+    expect(mockApi.listWorkflowRuns).not.toHaveBeenCalled();
+  });
+
+  it("keeps local git tabs visible when the git repository has no GitHub origin", async () => {
+    mockApi.githubOriginSlug.mockResolvedValue(null);
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+
+    expect(container.textContent).toContain("Files");
+    expect(container.textContent).toContain("Staged");
+    expect(container.textContent).toContain("Commits");
+    expect(container.textContent).not.toContain("GitHub");
+    expect(mockApi.githubOriginSlug).toHaveBeenCalledWith(REPO);
     expect(mockApi.listPullRequests).not.toHaveBeenCalled();
     expect(mockApi.listWorkflowRuns).not.toHaveBeenCalled();
   });
@@ -225,7 +245,22 @@ describe("RightPanel background tab loading", () => {
     });
     await flushPromises();
     expect(container.textContent).not.toContain("GitHub");
+    expect(container.textContent).not.toContain("Staged");
+    expect(container.textContent).not.toContain("Commits");
     expect(mockApi.githubOriginSlug).not.toHaveBeenCalled();
+
+    mockApi.isGitRepository.mockResolvedValueOnce(true);
+    mockApi.githubOriginSlug.mockResolvedValueOnce(null);
+    await act(async () => {
+      emitFsChanged({ paths: [], dotgit_changed: true });
+    });
+    await flushPromises();
+
+    expect(mockApi.isGitRepository).toHaveBeenCalledTimes(2);
+    expect(mockApi.githubOriginSlug).toHaveBeenCalledWith(REPO);
+    expect(container.textContent).toContain("Staged");
+    expect(container.textContent).toContain("Commits");
+    expect(container.textContent).not.toContain("GitHub");
 
     mockApi.isGitRepository.mockResolvedValueOnce(true);
     mockApi.githubOriginSlug.mockResolvedValueOnce("im-ian/acorn");
@@ -234,17 +269,18 @@ describe("RightPanel background tab loading", () => {
     });
     await flushPromises();
 
-    expect(mockApi.isGitRepository).toHaveBeenCalledTimes(2);
-    expect(mockApi.githubOriginSlug).toHaveBeenCalledWith(REPO);
+    expect(mockApi.isGitRepository).toHaveBeenCalledTimes(3);
     expect(container.textContent).toContain("GitHub");
   });
 
-  it("hides GitHub tabs when git metadata is removed", async () => {
+  it("hides git-backed tabs when git metadata is removed", async () => {
     await act(async () => {
       root.render(<RightPanel />);
     });
     await flushPromises();
     expect(container.textContent).toContain("GitHub");
+    expect(container.textContent).toContain("Staged");
+    expect(container.textContent).toContain("Commits");
 
     mockApi.isGitRepository.mockResolvedValueOnce(false);
     await act(async () => {
@@ -254,5 +290,7 @@ describe("RightPanel background tab loading", () => {
 
     expect(mockApi.isGitRepository).toHaveBeenCalledTimes(2);
     expect(container.textContent).not.toContain("GitHub");
+    expect(container.textContent).not.toContain("Staged");
+    expect(container.textContent).not.toContain("Commits");
   });
 });

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -49,8 +49,9 @@ import { classifyRightPanelFsChange } from "../lib/right-panel-invalidation";
 import { useSettings } from "../lib/settings";
 import { useAppStore } from "../store";
 import {
-  invalidateGitHubRepoStatus,
+  invalidateGitRepositoryStatus,
   prefetchGitHubRepoStatus,
+  useIsGitRepository,
   useIsGitHubRepo,
 } from "../lib/useIsGitHubRepo";
 import {
@@ -181,15 +182,15 @@ export function RightPanel() {
   const repoPath = useLiveRepoPath(active?.id ?? null, fallbackPath);
   const sessionHostRepoPath =
     active?.repo_path ?? activeWorkspaceTab?.repoPath ?? activeProject ?? repoPath;
-  const [githubRepoProbeVersion, setGithubRepoProbeVersion] = useState(0);
-  const invalidateGitHubProbe = useCallback(() => {
+  const [gitRepoProbeVersion, setGitRepoProbeVersion] = useState(0);
+  const invalidateGitProbe = useCallback(() => {
     if (!repoPath) return;
-    invalidateGitHubRepoStatus(repoPath);
-    setGithubRepoProbeVersion((version) => version + 1);
+    invalidateGitRepositoryStatus(repoPath);
+    setGitRepoProbeVersion((version) => version + 1);
   }, [repoPath]);
   const invalidations = useRightPanelInvalidations(
     repoPath,
-    invalidateGitHubProbe,
+    invalidateGitProbe,
   );
   const [expanded, setExpanded] = useState<ExpandedDiff | null>(null);
   const [prDetail, setPrDetail] = useState<{
@@ -212,23 +213,24 @@ export function RightPanel() {
     active?.worktree_path ?? null,
   );
   const showTodos = todosState.todos.length > 0;
-  // null while the first probe is in flight. Keep GitHub hidden until we know
-  // the path is a git repo with a GitHub origin so non-git projects never show
-  // GitHub-only actions.
-  const isGitHubRepo = useIsGitHubRepo(repoPath, githubRepoProbeVersion);
+  const isGitRepo = useIsGitRepository(repoPath, gitRepoProbeVersion);
+  const isGitHubRepo = useIsGitHubRepo(repoPath, gitRepoProbeVersion);
   const githubVisible = isGitHubRepo === true;
+  const gitBackedTabsVisible = isGitRepo !== false;
 
   const visibleTabsByGroup = useMemo<
     Record<RightGroup, ReadonlyArray<RightTab>>
   >(
     () => ({
-      code: tabsForGroup("code"),
+      code: gitBackedTabsVisible
+        ? tabsForGroup("code")
+        : tabsForGroup("code").filter((tab) => tab === "files"),
       github: githubVisible ? tabsForGroup("github") : [],
       agents: showTodos
         ? tabsForGroup("agents")
         : tabsForGroup("agents").filter((tab) => tab !== "todos"),
     }),
-    [githubVisible, showTodos],
+    [gitBackedTabsVisible, githubVisible, showTodos],
   );
   const visibleGroups = useMemo(
     () => RIGHT_GROUPS.filter((g) => visibleTabsByGroup[g].length > 0),
@@ -263,10 +265,17 @@ export function RightPanel() {
   useEffect(() => {
     if (visibleTabs.length === 0) return;
     if (!visibleTabs.includes(rightTab)) {
+      if (
+        isGitRepo === null &&
+        groupOfTab(rightTab) === "code" &&
+        rightTab !== "files"
+      ) {
+        return;
+      }
       if (isGitHubRepo === null && groupOfTab(rightTab) === "github") return;
       setRightTab(visibleTabs[0]);
     }
-  }, [isGitHubRepo, rightTab, visibleTabs, setRightTab]);
+  }, [isGitHubRepo, isGitRepo, rightTab, visibleTabs, setRightTab]);
 
   useEffect(() => {
     if (projects.length === 0) return;

--- a/src/lib/useIsGitHubRepo.ts
+++ b/src/lib/useIsGitHubRepo.ts
@@ -2,38 +2,69 @@ import { useEffect, useState } from "react";
 import { api } from "./api";
 
 /**
- * Per-repo cache for the git-repo + GitHub origin probe. The result rarely
- * changes during a session (only when the user runs `git init` or edits
- * `origin`), so we resolve once per repoPath and reuse across mounts.
+ * Per-repo caches for the git-repo + GitHub origin probes. The results rarely
+ * change during a session (only when the user runs `git init` or edits git
+ * metadata), so we resolve once per repoPath and reuse across mounts.
  * Concurrent callers for the same repoPath share one in-flight promise.
  */
-const cache = new Map<string, boolean>();
-const inFlight = new Map<string, Promise<boolean>>();
+const gitRepoCache = new Map<string, boolean>();
+const gitRepoInFlight = new Map<string, Promise<boolean>>();
+const githubRepoCache = new Map<string, boolean>();
+const githubRepoInFlight = new Map<string, Promise<boolean>>();
 const generations = new Map<string, number>();
 
 function generationOf(repoPath: string): number {
   return generations.get(repoPath) ?? 0;
 }
 
-async function probe(repoPath: string): Promise<boolean> {
-  const cached = cache.get(repoPath);
+async function probeGitRepository(repoPath: string): Promise<boolean> {
+  const cached = gitRepoCache.get(repoPath);
   if (cached !== undefined) return cached;
-  const existing = inFlight.get(repoPath);
+  const existing = gitRepoInFlight.get(repoPath);
   if (existing) return existing;
   const generation = generationOf(repoPath);
   const promise = api
     .isGitRepository(repoPath)
+    .then((isGitRepo) => {
+      if (generationOf(repoPath) === generation) {
+        gitRepoCache.set(repoPath, isGitRepo);
+      }
+      if (generationOf(repoPath) !== generation) return false;
+      return isGitRepo;
+    })
+    .catch((error) => {
+      // Treat probe failures as "not a git repo" so git-backed UI does not
+      // surface actions for paths whose repository state cannot be verified.
+      console.warn("[useIsGitHubRepo] git repository probe failed", error);
+      return false;
+    })
+    .finally(() => {
+      if (gitRepoInFlight.get(repoPath) === promise) {
+        gitRepoInFlight.delete(repoPath);
+      }
+    });
+  gitRepoInFlight.set(repoPath, promise);
+  return promise;
+}
+
+async function probeGitHubRepo(repoPath: string): Promise<boolean> {
+  const cached = githubRepoCache.get(repoPath);
+  if (cached !== undefined) return cached;
+  const existing = githubRepoInFlight.get(repoPath);
+  if (existing) return existing;
+  const generation = generationOf(repoPath);
+  const promise = probeGitRepository(repoPath)
     .then(async (isGitRepo) => {
       if (!isGitRepo) {
         if (generationOf(repoPath) === generation) {
-          cache.set(repoPath, false);
+          githubRepoCache.set(repoPath, false);
         }
         return false;
       }
       const slug = await api.githubOriginSlug(repoPath);
       const value = slug !== null;
       if (generationOf(repoPath) === generation) {
-        cache.set(repoPath, value);
+        githubRepoCache.set(repoPath, value);
       }
       if (generationOf(repoPath) !== generation) return false;
       return value;
@@ -45,22 +76,68 @@ async function probe(repoPath: string): Promise<boolean> {
       return false;
     })
     .finally(() => {
-      if (inFlight.get(repoPath) === promise) {
-        inFlight.delete(repoPath);
+      if (githubRepoInFlight.get(repoPath) === promise) {
+        githubRepoInFlight.delete(repoPath);
       }
     });
-  inFlight.set(repoPath, promise);
+  githubRepoInFlight.set(repoPath, promise);
   return promise;
 }
 
+export function prefetchGitRepositoryStatus(repoPath: string): Promise<boolean> {
+  return probeGitRepository(repoPath);
+}
+
 export function prefetchGitHubRepoStatus(repoPath: string): Promise<boolean> {
-  return probe(repoPath);
+  return probeGitHubRepo(repoPath);
+}
+
+export function invalidateGitRepositoryStatus(repoPath: string): void {
+  gitRepoCache.delete(repoPath);
+  gitRepoInFlight.delete(repoPath);
+  githubRepoCache.delete(repoPath);
+  githubRepoInFlight.delete(repoPath);
+  generations.set(repoPath, generationOf(repoPath) + 1);
 }
 
 export function invalidateGitHubRepoStatus(repoPath: string): void {
-  cache.delete(repoPath);
-  inFlight.delete(repoPath);
-  generations.set(repoPath, generationOf(repoPath) + 1);
+  invalidateGitRepositoryStatus(repoPath);
+}
+
+/**
+ * Returns `true` when `repoPath` is inside a git repo, `false` otherwise, or
+ * `null` while the first probe is in flight.
+ */
+export function useIsGitRepository(
+  repoPath: string | null,
+  refreshKey = 0,
+): boolean | null {
+  const [state, setState] = useState<boolean | null>(() =>
+    repoPath ? (gitRepoCache.get(repoPath) ?? null) : null,
+  );
+
+  useEffect(() => {
+    if (!repoPath) {
+      setState(null);
+      return;
+    }
+    const cached = gitRepoCache.get(repoPath);
+    if (cached !== undefined) {
+      setState(cached);
+      return;
+    }
+    setState(null);
+    let cancelled = false;
+    void probeGitRepository(repoPath).then((value) => {
+      if (cancelled) return;
+      setState(value);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey, repoPath]);
+
+  return state;
 }
 
 /**
@@ -72,7 +149,7 @@ export function useIsGitHubRepo(
   refreshKey = 0,
 ): boolean | null {
   const [state, setState] = useState<boolean | null>(() =>
-    repoPath ? (cache.get(repoPath) ?? null) : null,
+    repoPath ? (githubRepoCache.get(repoPath) ?? null) : null,
   );
 
   useEffect(() => {
@@ -80,14 +157,14 @@ export function useIsGitHubRepo(
       setState(null);
       return;
     }
-    const cached = cache.get(repoPath);
+    const cached = githubRepoCache.get(repoPath);
     if (cached !== undefined) {
       setState(cached);
       return;
     }
     setState(null);
     let cancelled = false;
-    void probe(repoPath).then((value) => {
+    void probeGitHubRepo(repoPath).then((value) => {
       if (cancelled) return;
       setState(value);
     });
@@ -101,7 +178,9 @@ export function useIsGitHubRepo(
 
 /** Test-only: clear the module-level cache between cases. */
 export function __resetIsGitHubRepoCacheForTests(): void {
-  cache.clear();
-  inFlight.clear();
+  gitRepoCache.clear();
+  gitRepoInFlight.clear();
+  githubRepoCache.clear();
+  githubRepoInFlight.clear();
   generations.clear();
 }

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -296,7 +296,9 @@ test.describe("right panel: groups", () => {
     // Code group is always there; Agents group is too. GitHub must be gone.
     await expect(page.getByRole("button", { name: "Code" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Agents" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Files" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Files", exact: true }),
+    ).toBeVisible();
     await expect(page.getByRole("button", { name: "Staged" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Commits" })).toBeVisible();
     await expect(page.getByRole("button", { name: "GitHub" })).toHaveCount(0);
@@ -313,7 +315,9 @@ test.describe("right panel: groups", () => {
 
     await expect(page.getByRole("button", { name: "Code" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Agents" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Files" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Files", exact: true }),
+    ).toBeVisible();
     await expect(page.getByRole("button", { name: "Staged" })).toHaveCount(0);
     await expect(page.getByRole("button", { name: "Commits" })).toHaveCount(0);
     await expect(page.getByRole("button", { name: "GitHub" })).toHaveCount(0);

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -296,10 +296,13 @@ test.describe("right panel: groups", () => {
     // Code group is always there; Agents group is too. GitHub must be gone.
     await expect(page.getByRole("button", { name: "Code" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Agents" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Files" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Staged" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Commits" })).toBeVisible();
     await expect(page.getByRole("button", { name: "GitHub" })).toHaveCount(0);
   });
 
-  test("GitHub group is hidden when project is not a git repository", async ({
+  test("git-backed tabs are hidden when project is not a git repository", async ({
     page,
     tauri,
   }) => {
@@ -310,6 +313,9 @@ test.describe("right panel: groups", () => {
 
     await expect(page.getByRole("button", { name: "Code" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Agents" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Files" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Staged" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Commits" })).toHaveCount(0);
     await expect(page.getByRole("button", { name: "GitHub" })).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Summary

This keeps local git tabs tied to git repository availability while preserving the stricter GitHub-origin gate for GitHub-only tabs.

1. **Git probe split:** Added a cached git-repository probe alongside the existing GitHub-origin probe so local git UI can depend on `git init` without requiring an `origin`.
2. **Right panel visibility:** Hide `Staged` and `Commits` when the active project is not a git repo; keep them visible for git repos even when `origin` is missing or non-GitHub.
3. **Regression coverage:** Added unit and Playwright assertions for non-git projects and git repos without GitHub origin.

## Expected impact

| Area | Impact |
| --- | --- |
| Non-git projects | Code group shows `Files` only; `Staged` and `Commits` disappear with the GitHub group. |
| Git repos without GitHub origin | `Staged` and `Commits` stay available; GitHub group remains hidden. |
| Runtime git changes | Existing `.git` watcher invalidation now refreshes both git and GitHub-origin visibility asynchronously. |

## Design notes

- Reused the existing repo probe module instead of introducing a separate cache manager for this small visibility rule.
- The git-repo cache and GitHub-origin cache share the same generation invalidation, so `git init`, `.git` removal, and origin edits cannot leave one probe stale while the other refreshes.
- GitHub tab prefetch still requires the GitHub-origin probe to pass; local git tabs only require `is_git_repository`.

## Test plan

- [x] `pnpm test -- src/components/RightPanel.test.tsx`
- [x] `pnpm typecheck`
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts --reporter=line`
- [x] `pnpm test`
- [x] `git diff --check`

## Notes

- Playwright prints the existing `NO_COLOR` / `FORCE_COLOR` warning during the e2e run; it did not fail the suite.