### PR TITLE
fix(worktree): prompt before deleting linked session worktrees

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -862,9 +862,8 @@ pub async fn remove_project(
             .collect();
         for session in session_ids {
             state.pty.kill(&session.id).ok();
-            if drop_worktrees && session.isolated {
-                let safe_name = sanitize_worktree_name(&session.name);
-                worktree::remove_worktree(&session.repo_path, &safe_name).ok();
+            if drop_worktrees {
+                remove_linked_worktree_at_path(&session.repo_path, &session.worktree_path).ok();
             }
             state.sessions.remove(&session.id).ok();
         }
@@ -886,9 +885,8 @@ pub async fn remove_session(
     if let Ok(dir) = persistence::data_dir() {
         scrollback::delete(&dir, &id.to_string()).ok();
     }
-    if session.isolated && remove_worktree.unwrap_or(false) {
-        let safe_name = sanitize_worktree_name(&session.name);
-        worktree::remove_worktree(&session.repo_path, &safe_name).ok();
+    if remove_worktree.unwrap_or(false) {
+        remove_linked_worktree_at_path(&session.repo_path, &session.worktree_path).ok();
     }
     state.sessions.remove(&id)?;
     persist(&state);
@@ -2365,6 +2363,13 @@ pub(crate) fn create_unique_worktree(
     }
 }
 
+pub(crate) fn remove_linked_worktree_at_path(
+    repo_path: &Path,
+    worktree_path: &Path,
+) -> AppResult<()> {
+    worktree::remove_worktree_at_path(repo_path, worktree_path)
+}
+
 /// Surface the "이전 Claude 대화 있음" candidate for a session — used by
 /// the frontend modal that pops on session focus. `None` means there is
 /// nothing the user needs to decide about (no claude has run, or the
@@ -2529,7 +2534,7 @@ mod tests {
     use super::{
         collect_memory_usage_from_roots, create_unique_worktree, font_name_from_path,
         infer_acornd_root_from_session_pids, inject_agent_hook_env, memory_root_pids,
-        validate_new_project_name, ProcessMemorySnapshot,
+        remove_linked_worktree_at_path, validate_new_project_name, ProcessMemorySnapshot,
     };
     use acorn_session::{Session, SessionAgentProvider, SessionKind};
     use std::collections::HashMap;
@@ -2769,6 +2774,40 @@ mod tests {
         );
         assert!(path.exists(), "worktree path should exist on disk");
 
+        std::fs::remove_dir_all(&repo_dir).ok();
+    }
+
+    #[test]
+    fn remove_linked_worktree_at_path_uses_actual_path_not_session_name() {
+        let repo_dir = unique_repo_dir("remove-by-path");
+        init_repo_with_commit(&repo_dir);
+        let (_name, path) =
+            create_unique_worktree(&repo_dir, "acorn-2").expect("worktree should be created");
+        assert!(path.exists(), "worktree path should exist before removal");
+
+        remove_linked_worktree_at_path(&repo_dir, &path).expect("remove by path");
+
+        assert!(
+            !path.exists(),
+            "worktree path should be removed even when the session name differs"
+        );
+        std::fs::remove_dir_all(&repo_dir).ok();
+    }
+
+    #[test]
+    fn remove_linked_worktree_at_path_handles_project_root_that_is_a_worktree() {
+        let repo_dir = unique_repo_dir("remove-project-root-worktree-main");
+        init_repo_with_commit(&repo_dir);
+        let (_name, path) =
+            create_unique_worktree(&repo_dir, "external").expect("worktree should be created");
+        assert!(path.exists(), "linked project root should exist before removal");
+
+        remove_linked_worktree_at_path(&path, &path).expect("remove linked project root by path");
+
+        assert!(
+            !path.exists(),
+            "linked project root should be removed when explicitly requested"
+        );
         std::fs::remove_dir_all(&repo_dir).ok();
     }
 

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -108,15 +108,38 @@ pub fn list_worktree_paths(repo_path: &Path) -> AppResult<Vec<std::path::PathBuf
     Ok(paths)
 }
 
-pub fn remove_worktree(repo_path: &Path, name: &str) -> AppResult<()> {
-    let repo = ensure_repo(repo_path)?;
-    let wt = repo.find_worktree(name)?;
-    wt.prune(None)?;
-    let path = worktree_root(repo_path).join(name);
-    if path.exists() {
-        std::fs::remove_dir_all(&path).ok();
+pub fn remove_worktree_at_path(repo_path: &Path, worktree_path: &Path) -> AppResult<()> {
+    if worktree_path.exists() && !is_linked_worktree_root(worktree_path) {
+        return Err(AppError::InvalidPath(format!(
+            "not a linked git worktree: {}",
+            worktree_path.display()
+        )));
     }
-    Ok(())
+
+    let repo = ensure_repo(repo_path)?;
+    let names = repo.worktrees()?;
+    for name in names.iter().flatten() {
+        let wt = repo.find_worktree(name)?;
+        if same_path(wt.path(), worktree_path) {
+            if worktree_path.exists() {
+                std::fs::remove_dir_all(worktree_path).ok();
+            }
+            wt.prune(None)?;
+            return Ok(());
+        }
+    }
+
+    Err(AppError::InvalidPath(format!(
+        "linked git worktree is not registered: {}",
+        worktree_path.display()
+    )))
+}
+
+fn same_path(left: &Path, right: &Path) -> bool {
+    match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
 }
 
 /// Returns `true` when `path` is the root of a *linked* git worktree.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import {
   shouldUseTinykeysToggleMultiInputFallback,
   useHotkeys,
 } from "./lib/hotkeys";
+import { hasRecordedWorktree } from "./lib/sessionWorktree";
 import {
   EQUALIZE_PANES_EVENT,
   EXPAND_PANEL_EVENT,
@@ -662,13 +663,13 @@ function App() {
     };
   }, [activeSessionId, sessionIdsKey]);
 
-  // Skip the confirmation dialog for non-isolated sessions when the user has
-  // opted out via Settings. Isolated worktrees always prompt because the
-  // delete-worktree choice still matters.
+  // Skip the confirmation dialog for plain sessions when the user has opted
+  // out via Settings. Recorded worktrees still prompt because the
+  // delete-worktree choice matters.
   useEffect(() => {
     if (!pendingRemove) return;
     const confirm = useSettings.getState().settings.sessions.confirmRemove;
-    if (confirm || pendingRemove.isolated) return;
+    if (confirm || hasRecordedWorktree(pendingRemove)) return;
     clearPendingRemove();
     removeSession(pendingRemove.id, false);
   }, [pendingRemove, clearPendingRemove, removeSession]);

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -49,6 +49,7 @@ import {
 import { formatHotkey, Hotkeys } from "../lib/hotkeys";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import { useSettings } from "../lib/settings";
+import { hasRecordedWorktree } from "../lib/sessionWorktree";
 import { useTranslation } from "../lib/useTranslation";
 import type { Direction, PaneId } from "../lib/layout";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
@@ -920,7 +921,7 @@ function TabItem({
           </span>
         )}
         {session &&
-        (liveInWorktree ?? (session.isolated || session.in_worktree)) ? (
+        (liveInWorktree ?? hasRecordedWorktree(session)) ? (
           <GitBranch
             size={10}
             className="pointer-events-none text-fg-muted"

--- a/src/components/RemoveProjectDialog.tsx
+++ b/src/components/RemoveProjectDialog.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle } from "lucide-react";
 import type { Project, Session } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
+import { hasRecordedWorktree } from "../lib/sessionWorktree";
 import { useTranslation } from "../lib/useTranslation";
 import { Modal, ModalHeader } from "./ui";
 
@@ -27,9 +28,13 @@ export function RemoveProjectDialog({
   onClose,
 }: RemoveProjectDialogProps) {
   const t = useTranslation();
-  const isolatedCount = sessions.filter((s) => s.isolated).length;
+  const worktreeSessions = sessions.filter(hasRecordedWorktree);
+  const worktreeCount = worktreeSessions.length;
+  const linkedCount = worktreeSessions.filter((s) => !s.isolated).length;
   const primaryChoice: RemoveProjectChoice =
-    isolatedCount > 0 ? "project_and_worktrees" : "project_only";
+    worktreeCount > 0 && linkedCount === 0
+      ? "project_and_worktrees"
+      : "project_only";
 
   useDialogShortcuts(project !== null, {
     onCancel: () => onClose("cancel"),
@@ -66,11 +71,11 @@ export function RemoveProjectDialog({
                   ? dt(t, "dialogs.removeProject.sessionSingular")
                   : dt(t, "dialogs.removeProject.sessionPlural")}{" "}
                 {dt(t, "dialogs.removeProject.willBeRemoved")}
-                {isolatedCount > 0
-                  ? ` (${isolatedCount} ${
-                      isolatedCount === 1
-                        ? dt(t, "dialogs.removeProject.isolatedWorktreeSingular")
-                        : dt(t, "dialogs.removeProject.isolatedWorktreePlural")
+                {worktreeCount > 0
+                  ? ` (${worktreeCount} ${
+                      worktreeCount === 1
+                        ? dt(t, "dialogs.removeProject.linkedWorktreeSingular")
+                        : dt(t, "dialogs.removeProject.linkedWorktreePlural")
                     })`
                   : ""}
                 .
@@ -85,7 +90,7 @@ export function RemoveProjectDialog({
             >
               {dt(t, "dialogs.common.cancel")}
             </button>
-            {isolatedCount > 0 ? (
+            {worktreeCount > 0 ? (
               <button
                 type="button"
                 onClick={() => onClose("project_only")}
@@ -98,12 +103,12 @@ export function RemoveProjectDialog({
               type="button"
               onClick={() =>
                 onClose(
-                  isolatedCount > 0 ? "project_and_worktrees" : "project_only",
+                  worktreeCount > 0 ? "project_and_worktrees" : "project_only",
                 )
               }
               className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
             >
-              {isolatedCount > 0
+              {worktreeCount > 0
                 ? dt(t, "dialogs.removeProject.closeDeleteWorktrees")
                 : dt(t, "dialogs.removeProject.closeProject")}
             </button>

--- a/src/components/RemoveSessionDialog.test.tsx
+++ b/src/components/RemoveSessionDialog.test.tsx
@@ -1,0 +1,71 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Session } from "../lib/types";
+import { useSettings } from "../lib/settings";
+import { RemoveSessionDialog } from "./RemoveSessionDialog";
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "session-1",
+    name: "Session 1",
+    repo_path: "/repo",
+    worktree_path: "/repo/.claude/worktrees/session-1",
+    branch: "main",
+    isolated: false,
+    status: "idle",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: null,
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: false,
+    ...overrides,
+  };
+}
+
+describe("RemoveSessionDialog", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    useSettings.getState().patchLanguage("en");
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) act(() => root.unmount());
+    container?.remove();
+    vi.clearAllMocks();
+  });
+
+  function renderDialog(target: Session) {
+    const onClose = vi.fn();
+    act(() => {
+      root.render(<RemoveSessionDialog session={target} onClose={onClose} />);
+    });
+    return onClose;
+  }
+
+  it("offers worktree deletion for a non-isolated linked worktree session", () => {
+    renderDialog(session({ in_worktree: true }));
+
+    expect(document.body.textContent).toContain(
+      "This session is using a linked git worktree:",
+    );
+    expect(document.body.textContent).toContain("Keep worktree");
+    expect(document.body.textContent).toContain("Delete worktree");
+    expect(document.body.textContent).not.toContain("Don't ask again");
+  });
+
+  it("keeps the plain session remove confirmation for non-worktree sessions", () => {
+    renderDialog(session({ worktree_path: "/repo" }));
+
+    expect(document.body.textContent).toContain("will not be touched");
+    expect(document.body.textContent).toContain("Don't ask again");
+    expect(document.body.textContent).not.toContain("Delete worktree");
+  });
+});

--- a/src/components/RemoveSessionDialog.tsx
+++ b/src/components/RemoveSessionDialog.tsx
@@ -4,6 +4,7 @@ import type { Session } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useSettings } from "../lib/settings";
+import { hasRecordedWorktree } from "../lib/sessionWorktree";
 import { useTranslation } from "../lib/useTranslation";
 import { Modal, ModalHeader } from "./ui";
 
@@ -22,6 +23,7 @@ interface RemoveSessionDialogProps {
 export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogProps) {
   const t = useTranslation();
   const isolated = session?.isolated ?? false;
+  const recordedWorktree = session ? hasRecordedWorktree(session) : false;
   const patchSessions = useSettings((s) => s.patchSessions);
   const [dontAskAgain, setDontAskAgain] = useState(false);
 
@@ -30,14 +32,14 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
     if (session) setDontAskAgain(false);
   }, [session?.id]);
 
-  // Enter triggers the same primary action as the rightmost destructive button:
-  // for isolated worktrees that means "Delete worktree", otherwise "Remove".
+  // Keep Enter conservative for non-isolated linked worktrees, which may be
+  // user-managed outside Acorn even though the session path is a real worktree.
   const primaryChoice: RemoveChoice = isolated
     ? "session_and_worktree"
     : "session_only";
 
   function commit(choice: RemoveChoice) {
-    if (choice !== "cancel" && dontAskAgain && !isolated) {
+    if (choice !== "cancel" && dontAskAgain && !recordedWorktree) {
       patchSessions({ confirmRemove: false });
     }
     onClose(choice);
@@ -68,10 +70,12 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
               {dt(t, "dialogs.removeSession.confirmPrefix")}{" "}
               <span className="font-mono text-accent">{session.name}</span>?
             </p>
-            {isolated ? (
+            {recordedWorktree ? (
               <div className="space-y-2 rounded-md border border-border bg-bg-sidebar/60 p-3">
                 <p className="text-xs text-fg-muted">
-                  {dt(t, "dialogs.removeSession.isolatedWorktree")}
+                  {isolated
+                    ? dt(t, "dialogs.removeSession.isolatedWorktree")
+                    : dt(t, "dialogs.removeSession.linkedWorktree")}
                 </p>
                 <p className="break-all font-mono text-xs text-fg">
                   {session.worktree_path}
@@ -87,7 +91,7 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
                 {dt(t, "dialogs.removeSession.willNotBeTouched")}
               </p>
             )}
-            {!isolated ? (
+            {!recordedWorktree ? (
               <label className="flex cursor-pointer items-center gap-2 pt-1 text-xs text-fg-muted">
                 <input
                   type="checkbox"
@@ -107,7 +111,7 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
             >
               {dt(t, "dialogs.common.cancel")}
             </button>
-            {isolated ? (
+            {recordedWorktree ? (
               <>
                 <button
                   type="button"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -54,6 +54,7 @@ import {
   type AcornSettings,
   type SessionTitleSource,
 } from "../lib/settings";
+import { hasRecordedWorktree } from "../lib/sessionWorktree";
 import { useTranslation } from "../lib/useTranslation";
 import {
   planChevronClick,
@@ -547,7 +548,7 @@ function SessionRowPreview({
           <span className="truncate text-[13px] font-medium leading-5 text-fg">
             {session.name}
           </span>
-          {session.isolated || session.in_worktree ? (
+          {hasRecordedWorktree(session) ? (
             <GitBranch size={10} className="shrink-0 text-fg-muted" />
           ) : null}
         </span>
@@ -1181,8 +1182,7 @@ function SessionRowLabel({
   // `in_worktree`) only apply as fallback when the session has no live PTY,
   // in which case `liveInWorktree[id]` is `undefined`.
   const liveInWorktree = useAppStore((s) => s.liveInWorktree[session.id]);
-  const inWorktree =
-    liveInWorktree ?? (session.isolated || session.in_worktree);
+  const inWorktree = liveInWorktree ?? hasRecordedWorktree(session);
   const body = (
     <span className="min-w-0 flex-1">
       <span className="flex h-5 items-center gap-1">

--- a/src/lib/sessionWorktree.test.ts
+++ b/src/lib/sessionWorktree.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type { Session } from "./types";
+import { hasRecordedWorktree } from "./sessionWorktree";
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "session-1",
+    name: "session-1",
+    repo_path: "/repo",
+    worktree_path: "/repo",
+    branch: "main",
+    isolated: false,
+    status: "idle",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: null,
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: false,
+    ...overrides,
+  };
+}
+
+describe("hasRecordedWorktree", () => {
+  it("treats Acorn isolated sessions as worktree-backed", () => {
+    expect(hasRecordedWorktree(session({ isolated: true }))).toBe(true);
+  });
+
+  it("treats adopted linked worktree sessions as worktree-backed", () => {
+    expect(hasRecordedWorktree(session({ in_worktree: true }))).toBe(true);
+  });
+
+  it("does not infer a removable worktree for ordinary repo sessions", () => {
+    expect(hasRecordedWorktree(session())).toBe(false);
+  });
+});

--- a/src/lib/sessionWorktree.ts
+++ b/src/lib/sessionWorktree.ts
@@ -1,0 +1,5 @@
+import type { Session } from "./types";
+
+export function hasRecordedWorktree(session: Session): boolean {
+  return session.isolated || session.in_worktree;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -798,6 +798,7 @@
       "title": "Remove session",
       "confirmPrefix": "Remove session",
       "isolatedWorktree": "This is an isolated worktree:",
+      "linkedWorktree": "This session is using a linked git worktree:",
       "deleteWorktreeQuestion": "Also delete the worktree from disk?",
       "filesIn": "Files in",
       "willNotBeTouched": "will not be touched.",
@@ -814,6 +815,8 @@
       "willBeRemoved": "will be removed",
       "isolatedWorktreeSingular": "isolated worktree",
       "isolatedWorktreePlural": "isolated worktrees",
+      "linkedWorktreeSingular": "linked worktree",
+      "linkedWorktreePlural": "linked worktrees",
       "closeKeepWorktrees": "Close · keep worktrees",
       "closeDeleteWorktrees": "Close · delete worktrees",
       "closeProject": "Close project"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -798,6 +798,7 @@
       "title": "세션 제거",
       "confirmPrefix": "세션 제거",
       "isolatedWorktree": "격리된 worktree입니다:",
+      "linkedWorktree": "이 세션은 linked git worktree를 사용 중입니다:",
       "deleteWorktreeQuestion": "디스크에서도 worktree를 삭제할까요?",
       "filesIn": "다음 위치의 파일은",
       "willNotBeTouched": "변경되지 않습니다.",
@@ -814,6 +815,8 @@
       "willBeRemoved": "제거됩니다",
       "isolatedWorktreeSingular": "격리된 worktree",
       "isolatedWorktreePlural": "격리된 worktree",
+      "linkedWorktreeSingular": "linked worktree",
+      "linkedWorktreePlural": "linked worktree",
       "closeKeepWorktrees": "닫기 · worktree 유지",
       "closeDeleteWorktrees": "닫기 · worktree 삭제",
       "closeProject": "프로젝트 닫기"


### PR DESCRIPTION
## Summary
Close-session cleanup now uses the same recorded-worktree signal as the UI worktree glyph, while keeping transient live-cwd changes out of destructive decisions.

1. **Prompt linked worktree sessions** — treat `session.isolated || session.in_worktree` as the recorded worktree condition for tab-close confirmation, so Acorn-managed isolated sessions and adopted/linked worktree sessions both offer keep/delete choices.
2. **Keep transient cwd non-destructive** — leave `liveInWorktree` as a display-only signal, so a user or agent temporarily `cd`ing into another worktree does not make that path a removal target.
3. **Delete by actual path** — replace session-name-derived worktree deletion with path-based git worktree lookup/removal, covering suffixed worktree names and linked-worktree project roots.
4. **Clarify copy and tests** — label non-isolated linked sessions as linked git worktrees, add focused React/unit tests, and cover backend deletion by actual path.

## Expected impact
| Scenario | Before | After |
| --- | --- | --- |
| Acorn isolated session close | Prompted to keep/delete worktree | Unchanged |
| `claude -w` / adopted linked worktree close | Could be treated like a plain session | Prompts to keep/delete recorded worktree |
| Agent temporarily `cd`s into a worktree | Worktree icon may show while live | Still display-only; no delete prompt solely from live cwd |
| Worktree name differs from session name | Delete could miss the actual worktree | Delete resolves the registered git worktree by path |

## Design notes
- `hasRecordedWorktree(session)` centralizes the static icon/removal signal and intentionally excludes the live PTY cwd map.
- Non-isolated linked worktrees default Enter to keeping the worktree, since those paths may be user-managed even when they are valid linked worktrees.
- Backend deletion validates the target as a linked worktree and matches against registered git worktree paths before removing the directory and pruning metadata.
- Project close now counts recorded linked worktrees, but avoids making linked non-isolated worktree deletion the keyboard-default action.

## Follow-up (not in this PR)
- Surface a more explicit warning for project-root linked worktrees if user testing shows the current linked-worktree wording is too subtle.

## Test plan
- [x] `pnpm run build:sidecar` — staged `acorn-ipc-aarch64-apple-darwin` and `acornd-aarch64-apple-darwin` in the clean PR worktree
- [x] `pnpm run typecheck` — passes in the clean PR worktree
- [x] `pnpm vitest run src/components/RemoveSessionDialog.test.tsx src/lib/sessionWorktree.test.ts src/store.test.ts src/lib/worktreeAdoption.test.ts` — 70 passed, 1 skipped
- [x] `cargo test -p acorn --lib commands::tests` — 16 passed
- [x] `cargo test -p acorn --lib worktree::tests` — 3 passed
- [x] `git diff --check` — passes

## Notes
- The implementation was prepared in a clean `/tmp/acorn-worktree-close-prompts` worktree from `origin/main` so pre-existing local dirty files on `feat/agent-hook-runtime-wrappers` are not included.
