### PR TITLE
build(cargo): shared target dir support for sidecar staging

### DIFF
--- a/docs/COMMON.md
+++ b/docs/COMMON.md
@@ -56,7 +56,7 @@ Two recurring traps in E2E:
 
 ```sh
 pnpm install
-pnpm run build:sidecar  # stage acorn-ipc — required for fresh checkouts / worktrees
+pnpm run build:sidecar  # stage Rust sidecars — required for fresh checkouts / worktrees
 pnpm run tauri dev      # full app (Rust + Vite)
 pnpm run dev            # Vite only — frontend in browser, no Tauri
 pnpm run test           # Vitest
@@ -65,7 +65,15 @@ pnpm run typecheck
 pnpm run build          # tsc + vite build
 ```
 
-`src-tauri/binaries/acorn-ipc-<target-triple>` is `.gitignore`d, so every fresh checkout — including each new `git worktree add` — starts without it, and Tauri's `externalBin` existence check fails the build before anything else runs. Run `pnpm run build:sidecar` once per worktree (and again after any IPC change); plain `cargo build -p acorn-ipc --bin acorn-ipc` is not enough because it skips the target-tripled staging step. See [`docs/CONTROL_SESSIONS.md`](CONTROL_SESSIONS.md#the-acorn-ipc-cli) for details.
+`src-tauri/binaries/<name>-<target-triple>` sidecars are `.gitignore`d, so every fresh checkout — including each new `git worktree add` — starts without them, and Tauri's `externalBin` existence check fails the build before anything else runs. Run `pnpm run build:sidecar` once per worktree (and again after any sidecar change); plain `cargo build -p acorn-ipc --bin acorn-ipc` is not enough because it skips the target-tripled staging step. See [`docs/CONTROL_SESSIONS.md`](CONTROL_SESSIONS.md#the-acorn-ipc-cli) for details.
+
+For local Rust work across multiple Acorn worktrees, set `CARGO_TARGET_DIR` to a shared directory outside the worktree so Cargo can reuse dependency artifacts across worktrees:
+
+```sh
+export CARGO_TARGET_DIR=/path/to/acorn/.acorn/cargo-target
+```
+
+`src-tauri/scripts/build-sidecar.sh` honours the same setting when staging Tauri sidecars. Keep this as a local environment setting rather than a committed default so CI and release builds keep their normal per-workspace target layout.
 
 **Launching `tauri dev` from inside a control session.** Acorn injects `ACORN_DATA_DIR` (and `ACORN_AGENT_STATE_DIR`, `ACORN_RESUME_TOKEN`, `ACORN_STAGED_REV`) into every control-session PTY so the bundled CLIs talk to the host profile. `acorn-paths::data_dir` honours `ACORN_DATA_DIR` ahead of the debug/release profile fallback, so a plain `pnpm run tauri dev` from that shell silently runs the debug build against `profiles/prod` — same daemon, same `sessions.json`, same staged shell-init dir as the installed app. Strip the overrides before launching:</p>
 

--- a/docs/CONTROL_SESSIONS.md
+++ b/docs/CONTROL_SESSIONS.md
@@ -157,17 +157,23 @@ If you are building from source rather than installing a release, the
 sidecar is staged for you when you run `tauri build`. For a dev loop:
 
 ```sh
-pnpm run build:sidecar   # one-time; run again after IPC changes
+pnpm run build:sidecar   # one-time; run again after sidecar changes
 pnpm run tauri dev
 ```
 
-`pnpm run build:sidecar` shells out to `src-tauri/scripts/build-sidecar.sh`
-which both compiles `acorn-ipc` *and* stages it at
-`src-tauri/binaries/acorn-ipc-<target-triple>`, the path Tauri's
+`pnpm run build:sidecar` shells out to `src-tauri/scripts/build-sidecar.sh`,
+which compiles the bundled sidecars and stages them at
+`src-tauri/binaries/<name>-<target-triple>`, the paths Tauri's
 `externalBin` existence check requires before `tauri dev` / `tauri build`
