### PR TITLE
feat(macos): ask before checking folder permissions

### DIFF
--- a/src/components/FolderPermissionWarmupModal.tsx
+++ b/src/components/FolderPermissionWarmupModal.tsx
@@ -111,12 +111,19 @@ export function FolderPermissionWarmupModal({
         title={dt(t, "dialogs.folderPermissionWarmup.title")}
         subtitle={dt(t, "dialogs.folderPermissionWarmup.subtitle")}
         titleId="acorn-folder-permission-warmup-title"
-        icon={<FolderCheck size={14} className="text-accent" />}
+        icon={
+          <span className="self-start pt-0.5">
+            <FolderCheck size={14} className="text-accent" />
+          </span>
+        }
         variant="dialog"
         onClose={closeForVersion}
       />
       <div className="space-y-3 px-4 py-4 text-xs text-fg-muted">
-        <p>{dt(t, "dialogs.folderPermissionWarmup.bodyIntro")}</p>
+        <p className="text-fg">
+          {dt(t, "dialogs.folderPermissionWarmup.question")}
+        </p>
+        <p>{dt(t, "dialogs.folderPermissionWarmup.reason")}</p>
         <p>{dt(t, "dialogs.folderPermissionWarmup.bodyPrompt")}</p>
         {error ? (
           <p className="rounded border border-danger/40 bg-danger/10 px-3 py-2 text-danger">
@@ -166,7 +173,11 @@ export function FolderPermissionWarmupModal({
             disabled={busy}
             className="inline-flex items-center gap-1.5 rounded bg-accent px-3 py-1 text-xs font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
           >
-            {busy ? <Loader2 size={12} className="animate-spin" /> : null}
+            {busy ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : (
+              <FolderCheck size={12} />
+            )}
             {busy
               ? dt(t, "dialogs.folderPermissionWarmup.checking")
               : dt(t, "dialogs.folderPermissionWarmup.check")}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -996,13 +996,14 @@
       "createdSuffix": "CLI that drives it ships in the next update; this terminal will start behaving like a regular shell until then."
     },
     "folderPermissionWarmup": {
-      "title": "Folder access check",
-      "subtitle": "Prepare macOS folder permissions after an update",
-      "bodyIntro": "macOS may ask again for access to protected folders after Acorn updates. You can check now so prompts happen before you start working.",
-      "bodyPrompt": "Acorn will briefly read Desktop, Documents, Downloads, and iCloud Drive. No files are changed.",
-      "check": "Check folder access",
+      "title": "Check folder permissions now?",
+      "subtitle": "Prepare macOS folder access after an update",
+      "question": "Do you want Acorn to check folder access before you start working?",
+      "reason": "After an update, macOS can re-evaluate protected-folder access and ask again later. This check opens those prompts up front for Desktop, Documents, Downloads, and iCloud Drive.",
+      "bodyPrompt": "Acorn briefly reads these folders only to trigger macOS permission checks. No files are changed.",
+      "check": "Check now",
       "checking": "Checking...",
-      "skip": "Skip for this version",
+      "skip": "Not now",
       "done": "Done",
       "genericError": "Could not check folder access.",
       "folder": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -996,13 +996,14 @@
       "createdSuffix": "CLI는 다음 업데이트에 포함됩니다. 그 전까지 이 터미널은 일반 셸처럼 동작합니다."
     },
     "folderPermissionWarmup": {
-      "title": "폴더 접근 권한 확인",
-      "subtitle": "업데이트 후 macOS 폴더 권한을 미리 준비합니다",
-      "bodyIntro": "Acorn 업데이트 후 macOS가 보호된 폴더 접근 권한을 다시 물어볼 수 있습니다. 작업을 시작하기 전에 지금 확인할 수 있습니다.",
-      "bodyPrompt": "Acorn은 데스크탑, 문서, 다운로드, iCloud Drive를 잠깐 읽습니다. 파일은 변경하지 않습니다.",
-      "check": "폴더 접근 확인",
+      "title": "폴더 권한을 지금 확인할까요?",
+      "subtitle": "업데이트 후 macOS 폴더 접근을 미리 확인합니다",
+      "question": "작업을 시작하기 전에 Acorn의 폴더 접근 권한을 확인할까요?",
+      "reason": "업데이트 후 macOS가 보호 폴더 접근을 다시 평가하면서 나중에 권한을 다시 물을 수 있습니다. 지금 확인하면 데스크탑, 문서, 다운로드, iCloud Drive 권한 요청을 미리 처리할 수 있습니다.",
+      "bodyPrompt": "Acorn은 macOS 권한 확인을 위해 이 폴더들을 잠깐 읽기만 합니다. 파일은 변경하지 않습니다.",
+      "check": "지금 확인",
       "checking": "확인 중...",
-      "skip": "이 버전에서는 건너뛰기",
+      "skip": "나중에",
       "done": "완료",
       "genericError": "폴더 접근 권한을 확인하지 못했습니다.",
       "folder": {

--- a/tests/e2e/permission-warmup.spec.ts
+++ b/tests/e2e/permission-warmup.spec.ts
@@ -39,10 +39,18 @@ test.describe("folder permission warmup", () => {
     await page.goto("/");
     const dialog = page.getByRole("dialog");
     await expect(
-      dialog.getByRole("heading", { name: "Folder access check" }),
+      dialog.getByRole("heading", { name: "Check folder permissions now?" }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByText(
+        "Do you want Acorn to check folder access before you start working?",
+      ),
+    ).toBeVisible();
+    await expect(
+      dialog.getByText("macOS can re-evaluate protected-folder access"),
     ).toBeVisible();
 
-    await dialog.getByRole("button", { name: "Check folder access" }).click();
+    await dialog.getByRole("button", { name: "Check now" }).click();
     await expect(dialog.getByText("Desktop", { exact: true })).toBeVisible();
     await expect(dialog.getByText("Ready")).toHaveCount(2);
 
@@ -66,7 +74,7 @@ test.describe("folder permission warmup", () => {
 
     await page.reload();
     await expect(
-      page.getByRole("heading", { name: "Folder access check" }),
+      page.getByRole("heading", { name: "Check folder permissions now?" }),
     ).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary
This PR turns the macOS folder permission flow into an explicit consent prompt before the read-only permission check runs.

1. **Consent-first modal:** Reframes the dialog title and primary copy as a direct question asking whether to check folder permissions now.
2. **Why text:** Adds short supporting copy explaining that macOS can re-evaluate protected-folder access after an update, so Acorn can surface those prompts before work starts.
3. **Aligned modal styling:** Keeps the header icon in the existing inline ModalHeader position, with top alignment matching other two-line informational dialogs.
4. **Button copy and coverage:** Updates English/Korean labels and the E2E test expectations for the new consent flow.

## Expected impact
| Area | Expected impact |
| --- | --- |
| macOS update flow | Users see a clearer choice before Acorn triggers protected-folder access prompts. |
| User trust | The modal explains why the check exists and confirms no files are changed. |
| Non-macOS platforms | No behavior change; the existing macOS/version gate still controls visibility. |

## Design notes
- The backend permission-check command is unchanged; this PR only changes the consent surface and test expectations.
- The explanatory copy avoids the user-facing term “warm” and uses “check” because the action briefly reads common folders to trigger macOS permission evaluation.
- The layout follows existing informational modals: inline accent icon in the header, plain explanatory paragraphs in the body, and right-aligned footer actions.

## Follow-up (not in this PR)
- We can review other modal icon alignments separately, as discussed.
- We can add a Settings entry for manually re-running the permission check if users want to prepare permissions later.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run src/lib/permissionWarmup.test.ts`
- [x] `pnpm run test:e2e -- permission-warmup.spec.ts`
- [x] `git diff --check`

## Notes
- Updated screenshot captured locally and opened in Preview: `/tmp/acorn-permission-warmup-modal.png`
- A stale Vite server from an old temporary worktree was occupying `localhost:1420`; after stopping it, the E2E ran against this branch and passed.
