### PR TITLE
feat(terminal): support file drops as mentions

### DIFF
--- a/src/components/PaneDropOverlay.tsx
+++ b/src/components/PaneDropOverlay.tsx
@@ -3,10 +3,9 @@ import { cn } from "../lib/cn";
 import {
   classifyDropZone,
   type DropZone,
-  getCurrentFilePayload,
   getCurrentTabPayload,
   isAcornDrag,
-  useAcornDragInProgress,
+  useTabDragInProgress,
 } from "../lib/dnd";
 import { useAppStore } from "../store";
 import type { PaneId } from "../lib/layout";
@@ -22,10 +21,8 @@ interface PaneDropOverlayProps {
  * append the moved tab into this pane.
  */
 export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
-  const dragging = useAcornDragInProgress();
+  const dragging = useTabDragInProgress();
   const moveTab = useAppStore((s) => s.moveTab);
-  const openCodeViewerTab = useAppStore((s) => s.openCodeViewerTab);
-  const setFocusedPane = useAppStore((s) => s.setFocusedPane);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [zone, setZone] = useState<DropZone | null>(null);
 
@@ -88,16 +85,6 @@ export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
         const target = computeZone(e);
         setZone(null);
         if (!target) return;
-        const filePayload = getCurrentFilePayload();
-        if (filePayload) {
-          // For now ignore edge zones for file drops — code tabs land
-          // inside the target pane regardless of which edge the user hit.
-          // Splitting a pane to host a code tab can be a follow-up if it
-          // turns out to be common.
-          setFocusedPane(paneId);
-          openCodeViewerTab(filePayload.path);
-          return;
-        }
         const payload = getCurrentTabPayload();
         if (!payload) return;
         if (target.kind === "center") {

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -16,6 +16,8 @@ import "@xterm/xterm/css/xterm.css";
 import { api } from "../lib/api";
 import type { BackgroundState } from "../lib/background";
 import { visibleMultiInputSessionIds } from "../lib/multiInput";
+import { getCurrentFilePayload } from "../lib/dnd";
+import { formatTerminalFileMention } from "../lib/fileMention";
 import { registerScrollbackFlusher } from "../lib/scrollback-coordinator";
 import {
   patchTerminalCellMeasurements,
@@ -1157,6 +1159,21 @@ export function Terminal({
     };
     container.addEventListener("paste", onPaste, true);
 
+    const onDragOver = (e: DragEvent) => {
+      if (!getCurrentFilePayload()) return;
+      e.preventDefault();
+      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    };
+    const onDrop = (e: DragEvent) => {
+      const payload = getCurrentFilePayload();
+      if (!payload) return;
+      e.preventDefault();
+      sendUserInputToPty(formatTerminalFileMention(payload.path, cwd));
+      term.focus();
+    };
+    container.addEventListener("dragover", onDragOver);
+    container.addEventListener("drop", onDrop);
+
     // Swallow xterm's compositionstart/update/end. Its compositionend
     // handler re-emits the entire textarea contents on top of the
     // per-syllable PTY writes our `onInput` path already issued,
@@ -1802,6 +1819,8 @@ export function Terminal({
       container.removeEventListener("input", onInput, true);
       container.removeEventListener("keydown", onKeydown, true);
       container.removeEventListener("paste", onPaste, true);
+      container.removeEventListener("dragover", onDragOver);
+      container.removeEventListener("drop", onDrop);
       container.removeEventListener("compositionstart", swallowComposition, true);
       container.removeEventListener("compositionupdate", swallowComposition, true);
       container.removeEventListener("compositionend", swallowComposition, true);

--- a/src/lib/fileMention.test.ts
+++ b/src/lib/fileMention.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatTerminalFileMention,
+  pathRelativeToCwd,
+} from "./fileMention";
+
+describe("pathRelativeToCwd", () => {
+  it("returns a repo-relative path for files under the terminal cwd", () => {
+    expect(
+      pathRelativeToCwd(
+        "/Users/me/repo/src/components/Terminal.tsx",
+        "/Users/me/repo",
+      ),
+    ).toBe("src/components/Terminal.tsx");
+  });
+
+  it("keeps absolute paths when the file is outside the terminal cwd", () => {
+    expect(
+      pathRelativeToCwd("/Users/me/other/file.ts", "/Users/me/repo"),
+    ).toBe("/Users/me/other/file.ts");
+  });
+
+  it("handles a cwd with a trailing slash", () => {
+    expect(pathRelativeToCwd("/Users/me/repo/README.md", "/Users/me/repo/")).toBe(
+      "README.md",
+    );
+  });
+});
+
+describe("formatTerminalFileMention", () => {
+  it("formats a simple repo-relative file mention", () => {
+    expect(
+      formatTerminalFileMention(
+        "/Users/me/repo/src/components/Terminal.tsx",
+        "/Users/me/repo",
+      ),
+    ).toBe("@src/components/Terminal.tsx ");
+  });
+
+  it("backslash-escapes whitespace so paths remain one mention token", () => {
+    expect(
+      formatTerminalFileMention(
+        "/Users/me/repo/docs/PR notes/final plan.md",
+        "/Users/me/repo",
+      ),
+    ).toBe("@docs/PR\\ notes/final\\ plan.md ");
+  });
+
+  it("backslash-escapes literal backslashes", () => {
+    expect(
+      formatTerminalFileMention(
+        "/Users/me/repo/docs/back\\slash.md",
+        "/Users/me/repo",
+      ),
+    ).toBe("@docs/back\\\\slash.md ");
+  });
+});

--- a/src/lib/fileMention.ts
+++ b/src/lib/fileMention.ts
@@ -1,0 +1,26 @@
+function normalizePath(path: string): string {
+  if (path === "/") return path;
+  return path.replace(/\/+$/u, "");
+}
+
+export function pathRelativeToCwd(filePath: string, cwd: string): string {
+  const normalizedFile = normalizePath(filePath);
+  const normalizedCwd = normalizePath(cwd);
+  if (normalizedFile === normalizedCwd) return ".";
+  const prefix = `${normalizedCwd}/`;
+  if (normalizedFile.startsWith(prefix)) {
+    return normalizedFile.slice(prefix.length);
+  }
+  return normalizedFile;
+}
+
+function escapeMentionPath(path: string): string {
+  return path.replace(/([\\\s])/gu, "\\$1");
+}
+
+export function formatTerminalFileMention(
+  filePath: string,
+  cwd: string,
+): string {
+  return `@${escapeMentionPath(pathRelativeToCwd(filePath, cwd))} `;
+}


### PR DESCRIPTION
## Summary

Adds a terminal drop path for file explorer entries so users can attach files to the active prompt as mention tokens.

1. **Terminal file drops:** Route file drags dropped over xterm into PTY input as `@path` mentions instead of opening a code tab.
2. **Pane drop behavior:** Keep pane-body overlays scoped to tab drags so file drops can reach the terminal surface.
3. **Mention formatting:** Add a small formatter for cwd-relative file mentions with whitespace and backslash escaping, plus focused coverage.

## Expected impact

| Area | Impact |
| --- | --- |
| Terminal UX | File explorer entries can be dropped directly into agent prompts as file mentions. |
| Pane drag/drop | Tab drag overlays no longer intercept file drops intended for terminals. |
| Reliability | Mention formatting handles spaces and literal backslashes in paths. |

## Design notes

The file drag payload already flows through the existing in-process drag mirror in `src/lib/dnd.ts`; this change moves the terminal-specific handling to `Terminal.tsx` while leaving tab movement in `PaneDropOverlay.tsx`. The formatter stays isolated in `src/lib/fileMention.ts` so other attach surfaces can adopt the same escaping rules later.

## Follow-up (not in this PR)

- Reuse `formatTerminalFileMention` from File Explorer context-menu and bulk attach actions so every file-mention insertion path shares the same escaping behavior.
- Track the terminal live cwd for drop formatting when the shell has `cd`'d away from the session worktree root.

## Test plan

- [x] `pnpm install --frozen-lockfile` - completed with lockfile unchanged.
- [x] `pnpm test` - 41 files passed, 338 tests passed, 1 skipped.
- [x] `pnpm exec tsc --noEmit --pretty false` - passed.

## Notes

No pre-existing flakes were observed in the local Vitest run.