### PR TITLE
fix(sidebar): skip close-project modal when project has no sessions

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -747,6 +747,34 @@ describe("removeProject", () => {
   });
 });
 
+describe("requestRemoveProject", () => {
+  it("opens the confirmation modal when the project still has sessions", async () => {
+    await seed(
+      [project(REPO_A, 0), project(REPO_B, 1)],
+      [session("b1", REPO_B)],
+    );
+
+    useAppStore.getState().requestRemoveProject(REPO_B);
+
+    expect(useAppStore.getState().pendingRemoveProject).toBe(REPO_B);
+    expect(mockApi.removeProject).not.toHaveBeenCalled();
+  });
+
+  it("removes the project directly without a confirmation modal when no sessions remain", async () => {
+    await seed([project(REPO_A, 0), project(REPO_B, 1)], []);
+    mockApi.removeProject.mockResolvedValueOnce(undefined);
+    mockApi.listProjects.mockResolvedValueOnce([project(REPO_A, 0)]);
+    mockApi.listSessions.mockResolvedValueOnce([]);
+
+    useAppStore.getState().requestRemoveProject(REPO_B);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(useAppStore.getState().pendingRemoveProject).toBeNull();
+    expect(mockApi.removeProject).toHaveBeenCalledWith(REPO_B, true, false);
+    expect(useAppStore.getState().workspaces[REPO_B]).toBeUndefined();
+  });
+});
+
 describe("reorderProjects", () => {
   it("optimistically reorders, then commits the server-returned order", async () => {
     await seed(

--- a/src/store.ts
+++ b/src/store.ts
@@ -1195,6 +1195,11 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   requestRemoveProject(repoPath) {
+    const hasSessions = get().sessions.some((s) => s.repo_path === repoPath);
+    if (!hasSessions) {
+      void get().removeProject(repoPath, false);
+      return;
+    }
     set({ pendingRemoveProject: repoPath });
   },
 

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -211,7 +211,7 @@ test.describe("sidebar: project lifecycle", () => {
     });
   });
 
-  test("Close project removes the project after confirming", async ({
+  test("Close project skips the confirmation modal when the project has no sessions", async ({
     page,
     tauri,
   }) => {
@@ -248,14 +248,80 @@ test.describe("sidebar: project lifecycle", () => {
     ).toBeVisible();
 
     // Hover the project header to reveal the (visually hidden) Close button,
-    // then click it. This opens the RemoveProjectDialog.
+    // then click it. With no sessions there should be no confirmation dialog.
     const projectRow = page.getByRole("button", { name: "Project demo" });
     await projectRow.hover();
     await page.getByRole("button", { name: "Close project" }).first().click();
 
-    // RemoveProjectDialog renders a Modal without an explicit aria-label,
-    // so we identify it by its heading. With no isolated worktrees the
-    // primary action button is also labeled "Close project".
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expect(page.getByText(/No projects yet/i)).toBeVisible();
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __removeCalls?: unknown[] }).__removeCalls,
+    )) as Array<{ repoPath: string; removeWorktrees: boolean }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0].repoPath).toBe("/tmp/demo");
+    expect(calls[0].removeWorktrees).toBe(false);
+  });
+
+  test("Close project still shows the confirmation modal when sessions exist", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => {
+      const w = window as unknown as { __projectRemoved?: boolean };
+      return w.__projectRemoved
+        ? []
+        : [
+            {
+              repo_path: "/tmp/demo",
+              name: "demo",
+              created_at: "2026-01-01T00:00:00Z",
+              position: 0,
+            },
+          ];
+    });
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __projectRemoved?: boolean };
+      return w.__projectRemoved
+        ? []
+        : [
+            {
+              id: "sess-1",
+              name: "work",
+              repo_path: "/tmp/demo",
+              worktree_path: "/tmp/demo",
+              branch: "main",
+              isolated: false,
+              status: "idle",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:05Z",
+              last_message: null,
+            },
+          ];
+    });
+    await tauri.handle("remove_project", (args) => {
+      const w = window as unknown as {
+        __removeCalls?: unknown[];
+        __projectRemoved?: boolean;
+      };
+      w.__removeCalls = w.__removeCalls ?? [];
+      w.__removeCalls.push(args);
+      w.__projectRemoved = true;
+      return null;
+    });
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("listitem").filter({ hasText: "demo" }),
+    ).toBeVisible();
+
+    const projectRow = page.getByRole("button", { name: "Project demo" });
+    await projectRow.hover();
+    await page.getByRole("button", { name: "Close project" }).first().click();
+
     const confirmDialog = page.getByRole("dialog");
     await expect(
       confirmDialog.getByRole("heading", { name: "Close project" }),


### PR DESCRIPTION
## Summary

Skip the close-project confirmation modal when the target project has no open sessions. Previously, closing an empty project still surfaced a confirmation dialog whose only meaningful branch — "keep vs. delete isolated worktrees" — was unreachable. With no sessions, the modal degenerated to a single "Close project" button, so the prompt added a click without adding any safety.

## Changes

- `src/store.ts` — `requestRemoveProject` checks whether any session matches `repo_path`. If none, it calls `removeProject(repoPath, false)` directly instead of opening the modal.
- `src/store.test.ts` — two new cases:
  - Modal opens (`pendingRemoveProject` set, `api.removeProject` not called) when sessions still exist.
  - Modal skipped (`pendingRemoveProject` stays `null`, `api.removeProject` called with `removeWorktrees=false`) when no sessions remain.
- `tests/e2e/sidebar.spec.ts` — splits the prior "Close project removes the project after confirming" spec into:
  - "Close project skips the confirmation modal when the project has no sessions" — asserts no `role=dialog` appears after clicking the close button and that `remove_project` still fires with `removeWorktrees=false`.
  - "Close project still shows the confirmation modal when sessions exist" — seeds a session via `list_sessions` and asserts the dialog appears and gates removal as before.

## Test plan

- [x] `pnpm exec vitest run src/store.test.ts` — 56 passed / 1 skipped.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm exec playwright test` — 76 passed.
