### PR TITLE
feat(macos): warm protected folder permissions after update

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -94,6 +94,87 @@ pub struct AcornIpcShim {
     pub exists: bool,
 }
 
+#[derive(Serialize)]
+pub struct FolderPermissionWarmupResult {
+    pub id: &'static str,
+    pub path: String,
+    pub status: &'static str,
+    pub error: Option<String>,
+}
+
+#[tauri::command]
+pub async fn warm_macos_folder_permissions() -> AppResult<Vec<FolderPermissionWarmupResult>> {
+    run_blocking("warm_macos_folder_permissions", move || {
+        Ok(warm_macos_folder_permissions_inner())
+    })
+    .await
+}
+
+fn warm_macos_folder_permissions_inner() -> Vec<FolderPermissionWarmupResult> {
+    if !cfg!(target_os = "macos") {
+        return Vec::new();
+    }
+
+    protected_folder_candidates()
+        .into_iter()
+        .map(|(id, path)| probe_folder_permission(id, path))
+        .collect()
+}
+
+fn protected_folder_candidates() -> Vec<(&'static str, PathBuf)> {
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        return Vec::new();
+    };
+    vec![
+        ("desktop", home.join("Desktop")),
+        ("documents", home.join("Documents")),
+        ("downloads", home.join("Downloads")),
+        (
+            "icloud",
+            home.join("Library")
+                .join("Mobile Documents")
+                .join("com~apple~CloudDocs"),
+        ),
+    ]
+}
+
+fn probe_folder_permission(id: &'static str, path: PathBuf) -> FolderPermissionWarmupResult {
+    let rendered = path.display().to_string();
+    if !path.exists() {
+        return FolderPermissionWarmupResult {
+            id,
+            path: rendered,
+            status: "missing",
+            error: None,
+        };
+    }
+
+    match std::fs::read_dir(&path) {
+        Ok(mut entries) => {
+            let _ = entries.next();
+            FolderPermissionWarmupResult {
+                id,
+                path: rendered,
+                status: "ok",
+                error: None,
+            }
+        }
+        Err(err) => {
+            let status = if err.kind() == std::io::ErrorKind::PermissionDenied {
+                "denied"
+            } else {
+                "error"
+            };
+            FolderPermissionWarmupResult {
+                id,
+                path: rendered,
+                status,
+                error: Some(err.to_string()),
+            }
+        }
+    }
+}
+
 /// Inspect the runtime environment for the `acorn-ipc` CLI: where the
 /// app-bundled binary lives, whether it exists yet, and whether the user
 /// has already installed a shim into one of the standard `$PATH` locations.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -545,6 +545,7 @@ pub fn run() {
             commands::prepare_claude_fork,
             commands::get_memory_usage,
             commands::get_acorn_ipc_status,
+            commands::warm_macos_folder_permissions,
             commands::ipc_restart,
             commands::list_system_fonts,
             commands::list_agent_history,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { SettingsModal } from "./components/SettingsModal";
 import { TerminalHost } from "./components/TerminalHost";
 import { ToastHost } from "./components/ToastHost";
 import { UpdateBanner } from "./components/UpdateBanner";
