### PR TITLE
fix(terminal): preserve pill cursor after terminal switches

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,10 +31,10 @@
 }
 
 .acorn-terminal.acorn-terminal-composing .composition-view.active {
-  background: #000;
+  background: #000 !important;
   box-sizing: border-box;
   color: inherit;
-  overflow: hidden;
+  overflow: visible !important;
   white-space: pre;
 }
 
@@ -104,15 +104,8 @@
 }
 
 .acorn-terminal.acorn-terminal-cursor-pill .xterm-cursor::after {
-  background: var(--acorn-terminal-cursor-pill-color);
-  border-radius: 999px;
-  content: "";
-  display: block;
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 3px;
+  content: none;
+  display: none;
 }
 
 .acorn-terminal-inactive .xterm-cursor,

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -154,6 +154,57 @@ function syncCursorStyleClass(
   container.classList.add(`${CURSOR_STYLE_CLASS_PREFIX}${style}`);
 }
 
+function syncCursorPresentation(
+  container: HTMLElement,
+  style: TerminalCursorStyle,
+): void {
+  const cursor = container.querySelector<HTMLElement>(".xterm-cursor");
+  if (!cursor) return;
+  const setImportant = (name: string, value: string) => {
+    if (
+      cursor.style.getPropertyValue(name) === value &&
+      cursor.style.getPropertyPriority(name) === "important"
+    ) {
+      return;
+    }
+    cursor.style.setProperty(name, value, "important");
+  };
+  const removeProperty = (name: string) => {
+    if (!cursor.style.getPropertyValue(name)) return;
+    cursor.style.removeProperty(name);
+  };
+
+  if (style !== "pill") {
+    removeProperty("background-color");
+    removeProperty("border-color");
+    removeProperty("border-left-color");
+    removeProperty("border-left-style");
+    removeProperty("border-left-width");
+    removeProperty("border-radius");
+    removeProperty("outline");
+    removeProperty("width");
+    return;
+  }
+
+  const color =
+    getComputedStyle(container)
+      .getPropertyValue("--acorn-terminal-cursor-pill-color")
+      .trim() || "var(--color-accent, #7dd3fc)";
+  setImportant("background-color", color);
+  setImportant("border-left-width", "0");
+  setImportant("border-radius", "999px");
+  setImportant("outline", "0");
+  setImportant("width", "3px");
+}
+
+function syncCursorStyle(
+  container: HTMLElement,
+  style: TerminalCursorStyle,
+): void {
+  syncCursorStyleClass(container, style);
+  syncCursorPresentation(container, style);
+}
+
 // Custom event the sticky-prompt banner listens to. Fired whenever the user
 // scrolls the terminal so the banner can swap to the prompt "in scope" at
 // the top of the viewport, then revert to the JSONL-latest prompt when the
