### PR TITLE
chore(privacy): remove local user identifiers

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -456,8 +456,8 @@ export function Terminal({
       // `convertEol: true` that bare LF gains a phantom CR, so the cursor
       // jumps to column 0 mid-redraw; the following save/restore pair lands
       // at the wrong x and subsequent shell echo overwrites previously
-      // rendered cells (e.g. the prompt user "jthefloor" renders as
-      // "rhefloor"). PTY output is the only writer here, so `false` is the
+      // rendered cells (e.g. the prompt user "developer" renders as
+      // "develope"). PTY output is the only writer here, so `false` is the
       // correct setting.
       convertEol: false,
     });

--- a/src/lib/terminalScrollback.test.ts
+++ b/src/lib/terminalScrollback.test.ts
@@ -13,7 +13,7 @@ describe("terminal scrollback restore hygiene", () => {
   it("does not restore a shell prompt with no session content", () => {
     expect(
       shouldRestoreScrollback(
-        "jthefloor@jthefloorui-MacBookPro acorn %     \r\n",
+        "developer@workstation acorn %     \r\n",
       ),
     ).toBe(false);
   });
@@ -29,7 +29,7 @@ describe("terminal scrollback restore hygiene", () => {
 
   it("keeps real command output restorable", () => {
     const saved = prepareScrollbackForSave(
-      "jthefloor@host acorn % npm test\r\nPASS src/lib/foo.test.ts\r\njthefloor@host acorn % ",
+      "developer@host acorn % npm test\r\nPASS src/lib/foo.test.ts\r\ndeveloper@host acorn % ",
     );
 
     expect(saved).toContain("PASS src/lib/foo.test.ts");


### PR DESCRIPTION
## Summary

This removes local machine/user identifiers from repository text and cleans up the leaked PR review wording.

1. **Repo text:** Replaced prompt examples that used a real local username with generic developer/workstation examples.
2. **PR hygiene:** Updated the earlier self-review body to remove a local absolute path emitted by a shell quoting mistake.

## Expected impact

| Area | Impact |
| --- | --- |
| Privacy hygiene | Repository comments/tests no longer include local user or machine identifiers. |
| Product behavior | No runtime behavior change. |

## Design notes

- This is text-only cleanup in a terminal comment and scrollback unit fixtures.
- No changelog entry is needed because there is no user-facing product change.

## Test plan

- [x] `pnpm test -- src/lib/terminalScrollback.test.ts`
- [x] `git diff --check`
- [x] Repository privacy scan returned no matches for local user/path identifiers.
- [x] Recent PR body/comment/review privacy scan returned no matches for local user/path identifiers.

## Notes

- CI will run the normal gates on the PR.