### PR TITLE
fix(tabs): separate close hit area from drag handle

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -940,15 +940,6 @@ function TabItem({
         ref={registerRef}
         role="button"
         tabIndex={0}
-        draggable={!editing}
-        style={
-          !editing
-            ? ({ WebkitUserDrag: "element" } as CSSProperties)
-            : undefined
-        }
-        onDragStart={(e) => {
-          setTabDragPayload(e, { tabId: tab.id, fromPaneId: paneId });
-        }}
         onClick={editing ? undefined : onSelect}
         onDoubleClick={(e) => {
           e.stopPropagation();
@@ -973,61 +964,72 @@ function TabItem({
           }
         }}
         className={cn(
-          "group relative flex min-w-[80px] shrink-0 cursor-pointer select-none items-center gap-1.5 border-r border-border pl-3 pr-1 text-[13px] leading-5 transition",
+          "group relative flex min-w-[96px] shrink-0 cursor-pointer select-none items-center border-r border-border pl-3 pr-1 text-[13px] leading-5 transition",
           active
             ? "bg-bg text-fg"
             : "bg-bg-elevated/40 text-fg-muted hover:bg-bg-elevated/70 hover:text-fg",
         )}
       >
-        {agentProvider ? (
-          <Tooltip label={agentProvider} side="bottom">
-            <AgentProviderIcon
-              provider={agentProvider}
+        <div
+          className="flex min-w-0 flex-1 items-center gap-1.5 self-stretch"
+          data-tab-drag-handle={tab.id}
+          draggable
+          style={{ WebkitUserDrag: "element" } as CSSProperties}
+          onDragStart={(e) => {
+            if (editing) setEditing(false);
+            setTabDragPayload(e, { tabId: tab.id, fromPaneId: paneId });
+          }}
+        >
+          {agentProvider ? (
+            <Tooltip label={agentProvider} side="bottom">
+              <AgentProviderIcon
+                provider={agentProvider}
+                className={cn(
+                  "pointer-events-none size-2.5",
+                  session && STATUS_ICON[session.status],
+                )}
+              />
+            </Tooltip>
+          ) : (
+            <span
               className={cn(
-                "pointer-events-none size-2.5",
-                session && STATUS_ICON[session.status],
+                "pointer-events-none size-1.5 shrink-0 rounded-full",
+                session ? STATUS_DOT[session.status] : "bg-fg-muted/50",
               )}
             />
-          </Tooltip>
-        ) : (
-          <span
-            className={cn(
-              "pointer-events-none size-1.5 rounded-full",
-              session ? STATUS_DOT[session.status] : "bg-fg-muted/50",
-            )}
-          />
-        )}
-        {editing ? (
-          <TabRenameInput
-            initial={tab.title}
-            onSubmit={async (next) => {
-              setEditing(false);
-              if (session && next && next !== session.name) {
-                await renameSession(session.id, next);
-              }
-            }}
-            onCancel={() => setEditing(false)}
-          />
-        ) : (
-          <span className="pointer-events-none max-w-[12rem] truncate leading-5">
-            {tab.title}
-          </span>
-        )}
-        {session &&
-        (liveInWorktree ?? hasRecordedWorktree(session)) ? (
-          <GitBranch
-            size={10}
-            className="pointer-events-none text-fg-muted"
-            aria-label={paneT(t, "pane.aria.worktree")}
-          />
-        ) : null}
-        {session?.kind === "control" ? (
-          <Bot
-            size={10}
-            className="pointer-events-none text-accent"
-            aria-label={paneT(t, "pane.aria.controlSession")}
-          />
-        ) : null}
+          )}
+          {editing ? (
+            <TabRenameInput
+              initial={tab.title}
+              onSubmit={async (next) => {
+                setEditing(false);
+                if (session && next && next !== session.name) {
+                  await renameSession(session.id, next);
+                }
+              }}
+              onCancel={() => setEditing(false)}
+            />
+          ) : (
+            <span className="pointer-events-none max-w-[12rem] truncate leading-5">
+              {tab.title}
+            </span>
+          )}
+          {session &&
+          (liveInWorktree ?? hasRecordedWorktree(session)) ? (
+            <GitBranch
+              size={10}
+              className="pointer-events-none shrink-0 text-fg-muted"
+              aria-label={paneT(t, "pane.aria.worktree")}
+            />
+          ) : null}
+          {session?.kind === "control" ? (
+            <Bot
+              size={10}
+              className="pointer-events-none shrink-0 text-accent"
+              aria-label={paneT(t, "pane.aria.controlSession")}
+            />
+          ) : null}
+        </div>
         <button
           type="button"
           aria-label={
@@ -1035,13 +1037,22 @@ function TabItem({
               ? paneT(t, "pane.aria.closeSession")
               : paneT(t, "pane.aria.closeTab")
           }
+          data-tab-close-button={tab.id}
+          draggable={false}
+          onMouseDown={(e) => {
+            e.stopPropagation();
+          }}
+          onDragStart={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
           onClick={(e) => {
             e.stopPropagation();
             onClose();
           }}
           onKeyDown={(e) => e.stopPropagation()}
           className={cn(
-            "ml-auto mr-1 shrink-0 rounded p-0.5 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg",
+            "ml-1 mr-0.5 flex size-6 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg",
             active
               ? "opacity-70 hover:opacity-100"
               : "opacity-0 group-hover:opacity-70 hover:opacity-100",
@@ -1082,10 +1093,17 @@ function TabRenameInput({ initial, onSubmit, onCancel }: TabRenameInputProps) {
     <input
       ref={inputRef}
       type="text"
+      data-tab-rename-input
       autoFocus
       value={value}
+      draggable={false}
       onChange={(e) => setValue(e.target.value)}
       onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onDragStart={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
       onKeyDown={(e) => {
         e.stopPropagation();
         if (e.key === "Enter") {

--- a/tests/e2e/panes.spec.ts
+++ b/tests/e2e/panes.spec.ts
@@ -137,6 +137,99 @@ test.describe("pane / sidebar shortcuts", () => {
     );
   });
 
+  test("tab close button has a reliable hit area outside the drag handle", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [SESSION]);
+
+    await page.goto("/");
+
+    await page
+      .locator('[data-panel-id="sidebar"]')
+      .getByRole("button", { name: /^alpha main · Idle/ })
+      .first()
+      .click();
+
+    const closeButton = page.locator('[data-tab-close-button="s-1"]');
+    const dragHandle = page.locator('[data-tab-drag-handle="s-1"]');
+    await expect(closeButton).toBeVisible();
+    await expect(dragHandle).toBeVisible();
+
+    await expect(closeButton).toHaveAttribute("draggable", "false");
+    await expect(dragHandle).toHaveAttribute("draggable", "true");
+
+    const geometry = await page.evaluate(() => {
+      const close = document.querySelector(
+        '[data-tab-close-button="s-1"]',
+      );
+      const handle = document.querySelector(
+        '[data-tab-drag-handle="s-1"]',
+      );
+      if (!close || !handle) return null;
+      const closeRect = close.getBoundingClientRect();
+      const handleRect = handle.getBoundingClientRect();
+      return {
+        closeWidth: closeRect.width,
+        closeHeight: closeRect.height,
+        closeLeft: closeRect.left,
+        handleRight: handleRect.right,
+      };
+    });
+
+    expect(geometry).not.toBeNull();
+    expect(geometry?.closeWidth).toBeGreaterThanOrEqual(24);
+    expect(geometry?.closeHeight).toBeGreaterThanOrEqual(24);
+    expect(geometry?.handleRight).toBeLessThanOrEqual(
+      geometry?.closeLeft ?? 0,
+    );
+
+    await closeButton.click({ position: { x: 1, y: 12 } });
+    await expect(
+      page.getByRole("heading", { name: "Remove session" }),
+    ).toBeVisible();
+  });
+
+  test("tab drag remains available after entering rename mode", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [SESSION]);
+
+    await page.goto("/");
+
+    await page
+      .locator('[data-panel-id="sidebar"]')
+      .getByRole("button", { name: /^alpha main · Idle/ })
+      .first()
+      .click();
+
+    const dragHandle = page.locator('[data-tab-drag-handle="s-1"]');
+    await dragHandle.dblclick();
+
+    const renameInput = page.locator("[data-tab-rename-input]");
+    await expect(renameInput).toBeFocused();
+    await expect(renameInput).toHaveAttribute("draggable", "false");
+    await expect(dragHandle).toHaveAttribute("draggable", "true");
+
+    await page.evaluate(() => {
+      const handle = document.querySelector(
+        '[data-tab-drag-handle="s-1"]',
+      );
+      if (!handle) throw new Error("missing tab drag handle");
+      const event = new DragEvent("dragstart", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: new DataTransfer(),
+      });
+      handle.dispatchEvent(event);
+    });
+
+    await expect(renameInput).toHaveCount(0);
+  });
+
   test("$mod+Alt+E dispatches equalize panes", async ({ page }) => {
     await page.goto("/");
     await page.evaluate(() => {


### PR DESCRIPTION
## Summary
This fixes tab interactions where the close button could accidentally enter drag mode and rename selection could block tab dragging.

1. **Close button hit area:** Gives the tab close button a stable 24px target and prevents mouse/drag events from bubbling into the tab drag path.
2. **Drag handle split:** Moves tab drag startup onto an explicit title/icon handle instead of the entire tab container.
3. **Rename-mode drag recovery:** Keeps the drag handle available after double-click rename while preventing the rename input itself from becoming a drag source.
4. **Regression coverage:** Adds E2E checks for close-button geometry, close click behavior, drag-handle separation, and rename-mode drag availability.

## Expected impact
| Area | Impact |
| --- | --- |
| Tab close UX | More reliable close clicks, including near button edges. |
| Tab dragging | Drag starts from the intended title/icon handle, not the X button. |
| Rename flow | Double-click rename no longer leaves tab dragging feeling stuck outside the input. |

## Design notes
The tab root still owns selection, keyboard activation, double-click rename, and context menu behavior. Drag initiation now lives on the inner handle so interactive children can opt out cleanly without depending on fragile propagation behavior in WebKit/Tauri.

## Test plan
- [x] `pnpm typecheck` passed.
- [x] `pnpm exec playwright test tests/e2e/panes.spec.ts --grep "tab (close button|drag remains)"` passed.

## Notes
The Playwright run still emits existing mock-environment warnings for `load_status` and user theme loading. They did not fail the test run and are not caused by this PR.
