### PR TITLE
feat(terminal): open file references in code viewer

### DIFF
--- a/docs/COMMON.md
+++ b/docs/COMMON.md
@@ -75,11 +75,15 @@ export CARGO_TARGET_DIR=/path/to/acorn/.acorn/cargo-target
 
 `src-tauri/scripts/build-sidecar.sh` honours the same setting when staging Tauri sidecars. Keep this as a local environment setting rather than a committed default so CI and release builds keep their normal per-workspace target layout.
 
-**Launching `tauri dev` from inside a control session.** Acorn injects `ACORN_DATA_DIR` (and `ACORN_AGENT_STATE_DIR`, `ACORN_RESUME_TOKEN`, `ACORN_STAGED_REV`) into every control-session PTY so the bundled CLIs talk to the host profile. `acorn-paths::data_dir` honours `ACORN_DATA_DIR` ahead of the debug/release profile fallback, so a plain `pnpm run tauri dev` from that shell silently runs the debug build against `profiles/prod` — same daemon, same `sessions.json`, same staged shell-init dir as the installed app. Strip the overrides before launching:</p>
+**Launching `tauri dev` from inside a control session.** Acorn injects `ACORN_DATA_DIR`, `ACORN_IPC_SOCKET`, `ACORN_DAEMON_SOCKET`, and related session metadata into every control-session PTY so bundled CLIs talk to the host profile. `acorn-paths::data_dir` honours `ACORN_DATA_DIR` ahead of the debug/release profile fallback, and `acorn-ipc` honours `ACORN_IPC_SOCKET` ahead of computed profile paths. A plain `pnpm run tauri dev` from that shell can silently run the debug app against `profiles/prod` — same daemon, same `sessions.json`, same staged shell-init dir as the installed app. Strip the overrides before launching:
 
 ```sh
 env -u ACORN_DATA_DIR \
+    -u ACORN_IPC_SOCKET \
+    -u ACORN_DAEMON_SOCKET \
     -u ACORN_AGENT_STATE_DIR \
+    -u ACORN_AGENT_WRAPPER_DIR \
+    -u ACORN_CLI_DIR \
     -u ACORN_RESUME_TOKEN \
     -u ACORN_STAGED_REV \
     -u ACORN_USER_ZDOTDIR \

--- a/docs/CONTROL_SESSIONS.md
+++ b/docs/CONTROL_SESSIONS.md
@@ -109,14 +109,16 @@ state, IPC sockets, daemon sockets, and staged shell init files to an
 explicit directory.
 
 > **Gotcha for agents running inside an Acorn terminal.** Acorn injects
-> `ACORN_DATA_DIR` into the PTY env so bundled CLIs talk to the right
+> `ACORN_DATA_DIR`, `ACORN_IPC_SOCKET`, `ACORN_DAEMON_SOCKET`, and related
+> session metadata into the PTY env so bundled CLIs talk to the right
 > profile. `acorn-paths::data_dir` resolves `ACORN_DATA_DIR` **before** the
-> profile fallback (see `src-tauri/crates/acorn-paths/src/lib.rs`), so
-> running `pnpm run tauri dev` from that shell makes the debug build inherit
-> the host's `profiles/prod` directory — it reuses the prod sessions, prod
-> daemon socket, and prod sidecar persistence, even though it is a debug
-> binary. The dev app and the installed app then fight over the same daemon
-> and `sessions.json`.
+> profile fallback (see `src-tauri/crates/acorn-paths/src/lib.rs`), and
+> `acorn-ipc` resolves `ACORN_IPC_SOCKET` **before** computed profile paths.
+> Running `pnpm run tauri dev` from that shell can make the debug build
+> inherit the host's `profiles/prod` directory or prod IPC socket — it reuses
+> the prod sessions, prod daemon socket, and prod sidecar persistence, even
+> though it is a debug binary. The dev app and the installed app then fight
+> over the same daemon and `sessions.json`.
 >
 > When launching `tauri dev` from inside a control session, strip the
 > inherited overrides (and any other prod-only env Acorn injects) and pin
@@ -124,7 +126,11 @@ explicit directory.
 >
 > ```sh
 > env -u ACORN_DATA_DIR \
+>     -u ACORN_IPC_SOCKET \
+>     -u ACORN_DAEMON_SOCKET \
 >     -u ACORN_AGENT_STATE_DIR \
+>     -u ACORN_AGENT_WRAPPER_DIR \
+>     -u ACORN_CLI_DIR \
 >     -u ACORN_RESUME_TOKEN \
 >     -u ACORN_STAGED_REV \
 >     -u ACORN_USER_ZDOTDIR \

