### PR TITLE
feat(ipc): self-promote terminal sessions into control

### DIFF
--- a/docs/CONTROL_SESSIONS.md
+++ b/docs/CONTROL_SESSIONS.md
@@ -27,6 +27,8 @@ Three entry points:
   whatever project is currently active.
 - Sidebar: hover a project header → click the `Bot` icon.
 - Command palette: `⌘P` → `New control session`.
+- Existing terminal: run `acorn-ipc promote-self` inside any Acorn terminal
+  session to mark that same session as the control session.
 
 The first time you create one, Acorn shows a one-time guide. You can re-open
 it from Settings → Sessions → "Control sessions" or by clearing
@@ -45,20 +47,23 @@ should be able to orchestrate siblings *immediately*, not only after the
 user has explained the protocol. Acorn ships that priming through two
 layers that fire automatically every time a control-session PTY spawns:
 
-1. **PTY environment.** Four pieces of state are injected into the
-   control session's PTY before any user code runs:
-   - `ACORN_SESSION_ID` — this session's UUID, so `acorn-ipc` knows who
-     is asking.
+1. **PTY environment.** All Acorn terminals get enough identity and socket
+   state to bootstrap `acorn-ipc`; control sessions get the privileged source
+   marker before any user code runs:
+   - `ACORN_RESUME_TOKEN` — this session's UUID. `acorn-ipc` uses it as a
+     fallback source id, which lets `promote-self` work from a regular
+     terminal.
    - `ACORN_DATA_DIR` — the resolved Acorn profile data directory. This
      keeps bundled release sidecars aligned with the app's selected
      profile.
    - `ACORN_IPC_SOCKET` — the canonical IPC socket path.
-   - `ACORN_DAEMON_SOCKET` — the background daemon control socket path.
    - `PATH` — the directory containing the bundled `acorn-ipc` binary is
