### PR TITLE
feat(sessions): add worktree auto-delete removal setting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -147,12 +147,24 @@ function App() {
   );
   const removeSession = useAppStore((s) => s.removeSession);
   const removeProject = useAppStore((s) => s.removeProject);
+  const confirmRemoveSession = useSettings(
+    (s) => s.settings.sessions.confirmRemove,
+  );
+  const autoDeleteWorktrees = useSettings(
+    (s) => s.settings.sessions.autoDeleteWorktrees,
+  );
   const pendingRemove = sessions.find((s) => s.id === pendingRemoveId) ?? null;
   const pendingProject =
     projects.find((p) => p.repo_path === pendingRemoveProject) ?? null;
   const pendingProjectSessions = pendingProject
     ? sessions.filter((s) => s.repo_path === pendingProject.repo_path)
     : [];
+  const pendingRemoveRecordedWorktree =
+    pendingRemove !== null && hasRecordedWorktree(pendingRemove);
+  const pendingRemoveSkipsDialog =
+    pendingRemove !== null &&
+    ((pendingRemoveRecordedWorktree && autoDeleteWorktrees) ||
+      (!pendingRemoveRecordedWorktree && !confirmRemoveSession));
   const sessionIdsKey = useMemo(
     () => sessions.map((session) => session.id).join("\0"),
     [sessions],
@@ -663,16 +675,27 @@ function App() {
     };
   }, [activeSessionId, sessionIdsKey]);
 
-  // Skip the confirmation dialog for plain sessions when the user has opted
-  // out via Settings. Recorded worktrees still prompt because the
-  // delete-worktree choice matters.
+  // Skip the confirmation dialog when Settings gives a deterministic removal
+  // choice: plain sessions can skip confirmation, and worktree-backed sessions
+  // can opt into always deleting the worktree from disk.
   useEffect(() => {
     if (!pendingRemove) return;
-    const confirm = useSettings.getState().settings.sessions.confirmRemove;
-    if (confirm || hasRecordedWorktree(pendingRemove)) return;
+    const recordedWorktree = hasRecordedWorktree(pendingRemove);
+    if (recordedWorktree && autoDeleteWorktrees) {
+      clearPendingRemove();
+      removeSession(pendingRemove.id, true);
+      return;
+    }
+    if (confirmRemoveSession || recordedWorktree) return;
     clearPendingRemove();
     removeSession(pendingRemove.id, false);
-  }, [pendingRemove, clearPendingRemove, removeSession]);
+  }, [
+    pendingRemove,
+    autoDeleteWorktrees,
+    clearPendingRemove,
+    confirmRemoveSession,
+    removeSession,
+  ]);
 
   // Restore the root layout (sidebar + right panel) and equalize the
   // workspace pane splits when the command palette fires the reset event.
@@ -1193,7 +1216,7 @@ function App() {
         }}
       />
       <RemoveSessionDialog
-        session={pendingRemove}
+        session={pendingRemoveSkipsDialog ? null : pendingRemove}
         onClose={(choice) => {
           const target = pendingRemove;
           clearPendingRemove();

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -114,6 +114,19 @@ function openTerminalTab() {
   });
 }
 
