### PR TITLE
chore(release): sync Cargo.lock to 1.4.0

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",


### PR DESCRIPTION
## Summary

The `1.4.0` release commit (`a64f0c9`) bumped `src-tauri/Cargo.toml` to `1.4.0` but left `Cargo.lock` at `1.3.0`. Every subsequent `cargo run` / `cargo build` regenerates the lock and leaves the worktree dirty, which is noisy in `git status` and risks accidental inclusion in unrelated PRs. This PR just commits the regenerated lock so it matches `Cargo.toml`.

## Changes

- `src-tauri/Cargo.lock` — one-line bump of the root `acorn` package version `1.3.0 → 1.4.0`.

## Test plan

- [x] `git status` clean after `cargo metadata --manifest-path src-tauri/Cargo.toml` (locally observed after the commit).
