### PR TITLE
fix(hotkeys): stop terminal shortcut bleedthrough

### DIFF
--- a/src/lib/hotkeys.react.test.tsx
+++ b/src/lib/hotkeys.react.test.tsx
@@ -1,0 +1,74 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHotkeys, type HotkeyBindings } from "./hotkeys";
+
+function HotkeyHarness({ bindings }: { bindings: HotkeyBindings }) {
+  useHotkeys(bindings);
+  return <input aria-label="hotkey target" />;
+}
+
+describe("useHotkeys", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(bindings: HotkeyBindings): HTMLInputElement {
+    act(() => {
+      root.render(<HotkeyHarness bindings={bindings} />);
+    });
+    const input = container.querySelector("input");
+    if (!input) throw new Error("missing hotkey target");
+    return input;
+  }
+
+  it("claims handled modifier shortcuts before focused descendants process them", () => {
+    const handler = vi.fn((event: KeyboardEvent) => event.preventDefault());
+    const input = render({ "Control+Shift+e": handler });
+    const descendantHandler = vi.fn();
+    input.addEventListener("keydown", descendantHandler, { capture: true });
+
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "e",
+        code: "KeyE",
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(descendantHandler).not.toHaveBeenCalled();
+  });
+
+  it("leaves unmodified shortcuts on the normal bubble path", () => {
+    const handler = vi.fn((event: KeyboardEvent) => event.preventDefault());
+    const input = render({ Escape: handler });
+    const descendantHandler = vi.fn();
+    input.addEventListener("keydown", descendantHandler, { capture: true });
+
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Escape",
+        code: "Escape",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(descendantHandler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -9,9 +9,15 @@ import { useEffect } from "react";
 import { tinykeys as tinykeysRaw } from "tinykeys";
 
 type KeyBindingMap = Record<string, (event: KeyboardEvent) => void>;
+interface TinykeysOptions {
+  capture?: boolean;
+  timeout?: number;
+}
+
 type Tinykeys = (
   target: Window | HTMLElement,
   keyBindingMap: KeyBindingMap,
+  options?: TinykeysOptions,
 ) => () => void;
 
 const tinykeys = tinykeysRaw as Tinykeys;
@@ -78,6 +84,18 @@ export type HotkeyId = keyof typeof Hotkeys;
 export type HotkeyHandler = (event: KeyboardEvent) => void;
 
 export type HotkeyBindings = Record<string, HotkeyHandler>;
+
+const MODIFIER_TOKENS = new Set([
+  "$mod",
+  "Meta",
+  "Cmd",
+  "Command",
+  "Control",
+  "Ctrl",
+  "Alt",
+  "Option",
+  "Shift",
+]);
 
 type TauriRuntimeWindow = Window & { __TAURI_INTERNALS__?: unknown };
 
@@ -178,6 +196,35 @@ function formatKey(part: string, mac: boolean): string {
   return NON_MAC_KEY_LABEL[normalized] ?? normalized.toUpperCase();
 }
 
+function bindingUsesModifier(binding: string): boolean {
+  return binding
+    .trim()
+    .split(/\s+/)
+    .some((chord) => {
+      const parts = chord.split(/\b\+/);
+      const modifiers = parts.slice(0, -1);
+      return modifiers.some((part) => MODIFIER_TOKENS.has(part));
+    });
+}
+
+function stopPropagationAfterHandling(
+  bindings: HotkeyBindings,
+): HotkeyBindings {
+  return Object.fromEntries(
+    Object.entries(bindings).map(([binding, handler]) => [
+      binding,
+      (event: KeyboardEvent) => {
+        handler(event);
+        // App-level shortcuts that handled the key must own it before focused
+        // surfaces like xterm also interpret the same chord.
+        if (event.defaultPrevented) {
+          event.stopImmediatePropagation();
+        }
+      },
+    ]),
+  );
+}
+
 /**
  * Render a tinykeys binding string (e.g. `$mod+Shift+t`) as a
  * platform-appropriate label suitable for context-menu shortcut hints.
@@ -206,9 +253,33 @@ export function formatHotkey(binding: string): string {
 export function useHotkeys(bindings: HotkeyBindings): void {
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const unsubscribe = tinykeys(window, bindings);
+
+    const captureBindings: HotkeyBindings = {};
+    const bubbleBindings: HotkeyBindings = {};
+    for (const [binding, handler] of Object.entries(bindings)) {
+      if (bindingUsesModifier(binding)) {
+        captureBindings[binding] = handler;
+      } else {
+        bubbleBindings[binding] = handler;
+      }
+    }
+
+    const unsubscribes: Array<() => void> = [];
+    if (Object.keys(captureBindings).length > 0) {
+      unsubscribes.push(
+        tinykeys(window, stopPropagationAfterHandling(captureBindings), {
+          capture: true,
+        }),
+      );
+    }
+    if (Object.keys(bubbleBindings).length > 0) {
+      unsubscribes.push(tinykeys(window, bubbleBindings));
+    }
+
     return () => {
-      unsubscribe();
+      for (const unsubscribe of unsubscribes) {
+        unsubscribe();
+      }
     };
   }, [bindings]);
 }

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -235,6 +235,77 @@ test.describe("terminal: spawn", () => {
       .toBeGreaterThanOrEqual(1);
   });
 
+  test("global modifier shortcuts are claimed before terminal key listeners", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+
+    const result = await page.evaluate(() => {
+      const textarea = document.querySelector<HTMLTextAreaElement>(
+        ".xterm-helper-textarea",
+      );
+      if (!textarea) throw new Error("xterm helper textarea missing");
+
+      let descendantListenerRan = false;
+      textarea.addEventListener(
+        "keydown",
+        () => {
+          descendantListenerRan = true;
+        },
+        { capture: true, once: true },
+      );
+
+      const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+      const canceled = !textarea.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "e",
+          code: "KeyE",
+          metaKey: isMac,
+          ctrlKey: !isMac,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+
+      return { canceled, descendantListenerRan };
+    });
+
+    expect(result).toEqual({
+      canceled: true,
+      descendantListenerRan: false,
+    });
+  });
+
   test("reattaching a live daemon session replays daemon scrollback instead of stale disk scrollback", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Modifier-key shortcut handling now claims app-level shortcuts before focused terminal surfaces can interpret the same key event.

1. **Capture modifier shortcuts** — split `useHotkeys` bindings so modifier chords register on `window` capture, while unmodified bindings such as `Escape` keep the existing bubble path.
2. **Stop handled key propagation** — once an app-level shortcut calls `preventDefault()`, stop the same event from reaching focused descendants like xterm helper textareas.
3. **Regression coverage** — add hook-level and Playwright coverage for terminal-focused modifier shortcuts, including the `Cmd/Ctrl+Shift+E` shape that previously leaked through.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal-focused app shortcuts | Some chords could also reach terminal/xterm listeners | Handled app shortcuts are claimed before terminal listeners |
| Unmodified shortcuts | Bubble-phase behavior | Unchanged |
| Shortcut regression coverage | Formatting/fallback tests only | Adds hook and terminal E2E propagation coverage |

## Design notes
- `tinykeys` already performs exact modifier matching, so the bug was not duplicate matching between `$mod+E` and `$mod+Shift+E`. The leak came from app shortcuts being handled at `window` bubble phase after focused terminal listeners had a chance to see the same keydown.
- Propagation only stops when the matched handler leaves `event.defaultPrevented === true`. This preserves existing no-op paths and keeps the contract explicit for future shortcut handlers.
- Non-modifier bindings stay on the original bubble listener so local input/dialog Escape behavior does not become more aggressive.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `/Users/jthefloor/Documents/Personal/acorn/node_modules/.bin/vitest run src/lib/hotkeys.test.ts src/lib/hotkeys.react.test.tsx` — 11 pass
- [x] `PATH=/Users/jthefloor/Documents/Personal/acorn/node_modules/.bin:$PATH /Users/jthefloor/Documents/Personal/acorn/node_modules/.bin/playwright test tests/e2e/terminal.spec.ts` — 4 pass
- [x] `PATH=/Users/jthefloor/Documents/Personal/acorn/node_modules/.bin:$PATH /Users/jthefloor/Documents/Personal/acorn/node_modules/.bin/playwright test tests/e2e/panes.spec.ts` — 9 pass

## Notes
- This worktree does not have its own `node_modules`, so direct `pnpm run test -- ...` cannot resolve `vitest`. Targeted test commands used the parent checkout's installed `node_modules/.bin` binaries. **Not caused by this PR**.