### PR TITLE
feat(themes): Monokai Pro + expanded built-in palette set

### DIFF
--- a/src/assets/themes/everforest-dark.css
+++ b/src/assets/themes/everforest-dark.css
@@ -1,0 +1,31 @@
+:root[data-acorn-theme="everforest-dark"] {
+  --color-bg: #2d353b;
+  --color-bg-elevated: #343f44;
+  --color-bg-sidebar: #232a2e;
+  --color-fg: #d3c6aa;
+  --color-fg-muted: #859289;
+  --color-border: #4f585e;
+  --color-accent: #a7c080;
+  --color-accent-hover: #83c092;
+  --color-danger: #e67e80;
+  --color-warning: #dbbc7f;
+  --color-terminal-bg: #2d353b;
+  --color-terminal-fg: #d3c6aa;
+  --color-term-selection: #543a48;
+  --color-term-black: #232a2e;
+  --color-term-red: #e67e80;
+  --color-term-green: #a7c080;
+  --color-term-yellow: #dbbc7f;
+  --color-term-blue: #7fbbb3;
+  --color-term-magenta: #d699b6;
+  --color-term-cyan: #83c092;
+  --color-term-white: #d3c6aa;
+  --color-term-bright-black: #7a8478;
+  --color-term-bright-red: #e67e80;
+  --color-term-bright-green: #a7c080;
+  --color-term-bright-yellow: #dbbc7f;
+  --color-term-bright-blue: #7fbbb3;
+  --color-term-bright-magenta: #d699b6;
+  --color-term-bright-cyan: #83c092;
+  --color-term-bright-white: #fdf6e3;
+}

--- a/src/assets/themes/flexoki-dark.css
+++ b/src/assets/themes/flexoki-dark.css
@@ -1,0 +1,31 @@
+:root[data-acorn-theme="flexoki-dark"] {
+  --color-bg: #100f0f;
+  --color-bg-elevated: #1c1b1a;
+  --color-bg-sidebar: #100f0f;
+  --color-fg: #cecdc3;
+  --color-fg-muted: #878580;
+  --color-border: #282726;
+  --color-accent: #3aa99f;
+  --color-accent-hover: #5abdac;
+  --color-danger: #d14d41;
+  --color-warning: #d0a215;
+  --color-terminal-bg: #100f0f;
+  --color-terminal-fg: #cecdc3;
+  --color-term-selection: rgba(30, 95, 91, 0.3);
+  --color-term-black: #100f0f;
+  --color-term-red: #d14d41;
+  --color-term-green: #879a39;
+  --color-term-yellow: #d0a215;
+  --color-term-blue: #4385be;
+  --color-term-magenta: #ce5d97;
+  --color-term-cyan: #3aa99f;
+  --color-term-white: #cecdc3;
+  --color-term-bright-black: #575653;
+  --color-term-bright-red: #e8705f;
+  --color-term-bright-green: #a0af54;
+  --color-term-bright-yellow: #dfb431;
+  --color-term-bright-blue: #66a0c8;
+  --color-term-bright-magenta: #e47da8;
+  --color-term-bright-cyan: #5abdac;
+  --color-term-bright-white: #fffcf0;
+}

--- a/src/assets/themes/flexoki-light.css
+++ b/src/assets/themes/flexoki-light.css
@@ -1,0 +1,32 @@
+/* @mode light */
+:root[data-acorn-theme="flexoki-light"] {
+  --color-bg: #fffcf0;
+  --color-bg-elevated: #f2f0e5;
+  --color-bg-sidebar: #e6e4d9;
+  --color-fg: #100f0f;
+  --color-fg-muted: #6f6e69;
+  --color-border: #cecdc3;
+  --color-accent: #24837b;
+  --color-accent-hover: #3aa99f;
+  --color-danger: #af3029;
+  --color-warning: #ad8301;
+  --color-terminal-bg: #fffcf0;
+  --color-terminal-fg: #100f0f;
+  --color-term-selection: rgba(187, 220, 206, 0.3);
+  --color-term-black: #100f0f;
+  --color-term-red: #af3029;
+  --color-term-green: #66800b;
+  --color-term-yellow: #ad8301;
+  --color-term-blue: #205ea6;
+  --color-term-magenta: #a02f6f;
+  --color-term-cyan: #24837b;
+  --color-term-white: #6f6e69;
+  --color-term-bright-black: #575653;
+  --color-term-bright-red: #d14d41;
+  --color-term-bright-green: #879a39;
+  --color-term-bright-yellow: #d0a215;
+  --color-term-bright-blue: #4385be;
+  --color-term-bright-magenta: #ce5d97;
+  --color-term-bright-cyan: #3aa99f;
+  --color-term-bright-white: #878580;
+}

