### PR TITLE
docs(control-sessions): flag dev-profile pollution when launching tauri dev from a control session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,20 @@ pnpm run build          # tsc + vite build
 
 `src-tauri/binaries/acorn-ipc-<target-triple>` is `.gitignore`d, so every fresh checkout — including each new `git worktree add` — starts without it, and Tauri's `externalBin` existence check fails the build before anything else runs. Run `pnpm run build:sidecar` once per worktree (and again after any IPC change); plain `cargo build -p acorn-ipc --bin acorn-ipc` is not enough because it skips the target-tripled staging step. See [`docs/CONTROL_SESSIONS.md`](docs/CONTROL_SESSIONS.md#the-acorn-ipc-cli) for details.
 
+**Launching `tauri dev` from inside a control session.** Acorn injects `ACORN_DATA_DIR` (and `ACORN_AGENT_STATE_DIR`, `ACORN_RESUME_TOKEN`, `ACORN_STAGED_REV`) into every control-session PTY so the bundled CLIs talk to the host profile. `acorn-paths::data_dir` honours `ACORN_DATA_DIR` ahead of the debug/release profile fallback, so a plain `pnpm run tauri dev` from that shell silently runs the debug build against `profiles/prod` — same daemon, same `sessions.json`, same staged shell-init dir as the installed app. Strip the overrides before launching:</p>
+
+```sh
+env -u ACORN_DATA_DIR \
+    -u ACORN_AGENT_STATE_DIR \
+    -u ACORN_RESUME_TOKEN \
+    -u ACORN_STAGED_REV \
+    -u ACORN_USER_ZDOTDIR \
+    ACORN_PROFILE=dev \
+    pnpm run tauri dev
+```
+
+Outside a control session (your own login shell, CI) the overrides aren't set, so a plain `pnpm run tauri dev` already lands on `profiles/dev`. See [`docs/CONTROL_SESSIONS.md`](docs/CONTROL_SESSIONS.md#the-acorn-ipc-cli) for the full env table.
+
 ## Reading webview logs in dev
 
 `vite-console-forward-plugin` is wired in `vite.config.ts` (dev only). Every `console.log` / `warn` / `error` / `info` / `debug` call inside the running webview is POSTed to the Vite dev server and printed to the same terminal `pnpm run tauri dev` is logging to, prefixed with `[browser]`. AI agents and humans can read app logs without opening the WKWebView inspector (which is blocked anyway by the keybinding guards in `src/main.tsx`).

--- a/docs/CONTROL_SESSIONS.md
+++ b/docs/CONTROL_SESSIONS.md
@@ -93,6 +93,36 @@ to select another profile, or `ACORN_DATA_DIR=<path>` to pin all runtime
 state, IPC sockets, daemon sockets, and staged shell init files to an
 explicit directory.
 
+> **Gotcha for agents running inside a control session.** Acorn injects
+> `ACORN_DATA_DIR` into the PTY env so the bundled CLIs talk to the right
+> profile. `acorn-paths::data_dir` resolves `ACORN_DATA_DIR` **before** the
+> profile fallback (see `src-tauri/crates/acorn-paths/src/lib.rs`), so
+> running `pnpm run tauri dev` from that shell makes the debug build inherit
+> the host's `profiles/prod` directory — it reuses the prod sessions, prod
+> daemon socket, and prod sidecar persistence, even though it is a debug
+> binary. The dev app and the installed app then fight over the same daemon
+> and `sessions.json`.
+>
+> When launching `tauri dev` from inside a control session, strip the
+> inherited overrides (and any other prod-only env Acorn injects) and pin
+> the dev profile explicitly:
+>
+> ```sh
+> env -u ACORN_DATA_DIR \
+>     -u ACORN_AGENT_STATE_DIR \
+>     -u ACORN_RESUME_TOKEN \
+>     -u ACORN_STAGED_REV \
+>     -u ACORN_USER_ZDOTDIR \
+>     ACORN_PROFILE=dev \
+>     pnpm run tauri dev
+> ```
+>
+> The same caveat applies to any process that should run in dev-profile
+> isolation while being launched from a control-session shell — including
+> `pnpm exec playwright test` if it spawns the bundled `acornd` sidecar.
+> Outside a control session (your own login shell, CI) there is nothing to
+> strip; debug builds already default to `profiles/dev` on their own.
+
 ### Install
 
 `acorn-ipc` ships inside the Acorn `.app` bundle (Tauri's `externalBin`


### PR DESCRIPTION
## Summary

Document a sharp-edged interaction between control sessions and `pnpm run tauri dev`. Acorn injects `ACORN_DATA_DIR` (and a handful of related state-pointing env vars) into every control-session PTY so the bundled CLIs talk to the host's profile. `acorn-paths::data_dir` honours that override **before** the debug/release profile fallback, so launching `tauri dev` from inside a control session silently runs the debug binary against `profiles/prod`: same daemon, same `sessions.json`, same staged shell-init dir as the installed app. Agents and humans hit this and assumed the dev/prod isolation from #250 was broken — it isn't, but the env override beats it.

This PR is docs-only.

## Changes

- `CLAUDE.md` — new note under "Build / run" calling out the gotcha and showing the env-strip + `ACORN_PROFILE=dev` command to use when launching `tauri dev` from inside a control session.
- `docs/CONTROL_SESSIONS.md` — extends the "Environment variables" subsection with the same warning and command, plus the reminder that outside a control session there is nothing to strip.

## Test plan

- [x] Verified the failure mode: running `pnpm run tauri dev` from a control-session shell launched `target/debug/acorn` with `ACORN_DATA_DIR=…/profiles/prod`, so the dev build resolved the prod data dir.
- [x] Verified the fix: relaunching with `env -u ACORN_DATA_DIR -u ACORN_AGENT_STATE_DIR -u ACORN_RESUME_TOKEN -u ACORN_STAGED_REV -u ACORN_USER_ZDOTDIR ACORN_PROFILE=dev pnpm run tauri dev` produced a dev process scoped to `profiles/dev`.
- [x] Markdown links checked (`docs/CONTROL_SESSIONS.md#the-acorn-ipc-cli`).
