### PR TITLE
fix(paths): profile data dirs + shell-init env guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ pnpm run tauri build    # 프로덕션 빌드
 
 > ℹ️ `pnpm run tauri dev` / `tauri build`는 Tauri의 `externalBin` 규약에 따라 `src-tauri/binaries/acorn-ipc-<target-triple>`, `acornd-<target-triple>` 파일이 존재해야 시작합니다. 이 경로는 `.gitignore`에 포함돼 있어 fresh checkout(특히 `git worktree add`로 만들어진 worktree)에서는 비어 있고, 미리 빌드해두지 않으면 `resource path 'binaries/...' doesn't exist` 에러로 빌드가 실패합니다. `pnpm run build:sidecar`가 호스트 타깃에 맞는 두 바이너리를 빌드하고 올바른 위치에 stage합니다.
 
+개발 모드의 런타임 데이터는 설치된 앱과 분리되어
+`~/Library/Application Support/io.im-ian.acorn/profiles/dev/` 아래에 저장됩니다.
+프로덕션 빌드는 `profiles/prod/`를 사용합니다. 임시 격리가 필요하면
+`ACORN_PROFILE=<name>` 또는 `ACORN_DATA_DIR=/tmp/acorn-test`로 앱, IPC CLI,
+daemon이 볼 데이터 디렉터리를 바꿀 수 있습니다.
+
 ### 테스트
 
 ```bash

--- a/docs/CONTROL_SESSIONS.md
+++ b/docs/CONTROL_SESSIONS.md
@@ -49,6 +49,9 @@ layers that fire automatically every time a control-session PTY spawns:
    control session's PTY before any user code runs:
    - `ACORN_SESSION_ID` — this session's UUID, so `acorn-ipc` knows who
      is asking.
+   - `ACORN_DATA_DIR` — the resolved Acorn profile data directory. This
+     keeps bundled release sidecars aligned with the app's selected
+     profile.
    - `ACORN_IPC_SOCKET` — the canonical IPC socket path.
    - `ACORN_DAEMON_SOCKET` — the background daemon control socket path.
    - `PATH` — the directory containing the bundled `acorn-ipc` binary is
@@ -77,11 +80,18 @@ When Acorn spawns a control session it injects these env vars into the PTY:
 | Env var             | Source                            |
 | ------------------- | --------------------------------- |
 | `ACORN_SESSION_ID`  | The session's UUID                |
+| `ACORN_DATA_DIR`    | Resolved Acorn profile data dir   |
 | `ACORN_IPC_SOCKET`  | Path to the in-app IPC socket     |
 | `ACORN_DAEMON_SOCKET` | Path to the daemon control socket |
 
 The `acorn-ipc` binary reads `ACORN_SESSION_ID` and `ACORN_IPC_SOCKET`, so
 commands run straight from the shell without flags.
+
+By default, release builds use `profiles/prod` and debug builds use
+`profiles/dev` below Acorn's app data directory. Set `ACORN_PROFILE=<name>`
+to select another profile, or `ACORN_DATA_DIR=<path>` to pin all runtime
+state, IPC sockets, daemon sockets, and staged shell init files to an
+explicit directory.
 
 ### Install
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8,6 +8,7 @@ version = "1.3.0"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",
+ "acorn-paths",
  "acorn-pty",
  "acorn-session",
  "acorn-transcript",
@@ -52,9 +53,9 @@ dependencies = [
 name = "acorn-daemon"
 version = "0.1.0"
 dependencies = [
+ "acorn-paths",
  "chrono",
  "dashmap",
- "directories",
  "interprocess",
  "nix 0.31.3",
  "parking_lot",
@@ -71,11 +72,18 @@ dependencies = [
 name = "acorn-ipc"
 version = "0.1.0"
 dependencies = [
+ "acorn-paths",
  "base64 0.22.1",
  "clap",
- "directories",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "acorn-paths"
+version = "0.1.0"
+dependencies = [
+ "directories",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     ".",
+    "crates/acorn-paths",
     "crates/acorn-daemon",
     "crates/acorn-ipc",
     "crates/acorn-pty",
@@ -91,6 +92,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 acorn-daemon = { path = "crates/acorn-daemon" }
 acorn-ipc = { path = "crates/acorn-ipc" }
+acorn-paths = { path = "crates/acorn-paths" }
 acorn-pty = { path = "crates/acorn-pty" }
 acorn-session = { path = "crates/acorn-session" }
 acorn-transcript = { path = "crates/acorn-transcript" }

--- a/src-tauri/crates/acorn-daemon/Cargo.toml
+++ b/src-tauri/crates/acorn-daemon/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 name = "acorn_daemon"
 
 [dependencies]
+acorn-paths = { path = "../acorn-paths" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
@@ -16,7 +17,6 @@ dashmap = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true }
 interprocess = { workspace = true }
-directories = { workspace = true }
 sysinfo = { workspace = true }
 portable-pty = { workspace = true }
 tracing = { workspace = true }

--- a/src-tauri/crates/acorn-daemon/src/paths.rs
+++ b/src-tauri/crates/acorn-daemon/src/paths.rs
@@ -166,4 +166,31 @@ mod tests {
         assert_eq!(p, custom);
         unsafe { std::env::remove_var(ENV_DAEMON_SOCKET_OVERRIDE) };
     }
+
+    #[test]
+    fn profile_env_selects_profile_subdir_under_acorn_app_dir() {
+        let _g = ENV_LOCK.lock();
+        unsafe {
+            std::env::remove_var(ENV_DATA_DIR_OVERRIDE);
+            std::env::set_var("ACORN_PROFILE", "unit-test");
+        }
+
+        let dir = data_dir().unwrap();
+        let rendered = dir.to_string_lossy();
+        assert!(
+            rendered.contains("io.im-ian.acorn") || rendered.contains("acorn"),
+            "profile dirs should stay rooted under the acorn app dir, got {dir:?}"
+        );
+        assert!(
+            !rendered.contains("acorn-dev"),
+            "profiles should not switch the app name to acorn-dev, got {dir:?}"
+        );
+        assert!(
+            dir.ends_with("profiles/unit-test"),
+            "profile data should live under profiles/<name>, got {dir:?}"
+        );
+
+        unsafe { std::env::remove_var("ACORN_PROFILE") };
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/src-tauri/crates/acorn-daemon/src/paths.rs
+++ b/src-tauri/crates/acorn-daemon/src/paths.rs
@@ -2,10 +2,10 @@
 //! daemon, app, and `acornd` CLI clients all derive the same locations
 //! without each rolling its own `directories::ProjectDirs` call.
 //!
-//! macOS layout (production):
+//! macOS layout (production profile):
 //!
 //! ```text
