### PR TITLE
fix(terminal): transcript-driven remote-control redraw

### DIFF
--- a/src-tauri/crates/acorn-daemon/src/server.rs
+++ b/src-tauri/crates/acorn-daemon/src/server.rs
@@ -290,13 +290,17 @@ impl Daemon {
                 target_session_id,
                 data_b64,
             } => match base64_decode(&data_b64) {
-                Ok(bytes) => match self.pty.write(&target_session_id, &bytes) {
-                    Ok(()) => ControlResult::Ack,
-                    Err(err) => ControlResult::Error {
-                        code: io_error_to_code(&err),
-                        message: err.to_string(),
-                    },
-                },
+                Ok(bytes) => {
+                    let scrollback = self.pty.scrollback_snapshot(&target_session_id);
+                    let bytes = normalize_input_for_terminal_mode(bytes, scrollback.as_deref());
+                    match self.pty.write(&target_session_id, &bytes) {
+                        Ok(()) => ControlResult::Ack,
+                        Err(err) => ControlResult::Error {
+                            code: io_error_to_code(&err),
+                            message: err.to_string(),
+                        },
+                    }
+                }
                 Err(msg) => ControlResult::Error {
                     code: ErrorCode::Invalid,
                     message: msg,
@@ -476,6 +480,8 @@ impl Daemon {
                     match frame {
                         StreamFrame::Input { data_b64 } => {
                             if let Ok(b) = base64_decode(&data_b64) {
+                                let scrollback = pty_for_input.scrollback_snapshot(&session_id);
+                                let b = normalize_input_for_terminal_mode(b, scrollback.as_deref());
                                 let _ = pty_for_input.write(&session_id, &b);
                             }
                         }
@@ -529,6 +535,44 @@ impl Daemon {
         };
         serde_json::to_string(&env).unwrap()
     }
+}
+
+const ENHANCED_ENTER: &[u8] = b"\x1b[13u";
+
+fn normalize_input_for_terminal_mode(mut bytes: Vec<u8>, scrollback: Option<&[u8]>) -> Vec<u8> {
+    if bytes.last() == Some(&b'\r')
+        && scrollback
+            .map(uses_enhanced_keyboard_protocol)
+            .unwrap_or(false)
+    {
+        bytes.pop();
+        bytes.extend_from_slice(ENHANCED_ENTER);
+    }
+    bytes
+}
+
+fn uses_enhanced_keyboard_protocol(bytes: &[u8]) -> bool {
+    let mut last_enable = None;
+    let mut last_disable = None;
+    for index in 0..bytes.len().saturating_sub(2) {
+        if bytes[index] != 0x1b || bytes[index + 1] != b'[' {
+            continue;
+        }
+        match bytes[index + 2] {
+            b'>' => {
+                if bytes[index + 3..bytes.len().min(index + 24)].contains(&b'u') {
+                    last_enable = Some(index);
+                }
+            }
+            b'<' => {
+                if bytes[index + 3..bytes.len().min(index + 24)].contains(&b'u') {
+                    last_disable = Some(index);
+                }
+            }
+            _ => {}
+        }
+    }
+    last_enable > last_disable
 }
 
 fn write_line<W: Write>(w: &mut W, line: &str) -> io::Result<()> {
@@ -645,6 +689,25 @@ mod tests {
             let decoded = base64_decode(&encoded).unwrap();
             assert_eq!(&decoded, input);
         }
+    }
+
+    #[test]
+    fn enter_is_rewritten_when_enhanced_keyboard_mode_is_active() {
+        let bytes = normalize_input_for_terminal_mode(b"hello\r".to_vec(), Some(b"\x1b[>7u"));
+        assert_eq!(bytes, b"hello\x1b[13u");
+    }
+
+    #[test]
+    fn enter_stays_carriage_return_without_enhanced_keyboard_mode() {
+        let bytes = normalize_input_for_terminal_mode(b"hello\r".to_vec(), Some(b"shell prompt"));
+        assert_eq!(bytes, b"hello\r");
+    }
+
+    #[test]
+    fn enhanced_keyboard_disable_clears_enter_rewrite() {
+        let bytes =
+            normalize_input_for_terminal_mode(b"hello\r".to_vec(), Some(b"\x1b[>7u later \x1b[<u"));
+        assert_eq!(bytes, b"hello\r");
     }
 
     #[test]

--- a/src-tauri/src/agent_transcript_watcher.rs
+++ b/src-tauri/src/agent_transcript_watcher.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 
 use crate::agent_resume;
 use crate::state::AppState;
+use acorn_session::SessionStatus;
 
 pub const AGENT_TRANSCRIPT_ADVANCED_EVENT: &str = "acorn:agent-transcript-advanced";
 
@@ -98,6 +99,8 @@ fn tick(
             continue;
         }
 
+        nudge_terminal_redraw(state, session.id, session.status);
+
         let payload = AgentTranscriptAdvancedPayload {
             session_id: session.id.to_string(),
             transcript_path: next.path.display().to_string(),
@@ -114,6 +117,30 @@ fn tick(
         }
 
         cursors.insert(session.id, next);
+    }
+}
+
+fn nudge_terminal_redraw(state: &AppState, session_id: Uuid, status: SessionStatus) {
+    if status == SessionStatus::Running {
+        return;
+    }
+    let Some(size) = state.stream_registry.size(&session_id) else {
+        return;
+    };
+    if size.cols < 2 || size.rows < 1 {
+        return;
+    }
+    let nudge_cols = size.cols.saturating_sub(1).max(1);
+    if let Err(err) = state
+        .daemon_bridge
+        .resize(session_id, nudge_cols, size.rows)
+        .and_then(|_| state.daemon_bridge.resize(session_id, size.cols, size.rows))
+    {
+        tracing::debug!(
+            %session_id,
+            error = %err,
+            "agent_transcript_watcher: redraw nudge failed",
+        );
     }
 }
 

--- a/src-tauri/src/agent_transcript_watcher.rs
+++ b/src-tauri/src/agent_transcript_watcher.rs
@@ -1,0 +1,181 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+use uuid::Uuid;
+
+use crate::agent_resume;
+use crate::state::AppState;
+
+pub const AGENT_TRANSCRIPT_ADVANCED_EVENT: &str = "acorn:agent-transcript-advanced";
+
+const POLL_INTERVAL: Duration = Duration::from_millis(300);
+const MAPPING_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentTranscriptAdvancedPayload {
+    pub session_id: String,
+    pub transcript_path: String,
+    pub size: u64,
+    pub updated_at: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TranscriptCursor {
+    path: PathBuf,
+    size: u64,
+    modified: Option<SystemTime>,
+}
+
+impl TranscriptCursor {
+    fn updated_at(&self) -> u64 {
+        self.modified
+            .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0)
+    }
+}
+
+pub fn spawn(app: AppHandle, state: AppState) {
+    std::thread::Builder::new()
+        .name("acorn-transcript-watcher".into())
+        .spawn(move || run(app, state))
+        .map(drop)
+        .unwrap_or_else(|err| {
+            tracing::warn!(error = %err, "agent_transcript_watcher: thread spawn failed");
+        });
+}
+
+fn run(app: AppHandle, state: AppState) {
+    let mut cursors = HashMap::new();
+    let mut last_mapping_refresh = Instant::now() - MAPPING_REFRESH_INTERVAL;
+    loop {
+        std::thread::sleep(POLL_INTERVAL);
+        let refresh_mappings = last_mapping_refresh.elapsed() >= MAPPING_REFRESH_INTERVAL;
+        tick(&app, &state, &mut cursors, refresh_mappings);
+        if refresh_mappings {
+            last_mapping_refresh = Instant::now();
+        }
+    }
+}
+
+fn tick(
+    app: &AppHandle,
+    state: &AppState,
+    cursors: &mut HashMap<Uuid, TranscriptCursor>,
+    refresh_mappings: bool,
+) {
+    let sessions = state.sessions.list();
+    let live_ids = sessions
+        .iter()
+        .map(|session| session.id)
+        .collect::<HashSet<_>>();
+    cursors.retain(|session_id, _| live_ids.contains(session_id));
+
+    for session in sessions {
+        let path = match (refresh_mappings, cursors.get(&session.id)) {
+            (true, _) | (_, None) => match agent_resume::live_transcript(session.id) {
+                Some(transcript) => transcript.path,
+                None => {
+                    cursors.remove(&session.id);
+                    continue;
+                }
+            },
+            (false, Some(cursor)) => cursor.path.clone(),
+        };
+
+        let Some(next) = stat_cursor(path) else {
+            cursors.remove(&session.id);
+            continue;
+        };
+
+        if !transcript_advanced(cursors.get(&session.id), &next) {
+            cursors.insert(session.id, next);
+            continue;
+        }
+
+        let payload = AgentTranscriptAdvancedPayload {
+            session_id: session.id.to_string(),
+            transcript_path: next.path.display().to_string(),
+            size: next.size,
+            updated_at: next.updated_at(),
+        };
+
+        if let Err(err) = app.emit(AGENT_TRANSCRIPT_ADVANCED_EVENT, payload) {
+            tracing::warn!(
+                error = %err,
+                event = AGENT_TRANSCRIPT_ADVANCED_EVENT,
+                "agent_transcript_watcher: emit failed",
+            );
+        }
+
+        cursors.insert(session.id, next);
+    }
+}
+
+fn stat_cursor(path: PathBuf) -> Option<TranscriptCursor> {
+    let metadata = fs::metadata(&path).ok()?;
+    Some(TranscriptCursor {
+        path,
+        size: metadata.len(),
+        modified: metadata.modified().ok(),
+    })
+}
+
+fn transcript_advanced(previous: Option<&TranscriptCursor>, next: &TranscriptCursor) -> bool {
+    match previous {
+        None => next.size > 0,
+        Some(previous) => {
+            previous.path != next.path
+                || previous.size != next.size
+                || previous.modified != next.modified
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{transcript_advanced, TranscriptCursor};
+    use std::path::PathBuf;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    fn cursor(path: &str, size: u64, seconds: u64) -> TranscriptCursor {
+        TranscriptCursor {
+            path: PathBuf::from(path),
+            size,
+            modified: Some(UNIX_EPOCH + Duration::from_secs(seconds)),
+        }
+    }
+
+    #[test]
+    fn first_non_empty_cursor_counts_as_advanced() {
+        assert!(transcript_advanced(None, &cursor("a.jsonl", 1, 1)));
+        assert!(!transcript_advanced(None, &cursor("a.jsonl", 0, 1)));
+    }
+
+    #[test]
+    fn size_mtime_or_path_change_counts_as_advanced() {
+        let previous = cursor("a.jsonl", 10, 1);
+
+        assert!(!transcript_advanced(
+            Some(&previous),
+            &cursor("a.jsonl", 10, 1)
+        ));
+        assert!(transcript_advanced(
+            Some(&previous),
+            &cursor("a.jsonl", 11, 1)
+        ));
+        assert!(transcript_advanced(
+            Some(&previous),
+            &cursor("a.jsonl", 10, 2)
+        ));
+        assert!(transcript_advanced(
+            Some(&previous),
+            &cursor("b.jsonl", 10, 1)
+        ));
+    }
+}

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -104,7 +104,7 @@ if [ -n "${ACORN_AGENT_HOOK_URL-}" ] &&
   ) &
   ACORN_CODEX_WATCHER_PID=$!
 
-  "$REAL_BIN" --enable codex_hooks -c "notify=[\"bash\",\"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"]" "$@"
+  "$REAL_BIN" --enable codex_hooks -c "notify=[\"/bin/sh\",\"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"]" "$@"
   ACORN_CODEX_STATUS=$?
 
   if [ -n "${ACORN_CODEX_WATCHER_PID-}" ]; then
