### PR TITLE
fix(files): preserve explorer expansion and restore session focus

### DIFF
--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -32,6 +32,7 @@ import type { FsChangePayload, FsGitStatus, FsGitStatusEntry } from "../lib/api"
 import { cn } from "../lib/cn";
 import { planGitRefresh } from "../lib/git-refresh-scheduler";
 import type { TranslationKey, Translator } from "../lib/i18n";
+import { rightPanelCache } from "../lib/right-panel-cache";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { setFileDragPayload } from "../lib/dnd";
 import { Tooltip } from "./Tooltip";
@@ -290,7 +291,9 @@ function setLocalBool(key: string, value: boolean) {
 export function FileExplorer({ rootPath }: FileExplorerProps) {
   const t = useTranslation();
   const [cache, setCache] = useState<Cache>({});
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [expanded, setExpanded] = useState<Set<string>>(() =>
+    rightPanelCache.getFileExplorerExpanded(rootPath),
+  );
   const [showHidden, setShowHidden] = useState(() =>
     getLocalBool(SHOW_HIDDEN_KEY, false),
   );
@@ -661,7 +664,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     if (rootRef.current !== rootPath) {
       rootRef.current = rootPath;
       setCache({});
-      setExpanded(new Set());
+      setExpanded(rightPanelCache.getFileExplorerExpanded(rootPath));
       setDraftRename(null);
       setActivePath(null);
     }
@@ -745,10 +748,11 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
             void fetchDir(path);
           }
         }
+        rightPanelCache.setFileExplorerExpanded(rootPath, next);
         return next;
       });
     },
