### PR TITLE
ci(release): trim tag-scoped cache saves + profile notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -91,8 +89,12 @@ jobs:
           workspaces: src-tauri
           # Per-target shared key (default key already factors in
           # Cargo.lock + rustc version). `cache-on-failure` lets the
-          # next run pick up partial progress when a build dies late.
+          # next run pick up partial progress when a non-tag build dies
+          # late. Release tag refs cannot restore caches created for
+          # sibling tags, so tag pushes restore only and avoid saving
+          # one-off caches that churn the repository's cache quota.
           shared-key: ${{ matrix.target }}
+          save-if: ${{ github.ref_type != 'tag' }}
           cache-on-failure: true
 
       # sccache backed by GitHub Actions cache. Speeds up COLD cargo
@@ -150,7 +152,7 @@ jobs:
           # GHA cache backend is reachable (see "Probe sccache GHA backend").
           CARGO_INCREMENTAL: "0"
         # `--profile release-ci` swaps fat LTO + codegen-units=1 for
-        # thin LTO + codegen-units=16 (defined in src-tauri/Cargo.toml).
+        # no LTO + codegen-units=32 (defined in src-tauri/Cargo.toml).
         # Output lands in target/<arch>/release-ci/ instead of release/.
         #
         # @tauri-apps/cli 2.10+ removed the top-level `--profile` flag and


### PR DESCRIPTION
## Summary
Release tag runs were paying cache-save cost for caches that later tag refs cannot restore, so this PR trims release post-job churn without changing build artifacts.

1. **Cargo cache save guard:** `Swatinem/rust-cache` still restores before the macOS Tauri build, but skips saving cache entries when the workflow ref is a tag.
2. **macOS pnpm cache trim:** macOS bundle jobs stop asking `actions/setup-node` to manage a tag-scoped pnpm cache that recent release runs were not reusing.
3. **Release profile note fix:** The `release-ci` comment now matches the actual Cargo profile: no LTO and `codegen-units = 32`.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Release post-job time | Tag release macOS jobs saved one-off Rust caches after each successful run. | Tag release macOS jobs restore only, avoiding cache-save work for sibling-tag-inaccessible entries. |
| Cache quota pressure | Recent tag releases accumulated duplicate Rust caches and pushed repo cache usage close to the default quota. | New tag releases stop adding those Rust cache entries. |
| macOS JS cache | Bundle jobs attempted setup-node pnpm cache management on tag refs. | Bundle jobs install JS deps without setup-node cache post-processing. |
| Release artifacts | No intended packaging or signing change. | Same Tauri build command, sidecar profile, DMGs, updater archives, and manifest flow. |

## Design notes

GitHub Actions cache scope allows a workflow to restore caches from the current ref and default branch, but not caches created for sibling tags. The release workflow is primarily triggered by version tag pushes, so saving a successful tag-run Cargo cache mostly creates a cache entry that future version tags cannot use.

The guard is intentionally `github.ref_type != 'tag'` rather than disabling saves globally. A manual `workflow_dispatch` run from `main` can still save a default-branch Rust cache if we want to warm a reusable cache explicitly.

## Test plan

- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml ok"'` parsed `release.yml` successfully.
- [x] `git diff --check`
- [x] Self-review of release cache scope and `workflow_dispatch` behavior.

## Notes

`actionlint` was not available locally, and `go` was also unavailable for an ad-hoc `go run` invocation. The Ruby command emitted pre-existing local gem extension warnings before printing `release.yml ok`; those warnings are not caused by this PR.