### PR TITLE
feat(terminal): cursor presets + default accent pill caret

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,11 +21,121 @@
   background-color: transparent !important;
 }
 
+.acorn-terminal {
+  --acorn-terminal-cursor-pill-color: var(--color-accent, #7dd3fc);
+}
+
+.acorn-terminal.acorn-terminal-composing .xterm-cursor,
+.acorn-terminal.acorn-terminal-composing .xterm-cursor.xterm-cursor-block {
+  opacity: 0 !important;
+}
+
+.acorn-terminal.acorn-terminal-composing .composition-view.active {
+  background: #000;
+  box-sizing: border-box;
+  color: inherit;
+  overflow: hidden;
+  white-space: pre;
+}
+
+.acorn-terminal.acorn-terminal-composing .composition-view.active::after {
+  content: "";
+  display: inline-block;
+  width: var(
+    --acorn-composition-cursor-width,
+    var(--acorn-composition-cell-width, 0.6em)
+  );
+  height: var(
+    --acorn-composition-cursor-height,
+    var(--acorn-composition-cell-height, 1em)
+  );
+  vertical-align: top;
+}
+
+.acorn-terminal.acorn-terminal-cursor-block .composition-view.active::after {
+  background: currentColor;
+}
+
+.acorn-terminal.acorn-terminal-cursor-bar .composition-view.active::after {
+  box-shadow: 1px 0 0 currentColor inset;
+}
+
+.acorn-terminal.acorn-terminal-cursor-underline .composition-view.active::after {
+  border-bottom: 1px solid currentColor;
+}
+
+.acorn-terminal.acorn-terminal-cursor-outline .composition-view.active::after {
+  outline: 1px solid currentColor;
+  outline-offset: -1px;
+}
+
+.acorn-terminal.acorn-terminal-cursor-pill .composition-view.active::after {
+  background: var(--acorn-terminal-cursor-pill-color);
+  border-radius: 999px;
+  width: 3px;
+}
+
+.acorn-terminal.acorn-terminal-cursor-outline
+  .xterm-cursor.xterm-cursor-block {
+  background-color: transparent !important;
+  color: inherit !important;
+  outline: 1px solid currentColor;
+  outline-offset: -1px;
+}
+
+.acorn-terminal.acorn-terminal-cursor-pill .xterm-cursor.xterm-cursor-bar {
+  background-color: var(--acorn-terminal-cursor-pill-color) !important;
+  border-left: 0 !important;
+  border-radius: 999px;
+  width: 3px !important;
+}
+
+.acorn-terminal.acorn-terminal-cursor-bar .xterm-cursor.xterm-cursor-block {
+  box-shadow: 1px 0 0 currentColor inset;
+}
+
+.acorn-terminal.acorn-terminal-cursor-underline
+  .xterm-cursor.xterm-cursor-block {
+  box-shadow: 0 -1px 0 currentColor inset;
+}
+
+.acorn-terminal.acorn-terminal-cursor-pill .xterm-cursor {
+  position: relative;
+}
+
+.acorn-terminal.acorn-terminal-cursor-pill .xterm-cursor::after {
+  background: var(--acorn-terminal-cursor-pill-color);
+  border-radius: 999px;
+  content: "";
+  display: block;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 3px;
+}
+
 .acorn-terminal-inactive .xterm-cursor,
 .acorn-terminal-inactive .xterm-cursor.xterm-cursor-block {
   outline: 1px solid color-mix(in oklab, var(--color-fg-muted) 70%, transparent);
   background-color: transparent !important;
   opacity: 0.55;
+}
+
+.acorn-terminal.acorn-terminal-cursor-bar .xterm-cursor,
+.acorn-terminal.acorn-terminal-cursor-underline .xterm-cursor,
+.acorn-terminal.acorn-terminal-cursor-pill .xterm-cursor {
+  outline: 0 !important;
+}
+
+.acorn-terminal.acorn-terminal-inactive.acorn-terminal-cursor-bar
+  .xterm-cursor {
+  box-shadow: 1px 0 0 currentColor inset;
+}
+
+.acorn-terminal.acorn-terminal-inactive.acorn-terminal-cursor-underline
+  .xterm-cursor {
+  box-shadow: 0 -1px 0 currentColor inset;
 }
 
 .acorn-terminal .xterm-scrollable-element > .scrollbar.vertical {

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -215,6 +215,38 @@ describe("SettingsModal font controls", () => {
     });
   });
 
