### PR TITLE
fix(tabs): stabilize concurrent tab and sidebar ordering

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -228,8 +228,9 @@ pub struct Session {
     pub owner: SessionOwner,
     /// User-defined display order within the project group. `None` means the
     /// session has never been reordered — the frontend falls back to
-    /// `updated_at DESC` for these. Once any session in a project is dragged,
-    /// every session in that project gets an explicit position.
+    /// `created_at DESC` for these so status/name/path updates do not reshuffle
+    /// the sidebar. Once any session in a project is dragged, every session in
+    /// that project gets an explicit position.
     #[serde(default)]
     pub position: Option<i64>,
     /// Identifier the `acornd` daemon uses for this session's live PTY.

--- a/src/lib/sessionGrouping.test.ts
+++ b/src/lib/sessionGrouping.test.ts
@@ -87,16 +87,18 @@ describe("buildProjectGroups", () => {
     expect(groups.map((group) => group.repoPath)).toEqual(["/repo/app"]);
   });
 
-  it("sorts sessions by explicit position before updated time", () => {
+  it("sorts sessions by explicit position before created time", () => {
     const groups = buildProjectGroups(
       [project("/repo/app", 0)],
       [
         session("newer", "/repo/app", {
+          created_at: "2026-01-03T00:00:00Z",
           updated_at: "2026-01-03T00:00:00Z",
         }),
         session("pos-1", "/repo/app", { position: 1 }),
         session("pos-0", "/repo/app", { position: 0 }),
         session("older", "/repo/app", {
+          created_at: "2026-01-02T00:00:00Z",
           updated_at: "2026-01-02T00:00:00Z",
         }),
       ],
@@ -109,6 +111,27 @@ describe("buildProjectGroups", () => {
       "older",
     ]);
   });
+
+  it("does not reorder unpositioned sessions when only updated time changes", () => {
+    const groups = buildProjectGroups(
+      [project("/repo/app", 0)],
+      [
+        session("older-created", "/repo/app", {
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-05T00:00:00Z",
+        }),
+        session("newer-created", "/repo/app", {
+          created_at: "2026-01-02T00:00:00Z",
+          updated_at: "2026-01-03T00:00:00Z",
+        }),
+      ],
+    );
+
+    expect(groups[0].sessions.map((s) => s.id)).toEqual([
+      "newer-created",
+      "older-created",
+    ]);
+  });
 });
 
 describe("buildLocalSessions", () => {
@@ -117,6 +140,7 @@ describe("buildLocalSessions", () => {
       session("project", "/repo/app"),
       session("newer", "/Users/me", {
         project_scoped: false,
+        created_at: "2026-01-03T00:00:00Z",
         updated_at: "2026-01-03T00:00:00Z",
       }),
       session("pos-0", "/Users/me", {
@@ -125,6 +149,7 @@ describe("buildLocalSessions", () => {
       }),
       session("older", "/Users/me", {
         project_scoped: false,
+        created_at: "2026-01-02T00:00:00Z",
         updated_at: "2026-01-02T00:00:00Z",
       }),
     ]);

--- a/src/lib/sessionGrouping.ts
+++ b/src/lib/sessionGrouping.ts
@@ -77,6 +77,9 @@ function sortSessions(sessions: Session[]): Session[] {
     const ap = a.position ?? Number.POSITIVE_INFINITY;
     const bp = b.position ?? Number.POSITIVE_INFINITY;
     if (ap !== bp) return ap - bp;
-    return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+    const createdDelta =
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    if (createdDelta !== 0) return createdDelta;
+    return a.id.localeCompare(b.id);
   });
 }

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -996,6 +996,35 @@ describe("reconcile via refreshSessions", () => {
     expect(s.panes[s.focusedPaneId].tabIds.sort()).toEqual(["a1", "a2"]);
   });
 
+  it("ignores stale refresh results that resolve after a newer session list", async () => {
+    const a1 = session("a1", REPO_A);
+    const a2 = session("a2", REPO_A);
+    await seed([project(REPO_A, 0)], [a1]);
+
+    const stale = deferred<Session[]>();
+    const fresh = deferred<Session[]>();
+    mockApi.listSessions
+      .mockImplementationOnce(() => stale.promise)
+      .mockImplementationOnce(() => fresh.promise);
+
+    const staleRefresh = useAppStore.getState().refreshSessions();
+    const freshRefresh = useAppStore.getState().refreshSessions();
+
+    fresh.resolve([a1, a2]);
+    await freshRefresh;
+    expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual([
+      "a1",
+      "a2",
+    ]);
+
+    stale.resolve([a1]);
+    await staleRefresh;
+
+    const s = useAppStore.getState();
+    expect(s.sessions.map((session) => session.id)).toEqual(["a1", "a2"]);
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1", "a2"]);
+  });
+
   it("does NOT wipe persisted tabIds when load_status reports unclean", async () => {
     // Seed: persisted layout with two sessions in one pane.
     await seed(
@@ -1413,6 +1442,87 @@ describe("createSession", () => {
       "a3",
     ]);
     expect(s.activeSessionId).toBe("a4");
+  });
+
+  it("keeps concurrent new tabs in request order when completions resolve out of order", async () => {
+    const a1 = session("a1", REPO_A);
+    const a2 = session("a2", REPO_A);
+    const c1 = session("c1", REPO_A);
+    const c2 = session("c2", REPO_A);
+    await seed([project(REPO_A, 0)], [a1, a2]);
+    useAppStore.getState().selectSession("a1");
+
+    const firstCreate = deferred<Session>();
+    const secondCreate = deferred<Session>();
+    let backendSessions = [a1, a2];
+    mockApi.createSession
+      .mockImplementationOnce(() => firstCreate.promise)
+      .mockImplementationOnce(() => secondCreate.promise);
+    mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
+    mockApi.listSessions.mockImplementation(async () => backendSessions);
+
+    const first = useAppStore.getState().createSession("c1", REPO_A);
+    const second = useAppStore.getState().createSession("c2", REPO_A);
+
+    backendSessions = [a1, a2, c2];
+    secondCreate.resolve(c2);
+    await second;
+
+    backendSessions = [a1, a2, c2, c1];
+    firstCreate.resolve(c1);
+    await first;
+
+    const s = useAppStore.getState();
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual([
+      "a1",
+      "c1",
+      "c2",
+      "a2",
+    ]);
+  });
+
+  it("keeps placement intents until delayed sibling sessions are visible", async () => {
+    const a1 = session("a1", REPO_A);
+    const a2 = session("a2", REPO_A);
+    const c1 = session("c1", REPO_A);
+    const c2 = session("c2", REPO_A);
+    await seed([project(REPO_A, 0)], [a1, a2]);
+    useAppStore.getState().selectSession("a1");
+
+    const firstCreate = deferred<Session>();
+    const secondCreate = deferred<Session>();
+    let backendSessions = [a1, a2];
+    mockApi.createSession
+      .mockImplementationOnce(() => firstCreate.promise)
+      .mockImplementationOnce(() => secondCreate.promise);
+    mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
+    mockApi.listSessions.mockImplementation(async () => backendSessions);
+
+    const first = useAppStore.getState().createSession("c1", REPO_A);
+    const second = useAppStore.getState().createSession("c2", REPO_A);
+
+    secondCreate.resolve(c2);
+    await second;
+    expect(useAppStore.getState().panes.root.tabIds).toEqual(["a1", "a2"]);
+
+    backendSessions = [a1, a2, c1];
+    firstCreate.resolve(c1);
+    await first;
+    expect(useAppStore.getState().panes.root.tabIds).toEqual([
+      "a1",
+      "c1",
+      "a2",
+    ]);
+
+    backendSessions = [a1, a2, c1, c2];
+    await useAppStore.getState().refreshSessions();
+
+    expect(useAppStore.getState().panes.root.tabIds).toEqual([
+      "a1",
+      "c1",
+      "c2",
+      "a2",
+    ]);
   });
 
   it("appends when the focused pane has no active tab yet", async () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -49,6 +49,18 @@ let pendingStatusPollAll = false;
 let pendingStatusPollIds = new Set<string>();
 let activeStatusPollAll = false;
 let activeStatusPollIds = new Set<string>();
+let refreshSessionsSeq = 0;
+let sessionPlacementSeq = 0;
+
+interface SessionPlacementIntent {
+  repoPath: string;
+  paneId: PaneId;
+  anchorTabId: string | null;
+  sequence: number;
+}
+
+const sessionPlacementById = new Map<string, SessionPlacementIntent>();
+const activeSessionPlacementIntents = new Set<SessionPlacementIntent>();
 
 export interface PaneState {
   id: PaneId;
@@ -553,6 +565,171 @@ function updateActiveWorkspace(
   };
 }
 
+function captureSessionPlacementIntent(
+  s: AppStateModel,
+  repoPath: string,
+): SessionPlacementIntent | null {
+  const ws = s.workspaces[repoPath];
+  if (!ws) return null;
+  const pane = ws.panes[ws.focusedPaneId];
+  if (!pane) return null;
+  return {
+    repoPath,
+    paneId: ws.focusedPaneId,
+    anchorTabId: pane.activeTabId,
+    sequence: ++sessionPlacementSeq,
+  };
+}
+
+function samePlacementGroup(
+  a: SessionPlacementIntent,
+  b: SessionPlacementIntent,
+): boolean {
+  return (
+    a.repoPath === b.repoPath &&
+    a.paneId === b.paneId &&
+    a.anchorTabId === b.anchorTabId
+  );
+}
+
+function pruneSessionPlacementGroup(
+  placement: SessionPlacementIntent,
+  sessions: Session[],
+): void {
+  for (const active of activeSessionPlacementIntents) {
+    if (samePlacementGroup(active, placement)) return;
+  }
+  const visibleSessionIds = new Set(sessions.map((session) => session.id));
+  // Keep sibling placement records until every created tab in the group has
+  // appeared in a session refresh; later siblings need earlier sequences.
+  for (const [sessionId, existing] of sessionPlacementById) {
+    if (
+      samePlacementGroup(existing, placement) &&
+      !visibleSessionIds.has(sessionId)
+    ) {
+      return;
+    }
+  }
+  for (const [sessionId, existing] of sessionPlacementById) {
+    if (samePlacementGroup(existing, placement)) {
+      sessionPlacementById.delete(sessionId);
+    }
+  }
+}
+
+function insertionIndexForPlacement(
+  tabIds: string[],
+  placement: SessionPlacementIntent,
+): number {
+  if (!placement.anchorTabId) {
+    const firstLaterSibling = tabIds.findIndex((id) => {
+      const other = sessionPlacementById.get(id);
+      return (
+        other !== undefined &&
+        samePlacementGroup(other, placement) &&
+        other.sequence > placement.sequence
+      );
+    });
+    return firstLaterSibling >= 0 ? firstLaterSibling : tabIds.length;
+  }
+
+  const anchorIndex = tabIds.indexOf(placement.anchorTabId);
+  if (anchorIndex < 0) return tabIds.length;
+
+  let index = anchorIndex + 1;
+  while (index < tabIds.length) {
+    const other = sessionPlacementById.get(tabIds[index]);
+    if (
+      !other ||
+      !samePlacementGroup(other, placement) ||
+      other.sequence > placement.sequence
+    ) {
+      break;
+    }
+    index += 1;
+  }
+  return index;
+}
+
+function applySessionPlacementIntent(
+  s: AppStateModel,
+  sessionId: string,
+  placement: SessionPlacementIntent | null,
+): AppStateModel | Partial<AppStateModel> {
+  if (!placement) return s;
+  if (!s.sessions.some((session) => session.id === sessionId)) return s;
+
+  const ws = s.workspaces[placement.repoPath];
+  const targetPane = ws?.panes[placement.paneId];
+  if (!ws || !targetPane) return s;
+
+  let changed = false;
+  const newPanes: Record<PaneId, PaneState> = {};
+  for (const [pid, pane] of Object.entries(ws.panes)) {
+    if (!pane.tabIds.includes(sessionId)) {
+      newPanes[pid as PaneId] = pane;
+      continue;
+    }
+    changed = true;
+    const tabIds = pane.tabIds.filter((id) => id !== sessionId);
+    newPanes[pid as PaneId] = {
+      ...pane,
+      tabIds,
+      activeTabId:
+        pane.activeTabId === sessionId
+          ? tabIds[tabIds.length - 1] ?? null
+          : pane.activeTabId,
+    };
+  }
+
+  const targetAfterRemoval = newPanes[placement.paneId] ?? targetPane;
+  const targetIds = [...targetAfterRemoval.tabIds];
+  const insertAt = insertionIndexForPlacement(targetIds, placement);
+  targetIds.splice(insertAt, 0, sessionId);
+  changed =
+    changed ||
+    targetAfterRemoval.tabIds.length !== targetIds.length ||
+    targetAfterRemoval.tabIds.some((id, index) => id !== targetIds[index]);
+
+  if (!changed) return s;
+
+  const newWs: ProjectWorkspace = {
+    ...ws,
+    panes: {
+      ...newPanes,
+      [placement.paneId]: {
+        ...targetAfterRemoval,
+        tabIds: targetIds,
+      },
+    },
+  };
+  const workspaces = { ...s.workspaces, [placement.repoPath]: newWs };
+  return {
+    workspaces,
+    ...(s.activeProject === placement.repoPath
+      ? mirrorActive(workspaces, placement.repoPath)
+      : {}),
+  };
+}
+
+function applyKnownSessionPlacementIntents(s: AppStateModel): AppStateModel {
+  let next = s;
+  const pruneAfterApply: SessionPlacementIntent[] = [];
+  for (const [sessionId, placement] of Array.from(sessionPlacementById)) {
+    const patch = applySessionPlacementIntent(next, sessionId, placement);
+    if (patch !== next) {
+      next = { ...next, ...patch };
+    }
+    if (next.sessions.some((session) => session.id === sessionId)) {
+      pruneAfterApply.push(placement);
+    }
+  }
+  for (const placement of pruneAfterApply) {
+    pruneSessionPlacementGroup(placement, next.sessions);
+  }
+  return next;
+}
+
 export const useAppStore = create<AppStateModel>()(
   persist(
     (set, get) => ({
@@ -606,9 +783,11 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   async refreshSessions() {
+    const seq = ++refreshSessionsSeq;
     set({ loading: true, error: null });
     try {
       const sessions = await api.listSessions();
+      if (seq !== refreshSessionsSeq) return;
       set((s) => {
         const allowEmptyWipe = s.sessionsLoadedCleanly;
         const reconciled = reconcileWorkspaces(
@@ -625,7 +804,8 @@ export const useAppStore = create<AppStateModel>()(
         const sessionIds = new Set(sessions.map((session) => session.id));
         const shouldPruneActivity =
           s.sessionsLoadedCleanly || sessions.length > 0;
-        return {
+        const nextState: AppStateModel = {
+          ...s,
           sessions,
           loading: false,
           error: null,
@@ -639,9 +819,11 @@ export const useAppStore = create<AppStateModel>()(
           activeProject: reconciled.activeProject,
           ...mirrorActive(reconciled.workspaces, reconciled.activeProject),
         };
+        return applyKnownSessionPlacementIntents(nextState);
       });
       void get().refreshLiveInWorktree();
     } catch (e) {
+      if (seq !== refreshSessionsSeq) return;
       set({ loading: false, error: errorMessage(e) });
     }
   },
@@ -1148,23 +1330,14 @@ export const useAppStore = create<AppStateModel>()(
     projectScoped = true,
   ) {
     set({ loading: true, error: null });
+    // Capture the user's intended insertion point before the backend call.
+    // Multiple creates can be in flight at once, so the intent records the
+    // anchor tab id plus a client-side sequence instead of a numeric index
+    // that may be stale by the time the session is returned.
+    const placement = captureSessionPlacementIntent(get(), repoPath);
+    if (placement) activeSessionPlacementIntents.add(placement);
+    let createdId: string | null = null;
     try {
-      // Snapshot the previously-active tab's index in the focused pane so
-      // we can land the new tab right after it (browser-style). Captured
-      // before `api.createSession` so the post-refresh reorder is anchored
-      // to the user's view at hotkey-press time, not the post-reconcile
-      // append position.
-      const beforeSnap = (() => {
-        const s = get();
-        const ws = s.workspaces[repoPath];
-        if (!ws) return null;
-        const paneId = ws.focusedPaneId;
-        const pane = ws.panes[paneId];
-        if (!pane?.activeTabId) return null;
-        const idx = pane.tabIds.indexOf(pane.activeTabId);
-        return idx >= 0 ? { paneId, idx } : null;
-      })();
-
       const created =
         projectScoped === false
           ? await api.createSession(
@@ -1182,41 +1355,12 @@ export const useAppStore = create<AppStateModel>()(
               kind,
               agentProvider,
             );
+      createdId = created.id;
       await get().refreshAll();
 
-      // Reorder so the new tab sits immediately after the previously-active
-      // tab in the same pane. `reconcileWorkspace` always appends new
-      // sessions at the end of `focusedPaneId.tabIds`; this step
-      // converts that to "next to active" without changing reconcile's
-      // boot-time behavior.
-      if (beforeSnap) {
-        set((s) => {
-          const ws = s.workspaces[repoPath];
-          if (!ws) return s;
-          const pane = ws.panes[beforeSnap.paneId];
-          if (!pane) return s;
-          const currentIdx = pane.tabIds.indexOf(created.id);
-          if (currentIdx < 0) return s;
-          const targetIdx = Math.min(
-            beforeSnap.idx + 1,
-            pane.tabIds.length - 1,
-          );
-          if (currentIdx === targetIdx) return s;
-          const ids = pane.tabIds.filter((id) => id !== created.id);
-          ids.splice(targetIdx, 0, created.id);
-          const newPane = { ...pane, tabIds: ids };
-          const newWs = {
-            ...ws,
-            panes: { ...ws.panes, [beforeSnap.paneId]: newPane },
-          };
-          const workspaces = { ...s.workspaces, [repoPath]: newWs };
-          return {
-            workspaces,
-            ...(s.activeProject === repoPath
-              ? mirrorActive(workspaces, repoPath)
-              : {}),
-          };
-        });
+      if (placement) {
+        sessionPlacementById.set(created.id, placement);
+        set((s) => applySessionPlacementIntent(s, created.id, placement));
       }
 
       // Focus the new session so Cmd+T (and any other entry point that goes
@@ -1248,11 +1392,22 @@ export const useAppStore = create<AppStateModel>()(
     } catch (e) {
       set({ loading: false, error: errorMessage(e) });
       return null;
+    } finally {
+      if (placement) {
+        activeSessionPlacementIntents.delete(placement);
+        if (
+          createdId === null ||
+          get().sessions.some((session) => session.id === createdId)
+        ) {
+          pruneSessionPlacementGroup(placement, get().sessions);
+        }
+      }
     }
   },
 
   async removeSession(id, removeWorktree = false) {
     const owning = findTabOwner(get(), id);
+    sessionPlacementById.delete(id);
     set((s) => {
       if (!s.sessions.some((session) => session.id === id)) return s;
 

--- a/tests/e2e/panes.spec.ts
+++ b/tests/e2e/panes.spec.ts
@@ -230,6 +230,193 @@ test.describe("pane / sidebar shortcuts", () => {
     await expect(renameInput).toHaveCount(0);
   });
 
+  test("concurrent new tabs keep request order when completions resolve out of order", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __sessions?: unknown[] };
+      return (
+        w.__sessions ?? [
+          {
+            id: "s-1",
+            name: "alpha",
+            repo_path: "/tmp/demo",
+            worktree_path: "/tmp/demo",
+            branch: "main",
+            isolated: false,
+            status: "idle",
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:05Z",
+            last_message: null,
+            kind: "regular",
+            owner: { kind: "user" },
+            position: null,
+            in_worktree: false,
+          },
+          {
+            id: "s-2",
+            name: "beta",
+            repo_path: "/tmp/demo",
+            worktree_path: "/tmp/demo",
+            branch: "main",
+            isolated: false,
+            status: "idle",
+            created_at: "2026-01-01T00:00:01Z",
+            updated_at: "2026-01-01T00:00:04Z",
+            last_message: null,
+            kind: "regular",
+            owner: { kind: "user" },
+            position: null,
+            in_worktree: false,
+          },
+        ]
+      );
+    });
+    await tauri.handle("create_session", () => {
+      const w = window as unknown as {
+        __createCalls?: number;
+        __resolveCreate1?: () => void;
+        __resolveCreate2?: () => void;
+      };
+      w.__createCalls = (w.__createCalls ?? 0) + 1;
+      const call = w.__createCalls;
+      const session = {
+        id: call === 1 ? "s-3" : "s-4",
+        name: call === 1 ? "gamma" : "delta",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at:
+          call === 1 ? "2026-01-01T00:00:02Z" : "2026-01-01T00:00:03Z",
+        updated_at:
+          call === 1 ? "2026-01-01T00:00:02Z" : "2026-01-01T00:00:03Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      };
+      return new Promise((resolve) => {
+        if (call === 1) w.__resolveCreate1 = () => resolve(session);
+        else w.__resolveCreate2 = () => resolve(session);
+      });
+    });
+
+    await page.goto("/");
+    await expect(page.locator('[data-tab-drag-handle="s-1"]')).toBeVisible();
+    await pressHotkey(page, { mod: true, key: "t" });
+    await pressHotkey(page, { mod: true, key: "t" });
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as unknown as { __createCalls?: number }).__createCalls,
+        ),
+      )
+      .toBe(2);
+
+    await page.evaluate(() => {
+      const w = window as unknown as {
+        __sessions: unknown[];
+        __resolveCreate2?: () => void;
+      };
+      w.__sessions = [
+        {
+          id: "s-1",
+          name: "alpha",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          status: "idle",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:05Z",
+          last_message: null,
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+        },
+        {
+          id: "s-2",
+          name: "beta",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          status: "idle",
+          created_at: "2026-01-01T00:00:01Z",
+          updated_at: "2026-01-01T00:00:04Z",
+          last_message: null,
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+        },
+        {
+          id: "s-4",
+          name: "delta",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          status: "idle",
+          created_at: "2026-01-01T00:00:03Z",
+          updated_at: "2026-01-01T00:00:03Z",
+          last_message: null,
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+        },
+      ];
+      w.__resolveCreate2?.();
+    });
+    await expect(page.locator('[data-tab-drag-handle="s-4"]')).toBeVisible();
+
+    await page.evaluate(() => {
+      const w = window as unknown as {
+        __sessions: unknown[];
+        __resolveCreate1?: () => void;
+      };
+      w.__sessions = [
+        ...(w.__sessions ?? []),
+        {
+          id: "s-3",
+          name: "gamma",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          status: "idle",
+          created_at: "2026-01-01T00:00:02Z",
+          updated_at: "2026-01-01T00:00:02Z",
+          last_message: null,
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+        },
+      ];
+      w.__resolveCreate1?.();
+    });
+
+    await expect(page.locator('[data-tab-drag-handle="s-3"]')).toBeVisible();
+    await expect
+      .poll(() =>
+        page
+          .locator("[data-pane-tab-strip] [data-tab-drag-handle]")
+          .evaluateAll((els) =>
+            els.map((el) => el.getAttribute("data-tab-drag-handle")),
+          ),
+      )
+      .toEqual(["s-1", "s-3", "s-4", "s-2"]);
+  });
+
   test("$mod+Alt+E dispatches equalize panes", async ({ page }) => {
     await page.goto("/");
     await page.evaluate(() => {

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -154,4 +154,69 @@ test.describe("sessions: list rendering", () => {
       page.locator('aside').getByLabel("worktree", { exact: true }),
     ).toHaveCount(1);
   });
+
+  test("unpositioned sidebar sessions keep created order when updated_at changes", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "older-created",
+        name: "older-created",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-05T00:00:00Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      },
+      {
+        id: "newer-created",
+        name: "newer-created",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-02T00:00:00Z",
+        updated_at: "2026-01-03T00:00:00Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      },
+    ]);
+
+    await page.goto("/");
+
+    const newer = page.getByRole("button", {
+      name: /^newer-created main · Idle$/,
+    });
+    const older = page.getByRole("button", {
+      name: /^older-created main · Idle$/,
+    });
+    await expect(newer).toBeVisible();
+    await expect(older).toBeVisible();
+
+    const newerBox = await newer.boundingBox();
+    const olderBox = await older.boundingBox();
+    expect(newerBox).not.toBeNull();
+    expect(olderBox).not.toBeNull();
+    expect(newerBox!.y).toBeLessThan(olderBox!.y);
+  });
 });


### PR DESCRIPTION
## Summary
Stabilizes workspace and sidebar session ordering under overlapping refresh and create flows.

1. **Workspace tab races:** Ignore stale session refreshes and place newly-created tabs by anchor tab plus client request order.
2. **Sidebar fallback ordering:** Sort unpositioned sessions by creation time instead of update time so metadata/status updates do not reshuffle the list.
3. **Regression coverage:** Add store and Playwright coverage for stale refreshes, out-of-order concurrent tab creation, delayed visibility, and sidebar fallback order.

## Expected impact
| Area | Expected impact |
| --- | --- |
| Workspace tabs | Concurrent session creation and refreshes should preserve intended tab order. |
| Sidebar sessions | Unpositioned sessions should keep creation order when status/name/path metadata updates. |
| Reliability | Race regressions are covered in Vitest and Playwright. |

## Design notes
- `refreshSessions` now uses a monotonic sequence and ignores stale responses.
- New session placement records pane, anchor tab, and client sequence instead of a numeric index.
- Placement records are kept until all sibling created tabs are visible so later refreshes can still restore request order.
- Sidebar fallback uses `created_at DESC` with an id tie-breaker while explicit positions still win.

## Test plan
- [x] `pnpm exec vitest run src/store.test.ts`
- [x] `pnpm run test`
- [x] `pnpm run typecheck`
- [x] `pnpm run test:e2e`

## Notes
- Full E2E still logs pre-existing DialogContent accessibility warnings and `NO_COLOR` warnings; the suite passed.