@@ -500,6 +551,7 @@ export function Terminal({
     // Snapshot terminal font preferences at mount; subsequent setting changes
     // are applied live via the subscription below.
     const initialSettings = useSettings.getState().settings;
+    let currentCursorStyle = initialSettings.terminal.cursorStyle;
     const term = new XTerm({
       theme: makeXtermTheme(
         terminalBackgroundActive(initialSettings.appearance.background),
@@ -600,7 +652,19 @@ export function Terminal({
     // PTY mid-composition. The canvas/webgl addons are faster but mis-handle
     // composition events on macOS/Linux IMEs — we pick correctness over fps.
     term.open(container);
-    syncCursorStyleClass(container, initialSettings.terminal.cursorStyle);
+    let cursorStyleFrame: number | null = null;
+    const applyCurrentCursorStyle = () => {
+      syncCursorStyle(container, currentCursorStyle);
+    };
+    const scheduleCursorStyleSync = () => {
+      if (cursorStyleFrame !== null) return;
+      cursorStyleFrame = requestAnimationFrame(() => {
+        cursorStyleFrame = null;
+        applyCurrentCursorStyle();
+      });
+    };
+    applyCurrentCursorStyle();
+    scheduleCursorStyleSync();
     const fitWithCellMeasurements = () => {
       const cjkEnabled =
         useSettings.getState().settings.experiments.cjkCellWidthHeuristic;
@@ -756,13 +820,16 @@ export function Terminal({
         }
       }
       if (next.cursorStyle !== previous.cursorStyle) {
+        currentCursorStyle = next.cursorStyle;
         term.options.cursorStyle = xtermCursorStyle(next.cursorStyle);
         term.options.cursorWidth = xtermCursorWidth(next.cursorStyle);
-        syncCursorStyleClass(container, next.cursorStyle);
+        applyCurrentCursorStyle();
+        scheduleCursorStyleSync();
         term.refresh(0, term.rows - 1);
       }
       if (state.settings.appearance.themeId !== prev.settings.appearance.themeId) {
         scheduleThemeRefresh();
+        scheduleCursorStyleSync();
       }
       const cjkNow = state.settings.experiments.cjkCellWidthHeuristic;
       const cjkPrev = prev.settings.experiments.cjkCellWidthHeuristic;
@@ -929,6 +996,10 @@ export function Terminal({
       const cell = getCellDims();
       container.classList.add(COMPOSING_CLASS);
       compositionView.textContent = text;
+      compositionView.style.backgroundColor = "#000";
+      compositionView.style.boxSizing = "border-box";
+      compositionView.style.overflow = "visible";
+      compositionView.style.whiteSpace = "pre";
       if (cell) {
         const buf = term.buffer.active;
         // xterm's visible cursor row = `baseY + cursorY - viewportY`
@@ -1384,7 +1455,10 @@ export function Terminal({
       compositionView.style.left = `${buf.cursorX * cell.width}px`;
       compositionView.style.top = `${cursorViewportY * cell.height}px`;
     };
-    const renderDisposable = term.onRender(repositionComposing);
+    const renderDisposable = term.onRender(() => {
+      scheduleCursorStyleSync();
+      repositionComposing();
+    });
     // PTY output that arrives while the user is mid-composition can scroll
     // the viewport or move the prompt to a new row without producing an
     // `onRender` event whose painted region overlaps the cursor cell — the
@@ -1978,6 +2052,10 @@ export function Terminal({
       }
       for (const off of unlistenFns) {
         try { off(); } catch { /* ignore */ }
+      }
+      if (cursorStyleFrame !== null) {
+        cancelAnimationFrame(cursorStyleFrame);
+        cursorStyleFrame = null;
       }
       invoke("pty_kill", { sessionId }).catch(() => {
         // Backend may not implement pty_kill yet — safe to ignore.

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -153,6 +153,13 @@ test.describe("terminal: IME (PR #104 regression)", () => {
   }) => {
     await seed(tauri);
     await activateTerminal(page);
+    await page.addStyleTag({
+      content: `
+        :root[data-acorn-theme="acorn-dark"] {
+          --color-accent: rgb(12, 34, 56);
+        }
+      `,
+    });
 
     await runIme(page, [
       { type: "keydown", key: "Process", keyCode: 229 },
@@ -174,6 +181,18 @@ test.describe("terminal: IME (PR #104 regression)", () => {
         compositionView.evaluate((el) => getComputedStyle(el).backgroundColor),
       )
       .toBe("rgb(0, 0, 0)");
+    await expect
+      .poll(async () =>
+        compositionView.evaluate((el) =>
+          getComputedStyle(el, "::after").backgroundColor,
+        ),
+      )
+      .toBe("rgb(12, 34, 56)");
+    await expect
+      .poll(async () =>
+        compositionView.evaluate((el) => getComputedStyle(el, "::after").width),
+      )
+      .toBe("3px");
 
     await runIme(page, [
       {

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -50,17 +50,115 @@ test.describe("terminal: spawn", () => {
 
     await expect
       .poll(async () =>
-        cursor.evaluate((el) => getComputedStyle(el, "::after").backgroundColor),
+        cursor.evaluate((el) => getComputedStyle(el).backgroundColor),
       )
       .toBe("rgb(12, 34, 56)");
     await expect
       .poll(async () =>
-        cursor.evaluate((el) => getComputedStyle(el, "::after").width),
+        cursor.evaluate((el) => getComputedStyle(el).width),
       )
       .toBe("3px");
     await expect
+      .poll(async () =>
+        cursor.evaluate((el) => getComputedStyle(el).borderRadius),
+      )
+      .toBe("999px");
+    await expect
+      .poll(async () =>
+        cursor.evaluate((el) => getComputedStyle(el, "::after").content),
+      )
+      .toBe("none");
+    await expect
       .poll(async () => cursor.evaluate((el) => getComputedStyle(el).outlineWidth))
       .toBe("0px");
+  });
+
+  test("pill cursor presentation survives switching terminals", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-alpha",
+        name: "alpha",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+      {
+        id: "s-beta",
+        name: "beta",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:01Z",
+        updated_at: "2026-01-01T00:00:06Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+
+    await page.goto("/");
+    await page.addStyleTag({
+      content: `
+        :root[data-acorn-theme="acorn-dark"] {
+          --color-accent: rgb(12, 34, 56);
+        }
+      `,
+    });
+
+    const activeCursor = page
+      .locator("[data-pane-body] .acorn-terminal .xterm-cursor")
+      .first();
+    const expectPill = async () => {
+      const textarea = page
+        .locator("[data-pane-body] .xterm-helper-textarea")
+        .first();
+      await textarea.waitFor({ state: "attached" });
+      await textarea.focus();
+      await textarea.evaluate((el) => el.blur());
+      await expect(activeCursor).toBeAttached();
+      await expect
+        .poll(async () =>
+          activeCursor.evaluate((el) => getComputedStyle(el).backgroundColor),
+        )
+        .toBe("rgb(12, 34, 56)");
+      await expect
+        .poll(async () =>
+          activeCursor.evaluate((el) => getComputedStyle(el).borderRadius),
+        )
+        .toBe("999px");
+      await expect
+        .poll(async () =>
+          activeCursor.evaluate((el) => getComputedStyle(el, "::after").content),
+        )
+        .toBe("none");
+    };
+
+    await page
+      .getByRole("button", { name: /^alpha main · Idle$/ })
+      .click();
+    await expectPill();
+
+    await page
+      .getByRole("button", { name: /^beta main · Idle$/ })
+      .click();
+    await expectPill();
   });
 
   test("activating a session calls pty_spawn with the session's cwd", async ({


### PR DESCRIPTION
## Summary

This fixes the default pill cursor losing its accent/rounded presentation when moving between terminal sessions.

1. **Pill cursor resync:** Reapply the pill cursor presentation after xterm render passes so newly attached or repainted terminal cursors keep the accent color, 3px width, and rounded shape.
2. **Single cursor source:** Remove the extra pill `::after` overlay and style the actual xterm cursor element directly, avoiding the double-cursor visual.
3. **IME preview parity:** Keep the IME composition background visible while allowing the composition caret to render as the configured pill cursor.
4. **Regression coverage:** Add e2e checks for default pill rendering, terminal switching, and IME composition cursor styling.

## Expected impact

| Area | Impact |
| --- | --- |
| Terminal UX | New and reselected terminal sessions keep the default pill cursor styling without requiring a settings toggle. |
| IME input | Composition preview keeps its dark background while the caret remains visible. |
| Rendering | Cursor presentation is resynced from xterm render events without observing the full terminal DOM. |

## Design notes

The previous CSS-only pill cursor depended on xterm leaving the cursor DOM styling untouched after initial mount. Switching sessions can cause xterm to recreate or repaint the cursor, which drops the Acorn-specific color/radius until the settings subscriber runs again. The fix applies the current cursor presentation after initial open, cursor-setting changes, theme changes, and xterm render passes.

The pill cursor now uses the real `.xterm-cursor` element rather than a pseudo-element overlay, so there is only one visible caret.

## Test plan

- [x] `pnpm exec tsc --noEmit` passed.
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts -g "pill cursor"` passed.
- [x] `pnpm exec playwright test tests/e2e/terminal-ime.spec.ts -g "active IME preview"` passed.
- [x] Manually checked in dev profile that switching terminals no longer requires toggling pill -> other -> pill.

## Notes

No pre-existing CI flakes were observed in the targeted local test runs.