--- a/src/assets/themes/github-dark.css
+++ b/src/assets/themes/github-dark.css
@@ -1,0 +1,31 @@
+:root[data-acorn-theme="github-dark"] {
+  --color-bg: #0d1117;
+  --color-bg-elevated: #161b22;
+  --color-bg-sidebar: #010409;
+  --color-fg: #e6edf3;
+  --color-fg-muted: #848d97;
+  --color-border: #30363d;
+  --color-accent: #2f81f7;
+  --color-accent-hover: #58a6ff;
+  --color-danger: #f85149;
+  --color-warning: #d29922;
+  --color-terminal-bg: #0d1117;
+  --color-terminal-fg: #e6edf3;
+  --color-term-selection: rgba(56, 139, 253, 0.4);
+  --color-term-black: #0d1117;
+  --color-term-red: #ff7b72;
+  --color-term-green: #3fb950;
+  --color-term-yellow: #d29922;
+  --color-term-blue: #58a6ff;
+  --color-term-magenta: #bc8cff;
+  --color-term-cyan: #76e3ea;
+  --color-term-white: #b1bac4;
+  --color-term-bright-black: #6e7681;
+  --color-term-bright-red: #ffa198;
+  --color-term-bright-green: #56d364;
+  --color-term-bright-yellow: #e3b341;
+  --color-term-bright-blue: #79c0ff;
+  --color-term-bright-magenta: #d2a8ff;
+  --color-term-bright-cyan: #b3f0ff;
+  --color-term-bright-white: #ffffff;
+}

--- a/src/assets/themes/high-contrast-dark.css
+++ b/src/assets/themes/high-contrast-dark.css
@@ -1,0 +1,31 @@
+:root[data-acorn-theme="high-contrast-dark"] {
+  --color-bg: #0a0c10;
+  --color-bg-elevated: #272b33;
+  --color-bg-sidebar: #010409;
+  --color-fg: #f0f3f6;
+  --color-fg-muted: #bdc4cc;
+  --color-border: #7a828e;
+  --color-accent: #71b7ff;
+  --color-accent-hover: #91cbff;
+  --color-danger: #ff6a69;
+  --color-warning: #f0b72f;
+  --color-terminal-bg: #0a0c10;
+  --color-terminal-fg: #f0f3f6;
+  --color-term-selection: rgba(64, 158, 255, 0.4);
+  --color-term-black: #0a0c10;
+  --color-term-red: #ff9492;
+  --color-term-green: #26cd4d;
+  --color-term-yellow: #f0b72f;
+  --color-term-blue: #71b7ff;
+  --color-term-magenta: #cb9eff;
+  --color-term-cyan: #76e3ea;
+  --color-term-white: #d9dee3;
+  --color-term-bright-black: #9ea7b3;
+  --color-term-bright-red: #ffb1af;
+  --color-term-bright-green: #4ae168;
+  --color-term-bright-yellow: #f7c843;
+  --color-term-bright-blue: #91cbff;
+  --color-term-bright-magenta: #dbb7ff;
+  --color-term-bright-cyan: #b3f0ff;
+  --color-term-bright-white: #ffffff;
+}

--- a/src/assets/themes/kanagawa-wave.css
+++ b/src/assets/themes/kanagawa-wave.css
@@ -1,0 +1,31 @@
+:root[data-acorn-theme="kanagawa-wave"] {
+  --color-bg: #1f1f28;
+  --color-bg-elevated: #2a2a37;
+  --color-bg-sidebar: #181820;
+  --color-fg: #dcd7ba;
+  --color-fg-muted: #727169;
+  --color-border: #363646;
+  --color-accent: #7e9cd8;
+  --color-accent-hover: #a3d4d5;
+  --color-danger: #e82424;
+  --color-warning: #ff9e3b;
+  --color-terminal-bg: #1f1f28;
+  --color-terminal-fg: #dcd7ba;
+  --color-term-selection: #223249;
+  --color-term-black: #16161d;
+  --color-term-red: #c34043;
+  --color-term-green: #76946a;
+  --color-term-yellow: #c0a36e;
+  --color-term-blue: #7e9cd8;
+  --color-term-magenta: #957fb8;
+  --color-term-cyan: #6a9589;
+  --color-term-white: #c8c093;
+  --color-term-bright-black: #727169;
+  --color-term-bright-red: #e82424;
+  --color-term-bright-green: #98bb6c;
+  --color-term-bright-yellow: #e6c384;
+  --color-term-bright-blue: #7fb4ca;
+  --color-term-bright-magenta: #938aa9;
+  --color-term-bright-cyan: #7aa89f;
+  --color-term-bright-white: #dcd7ba;
+}

