### PR TITLE
fix(terminal): stabilize Codex image paste fallback

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -34,7 +34,10 @@ import {
   shouldRestoreScrollback,
   stripRestoreMarkers,
 } from "../lib/terminalScrollback";
-import { terminalPasteAction } from "../lib/terminalPaste";
+import {
+  hasClipboardFilePayload,
+  terminalPasteAction,
+} from "../lib/terminalPaste";
 import {
   useSettings,
   type TerminalCursorStyle,
@@ -57,6 +60,7 @@ interface TerminalProps {
   sessionId: string;
   cwd: string;
   agentProvider?: SessionAgentProvider | null;
+  pasteAgentProvider?: SessionAgentProvider | null;
   /**
    * When the terminal is hidden behind another tab in the same pane and then
    * made visible again, the DOM renderer can leave the rows blank because it
@@ -470,6 +474,7 @@ export function Terminal({
   sessionId,
   cwd,
   agentProvider = null,
+  pasteAgentProvider = null,
   isActive = true,
   isFocusedPane = true,
 }: TerminalProps): ReactElement {
@@ -477,10 +482,16 @@ export function Terminal({
   const termRef = useRef<XTerm | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const fitTerminalRef = useRef<(() => void) | null>(null);
+  const pasteAgentProviderRef =
+    useRef<SessionAgentProvider | null>(pasteAgentProvider);
   const [linkTooltip, setLinkTooltip] = useState<{
     anchorRect: TooltipAnchorRect;
   } | null>(null);
   const [isScrolledBack, setIsScrolledBack] = useState(false);
+
+  useEffect(() => {
+    pasteAgentProviderRef.current = pasteAgentProvider;
+  }, [pasteAgentProvider]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -632,14 +643,15 @@ export function Terminal({
     let agentProbeTimer: number | null = null;
     let restoredDiskScrollback = false;
     let daemonSessionAliveAtMount = false;
-    let codexImagePasteActive = false;
+    let codexImagePasteActive = pasteAgentProviderRef.current === "codex";
 
     const refreshAgentDetection = () => {
       void api
         .detectSessionAgent(sessionId)
         .then((agent) => {
           if (disposed) return;
-          codexImagePasteActive = Boolean(agent.codex);
+          codexImagePasteActive =
+            pasteAgentProviderRef.current === "codex" || Boolean(agent.codex);
         })
         .catch((err: unknown) => {
           console.debug("[Terminal] agent detection failed", err);
@@ -1254,11 +1266,13 @@ export function Terminal({
     const onPaste = (e: Event) => {
       const ev = e as ClipboardEvent;
       const cd = ev.clipboardData;
+      if (!cd) return;
       const text = cd?.getData("text/plain") ?? "";
       const action = terminalPasteAction({
         text,
-        fileCount: cd?.files?.length ?? 0,
-        codexActive: codexImagePasteActive,
+        hasFilePayload: hasClipboardFilePayload(cd),
+        codexActive:
+          codexImagePasteActive || pasteAgentProviderRef.current === "codex",
       });
       if (action.kind === "native") return;
       if (action.kind === "pasteText") term.paste(action.text);

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -99,6 +99,7 @@ function PortaledTerminal({ session }: { session: Session }) {
       sessionId={session.id}
       cwd={session.worktree_path}
       agentProvider={resolveSessionAgentProvider(session)}
+      pasteAgentProvider={session.agent_provider ?? null}
       isActive={visiblePaneId !== null}
       isFocusedPane={isFocusedPane}
     />,

--- a/src/lib/terminalPaste.test.ts
+++ b/src/lib/terminalPaste.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   CODEX_IMAGE_PASTE_CONTROL,
+  hasClipboardFilePayload,
   terminalPasteAction,
 } from "./terminalPaste";
 
@@ -9,7 +10,7 @@ describe("terminalPasteAction", () => {
     expect(
       terminalPasteAction({
         text: "",
-        fileCount: 1,
+        hasFilePayload: true,
         codexActive: true,
       }),
     ).toEqual({ kind: "send", data: CODEX_IMAGE_PASTE_CONTROL });
@@ -19,7 +20,7 @@ describe("terminalPasteAction", () => {
     expect(
       terminalPasteAction({
         text: "",
-        fileCount: 1,
+        hasFilePayload: true,
         codexActive: false,
       }),
     ).toEqual({ kind: "native" });
@@ -29,9 +30,44 @@ describe("terminalPasteAction", () => {
     expect(
       terminalPasteAction({
         text: "hello",
-        fileCount: 1,
+        hasFilePayload: true,
         codexActive: true,
       }),
     ).toEqual({ kind: "pasteText", text: "hello" });
+  });
+});
+
+describe("hasClipboardFilePayload", () => {
+  it("accepts file payloads exposed through files", () => {
+    expect(hasClipboardFilePayload({ files: { length: 1 } })).toBe(true);
+  });
+
+  it("accepts image payloads exposed only through clipboard items", () => {
+    expect(
+      hasClipboardFilePayload({
+        files: { length: 0 },
+        items: { length: 1, 0: { kind: "string", type: "image/png" } },
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts image payloads exposed only through clipboard types", () => {
+    expect(
+      hasClipboardFilePayload({
+        files: { length: 0 },
+        items: { length: 0 },
+        types: { length: 1, 0: "image/tiff" },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects plain text clipboard payloads", () => {
+    expect(
+      hasClipboardFilePayload({
+        files: { length: 0 },
+        items: { length: 1, 0: { kind: "string", type: "text/plain" } },
+        types: { length: 1, 0: "text/plain" },
+      }),
+    ).toBe(false);
   });
 });

--- a/src/lib/terminalPaste.ts
+++ b/src/lib/terminalPaste.ts
@@ -2,8 +2,25 @@ export const CODEX_IMAGE_PASTE_CONTROL = "\x16";
 
 type TerminalPasteInput = {
   text: string;
-  fileCount: number;
+  hasFilePayload: boolean;
   codexActive: boolean;
+};
+
+type ClipboardFilePayloadInput = {
+  files?: { length: number } | null;
+  items?: {
+    length: number;
+    [index: number]: ClipboardItemLike | undefined;
+  } | null;
+  types?:
+    | { length: number; [index: number]: string | undefined }
+    | readonly string[]
+    | null;
+};
+
+type ClipboardItemLike = {
+  kind?: string;
+  type?: string;
 };
 
 export type TerminalPasteAction =
@@ -12,15 +29,42 @@ export type TerminalPasteAction =
   | { kind: "send"; data: string }
   | { kind: "handled" };
 
+export function hasClipboardFilePayload(
+  data: ClipboardFilePayloadInput | null | undefined,
+): boolean {
+  if (!data) return false;
+  if ((data.files?.length ?? 0) > 0) return true;
+
+  const items = data.items;
+  if (items) {
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item?.kind === "file" || item?.type?.startsWith("image/")) {
+        return true;
+      }
+    }
+  }
+
+  const types = data.types;
+  if (types) {
+    for (let i = 0; i < types.length; i++) {
+      const type = types[i];
+      if (type === "Files" || type?.startsWith("image/")) return true;
+    }
+  }
+
+  return false;
+}
+
 export function terminalPasteAction({
   text,
-  fileCount,
+  hasFilePayload,
   codexActive,
 }: TerminalPasteInput): TerminalPasteAction {
   if (text) {
     return { kind: "pasteText", text };
   }
-  if (fileCount > 0) {
+  if (hasFilePayload) {
     return codexActive
       ? { kind: "send", data: CODEX_IMAGE_PASTE_CONTROL }
       : { kind: "native" };


### PR DESCRIPTION
## Summary

This fixes intermittent Codex image paste failures in terminal sessions by making the paste path less dependent on one clipboard shape and one timing-sensitive agent probe.

1. **Broader clipboard detection:** Treat file/image clipboard payloads as present when WKWebView exposes them through `files`, `items`, or `types`, instead of only `files.length`.
2. **Codex paste fallback:** Let terminals explicitly marked with `agent_provider: "codex"` use the Codex Ctrl+V image-attachment path before async process detection has completed.
3. **Focused regression coverage:** Cover file, image-item, image-type, and plain-text clipboard shapes in `terminalPaste` tests.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Codex image paste | Image-only Cmd+V should route to Codex more consistently, including immediately after a Codex session is opened or focused. |
| Non-Codex terminals | Image-only paste keeps the native path unless the session is explicitly marked Codex or live Codex detection succeeds. |
| Text paste | Text paste behavior is unchanged and still goes through xterm bracketed paste handling. |

## Design notes

- The paste decision now receives a precomputed `hasFilePayload` boolean so browser/WebKit clipboard quirks stay isolated in `terminalPaste`.
- `TerminalHost` passes the raw persisted `session.agent_provider` separately from the display-oriented resolved provider. That avoids treating a name-inferred Codex label as enough to send image paste down the Codex Ctrl+V path.
- Live process detection remains authoritative for manually launched Codex sessions; the explicit provider path only removes the initial detection race for known Codex sessions.

## Test plan

- [x] `pnpm exec vitest run src/lib/terminalPaste.test.ts` — 7 tests passed.
- [x] `pnpm run typecheck` — passed.
- [x] `git diff --check` — passed.

## Notes

Self-review found one over-broad fallback risk in the initial implementation: display/name-inferred Codex sessions could have used the Codex image paste path before process detection. This PR narrows the fallback to the raw persisted `agent_provider` while keeping live detection for manually launched Codex.