-//! ~/Library/Application Support/io.im-ian.acorn/
+//! ~/Library/Application Support/io.im-ian.acorn/profiles/prod/
 //! ├── sessions.json           (app-owned, untouched by the daemon)
 //! ├── projects.json           (app-owned)
 //! ├── ipc.sock                (in-process IPC socket for the legacy CLI)
@@ -21,18 +21,12 @@
 //!     └── <utc-timestamp>.log (panic / abnormal-exit captures)
 //! ```
 //!
-//! Test override: every helper consults `ACORN_DATA_DIR` first. Set this in
-//! tests to redirect every artifact into a `tempdir` without monkey-patching
-//! `directories` globally.
+//! Test override: every helper consults `ACORN_DATA_DIR` first. When unset,
+//! `ACORN_PROFILE` selects a profile below `io.im-ian.acorn/profiles/`.
 
 use std::path::PathBuf;
 
-use directories::ProjectDirs;
-
-/// Override env var. When set and non-empty, every helper rebases off this
-/// directory instead of `ProjectDirs`. Tests use this to isolate daemon
-/// state to a tempdir; production never sets it.
-pub const ENV_DATA_DIR_OVERRIDE: &str = "ACORN_DATA_DIR";
+pub use acorn_paths::{ENV_DATA_DIR_OVERRIDE, ENV_PROFILE};
 
 /// Override env var for the daemon control socket. Mirrors the existing
 /// `ACORN_IPC_SOCKET` override pattern used by `acorn_ipc::socket_path`
