### PR TITLE
perf(right-panel): lazy-load staged file diffs for faster tab switches

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2085,21 +2085,30 @@ pub async fn list_commits(
     offset: Option<usize>,
     limit: Option<usize>,
 ) -> AppResult<Vec<CommitInfo>> {
-    git_ops::list_commits(
-        &PathBuf::from(repo_path),
-        offset.unwrap_or(0),
-        limit.unwrap_or(50),
-    )
+    run_blocking("list_commits", move || {
+        git_ops::list_commits(
+            &PathBuf::from(repo_path),
+            offset.unwrap_or(0),
+            limit.unwrap_or(50),
+        )
+    })
+    .await
 }
 
 #[tauri::command]
 pub async fn list_staged(repo_path: String) -> AppResult<Vec<StagedFile>> {
-    git_ops::list_staged(&PathBuf::from(repo_path))
+    run_blocking("list_staged", move || {
+        git_ops::list_staged(&PathBuf::from(repo_path))
+    })
+    .await
 }
 
 #[tauri::command]
 pub async fn commit_diff(repo_path: String, sha: String) -> AppResult<DiffPayload> {
-    git_ops::diff_for_commit(&PathBuf::from(repo_path), &sha)
+    run_blocking("commit_diff", move || {
+        git_ops::diff_for_commit(&PathBuf::from(repo_path), &sha)
+    })
+    .await
 }
 
 #[tauri::command]
