### PR TITLE
feat(pane): show control-session icon in tab strip

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -1,4 +1,5 @@
 import {
+  Bot,
   CircleX,
   Columns2,
   Copy,
@@ -916,6 +917,13 @@ function TabItem({
             size={10}
             className="pointer-events-none text-fg-muted"
             aria-label={paneT(t, "pane.aria.worktree")}
+          />
+        ) : null}
+        {session?.kind === "control" ? (
+          <Bot
+            size={10}
+            className="pointer-events-none text-accent"
+            aria-label={paneT(t, "pane.aria.controlSession")}
           />
         ) : null}
         <button

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -545,6 +545,7 @@
     },
     "aria": {
       "worktree": "worktree",
+      "controlSession": "control session",
       "closeSession": "Close session",
       "closeTab": "Close tab"
     },

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -545,6 +545,7 @@
     },
     "aria": {
       "worktree": "워크트리",
+      "controlSession": "컨트롤 세션",
       "closeSession": "세션 닫기",
       "closeTab": "탭 닫기"
     },


### PR DESCRIPTION
## Summary

The sidebar already renders a `Bot` glyph next to control-session rows (via `SessionRow` in `Sidebar.tsx`), but the tab strip omitted the same hint — so users running a control session in one tab and a regular session in another had no visual way to tell them apart from the tab title alone.

This PR adds the `Bot` icon next to the existing worktree `GitBranch` icon in `TabItem`, mirroring the sidebar's visual language (size 10, accent colour, trailing the title) so the two surfaces stay consistent.

## Changes

- `src/components/Pane.tsx`: import `Bot` from `lucide-react`; render it inside `TabItem` when `session.kind === "control"`, immediately after the worktree glyph.
- `src/locales/en.json` + `src/locales/ko.json`: add `pane.aria.controlSession` (`"control session"` / `"컨트롤 세션"`) so the icon's `aria-label` is localized.

The new icon follows the sidebar's existing gating policy (always shown when the session is control, no extra setting) to match what users already see on the left rail.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 314/315 pass (1 pre-existing skip)
- [ ] Manual: spawn a control session via ⌘⌥⇧T → confirm the `Bot` glyph appears in its tab next to the title, both when active and inactive
- [ ] Manual: spawn a regular session → confirm no `Bot` glyph
- [ ] Manual: spawn an isolated control session → confirm both `GitBranch` and `Bot` glyphs render side by side
