### PR TITLE
feat(activity): session activity center + unread badges

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const PORT = 1420;
+const PORT = Number(process.env.PLAYWRIGHT_PORT ?? 1420);
 const BASE_URL = `http://localhost:${PORT}`;
 
 export default defineConfig({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,7 @@ import {
   type UiScaleChangedDetail,
 } from "./lib/layoutEvents";
 import {
+  startSessionActivityInboxWatcher,
   startNotificationClickHandler,
   startSessionNotificationWatcher,
 } from "./lib/notifications";
@@ -560,6 +561,10 @@ function App() {
 
   useEffect(() => {
     return startSessionNotificationWatcher();
+  }, []);
+
+  useEffect(() => {
+    return startSessionActivityInboxWatcher();
   }, []);
 
   useEffect(() => {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -73,6 +73,8 @@ import type {
   PullRequestInfo,
   PullRequestLabel,
   PullRequestListing,
+  SessionNotification,
+  SessionNotificationKind,
   StagedFile,
   TodoItem,
   WorkflowJob,
@@ -191,6 +193,11 @@ export function RightPanel() {
   const rightTab = useAppStore((s) => s.rightTab);
   const setRightTab = useAppStore((s) => s.setRightTab);
   const setRightGroup = useAppStore((s) => s.setRightGroup);
+  const activityUnreadCount = useAppStore(
+    (s) =>
+      s.sessionNotifications.filter((notification) => !notification.readAt)
+        .length,
+  );
   const active = sessions.find((s) => s.id === activeSessionId);
   const activeWorkspaceTab = activeTabId ? workspaceTabs[activeTabId] : undefined;
   // The session's recorded worktree path is what we set at spawn time. The
@@ -417,7 +424,13 @@ export function RightPanel() {
               key={tab}
               icon={tabIcon(tab)}
               label={rt(t, tabLabelKey(tab))}
-              badge={tab === "todos" ? todosState.todos.length : undefined}
+              badge={
+                tab === "activity"
+                  ? activityUnreadCount
+                  : tab === "todos"
+                    ? todosState.todos.length
+                    : undefined
+              }
               active={tab === rightTab}
               onClick={() => setRightTab(tab)}
             />
@@ -425,7 +438,9 @@ export function RightPanel() {
         </nav>
       ) : null}
       <div className="flex-1 overflow-hidden">
-        {rightTab === "todos" ? (
+        {rightTab === "activity" ? (
+          <ActivityTab />
+        ) : rightTab === "todos" ? (
           active && showTodos ? (
             <TodosTab todos={todosState.todos} />
           ) : (
@@ -666,6 +681,8 @@ function tabIcon(tab: RightTab): ReactNode {
       return <GitPullRequest size={12} />;
     case "actions":
       return <Activity size={12} />;
+    case "activity":
+      return <CircleAlert size={12} />;
     case "todos":
       return <ListTodo size={12} />;
     case "history":
@@ -1199,6 +1216,167 @@ function countByStatus(todos: TodoItem[]) {
     else pending++;
   }
   return { pending, in_progress, completed };
+}
+
+const ACTIVITY_KIND_KEYS: Record<
+  SessionNotificationKind,
+  RightPanelTranslationKey
+> = {
+  needs_input: "rightPanel.activity.kind.needsInput",
+  failed: "rightPanel.activity.kind.failed",
+  completed: "rightPanel.activity.kind.completed",
+  became_idle: "rightPanel.activity.kind.becameIdle",
+};
+
+function ActivityTab() {
+  const t = useTranslation();
+  const notifications = useAppStore((s) => s.sessionNotifications);
+  const markAllRead = useAppStore((s) => s.markAllSessionNotificationsRead);
+  const clearRead = useAppStore((s) => s.clearReadSessionNotifications);
+  const unreadCount = notifications.filter((notification) => !notification.readAt)
+    .length;
+  const readCount = notifications.length - unreadCount;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 items-center justify-between border-b border-border px-3 py-2">
+        <div className="min-w-0 text-[10px] uppercase tracking-wide text-fg-muted">
+          <span className="mr-3">
+            {rtf(t, "rightPanel.activity.unreadCount", {
+              count: unreadCount,
+            })}
+          </span>
+          {readCount > 0 ? (
+            <span>
+              {rtf(t, "rightPanel.activity.readCount", { count: readCount })}
+            </span>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-1">
+          <Tooltip
+            label={rt(t, "rightPanel.activity.actions.markAllRead")}
+            side="top"
+          >
+            <button
+              type="button"
+              onClick={markAllRead}
+              disabled={unreadCount === 0}
+              className="rounded border border-border px-2 py-1 text-[10px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+            >
+              {rt(t, "rightPanel.activity.actions.markAllRead")}
+            </button>
+          </Tooltip>
+          <Tooltip
+            label={rt(t, "rightPanel.activity.actions.clearRead")}
+            side="top"
+          >
+            <button
+              type="button"
+              onClick={clearRead}
+              disabled={readCount === 0}
+              className="rounded border border-border px-2 py-1 text-[10px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+            >
+              {rt(t, "rightPanel.activity.actions.clearRead")}
+            </button>
+          </Tooltip>
+        </div>
+      </div>
+      {notifications.length === 0 ? (
+        <Empty msg={rt(t, "rightPanel.activity.empty")} />
+      ) : (
+        <ul className="acorn-no-scrollbar flex-1 overflow-y-auto p-2 text-xs">
+          {notifications.map((notification) => (
+            <ActivityRow key={notification.id} notification={notification} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ActivityRow({
+  notification,
+}: {
+  notification: SessionNotification;
+}) {
+  const t = useTranslation();
+  const selectSession = useAppStore((s) => s.selectSession);
+  const markRead = useAppStore((s) => s.markSessionNotificationRead);
+  const dismiss = useAppStore((s) => s.dismissSessionNotification);
+  const unread = !notification.readAt;
+
+  const openSession = () => {
+    markRead(notification.id);
+    selectSession(notification.sessionId);
+  };
+
+  return (
+    <li
+      className={cn(
+        "group mb-1 flex items-start gap-2 rounded px-2 py-2 transition",
+        "hover:bg-bg-elevated/60",
+        unread && "bg-warning/5",
+      )}
+    >
+      <button
+        type="button"
+        onClick={openSession}
+        className="flex min-w-0 flex-1 items-start gap-2 text-left"
+      >
+        <span
+          className={cn(
+            "mt-1 h-1.5 w-1.5 shrink-0 rounded-full",
+            activityDotClass(notification.kind),
+          )}
+        />
+        <span className="min-w-0 flex-1">
+          <span className="flex min-w-0 items-center gap-2">
+            <span
+              className={cn(
+                "truncate font-mono text-[11px]",
+                unread ? "text-fg" : "text-fg-muted",
+              )}
+            >
+              {rt(t, ACTIVITY_KIND_KEYS[notification.kind])}
+            </span>
+            <span className="shrink-0 font-mono text-[10px] text-fg-muted/70">
+              {formatActivityTime(notification.createdAt)}
+            </span>
+          </span>
+          <span className="block truncate text-[11px] text-fg">
+            {rtf(t, "rightPanel.activity.itemTitle", {
+              project: notification.projectName,
+              session: notification.sessionName,
+            })}
+          </span>
+          <span className="block truncate text-[10px] text-fg-muted">
+            {notification.repoPath}
+          </span>
+        </span>
+      </button>
+      <Tooltip label={rt(t, "rightPanel.activity.actions.dismiss")} side="top">
+        <button
+          type="button"
+          onClick={() => dismiss(notification.id)}
+          className="rounded p-1 text-fg-muted opacity-0 transition hover:bg-bg-sidebar hover:text-fg group-hover:opacity-100"
+        >
+          <X size={12} />
+        </button>
+      </Tooltip>
+    </li>
+  );
+}
+
+function activityDotClass(kind: SessionNotificationKind): string {
+  if (kind === "failed") return "bg-danger";
+  if (kind === "completed") return "bg-accent";
+  return "bg-warning";
+}
+
+function formatActivityTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
 function AgentHistoryTab({

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1370,6 +1370,15 @@ function StatusBarSection({
     >
       <div className="flex flex-col gap-1">
         <CheckboxRow
+          label={st(t, "settings.appearance.statusBar.sessionActivity.label")}
+          description={st(
+            t,
+            "settings.appearance.statusBar.sessionActivity.description",
+          )}
+          checked={statusBar.showSessionActivity !== false}
+          onChange={(v) => patch({ showSessionActivity: v })}
+        />
+        <CheckboxRow
           label={st(t, "settings.appearance.statusBar.sessionCount.label")}
           description={st(
             t,

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,13 +1,26 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { homeDir } from "@tauri-apps/api/path";
-import { Activity, Loader2, Settings } from "lucide-react";
+import {
+  Activity,
+  Bell,
+  CheckCheck,
+  Loader2,
+  Settings,
+  Trash2,
+  X,
+} from "lucide-react";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useSettings } from "../lib/settings";
 import { useToasts } from "../lib/toasts";
-import type { MemoryProcess, SessionStatus } from "../lib/types";
+import type {
+  MemoryProcess,
+  SessionNotification,
+  SessionNotificationKind,
+  SessionStatus,
+} from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
 import { useAppStore } from "../store";
 import { MemoryBreakdownModal } from "./MemoryBreakdownModal";
@@ -143,6 +156,9 @@ export function StatusBar() {
   const showSessionStatus = useSettings(
     (s) => s.settings.statusBar.showSessionStatus,
   );
+  const showSessionActivity = useSettings(
+    (s) => s.settings.statusBar.showSessionActivity !== false,
+  );
   const showGithubAccount = useSettings(
     (s) => s.settings.statusBar.showGithubAccount,
   );
@@ -175,6 +191,7 @@ export function StatusBar() {
             control-session socket or a stopped daemon without leaving
             the main view. */}
         <ServicesStatusButton />
+        {showSessionActivity ? <SessionNotificationsButton /> : null}
         {showSessionCount ? (
           <span className="whitespace-nowrap">
             {statusBarFormat(t, "statusBar.sessionCount", {
@@ -309,6 +326,297 @@ interface DaemonSnapshot {
 }
 
 type DotState = "ok" | "down" | "muted";
+
+const NOTIFICATION_KIND_KEYS: Record<
+  SessionNotificationKind,
+  StatusBarTranslationKey
+> = {
+  needs_input: "statusBar.notifications.kind.needsInput",
+  failed: "statusBar.notifications.kind.failed",
+  completed: "statusBar.notifications.kind.completed",
+  became_idle: "statusBar.notifications.kind.becameIdle",
+};
+
+function SessionNotificationsButton() {
+  const t = useTranslation();
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const notifications = useAppStore((s) => s.sessionNotifications);
+  const unreadCount = notifications.filter((notification) => !notification.readAt)
+    .length;
+  const tooltip =
+    unreadCount > 0
+      ? statusBarFormat(t, "statusBar.notifications.tooltipWithCount", {
+          count: unreadCount,
+        })
+      : statusBarText(t, "statusBar.notifications.tooltipEmpty");
+
+  return (
+    <>
+      <Tooltip label={tooltip} side="top">
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label={statusBarText(t, "statusBar.notifications.ariaLabel")}
+          className={cn(
+            "relative flex h-5 items-center gap-1.5 rounded px-1.5 transition",
+            "hover:bg-bg-elevated",
+            unreadCount > 0 ? "text-warning" : "text-fg-muted",
+          )}
+        >
+          <Bell size={12} />
+          {unreadCount > 0 ? (
+            <span className="min-w-3 rounded-full bg-warning px-1 text-center text-[9px] leading-3 text-bg-sidebar">
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </span>
+          ) : null}
+        </button>
+      </Tooltip>
+      {open ? (
+        <SessionNotificationsDropdown
+          anchor={triggerRef.current}
+          onClose={() => setOpen(false)}
+          notifications={notifications}
+        />
+      ) : null}
+    </>
+  );
+}
+
+interface SessionNotificationsDropdownProps {
+  anchor: HTMLElement | null;
+  onClose: () => void;
+  notifications: SessionNotification[];
+}
+
+function SessionNotificationsDropdown({
+  anchor,
+  onClose,
+  notifications,
+}: SessionNotificationsDropdownProps) {
+  const t = useTranslation();
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState<{ left: number; bottom: number } | null>(
+    null,
+  );
+  const unreadCount = notifications.filter((notification) => !notification.readAt)
+    .length;
+  const markAllRead = useAppStore((s) => s.markAllSessionNotificationsRead);
+  const clearRead = useAppStore((s) => s.clearReadSessionNotifications);
+
+  useLayoutEffect(() => {
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    setPosition({
+      left: rect.left,
+      bottom: Math.max(8, window.innerHeight - rect.top + 6),
+    });
+  }, [anchor]);
+
+  useLayoutEffect(() => {
+    if (!ref.current || !position) return;
+    const rect = ref.current.getBoundingClientRect();
+    const overflowRight = position.left + rect.width - (window.innerWidth - 8);
+    if (overflowRight > 0) {
+      setPosition((p) => (p ? { ...p, left: Math.max(8, p.left - overflowRight) } : p));
+    }
+  }, [position]);
+
+  useEffect(() => {
+    function onDown(e: MouseEvent) {
+      if (ref.current && ref.current.contains(e.target as Node)) return;
+      if (anchor && anchor.contains(e.target as Node)) return;
+      onClose();
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("resize", onClose);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("resize", onClose);
+    };
+  }, [anchor, onClose]);
+
+  if (!position) return null;
+
+  return createPortal(
+    <div
+      ref={ref}
+      role="menu"
+      style={{
+        position: "fixed",
+        left: position.left,
+        bottom: position.bottom,
+        zIndex: 60,
+      }}
+      className="flex max-h-[420px] w-96 flex-col overflow-hidden rounded-md border border-border bg-bg-elevated shadow-2xl"
+    >
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <div className="min-w-0">
+          <div className="font-mono text-xs text-fg">
+            {statusBarText(t, "statusBar.notifications.title")}
+          </div>
+          <div className="font-mono text-[10px] text-fg-muted">
+            {statusBarFormat(t, "statusBar.notifications.unreadCount", {
+              count: unreadCount,
+            })}
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <Tooltip
+            label={statusBarText(t, "statusBar.notifications.actions.markAllRead")}
+            side="top"
+          >
+            <button
+              type="button"
+              onClick={markAllRead}
+              disabled={unreadCount === 0}
+              className="rounded p-1 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+            >
+              <CheckCheck size={13} />
+            </button>
+          </Tooltip>
+          <Tooltip
+            label={statusBarText(t, "statusBar.notifications.actions.clearRead")}
+            side="top"
+          >
+            <button
+              type="button"
+              onClick={clearRead}
+              disabled={notifications.every((notification) => !notification.readAt)}
+              className="rounded p-1 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+            >
+              <Trash2 size={13} />
+            </button>
+          </Tooltip>
+        </div>
+      </div>
+      {notifications.length === 0 ? (
+        <div className="px-3 py-8 text-center text-xs text-fg-muted">
+          {statusBarText(t, "statusBar.notifications.empty")}
+        </div>
+      ) : (
+        <ul className="min-h-0 overflow-y-auto">
+          {notifications.map((notification) => (
+            <li key={notification.id}>
+              <NotificationRow
+                notification={notification}
+                onClose={onClose}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>,
+    document.body,
+  );
+}
+
+function NotificationRow({
+  notification,
+  onClose,
+}: {
+  notification: SessionNotification;
+  onClose: () => void;
+}) {
+  const t = useTranslation();
+  const selectSession = useAppStore((s) => s.selectSession);
+  const markRead = useAppStore((s) => s.markSessionNotificationRead);
+  const dismiss = useAppStore((s) => s.dismissSessionNotification);
+  const unread = !notification.readAt;
+
+  const openSession = () => {
+    markRead(notification.id);
+    selectSession(notification.sessionId);
+    onClose();
+  };
+
+  return (
+    <div
+      role="menuitem"
+      tabIndex={0}
+      onClick={openSession}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        openSession();
+      }}
+      className={cn(
+        "group flex w-full cursor-pointer items-start gap-2 border-b border-border/70 px-3 py-2 text-left transition last:border-b-0",
+        "hover:bg-bg-sidebar",
+        unread && "bg-warning/5",
+      )}
+    >
+      <span
+        className={cn(
+          "mt-1 h-1.5 w-1.5 shrink-0 rounded-full",
+          notificationDotClass(notification.kind),
+        )}
+      />
+      <span className="min-w-0 flex-1">
+        <span className="flex min-w-0 items-center gap-2">
+          <span
+            className={cn(
+              "truncate font-mono text-[11px]",
+              unread ? "text-fg" : "text-fg-muted",
+            )}
+          >
+            {statusBarText(t, NOTIFICATION_KIND_KEYS[notification.kind])}
+          </span>
+          <span className="shrink-0 font-mono text-[10px] text-fg-muted/70">
+            {formatNotificationTime(notification.createdAt)}
+          </span>
+        </span>
+        <span className="block truncate text-[11px] text-fg">
+          {statusBarFormat(t, "statusBar.notifications.itemTitle", {
+            project: notification.projectName,
+            session: notification.sessionName,
+          })}
+        </span>
+        <span className="block truncate text-[10px] text-fg-muted">
+          {notification.repoPath}
+        </span>
+      </span>
+      <span
+        role="button"
+        tabIndex={0}
+        aria-label={statusBarText(t, "statusBar.notifications.actions.dismiss")}
+        onClick={(event) => {
+          event.stopPropagation();
+          dismiss(notification.id);
+        }}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter" && event.key !== " ") return;
+          event.preventDefault();
+          event.stopPropagation();
+          dismiss(notification.id);
+        }}
+        className="rounded p-1 text-fg-muted opacity-0 transition hover:bg-bg-elevated hover:text-fg group-hover:opacity-100"
+      >
+        <X size={12} />
+      </span>
+    </div>
+  );
+}
+
+function notificationDotClass(kind: SessionNotificationKind): string {
+  if (kind === "failed") return "bg-danger";
+  if (kind === "completed") return "bg-accent";
+  return "bg-warning";
+}
+
+function formatNotificationTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
 
 function StatusDot({ state }: { state: DotState }) {
   return (

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -7,7 +7,12 @@ import {
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAppStore } from "../store";
 import { useSettings } from "./settings";
-import type { Session, SessionStatus } from "./types";
+import type {
+  Session,
+  SessionNotification,
+  SessionNotificationKind,
+  SessionStatus,
+} from "./types";
 
 // Notification body copy keyed by the status the session transitioned *into*.
 // The watcher only fires on transitions to `needs_input` / `failed` /
@@ -29,6 +34,7 @@ const STATUS_SENTENCE: Record<SessionStatus, string> = {
 // in System Settings since boot) gets corrected the moment the user asks
 // "does this actually work?".
 let cachedPermission: boolean | null = null;
+let inboxNotificationCounter = 0;
 
 async function checkPermission(): Promise<boolean> {
   try {
@@ -64,6 +70,18 @@ function shouldNotifyTransition(prev: SessionStatus, next: SessionStatus): {
   if (next === "failed") return { notify: true, key: "failed" };
   if (next === "completed") return { notify: true, key: "completed" };
   return { notify: false, key: null };
+}
+
+function notificationKindForTransition(
+  prev: SessionStatus,
+  next: SessionStatus,
+): SessionNotificationKind | null {
+  if (prev === next) return null;
+  if (next === "needs_input") return "needs_input";
+  if (next === "failed") return "failed";
+  if (next === "completed") return "completed";
+  if (next === "idle") return "became_idle";
+  return null;
 }
 
 /**
@@ -105,11 +123,63 @@ export function startSessionNotificationWatcher(): () => void {
   });
 }
 
+/**
+ * Watches session status transitions and records an in-app activity item for
+ * changes that need review. This is intentionally independent from the
+ * system-notification setting: the inbox is Acorn's local status history.
+ */
+export function startSessionActivityInboxWatcher(): () => void {
+  const lastStatus = new Map<string, SessionStatus>();
+  for (const s of useAppStore.getState().sessions) {
+    lastStatus.set(s.id, s.status);
+  }
+
+  return useAppStore.subscribe((state) => {
+    const sessions: Session[] = state.sessions;
+    const store = useAppStore.getState();
+
+    for (const s of sessions) {
+      const prev = lastStatus.get(s.id);
+      lastStatus.set(s.id, s.status);
+      if (prev === undefined) continue;
+
+      const kind = notificationKindForTransition(prev, s.status);
+      if (!kind) continue;
+      store.addSessionNotification(buildInboxNotification(s, prev, kind));
+    }
+
+    const known = new Set(sessions.map((s) => s.id));
+    for (const id of lastStatus.keys()) {
+      if (!known.has(id)) lastStatus.delete(id);
+    }
+  });
+}
+
 function projectNameFor(session: Session): string {
   const projects = useAppStore.getState().projects;
   const match = projects.find((p) => p.repo_path === session.repo_path);
   if (match) return match.name;
   return session.repo_path.split("/").pop() || session.repo_path;
+}
+
+function buildInboxNotification(
+  session: Session,
+  previousStatus: SessionStatus,
+  kind: SessionNotificationKind,
+): SessionNotification {
+  const createdAt = new Date().toISOString();
+  inboxNotificationCounter += 1;
+  return {
+    id: `${createdAt}:${inboxNotificationCounter}:${session.id}:${kind}`,
+    sessionId: session.id,
+    kind,
+    status: session.status,
+    previousStatus,
+    sessionName: session.name,
+    projectName: projectNameFor(session),
+    repoPath: session.repo_path,
+    createdAt,
+  };
 }
 
 async function fire(

--- a/src/lib/rightPanelGroups.ts
+++ b/src/lib/rightPanelGroups.ts
@@ -6,6 +6,7 @@ export type RightTab =
   | "commits"
   | "prs"
   | "actions"
+  | "activity"
   | "todos"
   | "history";
 
@@ -14,7 +15,7 @@ export const RIGHT_GROUPS: ReadonlyArray<RightGroup> = ["code", "github", "agent
 const TABS_BY_GROUP: Record<RightGroup, ReadonlyArray<RightTab>> = {
   code: ["files", "staged", "commits"],
   github: ["prs", "actions"],
-  agents: ["todos", "history"],
+  agents: ["activity", "history", "todos"],
 };
 
 export function tabsForGroup(group: RightGroup): ReadonlyArray<RightTab> {

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -103,6 +103,50 @@ describe("session removal settings", () => {
   });
 });
 
+describe("status bar settings", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("shows the session activity shortcut by default", () => {
+    expect(DEFAULT_SETTINGS.statusBar.showSessionActivity).toBe(true);
+  });
+
+  it("loads a persisted session activity shortcut preference", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ statusBar: { showSessionActivity: false } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.statusBar.showSessionActivity).toBe(
+      false,
+    );
+  });
+});
+
 describe("AI commit command resolution", () => {
   it("runs Codex through non-interactive exec mode", () => {
     expect(

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -232,6 +232,7 @@ export interface AcornSettings {
    * actually reduces the work acorn does — not just hides the readout.
    */
   statusBar: {
+    showSessionActivity: boolean;
     showSessionCount: boolean;
     showSessionStatus: boolean;
     showGithubAccount: boolean;
@@ -368,6 +369,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     },
   },
   statusBar: {
+    showSessionActivity: true,
     showSessionCount: true,
     showSessionStatus: true,
     showGithubAccount: true,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,25 @@ export type SessionStatus =
   | "failed"
   | "completed";
 
+export type SessionNotificationKind =
+  | "needs_input"
+  | "failed"
+  | "completed"
+  | "became_idle";
+
+export interface SessionNotification {
+  id: string;
+  sessionId: string;
+  kind: SessionNotificationKind;
+  status: SessionStatus;
+  previousStatus: SessionStatus;
+  sessionName: string;
+  projectName: string;
+  repoPath: string;
+  createdAt: string;
+  readAt?: string;
+}
+
 /**
  * Distinguishes ordinary terminal sessions from "control" sessions. Control
  * sessions are the entry point for the `acorn-ipc` CLI, which lets them

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -258,6 +258,10 @@
       "statusBar": {
         "label": "Status bar",
         "hint": "Choose which optional badges show in the bottom status bar.",
+        "sessionActivity": {
+          "label": "Session activity",
+          "description": "Bell shortcut for unread session activity. The Activity tab remains available when hidden."
+        },
         "sessionCount": {
           "label": "Session count",
           "description": "Total number of sessions across the active project (`sessions: N`)."
@@ -552,6 +556,26 @@
       "failed": "failed",
       "completed": "completed"
     },
+    "notifications": {
+      "ariaLabel": "Session notifications",
+      "tooltipEmpty": "No unread session notifications",
+      "tooltipWithCount": "{count} unread session notifications",
+      "title": "Session notifications",
+      "unreadCount": "{count} unread",
+      "empty": "No session status changes yet.",
+      "itemTitle": "{project} · {session}",
+      "kind": {
+        "needsInput": "Needs input",
+        "failed": "Failed",
+        "completed": "Completed",
+        "becameIdle": "Idle"
+      },
+      "actions": {
+        "markAllRead": "Mark all read",
+        "clearRead": "Clear read",
+        "dismiss": "Dismiss"
+      }
+    },
     "services": {
       "ariaLabel": "Service status",
       "tooltip": {
@@ -772,6 +796,7 @@
       "commits": "Commits",
       "staged": "Staged",
       "prs": "PRs",
+      "activity": "Activity",
       "history": "History",
       "actions": "Actions"
     },
@@ -782,6 +807,23 @@
     "todos": {
       "doneCount": "{completed}/{total} done",
       "inProgressCount": "{count} in progress"
+    },
+    "activity": {
+      "unreadCount": "{count} unread",
+      "readCount": "{count} read",
+      "empty": "No session activity yet",
+      "itemTitle": "{project} · {session}",
+      "kind": {
+        "needsInput": "Needs input",
+        "failed": "Failed",
+        "completed": "Completed",
+        "becameIdle": "Idle"
+      },
+      "actions": {
+        "markAllRead": "Mark all read",
+        "clearRead": "Clear read",
+        "dismiss": "Dismiss"
+      }
     },
     "loading": {
       "more": "Loading more…",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -258,6 +258,10 @@
       "statusBar": {
         "label": "상태 표시줄",
         "hint": "하단 상태 표시줄에 표시할 선택 배지를 고릅니다.",
+        "sessionActivity": {
+          "label": "세션 활동",
+          "description": "읽지 않은 세션 활동으로 바로 가는 벨 버튼입니다. 숨겨도 Activity 탭은 계속 사용할 수 있습니다."
+        },
         "sessionCount": {
           "label": "세션 수",
           "description": "활성 프로젝트 전체의 총 세션 수입니다(`sessions: N`)."
@@ -552,6 +556,26 @@
       "failed": "실패",
       "completed": "완료"
     },
+    "notifications": {
+      "ariaLabel": "세션 알림",
+      "tooltipEmpty": "읽지 않은 세션 알림 없음",
+      "tooltipWithCount": "읽지 않은 세션 알림 {count}개",
+      "title": "세션 알림",
+      "unreadCount": "읽지 않음 {count}개",
+      "empty": "아직 세션 상태 변경이 없습니다.",
+      "itemTitle": "{project} · {session}",
+      "kind": {
+        "needsInput": "입력 필요",
+        "failed": "실패",
+        "completed": "완료",
+        "becameIdle": "유휴"
+      },
+      "actions": {
+        "markAllRead": "모두 읽음",
+        "clearRead": "읽은 항목 지우기",
+        "dismiss": "닫기"
+      }
+    },
     "services": {
       "ariaLabel": "서비스 상태",
       "tooltip": {
@@ -772,6 +796,7 @@
       "commits": "커밋",
       "staged": "스테이징",
       "prs": "PR",
+      "activity": "활동",
       "history": "기록",
       "actions": "작업"
     },
@@ -782,6 +807,23 @@
     "todos": {
       "doneCount": "{completed}/{total} 완료",
       "inProgressCount": "{count}개 진행 중"
+    },
+    "activity": {
+      "unreadCount": "읽지 않음 {count}개",
+      "readCount": "읽음 {count}개",
+      "empty": "아직 세션 활동이 없습니다",
+      "itemTitle": "{project} · {session}",
+      "kind": {
+        "needsInput": "입력 필요",
+        "failed": "실패",
+        "completed": "완료",
+        "becameIdle": "유휴"
+      },
+      "actions": {
+        "markAllRead": "모두 읽음",
+        "clearRead": "읽은 항목 지우기",
+        "dismiss": "닫기"
+      }
     },
     "loading": {
       "more": "더 불러오는 중…",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Project, Session, SessionStatus } from "./lib/types";
+import type {
+  Project,
+  Session,
+  SessionNotification,
+  SessionStatus,
+} from "./lib/types";
 
 // Mock the Tauri-backed API surface used by the store.
 // Each method is a vi.fn so individual tests can stub return values.
@@ -79,6 +84,24 @@ function session(
   };
 }
 
+function notification(
+  id: string,
+  overrides: Partial<SessionNotification> = {},
+): SessionNotification {
+  return {
+    id,
+    sessionId: "s1",
+    kind: "needs_input",
+    status: "needs_input",
+    previousStatus: "running",
+    sessionName: "s1",
+    projectName: "repo-a",
+    repoPath: REPO_A,
+    createdAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
 /**
  * Reset the zustand store to a clean slate. We re-import the initial-shape
  * fields directly since zustand has no built-in reset.
@@ -100,6 +123,7 @@ function resetStore(): void {
       workspaceTabs: {},
       prAccountByRepo: {},
       pendingTerminalInput: {},
+      sessionNotifications: [],
       multiInputEnabled: false,
       loading: false,
       error: null,
@@ -160,6 +184,57 @@ describe("multi-input", () => {
     expect(useAppStore.getState().multiInputEnabled).toBe(true);
     expect(useAppStore.getState().toggleMultiInput()).toBe(false);
     expect(useAppStore.getState().multiInputEnabled).toBe(false);
+  });
+});
+
+describe("sessionNotifications", () => {
+  it("adds newest notifications first and caps the in-memory list", () => {
+    for (let i = 0; i < 105; i += 1) {
+      useAppStore.getState().addSessionNotification(notification(`n${i}`));
+    }
+
+    const items = useAppStore.getState().sessionNotifications;
+    expect(items).toHaveLength(100);
+    expect(items[0]?.id).toBe("n104");
+    expect(items[items.length - 1]?.id).toBe("n5");
+  });
+
+  it("marks individual and all notifications read, then clears read items", () => {
+    useAppStore.getState().addSessionNotification(notification("n1"));
+    useAppStore.getState().addSessionNotification(notification("n2"));
+
+    useAppStore.getState().markSessionNotificationRead("n1");
+    expect(
+      useAppStore
+        .getState()
+        .sessionNotifications.find((item) => item.id === "n1")?.readAt,
+    ).toBeTruthy();
+    expect(
+      useAppStore
+        .getState()
+        .sessionNotifications.find((item) => item.id === "n2")?.readAt,
+    ).toBeFalsy();
+
+    useAppStore.getState().markAllSessionNotificationsRead();
+    expect(
+      useAppStore
+        .getState()
+        .sessionNotifications.every((item) => item.readAt),
+    ).toBe(true);
+
+    useAppStore.getState().clearReadSessionNotifications();
+    expect(useAppStore.getState().sessionNotifications).toEqual([]);
+  });
+
+  it("dismisses one notification without touching others", () => {
+    useAppStore.getState().addSessionNotification(notification("n1"));
+    useAppStore.getState().addSessionNotification(notification("n2"));
+
+    useAppStore.getState().dismissSessionNotification("n1");
+
+    expect(
+      useAppStore.getState().sessionNotifications.map((item) => item.id),
+    ).toEqual(["n2"]);
   });
 });
 
@@ -387,6 +462,32 @@ describe("removeSession", () => {
     expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual(["a2"]);
   });
 
+  it("removes session activity locally before the backend delete finishes", async () => {
+    const a1 = session("a1", REPO_A);
+    const a2 = session("a2", REPO_A);
+    await seed([project(REPO_A, 0)], [a1, a2]);
+    useAppStore.getState().addSessionNotification(
+      notification("n1", { sessionId: "a1" }),
+    );
+    useAppStore.getState().addSessionNotification(
+      notification("n2", { sessionId: "a2" }),
+    );
+
+    const pending = deferred<void>();
+    mockApi.removeSession.mockReturnValueOnce(pending.promise);
+    mockApi.listSessions.mockResolvedValue([a2]);
+    mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
+
+    const removal = useAppStore.getState().removeSession("a1", true);
+
+    expect(
+      useAppStore.getState().sessionNotifications.map((item) => item.id),
+    ).toEqual(["n2"]);
+
+    pending.resolve(undefined);
+    await removal;
+  });
+
   it("refreshes from the backend if optimistic removal fails", async () => {
     const a1 = session("a1", REPO_A);
     await seed([project(REPO_A, 0)], [a1]);
@@ -527,6 +628,9 @@ describe("splitFocusedPane", () => {
     useAppStore.getState().setPaneSplitSizes(split.id, [25, 75]);
     useAppStore.getState().setActiveProject(REPO_B);
     useAppStore.getState().setActiveProject(REPO_A);
+    useAppStore.getState().addSessionNotification(
+      notification("n-persist", { sessionId: "a1" }),
+    );
 
     const restored = useAppStore.getState().layout;
     expect(restored.kind).toBe("split");
@@ -537,6 +641,9 @@ describe("splitFocusedPane", () => {
     expect(raw).not.toBeNull();
     const persisted = JSON.parse(raw!);
     expect(persisted.state.workspaces[REPO_A].layout.sizes).toEqual([25, 75]);
+    expect(persisted.state.sessionNotifications).toEqual([
+      notification("n-persist", { sessionId: "a1" }),
+    ]);
 
     resetStore();
     window.localStorage.setItem("acorn-workspaces", raw!);
@@ -546,6 +653,9 @@ describe("splitFocusedPane", () => {
     expect(rehydrated.kind).toBe("split");
     if (rehydrated.kind !== "split") throw new Error("expected split layout");
     expect(rehydrated.sizes).toEqual([25, 75]);
+    expect(useAppStore.getState().sessionNotifications).toEqual([
+      notification("n-persist", { sessionId: "a1" }),
+    ]);
   });
 });
 
@@ -740,6 +850,40 @@ describe("reconcile via refreshSessions", () => {
     const s = useAppStore.getState();
     expect(s.sessions.map((x) => x.id)).toEqual(["a1"]);
     expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1"]);
+  });
+
+  it("drops activity for sessions removed by backend refresh", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A), session("a2", REPO_A)],
+    );
+    useAppStore.getState().addSessionNotification(
+      notification("n1", { sessionId: "a1" }),
+    );
+    useAppStore.getState().addSessionNotification(
+      notification("n2", { sessionId: "a2" }),
+    );
+
+    mockApi.listSessions.mockResolvedValueOnce([session("a1", REPO_A)]);
+    await useAppStore.getState().refreshSessions();
+
+    expect(
+      useAppStore.getState().sessionNotifications.map((item) => item.id),
+    ).toEqual(["n1"]);
+  });
+
+  it("keeps activity when an unclean empty session load may be transient", async () => {
+    useAppStore.setState({ sessionsLoadedCleanly: false });
+    useAppStore.getState().addSessionNotification(
+      notification("n1", { sessionId: "a1" }),
+    );
+
+    mockApi.listSessions.mockResolvedValueOnce([]);
+    await useAppStore.getState().refreshSessions();
+
+    expect(
+      useAppStore.getState().sessionNotifications.map((item) => item.id),
+    ).toEqual(["n1"]);
   });
 
   // TODO(acorn-tests): cross-pane collapse on session removal reproduces
@@ -1358,7 +1502,7 @@ describe("right panel groups", () => {
     expect(s.rightTabByGroup.github).toBe("actions");
     // Other groups untouched.
     expect(s.rightTabByGroup.code).toBe("files");
-    expect(s.rightTabByGroup.agents).toBe("todos");
+    expect(s.rightTabByGroup.agents).toBe("activity");
   });
 
   it("setRightGroup restores the group's last sub-tab", () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,6 +6,7 @@ import type {
   Session,
   SessionAgentProvider,
   SessionKind,
+  SessionNotification,
 } from "./lib/types";
 import { commandRequestsWorktreeAdoption } from "./lib/worktreeAdoption";
 import { CONTROL_GUIDE_DISMISSED_KEY } from "./components/ControlSessionGuideModal";
@@ -111,6 +112,7 @@ interface AppStateModel {
    * resolver, so the value is in-memory only and never persisted.
    */
   pendingTerminalInput: Record<string, PendingTerminalInput>;
+  sessionNotifications: SessionNotification[];
   multiInputEnabled: boolean;
   loading: boolean;
   error: string | null;
@@ -195,6 +197,11 @@ interface AppStateModel {
   ) => void;
   /** Atomically read and remove the queued command for `sessionId`. */
   consumePendingTerminalInput: (sessionId: string) => PendingTerminalInput | null;
+  addSessionNotification: (notification: SessionNotification) => void;
+  markSessionNotificationRead: (id: string) => void;
+  markAllSessionNotificationsRead: () => void;
+  dismissSessionNotification: (id: string) => void;
+  clearReadSessionNotifications: () => void;
   toggleMultiInput: () => boolean;
   /** Open a readonly code viewer tab for `path` in the focused pane. */
   openCodeViewerTab: (path: string, repoPath?: string) => void;
@@ -494,6 +501,7 @@ export const useAppStore = create<AppStateModel>()(
   workspaceTabs: {},
   prAccountByRepo: {},
   pendingTerminalInput: {},
+  sessionNotifications: [],
   multiInputEnabled: false,
   loading: false,
   error: null,
@@ -542,11 +550,19 @@ export const useAppStore = create<AppStateModel>()(
         // results to be intentional (user removed them all). Drop the guard.
         const nextSessionsLoadedCleanly =
           s.sessionsLoadedCleanly || sessions.length > 0;
+        const sessionIds = new Set(sessions.map((session) => session.id));
+        const shouldPruneActivity =
+          s.sessionsLoadedCleanly || sessions.length > 0;
         return {
           sessions,
           loading: false,
           error: null,
           sessionsLoadedCleanly: nextSessionsLoadedCleanly,
+          sessionNotifications: shouldPruneActivity
+            ? s.sessionNotifications.filter((notification) =>
+                sessionIds.has(notification.sessionId),
+              )
+            : s.sessionNotifications,
           workspaces: reconciled.workspaces,
           activeProject: reconciled.activeProject,
           ...mirrorActive(reconciled.workspaces, reconciled.activeProject),
@@ -1179,6 +1195,9 @@ export const useAppStore = create<AppStateModel>()(
         error: null,
         liveInWorktree,
         pendingTerminalInput,
+        sessionNotifications: s.sessionNotifications.filter(
+          (notification) => notification.sessionId !== id,
+        ),
         workspaces: reconciled.workspaces,
         activeProject: reconciled.activeProject,
         ...mirrorActive(reconciled.workspaces, reconciled.activeProject),
@@ -1404,6 +1423,58 @@ export const useAppStore = create<AppStateModel>()(
     return consumed;
   },
 
+  addSessionNotification(notification) {
+    set((s) => ({
+      sessionNotifications: [
+        notification,
+        ...s.sessionNotifications.filter((n) => n.id !== notification.id),
+      ].slice(0, 100),
+    }));
+  },
+
+  markSessionNotificationRead(id) {
+    set((s) => {
+      const now = new Date().toISOString();
+      let changed = false;
+      const sessionNotifications = s.sessionNotifications.map((notification) => {
+        if (notification.id !== id || notification.readAt) return notification;
+        changed = true;
+        return { ...notification, readAt: now };
+      });
+      return changed ? { sessionNotifications } : s;
+    });
+  },
+
+  markAllSessionNotificationsRead() {
+    set((s) => {
+      if (s.sessionNotifications.every((notification) => notification.readAt)) {
+        return s;
+      }
+      const now = new Date().toISOString();
+      return {
+        sessionNotifications: s.sessionNotifications.map((notification) =>
+          notification.readAt ? notification : { ...notification, readAt: now },
+        ),
+      };
+    });
+  },
+
+  dismissSessionNotification(id) {
+    set((s) => ({
+      sessionNotifications: s.sessionNotifications.filter(
+        (notification) => notification.id !== id,
+      ),
+    }));
+  },
+
+  clearReadSessionNotifications() {
+    set((s) => ({
+      sessionNotifications: s.sessionNotifications.filter(
+        (notification) => !notification.readAt,
+      ),
+    }));
+  },
+
   toggleMultiInput() {
     let enabled = false;
     set((s) => {
@@ -1500,6 +1571,7 @@ export const useAppStore = create<AppStateModel>()(
         activeProject: state.activeProject,
         rightTab: state.rightTab,
         rightTabByGroup: state.rightTabByGroup,
+        sessionNotifications: state.sessionNotifications,
         workspaceTabs: Object.fromEntries(
           Object.entries(state.workspaceTabs).filter(([, tab]) =>
             isRestorableWorkspaceTab(tab),

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -429,6 +429,7 @@ test.describe("right panel: groups", () => {
     await expect(
       page.getByRole("button", { name: "Agents", exact: true }),
     ).toBeVisible();
+    await page.getByRole("button", { name: "History", exact: true }).click();
     await expect(page.getByText("Local Codex session")).toBeVisible();
     await expect
       .poll(

--- a/tests/e2e/session-notifications.spec.ts
+++ b/tests/e2e/session-notifications.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "./support";
+
+test.describe("session notification center", () => {
+  test("collects actionable session status transitions", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "session-1",
+        name: "agent run",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "running",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+    ]);
+    await tauri.handle("detect_session_statuses", () => [
+      {
+        id: "session-1",
+        status: "needs_input",
+        branch: null,
+        agent_provider: null,
+      },
+    ]);
+
+    await page.goto("/");
+
+    await expect(page.getByRole("button", { name: "Session notifications" }))
+      .toContainText("1");
+
+    await page.getByRole("button", { name: "Agents" }).click();
+    const subTabs = page.getByRole("navigation", {
+      name: "Right panel sub-tab",
+    });
+    const activityTab = subTabs.getByRole("button", { name: /Activity/ });
+    const historyTab = subTabs.getByRole("button", { name: "History" });
+    await expect(activityTab).toBeVisible();
+    await expect(activityTab).toContainText("1");
+    await expect(historyTab).toBeVisible();
+    const [activityBox, historyBox] = await Promise.all([
+      activityTab.boundingBox(),
+      historyTab.boundingBox(),
+    ]);
+    expect(activityBox?.x ?? 0).toBeLessThan(historyBox?.x ?? 0);
+    await expect(page.getByText("demo · agent run")).toBeVisible();
+
+    await page.getByRole("button", { name: "Session notifications" }).click();
+
+    await expect(
+      page.getByRole("menu").getByText("Needs input"),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menu").getByText("demo · agent run"),
+    ).toBeVisible();
+
+    await page.getByRole("menuitem", { name: /Needs input/ }).click();
+
+    await expect(page.getByRole("button", { name: "Session notifications" }))
+      .not.toContainText("1");
+    await expect(activityTab).not.toContainText("1");
+  });
+});


### PR DESCRIPTION
## Summary
This adds an in-app Activity center for session lifecycle changes so parallel agent work is easier to monitor.

1. **Activity inbox:** Records session transitions into needs input, failed, completed, and idle in a persistent activity list.
2. **Agents navigation:** Adds Activity as the first Agents sub-tab, followed by History and Todos, with an unread-count badge on Activity.
3. **Status bar shortcut:** Adds a bottom status-bar bell for unread activity, including mark-read/clear/dismiss actions and a Settings > Appearance > Status bar toggle that defaults visible.
4. **Session cleanup:** Removes activity entries when their session is removed or no longer exists after a clean backend refresh.
5. **Coverage:** Adds store, settings, and E2E coverage for persistence, cleanup, unread counts, and tab ordering.

## Expected impact
| Area | Impact |
| --- | --- |
| User-visible behavior | Users can review actionable session state changes from Activity and the status-bar bell. |
| Persistence | Activity entries survive app restarts through the existing workspace persistence store. |
| Reliability | Activity cleanup follows session deletion while preserving entries during unclean empty session loads. |
| Test workflow | Playwright can override the dev-server port via PLAYWRIGHT_PORT for parallel worktrees. |

## Design notes
- Activity is intentionally independent from macOS notification settings; disabling system notifications does not suppress the local inbox.
- The status-bar bell is hidden only when `showSessionActivity === false`, so missing legacy settings keep the shortcut visible by default.
- Clean backend session refreshes prune stale activity; unclean empty loads keep activity to avoid losing state during a transient/corrupt session-list read.
- The Activity tab reuses the same notification state as the status-bar dropdown so read/dismiss state stays consistent across both surfaces.

## Follow-up (not in this PR)
- Add richer grouping/filtering if the Activity list grows beyond the MVP cap.
- Consider extracting shared Activity row rendering if the status-bar dropdown and right-panel tab diverge further.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run src/store.test.ts src/lib/settings.test.ts`
- [x] `PLAYWRIGHT_PORT=1421 pnpm exec playwright test tests/e2e/session-notifications.spec.ts tests/e2e/right-panel.spec.ts`

## Notes
- Self-review found no blocking issues after checking persistence, cleanup, unread-count synchronization, and default-visible status-bar behavior.