@@ -2154,7 +2163,18 @@ pub async fn open_in_editor(command: String, args: Vec<String>, path: String) ->
 
 #[tauri::command]
 pub async fn staged_diff(repo_path: String) -> AppResult<DiffPayload> {
-    git_ops::diff_staged(&PathBuf::from(repo_path))
+    run_blocking("staged_diff", move || {
+        git_ops::diff_staged(&PathBuf::from(repo_path))
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn staged_file_diff(repo_path: String, path: String) -> AppResult<DiffPayload> {
+    run_blocking("staged_file_diff", move || {
+        git_ops::diff_staged_file(&PathBuf::from(repo_path), &path)
+    })
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -2,7 +2,7 @@ use git2::{DiffOptions, Repository};
 use serde::Serialize;
 use std::path::Path;
 
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 use crate::worktree::ensure_repo;
 
 #[derive(Debug, Clone, Serialize)]
@@ -312,14 +312,51 @@ pub fn diff_for_commit(repo_path: &Path, sha: &str) -> AppResult<DiffPayload> {
 }
 
 pub fn diff_staged(repo_path: &Path) -> AppResult<DiffPayload> {
+    diff_staged_with_pathspec(repo_path, None)
+}
+
+pub fn diff_staged_file(repo_path: &Path, path: &str) -> AppResult<DiffPayload> {
+    validate_relative_git_path(path)?;
+    diff_staged_with_pathspec(repo_path, Some(path))
+}
+
+fn diff_staged_with_pathspec(repo_path: &Path, pathspec: Option<&str>) -> AppResult<DiffPayload> {
     let repo = ensure_repo(repo_path)?;
     let head_tree = repo.head().ok().and_then(|r| r.peel_to_tree().ok());
     let mut opts = DiffOptions::new();
     opts.include_untracked(true)
         .recurse_untracked_dirs(true)
         .show_untracked_content(true);
+    if let Some(path) = pathspec {
+        opts.pathspec(path);
+    }
     let diff = repo.diff_tree_to_workdir_with_index(head_tree.as_ref(), Some(&mut opts))?;
     collect_diff(&repo, &diff)
+}
+
+fn validate_relative_git_path(path: &str) -> AppResult<()> {
+    if path.trim().is_empty() {
+        return Err(AppError::InvalidPath("empty git path".into()));
+    }
+    let p = Path::new(path);
+    if p.is_absolute() {
+        return Err(AppError::InvalidPath(
+            "git diff path must be relative".into(),
+        ));
+    }
+    for component in p.components() {
+        if matches!(
+            component,
+            std::path::Component::ParentDir
+                | std::path::Component::RootDir
+                | std::path::Component::Prefix(_)
+        ) {
+            return Err(AppError::InvalidPath(
+                "git diff path must stay inside the repository".into(),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn collect_diff(repo: &Repository, diff: &git2::Diff) -> AppResult<DiffPayload> {
@@ -506,14 +543,52 @@ mod tests {
         drop(first);
         drop(repo);
 
-        let payload = diff_for_commit(&root, &second_oid.to_string())
-            .expect("diff for second commit");
+        let payload =
+            diff_for_commit(&root, &second_oid.to_string()).expect("diff for second commit");
         assert_eq!(payload.files.len(), 1);
         let patch = &payload.files[0].patch;
         assert!(
             patch.lines().any(|l| l.starts_with("@@")),
             "patch should contain at least one hunk header, got: {patch:?}",
         );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn diff_staged_file_limits_payload_to_requested_path() {
+        let root = unique_temp_dir("staged-file-pathspec");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        let first_oid = commit_file(&repo, "a.txt", "alpha\n", "init a", &[]);
+        let first = repo.find_commit(first_oid).expect("first commit");
+        let second_oid = commit_file(&repo, "b.txt", "bravo\n", "init b", &[&first]);
+        let _second = repo.find_commit(second_oid).expect("second commit");
+        fs::write(root.join("a.txt"), "alpha\nchanged\n").expect("write a");
+        fs::write(root.join("b.txt"), "bravo\nchanged\n").expect("write b");
+        drop(_second);
+        drop(first);
+        drop(repo);
+
+        let payload = diff_staged_file(&root, "a.txt").expect("diff for a.txt");
+        assert_eq!(payload.files.len(), 1);
+        assert_eq!(payload.files[0].new_path.as_deref(), Some("a.txt"));
+        assert!(
+            payload.files[0].patch.contains("+changed"),
+            "expected selected file patch, got {:?}",
+            payload.files[0].patch
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn diff_staged_file_rejects_paths_outside_repo() {
+        let root = unique_temp_dir("staged-file-path-validation");
+        git2::Repository::init(&root).expect("init repo");
+
+        assert!(diff_staged_file(&root, "../outside.txt").is_err());
+        assert!(diff_staged_file(&root, "/tmp/outside.txt").is_err());
+        assert!(diff_staged_file(&root, "").is_err());
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -327,6 +327,7 @@ pub fn run() {
             commands::is_git_repository,
             commands::open_in_editor,
             commands::staged_diff,
+            commands::staged_file_diff,
             commands::list_pull_requests,
             commands::get_pull_request_detail,
             commands::get_pull_request_commit_diff,

--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -20,6 +20,9 @@ vi.mock("../lib/api", () => ({
     fsWatchSetRoot: vi.fn<() => Promise<void>>(),
     githubOriginSlug: vi.fn<() => Promise<string | null>>(),
     isGitRepository: vi.fn<() => Promise<boolean>>(),
+    listCommits: vi.fn<() => Promise<[]>>(),
+    listStaged: vi.fn<() => Promise<[]>>(),
+    stagedFileDiff: vi.fn<() => Promise<{ files: [] }>>(),
     listPullRequests:
       vi.fn<
         (
@@ -123,6 +126,9 @@ describe("RightPanel background tab loading", () => {
     mockApi.githubOriginSlug.mockResolvedValue("im-ian/acorn");
     mockApi.isGitRepository.mockResolvedValue(true);
     mockApi.fsWatchSetRoot.mockResolvedValue();
+    mockApi.listCommits.mockResolvedValue([]);
+    mockApi.listStaged.mockResolvedValue([]);
+    mockApi.stagedFileDiff.mockResolvedValue({ files: [] });
     mockApi.listPullRequests.mockResolvedValue({
       kind: "ok",
       items: [],

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1989,35 +1989,71 @@ function StagedTab({
 }) {
   const t = useTranslation();
   const cachedStaged = rightPanelCache.getStaged(repoPath);
+  const initialSelectedPath =
+    cachedStaged?.selectedPath &&
+    cachedStaged.files.some((file) => file.path === cachedStaged.selectedPath)
+      ? cachedStaged.selectedPath
+      : (cachedStaged?.files[0]?.path ?? null);
   const [files, setFiles] = useState<StagedFile[]>(
     () => cachedStaged?.files ?? [],
   );
-  const [diff, setDiff] = useState<DiffPayload | null>(
-    () => cachedStaged?.diff ?? null,
+  const [selectedPath, setSelectedPath] = useState<string | null>(
+    () => initialSelectedPath,
   );
-  const [error, setError] = useState<string | null>(null);
+  const [diffByPath, setDiffByPath] = useState<Record<string, DiffPayload>>(
+    () => cachedStaged?.diffByPath ?? {},
+  );
+  const [listError, setListError] = useState<string | null>(null);
+  const [diffError, setDiffError] = useState<string | null>(null);
   const [loadingFirst, setLoadingFirst] = useState(!cachedStaged);
+  const [loadingDiff, setLoadingDiff] = useState(false);
+  const [diffRefreshKey, setDiffRefreshKey] = useState(0);
   const [menu, setMenu] = useState<{
     x: number;
     y: number;
     file: StagedFile;
   } | null>(null);
   const generationRef = useRef(0);
+  const diffGenerationRef = useRef(0);
+  const diffByPathRef = useRef(diffByPath);
+
+  useEffect(() => {
+    diffByPathRef.current = diffByPath;
+  }, [diffByPath]);
+
+  const selectedFile = useMemo(
+    () => files.find((file) => file.path === selectedPath) ?? null,
+    [files, selectedPath],
+  );
+  const selectedDiff = selectedPath ? (diffByPath[selectedPath] ?? null) : null;
 
   const refresh = useCallback(async () => {
     const generation = generationRef.current;
     try {
-      const [f, d] = await Promise.all([
-        api.listStaged(repoPath),
-        api.stagedDiff(repoPath),
-      ]);
+      const f = await api.listStaged(repoPath);
       if (generationRef.current !== generation) return;
+      const nextPaths = new Set(f.map((file) => file.path));
       setFiles(f);
-      setDiff(d);
-      setError(null);
+      setSelectedPath((prev) =>
+        prev && nextPaths.has(prev) ? prev : (f[0]?.path ?? null),
+      );
+      setDiffByPath((prev) => {
+        let changed = false;
+        const next: Record<string, DiffPayload> = {};
+        for (const [path, payload] of Object.entries(prev)) {
+          if (nextPaths.has(path)) {
+            next[path] = payload;
+          } else {
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
+      });
+      setListError(null);
+      setDiffRefreshKey((key) => key + 1);
     } catch (e) {
       if (generationRef.current !== generation) return;
-      setError(String(e));
+      setListError(String(e));
     } finally {
       if (generationRef.current === generation) setLoadingFirst(false);
     }
@@ -2044,11 +2080,39 @@ function StagedTab({
     if (invalidateKey > 0) scheduleRefresh();
   }, [invalidateKey, scheduleRefresh]);
 
+  useEffect(() => {
+    if (!selectedPath) {
+      setLoadingDiff(false);
+      setDiffError(null);
+      return;
+    }
+    const token = ++diffGenerationRef.current;
+    const hasCachedDiff = Boolean(diffByPathRef.current[selectedPath]);
+    setLoadingDiff(!hasCachedDiff);
+    setDiffError(null);
+    void api
+      .stagedFileDiff(repoPath, selectedPath)
+      .then((payload) => {
+        if (diffGenerationRef.current !== token) return;
+        setDiffByPath((prev) => ({ ...prev, [selectedPath]: payload }));
+      })
+      .catch((e) => {
+        if (diffGenerationRef.current !== token) return;
+        setDiffError(String(e));
+      })
+      .finally(() => {
+        if (diffGenerationRef.current === token) setLoadingDiff(false);
+      });
+    return () => {
+      diffGenerationRef.current += 1;
+    };
+  }, [repoPath, selectedPath, diffRefreshKey]);
+
   // Mirror to module cache so the next mount for this repo hydrates instantly.
   useEffect(() => {
     if (loadingFirst) return;
-    rightPanelCache.setStaged(repoPath, { files, diff });
-  }, [repoPath, files, diff, loadingFirst]);
+    rightPanelCache.setStaged(repoPath, { files, selectedPath, diffByPath });
+  }, [repoPath, files, selectedPath, diffByPath, loadingFirst]);
 
   function isDeleted(file: StagedFile): boolean {
     return file.status.toLowerCase().includes("delete");
@@ -2058,35 +2122,37 @@ function StagedTab({
     try {
       await navigator.clipboard.writeText(text);
     } catch (e) {
-      setError(String(e));
+      setListError(String(e));
     }
   }
 
   async function openInEditor(file: StagedFile) {
     if (isDeleted(file)) {
-      setError(rt(t, "rightPanel.errors.deletedFile"));
+      setListError(rt(t, "rightPanel.errors.deletedFile"));
       return;
     }
     try {
       await openFileInEditor(joinPath(repoPath, file.path));
     } catch (e) {
-      setError(String(e));
+      setListError(String(e));
     }
   }
 
   async function openWithDefaultApp(file: StagedFile) {
     if (isDeleted(file)) {
-      setError(rt(t, "rightPanel.errors.deletedFile"));
+      setListError(rt(t, "rightPanel.errors.deletedFile"));
       return;
     }
     try {
       await openPath(joinPath(repoPath, file.path));
     } catch (e) {
-      setError(String(e));
+      setListError(String(e));
     }
   }
 
-  if (error) return <div className="p-3 text-xs text-danger">{error}</div>;
+  if (listError) {
+    return <div className="p-3 text-xs text-danger">{listError}</div>;
+  }
   if (files.length === 0) {
     if (loadingFirst) return <SkeletonList count={6} />;
     return <Empty msg={rt(t, "rightPanel.staged.empty")} />;
@@ -2099,6 +2165,7 @@ function StagedTab({
           {files.map((f) => (
             <li
               key={f.path}
+              onClick={() => setSelectedPath(f.path)}
               onContextMenu={(e) => {
                 e.preventDefault();
                 setMenu({ x: e.clientX, y: e.clientY, file: f });
@@ -2107,7 +2174,10 @@ function StagedTab({
                 if (isDeleted(f)) return;
                 void openWithDefaultApp(f);
               }}
-              className="flex cursor-default items-center gap-2 px-3 py-1.5 font-mono text-xs hover:bg-bg-elevated/40"
+              className={cn(
+                "flex cursor-default items-center gap-2 px-3 py-1.5 font-mono text-xs hover:bg-bg-elevated/40",
+                selectedPath === f.path && "bg-bg-elevated",
+              )}
             >
               <span className="w-24 shrink-0 truncate text-fg-muted">
                 {f.status}
@@ -2122,17 +2192,23 @@ function StagedTab({
       <ResizeHandle direction="vertical" />
       <Panel id="staged-diff" order={2} defaultSize={65} minSize={15}>
         <div className="acorn-no-scrollbar h-full overflow-y-auto">
-          {diff ? (
+          {selectedDiff ? (
             <DiffView
-              payload={diff}
+              payload={selectedDiff}
               onExpand={() =>
                 onExpand({
-                  payload: diff,
-                  title: rt(t, "rightPanel.staged.workingTreeChanges"),
+                  payload: selectedDiff,
+                  title:
+                    selectedFile?.path ??
+                    rt(t, "rightPanel.staged.workingTreeChanges"),
                   subtitle: <span className="font-mono">{repoPath}</span>,
                 })
               }
             />
+          ) : diffError ? (
+            <div className="p-3 text-xs text-danger">{diffError}</div>
+          ) : loadingDiff ? (
+            <Empty msg={rt(t, "rightPanel.loading.diffLower")} />
           ) : (
             <Empty msg={rt(t, "rightPanel.staged.noDiff")} />
           )}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -116,6 +116,9 @@ export const api = {
   stagedDiff(repoPath: string): Promise<DiffPayload> {
     return invoke<DiffPayload>("staged_diff", { repoPath });
   },
+  stagedFileDiff(repoPath: string, path: string): Promise<DiffPayload> {
+    return invoke<DiffPayload>("staged_file_diff", { repoPath, path });
+  },
   listPullRequests(
     repoPath: string,
     state: PrStateFilter = "open",

--- a/src/lib/right-panel-cache.ts
+++ b/src/lib/right-panel-cache.ts
@@ -10,7 +10,11 @@ import type {
 } from "./types";
 
 export type CommitsCacheEntry = { commits: CommitInfo[]; hasMore: boolean };
-export type StagedCacheEntry = { files: StagedFile[]; diff: DiffPayload | null };
+export type StagedCacheEntry = {
+  files: StagedFile[];
+  selectedPath: string | null;
+  diffByPath: Record<string, DiffPayload>;
+};
 
 interface FetchOptions {
   force?: boolean;

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -69,6 +69,7 @@ export const tauriMockSource = `
       return Promise.resolve(true);
     }
     if (cmd === 'staged_diff') return Promise.resolve({ files: [] });
+    if (cmd === 'staged_file_diff') return Promise.resolve({ files: [] });
     if (cmd === 'commit_diff') return Promise.resolve({ files: [] });
     if (cmd === 'scrollback_load') return Promise.resolve(null);
     if (cmd === 'get_memory_usage') {


### PR DESCRIPTION
## Summary
This PR shifts the Staged tab from eager full-diff loading to a list-first, file-diff-on-demand flow.

1. **Lazy staged diffs:** Load staged file names first, then fetch only the selected file's diff through a new `stagedFileDiff` command.
2. **Path-scoped backend diff:** Add a pathspec-backed staged diff helper with relative-path validation and focused Rust coverage.
3. **Blocking git work:** Move list/diff libgit2 calls onto Tauri's blocking pool so heavier git work does not occupy the async command executor.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Staged tab responsiveness | Faster initial render because the tab no longer waits for the full staged patch payload. |
| Large repositories | Better behavior when many files or large diffs exist, matching the list-first pattern used by Superset's Changes view. |
| User-visible behavior | File list still appears in Staged; the diff pane now follows the selected file and caches loaded file diffs. |

## Design notes

The old `staged_diff` command remains available, but the Staged tab now uses `staged_file_diff` for preview rendering. The frontend prunes cached per-file diffs when the staged file list changes so stale paths do not linger after refreshes.

## Follow-up (not in this PR)

Further profiling can look at sharing git status snapshots between Files, Staged, and Commits if status refreshes become the next dominant cost in very large repos.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml git_ops::tests::diff_staged_file -- --nocapture`
- [x] `rustfmt --edition 2021 --check src-tauri/src/git_ops.rs src-tauri/src/commands.rs`

## Notes

A full crate-root rustfmt check still reports unrelated pre-existing formatting differences in other Rust files; this PR leaves those files untouched.