### PR TITLE
fix(worktree): randomize isolated worktree names

### DIFF
--- a/src/lib/sessionName.test.ts
+++ b/src/lib/sessionName.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Session } from "./types";
 import { suggestLocalSessionName, suggestSessionName } from "./sessionName";
 
@@ -16,6 +16,18 @@ function session(name: string): Session {
     last_message: null,
   } as Session;
 }
+
+function mockRandomUuid(...uuids: ReturnType<Crypto["randomUUID"]>[]) {
+  const spy = vi.spyOn(crypto, "randomUUID");
+  for (const uuid of uuids) {
+    spy.mockReturnValueOnce(uuid);
+  }
+  return spy;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("suggestSessionName", () => {
   it("uses repo basename for a fresh regular session", () => {
@@ -38,36 +50,42 @@ describe("suggestSessionName", () => {
     );
   });
 
-  // Regression: isolated sessions used to inherit the same naming as regular
-  // ones (`acorn`), which collided with the existing `acorn` branch the
-  // moment libgit2 tried to auto-create a worktree branch — see
-  // `create_unique_worktree` in src-tauri/src/commands.rs.
-  it("uses `{repo}-worktree-{n}` for the first isolated session", () => {
+  it("uses `{repo}-worktree-{random}` for isolated sessions", () => {
+    mockRandomUuid("a3f5527e-9c10-4000-8000-000000000000");
+
     expect(suggestSessionName("/Users/x/acorn", [], "regular", true)).toBe(
-      "acorn-worktree-1",
+      "acorn-worktree-a3f5527e9c10",
     );
   });
 
-  it("bumps the worktree suffix on collision for isolated sessions", () => {
-    const existing = [session("acorn-worktree-1"), session("acorn-worktree-2")];
+  it("retries on random-name collision for isolated sessions", () => {
+    mockRandomUuid(
+      "a3f5527e-9c10-4000-8000-000000000000",
+      "b4c66311-2d21-4000-8000-000000000000",
+    );
+    const existing = [session("acorn-worktree-a3f5527e9c10")];
+
     expect(suggestSessionName("/Users/x/acorn", existing, "regular", true)).toBe(
-      "acorn-worktree-3",
+      "acorn-worktree-b4c663112d21",
     );
   });
 
   it("isolated naming ignores regular-session collisions in the same repo", () => {
-    // A regular session named `acorn` should not consume the
-    // `acorn-worktree-1` slot — the two namespaces are independent.
+    mockRandomUuid("a3f5527e-9c10-4000-8000-000000000000");
+    // A regular session named `acorn` should not consume the isolated
+    // worktree namespace.
     const existing = [session("acorn"), session("acorn-2")];
     expect(suggestSessionName("/Users/x/acorn", existing, "regular", true)).toBe(
-      "acorn-worktree-1",
+      "acorn-worktree-a3f5527e9c10",
     );
   });
 
   it("strips trailing separators when computing basename", () => {
+    mockRandomUuid("a3f5527e-9c10-4000-8000-000000000000");
+
     expect(suggestSessionName("/Users/x/acorn/", [])).toBe("acorn");
     expect(suggestSessionName("/Users/x/acorn/", [], "regular", true)).toBe(
-      "acorn-worktree-1",
+      "acorn-worktree-a3f5527e9c10",
     );
   });
 });

--- a/src/lib/sessionName.ts
+++ b/src/lib/sessionName.ts
@@ -7,17 +7,17 @@ function basename(path: string): string {
 /**
  * Pick a session name that doesn't collide with any name in `existing`.
  *
- * Isolated sessions follow a `{repo}-worktree-{n}` convention (n starts at 1)
- * because each one maps to a linked git worktree at
- * `.acorn/worktrees/<name>/`, and matching the directory grouping in the
- * sidebar makes "which worktree is this?" obvious. Control sessions get a
- * `control-` prefix so they sort into their own namespace. Regular sessions
- * use the bare repo basename and only get a numeric suffix on collision.
+ * Isolated sessions follow a `{repo}-worktree-{random}` convention because
+ * each one maps to a linked git worktree at `.acorn/worktrees/<name>/`.
+ * Avoiding sequential names keeps old agent transcripts from appearing to
+ * point at a newly-created worktree that happened to reuse the same path.
+ * Control sessions get a `control-` prefix so they sort into their own
+ * namespace. Regular sessions use the bare repo basename and only get a
+ * numeric suffix on collision.
  *
- * The numeric suffix is purely a frontend-side hint — the Rust backend's
- * `create_unique_worktree` still re-suffixes on its own if the candidate
- * collides with an existing branch or worktree, so a stale state where the
- * frontend's `existing` snapshot lags reality still produces a valid result.
+ * The generated isolated name is still only a candidate; the Rust backend's
+ * `create_unique_worktree` re-suffixes on its own if it collides with an
+ * existing branch or worktree.
  */
 export function suggestSessionName(
   repoPath: string,
@@ -28,9 +28,14 @@ export function suggestSessionName(
   const taken = new Set(existing.map((s) => s.name));
   if (isolated) {
     const base = `${basename(repoPath)}-worktree`;
-    let n = 1;
-    while (taken.has(`${base}-${n}`)) n++;
-    return `${base}-${n}`;
+    let candidate = `${base}-${randomWorktreeSuffix()}`;
+    for (let attempts = 0; attempts < 100; attempts++) {
+      if (!taken.has(candidate)) return candidate;
+      candidate = `${base}-${randomWorktreeSuffix()}`;
+    }
+    let n = 2;
+    while (taken.has(`${candidate}-${n}`)) n++;
+    return `${candidate}-${n}`;
   }
   const base =
     kind === "control"
@@ -53,4 +58,23 @@ export function suggestLocalSessionName(existing: Session[]): string {
     candidate = `${base}-${n++}`;
   }
   return candidate;
+}
+
+function randomWorktreeSuffix(): string {
+  const webCrypto = globalThis.crypto;
+  if (typeof webCrypto?.randomUUID === "function") {
+    return webCrypto.randomUUID().replace(/-/g, "").slice(0, 12);
+  }
+
+  const bytes = new Uint8Array(6);
+  if (webCrypto) {
+    webCrypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
 }


### PR DESCRIPTION

## Summary

Acorn isolated sessions now get random worktree names so old agent history cannot look attached to a newly reused sequential path.

1. **Random worktree naming** — changes isolated session suggestions from `{repo}-worktree-{n}` to `{repo}-worktree-{12-hex}` using Web Crypto when available.
2. **Collision handling** — retries generated names against loaded sessions, with backend `create_unique_worktree` still handling branch/path collisions.
3. **Tests** — updates session naming tests and keeps session creation policy covered.

## Expected impact

| Area | Impact |
| --- | --- |
| Agent History | Reduces false-positive active worktree indicators caused by sequential path reuse. |
| Session creation | Isolated session names become less predictable but remain readable and repo-scoped. |
| Existing sessions | No migration; existing names/history remain unchanged. |

## Design notes

- The UI-generated session name remains the worktree path candidate under `.acorn/worktrees/`; backend sanitization and suffixing still provide final safety.
- Uses `crypto.randomUUID()` when available and falls back to random bytes, preserving browser/Tauri compatibility.

## Test plan

- [x] `pnpm exec vitest run src/lib/sessionCreation.test.ts src/lib/sessionName.test.ts` — 2 files / 15 tests passed.
- [x] `pnpm run typecheck` — passed.
- [x] `git diff --check` — passed.

## Notes

- Self-review: no blocking findings.
- This intentionally affects newly-created isolated Acorn sessions only; existing History records and worktree paths are not rewritten.
