### PR TITLE
chore(release): v1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.6.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.5.0"
+version = "1.6.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
Prepare the next SemVer-correct Acorn release by bumping the app version from `1.5.0` to `1.6.0`.

1. **Version bump** — update `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json` to `1.6.0`.
2. **SemVer alignment** — use a minor bump because `v1.5.0` has accumulated user-visible features on `main`, including pane shortcuts, control-session promotion, control-session tab affordances, and expanded theme palettes.
3. **Release workflow compatibility** — keep the existing tag-driven release flow unchanged; after this merges, tag `v1.6.0` on the resulting commit to build/sign/publish via `.github/workflows/release.yml`.

## Expected impact
| Area | Impact |
| --- | --- |
| Versioning | Aligns the next release with SemVer: feature changes since `v1.5.0` produce `1.6.0`, not a patch release. |
| Updater metadata | Ensures Tauri app metadata, Rust package metadata, and frontend package metadata agree on `1.6.0`. |
| Changelog | Keeps this mechanical bump out of generated release notes; the release notes should be driven by the feature/fix PRs already merged since `v1.5.0`. |

## Design notes
- This PR intentionally changes only the four version files used by previous release bumps.
- No runtime behavior changes are included.
- Latest published release is `v1.5.0`; there are feature-labeled PRs merged after that release, so `1.6.0` is the SemVer-consistent next version.

## Follow-up (not in this PR)
- After merge, create and push tag `v1.6.0` on the merge commit.
- Confirm the Release workflow publishes both macOS bundles and `latest.json`.
- Verify the in-app updater sees the `1.6.0` release from a `1.5.0` install.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes: 40 files, 332 passed, 1 skipped
- [x] `cd src-tauri && cargo metadata --locked --format-version 1` passes
- [x] `git diff --check` passes
- [ ] CI green on this PR
- [ ] After merge: tag `v1.6.0` and confirm the release workflow completes

## Notes
- `git fetch --tags origin` reported a pre-existing local `v1.1.0` tag mismatch (`would clobber existing tag`). This PR did not modify tags; latest release/version selection was checked via GitHub Releases and `origin/main` history instead.
