### PR TITLE
fix(staged): open worktree files on double-click

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,6 +43,9 @@
     ]
   },
   "plugins": {
+    "opener": {
+      "requireLiteralLeadingDot": false
+    },
     "updater": {
       "active": true,
       "endpoints": [

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -39,7 +39,7 @@ import {
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Panel, PanelGroup } from "react-resizable-panels";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { openPath, openUrl } from "@tauri-apps/plugin-opener";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { api, FS_CHANGED_EVENT, type FsChangePayload } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openFileInEditor } from "../lib/editor";
@@ -2117,6 +2117,7 @@ function StagedTab({
   onExpand: (e: ExpandedDiff) => void;
 }) {
   const t = useTranslation();
+  const openCodeViewerTab = useAppStore((s) => s.openCodeViewerTab);
   const cachedStaged = rightPanelCache.getStaged(repoPath);
   const initialSelectedPath =
     cachedStaged?.selectedPath &&
@@ -2267,13 +2268,13 @@ function StagedTab({
     }
   }
 
-  async function openWithDefaultApp(file: StagedFile) {
+  function openInCodeViewer(file: StagedFile) {
     if (isDeleted(file)) {
       setListError(rt(t, "rightPanel.errors.deletedFile"));
       return;
     }
     try {
-      await openPath(joinPath(repoPath, file.path));
+      openCodeViewerTab(joinPath(repoPath, file.path), repoPath);
     } catch (e) {
       setListError(String(e));
     }
@@ -2300,8 +2301,7 @@ function StagedTab({
                 setMenu({ x: e.clientX, y: e.clientY, file: f });
               }}
               onDoubleClick={() => {
-                if (isDeleted(f)) return;
-                void openWithDefaultApp(f);
+                openInCodeViewer(f);
               }}
               className={cn(
                 "flex cursor-default items-center gap-2 px-3 py-1.5 font-mono text-xs hover:bg-bg-elevated/40",

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -101,6 +101,48 @@ test.describe("right panel: tab switching", () => {
     ).toBeVisible();
   });
 
+  test("double-clicking a staged worktree file opens it as a code tab", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveWorktreeSession(tauri);
+    await tauri.respond("list_staged", [
+      {
+        path: "src/components/Terminal.tsx",
+        status: "staged-modified",
+      },
+    ]);
+    await tauri.respond("staged_file_diff", { files: [] });
+    await tauri.handle("fs_read_file", (args) => {
+      const w = window as unknown as { __readFilePaths?: string[] };
+      w.__readFilePaths = w.__readFilePaths ?? [];
+      w.__readFilePaths.push((args as { path: string }).path);
+      return {
+        content: "export function Terminal() {}",
+        size: 29,
+        truncated: false,
+        binary: false,
+      };
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Staged" }).click();
+    await page.getByText("src/components/Terminal.tsx").dblclick();
+
+    await expect(
+      page.getByRole("button", { name: /Terminal\.tsx Close tab/ }),
+    ).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __readFilePaths?: string[] })
+              .__readFilePaths ?? [],
+        ),
+      )
+      .toContain("/tmp/demo/.acorn/worktrees/demo-1/src/components/Terminal.tsx");
+  });
+
   test("null read_session_todos does not crash the panel (regression)", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Staged file rows now open the actual worktree file in Acorn without tripping opener scope on hidden worktree directories.

1. **Staged double-click:** Routes staged row double-clicks through the workspace code viewer instead of the OS default opener.
2. **Hidden worktree paths:** Keeps the existing `**` opener scope useful for hidden worktree roots by disabling literal-dot-only matching in the opener plugin.
3. **Regression coverage:** Adds an E2E that double-clicks a staged file under `.acorn/worktrees/...` and verifies the code tab reads the correct absolute path.

## Expected impact

| Area | Impact |
| --- | --- |
| Staged tab | Double-clicking a staged file opens it as an Acorn code tab. |
| Worktree paths | Hidden worktree directories such as `.acorn` and `.claude` are covered by the existing opener scope. |
| Reliability | Avoids `Not allowed to open path` errors for staged files inside hidden worktree roots. |

## Design notes

- The context-menu `Open in editor` action is unchanged and remains the external-editor path.
- Double-click now matches the Files tab behavior by opening a frontend-owned code viewer tab.
- The opener capability remains broad (`**`); `requireLiteralLeadingDot: false` makes that scope behave consistently for hidden worktree directory strategies instead of enumerating specific folder names.

## Test plan

- [x] `pnpm exec tsc --noEmit` — passed.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — passed.
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts -g "double-clicking a staged worktree file"` — passed.

## Notes

- `cargo check` still reports the existing `AgentHookServer::start` dead-code warning; this PR did not introduce it.
- The focused E2E still prints existing mock warnings for `load_status` and theme loading; the test passed and those warnings are not caused by this PR.