### PR TITLE
fix(pane): hide workspace tab scrollbar

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -592,7 +592,8 @@ function TabStrip({
   return (
     <div
       ref={stripRef}
-      className="relative flex h-9 shrink-0 items-stretch overflow-x-auto border-b border-border"
+      data-pane-tab-strip={paneId}
+      className="acorn-no-scrollbar relative flex h-9 shrink-0 items-stretch overflow-x-auto border-b border-border"
       onDragEnter={(e) => {
         if (!isAcornDrag(e)) return;
         e.preventDefault();

--- a/tests/e2e/scrollbar-hidden.spec.ts
+++ b/tests/e2e/scrollbar-hidden.spec.ts
@@ -37,3 +37,48 @@ test.describe("scrollbar hidden in vertical scroll areas", () => {
     expect(count).toBeGreaterThanOrEqual(1);
   });
 });
+
+test.describe("scrollbar hidden in horizontal tab areas", () => {
+  test("workspace tab strip hides the horizontal scrollbar", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-1",
+        name: "alpha",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+
+    await page.goto("/");
+    await page
+      .locator('[data-panel-id="sidebar"]')
+      .getByRole("button", { name: /^alpha main · Idle/ })
+      .first()
+      .click();
+
+    const strip = page.locator('[data-pane-tab-strip="root"]');
+    await expect(strip).toBeVisible();
+
+    const scrollbarWidth = await strip.evaluate(
+      (el) => getComputedStyle(el).scrollbarWidth,
+    );
+    expect(scrollbarWidth).toBe("none");
+  });
+});


### PR DESCRIPTION
## Summary
Prevents native horizontal scrollbars from appearing in workspace tab strips while preserving horizontal overflow behavior.

1. **Workspace tab strip:** Applies the existing `acorn-no-scrollbar` utility to the pane tab strip and adds a stable test selector.
2. **Regression coverage:** Adds a Playwright check that the workspace tab strip computes `scrollbar-width: none`.

## Expected impact

| Area | Impact |
| --- | --- |
| Workspace tabs | Long or numerous tabs no longer show a visible horizontal scrollbar; existing horizontal scrolling remains available. |
| Reliability | The hidden-scrollbar behavior is covered by E2E regression coverage. |

## Test plan

- [x] `pnpm run test:e2e -- tests/e2e/scrollbar-hidden.spec.ts` — 3 passed.
- [x] `pnpm run typecheck` — passed.

## Notes

- The focused E2E run still emits existing Tauri-mock warnings around `load_status` and user theme loading; the tests pass and these warnings are not introduced by this PR.