### PR TITLE
ci(release): reuse release-ci sidecar artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,9 +128,12 @@ jobs:
 
       # Pull the prebuilt Vite output from the `frontend` job into `dist/`.
       # The `tauri build` step below skips `pnpm run build` by overriding
-      # `beforeBuildCommand` to only run the sidecar staging script — that
-      # half MUST stay in the matrix because each macOS target cross-builds
-      # `acorn-ipc` / `acornd` for its own triple.
+      # `beforeBuildCommand` to only run the sidecar staging script. Keep
+      # that sidecar build in the matrix because each macOS target needs
+      # its own `acorn-ipc` / `acornd` binaries, but use the same Cargo
+      # profile as the app build so Cargo can reuse release-ci artifacts
+      # instead of compiling release sidecars and release-ci app binaries
+      # back to back.
       - name: Download shared frontend bundle
         uses: actions/download-artifact@v6
         with:
@@ -161,7 +164,7 @@ jobs:
         # `frontend` job's artifact one step ago. The sidecar staging
         # script still runs per-target because it cross-compiles for each
         # apple triple.
-        run: pnpm run tauri build --target ${{ matrix.target }} --bundles app dmg --config '{"build":{"beforeBuildCommand":"pnpm run build:sidecar"}}' -- --profile release-ci
+        run: pnpm run tauri build --target ${{ matrix.target }} --bundles app dmg --config '{"build":{"beforeBuildCommand":"TAURI_SIDECAR_PROFILE=release-ci pnpm run build:sidecar"}}' -- --profile release-ci
 
       - name: Stage release artifacts
         id: stage
@@ -265,7 +268,7 @@ jobs:
         env:
           RUSTFLAGS: "-Z share-generics=y -Z threads=8"
           CARGO_INCREMENTAL: "0"
-        run: pnpm run tauri build --target aarch64-apple-darwin --bundles app --config '{"build":{"beforeBuildCommand":"pnpm run build:sidecar"}}' -- --profile release-ci
+        run: pnpm run tauri build --target aarch64-apple-darwin --bundles app --config '{"build":{"beforeBuildCommand":"TAURI_SIDECAR_PROFILE=release-ci pnpm run build:sidecar"}}' -- --profile release-ci
 
   release:
     name: Publish GitHub Release + latest.json

--- a/src-tauri/scripts/build-sidecar.sh
+++ b/src-tauri/scripts/build-sidecar.sh
@@ -48,6 +48,8 @@ for entry in "${sidecars[@]}"; do
 done
 if [ "$profile" = "release" ]; then
   cargo_flags+=(--release)
+elif [ "$profile" != "debug" ]; then
+  cargo_flags+=(--profile "$profile")
 fi
 
 # Tauri's build.rs verifies that every `externalBin` path exists at


### PR DESCRIPTION
## Summary
Release macOS bundle jobs now build sidecars with the same Cargo profile as the Tauri app so Cargo can reuse release-ci artifacts instead of compiling two optimized profiles back to back.

1. **Sidecar profile forwarding:** `build-sidecar.sh` now maps non-debug/non-release `TAURI_SIDECAR_PROFILE` values to `cargo build --profile <profile>`.
2. **Release workflow alignment:** macOS release and nightly experiment Tauri builds now run `build:sidecar` with `TAURI_SIDECAR_PROFILE=release-ci`.
3. **Build-time diagnosis:** Recent release logs showed frontend and publish jobs finishing quickly while each macOS bundle job spent roughly 8-12 minutes inside `Build & sign tauri bundle`, with sidecars built under `release` before the app rebuilt under `release-ci`.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Release build time | Sidecars compiled under `release`, then app compiled under `release-ci` for the same target. | Sidecars and app share `target/<triple>/release-ci`, reducing duplicate optimized Rust compilation. |
| Release reliability | sccache cache backend outages already fell back to uncached builds, but the fallback path remained expensive. | The uncached fallback path does less duplicate work even when sccache is unavailable. |
| Release artifacts | No intended behavior or packaging change. | Same app, DMG, updater tarball, and signatures, with sidecars staged from the matching CI profile. |

## Design notes

`build-sidecar.sh` keeps the existing local defaults: no profile override still means `release`, and `TAURI_SIDECAR_PROFILE=debug` still avoids passing a Cargo release/profile flag. The release workflow now explicitly opts into `release-ci` so the before-build sidecar step feeds the same target directory used by the subsequent Tauri app build.

The sccache probe remains unchanged. Recent runs showed the GitHub artifact cache backend returning service errors and sccache reporting zero compile requests, so this PR focuses on reducing duplicate work in the fallback path rather than changing cache behavior.

## Follow-up (not in this PR)

Consider adding a lightweight CI assertion or log marker for the selected sidecar profile if future release-time regressions become hard to spot from Actions logs alone.

## Test plan

- [x] `bash -n src-tauri/scripts/build-sidecar.sh`
- [x] `git diff --check`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml ok"'`
- [x] `TAURI_SIDECAR_PROFILE=release-ci CARGO_INCREMENTAL=0 ./src-tauri/scripts/build-sidecar.sh` completed successfully and staged `acorn-ipc-aarch64-apple-darwin` / `acornd-aarch64-apple-darwin`.

## Notes

Recent release logs showed sccache disabled by GitHub artifact cache service errors and reporting `0 hits / 0 misses`. That is pre-existing external cache behavior, not caused by this PR.