### PR TITLE
fix(sessions): remove worktree sessions optimistically

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -121,6 +121,20 @@ async function seed(
   await useAppStore.getState().refreshAll();
 }
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 beforeEach(() => {
   // resetAllMocks clears both call history *and* the queued
   // mockResolvedValueOnce return values; clearAllMocks leaves the queue
@@ -313,6 +327,50 @@ describe("workspace tabs", () => {
     expect(s.activeTabId).toBe("a1");
     expect(s.activeSessionId).toBe("a1");
     expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1"]);
+  });
+});
+
+describe("removeSession", () => {
+  it("removes the tab locally before the backend worktree delete finishes", async () => {
+    const a1 = session("a1", REPO_A, {
+      worktree_path: `${REPO_A}/.worktrees/a1`,
+    });
+    const a2 = session("a2", REPO_A, {
+      worktree_path: `${REPO_A}/.worktrees/a2`,
+    });
+    await seed([project(REPO_A, 0)], [a1, a2]);
+    useAppStore.getState().selectSession("a1");
+
+    const pending = deferred<void>();
+    mockApi.removeSession.mockReturnValueOnce(pending.promise);
+    mockApi.listSessions.mockResolvedValue([a2]);
+    mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
+
+    const removal = useAppStore.getState().removeSession("a1", true);
+
+    expect(mockApi.removeSession).toHaveBeenCalledWith("a1", true);
+    expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual(["a2"]);
+    expect(useAppStore.getState().activeSessionId).toBe("a2");
+
+    pending.resolve(undefined);
+    await removal;
+    expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual(["a2"]);
+  });
+
+  it("refreshes from the backend if optimistic removal fails", async () => {
+    const a1 = session("a1", REPO_A);
+    await seed([project(REPO_A, 0)], [a1]);
+
+    mockApi.removeSession.mockRejectedValueOnce(new Error("delete failed"));
+    mockApi.listSessions.mockResolvedValue([a1]);
+    mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
+
+    await useAppStore.getState().removeSession("a1", true);
+
+    const s = useAppStore.getState();
+    expect(s.error).toBe("delete failed");
+    expect(s.sessions.map((session) => session.id)).toEqual(["a1"]);
+    expect(s.activeSessionId).toBe("a1");
   });
 });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -446,6 +446,17 @@ function findPaneContainingTab(
   return null;
 }
 
+function findSessionOwner(
+  state: AppStateModel,
+  id: string,
+): { repoPath: string; paneId: PaneId } | null {
+  for (const [repoPath, ws] of Object.entries(state.workspaces)) {
+    const paneId = findPaneContainingTab(ws.panes, id);
+    if (paneId) return { repoPath, paneId };
+  }
+  return null;
+}
+
 function updateActiveWorkspace(
   s: AppStateModel,
   updater: (ws: ProjectWorkspace) => ProjectWorkspace,
@@ -1140,42 +1151,57 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   async removeSession(id, removeWorktree = false) {
-    try {
-      // Track which project + pane held this session so we can collapse the
-      // pane after reconcile if removing the tab leaves it empty. We only
-      // collapse panes that *became* empty as a side effect of this close —
-      // pre-existing empty panes (e.g. a split waiting for a drop target)
-      // stay untouched.
-      const before = get();
-      let owning: { repoPath: string; paneId: PaneId } | null = null;
-      for (const [repoPath, ws] of Object.entries(before.workspaces)) {
-        for (const [pid, p] of Object.entries(ws.panes)) {
-          if (p.tabIds.includes(id)) {
-            owning = { repoPath, paneId: pid as PaneId };
-            break;
-          }
-        }
-        if (owning) break;
-      }
+    const owning = findSessionOwner(get(), id);
+    set((s) => {
+      if (!s.sessions.some((session) => session.id === id)) return s;
 
-      await api.removeSession(id, removeWorktree);
-      await get().refreshAll();
+      const sessions = s.sessions.filter((session) => session.id !== id);
+      const reconciled = reconcileWorkspaces(
+        sessions,
+        s.projects,
+        s.workspaces,
+        s.activeProject,
+        true,
+      );
+      const liveInWorktree = { ...s.liveInWorktree };
+      delete liveInWorktree[id];
+      const pendingTerminalInput = { ...s.pendingTerminalInput };
+      delete pendingTerminalInput[id];
 
-      if (!owning) return;
+      return {
+        sessions,
+        sessionsLoadedCleanly: true,
+        error: null,
+        liveInWorktree,
+        pendingTerminalInput,
+        workspaces: reconciled.workspaces,
+        activeProject: reconciled.activeProject,
+        ...mirrorActive(reconciled.workspaces, reconciled.activeProject),
+      };
+    });
+
+    if (owning) {
       const after = get();
       const ws = after.workspaces[owning.repoPath];
-      if (!ws) return;
-      const pane = ws.panes[owning.paneId];
-      if (!pane) return;
-      if (pane.tabIds.length > 0) return;
-      if (Object.keys(ws.panes).length <= 1) return;
-      // Only auto-collapse for the currently active workspace's panes —
-      // closePane operates on the active workspace, so applying it to a
-      // background project would silently misfire.
-      if (after.activeProject !== owning.repoPath) return;
-      get().closePane(owning.paneId);
+      const pane = ws?.panes[owning.paneId];
+      if (
+        ws &&
+        pane &&
+        pane.tabIds.length === 0 &&
+        Object.keys(ws.panes).length > 1 &&
+        after.activeProject === owning.repoPath
+      ) {
+        get().closePane(owning.paneId);
+      }
+    }
+
+    try {
+      await api.removeSession(id, removeWorktree);
+      await get().refreshAll();
     } catch (e) {
-      set({ error: errorMessage(e) });
+      const message = errorMessage(e);
+      await get().refreshAll();
+      set({ error: message });
     }
   },
 


### PR DESCRIPTION
## Summary

Removing a session with worktree deletion now updates the UI immediately while the backend cleanup continues.

1. **Optimistic session removal:** Drop the session from the frontend store before `remove_session` finishes so the terminal/tab disappears as soon as the user confirms deletion.
2. **Pane and cache cleanup:** Reconcile panes immediately and clear per-session live worktree / pending terminal input cache entries.
3. **Failure recovery:** If backend deletion fails, refresh from the backend to restore the real session list and preserve the error message.
4. **Regression coverage:** Add store tests for pending backend deletion and optimistic-removal rollback.

## Expected impact

| Area | Expected impact |
| --- | --- |
| User-visible behavior | The remove-worktree confirmation no longer leaves the old terminal visible during slow filesystem cleanup. |
| Reliability | Failed backend deletion refreshes from source of truth so the UI can recover the session. |
| Performance | No backend performance change; perceived latency is reduced by updating local state first. |

## Design notes

The backend command still owns PTY shutdown, scrollback deletion, worktree removal, session persistence, and local project mirror cleanup. The frontend only removes the tab optimistically, then performs the same `refreshAll()` after the backend returns to reconcile with the persisted state.

On failure, the store refreshes before setting the error so a successful recovery refresh does not clear the deletion failure message.

## Test plan

- [x] `pnpm test -- src/store.test.ts src/components/RemoveSessionDialog.test.tsx` — 2 files passed, 68 tests passed, 1 skipped.
- [x] `pnpm run typecheck` — passed.