--- a/src/assets/themes/monokai-pro.css
+++ b/src/assets/themes/monokai-pro.css
@@ -1,0 +1,31 @@
+:root[data-acorn-theme="monokai-pro"] {
+  --color-bg: #2d2a2e;
+  --color-bg-elevated: #363437;
+  --color-bg-sidebar: #221f22;
+  --color-fg: #fcfcfa;
+  --color-fg-muted: #939293;
+  --color-border: #403e41;
+  --color-accent: #ffd866;
+  --color-accent-hover: #ffe38f;
+  --color-danger: #f65f87;
+  --color-warning: #ffd866;
+  --color-terminal-bg: #2d2a2e;
+  --color-terminal-fg: #fcfcfa;
+  --color-term-selection: #6e6c6f;
+  --color-term-black: #2d2a2e;
+  --color-term-red: #ff6188;
+  --color-term-green: #a9dc76;
+  --color-term-yellow: #ffd866;
+  --color-term-blue: #78dce8;
+  --color-term-magenta: #ab9df2;
+  --color-term-cyan: #78dce8;
+  --color-term-white: #fcfcfa;
+  --color-term-bright-black: #727072;
+  --color-term-bright-red: #ff7aa2;
+  --color-term-bright-green: #b6e98a;
+  --color-term-bright-yellow: #ffe38f;
+  --color-term-bright-blue: #8ee8f2;
+  --color-term-bright-magenta: #bbaaf8;
+  --color-term-bright-cyan: #8ee8f2;
+  --color-term-bright-white: #ffffff;
+}

--- a/src/assets/themes/solarized-dark.css
+++ b/src/assets/themes/solarized-dark.css
@@ -1,0 +1,31 @@
+:root[data-acorn-theme="solarized-dark"] {
+  --color-bg: #002b36;
+  --color-bg-elevated: #073642;
+  --color-bg-sidebar: #00212b;
+  --color-fg: #839496;
+  --color-fg-muted: #586e75;
+  --color-border: #073642;
+  --color-accent: #268bd2;
+  --color-accent-hover: #2aa198;
+  --color-danger: #dc322f;
+  --color-warning: #b58900;
+  --color-terminal-bg: #002b36;
+  --color-terminal-fg: #839496;
+  --color-term-selection: #073642;
+  --color-term-black: #073642;
+  --color-term-red: #dc322f;
+  --color-term-green: #859900;
+  --color-term-yellow: #b58900;
+  --color-term-blue: #268bd2;
+  --color-term-magenta: #d33682;
+  --color-term-cyan: #2aa198;
+  --color-term-white: #eee8d5;
+  --color-term-bright-black: #002b36;
+  --color-term-bright-red: #cb4b16;
+  --color-term-bright-green: #586e75;
+  --color-term-bright-yellow: #657b83;
+  --color-term-bright-blue: #839496;
+  --color-term-bright-magenta: #6c71c4;
+  --color-term-bright-cyan: #93a1a1;
+  --color-term-bright-white: #fdf6e3;
+}

