### PR TITLE
ci(release): cumulative patch release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,6 +282,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
 
       - name: Download all bundles
         uses: actions/download-artifact@v6
@@ -312,33 +319,13 @@ jobs:
           REPO: ${{ github.repository }}
           TAG: ${{ steps.meta.outputs.tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTPUT: release_notes.md
         run: |
           set -euo pipefail
-          # Generate the same auto-notes GitHub would compose from the
-          # tag, ahead of release creation, so they can be embedded into
-          # `latest.json` AND used as the release body. Falls back to a
-          # short "See release page" sentence if the API call fails
-          # (e.g. on the very first tag, before previous_tag_name has
-          # something to diff against).
-          if notes=$(gh api -X POST \
-              -H "Accept: application/vnd.github+json" \
-              "repos/${REPO}/releases/generate-notes" \
-              -f "tag_name=${TAG}" \
-              --jq .body 2>/dev/null); then
-            :
-          else
-            notes="See https://github.com/${REPO}/releases/tag/${TAG}"
-          fi
-          # Strip GitHub's provenance HTML comment
-          # (`<!-- Release notes generated using configuration in
-          # .github/release.yml at vX.Y.Z -->`). It is purely informational
-          # — not parsed back by the regenerate API — and renders as
-          # literal text in Acorn's in-app "What's new" modal.
-          notes=$(printf '%s' "$notes" | sed -E '/^[[:space:]]*<!--.*-->[[:space:]]*$/d')
-          # Persist to a file rather than $GITHUB_OUTPUT so newlines and
-          # markdown survive cleanly through later jq / action-gh-release
-          # consumers.
-          printf '%s' "$notes" > release_notes.md
+          # Stable patch releases carry cumulative notes for the current
+          # major.minor line, so an updater jump such as 1.8.0 -> 1.8.2
+          # shows the 1.8.0, 1.8.1, and 1.8.2 entries in "What's new".
+          node scripts/release-notes.mjs
           echo "Notes preview (first 400 chars):"
           head -c 400 release_notes.md || true
           echo

--- a/docs/PR_LABELS.md
+++ b/docs/PR_LABELS.md
@@ -1,6 +1,8 @@
 # PR labels
 
-Acorn's release pipeline reuses GitHub's auto-generated changelog as the body of `latest.json`'s `notes` field. The Tauri updater plugin then surfaces that text inside the app's About tab and the "What's new" banner.
+Acorn's release pipeline reuses GitHub's auto-generated changelog as the body of `latest.json`'s `notes` field.
+Stable patch releases include every release note entry in the current `major.minor` line, so an update from `1.8.0` to `1.8.2` surfaces the `1.8.0`, `1.8.1`, and `1.8.2` sections in the app.
+The Tauri updater plugin then surfaces that text inside the app's About tab and the "What's new" banner.
 
 To keep both the GitHub release page and the in-app changelog tidy, attach **one** of the labels below to every PR you open. The categorisation rules live in [`.github/release.yml`](../.github/release.yml).
 

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const STABLE_TAG_RE = /^v(\d+)\.(\d+)\.(\d+)$/;
+
+export function parseStableSemverTag(tag) {
+  const match = STABLE_TAG_RE.exec(tag);
+  if (!match) return null;
+  return {
+    tag,
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+export function compareStableTags(a, b) {
+  return (
+    a.major - b.major ||
+    a.minor - b.minor ||
+    a.patch - b.patch
+  );
+}
+
+export function selectCumulativeReleaseTags(tags, currentTag) {
+  const current = parseStableSemverTag(currentTag);
+  if (!current) return [currentTag];
+
+  const byTag = new Map();
+  for (const tag of tags) {
+    const parsed = parseStableSemverTag(tag);
+    if (parsed) byTag.set(parsed.tag, parsed);
+  }
+  byTag.set(current.tag, current);
+
+  return [...byTag.values()]
+    .filter(
+      (tag) =>
+        tag.major === current.major &&
+        tag.minor === current.minor &&
+        tag.patch <= current.patch,
+    )
+    .sort(compareStableTags)
+    .map((tag) => tag.tag);
+}
+
+export function previousStableTag(tags, currentTag) {
+  const current = parseStableSemverTag(currentTag);
+  if (!current) return null;
+
+  const sorted = tags
+    .map(parseStableSemverTag)
+    .filter((tag) => tag !== null)
+    .sort(compareStableTags);
+  const index = sorted.findIndex((tag) => tag.tag === current.tag);
+  return index > 0 ? sorted[index - 1].tag : null;
+}
+
+export function stripGithubGeneratedComments(body) {
+  return body
+    .split(/\r?\n/)
+    .filter((line) => !/^\s*<!--.*-->\s*$/.test(line))
+    .join("\n")
+    .trim();
+}
+
+function readGitTags() {
+  const stdout = execFileSync("git", ["tag", "-l", "v*.*.*"], {
+    encoding: "utf8",
+  });
+  return stdout.split(/\r?\n/).filter(Boolean);
+}
+
+function generateNotes(repo, tag, previousTag) {
+  const args = [
+    "api",
+    "-X",
+    "POST",
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${repo}/releases/generate-notes`,
+    "-f",
+    `tag_name=${tag}`,
+    "--jq",
+    ".body",
+  ];
+  if (previousTag) {
+    args.splice(
+      args.indexOf("--jq"),
+      0,
+      "-f",
+      `previous_tag_name=${previousTag}`,
+    );
+  }
+  return stripGithubGeneratedComments(
+    execFileSync("gh", args, { encoding: "utf8" }),
+  );
+}
+
+export function composeReleaseNotes(parts) {
+  const usableParts = parts.filter((part) => part.body.trim().length > 0);
+  if (usableParts.length === 0) return "";
+  if (usableParts.length === 1) return usableParts[0].body.trim();
+
+  return usableParts
+    .map((part) => `## ${part.tag}\n\n${part.body.trim()}`)
+    .join("\n\n");
+}
+
+export function buildReleaseNotes({ repo, currentTag, allTags }) {
+  const selectedTags = selectCumulativeReleaseTags(allTags, currentTag);
+  const allStableTags = [...new Set([...allTags, currentTag])]
+    .filter((tag) => parseStableSemverTag(tag) !== null)
+    .map(parseStableSemverTag)
+    .sort(compareStableTags)
+    .map((tag) => tag.tag);
+
+  const parts = [];
+  for (const tag of selectedTags) {
+    const previousTag = previousStableTag(allStableTags, tag);
+    parts.push({ tag, body: generateNotes(repo, tag, previousTag) });
+  }
+
+  return composeReleaseNotes(parts.reverse());
+}
+
+function main() {
+  const repo = process.env.REPO;
+  const currentTag = process.env.TAG;
+  const output = process.env.OUTPUT ?? "release_notes.md";
+  if (!repo || !currentTag) {
+    throw new Error("REPO and TAG environment variables are required");
+  }
+
+  const notes = buildReleaseNotes({
+    repo,
+    currentTag,
+    allTags: readGitTags(),
+  });
+  writeFileSync(output, notes, "utf8");
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  main();
+}


### PR DESCRIPTION
## Summary
Stable patch release notes now accumulate across the current `major.minor` line:

1. **Cumulative release-note generator** — add `scripts/release-notes.mjs`, which selects stable tags in the current patch line and regenerates each tag's GitHub auto-notes with explicit previous-tag bounds.
2. **Release workflow integration** — run the generator before publishing so both the GitHub release body and `latest.json.notes` contain the same cumulative content used by Acorn's "What's new" surfaces.
3. **Policy documentation** — document that stable patch updates such as `1.8.0 -> 1.8.2` show `1.8.0`, `1.8.1`, and `1.8.2` entries together.

## Expected impact
| Update path | Before | After |
| --- | --- | --- |
| `1.8.1 -> 1.8.2` | Shows `1.8.2` notes only | Shows `1.8.0`, `1.8.1`, and `1.8.2` notes |
| `1.8.0 -> 1.8.2` | Shows `1.8.2` notes only | Shows `1.8.0`, `1.8.1`, and `1.8.2` notes |
| `1.8.3 -> 1.9.0` | Shows `1.9.0` notes | Still shows the new minor's notes only |

## Design notes
- Stable tags are exact `vMAJOR.MINOR.PATCH` matches. Prerelease tags keep the previous single-tag behavior.
- The release job now checks out full tag history because the generator needs all prior stable tags to compute the patch-line range.
- The generator fails the release if any selected tag's notes cannot be generated. That is intentional: publishing incomplete cumulative notes would violate the updater contract.
- Self-review found and fixed one issue before opening this PR: an earlier version warned and skipped older patch notes on API failure, which could have silently omitted required content.

## Follow-up (not in this PR)
- Add a dedicated CI check for `scripts/release-notes.mjs` if more release tooling moves into scripts.

## Test plan
- [x] `node --check scripts/release-notes.mjs`
- [x] Node assertion smoke test for patch-line selection, previous-tag lookup, comment stripping, and multi-release markdown composition
- [x] `REPO=im-ian/acorn TAG=v1.8.2 OUTPUT=/tmp/acorn-release-notes-v1.8.2.md node scripts/release-notes.mjs` — generated `v1.8.2`, `v1.8.1`, and `v1.8.0` sections
- [x] `REPO=im-ian/acorn TAG=v1.8.3 OUTPUT=/tmp/acorn-release-notes-v1.8.3.md node scripts/release-notes.mjs` — generated `v1.8.3`, `v1.8.2`, `v1.8.1`, and `v1.8.0` sections
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`
- [x] `git diff --check`
- [x] `pnpm run typecheck`

## Notes
- `actionlint` is not installed in this worktree, so YAML validation was limited to parsing plus direct workflow review.
