### PR TITLE
feat(sidebar): rename chats to instant sessions + align local rows

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -412,7 +412,7 @@ export function Sidebar() {
   return (
     <aside className="flex h-full w-full flex-col bg-bg-sidebar">
       <header className="flex h-9 shrink-0 items-center justify-between gap-2 px-3">
-        <h2 className="text-sm font-medium tracking-tight text-fg-muted">
+        <h2 className="text-xs font-medium text-fg-muted">
           {sidebarText(t, "sidebar.projects.title")}
         </h2>
         <div className="flex items-center gap-1">
@@ -1418,10 +1418,10 @@ function LocalTerminalArea({
         "rounded-md focus:outline-none",
       )}
     >
-      <div className="mb-1 flex items-center justify-between px-2">
-        <span className="text-xs font-medium text-fg-muted">
+      <header className="flex h-9 shrink-0 items-center justify-between gap-2 px-3">
+        <h2 className="text-xs font-medium text-fg-muted">
           {sidebarText(t, "sidebar.localTerminals.title")}
-        </span>
+        </h2>
         <Tooltip
           label={sidebarText(t, "sidebar.localTerminals.newSession")}
           side="bottom"
@@ -1434,12 +1434,12 @@ function LocalTerminalArea({
               onCreate();
             }}
             onDoubleClick={(e) => e.stopPropagation()}
-            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+            className="rounded-md p-1.5 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
           >
-            <Plus size={12} />
+            <Plus size={14} />
           </button>
         </Tooltip>
-      </div>
+      </header>
       {sessions.length > 0 ? (
         <div onDoubleClick={(e) => e.stopPropagation()}>
           <SortableContext
@@ -1475,7 +1475,7 @@ function LocalTerminalArea({
             onCreate();
           }
         }}
-        className="mx-1 mt-1 flex min-h-16 flex-1 cursor-pointer items-center justify-center rounded-md px-2 py-6 text-center text-xs text-fg-muted transition-colors hover:bg-bg-elevated/20 hover:text-fg focus:outline-none"
+        className="mx-1 mt-1 flex items-center justify-center rounded px-3 py-3 text-center text-[11px] text-fg-muted select-none focus:outline-none focus-visible:ring-1 focus-visible:ring-border"
       >
         {sessions.length === 0
           ? sidebarText(t, "sidebar.localTerminals.empty")
@@ -1501,6 +1501,12 @@ function LocalSessionRow({
   const t = useTranslation();
   const renameSession = useAppStore((s) => s.renameSession);
   const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
+  const titleText = resolveSessionTitle(session, sessionDisplay.title);
+  const metadataText = composeSessionMetadata(
+    t,
+    session,
+    sessionDisplay.metadata,
+  );
   const agentProvider = sessionDisplay.icons.agentProvider
     ? resolveSessionAgentProvider(session)
     : null;
@@ -1599,7 +1605,7 @@ function LocalSessionRow({
         setMenu({ x: e.clientX, y: e.clientY });
       }}
       className={cn(
-        "group flex min-h-8 w-full items-center gap-1.5 rounded-md px-2 text-left text-sm transition",
+        "group flex w-full items-start gap-1.5 rounded-md px-2 py-1 text-left transition",
         active ? "bg-bg-elevated" : "hover:bg-bg-elevated/60",
         isDragging && "opacity-40",
       )}
@@ -1610,7 +1616,7 @@ function LocalSessionRow({
         {...listeners}
         onClick={(e) => e.stopPropagation()}
         aria-label={sidebarText(t, "sidebar.aria.dragToReorderSession")}
-        className="invisible flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
+        className="invisible mt-1 flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
       >
         <GripVertical size={10} />
       </span>
@@ -1633,22 +1639,21 @@ function LocalSessionRow({
           )}
         </span>
       ) : null}
-      {editing ? (
-        <RenameInput
-          initial={session.name}
-          onSubmit={async (next) => {
-            setEditing(false);
-            if (next && next !== session.name) {
-              await renameSession(session.id, next);
-            }
-          }}
-          onCancel={() => setEditing(false)}
-        />
-      ) : (
-        <span className="min-w-0 flex-1 truncate font-medium text-fg">
-          {session.name}
-        </span>
-      )}
+      <SessionRowLabel
+        editing={editing}
+        session={session}
+        titleText={titleText}
+        metadataText={metadataText}
+        showKindIcons={sessionDisplay.icons.sessionKind}
+        t={t}
+        onSubmitRename={async (next) => {
+          setEditing(false);
+          if (next && next !== session.name) {
+            await renameSession(session.id, next);
+          }
+        }}
+        onCancelRename={() => setEditing(false)}
+      />
       <span
         role="button"
         aria-label={sidebarText(t, "sidebar.actions.removeSession")}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -648,9 +648,9 @@
       "controlSession": "control session"
     },
     "localTerminals": {
-      "title": "Chats",
-      "newSession": "New chat",
-      "empty": "Double-click to start a chat."
+      "title": "Instant sessions",
+      "newSession": "New instant session",
+      "empty": "Double-click to start an instant session."
     },
     "emptyProject": {
       "createSession": "Double-click to start a session."

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -648,9 +648,9 @@
       "controlSession": "컨트롤 세션"
     },
     "localTerminals": {
-      "title": "채팅",
-      "newSession": "새 채팅",
-      "empty": "더블클릭하면 채팅을 시작할 수 있습니다."
+      "title": "인스턴트 세션",
+      "newSession": "새 인스턴트 세션",
+      "empty": "더블클릭하면 인스턴트 세션을 시작할 수 있습니다."
     },
     "emptyProject": {
       "createSession": "더블클릭하면 세션을 시작할 수 있습니다."

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -47,7 +47,7 @@ test.describe("sidebar: project lifecycle", () => {
     ).toBeVisible();
   });
 
-  test("clicking the chats add button creates a local terminal session", async ({
+  test("clicking the instant sessions add button creates a local terminal session", async ({
     page,
     tauri,
   }) => {
@@ -106,11 +106,11 @@ test.describe("sidebar: project lifecycle", () => {
 
     await page.goto("/");
     const chats = page.getByRole("region", { name: "Local terminal sessions" });
-    await chats.getByRole("button", { name: "New chat" }).click();
+    await chats.getByRole("button", { name: "New instant session" }).click();
 
-    await expect(page.getByText("Chats")).toBeVisible();
+    await expect(page.getByText("Instant sessions")).toBeVisible();
     await expect(
-      chats.getByRole("button", { name: "terminal", exact: true }),
+      chats.getByRole("button", { name: /^terminal\b/ }),
     ).toBeVisible();
 
     const calls = (await page.evaluate(
@@ -253,7 +253,7 @@ test.describe("sidebar: project lifecycle", () => {
     });
   });
 
-  test("clicking the chats area makes new-session hotkey create a chat", async ({
+  test("clicking the instant sessions area makes new-session hotkey create a local session", async ({
     page,
     tauri,
   }) => {


### PR DESCRIPTION
## Summary
Renames the unscoped local terminal area from Chats to Instant sessions and tightens its sidebar presentation.

1. **Instant sessions wording:** Updates English and Korean sidebar copy from Chats/채팅 to Instant sessions/인스턴트 세션.
2. **Sidebar hierarchy:** Reduces Projects and Instant sessions headers to the prior compact Chats header size.
3. **Local session rows:** Reuses the same session label treatment as project sessions so status, metadata, and session display settings remain consistent.
4. **Empty create area:** Keeps double-click creation available while removing hover/cursor affordances and keeping the create row size stable whether sessions exist or not.

## Expected impact
| Area | Impact |
| --- | --- |
| Sidebar copy | Unscoped terminal sessions are described more accurately as Instant sessions. |
| Sidebar layout | Projects and Instant sessions now read as lighter sibling groups. |
| Session creation | Double-click creation remains available without a large highlighted empty region. |
| Accessibility | The invisible create row keeps a keyboard focus ring via `focus-visible`. |

## Design notes
The empty Instant sessions create target intentionally keeps the same compact row dimensions in both empty and populated states. Text only appears when there are no instant sessions; otherwise the area stays visually blank but still supports double-click and keyboard creation.

## Follow-up (not in this PR)
A visual pass in the running app can fine-tune the exact spacing if the compact create row feels too subtle next to dense session lists.

## Test plan
- [x] `bun run typecheck` — passed.
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts --project=chromium` — passed.
- [x] `git diff --check` — passed.

## Notes
No browser screenshot pass was run for this PR.

