### PR TITLE
fix: keep CJK terminal metrics after resize

### DIFF
--- a/src/lib/terminal-cjk-cell-width-addon.test.ts
+++ b/src/lib/terminal-cjk-cell-width-addon.test.ts
@@ -152,6 +152,49 @@ describe("terminal CJK cell width patch", () => {
     expect(rowFactory).toMatchObject({ defaultSpacing: -4 });
   });
 
+  it("reapplies patched metrics synchronously when xterm resize resets dimensions", () => {
+    const rowContainer = document.createElement("div");
+    const rowElement = document.createElement("div");
+    const rowFactory = {};
+    const renderer = {
+      _rowContainer: rowContainer,
+      _rowFactory: rowFactory,
+      _rowElements: [rowElement],
+      _widthCache: {
+        clear: () => undefined,
+        get: (chars: string, _bold: boolean | number, _italic: boolean | number) => {
+          if (chars === "가" || chars === "あ" || chars === "汉" || chars === "漢") {
+            return 8;
+          }
+          return 8;
+        },
+      },
+      handleResize: (_cols: number, _rows: number) => {
+        renderer.dimensions.css.cell.width = 8;
+        renderer.dimensions.css.canvas.width = 48;
+        rowElement.style.width = "48px";
+        rowContainer.style.letterSpacing = "0px";
+        Object.assign(rowFactory, { defaultSpacing: 0 });
+      },
+      dimensions: { css: { cell: { width: 8 }, canvas: { width: 48 } } },
+    };
+    const terminal = {
+      cols: 6,
+      _core: {
+        _renderService: { _renderer: { value: renderer } },
+      },
+    };
+
+    patchTerminalCellMeasurements(terminal);
+    renderer.handleResize(6, 24);
+
+    expect(renderer.dimensions.css.cell.width).toBe(4);
+    expect(renderer.dimensions.css.canvas.width).toBe(24);
+    expect(rowElement.style.width).toBe("24px");
+    expect(rowContainer.style.letterSpacing).toBe("-4px");
+    expect(rowFactory).toMatchObject({ defaultSpacing: -4 });
+  });
+
   it("keeps CJK width cache measurements unclamped so row rendering applies per-glyph spacing", () => {
     const rowContainer = document.createElement("div");
     const renderer = {

--- a/src/lib/terminal-cjk-cell-width-addon.ts
+++ b/src/lib/terminal-cjk-cell-width-addon.ts
@@ -8,9 +8,11 @@ interface DomRenderer {
   _rowElements?: HTMLElement[];
   _rowFactory?: { defaultSpacing?: number };
   _setDefaultSpacing?: () => void;
+  handleResize?: (cols: number, rows: number) => void;
   _widthCache?: WidthCache;
   __acornCjkCellPatch?: {
     originalSetDefaultSpacing?: () => void;
+    originalHandleResize?: (cols: number, rows: number) => void;
     // Legacy fields from the previous CJK-basis implementation. Keep reading
     // them so dev/HMR sessions can recover without recreating the terminal.
     originalCellWidth?: number;
@@ -80,6 +82,7 @@ export function patchTerminalCellMeasurements(term: TerminalInternals): void {
   if (!renderer.__acornCjkCellPatch) {
     renderer.__acornCjkCellPatch = {
       originalSetDefaultSpacing: renderer._setDefaultSpacing?.bind(renderer),
+      originalHandleResize: renderer.handleResize?.bind(renderer),
       originalCellWidth: getCellWidth(renderer),
       originalCanvasWidth: renderer.dimensions?.css?.canvas?.width,
     };
@@ -92,6 +95,12 @@ export function patchTerminalCellMeasurements(term: TerminalInternals): void {
       }
       recalibrateDefaultSpacing(term, renderer, widthCache, targetCellWidth);
     };
+    if (renderer.handleResize) {
+      renderer.handleResize = (cols: number, rows: number) => {
+        renderer.__acornCjkCellPatch?.originalHandleResize?.(cols, rows);
+        patchTerminalCellMeasurements(term);
+      };
+    }
   }
 
   widthCache.clear?.();
@@ -124,9 +133,13 @@ function restoreTerminalCellMeasurements(
   if (!patch) return;
 
   const originalSetDefaultSpacing = patch.originalSetDefaultSpacing;
+  const originalHandleResize = patch.originalHandleResize;
   restoreLegacyCellWidthPatch(renderer);
   delete renderer.__acornCjkCellPatch;
 
+  if (originalHandleResize) {
+    renderer.handleResize = originalHandleResize;
+  }
   if (originalSetDefaultSpacing) {
     renderer._setDefaultSpacing = originalSetDefaultSpacing;
   } else {


### PR DESCRIPTION
## Summary
- Wrap xterm DOM renderer resize handling so CJK cell-width correction is reapplied immediately after resize resets metrics
- Add a regression test for resize resetting cell width, canvas width, and letter spacing

## Tests
- ../../node_modules/.bin/vitest src/lib/terminal-cjk-cell-width-addon.test.ts --run
- ../../node_modules/.bin/tsc --noEmit
- ../../node_modules/.bin/vitest --run