### PR TITLE
fix(right-panel): restore GitHub tabs after project selection

### DIFF
--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -200,6 +200,29 @@ describe("RightPanel background tab loading", () => {
     expect(mockApi.listWorkflowRuns).toHaveBeenCalledWith(REPO, 50);
   });
 
+  it("loads GitHub tabs after selecting a project whose workspace mirror is missing", async () => {
+    useAppStore.setState({
+      activeProject: null,
+      activeSessionId: null,
+      activeTabId: null,
+      workspaces: {},
+      rightTab: "prs",
+    });
+
+    act(() => {
+      useAppStore.getState().setActiveProject(REPO);
+    });
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+
+    expect(container.textContent).not.toContain("No project selected");
+    expect(mockApi.githubOriginSlug).toHaveBeenCalledWith(REPO);
+    expect(mockApi.listPullRequests).toHaveBeenCalledWith(REPO, "open", 50);
+  });
+
   it("prefetches other open projects once after startup", async () => {
     useAppStore.setState({
       projects: [

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -465,8 +465,11 @@ export function RightPanel() {
             <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : BACKGROUND_LOADED_TABS.has(rightTab) ? (
-          rightTab === "history" &&
-          (agentHistoryScope === "unscoped" || agentHistoryPath) ? null : (
+          rightTab === "history" ? (
+            agentHistoryScope === "unscoped" || agentHistoryPath ? null : (
+              <Empty msg={rt(t, "rightPanel.empty.noProject")} />
+            )
+          ) : projectPanelRepoPath ? null : (
             <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : (

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -239,6 +239,26 @@ describe("focusLocalSessions", () => {
   });
 });
 
+describe("setActiveProject", () => {
+  it("recreates a missing workspace mirror for a known project", async () => {
+    await seed([project(REPO_A, 0)], []);
+    useAppStore.setState({
+      activeProject: null,
+      activeTabId: null,
+      activeSessionId: null,
+      workspaces: {},
+    });
+
+    useAppStore.getState().setActiveProject(REPO_A);
+
+    const s = useAppStore.getState();
+    expect(s.activeProject).toBe(REPO_A);
+    expect(s.workspaces[REPO_A]).toBeDefined();
+    expect(s.activeTabId).toBeNull();
+    expect(s.activeSessionId).toBeNull();
+  });
+});
+
 describe("workspace tabs", () => {
   it("opens a code viewer as a workspace tab without making it the active session", async () => {
     await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);

--- a/src/store.ts
+++ b/src/store.ts
@@ -783,11 +783,20 @@ export const useAppStore = create<AppStateModel>()(
 
   setActiveProject(repoPath) {
     set((s) => {
-      if (!s.workspaces[repoPath]) return s;
-      if (s.activeProject === repoPath) return s;
+      const hasWorkspace = s.workspaces[repoPath] !== undefined;
+      const knownRepo =
+        hasWorkspace ||
+        s.projects.some((project) => project.repo_path === repoPath) ||
+        s.sessions.some((session) => session.repo_path === repoPath);
+      if (!knownRepo) return s;
+      if (s.activeProject === repoPath && hasWorkspace) return s;
+      const workspaces = hasWorkspace
+        ? s.workspaces
+        : { ...s.workspaces, [repoPath]: emptyWorkspace() };
       return {
+        workspaces,
         activeProject: repoPath,
-        ...mirrorActive(s.workspaces, repoPath),
+        ...mirrorActive(workspaces, repoPath),
       };
     });
   },


### PR DESCRIPTION
## Summary

Restore right-panel project scoping so GitHub tabs stay attached to the selected project.

1. **Workspace recovery:** allow `setActiveProject` to recreate a missing workspace mirror for known projects or project sessions instead of leaving `activeProject` unset.
2. **GitHub tab placeholder:** avoid rendering the background-loaded `No project selected` placeholder for PRs/Actions when a project repo path is available.
3. **Regression coverage:** add store and RightPanel tests for the missing-workspace project selection path.

## Expected impact

| Area | Impact |
| --- | --- |
| GitHub tabs | Selecting a project restores PRs/Actions instead of showing `No project selected`. |
| Project workspace state | Missing workspace mirrors recover without affecting unknown repos. |
| Local chat/history tabs | Existing unscoped history behavior remains unchanged. |

## Design notes

`setActiveProject` still ignores unknown repo paths, but now treats entries from `projects`, existing workspaces, or sessions as valid and creates an empty workspace mirror when needed. RightPanel keeps History's unscoped/project-specific logic separate from PRs and Actions because only History can be valid without a project repo path.

## Test plan

- [x] `pnpm vitest run src/store.test.ts src/components/RightPanel.test.tsx`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Local `pnpm run tauri dev` smoke-tested the right panel in dev profile

## Notes

The dev smoke test surfaced that inherited `ACORN_IPC_SOCKET` can point the IPC server at a prod socket even when `ACORN_PROFILE=dev`; app persistence still wrote to `profiles/dev`. That environment issue is pre-existing and not caused by this PR.
