### PR TITLE
feat(github): add PR row branch and CI toggles

### DIFF
--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -79,6 +79,15 @@ const labeledPullRequest = {
   ],
 };
 
+const detailedPullRequest = {
+  ...labeledPullRequest,
+  number: 248,
+  title: "Add PR row display options",
+  head_branch: "display-head",
+  base_branch: "display-base",
+  checks: { passed: 1, failed: 0, pending: 1 },
+};
+
 async function flushPromises() {
   await act(async () => {
     await Promise.resolve();
@@ -338,5 +347,58 @@ describe("RightPanel background tab loading", () => {
     expect(container.textContent).toContain("Hide git tabs outside repositories");
     expect(container.textContent).not.toContain("frontend");
     expect(container.textContent).not.toContain("fix");
+  });
+
+  it("hides PR row branches when the GitHub setting is disabled", async () => {
+    useSettings.setState({
+      settings: {
+        ...structuredClone(DEFAULT_SETTINGS),
+        github: {
+          ...DEFAULT_SETTINGS.github,
+          showBranches: false,
+        },
+      },
+    });
+    useAppStore.setState({ rightTab: "prs" });
+    mockApi.listPullRequests.mockResolvedValue({
+      kind: "ok",
+      items: [detailedPullRequest],
+      account: "tester",
+    });
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+
+    expect(container.textContent).toContain("Add PR row display options");
+    expect(container.textContent).not.toContain("display-head");
+    expect(container.textContent).not.toContain("display-base");
+  });
+
+  it("hides PR row CI status when the GitHub setting is disabled", async () => {
+    useSettings.setState({
+      settings: {
+        ...structuredClone(DEFAULT_SETTINGS),
+        github: {
+          ...DEFAULT_SETTINGS.github,
+          showChecks: false,
+        },
+      },
+    });
+    useAppStore.setState({ rightTab: "prs" });
+    mockApi.listPullRequests.mockResolvedValue({
+      kind: "ok",
+      items: [detailedPullRequest],
+      account: "tester",
+    });
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+
+    expect(container.textContent).toContain("Add PR row display options");
+    expect(container.textContent).not.toContain("1/2");
   });
 });

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -2391,6 +2391,8 @@ function PullRequestsTab({
   );
   const showAvatars = useSettings((s) => s.settings.github.showAvatars);
   const showLabels = useSettings((s) => s.settings.github.showLabels);
+  const showBranches = useSettings((s) => s.settings.github.showBranches);
+  const showChecks = useSettings((s) => s.settings.github.showChecks);
   const [stateFilter, setStateFilter] = useState<PrStateFilter>("open");
   const [listsByState, setListsByState] = useState(() =>
     initialPrListStates(repoPath),
@@ -2603,6 +2605,8 @@ function PullRequestsTab({
                 pr={pr}
                 showAvatar={showAvatars}
                 showLabels={showLabels}
+                showBranches={showBranches}
+                showChecks={showChecks}
                 onOpen={() => onOpenDetail(pr.number)}
                 onContextMenu={(e) => rowActions.openContextMenu(e, pr)}
               />
@@ -3430,6 +3434,8 @@ function PrRow({
   surface = "panel",
   showAvatar = false,
   showLabels = true,
+  showBranches = true,
+  showChecks = true,
 }: {
   pr: PullRequestInfo;
   onOpen: () => void;
@@ -3448,6 +3454,10 @@ function PrRow({
   showAvatar?: boolean;
   /** Render GitHub label chips next to the title. */
   showLabels?: boolean;
+  /** Render head/base branch names in the metadata row. */
+  showBranches?: boolean;
+  /** Render CI/check status in the metadata row. */
+  showChecks?: boolean;
 }) {
   const t = useTranslation();
   const hoverBg =
@@ -3520,22 +3530,28 @@ function PrRow({
           {showAvatar ? <AuthorAvatar login={pr.author} size={14} /> : null}
           <span className="truncate">{pr.author}</span>
         </span>
-        <span className="opacity-50">·</span>
-        <span className="flex min-w-0 items-center gap-1">
-          <Tooltip
-            label={`${pr.head_branch} → ${pr.base_branch}`}
-            side="top"
-            multiline
-            className="min-w-0"
-          >
-            <span className="flex min-w-0 items-center gap-1 font-mono">
-              <span className="truncate">{pr.head_branch}</span>
-              <span className="shrink-0">→</span>
-              <span className="truncate">{pr.base_branch}</span>
+        {showBranches || showChecks ? (
+          <>
+            <span className="opacity-50">·</span>
+            <span className="flex min-w-0 items-center gap-1">
+              {showBranches ? (
+                <Tooltip
+                  label={`${pr.head_branch} → ${pr.base_branch}`}
+                  side="top"
+                  multiline
+                  className="min-w-0"
+                >
+                  <span className="flex min-w-0 items-center gap-1 font-mono">
+                    <span className="truncate">{pr.head_branch}</span>
+                    <span className="shrink-0">→</span>
+                    <span className="truncate">{pr.base_branch}</span>
+                  </span>
+                </Tooltip>
+              ) : null}
+              {showChecks ? <PrChecksBadge checks={pr.checks} /> : null}
             </span>
-          </Tooltip>
-          <PrChecksBadge checks={pr.checks} />
-        </span>
+          </>
+        ) : null}
         <span className="shrink-0 opacity-50">·</span>
         <Tooltip
           label={absoluteTime(toUnixSeconds(pr.updated_at))}
@@ -3583,6 +3599,8 @@ function PullRequestSearchModal({
   const repoPath = open?.repoPath ?? null;
   const showAvatars = useSettings((s) => s.settings.github.showAvatars);
   const showLabels = useSettings((s) => s.settings.github.showLabels);
+  const showBranches = useSettings((s) => s.settings.github.showBranches);
+  const showChecks = useSettings((s) => s.settings.github.showChecks);
   const [rawQuery, setRawQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [stateFilter, setStateFilter] = useState<PrStateFilter>("all");
@@ -3755,6 +3773,8 @@ function PullRequestSearchModal({
                 surface="dialog"
                 showAvatar={showAvatars}
                 showLabels={showLabels}
+                showBranches={showBranches}
+                showChecks={showChecks}
                 onOpen={() => onOpenDetail(pr.number)}
                 onContextMenu={(e) => rowActions.openContextMenu(e, pr)}
               />

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -305,7 +305,7 @@ describe("SettingsModal font controls", () => {
     expect(document.body.textContent).toContain("글꼴 패밀리");
   });
 
-  it("patches the GitHub PR row labels toggle", async () => {
+  it("patches the GitHub PR row display toggles", async () => {
     const patchGithub = vi.fn();
     useSettings.setState({
       settings: cloneSettings(),
@@ -318,21 +318,34 @@ describe("SettingsModal font controls", () => {
     });
     openGithubTab();
 
-    const labelsToggle = Array.from(
-      document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
-    ).find((input) =>
-      input.closest("label")?.textContent?.includes("Show labels"),
-    );
+    const findToggle = (label: string) =>
+      Array.from(
+        document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+      ).find((input) => input.closest("label")?.textContent?.includes(label));
+
+    const labelsToggle = findToggle("Show labels");
+    const branchesToggle = findToggle("Show branches");
+    const checksToggle = findToggle("Show CI status");
 
     expect(document.body.textContent).toContain("Show labels");
+    expect(document.body.textContent).toContain("Show branches");
+    expect(document.body.textContent).toContain("Show CI status");
     expect(labelsToggle).toBeInstanceOf(HTMLInputElement);
+    expect(branchesToggle).toBeInstanceOf(HTMLInputElement);
+    expect(checksToggle).toBeInstanceOf(HTMLInputElement);
     expect(labelsToggle?.checked).toBe(true);
+    expect(branchesToggle?.checked).toBe(true);
+    expect(checksToggle?.checked).toBe(true);
 
     act(() => {
       labelsToggle?.click();
+      branchesToggle?.click();
+      checksToggle?.click();
     });
 
     expect(patchGithub).toHaveBeenCalledWith({ showLabels: false });
+    expect(patchGithub).toHaveBeenCalledWith({ showBranches: false });
+    expect(patchGithub).toHaveBeenCalledWith({ showChecks: false });
   });
 });
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -609,6 +609,18 @@ function GithubSettings() {
           checked={settings.github.showLabels}
           onChange={(v) => patchGithub({ showLabels: v })}
         />
+        <CheckboxRow
+          label={st(t, "settings.github.showBranches.label")}
+          description={st(t, "settings.github.showBranches.description")}
+          checked={settings.github.showBranches}
+          onChange={(v) => patchGithub({ showBranches: v })}
+        />
+        <CheckboxRow
+          label={st(t, "settings.github.showChecks.label")}
+          description={st(t, "settings.github.showChecks.description")}
+          checked={settings.github.showChecks}
+          onChange={(v) => patchGithub({ showChecks: v })}
+        />
       </Field>
     </section>
   );

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -105,6 +105,14 @@ describe("github settings", () => {
     expect(DEFAULT_SETTINGS.github.showLabels).toBe(true);
   });
 
+  it("shows PR row branches by default", () => {
+    expect(DEFAULT_SETTINGS.github.showBranches).toBe(true);
+  });
+
+  it("shows PR row CI status by default", () => {
+    expect(DEFAULT_SETTINGS.github.showChecks).toBe(true);
+  });
+
   it("loads a persisted PR row labels preference", async () => {
     localStorage.setItem(
       STORAGE_KEY,
@@ -115,6 +123,21 @@ describe("github settings", () => {
     const { useSettings } = await import("./settings");
 
     expect(useSettings.getState().settings.github.showLabels).toBe(false);
+  });
+
+  it("loads persisted PR row branch and CI status preferences", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        github: { showBranches: false, showChecks: false },
+      }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.github.showBranches).toBe(false);
+    expect(useSettings.getState().settings.github.showChecks).toBe(false);
   });
 });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -233,6 +233,10 @@ export interface AcornSettings {
     showAvatars: boolean;
     /** Show GitHub labels next to each PR row title. */
     showLabels: boolean;
+    /** Show source and target branches on each PR row. */
+    showBranches: boolean;
+    /** Show CI/check status on each PR row. */
+    showChecks: boolean;
   };
   /**
    * Sidebar session-row presentation. Mirrors Warp's "View as / Pane
@@ -354,6 +358,8 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     refreshIntervalMs: 60_000,
     showAvatars: true,
     showLabels: true,
+    showBranches: true,
+    showChecks: true,
   },
   sessionDisplay: {
     title: "name",
@@ -542,6 +548,8 @@ interface LegacyPullRequests {
   refreshIntervalMs?: number;
   showAvatars?: boolean;
   showLabels?: boolean;
+  showBranches?: boolean;
+  showChecks?: boolean;
 }
 
 function loadSettings(): AcornSettings {
@@ -705,6 +713,18 @@ function loadSettings(): AcornSettings {
             : typeof parsed.pullRequests?.showLabels === "boolean"
               ? parsed.pullRequests.showLabels
               : DEFAULT_SETTINGS.github.showLabels,
+        showBranches:
+          typeof parsed.github?.showBranches === "boolean"
+            ? parsed.github.showBranches
+            : typeof parsed.pullRequests?.showBranches === "boolean"
+              ? parsed.pullRequests.showBranches
+              : DEFAULT_SETTINGS.github.showBranches,
+        showChecks:
+          typeof parsed.github?.showChecks === "boolean"
+            ? parsed.github.showChecks
+            : typeof parsed.pullRequests?.showChecks === "boolean"
+              ? parsed.pullRequests.showChecks
+              : DEFAULT_SETTINGS.github.showChecks,
       },
       sessionDisplay: {
         title: normalizeSessionTitle(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -88,7 +88,7 @@
       "manualRefresh": "Manual refresh (the icon in each tab) always works regardless of this interval.",
       "listDensity": {
         "label": "List density",
-        "hint": "Author avatars make rows easier to scan at a glance, but each row gets thicker."
+        "hint": "Choose which optional details appear in each PR row."
       },
       "showAuthorAvatars": {
         "label": "Show author avatars",
@@ -97,6 +97,14 @@
       "showLabels": {
         "label": "Show labels",
         "description": "Render GitHub labels next to each PR row title."
+      },
+      "showBranches": {
+        "label": "Show branches",
+        "description": "Render the source and target branch names in each PR row."
+      },
+      "showChecks": {
+        "label": "Show CI status",
+        "description": "Render the CI/check completion summary in each PR row."
       }
     },
     "appearance": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -88,7 +88,7 @@
       "manualRefresh": "수동 새로고침(각 탭의 아이콘)은 이 간격과 관계없이 항상 작동합니다.",
       "listDensity": {
         "label": "목록 밀도",
-        "hint": "작성자 아바타는 행을 한눈에 훑기 쉽게 하지만 각 행이 더 두꺼워집니다."
+        "hint": "각 PR 행에 표시할 선택 정보를 고릅니다."
       },
       "showAuthorAvatars": {
         "label": "작성자 아바타 표시",
@@ -97,6 +97,14 @@
       "showLabels": {
         "label": "라벨 표시",
         "description": "각 PR 행 제목 옆에 GitHub 라벨을 표시합니다."
+      },
+      "showBranches": {
+        "label": "브랜치 표시",
+        "description": "각 PR 행에 소스 및 대상 브랜치 이름을 표시합니다."
+      },
+      "showChecks": {
+        "label": "CI 상태 표시",
+        "description": "각 PR 행에 CI/check 완료 요약을 표시합니다."
       }
     },
     "appearance": {


### PR DESCRIPTION
## Summary

This adds two GitHub PR row display options so users can control whether branch metadata and CI status appear in PR rows.

1. **Settings model:** Added github.showBranches and github.showChecks, both defaulting to true to preserve the current PR row layout.
2. **Settings UI:** Added GitHub > List density checkboxes for branch metadata and CI status, with English and Korean copy.
3. **PR row rendering:** Wired both options through the main PR list and PR search modal rows.
4. **Regression coverage:** Added settings loader, Settings modal, and RightPanel tests for the two new preferences.

## Expected impact

| Area | Impact |
| --- | --- |
| GitHub settings | Two new PR row display toggles under List density. |
| PR rows | Branch and CI/check status remain visible by default; disabling each option hides only that row detail. |
| Existing users | No visual change unless they turn an option off. |

## Design notes

- The options live beside showAvatars and showLabels because all four settings control optional PR row density.
- The default values are true to keep existing behavior stable after upgrade.
- Legacy pullRequests fallback accepts the new fields for consistency with the existing GitHub settings migration path.

## Test plan

- [x] pnpm test -- src/lib/settings.test.ts src/components/SettingsModal.test.tsx src/components/RightPanel.test.tsx
- [x] pnpm typecheck
- [x] pnpm test
- [x] pnpm exec playwright test tests/e2e/settings-tabs.spec.ts tests/e2e/right-panel.spec.ts --reporter=line
- [x] git diff --check
- [x] Repository privacy scan returned no matches for local user/path identifiers.

## Notes

- Playwright prints the existing NO_COLOR / FORCE_COLOR warning during the e2e run; it did not fail the suite.