@@ -131,7 +131,7 @@ case "$event" in
     event=""
     hook_event_name=$(printf '%s\n' "$input" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
     case "$hook_event_name" in
-      Start|UserPromptSubmit) event="start" ;;
+      Start|SessionStart|UserPromptSubmit) event="start" ;;
       Stop) event="stop" ;;
       PermissionRequest) event="needs_input" ;;
       Error) event="error" ;;
@@ -252,7 +252,10 @@ fn ensure_agent_wrapper_dir_at(base: &Path) -> io::Result<PathBuf> {
 
 fn write_claude_settings(dir: &Path) -> io::Result<()> {
     let notify_path = dir.join(CLAUDE_NOTIFY_NAME);
-    let command = format!("bash {}", shell_quote(&notify_path.display().to_string()));
+    let command = format!(
+        "/bin/sh {}",
+        shell_quote(&notify_path.display().to_string())
+    );
     let escaped = json_escape(&command);
     let body = format!(
         r#"{{
@@ -336,13 +339,15 @@ mod tests {
 
         let wrapper = fs::read_to_string(dir.join("codex")).unwrap();
         assert!(wrapper.contains("--enable codex_hooks"));
-        assert!(wrapper
-            .contains("notify=[\\\"bash\\\",\\\"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\\\"]"));
+        assert!(wrapper.contains(
+            "notify=[\\\"/bin/sh\\\",\\\"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\\\"]"
+        ));
         assert!(wrapper.contains("CODEX_TUI_RECORD_SESSION=1"));
         assert!(wrapper.contains("ACORN_AGENT_HOOK_URL"));
 
         let notify = fs::read_to_string(dir.join("acorn-codex-notify")).unwrap();
         assert!(notify.contains("\"provider\":\"codex\""));
+        assert!(notify.contains("Start|SessionStart|UserPromptSubmit"));
         assert!(notify.contains("agent-turn-complete|task_complete"));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
         assert!(notify.contains("ACORN_AGENT_HOOK_SESSION_ID"));
@@ -398,7 +403,7 @@ mod tests {
         assert!(
             settings.contains(&format!(
                 "\"command\":\"{}\"",
-                json_escape(&format!("bash {}", shell_quote_for_test(&notify_path)))
+                json_escape(&format!("/bin/sh {}", shell_quote_for_test(&notify_path)))
             )),
             "settings missing absolute notify command: {settings}"
         );
@@ -414,7 +419,7 @@ mod tests {
         assert!(
             settings.contains(&format!(
                 "\"command\":\"{}\"",
-                json_escape(&format!("bash {}", shell_quote_for_test(&notify_path)))
+                json_escape(&format!("/bin/sh {}", shell_quote_for_test(&notify_path)))
             )),
             "settings must shell-quote the notify command path: {settings}"
         );

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1458,6 +1458,7 @@ fn spawn_via_daemon<R: Runtime>(
             id,
             pid,
             replay_scrollback,
+            known_stream_size(cols, rows),
         )
         .map_err(|e| format!("daemon stream attach failed: {e}"))?;
         return Ok(());
@@ -1501,8 +1502,17 @@ fn spawn_via_daemon<R: Runtime>(
         id,
         outcome.pid,
         replay_scrollback,
+        known_stream_size(cols, rows),
     )
     .map_err(|e| format!("daemon stream attach failed: {e}"))
+}
+
+fn known_stream_size(cols: u16, rows: u16) -> Option<crate::daemon_stream::StreamSize> {
+    if cols == 0 || rows == 0 {
+        None
+    } else {
+        Some(crate::daemon_stream::StreamSize { cols, rows })
+    }
 }
 
 /// Drop a `<cwd>/.acorn-control.md` marker every time a control session
@@ -1577,10 +1587,12 @@ pub fn pty_resize(
 ) -> AppResult<()> {
     let id = parse_id(&session_id)?;
     if state.stream_registry.contains(&id) {
-        return state
+        state
             .daemon_bridge
             .resize(id, cols, rows)
-            .map_err(|e| AppError::Pty(e.to_string()));
+            .map_err(|e| AppError::Pty(e.to_string()))?;
+        state.stream_registry.set_size(&id, cols, rows);
+        return Ok(());
     }
     state
         .pty

--- a/src-tauri/src/daemon_bridge.rs
+++ b/src-tauri/src/daemon_bridge.rs
@@ -24,6 +24,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use base64::Engine;
 use parking_lot::Mutex;
 use uuid::Uuid;
 
@@ -367,6 +368,23 @@ impl DaemonBridge {
         }
     }
 
+    pub fn read_buffer(
+        &self,
+        target: Uuid,
+        max_bytes: Option<usize>,
+    ) -> BridgeResult<(Vec<u8>, bool)> {
+        match Self::unpack_error(self.call(ControlPayload::ReadBuffer {
+            target_session_id: target,
+            max_bytes,
+        })?)? {
+            ControlResult::Buffer {
+                data_b64,
+                truncated,
+            } => Ok((base64_decode(&data_b64)?, truncated)),
+            other => Err(unexpected(other)),
+        }
+    }
+
     pub fn kill(&self, target: Uuid) -> BridgeResult<()> {
         match Self::unpack_error(self.call(ControlPayload::KillSession {
             target_session_id: target,
@@ -439,6 +457,12 @@ fn base64_encode(input: &[u8]) -> String {
         _ => unreachable!(),
     }
     out
+}
+
+fn base64_decode(input: &str) -> io::Result<Vec<u8>> {
+    base64::engine::general_purpose::STANDARD
+        .decode(input)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
 }
 
 /// Convenience: peek at the data dir without going through the daemon

--- a/src-tauri/src/daemon_stream.rs
+++ b/src-tauri/src/daemon_stream.rs
@@ -52,12 +52,22 @@ pub struct StreamAttachment {
     /// Deadline for the sticky NeedsInput cue. Cleared by an input
     /// write or by the next status poll past the deadline.
     needs_input_until: Mutex<Option<Instant>>,
+    /// Last terminal size observed from the renderer. Transcript-driven
+    /// redraw nudges use this to trigger a real TUI repaint even when the
+    /// frontend is not currently focused on the target tab.
+    last_size: Mutex<Option<StreamSize>>,
 }
 
 impl StreamAttachment {
     pub fn stop(&self) {
         self.stop.store(true, Ordering::SeqCst);
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StreamSize {
+    pub cols: u16,
+    pub rows: u16,
 }
 
 /// App-wide registry of live stream attachments, keyed by the Acorn
@@ -77,6 +87,21 @@ impl StreamRegistry {
 
     pub fn contains(&self, id: &Uuid) -> bool {
         self.inner.contains_key(id)
+    }
+
+    pub fn set_size(&self, id: &Uuid, cols: u16, rows: u16) {
+        if cols == 0 || rows == 0 {
+            return;
+        }
+        if let Some(handle) = self.inner.get(id) {
+            *handle.value().last_size.lock() = Some(StreamSize { cols, rows });
+        }
+    }
+
+    pub fn size(&self, id: &Uuid) -> Option<StreamSize> {
+        self.inner
+            .get(id)
+            .and_then(|handle| *handle.value().last_size.lock())
     }
 
     /// Stop and remove the attachment for a session. Idempotent — a
@@ -153,6 +178,7 @@ pub fn attach<R: Runtime>(
     session_id: Uuid,
     pid: Option<u32>,
     replay_scrollback: bool,
+    initial_size: Option<StreamSize>,
 ) -> std::io::Result<()> {
     let mut conn = socket::connect_stream()?;
 
@@ -191,6 +217,7 @@ pub fn attach<R: Runtime>(
         pid,
         had_child: AtomicBool::new(false),
         needs_input_until: Mutex::new(None),
+        last_size: Mutex::new(initial_size),
     });
     registry.insert(session_id, handle);
 

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -475,13 +475,66 @@ fn handle_send_keys(
             };
         }
     };
-    if let Err(err) = state.pty.write(&target.id, &bytes) {
+    let result = if state.stream_registry.contains(&target.id) {
+        let tail = state
+            .daemon_bridge
+            .read_buffer(target.id, Some(64 * 1024))
+            .map(|(b, _)| b)
+            .ok();
+        let bytes = normalize_input_for_terminal_mode(bytes, tail.as_deref());
+        state
+            .daemon_bridge
+            .send_input(target.id, &bytes)
+            .map_err(|err| err.to_string())
+    } else {
+        let tail = state.pty.tail_bytes(&target.id, 64 * 1024).map(|(b, _)| b);
+        let bytes = normalize_input_for_terminal_mode(bytes, tail.as_deref());
+        state
+            .pty
+            .write(&target.id, &bytes)
+            .map_err(|err| err.to_string())
+    };
+    if let Err(err) = result {
         return Response::Error {
             code: ErrorCode::Internal,
             message: format!("pty write failed: {err}"),
         };
     }
     Response::Ack
+}
+
+const ENHANCED_ENTER: &[u8] = b"\x1b[13u";
+
+fn normalize_input_for_terminal_mode(mut bytes: Vec<u8>, tail: Option<&[u8]>) -> Vec<u8> {
+    if bytes.last() == Some(&b'\r') && tail.map(uses_enhanced_keyboard_protocol).unwrap_or(false) {
+        bytes.pop();
+        bytes.extend_from_slice(ENHANCED_ENTER);
+    }
+    bytes
+}
+
+fn uses_enhanced_keyboard_protocol(bytes: &[u8]) -> bool {
+    let mut last_enable = None;
+    let mut last_disable = None;
+    for index in 0..bytes.len().saturating_sub(2) {
+        if bytes[index] != 0x1b || bytes[index + 1] != b'[' {
+            continue;
+        }
+        match bytes[index + 2] {
+            b'>' => {
+                if bytes[index + 3..bytes.len().min(index + 24)].contains(&b'u') {
+                    last_enable = Some(index);
+                }
+            }
+            b'<' => {
+                if bytes[index + 3..bytes.len().min(index + 24)].contains(&b'u') {
+                    last_disable = Some(index);
+                }
+            }
+            _ => {}
+        }
+    }
+    last_enable > last_disable
 }
 
 fn handle_read_buffer(
@@ -496,7 +549,16 @@ fn handle_read_buffer(
         Err(err) => return err,
     };
     let cap = max_bytes.unwrap_or(64 * 1024).min(4 * 1024 * 1024);
-    match state.pty.tail_bytes(&target.id, cap) {
+    let buffer = if state.stream_registry.contains(&target.id) {
+        state
+            .daemon_bridge
+            .read_buffer(target.id, Some(cap))
+            .map_err(|err| err.to_string())
+            .ok()
+    } else {
+        state.pty.tail_bytes(&target.id, cap)
+    };
+    match buffer {
         Some((bytes, truncated)) => Response::Buffer {
             data_b64: base64::engine::general_purpose::STANDARD.encode(&bytes),
             truncated,
@@ -760,6 +822,18 @@ mod tests {
         let target = store.insert(make_session("/tmp/A", "user", SessionKind::Regular));
         let res = resolve_action_target(&ctl, &target.id.to_string(), &store, true);
         assert!(res.is_ok(), "allow_foreign should bypass owner guard");
+    }
+
+    #[test]
+    fn enter_is_rewritten_when_enhanced_keyboard_mode_is_active() {
+        let bytes = normalize_input_for_terminal_mode(b"hello\r".to_vec(), Some(b"\x1b[>7u"));
+        assert_eq!(bytes, b"hello\x1b[13u");
+    }
+
+    #[test]
+    fn enter_stays_carriage_return_without_enhanced_keyboard_mode() {
+        let bytes = normalize_input_for_terminal_mode(b"hello\r".to_vec(), Some(b"shell prompt"));
+        assert_eq!(bytes, b"hello\r");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod agent_history;
 mod agent_hooks;
 mod agent_resume;
 mod agent_resume_persister;
+mod agent_transcript_watcher;
 mod agent_wrappers;
 mod cli_resolver;
 mod commands;
@@ -337,6 +338,7 @@ pub fn run() {
             // `claude.id` / `codex.id` files. The focus-time resume modal
             // reads those files; no shim or PATH injection is required.
             agent_resume_persister::spawn(state.inner().clone());
+            agent_transcript_watcher::spawn(app.handle().clone(), state.inner().clone());
 
             Ok(())
         })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,9 @@ import { UpdateBanner } from "./components/UpdateBanner";
 import {
   api,
   AGENT_HOOK_STATUS_EVENT,
+  AGENT_TRANSCRIPT_ADVANCED_EVENT,
   STAGED_REV_MISMATCH_EVENT,
+  type AgentTranscriptAdvancedPayload,
   type AgentKind,
   type ResumeCandidate,
   type StagedRevMismatch,
@@ -814,6 +816,34 @@ function App() {
       })
       .catch((err) => {
         console.error("[App] failed to attach agent-hook-status listener", err);
+      });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+    listen<AgentTranscriptAdvancedPayload>(
+      AGENT_TRANSCRIPT_ADVANCED_EVENT,
+      () => {
+        useAppStore.getState().refreshSessions();
+      },
+    )
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      })
+      .catch((err) => {
+        console.error(
+          "[App] failed to attach agent-transcript-advanced listener",
+          err,
+        );
       });
     return () => {
       cancelled = true;

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -451,6 +451,7 @@ export function Terminal({
   const termRef = useRef<XTerm | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const fitTerminalRef = useRef<(() => void) | null>(null);
+  const forcePtyRedrawRef = useRef<(() => void) | null>(null);
   const previousStatusRef = useRef<SessionStatus | null>(null);
   const sessionStatus =
     useAppStore(
@@ -1247,6 +1248,7 @@ export function Terminal({
       // TUIs launched from an already-open shell observe the current pane size.
       sendPtyResize(true);
     };
+    forcePtyRedrawRef.current = syncViewportAndPtySize;
     const commandSizeSyncScheduler = createTerminalRepaintScheduler(
       syncViewportAndPtySize,
       120,
@@ -1864,6 +1866,9 @@ export function Terminal({
       termRef.current = null;
       fitRef.current = null;
       fitTerminalRef.current = null;
+      if (forcePtyRedrawRef.current === syncViewportAndPtySize) {
+        forcePtyRedrawRef.current = null;
+      }
     };
   }, [sessionId, cwd]);
 
@@ -1947,6 +1952,7 @@ export function Terminal({
     let unlisten: UnlistenFn | null = null;
     let cancelled = false;
     const refresh = () => {
+      forcePtyRedrawRef.current?.();
       repaintTerminalTail(termRef.current, containerRef.current);
     };
     const scheduler = createTerminalRepaintScheduler(refresh);

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -13,10 +13,19 @@ import { Channel, invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import "@xterm/xterm/css/xterm.css";
-import { api } from "../lib/api";
+import {
+  api,
+  AGENT_TRANSCRIPT_ADVANCED_EVENT,
+  type AgentTranscriptAdvancedPayload,
+} from "../lib/api";
 import type { BackgroundState } from "../lib/background";
 import { visibleMultiInputSessionIds } from "../lib/multiInput";
 import { registerScrollbackFlusher } from "../lib/scrollback-coordinator";
+import type { SessionStatus } from "../lib/types";
+import {
+  shouldRepaintTerminalForStatusTransition,
+  shouldRepaintTerminalForTranscriptAdvance,
+} from "../lib/terminalAttentionRepaint";
 import {
   patchTerminalCellMeasurements,
   unpatchTerminalCellMeasurements,
@@ -414,6 +423,24 @@ function encodeStringToBase64(input: string): string {
   return btoa(binary);
 }
 
+function repaintTerminalTail(
+  term: XTerm | null,
+  container: HTMLDivElement | null,
+) {
+  if (!term || !container) return;
+  void container.offsetHeight;
+  try {
+    term.refresh(0, Math.max(0, term.rows - 1));
+  } catch {
+    // Terminal may have been disposed between scheduling and repaint.
+  }
+  try {
+    term.scrollToBottom();
+  } catch {
+    // Best-effort; refresh is the important part.
+  }
+}
+
 export function Terminal({
   sessionId,
   cwd,
@@ -424,6 +451,11 @@ export function Terminal({
   const termRef = useRef<XTerm | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const fitTerminalRef = useRef<(() => void) | null>(null);
+  const previousStatusRef = useRef<SessionStatus | null>(null);
+  const sessionStatus =
+    useAppStore(
+      (s) => s.sessions.find((session) => session.id === sessionId)?.status,
+    ) ?? null;
   const [linkTooltip, setLinkTooltip] = useState<{
     anchorRect: TooltipAnchorRect;
   } | null>(null);
@@ -1891,6 +1923,68 @@ export function Terminal({
     scheduler.schedule();
     return scheduler.dispose;
   }, [isActive]);
+
+  useEffect(() => {
+    const previous = previousStatusRef.current;
+    previousStatusRef.current = sessionStatus;
+    if (
+      !isActive ||
+      !shouldRepaintTerminalForStatusTransition(previous, sessionStatus)
+    ) {
+      return;
+    }
+
+    const refresh = () => {
+      repaintTerminalTail(termRef.current, containerRef.current);
+    };
+
+    const scheduler = createTerminalRepaintScheduler(refresh);
+    scheduler.schedule();
+    return scheduler.dispose;
+  }, [isActive, sessionStatus]);
+
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+    const refresh = () => {
+      repaintTerminalTail(termRef.current, containerRef.current);
+    };
+    const scheduler = createTerminalRepaintScheduler(refresh);
+
+    listen<AgentTranscriptAdvancedPayload>(
+      AGENT_TRANSCRIPT_ADVANCED_EVENT,
+      (event) => {
+        if (
+          shouldRepaintTerminalForTranscriptAdvance({
+            activeSessionId: sessionId,
+            eventSessionId: event.payload?.sessionId ?? null,
+            isActive,
+          })
+        ) {
+          scheduler.schedule();
+        }
+      },
+    )
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      })
+      .catch((err) => {
+        console.error(
+          "[Terminal] failed to attach agent-transcript-advanced listener",
+          err,
+        );
+      });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+      scheduler.dispose();
+    };
+  }, [isActive, sessionId]);
 
   // WKWebView can defer paints while the app window is not focused. PTY
   // output still reaches xterm's buffer, but the DOM renderer may return with

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -729,3 +729,12 @@ export interface StagedRevMismatch {
 
 export const STAGED_REV_MISMATCH_EVENT = "acorn:staged-rev-mismatch";
 export const AGENT_HOOK_STATUS_EVENT = "acorn:agent-hook-status";
+export const AGENT_TRANSCRIPT_ADVANCED_EVENT =
+  "acorn:agent-transcript-advanced";
+
+export interface AgentTranscriptAdvancedPayload {
+  sessionId: string;
+  transcriptPath: string;
+  size: number;
+  updatedAt: number;
+}

--- a/src/lib/terminalAttentionRepaint.test.ts
+++ b/src/lib/terminalAttentionRepaint.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldRepaintTerminalForStatusTransition,
+  shouldRepaintTerminalForTranscriptAdvance,
+} from "./terminalAttentionRepaint";
+import type { SessionStatus } from "./types";
+
+describe("shouldRepaintTerminalForStatusTransition", () => {
+  it.each<SessionStatus>(["needs_input", "failed", "completed"])(
+    "repaints when a running session transitions to %s",
+    (next) => {
+      expect(shouldRepaintTerminalForStatusTransition("running", next)).toBe(
+        true,
+      );
+    },
+  );
+
+  it("does not repaint repeated attention states", () => {
+    expect(
+      shouldRepaintTerminalForStatusTransition("needs_input", "needs_input"),
+    ).toBe(false);
+  });
+
+  it("does not repaint on startup or non-attention transitions", () => {
+    expect(shouldRepaintTerminalForStatusTransition(null, "needs_input")).toBe(
+      false,
+    );
+    expect(shouldRepaintTerminalForStatusTransition("idle", "running")).toBe(
+      false,
+    );
+  });
+});
+
+describe("shouldRepaintTerminalForTranscriptAdvance", () => {
+  it("repaints only when the active terminal owns the advanced transcript", () => {
+    expect(
+      shouldRepaintTerminalForTranscriptAdvance({
+        activeSessionId: "session-a",
+        eventSessionId: "session-a",
+        isActive: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldRepaintTerminalForTranscriptAdvance({
+        activeSessionId: "session-a",
+        eventSessionId: "session-b",
+        isActive: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldRepaintTerminalForTranscriptAdvance({
+        activeSessionId: "session-a",
+        eventSessionId: "session-a",
+        isActive: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/terminalAttentionRepaint.ts
+++ b/src/lib/terminalAttentionRepaint.ts
@@ -1,0 +1,28 @@
+import type { SessionStatus } from "./types";
+
+const ATTENTION_STATUSES = new Set<SessionStatus>([
+  "needs_input",
+  "failed",
+  "completed",
+]);
+
+export function shouldRepaintTerminalForStatusTransition(
+  previous: SessionStatus | null,
+  next: SessionStatus | null,
+): boolean {
+  return previous === "running" && next !== null && ATTENTION_STATUSES.has(next);
+}
+
+export interface TranscriptAdvanceRepaintInput {
+  activeSessionId: string;
+  eventSessionId: string | null;
+  isActive: boolean;
+}
+
+export function shouldRepaintTerminalForTranscriptAdvance({
+  activeSessionId,
+  eventSessionId,
+  isActive,
+}: TranscriptAdvanceRepaintInput): boolean {
+  return isActive && eventSessionId === activeSessionId;
+}


### PR DESCRIPTION
## Summary
Remote-control terminal redraw now keys off transcript JSONL advancement instead of racing hook status transitions.

1. **Backend transcript watcher:** add a 300ms polling watcher that tracks live agent transcript path, size, and mtime per session, refreshing transcript mappings every 2s and emitting `acorn:agent-transcript-advanced` when a transcript advances.
2. **Frontend redraw wiring:** expose the new event payload type, refresh sessions from `App`, and repaint active terminals only when the advanced transcript belongs to that terminal session.
3. **PTY redraw nudge:** on transcript advancement, force a same-size PTY resize before repainting so Codex TUI can rewrite its current screen when remote-control output advanced the transcript without fresh PTY bytes.
4. **Hook helper hardening:** run Codex/Claude notify helpers through `/bin/sh` instead of PATH-dependent `bash`, and recognize Codex `SessionStart` hook payloads.
5. **Repaint policy tests:** add focused coverage for status-transition fallback redraws and transcript-advance redraw filtering.

## Expected impact
| Area | Impact |
| --- | --- |
| Remote-control reliability | Reduces blank/stale terminal redraws when status hooks arrive before assistant transcript writes finish, and handles transcript-only remote-control turns by nudging the TUI to redraw. |
| Terminal scrollback | No synthetic transcript text is injected; Acorn only refreshes existing xterm state and asks the PTY app to redraw via resize. |
| Backend overhead | Transcript path remapping is limited to every 2s; normal polling stats known transcript files every 300ms. |

## Design notes
- The watcher treats the first non-empty transcript cursor as an advancement so already-started remote-control turns can trigger a redraw once the transcript is discoverable.
- Missing live transcripts or missing files clear the cursor for that session, avoiding stale path tracking across agent rotations.
- Status-based repaint remains as a fallback for `running -> needs_input|failed|completed`, but transcript advancement is the reliable redraw signal.
- The PTY resize is intentionally same-size and text-free: it does not inject transcript content into scrollback, but it gives TUIs such as Codex a standard redraw signal.

## Follow-up (not in this PR)
- Transcript preview snapshot APIs remain separate from redraw. This PR intentionally does not parse or surface transcript text.

## Test plan
- [x] `pnpm test src/lib/terminalAttentionRepaint.test.ts` - passed, 6 tests.
- [x] `pnpm typecheck` - passed.
- [x] `cd src-tauri && cargo test -p acorn --lib agent_transcript_watcher -- --nocapture` - passed, 2 tests.
- [x] `cd src-tauri && cargo test -p acorn --lib agent_wrappers -- --nocapture` - passed, 6 tests.
- [ ] `cd src-tauri && cargo fmt --check` - failed on pre-existing rustfmt diffs in files not touched by this PR, including `crates/acorn-session/src/status.rs`, `src/commands.rs`, `src/fs_explorer.rs`, `src/persistence.rs`, and `src/pty_env.rs`.
- [x] `rustfmt --edition 2021 --check src-tauri/src/agent_transcript_watcher.rs src-tauri/src/agent_wrappers.rs` - passed.
- [x] `git diff --check` - passed.

## Notes
- The `cargo fmt --check` failure is not caused by this PR; the reported diffs are outside the changed file set.