### PR TITLE
chore(release): bump version to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.8.2",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.8.1"
+version = "1.8.2"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
Prepare the patch release for the Claude History meta-message fix.

1. **Version bump:** Update package, Tauri, and Cargo versions from `1.8.1` to `1.8.2`.

## Expected impact

| Area | Impact |
| --- | --- |
| Release packaging | `v1.8.2` bundles and updater metadata will carry the matching app version. |
| Changelog | No user-facing release-note entry from this bump PR; the prior fix PR supplies the changelog item. |

## Design notes
This PR only aligns version metadata before creating the `v1.8.2` tag.

## Test plan
- [x] `rg -n '1\\.8\\.1|1\\.8\\.2' package.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json pnpm-lock.yaml`\n- [x] `git diff --check`\n\n## Notes\nUse `skip-changelog` so this mechanical release bump does not appear in the generated in-app changelog.