### PR TITLE
fix(workspace): stabilize tab drag start across panes

### DIFF
--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -104,6 +104,41 @@ function resetStore(): void {
   );
 }
 
+function seedInactivePaneWithTab(tab: Session): void {
+  const layout = {
+    kind: "split" as const,
+    id: "split-test",
+    direction: "horizontal" as const,
+    a: { kind: "pane" as const, id: "root" },
+    b: { kind: "pane" as const, id: "pane-2" },
+  };
+  const panes = {
+    root: { id: "root", tabIds: [], activeTabId: null },
+    "pane-2": {
+      id: "pane-2",
+      tabIds: [tab.id],
+      activeTabId: tab.id,
+    },
+  };
+
+  useAppStore.setState((s) => ({
+    ...s,
+    sessions: [tab],
+    workspaces: {
+      [REPO]: {
+        layout,
+        panes,
+        focusedPaneId: "root",
+      },
+    },
+    layout,
+    panes,
+    focusedPaneId: "root",
+    activeTabId: null,
+    activeSessionId: null,
+  }));
+}
+
 describe("Pane empty state", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -231,5 +266,53 @@ describe("Pane empty state", () => {
       null,
       false,
     );
+  });
+
+  it("does not focus an inactive pane on primary mousedown in its tab strip", () => {
+    const inactive = session("inactive-session");
+    seedInactivePaneWithTab(inactive);
+
+    act(() => {
+      root.render(<Pane paneId="pane-2" />);
+    });
+
+    const tabStrip = container.querySelector('[data-pane-tab-strip="pane-2"]');
+    expect(tabStrip).not.toBeNull();
+
+    act(() => {
+      tabStrip?.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          button: 0,
+          cancelable: true,
+        }),
+      );
+    });
+
+    expect(useAppStore.getState().focusedPaneId).toBe("root");
+  });
+
+  it("keeps secondary mousedown on a tab strip focusing the pane", () => {
+    const inactive = session("inactive-session");
+    seedInactivePaneWithTab(inactive);
+
+    act(() => {
+      root.render(<Pane paneId="pane-2" />);
+    });
+
+    const tabStrip = container.querySelector('[data-pane-tab-strip="pane-2"]');
+    expect(tabStrip).not.toBeNull();
+
+    act(() => {
+      tabStrip?.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          button: 2,
+          cancelable: true,
+        }),
+      );
+    });
+
+    expect(useAppStore.getState().focusedPaneId).toBe("pane-2");
   });
 });

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -356,7 +356,8 @@ export function Pane({ paneId }: PaneProps) {
   return (
     <div
       className="relative flex h-full flex-col bg-bg"
-      onMouseDown={() => {
+      onMouseDown={(e) => {
+        if (e.button === 0 && isTabStripMouseDownTarget(e.target)) return;
         if (!isFocused) setFocusedPane(paneId);
       }}
     >
@@ -532,6 +533,12 @@ function isNonTerminalTextEditingTarget(target: EventTarget | null): boolean {
   const tag = target.tagName;
   if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
   return target.isContentEditable;
+}
+
+function isTabStripMouseDownTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement
+    ? target.closest("[data-pane-tab-strip]") !== null
+    : false;
 }
 
 interface TabStripProps {
@@ -968,14 +975,14 @@ function TabItem({
           }
         }}
         className={cn(
-          "group relative flex min-w-[96px] shrink-0 cursor-pointer select-none items-center border-r border-border pl-3 pr-1 text-[13px] leading-5 transition",
+          "group relative flex min-w-[96px] shrink-0 cursor-pointer select-none items-center border-r border-border pr-1 text-[13px] leading-5 transition",
           active
             ? "bg-bg text-fg"
             : "bg-bg-elevated/40 text-fg-muted hover:bg-bg-elevated/70 hover:text-fg",
         )}
       >
         <div
-          className="flex min-w-0 flex-1 items-center gap-1.5 self-stretch"
+          className="flex min-w-0 flex-1 items-center gap-1.5 self-stretch pl-3"
           data-tab-drag-handle={tab.id}
           draggable
           style={{ WebkitUserDrag: "element" } as CSSProperties}


### PR DESCRIPTION
## Summary
This fixes workspace tab drag startup so moving tabs between panes does not get interrupted by pane focus changes or a too-small drag handle.

1. **Tab drag focus guard:** skip pane-level focus changes on primary-button mousedown inside the tab strip so the tab element is not re-rendered before `dragstart` can fire.
2. **Drag hit area:** move the tab's left padding into the draggable handle so clicking the padded lead-in area can start a drag without changing the visible cursor behavior.
3. **Regression coverage:** add focused pane tests for primary versus secondary mousedown on an inactive pane's tab strip.

## Expected impact
| Area | Expected impact |
| --- | --- |
| Tab movement | More reliable drag start when moving tabs between panes. |
| Context menus | Right-click/secondary mousedown still focuses the target pane before showing tab actions. |
| Visuals | No intentional visual or cursor change. |

## Design notes
The fix keeps the existing HTML5 drag path and module-level drag payload. The change is scoped to when pane focus is updated: primary-button mousedown from the tab strip is allowed to proceed to the draggable tab without forcing a parent focus update first, while non-primary buttons keep the existing pane-focus behavior for context menus.

## Test plan
- [x] `pnpm run test -- src/components/Pane.test.tsx src/components/PaneDropOverlay.test.tsx src/lib/dnd.test.ts src/store.test.ts` — 46 files passed, 391 tests passed, 1 skipped.
- [x] `pnpm run typecheck` — passed.
- [x] `pnpm run test:e2e -- tests/e2e/panes.spec.ts` — 9 tests passed.

## Notes
Self-review found and fixed an initial regression risk where all tab-strip mousedown events, including right-clicks, would have skipped pane focusing. The committed version only defers primary-button mousedown.