@@ -45,39 +39,12 @@ pub const ENV_DAEMON_SOCKET_OVERRIDE: &str = "ACORN_DAEMON_SOCKET";
 /// colliding paths.
 pub const ENV_DAEMON_STREAM_OVERRIDE: &str = "ACORN_DAEMON_STREAM_SOCKET";
 
-/// Resolve the data directory, creating it on demand. Returns a `PathBuf`
-/// rather than `&Path` because callers typically want to append to it
-/// without re-rooting on each call.
-///
-/// Debug builds resolve `ProjectDirs` against `acorn-dev` so the daemon's
-/// socket / pidfile / log / metadata land in the same isolated data dir
-/// that `pnpm run tauri dev` uses for the app. Without this the dev app
-/// (`acorn-dev`) and a dev-built `acornd` (`acorn`) would each pick a
-/// different directory and never see each other's sockets. The release
-/// sidecar is built `--release` (see `scripts/build-sidecar.sh`), so it
-/// keeps using `acorn` and stays aligned with the installed app.
+/// Resolve the data directory, creating it on demand. `ACORN_DATA_DIR` wins;
+/// otherwise `ACORN_PROFILE` selects `profiles/<name>` under the stable
+/// `io.im-ian.acorn` app dir. Without `ACORN_PROFILE`, debug builds use
+/// `dev` and release builds use `prod`.
 pub fn data_dir() -> std::io::Result<PathBuf> {
-    if let Ok(over) = std::env::var(ENV_DATA_DIR_OVERRIDE) {
-        if !over.is_empty() {
-            let p = PathBuf::from(over);
-            std::fs::create_dir_all(&p)?;
-            return Ok(p);
-        }
-    }
-    let app_name = if cfg!(debug_assertions) {
-        "acorn-dev"
-    } else {
-        "acorn"
-    };
-    let pd = ProjectDirs::from("io", "im-ian", app_name).ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "could not resolve project data directory",
-        )
-    })?;
-    let p = pd.data_dir().to_path_buf();
-    std::fs::create_dir_all(&p)?;
-    Ok(p)
+    acorn_paths::data_dir()
 }
 
 /// Daemon control socket path. Honors `ACORN_DAEMON_SOCKET` override.
@@ -172,7 +139,7 @@ mod tests {
         let _g = ENV_LOCK.lock();
         unsafe {
             std::env::remove_var(ENV_DATA_DIR_OVERRIDE);
-            std::env::set_var("ACORN_PROFILE", "unit-test");
+            std::env::set_var(ENV_PROFILE, "unit-test");
         }
 
         let dir = data_dir().unwrap();
@@ -190,7 +157,7 @@ mod tests {
             "profile data should live under profiles/<name>, got {dir:?}"
         );
 
-        unsafe { std::env::remove_var("ACORN_PROFILE") };
+        unsafe { std::env::remove_var(ENV_PROFILE) };
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/crates/acorn-ipc/Cargo.toml
+++ b/src-tauri/crates/acorn-ipc/Cargo.toml
@@ -16,8 +16,8 @@ name = "acorn-ipc"
 path = "src/bin/acorn-ipc.rs"
 
 [dependencies]
+acorn-paths = { path = "../acorn-paths" }
 serde = { workspace = true }
 serde_json = { workspace = true }
-directories = { workspace = true }
 base64 = { workspace = true }
 clap = { workspace = true }

--- a/src-tauri/crates/acorn-ipc/src/socket_path.rs
+++ b/src-tauri/crates/acorn-ipc/src/socket_path.rs
@@ -5,24 +5,10 @@
 //! Resolution order:
 //! 1. `ACORN_IPC_SOCKET` env (override; takes precedence so test harnesses
 //!    can point at an isolated path).
-//! 2. `<data_dir>/ipc.sock`, where `data_dir` matches what the app uses for
-//!    `sessions.json` and friends (see `crate::persistence::data_dir`).
-//!
-//! The CLI cannot link `persistence::data_dir` without dragging the app's
-//! full module graph into the bin target, so this file re-derives the
-//! same `directories` lookup directly — the two paths must stay in lockstep.
-//!
-//! Debug vs release: `cfg!(debug_assertions)` swaps the project name to
-//! `acorn-dev` so `pnpm run tauri dev` cannot collide with the installed
-//! app. The sidecar `acorn-ipc` CLI is normally built `--release` (see
-//! `scripts/build-sidecar.sh`), so its fallback resolves to `acorn` even
-//! when the host runs debug. This is fine in practice because every
-//! control-session PTY gets `ACORN_IPC_SOCKET` injected and never reaches
-//! the fallback branch.
+//! 2. `<data_dir>/ipc.sock`, where `data_dir` comes from `acorn-paths` and
+//!    matches the app and daemon profile layout.
 
 use std::path::PathBuf;
-
-use directories::ProjectDirs;
 
 const SOCKET_FILE: &str = "ipc.sock";
 const ENV_OVERRIDE: &str = "ACORN_IPC_SOCKET";
@@ -35,14 +21,9 @@ pub fn resolve() -> Result<PathBuf, String> {
             return Ok(PathBuf::from(override_path));
         }
     }
