### PR TITLE
test: add regression coverage for PRs #294, #299, #300

### DIFF
--- a/src/lib/terminalMouseScale.test.ts
+++ b/src/lib/terminalMouseScale.test.ts
@@ -120,4 +120,99 @@ describe("patchTerminalMouseCoordinateScale", () => {
     expect(mouseService.getMouseReportCoords).toBe(getMouseReportCoords);
     expect(selectionService._getMouseEventScrollAmount).toBe(getScrollAmount);
   });
+
+  it("returns a no-op cleanup when xterm has no mouse service", () => {
+    const term = { _core: {} };
+    const unpatch = patchTerminalMouseCoordinateScale(term as never);
+    expect(typeof unpatch).toBe("function");
+    expect(() => unpatch()).not.toThrow();
+  });
+
+  it("falls back to core.screenElement when selection service has no screen element", () => {
+    const element = makeElement({
+      offsetWidth: 200,
+      offsetHeight: 100,
+      rect: { x: 100, y: 50, width: 250, height: 125 },
+    });
+    const getCoords = vi.fn(() => [1, 1] as [number, number]);
+    const getScrollAmount = vi.fn(() => 0);
+    const mouseService = { getCoords };
+    const selectionService = {
+      _screenElement: undefined,
+      _getMouseEventScrollAmount: getScrollAmount,
+    };
+    const term = {
+      _core: {
+        screenElement: element,
+        _mouseService: mouseService,
+        _selectionService: selectionService,
+      },
+    };
+
+    patchTerminalMouseCoordinateScale(term as never);
+
+    (
+      selectionService._getMouseEventScrollAmount as (
+        event: MouseEvent,
+      ) => number
+    )({ clientX: 150, clientY: 100 } as MouseEvent);
+
+    expect(getScrollAmount).toHaveBeenCalledWith({ clientX: 140, clientY: 90 });
+  });
+
+  it("passes the raw event through when no screen element is reachable", () => {
+    const getCoords = vi.fn(() => [1, 1] as [number, number]);
+    const getScrollAmount = vi.fn(() => 0);
+    const mouseService = { getCoords };
+    const selectionService = {
+      _screenElement: undefined,
+      _getMouseEventScrollAmount: getScrollAmount,
+    };
+    const term = {
+      _core: {
+        _mouseService: mouseService,
+        _selectionService: selectionService,
+      },
+    };
+
+    patchTerminalMouseCoordinateScale(term as never);
+
+    const event = { clientX: 150, clientY: 100 } as MouseEvent;
+    (
+      selectionService._getMouseEventScrollAmount as (
+        event: MouseEvent,
+      ) => number
+    )(event);
+    expect(getScrollAmount).toHaveBeenCalledWith(event);
+  });
+
+  it("leaves the selection service untouched when it exposes no scroll-amount helper", () => {
+    const mouseService = { getCoords: vi.fn(() => [0, 0] as [number, number]) };
+    const selectionService: { _screenElement?: HTMLElement } = {};
+    const term = {
+      _core: {
+        _mouseService: mouseService,
+        _selectionService: selectionService,
+      },
+    };
+
+    const unpatch = patchTerminalMouseCoordinateScale(term as never);
+    expect(
+      (selectionService as { _getMouseEventScrollAmount?: unknown })
+        ._getMouseEventScrollAmount,
+    ).toBeUndefined();
+    expect(() => unpatch()).not.toThrow();
+  });
+});
+
+describe("scaledMousePositionForElement edge cases", () => {
+  it("returns the original event when the element has zero offset width", () => {
+    const element = makeElement({
+      offsetWidth: 0,
+      offsetHeight: 100,
+      rect: { x: 0, y: 0, width: 200, height: 100 },
+    });
+    const event = { clientX: 50, clientY: 50 };
+    expect(scaledMousePositionForElement(event, element)).toBe(event);
+  });
 });

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -372,6 +372,90 @@ describe("removeSession", () => {
     expect(s.sessions.map((session) => session.id)).toEqual(["a1"]);
     expect(s.activeSessionId).toBe("a1");
   });
