### PR TITLE
feat(viewer): in-file search highlighting for code viewer

### DIFF
--- a/src/components/CodeDiffVirtualization.test.tsx
+++ b/src/components/CodeDiffVirtualization.test.tsx
@@ -41,6 +41,15 @@ async function flushPromises() {
   });
 }
 
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
 function makePatch(lineCount: number): string {
   return Array.from({ length: lineCount }, (_, index) => `+line-${index}`).join(
     "\n",
@@ -161,6 +170,30 @@ describe("virtualized code and diff rendering", () => {
       container.querySelector<HTMLButtonElement>('button[aria-pressed="true"]')
         ?.textContent,
     ).toContain("Source");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "f",
+          metaKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    const input = container.querySelector<HTMLInputElement>(
+      'input[aria-label="Find in file"]',
+    );
+    expect(input).not.toBeNull();
+
+    await act(async () => {
+      setInputValue(input!, "shipped");
+    });
+
+    expect(container.querySelectorAll("[data-acorn-preview-search]")).toHaveLength(
+      1,
+    );
+    expect(container.textContent).toContain("1/1");
   });
 
   it("copies selected text by source line in virtualized lists", () => {
@@ -196,6 +229,57 @@ describe("virtualized code and diff rendering", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(clipboard.getData("text/plain")).toBe("line-1\nline-2\nline-3");
+  });
+
+  it("finds and highlights matches inside a code viewer", async () => {
+    const content = "alpha\nbeta alpha\nALPHA";
+    vi.mocked(api.fsReadFile).mockResolvedValueOnce({
+      content,
+      size: content.length,
+      truncated: false,
+      binary: false,
+    });
+    vi.mocked(api.fsGitDiffLines).mockResolvedValueOnce([]);
+
+    await act(async () => {
+      root.render(<CodeViewer path="/repo/src/search.txt" isActive />);
+    });
+    await flushPromises();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "f",
+          metaKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    const input = container.querySelector<HTMLInputElement>(
+      'input[aria-label="Find in file"]',
+    );
+    expect(input).not.toBeNull();
+
+    await act(async () => {
+      setInputValue(input!, "alpha");
+    });
+
+    expect(container.querySelectorAll("mark")).toHaveLength(3);
+    expect(container.textContent).toContain("1/3");
+
+    await act(async () => {
+      input!.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    expect(container.textContent).toContain("2/3");
   });
 });
 

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Code2, Eye } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import { ChevronDown, ChevronUp, Code2, Eye, Search, X } from "lucide-react";
 import {
   api,
   type FsLineDiffEntry,
@@ -13,6 +14,7 @@ import {
   lineIndexProps,
   lineTextContentProps,
   VirtualizedLineList,
+  type VirtualizedLineListHandle,
 } from "./VirtualizedLines";
 import { Markdown } from "./ui/Markdown";
 
@@ -43,6 +45,26 @@ const DIFF_KIND_CLASS: Record<FsLineDiffEntry["kind"], string> = {
 
 const CODE_LINE_HEIGHT = 18;
 const MARKDOWN_EXT_RE = /\.(md|mdown|markdown|mdx)$/i;
+const SEARCH_MARK_CLASS = "rounded-[2px] px-0.5 text-fg";
+const SEARCH_MARK_ACTIVE_CLASS = `${SEARCH_MARK_CLASS} bg-accent/75`;
+const SEARCH_MARK_INACTIVE_CLASS = `${SEARCH_MARK_CLASS} bg-warning/60`;
+const PREVIEW_SEARCH_MARK_SELECTOR = "mark[data-acorn-preview-search]";
+const SHOW_TEXT_NODE = 4;
+const FILTER_ACCEPT = 1;
+const FILTER_REJECT = 2;
+
+interface SearchMatch {
+  line: number;
+  start: number;
+  end: number;
+  index: number;
+}
+
+interface LineSearchMatch {
+  start: number;
+  end: number;
+  active: boolean;
+}
 
 function isMarkdownPath(path: string): boolean {
   return MARKDOWN_EXT_RE.test(path);
@@ -53,6 +75,13 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
   const [state, setState] = useState<ViewerState>(EMPTY_STATE);
   const [diffLines, setDiffLines] = useState<FsLineDiffEntry[]>([]);
   const [previewMarkdown, setPreviewMarkdown] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [activeMatchIndex, setActiveMatchIndex] = useState(0);
+  const [previewMatchCount, setPreviewMatchCount] = useState(0);
+  const lineListRef = useRef<VirtualizedLineListHandle | null>(null);
+  const previewRef = useRef<HTMLDivElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
 
   const refreshDiff = useCallback(async () => {
     try {
@@ -67,6 +96,10 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
     let cancelled = false;
     setState(EMPTY_STATE);
     setPreviewMarkdown(false);
+    setSearchOpen(false);
+    setSearchQuery("");
+    setActiveMatchIndex(0);
+    setPreviewMatchCount(0);
     api
       .fsReadFile(path)
       .then(async (data) => {
@@ -124,6 +157,102 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
     () => estimateMaxLineWidthCh(sourceLines, gutterWidth + 7),
     [gutterWidth, sourceLines],
   );
+  const canPreviewMarkdown = isMarkdownPath(path);
+  const previewMode = previewMarkdown && canPreviewMarkdown;
+  const effectiveSearchQuery = searchOpen ? searchQuery : "";
+  const searchMatches = useMemo(
+    () => findLineMatches(sourceLines, effectiveSearchQuery),
+    [effectiveSearchQuery, sourceLines],
+  );
+  const searchMatchesByLine = useMemo(() => {
+    const map = new Map<number, LineSearchMatch[]>();
+    for (const match of searchMatches) {
+      const lineMatches = map.get(match.line) ?? [];
+      lineMatches.push({
+        start: match.start,
+        end: match.end,
+        active: match.index === activeMatchIndex,
+      });
+      map.set(match.line, lineMatches);
+    }
+    return map;
+  }, [activeMatchIndex, searchMatches]);
+  const currentMatchCount = previewMode
+    ? previewMatchCount
+    : searchMatches.length;
+
+  const openSearch = useCallback(() => {
+    setSearchOpen(true);
+    requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    });
+  }, []);
+
+  const closeSearch = useCallback(() => {
+    setSearchOpen(false);
+  }, []);
+
+  const stepMatch = useCallback(
+    (direction: 1 | -1) => {
+      if (currentMatchCount === 0) return;
+      setActiveMatchIndex(
+        (current) =>
+          (current + direction + currentMatchCount) % currentMatchCount,
+      );
+    },
+    [currentMatchCount],
+  );
+
+  useEffect(() => {
+    if (previewMode) return;
+    if (!searchOpen || searchQuery === "") return;
+    if (searchMatches.length === 0) {
+      setActiveMatchIndex(0);
+      return;
+    }
+    if (activeMatchIndex >= searchMatches.length) {
+      setActiveMatchIndex(searchMatches.length - 1);
+      return;
+    }
+    lineListRef.current?.scrollToIndex(searchMatches[activeMatchIndex].line);
+  }, [activeMatchIndex, previewMode, searchMatches, searchOpen, searchQuery]);
+
+  useEffect(() => {
+    if (!previewMode) {
+      setPreviewMatchCount(0);
+      return;
+    }
+    const root = previewRef.current;
+    if (!root) return;
+    const { count, activeElement } = highlightPreviewMatches(
+      root,
+      effectiveSearchQuery,
+      activeMatchIndex,
+    );
+    setPreviewMatchCount(count);
+    if (count === 0) {
+      setActiveMatchIndex(0);
+    } else if (activeMatchIndex >= count) {
+      setActiveMatchIndex(count - 1);
+    } else {
+      activeElement?.scrollIntoView?.({ block: "center", inline: "nearest" });
+    }
+    return () => {
+      removePreviewSearchMarks(root);
+    };
+  }, [activeMatchIndex, effectiveSearchQuery, previewMode]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (!isFindShortcut(event)) return;
+      event.preventDefault();
+      openSearch();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isActive, openSearch]);
 
   if (state.loading) {
     return (
@@ -153,8 +282,6 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
   if (!state.data) return null;
 
   const lines = state.highlightedLines ?? plainHighlightedLines;
-  const canPreviewMarkdown = isMarkdownPath(path);
-
   return (
     <div
       className={cn(
@@ -168,7 +295,10 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
         </div>
       ) : null}
       {previewMarkdown && canPreviewMarkdown ? (
-        <div className="acorn-selectable min-h-0 flex-1 overflow-auto px-8 py-6 pb-16">
+        <div
+          ref={previewRef}
+          className="acorn-selectable min-h-0 flex-1 overflow-auto px-8 py-6 pb-16"
+        >
           <Markdown
             content={state.data.content}
             className="mx-auto max-w-3xl text-[13px] leading-6"
@@ -176,6 +306,7 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
         </div>
       ) : (
         <VirtualizedLineList
+          ref={lineListRef}
           as="pre"
           count={sourceLines.length}
           className="acorn-selectable m-0 flex-1 cursor-text overflow-auto bg-transparent pb-12 font-mono text-[12px] leading-[1.5] text-fg"
@@ -190,10 +321,74 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
               tokens={lines[index] ?? null}
               diff={diffByLine.get(index + 1)}
               gutterWidth={gutterWidth}
+              searchMatches={searchMatchesByLine.get(index) ?? []}
             />
           )}
         />
       )}
+      {searchOpen ? (
+        <div className="absolute right-3 top-3 z-30 flex max-w-[calc(100%-1.5rem)] items-center gap-1 rounded-md border border-border bg-bg-elevated/95 p-1 shadow-lg backdrop-blur">
+          <Search size={13} className="ml-1 text-fg-muted" />
+          <input
+            ref={searchInputRef}
+            value={searchQuery}
+            onChange={(event) => {
+              setSearchQuery(event.target.value);
+              setActiveMatchIndex(0);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                stepMatch(event.shiftKey ? -1 : 1);
+              } else if (event.key === "Escape") {
+                event.preventDefault();
+                closeSearch();
+              }
+            }}
+            aria-label={t("codeViewer.findInFile")}
+            placeholder={t("codeViewer.findInFile")}
+            className="h-7 w-52 min-w-0 bg-transparent px-1 text-xs text-fg outline-none placeholder:text-fg-muted"
+          />
+          <span className="min-w-[4.5rem] text-center text-[11px] tabular-nums text-fg-muted">
+            {searchQuery === ""
+              ? t("codeViewer.findPrompt")
+              : currentMatchCount === 0
+                ? t("codeViewer.noMatches")
+                : t("codeViewer.matchCount")
+                    .replace("{current}", String(activeMatchIndex + 1))
+                    .replace("{total}", String(currentMatchCount))}
+          </span>
+          <button
+            type="button"
+            onClick={() => stepMatch(-1)}
+            disabled={currentMatchCount === 0}
+            aria-label={t("codeViewer.previousMatch")}
+            title={t("codeViewer.previousMatch")}
+            className="inline-flex size-7 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+          >
+            <ChevronUp size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={() => stepMatch(1)}
+            disabled={currentMatchCount === 0}
+            aria-label={t("codeViewer.nextMatch")}
+            title={t("codeViewer.nextMatch")}
+            className="inline-flex size-7 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+          >
+            <ChevronDown size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={closeSearch}
+            aria-label={t("codeViewer.closeFind")}
+            title={t("codeViewer.closeFind")}
+            className="inline-flex size-7 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      ) : null}
       {canPreviewMarkdown ? (
         <button
           type="button"
@@ -217,12 +412,14 @@ function CodeLine({
   tokens,
   diff,
   gutterWidth,
+  searchMatches,
 }: {
   index: number;
   rawText: string;
   tokens: string | null;
   diff?: FsLineDiffEntry["kind"];
   gutterWidth: number;
+  searchMatches: LineSearchMatch[];
 }) {
   return (
     <div className="flex whitespace-pre" {...lineIndexProps(index)}>
@@ -244,11 +441,157 @@ function CodeLine({
       <span
         {...lineTextContentProps()}
         className="grow"
-        {...(tokens
-          ? { dangerouslySetInnerHTML: { __html: tokens } }
-          : { children: rawText })}
+        {...(searchMatches.length > 0
+          ? { children: renderSearchLine(rawText, searchMatches) }
+          : tokens
+            ? { dangerouslySetInnerHTML: { __html: tokens } }
+            : { children: rawText })}
       />
     </div>
+  );
+}
+
+function findLineMatches(
+  lines: readonly string[],
+  query: string,
+): SearchMatch[] {
+  const matches: SearchMatch[] = [];
+  lines.forEach((line, lineIndex) => {
+    for (const range of findTextRanges(line, query)) {
+      matches.push({
+        line: lineIndex,
+        start: range.start,
+        end: range.end,
+        index: matches.length,
+      });
+    }
+  });
+  return matches;
+}
+
+function renderSearchLine(rawText: string, matches: readonly LineSearchMatch[]) {
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  matches.forEach((match, index) => {
+    if (match.start > cursor) {
+      nodes.push(rawText.slice(cursor, match.start));
+    }
+    nodes.push(
+      <mark
+        key={`${match.start}-${index}`}
+        className={
+          match.active ? SEARCH_MARK_ACTIVE_CLASS : SEARCH_MARK_INACTIVE_CLASS
+        }
+      >
+        {rawText.slice(match.start, match.end)}
+      </mark>,
+    );
+    cursor = match.end;
+  });
+  if (cursor < rawText.length) {
+    nodes.push(rawText.slice(cursor));
+  }
+  return nodes;
+}
+
+function highlightPreviewMatches(
+  root: HTMLElement,
+  query: string,
+  activeMatchIndex: number,
+): { count: number; activeElement: HTMLElement | null } {
+  removePreviewSearchMarks(root);
+  if (query === "") return { count: 0, activeElement: null };
+
+  const doc = root.ownerDocument;
+  const textNodes: Text[] = [];
+  const walker = doc.createTreeWalker(root, SHOW_TEXT_NODE, {
+    acceptNode(node) {
+      const text = node.nodeValue ?? "";
+      const parent = node.parentElement;
+      if (!parent || text === "") return FILTER_REJECT;
+      if (parent.closest(PREVIEW_SEARCH_MARK_SELECTOR)) {
+        return FILTER_REJECT;
+      }
+      if (parent.closest("script,style")) return FILTER_REJECT;
+      return findTextRanges(text, query).length > 0
+        ? FILTER_ACCEPT
+        : FILTER_REJECT;
+    },
+  });
+
+  let current = walker.nextNode();
+  while (current) {
+    textNodes.push(current as Text);
+    current = walker.nextNode();
+  }
+
+  let count = 0;
+  let activeElement: HTMLElement | null = null;
+  for (const node of textNodes) {
+    const text = node.data;
+    const ranges = findTextRanges(text, query);
+    const fragment = doc.createDocumentFragment();
+    let cursor = 0;
+    for (const range of ranges) {
+      if (range.start > cursor) {
+        fragment.append(text.slice(cursor, range.start));
+      }
+      const mark = doc.createElement("mark");
+      mark.dataset.acornPreviewSearch = "true";
+      mark.className =
+        count === activeMatchIndex
+          ? SEARCH_MARK_ACTIVE_CLASS
+          : SEARCH_MARK_INACTIVE_CLASS;
+      mark.textContent = text.slice(range.start, range.end);
+      if (count === activeMatchIndex) activeElement = mark;
+      fragment.append(mark);
+      count += 1;
+      cursor = range.end;
+    }
+    if (cursor < text.length) {
+      fragment.append(text.slice(cursor));
+    }
+    node.replaceWith(fragment);
+  }
+
+  return { count, activeElement };
+}
+
+function removePreviewSearchMarks(root: HTMLElement) {
+  const marks = Array.from(
+    root.querySelectorAll<HTMLElement>(PREVIEW_SEARCH_MARK_SELECTOR),
+  );
+  for (const mark of marks) {
+    const parent = mark.parentNode;
+    mark.replaceWith(root.ownerDocument.createTextNode(mark.textContent ?? ""));
+    parent?.normalize();
+  }
+}
+
+function findTextRanges(text: string, query: string): { start: number; end: number }[] {
+  if (query === "") return [];
+  const re = new RegExp(escapeRegExp(query), "giu");
+  const ranges: { start: number; end: number }[] = [];
+  for (const match of text.matchAll(re)) {
+    const start = match.index;
+    const value = match[0];
+    if (start === undefined || value === "") continue;
+    ranges.push({ start, end: start + value.length });
+  }
+  return ranges;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isFindShortcut(event: KeyboardEvent): boolean {
+  const primary = event.metaKey || event.ctrlKey;
+  return (
+    primary &&
+    !event.altKey &&
+    !event.shiftKey &&
+    event.key.toLocaleLowerCase() === "f"
   );
 }
 

--- a/src/components/VirtualizedLines.tsx
+++ b/src/components/VirtualizedLines.tsx
@@ -1,6 +1,8 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
+  forwardRef,
   useCallback,
+  useImperativeHandle,
   useMemo,
   useRef,
   type ClipboardEvent,
@@ -29,6 +31,10 @@ interface VirtualizedLineListProps {
   threshold?: number;
 }
 
+export interface VirtualizedLineListHandle {
+  scrollToIndex: (index: number, align?: "start" | "center" | "end") => void;
+}
+
 interface SelectionEndpoint {
   index: number;
   offset: number;
@@ -42,18 +48,24 @@ interface RenderedVirtualItem {
   size: number;
 }
 
-export function VirtualizedLineList({
-  as = "div",
-  count,
-  className,
-  innerClassName,
-  estimateSize,
-  getLineText,
-  renderLine,
-  minWidthCh,
-  overscan = DEFAULT_OVERSCAN,
-  threshold = VIRTUALIZED_LINE_THRESHOLD,
-}: VirtualizedLineListProps) {
+export const VirtualizedLineList = forwardRef<
+  VirtualizedLineListHandle,
+  VirtualizedLineListProps
+>(function VirtualizedLineList(
+  {
+    as = "div",
+    count,
+    className,
+    innerClassName,
+    estimateSize,
+    getLineText,
+    renderLine,
+    minWidthCh,
+    overscan = DEFAULT_OVERSCAN,
+    threshold = VIRTUALIZED_LINE_THRESHOLD,
+  },
+  ref,
+) {
   const scrollRef = useRef<HTMLElement | null>(null);
   const virtualized = count > threshold;
   const averageInitialSize = useMemo(() => {
@@ -91,6 +103,24 @@ export function VirtualizedLineList({
   const setScrollRef = useCallback((node: HTMLElement | null) => {
     scrollRef.current = node;
   }, []);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToIndex(index, align = "center") {
+        if (index < 0 || index >= count) return;
+        if (virtualized) {
+          virtualizer.scrollToIndex(index, { align });
+          return;
+        }
+        const line = scrollRef.current?.querySelector<HTMLElement>(
+          `[data-line-index="${index}"]`,
+        );
+        line?.scrollIntoView?.({ block: align, inline: "nearest" });
+      },
+    }),
+    [count, virtualized, virtualizer],
+  );
 
   const onCopy = useVirtualizedCopy({
     enabled: virtualized,
@@ -143,7 +173,7 @@ export function VirtualizedLineList({
   ) : (
     <div {...props}>{content}</div>
   );
-}
+});
 
 function buildFallbackItems(
   count: number,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -553,7 +553,14 @@
     "binaryFileBody": "{bytes} bytes - not shown in the readonly viewer.",
     "truncated": "File truncated to 2 MB. Open externally to view the rest.",
     "showPreview": "Preview",
-    "showSource": "Source"
+    "showSource": "Source",
+    "findInFile": "Find in file",
+    "findPrompt": "Find",
+    "noMatches": "No matches",
+    "matchCount": "{current}/{total}",
+    "previousMatch": "Previous match",
+    "nextMatch": "Next match",
+    "closeFind": "Close find"
   },
   "diffView": {
     "noChanges": "No changes in this diff.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -553,7 +553,14 @@
     "binaryFileBody": "{bytes}바이트 - 읽기 전용 뷰어에 표시되지 않습니다.",
     "truncated": "파일이 2 MB로 잘렸습니다. 나머지는 외부에서 열어 확인하세요.",
     "showPreview": "미리보기",
-    "showSource": "소스"
+    "showSource": "소스",
+    "findInFile": "파일에서 찾기",
+    "findPrompt": "찾기",
+    "noMatches": "일치 없음",
+    "matchCount": "{current}/{total}",
+    "previousMatch": "이전 일치",
+    "nextMatch": "다음 일치",
+    "closeFind": "찾기 닫기"
   },
   "diffView": {
     "noChanges": "이 diff에는 변경 사항이 없습니다.",

--- a/tests/e2e/file-explorer.spec.ts
+++ b/tests/e2e/file-explorer.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "./support";
+import { test, expect, pressHotkey } from "./support";
 
 test.describe("file explorer", () => {
   test("keeps expanded worktree folders after opening a file", async ({
@@ -158,5 +158,78 @@ test.describe("file explorer", () => {
     ).toBeVisible();
     await expect(page.getByRole("button", { name: "Source" })).toBeVisible();
     await expect(page.getByText("Markdown preview")).toBeVisible();
+
+    await pressHotkey(page, { mod: true, key: "f" });
+    await page.getByLabel("Find in file").fill("preview");
+
+    await expect(page.locator("[data-acorn-preview-search]")).toHaveCount(1);
+    await expect(page.getByText("1/1")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Project notes" }),
+    ).toBeVisible();
+  });
+
+  test("finds matches inside a code viewer tab", async ({ page, tauri }) => {
+    const repo = "/tmp/demo";
+
+    await tauri.respond("list_projects", [
+      {
+        repo_path: repo,
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", []);
+    await tauri.handle("fs_list_dir", (args) => {
+      const { path } = args as { path: string };
+      if (path !== "/tmp/demo") {
+        return { repo_root: "/tmp/demo", entries: [] };
+      }
+      return {
+        repo_root: "/tmp/demo",
+        entries: [
+          {
+            name: "search.txt",
+            path: "/tmp/demo/search.txt",
+            is_dir: false,
+            is_symlink: false,
+            size: 28,
+            modified_ms: 0,
+            gitignored: false,
+          },
+        ],
+      };
+    });
+    await tauri.handle("fs_read_file", (args) => {
+      const { path } = args as { path: string };
+      if (path !== "/tmp/demo/search.txt") {
+        throw new Error(`unexpected path: ${path}`);
+      }
+      return {
+        content: "alpha\nbeta alpha\nALPHA",
+        size: 22,
+        truncated: false,
+        binary: false,
+      };
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Code" }).click();
+    await page.getByRole("button", { name: "Files", exact: true }).click();
+
+    await page.getByRole("button", { name: "search.txt" }).dblclick();
+    await expect(
+      page.getByRole("button", { name: /search\.txt Close tab/ }),
+    ).toBeVisible();
+
+    await pressHotkey(page, { mod: true, key: "f" });
+    await page.getByLabel("Find in file").fill("alpha");
+
+    await expect(page.locator("mark")).toHaveCount(3);
+    await expect(page.getByText("1/3")).toBeVisible();
+
+    await page.getByLabel("Find in file").press("Enter");
+    await expect(page.getByText("2/3")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
Adds in-file search to the readonly code viewer, including source and Markdown preview modes:

1. **Find bar and shortcuts** — `Cmd+F` / `Ctrl+F` opens a viewer-scoped find bar with match counts, previous/next controls, Enter and Shift+Enter navigation, and Escape/close dismissal.
2. **Source-mode highlighting** — searches loaded file text across rendered and virtualized lines, highlights all matches, and scrolls the active match into view.
3. **Markdown preview support** — keeps Preview mode active while finding text in the rendered markdown DOM and highlighting visible preview text.
4. **Virtualized list navigation** — exposes a small `scrollToIndex` handle from `VirtualizedLineList` so search can move to matches outside the current render window.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Readonly source files | Browser find only saw rendered DOM and missed virtualized lines | Viewer search scans loaded file text and highlights matches |
| Markdown preview | Finding required switching back to source or using browser behavior | Preview mode supports visible-text search and highlighting |
| Large files | Matches outside the virtualized window were not reachable via DOM search | Active match scrolls the virtualized list to the right line |

## Design notes
- Search stays frontend-only and works against the existing `fs_read_file` payload, so no backend command or file IO contract changes are needed.
- Source-mode matches are computed from `sourceLines`; matching lines temporarily render React `<mark>` nodes instead of Shiki HTML so search marks do not mix with `dangerouslySetInnerHTML`.
- Preview-mode highlighting is scoped to the code viewer's preview container and wraps rendered text nodes after Markdown sanitization/rendering. The shared `Markdown` component remains unchanged.
- Closing the find bar hides highlights while preserving the query for the next open.

## Test plan
- [x] `pnpm exec vitest run src/components/CodeDiffVirtualization.test.tsx`
- [x] `pnpm run typecheck`
- [x] `pnpm exec playwright test tests/e2e/file-explorer.spec.ts`
- [x] `pnpm run build`
- [ ] CI green on this PR

## Notes
- `pnpm run build` still emits pre-existing Vite chunk/dynamic-import warnings for `api.ts`, `store.ts`, and large chunks. Build exits successfully; these warnings are not caused by this PR.