### PR TITLE
feat(sessions): local chat terminals + scoped session creation

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -5,6 +5,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use uuid::Uuid;
 
+fn default_true() -> bool {
+    true
+}
+
 /// Errors produced by `SessionStore` lookups. Kept local so the crate does
 /// not need to share `AppError` with the main `acorn` crate; the main crate
 /// adapts via `From<SessionError>`.
@@ -209,6 +213,11 @@ pub struct Session {
     pub branch: String,
     #[serde(default)]
     pub isolated: bool,
+    /// Whether this session belongs to a project entry. Older persisted
+    /// sessions predate this field and should keep their project-scoped
+    /// behavior.
+    #[serde(default = "default_true")]
+    pub project_scoped: bool,
     pub status: SessionStatus,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -275,6 +284,7 @@ impl Session {
             worktree_path,
             branch,
             isolated,
+            project_scoped: true,
             status: SessionStatus::Idle,
             created_at: now,
             updated_at: now,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -503,6 +503,13 @@ fn process_command_line(proc: &sysinfo::Process) -> String {
     parts.join(" ")
 }
 
+fn should_remove_local_project_mirror(removed: &Session, remaining: &[Session]) -> bool {
+    !removed.project_scoped
+        && !remaining
+            .iter()
+            .any(|session| session.project_scoped && session.repo_path == removed.repo_path)
+}
+
 fn process_memory_snapshot(pid: Pid, proc: &sysinfo::Process) -> ProcessMemorySnapshot {
     ProcessMemorySnapshot {
         pid: pid.as_u32(),
@@ -694,6 +701,7 @@ pub async fn create_session(
     isolated: Option<bool>,
     kind: Option<SessionKind>,
     agent_provider: Option<SessionAgentProvider>,
+    project_scoped: Option<bool>,
 ) -> AppResult<Session> {
     let repo = PathBuf::from(&repo_path);
     if !repo.exists() {
@@ -701,6 +709,7 @@ pub async fn create_session(
     }
 
     let isolated = isolated.unwrap_or(false);
+    let project_scoped = project_scoped.unwrap_or(true);
     let worktree_path = if isolated {
         let base = sanitize_worktree_name(&name);
         let (_safe_name, path) = create_unique_worktree(&repo, &base)?;
@@ -717,9 +726,12 @@ pub async fn create_session(
         isolated,
         kind.unwrap_or_default(),
     );
+    session.project_scoped = project_scoped;
     session.agent_provider = agent_provider;
     let inserted = state.sessions.insert(session);
-    state.projects.ensure(repo.clone(), project_basename(&repo));
+    if project_scoped {
+        state.projects.ensure(repo.clone(), project_basename(&repo));
+    }
     persist(&state);
     Ok(enrich_session(inserted))
 }
@@ -889,6 +901,9 @@ pub async fn remove_session(
         remove_linked_worktree_at_path(&session.repo_path, &session.worktree_path).ok();
     }
     state.sessions.remove(&id)?;
+    if should_remove_local_project_mirror(&session, &state.sessions.list()) {
+        state.projects.remove(&session.repo_path);
+    }
     persist(&state);
     Ok(())
 }
@@ -2534,12 +2549,26 @@ mod tests {
     use super::{
         collect_memory_usage_from_roots, create_unique_worktree, font_name_from_path,
         infer_acornd_root_from_session_pids, inject_agent_hook_env, memory_root_pids,
-        remove_linked_worktree_at_path, validate_new_project_name, ProcessMemorySnapshot,
+        remove_linked_worktree_at_path, should_remove_local_project_mirror,
+        validate_new_project_name, ProcessMemorySnapshot,
     };
     use acorn_session::{Session, SessionAgentProvider, SessionKind};
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
     use uuid::Uuid;
+
+    fn scoped_session(id: &str, repo_path: &str, project_scoped: bool) -> Session {
+        let mut session = Session::new(
+            id.to_string(),
+            PathBuf::from(repo_path),
+            PathBuf::from(repo_path),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        session.project_scoped = project_scoped;
+        session
+    }
 
     #[test]
     fn font_name_from_path_strips_compound_style_suffixes() {
@@ -2596,6 +2625,28 @@ mod tests {
             validate_new_project_name("parent\\fresh-app", false).unwrap(),
             "parent\\fresh-app"
         );
+    }
+
+    #[test]
+    fn local_session_removal_cleans_project_mirror_without_project_sessions() {
+        let removed = scoped_session("local", "/Users/me", false);
+
+        assert!(should_remove_local_project_mirror(&removed, &[]));
+    }
+
+    #[test]
+    fn local_session_removal_keeps_project_when_project_session_remains() {
+        let removed = scoped_session("local", "/Users/me", false);
+        let remaining = [scoped_session("project", "/Users/me", true)];
+
+        assert!(!should_remove_local_project_mirror(&removed, &remaining));
+    }
+
+    #[test]
+    fn project_session_removal_never_cleans_project_mirror() {
+        let removed = scoped_session("project", "/Users/me", true);
+
+        assert!(!should_remove_local_project_mirror(&removed, &[]));
     }
 
     #[test]

--- a/src-tauri/src/daemon_commands.rs
+++ b/src-tauri/src/daemon_commands.rs
@@ -311,6 +311,7 @@ pub fn daemon_adopt_session(
         worktree_path,
         branch,
         isolated: false,
+        project_scoped: true,
         status: acorn_session::SessionStatus::Idle,
         created_at: now,
         updated_at: now,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,6 +53,28 @@ impl Write for NonPanickingStderr {
     }
 }
 
+fn remove_empty_home_project_mirror(state: &AppState) -> bool {
+    let Some(home) = directories::UserDirs::new().map(|dirs| dirs.home_dir().to_path_buf()) else {
+        return false;
+    };
+    if state
+        .sessions
+        .list()
+        .iter()
+        .any(|session| session.project_scoped && session.repo_path == home)
+    {
+        return false;
+    }
+    let removed = state.projects.remove(&home).is_some();
+    if removed {
+        tracing::info!(
+            path = %home.display(),
+            "removed stale local home project mirror"
+        );
+    }
+    removed
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tracing_subscriber::fmt()
@@ -238,6 +260,9 @@ pub fn run() {
             // that has no project entry (e.g. older versions that did not
             // persist projects).
             for session in state.sessions.list() {
+                if !session.project_scoped {
+                    continue;
+                }
                 let name = session
                     .repo_path
                     .file_name()
@@ -245,6 +270,11 @@ pub fn run() {
                     .unwrap_or("project")
                     .to_string();
                 state.projects.ensure(session.repo_path.clone(), name);
+            }
+            if remove_empty_home_project_mirror(&state) {
+                if let Err(err) = persistence::save_projects(&state.projects.list()) {
+                    tracing::warn!("failed to persist projects after local mirror cleanup: {err}");
+                }
             }
             // Drop scrollback files that no longer have a matching session.
             // Skip when the session load was unclean — otherwise a transient

--- a/src/components/CommandRunDialog.tsx
+++ b/src/components/CommandRunDialog.tsx
@@ -6,6 +6,12 @@ import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useTranslation } from "../lib/useTranslation";
 import { Modal, ModalHeader, TextSwap } from "./ui";
+import {
+  applySessionCreateRequest,
+  buildSessionCreateRequestFromScope,
+  resolveActiveSessionScope,
+  resolveProjectScopedForRepoPath,
+} from "../lib/sessionCreation";
 
 type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
 
@@ -58,13 +64,33 @@ export function CommandRunDialog({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const projects = useAppStore((s) => s.projects);
+  const sessions = useAppStore((s) => s.sessions);
+  const activeSessionId = useAppStore((s) => s.activeSessionId);
+  const activeProject = useAppStore((s) => s.activeProject);
   const createSession = useAppStore((s) => s.createSession);
   const setPendingTerminalInput = useAppStore(
     (s) => s.setPendingTerminalInput,
   );
   const showToast = useToasts((s) => s.show);
 
-  const resolvedRepoPath = repoPath ?? projects[0]?.repo_path ?? null;
+  const resolvedScope = repoPath
+    ? {
+        repoPath,
+        projectScoped: resolveProjectScopedForRepoPath(
+          { sessions, projects },
+          repoPath,
+        ),
+      }
+    : (resolveActiveSessionScope({
+        sessions,
+        projects,
+        activeSessionId,
+        activeWorkspaceRepoPath: activeProject,
+      }) ??
+      (projects[0]
+        ? { repoPath: projects[0].repo_path, projectScoped: true }
+        : null));
+  const resolvedRepoPath = resolvedScope?.repoPath ?? null;
 
   function close() {
     if (busy) return;
@@ -91,16 +117,20 @@ export function CommandRunDialog({
   }
 
   async function handleRun() {
-    if (!resolvedRepoPath) {
+    if (!resolvedScope) {
       setError(dt(t, "dialogs.commandRun.noProjectError"));
       return;
     }
     setBusy(true);
     setError(null);
     try {
-      const created = await createSession(
-        deriveSessionName(command),
-        resolvedRepoPath,
+      const created = await applySessionCreateRequest(
+        createSession,
+        buildSessionCreateRequestFromScope(
+          { sessions, projects },
+          resolvedScope,
+          { name: deriveSessionName(command) },
+        ),
       );
       if (!created) {
         const storeError = useAppStore.getState().error;

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -37,6 +37,11 @@ import { setFileDragPayload } from "../lib/dnd";
 import { Tooltip } from "./Tooltip";
 import { IconInput, TextInput } from "./ui";
 import { useTranslation } from "../lib/useTranslation";
+import {
+  applySessionCreateRequest,
+  buildSessionCreateRequestFromScope,
+  resolveActiveSessionScope,
+} from "../lib/sessionCreation";
 
 const SHOW_HIDDEN_KEY = "acorn:fs-show-hidden";
 const RESPECT_GITIGNORE_KEY = "acorn:fs-respect-gitignore";
@@ -978,8 +983,13 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     try {
       const store = await import("../store");
       const state = store.useAppStore.getState();
-      const project = state.activeProject;
-      if (!project) {
+      const scope = resolveActiveSessionScope({
+        sessions: state.sessions,
+        projects: state.projects,
+        activeSessionId: state.activeSessionId,
+        activeWorkspaceRepoPath: state.activeProject,
+      });
+      if (!scope) {
         setError(fileExplorerText(t, "fileExplorer.errors.noActiveProject"));
         return;
       }
@@ -989,7 +999,14 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       // Spawn a regular session in the current project, then queue a
       // `cd <folder>` to land inside the clicked directory once the PTY
       // is up. Mirrors how CommandRunDialog primes new sessions.
-      const session = await state.createSession(name, project, false);
+      const session = await applySessionCreateRequest(
+        state.createSession,
+        buildSessionCreateRequestFromScope(
+          { sessions: state.sessions, projects: state.projects },
+          scope,
+          { name },
+        ),
+      );
       if (session) {
         state.setPendingTerminalInput(
           session.id,

--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -37,6 +37,7 @@ import { useAppStore } from "../store";
 import { defaultTabByGroup } from "../lib/rightPanelGroups";
 
 const REPO = "/Users/me/repo";
+const HOME = "/Users/me";
 
 function project(repoPath: string): Project {
   return {
@@ -47,12 +48,13 @@ function project(repoPath: string): Project {
   };
 }
 
-function session(id: string): Session {
+function session(id: string, overrides: Partial<Session> = {}): Session {
   return {
     id,
     name: id,
-    repo_path: REPO,
-    worktree_path: `${REPO}/.worktrees/${id}`,
+    repo_path: overrides.repo_path ?? REPO,
+    worktree_path:
+      overrides.worktree_path ?? `${overrides.repo_path ?? REPO}/.worktrees/${id}`,
     branch: `feat/${id}`,
     isolated: false,
     status: "idle",
@@ -63,6 +65,7 @@ function session(id: string): Session {
     owner: { kind: "user" },
     position: null,
     in_worktree: false,
+    ...overrides,
   };
 }
 
@@ -156,6 +159,77 @@ describe("Pane empty state", () => {
       false,
       "regular",
       null,
+    );
+  });
+
+  it("keeps tab-strip double-click creation in local chat scope", async () => {
+    const local = session("local-session", {
+      name: "terminal",
+      repo_path: HOME,
+      worktree_path: HOME,
+      project_scoped: false,
+    });
+    const created = session("local-session-2", {
+      name: "terminal-2",
+      repo_path: HOME,
+      worktree_path: HOME,
+      project_scoped: false,
+    });
+    mocks.createSession.mockResolvedValueOnce(created);
+    mocks.listSessions.mockResolvedValueOnce([local, created]);
+    mocks.listProjects.mockResolvedValueOnce([project(REPO)]);
+    useAppStore.setState((s) => ({
+      ...s,
+      sessions: [local],
+      activeProject: HOME,
+      activeSessionId: local.id,
+      activeTabId: local.id,
+      workspaces: {
+        ...s.workspaces,
+        [HOME]: {
+          layout: { kind: "pane", id: "root" },
+          panes: {
+            root: {
+              id: "root",
+              tabIds: [local.id],
+              activeTabId: local.id,
+            },
+          },
+          focusedPaneId: "root",
+        },
+      },
+      layout: { kind: "pane", id: "root" },
+      panes: {
+        root: {
+          id: "root",
+          tabIds: [local.id],
+          activeTabId: local.id,
+        },
+      },
+      focusedPaneId: "root",
+    }));
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+
+    const filler = container.querySelector('[data-pane-tab-filler="root"]');
+    expect(filler).not.toBeNull();
+
+    await act(async () => {
+      filler?.dispatchEvent(
+        new MouseEvent("dblclick", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(mocks.createSession).toHaveBeenCalledTimes(1);
+    expect(mocks.createSession).toHaveBeenCalledWith(
+      "terminal-2",
+      HOME,
+      false,
+      "regular",
+      null,
+      false,
     );
   });
 });

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -51,6 +51,12 @@ import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import { useSettings } from "../lib/settings";
 import { hasRecordedWorktree } from "../lib/sessionWorktree";
 import { useTranslation } from "../lib/useTranslation";
+import {
+  buildSessionCreateRequestFromScope,
+  resolveProjectScopedForRepoPath,
+  scopeForSession,
+  type SessionCreateScope,
+} from "../lib/sessionCreation";
 import type { Direction, PaneId } from "../lib/layout";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { PaneDropOverlay } from "./PaneDropOverlay";
@@ -183,6 +189,17 @@ export function Pane({ paneId }: PaneProps) {
   const isFocused = focusedPaneId === paneId;
   const lastEmptyPaneSpaceKeyDownAtRef = useRef<number | null>(null);
 
+  function scopeForTab(tab: PaneTab): SessionCreateScope {
+    if (tab.kind === "session") return scopeForSession(tab.session);
+    return {
+      repoPath: tab.repoPath,
+      projectScoped: resolveProjectScopedForRepoPath(
+        { sessions, projects },
+        tab.repoPath,
+      ),
+    };
+  }
+
   // Spawn a new session in the given project. Triggered by double-clicking
   // the empty pane body or the tab strip. `setFocusedPane` first so
   // `store.createSession` lands the new tab next to *this* pane's active
@@ -191,10 +208,28 @@ export function Pane({ paneId }: PaneProps) {
   async function spawnSession(
     repoPath: string,
     kind: SessionKind = "regular",
+    scope: SessionCreateScope = {
+      repoPath,
+      projectScoped: resolveProjectScopedForRepoPath(
+        { sessions, projects },
+        repoPath,
+      ),
+    },
   ) {
     setFocusedPane(paneId);
-    const name = suggestSessionName(repoPath, sessions);
-    await createSession(name, repoPath, false, kind);
+    const request = buildSessionCreateRequestFromScope(
+      { sessions, projects },
+      scope,
+      { kind },
+    );
+    await createSession(
+      request.name,
+      request.repoPath,
+      request.isolated,
+      request.kind,
+      request.agentProvider,
+      request.projectScoped,
+    );
   }
 
   // Fork an existing claude/codex conversation into a new Acorn session.
@@ -214,14 +249,19 @@ export function Pane({ paneId }: PaneProps) {
     isolated: boolean,
   ) {
     setFocusedPane(paneId);
-    const name = suggestSessionName(parent.repo_path, sessions);
+    const request = buildSessionCreateRequestFromScope(
+      { sessions, projects },
+      scopeForSession(parent),
+      { isolated, kind: "regular", agentProvider: kind },
+    );
     try {
       const created = await api.createSession(
-        name,
-        parent.repo_path,
-        isolated,
-        "regular",
-        kind,
+        request.name,
+        request.repoPath,
+        request.isolated,
+        request.kind,
+        request.agentProvider,
+        request.projectScoped,
       );
       // Claude resolves `--resume <uuid>` by looking under
       // `~/.claude/projects/<slug-of-cwd>/<uuid>.jsonl`.
@@ -259,18 +299,30 @@ export function Pane({ paneId }: PaneProps) {
 
   async function handleNewTabFromStrip() {
     if (tabs.length === 0) return;
-    await spawnSession(tabs[0].repoPath);
+    const anchor = active ?? tabs[0];
+    await spawnSession(anchor.repoPath, "regular", scopeForTab(anchor));
   }
 
   async function handleNewTabFromEmpty() {
     // Prefer the pane's project if any tabs exist (shouldn't here), else use
     // the globally active project. With no project at all, do nothing.
+    const anchor = active ?? tabs[0] ?? null;
     const repoPath =
-      tabs[0]?.repoPath ??
-      useAppStore.getState().activeProject ??
-      null;
+      anchor?.repoPath ?? useAppStore.getState().activeProject ?? null;
     if (!repoPath) return;
-    await spawnSession(repoPath);
+    await spawnSession(
+      repoPath,
+      "regular",
+      anchor
+        ? scopeForTab(anchor)
+        : {
+            repoPath,
+            projectScoped: resolveProjectScopedForRepoPath(
+              { sessions, projects },
+              repoPath,
+            ),
+          },
+    );
   }
 
   const hasProjects = projects.length > 0;
@@ -343,8 +395,8 @@ export function Pane({ paneId }: PaneProps) {
               splitSide: "after",
             });
           }}
-          onDuplicate={(repoPath, kind) => {
-            void spawnSession(repoPath, kind);
+          onDuplicate={(repoPath, kind, projectScoped) => {
+            void spawnSession(repoPath, kind, { repoPath, projectScoped });
           }}
           onFork={(parent, kind, parentAgentId, isolated) => {
             void forkSession(parent, kind, parentAgentId, isolated);
@@ -425,16 +477,6 @@ export function Pane({ paneId }: PaneProps) {
   );
 }
 
-function suggestSessionName(repoPath: string, existing: Session[]): string {
-  const base =
-    repoPath.split(/[\\/]/).filter(Boolean).pop() ?? repoPath;
-  const taken = new Set(existing.map((s) => s.name));
-  if (!taken.has(base)) return base;
-  let n = 2;
-  while (taken.has(`${base}-${n}`)) n += 1;
-  return `${base}-${n}`;
-}
-
 function EmptyPane({
   hasProjects,
   onDoubleClick,
@@ -501,7 +543,11 @@ interface TabStripProps {
   ) => void;
   onNewTab: () => void;
   onSplitTab: (tabId: string, direction: Direction) => void;
-  onDuplicate: (repoPath: string, kind: SessionKind) => void;
+  onDuplicate: (
+    repoPath: string,
+    kind: SessionKind,
+    projectScoped: boolean,
+  ) => void;
   onFork: (
     parent: Session,
     kind: SessionAgentProvider,
@@ -599,7 +645,12 @@ function TabStrip({
           onSplitTab={(direction) => onSplitTab(tab.id, direction)}
           onDuplicate={
             tab.kind === "session"
-              ? () => onDuplicate(tab.session.repo_path, tab.session.kind)
+              ? () =>
+                  onDuplicate(
+                    tab.session.repo_path,
+                    tab.session.kind,
+                    tab.session.project_scoped !== false,
+                  )
               : undefined
           }
           onFork={
@@ -626,6 +677,7 @@ function TabStrip({
         and double-click here too).
       */}
       <div
+        data-pane-tab-filler={paneId}
         className="min-w-[2.5rem] flex-1"
         onDoubleClick={(e) => {
           if (e.target !== e.currentTarget) return;

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -104,6 +104,12 @@ import {
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useTranslation } from "../lib/useTranslation";
+import {
+  applySessionCreateRequest,
+  buildSessionCreateRequest,
+  resolveProjectScopedForRepoPath,
+  scopeForSession,
+} from "../lib/sessionCreation";
 
 interface ExpandedDiff {
   payload: DiffPayload;
@@ -196,6 +202,14 @@ export function RightPanel() {
   const repoPath = useLiveRepoPath(active?.id ?? null, fallbackPath);
   const sessionHostRepoPath =
     active?.repo_path ?? activeWorkspaceTab?.repoPath ?? activeProject ?? repoPath;
+  const sessionHostProjectScoped = active
+    ? scopeForSession(active).projectScoped
+    : sessionHostRepoPath
+      ? resolveProjectScopedForRepoPath(
+          { sessions, projects },
+          sessionHostRepoPath,
+        )
+      : true;
   const [gitRepoProbeVersion, setGitRepoProbeVersion] = useState(0);
   const invalidateGitProbe = useCallback(() => {
     if (!repoPath) return;
@@ -421,6 +435,7 @@ export function RightPanel() {
               key={`history:${repoPath}`}
               repoPath={repoPath}
               sessionHostRepoPath={sessionHostRepoPath ?? repoPath}
+              sessionHostProjectScoped={sessionHostProjectScoped}
             />
           </BackgroundLoadedTab>
         ) : null}
@@ -1114,11 +1129,15 @@ function countByStatus(todos: TodoItem[]) {
 function AgentHistoryTab({
   repoPath,
   sessionHostRepoPath,
+  sessionHostProjectScoped,
 }: {
   repoPath: string;
   sessionHostRepoPath: string;
+  sessionHostProjectScoped: boolean;
 }) {
   const t = useTranslation();
+  const sessions = useAppStore((s) => s.sessions);
+  const projects = useAppStore((s) => s.projects);
   const createSession = useAppStore((s) => s.createSession);
   const adoptSessionWorktree = useAppStore((s) => s.adoptSessionWorktree);
   const setPendingTerminalInput = useAppStore((s) => s.setPendingTerminalInput);
@@ -1200,12 +1219,17 @@ function AgentHistoryTab({
       return;
     }
     try {
-      const created = await createSession(
-        `${item.provider} ${rt(t, "rightPanel.history.resumeSessionName")}`,
-        sessionHostRepoPath,
-        false,
-        "regular",
-        item.provider,
+      const created = await applySessionCreateRequest(
+        createSession,
+        buildSessionCreateRequest(
+          { sessions, projects },
+          {
+            name: `${item.provider} ${rt(t, "rightPanel.history.resumeSessionName")}`,
+            repoPath: sessionHostRepoPath,
+            agentProvider: item.provider,
+            projectScoped: sessionHostProjectScoped,
+          },
+        ),
       );
       if (!created) {
         setError(

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   X,
 } from "lucide-react";
 import { openPath } from "@tauri-apps/plugin-opener";
+import { homeDir } from "@tauri-apps/api/path";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import {
@@ -57,12 +58,24 @@ import {
 import { hasRecordedWorktree } from "../lib/sessionWorktree";
 import { useTranslation } from "../lib/useTranslation";
 import {
+  buildLocalSessions,
+  buildProjectGroups,
+  type ProjectGroup,
+} from "../lib/sessionGrouping";
+import {
+  applySessionCreateRequest,
+  buildLocalSessionCreateRequest,
+  buildSessionCreateRequest,
+  buildSessionCreateRequestFromScope,
+  resolveActiveSessionScope,
+  type SessionCreateScope,
+} from "../lib/sessionCreation";
+import {
   planChevronClick,
   planTitleClick,
   type ProjectClickPlan,
 } from "../lib/sidebar-actions";
-import type { Project, Session, SessionKind, SessionStatus } from "../lib/types";
-import { suggestSessionName } from "../lib/sessionName";
+import type { Session, SessionKind, SessionStatus } from "../lib/types";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { NewProjectDialog } from "./NewProjectDialog";
 import { Tooltip } from "./Tooltip";
@@ -87,6 +100,7 @@ const COLLAPSED_KEY = "acorn:sidebar:collapsed-projects";
 
 const PROJECT_DRAG_PREFIX = "project:";
 const SESSION_DRAG_PREFIX = "session:";
+const LOCAL_TERMINAL_AREA_SELECTOR = "[data-local-terminal-area='true']";
 
 type SidebarTranslationKey = Extract<TranslationKey, `sidebar.${string}`>;
 
@@ -98,10 +112,12 @@ function statusLabel(t: Translator, status: SessionStatus): string {
   return sidebarText(t, `sidebar.status.${status}`);
 }
 
-interface ProjectGroup {
-  repoPath: string;
-  name: string;
-  sessions: Session[];
+function isLocalTerminalAreaFocused(): boolean {
+  if (typeof document === "undefined") return false;
+  const active = document.activeElement;
+  return active instanceof HTMLElement
+    ? active.closest(LOCAL_TERMINAL_AREA_SELECTOR) !== null
+    : false;
 }
 
 export function Sidebar() {
@@ -130,6 +146,10 @@ export function Sidebar() {
   const projectGroups = useMemo(
     () => buildProjectGroups(projects, sessions),
     [projects, sessions],
+  );
+  const localSessions = useMemo(
+    () => buildLocalSessions(sessions),
+    [sessions],
   );
 
   const sensors = useSensors(
@@ -191,23 +211,44 @@ export function Sidebar() {
     (
       isolated: boolean,
       kind: SessionKind,
-      repoOverride?: string,
+      scopeOverride?: SessionCreateScope,
     ) => Promise<void>
   >(async () => {});
+  const onNewLocalSessionRef = useRef<() => Promise<void>>(async () => {});
   const onAddProjectRef = useRef<() => Promise<void>>(async () => {});
 
   useEffect(() => {
+    const activeScope = (): SessionCreateScope | null => {
+      const state = useAppStore.getState();
+      return resolveActiveSessionScope({
+        sessions: state.sessions,
+        projects: state.projects,
+        activeSessionId: state.activeSessionId,
+        activeWorkspaceRepoPath: state.activeProject,
+      });
+    };
     const newSession = () => {
-      const project = useAppStore.getState().activeProject;
-      void onNewSessionRef.current(false, "regular", project ?? undefined);
+      if (isLocalTerminalAreaFocused()) {
+        void onNewLocalSessionRef.current();
+        return;
+      }
+      void onNewSessionRef.current(false, "regular", activeScope() ?? undefined);
     };
     const newIsolated = () => {
-      const project = useAppStore.getState().activeProject;
-      void onNewSessionRef.current(true, "regular", project ?? undefined);
+      const scope = activeScope();
+      void onNewSessionRef.current(
+        true,
+        "regular",
+        scope?.projectScoped === false ? undefined : (scope ?? undefined),
+      );
     };
     const newControl = () => {
-      const project = useAppStore.getState().activeProject;
-      void onNewSessionRef.current(false, "control", project ?? undefined);
+      const scope = activeScope();
+      void onNewSessionRef.current(
+        false,
+        "control",
+        scope?.projectScoped === false ? undefined : (scope ?? undefined),
+      );
     };
     const newProject = () => {
       setNewProjectOpen(true);
@@ -232,11 +273,11 @@ export function Sidebar() {
   async function onNewSession(
     isolated: boolean,
     kind: SessionKind,
-    repoOverride?: string,
+    scopeOverride?: SessionCreateScope,
   ) {
     try {
-      const repoPath =
-        repoOverride ??
+      const pickedPath =
+        scopeOverride?.repoPath ??
         (await open({
           directory: true,
           multiple: false,
@@ -246,13 +287,23 @@ export function Sidebar() {
               ? sidebarText(t, "sidebar.dialog.selectControlDirectory")
               : sidebarText(t, "sidebar.dialog.selectDirectory"),
         }));
-      if (!repoPath || typeof repoPath !== "string") return;
-      const name = suggestSessionName(repoPath, sessions, kind, isolated);
-      await createSession(name, repoPath, isolated, kind);
+      if (!pickedPath || typeof pickedPath !== "string") return;
+      const request = buildSessionCreateRequest(
+        { sessions, projects },
+        {
+          repoPath: pickedPath,
+          isolated,
+          kind,
+          projectScoped:
+            scopeOverride?.projectScoped ??
+            (isolated || kind === "control" ? true : undefined),
+        },
+      );
+      await applySessionCreateRequest(createSession, request);
       setCollapsed((prev) => {
-        if (!prev.has(repoPath)) return prev;
+        if (!prev.has(request.repoPath)) return prev;
         const next = new Set(prev);
-        next.delete(repoPath);
+        next.delete(request.repoPath);
         return next;
       });
     } catch (e) {
@@ -260,7 +311,21 @@ export function Sidebar() {
     }
   }
 
+  async function onNewLocalSession() {
+    try {
+      const home = await homeDir();
+      if (!home) return;
+      await applySessionCreateRequest(
+        createSession,
+        buildLocalSessionCreateRequest({ sessions, projects }, home),
+      );
+    } catch (e) {
+      console.error("create local terminal session failed", e);
+    }
+  }
+
   onNewSessionRef.current = onNewSession;
+  onNewLocalSessionRef.current = onNewLocalSession;
   onAddProjectRef.current = onAddExistingProject;
 
   const projectIds = useMemo(
@@ -320,13 +385,21 @@ export function Sidebar() {
       const activeSession = sessions.find((s) => s.id === activeSid);
       const overSession = sessions.find((s) => s.id === overSid);
       if (!activeSession || !overSession) return;
+      if (
+        (activeSession.project_scoped === false) !==
+        (overSession.project_scoped === false)
+      ) {
+        return;
+      }
       // Cross-project drops are not supported yet — silently ignore.
       if (activeSession.repo_path !== overSession.repo_path) return;
-      const group = projectGroups.find(
-        (g) => g.repoPath === activeSession.repo_path,
-      );
-      if (!group) return;
-      const ids = group.sessions.map((s) => s.id);
+      const orderedSessions =
+        activeSession.project_scoped === false
+          ? localSessions
+          : (projectGroups.find((g) => g.repoPath === activeSession.repo_path)
+              ?.sessions ?? []);
+      if (orderedSessions.length === 0) return;
+      const ids = orderedSessions.map((s) => s.id);
       const fromIdx = ids.indexOf(activeSid);
       const toIdx = ids.indexOf(overSid);
       if (fromIdx < 0 || toIdx < 0 || fromIdx === toIdx) return;
@@ -373,17 +446,17 @@ export function Sidebar() {
           </Tooltip>
         </div>
       </header>
-      <div className="acorn-no-scrollbar flex-1 overflow-y-auto px-1 pb-2">
-        {projectGroups.length === 0 ? (
-          <EmptyState />
-        ) : (
-          <DndContext
-            sensors={sensors}
-            collisionDetection={scopedCollision}
-            onDragStart={onDragStart}
-            onDragEnd={onDragEnd}
-            onDragCancel={() => setActiveDragId(null)}
-          >
+      <div className="acorn-no-scrollbar flex flex-1 flex-col overflow-y-auto px-1 pb-2">
+        <DndContext
+          sensors={sensors}
+          collisionDetection={scopedCollision}
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+          onDragCancel={() => setActiveDragId(null)}
+        >
+          {projectGroups.length === 0 ? (
+            <EmptyState onOpenProject={onAddExistingProject} />
+          ) : (
             <SortableContext
               items={projectIds}
               strategy={verticalListSortingStrategy}
@@ -426,7 +499,10 @@ export function Sidebar() {
                     onSelectSession={selectSession}
                     onRemoveSession={(s) => requestRemoveSession(s.id)}
                     onAddSession={(isolated, kind) =>
-                      onNewSession(isolated, kind, project.repoPath)
+                      onNewSession(isolated, kind, {
+                        repoPath: project.repoPath,
+                        projectScoped: true,
+                      })
                     }
                     onRemoveProject={() =>
                       requestRemoveProject(project.repoPath)
@@ -435,13 +511,20 @@ export function Sidebar() {
                 ))}
               </ul>
             </SortableContext>
-            <DragOverlay dropAnimation={null}>
-              {activeDragId
-                ? renderDragOverlay(activeDragId, projectGroups, sessions, t)
-                : null}
-            </DragOverlay>
-          </DndContext>
-        )}
+          )}
+          <LocalTerminalArea
+            sessions={localSessions}
+            activeSessionId={activeSessionId}
+            onCreate={onNewLocalSession}
+            onSelectSession={selectSession}
+            onRemoveSession={(s) => requestRemoveSession(s.id)}
+          />
+          <DragOverlay dropAnimation={null}>
+            {activeDragId
+              ? renderDragOverlay(activeDragId, projectGroups, sessions, t)
+              : null}
+          </DragOverlay>
+        </DndContext>
       </div>
       <NewProjectDialog
         open={newProjectOpen}
@@ -858,13 +941,9 @@ function ProjectGroupView({
                     onAddSession(false, "regular");
                   }
                 }}
-                className="cursor-pointer rounded px-2 py-1 text-[11px] text-fg-muted transition select-none hover:bg-bg-elevated/40 hover:text-fg"
+                className="flex cursor-pointer items-center justify-center rounded px-3 py-3 text-center text-[11px] text-fg-muted transition select-none hover:bg-bg-elevated/40 hover:text-fg"
               >
-                {sidebarText(t, "sidebar.emptyProject.prefix")}{" "}
-                <Plus size={10} className="inline" />{" "}
-                {sidebarText(t, "sidebar.emptyProject.connector")}{" "}
-                <GitBranch size={10} className="inline" />
-                {sidebarText(t, "sidebar.emptyProject.suffix")}
+                {sidebarText(t, "sidebar.emptyProject.createSession")}
               </li>
             ) : (
               project.sessions.map((session) => (
@@ -947,9 +1026,22 @@ function SessionRow({
       // next to the active tab, auto-select, and auto-focus xterm. Carries
       // the source session's `kind` so a control session stays a control
       // session (preserves its IPC-dispatch role).
-      await useAppStore
-        .getState()
-        .createSession(next, session.repo_path, session.isolated, session.kind);
+      const state = useAppStore.getState();
+      await applySessionCreateRequest(
+        state.createSession,
+        buildSessionCreateRequestFromScope(
+          { sessions: state.sessions, projects: state.projects },
+          {
+            repoPath: session.repo_path,
+            projectScoped: session.project_scoped !== false,
+          },
+          {
+            name: next,
+            isolated: session.isolated,
+            kind: session.kind,
+          },
+        ),
+      );
     } catch (err) {
       console.error("[Sidebar] duplicate session failed", err);
     }
@@ -1053,9 +1145,8 @@ function SessionRow({
     },
   ];
 
-  return (
-    <li ref={setNodeRef} style={style}>
-      <div
+  const row = (
+    <div
         role="button"
         tabIndex={0}
         onClick={editing ? undefined : onSelect}
@@ -1074,7 +1165,6 @@ function SessionRow({
           e.stopPropagation();
           setMenu({ x: e.clientX, y: e.clientY });
         }}
-        title={hoverDetails ?? undefined}
         className={cn(
           "group flex w-full items-start gap-1.5 rounded-md px-2 py-1 text-left transition",
           active ? "bg-bg-elevated" : "hover:bg-bg-elevated/60",
@@ -1144,7 +1234,18 @@ function SessionRow({
         >
           <Trash2 size={12} />
         </span>
-      </div>
+    </div>
+  );
+
+  return (
+    <li ref={setNodeRef} style={style}>
+      {hoverDetails ? (
+        <Tooltip label={hoverDetails} side="right" multiline className="w-full">
+          {row}
+        </Tooltip>
+      ) : (
+        row
+      )}
       <ContextMenu
         open={menu !== null}
         x={menu?.x ?? 0}
@@ -1264,56 +1365,325 @@ function RenameInput({ initial, onSubmit, onCancel }: RenameInputProps) {
   );
 }
 
-function EmptyState() {
+function EmptyState({ onOpenProject }: { onOpenProject: () => void }) {
   const t = useTranslation();
 
   return (
-    <div className="px-3 py-6 text-xs text-fg-muted">
-      {sidebarText(t, "sidebar.emptyProjects.prefix")}{" "}
-      <span className="text-fg">+</span>
-      {sidebarText(t, "sidebar.emptyProjects.suffix")}
-    </div>
+    <button
+      type="button"
+      onClick={onOpenProject}
+      className="mx-1 flex cursor-pointer items-center justify-center rounded px-2 py-6 text-center text-xs text-fg-muted transition hover:bg-bg-elevated/40 hover:text-fg focus:outline-none"
+    >
+      {sidebarText(t, "sidebar.emptyProjects.openProject")}
+    </button>
   );
 }
 
-function buildProjectGroups(
-  projects: Project[],
-  sessions: Session[],
-): ProjectGroup[] {
-  const map = new Map<string, ProjectGroup>();
-  // Preserve incoming order: backend sorts by user-defined `position`.
-  for (const project of projects) {
-    map.set(project.repo_path, {
-      repoPath: project.repo_path,
-      name: project.name,
-      sessions: [],
-    });
-  }
-  for (const session of sessions) {
-    let group = map.get(session.repo_path);
-    if (!group) {
-      // Backfill: a session with no matching project entry — show it anyway,
-      // appended at the end so user-defined ordering for known projects wins.
-      group = {
-        repoPath: session.repo_path,
-        name: basename(session.repo_path),
-        sessions: [],
-      };
-      map.set(session.repo_path, group);
+interface LocalTerminalAreaProps {
+  sessions: Session[];
+  activeSessionId: string | null;
+  onCreate: () => void;
+  onSelectSession: (id: string) => void;
+  onRemoveSession: (session: Session) => void;
+}
+
+function LocalTerminalArea({
+  sessions,
+  activeSessionId,
+  onCreate,
+  onSelectSession,
+  onRemoveSession,
+}: LocalTerminalAreaProps) {
+  const t = useTranslation();
+  const sessionIds = useMemo(
+    () => sessions.map((s) => sessionDragId(s.id)),
+    [sessions],
+  );
+
+  return (
+    <section
+      tabIndex={-1}
+      data-local-terminal-area="true"
+      aria-label={sidebarText(t, "sidebar.aria.localTerminalSessions")}
+      onMouseDown={(e) => {
+        e.currentTarget.focus();
+      }}
+      className={cn(
+        "mt-4 flex min-h-28 flex-1 flex-col pt-2",
+        "rounded-md focus:outline-none",
+      )}
+    >
+      <div className="mb-1 flex items-center justify-between px-2">
+        <span className="text-xs font-medium text-fg-muted">
+          {sidebarText(t, "sidebar.localTerminals.title")}
+        </span>
+        <Tooltip
+          label={sidebarText(t, "sidebar.localTerminals.newSession")}
+          side="bottom"
+        >
+          <button
+            type="button"
+            aria-label={sidebarText(t, "sidebar.localTerminals.newSession")}
+            onClick={(e) => {
+              e.stopPropagation();
+              onCreate();
+            }}
+            onDoubleClick={(e) => e.stopPropagation()}
+            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          >
+            <Plus size={12} />
+          </button>
+        </Tooltip>
+      </div>
+      {sessions.length > 0 ? (
+        <div onDoubleClick={(e) => e.stopPropagation()}>
+          <SortableContext
+            items={sessionIds}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul className="flex flex-col gap-0.5">
+              {sessions.map((session) => (
+                <LocalSessionRow
+                  key={session.id}
+                  session={session}
+                  active={session.id === activeSessionId}
+                  onSelect={() => onSelectSession(session.id)}
+                  onRemove={() => onRemoveSession(session)}
+                />
+              ))}
+            </ul>
+          </SortableContext>
+        </div>
+      ) : null}
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label={
+          sessions.length > 0
+            ? sidebarText(t, "sidebar.localTerminals.newSession")
+            : undefined
+        }
+        onDoubleClick={onCreate}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onCreate();
+          }
+        }}
+        className="mx-1 mt-1 flex min-h-16 flex-1 cursor-pointer items-center justify-center rounded-md px-2 py-6 text-center text-xs text-fg-muted transition-colors hover:bg-bg-elevated/20 hover:text-fg focus:outline-none"
+      >
+        {sessions.length === 0
+          ? sidebarText(t, "sidebar.localTerminals.empty")
+          : null}
+      </div>
+    </section>
+  );
+}
+
+interface LocalSessionRowProps {
+  session: Session;
+  active: boolean;
+  onSelect: () => void;
+  onRemove: () => void;
+}
+
+function LocalSessionRow({
+  session,
+  active,
+  onSelect,
+  onRemove,
+}: LocalSessionRowProps) {
+  const t = useTranslation();
+  const renameSession = useAppStore((s) => s.renameSession);
+  const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
+  const agentProvider = sessionDisplay.icons.agentProvider
+    ? resolveSessionAgentProvider(session)
+    : null;
+  const hoverDetails = sessionDisplay.showDetailsOnHover
+    ? buildSessionHoverDetails(t, session)
+    : null;
+  const [editing, setEditing] = useState(false);
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: sessionDragId(session.id) });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  async function duplicate() {
+    const base = session.name;
+    const taken = new Set(useAppStore.getState().sessions.map((s) => s.name));
+    let next = `${base}-copy`;
+    let n = 2;
+    while (taken.has(next)) {
+      next = `${base}-copy-${n}`;
+      n += 1;
     }
-    group.sessions.push(session);
+    const state = useAppStore.getState();
+    await applySessionCreateRequest(
+      state.createSession,
+      buildSessionCreateRequestFromScope(
+        { sessions: state.sessions, projects: state.projects },
+        { repoPath: session.repo_path, projectScoped: false },
+        { name: next },
+      ),
+    );
   }
-  for (const group of map.values()) {
-    group.sessions.sort((a, b) => {
-      const ap = a.position ?? Number.POSITIVE_INFINITY;
-      const bp = b.position ?? Number.POSITIVE_INFINITY;
-      if (ap !== bp) return ap - bp;
-      return (
-        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
-      );
-    });
-  }
-  return Array.from(map.values());
+
+  const menuItems: ContextMenuItem[] = [
+    {
+      label: sidebarText(t, "sidebar.actions.rename"),
+      icon: <Pencil size={12} />,
+      onClick: () => setEditing(true),
+    },
+    {
+      label: sidebarText(t, "sidebar.actions.duplicateSession"),
+      icon: <Files size={12} />,
+      onClick: () => void duplicate(),
+    },
+    { type: "separator" },
+    {
+      label: sidebarText(t, "sidebar.actions.revealInFinder"),
+      icon: <FolderOpen size={12} />,
+      onClick: () => {
+        void openPath(session.worktree_path).catch((err: unknown) => {
+          console.error("[Sidebar] reveal failed", err);
+        });
+      },
+    },
+    {
+      label: sidebarText(t, "sidebar.actions.copyWorktreePath"),
+      icon: <Copy size={12} />,
+      onClick: () => void copyToClipboard(session.worktree_path),
+    },
+    { type: "separator" },
+    {
+      label: sidebarText(t, "sidebar.actions.remove"),
+      icon: <Trash2 size={12} />,
+      onClick: onRemove,
+    },
+  ];
+
+  const row = (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={editing ? undefined : onSelect}
+      onKeyDown={(e) => {
+        if (editing) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        } else if (e.key === "F2") {
+          e.preventDefault();
+          setEditing(true);
+        }
+      }}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setMenu({ x: e.clientX, y: e.clientY });
+      }}
+      className={cn(
+        "group flex min-h-8 w-full items-center gap-1.5 rounded-md px-2 text-left text-sm transition",
+        active ? "bg-bg-elevated" : "hover:bg-bg-elevated/60",
+        isDragging && "opacity-40",
+      )}
+    >
+      <span
+        ref={setActivatorNodeRef}
+        {...attributes}
+        {...listeners}
+        onClick={(e) => e.stopPropagation()}
+        aria-label={sidebarText(t, "sidebar.aria.dragToReorderSession")}
+        className="invisible flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
+      >
+        <GripVertical size={10} />
+      </span>
+      {sessionDisplay.icons.statusDot ? (
+        <span className="flex h-5 w-3 shrink-0 items-center justify-center">
+          {agentProvider ? (
+            <Tooltip label={agentProvider} side="right">
+              <AgentProviderIcon
+                provider={agentProvider}
+                className={cn("size-3", STATUS_ICON[session.status])}
+              />
+            </Tooltip>
+          ) : (
+            <span
+              className={cn(
+                "size-1.5 rounded-full",
+                STATUS_DOT[session.status],
+              )}
+            />
+          )}
+        </span>
+      ) : null}
+      {editing ? (
+        <RenameInput
+          initial={session.name}
+          onSubmit={async (next) => {
+            setEditing(false);
+            if (next && next !== session.name) {
+              await renameSession(session.id, next);
+            }
+          }}
+          onCancel={() => setEditing(false)}
+        />
+      ) : (
+        <span className="min-w-0 flex-1 truncate font-medium text-fg">
+          {session.name}
+        </span>
+      )}
+      <span
+        role="button"
+        aria-label={sidebarText(t, "sidebar.actions.removeSession")}
+        tabIndex={0}
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+            onRemove();
+          }
+        }}
+        className="invisible rounded p-1 text-fg-muted transition hover:text-danger group-hover:visible"
+      >
+        <Trash2 size={12} />
+      </span>
+    </div>
+  );
+
+  return (
+    <li ref={setNodeRef} style={style}>
+      {hoverDetails ? (
+        <Tooltip label={hoverDetails} side="right" multiline className="w-full">
+          {row}
+        </Tooltip>
+      ) : (
+        row
+      )}
+      <ContextMenu
+        open={menu !== null}
+        x={menu?.x ?? 0}
+        y={menu?.y ?? 0}
+        onClose={() => setMenu(null)}
+        items={menuItems}
+      />
+    </li>
+  );
 }
 
 function basename(path: string): string {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -39,14 +39,24 @@ export const api = {
     isolated = false,
     kind: SessionKind = "regular",
     agentProvider?: SessionAgentProvider | null,
+    projectScoped?: boolean,
   ): Promise<Session> {
-    return invoke<Session>("create_session", {
+    const args: {
+      name: string;
+      repoPath: string;
+      isolated: boolean;
+      kind: SessionKind;
+      agentProvider?: SessionAgentProvider | null;
+      projectScoped?: boolean;
+    } = {
       name,
       repoPath,
       isolated,
       kind,
       agentProvider,
-    });
+    };
+    if (projectScoped !== undefined) args.projectScoped = projectScoped;
+    return invoke<Session>("create_session", args);
   },
   removeSession(id: string, removeWorktree = false): Promise<void> {
     return invoke<void>("remove_session", { id, removeWorktree });

--- a/src/lib/sessionCreation.test.ts
+++ b/src/lib/sessionCreation.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSessionCreateRequest,
+  buildSessionCreateRequestFromScope,
+  resolveActiveSessionScope,
+  resolveProjectScopedForRepoPath,
+} from "./sessionCreation";
+import type { Project, Session } from "./types";
+
+function project(repoPath: string): Project {
+  return {
+    repo_path: repoPath,
+    name: repoPath.split("/").pop() ?? repoPath,
+    created_at: "2026-01-01T00:00:00Z",
+    position: 0,
+  };
+}
+
+function session(
+  id: string,
+  repoPath: string,
+  overrides: Partial<Session> = {},
+): Session {
+  return {
+    id,
+    name: id,
+    repo_path: repoPath,
+    worktree_path: repoPath,
+    branch: "main",
+    isolated: false,
+    status: "idle",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: null,
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: false,
+    ...overrides,
+  };
+}
+
+describe("session creation policy", () => {
+  it("keeps repo paths with only local sessions in local scope", () => {
+    const sessions = [
+      session("local", "/Users/me", { project_scoped: false }),
+    ];
+
+    expect(
+      resolveProjectScopedForRepoPath(
+        { sessions, projects: [project("/Users/me")] },
+        "/Users/me",
+      ),
+    ).toBe(false);
+  });
+
+  it("uses project scope when a project-scoped session exists", () => {
+    const sessions = [
+      session("local", "/repo/app", { project_scoped: false }),
+      session("project", "/repo/app", { project_scoped: true }),
+    ];
+
+    expect(
+      resolveProjectScopedForRepoPath({ sessions, projects: [] }, "/repo/app"),
+    ).toBe(true);
+  });
+
+  it("uses the active session scope before the active workspace repo path", () => {
+    const sessions = [
+      session("local", "/Users/me", { project_scoped: false }),
+    ];
+
+    expect(
+      resolveActiveSessionScope({
+        sessions,
+        projects: [project("/repo/app")],
+        activeSessionId: "local",
+        activeWorkspaceRepoPath: "/repo/app",
+      }),
+    ).toEqual({ repoPath: "/Users/me", projectScoped: false });
+  });
+
+  it("builds local session requests with local naming", () => {
+    const sessions = [
+      session("local", "/Users/me", {
+        name: "terminal",
+        project_scoped: false,
+      }),
+    ];
+
+    expect(
+      buildSessionCreateRequest(
+        { sessions, projects: [] },
+        { repoPath: "/Users/me", projectScoped: false },
+      ),
+    ).toMatchObject({
+      name: "terminal-2",
+      repoPath: "/Users/me",
+      projectScoped: false,
+    });
+  });
+
+  it("preserves explicit names and scope", () => {
+    expect(
+      buildSessionCreateRequestFromScope(
+        { sessions: [], projects: [] },
+        { repoPath: "/Users/me", projectScoped: false },
+        { name: "codex-copy", agentProvider: "codex" },
+      ),
+    ).toMatchObject({
+      name: "codex-copy",
+      repoPath: "/Users/me",
+      agentProvider: "codex",
+      projectScoped: false,
+    });
+  });
+});

--- a/src/lib/sessionCreation.ts
+++ b/src/lib/sessionCreation.ts
@@ -1,0 +1,145 @@
+import { suggestLocalSessionName, suggestSessionName } from "./sessionName";
+import type {
+  Project,
+  Session,
+  SessionAgentProvider,
+  SessionKind,
+} from "./types";
+
+export interface SessionCreationContext {
+  sessions: Session[];
+  projects: Project[];
+  activeSessionId?: string | null;
+  activeWorkspaceRepoPath?: string | null;
+}
+
+export interface SessionCreateScope {
+  repoPath: string;
+  projectScoped: boolean;
+}
+
+export interface SessionCreateRequest {
+  name: string;
+  repoPath: string;
+  isolated: boolean;
+  kind: SessionKind;
+  agentProvider: SessionAgentProvider | null;
+  projectScoped: boolean;
+}
+
+export interface BuildSessionCreateOptions {
+  repoPath: string;
+  isolated?: boolean;
+  kind?: SessionKind;
+  agentProvider?: SessionAgentProvider | null;
+  projectScoped?: boolean;
+  name?: string;
+}
+
+export function scopeForSession(session: Session): SessionCreateScope {
+  return {
+    repoPath: session.repo_path,
+    projectScoped: session.project_scoped !== false,
+  };
+}
+
+export function resolveActiveSessionScope(
+  context: SessionCreationContext,
+): SessionCreateScope | null {
+  const active = context.activeSessionId
+    ? context.sessions.find((session) => session.id === context.activeSessionId)
+    : null;
+  if (active) return scopeForSession(active);
+  if (!context.activeWorkspaceRepoPath) return null;
+  return {
+    repoPath: context.activeWorkspaceRepoPath,
+    projectScoped: resolveProjectScopedForRepoPath(
+      context,
+      context.activeWorkspaceRepoPath,
+    ),
+  };
+}
+
+export function resolveProjectScopedForRepoPath(
+  context: Pick<SessionCreationContext, "sessions" | "projects">,
+  repoPath: string,
+): boolean {
+  const hasLocalSessions = context.sessions.some(
+    (session) =>
+      session.repo_path === repoPath && session.project_scoped === false,
+  );
+  const hasProjectSessions = context.sessions.some(
+    (session) =>
+      session.repo_path === repoPath && session.project_scoped !== false,
+  );
+  if (hasLocalSessions && !hasProjectSessions) return false;
+  return true;
+}
+
+export function buildSessionCreateRequest(
+  context: Pick<SessionCreationContext, "sessions" | "projects">,
+  options: BuildSessionCreateOptions,
+): SessionCreateRequest {
+  const isolated = options.isolated ?? false;
+  const kind = options.kind ?? "regular";
+  const projectScoped =
+    options.projectScoped ??
+    resolveProjectScopedForRepoPath(context, options.repoPath);
+  const name =
+    options.name ??
+    (projectScoped
+      ? suggestSessionName(options.repoPath, context.sessions, kind, isolated)
+      : suggestLocalSessionName(context.sessions));
+
+  return {
+    name,
+    repoPath: options.repoPath,
+    isolated,
+    kind,
+    agentProvider: options.agentProvider ?? null,
+    projectScoped,
+  };
+}
+
+export function buildLocalSessionCreateRequest(
+  context: Pick<SessionCreationContext, "sessions" | "projects">,
+  repoPath: string,
+): SessionCreateRequest {
+  return buildSessionCreateRequest(context, {
+    repoPath,
+    projectScoped: false,
+  });
+}
+
+export function buildSessionCreateRequestFromScope(
+  context: Pick<SessionCreationContext, "sessions" | "projects">,
+  scope: SessionCreateScope,
+  options: Omit<BuildSessionCreateOptions, "repoPath" | "projectScoped"> = {},
+): SessionCreateRequest {
+  return buildSessionCreateRequest(context, {
+    ...options,
+    repoPath: scope.repoPath,
+    projectScoped: scope.projectScoped,
+  });
+}
+
+export function applySessionCreateRequest(
+  createSession: (
+    name: string,
+    repoPath: string,
+    isolated?: boolean,
+    kind?: SessionKind,
+    agentProvider?: SessionAgentProvider | null,
+    projectScoped?: boolean,
+  ) => Promise<Session | null>,
+  request: SessionCreateRequest,
+): Promise<Session | null> {
+  return createSession(
+    request.name,
+    request.repoPath,
+    request.isolated,
+    request.kind,
+    request.agentProvider,
+    request.projectScoped,
+  );
+}

--- a/src/lib/sessionGrouping.test.ts
+++ b/src/lib/sessionGrouping.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { buildLocalSessions, buildProjectGroups } from "./sessionGrouping";
+import type { Project, Session } from "./types";
+
+function project(repoPath: string, position: number): Project {
+  return {
+    repo_path: repoPath,
+    name: repoPath.split("/").pop() ?? repoPath,
+    created_at: "2026-01-01T00:00:00Z",
+    position,
+  };
+}
+
+function session(
+  id: string,
+  repoPath: string,
+  overrides: Partial<Session> = {},
+): Session {
+  return {
+    id,
+    name: id,
+    repo_path: repoPath,
+    worktree_path: repoPath,
+    branch: "main",
+    isolated: false,
+    status: "idle",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: null,
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: false,
+    ...overrides,
+  };
+}
+
+describe("buildProjectGroups", () => {
+  it("preserves project order and attaches matching sessions", () => {
+    const groups = buildProjectGroups(
+      [project("/repo/b", 0), project("/repo/a", 1)],
+      [session("a1", "/repo/a"), session("b1", "/repo/b")],
+    );
+
+    expect(groups.map((group) => group.repoPath)).toEqual([
+      "/repo/b",
+      "/repo/a",
+    ]);
+    expect(groups[0].sessions.map((s) => s.id)).toEqual(["b1"]);
+    expect(groups[1].sessions.map((s) => s.id)).toEqual(["a1"]);
+  });
+
+  it("backfills sessions whose project entry is missing", () => {
+    const groups = buildProjectGroups(
+      [project("/repo/known", 0)],
+      [session("ghost", "/repo/missing")],
+    );
+
+    expect(groups.map((group) => [group.repoPath, group.name])).toEqual([
+      ["/repo/known", "known"],
+      ["/repo/missing", "missing"],
+    ]);
+  });
+
+  it("excludes local sessions from project groups", () => {
+    const groups = buildProjectGroups(
+      [project("/repo/known", 0)],
+      [
+        session("project", "/repo/known"),
+        session("local", "/Users/me", { project_scoped: false }),
+      ],
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].sessions.map((s) => s.id)).toEqual(["project"]);
+  });
+
+  it("hides stale empty projects that only mirror local sessions", () => {
+    const groups = buildProjectGroups(
+      [project("/Users/me", 0), project("/repo/app", 1)],
+      [
+        session("local", "/Users/me", { project_scoped: false }),
+        session("project", "/repo/app"),
+      ],
+    );
+
+    expect(groups.map((group) => group.repoPath)).toEqual(["/repo/app"]);
+  });
+
+  it("sorts sessions by explicit position before updated time", () => {
+    const groups = buildProjectGroups(
+      [project("/repo/app", 0)],
+      [
+        session("newer", "/repo/app", {
+          updated_at: "2026-01-03T00:00:00Z",
+        }),
+        session("pos-1", "/repo/app", { position: 1 }),
+        session("pos-0", "/repo/app", { position: 0 }),
+        session("older", "/repo/app", {
+          updated_at: "2026-01-02T00:00:00Z",
+        }),
+      ],
+    );
+
+    expect(groups[0].sessions.map((s) => s.id)).toEqual([
+      "pos-0",
+      "pos-1",
+      "newer",
+      "older",
+    ]);
+  });
+});
+
+describe("buildLocalSessions", () => {
+  it("selects non-project sessions and uses the same ordering rules", () => {
+    const local = buildLocalSessions([
+      session("project", "/repo/app"),
+      session("newer", "/Users/me", {
+        project_scoped: false,
+        updated_at: "2026-01-03T00:00:00Z",
+      }),
+      session("pos-0", "/Users/me", {
+        project_scoped: false,
+        position: 0,
+      }),
+      session("older", "/Users/me", {
+        project_scoped: false,
+        updated_at: "2026-01-02T00:00:00Z",
+      }),
+    ]);
+
+    expect(local.map((s) => s.id)).toEqual(["pos-0", "newer", "older"]);
+  });
+});

--- a/src/lib/sessionGrouping.ts
+++ b/src/lib/sessionGrouping.ts
@@ -1,0 +1,82 @@
+import type { Project, Session } from "./types";
+
+export interface ProjectGroup {
+  repoPath: string;
+  name: string;
+  sessions: Session[];
+}
+
+export function buildProjectGroups(
+  projects: Project[],
+  sessions: Session[],
+): ProjectGroup[] {
+  const map = new Map<string, ProjectGroup>();
+  const projectSessions = sessions.filter(isProjectSession);
+  const projectSessionPaths = new Set(
+    projectSessions.map((session) => session.repo_path),
+  );
+  const localSessionPaths = new Set(
+    sessions.filter(isLocalSession).map((session) => session.repo_path),
+  );
+
+  // Preserve incoming order: backend sorts by user-defined `position`.
+  for (const project of projects) {
+    // Older boot backfill could persist a project entry for the user's home
+    // directory after a local chat session. Keep that stale empty project out
+    // of the Projects section while preserving real project sessions.
+    if (
+      !projectSessionPaths.has(project.repo_path) &&
+      localSessionPaths.has(project.repo_path)
+    ) {
+      continue;
+    }
+    map.set(project.repo_path, {
+      repoPath: project.repo_path,
+      name: project.name,
+      sessions: [],
+    });
+  }
+  for (const session of projectSessions) {
+    let group = map.get(session.repo_path);
+    if (!group) {
+      // Backfill: a session with no matching project entry shows anyway,
+      // appended after known projects so user-defined project ordering wins.
+      group = {
+        repoPath: session.repo_path,
+        name: basename(session.repo_path),
+        sessions: [],
+      };
+      map.set(session.repo_path, group);
+    }
+    group.sessions.push(session);
+  }
+  for (const group of map.values()) {
+    group.sessions = sortSessions(group.sessions);
+  }
+  return Array.from(map.values());
+}
+
+export function buildLocalSessions(sessions: Session[]): Session[] {
+  return sortSessions(sessions.filter(isLocalSession));
+}
+
+export function isProjectSession(session: Session): boolean {
+  return session.project_scoped !== false;
+}
+
+export function isLocalSession(session: Session): boolean {
+  return session.project_scoped === false;
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
+}
+
+function sortSessions(sessions: Session[]): Session[] {
+  return [...sessions].sort((a, b) => {
+    const ap = a.position ?? Number.POSITIVE_INFINITY;
+    const bp = b.position ?? Number.POSITIVE_INFINITY;
+    if (ap !== bp) return ap - bp;
+    return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+  });
+}

--- a/src/lib/sessionName.test.ts
+++ b/src/lib/sessionName.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Session } from "./types";
-import { suggestSessionName } from "./sessionName";
+import { suggestLocalSessionName, suggestSessionName } from "./sessionName";
 
 function session(name: string): Session {
   return {
@@ -69,5 +69,20 @@ describe("suggestSessionName", () => {
     expect(suggestSessionName("/Users/x/acorn/", [], "regular", true)).toBe(
       "acorn-worktree-1",
     );
+  });
+});
+
+describe("suggestLocalSessionName", () => {
+  it("uses a terminal namespace independent of cwd basename", () => {
+    expect(suggestLocalSessionName([])).toBe("terminal");
+  });
+
+  it("bumps numeric suffix on collision", () => {
+    expect(
+      suggestLocalSessionName([
+        session("terminal"),
+        session("terminal-2"),
+      ]),
+    ).toBe("terminal-3");
   });
 });

--- a/src/lib/sessionName.ts
+++ b/src/lib/sessionName.ts
@@ -43,3 +43,14 @@ export function suggestSessionName(
   }
   return candidate;
 }
+
+export function suggestLocalSessionName(existing: Session[]): string {
+  const taken = new Set(existing.map((s) => s.name));
+  const base = "terminal";
+  let candidate = base;
+  let n = 2;
+  while (taken.has(candidate)) {
+    candidate = `${base}-${n++}`;
+  }
+  return candidate;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -66,6 +66,7 @@ export interface Session {
   worktree_path: string;
   branch: string;
   isolated: boolean;
+  project_scoped?: boolean;
   status: SessionStatus;
   created_at: string;
   updated_at: string;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -515,17 +515,20 @@
       "newSessionInProject": "New session in this project",
       "newControlSessionInProject": "New control session in this project",
       "dragToReorderSession": "Drag to reorder session",
+      "localTerminalSessions": "Local terminal sessions",
       "worktree": "worktree",
       "controlSession": "control session"
     },
+    "localTerminals": {
+      "title": "Chats",
+      "newSession": "New chat",
+      "empty": "Double-click to start a chat."
+    },
     "emptyProject": {
-      "prefix": "No sessions. Add one with",
-      "connector": "or",
-      "suffix": ", or double-click here."
+      "createSession": "Double-click to start a session."
     },
     "emptyProjects": {
-      "prefix": "No projects yet. Click",
-      "suffix": "to add one."
+      "openProject": "Click to open a project."
     },
     "metadata": {
       "name": "Name",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -515,17 +515,20 @@
       "newSessionInProject": "이 프로젝트에 새 세션 만들기",
       "newControlSessionInProject": "이 프로젝트에 새 컨트롤 세션 만들기",
       "dragToReorderSession": "세션 순서를 바꾸려면 드래그",
+      "localTerminalSessions": "로컬 터미널 세션",
       "worktree": "worktree",
       "controlSession": "컨트롤 세션"
     },
+    "localTerminals": {
+      "title": "채팅",
+      "newSession": "새 채팅",
+      "empty": "더블클릭하면 채팅을 시작할 수 있습니다."
+    },
     "emptyProject": {
-      "prefix": "세션이 없습니다.",
-      "connector": "또는",
-      "suffix": "로 추가하거나 여기를 더블 클릭하세요."
+      "createSession": "더블클릭하면 세션을 시작할 수 있습니다."
     },
     "emptyProjects": {
-      "prefix": "아직 프로젝트가 없습니다.",
-      "suffix": "를 클릭해 추가하세요."
+      "openProject": "클릭하면 프로젝트를 열 수 있습니다."
     },
     "metadata": {
       "name": "이름",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -169,6 +169,13 @@ describe("refreshAll", () => {
     expect(useAppStore.getState().activeSessionId).toBeNull();
   });
 
+  it("can activate a local session workspace when there are no projects", async () => {
+    const local = session("local", "/Users/me", { project_scoped: false });
+    await seed([], [local]);
+    expect(useAppStore.getState().activeProject).toBe("/Users/me");
+    expect(useAppStore.getState().activeSessionId).toBe("local");
+  });
+
   it("sets error on api failure and leaves loading false", async () => {
     mockApi.listSessions.mockRejectedValueOnce(new Error("boom"));
     mockApi.listProjects.mockResolvedValueOnce([]);
@@ -889,6 +896,23 @@ describe("createSession", () => {
       false,
       "regular",
       "codex",
+    );
+  });
+
+  it("forwards local session scope only when requested", async () => {
+    mockApi.createSession.mockResolvedValueOnce(
+      session("terminal", "/Users/me", { project_scoped: false }),
+    );
+    await useAppStore
+      .getState()
+      .createSession("terminal", "/Users/me", false, "regular", null, false);
+    expect(mockApi.createSession).toHaveBeenCalledWith(
+      "terminal",
+      "/Users/me",
+      false,
+      "regular",
+      null,
+      false,
     );
   });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -161,6 +161,7 @@ interface AppStateModel {
     isolated?: boolean,
     kind?: SessionKind,
     agentProvider?: SessionAgentProvider | null,
+    projectScoped?: boolean,
   ) => Promise<Session | null>;
   removeSession: (id: string, removeWorktree?: boolean) => Promise<void>;
   renameSession: (id: string, name: string) => Promise<void>;
@@ -424,7 +425,11 @@ function reconcileWorkspaces(
     const withSession = projects.find(
       (p) => (byProject[p.repo_path]?.length ?? 0) > 0,
     );
-    newActive = withSession?.repo_path ?? projects[0]?.repo_path ?? null;
+    newActive =
+      withSession?.repo_path ??
+      projects[0]?.repo_path ??
+      sessions[0]?.repo_path ??
+      null;
   }
 
   return { workspaces: newWorkspaces, activeProject: newActive };
@@ -993,6 +998,7 @@ export const useAppStore = create<AppStateModel>()(
     isolated = false,
     kind = "regular",
     agentProvider = null,
+    projectScoped = true,
   ) {
     set({ loading: true, error: null });
     try {
@@ -1012,13 +1018,23 @@ export const useAppStore = create<AppStateModel>()(
         return idx >= 0 ? { paneId, idx } : null;
       })();
 
-      const created = await api.createSession(
-        name,
-        repoPath,
-        isolated,
-        kind,
-        agentProvider,
-      );
+      const created =
+        projectScoped === false
+          ? await api.createSession(
+              name,
+              repoPath,
+              isolated,
+              kind,
+              agentProvider,
+              false,
+            )
+          : await api.createSession(
+              name,
+              repoPath,
+              isolated,
+              kind,
+              agentProvider,
+            );
       await get().refreshAll();
 
       // Reorder so the new tab sits immediately after the previously-active

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -24,6 +24,7 @@ export const tauriMockSource = `
     if (cmd === 'plugin:notification|notify') return Promise.resolve(undefined);
     if (cmd === 'plugin:window|destroy') return Promise.resolve(undefined);
     if (cmd === 'plugin:window|close') return Promise.resolve(undefined);
+    if (cmd === 'plugin:path|resolve_directory') return Promise.resolve('/Users/tester');
     return undefined;
   }
 

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, seedSettingsLanguage } from "./support";
+import { test, expect, pressHotkey, seedSettingsLanguage } from "./support";
 
 test.describe("sidebar: project lifecycle", () => {
   test("Korean mode localizes project chrome and empty state", async ({
@@ -15,7 +15,11 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(
       page.getByRole("button", { name: "기존 프로젝트 추가" }),
     ).toBeVisible();
-    await expect(page.getByText(/아직 프로젝트가 없습니다/)).toBeVisible();
+    await expect(
+      page.getByRole("button", {
+        name: "클릭하면 프로젝트를 열 수 있습니다.",
+      }),
+    ).toBeVisible();
   });
 
   test("seeded project appears with name and add session affordances", async ({
@@ -37,8 +41,276 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(
       page.getByRole("listitem").filter({ hasText: "demo" }),
     ).toBeVisible();
-    await expect(page.getByText(/No projects yet/i)).toHaveCount(0);
-    await expect(page.getByText(/No sessions\./i)).toBeVisible();
+    await expect(page.getByText(/Click to open a project/i)).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Double-click to start a session." }),
+    ).toBeVisible();
+  });
+
+  test("clicking the chats add button creates a local terminal session", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("plugin:path|resolve_directory", () => "/Users/tester");
+    await tauri.handle("list_projects", () => []);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __localSessionCreated?: boolean };
+      return w.__localSessionCreated
+        ? [
+            {
+              id: "local-1",
+              name: "terminal",
+              repo_path: "/Users/tester",
+              worktree_path: "/Users/tester",
+              branch: "HEAD",
+              isolated: false,
+              project_scoped: false,
+              status: "idle",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:00Z",
+              last_message: null,
+              kind: "regular",
+              owner: { kind: "user" },
+              position: null,
+              in_worktree: false,
+            },
+          ]
+        : [];
+    });
+    await tauri.handle("create_session", (args) => {
+      const w = window as unknown as {
+        __localSessionCreated?: boolean;
+        __createSessionCalls?: unknown[];
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(args);
+      w.__localSessionCreated = true;
+      return {
+        id: "local-1",
+        name: "terminal",
+        repo_path: "/Users/tester",
+        worktree_path: "/Users/tester",
+        branch: "HEAD",
+        isolated: false,
+        project_scoped: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      };
+    });
+
+    await page.goto("/");
+    const chats = page.getByRole("region", { name: "Local terminal sessions" });
+    await chats.getByRole("button", { name: "New chat" }).click();
+
+    await expect(page.getByText("Chats")).toBeVisible();
+    await expect(
+      chats.getByRole("button", { name: "terminal", exact: true }),
+    ).toBeVisible();
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __createSessionCalls?: unknown[] })
+          .__createSessionCalls,
+    )) as Array<{
+      name: string;
+      repoPath: string;
+      isolated: boolean;
+      kind: string;
+      projectScoped: boolean;
+    }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      name: "terminal",
+      repoPath: "/Users/tester",
+      isolated: false,
+      kind: "regular",
+      projectScoped: false,
+    });
+  });
+
+  test("local chat sessions show agent provider icons", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => []);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "local-codex",
+        name: "codex",
+        repo_path: "/Users/tester",
+        worktree_path: "/Users/tester",
+        branch: "HEAD",
+        isolated: false,
+        project_scoped: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+        agent_provider: "codex",
+      },
+    ]);
+
+    await page.goto("/");
+
+    const chats = page.getByRole("region", { name: "Local terminal sessions" });
+    await expect(chats.getByRole("img", { name: "Codex" })).toBeVisible();
+    await expect(
+      chats.getByRole("button", { name: /codex/i }),
+    ).toBeVisible();
+  });
+
+  test("new-session hotkey preserves local chat scope", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => []);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __hotkeyLocalCreated?: boolean };
+      const sessions = [
+        {
+          id: "local-1",
+          name: "terminal",
+          repo_path: "/Users/tester",
+          worktree_path: "/Users/tester",
+          branch: "HEAD",
+          isolated: false,
+          project_scoped: false,
+          status: "idle",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+        },
+      ];
+      return w.__hotkeyLocalCreated
+        ? [
+            ...sessions,
+            {
+              ...sessions[0],
+              id: "local-2",
+              name: "terminal-2",
+            },
+          ]
+        : sessions;
+    });
+    await tauri.handle("create_session", (args) => {
+      const w = window as unknown as {
+        __hotkeyLocalCreated?: boolean;
+        __createSessionCalls?: unknown[];
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(args);
+      w.__hotkeyLocalCreated = true;
+      return {
+        id: "local-2",
+        name: "terminal-2",
+        repo_path: "/Users/tester",
+        worktree_path: "/Users/tester",
+        branch: "HEAD",
+        isolated: false,
+        project_scoped: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      };
+    });
+
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "t" });
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __createSessionCalls?: unknown[] })
+          .__createSessionCalls,
+    )) as Array<{
+      name: string;
+      repoPath: string;
+      projectScoped: boolean;
+    }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      name: "terminal-2",
+      repoPath: "/Users/tester",
+      projectScoped: false,
+    });
+  });
+
+  test("clicking the chats area makes new-session hotkey create a chat", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("plugin:path|resolve_directory", () => "/Users/tester");
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/repo/app",
+        name: "app",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => []);
+    await tauri.handle("create_session", (args) => {
+      const w = window as unknown as { __createSessionCalls?: unknown[] };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(args);
+      return {
+        id: "local-1",
+        name: "terminal",
+        repo_path: "/Users/tester",
+        worktree_path: "/Users/tester",
+        branch: "HEAD",
+        isolated: false,
+        project_scoped: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      };
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("region", { name: "Local terminal sessions" })
+      .click({ position: { x: 16, y: 48 } });
+    await pressHotkey(page, { mod: true, key: "t" });
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __createSessionCalls?: unknown[] })
+          .__createSessionCalls,
+    )) as Array<{
+      name: string;
+      repoPath: string;
+      projectScoped: boolean;
+    }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      name: "terminal",
+      repoPath: "/Users/tester",
+      projectScoped: false,
+    });
   });
 
   test("Add existing project invokes add_project with the picked path", async ({
@@ -83,6 +355,60 @@ test.describe("sidebar: project lifecycle", () => {
     )) as Array<{ repoPath: string }>;
     expect(calls).toHaveLength(1);
     expect(calls[0].repoPath).toBe("/tmp/picked");
+  });
+
+  test("empty project state opens an existing project picker", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("plugin:dialog|open", () => "/tmp/empty-picked");
+    await tauri.handle("list_projects", () => {
+      const w = window as unknown as { __projectOpened?: boolean };
+      return w.__projectOpened
+        ? [
+            {
+              repo_path: "/tmp/empty-picked",
+              name: "empty-picked",
+              created_at: "2026-01-01T00:00:00Z",
+              position: 0,
+            },
+          ]
+        : [];
+    });
+    await tauri.handle("add_project", (args) => {
+      const w = window as unknown as {
+        __addProjectCalls?: unknown[];
+        __projectOpened?: boolean;
+      };
+      w.__addProjectCalls = w.__addProjectCalls ?? [];
+      w.__addProjectCalls.push(args);
+      w.__projectOpened = true;
+      return {
+        repo_path: "/tmp/empty-picked",
+        name: "empty-picked",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      };
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", {
+        name: "Click to open a project.",
+      })
+      .click();
+
+    await expect(
+      page.getByRole("listitem").filter({ hasText: "empty-picked" }),
+    ).toBeVisible();
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __addProjectCalls?: unknown[] })
+          .__addProjectCalls,
+    )) as Array<{ repoPath: string }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0].repoPath).toBe("/tmp/empty-picked");
   });
 
   test("New project creates a git-backed project under the selected parent", async ({
@@ -254,7 +580,7 @@ test.describe("sidebar: project lifecycle", () => {
     await page.getByRole("button", { name: "Close project" }).first().click();
 
     await expect(page.getByRole("dialog")).toHaveCount(0);
-    await expect(page.getByText(/No projects yet/i)).toBeVisible();
+    await expect(page.getByText(/Click to open a project/i)).toBeVisible();
 
     const calls = (await page.evaluate(
       () =>
@@ -330,7 +656,7 @@ test.describe("sidebar: project lifecycle", () => {
       .getByRole("button", { name: /^Close project$/ })
       .click();
 
-    await expect(page.getByText(/No projects yet/i)).toBeVisible();
+    await expect(page.getByText(/Click to open a project/i)).toBeVisible();
 
     const calls = (await page.evaluate(
       () =>

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -15,7 +15,7 @@ test.describe("smoke: app boots in mocked browser", () => {
     await expect(
       page.getByRole("button", { name: "Add existing project" }),
     ).toBeVisible();
-    await expect(page.getByText(/No projects yet/i)).toBeVisible();
+    await expect(page.getByText(/Click to open a project/i)).toBeVisible();
     await expect(page.getByText(/update available/i)).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Summary
Adds non-project chat terminal sessions as a first-class session scope in the sidebar:

1. **Local Chats area** — adds a Chats section below Projects, with a Tooltip-backed New Chat button and double-click/Cmd+T creation from the local area. Local sessions start at the user home directory and stay visually separate from project sessions.
2. **Scoped session creation** — centralizes session creation policy in `sessionCreation` helpers so pane tabs, sidebar actions, history resume, file explorer actions, and command-run flows preserve project vs local scope consistently.
3. **Session grouping persistence** — adds `project_scoped` to persisted sessions and prevents local sessions from recreating username projects after restart.
4. **Sidebar polish** — local chat rows use the same agent provider icons as project rows, and session hover details now use the shared `Tooltip` component instead of native `title` attributes.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Non-project terminal sessions | Could be created only indirectly and could reappear under a username project | First-class Chats section, local scope persisted |
| New session shortcut | Followed active project context only | Follows Chats focus when the Chats area is focused |
| Session hover UI | Native browser title tooltip in sidebar rows | Shared Acorn Tooltip component |

## Design notes
- `project_scoped` defaults to `true` for compatibility. The frontend only sends `false` for explicitly local chat sessions, keeping existing project session creation unchanged.
- Backend project adoption skips `projects.ensure` for local sessions, and boot-time backfill ignores local sessions so they do not create synthetic projects.
- Creation intent now flows through `src/lib/sessionCreation.ts` instead of being recalculated separately in Sidebar, Pane, FileExplorer, RightPanel, and CommandRunDialog.
- The Chats area uses DOM focus only for the sidebar-local Cmd+T routing decision; existing store focus state continues to own active pane/session/workspace selection.

## Follow-up (not in this PR)
- Consider making the currently focused surface an explicit store-level concept if more non-pane command routing is added.

## Test plan
- [x] `git diff --check`
- [x] `pnpm typecheck`
- [x] `pnpm vitest run src/lib/sessionCreation.test.ts src/components/Pane.test.tsx src/lib/sessionGrouping.test.ts src/lib/sessionName.test.ts src/store.test.ts` — 84 passed, 1 skipped
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `pnpm test:e2e tests/e2e/sidebar.spec.ts tests/e2e/right-panel.spec.ts tests/e2e/command-hint.spec.ts --project=chromium` — 28 passed

## Notes
- `cargo check` still reports the pre-existing `AgentHookServer::start` dead-code warning. Not caused by this PR.
- Playwright logs include existing mocked-browser warnings for `load_status` and user theme loading. Tests pass; these warnings are not caused by this PR.