+
+  it("collapses an empty split pane before the backend worktree delete finishes", async () => {
+    const a1 = session("a1", REPO_A);
+    const a2 = session("a2", REPO_A);
+    await seed([project(REPO_A, 0)], [a1, a2]);
+    // Split, then move a2 to the new pane so each pane holds exactly one tab.
+    useAppStore.getState().splitFocusedPane("horizontal");
+    const focusedAfterSplit = useAppStore.getState().focusedPaneId;
+    const sourcePaneId = Object.keys(useAppStore.getState().panes).find(
+      (pid) => pid !== focusedAfterSplit,
+    )!;
+    useAppStore.getState().moveTab({
+      tabId: "a2",
+      fromPaneId: sourcePaneId,
+      toPaneId: focusedAfterSplit,
+    });
+    expect(useAppStore.getState().layout.kind).toBe("split");
+
+    const pending = deferred<void>();
+    mockApi.removeSession.mockReturnValueOnce(pending.promise);
+    mockApi.listSessions.mockResolvedValue([a1]);
+    mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
+
+    const removal = useAppStore.getState().removeSession("a2", true);
+
+    // Backend hasn't resolved yet — but the empty pane should already be gone.
+    const mid = useAppStore.getState();
+    expect(mid.layout.kind).toBe("pane");
+    expect(Object.keys(mid.panes)).toHaveLength(1);
+    expect(mid.panes[mid.focusedPaneId].tabIds).toEqual(["a1"]);
+    expect(mid.activeSessionId).toBe("a1");
+
+    pending.resolve(undefined);
+    await removal;
+
+    const after = useAppStore.getState();
+    expect(after.layout.kind).toBe("pane");
+    expect(after.sessions.map((s) => s.id)).toEqual(["a1"]);
+  });
+
+  it("does not collapse panes in a workspace that is not active", async () => {
+    const a1 = session("a1", REPO_A);
+    const b1 = session("b1", REPO_B);
+    const b2 = session("b2", REPO_B);
+    await seed([project(REPO_A, 0), project(REPO_B, 1)], [a1, b1, b2]);
+
+    // Set up REPO_B with a split where each pane has one tab.
+    useAppStore.getState().setActiveProject(REPO_B);
+    useAppStore.getState().splitFocusedPane("horizontal");
+    const bFocused = useAppStore.getState().focusedPaneId;
+    const bSource = Object.keys(useAppStore.getState().panes).find(
+      (pid) => pid !== bFocused,
+    )!;
+    useAppStore.getState().moveTab({
+      tabId: "b2",
+      fromPaneId: bSource,
+      toPaneId: bFocused,
+    });
+    expect(useAppStore.getState().layout.kind).toBe("split");
+
+    // Switch active project to REPO_A before the remove. The pane-collapse
+    // side effect must only run for the *active* workspace.
+    useAppStore.getState().setActiveProject(REPO_A);
+    const aLayoutBefore = useAppStore.getState().layout;
+
+    mockApi.listSessions.mockResolvedValue([a1, b1]);
+    mockApi.listProjects.mockResolvedValue([
+      project(REPO_A, 0),
+      project(REPO_B, 1),
+    ]);
+
+    await useAppStore.getState().removeSession("b2", true);
+
+    const after = useAppStore.getState();
+    // REPO_A workspace was active during the remove — its layout is untouched.
+    expect(after.activeProject).toBe(REPO_A);
+    expect(after.layout).toEqual(aLayoutBefore);
+    // REPO_B still has the split structure (collapse only happens for the
+    // active workspace; the empty pane is left for B to clean up next time).
+    expect(Object.keys(after.workspaces[REPO_B].panes).length).toBeGreaterThan(
+      1,
+    );
+    expect(after.sessions.map((s) => s.id).sort()).toEqual(["a1", "b1"]);
+  });
 });
 
 describe("splitFocusedPane", () => {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -451,9 +451,7 @@ describe("removeSession", () => {
     expect(after.layout).toEqual(aLayoutBefore);
     // REPO_B still has the split structure (collapse only happens for the
     // active workspace; the empty pane is left for B to clean up next time).
-    expect(Object.keys(after.workspaces[REPO_B].panes).length).toBeGreaterThan(
-      1,
-    );
+    expect(Object.keys(after.workspaces[REPO_B].panes)).toHaveLength(2);
     expect(after.sessions.map((s) => s.id).sort()).toEqual(["a1", "b1"]);
   });
 });

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -1,4 +1,93 @@
-import { test, expect } from "./support";
+import { test, expect, type Page } from "./support";
+import type { TauriMock } from "./support";
+
+// Tauri handler callbacks run in the page context and must not close over
+// variables declared in the test body. These helpers only define handlers
+// inline and only close over their own parameters, which keeps the
+// serialization boundary clean.
+async function seedAlphaBetaTerminals(tauri: TauriMock): Promise<void> {
+  await tauri.handle("list_projects", () => [
+    {
+      repo_path: "/tmp/demo",
+      name: "demo",
+      created_at: "2026-01-01T00:00:00Z",
+      position: 0,
+    },
+  ]);
+  await tauri.handle("list_sessions", () => [
+    {
+      id: "s-alpha",
+      name: "alpha",
+      repo_path: "/tmp/demo",
+      worktree_path: "/tmp/demo",
+      branch: "main",
+      isolated: false,
+      status: "idle",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:05Z",
+      last_message: null,
+    },
+    {
+      id: "s-beta",
+      name: "beta",
+      repo_path: "/tmp/demo",
+      worktree_path: "/tmp/demo",
+      branch: "main",
+      isolated: false,
+      status: "idle",
+      created_at: "2026-01-01T00:00:01Z",
+      updated_at: "2026-01-01T00:00:06Z",
+      last_message: null,
+    },
+  ]);
+  await tauri.handle("pty_spawn", () => null);
+}
+
+async function gotoWithAccent(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.addStyleTag({
+    content: `
+      :root[data-acorn-theme="acorn-dark"] {
+        --color-accent: rgb(12, 34, 56);
+      }
+    `,
+  });
+}
+
+function makePillCursorAssertion(page: Page): () => Promise<void> {
+  const activeCursor = page
+    .locator("[data-pane-body] .acorn-terminal .xterm-cursor")
+    .first();
+  return async () => {
+    const textarea = page
+      .locator("[data-pane-body] .xterm-helper-textarea")
+      .first();
+    await textarea.waitFor({ state: "attached" });
+    await textarea.focus();
+    await textarea.evaluate((el) => el.blur());
+    await expect(activeCursor).toBeAttached();
+    await expect
+      .poll(async () =>
+        activeCursor.evaluate((el) => getComputedStyle(el).backgroundColor),
+      )
+      .toBe("rgb(12, 34, 56)");
+    await expect
+      .poll(async () =>
+        activeCursor.evaluate((el) => getComputedStyle(el).borderRadius),
+      )
+      .toBe("999px");
+    await expect
+      .poll(async () =>
+        activeCursor.evaluate((el) => getComputedStyle(el, "::after").content),
+      )
+      .toBe("none");
+    await expect
+      .poll(async () =>
+        activeCursor.evaluate((el) => getComputedStyle(el).outlineWidth),
+      )
+      .toBe("0px");
+  };
+}
 
 test.describe("terminal: spawn", () => {
   test("default pill cursor uses the active theme accent after the helper textarea blurs", async ({
@@ -77,78 +166,9 @@ test.describe("terminal: spawn", () => {
     page,
     tauri,
   }) => {
-    await tauri.handle("list_projects", () => [
-      {
-        repo_path: "/tmp/demo",
-        name: "demo",
-        created_at: "2026-01-01T00:00:00Z",
-        position: 0,
-      },
-    ]);
-    await tauri.handle("list_sessions", () => [
-      {
-        id: "s-alpha",
-        name: "alpha",
-        repo_path: "/tmp/demo",
-        worktree_path: "/tmp/demo",
-        branch: "main",
-        isolated: false,
-        status: "idle",
-        created_at: "2026-01-01T00:00:00Z",
-        updated_at: "2026-01-01T00:00:05Z",
-        last_message: null,
-      },
-      {
-        id: "s-beta",
-        name: "beta",
-        repo_path: "/tmp/demo",
-        worktree_path: "/tmp/demo",
-        branch: "main",
-        isolated: false,
-        status: "idle",
-        created_at: "2026-01-01T00:00:01Z",
-        updated_at: "2026-01-01T00:00:06Z",
-        last_message: null,
-      },
-    ]);
-    await tauri.handle("pty_spawn", () => null);
-
-    await page.goto("/");
-    await page.addStyleTag({
-      content: `
-        :root[data-acorn-theme="acorn-dark"] {
-          --color-accent: rgb(12, 34, 56);
-        }
-      `,
-    });
-
-    const activeCursor = page
-      .locator("[data-pane-body] .acorn-terminal .xterm-cursor")
-      .first();
-    const expectPill = async () => {
-      const textarea = page
-        .locator("[data-pane-body] .xterm-helper-textarea")
-        .first();
-      await textarea.waitFor({ state: "attached" });
-      await textarea.focus();
-      await textarea.evaluate((el) => el.blur());
-      await expect(activeCursor).toBeAttached();
-      await expect
-        .poll(async () =>
-          activeCursor.evaluate((el) => getComputedStyle(el).backgroundColor),
-        )
-        .toBe("rgb(12, 34, 56)");
-      await expect
-        .poll(async () =>
-          activeCursor.evaluate((el) => getComputedStyle(el).borderRadius),
-        )
-        .toBe("999px");
-      await expect
-        .poll(async () =>
-          activeCursor.evaluate((el) => getComputedStyle(el, "::after").content),
-        )
-        .toBe("none");
-    };
+    await seedAlphaBetaTerminals(tauri);
+    await gotoWithAccent(page);
+    const expectPill = makePillCursorAssertion(page);
 
     await page
       .getByRole("button", { name: /^alpha main · Idle$/ })
@@ -165,78 +185,9 @@ test.describe("terminal: spawn", () => {
     page,
     tauri,
   }) => {
-    await tauri.handle("list_projects", () => [
-      {
-        repo_path: "/tmp/demo",
-        name: "demo",
-        created_at: "2026-01-01T00:00:00Z",
-        position: 0,
-      },
-    ]);
-    await tauri.handle("list_sessions", () => [
-      {
-        id: "s-alpha",
-        name: "alpha",
-        repo_path: "/tmp/demo",
-        worktree_path: "/tmp/demo",
-        branch: "main",
-        isolated: false,
-        status: "idle",
-        created_at: "2026-01-01T00:00:00Z",
-        updated_at: "2026-01-01T00:00:05Z",
-        last_message: null,
-      },
-      {
-        id: "s-beta",
-        name: "beta",
-        repo_path: "/tmp/demo",
-        worktree_path: "/tmp/demo",
-        branch: "main",
-        isolated: false,
-        status: "idle",
-        created_at: "2026-01-01T00:00:01Z",
-        updated_at: "2026-01-01T00:00:06Z",
-        last_message: null,
-      },
-    ]);
-    await tauri.handle("pty_spawn", () => null);
-
-    await page.goto("/");
-    await page.addStyleTag({
-      content: `
-        :root[data-acorn-theme="acorn-dark"] {
-          --color-accent: rgb(12, 34, 56);
-        }
-      `,
-    });
-
-    const activeCursor = page
-      .locator("[data-pane-body] .acorn-terminal .xterm-cursor")
-      .first();
-    const expectPill = async () => {
-      const textarea = page
-        .locator("[data-pane-body] .xterm-helper-textarea")
-        .first();
-      await textarea.waitFor({ state: "attached" });
-      await textarea.focus();
-      await textarea.evaluate((el) => el.blur());
-      await expect(activeCursor).toBeAttached();
-      await expect
-        .poll(async () =>
-          activeCursor.evaluate((el) => getComputedStyle(el).backgroundColor),
-        )
-        .toBe("rgb(12, 34, 56)");
-      await expect
-        .poll(async () =>
-          activeCursor.evaluate((el) => getComputedStyle(el).borderRadius),
-        )
-        .toBe("999px");
-      await expect
-        .poll(async () =>
-          activeCursor.evaluate((el) => getComputedStyle(el, "::after").content),
-        )
-        .toBe("none");
-    };
+    await seedAlphaBetaTerminals(tauri);
+    await gotoWithAccent(page);
+    const expectPill = makePillCursorAssertion(page);
 
     // Visit alpha → beta → alpha to catch regressions that only show up when
     // the same terminal is reactivated after another one has been mounted.

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -161,6 +161,101 @@ test.describe("terminal: spawn", () => {
     await expectPill();
   });
 
+  test("pill cursor restores after a round-trip through another terminal", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-alpha",
+        name: "alpha",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+      {
+        id: "s-beta",
+        name: "beta",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:01Z",
+        updated_at: "2026-01-01T00:00:06Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+
+    await page.goto("/");
+    await page.addStyleTag({
+      content: `
+        :root[data-acorn-theme="acorn-dark"] {
+          --color-accent: rgb(12, 34, 56);
+        }
+      `,
+    });
+
+    const activeCursor = page
+      .locator("[data-pane-body] .acorn-terminal .xterm-cursor")
+      .first();
+    const expectPill = async () => {
+      const textarea = page
+        .locator("[data-pane-body] .xterm-helper-textarea")
+        .first();
+      await textarea.waitFor({ state: "attached" });
+      await textarea.focus();
+      await textarea.evaluate((el) => el.blur());
+      await expect(activeCursor).toBeAttached();
+      await expect
+        .poll(async () =>
+          activeCursor.evaluate((el) => getComputedStyle(el).backgroundColor),
+        )
+        .toBe("rgb(12, 34, 56)");
+      await expect
+        .poll(async () =>
+          activeCursor.evaluate((el) => getComputedStyle(el).borderRadius),
+        )
+        .toBe("999px");
+      await expect
+        .poll(async () =>
+          activeCursor.evaluate((el) => getComputedStyle(el, "::after").content),
+        )
+        .toBe("none");
+    };
+
+    // Visit alpha → beta → alpha to catch regressions that only show up when
+    // the same terminal is reactivated after another one has been mounted.
+    await page
+      .getByRole("button", { name: /^alpha main · Idle$/ })
+      .click();
+    await expectPill();
+
+    await page
+      .getByRole("button", { name: /^beta main · Idle$/ })
+      .click();
+    await expectPill();
+
+    await page
+      .getByRole("button", { name: /^alpha main · Idle$/ })
+      .click();
+    await expectPill();
+  });
+
   test("activating a session calls pty_spawn with the session's cwd", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

Closes test-coverage gaps surfaced while auditing v1.8.0…HEAD. Each PR below already shipped, but had one or more behaviors covered only by manual verification or only by happy-path unit tests. This adds focused regression tests for those gaps; no production code changes.

- **#299** — Adds two store-level cases for optimistic worktree session removal: empty split pane collapses before the backend resolves; non-active workspace pane layout is left untouched.
- **#294** — Adds an `alpha → beta → alpha` round-trip E2E for pill-cursor preservation. The PR's own test only covered a single direction switch.
- **#300** — Adds defensive-branch coverage for `patchTerminalMouseCoordinateScale`: missing mouse service, missing selection screen element, missing scroll-amount helper, and a zero-`offsetWidth` edge case for `scaledMousePositionForElement`.

## Files touched

- `src/store.test.ts` (+2 tests)
- `src/lib/terminalMouseScale.test.ts` (+4 tests + 1 edge-case describe)
- `tests/e2e/terminal.spec.ts` (+1 test)

## Test plan

- [x] `pnpm exec vitest run src/store.test.ts src/lib/terminalMouseScale.test.ts` — 2 files / 76 passed, 1 skipped
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts -g "round-trip"` — 1 passed (6.7s)
- [x] `git diff --check` — passed
- [ ] CI green on this PR before merge

## Notes

- New tests only — no production code change. Coverage delta is additive.
- The Playwright run logs the existing mocked-environment `load_status` / user-theme warnings; the test passes and these warnings are not introduced by this PR.