### PR TITLE
fix(panes): open file drops in empty panes

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -455,7 +455,10 @@ export function Pane({ paneId }: PaneProps) {
             }}
           />
         )}
-        <PaneDropOverlay paneId={paneId} />
+        <PaneDropOverlay
+          paneId={paneId}
+          acceptFileDrops={active?.kind !== "session"}
+        />
       </div>
       <ContextMenu
         open={paneMenu !== null}

--- a/src/components/PaneDropOverlay.test.tsx
+++ b/src/components/PaneDropOverlay.test.tsx
@@ -1,0 +1,166 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { Project } from "../lib/types";
+
+vi.mock("../lib/api", () => ({
+  api: {},
+}));
+
+import {
+  clearTabDragPayload,
+  setFileDragPayload,
+} from "../lib/dnd";
+import { makePaneNode } from "../lib/layout";
+import { defaultTabByGroup } from "../lib/rightPanelGroups";
+import { useAppStore } from "../store";
+import { PaneDropOverlay } from "./PaneDropOverlay";
+
+const REPO = "/tmp/acorn-repo";
+const FILE = `${REPO}/src/App.tsx`;
+
+function project(repoPath: string): Project {
+  return {
+    repo_path: repoPath,
+    name: "acorn-repo",
+    created_at: "2026-01-01T00:00:00Z",
+    position: 0,
+  };
+}
+
+function resetStore(): void {
+  const rootPane = { id: "root", tabIds: [], activeTabId: null };
+  useAppStore.setState(
+    {
+      sessions: [],
+      projects: [project(REPO)],
+      workspaces: {
+        [REPO]: {
+          layout: makePaneNode("root"),
+          panes: { root: rootPane },
+          focusedPaneId: "root",
+        },
+      },
+      activeProject: REPO,
+      layout: makePaneNode("root"),
+      panes: { root: rootPane },
+      focusedPaneId: "root",
+      activeTabId: null,
+      activeSessionId: null,
+      rightTab: "commits",
+      rightTabByGroup: defaultTabByGroup(),
+      workspaceTabs: {},
+      prAccountByRepo: {},
+      pendingTerminalInput: {},
+      multiInputEnabled: false,
+      loading: false,
+      error: null,
+      pendingRemoveId: null,
+      pendingRemoveProject: null,
+      sessionsLoadedCleanly: true,
+      liveInWorktree: {},
+    },
+    false,
+  );
+}
+
+function makeDataTransfer(): DataTransfer {
+  return {
+    dropEffect: "none",
+    effectAllowed: "all",
+    setData: vi.fn(),
+    getData: vi.fn(() => ""),
+    clearData: vi.fn(),
+    files: [] as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    types: [],
+    setDragImage: vi.fn(),
+  };
+}
+
+function dispatchDrop(target: Element, dataTransfer: DataTransfer): void {
+  const event = new Event("drop", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+  Object.defineProperty(event, "clientX", { value: 10 });
+  Object.defineProperty(event, "clientY", { value: 10 });
+  target.dispatchEvent(event);
+}
+
+describe("PaneDropOverlay", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    resetStore();
+    clearTabDragPayload();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    clearTabDragPayload();
+  });
+
+  it("opens a code viewer tab when a file is dropped on an empty pane", () => {
+    const dataTransfer = makeDataTransfer();
+    setFileDragPayload(
+      { dataTransfer } as unknown as React.DragEvent,
+      { path: FILE },
+    );
+
+    act(() => {
+      root.render(<PaneDropOverlay paneId="root" />);
+    });
+
+    const overlay = container.firstElementChild;
+    if (!overlay) throw new Error("overlay did not render");
+
+    act(() => {
+      dispatchDrop(overlay, dataTransfer);
+    });
+
+    const state = useAppStore.getState();
+    const pane = state.panes.root;
+    expect(pane.tabIds).toHaveLength(1);
+    expect(pane.activeTabId).toBe(pane.tabIds[0]);
+    expect(state.workspaceTabs[pane.activeTabId!]).toMatchObject({
+      kind: "code",
+      path: FILE,
+      repoPath: REPO,
+    });
+  });
+
+  it("does not intercept file drops when the pane reserves them for the terminal", () => {
+    const dataTransfer = makeDataTransfer();
+    setFileDragPayload(
+      { dataTransfer } as unknown as React.DragEvent,
+      { path: FILE },
+    );
+
+    act(() => {
+      root.render(<PaneDropOverlay paneId="root" acceptFileDrops={false} />);
+    });
+
+    const overlay = container.firstElementChild;
+    if (!overlay) throw new Error("overlay did not render");
+    expect(overlay.className).toContain("pointer-events-none");
+
+    act(() => {
+      dispatchDrop(overlay, dataTransfer);
+    });
+
+    const state = useAppStore.getState();
+    expect(state.panes.root.tabIds).toEqual([]);
+    expect(state.workspaceTabs).toEqual({});
+  });
+});

