### PR TITLE
feat(viewer): markdown preview toggle for file viewer

### DIFF
--- a/src/components/CodeDiffVirtualization.test.tsx
+++ b/src/components/CodeDiffVirtualization.test.tsx
@@ -20,6 +20,10 @@ vi.mock("../lib/api", () => ({
   },
 }));
 
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(async () => undefined),
+}));
+
 import { api } from "../lib/api";
 import { CodeViewer } from "./CodeViewer";
 import { DiffView } from "./DiffView";
@@ -123,6 +127,40 @@ describe("virtualized code and diff rendering", () => {
     expect(renderedLines.length).toBeGreaterThan(0);
     expect(renderedLines.length).toBeLessThan(lineCount);
     expect(container.textContent).toContain("const line0 = 0;");
+    expect(container.querySelector('button[aria-pressed="false"]')).toBeNull();
+  });
+
+  it("toggles markdown files between source and preview", async () => {
+    const content = "# Title\n\n- [x] shipped";
+    vi.mocked(api.fsReadFile).mockResolvedValueOnce({
+      content,
+      size: content.length,
+      truncated: false,
+      binary: false,
+    });
+    vi.mocked(api.fsGitDiffLines).mockResolvedValueOnce([]);
+
+    await act(async () => {
+      root.render(<CodeViewer path="/repo/README.md" isActive />);
+    });
+    await flushPromises();
+
+    expect(container.querySelector("h1")).toBeNull();
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[aria-pressed="false"]',
+    );
+    expect(toggle?.textContent).toContain("Preview");
+
+    await act(async () => {
+      toggle?.click();
+    });
+
+    expect(container.querySelector("h1")?.textContent).toBe("Title");
+    expect(container.querySelector("pre")).toBeNull();
+    expect(
+      container.querySelector<HTMLButtonElement>('button[aria-pressed="true"]')
+        ?.textContent,
+    ).toContain("Source");
   });
 
   it("copies selected text by source line in virtualized lists", () => {

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { Code2, Eye } from "lucide-react";
 import {
   api,
   type FsLineDiffEntry,
@@ -13,6 +14,7 @@ import {
   lineTextContentProps,
   VirtualizedLineList,
 } from "./VirtualizedLines";
+import { Markdown } from "./ui/Markdown";
 
 interface CodeViewerProps {
   path: string;
@@ -40,11 +42,17 @@ const DIFF_KIND_CLASS: Record<FsLineDiffEntry["kind"], string> = {
 };
 
 const CODE_LINE_HEIGHT = 18;
+const MARKDOWN_EXT_RE = /\.(md|mdown|markdown|mdx)$/i;
+
+function isMarkdownPath(path: string): boolean {
+  return MARKDOWN_EXT_RE.test(path);
+}
 
 export function CodeViewer({ path, isActive }: CodeViewerProps) {
   const t = useTranslation();
   const [state, setState] = useState<ViewerState>(EMPTY_STATE);
   const [diffLines, setDiffLines] = useState<FsLineDiffEntry[]>([]);
+  const [previewMarkdown, setPreviewMarkdown] = useState(false);
 
   const refreshDiff = useCallback(async () => {
     try {
@@ -58,6 +66,7 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
   useEffect(() => {
     let cancelled = false;
     setState(EMPTY_STATE);
+    setPreviewMarkdown(false);
     api
       .fsReadFile(path)
       .then(async (data) => {
@@ -144,11 +153,12 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
   if (!state.data) return null;
 
   const lines = state.highlightedLines ?? plainHighlightedLines;
+  const canPreviewMarkdown = isMarkdownPath(path);
 
   return (
     <div
       className={cn(
-        "flex h-full w-full flex-col bg-bg",
+        "relative flex h-full w-full flex-col bg-bg",
         isActive ? "" : "pointer-events-none opacity-50",
       )}
     >
@@ -157,24 +167,46 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
           {t("codeViewer.truncated")}
         </div>
       ) : null}
-      <VirtualizedLineList
-        as="pre"
-        count={sourceLines.length}
-        className="acorn-selectable m-0 flex-1 cursor-text overflow-auto bg-transparent font-mono text-[12px] leading-[1.5] text-fg"
-        estimateSize={() => CODE_LINE_HEIGHT}
-        getLineText={(index) => sourceLines[index] ?? ""}
-        minWidthCh={minWidthCh}
-        renderLine={(index) => (
-          <CodeLine
-            key={index}
-            index={index}
-            rawText={sourceLines[index] ?? ""}
-            tokens={lines[index] ?? null}
-            diff={diffByLine.get(index + 1)}
-            gutterWidth={gutterWidth}
+      {previewMarkdown && canPreviewMarkdown ? (
+        <div className="acorn-selectable min-h-0 flex-1 overflow-auto px-8 py-6 pb-16">
+          <Markdown
+            content={state.data.content}
+            className="mx-auto max-w-3xl text-[13px] leading-6"
           />
-        )}
-      />
+        </div>
+      ) : (
+        <VirtualizedLineList
+          as="pre"
+          count={sourceLines.length}
+          className="acorn-selectable m-0 flex-1 cursor-text overflow-auto bg-transparent pb-12 font-mono text-[12px] leading-[1.5] text-fg"
+          estimateSize={() => CODE_LINE_HEIGHT}
+          getLineText={(index) => sourceLines[index] ?? ""}
+          minWidthCh={minWidthCh}
+          renderLine={(index) => (
+            <CodeLine
+              key={index}
+              index={index}
+              rawText={sourceLines[index] ?? ""}
+              tokens={lines[index] ?? null}
+              diff={diffByLine.get(index + 1)}
+              gutterWidth={gutterWidth}
+            />
+          )}
+        />
+      )}
+      {canPreviewMarkdown ? (
+        <button
+          type="button"
+          aria-pressed={previewMarkdown}
+          onClick={() => setPreviewMarkdown((v) => !v)}
+          className="absolute bottom-3 right-3 z-20 inline-flex items-center gap-1.5 rounded-md border border-border bg-bg-elevated/95 px-2.5 py-1.5 text-[11px] text-fg-muted shadow-lg backdrop-blur transition hover:bg-bg-sidebar hover:text-fg focus:outline-none focus:ring-2 focus:ring-accent/60"
+        >
+          {previewMarkdown ? <Code2 size={13} /> : <Eye size={13} />}
+          {previewMarkdown
+            ? t("codeViewer.showSource")
+            : t("codeViewer.showPreview")}
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -557,7 +557,9 @@
     "loading": "Loading...",
     "binaryFile": "Binary file",
     "binaryFileBody": "{bytes} bytes - not shown in the readonly viewer.",
-    "truncated": "File truncated to 2 MB. Open externally to view the rest."
+    "truncated": "File truncated to 2 MB. Open externally to view the rest.",
+    "showPreview": "Preview",
+    "showSource": "Source"
   },
   "diffView": {
     "noChanges": "No changes in this diff.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -557,7 +557,9 @@
     "loading": "불러오는 중...",
     "binaryFile": "바이너리 파일",
     "binaryFileBody": "{bytes}바이트 - 읽기 전용 뷰어에 표시되지 않습니다.",
-    "truncated": "파일이 2 MB로 잘렸습니다. 나머지는 외부에서 열어 확인하세요."
+    "truncated": "파일이 2 MB로 잘렸습니다. 나머지는 외부에서 열어 확인하세요.",
+    "showPreview": "미리보기",
+    "showSource": "소스"
   },
   "diffView": {
     "noChanges": "이 diff에는 변경 사항이 없습니다.",

--- a/tests/e2e/file-explorer.spec.ts
+++ b/tests/e2e/file-explorer.spec.ts
@@ -89,4 +89,74 @@ test.describe("file explorer", () => {
       page.getByRole("button", { name: "App.tsx", exact: true }),
     ).toBeVisible();
   });
+
+  test("previews markdown files from a code viewer tab", async ({
+    page,
+    tauri,
+  }) => {
+    const repo = "/tmp/demo";
+
+    await tauri.respond("list_projects", [
+      {
+        repo_path: repo,
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", []);
+    await tauri.handle("fs_list_dir", (args) => {
+      const { path } = args as { path: string };
+      if (path !== "/tmp/demo") {
+        return { repo_root: "/tmp/demo", entries: [] };
+      }
+      return {
+        repo_root: "/tmp/demo",
+        entries: [
+          {
+            name: "README.md",
+            path: "/tmp/demo/README.md",
+            is_dir: false,
+            is_symlink: false,
+            size: 40,
+            modified_ms: 0,
+            gitignored: false,
+          },
+        ],
+      };
+    });
+    await tauri.handle("fs_read_file", (args) => {
+      const { path } = args as { path: string };
+      if (path !== "/tmp/demo/README.md") {
+        throw new Error(`unexpected path: ${path}`);
+      }
+      return {
+        content: "# Project notes\n\n- [x] Markdown preview",
+        size: 40,
+        truncated: false,
+        binary: false,
+      };
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Code" }).click();
+    await page.getByRole("button", { name: "Files", exact: true }).click();
+
+    await page.getByRole("button", { name: "README.md" }).dblclick();
+
+    await expect(
+      page.getByRole("button", { name: /README\.md Close tab/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Project notes" }),
+    ).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Preview" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Project notes" }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Source" })).toBeVisible();
+    await expect(page.getByText("Markdown preview")).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
Markdown files opened from the file viewer can now switch between source and rendered preview without leaving Acorn.

1. **Markdown-only preview toggle** — detect `.md`, `.mdown`, `.markdown`, and `.mdx` files in the readonly code viewer and show a bottom-right Preview/Source toggle only for those paths.
2. **Rendered preview mode** — reuse the existing sanitized Markdown renderer so headings, lists, task checkboxes, tables, and inline content render consistently with PR/comment markdown.
3. **Coverage for file-viewer workflow** — add unit and E2E coverage for Markdown preview behavior, including a guard that non-Markdown code files do not show the preview toggle.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Markdown file viewing | Source-only code viewer | Toggle between source and rendered preview |
| Non-Markdown file viewing | Source-only code viewer | Unchanged; no preview toggle shown |
| File explorer workflow | Double-click opens raw file tab | Double-click opens raw file tab with Markdown preview available when applicable |

## Design notes
- The feature stays inside `CodeViewer` so existing file-tab reuse, binary handling, truncation warnings, line virtualization, and diff gutter behavior remain unchanged for source mode.
- Preview eligibility is path-extension based and intentionally narrow: `.md`, `.mdown`, `.markdown`, and `.mdx`.
- Preview mode resets to Source when the opened path changes, avoiding accidental carryover between files.

## Follow-up (not in this PR)
- Add richer local-asset handling for relative Markdown image/link paths if the file viewer needs README-style asset resolution.
- Consider a persisted per-user default for Markdown preview mode if users consistently prefer rendered view.

## Test plan
- [x] `pnpm exec vitest run src/components/CodeDiffVirtualization.test.tsx src/components/ui/Markdown.test.tsx` — 2 files / 8 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec playwright test tests/e2e/file-explorer.spec.ts` — 2 tests passed

## Notes
- Playwright logs pre-existing mock-environment warnings for `load_status` and user theme loading during these file-explorer tests. The tests pass and the warnings are not caused by this PR.
