### PR TITLE
fix(sidebar): project row rename + full-row drag

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,7 +8,6 @@ import {
   FolderOpen,
   FolderPlus,
   GitBranch,
-  GripVertical,
   Pencil,
   PencilLine,
   Plus,
@@ -594,9 +593,6 @@ function ProjectHeaderPreview({
 }) {
   return (
     <div className="flex min-h-8 items-center gap-1 rounded-md bg-bg-elevated/95 px-1 py-1.5 shadow-lg ring-1 ring-border/60">
-      <span className="flex size-4 shrink-0 items-center justify-center text-fg-muted/60">
-        <GripVertical size={12} />
-      </span>
       <span className="flex size-5 shrink-0 items-center justify-center rounded text-fg-muted">
         <ChevronRight size={14} />
       </span>
@@ -619,48 +615,48 @@ function SessionRowPreview({
   session: Session;
   t: Translator;
 }) {
-  const showAgentProviderIcons = useSettings(
-    (s) => s.settings.sessionDisplay.icons.agentProvider,
+  const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
+  const titleText = resolveSessionTitle(session, sessionDisplay.title);
+  const metadataText = composeSessionMetadata(
+    t,
+    session,
+    sessionDisplay.metadata,
   );
-  const agentProvider = showAgentProviderIcons
+  const agentProvider = sessionDisplay.icons.agentProvider
     ? resolveSessionAgentProvider(session)
     : null;
 
   return (
     <div className="flex w-full items-start gap-1.5 rounded-md bg-bg-elevated/95 px-2 py-1 shadow-lg ring-1 ring-border/60">
-      <span className="mt-1 flex shrink-0 items-center text-fg-muted/60">
-        <GripVertical size={10} />
-      </span>
-      <span className="flex h-5 w-3 shrink-0 items-center justify-center">
-        {agentProvider ? (
-          <Tooltip label={agentProvider} side="right">
-            <AgentProviderIcon
-              provider={agentProvider}
-              className={cn("size-3", STATUS_ICON[session.status])}
+      {sessionDisplay.icons.statusDot ? (
+        <span className="flex h-5 w-3 shrink-0 items-center justify-center">
+          {agentProvider ? (
+            <Tooltip label={agentProvider} side="right">
+              <AgentProviderIcon
+                provider={agentProvider}
+                className={cn("size-3", STATUS_ICON[session.status])}
+              />
+            </Tooltip>
+          ) : (
+            <span
+              className={cn(
+                "size-1.5 rounded-full",
+                STATUS_DOT[session.status],
+              )}
             />
-          </Tooltip>
-        ) : (
-          <span
-            className={cn(
-              "size-1.5 rounded-full",
-              STATUS_DOT[session.status],
-            )}
-          />
-        )}
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="flex h-5 items-center gap-1">
-          <span className="truncate text-[13px] font-medium leading-5 text-fg">
-            {session.name}
-          </span>
-          {hasRecordedWorktree(session) ? (
-            <GitBranch size={10} className="shrink-0 text-fg-muted" />
-          ) : null}
+          )}
         </span>
-        <span className="block truncate text-[11px] text-fg-muted">
-          {session.branch} · {statusLabel(t, session.status)}
-        </span>
-      </span>
+      ) : null}
+      <SessionRowLabel
+        editing={false}
+        session={session}
+        titleText={titleText}
+        metadataText={metadataText}
+        showKindIcons={sessionDisplay.icons.sessionKind}
+        t={t}
+        onSubmitRename={() => undefined}
+        onCancelRename={() => undefined}
+      />
     </div>
   );
 }
@@ -768,10 +764,17 @@ function ProjectGroupView({
       className={cn("relative", isDragging && "opacity-40")}
     >
       <div
+        ref={setActivatorNodeRef}
+        {...attributes}
         role="button"
         tabIndex={0}
         onClick={onTitleClick}
+        onPointerDown={(e) => {
+          listeners?.onPointerDown?.(e);
+        }}
         onKeyDown={(e) => {
+          listeners?.onKeyDown?.(e);
+          if (e.defaultPrevented) return;
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             onTitleClick();
@@ -788,23 +791,9 @@ function ProjectGroupView({
           isActiveProject && "bg-bg-elevated/30",
         )}
       >
-        <Tooltip
-          label={sidebarText(t, "sidebar.actions.dragToReorder")}
-          side="bottom"
-        >
-          <span
-            ref={setActivatorNodeRef}
-            {...attributes}
-            {...listeners}
-            onClick={(e) => e.stopPropagation()}
-            aria-label={sidebarText(t, "sidebar.aria.dragToReorderProject")}
-            className="invisible flex size-4 shrink-0 cursor-grab items-center justify-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
-          >
-            <GripVertical size={12} />
-          </span>
-        </Tooltip>
         <button
           type="button"
+          onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
             onChevronClick();
@@ -836,6 +825,7 @@ function ProjectGroupView({
         >
           <button
             type="button"
+            onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => {
               e.stopPropagation();
               onAddSession(false, "regular");
@@ -852,6 +842,7 @@ function ProjectGroupView({
         >
           <button
             type="button"
+            onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => {
               e.stopPropagation();
               onAddSession(true, "regular");
@@ -871,6 +862,7 @@ function ProjectGroupView({
         >
           <button
             type="button"
+            onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => {
               e.stopPropagation();
               onAddSession(false, "control");
@@ -890,6 +882,7 @@ function ProjectGroupView({
         >
           <button
             type="button"
+            onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => {
               e.stopPropagation();
               onRemoveProject();
@@ -1175,95 +1168,98 @@ function SessionRow({
 
   const row = (
     <div
-        role="button"
-        tabIndex={0}
-        onClick={editing ? undefined : onSelect}
-        onKeyDown={(e) => {
-          if (editing) return;
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            onSelect();
-          } else if (e.key === "F2") {
-            e.preventDefault();
-            setEditing(true);
+      ref={setActivatorNodeRef}
+      {...attributes}
+      role="button"
+      tabIndex={0}
+      onClick={editing ? undefined : onSelect}
+      onPointerDown={(e) => {
+        if (editing) return;
+        listeners?.onPointerDown?.(e);
+      }}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        setEditing(true);
+      }}
+      onKeyDown={(e) => {
+        if (editing) return;
+        listeners?.onKeyDown?.(e);
+        if (e.defaultPrevented) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        } else if (e.key === "F2") {
+          e.preventDefault();
+          setEditing(true);
+        }
+      }}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setMenu({ x: e.clientX, y: e.clientY });
+      }}
+      className={cn(
+        "group flex w-full items-start gap-1.5 rounded-md px-2 py-1 text-left transition",
+        active ? "bg-bg-elevated" : "hover:bg-bg-elevated/60",
+        isDragging && "opacity-40",
+      )}
+    >
+      {sessionDisplay.icons.statusDot ? (
+        <span className="flex h-5 w-3 shrink-0 items-center justify-center">
+          {agentProvider ? (
+            <Tooltip label={agentProvider} side="right">
+              <AgentProviderIcon
+                provider={agentProvider}
+                className={cn("size-3", STATUS_ICON[session.status])}
+              />
+            </Tooltip>
+          ) : (
+            <span
+              className={cn(
+                "size-1.5 rounded-full",
+                STATUS_DOT[session.status],
+              )}
+            />
+          )}
+        </span>
+      ) : null}
+      <SessionRowLabel
+        editing={editing}
+        session={session}
+        titleText={titleText}
+        metadataText={metadataText}
+        showKindIcons={sessionDisplay.icons.sessionKind}
+        t={t}
+        onSubmitRename={async (next) => {
+          setEditing(false);
+          if (next && next !== session.name) {
+            await renameSession(session.id, next);
+            const error = useAppStore.getState().consumeError();
+            if (error) showToast(`${t("toasts.session.renameFailed")} ${error}`);
           }
         }}
-        onContextMenu={(e) => {
-          e.preventDefault();
+        onCancelRename={() => setEditing(false)}
+      />
+      <span
+        role="button"
+        aria-label={sidebarText(t, "sidebar.actions.removeSession")}
+        tabIndex={0}
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={(e) => {
           e.stopPropagation();
-          setMenu({ x: e.clientX, y: e.clientY });
+          onRemove();
         }}
-        className={cn(
-          "group flex w-full items-start gap-1.5 rounded-md px-2 py-1 text-left transition",
-          active ? "bg-bg-elevated" : "hover:bg-bg-elevated/60",
-          isDragging && "opacity-40",
-        )}
-      >
-        <span
-          ref={setActivatorNodeRef}
-          {...attributes}
-          {...listeners}
-          onClick={(e) => e.stopPropagation()}
-          aria-label={sidebarText(t, "sidebar.aria.dragToReorderSession")}
-          className="invisible mt-1 flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
-        >
-          <GripVertical size={10} />
-        </span>
-        {sessionDisplay.icons.statusDot ? (
-          <span className="flex h-5 w-3 shrink-0 items-center justify-center">
-            {agentProvider ? (
-              <Tooltip label={agentProvider} side="right">
-                <AgentProviderIcon
-                  provider={agentProvider}
-                  className={cn("size-3", STATUS_ICON[session.status])}
-                />
-              </Tooltip>
-            ) : (
-              <span
-                className={cn(
-                  "size-1.5 rounded-full",
-                  STATUS_DOT[session.status],
-                )}
-              />
-            )}
-          </span>
-        ) : null}
-        <SessionRowLabel
-          editing={editing}
-          session={session}
-          titleText={titleText}
-          metadataText={metadataText}
-          showKindIcons={sessionDisplay.icons.sessionKind}
-          t={t}
-          onSubmitRename={async (next) => {
-            setEditing(false);
-            if (next && next !== session.name) {
-              await renameSession(session.id, next);
-              const error = useAppStore.getState().consumeError();
-              if (error) showToast(`${t("toasts.session.renameFailed")} ${error}`);
-            }
-          }}
-          onCancelRename={() => setEditing(false)}
-        />
-        <span
-          role="button"
-          aria-label={sidebarText(t, "sidebar.actions.removeSession")}
-          tabIndex={0}
-          onClick={(e) => {
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
             e.stopPropagation();
             onRemove();
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              e.stopPropagation();
-              onRemove();
-            }
-          }}
-          className="invisible rounded p-1 text-fg-muted transition hover:text-danger group-hover:visible"
-        >
-          <Trash2 size={12} />
-        </span>
+          }
+        }}
+        className="invisible rounded p-1 text-fg-muted transition hover:text-danger group-hover:visible"
+      >
+        <Trash2 size={12} />
+      </span>
     </div>
   );
 
@@ -1375,8 +1371,10 @@ function RenameInput({ initial, onSubmit, onCancel }: RenameInputProps) {
     <input
       type="text"
       autoFocus
+      draggable={false}
       value={value}
       onChange={(e) => setValue(e.target.value)}
+      onPointerDown={(e) => e.stopPropagation()}
       onClick={(e) => e.stopPropagation()}
       onFocus={(e) => e.currentTarget.select()}
       onKeyDown={(e) => {
@@ -1619,11 +1617,23 @@ function LocalSessionRow({
 
   const row = (
     <div
+      ref={setActivatorNodeRef}
+      {...attributes}
       role="button"
       tabIndex={0}
       onClick={editing ? undefined : onSelect}
+      onPointerDown={(e) => {
+        if (editing) return;
+        listeners?.onPointerDown?.(e);
+      }}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        setEditing(true);
+      }}
       onKeyDown={(e) => {
         if (editing) return;
+        listeners?.onKeyDown?.(e);
+        if (e.defaultPrevented) return;
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           onSelect();
@@ -1643,16 +1653,6 @@ function LocalSessionRow({
         isDragging && "opacity-40",
       )}
     >
-      <span
-        ref={setActivatorNodeRef}
-        {...attributes}
-        {...listeners}
-        onClick={(e) => e.stopPropagation()}
-        aria-label={sidebarText(t, "sidebar.aria.dragToReorderSession")}
-        className="invisible mt-1 flex shrink-0 cursor-grab items-center text-fg-muted/60 active:cursor-grabbing group-hover:visible"
-      >
-        <GripVertical size={10} />
-      </span>
       {sessionDisplay.icons.statusDot ? (
         <span className="flex h-5 w-3 shrink-0 items-center justify-center">
           {agentProvider ? (
@@ -1693,6 +1693,7 @@ function LocalSessionRow({
         role="button"
         aria-label={sidebarText(t, "sidebar.actions.removeSession")}
         tabIndex={0}
+        onPointerDown={(e) => e.stopPropagation()}
         onClick={(e) => {
           e.stopPropagation();
           onRemove();

--- a/tests/e2e/session-lifecycle.spec.ts
+++ b/tests/e2e/session-lifecycle.spec.ts
@@ -77,6 +77,43 @@ test.describe("session lifecycle", () => {
     expect(calls[0]).toEqual({ id: "s-1", name: "renamed" });
   });
 
+  test("double-clicking a project session row starts rename", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [BASE_SESSION]);
+    await tauri.handle("rename_session", (args) => {
+      const w = window as unknown as { __renameCalls?: unknown[] };
+      w.__renameCalls = w.__renameCalls ?? [];
+      w.__renameCalls.push(args);
+      const a = args as { id: string; name: string };
+      return { ...BASE_SESSION, id: a.id, name: a.name };
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-panel-id="sidebar"]');
+    const row = sidebar
+      .getByRole("button", { name: /^alpha main · Idle/ })
+      .first();
+    await row.dblclick();
+
+    const input = sidebar.locator("input[type='text']");
+    await expect(input).toBeFocused();
+    await input.fill("renamed from double click");
+    await input.press("Enter");
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __renameCalls?: unknown[] }).__renameCalls,
+    )) as Array<{ id: string; name: string }>;
+    expect(calls[0]).toEqual({
+      id: "s-1",
+      name: "renamed from double click",
+    });
+  });
+
   test("Remove session button → confirm → remove_session is invoked", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
This fixes the Projects sidebar so project-scoped sessions behave like workspace tabs during rename and drag interactions.

1. **Project session rename:** Double-clicking a session row in Projects now enters inline rename mode, matching workspace tab behavior.
2. **Full-row drag:** Project and session rows now use the full row as the drag activator instead of a separate grip handle, while nested action buttons and rename inputs remain interactive.
3. **Drag preview parity:** Session drag overlays now reuse the same title, metadata, status, and kind display settings as the source row so branch/status labels such as `HEAD` and `Idle` stay visible.

## Expected impact
| Area | Impact |
| --- | --- |
| Sidebar usability | Projects rows support double-click rename and easier full-row drag starts. |
| Drag preview reliability | Ghost rows keep the same configured session title/metadata as the source row. |
| Existing controls | Chevron, add, branch, close, remove, and rename inputs keep their click/edit behavior. |

## Design notes
- Kept the existing dnd-kit sortable structure and moved activator wiring onto the row container.
- Stopped pointer propagation on nested controls so full-row dragging does not hijack button clicks or rename editing.
- Reused `SessionRowLabel` in the drag overlay instead of duplicating session display formatting.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm exec playwright test tests/e2e/session-lifecycle.spec.ts tests/e2e/sidebar.spec.ts`
- [x] `git diff --check`

## Notes
- Self-review found one rebase conflict with newer sidebar toast handling; resolved by preserving the newer toast/error path while keeping full-row drag and double-click rename behavior.
