### PR TITLE
chore(release): v1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.7.1",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.7.0"
+version = "1.7.1"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Release v1.7.1. Bumps `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json` from 1.7.0 to 1.7.1.

1. **Patch version bump:** align the app, Tauri, and Cargo package versions on `1.7.1`.
2. **Release contents:** includes the right-panel project selection fix merged after v1.7.0.

## Expected impact

| Area | Impact |
| --- | --- |
| Release channel | Publishes a patch release for the GitHub tab project-selection fix. |
| Updater metadata | `latest.json` will advertise version `1.7.1` once the release workflow completes. |

## Test plan

- [x] `pnpm typecheck`
- [ ] CI green
- [ ] Release workflow publishes `v1.7.1` assets and `latest.json`