-    let app_name = if cfg!(debug_assertions) {
-        "acorn-dev"
-    } else {
-        "acorn"
-    };
-    let project_dirs = ProjectDirs::from("io", "im-ian", app_name)
-        .ok_or_else(|| "could not resolve project data directory".to_string())?;
-    Ok(project_dirs.data_dir().join(SOCKET_FILE))
+    Ok(acorn_paths::data_dir()
+        .map_err(|err| err.to_string())?
+        .join(SOCKET_FILE))
 }
 
 #[cfg(test)]
@@ -74,15 +55,26 @@ mod tests {
     fn falls_back_to_data_dir() {
         let _guard = ENV_LOCK.lock().expect("env lock");
         let prev = std::env::var(ENV_OVERRIDE).ok();
+        let prev_profile = std::env::var(acorn_paths::ENV_PROFILE).ok();
         unsafe {
             std::env::remove_var(ENV_OVERRIDE);
+            std::env::set_var(acorn_paths::ENV_PROFILE, "ipc-test");
         }
         let resolved = resolve().expect("default resolves");
         assert!(resolved.ends_with(SOCKET_FILE));
+        assert!(
+            resolved.ends_with("profiles/ipc-test/ipc.sock"),
+            "fallback socket should use the selected profile data dir, got {resolved:?}"
+        );
         unsafe {
             if let Some(v) = prev {
                 std::env::set_var(ENV_OVERRIDE, v);
             }
+            match prev_profile {
+                Some(v) => std::env::set_var(acorn_paths::ENV_PROFILE, v),
+                None => std::env::remove_var(acorn_paths::ENV_PROFILE),
+            }
         }
+        let _ = std::fs::remove_dir_all(resolved.parent().unwrap());
     }
 }

--- a/src-tauri/crates/acorn-paths/Cargo.toml
+++ b/src-tauri/crates/acorn-paths/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "acorn-paths"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+name = "acorn_paths"
+
+[dependencies]
+directories = { workspace = true }

--- a/src-tauri/crates/acorn-paths/src/lib.rs
+++ b/src-tauri/crates/acorn-paths/src/lib.rs
@@ -11,8 +11,8 @@ use directories::ProjectDirs;
 pub const ENV_DATA_DIR_OVERRIDE: &str = "ACORN_DATA_DIR";
 pub const ENV_PROFILE: &str = "ACORN_PROFILE";
 
