### PR TITLE
feat(toast): configurable stack + worktree feedback

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -173,3 +173,86 @@ textarea,
   transform: scale(var(--acorn-ui-scale, 1));
   transform-origin: top left;
 }
+
+.acorn-toast-progress {
+  animation: acorn-toast-progress var(--toast-duration) linear forwards;
+}
+
+.acorn-toast-progress[data-paused="true"],
+.acorn-toast-motion[data-state="exit"] .acorn-toast-progress {
+  animation-play-state: paused;
+}
+
+.acorn-toast-motion[data-position="top"][data-state="enter"] {
+  animation: acorn-toast-enter-top 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.acorn-toast-motion[data-position="top"][data-state="exit"] {
+  animation: acorn-toast-exit-top 160ms cubic-bezier(0.7, 0, 0.84, 0) both;
+}
+
+.acorn-toast-motion[data-position="bottom"][data-state="enter"] {
+  animation: acorn-toast-enter-bottom 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.acorn-toast-motion[data-position="bottom"][data-state="exit"] {
+  animation: acorn-toast-exit-bottom 160ms cubic-bezier(0.7, 0, 0.84, 0) both;
+}
+
+@keyframes acorn-toast-progress {
+  from {
+    transform: scaleX(1);
+  }
+
+  to {
+    transform: scaleX(0);
+  }
+}
+
+@keyframes acorn-toast-enter-top {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes acorn-toast-exit-top {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+}
+
+@keyframes acorn-toast-enter-bottom {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes acorn-toast-exit-bottom {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -200,6 +200,19 @@ function App() {
   const refreshThemes = useThemes((s) => s.refresh);
   const appearance = useSettings((s) => s.settings.appearance);
   const currentVersion = useUpdater((s) => s.currentVersion);
+  const showToast = useToasts((s) => s.show);
+
+  const showStoreOperationToast = useCallback(
+    (successKey: TranslationKey | null, failureKey: TranslationKey) => {
+      const error = useAppStore.getState().consumeError();
+      if (error) {
+        showToast(`${t(failureKey)} ${error}`);
+      } else if (successKey) {
+        showToast(t(successKey));
+      }
+    },
+    [showToast, t],
+  );
 
   useEffect(() => {
     void refreshThemes();
@@ -710,18 +723,29 @@ function App() {
     const recordedWorktree = hasRecordedWorktree(pendingRemove);
     if (recordedWorktree && autoDeleteWorktrees) {
       clearPendingRemove();
-      removeSession(pendingRemove.id, true);
+      void removeSession(pendingRemove.id, true).then(() =>
+        showStoreOperationToast(
+          "toasts.session.worktreeRemoved",
+          "toasts.session.worktreeRemoveFailed",
+        ),
+      );
       return;
     }
     if (confirmRemoveSession || recordedWorktree) return;
     clearPendingRemove();
-    removeSession(pendingRemove.id, false);
+    void removeSession(pendingRemove.id, false).then(() =>
+      showStoreOperationToast(
+        null,
+        "toasts.session.removeFailed",
+      ),
+    );
   }, [
     pendingRemove,
     autoDeleteWorktrees,
     clearPendingRemove,
     confirmRemoveSession,
     removeSession,
+    showStoreOperationToast,
   ]);
 
   // Restore the root layout (sidebar + right panel) and equalize the
@@ -1253,7 +1277,17 @@ function App() {
           const target = pendingRemove;
           clearPendingRemove();
           if (!target || choice === "cancel") return;
-          removeSession(target.id, choice === "session_and_worktree");
+          void removeSession(target.id, choice === "session_and_worktree").then(
+            () =>
+              showStoreOperationToast(
+                choice === "session_and_worktree"
+                  ? "toasts.session.worktreeRemoved"
+                  : null,
+                choice === "session_and_worktree"
+                  ? "toasts.session.worktreeRemoveFailed"
+                  : "toasts.session.removeFailed",
+              ),
+          );
         }}
       />
       <RemoveProjectDialog
@@ -1263,7 +1297,19 @@ function App() {
           const target = pendingProject;
           clearPendingRemoveProject();
           if (!target || choice === "cancel") return;
-          removeProject(target.repo_path, choice === "project_and_worktrees");
+          void removeProject(
+            target.repo_path,
+            choice === "project_and_worktrees",
+          ).then(() =>
+            showStoreOperationToast(
+              choice === "project_and_worktrees"
+                ? "toasts.project.worktreesRemoved"
+                : null,
+              choice === "project_and_worktrees"
+                ? "toasts.project.worktreesRemoveFailed"
+                : "toasts.project.removeFailed",
+            ),
+          );
         }}
       />
     </div>

--- a/src/components/BackgroundSessionsSettings.tsx
+++ b/src/components/BackgroundSessionsSettings.tsx
@@ -15,6 +15,7 @@ import type { Translator } from "../lib/i18n";
 import { useTranslation } from "../lib/useTranslation";
 import { useAppStore } from "../store";
 import type { Session } from "../lib/types";
+import { useToasts } from "../lib/toasts";
 import { Tooltip } from "./Tooltip";
 import { CheckboxRow, Field } from "./ui";
 
@@ -37,6 +38,7 @@ export function BackgroundSessionsSettings() {
   const [busy, setBusy] = useState<string | null>(null);
   const [confirmShutdown, setConfirmShutdown] = useState(false);
   const appSessions = useAppStore((s) => s.sessions);
+  const showToast = useToasts((s) => s.show);
 
   const refresh = useCallback(async () => {
     try {
@@ -72,12 +74,19 @@ export function BackgroundSessionsSettings() {
       writeKillswitch(next);
       try {
         await api.daemonSetEnabled(next);
+        showToast(
+          next
+            ? t("backgroundSessions.toasts.enabled")
+            : t("backgroundSessions.toasts.disabled"),
+        );
       } catch (err) {
-        setStatusError(err instanceof Error ? err.message : String(err));
+        const message = err instanceof Error ? err.message : String(err);
+        setStatusError(message);
+        showToast(`${t("backgroundSessions.toasts.toggleFailed")} ${message}`);
       }
       void refresh();
     },
-    [refresh],
+    [refresh, showToast, t],
   );
 
   const handleRestart = useCallback(async () => {
@@ -86,12 +95,15 @@ export function BackgroundSessionsSettings() {
     try {
       await api.daemonRestart();
       await refresh();
+      showToast(t("backgroundSessions.toasts.restarted"));
     } catch (err) {
-      setStatusError(err instanceof Error ? err.message : String(err));
+      const message = err instanceof Error ? err.message : String(err);
+      setStatusError(message);
+      showToast(`${t("backgroundSessions.toasts.restartFailed")} ${message}`);
     } finally {
       setBusy(null);
     }
-  }, [refresh]);
+  }, [refresh, showToast, t]);
 
   const handleShutdown = useCallback(async () => {
     setBusy("shutdown");
@@ -100,12 +112,15 @@ export function BackgroundSessionsSettings() {
       await api.daemonShutdown();
       setConfirmShutdown(false);
       await refresh();
+      showToast(t("backgroundSessions.toasts.shutdown"));
     } catch (err) {
-      setStatusError(err instanceof Error ? err.message : String(err));
+      const message = err instanceof Error ? err.message : String(err);
+      setStatusError(message);
+      showToast(`${t("backgroundSessions.toasts.shutdownFailed")} ${message}`);
     } finally {
       setBusy(null);
     }
-  }, [refresh]);
+  }, [refresh, showToast, t]);
 
   const running = status?.running ?? false;
   const indicator = !enabled
@@ -281,6 +296,7 @@ function SessionsList({
 }) {
   const [rowBusy, setRowBusy] = useState<string | null>(null);
   const [rowError, setRowError] = useState<string | null>(null);
+  const showToast = useToasts((s) => s.show);
   const appById = useMemo(() => {
     const m = new Map<string, Session>();
     for (const s of appSessions) m.set(s.id, s);
@@ -288,19 +304,22 @@ function SessionsList({
   }, [appSessions]);
 
   const runRowAction = useCallback(
-    async (id: string, fn: () => Promise<void>) => {
+    async (id: string, fn: () => Promise<void>, successMessage: string) => {
       setRowBusy(id);
       setRowError(null);
       try {
         await fn();
         await onRefresh();
+        showToast(successMessage);
       } catch (err) {
-        setRowError(err instanceof Error ? err.message : String(err));
+        const message = err instanceof Error ? err.message : String(err);
+        setRowError(message);
+        showToast(`${t("backgroundSessions.toasts.sessionActionFailed")} ${message}`);
       } finally {
         setRowBusy(null);
       }
     },
-    [onRefresh],
+    [onRefresh, showToast, t],
   );
 
   if (!enabled) {
@@ -399,8 +418,10 @@ function SessionsList({
                     <RowButton
                       busy={busy}
                       onClick={() =>
-                        void runRowAction(s.id, () =>
-                          api.daemonKillSession(s.id),
+                        void runRowAction(
+                          s.id,
+                          () => api.daemonKillSession(s.id),
+                          t("backgroundSessions.toasts.sessionKilled"),
                         )
                       }
                       tone="danger"
@@ -417,8 +438,10 @@ function SessionsList({
                     <RowButton
                       busy={busy}
                       onClick={() =>
-                        void runRowAction(s.id, () =>
-                          api.daemonAdoptSession(s.id),
+                        void runRowAction(
+                          s.id,
+                          () => api.daemonAdoptSession(s.id),
+                          t("backgroundSessions.toasts.sessionRestored"),
                         )
                       }
                       aria-label={t("backgroundSessions.actions.restore")}
@@ -439,8 +462,10 @@ function SessionsList({
                     busy={busy}
                     disabled={s.alive}
                     onClick={() =>
-                      void runRowAction(s.id, () =>
-                        api.daemonForgetSession(s.id),
+                      void runRowAction(
+                        s.id,
+                        () => api.daemonForgetSession(s.id),
+                        t("backgroundSessions.toasts.sessionForgotten"),
                       )
                     }
                     aria-label={t("backgroundSessions.actions.forget")}

--- a/src/components/ClosePullRequestDialog.tsx
+++ b/src/components/ClosePullRequestDialog.tsx
@@ -3,6 +3,7 @@ import { GitPullRequestClosed } from "lucide-react";
 import { api } from "../lib/api";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
+import { useToasts } from "../lib/toasts";
 import type { PullRequestDetail } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
 import { Modal, ModalHeader, TextSwap } from "./ui";
@@ -29,6 +30,7 @@ export function ClosePullRequestDialog({
   onClosed,
 }: ClosePullRequestDialogProps) {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -55,7 +57,9 @@ export function ClosePullRequestDialog({
       await api.closePullRequest(repoPath, detail.number);
       onClosed();
     } catch (e) {
-      setError(String(e));
+      const message = String(e);
+      setError(message);
+      showToast(`${t("toasts.pullRequests.closeFailed")} ${message}`);
       setSubmitting(false);
     }
   }

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -82,8 +82,11 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   }
 
   async function handleRefresh() {
+    const show = useToasts.getState().show;
     try {
       await useAppStore.getState().refreshSessions();
+      const error = useAppStore.getState().consumeError();
+      if (error) show(`${t("toasts.session.refreshFailed")} ${error}`);
     } finally {
       close();
     }
@@ -95,8 +98,11 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   }
 
   async function handleRemoveSession(id: string) {
+    const show = useToasts.getState().show;
     try {
       await useAppStore.getState().removeSession(id);
+      const error = useAppStore.getState().consumeError();
+      if (error) show(`${t("toasts.session.removeFailed")} ${error}`);
     } finally {
       close();
     }

--- a/src/components/CommandRunDialog.tsx
+++ b/src/components/CommandRunDialog.tsx
@@ -133,8 +133,9 @@ export function CommandRunDialog({
         ),
       );
       if (!created) {
-        const storeError = useAppStore.getState().error;
+        const storeError = useAppStore.getState().consumeError();
         setError(storeError ?? dt(t, "dialogs.commandRun.createFailed"));
+        showToast(`${t("toasts.session.createFailed")} ${storeError ?? ""}`.trim());
         setBusy(false);
         return;
       }
@@ -147,6 +148,7 @@ export function CommandRunDialog({
       onClose();
     } catch (e) {
       setError(String(e));
+      showToast(`${t("toasts.session.createFailed")} ${String(e)}`);
       setBusy(false);
     }
   }

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -36,6 +36,7 @@ import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { setFileDragPayload } from "../lib/dnd";
 import { Tooltip } from "./Tooltip";
 import { IconInput, TextInput } from "./ui";
+import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
 import {
   applySessionCreateRequest,
@@ -289,6 +290,7 @@ function setLocalBool(key: string, value: boolean) {
 
 export function FileExplorer({ rootPath }: FileExplorerProps) {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const [cache, setCache] = useState<Cache>({});
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [showHidden, setShowHidden] = useState(() =>
@@ -794,9 +796,11 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       setDraftRename(null);
       await fetchDir(parentOf(path));
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      const message = e instanceof Error ? e.message : String(e);
+      setError(message);
+      showToast(`${t("toasts.files.renameFailed")} ${message}`);
     }
-  }, [draftRename, fetchDir]);
+  }, [draftRename, fetchDir, showToast, t]);
 
   const handleTrash = useCallback(
     async (entry: FsEntry) => {
@@ -804,10 +808,12 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
         await api.fsTrash(entry.path);
         await fetchDir(parentOf(entry.path));
       } catch (e) {
-        setError(e instanceof Error ? e.message : String(e));
+        const message = e instanceof Error ? e.message : String(e);
+        setError(message);
+        showToast(`${t("toasts.files.trashFailed")} ${message}`);
       }
     },
-    [fetchDir],
+    [fetchDir, showToast, t],
   );
 
   const dirtyAncestors = useMemo(
@@ -940,7 +946,9 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       try {
         await api.fsTrash(p);
       } catch (e) {
-        setError(e instanceof Error ? e.message : String(e));
+        const message = e instanceof Error ? e.message : String(e);
+        setError(message);
+        showToast(`${t("toasts.files.trashFailed")} ${message}`);
       }
     }
     setSelection(new Set());
@@ -948,7 +956,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     pendingWorkingTreeRef.current = true;
     scheduleGitStatusRefresh("user");
     scheduleGitDiffStats();
-  }, [selection, scheduleGitStatusRefresh, scheduleGitDiffStats]);
+  }, [selection, scheduleGitStatusRefresh, scheduleGitDiffStats, showToast, t]);
 
   const handleBulkCopyPaths = useCallback(
     async (mode: "relative" | "absolute") => {
@@ -958,11 +966,13 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       );
       try {
         await navigator.clipboard.writeText(lines.join("\n"));
+        showToast(t("toasts.files.pathsCopied"));
       } catch {
         setError(fileExplorerText(t, "fileExplorer.errors.clipboardWriteFailed"));
+        showToast(t("toasts.files.copyFailed"));
       }
     },
-    [selection, rootPath, t],
+    [selection, rootPath, showToast, t],
   );
 
   const handleBulkAttach = useCallback(async () => {

--- a/src/components/MergePullRequestDialog.tsx
+++ b/src/components/MergePullRequestDialog.tsx
@@ -10,6 +10,7 @@ import {
   resolveAiCommitCommand,
   useSettings,
 } from "../lib/settings";
+import { useToasts } from "../lib/toasts";
 import type {
   MergeMethod,
   PullRequestCheck,
@@ -94,6 +95,7 @@ export function MergePullRequestDialog({
   onMerged,
 }: MergePullRequestDialogProps) {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const settings = useSettings((s) => s.settings);
   const [method, setMethod] = useState<MergeMethod>(() => loadLastMergeMethod());
   const [title, setTitle] = useState("");
@@ -167,7 +169,9 @@ export function MergePullRequestDialog({
       );
       onMerged();
     } catch (e) {
-      setError(String(e));
+      const message = String(e);
+      setError(message);
+      showToast(`${t("toasts.pullRequests.mergeFailed")} ${message}`);
       setSubmitting(false);
     }
   }

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -50,6 +50,7 @@ import { formatHotkey, Hotkeys } from "../lib/hotkeys";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import { useSettings } from "../lib/settings";
 import { hasRecordedWorktree } from "../lib/sessionWorktree";
+import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
 import {
   buildSessionCreateRequestFromScope,
@@ -115,6 +116,7 @@ type PaneTab =
  */
 export function Pane({ paneId }: PaneProps) {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const sessions = useAppStore((s) => s.sessions);
   const projects = useAppStore((s) => s.projects);
   const pane = useAppStore((s) => s.panes[paneId]);
@@ -230,6 +232,8 @@ export function Pane({ paneId }: PaneProps) {
       request.agentProvider,
       request.projectScoped,
     );
+    const error = useAppStore.getState().consumeError();
+    if (error) showToast(`${t("toasts.session.createFailed")} ${error}`);
   }
 
   // Fork an existing claude/codex conversation into a new Acorn session.
@@ -294,6 +298,7 @@ export function Pane({ paneId }: PaneProps) {
       selectTab(created.id);
     } catch (err) {
       console.error("[Pane] fork session failed", err);
+      showToast(`${t("toasts.session.createFailed")} ${String(err)}`);
     }
   }
 
@@ -728,6 +733,7 @@ function TabItem({
   registerRef,
 }: TabItemProps) {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const renameSession = useAppStore((s) => s.renameSession);
   const session = tab.kind === "session" ? tab.session : null;
   const showAgentProviderIcons = useSettings(
@@ -1009,6 +1015,10 @@ function TabItem({
                 setEditing(false);
                 if (session && next && next !== session.name) {
                   await renameSession(session.id, next);
+                  const error = useAppStore.getState().consumeError();
+                  if (error) {
+                    showToast(`${t("toasts.session.renameFailed")} ${error}`);
+                  }
                 }
               }}
               onCancel={() => setEditing(false)}

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -26,6 +26,7 @@ import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useSettings } from "../lib/settings";
+import { useToasts } from "../lib/toasts";
 import { ResizeHandle } from "./ResizeHandle";
 import type {
   DiffPayload,
@@ -92,6 +93,7 @@ export function PullRequestDetailModal({
   onMutated,
 }: PullRequestDetailModalProps) {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const refreshIntervalMs = useSettings(
     (s) => s.settings.github.refreshIntervalMs,
   );
@@ -239,11 +241,13 @@ export function PullRequestDetailModal({
         })
         .catch((e) => {
           if (seq !== bodyWriteSeqRef.current) return;
+          const message = String(e);
           setBodyOverride(null);
-          setBodySaveError(String(e));
+          setBodySaveError(message);
+          showToast(`${t("toasts.pullRequests.bodyUpdateFailed")} ${message}`);
         });
     },
-    [open, detail, prKey, bodyOverride],
+    [open, detail, prKey, bodyOverride, showToast, t],
   );
 
   return (

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -103,6 +103,7 @@ import {
 } from "./ui";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
+import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
 import {
   applySessionCreateRequest,
@@ -1212,6 +1213,7 @@ function AgentHistoryTab({
   sessionHostProjectScoped: boolean;
 }) {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const sessions = useAppStore((s) => s.sessions);
   const projects = useAppStore((s) => s.projects);
   const createSession = useAppStore((s) => s.createSession);
@@ -1320,17 +1322,25 @@ function AgentHistoryTab({
         ),
       );
       if (!created) {
-        setError(
-          useAppStore.getState().error ??
-            rt(t, "rightPanel.history.createFailed"),
-        );
+        const storeError = useAppStore.getState().consumeError();
+        const message = storeError ?? rt(t, "rightPanel.history.createFailed");
+        setError(message);
+        showToast(`${t("toasts.session.createFailed")} ${message}`);
         return;
       }
       if (shouldUseWorktree && item.worktree) {
         try {
           await adoptSessionWorktree(created.id, item.worktree.path);
+          const error = useAppStore.getState().consumeError();
+          if (error) {
+            setError(error);
+            showToast(`${t("toasts.session.worktreeAdoptFailed")} ${error}`);
+            return;
+          }
         } catch (e) {
-          setError(String(e));
+          const message = String(e);
+          setError(message);
+          showToast(`${t("toasts.session.worktreeAdoptFailed")} ${message}`);
           return;
         }
       }
@@ -1341,7 +1351,9 @@ function AgentHistoryTab({
         setWorktreeNotice(item.worktree);
       }
     } catch (e) {
-      setError(String(e));
+      const message = String(e);
+      setError(message);
+      showToast(`${t("toasts.session.createFailed")} ${message}`);
     }
   }
 
@@ -1366,8 +1378,10 @@ function AgentHistoryTab({
       });
       setTrashCandidate(null);
     } catch (e) {
+      const message = String(e);
       setTrashCandidate(null);
-      setError(String(e));
+      setError(message);
+      showToast(`${t("toasts.files.trashFailed")} ${message}`);
     }
   }
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -37,15 +37,18 @@ import {
   AGENT_OPTIONS,
   PR_REFRESH_INTERVAL_OPTIONS,
   SESSION_TITLE_OPTIONS,
+  TOAST_POSITION_OPTIONS,
   type SelectedAgent,
   type SessionTitleSource,
   type AcornSettings,
   type TerminalFontWeight,
   type TerminalLinkActivation,
+  type ToastPosition,
   TERMINAL_FONT_WEIGHTS,
   useSettings,
 } from "../lib/settings";
 import { revealThemesFolder, useThemes } from "../lib/themes";
+import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
 import {
   CheckboxRow,
@@ -871,6 +874,10 @@ function AppearanceSettings() {
         themeId={appearance.themeId}
         onChange={(themeId) => patchAppearance({ themeId })}
       />
+      <ToastPositionSection
+        value={appearance.toastPosition}
+        onChange={(toastPosition) => patchAppearance({ toastPosition })}
+      />
       <BackgroundSection
         state={appearance.background}
         onChange={(background) => patchAppearance({ background })}
@@ -1004,6 +1011,39 @@ function ThemeSection({
   );
 }
 
+function ToastPositionSection({
+  value,
+  onChange,
+}: {
+  value: ToastPosition;
+  onChange: (value: ToastPosition) => void;
+}) {
+  const t = useTranslation();
+
+  return (
+    <Field
+      label={st(t, "settings.appearance.toastPosition.label")}
+      hint={st(t, "settings.appearance.toastPosition.hint")}
+    >
+      <div className="grid max-w-md grid-cols-2 gap-2">
+        {TOAST_POSITION_OPTIONS.map((option) => (
+          <RadioCard<ToastPosition>
+            key={option.value}
+            name="toast-position"
+            value={option.value}
+            current={value}
+            label={st(
+              t,
+              `settings.appearance.toastPosition.options.${option.value}`,
+            )}
+            onSelect={onChange}
+          />
+        ))}
+      </div>
+    </Field>
+  );
+}
+
 type BackgroundSettings = AcornSettings["appearance"]["background"];
 
 function BackgroundSection({
@@ -1016,6 +1056,7 @@ function BackgroundSection({
   const [pickError, setPickError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
 
   const handleFileChange = async (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -1034,21 +1075,35 @@ function BackgroundSection({
         applyToApp: true,
         applyToTerminal: true,
       });
+      showToast(st(t, "settings.appearance.background.toasts.imported"));
     } catch (err) {
-      setPickError(err instanceof Error ? err.message : String(err));
+      const message = err instanceof Error ? err.message : String(err);
+      setPickError(message);
+      showToast(
+        `${st(t, "settings.appearance.background.toasts.importFailed")} ${message}`,
+      );
     }
   };
 
   const remove = async () => {
-    if (state.relativePath) {
-      await removeBackgroundImage(state.relativePath).catch(() => {});
+    try {
+      if (state.relativePath) {
+        await removeBackgroundImage(state.relativePath);
+      }
+      onChange({
+        relativePath: null,
+        fileName: null,
+        applyToApp: false,
+        applyToTerminal: false,
+      });
+      showToast(st(t, "settings.appearance.background.toasts.removed"));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setPickError(message);
+      showToast(
+        `${st(t, "settings.appearance.background.toasts.removeFailed")} ${message}`,
+      );
     }
-    onChange({
-      relativePath: null,
-      fileName: null,
-      applyToApp: false,
-      applyToTerminal: false,
-    });
   };
 
   return (
@@ -1401,6 +1456,7 @@ function NotificationSettings() {
     | { tone: "success" | "warning" | "danger"; text: string }
     | null
   >(null);
+  const showToast = useToasts((s) => s.show);
 
   async function handleTest() {
     setTesting(true);
@@ -1408,20 +1464,26 @@ function NotificationSettings() {
     try {
       const result = await sendTestNotification();
       if (result === "sent") {
+        const text = st(t, "settings.notifications.test.result.sent");
         setTestResult({
           tone: "success",
-          text: st(t, "settings.notifications.test.result.sent"),
+          text,
         });
+        showToast(text);
       } else if (result === "denied") {
+        const text = st(t, "settings.notifications.test.result.denied");
         setTestResult({
           tone: "warning",
-          text: st(t, "settings.notifications.test.result.denied"),
+          text,
         });
+        showToast(text);
       } else {
+        const text = st(t, "settings.notifications.test.result.failed");
         setTestResult({
           tone: "danger",
-          text: st(t, "settings.notifications.test.result.failed"),
+          text,
         });
+        showToast(text);
       }
     } finally {
       setTesting(false);
@@ -1653,6 +1715,7 @@ function StorageSettings() {
   const [busy, setBusy] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
+  const showToast = useToasts((s) => s.show);
 
   const refreshSizes = useCallback(async () => {
     const results = await Promise.allSettled(
@@ -1688,7 +1751,7 @@ function StorageSettings() {
         (sum, r) => sum + (r.status === "fulfilled" ? r.value : 0),
         0,
       );
-      setStatus(
+      const message =
         totalRemoved > 0
           ? stf(
               t,
@@ -1697,12 +1760,15 @@ function StorageSettings() {
                 : "settings.storage.status.clearedPlural",
               { count: totalRemoved },
             )
-          : st(t, "settings.storage.status.nothingToClear"),
-      );
+          : st(t, "settings.storage.status.nothingToClear");
+      setStatus(message);
+      showToast(message);
       await refreshSizes();
     } catch (err) {
       console.error("[Settings] cache clear failed", err);
-      setStatus(st(t, "settings.storage.status.clearFailed"));
+      const message = st(t, "settings.storage.status.clearFailed");
+      setStatus(message);
+      showToast(message);
     } finally {
       setBusy(false);
       setConfirming(false);
@@ -1930,6 +1996,7 @@ function AboutSettings() {
   const [currentNotes, setCurrentNotes] = useState<ReleaseNotes | null>(null);
   const [notesLoading, setNotesLoading] = useState(false);
   const [notesError, setNotesError] = useState<string | null>(null);
+  const showToast = useToasts((s) => s.show);
 
   useEffect(() => {
     void init();
@@ -1978,13 +2045,38 @@ function AboutSettings() {
         isFallback: true,
       });
     } catch (err) {
-      setNotesError(
-        err instanceof Error ? err.message : "Failed to fetch release notes",
-      );
+      const message =
+        err instanceof Error ? err.message : "Failed to fetch release notes";
+      setNotesError(message);
+      showToast(`${st(t, "settings.about.toasts.releaseNotesFailed")} ${message}`);
     } finally {
       setNotesLoading(false);
     }
-  }, [currentVersion, currentNotes]);
+  }, [currentVersion, currentNotes, showToast, t]);
+
+  const handleCheck = useCallback(async () => {
+    await check();
+    const next = useUpdater.getState();
+    if (next.error) {
+      showToast(`${st(t, "settings.about.toasts.checkFailed")} ${next.error}`);
+    } else if (next.available) {
+      showToast(
+        stf(t, "settings.about.toasts.updateAvailable", {
+          version: next.available.version,
+        }),
+      );
+    } else {
+      showToast(st(t, "settings.about.toasts.upToDate"));
+    }
+  }, [check, showToast, t]);
+
+  const handleInstall = useCallback(async () => {
+    await install();
+    const next = useUpdater.getState();
+    if (next.error) {
+      showToast(`${st(t, "settings.about.toasts.installFailed")} ${next.error}`);
+    }
+  }, [install, showToast, t]);
 
   return (
     <section className="space-y-4">
@@ -2044,7 +2136,7 @@ function AboutSettings() {
               ) : null}
               <button
                 type="button"
-                onClick={() => void install()}
+                onClick={() => void handleInstall()}
                 disabled={busy}
                 className="inline-flex items-center gap-1.5 rounded bg-accent px-2 py-1 text-[11px] font-medium text-white transition hover:bg-accent/90 disabled:opacity-50"
               >
@@ -2092,7 +2184,7 @@ function AboutSettings() {
         </button>
         <button
           type="button"
-          onClick={() => void check()}
+          onClick={() => void handleCheck()}
           disabled={busy}
           className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 text-[11px] text-fg-muted transition hover:border-accent/60 hover:text-fg disabled:opacity-50"
         >
@@ -2115,7 +2207,9 @@ function AboutSettings() {
         busy={busy}
         error={whatsNewSource?.kind === "update" ? error : null}
         onInstall={
-          whatsNewSource?.kind === "update" ? () => void install() : undefined
+          whatsNewSource?.kind === "update"
+            ? () => void handleInstall()
+            : undefined
         }
         htmlUrl={
           whatsNewSource?.kind === "current" ? whatsNewSource.htmlUrl : undefined

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -56,6 +56,7 @@ import {
   type SessionTitleSource,
 } from "../lib/settings";
 import { hasRecordedWorktree } from "../lib/sessionWorktree";
+import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
 import {
   buildLocalSessions,
@@ -122,6 +123,7 @@ function isLocalTerminalAreaFocused(): boolean {
 
 export function Sidebar() {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const sessions = useAppStore((s) => s.sessions);
   const projects = useAppStore((s) => s.projects);
   const activeSessionId = useAppStore((s) => s.activeSessionId);
@@ -203,8 +205,11 @@ export function Sidebar() {
       });
       if (!repoPath || typeof repoPath !== "string") return;
       await addProject(repoPath);
+      const error = useAppStore.getState().consumeError();
+      if (error) showToast(`${t("toasts.project.addFailed")} ${error}`);
     } catch (e) {
       console.error("add project failed", e);
+      showToast(`${t("toasts.project.addFailed")} ${String(e)}`);
     }
   }
 
@@ -300,7 +305,11 @@ export function Sidebar() {
             (isolated || kind === "control" ? true : undefined),
         },
       );
-      await applySessionCreateRequest(createSession, request);
+      const created = await applySessionCreateRequest(createSession, request);
+      const error = useAppStore.getState().consumeError();
+      if (!created || error) {
+        showToast(`${t("toasts.session.createFailed")} ${error ?? ""}`.trim());
+      }
       setCollapsed((prev) => {
         if (!prev.has(request.repoPath)) return prev;
         const next = new Set(prev);
@@ -309,6 +318,7 @@ export function Sidebar() {
       });
     } catch (e) {
       console.error("create session failed", e);
+      showToast(`${t("toasts.session.createFailed")} ${String(e)}`);
     }
   }
 
@@ -316,12 +326,17 @@ export function Sidebar() {
     try {
       const home = await homeDir();
       if (!home) return;
-      await applySessionCreateRequest(
+      const created = await applySessionCreateRequest(
         createSession,
         buildLocalSessionCreateRequest({ sessions, projects }, home),
       );
+      const error = useAppStore.getState().consumeError();
+      if (!created || error) {
+        showToast(`${t("toasts.session.createFailed")} ${error ?? ""}`.trim());
+      }
     } catch (e) {
       console.error("create local terminal session failed", e);
+      showToast(`${t("toasts.session.createFailed")} ${String(e)}`);
     }
   }
 
@@ -532,7 +547,12 @@ export function Sidebar() {
         open={newProjectOpen}
         onClose={() => setNewProjectOpen(false)}
         onCreate={async (parentPath, name, ignoreSafeName) => {
-          await createNewProject(parentPath, name, ignoreSafeName);
+          try {
+            await createNewProject(parentPath, name, ignoreSafeName);
+          } catch (e) {
+            showToast(`${t("toasts.project.createFailed")} ${String(e)}`);
+            throw e;
+          }
         }}
       />
     </aside>
@@ -982,6 +1002,7 @@ function SessionRow({
   onRemove,
 }: SessionRowProps) {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const renameSession = useAppStore((s) => s.renameSession);
   const editorCommand = useSettings((s) => s.settings.editor.command);
   const editorConfigured = editorCommand.trim().length > 0;
@@ -1029,7 +1050,7 @@ function SessionRow({
       // the source session's `kind` so a control session stays a control
       // session (preserves its IPC-dispatch role).
       const state = useAppStore.getState();
-      await applySessionCreateRequest(
+      const created = await applySessionCreateRequest(
         state.createSession,
         buildSessionCreateRequestFromScope(
           { sessions: state.sessions, projects: state.projects },
@@ -1044,8 +1065,13 @@ function SessionRow({
           },
         ),
       );
+      const error = useAppStore.getState().consumeError();
+      if (!created || error) {
+        showToast(`${t("toasts.session.duplicateFailed")} ${error ?? ""}`.trim());
+      }
     } catch (err) {
       console.error("[Sidebar] duplicate session failed", err);
+      showToast(`${t("toasts.session.duplicateFailed")} ${String(err)}`);
     }
   }
 
@@ -1213,6 +1239,8 @@ function SessionRow({
             setEditing(false);
             if (next && next !== session.name) {
               await renameSession(session.id, next);
+              const error = useAppStore.getState().consumeError();
+              if (error) showToast(`${t("toasts.session.renameFailed")} ${error}`);
             }
           }}
           onCancelRename={() => setEditing(false)}
@@ -1499,6 +1527,7 @@ function LocalSessionRow({
   onRemove,
 }: LocalSessionRowProps) {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const renameSession = useAppStore((s) => s.renameSession);
   const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
   const titleText = resolveSessionTitle(session, sessionDisplay.title);
@@ -1540,7 +1569,7 @@ function LocalSessionRow({
       n += 1;
     }
     const state = useAppStore.getState();
-    await applySessionCreateRequest(
+    const created = await applySessionCreateRequest(
       state.createSession,
       buildSessionCreateRequestFromScope(
         { sessions: state.sessions, projects: state.projects },
@@ -1548,6 +1577,10 @@ function LocalSessionRow({
         { name: next },
       ),
     );
+    const error = useAppStore.getState().consumeError();
+    if (!created || error) {
+      showToast(`${t("toasts.session.duplicateFailed")} ${error ?? ""}`.trim());
+    }
   }
 
   const menuItems: ContextMenuItem[] = [
@@ -1650,6 +1683,8 @@ function LocalSessionRow({
           setEditing(false);
           if (next && next !== session.name) {
             await renameSession(session.id, next);
+            const error = useAppStore.getState().consumeError();
+            if (error) showToast(`${t("toasts.session.renameFailed")} ${error}`);
           }
         }}
         onCancelRename={() => setEditing(false)}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -6,6 +6,7 @@ import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useSettings } from "../lib/settings";
+import { useToasts } from "../lib/toasts";
 import type { MemoryProcess, SessionStatus } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
 import { useAppStore } from "../store";
@@ -327,6 +328,7 @@ function StatusDot({ state }: { state: DotState }) {
 
 function ServicesStatusButton() {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const [open, setOpen] = useState(false);
 
@@ -378,12 +380,14 @@ function ServicesStatusButton() {
       await api.ipcRestart();
       await refreshIpc();
       setIpc((s) => ({ ...s, busy: false }));
+      showToast(t("toasts.ipc.restarted"));
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       await refreshIpc();
       setIpc((s) => ({ ...s, busy: false, lastError: msg }));
+      showToast(`${t("toasts.ipc.restartFailed")} ${msg}`);
     }
-  }, [ipc.busy, refreshIpc]);
+  }, [ipc.busy, refreshIpc, showToast, t]);
 
   const openDaemonSettings = useCallback(() => {
     window.dispatchEvent(

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -47,7 +47,11 @@ import {
 import { buildXtermTheme } from "../lib/terminalTheme";
 import { useThemes, type ThemeMode } from "../lib/themes";
 import type { SessionAgentProvider } from "../lib/types";
-import { useToasts } from "../lib/toasts";
+import {
+  showStoreResultToast,
+  showTranslatedErrorToast,
+  showTranslatedToast,
+} from "../lib/operationToasts";
 import {
   chooseWorktreeToAdoptAfterExit,
   type WorktreeAdoptionIntent,
@@ -1654,10 +1658,18 @@ export function Terminal({
             worktreeAdoptionIntent = { kind: "none" };
             if (adoptedPath) {
               const name = adoptedPath.split("/").pop() || adoptedPath;
-              useToasts.getState().show(`Adopted new worktree: ${name}`);
               await useAppStore
                 .getState()
                 .adoptSessionWorktree(sessionId, adoptedPath);
+              const error = useAppStore.getState().consumeError();
+              if (error) {
+                showTranslatedErrorToast(
+                  "toasts.session.worktreeAdoptFailed",
+                  error,
+                );
+              } else {
+                showTranslatedToast("toasts.session.worktreeAdopted", { name });
+              }
               // The store now holds the new worktree_path; TerminalHost
               // re-renders with the updated cwd prop, this entire effect
               // tears down via cleanup, and a fresh mount spawns the PTY
@@ -1678,7 +1690,12 @@ export function Terminal({
               if (session && hasRecordedWorktree(session)) {
                 store.requestRemoveSession(sessionId);
               } else {
-                void store.removeSession(sessionId, false);
+                void store.removeSession(sessionId, false).then(() => {
+                  showStoreResultToast(
+                    null,
+                    "toasts.session.removeFailed",
+                  );
+                });
               }
               return;
             }

--- a/src/components/ToastHost.tsx
+++ b/src/components/ToastHost.tsx
@@ -1,25 +1,151 @@
-import type { ReactElement } from "react";
-import { useToasts } from "../lib/toasts";
+import { useEffect, useState, type CSSProperties, type ReactElement } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "../lib/cn";
+import { useSettings } from "../lib/settings";
+import { useToasts, type ToastItem } from "../lib/toasts";
+
+const TOAST_EXIT_MS = 180;
+
+type RenderedToast = ToastItem & { exiting: boolean };
 
 /**
- * Renders the active toast (if any) at the bottom-center of the viewport.
- * Pointer-events disabled so the toast never blocks clicks on the
- * underlying UI. Auto-dismisses via the store's TTL — there is no manual
- * close affordance because every existing trigger is a deliberate user
- * action whose feedback is fine to fade.
+ * Renders the active toast (if any) at the top-center of the viewport.
+ * The viewport overlay ignores pointer events; the toast itself accepts
+ * hover and click so users can pause the TTL or dismiss/activate it.
  */
 export function ToastHost(): ReactElement | null {
-  const message = useToasts((s) => s.message);
-  if (!message) return null;
-  return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-6 z-50 flex justify-center">
+  const toasts = useToasts((s) => s.toasts);
+  const hide = useToasts((s) => s.hide);
+  const pause = useToasts((s) => s.pause);
+  const resume = useToasts((s) => s.resume);
+  const position = useSettings((s) => s.settings.appearance.toastPosition);
+  const [rendered, setRendered] = useState<RenderedToast[]>([]);
+  const [mounted, setMounted] = useState(false);
+  const [stackPaused, setStackPaused] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    setRendered((previous) => {
+      const currentById = new Map(toasts.map((toast) => [toast.id, toast]));
+      const previousIds = new Set(previous.map((toast) => toast.id));
+      const next = previous.map((toast) => {
+        const current = currentById.get(toast.id);
+        if (current) return { ...current, exiting: false };
+        return toast.exiting ? toast : { ...toast, exiting: true };
+      });
+      for (const toast of toasts) {
+        if (!previousIds.has(toast.id)) {
+          next.push({ ...toast, exiting: false });
+        }
+      }
+      return next;
+    });
+  }, [toasts]);
+
+  useEffect(() => {
+    const exitingIds = rendered
+      .filter((toast) => toast.exiting)
+      .map((toast) => toast.id);
+    if (exitingIds.length === 0) return;
+    const timeout = window.setTimeout(() => {
+      setRendered((previous) =>
+        previous.filter((toast) => !exitingIds.includes(toast.id)),
+      );
+    }, TOAST_EXIT_MS);
+    return () => window.clearTimeout(timeout);
+  }, [rendered]);
+
+  useEffect(() => {
+    if (toasts.length === 0) {
+      setStackPaused(false);
+      return;
+    }
+    if (!stackPaused) return;
+    for (const toast of toasts) {
+      pause(toast.id);
+    }
+  }, [pause, stackPaused, toasts]);
+
+  if (rendered.length === 0 || !mounted) return null;
+  const pauseAll = () => {
+    setStackPaused(true);
+    for (const toast of toasts) {
+      pause(toast.id);
+    }
+  };
+  const resumeAll = () => {
+    setStackPaused(false);
+    for (const toast of toasts) {
+      resume(toast.id);
+    }
+  };
+  const handleClick = (toast: RenderedToast) => {
+    if (toast.exiting) return;
+    try {
+      if (toast.action) {
+        void Promise.resolve(toast.action()).catch((err: unknown) => {
+          console.error("[ToastHost] toast action failed", err);
+        });
+      }
+    } catch (err) {
+      console.error("[ToastHost] toast action failed", err);
+    } finally {
+      hide(toast.id);
+    }
+  };
+  return createPortal(
+    <div
+      className={cn(
+        "pointer-events-none fixed inset-x-0 z-[120] flex justify-center gap-2",
+        position === "top"
+          ? "top-6 flex-col items-center"
+          : "bottom-6 flex-col-reverse items-center",
+      )}
+    >
       <div
-        role="status"
-        aria-live="polite"
-        className="rounded border border-border bg-bg-elevated px-3 py-1.5 text-xs text-fg shadow-md"
+        className={cn(
+          "pointer-events-auto flex gap-2",
+          position === "top"
+            ? "flex-col items-center"
+            : "flex-col-reverse items-center",
+        )}
+        onMouseEnter={pauseAll}
+        onMouseLeave={resumeAll}
+        onFocus={pauseAll}
+        onBlur={resumeAll}
       >
-        {message}
+        {rendered.map((toast) => {
+          const progressStyle = {
+            "--toast-duration": `${toast.durationMs}ms`,
+          } as CSSProperties;
+          return (
+            <button
+              key={toast.id}
+              type="button"
+              role="status"
+              aria-live="polite"
+              onClick={() => handleClick(toast)}
+              data-position={position}
+              data-state={toast.exiting ? "exit" : "enter"}
+              className="acorn-toast-motion relative cursor-pointer overflow-hidden rounded-full border border-border bg-bg-elevated px-4 py-2 text-xs text-fg shadow-md transition-[background-color,border-color,box-shadow] duration-200 ease-out hover:border-accent/60 hover:bg-bg-elevated/95 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-accent/50"
+            >
+              {toast.message}
+              <div
+                aria-hidden="true"
+                className="acorn-toast-progress absolute inset-x-0 bottom-0 h-0.5 origin-left bg-accent/80"
+                data-paused={
+                  toast.paused && !toast.exiting ? "true" : undefined
+                }
+                style={progressStyle}
+              />
+            </button>
+          );
+        })}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/lib/operationToasts.ts
+++ b/src/lib/operationToasts.ts
@@ -1,0 +1,47 @@
+import { createTranslator, type TranslationKey } from "./i18n";
+import { useSettings } from "./settings";
+import { useToasts } from "./toasts";
+import { useAppStore } from "../store";
+
+export function currentText(
+  key: TranslationKey,
+  values?: Record<string, string | number>,
+): string {
+  const t = createTranslator(useSettings.getState().settings.language);
+  const template = t(key);
+  if (!values) return template;
+  return template.replace(/\{(\w+)\}/g, (match, name) =>
+    Object.prototype.hasOwnProperty.call(values, name)
+      ? String(values[name])
+      : match,
+  );
+}
+
+export function showTranslatedToast(
+  key: TranslationKey,
+  values?: Record<string, string | number>,
+): void {
+  useToasts.getState().show(currentText(key, values));
+}
+
+export function showTranslatedErrorToast(
+  key: TranslationKey,
+  error: unknown,
+): void {
+  const message = error instanceof Error ? error.message : String(error);
+  useToasts.getState().show(`${currentText(key)} ${message}`);
+}
+
+export function showStoreResultToast(
+  successKey: TranslationKey | null,
+  failureKey: TranslationKey,
+): void {
+  const error = useAppStore.getState().consumeError();
+  if (error) {
+    showTranslatedErrorToast(failureKey, error);
+    return;
+  }
+  if (successKey) {
+    showTranslatedToast(successKey);
+  }
+}

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -226,6 +226,7 @@ describe("appearance settings migration", () => {
     );
     expect(settings.appearance.background.relativePath).toBeNull();
     expect(settings.appearance.uiScalePercent).toBe(100);
+    expect(settings.appearance.toastPosition).toBe("top");
   });
 
   it("keeps terminal.fontFamily as the source of truth on load", async () => {
@@ -385,5 +386,33 @@ describe("appearance settings migration", () => {
     const { useSettings } = await import("./settings");
 
     expect(useSettings.getState().settings.appearance.uiScalePercent).toBe(100);
+  });
+
+  it("normalizes stored toast position", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ appearance: { toastPosition: "bottom" } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.appearance.toastPosition).toBe(
+      "bottom",
+    );
+  });
+
+  it("falls back to default toast position when stored value is invalid", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ appearance: { toastPosition: "left" } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.appearance.toastPosition).toBe(
+      "top",
+    );
   });
 });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -79,6 +79,16 @@ export const UI_SCALE_PERCENT_MIN = 75;
 export const UI_SCALE_PERCENT_MAX = 150;
 export const UI_SCALE_PERCENT_STEP = 5;
 
+export type ToastPosition = "top" | "bottom";
+
+export const TOAST_POSITION_OPTIONS: ReadonlyArray<{
+  value: ToastPosition;
+  label: string;
+}> = [
+  { value: "top", label: "Top" },
+  { value: "bottom", label: "Bottom" },
+];
+
 export type TerminalFontWeight =
   | 100
   | 200
@@ -285,6 +295,7 @@ export interface AcornSettings {
     background: BackgroundState;
     fontSlots: [string, string | null, string | null];
     uiScalePercent: number;
+    toastPosition: ToastPosition;
   };
   /**
    * Opt-in toggles for unfinished features. Anything under here is
@@ -397,6 +408,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     },
     fontSlots: ["JetBrains Mono", "Fira Code", "Menlo"],
     uiScalePercent: 100,
+    toastPosition: "top",
   },
   experiments: {
     stickyPrompt: false,
@@ -422,6 +434,7 @@ const VALID_PR_INTERVALS = new Set<number>(
 );
 
 const VALID_BG_FITS = new Set<BackgroundFit>(["cover", "contain", "tile"]);
+const VALID_TOAST_POSITIONS = new Set<ToastPosition>(["top", "bottom"]);
 
 function normalizeBgFit(v: unknown, fallback: BackgroundFit): BackgroundFit {
   if (typeof v === "string" && VALID_BG_FITS.has(v as BackgroundFit)) {
@@ -457,6 +470,19 @@ function normalizeThemeId(v: unknown, fallback: string): string {
   // id isn't in the merged registry at apply time.
   if (typeof v === "string" && v.trim().length > 0) {
     return v;
+  }
+  return fallback;
+}
+
+function normalizeToastPosition(
+  v: unknown,
+  fallback: ToastPosition,
+): ToastPosition {
+  if (
+    typeof v === "string" &&
+    VALID_TOAST_POSITIONS.has(v as ToastPosition)
+  ) {
+    return v as ToastPosition;
   }
   return fallback;
 }
@@ -621,6 +647,10 @@ function loadSettings(): AcornSettings {
       uiScalePercent: normalizeUiScalePercent(
         appearanceRaw.uiScalePercent,
         DEFAULT_SETTINGS.appearance.uiScalePercent,
+      ),
+      toastPosition: normalizeToastPosition(
+        appearanceRaw.toastPosition,
+        DEFAULT_SETTINGS.appearance.toastPosition,
       ),
       background: {
         relativePath:

--- a/src/lib/toasts.ts
+++ b/src/lib/toasts.ts
@@ -1,39 +1,122 @@
 import { create } from "zustand";
 
-/**
- * Lightweight one-shot toast store. A single message at a time — calling
- * `show` while another is visible replaces it and resets the timer. Used
- * for transient confirmations that don't deserve a full dialog (e.g.
- * "Shell environment reloaded"). Mount [`ToastHost`] once near the app
- * root for these to render.
- */
-interface ToastState {
-  message: string | null;
-  show: (message: string) => void;
-  hide: () => void;
+type ToastAction = () => void | Promise<void>;
+
+interface ToastOptions {
+  action?: ToastAction;
 }
 
-const TOAST_TTL_MS = 3000;
+export interface ToastItem {
+  id: number;
+  message: string;
+  durationMs: number;
+  action: ToastAction | null;
+  paused: boolean;
+}
 
-let dismissTimer: ReturnType<typeof setTimeout> | null = null;
+/**
+ * Lightweight toast stack store. `show` appends a transient message,
+ * each with its own TTL so simultaneous background completions don't
+ * overwrite each other.
+ */
+interface ToastState {
+  toasts: ToastItem[];
+  show: (message: string, options?: ToastOptions) => void;
+  hide: (id?: number) => void;
+  pause: (id: number) => void;
+  resume: (id: number) => void;
+}
 
-export const useToasts = create<ToastState>((set) => ({
-  message: null,
-  show: (message: string) => {
-    if (dismissTimer !== null) {
-      clearTimeout(dismissTimer);
-    }
-    set({ message });
-    dismissTimer = setTimeout(() => {
-      set({ message: null });
-      dismissTimer = null;
-    }, TOAST_TTL_MS);
+export const TOAST_TTL_MS = 5_000;
+
+const dismissTimers = new Map<number, ReturnType<typeof setTimeout>>();
+const startedAt = new Map<number, number>();
+const remainingMs = new Map<number, number>();
+
+let nextToastId = 0;
+
+function clearDismissTimer(id: number) {
+  const timer = dismissTimers.get(id);
+  if (timer) {
+    clearTimeout(timer);
+    dismissTimers.delete(id);
+  }
+}
+
+export const useToasts = create<ToastState>((set, get) => ({
+  toasts: [],
+  show: (message: string, options?: ToastOptions) => {
+    const id = ++nextToastId;
+    startedAt.set(id, Date.now());
+    remainingMs.set(id, TOAST_TTL_MS);
+    set((state) => ({
+      toasts: [
+        ...state.toasts,
+        {
+          id,
+          message,
+          durationMs: TOAST_TTL_MS,
+          action: options?.action ?? null,
+          paused: false,
+        },
+      ],
+    }));
+    dismissTimers.set(
+      id,
+      setTimeout(() => {
+        get().hide(id);
+      }, TOAST_TTL_MS),
+    );
   },
-  hide: () => {
-    if (dismissTimer !== null) {
-      clearTimeout(dismissTimer);
-      dismissTimer = null;
+  hide: (id?: number) => {
+    if (id === undefined) {
+      for (const toast of get().toasts) {
+        clearDismissTimer(toast.id);
+        startedAt.delete(toast.id);
+        remainingMs.delete(toast.id);
+      }
+      set({ toasts: [] });
+      return;
     }
-    set({ message: null });
+    clearDismissTimer(id);
+    startedAt.delete(id);
+    remainingMs.delete(id);
+    set((state) => ({
+      toasts: state.toasts.filter((toast) => toast.id !== id),
+    }));
+  },
+  pause: (id: number) => {
+    const toast = get().toasts.find((item) => item.id === id);
+    if (!toast || toast.paused) return;
+    clearDismissTimer(id);
+    const started = startedAt.get(id) ?? Date.now();
+    const remaining = remainingMs.get(id) ?? TOAST_TTL_MS;
+    remainingMs.set(id, Math.max(0, remaining - (Date.now() - started)));
+    set((state) => ({
+      toasts: state.toasts.map((item) =>
+        item.id === id ? { ...item, paused: true } : item,
+      ),
+    }));
+  },
+  resume: (id: number) => {
+    const toast = get().toasts.find((item) => item.id === id);
+    if (!toast || !toast.paused) return;
+    const remaining = remainingMs.get(id) ?? 0;
+    if (remaining <= 0) {
+      get().hide(id);
+      return;
+    }
+    startedAt.set(id, Date.now());
+    set((state) => ({
+      toasts: state.toasts.map((item) =>
+        item.id === id ? { ...item, paused: false } : item,
+      ),
+    }));
+    dismissTimers.set(
+      id,
+      setTimeout(() => {
+        get().hide(id);
+      }, remaining),
+    );
   },
 }));

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,4 +1,39 @@
 {
+  "toasts": {
+    "session": {
+      "createFailed": "Failed to create session:",
+      "duplicateFailed": "Failed to duplicate session:",
+      "removeFailed": "Failed to remove session:",
+      "worktreeRemoved": "Worktree deleted from disk.",
+      "worktreeRemoveFailed": "Failed to delete worktree:",
+      "refreshFailed": "Failed to refresh sessions:",
+      "renameFailed": "Failed to rename session:",
+      "worktreeAdopted": "Adopted new worktree: {name}",
+      "worktreeAdoptFailed": "Failed to adopt worktree:"
+    },
+    "project": {
+      "addFailed": "Failed to add project:",
+      "createFailed": "Failed to create project:",
+      "removeFailed": "Failed to remove project:",
+      "worktreesRemoved": "Project worktrees deleted from disk.",
+      "worktreesRemoveFailed": "Failed to delete project worktrees:"
+    },
+    "ipc": {
+      "restarted": "IPC server restarted.",
+      "restartFailed": "Failed to restart IPC server:"
+    },
+    "files": {
+      "renameFailed": "Failed to rename file:",
+      "trashFailed": "Failed to move to trash:",
+      "pathsCopied": "File paths copied.",
+      "copyFailed": "Failed to copy file paths."
+    },
+    "pullRequests": {
+      "mergeFailed": "Failed to merge pull request:",
+      "closeFailed": "Failed to close pull request:",
+      "bodyUpdateFailed": "Failed to update pull request:"
+    }
+  },
   "settings": {
     "title": "Settings",
     "reset": "Reset to defaults",
@@ -128,6 +163,14 @@
         "refresh": "Refresh",
         "revealFolder": "Reveal folder"
       },
+      "toastPosition": {
+        "label": "Toast position",
+        "hint": "Choose where transient app messages appear.",
+        "options": {
+          "top": "Top",
+          "bottom": "Bottom"
+        }
+      },
       "background": {
         "label": "Background image",
         "hint": "One image can be applied to the app area, terminal area, or both.",
@@ -147,7 +190,13 @@
           "label": "Opacity",
           "hint": "0 is transparent, 100 is opaque."
         },
-        "blur": "Blur"
+        "blur": "Blur",
+        "toasts": {
+          "imported": "Background image imported.",
+          "importFailed": "Failed to import background image:",
+          "removed": "Background image removed.",
+          "removeFailed": "Failed to remove background image:"
+        }
       },
       "sessionDisplay": {
         "title": {
@@ -462,6 +511,13 @@
       "whatsNewInVersion": "What's new in {version}",
       "checking": "Checking...",
       "checkForUpdates": "Check for updates",
+      "toasts": {
+        "upToDate": "Acorn is up to date.",
+        "updateAvailable": "Acorn {version} is available.",
+        "checkFailed": "Update check failed:",
+        "installFailed": "Update install failed:",
+        "releaseNotesFailed": "Failed to load release notes:"
+      },
       "relative": {
         "never": "never",
         "justNow": "just now",
@@ -1241,6 +1297,19 @@
     },
     "relativeTime": {
       "ago": "ago"
+    },
+    "toasts": {
+      "enabled": "Background sessions enabled.",
+      "disabled": "Background sessions disabled.",
+      "toggleFailed": "Failed to update background sessions:",
+      "restarted": "Daemon restarted.",
+      "restartFailed": "Failed to restart daemon:",
+      "shutdown": "Daemon shut down.",
+      "shutdownFailed": "Failed to quit daemon:",
+      "sessionKilled": "PTY killed.",
+      "sessionRestored": "Session restored.",
+      "sessionForgotten": "Session forgotten.",
+      "sessionActionFailed": "Daemon session action failed:"
     }
   }
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1,4 +1,39 @@
 {
+  "toasts": {
+    "session": {
+      "createFailed": "세션을 만들지 못했습니다:",
+      "duplicateFailed": "세션을 복제하지 못했습니다:",
+      "removeFailed": "세션을 제거하지 못했습니다:",
+      "worktreeRemoved": "디스크에서 worktree를 삭제했습니다.",
+      "worktreeRemoveFailed": "worktree를 삭제하지 못했습니다:",
+      "refreshFailed": "세션을 새로고침하지 못했습니다:",
+      "renameFailed": "세션 이름을 변경하지 못했습니다:",
+      "worktreeAdopted": "새 worktree를 가져왔습니다: {name}",
+      "worktreeAdoptFailed": "worktree를 가져오지 못했습니다:"
+    },
+    "project": {
+      "addFailed": "프로젝트를 추가하지 못했습니다:",
+      "createFailed": "프로젝트를 만들지 못했습니다:",
+      "removeFailed": "프로젝트를 제거하지 못했습니다:",
+      "worktreesRemoved": "디스크에서 프로젝트 worktree를 삭제했습니다.",
+      "worktreesRemoveFailed": "프로젝트 worktree를 삭제하지 못했습니다:"
+    },
+    "ipc": {
+      "restarted": "IPC 서버를 다시 시작했습니다.",
+      "restartFailed": "IPC 서버를 다시 시작하지 못했습니다:"
+    },
+    "files": {
+      "renameFailed": "파일 이름을 변경하지 못했습니다:",
+      "trashFailed": "휴지통으로 이동하지 못했습니다:",
+      "pathsCopied": "파일 경로를 복사했습니다.",
+      "copyFailed": "파일 경로를 복사하지 못했습니다."
+    },
+    "pullRequests": {
+      "mergeFailed": "Pull request를 병합하지 못했습니다:",
+      "closeFailed": "Pull request를 닫지 못했습니다:",
+      "bodyUpdateFailed": "Pull request를 업데이트하지 못했습니다:"
+    }
+  },
   "settings": {
     "title": "설정",
     "reset": "기본값으로 재설정",
@@ -128,6 +163,14 @@
         "refresh": "새로고침",
         "revealFolder": "폴더 보기"
       },
+      "toastPosition": {
+        "label": "토스트 위치",
+        "hint": "일시적인 앱 메시지를 표시할 위치를 선택합니다.",
+        "options": {
+          "top": "상단",
+          "bottom": "하단"
+        }
+      },
       "background": {
         "label": "배경 이미지",
         "hint": "이미지 하나를 앱 영역, 터미널 영역 또는 둘 다에 적용할 수 있습니다.",
@@ -147,7 +190,13 @@
           "label": "불투명도",
           "hint": "0은 투명, 100은 불투명입니다."
         },
-        "blur": "흐림"
+        "blur": "흐림",
+        "toasts": {
+          "imported": "배경 이미지를 가져왔습니다.",
+          "importFailed": "배경 이미지를 가져오지 못했습니다:",
+          "removed": "배경 이미지를 제거했습니다.",
+          "removeFailed": "배경 이미지를 제거하지 못했습니다:"
+        }
       },
       "sessionDisplay": {
         "title": {
@@ -462,6 +511,13 @@
       "whatsNewInVersion": "{version}의 새로운 내용",
       "checking": "확인 중...",
       "checkForUpdates": "업데이트 확인",
+      "toasts": {
+        "upToDate": "Acorn이 최신 상태입니다.",
+        "updateAvailable": "Acorn {version}을 사용할 수 있습니다.",
+        "checkFailed": "업데이트 확인에 실패했습니다:",
+        "installFailed": "업데이트 설치에 실패했습니다:",
+        "releaseNotesFailed": "릴리스 노트를 불러오지 못했습니다:"
+      },
       "relative": {
         "never": "확인한 적 없음",
         "justNow": "방금 전",
@@ -1241,6 +1297,19 @@
     },
     "relativeTime": {
       "ago": "전"
+    },
+    "toasts": {
+      "enabled": "백그라운드 세션을 켰습니다.",
+      "disabled": "백그라운드 세션을 껐습니다.",
+      "toggleFailed": "백그라운드 세션 설정을 변경하지 못했습니다:",
+      "restarted": "데몬을 다시 시작했습니다.",
+      "restartFailed": "데몬을 다시 시작하지 못했습니다:",
+      "shutdown": "데몬을 종료했습니다.",
+      "shutdownFailed": "데몬을 종료하지 못했습니다:",
+      "sessionKilled": "PTY를 종료했습니다.",
+      "sessionRestored": "세션을 복원했습니다.",
+      "sessionForgotten": "세션을 잊었습니다.",
+      "sessionActionFailed": "데몬 세션 작업에 실패했습니다:"
     }
   }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -84,6 +84,7 @@ interface AppStateModel {
   focusedPaneId: PaneId;
   activeTabId: string | null;
   activeSessionId: string | null;
+  consumeError: () => string | null;
 
   rightTab: RightTab;
   /**
@@ -496,6 +497,11 @@ export const useAppStore = create<AppStateModel>()(
   multiInputEnabled: false,
   loading: false,
   error: null,
+  consumeError() {
+    const error = get().error;
+    if (error) set({ error: null });
+    return error;
+  },
   pendingRemoveId: null,
   pendingRemoveProject: null,
   sessionsLoadedCleanly: true,
@@ -539,6 +545,7 @@ export const useAppStore = create<AppStateModel>()(
         return {
           sessions,
           loading: false,
+          error: null,
           sessionsLoadedCleanly: nextSessionsLoadedCleanly,
           workspaces: reconciled.workspaces,
           activeProject: reconciled.activeProject,
@@ -1196,6 +1203,7 @@ export const useAppStore = create<AppStateModel>()(
     try {
       await api.removeSession(id, removeWorktree);
       await get().refreshAll();
+      set({ error: null });
     } catch (e) {
       const message = errorMessage(e);
       await get().refreshAll();
@@ -1207,6 +1215,7 @@ export const useAppStore = create<AppStateModel>()(
     try {
       await api.renameSession(id, name);
       await get().refreshSessions();
+      set({ error: null });
     } catch (e) {
       set({ error: errorMessage(e) });
     }
@@ -1216,6 +1225,7 @@ export const useAppStore = create<AppStateModel>()(
     try {
       await api.updateSessionWorktree(id, worktreePath);
       await get().refreshSessions();
+      set({ error: null });
     } catch (e) {
       set({ error: errorMessage(e) });
     }
@@ -1233,6 +1243,7 @@ export const useAppStore = create<AppStateModel>()(
     try {
       await api.addProject(repoPath);
       await get().refreshProjects();
+      set({ error: null });
     } catch (e) {
       set({ error: errorMessage(e) });
     }
@@ -1271,6 +1282,7 @@ export const useAppStore = create<AppStateModel>()(
         };
       });
       await get().refreshAll();
+      set({ error: null });
     } catch (e) {
       set({ error: errorMessage(e) });
     }


### PR DESCRIPTION
## Summary
This PR tightens Acorn's toast system so transient feedback is more visible and reserved for operations whose results are otherwise hard to verify.

1. **Toast stack UX:** Replaces the single-message toast with a stacked host, top/bottom positioning, entry/exit animation, a duration progress indicator, click-to-dismiss/action behavior, and hover/focus pause for the whole stack.
2. **Settings control:** Adds a Settings → Appearance option for toast placement and persists/normalizes the choice.
3. **Operational feedback:** Adds toast coverage for background daemon actions, worktree deletion outcomes, hard-to-see failures, copy confirmations, update checks, and selected async Settings operations without showing redundant success toasts for obvious UI changes.
4. **Error consumption:** Adds a small `consumeError()` store helper so errors surfaced by toast do not also remain duplicated in the status bar.

## Expected impact

| Area | Impact |
| --- | --- |
| User-visible behavior | Toasts are more visible, can appear above modals, and can be positioned from Settings. |
| Reliability | Background/worktree/file/PR failures are easier to notice without relying only on inline or status-bar state. |
| Noise | Success toasts are limited to operations where the outcome is not immediately visible, such as worktree deletion from disk. |

## Design notes

- Toasts render through a `document.body` portal at `z-[120]`, above existing modal overlays.
- The toast store now tracks independent toast ids, timers, pause state, actions, and remaining TTL.
- Hover/focus over the toast stack pauses all active toasts, including toasts added while the stack is already paused.
- Store-level errors remain available for inline/status-bar display until a caller explicitly consumes them for toast feedback.
- The temporary dev refresh preview toasts used during iteration were removed before opening this PR.

## Follow-up (not in this PR)

- Consider replacing store-level `error` reads with explicit operation result objects for session/project mutations.
- Add focused component tests for toast pause/resume timing if this UI grows more behavior.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm vitest run src/lib/settings.test.ts src/store.test.ts`
- [x] `pnpm test`

## Notes

Self-review found and fixed two issues before opening: the dev-only preview toasts were still present, and newly added toasts did not pause if they appeared while the stack was already hovered.
