### PR TITLE
fix(terminal): normalize mouse coords after UI scale

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,8 @@ import {
   EXPAND_PANEL_EVENT,
   type ExpandPanelDetail,
   RESET_PANEL_SIZES_EVENT,
+  UI_SCALE_CHANGED_EVENT,
+  type UiScaleChangedDetail,
 } from "./lib/layoutEvents";
 import {
   startNotificationClickHandler,
@@ -409,6 +411,10 @@ function App() {
       "--acorn-ui-scale",
       String(appearance.uiScalePercent / 100),
     );
+    const detail: UiScaleChangedDetail = {
+      uiScalePercent: appearance.uiScalePercent,
+    };
+    window.dispatchEvent(new CustomEvent(UI_SCALE_CHANGED_EVENT, { detail }));
   }, [appearance.uiScalePercent]);
 
   useEffect(() => {

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -28,6 +28,8 @@ import {
   createTerminalRepaintScheduler,
   repaintTerminalViewport,
 } from "../lib/terminalRepaint";
+import { patchTerminalMouseCoordinateScale } from "../lib/terminalMouseScale";
+import { UI_SCALE_CHANGED_EVENT } from "../lib/layoutEvents";
 import {
   prepareScrollbackForSave,
   RESTORE_MARKER_TEXT,
@@ -652,6 +654,7 @@ export function Terminal({
     // PTY mid-composition. The canvas/webgl addons are faster but mis-handle
     // composition events on macOS/Linux IMEs — we pick correctness over fps.
     term.open(container);
+    const unpatchMouseCoordinateScale = patchTerminalMouseCoordinateScale(term);
     let cursorStyleFrame: number | null = null;
     const applyCurrentCursorStyle = () => {
       syncCursorStyle(container, currentCursorStyle);
@@ -2060,6 +2063,7 @@ export function Terminal({
       invoke("pty_kill", { sessionId }).catch(() => {
         // Backend may not implement pty_kill yet — safe to ignore.
       });
+      unpatchMouseCoordinateScale();
       try { fitAddon.dispose(); } catch { /* ignore */ }
       try { webLinksAddon.dispose(); } catch { /* ignore */ }
       try { serializeAddon.dispose(); } catch { /* ignore */ }
@@ -2127,11 +2131,10 @@ export function Terminal({
     return scheduler.dispose;
   }, [isActive]);
 
-  // WKWebView can defer paints while the app window is not focused. PTY
-  // output still reaches xterm's buffer, but the DOM renderer may return with
-  // stale row elements until another terminal event happens. On focus/visible
-  // return, force the same layout + full-row repaint used for tab activation,
-  // without scrolling the user's viewport.
+  // WKWebView can defer paints while the app window is not focused. App-level
+  // scale changes also adjust the transformed coordinate space around xterm.
+  // Force the same layout + full-row repaint used for tab activation, without
+  // scrolling the user's viewport.
   useEffect(() => {
     if (!isActive) return;
 
@@ -2149,9 +2152,11 @@ export function Terminal({
     };
 
     window.addEventListener("focus", scheduler.schedule);
+    window.addEventListener(UI_SCALE_CHANGED_EVENT, scheduler.schedule);
     document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
       window.removeEventListener("focus", scheduler.schedule);
+      window.removeEventListener(UI_SCALE_CHANGED_EVENT, scheduler.schedule);
       document.removeEventListener("visibilitychange", onVisibilityChange);
       scheduler.dispose();
     };

--- a/src/lib/layoutEvents.ts
+++ b/src/lib/layoutEvents.ts
@@ -11,6 +11,9 @@ export const EQUALIZE_PANES_EVENT = "acorn:equalize-panes";
 /** Restore the root sidebar/right panel widths and equalize the workspace. */
 export const RESET_PANEL_SIZES_EVENT = "acorn:reset-panel-sizes";
 
+/** Notify layout-sensitive surfaces that the app-level UI scale changed. */
+export const UI_SCALE_CHANGED_EVENT = "acorn:ui-scale-changed";
+
 /**
  * Request that a specific Panel be expanded to its minSize. Dispatched by
  * `ResizeHandle` on double-click; App.tsx wires it to the matching
@@ -20,4 +23,8 @@ export const EXPAND_PANEL_EVENT = "acorn:expand-panel";
 
 export interface ExpandPanelDetail {
   panelId: string;
+}
+
+export interface UiScaleChangedDetail {
+  uiScalePercent: number;
 }

--- a/src/lib/terminalMouseScale.test.ts
+++ b/src/lib/terminalMouseScale.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  patchTerminalMouseCoordinateScale,
+  scaledMousePositionForElement,
+} from "./terminalMouseScale";
+
+function makeElement({
+  offsetWidth,
+  offsetHeight,
+  rect,
+}: {
+  offsetWidth: number;
+  offsetHeight: number;
+  rect: DOMRectInit;
+}): HTMLElement {
+  const element = document.createElement("div");
+  Object.defineProperty(element, "offsetWidth", {
+    configurable: true,
+    value: offsetWidth,
+  });
+  Object.defineProperty(element, "offsetHeight", {
+    configurable: true,
+    value: offsetHeight,
+  });
+  vi.spyOn(element, "getBoundingClientRect").mockReturnValue(
+    DOMRect.fromRect(rect),
+  );
+  return element;
+}
+
+describe("scaledMousePositionForElement", () => {
+  it("converts visual coordinates back into unscaled element coordinates", () => {
+    const element = makeElement({
+      offsetWidth: 200,
+      offsetHeight: 100,
+      rect: { x: 100, y: 50, width: 250, height: 125 },
+    });
+
+    expect(
+      scaledMousePositionForElement({ clientX: 150, clientY: 100 }, element),
+    ).toEqual({ clientX: 140, clientY: 90 });
+  });
+
+  it("leaves coordinates unchanged when no transform scale is present", () => {
+    const event = { clientX: 150, clientY: 100 };
+    const element = makeElement({
+      offsetWidth: 200,
+      offsetHeight: 100,
+      rect: { x: 100, y: 50, width: 200, height: 100 },
+    });
+
+    expect(scaledMousePositionForElement(event, element)).toBe(event);
+  });
+});
+
+describe("patchTerminalMouseCoordinateScale", () => {
+  it("normalizes xterm mouse service inputs and restores originals", () => {
+    const element = makeElement({
+      offsetWidth: 200,
+      offsetHeight: 100,
+      rect: { x: 100, y: 50, width: 250, height: 125 },
+    });
+    const getCoords = vi.fn(() => [1, 1] as [number, number]);
+    const getMouseReportCoords = vi.fn(() => ({ col: 0, row: 0, x: 0, y: 0 }));
+    const getScrollAmount = vi.fn(() => 0);
+    const mouseService = { getCoords, getMouseReportCoords };
+    const selectionService = {
+      _screenElement: element,
+      _getMouseEventScrollAmount: getScrollAmount,
+    };
+    const term = {
+      _core: {
+        _mouseService: mouseService,
+        _selectionService: selectionService,
+      },
+    };
+
+    const unpatch = patchTerminalMouseCoordinateScale(term as never);
+
+    (
+      mouseService.getCoords as (
+        event: { clientX: number; clientY: number },
+        element: HTMLElement,
+        colCount: number,
+        rowCount: number,
+        isSelection?: boolean,
+      ) => [number, number] | undefined
+    )({ clientX: 150, clientY: 100 }, element, 80, 24, true);
+    (
+      mouseService.getMouseReportCoords as (
+        event: MouseEvent,
+        element: HTMLElement,
+      ) => { col: number; row: number; x: number; y: number }
+    )({ clientX: 150, clientY: 100 } as MouseEvent, element);
+    (
+      selectionService._getMouseEventScrollAmount as (
+        event: MouseEvent,
+      ) => number
+    )({
+      clientX: 150,
+      clientY: 100,
+    } as MouseEvent);
+
+    expect(getCoords).toHaveBeenCalledWith(
+      { clientX: 140, clientY: 90 },
+      element,
+      80,
+      24,
+      true,
+    );
+    expect(getMouseReportCoords).toHaveBeenCalledWith(
+      { clientX: 140, clientY: 90 },
+      element,
+    );
+    expect(getScrollAmount).toHaveBeenCalledWith({ clientX: 140, clientY: 90 });
+
+    unpatch();
+
+    expect(mouseService.getCoords).toBe(getCoords);
+    expect(mouseService.getMouseReportCoords).toBe(getMouseReportCoords);
+    expect(selectionService._getMouseEventScrollAmount).toBe(getScrollAmount);
+  });
+});

--- a/src/lib/terminalMouseScale.ts
+++ b/src/lib/terminalMouseScale.ts
@@ -1,0 +1,110 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+interface MousePosition {
+  clientX: number;
+  clientY: number;
+}
+
+interface XtermMouseService {
+  getCoords(
+    event: MousePosition,
+    element: HTMLElement,
+    colCount: number,
+    rowCount: number,
+    isSelection?: boolean,
+  ): [number, number] | undefined;
+  getMouseReportCoords?(
+    event: MouseEvent,
+    element: HTMLElement,
+  ): { col: number; row: number; x: number; y: number } | undefined;
+}
+
+interface XtermSelectionService {
+  _screenElement?: HTMLElement;
+  _getMouseEventScrollAmount?(event: MouseEvent): number;
+}
+
+interface XtermMouseInternals {
+  _core?: {
+    screenElement?: HTMLElement;
+    _mouseService?: XtermMouseService;
+    _selectionService?: XtermSelectionService;
+  };
+}
+
+export function scaledMousePositionForElement<T extends MousePosition>(
+  event: T,
+  element: HTMLElement,
+): MousePosition {
+  const rect = element.getBoundingClientRect();
+  const scaleX = element.offsetWidth > 0 ? rect.width / element.offsetWidth : 1;
+  const scaleY =
+    element.offsetHeight > 0 ? rect.height / element.offsetHeight : 1;
+  if (
+    !Number.isFinite(scaleX) ||
+    !Number.isFinite(scaleY) ||
+    (Math.abs(scaleX - 1) < 0.001 && Math.abs(scaleY - 1) < 0.001)
+  ) {
+    return event;
+  }
+
+  return {
+    clientX: rect.left + (event.clientX - rect.left) / scaleX,
+    clientY: rect.top + (event.clientY - rect.top) / scaleY,
+  };
+}
+
+export function patchTerminalMouseCoordinateScale(term: XTerm): () => void {
+  const core = (term as unknown as XtermMouseInternals)._core;
+  const mouseService = core?._mouseService;
+  if (!mouseService) return () => {};
+
+  const originalGetCoords = mouseService.getCoords;
+  const originalGetMouseReportCoords = mouseService.getMouseReportCoords;
+  const selectionService = core?._selectionService;
+  const originalGetMouseEventScrollAmount =
+    selectionService?._getMouseEventScrollAmount;
+
+  mouseService.getCoords = (event, element, colCount, rowCount, isSelection) =>
+    originalGetCoords.call(
+      mouseService,
+      scaledMousePositionForElement(event, element),
+      element,
+      colCount,
+      rowCount,
+      isSelection,
+    );
+
+  if (originalGetMouseReportCoords) {
+    mouseService.getMouseReportCoords = (event, element) =>
+      originalGetMouseReportCoords.call(
+        mouseService,
+        scaledMousePositionForElement(event, element) as MouseEvent,
+        element,
+      );
+  }
+
+  if (selectionService && originalGetMouseEventScrollAmount) {
+    selectionService._getMouseEventScrollAmount = (event) => {
+      const element = selectionService._screenElement ?? core?.screenElement;
+      if (!element) {
+        return originalGetMouseEventScrollAmount.call(selectionService, event);
+      }
+      return originalGetMouseEventScrollAmount.call(
+        selectionService,
+        scaledMousePositionForElement(event, element) as MouseEvent,
+      );
+    };
+  }
+
+  return () => {
+    mouseService.getCoords = originalGetCoords;
+    if (originalGetMouseReportCoords) {
+      mouseService.getMouseReportCoords = originalGetMouseReportCoords;
+    }
+    if (selectionService && originalGetMouseEventScrollAmount) {
+      selectionService._getMouseEventScrollAmount =
+        originalGetMouseEventScrollAmount;
+    }
+  };
+}


### PR DESCRIPTION
## Summary

This keeps xterm mouse interactions aligned after Acorn UI scale changes.

1. **UI-scale repaint signal** — dispatch `acorn:ui-scale-changed` from the app shell scale effect and have active terminals schedule the existing fit + refresh repaint path.
2. **Mouse coordinate normalization** — wrap xterm mouse coordinate internals so selection, link hover, mouse-reporting TUIs, and drag-scroll convert transformed visual coordinates back into xterm's unscaled cell coordinate space.
3. **Regression coverage** — add unit coverage for the coordinate conversion and patch/restore behavior.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Terminal selection | Drag/selection hit testing stays aligned when UI scale is not 100%. |
| TUI mouse interactions | xterm mouse reports use normalized cell coordinates under app-level scaling. |
| UI scale changes | Active terminals repaint after scale changes without requiring tab switches or manual resize. |

## Design notes

Acorn's UI scale uses a transformed app shell, while xterm computes mouse cells from unscaled renderer dimensions. The patch keeps the existing UI scale model and normalizes the mouse event coordinates at the xterm service boundary.

The xterm private-internal use is scoped to terminal mount/unmount and mirrors existing Acorn xterm internals usage for renderer dimensions. Cleanup restores original function identities.

## Test plan

- [x] `pnpm run typecheck` — passed.
- [x] `pnpm exec vitest run src/lib/terminalRepaint.test.ts src/lib/terminalMouseScale.test.ts` — passed; 2 files / 8 tests.
- [x] `git diff --check` — passed.
- [x] `CARGO_TARGET_DIR=/Users/ian/Documents/Works/acorn/.acorn/cargo-target ACORN_PROFILE=dev pnpm run tauri dev` with prod Acorn env unset — launched dev profile and confirmed `profiles/dev/ipc.sock`; manual terminal drag/selection check looked good.

## Notes

- `tauri dev` still emits the existing `AgentHookServer::start` dead-code warning; this PR does not introduce it.