+  it("patches terminal cursor style from presets", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openTerminalTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const patchTerminal = useSettings.getState().patchTerminal;
+    const cursorStyle = Array.from(
+      document.querySelectorAll<HTMLSelectElement>("select"),
+    ).find((element) => element.value === DEFAULT_SETTINGS.terminal.cursorStyle);
+
+    expect(document.body.textContent).toContain("Cursor style");
+    expect(cursorStyle?.textContent).toContain("Block");
+    expect(cursorStyle?.textContent).toContain("Bar");
+    expect(cursorStyle?.textContent).toContain("Underline");
+    expect(cursorStyle?.textContent).toContain("Outline");
+    expect(cursorStyle?.textContent).toContain("Pill");
+    expect(cursorStyle).toBeInstanceOf(HTMLSelectElement);
+
+    act(() => {
+      if (!cursorStyle) throw new Error("Cursor style select not found");
+      cursorStyle.value = "pill";
+      cursorStyle.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expect(patchTerminal).toHaveBeenCalledWith({ cursorStyle: "pill" });
+  });
+
   it("does not render the Appearance font dropdown controls", async () => {
     await act(async () => {
       root = createRoot(container);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -40,6 +40,7 @@ import {
   type AcornSettings,
   type TerminalFontWeight,
   type TerminalLinkActivation,
+  TERMINAL_CURSOR_STYLE_OPTIONS,
   TERMINAL_FONT_WEIGHTS,
   useSettings,
 } from "../lib/settings";
@@ -269,6 +270,26 @@ function TerminalSettings() {
           format={(n) => n.toFixed(2)}
           onChange={(n) => patchTerminal({ lineHeight: n })}
         />
+      </Field>
+      <Field
+        label={st(t, "settings.terminal.cursorStyle.label")}
+        hint={st(t, "settings.terminal.cursorStyle.hint")}
+      >
+        <Select
+          value={settings.terminal.cursorStyle}
+          onChange={(e) =>
+            patchTerminal({
+              cursorStyle: e.target.value as AcornSettings["terminal"]["cursorStyle"],
+            })
+          }
+          className="w-48"
+        >
+          {TERMINAL_CURSOR_STYLE_OPTIONS.map((style) => (
+            <option key={style.value} value={style.value}>
+              {st(t, `settings.terminal.cursorStyle.options.${style.value}`)}
+            </option>
+          ))}
+        </Select>
       </Field>
       <Field
         label={st(t, "settings.terminal.openLinksOn.label")}

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -37,6 +37,7 @@ import {
 import { terminalPasteAction } from "../lib/terminalPaste";
 import {
   useSettings,
+  type TerminalCursorStyle,
   type TerminalLinkActivation,
 } from "../lib/settings";
 import { buildXtermTheme } from "../lib/terminalTheme";
@@ -124,6 +125,30 @@ const ANSI_RED = "\x1b[31m";
 const ANSI_RESET = "\x1b[0m";
 const ANSI_DIM = "\x1b[2m";
 const SCROLL_TO_BOTTOM_VISIBLE_ROWS = 10;
+const COMPOSING_CLASS = "acorn-terminal-composing";
+const CURSOR_STYLE_CLASS_PREFIX = "acorn-terminal-cursor-";
+
+function xtermCursorStyle(style: TerminalCursorStyle): "block" | "bar" | "underline" {
+  if (style === "outline") return "block";
+  if (style === "pill") return "bar";
+  return style;
+}
+
+function xtermCursorWidth(style: TerminalCursorStyle): number {
+  return style === "pill" ? 3 : 1;
+}
+
+function syncCursorStyleClass(
+  container: HTMLElement,
+  style: TerminalCursorStyle,
+): void {
+  for (const className of Array.from(container.classList)) {
+    if (className.startsWith(CURSOR_STYLE_CLASS_PREFIX)) {
+      container.classList.remove(className);
+    }
+  }
+  container.classList.add(`${CURSOR_STYLE_CLASS_PREFIX}${style}`);
+}
 
 // Custom event the sticky-prompt banner listens to. Fired whenever the user
 // scrolls the terminal so the banner can swap to the prompt "in scope" at
@@ -475,6 +500,8 @@ export function Terminal({
       fontWeightBold: initialSettings.terminal.fontWeightBold,
       lineHeight: initialSettings.terminal.lineHeight,
       cursorBlink: isFocusedPane,
+      cursorStyle: xtermCursorStyle(initialSettings.terminal.cursorStyle),
+      cursorWidth: xtermCursorWidth(initialSettings.terminal.cursorStyle),
       allowProposedApi: true,
       scrollback: 5000,
       // `convertEol` rewrites every bare `\n` from the PTY into `\r\n` before
@@ -562,6 +589,7 @@ export function Terminal({
     // PTY mid-composition. The canvas/webgl addons are faster but mis-handle
     // composition events on macOS/Linux IMEs — we pick correctness over fps.
     term.open(container);
+    syncCursorStyleClass(container, initialSettings.terminal.cursorStyle);
     const fitWithCellMeasurements = () => {
       const cjkEnabled =
         useSettings.getState().settings.experiments.cjkCellWidthHeuristic;
@@ -714,6 +742,12 @@ export function Terminal({
         if (next.linkActivation !== "modifier-click") {
           setLinkTooltip(null);
         }
+      }
+      if (next.cursorStyle !== previous.cursorStyle) {
+        term.options.cursorStyle = xtermCursorStyle(next.cursorStyle);
+        term.options.cursorWidth = xtermCursorWidth(next.cursorStyle);
+        syncCursorStyleClass(container, next.cursorStyle);
+        term.refresh(0, term.rows - 1);
       }
       if (state.settings.appearance.themeId !== prev.settings.appearance.themeId) {
         scheduleThemeRefresh();
@@ -875,11 +909,13 @@ export function Terminal({
     const showComposing = (text: string) => {
       if (!compositionView) return;
       if (text.length === 0) {
+        container.classList.remove(COMPOSING_CLASS);
         compositionView.classList.remove("active");
         compositionView.textContent = "";
         return;
       }
       const cell = getCellDims();
+      container.classList.add(COMPOSING_CLASS);
       compositionView.textContent = text;
       if (cell) {
         const buf = term.buffer.active;
@@ -897,8 +933,32 @@ export function Terminal({
         const cursorViewportY = buf.baseY + buf.cursorY - buf.viewportY;
         compositionView.style.left = `${buf.cursorX * cell.width}px`;
         compositionView.style.top = `${cursorViewportY * cell.height}px`;
+        compositionView.style.height = `${cell.height}px`;
         compositionView.style.minHeight = `${cell.height}px`;
         compositionView.style.lineHeight = `${cell.height}px`;
+        const cursorRect = container
+          .querySelector<HTMLElement>(".xterm-cursor")
+          ?.getBoundingClientRect();
+        const cursorWidth =
+          cursorRect && cursorRect.width > 0 ? cursorRect.width : cell.width;
+        const cursorHeight =
+          cursorRect && cursorRect.height > 0 ? cursorRect.height : cell.height;
+        compositionView.style.setProperty(
+          "--acorn-composition-cell-width",
+          `${cell.width}px`,
+        );
+        compositionView.style.setProperty(
+          "--acorn-composition-cell-height",
+          `${cell.height}px`,
+        );
+        compositionView.style.setProperty(
+          "--acorn-composition-cursor-width",
+          `${cursorWidth}px`,
+        );
+        compositionView.style.setProperty(
+          "--acorn-composition-cursor-height",
+          `${cursorHeight}px`,
+        );
       }
       // Sync font with the current xterm options so the preview uses the
       // user's configured terminal font/size, not the default sans inherited
@@ -919,6 +979,7 @@ export function Terminal({
     };
     const hideComposing = () => {
       if (!compositionView) return;
+      container.classList.remove(COMPOSING_CLASS);
       compositionView.classList.remove("active");
       compositionView.textContent = "";
     };

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -59,6 +59,66 @@ describe("terminal.linkActivation default", () => {
   });
 });
 
+describe("terminal cursor settings", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("uses acorn's pill cursor by default", () => {
+    expect(DEFAULT_SETTINGS.terminal.cursorStyle).toBe("pill");
+  });
+
+  it("loads a persisted cursor style from the preset set", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ terminal: { cursorStyle: "pill" } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.terminal.cursorStyle).toBe(
+      "pill",
+    );
+  });
+
+  it("falls back for an unsupported cursor style", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        terminal: { cursorStyle: "beam" },
+      }),
+    );
+
+    vi.resetModules();
+    const { useSettings, DEFAULT_SETTINGS } = await import("./settings");
+
+    expect(useSettings.getState().settings.terminal.cursorStyle).toBe(
+      DEFAULT_SETTINGS.terminal.cursorStyle,
+    );
+  });
+});
+
 describe("AI commit command resolution", () => {
   it("runs Codex through non-interactive exec mode", () => {
     expect(

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -98,6 +98,24 @@ export type TerminalFontWeight =
  */
 export type TerminalLinkActivation = "click" | "modifier-click";
 
+export type TerminalCursorStyle =
+  | "block"
+  | "bar"
+  | "underline"
+  | "outline"
+  | "pill";
+
+export const TERMINAL_CURSOR_STYLE_OPTIONS: ReadonlyArray<{
+  value: TerminalCursorStyle;
+  label: string;
+}> = [
+  { value: "block", label: "Block" },
+  { value: "bar", label: "Bar" },
+  { value: "underline", label: "Underline" },
+  { value: "outline", label: "Outline" },
+  { value: "pill", label: "Pill" },
+];
+
 /**
  * Which field acorn shows as the primary line of a sidebar session row.
  * Mirrors Warp's "Pane title as" picker — `name` is the editable session
@@ -161,6 +179,7 @@ export interface AcornSettings {
      * stray click on output containing a URL doesn't steal focus.
      */
     linkActivation: TerminalLinkActivation;
+    cursorStyle: TerminalCursorStyle;
   };
   /**
    * The single AI agent acorn uses everywhere AI features fire (currently
@@ -327,6 +346,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     fontWeightBold: 700,
     lineHeight: 1.0,
     linkActivation: "click",
+    cursorStyle: "pill",
   },
   agents: {
     selected: "claude",
@@ -413,6 +433,9 @@ const VALID_AGENTS = new Set<AgentProvider>([
 const VALID_PR_INTERVALS = new Set<number>(
   PR_REFRESH_INTERVAL_OPTIONS.map((o) => o.value),
 );
+const VALID_CURSOR_STYLES = new Set<TerminalCursorStyle>(
+  TERMINAL_CURSOR_STYLE_OPTIONS.map((o) => o.value),
+);
 
 const VALID_BG_FITS = new Set<BackgroundFit>(["cover", "contain", "tile"]);
 
@@ -473,6 +496,16 @@ function normalizeLinkActivation(
   fallback: TerminalLinkActivation,
 ): TerminalLinkActivation {
   if (v === "click" || v === "modifier-click") return v;
+  return fallback;
+}
+
+function normalizeCursorStyle(
+  v: unknown,
+  fallback: TerminalCursorStyle,
+): TerminalCursorStyle {
+  if (typeof v === "string" && VALID_CURSOR_STYLES.has(v as TerminalCursorStyle)) {
+    return v as TerminalCursorStyle;
+  }
   return fallback;
 }
 
@@ -666,6 +699,10 @@ function loadSettings(): AcornSettings {
         linkActivation: normalizeLinkActivation(
           (terminalRaw as { linkActivation?: unknown }).linkActivation,
           DEFAULT_SETTINGS.terminal.linkActivation,
+        ),
+        cursorStyle: normalizeCursorStyle(
+          (terminalRaw as { cursorStyle?: unknown }).cursorStyle,
+          DEFAULT_SETTINGS.terminal.cursorStyle,
         ),
       },
       agents: {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -41,6 +41,17 @@
         "label": "Line height",
         "hint": "Cell-height multiplier. 1.00 packs rows flush; raise for more vertical breathing room. Range 1.00-2.00."
       },
+      "cursorStyle": {
+        "label": "Cursor style",
+        "hint": "Shape used for both the xterm cursor and the IME composition preview cursor.",
+        "options": {
+          "block": "Block",
+          "bar": "Bar",
+          "underline": "Underline",
+          "outline": "Outline",
+          "pill": "Pill"
+        }
+      },
       "openLinksOn": {
         "label": "Open links on",
         "hint": "How to follow URLs that xterm detects in terminal output.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -41,6 +41,17 @@
         "label": "줄 높이",
         "hint": "셀 높이 배율입니다. 1.00은 행을 촘촘히 배치하며, 값을 높이면 세로 여백이 늘어납니다. 범위는 1.00-2.00입니다."
       },
+      "cursorStyle": {
+        "label": "커서 스타일",
+        "hint": "xterm 커서와 IME 조합 미리보기 커서에 사용할 모양입니다.",
+        "options": {
+          "block": "블록",
+          "bar": "세로선",
+          "underline": "밑줄",
+          "outline": "외곽선",
+          "pill": "알약형"
+        }
+      },
       "openLinksOn": {
         "label": "링크 열기 방식",
         "hint": "xterm이 터미널 출력에서 감지한 URL을 여는 방식입니다.",

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -147,6 +147,48 @@ async function getWrites(page: Page): Promise<string[]> {
 }
 
 test.describe("terminal: IME (PR #104 regression)", () => {
+  test("active IME preview owns the visible caret until commit", async ({
+    page,
+    tauri,
+  }) => {
+    await seed(tauri);
+    await activateTerminal(page);
+
+    await runIme(page, [
+      { type: "keydown", key: "Process", keyCode: 229 },
+      {
+        type: "input",
+        inputType: "insertCompositionText",
+        data: "입",
+        taValue: "입",
+      },
+    ]);
+
+    await expect(page.locator(".acorn-terminal")).toHaveClass(
+      /acorn-terminal-composing/,
+    );
+    const compositionView = page.locator(".composition-view.active");
+    await expect(compositionView).toHaveText("입");
+    await expect
+      .poll(async () =>
+        compositionView.evaluate((el) => getComputedStyle(el).backgroundColor),
+      )
+      .toBe("rgb(0, 0, 0)");
+
+    await runIme(page, [
+      {
+        type: "input",
+        inputType: "insertFromComposition",
+        data: "입",
+        taValue: "",
+      },
+    ]);
+
+    await expect(page.locator(".acorn-terminal")).not.toHaveClass(
+      /acorn-terminal-composing/,
+    );
+  });
+
   test("Korean syllable + spacebar terminator emits the syllable exactly once", async ({
     page,
     tauri,

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -1,6 +1,68 @@
 import { test, expect } from "./support";
 
 test.describe("terminal: spawn", () => {
+  test("default pill cursor uses the active theme accent after the helper textarea blurs", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+
+    await page.goto("/");
+    await page.addStyleTag({
+      content: `
+        :root[data-acorn-theme="acorn-dark"] {
+          --color-accent: rgb(12, 34, 56);
+        }
+      `,
+    });
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    const textarea = page.locator(".xterm-helper-textarea");
+    await textarea.waitFor({ state: "attached" });
+    await textarea.focus();
+
+    const cursor = page.locator(".acorn-terminal .xterm-cursor").first();
+    await expect(cursor).toBeAttached();
+    await textarea.evaluate((el) => el.blur());
+
+    await expect
+      .poll(async () =>
+        cursor.evaluate((el) => getComputedStyle(el, "::after").backgroundColor),
+      )
+      .toBe("rgb(12, 34, 56)");
+    await expect
+      .poll(async () =>
+        cursor.evaluate((el) => getComputedStyle(el, "::after").width),
+      )
+      .toBe("3px");
+    await expect
+      .poll(async () => cursor.evaluate((el) => getComputedStyle(el).outlineWidth))
+      .toBe("0px");
+  });
+
   test("activating a session calls pty_spawn with the session's cwd", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
This PR makes the terminal cursor configurable while switching Acorn's default caret to a theme-accent pill style.

1. **Cursor presets:** Adds terminal cursor style settings for `block`, `bar`, `underline`, `outline`, and `pill`, including persistence validation, Settings UI, and English/Korean labels.
2. **Default Acorn caret:** Changes the default terminal cursor to `pill`, using the active theme's `--color-accent` color and preserving xterm blink behavior.
3. **IME preview alignment:** Keeps the IME composition preview caret in sync with the selected cursor style while preserving the black composition highlight behind composing text.
4. **Blur/focus behavior:** Keeps non-block cursor markers visible after helper textarea blur without showing xterm's default inactive outline on top.

## Expected impact

| Area | Impact |
| --- | --- |
| Terminal UX | New installs/default settings use a theme-accent pill cursor; users can switch to other presets in Settings. |
| IME input | CJK composition preview keeps the black candidate background and uses the selected cursor shape. |
| Existing users | Existing persisted `terminal.cursorStyle` values are respected; missing or invalid values normalize safely. |
| Build/runtime | No dependency or backend changes. |

## Design notes

- `pill` maps to xterm's `bar` cursor with a 3px width, then uses Acorn CSS to render the rounded accent marker consistently across focused and blurred states.
- `outline` maps to xterm `block` and is styled via CSS so it can remain one of the bounded preset choices.
- The pill color is `var(--color-accent)` so theme changes automatically recolor the cursor without adding another theme token.
- IME composition uses xterm's `.composition-view` but hides the underlying xterm cursor during active composition to avoid duplicate carets.

## Follow-up (not in this PR)

- Consider adding more accent-based cursor variants only after the initial preset set has had real usage.
- Consider exposing cursor blink as a separate setting if users want to disable blinking independently of cursor shape.

## Test plan

- [x] `pnpm run test -- src/lib/settings.test.ts` — 44 files passed, 367 tests passed, 1 skipped.
- [x] `pnpm run test -- src/components/SettingsModal.test.tsx` — 44 files passed, 367 tests passed, 1 skipped.
- [x] `pnpm run test:e2e -- tests/e2e/terminal.spec.ts -g "default pill cursor"` — 4 passed.
- [x] `pnpm run test:e2e -- tests/e2e/terminal.spec.ts -g "pill cursor keeps"` — 4 passed.
- [x] `pnpm run test:e2e -- tests/e2e/terminal-ime.spec.ts -g "active IME preview"` — 11 passed.
- [x] `pnpm run typecheck` — passed.
- [x] `git diff --check` — passed.

## Notes

- E2E runs still emit pre-existing mock warnings for `load_status` and user themes in the local dev harness; they did not fail the tests and are not introduced by this PR.
