### PR TITLE
feat(settings): shortcut hints tab for keyboard commands

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -126,6 +126,19 @@ function openGithubTab() {
   });
 }
 
+function openShortcutsTab() {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (element) =>
+      element.textContent === "Shortcuts" || element.textContent === "단축키",
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error("Shortcuts tab button not found");
+  }
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
 function setInputValue(input: HTMLInputElement, value: string) {
   const setter = Object.getOwnPropertyDescriptor(
     window.HTMLInputElement.prototype,
@@ -355,6 +368,7 @@ describe("SettingsModal font controls", () => {
       "GitHub",
       "편집기",
       "알림",
+      "단축키",
       "저장 공간",
       "실험 기능",
       "정보",
@@ -368,6 +382,25 @@ describe("SettingsModal font controls", () => {
     expect(document.body.textContent).toContain("설정");
     expect(document.body.textContent).toContain("기본값으로 재설정");
     expect(document.body.textContent).toContain("언어");
+  });
+
+  it("renders shortcut hints with the edit-coming-soon notice", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openShortcutsTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const bodyText = document.body.textContent ?? "";
+
+    expect(bodyText).toContain("Shortcut editing is coming soon.");
+    expect(bodyText).toContain("Open command palette");
+    expect(bodyText).toContain("New control session");
+    expect(bodyText).toContain("Right panel");
+    expect(bodyText).toMatch(/⌘P|Ctrl\+P/);
   });
 
   it("patches the GitHub PR row display toggles", async () => {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -2,6 +2,7 @@ import {
   Download,
   FolderOpen,
   ImagePlus,
+  Keyboard,
   RefreshCcw,
   Settings as SettingsIcon,
   Sparkles,
@@ -16,6 +17,7 @@ import {
 } from "../lib/background";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
+import { formatHotkey, Hotkeys, type HotkeyId } from "../lib/hotkeys";
 import {
   LANGUAGE_OPTIONS,
   type Language,
@@ -69,6 +71,7 @@ type Tab =
   | "github"
   | "editor"
   | "notifications"
+  | "shortcuts"
   | "storage"
   | "experiments"
   | "about";
@@ -83,6 +86,7 @@ const TABS: Array<{ id: Tab; labelKey: TranslationKey }> = [
   { id: "github", labelKey: "settings.tabs.github" },
   { id: "editor", labelKey: "settings.tabs.editor" },
   { id: "notifications", labelKey: "settings.tabs.notifications" },
+  { id: "shortcuts", labelKey: "settings.tabs.shortcuts" },
   { id: "storage", labelKey: "settings.tabs.storage" },
   { id: "experiments", labelKey: "settings.tabs.experiments" },
   { id: "about", labelKey: "settings.tabs.about" },
@@ -90,6 +94,175 @@ const TABS: Array<{ id: Tab; labelKey: TranslationKey }> = [
 
 const TAB_IDS = new Set<string>(TABS.map((t) => t.id));
 type SettingsTranslator = Translator;
+
+type ShortcutItem = {
+  id: HotkeyId;
+  labelKey: TranslationKey;
+  descriptionKey?: TranslationKey;
+};
+
+type ShortcutGroup = {
+  titleKey: TranslationKey;
+  items: ShortcutItem[];
+};
+
+const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    titleKey: "settings.shortcuts.groups.general",
+    items: [
+      {
+        id: "openPalette",
+        labelKey: "settings.shortcuts.items.openPalette.label",
+      },
+      {
+        id: "openSettings",
+        labelKey: "settings.shortcuts.items.openSettings.label",
+      },
+      {
+        id: "newSession",
+        labelKey: "settings.shortcuts.items.newSession.label",
+      },
+      {
+        id: "newIsolatedSession",
+        labelKey: "settings.shortcuts.items.newIsolatedSession.label",
+      },
+      {
+        id: "newControlSession",
+        labelKey: "settings.shortcuts.items.newControlSession.label",
+      },
+      {
+        id: "addProject",
+        labelKey: "settings.shortcuts.items.addProject.label",
+      },
+    ],
+  },
+  {
+    titleKey: "settings.shortcuts.groups.navigation",
+    items: [
+      {
+        id: "focusSidebar",
+        labelKey: "settings.shortcuts.items.focusSidebar.label",
+      },
+      {
+        id: "focusMain",
+        labelKey: "settings.shortcuts.items.focusMain.label",
+      },
+      {
+        id: "focusRight",
+        labelKey: "settings.shortcuts.items.focusRight.label",
+      },
+      {
+        id: "nextTab",
+        labelKey: "settings.shortcuts.items.nextTab.label",
+      },
+      {
+        id: "prevTab",
+        labelKey: "settings.shortcuts.items.prevTab.label",
+      },
+      {
+        id: "nextProject",
+        labelKey: "settings.shortcuts.items.nextProject.label",
+      },
+      {
+        id: "prevProject",
+        labelKey: "settings.shortcuts.items.prevProject.label",
+      },
+    ],
+  },
+  {
+    titleKey: "settings.shortcuts.groups.layout",
+    items: [
+      {
+        id: "toggleSidebar",
+        labelKey: "settings.shortcuts.items.toggleSidebar.label",
+      },
+      {
+        id: "toggleRightPanel",
+        labelKey: "settings.shortcuts.items.toggleRightPanel.label",
+      },
+      {
+        id: "splitVertical",
+        labelKey: "settings.shortcuts.items.splitVertical.label",
+      },
+      {
+        id: "splitHorizontal",
+        labelKey: "settings.shortcuts.items.splitHorizontal.label",
+      },
+      {
+        id: "equalizePanes",
+        labelKey: "settings.shortcuts.items.equalizePanes.label",
+      },
+      {
+        id: "closeTab",
+        labelKey: "settings.shortcuts.items.closeTab.label",
+      },
+      {
+        id: "closeEmptyPane",
+        labelKey: "settings.shortcuts.items.closeEmptyPane.label",
+        descriptionKey: "settings.shortcuts.items.closeEmptyPane.description",
+      },
+    ],
+  },
+  {
+    titleKey: "settings.shortcuts.groups.rightPanel",
+    items: [
+      {
+        id: "toggleTodos",
+        labelKey: "settings.shortcuts.items.toggleTodos.label",
+      },
+      {
+        id: "toggleCommits",
+        labelKey: "settings.shortcuts.items.toggleCommits.label",
+      },
+      {
+        id: "toggleStaged",
+        labelKey: "settings.shortcuts.items.toggleStaged.label",
+      },
+      {
+        id: "togglePrs",
+        labelKey: "settings.shortcuts.items.togglePrs.label",
+      },
+      {
+        id: "toggleFiles",
+        labelKey: "settings.shortcuts.items.toggleFiles.label",
+      },
+    ],
+  },
+  {
+    titleKey: "settings.shortcuts.groups.terminal",
+    items: [
+      {
+        id: "clearTerminal",
+        labelKey: "settings.shortcuts.items.clearTerminal.label",
+      },
+      {
+        id: "toggleMultiInput",
+        labelKey: "settings.shortcuts.items.toggleMultiInput.label",
+      },
+      {
+        id: "reloadShellEnv",
+        labelKey: "settings.shortcuts.items.reloadShellEnv.label",
+      },
+    ],
+  },
+  {
+    titleKey: "settings.shortcuts.groups.view",
+    items: [
+      {
+        id: "uiScaleDown",
+        labelKey: "settings.shortcuts.items.uiScaleDown.label",
+      },
+      {
+        id: "uiScaleUp",
+        labelKey: "settings.shortcuts.items.uiScaleUp.label",
+      },
+      {
+        id: "uiScaleReset",
+        labelKey: "settings.shortcuts.items.uiScaleReset.label",
+      },
+    ],
+  },
+];
 
 function st(t: SettingsTranslator, key: TranslationKey): string {
   return t(key);
@@ -199,6 +372,8 @@ export function SettingsModal() {
             <EditorSettings />
           ) : tab === "notifications" ? (
             <NotificationSettings />
+          ) : tab === "shortcuts" ? (
+            <ShortcutsSettings />
           ) : tab === "storage" ? (
             <StorageSettings />
           ) : tab === "experiments" ? (
@@ -1692,6 +1867,54 @@ function ExperimentsSettings() {
         label={st(t, "settings.experiments.resumeModal.label")}
         description={st(t, "settings.experiments.resumeModal.description")}
       />
+    </section>
+  );
+}
+
+function ShortcutsSettings() {
+  const t = useTranslation();
+
+  return (
+    <section className="space-y-4">
+      <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] leading-snug text-fg-muted">
+        <Sparkles size={11} className="mr-1 inline align-text-bottom text-warning" />
+        {st(t, "settings.shortcuts.editingSoon")}
+      </div>
+      <div className="space-y-3">
+        {SHORTCUT_GROUPS.map((group) => (
+          <section
+            key={group.titleKey}
+            className="rounded-md border border-border bg-bg"
+          >
+            <div className="flex items-center gap-1.5 border-b border-border px-3 py-2 text-[11px] font-medium uppercase text-fg-muted">
+              <Keyboard size={11} />
+              {st(t, group.titleKey)}
+            </div>
+            <div className="divide-y divide-border">
+              {group.items.map((item) => (
+                <div
+                  key={item.id}
+                  className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <div className="text-xs font-medium text-fg">
+                      {st(t, item.labelKey)}
+                    </div>
+                    {item.descriptionKey ? (
+                      <div className="mt-0.5 text-[11px] leading-snug text-fg-muted">
+                        {st(t, item.descriptionKey)}
+                      </div>
+                    ) : null}
+                  </div>
+                  <kbd className="rounded border border-border bg-bg-elevated px-1.5 py-0.5 font-mono text-[11px] leading-5 text-fg">
+                    {formatHotkey(Hotkeys[item.id])}
+                  </kbd>
+                </div>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
     </section>
   );
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -12,6 +12,7 @@
       "github": "GitHub",
       "editor": "Editor",
       "notifications": "Notifications",
+      "shortcuts": "Shortcuts",
       "storage": "Storage",
       "experiments": "Experiments",
       "about": "About"
@@ -277,6 +278,113 @@
         }
       },
       "permissionHint": "macOS may ask once for permission the first time a notification fires."
+    },
+    "shortcuts": {
+      "editingSoon": "Shortcut editing is coming soon.",
+      "groups": {
+        "general": "General",
+        "navigation": "Navigation",
+        "layout": "Layout",
+        "rightPanel": "Right panel",
+        "terminal": "Terminal",
+        "view": "View"
+      },
+      "items": {
+        "openPalette": {
+          "label": "Open command palette"
+        },
+        "openSettings": {
+          "label": "Open settings"
+        },
+        "newSession": {
+          "label": "New session"
+        },
+        "newIsolatedSession": {
+          "label": "New isolated session"
+        },
+        "newControlSession": {
+          "label": "New control session"
+        },
+        "addProject": {
+          "label": "Add project"
+        },
+        "focusSidebar": {
+          "label": "Focus sidebar"
+        },
+        "focusMain": {
+          "label": "Focus main area"
+        },
+        "focusRight": {
+          "label": "Focus right panel"
+        },
+        "nextTab": {
+          "label": "Next tab"
+        },
+        "prevTab": {
+          "label": "Previous tab"
+        },
+        "nextProject": {
+          "label": "Next project"
+        },
+        "prevProject": {
+          "label": "Previous project"
+        },
+        "toggleSidebar": {
+          "label": "Toggle sidebar"
+        },
+        "toggleRightPanel": {
+          "label": "Toggle right panel"
+        },
+        "splitVertical": {
+          "label": "Split pane vertically"
+        },
+        "splitHorizontal": {
+          "label": "Split pane horizontally"
+        },
+        "equalizePanes": {
+          "label": "Equalize pane sizes"
+        },
+        "closeTab": {
+          "label": "Close focused tab"
+        },
+        "closeEmptyPane": {
+          "label": "Close empty pane",
+          "description": "Only works when the focused pane has no tabs."
+        },
+        "toggleTodos": {
+          "label": "Show todos"
+        },
+        "toggleCommits": {
+          "label": "Show commits"
+        },
+        "toggleStaged": {
+          "label": "Show staged changes"
+        },
+        "togglePrs": {
+          "label": "Show pull requests"
+        },
+        "toggleFiles": {
+          "label": "Show files"
+        },
+        "clearTerminal": {
+          "label": "Clear terminal"
+        },
+        "toggleMultiInput": {
+          "label": "Toggle multi-input"
+        },
+        "reloadShellEnv": {
+          "label": "Reload shell environment"
+        },
+        "uiScaleDown": {
+          "label": "Decrease UI scale"
+        },
+        "uiScaleUp": {
+          "label": "Increase UI scale"
+        },
+        "uiScaleReset": {
+          "label": "Reset UI scale"
+        }
+      }
     },
     "agents": {
       "intro": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -12,6 +12,7 @@
       "github": "GitHub",
       "editor": "편집기",
       "notifications": "알림",
+      "shortcuts": "단축키",
       "storage": "저장 공간",
       "experiments": "실험 기능",
       "about": "정보"
@@ -277,6 +278,113 @@
         }
       },
       "permissionHint": "처음 알림이 발생할 때 macOS가 한 번 권한을 요청할 수 있습니다."
+    },
+    "shortcuts": {
+      "editingSoon": "단축키 편집 기능은 준비 중이다.",
+      "groups": {
+        "general": "일반",
+        "navigation": "이동",
+        "layout": "레이아웃",
+        "rightPanel": "오른쪽 패널",
+        "terminal": "터미널",
+        "view": "보기"
+      },
+      "items": {
+        "openPalette": {
+          "label": "명령 팔레트 열기"
+        },
+        "openSettings": {
+          "label": "설정 열기"
+        },
+        "newSession": {
+          "label": "새 세션"
+        },
+        "newIsolatedSession": {
+          "label": "새 격리 세션"
+        },
+        "newControlSession": {
+          "label": "새 컨트롤 세션"
+        },
+        "addProject": {
+          "label": "프로젝트 추가"
+        },
+        "focusSidebar": {
+          "label": "사이드바로 포커스 이동"
+        },
+        "focusMain": {
+          "label": "메인 영역으로 포커스 이동"
+        },
+        "focusRight": {
+          "label": "오른쪽 패널로 포커스 이동"
+        },
+        "nextTab": {
+          "label": "다음 탭"
+        },
+        "prevTab": {
+          "label": "이전 탭"
+        },
+        "nextProject": {
+          "label": "다음 프로젝트"
+        },
+        "prevProject": {
+          "label": "이전 프로젝트"
+        },
+        "toggleSidebar": {
+          "label": "사이드바 열기/닫기"
+        },
+        "toggleRightPanel": {
+          "label": "오른쪽 패널 열기/닫기"
+        },
+        "splitVertical": {
+          "label": "Pane 세로 분할"
+        },
+        "splitHorizontal": {
+          "label": "Pane 가로 분할"
+        },
+        "equalizePanes": {
+          "label": "Pane 크기 균등화"
+        },
+        "closeTab": {
+          "label": "포커스된 탭 닫기"
+        },
+        "closeEmptyPane": {
+          "label": "빈 Pane 닫기",
+          "description": "포커스된 Pane에 탭이 없을 때만 작동합니다."
+        },
+        "toggleTodos": {
+          "label": "Todos 보기"
+        },
+        "toggleCommits": {
+          "label": "Commits 보기"
+        },
+        "toggleStaged": {
+          "label": "Staged 변경 보기"
+        },
+        "togglePrs": {
+          "label": "Pull requests 보기"
+        },
+        "toggleFiles": {
+          "label": "Files 보기"
+        },
+        "clearTerminal": {
+          "label": "터미널 지우기"
+        },
+        "toggleMultiInput": {
+          "label": "다중 입력 켜기/끄기"
+        },
+        "reloadShellEnv": {
+          "label": "셸 환경 다시 불러오기"
+        },
+        "uiScaleDown": {
+          "label": "UI 배율 줄이기"
+        },
+        "uiScaleUp": {
+          "label": "UI 배율 키우기"
+        },
+        "uiScaleReset": {
+          "label": "UI 배율 초기화"
+        }
+      }
     },
     "agents": {
       "intro": {


### PR DESCRIPTION
## Summary
Adds a Settings surface for discovering Acorn keyboard shortcuts while editing support is still pending.

1. **Shortcuts tab:** Adds Settings -> Shortcuts with grouped shortcut hints for general actions, navigation, layout, right panel, terminal, and view controls.
2. **Platform-aware labels:** Renders every shortcut from the existing `Hotkeys` constants through `formatHotkey`, so macOS and non-macOS labels stay consistent with app behavior.
3. **Localized copy:** Adds English and Korean strings, including the top notice that shortcut editing is coming soon.
4. **Coverage:** Extends SettingsModal tests to assert the new tab, notice, and representative shortcut hints render.

## Expected impact

| Area | Impact |
| --- | --- |
| User-visible behavior | Users can discover current keyboard shortcuts from Settings. |
| Reliability | Shortcut display is tied to the existing hotkey constants instead of duplicating raw keybindings in UI copy. |
| Build/test | No expected runtime or build-speed impact. |

## Design notes

The new tab mirrors the Experiments notice treatment for the "editing coming soon" state, but keeps the shortcut list read-only. Shortcut groups live next to the Settings modal because the list is presentation metadata over the existing `Hotkeys` registry, not a new settings domain yet.

## Follow-up (not in this PR)

Add editable keybindings once the settings model supports persistence, conflict detection, and reset behavior.

## Test plan

- [x] `pnpm exec vitest run src/components/SettingsModal.test.tsx src/lib/hotkeys.test.ts` - 2 files passed, 18 tests passed.
- [x] `pnpm run typecheck` - passed.

## Notes

Self-review found no blocking issues. Vite-only browser smoke was not used as a pass/fail signal because this app expects the Tauri runtime; without it, existing `invoke` / event-listener calls fail before the Settings UI can be exercised.