-const PROD_PROFILE: &str = "prod";
-const DEV_PROFILE: &str = "dev";
+pub const PROD_PROFILE: &str = "prod";
+pub const DEV_PROFILE: &str = "dev";
 
 pub fn default_profile() -> &'static str {
     if cfg!(debug_assertions) {

--- a/src-tauri/crates/acorn-paths/src/lib.rs
+++ b/src-tauri/crates/acorn-paths/src/lib.rs
@@ -1,0 +1,128 @@
+//! Shared filesystem path resolution for the Acorn app, daemon, and CLIs.
+//!
+//! The macOS application identity stays rooted at `io.im-ian.acorn`; runtime
+//! state is isolated below that directory with a profile segment.
+
+use std::io;
+use std::path::PathBuf;
+
+use directories::ProjectDirs;
+
+pub const ENV_DATA_DIR_OVERRIDE: &str = "ACORN_DATA_DIR";
+pub const ENV_PROFILE: &str = "ACORN_PROFILE";
+
+const PROD_PROFILE: &str = "prod";
+const DEV_PROFILE: &str = "dev";
+
+pub fn default_profile() -> &'static str {
+    if cfg!(debug_assertions) {
+        DEV_PROFILE
+    } else {
+        PROD_PROFILE
+    }
+}
+
+fn profile_from_env() -> io::Result<Option<String>> {
+    let Ok(raw) = std::env::var(ENV_PROFILE) else {
+        return Ok(None);
+    };
+    let profile = raw.trim();
+    if profile.is_empty() {
+        return Ok(None);
+    }
+    let valid = profile
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'));
+    if !valid {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{ENV_PROFILE} contains unsupported path characters"),
+        ));
+    }
+    Ok(Some(profile.to_string()))
+}
+
+pub fn effective_profile() -> io::Result<String> {
+    Ok(profile_from_env()?.unwrap_or_else(|| default_profile().to_string()))
+}
+
+pub fn base_data_dir() -> io::Result<PathBuf> {
+    let pd = ProjectDirs::from("io", "im-ian", "acorn").ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "could not resolve project data directory",
+        )
+    })?;
+    Ok(pd.data_dir().to_path_buf())
+}
+
+pub fn data_dir() -> io::Result<PathBuf> {
+    if let Ok(over) = std::env::var(ENV_DATA_DIR_OVERRIDE) {
+        if !over.is_empty() {
+            let p = PathBuf::from(over);
+            std::fs::create_dir_all(&p)?;
+            return Ok(p);
+        }
+    }
+
+    let dir = base_data_dir()?.join("profiles").join(effective_profile()?);
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn profile_env_selects_subdir_under_acorn_app_dir() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(ENV_DATA_DIR_OVERRIDE);
+            std::env::set_var(ENV_PROFILE, "unit-test");
+        }
+
+        let dir = data_dir().unwrap();
+        let rendered = dir.to_string_lossy();
+        assert!(rendered.contains("io.im-ian.acorn") || rendered.contains("acorn"));
+        assert!(!rendered.contains("acorn-dev"));
+        assert!(dir.ends_with("profiles/unit-test"));
+
+        unsafe { std::env::remove_var(ENV_PROFILE) };
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn data_dir_override_wins_over_profile() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = PathBuf::from("/tmp").join(format!("acorn-paths-{}", std::process::id()));
+        unsafe {
+            std::env::set_var(ENV_DATA_DIR_OVERRIDE, &tmp);
+            std::env::set_var(ENV_PROFILE, "ignored");
+        }
+
+        assert_eq!(data_dir().unwrap(), tmp);
+
+        unsafe {
+            std::env::remove_var(ENV_DATA_DIR_OVERRIDE);
+            std::env::remove_var(ENV_PROFILE);
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn profile_rejects_path_traversal() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(ENV_DATA_DIR_OVERRIDE);
+            std::env::set_var(ENV_PROFILE, "../prod");
+        }
+
+        assert_eq!(data_dir().unwrap_err().kind(), io::ErrorKind::InvalidInput);
+
+        unsafe { std::env::remove_var(ENV_PROFILE) };
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1188,6 +1188,13 @@ pub async fn pty_spawn<R: Runtime>(
         tracing::warn!(%id, "agent state dir setup failed; resume modal will be inactive for this session");
     }
 
+    if let Ok(data_dir) = acorn_daemon::paths::data_dir() {
+        effective_env.insert(
+            acorn_daemon::paths::ENV_DATA_DIR_OVERRIDE.to_string(),
+            data_dir.display().to_string(),
+        );
+    }
+
     // OSC 7 emitter — only zsh needs file-side help (bash/fish self-serve).
     // Override `ZDOTDIR` with Acorn's staged dir so our `.zshrc` runs; stash
     // the user's original under `ACORN_USER_ZDOTDIR` so the staged rc can