+import { FolderPermissionWarmupModal } from "./components/FolderPermissionWarmupModal";
 import {
   api,
   AGENT_HOOK_STATUS_EVENT,
@@ -57,6 +58,7 @@ import { isSessionTabId } from "./lib/workspaceTabs";
 import { flushAllScrollbacks } from "./lib/scrollback-coordinator";
 import { useToasts } from "./lib/toasts";
 import { useUpdater } from "./lib/updater-store";
+import { shouldShowPermissionWarmup } from "./lib/permissionWarmup";
 import {
   normalizeUiScalePercent,
   UI_SCALE_PERCENT_STEP,
@@ -173,6 +175,7 @@ function App() {
   );
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [controlGuideOpen, setControlGuideOpen] = useState(false);
+  const [permissionWarmupOpen, setPermissionWarmupOpen] = useState(false);
   const activeSessionId = useAppStore((s) => s.activeSessionId);
   const [resumeCandidates, setResumeCandidates] = useState<
     Map<string, { agent: AgentKind; candidate: ResumeCandidate }>
@@ -196,6 +199,7 @@ function App() {
   const themes = useThemes((s) => s.themes);
   const refreshThemes = useThemes((s) => s.refresh);
   const appearance = useSettings((s) => s.settings.appearance);
+  const currentVersion = useUpdater((s) => s.currentVersion);
 
   useEffect(() => {
     void refreshThemes();
@@ -523,6 +527,23 @@ function App() {
     );
     return () => window.clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined") return;
+    const testWindow = window as typeof window & {
+      __ACORN_TEST_MODE__?: boolean;
+      __ACORN_ENABLE_PERMISSION_WARMUP__?: boolean;
+    };
+    if (
+      testWindow.__ACORN_TEST_MODE__ &&
+      !testWindow.__ACORN_ENABLE_PERMISSION_WARMUP__
+    ) {
+      return;
+    }
+    if (shouldShowPermissionWarmup(currentVersion, navigator.platform)) {
+      setPermissionWarmupOpen(true);
+    }
+  }, [currentVersion]);
 
   useEffect(() => {
     return startSessionNotificationWatcher();
@@ -1200,6 +1221,11 @@ function App() {
             window.localStorage.setItem(CONTROL_GUIDE_DISMISSED_KEY, "1");
           }
         }}
+      />
+      <FolderPermissionWarmupModal
+        open={permissionWarmupOpen}
+        currentVersion={currentVersion}
+        onClose={() => setPermissionWarmupOpen(false)}
       />
       <SettingsModal />
       <StagedRevMismatchModal

--- a/src/components/FolderPermissionWarmupModal.tsx
+++ b/src/components/FolderPermissionWarmupModal.tsx
@@ -1,0 +1,178 @@
+import { useState, type ReactElement } from "react";
+import { FolderCheck, Loader2 } from "lucide-react";
+import { api } from "../lib/api";
+import {
+  markPermissionWarmupHandled,
+  type FolderPermissionWarmupResult,
+  type FolderPermissionWarmupStatus,
+} from "../lib/permissionWarmup";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useTranslation } from "../lib/useTranslation";
+import { Modal } from "./ui/Modal";
+import { ModalHeader } from "./ui/ModalHeader";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
+
+interface FolderPermissionWarmupModalProps {
+  open: boolean;
+  currentVersion: string | null;
+  onClose: () => void;
+}
+
+function folderName(
+  t: Translator,
+  id: FolderPermissionWarmupResult["id"],
+): string {
+  switch (id) {
+    case "desktop":
+      return dt(t, "dialogs.folderPermissionWarmup.folder.desktop");
+    case "documents":
+      return dt(t, "dialogs.folderPermissionWarmup.folder.documents");
+    case "downloads":
+      return dt(t, "dialogs.folderPermissionWarmup.folder.downloads");
+    case "icloud":
+      return dt(t, "dialogs.folderPermissionWarmup.folder.icloud");
+  }
+}
+
+function statusText(t: Translator, status: FolderPermissionWarmupStatus): string {
+  switch (status) {
+    case "ok":
+      return dt(t, "dialogs.folderPermissionWarmup.status.ok");
+    case "missing":
+      return dt(t, "dialogs.folderPermissionWarmup.status.missing");
+    case "denied":
+      return dt(t, "dialogs.folderPermissionWarmup.status.denied");
+    case "error":
+      return dt(t, "dialogs.folderPermissionWarmup.status.error");
+  }
+}
+
+function statusClass(status: FolderPermissionWarmupStatus): string {
+  switch (status) {
+    case "ok":
+      return "text-accent";
+    case "missing":
+      return "text-fg-muted";
+    case "denied":
+    case "error":
+      return "text-danger";
+  }
+}
+
+export function FolderPermissionWarmupModal({
+  open,
+  currentVersion,
+  onClose,
+}: FolderPermissionWarmupModalProps): ReactElement | null {
+  const t = useTranslation();
+  const [busy, setBusy] = useState(false);
+  const [results, setResults] = useState<FolderPermissionWarmupResult[] | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  function closeForVersion() {
+    if (currentVersion) markPermissionWarmupHandled(currentVersion);
+    onClose();
+  }
+
+  async function runWarmup() {
+    setBusy(true);
+    setError(null);
+    try {
+      const next = await api.warmMacosFolderPermissions();
+      setResults(next);
+    } catch (err) {
+      console.error("[FolderPermissionWarmupModal] warmup failed", err);
+      setError(
+        err instanceof Error
+          ? err.message
+          : dt(t, "dialogs.folderPermissionWarmup.genericError"),
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={closeForVersion}
+      variant="dialog"
+      size="lg"
+      ariaLabelledBy="acorn-folder-permission-warmup-title"
+    >
+      <ModalHeader
+        title={dt(t, "dialogs.folderPermissionWarmup.title")}
+        subtitle={dt(t, "dialogs.folderPermissionWarmup.subtitle")}
+        titleId="acorn-folder-permission-warmup-title"
+        icon={<FolderCheck size={14} className="text-accent" />}
+        variant="dialog"
+        onClose={closeForVersion}
+      />
+      <div className="space-y-3 px-4 py-4 text-xs text-fg-muted">
+        <p>{dt(t, "dialogs.folderPermissionWarmup.bodyIntro")}</p>
+        <p>{dt(t, "dialogs.folderPermissionWarmup.bodyPrompt")}</p>
+        {error ? (
+          <p className="rounded border border-danger/40 bg-danger/10 px-3 py-2 text-danger">
+            {error}
+          </p>
+        ) : null}
+        {results ? (
+          <div className="rounded border border-border bg-bg">
+            {results.map((result) => (
+              <div
+                key={result.id}
+                className="flex items-center justify-between gap-3 border-b border-border px-3 py-2 last:border-b-0"
+              >
+                <div className="min-w-0">
+                  <div className="font-medium text-fg">
+                    {folderName(t, result.id)}
+                  </div>
+                  <div className="truncate text-[11px] text-fg-muted">
+                    {result.path}
+                  </div>
+                </div>
+                <div
+                  className={`shrink-0 text-[11px] font-medium ${statusClass(result.status)}`}
+                >
+                  {statusText(t, result.status)}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
+      <footer className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+        <button
+          type="button"
+          onClick={closeForVersion}
+          disabled={busy}
+          className="rounded px-3 py-1 text-xs text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
+        >
+          {results || error
+            ? dt(t, "dialogs.folderPermissionWarmup.done")
+            : dt(t, "dialogs.folderPermissionWarmup.skip")}
+        </button>
+        {!results && !error ? (
+          <button
+            type="button"
+            onClick={() => void runWarmup()}
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
+          >
+            {busy ? <Loader2 size={12} className="animate-spin" /> : null}
+            {busy
+              ? dt(t, "dialogs.folderPermissionWarmup.checking")
+              : dt(t, "dialogs.folderPermissionWarmup.check")}
+          </button>
+        ) : null}
+      </footer>
+    </Modal>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -20,6 +20,7 @@ import type {
   WorkflowRunDetailListing,
   WorkflowRunsListing,
 } from "./types";
+import type { FolderPermissionWarmupResult } from "./permissionWarmup";
 
 export interface LoadStatus {
   sessionsClean: boolean;
@@ -251,6 +252,11 @@ export const api = {
    */
   getAcornIpcStatus(): Promise<AcornIpcStatus> {
     return invoke<AcornIpcStatus>("get_acorn_ipc_status");
+  },
+  warmMacosFolderPermissions(): Promise<FolderPermissionWarmupResult[]> {
+    return invoke<FolderPermissionWarmupResult[]>(
+      "warm_macos_folder_permissions",
+    );
   },
   /**
    * Stop the in-process IPC listener and spawn a fresh one. Used when the

--- a/src/lib/permissionWarmup.test.ts
+++ b/src/lib/permissionWarmup.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  isMacPlatform,
+  markPermissionWarmupHandled,
+  PERMISSION_WARMUP_STORAGE_KEY,
+  shouldShowPermissionWarmup,
+} from "./permissionWarmup";
+
+function memoryStorage(initial: string | null = null) {
+  let value = initial;
+  return {
+    getItem: (key: string) =>
+      key === PERMISSION_WARMUP_STORAGE_KEY ? value : null,
+    setItem: (key: string, next: string) => {
+      if (key === PERMISSION_WARMUP_STORAGE_KEY) value = next;
+    },
+  };
+}
+
+describe("permission warmup gate", () => {
+  it("only targets macOS-like platforms", () => {
+    expect(isMacPlatform("MacIntel")).toBe(true);
+    expect(isMacPlatform("Linux x86_64")).toBe(false);
+    expect(isMacPlatform("Win32")).toBe(false);
+  });
+
+  it("shows once per app version on macOS", () => {
+    const storage = memoryStorage();
+
+    expect(shouldShowPermissionWarmup("1.2.3", "MacIntel", storage)).toBe(true);
+    markPermissionWarmupHandled("1.2.3", storage);
+    expect(shouldShowPermissionWarmup("1.2.3", "MacIntel", storage)).toBe(false);
+    expect(shouldShowPermissionWarmup("1.2.4", "MacIntel", storage)).toBe(true);
+  });
+
+  it("does not show when current version is missing or platform is not macOS", () => {
+    const storage = memoryStorage();
+
+    expect(shouldShowPermissionWarmup(null, "MacIntel", storage)).toBe(false);
+    expect(shouldShowPermissionWarmup("1.2.3", "Linux x86_64", storage)).toBe(
+      false,
+    );
+  });
+});

--- a/src/lib/permissionWarmup.ts
+++ b/src/lib/permissionWarmup.ts
@@ -1,0 +1,52 @@
+const STORAGE_KEY = "acorn:folder-permission-warmup:v1";
+
+export type FolderPermissionWarmupStatus =
+  | "ok"
+  | "missing"
+  | "denied"
+  | "error";
+
+export interface FolderPermissionWarmupResult {
+  id: "desktop" | "documents" | "downloads" | "icloud";
+  path: string;
+  status: FolderPermissionWarmupStatus;
+  error: string | null;
+}
+
+export function isMacPlatform(platform: string): boolean {
+  return platform.startsWith("Mac");
+}
+
+export function shouldShowPermissionWarmup(
+  currentVersion: string | null,
+  platform: string,
+  storage: Pick<Storage, "getItem"> | null = browserStorage(),
+): boolean {
+  if (!currentVersion) return false;
+  if (!isMacPlatform(platform)) return false;
+  if (!storage) return false;
+  try {
+    return storage.getItem(STORAGE_KEY) !== currentVersion;
+  } catch {
+    return false;
+  }
+}
+
+export function markPermissionWarmupHandled(
+  version: string,
+  storage: Pick<Storage, "setItem"> | null = browserStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(STORAGE_KEY, version);
+  } catch {
+    // localStorage can be unavailable in private / restricted contexts.
+  }
+}
+
+function browserStorage(): Storage | null {
+  if (typeof localStorage === "undefined") return null;
+  return localStorage;
+}
+
+export const PERMISSION_WARMUP_STORAGE_KEY = STORAGE_KEY;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -995,6 +995,29 @@
       "createdPrefix": "You just created a control session. The",
       "createdSuffix": "CLI that drives it ships in the next update; this terminal will start behaving like a regular shell until then."
     },
+    "folderPermissionWarmup": {
+      "title": "Folder access check",
+      "subtitle": "Prepare macOS folder permissions after an update",
+      "bodyIntro": "macOS may ask again for access to protected folders after Acorn updates. You can check now so prompts happen before you start working.",
+      "bodyPrompt": "Acorn will briefly read Desktop, Documents, Downloads, and iCloud Drive. No files are changed.",
+      "check": "Check folder access",
+      "checking": "Checking...",
+      "skip": "Skip for this version",
+      "done": "Done",
+      "genericError": "Could not check folder access.",
+      "folder": {
+        "desktop": "Desktop",
+        "documents": "Documents",
+        "downloads": "Downloads",
+        "icloud": "iCloud Drive"
+      },
+      "status": {
+        "ok": "Ready",
+        "missing": "Not found",
+        "denied": "Denied",
+        "error": "Error"
+      }
+    },
     "commandRun": {
       "title": "Run this command?",
       "ariaLabel": "Run command",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -995,6 +995,29 @@
       "createdPrefix": "방금 컨트롤 세션을 만들었습니다.",
       "createdSuffix": "CLI는 다음 업데이트에 포함됩니다. 그 전까지 이 터미널은 일반 셸처럼 동작합니다."
     },
+    "folderPermissionWarmup": {
+      "title": "폴더 접근 권한 확인",
+      "subtitle": "업데이트 후 macOS 폴더 권한을 미리 준비합니다",
+      "bodyIntro": "Acorn 업데이트 후 macOS가 보호된 폴더 접근 권한을 다시 물어볼 수 있습니다. 작업을 시작하기 전에 지금 확인할 수 있습니다.",
+      "bodyPrompt": "Acorn은 데스크탑, 문서, 다운로드, iCloud Drive를 잠깐 읽습니다. 파일은 변경하지 않습니다.",
+      "check": "폴더 접근 확인",
+      "checking": "확인 중...",
+      "skip": "이 버전에서는 건너뛰기",
+      "done": "완료",
+      "genericError": "폴더 접근 권한을 확인하지 못했습니다.",
+      "folder": {
+        "desktop": "데스크탑",
+        "documents": "문서",
+        "downloads": "다운로드",
+        "icloud": "iCloud Drive"
+      },
+      "status": {
+        "ok": "준비됨",
+        "missing": "없음",
+        "denied": "거부됨",
+        "error": "오류"
+      }
+    },
     "commandRun": {
       "title": "이 명령을 실행할까요?",
       "ariaLabel": "명령 실행",

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -104,6 +104,7 @@ export const tauriMockSource = `
         shim_paths: [],
       });
     }
+    if (cmd === 'warm_macos_folder_permissions') return Promise.resolve([]);
     if (cmd === 'ipc_restart') return Promise.resolve(undefined);
     if (cmd === 'reorder_projects') return Promise.resolve([]);
     if (cmd === 'reorder_sessions') return Promise.resolve([]);

--- a/tests/e2e/permission-warmup.spec.ts
+++ b/tests/e2e/permission-warmup.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "./support";
+
+test.describe("folder permission warmup", () => {
+  test("checks protected folders and stores the handled version", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      (window as unknown as { __ACORN_ENABLE_PERMISSION_WARMUP__?: boolean })
+        .__ACORN_ENABLE_PERMISSION_WARMUP__ = true;
+      Object.defineProperty(Navigator.prototype, "platform", {
+        configurable: true,
+        get: () => "MacIntel",
+      });
+      if (!window.sessionStorage.getItem("__acornWarmupCleared")) {
+        window.localStorage.removeItem("acorn:folder-permission-warmup:v1");
+        window.sessionStorage.setItem("__acornWarmupCleared", "true");
+      }
+    });
+    await tauri.handle("warm_macos_folder_permissions", () => {
+      const w = window as unknown as { __warmupCalls?: number };
+      w.__warmupCalls = (w.__warmupCalls ?? 0) + 1;
+      return [
+        {
+          id: "desktop",
+          path: "/Users/tester/Desktop",
+          status: "ok",
+          error: null,
+        },
+        {
+          id: "documents",
+          path: "/Users/tester/Documents",
+          status: "ok",
+          error: null,
+        },
+      ];
+    });
+
+    await page.goto("/");
+    const dialog = page.getByRole("dialog");
+    await expect(
+      dialog.getByRole("heading", { name: "Folder access check" }),
+    ).toBeVisible();
+
+    await dialog.getByRole("button", { name: "Check folder access" }).click();
+    await expect(dialog.getByText("Desktop", { exact: true })).toBeVisible();
+    await expect(dialog.getByText("Ready")).toHaveCount(2);
+
+    await dialog.getByRole("button", { name: "Done" }).click();
+    await expect(dialog).toHaveCount(0);
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as unknown as { __warmupCalls?: number }).__warmupCalls,
+        ),
+      )
+      .toBe(1);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.localStorage.getItem("acorn:folder-permission-warmup:v1"),
+        ),
+      )
+      .toBe("0.0.0-test");
+
+    await page.reload();
+    await expect(
+      page.getByRole("heading", { name: "Folder access check" }),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a macOS-only folder permission warm-up flow so protected-folder prompts can happen before the user starts working after an update.

1. **Renderer gate:** Shows a folder access check dialog once per running app version on macOS, with a skip/done path stored in localStorage.
2. **Tauri probe command:** Adds `warm_macos_folder_permissions`, which briefly reads Desktop, Documents, Downloads, and iCloud Drive and returns per-folder status without modifying files.
3. **Test coverage:** Adds unit coverage for the version/platform gate plus an E2E flow that verifies the dialog, command invocation, persisted marker, and reload behavior.

## Expected impact
| Area | Expected impact |
| --- | --- |
| macOS update flow | Users can trigger protected-folder permission prompts up front instead of encountering them mid-work. |
| File safety | The warm-up performs read-only directory probes and does not write or mutate user files. |
| Non-macOS platforms | No user-visible behavior; the backend command returns an empty result outside macOS and the dialog is platform-gated. |
| E2E reliability | Existing E2Es stay quiet via the test-mode gate unless a test explicitly enables the warm-up dialog. |

## Design notes
- The prompt is keyed by the running app version, not by update metadata, so each version can be acknowledged exactly once.
- The backend classifies folders as `ok`, `missing`, `denied`, or `error` so the UI can report what happened without assuming every user has iCloud Drive enabled.
- The command reads only enough to force macOS/TCC to evaluate access for each protected folder.

## Follow-up (not in this PR)
- Stable Developer ID signing remains the stronger long-term fix for macOS treating updates as different apps.
- We can tune the copy or entry point after seeing whether users prefer this as a first-run prompt, settings action, or both.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run src/lib/permissionWarmup.test.ts`
- [x] `pnpm run test:e2e -- permission-warmup.spec.ts`
- [x] `pnpm run build:sidecar`
- [x] `cargo check -p acorn`
- [x] `git diff --check`

## Notes
- `pnpm run build:sidecar` and `cargo check -p acorn` both report the existing `AgentHookServer::start` dead-code warning; this PR does not introduce that warning.
