### PR TITLE
fix(terminal): pinned prompt icon matches agent state

### DIFF
--- a/src/components/StickyUserPrompt.tsx
+++ b/src/components/StickyUserPrompt.tsx
@@ -1,8 +1,10 @@
-import { ChevronDown, MessageSquare } from "lucide-react";
+import { ChevronDown, MessageSquare, Terminal } from "lucide-react";
 import { useEffect, useState, type ReactElement } from "react";
+import type { SessionAgentProvider } from "../lib/types";
 
 interface StickyUserPromptProps {
   sessionId: string;
+  agentProvider?: SessionAgentProvider | null;
 }
 
 // Custom event the Terminal dispatches whenever its buffer changes shape
@@ -22,6 +24,7 @@ const EXPANDED_MAX_HEIGHT_PX = 160;
 
 export function StickyUserPrompt({
   sessionId,
+  agentProvider = null,
 }: StickyUserPromptProps): ReactElement | null {
   const [prompt, setPrompt] = useState<string | null>(null);
   // Compact by default so a freshly-arrived prompt never pushes an
@@ -57,6 +60,7 @@ export function StickyUserPrompt({
   }, [sessionId]);
 
   if (!prompt) return null;
+  const PromptIcon = agentProvider ? MessageSquare : Terminal;
   // Heuristic for "is there anything to expand?" — we collect
   // continuation rows in the scanner and join them with `\n`, so any
   // newline means hidden content under the 1-line clamp. Length-based
@@ -104,7 +108,7 @@ export function StickyUserPrompt({
             className="flex h-[16.5px] shrink-0 items-center text-fg-muted"
             aria-hidden
           >
-            <MessageSquare size={12} />
+            <PromptIcon size={12} />
           </span>
           <div
             className="min-w-0 flex-1 whitespace-pre-wrap break-words"

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -41,6 +41,7 @@ import {
 } from "../lib/settings";
 import { buildXtermTheme } from "../lib/terminalTheme";
 import { useThemes, type ThemeMode } from "../lib/themes";
+import type { SessionAgentProvider } from "../lib/types";
 import { useToasts } from "../lib/toasts";
 import {
   chooseWorktreeToAdoptAfterExit,
@@ -54,6 +55,7 @@ import { FloatingTooltip, Tooltip, type TooltipAnchorRect } from "./Tooltip";
 interface TerminalProps {
   sessionId: string;
   cwd: string;
+  agentProvider?: SessionAgentProvider | null;
   /**
    * When the terminal is hidden behind another tab in the same pane and then
    * made visible again, the DOM renderer can leave the rows blank because it
@@ -442,6 +444,7 @@ function encodeStringToBase64(input: string): string {
 export function Terminal({
   sessionId,
   cwd,
+  agentProvider = null,
   isActive = true,
   isFocusedPane = true,
 }: TerminalProps): ReactElement {
@@ -2053,7 +2056,7 @@ export function Terminal({
         dismissOnScroll={false}
       />
       {/* Pinned-prompt overlay. */}
-      <StickyUserPrompt sessionId={sessionId} />
+      <StickyUserPrompt sessionId={sessionId} agentProvider={agentProvider} />
     </div>
   );
 }

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useRef } from "react";
 import { createPortal } from "react-dom";
+import { resolveSessionAgentProvider } from "../lib/agentProvider";
 import { getTerminalLimbo } from "../lib/terminalLimbo";
 import { isSessionInFocusedPane } from "../lib/multiInput";
 import { useAppStore } from "../store";
@@ -97,6 +98,7 @@ function PortaledTerminal({ session }: { session: Session }) {
     <Terminal
       sessionId={session.id}
       cwd={session.worktree_path}
+      agentProvider={resolveSessionAgentProvider(session)}
       isActive={visiblePaneId !== null}
       isFocusedPane={isFocusedPane}
     />,


### PR DESCRIPTION
Pinned prompt banners now use the terminal glyph for plain shell sessions while preserving the message icon for Claude/Codex sessions.

## Summary

1. **Provider-aware pinned prompt icon:** Thread the resolved session agent provider from `TerminalHost` through `Terminal` into `StickyUserPrompt`.
2. **Plain terminal fallback:** Render the lucide terminal icon for sessions without a Claude/Codex provider and keep the message icon for agent-backed sessions.
3. **Consistent provider resolution:** Reuse the same provider inference path as sidebar/tab UI so pinned prompts do not diverge from existing session chrome.

## Expected impact

| Area | Impact |
| --- | --- |
| User-visible behavior | Plain terminal pinned prompts show a `>_` terminal icon; Claude/Codex pinned prompts keep the message icon. |
| Reliability | No backend or polling contract changes; this is a presentational prop pass-through. |
| Performance | No measurable impact. |

## Design notes

The icon decision stays at the sticky prompt rendering edge. `TerminalHost` already owns the full `Session`, so it resolves the provider once using the established `resolveSessionAgentProvider` helper and passes that through the existing terminal portal tree.

## Test plan

- [x] `pnpm run typecheck` - passed
- [x] `pnpm run test -- src/lib/sessionStatusPolling.test.ts src/lib/agentProvider.test.ts` - passed; Vitest ran the related test set successfully
- [x] `git diff --check` - passed

## Notes

Self-review found and fixed one consistency issue before PR creation: the first implementation used raw `session.agent_provider`, then was updated to use the same provider inference helper as sidebar/tab UI.