+function openSessionsTab() {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (element) =>
+      element.textContent === "Sessions" || element.textContent === "세션",
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error("Sessions tab button not found");
+  }
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
 function openGithubTab() {
   const button = Array.from(document.querySelectorAll("button")).find(
     (element) => element.textContent === "GitHub",
@@ -401,6 +414,45 @@ describe("SettingsModal font controls", () => {
     expect(bodyText).toContain("New control session");
     expect(bodyText).toContain("Right panel");
     expect(bodyText).toMatch(/⌘P|Ctrl\+P/);
+  });
+
+  it("patches the worktree auto-delete session toggle", async () => {
+    const patchSessions = vi.fn();
+    useSettings.setState({
+      settings: cloneSettings(),
+      patchSessions,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openSessionsTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const toggle = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    ).find((input) =>
+      input
+        .closest("label")
+        ?.textContent?.includes("Always delete worktree-backed sessions"),
+    );
+
+    expect(document.body.textContent).toContain(
+      "Delete worktrees without asking",
+    );
+    expect(toggle).toBeInstanceOf(HTMLInputElement);
+    expect(toggle?.checked).toBe(false);
+
+    act(() => {
+      toggle?.click();
+    });
+
+    expect(patchSessions).toHaveBeenCalledWith({
+      autoDeleteWorktrees: true,
+    });
   });
 
   it("patches the GitHub PR row display toggles", async () => {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -600,6 +600,22 @@ function SessionSettings() {
         </label>
       </Field>
       <Field
+        label={st(t, "settings.sessions.autoDeleteWorktrees.label")}
+        hint={st(t, "settings.sessions.autoDeleteWorktrees.hint")}
+      >
+        <label className="flex items-center gap-2 text-xs text-fg">
+          <input
+            type="checkbox"
+            checked={settings.sessions.autoDeleteWorktrees}
+            onChange={(e) =>
+              patchSessions({ autoDeleteWorktrees: e.target.checked })
+            }
+            className="accent-[var(--color-accent)]"
+          />
+          {st(t, "settings.sessions.autoDeleteWorktrees.checkbox")}
+        </label>
+      </Field>
+      <Field
         label={st(t, "settings.sessions.closeOnExit.label")}
         hint={st(t, "settings.sessions.closeOnExit.hint")}
       >

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1799,8 +1799,8 @@ export function Terminal({
               return;
             }
             // User opted into auto-close: drop ordinary sessions immediately,
-            // but route worktree-backed sessions through the same
-            // delete-worktree confirmation as tab close.
+            // but route worktree-backed sessions through the same removal
+            // policy as tab close.
             if (useSettings.getState().settings.sessions.closeOnExit) {
               exited = true;
               const store = useAppStore.getState();

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -59,6 +59,50 @@ describe("terminal.linkActivation default", () => {
   });
 });
 
+describe("session removal settings", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("keeps worktree auto-delete off by default", () => {
+    expect(DEFAULT_SETTINGS.sessions.autoDeleteWorktrees).toBe(false);
+  });
+
+  it("loads a persisted worktree auto-delete preference", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ sessions: { autoDeleteWorktrees: true } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.sessions.autoDeleteWorktrees).toBe(
+      true,
+    );
+  });
+});
+
 describe("terminal cursor settings", () => {
   const STORAGE_KEY = "acorn:settings:v1";
   let storage: Map<string, string>;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -201,10 +201,16 @@ export interface AcornSettings {
   sessions: {
     /**
      * Show the confirmation dialog before removing a non-isolated session.
-     * Isolated worktrees always prompt because the worktree-deletion choice
-     * matters. Set false to skip the prompt for plain sessions.
+     * Set false to skip the prompt for plain sessions. Worktree-backed
+     * sessions follow `autoDeleteWorktrees`.
      */
     confirmRemove: boolean;
+    /**
+     * Remove worktree-backed sessions without asking whether to keep the
+     * worktree directory. When enabled, the backend receives
+     * `removeWorktree = true` for linked and isolated worktree sessions.
+     */
+    autoDeleteWorktrees: boolean;
     /**
      * When the session's PTY process exits (e.g. user typed `exit`), close
      * the session tab automatically instead of showing the
@@ -356,6 +362,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   },
   sessions: {
     confirmRemove: true,
+    autoDeleteWorktrees: false,
     closeOnExit: false,
   },
   editor: {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -68,12 +68,17 @@
     "sessions": {
       "confirmRemove": {
         "label": "Confirm before removing a session",
-        "hint": "Linked worktrees always prompt because the delete-worktree choice still matters.",
+        "hint": "Applies to plain sessions. Worktree-backed sessions follow the delete-worktree setting below.",
         "checkbox": "Show confirmation dialog"
+      },
+      "autoDeleteWorktrees": {
+        "label": "Delete worktrees without asking",
+        "hint": "When removing a session that uses an isolated or linked worktree, skip the keep/delete prompt and always delete the worktree from disk.",
+        "checkbox": "Always delete worktree-backed sessions from disk"
       },
       "closeOnExit": {
         "label": "Close tab when the process exits",
-        "hint": "When the session's shell or agent exits (e.g. you type `exit`), close the tab automatically instead of showing the press-Enter restart prompt. Linked worktrees still ask what to do.",
+        "hint": "When the session's shell or agent exits (e.g. you type `exit`), close the tab automatically instead of showing the press-Enter restart prompt. Worktree-backed sessions follow the delete-worktree setting above.",
         "checkbox": "Auto-close on exit"
       },
       "background": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -68,12 +68,17 @@
     "sessions": {
       "confirmRemove": {
         "label": "세션 제거 전 확인",
-        "hint": "linked worktree는 delete-worktree 선택이 여전히 중요하므로 항상 확인합니다.",
+        "hint": "일반 세션에 적용됩니다. worktree가 있는 세션은 아래 worktree 삭제 설정을 따릅니다.",
         "checkbox": "확인 대화상자 표시"
+      },
+      "autoDeleteWorktrees": {
+        "label": "묻지 않고 worktree 삭제",
+        "hint": "격리 또는 linked worktree를 사용하는 세션을 제거할 때 유지/삭제 확인을 건너뛰고 디스크의 worktree를 항상 삭제합니다.",
+        "checkbox": "worktree가 있는 세션은 항상 디스크에서도 삭제"
       },
       "closeOnExit": {
         "label": "프로세스 종료 시 탭 닫기",
-        "hint": "세션의 셸이나 에이전트가 종료되면(예: `exit` 입력) Enter를 눌러 재시작하라는 프롬프트 대신 탭을 자동으로 닫습니다. linked worktree는 그래도 처리 방식을 묻습니다.",
+        "hint": "세션의 셸이나 에이전트가 종료되면(예: `exit` 입력) Enter를 눌러 재시작하라는 프롬프트 대신 탭을 자동으로 닫습니다. worktree가 있는 세션은 위 worktree 삭제 설정을 따릅니다.",
         "checkbox": "종료 시 자동 닫기"
       },
       "background": {

--- a/tests/e2e/session-lifecycle.spec.ts
+++ b/tests/e2e/session-lifecycle.spec.ts
@@ -151,4 +151,78 @@ test.describe("session lifecycle", () => {
     // which the store passes as removeWorktree = false.
     expect(calls[0].removeWorktree).toBe(false);
   });
+
+  test("worktree auto-delete skips the remove confirmation", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          sessions: {
+            confirmRemove: true,
+            autoDeleteWorktrees: true,
+            closeOnExit: false,
+          },
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __sessionRemoved?: boolean };
+      return w.__sessionRemoved
+        ? []
+        : [
+            {
+              id: "s-1",
+              name: "alpha",
+              repo_path: "/tmp/demo",
+              worktree_path: "/tmp/demo/.acorn/worktrees/alpha",
+              branch: "main",
+              isolated: false,
+              in_worktree: true,
+              status: "idle",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:05Z",
+              last_message: null,
+            },
+          ];
+    });
+    await tauri.handle("remove_session", (args) => {
+      const w = window as unknown as {
+        __removeCalls?: unknown[];
+        __sessionRemoved?: boolean;
+      };
+      w.__removeCalls = w.__removeCalls ?? [];
+      w.__removeCalls.push(args);
+      w.__sessionRemoved = true;
+      return null;
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-panel-id="sidebar"]');
+    const row = sidebar
+      .getByRole("button", { name: /^alpha worktree main · Idle/ })
+      .first();
+    await expect(row).toBeVisible();
+
+    await row.hover();
+    await sidebar
+      .getByRole("button", { name: "Remove session", exact: true })
+      .click();
+
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expect(
+      sidebar.getByRole("button", { name: /^alpha worktree main · Idle/ }),
+    ).toHaveCount(0);
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __removeCalls?: unknown[] }).__removeCalls,
+    )) as Array<{ id: string; removeWorktree: boolean }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ id: "s-1", removeWorktree: true });
+  });
 });


### PR DESCRIPTION
## Summary

Adds a session setting for users who want worktree-backed closes to always delete the worktree without another prompt.

1. **Settings model:** adds `sessions.autoDeleteWorktrees`, defaulting off so existing keep/delete confirmation behavior is preserved.
2. **Removal flow:** skips the remove-session dialog for linked or isolated worktree sessions when the setting is enabled and calls `remove_session` with `removeWorktree: true`.
3. **Settings UI + locales:** exposes the toggle in Settings → Sessions with English and Korean copy, and updates related hints.
4. **Regression coverage:** adds Vitest coverage for persisted settings/UI patching and Playwright coverage for the prompt-skipping removal path.

## Expected impact

| Area | Impact |
| --- | --- |
| User-visible behavior | Users can opt into always deleting worktrees on session close, avoiding the keep/delete prompt. |
| Safety | Default remains off, so existing users keep the confirmation behavior until they choose otherwise. |
| Reliability | Auto-close-on-exit routes through the same removal policy as manual tab close. |

## Design notes

The setting lives alongside the existing session removal preferences because the choice is frontend policy over the existing backend `removeWorktree` flag. `App.tsx` also passes `null` into `RemoveSessionDialog` for auto-handled removals so the dialog cannot flash for a frame before the effect removes the session.

## Test plan

- [x] `pnpm exec vitest run src/lib/settings.test.ts src/components/SettingsModal.test.tsx` — 2 files / 36 tests passed.
- [x] `pnpm exec playwright test tests/e2e/session-lifecycle.spec.ts` — 3 tests passed.
- [x] `pnpm run typecheck` — passed.

## Notes

Playwright still prints existing mocked-dev warnings for `load_status` and user-theme loading during this spec; the tests passed and those warnings are not introduced by this PR.