-    [cache, fetchDir],
+    [cache, fetchDir, rootPath],
   );
 
   const openInEditor = useCallback(async (entry: FsEntry) => {

--- a/src/lib/right-panel-cache.test.ts
+++ b/src/lib/right-panel-cache.test.ts
@@ -95,6 +95,18 @@ describe("rightPanelCache", () => {
     expect(rightPanelCache.getWorkflowRuns(REPO, 50)).toBeNull();
   });
 
+  it("preserves file explorer expansion by repo until the repo is pruned", () => {
+    const expanded = new Set([`${REPO}/src`, `${REPO}/tests`]);
+
+    rightPanelCache.setFileExplorerExpanded(REPO, expanded);
+
+    expect(rightPanelCache.getFileExplorerExpanded(REPO)).toEqual(expanded);
+    expect(rightPanelCache.getFileExplorerExpanded(REPO)).not.toBe(expanded);
+
+    rightPanelCache.retainRepos([OTHER_REPO]);
+    expect(rightPanelCache.getFileExplorerExpanded(REPO)).toEqual(new Set());
+  });
+
   it("dedupes in-flight unscoped history fetches and reuses cached results", async () => {
     const history: AgentHistoryItem[] = [];
     const pending = deferred<AgentHistoryItem[]>();

--- a/src/lib/right-panel-cache.ts
+++ b/src/lib/right-panel-cache.ts
@@ -33,6 +33,7 @@ class RightPanelCacheManager {
   >();
   private commitsCache = new Map<string, CommitsCacheEntry>();
   private stagedCache = new Map<string, StagedCacheEntry>();
+  private fileExplorerExpanded = new Map<string, Set<string>>();
   private prListCache = new Map<string, PullRequestListing>();
   private prListInFlight = new Map<string, Promise<PullRequestListing>>();
   private workflowRunsCache = new Map<string, WorkflowRunsListing>();
@@ -56,6 +57,7 @@ class RightPanelCacheManager {
     this.collectRemovedStringKeys(this.agentHistoryInFlight, next, removed);
     this.collectRemovedStringKeys(this.commitsCache, next, removed);
     this.collectRemovedStringKeys(this.stagedCache, next, removed);
+    this.collectRemovedStringKeys(this.fileExplorerExpanded, next, removed);
     this.collectRemovedStringValues(this.prefetchedProjectRepos, next, removed);
     this.collectRemovedJsonKeys(this.prListCache, next, removed);
     this.collectRemovedJsonKeys(this.prListInFlight, next, removed);
@@ -68,6 +70,7 @@ class RightPanelCacheManager {
     this.pruneStringKeyedMap(this.agentHistoryInFlight, next);
     this.pruneStringKeyedMap(this.commitsCache, next);
     this.pruneStringKeyedMap(this.stagedCache, next);
+    this.pruneStringKeyedMap(this.fileExplorerExpanded, next);
     this.pruneStringKeyedSet(this.prefetchedProjectRepos, next);
     this.pruneJsonKeyedMap(this.prListCache, next);
     this.pruneJsonKeyedMap(this.prListInFlight, next);
@@ -155,6 +158,15 @@ class RightPanelCacheManager {
     this.stagedCache.set(repoPath, entry);
   }
 
+  getFileExplorerExpanded(repoPath: string): Set<string> {
+    return new Set(this.fileExplorerExpanded.get(repoPath) ?? []);
+  }
+
+  setFileExplorerExpanded(repoPath: string, expanded: Iterable<string>): void {
+    if (!this.canStore(repoPath)) return;
+    this.fileExplorerExpanded.set(repoPath, new Set(expanded));
+  }
+
   getPullRequests(
     repoPath: string,
     filter: PrStateFilter,
@@ -230,6 +242,7 @@ class RightPanelCacheManager {
     this.unscopedAgentHistoryInFlight.clear();
     this.commitsCache.clear();
     this.stagedCache.clear();
+    this.fileExplorerExpanded.clear();
     this.prListCache.clear();
     this.prListInFlight.clear();
     this.workflowRunsCache.clear();

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -358,6 +358,24 @@ describe("workspace tabs", () => {
     expect(s.activeSessionId).toBe("a1");
     expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1"]);
   });
+
+  it("returns to the last focused session when closing an active code viewer", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A), session("a2", REPO_A)],
+    );
+    useAppStore.getState().selectSession("a2");
+    useAppStore.getState().openCodeViewerTab(`${REPO_A}/src/App.tsx`);
+    const tabId = useAppStore.getState().activeTabId!;
+
+    useAppStore.getState().closeWorkspaceTab(tabId);
+
+    const s = useAppStore.getState();
+    expect(s.workspaceTabs[tabId]).toBeUndefined();
+    expect(s.activeTabId).toBe("a2");
+    expect(s.activeSessionId).toBe("a2");
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1", "a2"]);
+  });
 });
 
 describe("removeSession", () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -25,6 +25,7 @@ import {
 import {
   activeSessionIdFromTabId,
   isRestorableWorkspaceTab,
+  isSessionTabId,
   isWorkspaceTabId,
   makeCodeWorkspaceTab,
   type FrontendWorkspaceTab,
@@ -53,6 +54,7 @@ export interface PaneState {
   id: PaneId;
   tabIds: string[];
   activeTabId: string | null;
+  lastActiveSessionTabId?: string | null;
 }
 
 export interface ProjectWorkspace {
@@ -224,13 +226,29 @@ function nextSplitId(): string {
 }
 
 function emptyPane(id: PaneId): PaneState {
-  return { id, tabIds: [], activeTabId: null };
+  return { id, tabIds: [], activeTabId: null, lastActiveSessionTabId: null };
 }
 
 type PersistedPaneState = Partial<PaneState> & {
   sessionIds?: string[];
   activeSessionId?: string | null;
 };
+
+function lastSessionTabId(ids: readonly string[]): string | null {
+  for (let i = ids.length - 1; i >= 0; i -= 1) {
+    if (isSessionTabId(ids[i])) return ids[i];
+  }
+  return null;
+}
+
+function preferredSessionTabId(
+  pane: Pick<PaneState, "lastActiveSessionTabId">,
+  ids: readonly string[],
+): string | null {
+  const last = pane.lastActiveSessionTabId;
+  if (last && ids.includes(last) && isSessionTabId(last)) return last;
+  return lastSessionTabId(ids);
+}
 
 function normalizePaneState(
   pane: PersistedPaneState | undefined,
@@ -247,7 +265,15 @@ function normalizePaneState(
       : pane?.activeSessionId !== undefined
         ? pane.activeSessionId
         : null;
-  return { id, tabIds, activeTabId };
+  const lastActiveSessionTabId =
+    typeof pane?.lastActiveSessionTabId === "string" &&
+    tabIds.includes(pane.lastActiveSessionTabId) &&
+    isSessionTabId(pane.lastActiveSessionTabId)
+      ? pane.lastActiveSessionTabId
+      : activeTabId && isSessionTabId(activeTabId)
+        ? activeTabId
+        : lastSessionTabId(tabIds);
+  return { id, tabIds, activeTabId, lastActiveSessionTabId };
 }
 
 function emptyWorkspace(): ProjectWorkspace {
@@ -344,10 +370,12 @@ function reconcileWorkspace(
       existing.activeTabId && filtered.includes(existing.activeTabId)
         ? existing.activeTabId
         : filtered[filtered.length - 1] ?? null;
+    const lastActiveSessionTabId = preferredSessionTabId(existing, filtered);
     newPanes[pid] = {
       id: pid,
       tabIds: filtered,
       activeTabId: active,
+      lastActiveSessionTabId,
     };
   }
 
@@ -367,6 +395,7 @@ function reconcileWorkspace(
         ...pane,
         tabIds: [...pane.tabIds, s.id],
         activeTabId: pane.activeTabId ?? s.id,
+        lastActiveSessionTabId: pane.lastActiveSessionTabId ?? s.id,
       };
       assigned.add(s.id);
     }
@@ -748,6 +777,7 @@ export const useAppStore = create<AppStateModel>()(
             ...pane,
             tabIds,
             activeTabId: id,
+            lastActiveSessionTabId: id,
           },
         },
         focusedPaneId: targetPaneId,
@@ -815,7 +845,21 @@ export const useAppStore = create<AppStateModel>()(
       const patch = updateActiveWorkspace(s, (ws) => {
         if (!ws.panes[paneId]) return ws;
         if (ws.focusedPaneId === paneId) return ws;
-        return { ...ws, focusedPaneId: paneId };
+        const pane = ws.panes[paneId];
+        return {
+          ...ws,
+          panes: {
+            ...ws.panes,
+            [paneId]: {
+              ...pane,
+              lastActiveSessionTabId:
+                pane.activeTabId && isSessionTabId(pane.activeTabId)
+                  ? pane.activeTabId
+                  : pane.lastActiveSessionTabId,
+            },
+          },
+          focusedPaneId: paneId,
+        };
       });
       return patch ?? s;
     });
@@ -830,7 +874,21 @@ export const useAppStore = create<AppStateModel>()(
           direction,
         );
         if (!nextPaneId || !ws.panes[nextPaneId]) return ws;
-        return { ...ws, focusedPaneId: nextPaneId };
+        const pane = ws.panes[nextPaneId];
+        return {
+          ...ws,
+          panes: {
+            ...ws.panes,
+            [nextPaneId]: {
+              ...pane,
+              lastActiveSessionTabId:
+                pane.activeTabId && isSessionTabId(pane.activeTabId)
+                  ? pane.activeTabId
+                  : pane.lastActiveSessionTabId,
+            },
+          },
+          focusedPaneId: nextPaneId,
+        };
       });
       return patch ?? s;
     });
@@ -892,7 +950,13 @@ export const useAppStore = create<AppStateModel>()(
           ...ws,
           panes: {
             ...ws.panes,
-            [ws.focusedPaneId]: { ...pane, activeTabId: nextId },
+            [ws.focusedPaneId]: {
+              ...pane,
+              activeTabId: nextId,
+              lastActiveSessionTabId: isSessionTabId(nextId)
+                ? nextId
+                : pane.lastActiveSessionTabId,
+            },
           },
         };
       });