@@ -1206,7 +1213,11 @@ pub async fn pty_spawn<R: Runtime>(
             .canonicalize()
             .map(|path| path == shell_init_dir)
             .unwrap_or(false);
-        if user_zdotdir.is_empty() || points_at_shell_init {
+        let points_at_acorn_shell_init = Path::new(&user_zdotdir)
+            .canonicalize()
+            .map(|path| crate::shell_init::is_shell_init_dir(&path))
+            .unwrap_or(false);
+        if user_zdotdir.is_empty() || points_at_shell_init || points_at_acorn_shell_init {
             user_zdotdir = effective_env
                 .get("HOME")
                 .cloned()

--- a/src-tauri/src/daemon_bridge.rs
+++ b/src-tauri/src/daemon_bridge.rs
@@ -204,7 +204,12 @@ impl DaemonBridge {
         }
         // `--detach` so the daemon survives the app's exit. Spawn
         // returns immediately; the detached grandchild keeps running.
-        Command::new(&path).arg("serve").arg("--detach").spawn()?;
+        let data_dir = paths::data_dir()?;
+        Command::new(&path)
+            .arg("serve")
+            .arg("--detach")
+            .env(paths::ENV_DATA_DIR_OVERRIDE, data_dir)
+            .spawn()?;
         // Wait for the socket to come up.
         let deadline = Instant::now() + SOCKET_WAIT_TIMEOUT;
         while Instant::now() < deadline {

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -214,4 +214,33 @@ mod tests {
         );
         let _ = fs::remove_dir_all(&tmp);
     }
+
+    #[test]
+    fn copies_legacy_persistence_file_only_when_profile_missing() {
+        let tmp = std::env::temp_dir().join(format!(
+            "acorn-persist-migrate-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let legacy = tmp.join("legacy");
+        let profile = tmp.join("profile");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::create_dir_all(&profile).unwrap();
+
+        fs::write(legacy.join(SESSIONS_FILE), b"legacy").unwrap();
+        copy_legacy_file_if_missing(&legacy, &profile, SESSIONS_FILE).unwrap();
+        assert_eq!(fs::read(profile.join(SESSIONS_FILE)).unwrap(), b"legacy");
+
+        fs::write(legacy.join(PROJECTS_FILE), b"legacy-projects").unwrap();
+        fs::write(profile.join(PROJECTS_FILE), b"profile-projects").unwrap();
+        copy_legacy_file_if_missing(&legacy, &profile, PROJECTS_FILE).unwrap();
+        assert_eq!(
+            fs::read(profile.join(PROJECTS_FILE)).unwrap(),
+            b"profile-projects"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
 }

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -54,8 +54,21 @@ fn copy_legacy_file_if_missing(
     Ok(())
 }
 
+fn data_dir_override_is_set() -> bool {
+    std::env::var(acorn_paths::ENV_DATA_DIR_OVERRIDE)
+        .map(|value| !value.is_empty())
+        .unwrap_or(false)
+}
+
+fn should_migrate_legacy_prod_files() -> AppResult<bool> {
+    if data_dir_override_is_set() {
+        return Ok(false);
+    }
+    Ok(acorn_paths::effective_profile()? == acorn_paths::PROD_PROFILE)
+}
+
 fn migrate_legacy_prod_files(profile_dir: &Path) -> AppResult<()> {
-    if acorn_paths::effective_profile()? != acorn_paths::PROD_PROFILE {
+    if !should_migrate_legacy_prod_files()? {
         return Ok(());
     }
     let legacy_base = acorn_paths::base_data_dir()?;
@@ -203,6 +216,9 @@ pub fn save_projects(projects: &[Project]) -> AppResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn data_dir_is_resolvable() {
@@ -271,5 +287,18 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn legacy_migration_skips_explicit_data_dir_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var(acorn_paths::ENV_DATA_DIR_OVERRIDE, "/tmp/acorn-explicit-data-dir");
+            std::env::remove_var(acorn_paths::ENV_PROFILE);
+        }
+
+        assert!(!should_migrate_legacy_prod_files().unwrap());
+
+        unsafe { std::env::remove_var(acorn_paths::ENV_DATA_DIR_OVERRIDE) };
     }
 }

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -2,8 +2,6 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use directories::ProjectDirs;
-
 use crate::error::{AppError, AppResult};
 use acorn_session::{Project, Session};
 
@@ -44,19 +42,11 @@ fn backup_corrupt_file(path: &Path) {
 
 /// Resolve the application's data directory, creating it if missing.
 ///
-/// Debug builds (`pnpm run tauri dev`) write to `acorn-dev` so local testing
-/// does not clobber the installed Acorn's sessions/projects.
+/// Runtime state lives under the stable `io.im-ian.acorn` app dir, split by
+/// `ACORN_PROFILE` or by the build default (`dev` for debug, `prod` for
+/// release). `ACORN_DATA_DIR` can still redirect the whole tree for tests.
 pub fn data_dir() -> AppResult<PathBuf> {
-    let app_name = if cfg!(debug_assertions) {
-        "acorn-dev"
-    } else {
-        "acorn"
-    };
-    let project_dirs = ProjectDirs::from("io", "im-ian", app_name)
-        .ok_or_else(|| AppError::Other("could not resolve project data directory".to_string()))?;
-    let dir = project_dirs.data_dir().to_path_buf();
-    fs::create_dir_all(&dir)?;
-    Ok(dir)
+    Ok(acorn_paths::data_dir()?)
 }
 
 fn sessions_path() -> AppResult<PathBuf> {

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -40,13 +40,42 @@ fn backup_corrupt_file(path: &Path) {
     }
 }
 
+fn copy_legacy_file_if_missing(
+    legacy_base: &Path,
+    profile_dir: &Path,
+    file_name: &str,
+) -> std::io::Result<()> {
+    let source = legacy_base.join(file_name);
+    let target = profile_dir.join(file_name);
+    if target.exists() || !source.is_file() {
+        return Ok(());
+    }
+    fs::copy(source, target)?;
+    Ok(())
+}
+
+fn migrate_legacy_prod_files(profile_dir: &Path) -> AppResult<()> {
+    if acorn_paths::effective_profile()? != acorn_paths::PROD_PROFILE {
+        return Ok(());
+    }
+    let legacy_base = acorn_paths::base_data_dir()?;
+    if legacy_base == profile_dir {
+        return Ok(());
+    }
+    copy_legacy_file_if_missing(&legacy_base, profile_dir, SESSIONS_FILE)?;
+    copy_legacy_file_if_missing(&legacy_base, profile_dir, PROJECTS_FILE)?;
+    Ok(())
+}
+
 /// Resolve the application's data directory, creating it if missing.
 ///
 /// Runtime state lives under the stable `io.im-ian.acorn` app dir, split by
 /// `ACORN_PROFILE` or by the build default (`dev` for debug, `prod` for
 /// release). `ACORN_DATA_DIR` can still redirect the whole tree for tests.
 pub fn data_dir() -> AppResult<PathBuf> {
-    Ok(acorn_paths::data_dir()?)
+    let dir = acorn_paths::data_dir()?;
+    migrate_legacy_prod_files(&dir)?;
+    Ok(dir)
 }
 
 fn sessions_path() -> AppResult<PathBuf> {

--- a/src-tauri/src/shell_init.rs
+++ b/src-tauri/src/shell_init.rs
@@ -61,6 +61,19 @@ fn ensure_shell_init_dir_at(base: &Path) -> io::Result<PathBuf> {
     Ok(dir)
 }
 
+pub(crate) fn is_shell_init_dir(path: &Path) -> bool {
+    let zshenv = path.join(ZSHENV_NAME);
+    let zshrc = path.join(ZSHRC_NAME);
+    path.file_name()
+        .is_some_and(|name| name == SHELL_INIT_DIR_NAME)
+        && fs::read_to_string(zshenv)
+            .map(|body| body.contains("Acorn zsh env init."))
+            .unwrap_or(false)
+        && fs::read_to_string(zshrc)
+            .map(|body| body.contains("Acorn zsh interactive init."))
+            .unwrap_or(false)
+}
+
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
@@ -153,6 +166,14 @@ mod tests {
         let a = ensure_shell_init_dir_at(base.path()).unwrap();
         let b = ensure_shell_init_dir_at(base.path()).unwrap();
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn detects_acorn_shell_init_dirs() {
+        let base = ScratchDir::new("detect");
+        let dir = ensure_shell_init_dir_at(base.path()).unwrap();
+        assert!(is_shell_init_dir(&dir));
+        assert!(!is_shell_init_dir(base.path()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This moves dev/prod runtime isolation under a stable Acorn app data root and prevents Acorn shell-init dirs from being reused as user zsh config.

1. **Shared profile paths:** Added `acorn-paths` so app persistence, daemon paths, and `acorn-ipc` fallback sockets resolve through `ACORN_DATA_DIR`, then `ACORN_PROFILE`, then debug=`dev` / release=`prod`.
2. **Runtime env propagation:** The app now passes the resolved `ACORN_DATA_DIR` into spawned daemons and PTY children so release-built sidecars and shell commands stay on the same profile.
3. **Shell-init recursion guard:** PTY spawn now treats any Acorn-managed `shell-init` directory as internal and falls back to `$HOME` for `ACORN_USER_ZDOTDIR`, avoiding prod/dev staged `.zshenv` recursion.
4. **Prod file carry-forward:** Existing root-level prod `sessions.json` and `projects.json` are copied into `profiles/prod` on first access when the profile files do not already exist.
5. **Docs:** README and control-session docs now describe profile data dirs and the `ACORN_PROFILE` / `ACORN_DATA_DIR` override model.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Dev/prod data isolation | Debug builds used a separate `io.im-ian.acorn-dev` app dir. | All builds use `io.im-ian.acorn/profiles/<profile>`, with debug defaulting to `dev` and release to `prod`. |
| IPC/daemon alignment | App, IPC fallback, and daemon each duplicated path logic. | Shared resolver keeps persistence, IPC socket, daemon sockets, pid/log, and shell-init in one profile. |
| zsh startup reliability | A sibling Acorn shell-init dir could be mistaken for user dotfiles and recurse. | Acorn shell-init dirs are detected and skipped as user `ZDOTDIR` targets. |
| Existing prod sessions/projects | Root-level prod files would otherwise be missed after the profile move. | Missing `profiles/prod` files are seeded from the legacy root files without overwriting newer profile data. |
| Developer docs | Runtime data layout was implicit in code comments. | Source-build and control-session docs mention profile dirs and env overrides. |

## Design notes

`ACORN_DATA_DIR` remains the strongest override for tests and explicit launches. `ACORN_PROFILE` is validated to simple path-safe profile names before it becomes a `profiles/<name>` segment, so values like `../prod` are rejected instead of traversing out of the data root.

The daemon spawn path passes `ACORN_DATA_DIR` rather than relying on the sidecar build profile. This matters because bundled sidecars may be release-built even when the host app is running a dev profile.

Legacy prod migration is intentionally limited to app-owned `sessions.json` and `projects.json`; sockets, pid files, logs, staged shell-init files, and daemon metadata can be recreated under the new profile directory. Explicit `ACORN_DATA_DIR` overrides skip the legacy copy path so isolated test/custom dirs stay isolated.

## Follow-up (not in this PR)

1. Consider a cleanup path for stale legacy root files once the profile layout has shipped and settled.

## Test plan

- [x] `cargo test -p acorn-daemon paths::tests::profile_env_selects_profile_subdir_under_acorn_app_dir` failed before implementation with `acorn-dev`, then passed after the resolver change.
- [x] `cargo test -p acorn persistence::tests::copies_legacy_persistence_file_only_when_profile_missing` failed before migration implementation, then passed after adding the carry-forward helper.
- [x] `pnpm run dev:sidecar` completed and staged local sidecar binaries for Tauri build-script checks.
- [x] `cargo test -p acorn-paths` passed: 3 tests.
- [x] `cargo test -p acorn-daemon paths::tests` passed: 3 tests.
- [x] `cargo test -p acorn-ipc socket_path::tests` passed: 2 tests.
- [x] `cargo test -p acorn persistence::tests` passed: 5 tests.
- [x] `cargo test -p acorn shell_init::tests::detects_acorn_shell_init_dirs` passed.
- [x] `env -u ZDOTDIR -u ACORN_USER_ZDOTDIR ACORN_PROFILE=dev pnpm run tauri dev` launched successfully and logged `profiles/dev` paths.

## Notes

`pnpm run dev:sidecar` created ignored files under `src-tauri/binaries/` so the Tauri build script could validate externalBin paths locally. Those generated binaries are not part of the PR.