-     prepended (de-duplicated), so the agent can invoke `acorn-ipc` by
-     name without the user installing a shim. Regular sessions do not
-     receive this prefix, keeping the IPC surface invisible outside
-     control sessions.
+     prepended (de-duplicated), so the agent can invoke `acorn-ipc` by name
+     without the user installing a shim.
+   - `ACORN_SESSION_ID` — injected only for sessions already marked as
+     control. This remains the primary source id for privileged operations.
+   - `ACORN_DAEMON_SOCKET` — injected for control sessions so scripts can
+     also reach the background daemon control socket.
 2. **Worktree marker file.** A `.acorn-control.md` is written to the
    session's cwd on every spawn (overwritten each time so the substituted
    session id is current). Agents that read project docs (Claude Code,
@@ -75,17 +80,25 @@ text at any time with `acorn-ipc context`.
 
 ## The `acorn-ipc` CLI
 
-When Acorn spawns a control session it injects these env vars into the PTY:
+When Acorn spawns a terminal it injects these env vars into the PTY:
+
+| Env var             | Source                            |
+| ------------------- | --------------------------------- |
+| `ACORN_RESUME_TOKEN` | The session's UUID               |
+| `ACORN_DATA_DIR`    | Resolved Acorn profile data dir   |
+| `ACORN_IPC_SOCKET`  | Path to the in-app IPC socket     |
+
+Control sessions additionally receive:
 
 | Env var             | Source                            |
 | ------------------- | --------------------------------- |
 | `ACORN_SESSION_ID`  | The session's UUID                |
-| `ACORN_DATA_DIR`    | Resolved Acorn profile data dir   |
-| `ACORN_IPC_SOCKET`  | Path to the in-app IPC socket     |
 | `ACORN_DAEMON_SOCKET` | Path to the daemon control socket |
 
-The `acorn-ipc` binary reads `ACORN_SESSION_ID` and `ACORN_IPC_SOCKET`, so
-commands run straight from the shell without flags.
+The `acorn-ipc` binary reads `ACORN_SESSION_ID` first, then falls back to
+`ACORN_RESUME_TOKEN`, and uses `ACORN_IPC_SOCKET` for transport. Commands run
+straight from the shell without flags. Except for `promote-self`, the server
+still rejects requests unless the source session is already `Control`.
 
 By default, release builds use `profiles/prod` and debug builds use
 `profiles/dev` below Acorn's app data directory. Set `ACORN_PROFILE=<name>`
@@ -93,8 +106,8 @@ to select another profile, or `ACORN_DATA_DIR=<path>` to pin all runtime
 state, IPC sockets, daemon sockets, and staged shell init files to an
 explicit directory.
 
-> **Gotcha for agents running inside a control session.** Acorn injects
-> `ACORN_DATA_DIR` into the PTY env so the bundled CLIs talk to the right
+> **Gotcha for agents running inside an Acorn terminal.** Acorn injects
+> `ACORN_DATA_DIR` into the PTY env so bundled CLIs talk to the right
 > profile. `acorn-paths::data_dir` resolves `ACORN_DATA_DIR` **before** the
 > profile fallback (see `src-tauri/crates/acorn-paths/src/lib.rs`), so
 > running `pnpm run tauri dev` from that shell makes the debug build inherit
@@ -118,20 +131,21 @@ explicit directory.
 > ```
 >
 > The same caveat applies to any process that should run in dev-profile
-> isolation while being launched from a control-session shell — including
+> isolation while being launched from an Acorn-managed shell — including
 > `pnpm exec playwright test` if it spawns the bundled `acornd` sidecar.
-> Outside a control session (your own login shell, CI) there is nothing to
+> Outside an Acorn-managed shell (your own login shell, CI) there is nothing to
 > strip; debug builds already default to `profiles/dev` on their own.
 
 ### Install
 
 `acorn-ipc` ships inside the Acorn `.app` bundle (Tauri's `externalBin`
-mechanism — see `src-tauri/tauri.conf.json`). Inside a control session
-PTY there is **nothing to install**: the bundled binary's directory is
-prepended to `PATH`, so `acorn-ipc list-sessions` works out of the box.
+mechanism — see `src-tauri/tauri.conf.json`). Inside an Acorn PTY there is
+**nothing to install**: the bundled binary's directory is prepended to `PATH`,
+so `acorn-ipc promote-self` and, once promoted, `acorn-ipc list-sessions` work
+out of the box.
 
 You only need a system-wide install when you want to call `acorn-ipc`
-from **outside** a control session (debugging from your own shell, an
+from **outside** an Acorn terminal (debugging from your own shell, an
 external script, a Makefile, …). In that case use the Settings shortcut
 under Sessions → "Control sessions", which generates a single-line
 `ln -sf` command pointing at the bundled binary. The Copy button lands
@@ -168,6 +182,7 @@ acorn-ipc --help
 ### Commands
 
 ```text
+acorn-ipc promote-self
 acorn-ipc context
 acorn-ipc list-sessions
 acorn-ipc new-session   <name> [--isolated] [--owner me|user]
@@ -193,7 +208,7 @@ exits non-zero with a stable code on error:
 
 Sessions created from the UI are owned by `user`. Sessions created through
 `acorn-ipc new-session` are owned by the source control session by default
-(`control:<ACORN_SESSION_ID>`), unless the caller passes `--owner user`.
+(`control:<source session id>`), unless the caller passes `--owner user`.
 
 `list-sessions` shows each session's owner and whether it is owned by the
 current controller. By default, `send-keys`, `read-buffer`, `select-session`,
@@ -218,6 +233,7 @@ done
 Spin up a fresh isolated worktree and focus it:
 
 ```sh
+acorn-ipc promote-self   # no-op if this terminal is already control
 new_id=$(acorn-ipc new-session "patch-bot" --isolated)
 acorn-ipc select-session -t "$new_id"
 ```
@@ -226,9 +242,10 @@ acorn-ipc select-session -t "$new_id"
 
 - The socket file is created with mode `0600`, so only the user the Acorn
   app is running as can connect.
-- Every request carries the source session's UUID. The server rejects any
-  request whose source is missing, expired, or whose `SessionKind` is not
-  `Control`.
+- Every request carries the source session's UUID. `promote-self` is the
+  bootstrap exception: it may mark its own regular source session as
+  `Control`. The server rejects every other request whose source is missing,
+  expired, or whose `SessionKind` is not `Control`.
 - Target lookups are scoped to the source's project (`repo_path`).
   Cross-project requests surface a distinct `OutOfScope` error so the CLI
   can give an accurate diagnostic instead of a misleading "not found".
@@ -236,8 +253,9 @@ acorn-ipc select-session -t "$new_id"
   badly-written agent can't accidentally remove the only seat it has.
 
 There is currently no inter-process whitelist beyond the env-var handshake.
-If a control session leaks its `ACORN_SESSION_ID` to a child it does not
-trust, that child can use it. Treat the env var like a credential.
+If an Acorn terminal leaks its `ACORN_RESUME_TOKEN` or a control session leaks
+its `ACORN_SESSION_ID` to a child it does not trust, that child can use it.
+Treat both env vars like credentials.
 
 ## Wire protocol
 
@@ -262,9 +280,9 @@ version `1`. See `src-tauri/src/ipc/proto.rs` for the canonical types.
 
 | Symptom                                              | Likely cause                                                          |
 | ---------------------------------------------------- | --------------------------------------------------------------------- |
-| `ACORN_SESSION_ID is unset`                          | Running `acorn-ipc` from a non-control session                        |
+| `source session id is unset`                         | Running `acorn-ipc` outside an Acorn-managed terminal without `--source` |
 | `connect: No such file or directory`                 | App not running, or socket path overridden                            |
-| Exit 2 inside a control session                      | Session was removed in the UI; env still pointing at a stale UUID     |
+| Exit 2 after `promote-self`                          | Session was removed in the UI; env still pointing at a stale UUID     |
 | Exit 4 even though both sessions look right          | Sessions belong to different `repo_path`s; check Sidebar grouping     |
 | `read-buffer` returns `truncated` for short sessions | Bytes still in flight to xterm but cleared by `clear`/`reset` already |
 

--- a/docs/CONTROL_SESSIONS.md
+++ b/docs/CONTROL_SESSIONS.md
@@ -28,7 +28,9 @@ Three entry points:
 - Sidebar: hover a project header → click the `Bot` icon.
 - Command palette: `⌘P` → `New control session`.
 - Existing terminal: run `acorn-ipc promote-self` inside any Acorn terminal
-  session to mark that same session as the control session.
+  session to mark that same session as the control session. The command prints
+  the control-session primer so an already-running agent can continue without
+  opening a new tab.
 
 The first time you create one, Acorn shows a one-time guide. You can re-open
 it from Settings → Sessions → "Control sessions" or by clearing

--- a/src-tauri/crates/acorn-ipc/src/bin/acorn-ipc.rs
+++ b/src-tauri/crates/acorn-ipc/src/bin/acorn-ipc.rs
@@ -1,9 +1,10 @@
 //! `acorn-ipc` — command-line client for the in-app IPC server.
 //!
-//! Run from inside a control session's PTY: the spawning code in
-//! `commands::pty_spawn` injects `ACORN_SESSION_ID` and `ACORN_IPC_SOCKET`
-//! into the environment so this binary can locate the server and identify
-//! itself without flags.
+//! Run from inside an Acorn PTY: the spawning code in `commands::pty_spawn`
+//! injects Acorn identity/path environment so this binary can locate the
+//! server and identify itself without flags. Regular sessions can bootstrap
+//! themselves with `promote-self`; other commands still require a control
+//! source session.
 //!
 //! Exits non-zero on protocol errors so it composes cleanly in shell scripts;
 //! the exit code maps the server's `ErrorCode` so callers can branch on the
@@ -23,16 +24,17 @@ use acorn_ipc::proto::{
 use acorn_ipc::socket_path;
 
 const ENV_SESSION_ID: &str = "ACORN_SESSION_ID";
+const ENV_RESUME_TOKEN: &str = "ACORN_RESUME_TOKEN";
 
 #[derive(Parser)]
 #[command(
     name = "acorn-ipc",
-    about = "Talk to a running Acorn app from inside a control session.",
+    about = "Talk to a running Acorn app from inside an Acorn terminal.",
     long_about = "acorn-ipc speaks to the in-app IPC server over a Unix \
-                  socket. The control session that launched this process \
-                  exports ACORN_SESSION_ID and ACORN_IPC_SOCKET into its \
-                  PTY environment — leave those alone unless you know what \
-                  you're doing."
+                  socket. Acorn terminals export session identity and socket \
+                  paths into their PTY environment. Run `promote-self` once \
+                  from a regular Acorn terminal to turn it into a control \
+                  session; other commands require that control permission."
 )]
 struct Cli {
     /// Print responses as raw JSON instead of the default table/text. Useful
@@ -45,7 +47,8 @@ struct Cli {
     #[arg(long, global = true, value_name = "PATH")]
     socket: Option<PathBuf>,
 
-    /// Override the source session id. Falls back to `$ACORN_SESSION_ID`.
+    /// Override the source session id. Falls back to `$ACORN_SESSION_ID`,
+    /// then `$ACORN_RESUME_TOKEN`.
     #[arg(long, global = true, value_name = "UUID")]
     source: Option<String>,
 
@@ -55,6 +58,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// Promote this Acorn terminal into a control session.
+    PromoteSelf,
     /// Print the Acorn control-session context an agent should load.
     Context,
     /// List the sessions in your project, including this control session.
@@ -136,9 +141,7 @@ enum Command {
         allow_foreign: bool,
     },
     /// Report IPC reachability: socket path, file presence, and whether
-    /// the in-app server accepts connections. No `ACORN_SESSION_ID`
-    /// required — `status` is the only command that works before the
-    /// control-session env has been set up.
+    /// the in-app server accepts connections. No source session id required.
     Status,
 }
 
@@ -162,15 +165,11 @@ fn main() -> ExitCode {
         return run_status(&socket_path, cli.json);
     }
 
-    let source = match cli
-        .source
-        .clone()
-        .or_else(|| std::env::var(ENV_SESSION_ID).ok())
-    {
+    let source = match resolve_source_id(cli.source.clone()) {
         Some(s) if !s.is_empty() => s,
         _ => {
             eprintln!(
-                "acorn-ipc: ACORN_SESSION_ID is unset. Run me from inside a control session, \
+                "acorn-ipc: source session id is unset. Run me from inside an Acorn session, \
                  or pass --source <uuid>.",
             );
             return ExitCode::from(map_error_exit(ErrorCode::Unauthorized));
@@ -208,6 +207,7 @@ fn main() -> ExitCode {
 
 fn build_request(cmd: &Command) -> Result<Request, String> {
     Ok(match cmd {
+        Command::PromoteSelf => Request::PromoteSelf,
         Command::Context => Request::Context,
         Command::ListSessions => Request::ListSessions,
         Command::SendKeys {
@@ -284,6 +284,25 @@ fn build_request(cmd: &Command) -> Result<Request, String> {
     })
 }
 
+fn resolve_source_id(explicit: Option<String>) -> Option<String> {
+    resolve_source_id_from(
+        explicit,
+        std::env::var(ENV_SESSION_ID).ok(),
+        std::env::var(ENV_RESUME_TOKEN).ok(),
+    )
+}
+
+fn resolve_source_id_from(
+    explicit: Option<String>,
+    session_env: Option<String>,
+    resume_env: Option<String>,
+) -> Option<String> {
+    [explicit, session_env, resume_env]
+        .into_iter()
+        .flatten()
+        .find(|s| !s.is_empty())
+}
+
 /// Probe the IPC socket and print a short reachability report. Connection
 /// failure is *not* a CLI error — the whole point of `status` is to surface
 /// down servers, so we exit 0 in both branches and let callers parse the
@@ -299,7 +318,7 @@ fn run_status(socket_path: &Path, json: bool) -> ExitCode {
         }
         Err(err) => (false, Some(err.to_string())),
     };
-    let source_env = std::env::var(ENV_SESSION_ID).ok().filter(|s| !s.is_empty());
+    let source_env = resolve_source_id(None);
     if json {
         let payload = serde_json::json!({
             "socket_path": socket_path.display().to_string(),
@@ -397,6 +416,17 @@ fn render(response: &Response, json: bool) -> ExitCode {
         }
         Response::SessionCreated { session_id } => {
             println!("{session_id}");
+            ExitCode::SUCCESS
+        }
+        Response::SelfPromoted {
+            session_id,
+            already_control,
+        } => {
+            if *already_control {
+                println!("session {session_id} is already a control session");
+            } else {
+                println!("promoted session {session_id} to control session");
+            }
             ExitCode::SUCCESS
         }
         Response::Error { code, message } => {

--- a/src-tauri/crates/acorn-ipc/src/bin/acorn-ipc.rs
+++ b/src-tauri/crates/acorn-ipc/src/bin/acorn-ipc.rs
@@ -563,6 +563,25 @@ mod tests {
     }
 
     #[test]
+    fn promote_self_command_builds_request() {
+        let req = build_request(&Command::PromoteSelf).expect("build");
+        assert!(matches!(req, Request::PromoteSelf));
+    }
+
+    #[test]
+    fn source_resolution_falls_back_to_resume_token() {
+        let source = resolve_source_id_from(
+            None,
+            None,
+            Some("00000000-0000-0000-0000-000000000123".to_string()),
+        );
+        assert_eq!(
+            source.as_deref(),
+            Some("00000000-0000-0000-0000-000000000123")
+        );
+    }
+
+    #[test]
     fn new_session_owner_user_is_forwarded() {
         let req = build_request(&Command::NewSession {
             name: "worker".to_string(),

--- a/src-tauri/crates/acorn-ipc/src/bin/acorn-ipc.rs
+++ b/src-tauri/crates/acorn-ipc/src/bin/acorn-ipc.rs
@@ -421,12 +421,15 @@ fn render(response: &Response, json: bool) -> ExitCode {
         Response::SelfPromoted {
             session_id,
             already_control,
+            context,
         } => {
             if *already_control {
                 println!("session {session_id} is already a control session");
             } else {
                 println!("promoted session {session_id} to control session");
             }
+            println!();
+            println!("{context}");
             ExitCode::SUCCESS
         }
         Response::Error { code, message } => {

--- a/src-tauri/crates/acorn-ipc/src/primer.rs
+++ b/src-tauri/crates/acorn-ipc/src/primer.rs
@@ -88,6 +88,7 @@ pub fn primer_for(
          \n\
          Available commands (project-scoped — other projects are not reachable):\n\
          \n\
+           acorn-ipc promote-self                       # idempotent; already promoted\n\
            acorn-ipc context                             # print this context\n\
            acorn-ipc list-sessions                       # see siblings + self\n\
            acorn-ipc new-session   <name> [--isolated] [--owner me|user]\n\

--- a/src-tauri/crates/acorn-ipc/src/proto.rs
+++ b/src-tauri/crates/acorn-ipc/src/proto.rs
@@ -19,9 +19,9 @@ use serde::{Deserialize, Serialize};
 pub const PROTOCOL_VERSION: u32 = 1;
 
 /// Every request opens with the source session's UUID, captured by the CLI
-/// from the `ACORN_SESSION_ID` env var set on control-session PTYs. The
-/// server rejects requests from sessions that do not exist or whose
-/// `SessionKind` is not `Control`.
+/// from the PTY environment. The server rejects ordinary requests from
+/// sessions that do not exist or whose `SessionKind` is not `Control`;
+/// `PromoteSelf` is the explicit bootstrap exception.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Envelope {
     pub protocol_version: u32,
@@ -32,6 +32,9 @@ pub struct Envelope {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum Request {
+    /// Mark the source session itself as a control session. This is the only
+    /// request intentionally accepted from a regular source session.
+    PromoteSelf,
     /// Return the control-session context primer the agent should load before
     /// interpreting natural-language requests like "new session".
     Context,
@@ -111,6 +114,10 @@ pub enum Response {
     },
     SessionCreated {
         session_id: String,
+    },
+    SelfPromoted {
+        session_id: String,
+        already_control: bool,
     },
     Error {
         code: ErrorCode,

--- a/src-tauri/crates/acorn-ipc/src/proto.rs
+++ b/src-tauri/crates/acorn-ipc/src/proto.rs
@@ -197,4 +197,15 @@ mod tests {
         let parsed: Result<Envelope, _> = serde_json::from_str(bad);
         assert!(parsed.is_err());
     }
+
+    #[test]
+    fn promote_self_request_uses_kebab_case_kind() {
+        let env = Envelope {
+            protocol_version: PROTOCOL_VERSION,
+            source_session_id: "00000000-0000-0000-0000-000000000001".to_string(),
+            request: Request::PromoteSelf,
+        };
+        let encoded = serde_json::to_string(&env).expect("encode");
+        assert!(encoded.contains("\"kind\":\"promote-self\""));
+    }
 }

--- a/src-tauri/crates/acorn-ipc/src/proto.rs
+++ b/src-tauri/crates/acorn-ipc/src/proto.rs
@@ -215,4 +215,18 @@ mod tests {
         let encoded = serde_json::to_string(&env).expect("encode");
         assert!(encoded.contains("\"kind\":\"promote-self\""));
     }
+
+    #[test]
+    fn self_promoted_response_carries_context_text() {
+        let response = Response::SelfPromoted {
+            session_id: "00000000-0000-0000-0000-000000000001".to_string(),
+            already_control: false,
+            context: "acorn-ipc list-sessions".to_string(),
+        };
+        let encoded = serde_json::to_string(&response).expect("encode");
+        assert!(encoded.contains("\"kind\":\"self-promoted\""));
+        assert!(encoded.contains("\"context\":\"acorn-ipc list-sessions\""));
+        let decoded: Response = serde_json::from_str(&encoded).expect("decode");
+        assert_eq!(decoded, response);
+    }
 }

--- a/src-tauri/crates/acorn-ipc/src/proto.rs
+++ b/src-tauri/crates/acorn-ipc/src/proto.rs
@@ -118,6 +118,7 @@ pub enum Response {
     SelfPromoted {
         session_id: String,
         already_control: bool,
+        context: String,
     },
     Error {
         code: ErrorCode,

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -499,4 +499,20 @@ mod tests {
         let result = store.reconcile_missing_worktree(&Uuid::new_v4());
         assert!(matches!(result, Err(SessionError::NotFound(_))));
     }
+
+    #[test]
+    fn set_kind_promotes_regular_session() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+
+        let promoted = store
+            .set_kind(&session.id, SessionKind::Control)
+            .expect("session exists");
+
+        assert_eq!(promoted.kind, SessionKind::Control);
+        assert_eq!(
+            store.get(&session.id).expect("session persisted").kind,
+            SessionKind::Control
+        );
+    }
 }

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -366,6 +366,16 @@ impl SessionStore {
         Ok(entry.clone())
     }
 
+    pub fn set_kind(&self, id: &Uuid, kind: SessionKind) -> SessionResult<Session> {
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        entry.kind = kind;
+        entry.updated_at = Utc::now();
+        Ok(entry.clone())
+    }
+
     pub fn rename(&self, id: &Uuid, name: String) -> SessionResult<Session> {
         let mut entry = self
             .inner

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1141,10 +1141,10 @@ pub async fn pty_spawn<R: Runtime>(
     // to opening the user's native terminal.
     let resolved_command = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
     let resolved_args: Vec<String> = crate::shell_args::login_args_for(&resolved_command);
-    // Inject IPC env vars for control sessions so the user's shell (and any
-    // agent it launches) can address the running app via the `acorn-ipc`
-    // CLI without per-session configuration. Only control sessions get the
-    // env; regular sessions stay sandboxed from the IPC surface.
+    // Inject Acorn session identity and CLI reachability so a regular
+    // terminal can explicitly bootstrap itself with `acorn-ipc promote-self`.
+    // Privileged IPC commands still fail server-side until the session kind
+    // has been promoted to Control.
     let mut effective_env = env.unwrap_or_default();
     let mut primed_args = resolved_args;
 
@@ -1200,6 +1200,30 @@ pub async fn pty_spawn<R: Runtime>(
         );
     }
 
+    let ipc_socket = acorn_ipc::socket_path::resolve().unwrap_or_default();
+    if !ipc_socket.as_os_str().is_empty() {
+        effective_env
+            .entry("ACORN_IPC_SOCKET".to_string())
+            .or_insert_with(|| ipc_socket.display().to_string());
+    }
+    if let Some(bin_dir) = acorn_ipc::cli_path::bundled_cli_dir() {
+        let existing = effective_env
+            .get("PATH")
+            .cloned()
+            .or_else(|| std::env::var("PATH").ok())
+            .unwrap_or_default();
+        effective_env.insert(
+            "PATH".to_string(),
+            acorn_ipc::cli_path::prepend_to_path(&bin_dir, &existing),
+        );
+        // Expose the dir so the staged `.zshrc` can re-prepend the IPC CLI
+        // entry after the user's rc runs — covers `export PATH="…"` patterns
+        // that wipe Acorn's earlier prepend.
+        effective_env
+            .entry("ACORN_CLI_DIR".to_string())
+            .or_insert_with(|| bin_dir.display().to_string());
+    }
+
     // OSC 7 emitter — only zsh needs file-side help (bash/fish self-serve).
     // Override `ZDOTDIR` with Acorn's staged dir so our `.zshrc` runs; stash
     // the user's original under `ACORN_USER_ZDOTDIR` so the staged rc can
@@ -1240,12 +1264,6 @@ pub async fn pty_spawn<R: Runtime>(
             effective_env
                 .entry("ACORN_SESSION_ID".to_string())
                 .or_insert_with(|| session.id.to_string());
-            let socket = acorn_ipc::socket_path::resolve().unwrap_or_default();
-            if !socket.as_os_str().is_empty() {
-                effective_env
-                    .entry("ACORN_IPC_SOCKET".to_string())
-                    .or_insert_with(|| socket.display().to_string());
-            }
             // Daemon socket for the `acornd` CLI. Coexists with
             // `ACORN_IPC_SOCKET`: scripts that call `acorn-ipc` reach
             // the in-process server, while `acornd <subcommand>`
@@ -1258,31 +1276,6 @@ pub async fn pty_spawn<R: Runtime>(
                     .entry("ACORN_DAEMON_SOCKET".to_string())
                     .or_insert_with(|| daemon_sock.display().to_string());
             }
-            // Make the bundled `acorn-ipc` AND `acornd` CLIs resolvable
-            // from inside this PTY without the user installing a PATH
-            // shim. Both binaries ship in the same directory, so a
-            // single prepend covers both. Prepending — not replacing —
-            // keeps the user's existing PATH intact for every other
-            // binary; dedup in `prepend_to_path` prevents the entry
-            // from accumulating across reconnects.
-            if let Some(bin_dir) = acorn_ipc::cli_path::bundled_cli_dir() {
-                let existing = effective_env
-                    .get("PATH")
-                    .cloned()
-                    .or_else(|| std::env::var("PATH").ok())
-                    .unwrap_or_default();
-                effective_env.insert(
-                    "PATH".to_string(),
-                    acorn_ipc::cli_path::prepend_to_path(&bin_dir, &existing),
-                );
-                // Expose the dir so the staged `.zshrc` can re-prepend
-                // the IPC CLI entry after the user's rc runs — covers
-                // `export PATH="…"` patterns that wipe Acorn's earlier
-                // prepend.
-                effective_env
-                    .entry("ACORN_CLI_DIR".to_string())
-                    .or_insert_with(|| bin_dir.display().to_string());
-            }
             // Drop the primer in a worktree-local marker file so whichever
             // agent the user invokes inside the shell can read the IPC
             // protocol. `inject_primer_args` is a no-op while `$SHELL` is
@@ -1293,7 +1286,7 @@ pub async fn pty_spawn<R: Runtime>(
             let primer = acorn_ipc::primer::primer_for(
                 &session.id.to_string(),
                 &session.repo_path,
-                &socket,
+                &ipc_socket,
                 daemon_socket.as_deref(),
             );
             let flavor = acorn_ipc::primer::AgentFlavor::detect(&resolved_command);

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -40,9 +40,9 @@ use uuid::Uuid;
 
 use crate::commands::{create_unique_worktree, sanitize_worktree_name};
 use crate::persistence;
-use acorn_session::{Session, SessionKind, SessionOwner, SessionStore};
 use crate::state::AppState;
 use crate::worktree;
+use acorn_session::{Session, SessionKind, SessionOwner, SessionStore};
 
 /// Tauri event the frontend listens for to focus a session requested via
 /// the IPC `select-session` command. Kept in lockstep with the listener
@@ -220,9 +220,10 @@ fn handle_connection<R: Runtime>(
     Ok(())
 }
 
-/// Top-level request dispatch. Resolves the source session and enforces the
-/// "must be Control" gate before invoking command-specific handlers, so
-/// each handler can assume `source` is a live, authorized session.
+/// Top-level request dispatch. Except for `promote-self`, resolves the source
+/// session and enforces the "must be Control" gate before invoking
+/// command-specific handlers, so each handler can assume `source` is a live,
+/// authorized session.
 fn dispatch<R: Runtime>(envelope: Envelope, app: &AppHandle<R>, state: &AppState) -> Response {
     if envelope.protocol_version != PROTOCOL_VERSION {
         return Response::Error {
@@ -232,6 +233,9 @@ fn dispatch<R: Runtime>(envelope: Envelope, app: &AppHandle<R>, state: &AppState
                 envelope.protocol_version, PROTOCOL_VERSION
             ),
         };
+    }
+    if matches!(&envelope.request, Request::PromoteSelf) {
+        return handle_promote_self(&envelope.source_session_id, app, state);
     }
     let source = match resolve_source(&envelope.source_session_id, &state.sessions) {
         Ok(s) => s,
@@ -244,6 +248,7 @@ fn dispatch<R: Runtime>(envelope: Envelope, app: &AppHandle<R>, state: &AppState
         "ipc: dispatch",
     );
     match envelope.request {
+        Request::PromoteSelf => handle_promote_self(&source.id.to_string(), app, state),
         Request::Context => handle_context(&source),
         Request::ListSessions => handle_list_sessions(&source, &state.sessions),
         Request::SendKeys {
@@ -274,6 +279,7 @@ fn dispatch<R: Runtime>(envelope: Envelope, app: &AppHandle<R>, state: &AppState
 
 fn request_label(req: &Request) -> &'static str {
     match req {
+        Request::PromoteSelf => "promote-self",
         Request::Context => "context",
         Request::ListSessions => "list-sessions",
         Request::SendKeys { .. } => "send-keys",
@@ -300,6 +306,57 @@ fn resolve_source(raw_id: &str, sessions: &SessionStore) -> Result<Session, Resp
         });
     }
     Ok(session)
+}
+
+fn promote_source_session(
+    raw_id: &str,
+    sessions: &SessionStore,
+) -> Result<(Session, bool), Response> {
+    let id = Uuid::parse_str(raw_id).map_err(|_| Response::Error {
+        code: ErrorCode::Unauthorized,
+        message: format!("source session id is not a valid uuid: {raw_id}"),
+    })?;
+    let session = sessions.get(&id).map_err(|_| Response::Error {
+        code: ErrorCode::Unauthorized,
+        message: "source session not found; is the Acorn session id still valid?".to_string(),
+    })?;
+    if session.kind == SessionKind::Control {
+        return Ok((session, true));
+    }
+    let promoted = sessions
+        .set_kind(&id, SessionKind::Control)
+        .map_err(|err| Response::Error {
+            code: ErrorCode::Internal,
+            message: format!("promote-self failed: {err}"),
+        })?;
+    Ok((promoted, false))
+}
+
+fn handle_promote_self<R: Runtime>(
+    source_id: &str,
+    app: &AppHandle<R>,
+    state: &AppState,
+) -> Response {
+    let (session, already_control) = match promote_source_session(source_id, &state.sessions) {
+        Ok(result) => result,
+        Err(err) => return err,
+    };
+    if !already_control {
+        if let Err(err) = persistence::save_sessions(&state.sessions.list()) {
+            tracing::warn!(error = %err, "ipc: persist after promote-self failed");
+        }
+        if let Err(err) = app.emit(SESSIONS_CHANGED_EVENT, session.id.to_string()) {
+            tracing::warn!(
+                error = %err,
+                event = SESSIONS_CHANGED_EVENT,
+                "ipc: sessions-changed emit failed after promote-self",
+            );
+        }
+    }
+    Response::SelfPromoted {
+        session_id: session.id.to_string(),
+        already_control,
+    }
 }
 
 /// Resolve a target session id, enforcing project scope. Returns

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -699,4 +699,34 @@ mod tests {
         let res = resolve_action_target(&ctl, &target.id.to_string(), &store, true);
         assert!(res.is_ok(), "allow_foreign should bypass owner guard");
     }
+
+    #[test]
+    fn promote_regular_source_session_sets_control_kind() {
+        let store = SessionStore::new();
+        let regular = store.insert(make_session("/tmp/A", "regular", SessionKind::Regular));
+
+        let (promoted, already_control) =
+            promote_source_session(&regular.id.to_string(), &store).expect("promoted");
+
+        assert_eq!(promoted.id, regular.id);
+        assert_eq!(promoted.kind, SessionKind::Control);
+        assert!(!already_control);
+        assert_eq!(
+            store.get(&regular.id).expect("session persisted").kind,
+            SessionKind::Control
+        );
+    }
+
+    #[test]
+    fn promote_control_source_session_is_idempotent() {
+        let store = SessionStore::new();
+        let ctl = store.insert(make_session("/tmp/A", "ctl", SessionKind::Control));
+
+        let (promoted, already_control) =
+            promote_source_session(&ctl.id.to_string(), &store).expect("promoted");
+
+        assert_eq!(promoted.id, ctl.id);
+        assert_eq!(promoted.kind, SessionKind::Control);
+        assert!(already_control);
+    }
 }

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -356,6 +356,7 @@ fn handle_promote_self<R: Runtime>(
     Response::SelfPromoted {
         session_id: session.id.to_string(),
         already_control,
+        context: control_context_text(&session),
     }
 }
 
@@ -410,16 +411,20 @@ fn resolve_action_target(
 }
 
 fn handle_context(source: &Session) -> Response {
+    Response::Context {
+        text: control_context_text(source),
+    }
+}
+
+fn control_context_text(source: &Session) -> String {
     let socket = socket_path::resolve().unwrap_or_default();
     let daemon_socket = acorn_daemon::paths::control_socket_path().ok();
-    Response::Context {
-        text: primer::primer_for(
-            &source.id.to_string(),
-            &source.repo_path,
-            &socket,
-            daemon_socket.as_deref(),
-        ),
-    }
+    primer::primer_for(
+        &source.id.to_string(),
+        &source.repo_path,
+        &socket,
+        daemon_socket.as_deref(),
+    )
 }
 
 fn handle_list_sessions(source: &Session, sessions: &SessionStore) -> Response {


### PR DESCRIPTION
## Summary

This adds an explicit bootstrap path for an existing Acorn terminal to become its own control session without opening a replacement tab.

1. **Self-promotion command.** Adds `acorn-ipc promote-self`, a guarded IPC request that marks the source session as `SessionKind::Control` and is idempotent for existing control sessions.
2. **Same-shell continuation.** Lets `acorn-ipc` fall back from `ACORN_SESSION_ID` to `ACORN_RESUME_TOKEN`, so an already-running regular terminal can promote itself and immediately run follow-up commands from the same shell.
3. **Primer handoff.** Returns the control-session primer in the `promote-self` response and prints it in the CLI, so an already-running agent can learn the available orchestration commands after promotion.
4. **Spawn env and docs.** Makes new Acorn PTYs receive the IPC socket and bundled CLI path needed for bootstrap, while keeping privileged IPC operations server-gated until promotion.

## Expected impact

| Area | Impact |
| --- | --- |
| Control-session UX | Existing Acorn terminal sessions can become control sessions in place and then create/manage sibling sessions. |
| Agent workflow | Codex/Claude running in an ordinary Acorn terminal can call `promote-self`, read the printed primer, and continue without a new tab/resume flow. |
| Security model | The bootstrap surface is broader by design: any process with the session id inside an Acorn PTY can promote that same session. Other IPC commands still require `SessionKind::Control`, project scoping, and owner checks. |
| Compatibility | Existing control commands keep their current behavior; `promote-self` is the new additive entry point. |

## Design notes

`promote-self` is handled before the normal control-session authorization gate, but only for the source session id carried in the request. All other requests still go through `resolve_source`, so regular sessions cannot list, create, read, send keys, select, or kill until they have explicitly promoted themselves.

The CLI source lookup now prefers `ACORN_SESSION_ID` and falls back to `ACORN_RESUME_TOKEN`. This preserves the existing control-session path while making already-running regular PTYs usable after promotion, because their process environment cannot be mutated retroactively to add `ACORN_SESSION_ID`.

## Test plan

- [x] `env -u ACORN_DATA_DIR cargo test -p acorn-ipc`
- [x] `cargo test -p acorn-session`
- [x] `pnpm run build:sidecar`
- [x] `cargo test -p acorn`

## Notes

The first clean-worktree `cargo test -p acorn` attempt failed before compiling tests because Tauri required the staged sidecar binaries. Running `pnpm run build:sidecar` created `acorn-ipc-aarch64-apple-darwin` and `acornd-aarch64-apple-darwin`; the subsequent `cargo test -p acorn` passed.