### PR TITLE
feat(github): add PR row label visibility setting

### DIFF
--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -52,6 +52,7 @@ vi.mock("./FileExplorer", () => ({
 import { api } from "../lib/api";
 import { listen } from "@tauri-apps/api/event";
 import { rightPanelCache } from "../lib/right-panel-cache";
+import { DEFAULT_SETTINGS, useSettings } from "../lib/settings";
 import { __resetIsGitHubRepoCacheForTests } from "../lib/useIsGitHubRepo";
 import { useAppStore } from "../store";
 import { RightPanel } from "./RightPanel";
@@ -60,6 +61,23 @@ const mockApi = vi.mocked(api);
 const mockListen = vi.mocked(listen);
 const REPO = "/tmp/acorn-test-repo";
 const REPO_B = "/tmp/acorn-other-repo";
+
+const labeledPullRequest = {
+  number: 247,
+  title: "Hide git tabs outside repositories",
+  state: "OPEN",
+  author: "im-ian",
+  head_branch: "feature",
+  base_branch: "main",
+  url: "https://github.com/im-ian/acorn/pull/247",
+  updated_at: "2026-05-19T00:00:00Z",
+  is_draft: false,
+  checks: null,
+  labels: [
+    { name: "fix", color: "D93F0B" },
+    { name: "frontend", color: "0969DA" },
+  ],
+};
 
 async function flushPromises() {
   await act(async () => {
@@ -107,6 +125,7 @@ describe("RightPanel background tab loading", () => {
     });
     mockApi.listAgentHistory.mockResolvedValue([]);
     mockApi.readSessionTodos.mockResolvedValue([]);
+    useSettings.setState({ settings: structuredClone(DEFAULT_SETTINGS) });
     useAppStore.setState({
       sessions: [],
       projects: [
@@ -292,5 +311,32 @@ describe("RightPanel background tab loading", () => {
     expect(container.textContent).not.toContain("GitHub");
     expect(container.textContent).not.toContain("Staged");
     expect(container.textContent).not.toContain("Commits");
+  });
+
+  it("hides PR row labels when the GitHub setting is disabled", async () => {
+    useSettings.setState({
+      settings: {
+        ...structuredClone(DEFAULT_SETTINGS),
+        github: {
+          ...DEFAULT_SETTINGS.github,
+          showLabels: false,
+        },
+      },
+    });
+    useAppStore.setState({ rightTab: "prs" });
+    mockApi.listPullRequests.mockResolvedValue({
+      kind: "ok",
+      items: [labeledPullRequest],
+      account: "tester",
+    });
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+
+    expect(container.textContent).toContain("Hide git tabs outside repositories");
+    expect(container.textContent).not.toContain("frontend");
+    expect(container.textContent).not.toContain("fix");
   });
 });

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -2390,6 +2390,7 @@ function PullRequestsTab({
     (s) => s.settings.github.refreshIntervalMs,
   );
   const showAvatars = useSettings((s) => s.settings.github.showAvatars);
+  const showLabels = useSettings((s) => s.settings.github.showLabels);
   const [stateFilter, setStateFilter] = useState<PrStateFilter>("open");
   const [listsByState, setListsByState] = useState(() =>
     initialPrListStates(repoPath),
@@ -2601,6 +2602,7 @@ function PullRequestsTab({
                 key={pr.number}
                 pr={pr}
                 showAvatar={showAvatars}
+                showLabels={showLabels}
                 onOpen={() => onOpenDetail(pr.number)}
                 onContextMenu={(e) => rowActions.openContextMenu(e, pr)}
               />
@@ -3427,6 +3429,7 @@ function PrRow({
   onContextMenu,
   surface = "panel",
   showAvatar = false,
+  showLabels = true,
 }: {
   pr: PullRequestInfo;
   onOpen: () => void;
@@ -3443,6 +3446,8 @@ function PrRow({
    * recognition. Controlled by the `github.showAvatars` setting.
    */
   showAvatar?: boolean;
+  /** Render GitHub label chips next to the title. */
+  showLabels?: boolean;
 }) {
   const t = useTranslation();
   const hoverBg =
@@ -3494,7 +3499,7 @@ function PrRow({
         >
           <span className="min-w-0 flex-1 truncate text-fg">{pr.title}</span>
         </Tooltip>
-        {pr.labels.length > 0 ? (
+        {showLabels && pr.labels.length > 0 ? (
           <span className="flex shrink-0 items-center gap-1">
             {pr.labels.slice(0, 3).map((label) => (
               <PrLabelChip key={label.name} label={label} />
@@ -3577,6 +3582,7 @@ function PullRequestSearchModal({
   const t = useTranslation();
   const repoPath = open?.repoPath ?? null;
   const showAvatars = useSettings((s) => s.settings.github.showAvatars);
+  const showLabels = useSettings((s) => s.settings.github.showLabels);
   const [rawQuery, setRawQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [stateFilter, setStateFilter] = useState<PrStateFilter>("all");
@@ -3748,6 +3754,7 @@ function PullRequestSearchModal({
                 pr={pr}
                 surface="dialog"
                 showAvatar={showAvatars}
+                showLabels={showLabels}
                 onOpen={() => onOpenDetail(pr.number)}
                 onContextMenu={(e) => rowActions.openContextMenu(e, pr)}
               />

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -87,6 +87,18 @@ function openAppearanceTab() {
   });
 }
 
+function openGithubTab() {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (element) => element.textContent === "GitHub",
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error("GitHub tab button not found");
+  }
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
 function setInputValue(input: HTMLInputElement, value: string) {
   const setter = Object.getOwnPropertyDescriptor(
     window.HTMLInputElement.prototype,
@@ -291,6 +303,36 @@ describe("SettingsModal font controls", () => {
     expect(document.body.textContent).toContain("설정");
     expect(document.body.textContent).toContain("기본값으로 재설정");
     expect(document.body.textContent).toContain("글꼴 패밀리");
+  });
+
+  it("patches the GitHub PR row labels toggle", async () => {
+    const patchGithub = vi.fn();
+    useSettings.setState({
+      settings: cloneSettings(),
+      patchGithub,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openGithubTab();
+
+    const labelsToggle = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    ).find((input) =>
+      input.closest("label")?.textContent?.includes("Show labels"),
+    );
+
+    expect(document.body.textContent).toContain("Show labels");
+    expect(labelsToggle).toBeInstanceOf(HTMLInputElement);
+    expect(labelsToggle?.checked).toBe(true);
+
+    act(() => {
+      labelsToggle?.click();
+    });
+
+    expect(patchGithub).toHaveBeenCalledWith({ showLabels: false });
   });
 });
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -603,6 +603,12 @@ function GithubSettings() {
           checked={settings.github.showAvatars}
           onChange={(v) => patchGithub({ showAvatars: v })}
         />
+        <CheckboxRow
+          label={st(t, "settings.github.showLabels.label")}
+          description={st(t, "settings.github.showLabels.description")}
+          checked={settings.github.showLabels}
+          onChange={(v) => patchGithub({ showLabels: v })}
+        />
       </Field>
     </section>
   );

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -76,6 +76,48 @@ describe("AI commit command resolution", () => {
   });
 });
 
+describe("github settings", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("shows PR row labels by default", () => {
+    expect(DEFAULT_SETTINGS.github.showLabels).toBe(true);
+  });
+
+  it("loads a persisted PR row labels preference", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ github: { showLabels: false } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.github.showLabels).toBe(false);
+  });
+});
+
 describe("appearance settings migration", () => {
   const STORAGE_KEY = "acorn:settings:v1";
   let storage: Map<string, string>;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -231,6 +231,8 @@ export interface AcornSettings {
      * which already shows avatars in its header / conversation.
      */
     showAvatars: boolean;
+    /** Show GitHub labels next to each PR row title. */
+    showLabels: boolean;
   };
   /**
    * Sidebar session-row presentation. Mirrors Warp's "View as / Pane
@@ -351,6 +353,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   github: {
     refreshIntervalMs: 60_000,
     showAvatars: true,
+    showLabels: true,
   },
   sessionDisplay: {
     title: "name",
@@ -538,6 +541,7 @@ interface LegacyCommitMessage {
 interface LegacyPullRequests {
   refreshIntervalMs?: number;
   showAvatars?: boolean;
+  showLabels?: boolean;
 }
 
 function loadSettings(): AcornSettings {
@@ -695,6 +699,12 @@ function loadSettings(): AcornSettings {
             : typeof parsed.pullRequests?.showAvatars === "boolean"
               ? parsed.pullRequests.showAvatars
               : DEFAULT_SETTINGS.github.showAvatars,
+        showLabels:
+          typeof parsed.github?.showLabels === "boolean"
+            ? parsed.github.showLabels
+            : typeof parsed.pullRequests?.showLabels === "boolean"
+              ? parsed.pullRequests.showLabels
+              : DEFAULT_SETTINGS.github.showLabels,
       },
       sessionDisplay: {
         title: normalizeSessionTitle(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -93,6 +93,10 @@
       "showAuthorAvatars": {
         "label": "Show author avatars",
         "description": "Render the GitHub avatar next to each PR row."
+      },
+      "showLabels": {
+        "label": "Show labels",
+        "description": "Render GitHub labels next to each PR row title."
       }
     },
     "appearance": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -93,6 +93,10 @@
       "showAuthorAvatars": {
         "label": "작성자 아바타 표시",
         "description": "각 PR 행 옆에 GitHub 아바타를 표시합니다."
+      },
+      "showLabels": {
+        "label": "라벨 표시",
+        "description": "각 PR 행 제목 옆에 GitHub 라벨을 표시합니다."
       }
     },
     "appearance": {


### PR DESCRIPTION
## Summary

This adds a GitHub setting that lets users choose whether PR rows show GitHub label chips.

1. **Settings model:** Added `github.showLabels`, defaulting to `true` so existing PR rows keep showing labels.
2. **Settings UI:** Added a GitHub → List density checkbox for PR row labels with English and Korean copy.
3. **PR row rendering:** Wired the setting into PR list rows and PR search rows so labels can be hidden consistently.
4. **Regression coverage:** Added settings loader, Settings modal, and RightPanel tests for the new preference.

## Expected impact

| Area | Impact |
| --- | --- |
| GitHub settings | New checkbox under List density controls PR row labels. |
| PR rows | Labels remain visible by default; disabling the option hides label chips in PR lists and search results. |
| Existing users | No visual change unless they turn the setting off. |

## Design notes

- The option lives under the existing `github` settings block next to `showAvatars` because both affect PR row density.
- The default is `true` to preserve the current UI and avoid surprising users after upgrade.
- Legacy `pullRequests.showLabels` is accepted as a fallback for consistency with the existing legacy GitHub settings migration path.

## Test plan

- [x] `pnpm test -- src/lib/settings.test.ts src/components/SettingsModal.test.tsx src/components/RightPanel.test.tsx`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm exec playwright test tests/e2e/settings-tabs.spec.ts tests/e2e/right-panel.spec.ts --reporter=line`
- [x] `git diff --check`

## Notes

- Playwright still prints the existing `NO_COLOR` / `FORCE_COLOR` warning; it did not fail the run.