--- a/src/lib/themes.test.ts
+++ b/src/lib/themes.test.ts
@@ -16,6 +16,13 @@ describe("BUILT_IN_THEMES", () => {
     expect(BUILT_IN_THEMES.map((theme) => theme.id)).toEqual([
       "acorn-dark",
       "one-dark-pro",
+      "monokai-pro",
+      "kanagawa-wave",
+      "everforest-dark",
+      "github-dark",
+      "solarized-dark",
+      "flexoki-dark",
+      "high-contrast-dark",
       "tokyo-night",
       "dracula",
       "catppuccin-mocha",
@@ -25,16 +32,19 @@ describe("BUILT_IN_THEMES", () => {
       "ayu-dark",
       "acorn-light",
       "github-light",
+      "flexoki-light",
       "solarized-light",
       "catppuccin-latte",
       "one-light",
       "gruvbox-light",
     ]);
-    expect(BUILT_IN_THEMES).toHaveLength(15);
-    expect(BUILT_IN_THEMES.filter((theme) => theme.mode === "dark")).toHaveLength(9);
+    expect(BUILT_IN_THEMES).toHaveLength(23);
+    expect(BUILT_IN_THEMES.filter((theme) => theme.mode === "dark")).toHaveLength(
+      16,
+    );
     expect(
       BUILT_IN_THEMES.filter((theme) => theme.mode === "light"),
-    ).toHaveLength(6);
+    ).toHaveLength(7);
   });
 
   it("every built-in css passes validation", () => {

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -9,13 +9,21 @@ import ayuDarkCss from "../assets/themes/ayu-dark.css?raw";
 import catppuccinLatteCss from "../assets/themes/catppuccin-latte.css?raw";
 import catppuccinMochaCss from "../assets/themes/catppuccin-mocha.css?raw";
 import draculaCss from "../assets/themes/dracula.css?raw";
+import everforestDarkCss from "../assets/themes/everforest-dark.css?raw";
+import flexokiDarkCss from "../assets/themes/flexoki-dark.css?raw";
+import flexokiLightCss from "../assets/themes/flexoki-light.css?raw";
+import githubDarkCss from "../assets/themes/github-dark.css?raw";
 import githubLightCss from "../assets/themes/github-light.css?raw";
 import gruvboxDarkCss from "../assets/themes/gruvbox-dark.css?raw";
 import gruvboxLightCss from "../assets/themes/gruvbox-light.css?raw";
+import highContrastDarkCss from "../assets/themes/high-contrast-dark.css?raw";
+import kanagawaWaveCss from "../assets/themes/kanagawa-wave.css?raw";
+import monokaiProCss from "../assets/themes/monokai-pro.css?raw";
 import nordCss from "../assets/themes/nord.css?raw";
 import oneDarkProCss from "../assets/themes/one-dark-pro.css?raw";
 import oneLightCss from "../assets/themes/one-light.css?raw";
 import rosePineCss from "../assets/themes/rose-pine.css?raw";
+import solarizedDarkCss from "../assets/themes/solarized-dark.css?raw";
 import solarizedLightCss from "../assets/themes/solarized-light.css?raw";
 import tokyoNightCss from "../assets/themes/tokyo-night.css?raw";
 
@@ -57,6 +65,55 @@ export const BUILT_IN_THEMES: ReadonlyArray<AcornTheme> = [
     label: "One Dark Pro",
     mode: "dark",
     css: oneDarkProCss,
+    source: "builtin",
+  },
+  {
+    id: "monokai-pro",
+    label: "Monokai Pro",
+    mode: "dark",
+    css: monokaiProCss,
+    source: "builtin",
+  },
+  {
+    id: "kanagawa-wave",
+    label: "Kanagawa Wave",
+    mode: "dark",
+    css: kanagawaWaveCss,
+    source: "builtin",
+  },
+  {
+    id: "everforest-dark",
+    label: "Everforest Dark",
+    mode: "dark",
+    css: everforestDarkCss,
+    source: "builtin",
+  },
+  {
+    id: "github-dark",
+    label: "GitHub Dark",
+    mode: "dark",
+    css: githubDarkCss,
+    source: "builtin",
+  },
+  {
+    id: "solarized-dark",
+    label: "Solarized Dark",
+    mode: "dark",
+    css: solarizedDarkCss,
+    source: "builtin",
+  },
+  {
+    id: "flexoki-dark",
+    label: "Flexoki Dark",
+    mode: "dark",
+    css: flexokiDarkCss,
+    source: "builtin",
+  },
+  {
+    id: "high-contrast-dark",
+    label: "High Contrast Dark",
+    mode: "dark",
+    css: highContrastDarkCss,
     source: "builtin",
   },
   {
@@ -120,6 +177,13 @@ export const BUILT_IN_THEMES: ReadonlyArray<AcornTheme> = [
     label: "GitHub Light",
     mode: "light",
     css: githubLightCss,
+    source: "builtin",
+  },
+  {
+    id: "flexoki-light",
+    label: "Flexoki Light",
+    mode: "light",
+    css: flexokiLightCss,
     source: "builtin",
   },
   {


### PR DESCRIPTION
## Summary
This PR expands Acorn's built-in theme picker with additional dark/light palettes and terminal color overrides.

1. **Theme catalog:** Adds Monokai Pro, Kanagawa Wave, Everforest Dark, GitHub Dark, Solarized Dark, Flexoki Dark, Flexoki Light, and High Contrast Dark as built-in themes.
2. **Terminal parity:** Defines terminal foreground/background, selection, and ANSI colors for each new palette so xterm output stays readable after switching themes.
3. **Registry coverage:** Registers the new themes in `BUILT_IN_THEMES` and updates the theme test expectations to validate the expanded catalog.

## Expected impact

| Area | Impact |
| --- | --- |
| User-visible behavior | Appearance settings now offer 8 additional built-in themes. |
| Terminal readability | New themes provide explicit ANSI overrides instead of inheriting the generic dark/light defaults. |
| Reliability | Existing CSS-variable validation now covers 23 built-in themes. |
| Build/runtime cost | No expected runtime cost beyond the existing raw CSS import pattern. |

## Design notes

The implementation follows the existing built-in theme pattern: one CSS file per palette, raw CSS imports in `src/lib/themes.ts`, and explicit `mode` metadata for light/dark terminal defaults. Palette values are mapped from the source theme color systems into Acorn's smaller UI variable set, with terminal-specific variables included where the palette exposes ANSI-friendly colors.

## Follow-up (not in this PR)

None.

## Test plan

- [x] `pnpm test` — 36 files passed, 312 tests passed, 1 existing skipped test.
- [x] `pnpm typecheck` — passed.

## Notes

The skipped Vitest test is pre-existing suite behavior and is not caused by this PR.
