### PR TITLE
fix(workspace): restore worktree file tab reselection

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -314,6 +314,36 @@ describe("workspace tabs", () => {
     });
   });
 
+  it("reselects a worktree-scoped code tab after switching projects", async () => {
+    const a1 = session("a1", REPO_A, {
+      worktree_path: `${REPO_A}/.worktrees/a1`,
+    });
+    const b1 = session("b1", REPO_B);
+    await seed(
+      [project(REPO_A, 0), project(REPO_B, 1)],
+      [a1, b1],
+    );
+
+    useAppStore
+      .getState()
+      .openCodeViewerTab(`${a1.worktree_path}/README.md`, a1.worktree_path);
+    const tabId = useAppStore.getState().activeTabId!;
+
+    useAppStore.getState().selectSession("a1");
+    useAppStore.getState().setActiveProject(REPO_B);
+    useAppStore.getState().setActiveProject(REPO_A);
+    useAppStore.getState().selectTab(tabId);
+
+    const s = useAppStore.getState();
+    expect(s.activeProject).toBe(REPO_A);
+    expect(s.activeTabId).toBe(tabId);
+    expect(s.activeSessionId).toBeNull();
+    expect(s.workspaceTabs[tabId]).toMatchObject({
+      path: `${a1.worktree_path}/README.md`,
+      repoPath: a1.worktree_path,
+    });
+  });
+
   it("closes the active code viewer instead of requesting session removal", async () => {
     await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
     useAppStore.getState().openCodeViewerTab(`${REPO_A}/src/App.tsx`);

--- a/src/store.ts
+++ b/src/store.ts
@@ -446,7 +446,7 @@ function findPaneContainingTab(
   return null;
 }
 
-function findSessionOwner(
+function findTabOwner(
   state: AppStateModel,
   id: string,
 ): { repoPath: string; paneId: PaneId } | null {
@@ -703,27 +703,25 @@ export const useAppStore = create<AppStateModel>()(
 
       if (isWorkspaceTabId(id)) {
         const tab = s.workspaceTabs[id];
-        const targetProject = tab?.repoPath ?? s.activeProject;
-        if (!targetProject) return s;
-        const ws = s.workspaces[targetProject];
+        const owner = findTabOwner(s, id);
+        if (!tab || !owner) return s;
+        const ws = s.workspaces[owner.repoPath];
         if (!ws) return s;
-        const containing = findPaneContainingTab(ws.panes, id);
-        if (!containing) return s;
-        const pane = ws.panes[containing];
+        const pane = ws.panes[owner.paneId];
         if (!pane) return s;
         const nextWs: ProjectWorkspace = {
           ...ws,
           panes: {
             ...ws.panes,
-            [containing]: { ...pane, activeTabId: id },
+            [owner.paneId]: { ...pane, activeTabId: id },
           },
-          focusedPaneId: containing,
+          focusedPaneId: owner.paneId,
         };
-        const workspaces = { ...s.workspaces, [targetProject]: nextWs };
+        const workspaces = { ...s.workspaces, [owner.repoPath]: nextWs };
         return {
           workspaces,
-          activeProject: targetProject,
-          ...mirrorActive(workspaces, targetProject),
+          activeProject: owner.repoPath,
+          ...mirrorActive(workspaces, owner.repoPath),
         };
       }
 
@@ -1151,7 +1149,7 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   async removeSession(id, removeWorktree = false) {
-    const owning = findSessionOwner(get(), id);
+    const owning = findTabOwner(get(), id);
     set((s) => {
       if (!s.sessions.some((session) => session.id === id)) return s;
 

--- a/tests/e2e/file-explorer.spec.ts
+++ b/tests/e2e/file-explorer.spec.ts
@@ -159,4 +159,102 @@ test.describe("file explorer", () => {
     await expect(page.getByRole("button", { name: "Source" })).toBeVisible();
     await expect(page.getByText("Markdown preview")).toBeVisible();
   });
+
+  test("reopens a worktree file tab after switching away and back to its project", async ({
+    page,
+    tauri,
+  }) => {
+    const repoA = "/tmp/alpha";
+    const repoB = "/tmp/beta";
+    const worktreeA = "/tmp/alpha/.worktrees/a-session";
+
+    await tauri.respond("list_projects", [
+      {
+        repo_path: repoA,
+        name: "alpha",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+      {
+        repo_path: repoB,
+        name: "beta",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 1,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "a-session",
+        name: "a-session",
+        repo_path: repoA,
+        worktree_path: worktreeA,
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+      {
+        id: "b-session",
+        name: "b-session",
+        repo_path: repoB,
+        worktree_path: "/tmp/beta/.worktrees/b-session",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("fs_list_dir", (args) => {
+      const { path } = args as { path: string };
+      if (path !== "/tmp/alpha/.worktrees/a-session") {
+        return { repo_root: path, entries: [] };
+      }
+      return {
+        repo_root: "/tmp/alpha/.worktrees/a-session",
+        entries: [
+          {
+            name: "README.md",
+            path: "/tmp/alpha/.worktrees/a-session/README.md",
+            is_dir: false,
+            is_symlink: false,
+            size: 28,
+            modified_ms: 0,
+            gitignored: false,
+          },
+        ],
+      };
+    });
+    await tauri.handle("fs_read_file", (args) => {
+      const { path } = args as { path: string };
+      if (path !== "/tmp/alpha/.worktrees/a-session/README.md") {
+        throw new Error(`unexpected path: ${path}`);
+      }
+      return {
+        content: "# Alpha README\n\nProject A notes",
+        size: 28,
+        truncated: false,
+        binary: false,
+      };
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Code" }).click();
+    await page.getByRole("button", { name: "Files", exact: true }).click();
+
+    await page.getByRole("button", { name: "README.md" }).dblclick();
+    await expect(
+      page.getByRole("button", { name: /README\.md Close tab/ }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: /a-session Close session/ }).click();
+    await page.getByRole("button", { name: "Project beta" }).click();
+    await page.getByRole("button", { name: "Project alpha" }).click();
+    await page.getByRole("button", { name: /README\.md Close tab/ }).click();
+
+    await expect(page.getByRole("button", { name: "Preview" })).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
Fixes a workspace-tab routing bug where a README/code-viewer tab opened from a worktree could become unselectable after switching to another project and back.

1. **Workspace tab selection:** Resolve frontend-owned tab ownership by scanning the workspace panes that actually contain the tab ID instead of treating the tab descriptor repo path as a workspace key.
2. **Regression coverage:** Add store coverage for worktree-scoped code tabs and an E2E path that opens README.md, switches projects, returns, and reselects the README tab.

## Expected impact

| Area | Impact |
| --- | --- |
| File tabs | README/code-viewer tabs opened from worktrees can be selected again after project switches. |
| Workspace routing | Session tabs keep existing behavior; frontend-owned tabs now route through their owning pane/workspace. |
| Reliability | Adds targeted unit and browser coverage for the reported project-switch flow. |

## Design notes

The tab descriptor `repoPath` is still allowed to represent the file/root path used by the code viewer and right-panel context. Selection now uses the tab ID as the source of truth for ownership because pane membership already records which project workspace owns the tab.

Self-review found no broader structure needed: tab IDs are globally unique, and the existing pane lookup helper already matches the desired ownership contract.

## Test plan

- [x] `pnpm exec vitest run src/store.test.ts` - 1 file passed, 69 passed / 1 skipped.
- [x] `pnpm exec playwright test tests/e2e/file-explorer.spec.ts` - 3 passed.
- [x] `pnpm run typecheck` - passed.

## Notes

`pnpm install` was run in this worktree because `node_modules` was absent; it did not change tracked dependency files.