@@ -970,14 +1034,21 @@ export const useAppStore = create<AppStateModel>()(
         );
         const srcActive =
           fromPane.activeTabId === args.tabId
-            ? srcTabIds[srcTabIds.length - 1] ?? null
+            ? (preferredSessionTabId(fromPane, srcTabIds) ??
+              srcTabIds[srcTabIds.length - 1] ??
+              null)
             : fromPane.activeTabId;
+        const srcLastActiveSessionTabId =
+          fromPane.lastActiveSessionTabId === args.tabId
+            ? lastSessionTabId(srcTabIds)
+            : fromPane.lastActiveSessionTabId;
         let newPanes: Record<PaneId, PaneState> = {
           ...ws.panes,
           [args.fromPaneId]: {
             ...fromPane,
             tabIds: srcTabIds,
             activeTabId: srcActive,
+            lastActiveSessionTabId: srcLastActiveSessionTabId,
           },
         };
 
@@ -1011,6 +1082,9 @@ export const useAppStore = create<AppStateModel>()(
           ...toPane,
           tabIds: targetIds,
           activeTabId: args.tabId,
+          lastActiveSessionTabId: isSessionTabId(args.tabId)
+            ? args.tabId
+            : toPane.lastActiveSessionTabId,
         };
 
         const totalPanes = Object.keys(newPanes).length;
@@ -1460,12 +1534,15 @@ export const useAppStore = create<AppStateModel>()(
           const ids = pane.tabIds.filter((sid) => sid !== id);
           const nextActive =
             pane.activeTabId === id
-              ? ids[ids.length - 1] ?? null
+              ? (preferredSessionTabId(pane, ids) ??
+                ids[ids.length - 1] ??
+                null)
               : pane.activeTabId;
           newPanes[pid as PaneId] = {
             ...pane,
             tabIds: ids,
             activeTabId: nextActive,
+            lastActiveSessionTabId: preferredSessionTabId(pane, ids),
           };
         }
         newWorkspaces[key] = { ...ws, panes: newPanes };
