### PR TITLE
fix(hotkeys): bypass macOS Option dead-key for Alt+letter bindings

### DIFF
--- a/src/lib/hotkeys.test.ts
+++ b/src/lib/hotkeys.test.ts
@@ -61,6 +61,12 @@ describe("formatHotkey", () => {
       expect(formatHotkey("Control+Tab")).toBe("⌃⇥");
       expect(formatHotkey("$mod+Alt+ArrowLeft")).toBe("⌥⌘←");
     });
+
+    it("renders `event.code` tokens as the bare letter/digit", () => {
+      expect(formatHotkey("$mod+Alt+KeyT")).toBe("⌥⌘T");
+      expect(formatHotkey("$mod+Alt+Shift+KeyT")).toBe("⌥⇧⌘T");
+      expect(formatHotkey("$mod+Digit3")).toBe("⌘3");
+    });
   });
 
   describe("off macOS", () => {
@@ -72,6 +78,11 @@ describe("formatHotkey", () => {
 
     it("keeps `+` separators and modifier order", () => {
       expect(formatHotkey("$mod+Shift+Alt+t")).toBe("Ctrl+Alt+Shift+T");
+    });
+
+    it("renders `event.code` tokens as the bare letter/digit", () => {
+      expect(formatHotkey("$mod+Alt+KeyT")).toBe("Ctrl+Alt+T");
+      expect(formatHotkey("$mod+Digit3")).toBe("Ctrl+3");
     });
   });
 });

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -24,11 +24,15 @@ export const Hotkeys = {
   openPalette: "$mod+p",
   clearTerminal: "$mod+k",
   newSession: "$mod+t",
-  newIsolatedSession: "$mod+Alt+t",
+  // tinykeys matches `event.key` OR `event.code`. On macOS, Option as
+  // modifier rewrites `event.key` to a dead-key glyph (Option+T → "†"),
+  // so the literal-letter form never fires. The `KeyT` form falls back
+  // to `event.code`, which Option does not perturb.
+  newIsolatedSession: "$mod+Alt+KeyT",
   // "Control session" — extends the new-session family. Future PRs add the
   // `acorn-ipc` CLI so this kind of session can drive sibling sessions; the
   // hotkey lives next to the other terminal-creation bindings for symmetry.
-  newControlSession: "$mod+Alt+Shift+t",
+  newControlSession: "$mod+Alt+Shift+KeyT",
   addProject: "$mod+Shift+n",
   focusSidebar: "$mod+1",
   focusMain: "$mod+2",
@@ -45,14 +49,14 @@ export const Hotkeys = {
   uiScaleUp: "$mod+=",
   uiScaleUpShift: "$mod+Shift+Equal",
   uiScaleReset: "$mod+0",
-  toggleMultiInput: "$mod+Alt+i",
+  toggleMultiInput: "$mod+Alt+KeyI",
   focusPaneLeft: "$mod+Alt+ArrowLeft",
   focusPaneRight: "$mod+Alt+ArrowRight",
   focusPaneUp: "$mod+Alt+ArrowUp",
   focusPaneDown: "$mod+Alt+ArrowDown",
   splitVertical: "$mod+d",
   splitHorizontal: "$mod+Shift+d",
-  equalizePanes: "$mod+Alt+e",
+  equalizePanes: "$mod+Alt+KeyE",
   closeTab: "$mod+w",
   closeEmptyPane: "Escape",
   openSettings: "$mod+Comma",
@@ -155,11 +159,23 @@ const NON_MAC_KEY_LABEL: Record<string, string> = {
 const MAC_MODIFIER_ORDER = ["⌃", "⌥", "⇧", "⌘"];
 const NON_MAC_MODIFIER_ORDER = ["Ctrl", "Alt", "Shift", "Meta"];
 
+// `KeyboardEvent.code` tokens (`KeyT`, `Digit3`, …) are used in binding
+// strings to bypass macOS Option dead-keys. Strip the prefix for display
+// so users see the natural letter/digit, not the raw code name.
+function stripCodePrefix(part: string): string {
+  const keyMatch = /^Key([A-Z])$/.exec(part);
+  if (keyMatch) return keyMatch[1];
+  const digitMatch = /^Digit([0-9])$/.exec(part);
+  if (digitMatch) return digitMatch[1];
+  return part;
+}
+
 function formatKey(part: string, mac: boolean): string {
+  const normalized = stripCodePrefix(part);
   if (mac) {
-    return MAC_KEY_SYMBOL[part] ?? part.toUpperCase();
+    return MAC_KEY_SYMBOL[normalized] ?? normalized.toUpperCase();
   }
-  return NON_MAC_KEY_LABEL[part] ?? part.toUpperCase();
+  return NON_MAC_KEY_LABEL[normalized] ?? normalized.toUpperCase();
 }
 
 /**


### PR DESCRIPTION
## Summary

`Cmd+Alt+T` (new isolated session) and the other three `$mod+Alt+<letter>` hotkeys silently failed on macOS inside the Tauri webview because `tinykeys` matches `event.key`, and Option as a modifier rewrites `event.key` to a dead-key glyph (Option+T → "†"). Switching the four affected bindings to the `KeyT` / `KeyI` / `KeyE` form makes `tinykeys` fall back to `event.code`, which Option does not perturb.

`formatHotkey` now strips the `Key` / `Digit` prefix when rendering so context-menu shortcut hints still read `⌥⌘T` rather than `⌥⌘KEYT`.

## Bindings touched

| Hotkey | Before | After |
| --- | --- | --- |
| `newIsolatedSession` | `$mod+Alt+t` | `$mod+Alt+KeyT` |
| `newControlSession` | `$mod+Alt+Shift+t` | `$mod+Alt+Shift+KeyT` |
| `toggleMultiInput` | `$mod+Alt+i` | `$mod+Alt+KeyI` |
| `equalizePanes` | `$mod+Alt+e` | `$mod+Alt+KeyE` |

The native macOS menu accelerator for `toggleMultiInput` in `src-tauri/src/lib.rs` (`CmdOrCtrl+Alt+I`) is left alone — AppKit matches accelerators against `charactersIgnoringModifiers`, which is not affected by Option, so the OS-level path was already firing correctly. Only the in-webview tinykeys fallback was broken.

## Test plan

- [x] `pnpm run test src/lib/hotkeys.test.ts` — 9/9 pass (new cases cover mac + non-mac rendering of `KeyT` / `Digit3`)
- [x] `pnpm run typecheck` — clean
- [ ] Manual: launch `pnpm run tauri dev`, focus the app, press ⌘⌥T → new isolated session is created
- [ ] Manual: press ⌘⌥⇧T → new control session
- [ ] Manual: press ⌘⌥E in a multi-pane layout → panes equalize
- [ ] Manual: confirm the context-menu shortcut hint for "New Isolated Session" still renders as `⌥⌘T`
