### PR TITLE
fix(sessions): confirm worktree cleanup on auto-close exit

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -45,6 +45,7 @@ import {
   chooseWorktreeToAdoptAfterExit,
   type WorktreeAdoptionIntent,
 } from "../lib/worktreeAdoption";
+import { hasRecordedWorktree } from "../lib/sessionWorktree";
 import { useAppStore } from "../store";
 import { StickyUserPrompt } from "./StickyUserPrompt";
 import { FloatingTooltip, type TooltipAnchorRect } from "./Tooltip";
@@ -1596,12 +1597,20 @@ export function Terminal({
               // briefly flash on the way out.
               return;
             }
-            // User opted into auto-close: drop the session tab now instead
-            // of writing the press-Enter prompt. The worktree is preserved
-            // (removeSession(id, false)); only the in-app tab disappears.
+            // User opted into auto-close: drop ordinary sessions immediately,
+            // but route worktree-backed sessions through the same
+            // delete-worktree confirmation as tab close.
             if (useSettings.getState().settings.sessions.closeOnExit) {
               exited = true;
-              void useAppStore.getState().removeSession(sessionId, false);
+              const store = useAppStore.getState();
+              const session =
+                store.sessions.find((candidate) => candidate.id === sessionId) ??
+                null;
+              if (session && hasRecordedWorktree(session)) {
+                store.requestRemoveSession(sessionId);
+              } else {
+                void store.removeSession(sessionId, false);
+              }
               return;
             }
             exited = true;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -54,12 +54,12 @@
     "sessions": {
       "confirmRemove": {
         "label": "Confirm before removing a session",
-        "hint": "Isolated worktrees always prompt because the delete-worktree choice still matters.",
+        "hint": "Linked worktrees always prompt because the delete-worktree choice still matters.",
         "checkbox": "Show confirmation dialog"
       },
       "closeOnExit": {
         "label": "Close tab when the process exits",
-        "hint": "When the session's shell or agent exits (e.g. you type `exit`), close the tab automatically instead of showing the press-Enter restart prompt. The worktree is preserved either way.",
+        "hint": "When the session's shell or agent exits (e.g. you type `exit`), close the tab automatically instead of showing the press-Enter restart prompt. Linked worktrees still ask what to do.",
         "checkbox": "Auto-close on exit"
       },
       "background": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -54,12 +54,12 @@
     "sessions": {
       "confirmRemove": {
         "label": "세션 제거 전 확인",
-        "hint": "격리된 worktree는 delete-worktree 선택이 여전히 중요하므로 항상 확인합니다.",
+        "hint": "linked worktree는 delete-worktree 선택이 여전히 중요하므로 항상 확인합니다.",
         "checkbox": "확인 대화상자 표시"
       },
       "closeOnExit": {
         "label": "프로세스 종료 시 탭 닫기",
-        "hint": "세션의 셸이나 에이전트가 종료되면(예: `exit` 입력) Enter를 눌러 재시작하라는 프롬프트 대신 탭을 자동으로 닫습니다. 어느 쪽이든 worktree는 보존됩니다.",
+        "hint": "세션의 셸이나 에이전트가 종료되면(예: `exit` 입력) Enter를 눌러 재시작하라는 프롬프트 대신 탭을 자동으로 닫습니다. linked worktree는 그래도 처리 방식을 묻습니다.",
         "checkbox": "종료 시 자동 닫기"
       },
       "background": {


### PR DESCRIPTION
## Summary
Auto-close now preserves the existing worktree cleanup decision instead of silently keeping linked worktrees.

1. **Exit auto-close:** Route worktree-backed sessions through the existing remove-session confirmation dialog when the process exits.
2. **Ordinary sessions:** Keep the current immediate auto-close behavior for non-worktree sessions.
3. **Settings copy:** Update English and Korean hints so the documented behavior matches linked worktree prompting.

## Expected impact

| Area | Impact |
| --- | --- |
| Session exit behavior | `exit` in linked worktree sessions now asks whether to keep or delete the worktree before closing. |
| Ordinary session auto-close | Unchanged; non-worktree sessions still close immediately when enabled. |
| Changelog/user docs | Settings hints now describe linked worktree prompting accurately. |

## Design notes

The change reuses `hasRecordedWorktree(session)` and `requestRemoveSession(sessionId)`, so exit-driven cleanup follows the same dialog path as tab close instead of adding a separate prompt path in the terminal layer.

## Test plan

- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec vitest run src/lib/sessionWorktree.test.ts`
- [x] `git diff --check`

## Notes

Verification ran in a clean worktree linked to the existing local `node_modules` install from the main checkout.