### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.7.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.6.0"
+version = "1.7.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Release v1.7.0. Bumps `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json` from 1.6.0 to 1.7.0.

## Changes since v1.6.0

### Features
- feat(agent-hooks): runtime wrappers + transcript refresh + terminal tail controls (#279)
- feat(sessions): local chat terminals + scoped session creation (#274)
- feat(terminal): support file drops as mentions (#272)

### Fixes
- fix(chats): show unscoped agent history (#282)
- fix(terminal): pinned prompt icon matches agent state (#281)
- fix(terminal): revert transcript watcher changes + keep tail button (#280)
- fix(tabs): separate close hit area from drag handle (#278)
- fix(panes): open file drops in empty panes (#277)
- fix(sessions): confirm worktree cleanup on auto-close exit (#276)
- fix(workspace): persist pane split sizes across projects (#273)

### Docs
- docs: extract CLAUDE.md content into docs/COMMON.md (#275)

## Test plan

- [ ] `bun run tauri dev` launches with version 1.7.0 displayed
- [ ] In-app changelog renders the buckets above via `.github/release.yml`
- [ ] CI green
