### PR TITLE
refactor(agent-provider): registry + provider-aware hook env seam

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -187,6 +187,19 @@ pub enum SessionAgentProvider {
     Codex,
 }
 
+impl SessionAgentProvider {
+    pub fn supports_hooks(self) -> bool {
+        matches!(self, Self::Claude | Self::Codex)
+    }
+
+    pub fn hook_provider_env_value(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     pub id: Uuid,
@@ -523,6 +536,20 @@ mod tests {
         assert_eq!(
             store.get(&session.id).expect("session persisted").kind,
             SessionKind::Control
+        );
+    }
+
+    #[test]
+    fn session_agent_provider_reports_hook_env_metadata() {
+        assert!(SessionAgentProvider::Claude.supports_hooks());
+        assert!(SessionAgentProvider::Codex.supports_hooks());
+        assert_eq!(
+            SessionAgentProvider::Claude.hook_provider_env_value(),
+            "claude"
+        );
+        assert_eq!(
+            SessionAgentProvider::Codex.hook_provider_env_value(),
+            "codex"
         );
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -40,6 +40,13 @@ fn inject_agent_hook_env(
     session: &Session,
     hooks: Option<&crate::agent_hooks::AgentHookServer>,
 ) {
+    let Some(provider) = session.agent_provider else {
+        return;
+    };
+    if !provider.supports_hooks() {
+        return;
+    }
+
     let Some(hooks) = hooks else {
         return;
     };
@@ -54,30 +61,9 @@ fn inject_agent_hook_env(
         .entry("ACORN_AGENT_HOOK_SESSION_ID".to_string())
         .or_insert_with(|| session.id.to_string());
 
-    let Some(provider) = session.agent_provider else {
-        return;
-    };
-    if !hooks_enabled_for(provider) {
-        return;
-    }
-
     effective_env
         .entry("ACORN_AGENT_HOOK_PROVIDER".to_string())
-        .or_insert_with(|| agent_hook_provider_name(provider).to_string());
-}
-
-fn hooks_enabled_for(provider: SessionAgentProvider) -> bool {
-    matches!(
-        provider,
-        SessionAgentProvider::Claude | SessionAgentProvider::Codex
-    )
-}
-
-fn agent_hook_provider_name(provider: SessionAgentProvider) -> &'static str {
-    match provider {
-        SessionAgentProvider::Claude => "claude",
-        SessionAgentProvider::Codex => "codex",
-    }
+        .or_insert_with(|| provider.hook_provider_env_value().to_string());
 }
 
 #[derive(Serialize)]
@@ -438,11 +424,12 @@ fn enrich_session(mut s: Session) -> Session {
         s.branch = branch;
     }
     s.in_worktree = worktree::is_linked_worktree_root(&s.worktree_path);
-    s.agent_provider =
+    let live_provider =
         crate::agent_resume::live_transcript(s.id).map(|transcript| match transcript.kind {
             crate::agent_resume::AgentKind::Claude => acorn_session::SessionAgentProvider::Claude,
             crate::agent_resume::AgentKind::Codex => acorn_session::SessionAgentProvider::Codex,
         });
+    s.agent_provider = live_provider.or(s.agent_provider);
     s
 }
 
@@ -706,6 +693,7 @@ pub async fn create_session(
     repo_path: String,
     isolated: Option<bool>,
     kind: Option<SessionKind>,
+    agent_provider: Option<SessionAgentProvider>,
 ) -> AppResult<Session> {
     let repo = PathBuf::from(&repo_path);
     if !repo.exists() {
@@ -721,7 +709,7 @@ pub async fn create_session(
         repo.clone()
     };
     let branch = worktree::current_branch(&worktree_path).unwrap_or_else(|_| "HEAD".to_string());
-    let session = Session::new(
+    let mut session = Session::new(
         name,
         repo.clone(),
         worktree_path,
@@ -729,6 +717,7 @@ pub async fn create_session(
         isolated,
         kind.unwrap_or_default(),
     );
+    session.agent_provider = agent_provider;
     let inserted = state.sessions.insert(session);
     state.projects.ensure(repo.clone(), project_basename(&repo));
     persist(&state);
@@ -2662,7 +2651,7 @@ mod tests {
     }
 
     #[test]
-    fn inject_agent_hook_env_stamps_base_env_before_provider_is_known() {
+    fn inject_agent_hook_env_skips_until_provider_is_known() {
         let hooks = crate::agent_hooks::AgentHookServer::start().expect("hook server starts");
         let mut session = Session::new(
             "Shell".to_string(),
@@ -2678,18 +2667,9 @@ mod tests {
         let mut env = HashMap::new();
         inject_agent_hook_env(&mut env, &session, Some(&hooks));
 
-        assert_eq!(
-            env.get("ACORN_AGENT_HOOK_URL"),
-            Some(&hooks.hook_url().to_string())
-        );
-        assert_eq!(
-            env.get("ACORN_AGENT_HOOK_TOKEN"),
-            Some(&hooks.token().to_string())
-        );
-        assert_eq!(
-            env.get("ACORN_AGENT_HOOK_SESSION_ID"),
-            Some(&session.id.to_string())
-        );
+        assert!(!env.contains_key("ACORN_AGENT_HOOK_URL"));
+        assert!(!env.contains_key("ACORN_AGENT_HOOK_TOKEN"));
+        assert!(!env.contains_key("ACORN_AGENT_HOOK_SESSION_ID"));
         assert!(!env.contains_key("ACORN_AGENT_HOOK_PROVIDER"));
     }
 

--- a/src/components/AgentResumeModal.tsx
+++ b/src/components/AgentResumeModal.tsx
@@ -1,10 +1,7 @@
 import { Copy, History, Play } from "lucide-react";
 import { useMemo, type ReactElement } from "react";
-import {
-  api,
-  type AgentKind,
-  type ResumeCandidate,
-} from "../lib/api";
+import { api, type AgentKind, type ResumeCandidate } from "../lib/api";
+import { buildAgentResumeCommand } from "../lib/agentProvider";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
@@ -28,7 +25,6 @@ interface AgentResumeModalProps {
 }
 
 interface AgentCopy {
-  resumeCommand: (uuid: string) => string;
   bodyKey: DialogTranslationKey;
   ariaLabelledBy: string;
 }
@@ -41,12 +37,10 @@ function dt(t: Translator, key: DialogTranslationKey): string {
 
 const COPY: Record<AgentKind, AgentCopy> = {
   claude: {
-    resumeCommand: (uuid) => `claude --resume ${uuid}`,
     bodyKey: "dialogs.agentResume.bodyClaude",
     ariaLabelledBy: "acorn-claude-resume-title",
   },
   codex: {
-    resumeCommand: (uuid) => `codex resume ${uuid}`,
     bodyKey: "dialogs.agentResume.bodyCodex",
     ariaLabelledBy: "acorn-codex-resume-title",
   },
@@ -94,7 +88,7 @@ export function AgentResumeModal({
     // PTYs expect a carriage return (`\r`, what xterm sends when the
     // user presses Enter) to commit a line. Using `\n` lands as a
     // literal LF in zsh's line buffer instead of running the command.
-    const cmd = `${copy.resumeCommand(candidate.uuid)}\r`;
+    const cmd = `${buildAgentResumeCommand(agent, candidate.uuid)}\r`;
     void api.ptyWrite(sessionId, cmd).catch((err: unknown) => {
       console.error("[AgentResumeModal] failed to write resume cmd", err);
     });
@@ -130,7 +124,7 @@ export function AgentResumeModal({
     // `#`, and run it. Multi-line hints would need bracketed-paste
     // escapes to keep zle from collapsing the two `\r`s into one
     // input row; a single line dodges that entire problem.
-    const hint = `# ${copy.resumeCommand(candidate.uuid)}\r`;
+    const hint = `# ${buildAgentResumeCommand(agent, candidate.uuid)}\r`;
     void api.ptyWrite(sessionId, hint).catch((err: unknown) => {
       console.error("[AgentResumeModal] failed to write cancel hint", err);
     });

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -28,6 +28,8 @@ import { CodeViewer } from "./CodeViewer";
 import { api } from "../lib/api";
 import {
   AgentProviderIcon,
+  buildAgentForkCommand,
+  providerRequiresForkTranscriptPrep,
   resolveSessionAgentProvider,
 } from "../lib/agentProvider";
 import { cn } from "../lib/cn";
@@ -51,7 +53,12 @@ import type { Direction, PaneId } from "../lib/layout";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { PaneDropOverlay } from "./PaneDropOverlay";
 import { Tooltip } from "./Tooltip";
-import type { Session, SessionKind, SessionStatus } from "../lib/types";
+import type {
+  Session,
+  SessionAgentProvider,
+  SessionKind,
+  SessionStatus,
+} from "../lib/types";
 import {
   makeSessionWorkspaceTab,
   type CodeWorkspaceTab,
@@ -197,7 +204,7 @@ export function Pane({ paneId }: PaneProps) {
   // args intact.
   async function forkSession(
     parent: Session,
-    kind: "claude" | "codex",
+    kind: SessionAgentProvider,
     parentAgentId: string,
     isolated: boolean,
   ) {
@@ -208,6 +215,8 @@ export function Pane({ paneId }: PaneProps) {
         name,
         parent.repo_path,
         isolated,
+        "regular",
+        kind,
       );
       // Claude resolves `--resume <uuid>` by looking under
       // `~/.claude/projects/<slug-of-cwd>/<uuid>.jsonl`.
@@ -225,18 +234,17 @@ export function Pane({ paneId }: PaneProps) {
       // before queuing the resume. Codex stores rollouts cwd-
       // independently under `$CODEX_HOME/sessions/`, so neither branch
       // requires staging for codex.
-      if (kind === "claude" && isolated) {
+      if (providerRequiresForkTranscriptPrep(kind) && isolated) {
         try {
           await api.prepareClaudeFork(parentAgentId, created.worktree_path);
         } catch (err) {
           console.error("[Pane] prepare_claude_fork failed", err);
         }
       }
-      const command =
-        kind === "claude"
-          ? `claude --resume ${parentAgentId} --fork-session`
-          : `codex fork ${parentAgentId}`;
-      useAppStore.getState().setPendingTerminalInput(created.id, command);
+      const command = buildAgentForkCommand(kind, parentAgentId);
+      useAppStore.getState().setPendingTerminalInput(created.id, command, {
+        agentProvider: kind,
+      });
       await useAppStore.getState().refreshAll();
       selectTab(created.id);
     } catch (err) {
@@ -453,7 +461,7 @@ interface TabStripProps {
   onDuplicate: (repoPath: string, kind: SessionKind) => void;
   onFork: (
     parent: Session,
-    kind: "claude" | "codex",
+    kind: SessionAgentProvider,
     parentAgentId: string,
     isolated: boolean,
   ) => void;
@@ -597,7 +605,7 @@ interface TabItemProps {
   onSplitTab: (direction: Direction) => void;
   onDuplicate?: () => void;
   onFork?: (
-    kind: "claude" | "codex",
+    kind: SessionAgentProvider,
     parentAgentId: string,
     isolated: boolean,
   ) => void;

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1203,6 +1203,9 @@ function AgentHistoryTab({
       const created = await createSession(
         `${item.provider} ${rt(t, "rightPanel.history.resumeSessionName")}`,
         sessionHostRepoPath,
+        false,
+        "regular",
+        item.provider,
       );
       if (!created) {
         setError(
@@ -1219,7 +1222,9 @@ function AgentHistoryTab({
           return;
         }
       }
-      setPendingTerminalInput(created.id, item.resume_command);
+      setPendingTerminalInput(created.id, item.resume_command, {
+        agentProvider: item.provider,
+      });
       if (shouldUseWorktree && item.worktree) {
         setWorktreeNotice(item.worktree);
       }

--- a/src/lib/agentProvider.test.ts
+++ b/src/lib/agentProvider.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_PROVIDER_ORDER,
+  AGENT_PROVIDER_REGISTRY,
+  buildAgentForkCommand,
+  buildAgentResumeCommand,
+  collectSessionAgentProviders,
+  getAgentProviderDefinition,
+  inferAgentProvider,
+  getAgentHookProviderEnvValue,
+  providerRequiresForkTranscriptPrep,
+  providerSupportsHooks,
+  providerSupportsCapability,
+  resolveSessionAgentProvider,
+} from "./agentProvider";
+
+describe("agent provider registry", () => {
+  it("registers claude and codex in display order", () => {
+    expect(AGENT_PROVIDER_ORDER).toEqual(["claude", "codex"]);
+    expect(Object.keys(AGENT_PROVIDER_REGISTRY)).toEqual(["claude", "codex"]);
+  });
+
+  it("captures user-facing metadata and supported capabilities", () => {
+    expect(getAgentProviderDefinition("claude")).toMatchObject({
+      id: "claude",
+      label: "Claude",
+      icon: { kind: "mask", alt: "Claude" },
+      hooks: { supportsHooks: true, providerEnvValue: "claude" },
+      session: {
+        resumeCommandPrefix: "claude --resume",
+        forkCommandPrefix: "claude --resume",
+        forkCommandSuffix: "--fork-session",
+        markerFile: "claude.id",
+      },
+    });
+    expect(getAgentProviderDefinition("claude").capabilities).toEqual(
+      expect.arrayContaining(["history", "resume", "fork", "status", "hooks"]),
+    );
+
+    expect(getAgentProviderDefinition("codex")).toMatchObject({
+      id: "codex",
+      label: "Codex",
+      icon: { kind: "mask", alt: "Codex" },
+      hooks: { supportsHooks: true, providerEnvValue: "codex" },
+      session: {
+        resumeCommandPrefix: "codex resume",
+        forkCommandPrefix: "codex fork",
+        markerFile: "codex.id",
+      },
+    });
+  });
+
+  it("builds session commands from registry metadata", () => {
+    expect(buildAgentResumeCommand("claude", "session-1")).toBe(
+      "claude --resume session-1",
+    );
+    expect(buildAgentResumeCommand("codex", "session-2")).toBe(
+      "codex resume session-2",
+    );
+    expect(buildAgentForkCommand("claude", "session-3")).toBe(
+      "claude --resume session-3 --fork-session",
+    );
+    expect(buildAgentForkCommand("codex", "session-4")).toBe(
+      "codex fork session-4",
+    );
+  });
+
+  it("exposes capability and fork-prep decisions through registry helpers", () => {
+    expect(providerSupportsCapability("claude", "hooks")).toBe(true);
+    expect(providerSupportsCapability("codex", "resume")).toBe(true);
+    expect(providerRequiresForkTranscriptPrep("claude")).toBe(true);
+    expect(providerRequiresForkTranscriptPrep("codex")).toBe(false);
+  });
+
+  it("exposes hook env support through registry metadata", () => {
+    expect(providerSupportsHooks("claude")).toBe(true);
+    expect(providerSupportsHooks("codex")).toBe(true);
+    expect(getAgentHookProviderEnvValue("claude")).toBe("claude");
+    expect(getAgentHookProviderEnvValue("codex")).toBe("codex");
+  });
+});
+
+describe("agent provider helpers", () => {
+  it("prefers explicit session provider over name inference", () => {
+    expect(
+      resolveSessionAgentProvider({
+        agent_provider: "codex",
+        name: "Claude worktree",
+      }),
+    ).toBe("codex");
+  });
+
+  it("infers known providers from session names", () => {
+    expect(inferAgentProvider("Claude worktree")).toBe("claude");
+    expect(inferAgentProvider("resume codex session")).toBe("codex");
+    expect(inferAgentProvider("plain shell")).toBeNull();
+  });
+
+  it("collects providers once in registry order", () => {
+    expect(
+      collectSessionAgentProviders([
+        { agent_provider: "codex", name: "first" },
+        { agent_provider: null, name: "claude fork" },
+        { agent_provider: "codex", name: "second" },
+      ]),
+    ).toEqual(["claude", "codex"]);
+  });
+});

--- a/src/lib/agentProvider.tsx
+++ b/src/lib/agentProvider.tsx
@@ -1,18 +1,24 @@
 import type { CSSProperties } from "react";
-import claudeIconUrl from "../assets/vendor/lobe-icons/claude.svg";
-import codexIconUrl from "../assets/vendor/lobe-icons/codex.svg";
 import { cn } from "./cn";
+import {
+  AGENT_PROVIDER_ORDER,
+  getAgentProviderDefinition,
+  inferAgentProvider,
+} from "./agentProviderRegistry";
 import type { Session, SessionAgentProvider } from "./types";
 
-const ICON_URL: Record<SessionAgentProvider, string> = {
-  claude: claudeIconUrl,
-  codex: codexIconUrl,
-};
-
-const LABEL: Record<SessionAgentProvider, string> = {
-  claude: "Claude",
-  codex: "Codex",
-};
+export {
+  AGENT_PROVIDER_ORDER,
+  AGENT_PROVIDER_REGISTRY,
+  buildAgentForkCommand,
+  buildAgentResumeCommand,
+  getAgentHookProviderEnvValue,
+  getAgentProviderDefinition,
+  inferAgentProvider,
+  providerRequiresForkTranscriptPrep,
+  providerSupportsHooks,
+  providerSupportsCapability,
+} from "./agentProviderRegistry";
 
 export function resolveSessionAgentProvider(
   session: Pick<Session, "agent_provider" | "name">,
@@ -29,9 +35,7 @@ export function collectSessionAgentProviders(
     const provider = resolveSessionAgentProvider(session);
     if (provider) providers.add(provider);
   }
-  return (["claude", "codex"] as const).filter((provider) =>
-    providers.has(provider),
-  );
+  return AGENT_PROVIDER_ORDER.filter((provider) => providers.has(provider));
 }
 
 export function AgentProviderIcon({
@@ -41,12 +45,13 @@ export function AgentProviderIcon({
   provider: SessionAgentProvider;
   className?: string;
 }) {
+  const definition = getAgentProviderDefinition(provider);
   const iconStyle: CSSProperties = {
-    WebkitMaskImage: `url("${ICON_URL[provider]}")`,
+    WebkitMaskImage: `url("${definition.icon.url}")`,
     WebkitMaskPosition: "center",
     WebkitMaskRepeat: "no-repeat",
     WebkitMaskSize: "contain",
-    maskImage: `url("${ICON_URL[provider]}")`,
+    maskImage: `url("${definition.icon.url}")`,
     maskPosition: "center",
     maskRepeat: "no-repeat",
     maskSize: "contain",
@@ -55,7 +60,7 @@ export function AgentProviderIcon({
   return (
     <span
       role="img"
-      aria-label={LABEL[provider]}
+      aria-label={definition.icon.alt}
       className={cn(
         "inline-flex size-3 shrink-0 items-center justify-center bg-current align-middle",
         className,
@@ -63,11 +68,4 @@ export function AgentProviderIcon({
       style={iconStyle}
     />
   );
-}
-
-function inferAgentProvider(name: string): SessionAgentProvider | null {
-  const normalized = name.toLowerCase();
-  if (/\bclaude\b/.test(normalized)) return "claude";
-  if (/\bcodex\b/.test(normalized)) return "codex";
-  return null;
 }

--- a/src/lib/agentProviderRegistry.ts
+++ b/src/lib/agentProviderRegistry.ts
@@ -1,0 +1,137 @@
+import claudeIconUrl from "../assets/vendor/lobe-icons/claude.svg";
+import codexIconUrl from "../assets/vendor/lobe-icons/codex.svg";
+import type { AgentProviderDefinition, SessionAgentProvider } from "./types";
+
+export const AGENT_PROVIDER_ORDER = [
+  "claude",
+  "codex",
+] as const satisfies readonly SessionAgentProvider[];
+
+type AgentProviderRegistry = {
+  readonly [Provider in SessionAgentProvider]: AgentProviderDefinition<Provider>;
+};
+
+export const AGENT_PROVIDER_REGISTRY = {
+  claude: {
+    id: "claude",
+    label: "Claude",
+    icon: {
+      kind: "mask",
+      url: claudeIconUrl,
+      alt: "Claude",
+    },
+    capabilities: ["history", "resume", "fork", "status", "hooks"],
+    hooks: {
+      supportsHooks: true,
+      providerEnvValue: "claude",
+    },
+    session: {
+      supportsSessionResume: true,
+      markerFile: "claude.id",
+      acknowledgedMarkerFile: "claude.id.acknowledged",
+      resumeCommandPrefix: "claude --resume",
+      forkCommandPrefix: "claude --resume",
+      forkCommandSuffix: "--fork-session",
+      requiresForkTranscriptPrep: true,
+    },
+    inferNamePattern: /\bclaude\b/i,
+  },
+  codex: {
+    id: "codex",
+    label: "Codex",
+    icon: {
+      kind: "mask",
+      url: codexIconUrl,
+      alt: "Codex",
+    },
+    capabilities: ["history", "resume", "fork", "status", "hooks"],
+    hooks: {
+      supportsHooks: true,
+      providerEnvValue: "codex",
+    },
+    session: {
+      supportsSessionResume: true,
+      markerFile: "codex.id",
+      acknowledgedMarkerFile: "codex.id.acknowledged",
+      resumeCommandPrefix: "codex resume",
+      forkCommandPrefix: "codex fork",
+      requiresForkTranscriptPrep: false,
+    },
+    inferNamePattern: /\bcodex\b/i,
+  },
+} as const satisfies AgentProviderRegistry;
+
+export function getAgentProviderDefinition(
+  provider: SessionAgentProvider,
+): AgentProviderDefinition {
+  return AGENT_PROVIDER_REGISTRY[provider];
+}
+
+export function inferAgentProvider(name: string): SessionAgentProvider | null {
+  for (const provider of AGENT_PROVIDER_ORDER) {
+    const definition = getAgentProviderDefinition(provider);
+    if (definition.inferNamePattern.test(name)) return provider;
+  }
+  return null;
+}
+
+export function providerSupportsCapability(
+  provider: SessionAgentProvider,
+  capability: AgentProviderDefinition["capabilities"][number],
+): boolean {
+  return getAgentProviderDefinition(provider).capabilities.includes(capability);
+}
+
+export function providerSupportsHooks(provider: SessionAgentProvider): boolean {
+  const definition = getAgentProviderDefinition(provider);
+  return (
+    definition.hooks.supportsHooks &&
+    providerSupportsCapability(provider, "hooks") &&
+    Boolean(definition.hooks.providerEnvValue)
+  );
+}
+
+export function getAgentHookProviderEnvValue(
+  provider: SessionAgentProvider,
+): SessionAgentProvider | null {
+  if (!providerSupportsHooks(provider)) return null;
+  return getAgentProviderDefinition(provider).hooks.providerEnvValue ?? null;
+}
+
+export function buildAgentResumeCommand(
+  provider: SessionAgentProvider,
+  sessionId: string,
+): string {
+  const definition = getAgentProviderDefinition(provider);
+  const { session } = definition;
+  if (
+    !session.supportsSessionResume ||
+    !providerSupportsCapability(provider, "resume") ||
+    !session.resumeCommandPrefix
+  ) {
+    throw new Error(`${definition.label} does not support session resume`);
+  }
+  return `${session.resumeCommandPrefix} ${sessionId}`;
+}
+
+export function buildAgentForkCommand(
+  provider: SessionAgentProvider,
+  sessionId: string,
+): string {
+  const definition = getAgentProviderDefinition(provider);
+  const { session } = definition;
+  if (!providerSupportsCapability(provider, "fork") || !session.forkCommandPrefix) {
+    throw new Error(`${definition.label} does not support session fork`);
+  }
+  return [session.forkCommandPrefix, sessionId, session.forkCommandSuffix]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export function providerRequiresForkTranscriptPrep(
+  provider: SessionAgentProvider,
+): boolean {
+  return Boolean(
+    getAgentProviderDefinition(provider).session.requiresForkTranscriptPrep,
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -38,12 +38,14 @@ export const api = {
     repoPath: string,
     isolated = false,
     kind: SessionKind = "regular",
+    agentProvider?: SessionAgentProvider | null,
   ): Promise<Session> {
     return invoke<Session>("create_session", {
       name,
       repoPath,
       isolated,
       kind,
+      agentProvider,
     });
   },
   removeSession(id: string, removeWorktree = false): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,46 @@ export type SessionOwner =
 
 export type SessionAgentProvider = "claude" | "codex";
 
+export type AgentProviderCapability =
+  | "history"
+  | "resume"
+  | "fork"
+  | "status"
+  | "hooks";
+
+export interface AgentProviderIconMetadata {
+  kind: "mask";
+  url: string;
+  alt: string;
+}
+
+export interface AgentProviderHookMetadata {
+  supportsHooks: boolean;
+  providerEnvValue?: SessionAgentProvider;
+}
+
+export interface AgentProviderSessionMetadata {
+  markerFile?: string;
+  acknowledgedMarkerFile?: string;
+  resumeCommandPrefix?: string;
+  forkCommandPrefix?: string;
+  forkCommandSuffix?: string;
+  supportsSessionResume: boolean;
+  requiresForkTranscriptPrep?: boolean;
+}
+
+export interface AgentProviderDefinition<
+  TProvider extends SessionAgentProvider = SessionAgentProvider,
+> {
+  id: TProvider;
+  label: string;
+  icon: AgentProviderIconMetadata;
+  capabilities: readonly AgentProviderCapability[];
+  hooks: AgentProviderHookMetadata;
+  session: AgentProviderSessionMetadata;
+  inferNamePattern: RegExp;
+}
+
 export interface Session {
   id: string;
   name: string;

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -822,6 +822,7 @@ describe("createSession", () => {
       REPO_A,
       false,
       "regular",
+      null,
     );
   });
 
@@ -837,6 +838,23 @@ describe("createSession", () => {
       REPO_A,
       false,
       "control",
+      null,
+    );
+  });
+
+  it("forwards an explicit agent provider to the backend", async () => {
+    mockApi.createSession.mockResolvedValueOnce(
+      session("agent", REPO_A, { agent_provider: "codex" }),
+    );
+    await useAppStore
+      .getState()
+      .createSession("agent", REPO_A, false, "regular", "codex");
+    expect(mockApi.createSession).toHaveBeenCalledWith(
+      "agent",
+      REPO_A,
+      false,
+      "regular",
+      "codex",
     );
   });
 
@@ -1018,6 +1036,19 @@ describe("pendingTerminalInput", () => {
     expect(consumePendingTerminalInput("sess-1")).toEqual({
       command: "claude --worktree",
       adoptWorktreeOnExit: true,
+    });
+  });
+
+  it("keeps queued provider metadata with pending terminal input", () => {
+    const { setPendingTerminalInput, consumePendingTerminalInput } =
+      useAppStore.getState();
+    setPendingTerminalInput("sess-1", "codex resume abc", {
+      agentProvider: "codex",
+    });
+    expect(consumePendingTerminalInput("sess-1")).toEqual({
+      command: "codex resume abc",
+      adoptWorktreeOnExit: false,
+      agentProvider: "codex",
     });
   });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,7 +1,12 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { api } from "./lib/api";
-import type { Project, Session, SessionKind } from "./lib/types";
+import type {
+  Project,
+  Session,
+  SessionAgentProvider,
+  SessionKind,
+} from "./lib/types";
 import { commandRequestsWorktreeAdoption } from "./lib/worktreeAdoption";
 import { CONTROL_GUIDE_DISMISSED_KEY } from "./components/ControlSessionGuideModal";
 import {
@@ -153,6 +158,7 @@ interface AppStateModel {
     repoPath: string,
     isolated?: boolean,
     kind?: SessionKind,
+    agentProvider?: SessionAgentProvider | null,
   ) => Promise<Session | null>;
   removeSession: (id: string, removeWorktree?: boolean) => Promise<void>;
   renameSession: (id: string, name: string) => Promise<void>;
@@ -194,10 +200,12 @@ interface AppStateModel {
 export interface PendingTerminalInput {
   command: string;
   adoptWorktreeOnExit: boolean;
+  agentProvider?: SessionAgentProvider;
 }
 
 export interface PendingTerminalInputOptions {
   adoptWorktreeOnExit?: boolean;
+  agentProvider?: SessionAgentProvider;
 }
 
 let paneCounter = 0;
@@ -966,7 +974,13 @@ export const useAppStore = create<AppStateModel>()(
     });
   },
 
-  async createSession(name, repoPath, isolated = false, kind = "regular") {
+  async createSession(
+    name,
+    repoPath,
+    isolated = false,
+    kind = "regular",
+    agentProvider = null,
+  ) {
     set({ loading: true, error: null });
     try {
       // Snapshot the previously-active tab's index in the focused pane so
@@ -985,7 +999,13 @@ export const useAppStore = create<AppStateModel>()(
         return idx >= 0 ? { paneId, idx } : null;
       })();
 
-      const created = await api.createSession(name, repoPath, isolated, kind);
+      const created = await api.createSession(
+        name,
+        repoPath,
+        isolated,
+        kind,
+        agentProvider,
+      );
       await get().refreshAll();
 
       // Reorder so the new tab sits immediately after the previously-active
@@ -1260,6 +1280,9 @@ export const useAppStore = create<AppStateModel>()(
           adoptWorktreeOnExit:
             options?.adoptWorktreeOnExit ??
             commandRequestsWorktreeAdoption(command),
+          ...(options?.agentProvider
+            ? { agentProvider: options.agentProvider }
+            : {}),
         },
       },
     }));


### PR DESCRIPTION
## Summary

This PR moves Acorn's current Claude/Codex provider handling behind a typed registry and wires the first provider-aware hook env seam into session launch.

1. **Provider registry:** Adds a typed frontend registry for `claude` and `codex` with labels, icon metadata, capabilities, hook support metadata, and current resume/fork/session metadata.
2. **Registry-backed call sites:** Replaces hardcoded label/icon/order/inference handling, resume command generation, fork command generation, and Claude fork transcript-prep decisions with registry helpers.
3. **Explicit provider flow:** Carries `agent_provider` through provider-backed session creation paths, including history resume and fork-created sessions, while keeping name inference as a fallback for legacy/ordinary sessions.
4. **Hook env seam:** Changes backend hook env injection to activate only for known provider sessions, and centralizes Claude/Codex hook env string mapping on `SessionAgentProvider` helpers.
5. **Focused coverage:** Adds frontend and Rust tests for registry hook metadata, explicit provider forwarding, pending provider metadata, and provider-aware hook env injection.

## Expected impact

| Area | Expected impact |
| --- | --- |
| User-visible UI | No intended visual or workflow change. |
| Hook runtime | Hook env is only stamped for known provider sessions, avoiding generic shell sessions receiving hook URL/token/session env. |
| Provider extensibility | Future providers can add frontend metadata and backend provider helpers without adding more scattered Claude/Codex command branches. |
| Compatibility | Existing Claude/Codex resume/fork commands and Rust enum serialization remain compatible. |

## Design notes

- This keeps the backend provider model deliberately small: Claude/Codex remain the only Rust enum variants, with helper methods for hook support and provider env values.
- The frontend registry remains the source of truth for label/icon/capability/session command metadata.
- `agent_provider` is passed explicitly for provider-created sessions; existing name-based inference remains only as a UI fallback.
- Hook server/config writer work is not added here. `ACORN_AGENT_HOOK_URL` and `ACORN_AGENT_HOOK_TOKEN` are still injected only when the runtime hook server exists, and now only after a known hook-capable provider is present.

## Follow-up (not in this PR)

- Add Gemini/OpenCode entries once their transcript, resume, status, and hook semantics are defined.
- Move provider-specific backend command names and agent-detection payloads behind a broader provider API in a later cleanup.
- Implement hook config file writing/runtime integration separately from this env seam.
- Add terminal output classification separately if needed.

## Test plan

- [x] `pnpm typecheck` - passed.
- [x] `pnpm test -- --run src/lib/agentProvider.test.ts src/components/AgentResumeModal.test.tsx src/store.test.ts` - passed, 73 passed / 1 skipped.
- [x] `TAURI_SIDECAR_PROFILE=debug ./src-tauri/scripts/build-sidecar.sh` - passed; staged local debug sidecar binaries required by Tauri test build checks.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml inject_agent_hook_env` - passed, 3 tests.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-session session_agent_provider_reports_hook_env_metadata` - passed, 1 test.

## Notes

- `docs/HOOK_ENV_INJECTION_PLAN.md` was requested for review but is not present in this worktree.
- The generated sidecar binaries are ignored build artifacts and were not committed.