@@ -1547,6 +1624,7 @@ export const useAppStore = create<AppStateModel>()(
               ...normalized,
               tabIds: ids,
               activeTabId: active,
+              lastActiveSessionTabId: preferredSessionTabId(normalized, ids),
             };
           }
           sanitized[key] = { ...ws, panes: newPanes };

--- a/tests/e2e/file-explorer.spec.ts
+++ b/tests/e2e/file-explorer.spec.ts
@@ -1,14 +1,12 @@
 import { test, expect, pressHotkey } from "./support";
 
 test.describe("file explorer", () => {
-  test("keeps expanded worktree folders after opening a file", async ({
+  test("keeps expanded worktree folders after opening and closing a file", async ({
     page,
     tauri,
   }) => {
     const repo = "/tmp/demo";
     const worktree = "/tmp/demo-worktree";
-    const src = `${worktree}/src`;
-    const file = `${src}/App.tsx`;
 
     await tauri.respond("list_projects", [
       {
@@ -36,6 +34,7 @@ test.describe("file explorer", () => {
     await tauri.handle("fs_list_dir", (args) => {
       const worktree = "/tmp/demo-worktree";
       const src = `${worktree}/src`;
+      const docs = `${worktree}/docs`;
       const file = `${src}/App.tsx`;
       const { path } = args as { path: string };
       if (path === worktree) {
@@ -45,6 +44,15 @@ test.describe("file explorer", () => {
             {
               name: "src",
               path: src,
+              is_dir: true,
+              is_symlink: false,
+              size: 0,
+              modified_ms: 0,
+              gitignored: false,
+            },
+            {
+              name: "docs",
+              path: docs,
               is_dir: true,
               is_symlink: false,
               size: 0,
@@ -70,6 +78,22 @@ test.describe("file explorer", () => {
           ],
         };
       }
+      if (path === docs) {
+        return {
+          repo_root: worktree,
+          entries: [
+            {
+              name: "Guide.md",
+              path: `${docs}/Guide.md`,
+              is_dir: false,
+              is_symlink: false,
+              size: 24,
+              modified_ms: 0,
+              gitignored: false,
+            },
+          ],
+        };
+      }
       return { repo_root: path, entries: [] };
     });
 
@@ -79,6 +103,8 @@ test.describe("file explorer", () => {
 
     await page.getByRole("button", { name: "src" }).click();
     await expect(page.getByRole("button", { name: "App.tsx" })).toBeVisible();
+    await page.getByRole("button", { name: "docs" }).click();
+    await expect(page.getByRole("button", { name: "Guide.md" })).toBeVisible();
 
     await page.getByRole("button", { name: "App.tsx" }).dblclick();
 
@@ -87,6 +113,15 @@ test.describe("file explorer", () => {
     ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "App.tsx", exact: true }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: /App\.tsx Close tab/ }).click();
+
+    await expect(
+      page.getByRole("button", { name: "App.tsx", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Guide.md", exact: true }),
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary
File explorer state now survives code-viewer tab churn, and closing a file returns focus to the session the user came from.

1. **Preserve expanded folders** — cache File Explorer expanded directory paths by repo/root in the right-panel cache, then restore them when the file panel remounts or the root swaps back.
2. **Restore session focus on file close** — track the last focused session tab per pane so closing a frontend-owned code viewer returns to the previous session instead of falling through to an arbitrary last tab.
3. **Regression coverage** — extend the file-explorer e2e to cover unrelated expanded folders, and add store/cache unit coverage for expansion retention and focus restoration.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| File Explorer folders | Opening/closing a file tab could collapse expanded folders after remount/root churn | Expanded folders stay open for the same root |
| Code viewer close focus | Closing a file tab could focus whichever tab happened to be last in the pane | Focus returns to the last focused session in that pane |

## Design notes
- Expanded directory state is in-memory and scoped by root path through `rightPanelCache`, matching the existing right-panel cache lifetime and pruning rules.
- The focus fix adds a pane-level `lastActiveSessionTabId` so frontend-owned tabs can be closed without losing the session context that launched them.
- This is intentionally a bug-fix-sized implementation. A follow-up should replace the session-specific focus state with a general pane tab activation history model.

## Follow-up (not in this PR)
- Replace `lastActiveSessionTabId` with pane-level tab activation history so all tab close behavior shares one model instead of a code-viewer/session-specific policy.

## Test plan
- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm exec vitest run src/store.test.ts src/lib/right-panel-cache.test.ts` — 76 passed, 1 skipped
- [x] `pnpm exec playwright test tests/e2e/file-explorer.spec.ts` — 4 passed
- [x] `git diff --check` passes
