### PR TITLE
ci(actions): update workflows for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
     name: Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9.15.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -44,15 +44,15 @@ jobs:
     name: E2E
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9.15.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -69,7 +69,7 @@ jobs:
         run: echo "version=$(node -p "require('./node_modules/@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,15 +23,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9.15.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -44,7 +44,7 @@ jobs:
         run: pnpm run build
 
       - name: Upload frontend artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: frontend-dist
           path: dist/
@@ -66,15 +66,15 @@ jobs:
           - x86_64-apple-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9.15.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -132,7 +132,7 @@ jobs:
       # half MUST stay in the matrix because each macOS target cross-builds
       # `acorn-ipc` / `acornd` for its own triple.
       - name: Download shared frontend bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: frontend-dist
           path: dist/
@@ -212,7 +212,7 @@ jobs:
           echo "dir=$out" >> "$GITHUB_OUTPUT"
 
       - name: Upload bundle artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bundles-${{ matrix.target }}
           path: ${{ steps.stage.outputs.dir }}/**
@@ -230,13 +230,13 @@ jobs:
     needs: frontend
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 9.15.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -244,7 +244,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           name: frontend-dist
           path: dist/
@@ -276,10 +276,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all bundles
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: bundles
           pattern: bundles-*
@@ -399,7 +399,7 @@ jobs:
           cat latest.json
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: ${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions workflow dependencies so CI and release jobs no longer run JavaScript actions on the deprecated Node 20 runtime.

1. **Core GitHub actions:** Bump checkout, setup-node, cache, upload-artifact, and download-artifact to Node 24-compatible major versions.
2. **pnpm setup:** Bump pnpm/action-setup to the current Node 24-compatible major while keeping the pinned pnpm version unchanged.
3. **Release publishing:** Bump softprops/action-gh-release to v3 so publishing also uses the Node 24 runtime.

## Expected impact

| Area | Expected impact |
| --- | --- |
| CI reliability | Removes Node 20 deprecation warnings before GitHub switches default action runtime behavior. |
| Release reliability | Keeps tag-triggered release publishing compatible with Node 24 runners. |
| Runtime behavior | No application behavior change; workflow-only update. |

## Design notes

- Kept the configured project Node version at `22`; this change updates action runtimes, not the app build runtime.
- Kept `pnpm` pinned to `9.15.0` to avoid introducing package-manager drift.
- Used major tags that advertise Node 24 support and verified each tag exists upstream.

## Follow-up (not in this PR)

- Consider pinning actions by SHA if the repo wants stricter supply-chain immutability.

## Test plan

- [x] `git diff --check`
- [x] Parsed `.github/workflows/*.yml` with Ruby YAML loader
- [x] Verified each updated action tag exists with `git ls-remote --tags`

## Notes

- `actionlint` is not installed locally, so full workflow linting was not run here.