--- a/src/components/CodeDiffVirtualization.test.tsx
+++ b/src/components/CodeDiffVirtualization.test.tsx
@@ -139,6 +139,32 @@ describe("virtualized code and diff rendering", () => {
     expect(container.querySelector('button[aria-pressed="false"]')).toBeNull();
   });
 
+  it("marks a requested code viewer target line", async () => {
+    const content = "one\ntwo\nthree";
+    vi.mocked(api.fsReadFile).mockResolvedValueOnce({
+      content,
+      size: content.length,
+      truncated: false,
+      binary: false,
+    });
+    vi.mocked(api.fsGitDiffLines).mockResolvedValueOnce([]);
+
+    await act(async () => {
+      root.render(
+        <CodeViewer
+          path="/repo/src/App.tsx"
+          isActive
+          target={{ line: 2, token: "target-1" }}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const target = container.querySelector('[data-acorn-target-line="true"]');
+    expect(target?.textContent).toContain("2");
+    expect(target?.textContent).toContain("two");
+  });
+
   it("toggles markdown files between source and preview", async () => {
     const content = "# Title\n\n- [x] shipped";
     vi.mocked(api.fsReadFile).mockResolvedValueOnce({

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -17,10 +17,12 @@ import {
   type VirtualizedLineListHandle,
 } from "./VirtualizedLines";
 import { Markdown } from "./ui/Markdown";
+import type { CodeWorkspaceTabTarget } from "../lib/workspaceTabs";
 
 interface CodeViewerProps {
   path: string;
   isActive: boolean;
+  target?: CodeWorkspaceTabTarget;
 }
 
 interface ViewerState {
@@ -70,7 +72,7 @@ function isMarkdownPath(path: string): boolean {
   return MARKDOWN_EXT_RE.test(path);
 }
 
-export function CodeViewer({ path, isActive }: CodeViewerProps) {
+export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
   const t = useTranslation();
   const [state, setState] = useState<ViewerState>(EMPTY_STATE);
   const [diffLines, setDiffLines] = useState<FsLineDiffEntry[]>([]);
@@ -180,6 +182,13 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
   const currentMatchCount = previewMode
     ? previewMatchCount
     : searchMatches.length;
+  const targetLineIndex =
+    target &&
+    target.line >= 1 &&
+    target.line <= sourceLines.length &&
+    !previewMode
+      ? target.line - 1
+      : null;
 
   const openSearch = useCallback(() => {
     setSearchOpen(true);
@@ -242,6 +251,11 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
       removePreviewSearchMarks(root);
     };
   }, [activeMatchIndex, effectiveSearchQuery, previewMode]);
+
+  useEffect(() => {
+    if (targetLineIndex === null) return;
+    lineListRef.current?.scrollToIndex(targetLineIndex, "center");
+  }, [target?.token, targetLineIndex]);
 
   useEffect(() => {
     if (!isActive) return;
@@ -322,6 +336,7 @@ export function CodeViewer({ path, isActive }: CodeViewerProps) {
               diff={diffByLine.get(index + 1)}
               gutterWidth={gutterWidth}
               searchMatches={searchMatchesByLine.get(index) ?? []}
+              focused={targetLineIndex === index}
             />
           )}
         />
@@ -413,6 +428,7 @@ function CodeLine({
   diff,
   gutterWidth,
   searchMatches,
+  focused,
 }: {
   index: number;
   rawText: string;
@@ -420,9 +436,14 @@ function CodeLine({
   diff?: FsLineDiffEntry["kind"];
   gutterWidth: number;
   searchMatches: LineSearchMatch[];
+  focused: boolean;
 }) {
   return (
-    <div className="flex whitespace-pre" {...lineIndexProps(index)}>
+    <div
+      className={cn("flex whitespace-pre", focused ? "bg-accent/10" : "")}
+      data-acorn-target-line={focused ? "true" : undefined}
+      {...lineIndexProps(index)}
+    >
       <span
         aria-hidden
         className={cn(

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -175,6 +175,7 @@ export function Pane({ paneId }: PaneProps) {
           repoPath: workspaceTab.repoPath,
           lifecycle: workspaceTab.lifecycle,
           path: workspaceTab.path,
+          target: workspaceTab.target,
         });
       }
     }
@@ -437,6 +438,7 @@ export function Pane({ paneId }: PaneProps) {
         {active?.kind === "code" ? (
           <CodeViewer
             path={active.path}
+            target={active.target}
             isActive={isFocused}
           />
         ) : null}

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type ReactElement } from "react";
 import {
   Terminal as XTerm,
   type IBuffer,
+  type IDisposable,
   type ITheme,
   type IViewportRange,
 } from "@xterm/xterm";
@@ -40,6 +41,11 @@ import {
   hasClipboardFilePayload,
   terminalPasteAction,
 } from "../lib/terminalPaste";
+import {
+  createTerminalFileLinkProvider,
+  resolveTerminalFilePath,
+  type TerminalFileReference,
+} from "../lib/terminalFileLinks";
 import {
   useSettings,
   type TerminalLinkActivation,
@@ -536,6 +542,22 @@ export function Terminal({
       }
       setLinkTooltip(null);
     };
+    const openTerminalFileReference = (reference: TerminalFileReference) => {
+      void (async () => {
+        let baseCwd = cwd;
+        try {
+          baseCwd = (await api.ptyCwd(sessionId)) ?? cwd;
+        } catch (err: unknown) {
+          console.debug("[Terminal] pty_cwd for file link failed", err);
+        }
+        const path = resolveTerminalFilePath(baseCwd, reference.path);
+        const target =
+          reference.line === undefined
+            ? undefined
+            : { line: reference.line, column: reference.column };
+        useAppStore.getState().openCodeViewerTab(path, cwd, target);
+      })();
+    };
     const webLinksAddon = new WebLinksAddon(
       (event, uri) => {
         event.preventDefault();
@@ -554,6 +576,25 @@ export function Terminal({
           hideLinkTooltip();
         },
       },
+    );
+    let fileLinksDisposable: IDisposable | null = term.registerLinkProvider(
+      createTerminalFileLinkProvider(term, {
+        activate: (event, reference) => {
+          event.preventDefault();
+          hideLinkTooltip();
+          if (linkActivation === "modifier-click" && !modifierHeld(event)) {
+            return;
+          }
+          openTerminalFileReference(reference);
+        },
+        hover: (_event, _reference, link) => {
+          if (linkActivation !== "modifier-click") return;
+          showLinkTooltip(link.range);
+        },
+        leave: () => {
+          hideLinkTooltip();
+        },
+      }),
     );
     const serializeAddon = new SerializeAddon();
     const unicode11Addon = new Unicode11Addon();
@@ -1925,6 +1966,8 @@ export function Terminal({
         // Backend may not implement pty_kill yet — safe to ignore.
       });
       unpatchMouseCoordinateScale();
+      try { fileLinksDisposable?.dispose(); } catch { /* ignore */ }
+      fileLinksDisposable = null;
       try { fitAddon.dispose(); } catch { /* ignore */ }
       try { webLinksAddon.dispose(); } catch { /* ignore */ }
       try { serializeAddon.dispose(); } catch { /* ignore */ }

--- a/src/lib/terminalFileLinks.test.ts
+++ b/src/lib/terminalFileLinks.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+  createTerminalFileLinkProvider,
+  findTerminalFileReferences,
+  resolveTerminalFilePath,
+} from "./terminalFileLinks";
+import type { IBufferCell, IBufferLine, Terminal as XTerm } from "@xterm/xterm";
+
+function makeBufferCell(chars: string, width = 1): IBufferCell {
+  return {
+    getChars: () => chars,
+    getWidth: () => width,
+  } as unknown as IBufferCell;
+}
+
+function makeBufferLine(
+  text: string,
+  cells = Array.from(text, (char) => makeBufferCell(char)),
+): IBufferLine {
+  return {
+    length: cells.length,
+    getCell: (index: number) => cells[index],
+    translateToString: () => text,
+  } as unknown as IBufferLine;
+}
+
+function makeTerminalWithLine(line: IBufferLine): XTerm {
+  return {
+    buffer: {
+      active: {
+        getLine: () => line,
+      },
+    },
+  } as unknown as XTerm;
+}
+
+describe("terminal file links", () => {
+  it("finds repo-relative file references with line numbers", () => {
+    expect(
+      findTerminalFileReferences(
+        "open src/components/FolderPermissionWarmupModal.tsx:78",
+      ),
+    ).toEqual([
+      {
+        path: "src/components/FolderPermissionWarmupModal.tsx",
+        line: 78,
+        text: "src/components/FolderPermissionWarmupModal.tsx:78",
+        startIndex: 5,
+      },
+    ]);
+  });
+
+  it("keeps optional column numbers and skips url-looking text", () => {
+    expect(
+      findTerminalFileReferences(
+        "at ./src/App.tsx:12:5 and https://example.test/src/App.tsx:99",
+      ),
+    ).toEqual([
+      {
+        path: "./src/App.tsx",
+        line: 12,
+        column: 5,
+        text: "./src/App.tsx:12:5",
+        startIndex: 3,
+      },
+    ]);
+  });
+
+  it("finds absolute file references", () => {
+    expect(findTerminalFileReferences("see /tmp/demo/src/App.tsx:4")).toEqual([
+      {
+        path: "/tmp/demo/src/App.tsx",
+        line: 4,
+        text: "/tmp/demo/src/App.tsx:4",
+        startIndex: 4,
+      },
+    ]);
+  });
+
+  it("finds file references with a trailing colon and no line number", () => {
+    expect(
+      findTerminalFileReferences(
+        "Path /Users/jthefloor/Desktop/helloworld/a.tsx:",
+      ),
+    ).toEqual([
+      {
+        path: "/Users/jthefloor/Desktop/helloworld/a.tsx",
+        text: "/Users/jthefloor/Desktop/helloworld/a.tsx:",
+        startIndex: 5,
+      },
+    ]);
+  });
+
+  it("finds root file references", () => {
+    expect(findTerminalFileReferences("Loaded b.tsx and README.md:12")).toEqual(
+      [
+        {
+          path: "b.tsx",
+          text: "b.tsx",
+          startIndex: 7,
+        },
+        {
+          path: "README.md",
+          line: 12,
+          text: "README.md:12",
+          startIndex: 17,
+        },
+      ],
+    );
+  });
+
+  it("finds explicit relative file references without a trailing colon", () => {
+    expect(
+      findTerminalFileReferences(
+        "Loaded ../../.claude/rules/typescript/coding-style.md",
+      ),
+    ).toEqual([
+      {
+        path: "../../.claude/rules/typescript/coding-style.md",
+        text: "../../.claude/rules/typescript/coding-style.md",
+        startIndex: 7,
+      },
+    ]);
+  });
+
+  it("does not treat path-colon-word text as a file reference", () => {
+    expect(findTerminalFileReferences("skip src/App.tsx:error")).toEqual([]);
+  });
+
+  it("does not treat version-looking text as a file reference", () => {
+    expect(findTerminalFileReferences("using package 1.2.3")).toEqual([]);
+  });
+
+  it("does not treat common abbreviation-looking text as a file reference", () => {
+    expect(findTerminalFileReferences("for example, e.g. this")).toEqual([]);
+  });
+
+  it("resolves relative paths from the terminal cwd", () => {
+    expect(resolveTerminalFilePath("/repo/app", "src/App.tsx")).toBe(
+      "/repo/app/src/App.tsx",
+    );
+    expect(resolveTerminalFilePath("/repo/app/src", "../README.md")).toBe(
+      "/repo/app/README.md",
+    );
+    expect(resolveTerminalFilePath("/repo/app", "/tmp/file.ts")).toBe(
+      "/tmp/file.ts",
+    );
+  });
+
+  it("keeps file link hover decorations from drawing xterm underlines", () => {
+    const provider = createTerminalFileLinkProvider(
+      makeTerminalWithLine(makeBufferLine("src/App.tsx:12")),
+      { activate: () => undefined },
+    );
+
+    provider.provideLinks(1, (links) => {
+      expect(links?.[0]?.decorations).toEqual({
+        pointerCursor: true,
+        underline: false,
+      });
+    });
+  });
+
+  it("maps file link ranges using terminal cell columns", () => {
+    const provider = createTerminalFileLinkProvider(
+      makeTerminalWithLine(
+        makeBufferLine("경로 /tmp/a.tsx:2", [
+          makeBufferCell("경", 2),
+          makeBufferCell("", 0),
+          makeBufferCell("로", 2),
+          makeBufferCell("", 0),
+          makeBufferCell(" "),
+          ...Array.from("/tmp/a.tsx:2", (char) => makeBufferCell(char)),
+        ]),
+      ),
+      { activate: () => undefined },
+    );
+
+    provider.provideLinks(1, (links) => {
+      expect(links?.[0]?.range).toEqual({
+        start: { x: 6, y: 1 },
+        end: { x: 17, y: 1 },
+      });
+    });
+  });
+});

--- a/src/lib/terminalFileLinks.ts
+++ b/src/lib/terminalFileLinks.ts
@@ -1,0 +1,178 @@
+import type {
+  IBufferLine,
+  ILink,
+  ILinkProvider,
+  Terminal as XTerm,
+} from "@xterm/xterm";
+
+export interface TerminalFileReference {
+  path: string;
+  line?: number;
+  column?: number;
+  text: string;
+  startIndex: number;
+}
+
+export interface TerminalFileLinkProviderOptions {
+  activate: (event: MouseEvent, reference: TerminalFileReference) => void;
+  hover?: (
+    event: MouseEvent,
+    reference: TerminalFileReference,
+    link: ILink,
+  ) => void;
+  leave?: (event: MouseEvent, reference: TerminalFileReference) => void;
+}
+
+const FILE_REF_RE =
+  /(^|[\s([{"'`<])((?:\.{1,2}\/|\/)?(?:(?:[A-Za-z0-9._@+-]+\/)+[A-Za-z0-9._@+-]+|[A-Za-z0-9._@+-]*\.[A-Za-z0-9._@+-]+)):(?:(\d{1,7})(?::(\d{1,5}))?)?(?=$|[\s)\]}>,.;!?:])/g;
+const FILE_PATH_RE =
+  /(^|[\s([{"'`<])((?:\.{1,2}\/|\/)?(?:(?:[A-Za-z0-9._@+-]+\/)+[A-Za-z0-9._@+-]*\.[A-Za-z][A-Za-z0-9_@+-]+|[A-Za-z0-9._@+-]*\.[A-Za-z][A-Za-z0-9_@+-]+))(?=$|[\s)\]}>,.;!?])/g;
+
+export function createTerminalFileLinkProvider(
+  terminal: XTerm,
+  options: TerminalFileLinkProviderOptions,
+): ILinkProvider {
+  return {
+    provideLinks(bufferLineNumber, callback) {
+      const line = terminal.buffer.active.getLine(bufferLineNumber - 1);
+      if (!line) {
+        callback(undefined);
+        return;
+      }
+      const text = line.translateToString(true);
+      const references = findTerminalFileReferences(text);
+      if (references.length === 0) {
+        callback(undefined);
+        return;
+      }
+      callback(
+        references.map((reference) => {
+          const startColumn = stringIndexToBufferColumn(
+            line,
+            reference.startIndex,
+          );
+          const endColumn = stringIndexToBufferColumn(
+            line,
+            reference.startIndex + reference.text.length,
+          );
+          const link: ILink = {
+            range: {
+              start: {
+                x: startColumn + 1,
+                y: bufferLineNumber,
+              },
+              end: {
+                x: endColumn,
+                y: bufferLineNumber,
+              },
+            },
+            text: reference.text,
+            decorations: {
+              pointerCursor: true,
+              underline: false,
+            },
+            activate: (event) => options.activate(event, reference),
+          };
+          if (options.hover) {
+            link.hover = (event) => options.hover?.(event, reference, link);
+          }
+          if (options.leave) {
+            link.leave = (event) => options.leave?.(event, reference);
+          }
+          return link;
+        }),
+      );
+    },
+  };
+}
+
+export function findTerminalFileReferences(
+  text: string,
+): TerminalFileReference[] {
+  const references: TerminalFileReference[] = [];
+  collectTerminalFileReferences(text, FILE_REF_RE, references, true);
+  collectTerminalFileReferences(text, FILE_PATH_RE, references, false);
+  return references.sort((a, b) => a.startIndex - b.startIndex);
+}
+
+function collectTerminalFileReferences(
+  text: string,
+  pattern: RegExp,
+  references: TerminalFileReference[],
+  includesLocation: boolean,
+): void {
+  const regex = new RegExp(pattern.source, pattern.flags);
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    const prefix = match[1] ?? "";
+    const path = match[2] ?? "";
+    const referenceText = match[0].slice(prefix.length);
+    const lineText = includesLocation ? match[3] : undefined;
+    const line = lineText ? Number(lineText) : undefined;
+    const column =
+      includesLocation && match[4] ? Number(match[4]) : undefined;
+    if (line !== undefined && (!Number.isSafeInteger(line) || line < 1)) {
+      continue;
+    }
+    if (column !== undefined && (!Number.isSafeInteger(column) || column < 1)) {
+      continue;
+    }
+    references.push({
+      path,
+      ...(line === undefined ? {} : { line }),
+      ...(column === undefined ? {} : { column }),
+      text: referenceText,
+      startIndex: match.index + prefix.length,
+    });
+  }
+}
+
+function stringIndexToBufferColumn(
+  bufferLine: IBufferLine,
+  targetIndex: number,
+): number {
+  let stringIndex = 0;
+  for (let column = 0; column < bufferLine.length; column += 1) {
+    const cell = bufferLine.getCell(column);
+    if (!cell) break;
+    const width = cell.getWidth();
+    if (width === 0) continue;
+    if (targetIndex <= stringIndex) return column;
+    const chars = cell.getChars();
+    const nextStringIndex = stringIndex + (chars.length || 1);
+    if (targetIndex < nextStringIndex) return column;
+    if (targetIndex === nextStringIndex) return column + Math.max(width, 1);
+    stringIndex = nextStringIndex;
+  }
+  return bufferLine.length;
+}
+
+export function resolveTerminalFilePath(
+  cwd: string,
+  referencePath: string,
+): string {
+  if (referencePath.startsWith("/")) {
+    return normalizePosixPath(referencePath);
+  }
+  return normalizePosixPath(`${cwd.replace(/\/+$/u, "")}/${referencePath}`);
+}
+
+function normalizePosixPath(path: string): string {
+  const absolute = path.startsWith("/");
+  const parts: string[] = [];
+  for (const part of path.split("/")) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      if (parts.length > 0 && parts[parts.length - 1] !== "..") {
+        parts.pop();
+      } else if (!absolute) {
+        parts.push(part);
+      }
+      continue;
+    }
+    parts.push(part);
+  }
+  const normalized = parts.join("/");
+  if (absolute) return `/${normalized}`;
+  return normalized || ".";
+}

--- a/src/lib/workspaceTabs.test.ts
+++ b/src/lib/workspaceTabs.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   activeSessionIdFromTabId,
   isProcessBackedWorkspaceTab,
@@ -8,6 +8,10 @@ import {
   makeCodeWorkspaceTab,
   makeSessionWorkspaceTab,
 } from "./workspaceTabs";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("workspace tab identity", () => {
   it("treats session ids as process-backed tab ids", () => {
@@ -62,5 +66,22 @@ describe("workspace tab lifecycle", () => {
     });
     expect(isRestorableWorkspaceTab(ephemeral)).toBe(false);
     expect(isRestorableWorkspaceTab(restorable)).toBe(true);
+  });
+
+  it("adds one-shot code viewer targets when requested", () => {
+    vi.spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000001")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000002");
+
+    const tab = makeCodeWorkspaceTab("/repo/src/App.tsx", "/repo", "ephemeral", {
+      line: 42,
+      column: 7,
+    });
+
+    expect(tab.target).toEqual({
+      line: 42,
+      column: 7,
+      token: "00000000-0000-4000-8000-000000000002",
+    });
   });
 });

--- a/src/lib/workspaceTabs.ts
+++ b/src/lib/workspaceTabs.ts
@@ -24,6 +24,13 @@ export interface SessionWorkspaceTab
 export interface CodeWorkspaceTab
   extends WorkspaceTabBase<"code", "ephemeral" | "restorable"> {
   path: string;
+  target?: CodeWorkspaceTabTarget;
+}
+
+export interface CodeWorkspaceTabTarget {
+  line: number;
+  column?: number;
+  token: string;
 }
 
 export type WorkspaceTab = SessionWorkspaceTab | CodeWorkspaceTab;
@@ -74,6 +81,7 @@ export function makeCodeWorkspaceTab(
   path: string,
   repoPath: string,
   lifecycle: CodeWorkspaceTab["lifecycle"] = "ephemeral",
+  target?: Omit<CodeWorkspaceTabTarget, "token">,
 ): CodeWorkspaceTab {
   return {
     id: `${CODE_VIEWER_TAB_PREFIX}${crypto.randomUUID()}`,
@@ -82,6 +90,17 @@ export function makeCodeWorkspaceTab(
     path,
     repoPath,
     title: basename(path),
+    ...(target ? { target: makeCodeWorkspaceTabTarget(target) } : {}),
+  };
+}
+
+export function makeCodeWorkspaceTabTarget(
+  target: Omit<CodeWorkspaceTabTarget, "token">,
+): CodeWorkspaceTabTarget {
+  return {
+    line: target.line,
+    ...(target.column === undefined ? {} : { column: target.column }),
+    token: crypto.randomUUID(),
   };
 }
 

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -314,6 +314,26 @@ describe("workspace tabs", () => {
     });
   });
 
+  it("updates an existing code viewer tab with a line target", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+
+    useAppStore
+      .getState()
+      .openCodeViewerTab(`${REPO_A}/src/App.tsx`, REPO_A, { line: 78 });
+    const tabId = useAppStore.getState().activeTabId!;
+    const firstTarget = useAppStore.getState().workspaceTabs[tabId].target;
+
+    useAppStore
+      .getState()
+      .openCodeViewerTab(`${REPO_A}/src/App.tsx`, REPO_A, { line: 12 });
+
+    const s = useAppStore.getState();
+    expect(s.activeTabId).toBe(tabId);
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1", tabId]);
+    expect(s.workspaceTabs[tabId].target).toMatchObject({ line: 12 });
+    expect(s.workspaceTabs[tabId].target?.token).not.toBe(firstTarget?.token);
+  });
+
   it("reselects a worktree-scoped code tab after switching projects", async () => {
     const a1 = session("a1", REPO_A, {
       worktree_path: `${REPO_A}/.worktrees/a1`,

--- a/src/store.ts
+++ b/src/store.ts
@@ -27,6 +27,7 @@ import {
   isRestorableWorkspaceTab,
   isWorkspaceTabId,
   makeCodeWorkspaceTab,
+  makeCodeWorkspaceTabTarget,
   type FrontendWorkspaceTab,
 } from "./lib/workspaceTabs";
 import {
@@ -196,7 +197,11 @@ interface AppStateModel {
   consumePendingTerminalInput: (sessionId: string) => PendingTerminalInput | null;
   toggleMultiInput: () => boolean;
   /** Open a readonly code viewer tab for `path` in the focused pane. */
-  openCodeViewerTab: (path: string, repoPath?: string) => void;
+  openCodeViewerTab: (
+    path: string,
+    repoPath?: string,
+    target?: { line?: number; column?: number },
+  ) => void;
   /** Close any frontend-owned tab and remove it from panes. */
   closeWorkspaceTab: (id: string) => void;
 }
@@ -1401,7 +1406,7 @@ export const useAppStore = create<AppStateModel>()(
     return enabled;
   },
 
-  openCodeViewerTab(path, repoPath) {
+  openCodeViewerTab(path, repoPath, target) {
     set((s) => {
       if (!s.activeProject) return s;
       const ws = s.workspaces[s.activeProject];
@@ -1422,7 +1427,30 @@ export const useAppStore = create<AppStateModel>()(
           tab.path === path &&
           tab.repoPath === targetRepoPath,
       );
-      const tab = existing ?? makeCodeWorkspaceTab(path, targetRepoPath);
+      const normalizedTarget =
+        target?.line && Number.isSafeInteger(target.line) && target.line > 0
+          ? {
+              line: target.line,
+              ...(target.column &&
+              Number.isSafeInteger(target.column) &&
+              target.column > 0
+                ? { column: target.column }
+                : {}),
+            }
+          : undefined;
+      const tab = existing
+        ? {
+            ...existing,
+            target: normalizedTarget
+              ? makeCodeWorkspaceTabTarget(normalizedTarget)
+              : undefined,
+          }
+        : makeCodeWorkspaceTab(
+            path,
+            targetRepoPath,
+            "ephemeral",
+            normalizedTarget,
+          );
       const alreadyInPane = pane.tabIds.includes(tab.id);
       const newPane: PaneState = alreadyInPane
         ? { ...pane, activeTabId: tab.id }
@@ -1441,7 +1469,7 @@ export const useAppStore = create<AppStateModel>()(
       };
       return {
         workspaceTabs: existing
-          ? s.workspaceTabs
+          ? { ...s.workspaceTabs, [existing.id]: tab }
           : { ...s.workspaceTabs, [tab.id]: tab },
         workspaces: newWorkspaces,
         ...mirrorActive(newWorkspaces, s.activeProject),

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -175,6 +175,206 @@ test.describe("terminal: spawn", () => {
     expect(first.parentLimbo).toBeNull();
   });
 
+  test("opens file:line terminal links in the code viewer", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_cwd", () => "/tmp/demo");
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __fileLinkChannelId?: number;
+        [key: string]: unknown;
+      };
+      w.__fileLinkChannelId = channel.id;
+      return 1;
+    });
+    await tauri.handle("fs_read_file", (args) => {
+      const { path } = args as { path: string };
+      if (path !== "/tmp/demo/src/components/FolderPermissionWarmupModal.tsx") {
+        throw new Error(`unexpected path: ${path}`);
+      }
+      const lines = Array.from(
+        { length: 100 },
+        (_, index) => `line ${index + 1}`,
+      );
+      lines[77] = "target line 78";
+      return {
+        content: lines.join("\n"),
+        size: 1024,
+        truncated: false,
+        binary: false,
+      };
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+
+    const linkText = "src/components/FolderPermissionWarmupModal.tsx:78";
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __fileLinkChannelId?: number })
+              .__fileLinkChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+    await page.evaluate((text) => {
+      const w = window as unknown as {
+        __fileLinkChannelId?: number;
+        [key: string]: unknown;
+      };
+      const id = w.__fileLinkChannelId;
+      if (id === undefined) throw new Error("missing terminal output channel");
+      const callback = w[`_${id}`] as
+        | ((payload: { index: number; message: number[] }) => void)
+        | undefined;
+      if (!callback) throw new Error("missing terminal output callback");
+      callback({
+        index: 0,
+        message: Array.from(new TextEncoder().encode(`${text}\r\n`)),
+      });
+    }, linkText);
+    await expect(page.locator(".xterm")).toContainText(linkText);
+    const screenBox = await page.locator(".xterm-screen").boundingBox();
+    expect(screenBox).not.toBeNull();
+    await page.mouse.move(screenBox!.x + 12, screenBox!.y + 10);
+    await page.mouse.click(screenBox!.x + 12, screenBox!.y + 10);
+
+    await expect(
+      page.getByRole("button", {
+        name: /FolderPermissionWarmupModal\.tsx Close tab/,
+      }),
+    ).toBeVisible();
+    await expect(page.locator('[data-acorn-target-line="true"]')).toContainText(
+      "target line 78",
+    );
+  });
+
+  test("opens file-only terminal links in the code viewer", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_cwd", () => "/tmp/demo/src/components");
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __fileLinkChannelId?: number;
+        [key: string]: unknown;
+      };
+      w.__fileLinkChannelId = channel.id;
+      return 1;
+    });
+    await tauri.handle("fs_read_file", (args) => {
+      const { path } = args as { path: string };
+      if (path !== "/tmp/demo/.claude/rules/typescript/coding-style.md") {
+        throw new Error(`unexpected path: ${path}`);
+      }
+      return {
+        content: "file-only link target\nline 2",
+        size: 128,
+        truncated: false,
+        binary: false,
+      };
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+
+    const linkText = "../../.claude/rules/typescript/coding-style.md";
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __fileLinkChannelId?: number })
+              .__fileLinkChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+    await page.evaluate((text) => {
+      const w = window as unknown as {
+        __fileLinkChannelId?: number;
+        [key: string]: unknown;
+      };
+      const id = w.__fileLinkChannelId;
+      if (id === undefined) throw new Error("missing terminal output channel");
+      const callback = w[`_${id}`] as
+        | ((payload: { index: number; message: number[] }) => void)
+        | undefined;
+      if (!callback) throw new Error("missing terminal output callback");
+      callback({
+        index: 0,
+        message: Array.from(new TextEncoder().encode(`${text}\r\n`)),
+      });
+    }, linkText);
+    await expect(page.locator(".xterm")).toContainText(linkText);
+    const screenBox = await page.locator(".xterm-screen").boundingBox();
+    expect(screenBox).not.toBeNull();
+    await page.mouse.move(screenBox!.x + 12, screenBox!.y + 10);
+    await page.mouse.click(screenBox!.x + 12, screenBox!.y + 10);
+
+    await expect(
+      page.getByRole("button", {
+        name: /coding-style\.md Close tab/,
+      }),
+    ).toBeVisible();
+    await expect(page.getByText("file-only link target")).toBeVisible();
+    await expect(page.locator('[data-acorn-target-line="true"]')).toHaveCount(
+      0,
+    );
+  });
+
   test("submitting a command resyncs the PTY size for agent TUIs", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Terminal output now opens recognized file references directly in Acorn CodeViewer tabs.

1. **Terminal file links**: add a custom xterm link provider for POSIX-style file references, resolving relative paths against the live PTY cwd.
2. **CodeViewer targets**: carry optional line/column targets through workspace tabs so reused code tabs scroll to and highlight the requested line.
3. **Dev-profile notes**: document the Acorn control-session env vars that must be stripped before launching `tauri dev` from an Acorn terminal.

## Expected impact
| Area | Impact |
| --- | --- |
| Terminal UX | File references in agent output can be clicked to open the file in CodeViewer. |
| Code navigation | `file:line` and `file:line:column` references reuse existing code tabs and refresh the target line. |
| Link rendering | File links use pointer cursor without xterm underline decoration to avoid misaligned underline artifacts. |
| Dev sessions | Docs now call out prod-profile env leakage when launching dev builds from Acorn-controlled PTYs. |

## Design notes
Supported terminal file reference formats:

```text
src/components/Foo.tsx
src/components/Foo.tsx:
src/components/Foo.tsx:78
src/components/Foo.tsx:78:5
```

```text
./src/Foo.tsx
./src/Foo.tsx:78
../README.md
../../.claude/rules/typescript/coding-style.md
```

```text
/Users/jthefloor/Desktop/helloworld/a.tsx
/Users/jthefloor/Desktop/helloworld/a.tsx:
/Users/jthefloor/Desktop/helloworld/a.tsx:2
/Users/jthefloor/Desktop/helloworld/a.tsx:2:1
```

```text
b.tsx
b.tsx:
b.tsx:10
README.md
README.md:12
README.md:12:3
.env
```

Parsing notes:
- Relative paths resolve from `pty_cwd`, falling back to the session cwd if the backend cwd probe fails.
- `file:line` scrolls/highlights the line; `file:line:column` preserves the column in the target payload; `file:` and `file` open the file without a line target.
- URL-looking text remains handled by the existing web-links addon. `src/App.tsx:error`, `1.2.3`, and `e.g.` are intentionally not treated as file links.
- Path-only links require a dotted basename with a two-or-more-character extension to reduce prose/version false positives; line-suffixed links remain broader because the location suffix is a stronger signal.
- xterm link ranges are mapped from string indexes to terminal cell columns so CJK prefixes before a path do not shift the clickable region.

## Follow-up (not in this PR)
- Consider an existence check before presenting file links if false positives become visible in real agent transcripts.
- Consider source-mode forcing for markdown line targets if markdown preview becomes the default.

## Test plan
- [x] `pnpm exec vitest run src/lib/terminalFileLinks.test.ts` — 12 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts` — 5 passed
- [x] `pnpm run test` — 47 files passed, 404 passed, 1 skipped
- [x] `git diff --cached --check` — passed

## Notes
- Local unrelated dirty files were left unstaged and are not part of this PR: permission warmup/locales/Tauri config changes plus local worktree artifacts.