-will even start. Plain `cargo build -p acorn-ipc --bin acorn-ipc` skips the staging
-step, so the build fails with
+will even start. Plain `cargo build -p acorn-ipc --bin acorn-ipc` skips the
+staging step, so the build fails with
 `resource path 'binaries/acorn-ipc-...' doesn't exist`.
+
+When working across multiple local worktrees, you can set `CARGO_TARGET_DIR`
+to a shared directory outside the worktree, for example
+`/path/to/acorn/.acorn/cargo-target`. The sidecar script
+honours that setting for Cargo's build output while still staging the final
+binaries under `src-tauri/binaries/`, where Tauri expects them.
 
 Settings → Services → "Control sessions" shows the resolved binary path
 Acorn currently sees (it looks for `acorn-ipc` next to the running app

--- a/src-tauri/scripts/build-sidecar.sh
+++ b/src-tauri/scripts/build-sidecar.sh
@@ -23,6 +23,7 @@ cd "$(dirname "$0")/.."
 
 profile="${TAURI_SIDECAR_PROFILE:-release}"
 target_triple="${TAURI_ENV_TARGET_TRIPLE:-$(rustc -vV | sed -n 's|host: ||p')}"
+target_dir="${CARGO_TARGET_DIR:-target}"
 
 if [ -z "$target_triple" ]; then
   echo "error: could not determine target triple (TAURI_ENV_TARGET_TRIPLE unset and \`rustc -vV\` produced no host line)" >&2
@@ -74,7 +75,7 @@ cargo build "${cargo_flags[@]}"
 
 for entry in "${sidecars[@]}"; do
   bin="${entry%%:*}"
-  src="target/$target_triple/$profile/$bin"
+  src="$target_dir/$target_triple/$profile/$bin"
   dest="$dest_dir/$bin-$target_triple"
   if [ ! -f "$src" ]; then
     echo "error: expected built binary at $src" >&2


### PR DESCRIPTION
## Summary

This keeps local worktree Rust builds cacheable without changing the default CI or release target layout.

1. **Sidecar target lookup** — make `src-tauri/scripts/build-sidecar.sh` read built sidecar binaries from `${CARGO_TARGET_DIR:-target}` before staging them into `src-tauri/binaries/`.
2. **Agent-facing guidance** — update `docs/COMMON.md` with a copyable local `CARGO_TARGET_DIR` example for shared worktree caches.
3. **Control-session docs** — align sidecar staging docs with the current `acorn-ipc` + `acornd` sidecar set and the shared target-dir opt-in.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Local worktree builds | Agents/developers can opt into a shared Cargo target cache across Acorn worktrees. |
| CI/release builds | No behavior change unless `CARGO_TARGET_DIR` is explicitly set. |
| Sidecar staging | `src-tauri/binaries/<name>-<target-triple>` remains the final Tauri `externalBin` staging location. |

## Design notes

`CARGO_TARGET_DIR` stays opt-in. The script defaults to `target`, preserving the existing per-worktree `src-tauri/target` layout for users, CI, and release automation that do not set the variable.

The docs use `/path/to/acorn/.acorn/cargo-target` instead of a machine-specific home directory so agents can adapt the example to the active checkout.

## Test plan

- [x] `bash -n src-tauri/scripts/build-sidecar.sh` — passed.
- [x] `git diff --check` — passed.
- [x] `CARGO_TARGET_DIR=/Users/ian/Documents/Works/acorn/.acorn/cargo-target cargo check --workspace` from `src-tauri/` — passed; first shared-target run finished in 1m 23s, warm rerun finished in 4.58s.
- [x] `CARGO_TARGET_DIR=/Users/ian/Documents/Works/acorn/.acorn/cargo-target TAURI_SIDECAR_PROFILE=debug ./src-tauri/scripts/build-sidecar.sh` — passed; first target-triple sidecar run finished in 2m 03s, warm rerun finished in 11.34s and staged both sidecars.

## Notes

- `cargo check` / sidecar builds still emit the existing `AgentHookServer::start` dead-code warning in `src/agent_hooks.rs`; this PR does not introduce that warning.