### PR TITLE
chore(release): v1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.8.3",
+  "version": "1.9.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.8.3"
+version = "1.9.0"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.8.3"
+version = "1.9.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.8.3",
+  "version": "1.9.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
Prepare the minor release for the feature and fix work merged after `v1.8.3`.

1. **Version bump:** Update package, Tauri, and Cargo versions from `1.8.3` to `1.9.0`.
2. **Release scope:** Include the viewer search, macOS permission warmup, activity center, toast/worktree feedback, and stability fixes already merged to `main`.

## Expected impact

| Area | Impact |
| --- | --- |
| Release packaging | `v1.9.0` bundles and updater metadata will carry the matching app version. |
| Changelog | No user-facing release-note entry from this bump PR; prior feature/fix PRs supply the changelog items. |

## Design notes
This PR only aligns version metadata before creating the `v1.9.0` tag. Semantic versioning points to a minor bump because multiple `feat(...)` changes landed after `v1.8.3`.

## Test plan
- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` confirmed app version `1.9.0`
- [x] `rg -n '1\\.8\\.3|1\\.9\\.0' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock`\n- [x] `git diff --check`\n- [ ] CI green\n- [ ] Release workflow publishes `v1.9.0` assets and `latest.json`\n\n## Notes\nUse `skip-changelog` so this mechanical release bump does not appear in the generated in-app changelog.