### PR TITLE
fix(chats): show unscoped agent history

### DIFF
--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -55,8 +55,29 @@ pub fn list_agent_history(
     let limit = limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
 
     let mut items = Vec::new();
-    items.extend(scan_codex(&repo));
-    items.extend(scan_claude(&repo));
+    let scope = HistoryScope::Project(&repo);
+    items.extend(scan_codex(scope));
+    items.extend(scan_claude(scope));
+    items.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    items.truncate(limit);
+    Ok(items)
+}
+
+pub fn list_unscoped_agent_history(
+    project_paths: Vec<PathBuf>,
+    limit: Option<usize>,
+) -> AppResult<Vec<AgentHistoryItem>> {
+    let projects = project_paths
+        .into_iter()
+        .map(|path| normalize_path(&path))
+        .filter(|path| !path.as_os_str().is_empty())
+        .collect::<Vec<_>>();
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+
+    let mut items = Vec::new();
+    let scope = HistoryScope::Unscoped { projects: &projects };
+    items.extend(scan_codex(scope));
+    items.extend(scan_claude(scope));
     items.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
     items.truncate(limit);
     Ok(items)
@@ -124,7 +145,33 @@ pub fn trash_agent_history_transcript(
     Ok(())
 }
 
-fn scan_codex(repo: &Path) -> Vec<AgentHistoryItem> {
+#[derive(Clone, Copy)]
+enum HistoryScope<'a> {
+    Project(&'a Path),
+    Unscoped { projects: &'a [PathBuf] },
+}
+
+impl HistoryScope<'_> {
+    fn accepts_cwd(self, cwd: &str) -> bool {
+        match self {
+            HistoryScope::Project(repo) => path_belongs_to_project(cwd, repo),
+            HistoryScope::Unscoped { projects } => !projects
+                .iter()
+                .any(|project| path_belongs_to_project(cwd, project)),
+        }
+    }
+
+    fn worktree_for_cwd(self, cwd: &str) -> Option<AgentHistoryWorktree> {
+        match self {
+            HistoryScope::Project(repo) => worktree_for_cwd(cwd, repo),
+            HistoryScope::Unscoped { .. } => {
+                discovered_worktree_for_cwd(cwd).or_else(|| managed_worktree_from_path(cwd))
+            }
+        }
+    }
+}
+
+fn scan_codex(scope: HistoryScope<'_>) -> Vec<AgentHistoryItem> {
     let Some(root) = codex_sessions_root() else {
         return Vec::new();
     };
@@ -138,11 +185,11 @@ fn scan_codex(repo: &Path) -> Vec<AgentHistoryItem> {
     });
     files
         .into_iter()
-        .filter_map(|path| parse_codex_file(&path, repo))
+        .filter_map(|path| parse_codex_file(&path, scope))
         .collect()
 }
 
-fn scan_claude(repo: &Path) -> Vec<AgentHistoryItem> {
+fn scan_claude(scope: HistoryScope<'_>) -> Vec<AgentHistoryItem> {
     let Some(root) = home_dir().map(|home| home.join(".claude")) else {
         return Vec::new();
     };
@@ -151,7 +198,7 @@ fn scan_claude(repo: &Path) -> Vec<AgentHistoryItem> {
     });
     files
         .into_iter()
-        .filter_map(|path| parse_claude_file(&path, repo))
+        .filter_map(|path| parse_claude_file(&path, scope))
         .collect()
 }
 
@@ -184,7 +231,7 @@ fn collect_files(root: &Path, accept: impl Fn(&Path) -> bool) -> Vec<PathBuf> {
     out
 }
 
-fn parse_codex_file(path: &Path, repo: &Path) -> Option<AgentHistoryItem> {
+fn parse_codex_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistoryItem> {
     let mut state = ParsedAgentFile::default();
     for line in sample_lines(path).ok()? {
         let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
@@ -217,10 +264,10 @@ fn parse_codex_file(path: &Path, repo: &Path) -> Option<AgentHistoryItem> {
     }
 
     let cwd = state.cwd.clone()?;
-    if !path_belongs_to_project(&cwd, repo) {
+    if !scope.accepts_cwd(&cwd) {
         return None;
     }
-    let worktree = worktree_for_cwd(&cwd, repo);
+    let worktree = scope.worktree_for_cwd(&cwd);
     let id = state.id.or_else(|| codex_id_from_filename(path))?;
     let title = state
         .title
@@ -242,7 +289,7 @@ fn parse_codex_file(path: &Path, repo: &Path) -> Option<AgentHistoryItem> {
     })
 }
 
-fn parse_claude_file(path: &Path, repo: &Path) -> Option<AgentHistoryItem> {
+fn parse_claude_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistoryItem> {
     let mut state = ParsedAgentFile::default();
     for line in sample_lines(path).ok()? {
         let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
@@ -266,10 +313,10 @@ fn parse_claude_file(path: &Path, repo: &Path) -> Option<AgentHistoryItem> {
     }
 
     let cwd = state.cwd.clone()?;
-    if !path_belongs_to_project(&cwd, repo) {
+    if !scope.accepts_cwd(&cwd) {
         return None;
     }
-    let worktree = worktree_for_cwd(&cwd, repo);
+    let worktree = scope.worktree_for_cwd(&cwd);
     let id = state.id.or_else(|| {
         path.file_stem()
             .and_then(|s| s.to_str())
@@ -624,5 +671,50 @@ mod tests {
         .unwrap();
 
         assert!(codex_transcript_matches_id(&path, "payload-id"));
+    }
+
+    #[test]
+    fn unscoped_history_accepts_cwd_inside_unregistered_git_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        let nested = repo.join("src");
+        fs::create_dir_all(&nested).unwrap();
+        git2::Repository::init(&repo).unwrap();
+
+        let projects: Vec<PathBuf> = Vec::new();
+        let scope = HistoryScope::Unscoped {
+            projects: &projects,
+        };
+
+        assert!(scope.accepts_cwd(nested.to_str().unwrap()));
+    }
+
+    #[test]
+    fn unscoped_history_rejects_cwd_inside_registered_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        let nested = project.join("src");
+        fs::create_dir_all(&nested).unwrap();
+
+        let projects = vec![normalize_path(&project)];
+        let scope = HistoryScope::Unscoped {
+            projects: &projects,
+        };
+
+        assert!(!scope.accepts_cwd(nested.to_str().unwrap()));
+    }
+
+    #[test]
+    fn unscoped_history_accepts_cwd_outside_git_repos_and_projects() {
+        let tmp = tempfile::tempdir().unwrap();
+        let local = tmp.path().join("scratch");
+        fs::create_dir_all(&local).unwrap();
+
+        let projects: Vec<PathBuf> = Vec::new();
+        let scope = HistoryScope::Unscoped {
+            projects: &projects,
+        };
+
+        assert!(scope.accepts_cwd(local.to_str().unwrap()));
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -159,6 +159,23 @@ pub async fn list_agent_history(
 }
 
 #[tauri::command]
+pub async fn list_unscoped_agent_history(
+    state: State<'_, AppState>,
+    limit: Option<usize>,
+) -> AppResult<Vec<AgentHistoryItem>> {
+    let project_paths = state
+        .projects
+        .list()
+        .into_iter()
+        .map(|project| PathBuf::from(project.repo_path))
+        .collect();
+    run_blocking("list_unscoped_agent_history", move || {
+        agent_history::list_unscoped_agent_history(project_paths, limit)
+    })
+    .await
+}
+
+#[tauri::command]
 pub fn trash_agent_history_transcript(
     provider: agent_history::AgentHistoryProvider,
     id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -430,6 +430,7 @@ pub fn run() {
             commands::ipc_restart,
             commands::list_system_fonts,
             commands::list_agent_history,
+            commands::list_unscoped_agent_history,
             commands::trash_agent_history_transcript,
             commands::get_claude_resume_candidate,
             commands::acknowledge_claude_resume,

--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -36,7 +36,10 @@ vi.mock("../lib/api", () => ({
     getWorkflowRunDetail: vi.fn(),
     listAgentHistory:
       vi.fn<(repoPath: string, limit: number) => Promise<AgentHistoryItem[]>>(),
+    listUnscopedAgentHistory:
+      vi.fn<(limit: number) => Promise<AgentHistoryItem[]>>(),
     readSessionTodos: vi.fn<() => Promise<[]>>(),
+    ptyRepoRoot: vi.fn<() => Promise<string | null>>(),
   },
 }));
 
@@ -65,6 +68,12 @@ const mockApi = vi.mocked(api);
 const mockListen = vi.mocked(listen);
 const REPO = "/tmp/acorn-test-repo";
 const REPO_B = "/tmp/acorn-other-repo";
+
+function exactButtonCount(container: HTMLElement, label: string): number {
+  return Array.from(container.querySelectorAll("button")).filter(
+    (button) => button.textContent?.trim() === label,
+  ).length;
+}
 
 const labeledPullRequest = {
   number: 247,
@@ -140,7 +149,9 @@ describe("RightPanel background tab loading", () => {
       account: "tester",
     });
     mockApi.listAgentHistory.mockResolvedValue([]);
+    mockApi.listUnscopedAgentHistory.mockResolvedValue([]);
     mockApi.readSessionTodos.mockResolvedValue([]);
+    mockApi.ptyRepoRoot.mockResolvedValue(null);
     useSettings.setState({ settings: structuredClone(DEFAULT_SETTINGS) });
     useAppStore.setState({
       sessions: [],
@@ -270,6 +281,61 @@ describe("RightPanel background tab loading", () => {
     expect(mockApi.githubOriginSlug).toHaveBeenCalledWith(REPO);
     expect(mockApi.listPullRequests).not.toHaveBeenCalled();
     expect(mockApi.listWorkflowRuns).not.toHaveBeenCalled();
+  });
+
+  it("hides Code and loads local agent history for local chat sessions", async () => {
+    useAppStore.setState({
+      sessions: [
+        {
+          id: "local-1",
+          name: "codex",
+          repo_path: "/Users/tester",
+          worktree_path: "/Users/tester",
+          branch: "HEAD",
+          isolated: false,
+          project_scoped: false,
+          status: "idle",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+          agent_provider: "codex",
+        },
+      ],
+      activeSessionId: "local-1",
+      activeTabId: "local-1",
+      activeProject: REPO,
+      rightTab: "commits",
+    });
+    mockApi.listUnscopedAgentHistory.mockResolvedValue([
+      {
+        provider: "codex",
+        id: "codex-local",
+        title: "Local Codex session",
+        preview: null,
+        cwd: "/Users/tester",
+        worktree: null,
+        transcript_path: "/Users/tester/.codex/session.jsonl",
+        updated_at: 1770000000,
+        resume_command: "codex resume codex-local",
+      },
+    ]);
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+
+    expect(exactButtonCount(container, "Code")).toBe(0);
+    expect(exactButtonCount(container, "GitHub")).toBe(0);
+    expect(exactButtonCount(container, "Agents")).toBe(1);
+    expect(mockApi.isGitRepository).not.toHaveBeenCalled();
+    expect(mockApi.githubOriginSlug).not.toHaveBeenCalled();
+    expect(mockApi.listAgentHistory).not.toHaveBeenCalled();
+    expect(mockApi.listUnscopedAgentHistory).toHaveBeenCalledWith(100);
   });
 
   it("reprobes GitHub visibility when git metadata changes", async () => {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -200,10 +200,26 @@ export function RightPanel() {
   const fallbackPath =
     active?.worktree_path ?? activeWorkspaceTab?.repoPath ?? activeProject ?? null;
   const repoPath = useLiveRepoPath(active?.id ?? null, fallbackPath);
+  const activeIsLocalChat = active?.project_scoped === false;
+  const agentHistoryScope =
+    activeIsLocalChat || (!active && activeProject === null)
+      ? "unscoped"
+      : "project";
+  const projectPanelRepoPath = activeIsLocalChat ? null : repoPath;
+  const agentHistoryPath = agentHistoryScope === "project" ? repoPath : null;
+  const localSessionHostPath =
+    sessions.find((session) => session.project_scoped === false)?.repo_path ??
+    null;
   const sessionHostRepoPath =
-    active?.repo_path ?? activeWorkspaceTab?.repoPath ?? activeProject ?? repoPath;
+    active?.repo_path ??
+    activeWorkspaceTab?.repoPath ??
+    activeProject ??
+    localSessionHostPath ??
+    repoPath;
   const sessionHostProjectScoped = active
     ? scopeForSession(active).projectScoped
+    : agentHistoryScope === "unscoped"
+      ? false
     : sessionHostRepoPath
       ? resolveProjectScopedForRepoPath(
           { sessions, projects },
@@ -212,12 +228,12 @@ export function RightPanel() {
       : true;
   const [gitRepoProbeVersion, setGitRepoProbeVersion] = useState(0);
   const invalidateGitProbe = useCallback(() => {
-    if (!repoPath) return;
-    invalidateGitRepositoryStatus(repoPath);
+    if (!projectPanelRepoPath) return;
+    invalidateGitRepositoryStatus(projectPanelRepoPath);
     setGitRepoProbeVersion((version) => version + 1);
-  }, [repoPath]);
+  }, [projectPanelRepoPath]);
   const invalidations = useRightPanelInvalidations(
-    repoPath,
+    projectPanelRepoPath,
     invalidateGitProbe,
   );
   const [expanded, setExpanded] = useState<ExpandedDiff | null>(null);
@@ -241,24 +257,34 @@ export function RightPanel() {
     active?.worktree_path ?? null,
   );
   const showTodos = todosState.todos.length > 0;
-  const isGitRepo = useIsGitRepository(repoPath, gitRepoProbeVersion);
-  const isGitHubRepo = useIsGitHubRepo(repoPath, gitRepoProbeVersion);
+  const isGitRepo = useIsGitRepository(
+    projectPanelRepoPath,
+    gitRepoProbeVersion,
+  );
+  const isGitHubRepo = useIsGitHubRepo(
+    projectPanelRepoPath,
+    gitRepoProbeVersion,
+  );
   const githubVisible = isGitHubRepo === true;
-  const gitBackedTabsVisible = isGitRepo !== false;
+  const gitBackedTabsVisible =
+    projectPanelRepoPath !== null && isGitRepo !== false;
 
   const visibleTabsByGroup = useMemo<
     Record<RightGroup, ReadonlyArray<RightTab>>
   >(
     () => ({
-      code: gitBackedTabsVisible
-        ? tabsForGroup("code")
-        : tabsForGroup("code").filter((tab) => tab === "files"),
+      code:
+        projectPanelRepoPath === null
+          ? []
+          : gitBackedTabsVisible
+            ? tabsForGroup("code")
+            : tabsForGroup("code").filter((tab) => tab === "files"),
       github: githubVisible ? tabsForGroup("github") : [],
       agents: showTodos
         ? tabsForGroup("agents")
         : tabsForGroup("agents").filter((tab) => tab !== "todos"),
     }),
-    [gitBackedTabsVisible, githubVisible, showTodos],
+    [gitBackedTabsVisible, githubVisible, projectPanelRepoPath, showTodos],
   );
   const visibleGroups = useMemo(
     () => RIGHT_GROUPS.filter((g) => visibleTabsByGroup[g].length > 0),
@@ -269,7 +295,7 @@ export function RightPanel() {
     : (visibleGroups[0] ?? "code");
   const visibleTabs = visibleTabsByGroup[activeGroup];
   const shouldLoadGitHubTabs =
-    repoPath !== null && isGitHubRepo === true;
+    projectPanelRepoPath !== null && isGitHubRepo === true;
   const projectKey = useMemo(
     () => projects.map((project) => project.repo_path).join("\0"),
     [projects],
@@ -291,19 +317,46 @@ export function RightPanel() {
   // GitHub origin disappeared, etc.), slide them to the nearest visible tab
   // rather than render the panel against a stale selection.
   useEffect(() => {
+    if (
+      projectPanelRepoPath === null &&
+      activeProject === null &&
+      !active &&
+      projects.length === 0 &&
+      sessions.length === 0
+    ) {
+      return;
+    }
     if (visibleTabs.length === 0) return;
     if (!visibleTabs.includes(rightTab)) {
       if (
+        projectPanelRepoPath !== null &&
         isGitRepo === null &&
         groupOfTab(rightTab) === "code" &&
         rightTab !== "files"
       ) {
         return;
       }
-      if (isGitHubRepo === null && groupOfTab(rightTab) === "github") return;
+      if (
+        projectPanelRepoPath !== null &&
+        isGitHubRepo === null &&
+        groupOfTab(rightTab) === "github"
+      ) {
+        return;
+      }
       setRightTab(visibleTabs[0]);
     }
-  }, [isGitHubRepo, isGitRepo, rightTab, visibleTabs, setRightTab]);
+  }, [
+    isGitHubRepo,
+    isGitRepo,
+    active,
+    activeProject,
+    projectPanelRepoPath,
+    projects.length,
+    rightTab,
+    sessions.length,
+    visibleTabs,
+    setRightTab,
+  ]);
 
   useEffect(() => {
     if (projects.length === 0) return;
@@ -378,13 +431,13 @@ export function RightPanel() {
             <Empty msg={rt(t, "rightPanel.empty.noTodos")} />
           )
         ) : rightTab === "commits" ? (
-          repoPath ? (
+          projectPanelRepoPath ? (
             // `key` forces a full remount on project switch so any in-flight
             // git request from the previous repo cannot land its `setState`
             // into the new repo's component (cross-project data leak).
             <CommitsTab
-              key={repoPath}
-              repoPath={repoPath}
+              key={projectPanelRepoPath}
+              repoPath={projectPanelRepoPath}
               invalidateKey={invalidations.commits}
               onExpand={setExpanded}
             />
@@ -392,10 +445,10 @@ export function RightPanel() {
             <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : rightTab === "staged" ? (
-          repoPath ? (
+          projectPanelRepoPath ? (
             <StagedTab
-              key={repoPath}
-              repoPath={repoPath}
+              key={projectPanelRepoPath}
+              repoPath={projectPanelRepoPath}
               invalidateKey={invalidations.staged}
               onExpand={setExpanded}
             />
@@ -403,38 +456,56 @@ export function RightPanel() {
             <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : rightTab === "files" ? (
-          repoPath ? (
-            <FileExplorer key={repoPath} rootPath={repoPath} />
+          projectPanelRepoPath ? (
+            <FileExplorer
+              key={projectPanelRepoPath}
+              rootPath={projectPanelRepoPath}
+            />
           ) : (
             <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : BACKGROUND_LOADED_TABS.has(rightTab) ? (
-          repoPath ? null : <Empty msg={rt(t, "rightPanel.empty.noProject")} />
+          rightTab === "history" &&
+          (agentHistoryScope === "unscoped" || agentHistoryPath) ? null : (
+            <Empty msg={rt(t, "rightPanel.empty.noProject")} />
+          )
         ) : (
           <Empty msg={rt(t, "rightPanel.empty.noProject")} />
         )}
-        {repoPath && shouldLoadGitHubTabs ? (
+        {projectPanelRepoPath && shouldLoadGitHubTabs ? (
           <>
             <BackgroundLoadedTab active={rightTab === "prs"}>
               <PullRequestsTab
-                key={`prs:${repoPath}`}
-                repoPath={repoPath}
-                onOpenDetail={(number) => setPrDetail({ repoPath, number })}
-                onOpenSearch={() => setPrSearch({ repoPath })}
+                key={`prs:${projectPanelRepoPath}`}
+                repoPath={projectPanelRepoPath}
+                onOpenDetail={(number) =>
+                  setPrDetail({ repoPath: projectPanelRepoPath, number })
+                }
+                onOpenSearch={() =>
+                  setPrSearch({ repoPath: projectPanelRepoPath })
+                }
                 refreshKey={prListVersion}
               />
             </BackgroundLoadedTab>
             <BackgroundLoadedTab active={rightTab === "actions"}>
-              <ActionsTab key={`actions:${repoPath}`} repoPath={repoPath} />
+              <ActionsTab
+                key={`actions:${projectPanelRepoPath}`}
+                repoPath={projectPanelRepoPath}
+              />
             </BackgroundLoadedTab>
           </>
         ) : null}
-        {repoPath ? (
+        {agentHistoryScope === "unscoped" || agentHistoryPath ? (
           <BackgroundLoadedTab active={rightTab === "history"}>
             <AgentHistoryTab
-              key={`history:${repoPath}`}
-              repoPath={repoPath}
-              sessionHostRepoPath={sessionHostRepoPath ?? repoPath}
+              key={
+                agentHistoryScope === "unscoped"
+                  ? "history:unscoped"
+                  : `history:${agentHistoryPath}`
+              }
+              scope={agentHistoryScope}
+              repoPath={agentHistoryPath}
+              sessionHostRepoPath={sessionHostRepoPath}
               sessionHostProjectScoped={sessionHostProjectScoped}
             />
           </BackgroundLoadedTab>
@@ -446,7 +517,7 @@ export function RightPanel() {
         subtitle={expanded?.subtitle}
         headerActions={expanded?.headerActions}
         body={expanded?.body}
-        cwd={repoPath ?? undefined}
+        cwd={projectPanelRepoPath ?? undefined}
         onClose={() => setExpanded(null)}
       />
       <PullRequestSearchModal
@@ -460,7 +531,7 @@ export function RightPanel() {
       />
       <PullRequestDetailModal
         open={prDetail}
-        cwd={repoPath ?? undefined}
+        cwd={projectPanelRepoPath ?? undefined}
         onClose={() => setPrDetail(null)}
         onMutated={() => setPrListVersion((v) => v + 1)}
       />
@@ -1127,12 +1198,14 @@ function countByStatus(todos: TodoItem[]) {
 }
 
 function AgentHistoryTab({
+  scope,
   repoPath,
   sessionHostRepoPath,
   sessionHostProjectScoped,
 }: {
-  repoPath: string;
-  sessionHostRepoPath: string;
+  scope: "project" | "unscoped";
+  repoPath: string | null;
+  sessionHostRepoPath: string | null;
   sessionHostProjectScoped: boolean;
 }) {
   const t = useTranslation();
@@ -1144,11 +1217,15 @@ function AgentHistoryTab({
   const showAgentProviderIcons = useSettings(
     (s) => s.settings.sessionDisplay.icons.agentProvider,
   );
-  // Hydrate from the module-level cache so re-opening a project shows its
-  // list instantly. The accompanying fetch below still runs (SWR-style)
-  // to surface new sessions created since the cached snapshot.
+  const historyLimit = 100;
+  // Hydrate from the module-level cache so re-opening a project or the
+  // unscoped Chats history shows its list instantly.
   const [items, setItems] = useState<AgentHistoryItem[] | null>(() =>
-    rightPanelCache.getAgentHistory(repoPath),
+    scope === "project" && repoPath
+      ? rightPanelCache.getAgentHistory(repoPath)
+      : scope === "unscoped"
+        ? rightPanelCache.getUnscopedAgentHistory(historyLimit)
+      : null,
   );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -1176,14 +1253,17 @@ function AgentHistoryTab({
   // latest token is allowed to commit.
   const fetchTokenRef = useRef(0);
 
-  const fetchHistory = useCallback(async () => {
+  const fetchHistory = useCallback(async (options: { force?: boolean } = {}) => {
     const token = ++fetchTokenRef.current;
     setLoading(true);
     setError(null);
     try {
-      const result = await rightPanelCache.fetchAgentHistory(repoPath, {
-        force: true,
-      });
+      const result =
+        scope === "unscoped"
+          ? await rightPanelCache.fetchUnscopedAgentHistory(historyLimit, options)
+          : repoPath
+            ? await rightPanelCache.fetchAgentHistory(repoPath, options)
+            : [];
       if (token !== fetchTokenRef.current) return;
       setItems(result);
     } catch (e) {
@@ -1192,7 +1272,7 @@ function AgentHistoryTab({
     } finally {
       if (token === fetchTokenRef.current) setLoading(false);
     }
-  }, [repoPath]);
+  }, [repoPath, scope]);
 
   useEffect(() => {
     void fetchHistory();
@@ -1219,13 +1299,18 @@ function AgentHistoryTab({
       return;
     }
     try {
+      const targetRepoPath = sessionHostRepoPath ?? item.cwd;
+      if (!targetRepoPath) {
+        setError(rt(t, "rightPanel.history.createFailed"));
+        return;
+      }
       const created = await applySessionCreateRequest(
         createSession,
         buildSessionCreateRequest(
           { sessions, projects },
           {
             name: `${item.provider} ${rt(t, "rightPanel.history.resumeSessionName")}`,
-            repoPath: sessionHostRepoPath,
+            repoPath: targetRepoPath,
             agentProvider: item.provider,
             projectScoped: sessionHostProjectScoped,
           },
@@ -1269,7 +1354,11 @@ function AgentHistoryTab({
             candidate.id !== item.id ||
             candidate.transcript_path !== item.transcript_path,
         );
-        rightPanelCache.setAgentHistory(repoPath, next);
+        if (scope === "project" && repoPath) {
+          rightPanelCache.setAgentHistory(repoPath, next);
+        } else if (scope === "unscoped") {
+          rightPanelCache.setUnscopedAgentHistory(historyLimit, next);
+        }
         return next;
       });
       setTrashCandidate(null);
@@ -1288,7 +1377,7 @@ function AgentHistoryTab({
             : rt(t, "rightPanel.history.loading")}
         </div>
         <RefreshButton
-          onClick={() => void fetchHistory()}
+          onClick={() => void fetchHistory({ force: true })}
           loading={loading}
           size={12}
         />
@@ -1389,6 +1478,14 @@ function AgentHistoryTab({
                             >
                               {item.worktree.name}
                             </span>
+                          </div>
+                        </Tooltip>
+                      ) : null}
+                      {scope === "unscoped" && item.cwd ? (
+                        <Tooltip label={item.cwd} side="bottom">
+                          <div className="mt-1 flex min-w-0 items-center gap-1 text-[10.5px] font-mono text-fg-muted">
+                            <FolderTree size={11} className="shrink-0" />
+                            <span className="truncate">{item.cwd}</span>
                           </div>
                         </Tooltip>
                       ) : null}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -127,6 +127,7 @@ export function Sidebar() {
   const activeSessionId = useAppStore((s) => s.activeSessionId);
   const activeProject = useAppStore((s) => s.activeProject);
   const selectSession = useAppStore((s) => s.selectSession);
+  const focusLocalSessions = useAppStore((s) => s.focusLocalSessions);
   const setActiveProject = useAppStore((s) => s.setActiveProject);
   const createSession = useAppStore((s) => s.createSession);
   const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
@@ -516,6 +517,7 @@ export function Sidebar() {
             sessions={localSessions}
             activeSessionId={activeSessionId}
             onCreate={onNewLocalSession}
+            onFocusArea={focusLocalSessions}
             onSelectSession={selectSession}
             onRemoveSession={(s) => requestRemoveSession(s.id)}
           />
@@ -1383,6 +1385,7 @@ interface LocalTerminalAreaProps {
   sessions: Session[];
   activeSessionId: string | null;
   onCreate: () => void;
+  onFocusArea: () => void;
   onSelectSession: (id: string) => void;
   onRemoveSession: (session: Session) => void;
 }
@@ -1391,6 +1394,7 @@ function LocalTerminalArea({
   sessions,
   activeSessionId,
   onCreate,
+  onFocusArea,
   onSelectSession,
   onRemoveSession,
 }: LocalTerminalAreaProps) {
@@ -1407,6 +1411,7 @@ function LocalTerminalArea({
       aria-label={sidebarText(t, "sidebar.aria.localTerminalSessions")}
       onMouseDown={(e) => {
         e.currentTarget.focus();
+        onFocusArea();
       }}
       className={cn(
         "mt-4 flex min-h-28 flex-1 flex-col pt-2",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -270,6 +270,11 @@ export const api = {
       limit,
     });
   },
+  listUnscopedAgentHistory(limit = 100): Promise<AgentHistoryItem[]> {
+    return invoke<AgentHistoryItem[]>("list_unscoped_agent_history", {
+      limit,
+    });
+  },
   trashAgentHistoryTranscript(item: AgentHistoryItem): Promise<void> {
     return invoke<void>("trash_agent_history_transcript", {
       provider: item.provider,

--- a/src/lib/right-panel-cache.test.ts
+++ b/src/lib/right-panel-cache.test.ts
@@ -9,6 +9,8 @@ vi.mock("./api", () => ({
   api: {
     listAgentHistory:
       vi.fn<(repoPath: string, limit: number) => Promise<AgentHistoryItem[]>>(),
+    listUnscopedAgentHistory:
+      vi.fn<(limit: number) => Promise<AgentHistoryItem[]>>(),
     listPullRequests:
       vi.fn<
         (
@@ -91,6 +93,24 @@ describe("rightPanelCache", () => {
     rightPanelCache.retainRepos([OTHER_REPO]);
     expect(rightPanelCache.getAgentHistory(REPO)).toBeNull();
     expect(rightPanelCache.getWorkflowRuns(REPO, 50)).toBeNull();
+  });
+
+  it("dedupes in-flight unscoped history fetches and reuses cached results", async () => {
+    const history: AgentHistoryItem[] = [];
+    const pending = deferred<AgentHistoryItem[]>();
+    mockApi.listUnscopedAgentHistory.mockReturnValueOnce(pending.promise);
+
+    const first = rightPanelCache.fetchUnscopedAgentHistory(100);
+    const second = rightPanelCache.fetchUnscopedAgentHistory(100);
+    expect(first).toBe(second);
+    expect(mockApi.listUnscopedAgentHistory).toHaveBeenCalledTimes(1);
+
+    pending.resolve(history);
+    await expect(first).resolves.toBe(history);
+    await expect(rightPanelCache.fetchUnscopedAgentHistory(100)).resolves.toBe(
+      history,
+    );
+    expect(mockApi.listUnscopedAgentHistory).toHaveBeenCalledTimes(1);
   });
 
   it("does not repopulate a pruned repo from a stale in-flight request", async () => {

--- a/src/lib/right-panel-cache.ts
+++ b/src/lib/right-panel-cache.ts
@@ -26,6 +26,11 @@ class RightPanelCacheManager {
   private prefetchedProjectRepos = new Set<string>();
   private agentHistoryCache = new Map<string, AgentHistoryItem[]>();
   private agentHistoryInFlight = new Map<string, Promise<AgentHistoryItem[]>>();
+  private unscopedAgentHistoryCache = new Map<number, AgentHistoryItem[]>();
+  private unscopedAgentHistoryInFlight = new Map<
+    number,
+    Promise<AgentHistoryItem[]>
+  >();
   private commitsCache = new Map<string, CommitsCacheEntry>();
   private stagedCache = new Map<string, StagedCacheEntry>();
   private prListCache = new Map<string, PullRequestListing>();
@@ -100,6 +105,35 @@ class RightPanelCacheManager {
         this.agentHistoryInFlight.delete(repoPath);
       });
     this.agentHistoryInFlight.set(repoPath, promise);
+    return promise;
+  }
+
+  getUnscopedAgentHistory(limit: number): AgentHistoryItem[] | null {
+    return this.unscopedAgentHistoryCache.get(limit) ?? null;
+  }
+
+  setUnscopedAgentHistory(limit: number, items: AgentHistoryItem[]): void {
+    this.unscopedAgentHistoryCache.set(limit, items);
+  }
+
+  fetchUnscopedAgentHistory(
+    limit: number,
+    options: FetchOptions = {},
+  ): Promise<AgentHistoryItem[]> {
+    const cached = this.unscopedAgentHistoryCache.get(limit);
+    if (cached && !options.force) return Promise.resolve(cached);
+    const existing = this.unscopedAgentHistoryInFlight.get(limit);
+    if (existing) return existing;
+    const promise = api
+      .listUnscopedAgentHistory(limit)
+      .then((items) => {
+        this.unscopedAgentHistoryCache.set(limit, items);
+        return items;
+      })
+      .finally(() => {
+        this.unscopedAgentHistoryInFlight.delete(limit);
+      });
+    this.unscopedAgentHistoryInFlight.set(limit, promise);
     return promise;
   }
 
@@ -192,6 +226,8 @@ class RightPanelCacheManager {
     this.prefetchedProjectRepos.clear();
     this.agentHistoryCache.clear();
     this.agentHistoryInFlight.clear();
+    this.unscopedAgentHistoryCache.clear();
+    this.unscopedAgentHistoryInFlight.clear();
     this.commitsCache.clear();
     this.stagedCache.clear();
     this.prListCache.clear();

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -218,6 +218,27 @@ describe("selectSession", () => {
   });
 });
 
+describe("focusLocalSessions", () => {
+  it("activates a local session so project focus is cleared in the UI", async () => {
+    const local = session("local", "/Users/me", { project_scoped: false });
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A), local]);
+
+    useAppStore.getState().focusLocalSessions();
+
+    expect(useAppStore.getState().activeProject).toBe("/Users/me");
+    expect(useAppStore.getState().activeSessionId).toBe("local");
+  });
+
+  it("clears project focus when there are no local sessions", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+
+    useAppStore.getState().focusLocalSessions();
+
+    expect(useAppStore.getState().activeProject).toBeNull();
+    expect(useAppStore.getState().activeSessionId).toBeNull();
+  });
+});
+
 describe("workspace tabs", () => {
   it("opens a code viewer as a workspace tab without making it the active session", async () => {
     await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);

--- a/src/store.ts
+++ b/src/store.ts
@@ -147,6 +147,7 @@ interface AppStateModel {
   pollSessionStatuses: (ids?: string[]) => Promise<void>;
   selectTab: (id: string | null) => void;
   selectSession: (id: string | null) => void;
+  focusLocalSessions: () => void;
   setActiveProject: (repoPath: string) => void;
   setFocusedPane: (paneId: PaneId) => void;
   focusAdjacentPane: (direction: PaneFocusDirection) => void;
@@ -753,6 +754,31 @@ export const useAppStore = create<AppStateModel>()(
 
   selectSession(id) {
     get().selectTab(id);
+  },
+
+  focusLocalSessions() {
+    const state = get();
+    const currentLocal = state.activeSessionId
+      ? state.sessions.find(
+          (session) =>
+            session.id === state.activeSessionId &&
+            session.project_scoped === false,
+        )
+      : null;
+    const local =
+      currentLocal ??
+      state.sessions.find((session) => session.project_scoped === false);
+    if (local) {
+      get().selectSession(local.id);
+      return;
+    }
+    set((s) => {
+      if (s.activeProject === null && s.activeTabId === null) return s;
+      return {
+        activeProject: null,
+        ...fallbackEmptyMirror(),
+      };
+    });
   },
 
   setActiveProject(repoPath) {

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -50,6 +50,7 @@ export const tauriMockSource = `
     if (cmd === 'list_commits') return Promise.resolve([]);
     if (cmd === 'resolve_commit_logins') return Promise.resolve({});
     if (cmd === 'list_staged') return Promise.resolve([]);
+    if (cmd === 'list_unscoped_agent_history') return Promise.resolve([]);
     if (cmd === 'list_pull_requests') {
       return Promise.resolve({ items: [], account: null, error: null });
     }

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -323,6 +323,84 @@ test.describe("right panel: groups", () => {
     await expect(page.getByRole("button", { name: "GitHub" })).toHaveCount(0);
   });
 
+  test("local chat focus hides Code and shows local agent history", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "local-codex",
+        name: "codex",
+        repo_path: "/Users/tester",
+        worktree_path: "/Users/tester",
+        branch: "HEAD",
+        isolated: false,
+        project_scoped: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+        agent_provider: "codex",
+      },
+    ]);
+    await tauri.handle("pty_repo_root", () => null);
+    await tauri.handle("list_unscoped_agent_history", () => {
+      const w = window as unknown as { __unscopedHistoryCalls?: number };
+      w.__unscopedHistoryCalls = (w.__unscopedHistoryCalls ?? 0) + 1;
+      return [
+        {
+          provider: "codex",
+          id: "codex-local",
+          title: "Local Codex session",
+          preview: null,
+          cwd: "/Users/tester",
+          worktree: null,
+          transcript_path: "/Users/tester/.codex/session.jsonl",
+          updated_at: 1770000000,
+          resume_command: "codex resume codex-local",
+        },
+      ];
+    });
+
+    await page.goto("/");
+    const chats = page.getByRole("region", { name: "Local terminal sessions" });
+    await chats.getByRole("button", { name: /codex/i }).click();
+
+    await expect(
+      page.getByRole("button", { name: "Code", exact: true }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "GitHub", exact: true }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Agents", exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText("Local Codex session")).toBeVisible();
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __unscopedHistoryCalls?: number })
+                .__unscopedHistoryCalls ?? 0,
+          ),
+        { timeout: 3_000 },
+      )
+      .toBeGreaterThan(0);
+  });
+
   test("History sub-tab is labeled 'History' (renamed from 'Sessions')", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Local chats now show global agent transcript history without leaking project Code context.

1. **Chats focus** clears project-panel code context so Code/GitHub tabs are hidden for local chat focus.
2. **Unscoped history** scans Codex and Claude Code transcript stores while excluding registered Acorn project paths.
3. **History caching** routes unscoped agent history through the right panel cache manager with in-flight request dedupe.
4. **Coverage** adds backend, store, component, cache, and e2e checks for local chat history behavior.

## Expected impact

| Area | Impact |
| --- | --- |
| Chats right panel | Local chats show agent history instead of stale project Code context. |
| Project right panel | Project-scoped history remains scoped to the selected project. |
| Performance | Reopening Chats history reuses cached transcript results unless manually refreshed. |

## Design notes

Unscoped history filters by registered Acorn project paths, not by arbitrary git repositories, so Codex/Claude sessions started from non-Acorn repos still appear under Chats. Claude Desktop IndexedDB history is intentionally out of scope; this uses Claude Code JSONL transcripts under `~/.claude/projects`.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run src/store.test.ts src/lib/right-panel-cache.test.ts src/components/RightPanel.test.tsx`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml agent_history::tests --lib`
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts`

## Notes

`cargo check --manifest-path src-tauri/Cargo.toml` was also run before the final clean branch and only reported the pre-existing `AgentHookServer::start` dead-code warning.