--- a/src/components/PaneDropOverlay.tsx
+++ b/src/components/PaneDropOverlay.tsx
@@ -3,25 +3,34 @@ import { cn } from "../lib/cn";
 import {
   classifyDropZone,
   type DropZone,
+  getCurrentDragPayload,
+  getCurrentFilePayload,
   getCurrentTabPayload,
-  isAcornDrag,
-  useTabDragInProgress,
+  useAcornDragInProgress,
 } from "../lib/dnd";
 import { useAppStore } from "../store";
 import type { PaneId } from "../lib/layout";
 
 interface PaneDropOverlayProps {
   paneId: PaneId;
+  acceptFileDrops?: boolean;
 }
 
 /**
- * Edge + center drop overlay for a pane body. Renders only while a tab is
- * being dragged so it doesn't intercept normal pointer interactions. Drops
- * on edge zones split the target pane in that direction; drops on the center
- * append the moved tab into this pane.
+ * Edge + center drop overlay for a pane body. Tab drops can move or split
+ * panes; file drops open a code viewer tab when the pane body is allowed to
+ * handle files. Terminal panes opt out so xterm can keep accepting file
+ * mentions directly.
  */
-export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
-  const dragging = useTabDragInProgress();
+export function PaneDropOverlay({
+  paneId,
+  acceptFileDrops = true,
+}: PaneDropOverlayProps) {
+  const dragging = useAcornDragInProgress();
+  const dragPayload = dragging ? getCurrentDragPayload() : null;
+  const acceptsDrag =
+    dragPayload?.kind === "tab" ||
+    (acceptFileDrops && dragPayload?.kind === "file");
   const moveTab = useAppStore((s) => s.moveTab);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [zone, setZone] = useState<DropZone | null>(null);
@@ -33,6 +42,7 @@ export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
   }, [dragging, zone]);
 
   function computeZone(e: React.DragEvent): DropZone | null {
+    if (getCurrentFilePayload()) return { kind: "center" };
     const el = containerRef.current;
     if (!el) return null;
     const rect = el.getBoundingClientRect();
@@ -43,23 +53,23 @@ export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
   }
 
   // Always mount so the very first dragenter into a pane body is captured;
-  // toggle pointer-events so the overlay only intercepts events while a tab
-  // drag is actually in progress.
+  // toggle pointer-events so the overlay only intercepts drags this pane body
+  // can handle.
   return (
     <div
       ref={containerRef}
       className={
-        dragging
+        acceptsDrag
           ? "absolute inset-0 z-20"
           : "pointer-events-none absolute inset-0 z-20"
       }
       onDragEnter={(e) => {
-        if (!isAcornDrag(e)) return;
+        if (!acceptsDrag) return;
         e.preventDefault();
         setZone(computeZone(e));
       }}
       onDragOver={(e) => {
-        if (!isAcornDrag(e)) return;
+        if (!acceptsDrag) return;
         e.preventDefault();
         e.dataTransfer.dropEffect =
           getCurrentTabPayload() !== null ? "move" : "copy";
@@ -80,10 +90,16 @@ export function PaneDropOverlay({ paneId }: PaneDropOverlayProps) {
         if (e.currentTarget === e.target) setZone(null);
       }}
       onDrop={(e) => {
-        if (!isAcornDrag(e)) return;
+        if (!acceptsDrag) return;
         e.preventDefault();
-        const target = computeZone(e);
         setZone(null);
+        const filePayload = getCurrentFilePayload();
+        if (filePayload) {
+          useAppStore.getState().setFocusedPane(paneId);
+          useAppStore.getState().openCodeViewerTab(filePayload.path);
+          return;
+        }
+        const target = computeZone(e);
         if (!target) return;
         const payload = getCurrentTabPayload();
         if (!payload) return;


### PR DESCRIPTION
## Summary
This fixes file drag-and-drop from the Files tab into empty workspace panes.

1. **File drops on empty panes:** Allows pane drop overlays to accept Acorn file drags and open the dropped path in a code viewer tab.
2. **Terminal drop behavior:** Keeps active terminal panes opted out so file drops continue to insert terminal file mentions instead of being intercepted by the pane overlay.
3. **Regression coverage:** Adds component coverage for empty-pane file drops and the terminal opt-out path.

## Expected impact
| Area | Impact |
| --- | --- |
| User-visible behavior | Dropping a file from Code → Files onto an empty pane now opens that file instead of doing nothing. |
| Existing terminal behavior | File drops on active terminal panes still route to terminal mention insertion. |
| Reliability | Adds a regression guard for both accepted and ignored file drop paths. |

## Design notes
The pane overlay now tracks any Acorn drag payload, but only enables pointer events for tabs or for files when the pane body can handle file drops. `Pane` disables file interception for active session tabs so the existing terminal drop listener remains authoritative there.

## Test plan
- [x] `pnpm vitest run src/components/PaneDropOverlay.test.tsx src/lib/dnd.test.ts` — 2 files / 10 tests passed.
- [x] `pnpm run typecheck` — passed.
- [x] `git diff --check` — passed.