### PR TITLE
feat(session): auto-generate agent tab titles

### DIFF
--- a/src-tauri/crates/acorn-session/src/lib.rs
+++ b/src-tauri/crates/acorn-session/src/lib.rs
@@ -16,5 +16,5 @@ pub mod status;
 
 pub use session::{
     Project, ProjectStore, Session, SessionAgentProvider, SessionError, SessionKind, SessionOwner,
-    SessionResult, SessionStatus, SessionStore,
+    SessionResult, SessionStatus, SessionStore, SessionTitleSource,
 };

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -186,6 +186,18 @@ impl SessionOwner {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+pub enum SessionTitleSource {
+    Default,
+    Generated,
+    Manual,
+}
+
+fn default_title_source_for_existing_sessions() -> SessionTitleSource {
+    SessionTitleSource::Manual
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
 pub enum SessionAgentProvider {
     Claude,
     Codex,
@@ -222,6 +234,8 @@ pub struct Session {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub last_message: Option<String>,
+    #[serde(default = "default_title_source_for_existing_sessions")]
+    pub title_source: SessionTitleSource,
     #[serde(default)]
     pub kind: SessionKind,
     #[serde(default)]
@@ -289,6 +303,7 @@ impl Session {
             created_at: now,
             updated_at: now,
             last_message: None,
+            title_source: SessionTitleSource::Default,
             kind,
             owner: SessionOwner::User,
             position: None,
@@ -405,7 +420,18 @@ impl SessionStore {
             .get_mut(id)
             .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
         entry.name = name;
+        entry.title_source = SessionTitleSource::Manual;
         entry.updated_at = Utc::now();
+        Ok(entry.clone())
+    }
+
+    pub fn set_generated_title(&self, id: &Uuid, name: String) -> SessionResult<Session> {
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        entry.name = name;
+        entry.title_source = SessionTitleSource::Generated;
         Ok(entry.clone())
     }
 
@@ -508,6 +534,40 @@ mod tests {
     }
 
     #[test]
+    fn new_sessions_start_with_default_title_source() {
+        let session = fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false);
+
+        assert_eq!(session.title_source, SessionTitleSource::Default);
+    }
+
+    #[test]
+    fn persisted_sessions_without_title_source_load_as_manual() {
+        let mut session = fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false);
+        session.title_source = SessionTitleSource::Default;
+        let mut json = serde_json::to_value(&session).expect("session serializes");
+        json.as_object_mut()
+            .expect("session json is an object")
+            .remove("title_source");
+
+        let restored: Session = serde_json::from_value(json).expect("session deserializes");
+
+        assert_eq!(restored.title_source, SessionTitleSource::Manual);
+    }
+
+    #[test]
+    fn manual_rename_marks_title_source_as_manual() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+
+        let updated = store
+            .rename(&session.id, "manual title".to_string())
+            .expect("session exists");
+
+        assert_eq!(updated.name, "manual title");
+        assert_eq!(updated.title_source, SessionTitleSource::Manual);
+    }
+
+    #[test]
     fn reconcile_missing_worktree_resets_path_and_isolation() {
         let store = SessionStore::new();
         let session = store.insert(fake_session(
@@ -547,6 +607,21 @@ mod tests {
             store.get(&session.id).expect("session persisted").kind,
             SessionKind::Control
         );
+    }
+
+    #[test]
+    fn set_generated_title_does_not_reorder_session() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        let original_updated_at = session.updated_at;
+
+        let updated = store
+            .set_generated_title(&session.id, "generated title".to_string())
+            .expect("session exists");
+
+        assert_eq!(updated.name, "generated title");
+        assert_eq!(updated.title_source, SessionTitleSource::Generated);
+        assert_eq!(updated.updated_at, original_updated_at);
     }
 
     #[test]

--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -225,6 +225,80 @@ fn collect_files(root: &Path, accept: impl Fn(&Path) -> bool) -> Vec<PathBuf> {
 }
 
 fn parse_codex_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistoryItem> {
+    let state = parse_codex_state(path)?;
+    let cwd = state.cwd.clone()?;
+    if !scope.accepts_cwd(&cwd) {
+        return None;
+    }
+    let worktree = scope.worktree_for_cwd(&cwd);
+    let id = state.id.or_else(|| codex_id_from_filename(path))?;
+    let title = state
+        .title
+        .or_else(|| state.preview.clone())
+        .unwrap_or_else(|| "Codex session".to_string());
+    Some(AgentHistoryItem {
+        provider: AgentHistoryProvider::Codex,
+        resume_command: Some(format!("codex resume {id}")),
+        id,
+        title: collapse_preview(&title, PREVIEW_CHARS)
+            .unwrap_or_else(|| "Codex session".to_string()),
+        preview: state
+            .preview
+            .and_then(|s| collapse_preview(&s, PREVIEW_CHARS)),
+        cwd: Some(cwd),
+        worktree,
+        transcript_path: path.display().to_string(),
+        updated_at: file_updated_at(path),
+    })
+}
+
+fn parse_claude_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistoryItem> {
+    let state = parse_claude_state(path)?;
+    let cwd = state.cwd.clone()?;
+    if !scope.accepts_cwd(&cwd) {
+        return None;
+    }
+    let worktree = scope.worktree_for_cwd(&cwd);
+    let id = state.id.or_else(|| {
+        path.file_stem()
+            .and_then(|s| s.to_str())
+            .map(str::to_string)
+    })?;
+    let title = state
+        .title
+        .or_else(|| state.preview.clone())
+        .unwrap_or_else(|| "Claude session".to_string());
+    Some(AgentHistoryItem {
+        provider: AgentHistoryProvider::Claude,
+        resume_command: Some(format!("claude --resume {id}")),
+        id,
+        title: collapse_preview(&title, PREVIEW_CHARS)
+            .unwrap_or_else(|| "Claude session".to_string()),
+        preview: state
+            .preview
+            .and_then(|s| collapse_preview(&s, PREVIEW_CHARS)),
+        cwd: Some(cwd),
+        worktree,
+        transcript_path: path.display().to_string(),
+        updated_at: file_updated_at(path),
+    })
+}
+
+pub fn transcript_first_user_message(
+    provider: AgentHistoryProvider,
+    path: &Path,
+    max_chars: usize,
+) -> Option<String> {
+    let state = match provider {
+        AgentHistoryProvider::Codex => parse_codex_state(path)?,
+        AgentHistoryProvider::Claude => parse_claude_state(path)?,
+    };
+    state
+        .title
+        .and_then(|title| collapse_preview(&title, max_chars))
+}
+
+fn parse_codex_state(path: &Path) -> Option<ParsedAgentFile> {
     let mut state = ParsedAgentFile::default();
     for line in sample_lines(path).ok()? {
         let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
@@ -256,33 +330,10 @@ fn parse_codex_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistory
         }
     }
 
-    let cwd = state.cwd.clone()?;
-    if !scope.accepts_cwd(&cwd) {
-        return None;
-    }
-    let worktree = scope.worktree_for_cwd(&cwd);
-    let id = state.id.or_else(|| codex_id_from_filename(path))?;
-    let title = state
-        .title
-        .or_else(|| state.preview.clone())
-        .unwrap_or_else(|| "Codex session".to_string());
-    Some(AgentHistoryItem {
-        provider: AgentHistoryProvider::Codex,
-        resume_command: Some(format!("codex resume {id}")),
-        id,
-        title: collapse_preview(&title, PREVIEW_CHARS)
-            .unwrap_or_else(|| "Codex session".to_string()),
-        preview: state
-            .preview
-            .and_then(|s| collapse_preview(&s, PREVIEW_CHARS)),
-        cwd: Some(cwd),
-        worktree,
-        transcript_path: path.display().to_string(),
-        updated_at: file_updated_at(path),
-    })
+    Some(state)
 }
 
-fn parse_claude_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistoryItem> {
+fn parse_claude_state(path: &Path) -> Option<ParsedAgentFile> {
     let mut state = ParsedAgentFile::default();
     for line in sample_lines(path).ok()? {
         let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
@@ -308,34 +359,7 @@ fn parse_claude_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistor
         }
     }
 
-    let cwd = state.cwd.clone()?;
-    if !scope.accepts_cwd(&cwd) {
-        return None;
-    }
-    let worktree = scope.worktree_for_cwd(&cwd);
-    let id = state.id.or_else(|| {
-        path.file_stem()
-            .and_then(|s| s.to_str())
-            .map(str::to_string)
-    })?;
-    let title = state
-        .title
-        .or_else(|| state.preview.clone())
-        .unwrap_or_else(|| "Claude session".to_string());
-    Some(AgentHistoryItem {
-        provider: AgentHistoryProvider::Claude,
-        resume_command: Some(format!("claude --resume {id}")),
-        id,
-        title: collapse_preview(&title, PREVIEW_CHARS)
-            .unwrap_or_else(|| "Claude session".to_string()),
-        preview: state
-            .preview
-            .and_then(|s| collapse_preview(&s, PREVIEW_CHARS)),
-        cwd: Some(cwd),
-        worktree,
-        transcript_path: path.display().to_string(),
-        updated_at: file_updated_at(path),
-    })
+    Some(state)
 }
 
 #[derive(Default)]
@@ -929,6 +953,35 @@ mod tests {
 
         assert_eq!(item.title, "Show me recent sessions");
         assert_eq!(item.preview.as_deref(), Some("Here is the real answer."));
+    }
+
+    #[test]
+    fn transcript_first_user_message_returns_collapsed_first_user_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = dir
+            .path()
+            .join("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl");
+        let mut file = fs::File::create(&transcript).unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "type": "user",
+                "sessionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "cwd": "/tmp/demo",
+                "message": {
+                    "role": "user",
+                    "content": "Please inspect\n\n  the failing release workflow and summarize the fix",
+                },
+            })
+        )
+        .unwrap();
+        drop(file);
+
+        let title =
+            transcript_first_user_message(AgentHistoryProvider::Claude, &transcript, 32).unwrap();
+
+        assert_eq!(title, "Please inspect the failing relea…");
     }
 
     #[test]

--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -1,0 +1,122 @@
+use std::io::{Read, Write};
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::cli_resolver;
+use crate::error::{AppError, AppResult};
+
+const ONESHOT_TIMEOUT: Duration = Duration::from_secs(60);
+
+pub fn run_oneshot(
+    command: &str,
+    args: &[String],
+    prompt: &str,
+    settings_label: &str,
+) -> AppResult<String> {
+    let resolved = cli_resolver::resolve(command).map_err(|_| {
+        AppError::Other(format!(
+            "`{command}` not found. Install the configured AI CLI or change the provider in {settings_label}."
+        ))
+    })?;
+    let mut child = Command::new(&resolved)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                cli_resolver::invalidate(command);
+                AppError::Other(format!(
+                    "`{command}` not found. Install the configured AI CLI or change the provider in {settings_label}."
+                ))
+            } else {
+                AppError::Other(format!("failed to invoke {command}: {e}"))
+            }
+        })?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(prompt.as_bytes())
+            .map_err(|e| AppError::Other(format!("failed to write to {command}: {e}")))?;
+    } else {
+        return Err(AppError::Other(format!("{command} stdin missing")));
+    }
+
+    let output = wait_with_timeout(command, child, ONESHOT_TIMEOUT)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("{command} exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn wait_with_timeout(
+    command: &str,
+    mut child: std::process::Child,
+    timeout: Duration,
+) -> AppResult<Output> {
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| AppError::Other(format!("{command} stdout missing")))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| AppError::Other(format!("{command} stderr missing")))?;
+
+    let stdout_reader = thread::spawn(move || {
+        let mut reader = stdout;
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf).map(|_| buf)
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut reader = stderr;
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf).map(|_| buf)
+    });
+
+    let started = Instant::now();
+    let status = loop {
+        match child
+            .try_wait()
+            .map_err(|e| AppError::Other(format!("failed waiting for {command}: {e}")))?
+        {
+            Some(status) => break status,
+            None if started.elapsed() >= timeout => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = stdout_reader.join();
+                let _ = stderr_reader.join();
+                return Err(AppError::Other(format!(
+                    "{command} timed out after {} seconds",
+                    timeout.as_secs()
+                )));
+            }
+            None => thread::sleep(Duration::from_millis(50)),
+        }
+    };
+
+    let stdout = stdout_reader
+        .join()
+        .map_err(|_| AppError::Other(format!("{command} stdout reader failed")))?
+        .map_err(|e| AppError::Other(format!("failed reading {command} stdout: {e}")))?;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| AppError::Other(format!("{command} stderr reader failed")))?
+        .map_err(|e| AppError::Other(format!("failed reading {command} stderr: {e}")))?;
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}

--- a/src-tauri/src/cli_resolver.rs
+++ b/src-tauri/src/cli_resolver.rs
@@ -120,18 +120,30 @@ pub fn spawn_error(name: &str, e: std::io::Error) -> AppError {
     }
 }
 
-/// Run `$SHELL -l -i -c 'command -v <name>'` and parse stdout for the
+/// Run `$SHELL -l -i -c '<path lookup>'` and parse stdout for the
 /// resolved absolute path. The shell sources rc files (so PATH from
-/// Homebrew/npm/asdf/etc. is loaded) before running `command -v`, mirroring
+/// Homebrew/npm/asdf/etc. is loaded) before resolving the binary, mirroring
 /// the rc-loading approach in `commands.rs::pty_spawn`.
 fn shell_resolve(name: &str) -> AppResult<PathBuf> {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
-    // Wrap `command -v` in an exclusive marker so we can pull the path out
-    // even if the user's rc files print banners (p10k, oh-my-zsh, login
-    // greetings) to stdout during shell startup.
+    // `command -v` reports aliases in interactive zsh, which is exactly the
+    // shell mode we need for rc-loaded PATH. Prefer shell-specific external
+    // command lookup first, then fall back to POSIX `command -v`.
     let script = format!(
-        "printf '<<<ACORN_CLI_PATH>>>%s<<<END>>>' \"$(command -v {} 2>/dev/null)\"",
-        shell_quote(name)
+        "\
+_acorn_name={name};
+_acorn_path='';
+if [ -n \"${{ZSH_VERSION-}}\" ]; then
+  _acorn_path=$(whence -p -- \"$_acorn_name\" 2>/dev/null || :);
+fi;
+if [ -z \"$_acorn_path\" ] && [ -n \"${{BASH_VERSION-}}\" ]; then
+  _acorn_path=$(type -P -- \"$_acorn_name\" 2>/dev/null || :);
+fi;
+if [ -z \"$_acorn_path\" ]; then
+  _acorn_path=$(command -v \"$_acorn_name\" 2>/dev/null || :);
+fi;
+printf '<<<ACORN_CLI_PATH>>>%s<<<END>>>' \"$_acorn_path\"",
+        name = shell_quote(name)
     );
     let out = Command::new(&shell)
         .args(["-l", "-i", "-c", &script])

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -21,7 +21,9 @@ use crate::worktree;
 use acorn_session::scrollback;
 use acorn_session::status as session_status;
 use acorn_session::status::AgentKind as StatusAgentKind;
-use acorn_session::{Project, Session, SessionAgentProvider, SessionKind, SessionStatus};
+use acorn_session::{
+    Project, Session, SessionAgentProvider, SessionKind, SessionOwner, SessionStatus,
+};
 
 use serde::Serialize;
 
@@ -1032,9 +1034,162 @@ pub fn rename_session(state: State<'_, AppState>, id: String, name: String) -> A
     if trimmed.is_empty() {
         return Err(AppError::Other("name must not be empty".to_string()));
     }
+    let current = state.sessions.get(&id)?;
+    if matches!(current.owner, SessionOwner::Control { .. }) {
+        return Err(AppError::Other(
+            "control-session owned tabs cannot be renamed".to_string(),
+        ));
+    }
     let updated = state.sessions.rename(&id, trimmed)?;
     persist(&state);
     Ok(enrich_session(updated))
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum GenerateSessionTitleStatus {
+    Generated,
+    NotReady,
+    Skipped,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GenerateSessionTitleResult {
+    status: GenerateSessionTitleStatus,
+    session: Session,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SessionTitleReadinessStatus {
+    Ready,
+    NotReady,
+    Skipped,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionTitleReadinessResult {
+    status: SessionTitleReadinessStatus,
+    session: Session,
+}
+
+#[tauri::command]
+pub async fn session_title_readiness(
+    state: State<'_, AppState>,
+    id: String,
+) -> AppResult<SessionTitleReadinessResult> {
+    let state = state.inner().clone();
+    run_blocking("session_title_readiness", move || {
+        session_title_readiness_inner(state, id)
+    })
+    .await
+}
+
+fn session_title_readiness_inner(
+    state: AppState,
+    id: String,
+) -> AppResult<SessionTitleReadinessResult> {
+    let id = parse_id(&id)?;
+    let session = state.sessions.get(&id)?;
+    if !crate::session_titles::can_generate_title(&session) {
+        return Ok(SessionTitleReadinessResult {
+            status: SessionTitleReadinessStatus::Skipped,
+            session: enrich_session(session),
+        });
+    }
+    if crate::session_titles::resolve_first_user_message(id).is_none() {
+        return Ok(SessionTitleReadinessResult {
+            status: SessionTitleReadinessStatus::NotReady,
+            session: enrich_session(session),
+        });
+    }
+    Ok(SessionTitleReadinessResult {
+        status: SessionTitleReadinessStatus::Ready,
+        session: enrich_session(session),
+    })
+}
+
+#[tauri::command]
+pub async fn generate_session_title(
+    state: State<'_, AppState>,
+    id: String,
+    command: String,
+    args: Vec<String>,
+    prompt: Option<String>,
+) -> AppResult<GenerateSessionTitleResult> {
+    let state = state.inner().clone();
+    run_blocking("generate_session_title", move || {
+        generate_session_title_inner(state, id, command, args, prompt)
+    })
+    .await
+}
+
+fn generate_session_title_inner(
+    state: AppState,
+    id: String,
+    command: String,
+    args: Vec<String>,
+    prompt: Option<String>,
+) -> AppResult<GenerateSessionTitleResult> {
+    let id = parse_id(&id)?;
+    let session = state.sessions.get(&id)?;
+    if !crate::session_titles::can_generate_title(&session) {
+        return Ok(GenerateSessionTitleResult {
+            status: GenerateSessionTitleStatus::Skipped,
+            session: enrich_session(session),
+        });
+    }
+    let Some(first_user_message) = crate::session_titles::resolve_first_user_message(id) else {
+        return Ok(GenerateSessionTitleResult {
+            status: GenerateSessionTitleStatus::NotReady,
+            session: enrich_session(session),
+        });
+    };
+    let generated = crate::session_titles::generate_title(
+        &command,
+        &args,
+        prompt.as_deref(),
+        &first_user_message,
+    )?;
+    let latest = state.sessions.get(&id)?;
+    if !crate::session_titles::can_generate_title(&latest) {
+        return Ok(GenerateSessionTitleResult {
+            status: GenerateSessionTitleStatus::Skipped,
+            session: enrich_session(latest),
+        });
+    }
+    let updated = state.sessions.set_generated_title(&id, generated)?;
+    persist(&state);
+    Ok(GenerateSessionTitleResult {
+        status: GenerateSessionTitleStatus::Generated,
+        session: enrich_session(updated),
+    })
+}
+
+#[tauri::command]
+pub async fn preview_session_title(
+    command: String,
+    args: Vec<String>,
+    prompt: Option<String>,
+    first_user_message: String,
+) -> AppResult<String> {
+    run_blocking("preview_session_title", move || {
+        let first_user_message = first_user_message.trim().to_string();
+        if first_user_message.is_empty() {
+            return Err(AppError::Other(
+                "first user message must not be empty".to_string(),
+            ));
+        }
+        crate::session_titles::generate_title(
+            &command,
+            &args,
+            prompt.as_deref(),
+            &first_user_message,
+        )
+    })
+    .await
 }
 
 /// Re-point a session at a new worktree directory and persist the change.
@@ -2956,7 +3111,10 @@ mod tests {
         init_repo_with_commit(&repo_dir);
         let (_name, path) =
             create_unique_worktree(&repo_dir, "external").expect("worktree should be created");
-        assert!(path.exists(), "linked project root should exist before removal");
+        assert!(
+            path.exists(),
+            "linked project root should exist before removal"
+        );
 
         remove_linked_worktree_at_path(&path, &path).expect("remove linked project root by path");
 

--- a/src-tauri/src/daemon_commands.rs
+++ b/src-tauri/src/daemon_commands.rs
@@ -316,6 +316,7 @@ pub fn daemon_adopt_session(
         created_at: now,
         updated_at: now,
         last_message: None,
+        title_source: acorn_session::SessionTitleSource::Manual,
         kind,
         owner: acorn_session::SessionOwner::User,
         position: None,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod agent_hooks;
 mod agent_resume;
 mod agent_resume_persister;
 mod agent_wrappers;
+mod ai;
 mod cli_resolver;
 mod commands;
 mod daemon_bridge;
@@ -16,6 +17,7 @@ mod persistence;
 pub mod pty_env;
 mod pty_output;
 mod pull_requests;
+mod session_titles;
 mod shell_args;
 mod shell_env;
 mod shell_init;
@@ -495,6 +497,9 @@ pub fn run() {
             commands::remove_session,
             commands::set_session_status,
             commands::rename_session,
+            commands::session_title_readiness,
+            commands::generate_session_title,
+            commands::preview_session_title,
             commands::list_projects,
             commands::add_project,
             commands::create_new_project,

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -1644,7 +1644,7 @@ pub fn generate_pr_commit_message(
 
     let (view, diff) = context;
     let prompt = build_commit_message_prompt(method, &view, &diff);
-    let raw = run_ai_oneshot(&command, &args, &prompt)?;
+    let raw = crate::ai::run_oneshot(&command, &args, &prompt, "Settings → Agents")?;
     Ok(parse_commit_message_response(&raw))
 }
 
@@ -1701,67 +1701,6 @@ fn parse_commit_message_response(raw: &str) -> GeneratedCommitMessage {
     let remaining: String = lines.collect::<Vec<_>>().join("\n");
     let body = remaining.trim_start_matches('\n').trim().to_string();
     GeneratedCommitMessage { title, body }
-}
-
-/// Provider-agnostic one-shot CLI invocation: `command` is spawned with
-/// `args`, the prompt is piped in via stdin, and stdout is returned. We
-/// surface a typed error when the binary is missing so the frontend can
-/// point the user at install instructions for the configured provider.
-///
-/// Routes through `cli_resolver` so user-installed AI CLIs (claude, gemini,
-/// ollama, llm, …) resolve correctly even under the sanitized PATH that
-/// macOS hands GUI-launched apps.
-fn run_ai_oneshot(command: &str, args: &[String], prompt: &str) -> AppResult<String> {
-    use std::io::Write;
-    use std::process::Stdio;
-
-    let resolved = cli_resolver::resolve(command).map_err(|_| {
-        AppError::Other(format!(
-            "`{command}` not found. Install the configured AI CLI or change the provider in Settings → Commit message AI."
-        ))
-    })?;
-    let mut child = Command::new(&resolved)
-        .args(args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                cli_resolver::invalidate(command);
-                AppError::Other(format!(
-                    "`{command}` not found. Install the configured AI CLI or change the provider in Settings → Commit message AI."
-                ))
-            } else {
-                AppError::Other(format!("failed to invoke {command}: {e}"))
-            }
-        })?;
-
-    {
-        let stdin = child
-            .stdin
-            .as_mut()
-            .ok_or_else(|| AppError::Other(format!("{command} stdin missing")))?;
-        stdin
-            .write_all(prompt.as_bytes())
-            .map_err(|e| AppError::Other(format!("failed to write to {command}: {e}")))?;
-    }
-
-    let output = child
-        .wait_with_output()
-        .map_err(|e| AppError::Other(format!("failed waiting for {command}: {e}")))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let msg = if stderr.is_empty() {
-            format!("{command} exited with status {}", output.status)
-        } else {
-            stderr
-        };
-        return Err(AppError::Other(msg));
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 /// Single GitHub Actions workflow run. Mirrors the fields the Actions tab

--- a/src-tauri/src/session_titles.rs
+++ b/src-tauri/src/session_titles.rs
@@ -1,0 +1,189 @@
+use std::path::PathBuf;
+
+use acorn_session::{Session, SessionKind, SessionOwner, SessionTitleSource};
+
+use crate::agent_history::{self, AgentHistoryProvider};
+use crate::agent_resume;
+use crate::error::{AppError, AppResult};
+use crate::todos;
+
+const TITLE_INPUT_CHARS: usize = 2_000;
+const GENERATED_TITLE_CHARS: usize = 29;
+const SESSION_TITLE_PROMPT_CHARS: usize = 1_000;
+
+pub const DEFAULT_SESSION_TITLE_PROMPT: &str = "\
+You are naming an Acorn terminal tab from the user's first agent prompt.
+
+Return only a concise title for the tab.
+Rules:
+- 2 to 5 words.
+- Separate each word with hyphens.
+- Use lowercase words only.
+- Fewer than 30 characters.
+- No quotes, Markdown, trailing punctuation, or extra commentary.
+- Prefer the concrete task over generic words like \"help\" or \"question\".
+";
+
+pub fn can_generate_title(session: &Session) -> bool {
+    session.kind == SessionKind::Regular
+        && matches!(session.owner, SessionOwner::User)
+        && session.title_source == SessionTitleSource::Default
+}
+
+pub fn build_prompt(prompt: Option<&str>, first_user_message: &str) -> String {
+    let header = effective_prompt(prompt);
+    format!("{header}\nFirst user prompt:\n{first_user_message}\n")
+}
+
+fn effective_prompt(prompt: Option<&str>) -> String {
+    let raw = prompt.unwrap_or(DEFAULT_SESSION_TITLE_PROMPT);
+    let prompt = if raw.trim().is_empty() {
+        DEFAULT_SESSION_TITLE_PROMPT
+    } else {
+        raw
+    };
+    prompt.chars().take(SESSION_TITLE_PROMPT_CHARS).collect()
+}
+
+pub fn resolve_first_user_message(session_id: uuid::Uuid) -> Option<String> {
+    let (path, provider) = resolve_transcript(session_id)?;
+    agent_history::transcript_first_user_message(provider, &path, TITLE_INPUT_CHARS)
+}
+
+pub fn normalize_generated_title(raw: &str) -> Option<String> {
+    let line = raw
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())?
+        .trim_matches(|c: char| {
+            c.is_whitespace()
+                || matches!(
+                    c,
+                    '"' | '\'' | '`' | '*' | '#' | '-' | ':' | '.' | '!' | '?'
+                )
+        });
+    let collapsed = line.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() {
+        return None;
+    }
+    let mut out = collapsed
+        .chars()
+        .take(GENERATED_TITLE_CHARS)
+        .collect::<String>();
+    out = out
+        .trim()
+        .trim_end_matches(['.', '!', '?', ':'])
+        .to_string();
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+pub fn generate_title(
+    command: &str,
+    args: &[String],
+    prompt: Option<&str>,
+    first_user_message: &str,
+) -> AppResult<String> {
+    if command.trim().is_empty() {
+        return Err(AppError::Other(
+            "No AI command configured. Open Settings → Agents to pick a provider.".to_string(),
+        ));
+    }
+    let prompt = build_prompt(prompt, first_user_message);
+    let raw = crate::ai::run_oneshot(command, args, &prompt, "Settings → Agents")?;
+    normalize_generated_title(&raw)
+        .ok_or_else(|| AppError::Other("AI returned an empty session title.".to_string()))
+}
+
+fn resolve_transcript(session_id: uuid::Uuid) -> Option<(PathBuf, AgentHistoryProvider)> {
+    if let Some(live) = agent_resume::live_transcript(session_id) {
+        let provider = match live.kind {
+            agent_resume::AgentKind::Claude => AgentHistoryProvider::Claude,
+            agent_resume::AgentKind::Codex => AgentHistoryProvider::Codex,
+        };
+        return Some((live.path, provider));
+    }
+
+    todos::locate_transcript_for(&session_id.to_string())
+        .ok()
+        .flatten()
+        .map(|path| (path, AgentHistoryProvider::Claude))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use acorn_session::{Session, SessionKind};
+
+    #[test]
+    fn prompt_contains_first_user_message_and_rules() {
+        let prompt = build_prompt(None, "Fix the release workflow failure");
+
+        assert!(prompt.contains("2 to 5 words"));
+        assert!(prompt.contains("Separate each word with hyphens"));
+        assert!(prompt.contains("Use lowercase words only"));
+        assert!(prompt.contains("Fix the release workflow failure"));
+    }
+
+    #[test]
+    fn prompt_uses_custom_instructions() {
+        let prompt = build_prompt(
+            Some("Name this tab in Korean. Return only the title."),
+            "Fix the release workflow failure",
+        );
+
+        assert!(prompt.contains("Name this tab in Korean"));
+        assert!(prompt.contains("Fix the release workflow failure"));
+    }
+
+    #[test]
+    fn blank_prompt_falls_back_to_default_instructions() {
+        let prompt = build_prompt(Some("  \n  "), "Fix the release workflow failure");
+
+        assert!(prompt.contains("2 to 5 words"));
+        assert!(prompt.contains("Separate each word with hyphens"));
+        assert!(prompt.contains("Fix the release workflow failure"));
+    }
+
+    #[test]
+    fn normalize_generated_title_keeps_titles_under_thirty_chars() {
+        let title = normalize_generated_title("Investigate release workflow regression").unwrap();
+
+        assert!(title.chars().count() < 30);
+    }
+
+    #[test]
+    fn normalize_generated_title_strips_wrapper_text() {
+        assert_eq!(
+            normalize_generated_title("\"Fix Release Workflow.\"").as_deref(),
+            Some("Fix Release Workflow")
+        );
+        assert_eq!(
+            normalize_generated_title("### Investigate Codex Resume\nextra").as_deref(),
+            Some("Investigate Codex Resume")
+        );
+    }
+
+    #[test]
+    fn generation_is_limited_to_user_owned_default_regular_sessions() {
+        let mut session = Session::new(
+            "repo".to_string(),
+            PathBuf::from("/tmp/repo"),
+            PathBuf::from("/tmp/repo"),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        assert!(can_generate_title(&session));
+
+        session.title_source = SessionTitleSource::Manual;
+        assert!(!can_generate_title(&session));
+
+        session.title_source = SessionTitleSource::Default;
+        session.owner = SessionOwner::control(uuid::Uuid::new_v4());
+        assert!(!can_generate_title(&session));
+    }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -90,6 +90,63 @@
   background: var(--color-terminal-bg, #1f2326);
 }
 
+.acorn-session-title-indicator {
+  position: relative;
+  display: inline-flex;
+  width: 0.875rem;
+  height: 0.875rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-accent);
+  border-radius: 9999px;
+  background: color-mix(in oklab, var(--color-accent) 14%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in oklab, var(--color-accent) 36%, transparent),
+    0 0 8px color-mix(in oklab, var(--color-accent) 24%, transparent);
+}
+
+.acorn-session-title-indicator::after {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  border: 1px solid transparent;
+  border-top-color: color-mix(in oklab, var(--color-accent) 90%, transparent);
+  border-right-color: color-mix(in oklab, var(--color-accent) 45%, transparent);
+  animation: acorn-title-orbit 0.9s linear infinite;
+}
+
+.acorn-session-title-indicator-icon {
+  animation: acorn-title-twinkle 1.1s ease-in-out infinite;
+}
+
+@keyframes acorn-title-orbit {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes acorn-title-twinkle {
+  0%,
+  100% {
+    transform: scale(0.88);
+    opacity: 0.72;
+  }
+
+  45% {
+    transform: scale(1.08);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .acorn-session-title-indicator::after,
+  .acorn-session-title-indicator-icon {
+    animation: none;
+  }
+}
+
 :root[data-bg-terminal="on"] .acorn-terminal-shell {
   background: color-mix(
     in srgb,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,9 +61,12 @@ import { useUpdater } from "./lib/updater-store";
 import { shouldShowPermissionWarmup } from "./lib/permissionWarmup";
 import {
   normalizeUiScalePercent,
+  resolveAiOneshotCommand,
+  resolveSessionTitlePrompt,
   UI_SCALE_PERCENT_STEP,
   useSettings,
 } from "./lib/settings";
+import { planAutoGenerateSessionTitles } from "./lib/sessionTitle";
 import { applyBackgroundVars, clearBackgroundVars } from "./lib/background";
 import { applyTheme, useThemes } from "./lib/themes";
 import { extractTabFromEvent } from "./lib/settings-events";
@@ -79,6 +82,8 @@ import { useTranslation } from "./lib/useTranslation";
 
 const FOCUSABLE_SELECTOR =
   "textarea, input:not([type='hidden']), button, [tabindex]:not([tabindex='-1']), a[href]";
+const SESSION_TITLE_RETRY_MS = 30_000;
+const SESSION_TITLE_NOT_READY_RETRY_MS = 1_000;
 
 const SIDEBAR_DEFAULT_SIZE = 18;
 const SIDEBAR_MIN_SIZE = 12;
@@ -157,6 +162,7 @@ function App() {
   const autoDeleteWorktrees = useSettings(
     (s) => s.settings.sessions.autoDeleteWorktrees,
   );
+  const settings = useSettings((s) => s.settings);
   const pendingRemove = sessions.find((s) => s.id === pendingRemoveId) ?? null;
   const pendingProject =
     projects.find((p) => p.repo_path === pendingRemoveProject) ?? null;
@@ -180,6 +186,12 @@ function App() {
   const [resumeCandidates, setResumeCandidates] = useState<
     Map<string, { agent: AgentKind; candidate: ResumeCandidate }>
   >(new Map());
+  const titleGenerationInFlightRef = useRef<Set<string>>(new Set());
+  const titleGenerationLastAttemptAtRef = useRef<Map<string, number>>(
+    new Map(),
+  );
+  const titleGenerationConfigKeyRef = useRef<string | null>(null);
+  const [sessionTitleRetryTick, setSessionTitleRetryTick] = useState(0);
   const [stagedRevMismatch, setStagedRevMismatch] =
     useState<StagedRevMismatch | null>(null);
 
@@ -548,6 +560,110 @@ function App() {
   useEffect(() => {
     return startSessionNotificationWatcher();
   }, []);
+
+  useEffect(() => {
+    if (!settings.agents.autoGenerateSessionTitles) return;
+
+    let cancelled = false;
+    const retryTimers = new Set<ReturnType<typeof window.setTimeout>>();
+    const scheduleRetryTick = (delayMs: number, allowAfterCleanup = false) => {
+      if (cancelled && !allowAfterCleanup) return;
+      const fireAfterCleanup = allowAfterCleanup;
+      const timeout = window.setTimeout(() => {
+        retryTimers.delete(timeout);
+        if (!cancelled || fireAfterCleanup) {
+          setSessionTitleRetryTick((tick) => tick + 1);
+        }
+      }, delayMs);
+      retryTimers.add(timeout);
+    };
+
+    const now = Date.now();
+    const { command, args } = resolveAiOneshotCommand(settings);
+    const prompt = resolveSessionTitlePrompt(settings);
+    const configKey = JSON.stringify([command, args, prompt]);
+    const inFlight = titleGenerationInFlightRef.current;
+    const lastAttemptAt = titleGenerationLastAttemptAtRef.current;
+    const latestTitleConfigMatches = () => {
+      const latestSettings = useSettings.getState().settings;
+      const latestCommand = resolveAiOneshotCommand(latestSettings);
+      const latestPrompt = resolveSessionTitlePrompt(latestSettings);
+      const latestConfigKey = JSON.stringify([
+        latestCommand.command,
+        latestCommand.args,
+        latestPrompt,
+      ]);
+      return (
+        latestSettings.agents.autoGenerateSessionTitles &&
+        latestConfigKey === configKey
+      );
+    };
+    const scheduleAfterStatus = (
+      sessionId: string,
+      status: "not_ready" | "skipped",
+    ) => {
+      if (status === "not_ready") {
+        lastAttemptAt.delete(sessionId);
+        scheduleRetryTick(SESSION_TITLE_NOT_READY_RETRY_MS, true);
+        return;
+      }
+      lastAttemptAt.set(sessionId, Date.now());
+      scheduleRetryTick(SESSION_TITLE_RETRY_MS, true);
+    };
+    if (titleGenerationConfigKeyRef.current !== configKey) {
+      titleGenerationConfigKeyRef.current = configKey;
+      lastAttemptAt.clear();
+    }
+    const plan = planAutoGenerateSessionTitles({
+      sessions,
+      enabled: settings.agents.autoGenerateSessionTitles,
+      inFlightIds: inFlight,
+      lastAttemptAt,
+      now,
+      retryMs: SESSION_TITLE_RETRY_MS,
+    });
+
+    for (const sessionId of plan.sessionIds) {
+      inFlight.add(sessionId);
+      void api
+        .sessionTitleReadiness(sessionId)
+        .then(async (readiness) => {
+          if (!latestTitleConfigMatches()) return;
+          if (readiness.status !== "ready") {
+            scheduleAfterStatus(sessionId, readiness.status);
+            return;
+          }
+
+          const status = await useAppStore
+            .getState()
+            .generateSessionTitle(sessionId, command, args, prompt);
+          if (!latestTitleConfigMatches()) return;
+          if (status !== "generated") {
+            scheduleAfterStatus(sessionId, status);
+          }
+        })
+        .catch((err) => {
+          console.warn("[acorn] session title readiness failed", err);
+          if (!latestTitleConfigMatches()) return;
+          scheduleAfterStatus(sessionId, "skipped");
+        })
+        .finally(() => {
+          inFlight.delete(sessionId);
+        });
+    }
+
+    if (plan.retryDelayMs !== null) {
+      scheduleRetryTick(plan.retryDelayMs);
+    }
+
+    return () => {
+      cancelled = true;
+      for (const timeout of retryTimers) {
+        window.clearTimeout(timeout);
+      }
+      retryTimers.clear();
+    };
+  }, [sessions, settings, sessionTitleRetryTick]);
 
   useEffect(() => {
     let dispose: (() => void) | null = null;

--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -61,6 +61,7 @@ function session(id: string, overrides: Partial<Session> = {}): Session {
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     last_message: null,
+    title_source: "default",
     kind: "regular",
     owner: { kind: "user" },
     position: null,
@@ -99,6 +100,7 @@ function resetStore(): void {
       pendingRemoveProject: null,
       sessionsLoadedCleanly: true,
       liveInWorktree: {},
+      generatingSessionTitleIds: {},
     },
     false,
   );
@@ -231,5 +233,96 @@ describe("Pane empty state", () => {
       null,
       false,
     );
+  });
+
+  it("shows a session-title generation indicator on the tab", async () => {
+    const active = session("agent-session", { agent_provider: "codex" });
+    useAppStore.setState((s) => ({
+      ...s,
+      sessions: [active],
+      activeProject: REPO,
+      activeSessionId: active.id,
+      activeTabId: active.id,
+      generatingSessionTitleIds: { [active.id]: true },
+      workspaces: {
+        ...s.workspaces,
+        [REPO]: {
+          layout: { kind: "pane", id: "root" },
+          panes: {
+            root: {
+              id: "root",
+              tabIds: [active.id],
+              activeTabId: active.id,
+            },
+          },
+          focusedPaneId: "root",
+        },
+      },
+      panes: {
+        root: {
+          id: "root",
+          tabIds: [active.id],
+          activeTabId: active.id,
+        },
+      },
+    }));
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+
+    expect(
+      container.querySelector('[aria-label="Generating session title"]'),
+    ).toBeInstanceOf(HTMLElement);
+  });
+
+  it("does not enter tab rename while title generation is active", async () => {
+    const active = session("agent-session", { agent_provider: "codex" });
+    useAppStore.setState((s) => ({
+      ...s,
+      sessions: [active],
+      activeProject: REPO,
+      activeSessionId: active.id,
+      activeTabId: active.id,
+      generatingSessionTitleIds: { [active.id]: true },
+      workspaces: {
+        ...s.workspaces,
+        [REPO]: {
+          layout: { kind: "pane", id: "root" },
+          panes: {
+            root: {
+              id: "root",
+              tabIds: [active.id],
+              activeTabId: active.id,
+            },
+          },
+          focusedPaneId: "root",
+        },
+      },
+      panes: {
+        root: {
+          id: "root",
+          tabIds: [active.id],
+          activeTabId: active.id,
+        },
+      },
+    }));
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+
+    const dragHandle = container.querySelector(
+      `[data-tab-drag-handle="${active.id}"]`,
+    );
+    const tab = dragHandle?.closest('[role="button"]');
+
+    await act(async () => {
+      tab?.dispatchEvent(
+        new MouseEvent("dblclick", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(container.querySelector("[data-tab-rename-input]")).toBeNull();
   });
 });

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -49,6 +49,7 @@ import {
 import { formatHotkey, Hotkeys } from "../lib/hotkeys";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import { useSettings } from "../lib/settings";
+import { canRenameSession } from "../lib/sessionTitle";
 import { hasRecordedWorktree } from "../lib/sessionWorktree";
 import { useTranslation } from "../lib/useTranslation";
 import {
@@ -60,6 +61,7 @@ import {
 import type { Direction, PaneId } from "../lib/layout";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { PaneDropOverlay } from "./PaneDropOverlay";
+import { SessionTitleGeneratingIndicator } from "./SessionTitleGeneratingIndicator";
 import { Tooltip } from "./Tooltip";
 import type {
   Session,
@@ -730,6 +732,12 @@ function TabItem({
   const t = useTranslation();
   const renameSession = useAppStore((s) => s.renameSession);
   const session = tab.kind === "session" ? tab.session : null;
+  const isGeneratingTitle = useAppStore((s) =>
+    session ? Boolean(s.generatingSessionTitleIds[session.id]) : false,
+  );
+  const canRename = session
+    ? canRenameSession(session, { isGeneratingTitle })
+    : false;
   const showAgentProviderIcons = useSettings(
     (s) => s.settings.sessionDisplay.icons.agentProvider,
   );
@@ -778,6 +786,10 @@ function TabItem({
     };
   }, [menu, session]);
 
+  useEffect(() => {
+    if (isGeneratingTitle && editing) setEditing(false);
+  }, [editing, isGeneratingTitle]);
+
   const forkItems: ContextMenuItem[] = (() => {
     if (!agent || !onFork) return [];
     const items: ContextMenuItem[] = [];
@@ -824,7 +836,7 @@ function TabItem({
       label: paneT(t, "pane.menu.rename"),
       icon: <Pencil size={12} />,
       onClick: () => setEditing(true),
-      disabled: !session,
+      disabled: !canRename,
     },
     {
       label: paneT(t, "pane.menu.duplicateSession"),
@@ -947,7 +959,7 @@ function TabItem({
         onClick={editing ? undefined : onSelect}
         onDoubleClick={(e) => {
           e.stopPropagation();
-          if (session) setEditing(true);
+          if (canRename) setEditing(true);
         }}
         onContextMenu={(e) => {
           e.preventDefault();
@@ -964,7 +976,7 @@ function TabItem({
             onSelect();
           } else if (e.key === "F2") {
             e.preventDefault();
-            if (session) setEditing(true);
+            if (canRename) setEditing(true);
           }
         }}
         className={cn(
@@ -1007,17 +1019,24 @@ function TabItem({
               initial={tab.title}
               onSubmit={async (next) => {
                 setEditing(false);
-                if (session && next && next !== session.name) {
+                if (session && canRename && next && next !== session.name) {
                   await renameSession(session.id, next);
                 }
               }}
               onCancel={() => setEditing(false)}
             />
           ) : (
-            <span className="pointer-events-none max-w-[12rem] truncate leading-5">
+            <span
+              className="pointer-events-none max-w-[12rem] truncate leading-5"
+            >
               {tab.title}
             </span>
           )}
+          {isGeneratingTitle && !editing ? (
+            <SessionTitleGeneratingIndicator
+              label={paneT(t, "pane.aria.generatingSessionTitle")}
+            />
+          ) : null}
           {session &&
           (liveInWorktree ?? hasRecordedWorktree(session)) ? (
             <GitBranch

--- a/src/components/RemoveSessionDialog.test.tsx
+++ b/src/components/RemoveSessionDialog.test.tsx
@@ -17,6 +17,7 @@ function session(overrides: Partial<Session> = {}): Session {
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     last_message: null,
+    title_source: "default",
     kind: "regular",
     owner: { kind: "user" },
     position: null,

--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -321,6 +321,7 @@ describe("RightPanel background tab loading", () => {
           created_at: "2026-01-01T00:00:00Z",
           updated_at: "2026-01-01T00:00:00Z",
           last_message: null,
+          title_source: "default",
           kind: "regular",
           owner: { kind: "user" },
           position: null,

--- a/src/components/SessionTitleGeneratingIndicator.tsx
+++ b/src/components/SessionTitleGeneratingIndicator.tsx
@@ -1,0 +1,31 @@
+import { Sparkles } from "lucide-react";
+import { cn } from "../lib/cn";
+import { Tooltip } from "./Tooltip";
+
+interface SessionTitleGeneratingIndicatorProps {
+  label: string;
+  side?: "top" | "bottom" | "left" | "right";
+  className?: string;
+}
+
+export function SessionTitleGeneratingIndicator({
+  label,
+  side = "bottom",
+  className,
+}: SessionTitleGeneratingIndicatorProps) {
+  return (
+    <Tooltip label={label} side={side}>
+      <span
+        role="img"
+        aria-label={label}
+        className={cn("acorn-session-title-indicator", className)}
+      >
+        <Sparkles
+          size={9}
+          aria-hidden="true"
+          className="acorn-session-title-indicator-icon"
+        />
+      </span>
+    </Tooltip>
+  );
+}

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -7,10 +7,20 @@ const mocks = vi.hoisted(() => ({
     (name: string, bytes: Uint8Array) => Promise<{ relativePath: string; fileName: string }>
   >(),
   removeBackgroundImage: vi.fn<() => Promise<void>>(),
+  previewSessionTitle: vi.fn<
+    (
+      command: string,
+      args: string[],
+      prompt: string,
+      firstUserMessage: string,
+    ) => Promise<string>
+  >(),
 }));
 
 vi.mock("../lib/api", () => ({
-  api: {},
+  api: {
+    previewSessionTitle: mocks.previewSessionTitle,
+  },
 }));
 
 vi.mock("../lib/background", () => ({
@@ -67,8 +77,15 @@ vi.mock("../lib/updater-store", () => ({
   }),
 }));
 
-import { DEFAULT_SETTINGS, useSettings } from "../lib/settings";
+import { api } from "../lib/api";
+import {
+  DEFAULT_SETTINGS,
+  SESSION_TITLE_PROMPT_PREVIEW_MESSAGE,
+  useSettings,
+} from "../lib/settings";
 import { SettingsModal } from "./SettingsModal";
+
+const mockApi = vi.mocked(api);
 
 function cloneSettings() {
   return structuredClone(DEFAULT_SETTINGS);
@@ -111,6 +128,35 @@ function openTerminalTab() {
   }
   act(() => {
     button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+function openAgentsTab() {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (element) =>
+      element.textContent === "Agents" || element.textContent === "에이전트",
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error("Agents tab button not found");
+  }
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+async function openSessionTitlePromptDialog() {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (element) =>
+      element.getAttribute("aria-label") === "Configure title prompt" ||
+      element.getAttribute("aria-label") === "제목 프롬프트 설정",
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error("Session title prompt settings button not found");
+  }
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
   });
 }
 
@@ -421,6 +467,141 @@ describe("SettingsModal font controls", () => {
     expect(patchSessions).toHaveBeenCalledWith({
       autoDeleteWorktrees: true,
     });
+  });
+
+  it("patches the automatic session title agent toggle", async () => {
+    const patchAgents = vi.fn();
+    useSettings.setState({
+      settings: cloneSettings(),
+      patchAgents,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openAgentsTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const toggle = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    ).find((input) =>
+      input
+        .closest("label")
+        ?.textContent?.includes("Auto-generate session titles"),
+    );
+
+    expect(document.body.textContent).toContain("Session titles");
+    expect(
+      document.querySelector<HTMLTextAreaElement>(
+        'textarea[aria-label="Session title prompt"]',
+      ),
+    ).toBeNull();
+    expect(
+      Array.from(document.querySelectorAll("button")).find(
+        (button) =>
+          button.getAttribute("aria-label") === "Configure title prompt",
+      ),
+    ).toBeInstanceOf(HTMLButtonElement);
+    expect(toggle).toBeInstanceOf(HTMLInputElement);
+    expect(toggle?.checked).toBe(false);
+
+    act(() => {
+      toggle?.click();
+    });
+
+    expect(patchAgents).toHaveBeenCalledWith({
+      autoGenerateSessionTitles: true,
+    });
+  });
+
+  it("patches and resets the session title prompt", async () => {
+    const patchAgents = vi.fn();
+    useSettings.setState({
+      settings: {
+        ...cloneSettings(),
+        agents: {
+          ...cloneSettings().agents,
+          sessionTitlePrompt: "Custom naming instructions",
+        },
+      },
+      patchAgents,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openAgentsTab();
+    await openSessionTitlePromptDialog();
+
+    const textarea = document.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Session title prompt"]',
+    );
+    expect(textarea).toBeInstanceOf(HTMLTextAreaElement);
+    expect(textarea?.value).toBe("Custom naming instructions");
+
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(textarea, "Name the tab in Korean.");
+      textarea?.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(patchAgents).toHaveBeenCalledWith({
+      sessionTitlePrompt: "Name the tab in Korean.",
+    });
+
+    const reset = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Reset prompt"),
+    );
+    expect(reset).toBeInstanceOf(HTMLButtonElement);
+
+    act(() => {
+      reset?.click();
+    });
+
+    expect(patchAgents).toHaveBeenCalledWith({
+      sessionTitlePrompt: DEFAULT_SETTINGS.agents.sessionTitlePrompt,
+    });
+  });
+
+  it("generates a session title prompt preview", async () => {
+    mockApi.previewSessionTitle.mockResolvedValueOnce("Preview Tab Titles");
+    useSettings.setState({
+      settings: cloneSettings(),
+      patchAgents: vi.fn(),
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openAgentsTab();
+    await openSessionTitlePromptDialog();
+
+    const generate = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Generate preview"),
+    );
+    expect(generate).toBeInstanceOf(HTMLButtonElement);
+
+    await act(async () => {
+      generate?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockApi.previewSessionTitle).toHaveBeenCalledWith(
+      "claude",
+      ["-p", "--output-format", "text"],
+      DEFAULT_SETTINGS.agents.sessionTitlePrompt,
+      SESSION_TITLE_PROMPT_PREVIEW_MESSAGE,
+    );
+    expect(document.body.textContent).toContain("Preview Tab Titles");
   });
 
   it("patches the GitHub PR row display toggles", async () => {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -3,6 +3,7 @@ import {
   FolderOpen,
   ImagePlus,
   Keyboard,
+  Loader2,
   RefreshCcw,
   Settings as SettingsIcon,
   Sparkles,
@@ -35,7 +36,12 @@ import { BackgroundSessionsSettings } from "./BackgroundSessionsSettings";
 import { WhatsNewModal } from "./WhatsNewModal";
 import {
   AGENT_OPTIONS,
+  DEFAULT_SESSION_TITLE_PROMPT,
   PR_REFRESH_INTERVAL_OPTIONS,
+  resolveAiOneshotCommand,
+  resolveSessionTitlePrompt,
+  SESSION_TITLE_PROMPT_PREVIEW_MESSAGE,
+  SESSION_TITLE_PROMPT_MAX_CHARS,
   SESSION_TITLE_OPTIONS,
   type SelectedAgent,
   type SessionTitleSource,
@@ -279,6 +285,12 @@ function stf(
   );
 }
 
+function messageFromUnknownError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "Unknown error";
+}
+
 export function SettingsModal() {
   const open = useSettings((s) => s.open);
   const setOpen = useSettings((s) => s.setOpen);
@@ -286,6 +298,7 @@ export function SettingsModal() {
   const pendingTab = useSettings((s) => s.pendingTab);
   const consumePendingTab = useSettings((s) => s.consumePendingTab);
   const [tab, setTab] = useState<Tab>("interface");
+  const [sessionTitlePromptOpen, setSessionTitlePromptOpen] = useState(false);
   const t = useTranslation();
 
   // When the store reports a pending tab (e.g. StatusBar daemon button
@@ -303,9 +316,14 @@ export function SettingsModal() {
     }
   }, [open, pendingTab, consumePendingTab]);
 
+  useEffect(() => {
+    if (!open) setSessionTitlePromptOpen(false);
+  }, [open]);
+
   // Esc cancels, Enter (outside inputs) closes — settings autosave on every
-  // change so there is no separate confirm step.
-  useDialogShortcuts(open, {
+  // change so there is no separate confirm step. While a child settings dialog
+  // is open, let that dialog own Escape.
+  useDialogShortcuts(open && !sessionTitlePromptOpen, {
     onCancel: () => setOpen(false),
     onConfirm: () => setOpen(false),
   });
@@ -360,7 +378,10 @@ export function SettingsModal() {
           ) : tab === "terminal" ? (
             <TerminalSettings />
           ) : tab === "agents" ? (
-            <AgentSettings />
+            <AgentSettings
+              sessionTitlePromptOpen={sessionTitlePromptOpen}
+              onSessionTitlePromptOpenChange={setSessionTitlePromptOpen}
+            />
           ) : tab === "sessions" ? (
             <SessionSettings />
           ) : tab === "services" ? (
@@ -1523,7 +1544,15 @@ function NotificationSettings() {
   );
 }
 
-function AgentSettings() {
+interface AgentSettingsProps {
+  sessionTitlePromptOpen: boolean;
+  onSessionTitlePromptOpenChange: (open: boolean) => void;
+}
+
+function AgentSettings({
+  sessionTitlePromptOpen,
+  onSessionTitlePromptOpenChange,
+}: AgentSettingsProps) {
   const settings = useSettings((s) => s.settings);
   const patchAgents = useSettings((s) => s.patchAgents);
   const t = useTranslation();
@@ -1602,10 +1631,220 @@ function AgentSettings() {
           />
         </Field>
       ) : null}
+      <Field
+        label={st(t, "settings.agents.sessionTitles.label")}
+        hint={st(t, "settings.agents.sessionTitles.hint")}
+      >
+        <div className="flex items-center justify-between gap-3">
+          <label className="flex min-w-0 items-center gap-2 text-xs text-fg">
+            <input
+              type="checkbox"
+              checked={settings.agents.autoGenerateSessionTitles}
+              onChange={(e) =>
+                patchAgents({ autoGenerateSessionTitles: e.target.checked })
+              }
+              className="accent-[var(--color-accent)]"
+            />
+            <span className="truncate">
+              {st(t, "settings.agents.sessionTitles.checkbox")}
+            </span>
+          </label>
+          <button
+            type="button"
+            aria-haspopup="dialog"
+            aria-expanded={sessionTitlePromptOpen}
+            aria-label={st(t, "settings.agents.sessionTitlePrompt.open")}
+            title={st(t, "settings.agents.sessionTitlePrompt.open")}
+            onClick={() => onSessionTitlePromptOpenChange(true)}
+            className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border bg-bg px-2 text-[11px] font-medium text-fg-muted transition hover:border-accent/60 hover:bg-bg-elevated hover:text-fg"
+          >
+            <SettingsIcon size={12} />
+            {st(t, "settings.agents.sessionTitlePrompt.shortButton")}
+          </button>
+        </div>
+      </Field>
+      <SessionTitlePromptModal
+        open={sessionTitlePromptOpen}
+        onClose={() => onSessionTitlePromptOpenChange(false)}
+      />
       <p className="text-[11px] text-fg-muted">
         {st(t, "settings.agents.requirement")}
       </p>
     </section>
+  );
+}
+
+type SessionTitlePreviewState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; title: string }
+  | { status: "error"; message?: string };
+
+interface SessionTitlePromptModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+function SessionTitlePromptModal({
+  open,
+  onClose,
+}: SessionTitlePromptModalProps) {
+  const settings = useSettings((s) => s.settings);
+  const patchAgents = useSettings((s) => s.patchAgents);
+  const t = useTranslation();
+  const sessionTitlePromptLength = Array.from(
+    settings.agents.sessionTitlePrompt,
+  ).length;
+  const [titlePreview, setTitlePreview] = useState<SessionTitlePreviewState>({
+    status: "idle",
+  });
+
+  useDialogShortcuts(open, {
+    onCancel: onClose,
+  });
+
+  useEffect(() => {
+    setTitlePreview({ status: "idle" });
+  }, [
+    open,
+    settings.agents.selected,
+    settings.agents.customCommand,
+    settings.agents.ollama.model,
+    settings.agents.llm.model,
+    settings.agents.sessionTitlePrompt,
+  ]);
+
+  async function handlePreviewSessionTitle() {
+    setTitlePreview({ status: "loading" });
+    const { command, args } = resolveAiOneshotCommand(settings);
+    const prompt = resolveSessionTitlePrompt(settings);
+    try {
+      const title = await api.previewSessionTitle(
+        command,
+        args,
+        prompt,
+        SESSION_TITLE_PROMPT_PREVIEW_MESSAGE,
+      );
+      setTitlePreview({ status: "success", title });
+    } catch (error) {
+      setTitlePreview({
+        status: "error",
+        message: messageFromUnknownError(error),
+      });
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      variant="dialog"
+      size="xl"
+      ariaLabelledBy="session-title-prompt-title"
+      className="max-h-[calc(100vh-8rem)]"
+    >
+      <ModalHeader
+        title={st(t, "settings.agents.sessionTitlePrompt.label")}
+        subtitle={st(t, "settings.agents.sessionTitlePrompt.hint")}
+        titleId="session-title-prompt-title"
+        icon={<SettingsIcon size={14} className="text-fg-muted" />}
+        variant="dialog"
+        onClose={onClose}
+      />
+      <div className="max-h-[calc(100vh-12rem)] overflow-y-auto p-4">
+        <Field
+          label={st(t, "settings.agents.sessionTitlePrompt.editorLabel")}
+        >
+          <div className="flex flex-col gap-2">
+            <textarea
+              aria-label={st(t, "settings.agents.sessionTitlePrompt.label")}
+              value={settings.agents.sessionTitlePrompt}
+              maxLength={SESSION_TITLE_PROMPT_MAX_CHARS}
+              spellCheck={false}
+              onChange={(e) =>
+                patchAgents({ sessionTitlePrompt: e.target.value })
+              }
+              className="min-h-40 w-full resize-y rounded-md border border-border bg-bg px-2 py-2 font-mono text-xs leading-relaxed text-fg outline-none focus:border-accent"
+            />
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-[11px] text-fg-muted">
+                {stf(t, "settings.agents.sessionTitlePrompt.count", {
+                  count: sessionTitlePromptLength,
+                  max: SESSION_TITLE_PROMPT_MAX_CHARS,
+                })}
+              </span>
+              <button
+                type="button"
+                onClick={() =>
+                  patchAgents({
+                    sessionTitlePrompt: DEFAULT_SESSION_TITLE_PROMPT,
+                  })
+                }
+                disabled={
+                  settings.agents.sessionTitlePrompt ===
+                  DEFAULT_SESSION_TITLE_PROMPT
+                }
+                title={st(t, "settings.agents.sessionTitlePrompt.reset")}
+                className="inline-flex items-center gap-1 rounded-md border border-border bg-bg px-2 py-1 text-[11px] text-fg-muted transition hover:border-accent/60 hover:text-fg disabled:cursor-not-allowed disabled:opacity-45"
+              >
+                <RefreshCcw size={11} />
+                {st(t, "settings.agents.sessionTitlePrompt.reset")}
+              </button>
+            </div>
+            <div className="rounded-md border border-border bg-bg-sidebar/30 p-2">
+              <div className="mb-1 text-[11px] font-medium text-fg-muted">
+                {st(t, "settings.agents.sessionTitlePrompt.preview.sample")}
+              </div>
+              <p className="font-mono text-[11px] leading-relaxed text-fg">
+                {SESSION_TITLE_PROMPT_PREVIEW_MESSAGE}
+              </p>
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => void handlePreviewSessionTitle()}
+                  disabled={titlePreview.status === "loading"}
+                  className="inline-flex h-7 items-center gap-1.5 rounded-md border border-border bg-bg px-2.5 text-[11px] font-medium text-fg transition hover:border-accent/50 hover:bg-bg-elevated disabled:cursor-wait disabled:bg-bg-sidebar/40 disabled:text-fg-muted"
+                >
+                  {titlePreview.status === "loading" ? (
+                    <Loader2 size={12} className="animate-spin text-fg-muted" />
+                  ) : (
+                    <Sparkles size={12} className="text-accent" />
+                  )}
+                  {titlePreview.status === "loading"
+                    ? st(
+                        t,
+                        "settings.agents.sessionTitlePrompt.preview.generating",
+                      )
+                    : st(
+                        t,
+                        "settings.agents.sessionTitlePrompt.preview.generate",
+                      )}
+                </button>
+                {titlePreview.status === "success" && titlePreview.title ? (
+                  <div className="inline-flex h-7 max-w-full items-center gap-1 rounded-md border border-border bg-bg px-2 text-xs text-fg">
+                    <span className="text-[10px] text-fg-muted">
+                      {st(
+                        t,
+                        "settings.agents.sessionTitlePrompt.preview.result",
+                      )}
+                    </span>
+                    <span className="max-w-48 truncate font-medium">
+                      {titlePreview.title}
+                    </span>
+                  </div>
+                ) : null}
+              </div>
+              {titlePreview.status === "error" ? (
+                <p className="mt-2 text-[11px] text-danger">
+                  {st(t, "settings.agents.sessionTitlePrompt.preview.failed")}
+                  {titlePreview.message ? `: ${titlePreview.message}` : ""}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        </Field>
+      </div>
+    </Modal>
   );
 }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -55,6 +55,7 @@ import {
   type AcornSettings,
   type SessionTitleSource,
 } from "../lib/settings";
+import { canRenameSession } from "../lib/sessionTitle";
 import { hasRecordedWorktree } from "../lib/sessionWorktree";
 import { useTranslation } from "../lib/useTranslation";
 import {
@@ -78,6 +79,7 @@ import {
 import type { Session, SessionKind, SessionStatus } from "../lib/types";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { NewProjectDialog } from "./NewProjectDialog";
+import { SessionTitleGeneratingIndicator } from "./SessionTitleGeneratingIndicator";
 import { Tooltip } from "./Tooltip";
 
 const STATUS_DOT: Record<SessionStatus, string> = {
@@ -996,6 +998,10 @@ function SessionRow({
   const hoverDetails = sessionDisplay.showDetailsOnHover
     ? buildSessionHoverDetails(t, session)
     : null;
+  const isGeneratingTitle = useAppStore((s) =>
+    Boolean(s.generatingSessionTitleIds[session.id]),
+  );
+  const canRename = canRenameSession(session, { isGeneratingTitle });
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const {
@@ -1012,6 +1018,10 @@ function SessionRow({
     transform: CSS.Transform.toString(transform),
     transition,
   };
+
+  useEffect(() => {
+    if (isGeneratingTitle && editing) setEditing(false);
+  }, [editing, isGeneratingTitle]);
 
   async function duplicate() {
     const base = session.name;
@@ -1062,6 +1072,7 @@ function SessionRow({
       label: sidebarText(t, "sidebar.actions.rename"),
       icon: <Pencil size={12} />,
       onClick: () => setEditing(true),
+      disabled: !canRename,
     },
     {
       label: sidebarText(t, "sidebar.actions.duplicateSession"),
@@ -1159,7 +1170,7 @@ function SessionRow({
             onSelect();
           } else if (e.key === "F2") {
             e.preventDefault();
-            setEditing(true);
+            if (canRename) setEditing(true);
           }
         }}
         onContextMenu={(e) => {
@@ -1208,10 +1219,11 @@ function SessionRow({
           titleText={titleText}
           metadataText={metadataText}
           showKindIcons={sessionDisplay.icons.sessionKind}
+          isGeneratingTitle={isGeneratingTitle}
           t={t}
           onSubmitRename={async (next) => {
             setEditing(false);
-            if (next && next !== session.name) {
+            if (canRename && next && next !== session.name) {
               await renameSession(session.id, next);
             }
           }}
@@ -1265,6 +1277,7 @@ interface SessionRowLabelProps {
   titleText: string;
   metadataText: string;
   showKindIcons: boolean;
+  isGeneratingTitle: boolean;
   t: Translator;
   onSubmitRename: (value: string) => void | Promise<void>;
   onCancelRename: () => void;
@@ -1276,6 +1289,7 @@ function SessionRowLabel({
   titleText,
   metadataText,
   showKindIcons,
+  isGeneratingTitle,
   t,
   onSubmitRename,
   onCancelRename,
@@ -1300,6 +1314,12 @@ function SessionRowLabel({
             {titleText}
           </span>
         )}
+        {isGeneratingTitle && !editing ? (
+          <SessionTitleGeneratingIndicator
+            label={sidebarText(t, "sidebar.aria.generatingSessionTitle")}
+            side="right"
+          />
+        ) : null}
         {showKindIcons && inWorktree ? (
           <GitBranch
             size={10}
@@ -1513,6 +1533,10 @@ function LocalSessionRow({
   const hoverDetails = sessionDisplay.showDetailsOnHover
     ? buildSessionHoverDetails(t, session)
     : null;
+  const isGeneratingTitle = useAppStore((s) =>
+    Boolean(s.generatingSessionTitleIds[session.id]),
+  );
+  const canRename = canRenameSession(session, { isGeneratingTitle });
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const {
@@ -1529,6 +1553,10 @@ function LocalSessionRow({
     transform: CSS.Transform.toString(transform),
     transition,
   };
+
+  useEffect(() => {
+    if (isGeneratingTitle && editing) setEditing(false);
+  }, [editing, isGeneratingTitle]);
 
   async function duplicate() {
     const base = session.name;
@@ -1555,6 +1583,7 @@ function LocalSessionRow({
       label: sidebarText(t, "sidebar.actions.rename"),
       icon: <Pencil size={12} />,
       onClick: () => setEditing(true),
+      disabled: !canRename,
     },
     {
       label: sidebarText(t, "sidebar.actions.duplicateSession"),
@@ -1596,7 +1625,7 @@ function LocalSessionRow({
           onSelect();
         } else if (e.key === "F2") {
           e.preventDefault();
-          setEditing(true);
+          if (canRename) setEditing(true);
         }
       }}
       onContextMenu={(e) => {
@@ -1645,10 +1674,11 @@ function LocalSessionRow({
         titleText={titleText}
         metadataText={metadataText}
         showKindIcons={sessionDisplay.icons.sessionKind}
+        isGeneratingTitle={isGeneratingTitle}
         t={t}
         onSubmitRename={async (next) => {
           setEditing(false);
-          if (next && next !== session.name) {
+          if (canRename && next && next !== session.name) {
             await renameSession(session.id, next);
           }
         }}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,6 +4,7 @@ import type {
   AgentHistoryItem,
   CommitInfo,
   DiffPayload,
+  GenerateSessionTitleResult,
   GeneratedCommitMessage,
   MemoryUsage,
   MergeMethod,
@@ -15,6 +16,7 @@ import type {
   SessionAgentProvider,
   SessionKind,
   SessionStatus,
+  SessionTitleReadinessResult,
   StagedFile,
   TodoItem,
   WorkflowRunDetailListing,
@@ -67,6 +69,37 @@ export const api = {
   },
   renameSession(id: string, name: string): Promise<Session> {
     return invoke<Session>("rename_session", { id, name });
+  },
+  sessionTitleReadiness(id: string): Promise<SessionTitleReadinessResult> {
+    return invoke<SessionTitleReadinessResult>("session_title_readiness", {
+      id,
+    });
+  },
+  generateSessionTitle(
+    id: string,
+    command: string,
+    args: string[],
+    prompt: string,
+  ): Promise<GenerateSessionTitleResult> {
+    return invoke<GenerateSessionTitleResult>("generate_session_title", {
+      id,
+      command,
+      args,
+      prompt,
+    });
+  },
+  previewSessionTitle(
+    command: string,
+    args: string[],
+    prompt: string,
+    firstUserMessage: string,
+  ): Promise<string> {
+    return invoke<string>("preview_session_title", {
+      command,
+      args,
+      prompt,
+      firstUserMessage,
+    });
   },
   listProjects(): Promise<Project[]> {
     return invoke<Project[]>("list_projects");

--- a/src/lib/sessionCreation.test.ts
+++ b/src/lib/sessionCreation.test.ts
@@ -32,6 +32,7 @@ function session(
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     last_message: null,
+    title_source: "default",
     kind: "regular",
     owner: { kind: "user" },
     position: null,

--- a/src/lib/sessionGrouping.test.ts
+++ b/src/lib/sessionGrouping.test.ts
@@ -27,6 +27,7 @@ function session(
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     last_message: null,
+    title_source: "default",
     kind: "regular",
     owner: { kind: "user" },
     position: null,

--- a/src/lib/sessionStatusPolling.test.ts
+++ b/src/lib/sessionStatusPolling.test.ts
@@ -24,6 +24,7 @@ function session(id: string, status: SessionStatus): Session {
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     last_message: null,
+    title_source: "default",
     kind: "regular",
     owner: { kind: "user" },
     position: null,

--- a/src/lib/sessionTitle.test.ts
+++ b/src/lib/sessionTitle.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { Session } from "./types";
+import {
+  canAutoGenerateSessionTitle,
+  canGenerateSessionTitle,
+  canRenameSession,
+  planAutoGenerateSessionTitles,
+} from "./sessionTitle";
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "s1",
+    name: "repo",
+    repo_path: "/tmp/repo",
+    worktree_path: "/tmp/repo",
+    branch: "main",
+    isolated: false,
+    status: "idle",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: null,
+    title_source: "default",
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: false,
+    agent_provider: "codex",
+    ...overrides,
+  };
+}
+
+describe("session title helpers", () => {
+  it("allows rename for user-owned sessions only", () => {
+    expect(canRenameSession(session())).toBe(true);
+    expect(
+      canRenameSession(
+        session({ owner: { kind: "control", session_id: "control-1" } }),
+      ),
+    ).toBe(false);
+    expect(
+      canRenameSession(session(), { isGeneratingTitle: true }),
+    ).toBe(false);
+  });
+
+  it("generates titles only for default user-owned agent sessions", () => {
+    expect(canGenerateSessionTitle(session())).toBe(true);
+    expect(canGenerateSessionTitle(session({ title_source: "manual" }))).toBe(
+      false,
+    );
+    expect(canGenerateSessionTitle(session({ kind: "control" }))).toBe(false);
+    expect(
+      canGenerateSessionTitle(
+        session({ owner: { kind: "control", session_id: "control-1" } }),
+      ),
+    ).toBe(false);
+    expect(canGenerateSessionTitle(session({ agent_provider: null }))).toBe(
+      false,
+    );
+  });
+
+  it("requires the global automatic title setting for background generation", () => {
+    expect(canAutoGenerateSessionTitle(session(), false)).toBe(false);
+    expect(canAutoGenerateSessionTitle(session(), true)).toBe(true);
+  });
+
+  it("plans immediate generation for eligible sessions only", () => {
+    expect(
+      planAutoGenerateSessionTitles({
+        sessions: [
+          session({ id: "ready" }),
+          session({ id: "manual", title_source: "manual" }),
+          session({ id: "terminal", agent_provider: null }),
+        ],
+        enabled: true,
+        inFlightIds: new Set(),
+        lastAttemptAt: new Map(),
+        now: 1_000,
+        retryMs: 30_000,
+      }),
+    ).toEqual({ sessionIds: ["ready"], retryDelayMs: null });
+  });
+
+  it("returns the next retry delay for recently attempted sessions", () => {
+    expect(
+      planAutoGenerateSessionTitles({
+        sessions: [session({ id: "recent" }), session({ id: "later" })],
+        enabled: true,
+        inFlightIds: new Set(),
+        lastAttemptAt: new Map([
+          ["recent", 5_000],
+          ["later", 10_000],
+        ]),
+        now: 20_000,
+        retryMs: 30_000,
+      }),
+    ).toEqual({ sessionIds: [], retryDelayMs: 15_000 });
+  });
+
+  it("skips in-flight sessions while planning retries", () => {
+    expect(
+      planAutoGenerateSessionTitles({
+        sessions: [session({ id: "busy" })],
+        enabled: true,
+        inFlightIds: new Set(["busy"]),
+        lastAttemptAt: new Map(),
+        now: 1_000,
+        retryMs: 30_000,
+      }),
+    ).toEqual({ sessionIds: [], retryDelayMs: null });
+  });
+});

--- a/src/lib/sessionTitle.ts
+++ b/src/lib/sessionTitle.ts
@@ -1,0 +1,75 @@
+import type { Session } from "./types";
+
+export interface AutoSessionTitlePlanOptions {
+  sessions: readonly Session[];
+  enabled: boolean;
+  inFlightIds: ReadonlySet<string>;
+  lastAttemptAt: ReadonlyMap<string, number>;
+  now: number;
+  retryMs: number;
+}
+
+export interface AutoSessionTitlePlan {
+  sessionIds: string[];
+  retryDelayMs: number | null;
+}
+
+export interface SessionRenameOptions {
+  isGeneratingTitle?: boolean;
+}
+
+export function canRenameSession(
+  session: Session,
+  options: SessionRenameOptions = {},
+): boolean {
+  return session.owner.kind !== "control" && !options.isGeneratingTitle;
+}
+
+export function canGenerateSessionTitle(session: Session): boolean {
+  return (
+    session.kind === "regular" &&
+    session.owner.kind === "user" &&
+    session.title_source === "default" &&
+    session.agent_provider != null
+  );
+}
+
+export function canAutoGenerateSessionTitle(
+  session: Session,
+  enabled: boolean,
+): boolean {
+  return enabled && canGenerateSessionTitle(session);
+}
+
+export function planAutoGenerateSessionTitles({
+  sessions,
+  enabled,
+  inFlightIds,
+  lastAttemptAt,
+  now,
+  retryMs,
+}: AutoSessionTitlePlanOptions): AutoSessionTitlePlan {
+  if (!enabled) return { sessionIds: [], retryDelayMs: null };
+
+  const sessionIds: string[] = [];
+  let retryDelayMs: number | null = null;
+
+  for (const session of sessions) {
+    if (!canAutoGenerateSessionTitle(session, enabled)) continue;
+    if (inFlightIds.has(session.id)) continue;
+
+    const last = lastAttemptAt.get(session.id);
+    if (last !== undefined) {
+      const remaining = retryMs - (now - last);
+      if (remaining > 0) {
+        retryDelayMs =
+          retryDelayMs === null ? remaining : Math.min(retryDelayMs, remaining);
+        continue;
+      }
+    }
+
+    sessionIds.push(session.id);
+  }
+
+  return { sessionIds, retryDelayMs };
+}

--- a/src/lib/sessionWorktree.test.ts
+++ b/src/lib/sessionWorktree.test.ts
@@ -14,6 +14,7 @@ function session(overrides: Partial<Session> = {}): Session {
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     last_message: null,
+    title_source: "default",
     kind: "regular",
     owner: { kind: "user" },
     position: null,

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -2,7 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AGENT_OPTIONS,
   DEFAULT_SETTINGS,
+  DEFAULT_SESSION_TITLE_PROMPT,
   resolveAiCommitCommand,
+  resolveAiOneshotCommand,
+  resolveSessionTitlePrompt,
+  SESSION_TITLE_PROMPT_MAX_CHARS,
 } from "./settings";
 
 describe("language settings", () => {
@@ -104,6 +108,102 @@ describe("session removal settings", () => {
 });
 
 describe("AI commit command resolution", () => {
+  it("keeps automatic session title generation off by default", () => {
+    expect(DEFAULT_SETTINGS.agents.autoGenerateSessionTitles).toBe(false);
+  });
+
+  it("loads a persisted automatic session title preference", async () => {
+    localStorage.setItem(
+      "acorn:settings:v1",
+      JSON.stringify({ agents: { autoGenerateSessionTitles: true } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(
+      useSettings.getState().settings.agents.autoGenerateSessionTitles,
+    ).toBe(true);
+  });
+
+  it("keeps the default session title prompt in settings", () => {
+    expect(DEFAULT_SETTINGS.agents.sessionTitlePrompt).toBe(
+      DEFAULT_SESSION_TITLE_PROMPT,
+    );
+    expect(DEFAULT_SESSION_TITLE_PROMPT).toContain(
+      "Separate each word with hyphens.",
+    );
+    expect(DEFAULT_SESSION_TITLE_PROMPT).toContain("Use lowercase words only.");
+  });
+
+  it("loads a persisted session title prompt", async () => {
+    localStorage.setItem(
+      "acorn:settings:v1",
+      JSON.stringify({
+        agents: { sessionTitlePrompt: "Name the tab in Korean." },
+      }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.agents.sessionTitlePrompt).toBe(
+      "Name the tab in Korean.",
+    );
+  });
+
+  it("migrates the old default session title prompt to the current default", async () => {
+    localStorage.setItem(
+      "acorn:settings:v1",
+      JSON.stringify({
+        agents: {
+          sessionTitlePrompt: `You are naming an Acorn terminal tab from the user's first agent prompt.
+
+Return only a concise title for the tab.
+Rules:
+- 2 to 5 words.
+- Fewer than 30 characters.
+- No quotes, Markdown, trailing punctuation, or extra commentary.
+- Prefer the concrete task over generic words like "help" or "question".`,
+        },
+      }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.agents.sessionTitlePrompt).toBe(
+      DEFAULT_SESSION_TITLE_PROMPT,
+    );
+  });
+
+  it("limits persisted session title prompts", async () => {
+    localStorage.setItem(
+      "acorn:settings:v1",
+      JSON.stringify({
+        agents: {
+          sessionTitlePrompt: "x".repeat(SESSION_TITLE_PROMPT_MAX_CHARS + 1),
+        },
+      }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(
+      useSettings.getState().settings.agents.sessionTitlePrompt,
+    ).toHaveLength(SESSION_TITLE_PROMPT_MAX_CHARS);
+  });
+
+  it("falls back to the default session title prompt when blank", () => {
+    expect(
+      resolveSessionTitlePrompt({
+        ...DEFAULT_SETTINGS,
+        agents: { ...DEFAULT_SETTINGS.agents, sessionTitlePrompt: "  \n " },
+      }),
+    ).toBe(DEFAULT_SESSION_TITLE_PROMPT);
+  });
+
   it("runs Codex through non-interactive exec mode", () => {
     expect(
       resolveAiCommitCommand({
@@ -117,6 +217,19 @@ describe("AI commit command resolution", () => {
     expect(AGENT_OPTIONS.find((o) => o.value === "codex")?.oneshotHint).toBe(
       "codex exec",
     );
+  });
+
+  it("uses the Settings Agents model for one-shot providers that take one", () => {
+    expect(
+      resolveAiOneshotCommand({
+        ...DEFAULT_SETTINGS,
+        agents: {
+          ...DEFAULT_SETTINGS.agents,
+          selected: "ollama",
+          ollama: { model: "qwen2.5-coder" },
+        },
+      }),
+    ).toEqual({ command: "ollama", args: ["run", "qwen2.5-coder"] });
   });
 });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -56,6 +56,30 @@ export const AGENT_OPTIONS: ReadonlyArray<{
   },
 ];
 
+const LEGACY_DEFAULT_SESSION_TITLE_PROMPT = `You are naming an Acorn terminal tab from the user's first agent prompt.
+
+Return only a concise title for the tab.
+Rules:
+- 2 to 5 words.
+- Fewer than 30 characters.
+- No quotes, Markdown, trailing punctuation, or extra commentary.
+- Prefer the concrete task over generic words like "help" or "question".`;
+
+export const DEFAULT_SESSION_TITLE_PROMPT = `You are naming an Acorn terminal tab from the user's first agent prompt.
+
+Return only a concise title for the tab.
+Rules:
+- 2 to 5 words.
+- Separate each word with hyphens.
+- Use lowercase words only.
+- Fewer than 30 characters.
+- No quotes, Markdown, trailing punctuation, or extra commentary.
+- Prefer the concrete task over generic words like "help" or "question".`;
+
+export const SESSION_TITLE_PROMPT_MAX_CHARS = 1_000;
+
+export const SESSION_TITLE_PROMPT_PREVIEW_MESSAGE =
+  "Add a Settings button that previews generated tab titles without creating a session.";
 
 /**
  * Allowed PRs-tab refresh intervals shown in the Settings UI. Picked to
@@ -170,6 +194,17 @@ export interface AcornSettings {
    */
   agents: {
     selected: SelectedAgent;
+    /**
+     * When enabled, new user-owned agent sessions can have their default tab
+     * name replaced by an AI-generated title from the first user prompt.
+     * Default off: this can send prompt text to the configured AI CLI.
+     */
+    autoGenerateSessionTitles: boolean;
+    /**
+     * Instructions prepended to the first user prompt when Acorn asks the
+     * selected AI CLI to name a new session tab.
+     */
+    sessionTitlePrompt: string;
     /**
      * Used when `selected === "custom"`. Whitespace-separated; no shell
      * expansion. Powers the one-shot commit-message invocation; empty
@@ -336,6 +371,8 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   },
   agents: {
     selected: "claude",
+    autoGenerateSessionTitles: false,
+    sessionTitlePrompt: DEFAULT_SESSION_TITLE_PROMPT,
     customCommand: "",
     ollama: { model: "" },
     llm: { model: "" },
@@ -537,6 +574,14 @@ function normalizeSelectedAgent(
   return fallback;
 }
 
+function normalizeSessionTitlePrompt(v: unknown, fallback: string): string {
+  if (typeof v !== "string") return fallback;
+  if (v.trim() === LEGACY_DEFAULT_SESSION_TITLE_PROMPT) {
+    return DEFAULT_SESSION_TITLE_PROMPT;
+  }
+  return Array.from(v).slice(0, SESSION_TITLE_PROMPT_MAX_CHARS).join("");
+}
+
 function normalizeLanguage(v: unknown, fallback: Language): Language {
   return isLanguage(v) ? v : fallback;
 }
@@ -580,6 +625,8 @@ function loadSettings(): AcornSettings {
     // `commitMessage` shape, then to the Claude default.
     const agentsRaw = (parsed.agents ?? {}) as {
       selected?: string;
+      autoGenerateSessionTitles?: boolean;
+      sessionTitlePrompt?: unknown;
       customCommand?: string;
       ollama?: { model?: string };
       llm?: { model?: string };
@@ -677,6 +724,14 @@ function loadSettings(): AcornSettings {
       },
       agents: {
         selected,
+        autoGenerateSessionTitles:
+          typeof agentsRaw.autoGenerateSessionTitles === "boolean"
+            ? agentsRaw.autoGenerateSessionTitles
+            : DEFAULT_SETTINGS.agents.autoGenerateSessionTitles,
+        sessionTitlePrompt: normalizeSessionTitlePrompt(
+          agentsRaw.sessionTitlePrompt,
+          DEFAULT_SETTINGS.agents.sessionTitlePrompt,
+        ),
         customCommand,
         ollama: { model: ollamaModel },
         llm: { model: llmModel },
@@ -803,6 +858,8 @@ interface SettingsState {
   patchAgents: (
     patch: Partial<{
       selected: SelectedAgent;
+      autoGenerateSessionTitles: boolean;
+      sessionTitlePrompt: string;
       customCommand: string;
       ollama: Partial<AcornSettings["agents"]["ollama"]>;
       llm: Partial<AcornSettings["agents"]["llm"]>;
@@ -867,6 +924,17 @@ export const useSettings = create<SettingsState>((set, get) => ({
         agents: {
           ...s.settings.agents,
           ...(patch.selected !== undefined ? { selected: patch.selected } : {}),
+          ...(patch.autoGenerateSessionTitles !== undefined
+            ? { autoGenerateSessionTitles: patch.autoGenerateSessionTitles }
+            : {}),
+          ...(patch.sessionTitlePrompt !== undefined
+            ? {
+                sessionTitlePrompt: normalizeSessionTitlePrompt(
+                  patch.sessionTitlePrompt,
+                  DEFAULT_SETTINGS.agents.sessionTitlePrompt,
+                ),
+              }
+            : {}),
           ...(patch.customCommand !== undefined
             ? { customCommand: patch.customCommand }
             : {}),
@@ -1004,8 +1072,8 @@ interface ResolvedCommand {
 }
 
 /**
- * One-shot stdin → stdout invocation for an agent. Used by the merge
- * dialog's "Generate with AI" action.
+ * One-shot stdin → stdout invocation for an agent. Used by AI features that
+ * need a single prompt/response round trip.
  */
 function agentOneshotCommand(
   agent: AgentProvider,
@@ -1039,11 +1107,11 @@ function tokenizeCustom(raw: string): ResolvedCommand | null {
 }
 
 /**
- * Resolve the AI CLI invocation for the merge dialog's "Generate with AI"
- * action. The resolved value is sent to the Rust backend as
- * `(command, args)` so the backend stays provider-agnostic.
+ * Resolve the AI CLI invocation selected under Settings → Agents. The
+ * resolved value is sent to the Rust backend as `(command, args)` so the
+ * backend stays provider-agnostic.
  */
-export function resolveAiCommitCommand(s: AcornSettings): ResolvedCommand {
+export function resolveAiOneshotCommand(s: AcornSettings): ResolvedCommand {
   if (s.agents.selected === "custom") {
     return (
       tokenizeCustom(s.agents.customCommand) ??
@@ -1052,6 +1120,15 @@ export function resolveAiCommitCommand(s: AcornSettings): ResolvedCommand {
   }
   return agentOneshotCommand(s.agents.selected, s.agents);
 }
+
+export function resolveSessionTitlePrompt(s: AcornSettings): string {
+  return s.agents.sessionTitlePrompt.trim()
+    ? s.agents.sessionTitlePrompt
+    : DEFAULT_SESSION_TITLE_PROMPT;
+}
+
+/** Backwards-compat alias for callers that still read this name. */
+export const resolveAiCommitCommand = resolveAiOneshotCommand;
 
 /**
  * Human-friendly label for the global agent selection. Used by the merge

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,7 +17,26 @@ export type SessionOwner =
   | { kind: "user" }
   | { kind: "control"; session_id: string };
 
+export type SessionTitleSource = "default" | "generated" | "manual";
+
 export type SessionAgentProvider = "claude" | "codex";
+
+export type SessionTitleGenerationStatus =
+  | "generated"
+  | "not_ready"
+  | "skipped";
+
+export type SessionTitleReadinessStatus = "ready" | "not_ready" | "skipped";
+
+export interface GenerateSessionTitleResult {
+  status: SessionTitleGenerationStatus;
+  session: Session;
+}
+
+export interface SessionTitleReadinessResult {
+  status: SessionTitleReadinessStatus;
+  session: Session;
+}
 
 export type AgentProviderCapability =
   | "history"
@@ -71,6 +90,7 @@ export interface Session {
   created_at: string;
   updated_at: string;
   last_message: string | null;
+  title_source: SessionTitleSource;
   kind: SessionKind;
   owner: SessionOwner;
   position: number | null;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -406,6 +406,27 @@
         "label": "Custom command",
         "hint": "Used for both interactive sessions and one-shot AI generation. Falls back to Claude Code when blank."
       },
+      "sessionTitles": {
+        "label": "Session titles",
+        "hint": "When enabled, acorn sends the first user prompt in a new agent session to the selected AI CLI and replaces the default tab name with a concise title.",
+        "checkbox": "Auto-generate session titles"
+      },
+      "sessionTitlePrompt": {
+        "label": "Session title prompt",
+        "hint": "Instructions sent before the first user prompt. Leave blank to use the default prompt.",
+        "open": "Configure title prompt",
+        "shortButton": "Prompt",
+        "editorLabel": "Prompt",
+        "count": "{count} / {max}",
+        "reset": "Reset prompt",
+        "preview": {
+          "sample": "Acorn sample first message",
+          "generate": "Generate preview",
+          "generating": "Generating preview",
+          "result": "Tab",
+          "failed": "Preview failed"
+        }
+      },
       "requirement": "The selected agent's CLI must already be installed and authenticated on this machine. Surfaces a clear error when the binary is missing."
     },
     "storage": {
@@ -641,7 +662,8 @@
       "dragToReorderSession": "Drag to reorder session",
       "localTerminalSessions": "Local terminal sessions",
       "worktree": "worktree",
-      "controlSession": "control session"
+      "controlSession": "control session",
+      "generatingSessionTitle": "Generating session title"
     },
     "localTerminals": {
       "title": "Instant sessions",
@@ -673,6 +695,7 @@
     "aria": {
       "worktree": "worktree",
       "controlSession": "control session",
+      "generatingSessionTitle": "Generating session title",
       "closeSession": "Close session",
       "closeTab": "Close tab"
     },

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -406,6 +406,27 @@
         "label": "사용자 지정 명령",
         "hint": "대화형 세션과 일회성 AI 생성 모두에 사용됩니다. 비워 두면 Claude Code로 대체됩니다."
       },
+      "sessionTitles": {
+        "label": "세션 제목",
+        "hint": "켜면 새 에이전트 세션의 첫 사용자 프롬프트를 선택한 AI CLI로 보내고 기본 탭 이름을 간결한 제목으로 바꿉니다.",
+        "checkbox": "세션 제목 자동 생성"
+      },
+      "sessionTitlePrompt": {
+        "label": "세션 제목 프롬프트",
+        "hint": "첫 사용자 프롬프트 앞에 함께 보낼 지시문입니다. 비워 두면 기본 프롬프트를 사용합니다.",
+        "open": "제목 프롬프트 설정",
+        "shortButton": "프롬프트",
+        "editorLabel": "프롬프트",
+        "count": "{count} / {max}",
+        "reset": "프롬프트 초기화",
+        "preview": {
+          "sample": "Acorn 샘플 첫 메시지",
+          "generate": "미리보기 생성",
+          "generating": "미리보기 생성 중",
+          "result": "탭",
+          "failed": "미리보기 실패"
+        }
+      },
       "requirement": "선택한 에이전트의 CLI는 이 컴퓨터에 이미 설치되어 있고 인증되어 있어야 합니다. 바이너리가 없으면 명확한 오류를 표시합니다."
     },
     "storage": {
@@ -641,7 +662,8 @@
       "dragToReorderSession": "세션 순서를 바꾸려면 드래그",
       "localTerminalSessions": "로컬 터미널 세션",
       "worktree": "worktree",
-      "controlSession": "컨트롤 세션"
+      "controlSession": "컨트롤 세션",
+      "generatingSessionTitle": "세션 제목 생성 중"
     },
     "localTerminals": {
       "title": "인스턴트 세션",
@@ -673,6 +695,7 @@
     "aria": {
       "worktree": "워크트리",
       "controlSession": "컨트롤 세션",
+      "generatingSessionTitle": "세션 제목 생성 중",
       "closeSession": "세션 닫기",
       "closeTab": "탭 닫기"
     },

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Project, Session, SessionStatus } from "./lib/types";
+import type {
+  GenerateSessionTitleResult,
+  Project,
+  Session,
+  SessionStatus,
+} from "./lib/types";
 
 // Mock the Tauri-backed API surface used by the store.
 // Each method is a vi.fn so individual tests can stub return values.
@@ -20,6 +25,13 @@ vi.mock("./lib/api", () => {
       createSession: vi.fn(async () => ({}) as Session),
       removeSession: vi.fn(async () => undefined),
       renameSession: vi.fn(async () => ({}) as Session),
+      generateSessionTitle: vi.fn(
+        async () =>
+          ({
+            status: "skipped",
+            session: {} as Session,
+          }) as GenerateSessionTitleResult,
+      ),
       addProject: vi.fn(async () => ({}) as Project),
       removeProject: vi.fn(async () => undefined),
       reorderProjects: vi.fn(async (paths: string[]) =>
@@ -71,6 +83,7 @@ function session(
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     last_message: null,
+    title_source: "default",
     kind: "regular",
     owner: { kind: "user" },
     position: null,
@@ -107,6 +120,7 @@ function resetStore(): void {
       pendingRemoveProject: null,
       sessionsLoadedCleanly: true,
       liveInWorktree: {},
+      generatingSessionTitleIds: {},
     },
     false,
   );
@@ -974,6 +988,113 @@ describe("pollSessionStatuses", () => {
   it("is a no-op when there are no sessions to poll", async () => {
     await useAppStore.getState().pollSessionStatuses();
     expect(mockApi.detectSessionStatuses).not.toHaveBeenCalled();
+  });
+});
+
+describe("generateSessionTitle", () => {
+  it("does not manually rename a session while title generation is active", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+    useAppStore.setState({
+      generatingSessionTitleIds: { a1: true },
+    });
+
+    await useAppStore.getState().renameSession("a1", "Manual title");
+
+    expect(mockApi.renameSession).not.toHaveBeenCalled();
+  });
+
+  it("merges the generated session title without refreshing all sessions", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+    mockApi.generateSessionTitle.mockResolvedValueOnce(
+      {
+        status: "generated",
+        session: session("a1", REPO_A, {
+          name: "Fix Release Workflow",
+          title_source: "generated",
+        }),
+      },
+    );
+
+    const status = await useAppStore
+      .getState()
+      .generateSessionTitle("a1", "codex", ["exec"], "Title prompt");
+
+    expect(status).toBe("generated");
+    expect(mockApi.generateSessionTitle).toHaveBeenCalledWith(
+      "a1",
+      "codex",
+      ["exec"],
+      "Title prompt",
+    );
+    expect(mockApi.listSessions).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().sessions[0]?.name).toBe(
+      "Fix Release Workflow",
+    );
+    expect(useAppStore.getState().sessions[0]?.title_source).toBe("generated");
+  });
+
+  it("returns not_ready without replacing the session title", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+    mockApi.generateSessionTitle.mockResolvedValueOnce({
+      status: "not_ready",
+      session: session("a1", REPO_A, {
+        name: "Backend no-op title",
+        title_source: "default",
+      }),
+    });
+
+    const status = await useAppStore
+      .getState()
+      .generateSessionTitle("a1", "codex", ["exec"], "Title prompt");
+
+    expect(status).toBe("not_ready");
+    expect(useAppStore.getState().sessions[0]?.name).toBe("a1");
+    expect(useAppStore.getState().sessions[0]?.title_source).toBe("default");
+    expect(useAppStore.getState().generatingSessionTitleIds).toEqual({});
+  });
+
+  it("tracks title generation while the backend request is in flight", async () => {
+    vi.useFakeTimers();
+    try {
+      await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+      let resolveTitle!: (value: GenerateSessionTitleResult) => void;
+      mockApi.generateSessionTitle.mockImplementationOnce(
+        () =>
+          new Promise<GenerateSessionTitleResult>((resolve) => {
+            resolveTitle = resolve;
+          }),
+      );
+
+      const request = useAppStore
+        .getState()
+        .generateSessionTitle("a1", "codex", ["exec"], "Title prompt");
+
+      expect(useAppStore.getState().generatingSessionTitleIds).toEqual({
+        a1: true,
+      });
+
+      resolveTitle(
+        {
+          status: "generated",
+          session: session("a1", REPO_A, {
+            name: "Fix Release Workflow",
+            title_source: "generated",
+          }),
+        },
+      );
+      await Promise.resolve();
+
+      expect(useAppStore.getState().generatingSessionTitleIds).toEqual({
+        a1: true,
+      });
+
+      await vi.advanceTimersByTimeAsync(900);
+      await request;
+
+      expect(useAppStore.getState().generatingSessionTitleIds).toEqual({});
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,6 +6,7 @@ import type {
   Session,
   SessionAgentProvider,
   SessionKind,
+  SessionTitleGenerationStatus,
 } from "./lib/types";
 import { commandRequestsWorktreeAdoption } from "./lib/worktreeAdoption";
 import { CONTROL_GUIDE_DISMISSED_KEY } from "./components/ControlSessionGuideModal";
@@ -41,6 +42,7 @@ import {
 export type { RightGroup, RightTab };
 
 const ROOT_PANE_ID: PaneId = "root";
+const SESSION_TITLE_GENERATING_MIN_MS = 900;
 
 let statusPollRunning = false;
 let statusPollChain: Promise<void> | null = null;
@@ -48,6 +50,10 @@ let pendingStatusPollAll = false;
 let pendingStatusPollIds = new Set<string>();
 let activeStatusPollAll = false;
 let activeStatusPollIds = new Set<string>();
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
+}
 
 export interface PaneState {
   id: PaneId;
@@ -135,6 +141,8 @@ interface AppStateModel {
    * never on an interval, so the batched probe stays cheap.
    */
   liveInWorktree: Record<string, boolean>;
+  /** Session ids currently waiting for an AI-generated tab title. Ephemeral. */
+  generatingSessionTitleIds: Record<string, true>;
   loadInitialStatus: () => Promise<void>;
   refreshSessions: () => Promise<void>;
   /** Re-probe every session's live cwd in one batched backend call. */
@@ -166,6 +174,12 @@ interface AppStateModel {
   ) => Promise<Session | null>;
   removeSession: (id: string, removeWorktree?: boolean) => Promise<void>;
   renameSession: (id: string, name: string) => Promise<void>;
+  generateSessionTitle: (
+    id: string,
+    command: string,
+    args: string[],
+    prompt: string,
+  ) => Promise<SessionTitleGenerationStatus>;
   adoptSessionWorktree: (id: string, worktreePath: string) => Promise<void>;
   requestRemoveSession: (id: string) => void;
   clearPendingRemove: () => void;
@@ -500,6 +514,7 @@ export const useAppStore = create<AppStateModel>()(
   pendingRemoveProject: null,
   sessionsLoadedCleanly: true,
   liveInWorktree: {},
+  generatingSessionTitleIds: {},
 
   async loadInitialStatus() {
     try {
@@ -1204,12 +1219,53 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   async renameSession(id, name) {
+    if (get().generatingSessionTitleIds[id]) return;
+
     try {
       await api.renameSession(id, name);
       await get().refreshSessions();
     } catch (e) {
       set({ error: errorMessage(e) });
     }
+  },
+
+  async generateSessionTitle(id, command, args, prompt) {
+    const startedAt = Date.now();
+    let resultStatus: SessionTitleGenerationStatus = "skipped";
+    set((s) => ({
+      generatingSessionTitleIds: {
+        ...s.generatingSessionTitleIds,
+        [id]: true,
+      },
+    }));
+    try {
+      const result = await api.generateSessionTitle(id, command, args, prompt);
+      resultStatus = result.status;
+      const updated = result.session;
+      if (result.status === "generated" && updated?.id) {
+        set((s) => ({
+          sessions: s.sessions.map((session) =>
+            session.id === updated.id ? updated : session,
+          ),
+        }));
+      }
+    } catch (e) {
+      console.warn("[acorn] generateSessionTitle failed", e);
+    } finally {
+      const remainingMs =
+        resultStatus === "generated"
+          ? SESSION_TITLE_GENERATING_MIN_MS - (Date.now() - startedAt)
+          : 0;
+      if (remainingMs > 0) {
+        await delay(remainingMs);
+      }
+      set((s) => {
+        if (!s.generatingSessionTitleIds[id]) return s;
+        const { [id]: _, ...rest } = s.generatingSessionTitleIds;
+        return { generatingSessionTitleIds: rest };
+      });
+    }
+    return resultStatus;
   },
 
   async adoptSessionWorktree(id, worktreePath) {

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -54,6 +54,12 @@ export const tauriMockSource = `
       });
     }
     if (cmd === 'detect_session_statuses') return Promise.resolve([]);
+    if (cmd === 'session_title_readiness') {
+      return Promise.resolve({ status: 'skipped', session: {} });
+    }
+    if (cmd === 'generate_session_title') {
+      return Promise.resolve({ status: 'skipped', session: {} });
+    }
     if (cmd === 'detect_session_agent') {
       return Promise.resolve({ claude: null, codex: null });
     }


### PR DESCRIPTION
## Summary
Adds opt-in AI-generated tab titles for new agent sessions, with prompt controls kept out of the main Settings scroll path.

1. **Session title lifecycle** — track `title_source` on sessions, preserve existing sessions as manual, block control-owned tab rename, and add backend readiness/generation/preview commands.
2. **AI generation flow** — reuse the Settings → Agents provider/model for one-shot title generation, extract the first user prompt from Claude/Codex transcripts, normalize generated titles, and add a timeout to one-shot AI calls.
3. **Frontend orchestration** — plan eligible agent sessions for title generation, retry when transcripts are not ready, show an in-progress tab/sidebar indicator only during actual generation, and disable manual rename while generation is active.
4. **Settings prompt UI** — add an opt-in “Auto-generate session titles” setting plus a compact prompt settings button that opens a dedicated modal with prompt editing, reset, 1000-character limit, and preview generation.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| New agent session tabs | Default session name until manually renamed | Optional AI-generated concise title from the first user prompt |
| Settings → Agents scroll length | Prompt editor rendered inline | Prompt editor opens in a separate dialog from a compact row action |
| Control-session children | Rename path could be attempted from UI/backend | Control-owned tabs are explicitly not renameable |
| AI one-shot calls | Could wait indefinitely on hung CLI output | Shared one-shot runner times out after 60 seconds |

## Design notes
- Existing persisted sessions deserialize missing `title_source` as `manual`, so auto-generation only targets sessions created after this feature lands.
- Generation is split into `session_title_readiness` and `generate_session_title`; readiness probes do not trigger the visible generating indicator.
- Backend rechecks title eligibility immediately before committing the generated title, so a manual rename or ownership change wins over stale generation results.
- The session-title prompt is user-editable, but blank values fall back to the default prompt and persisted values are capped at 1000 characters.

## Follow-up (not in this PR)
- Consider a broader generated-title history/audit surface only if users need to inspect or restore prior generated titles.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm exec vitest run` — 47 files, 412 passed, 1 skipped
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 172 passed, 1 ignored
- [x] `pnpm run build` passes; existing Vite warnings about mixed static/dynamic imports and large chunks remain
- [x] `pnpm exec playwright test tests/e2e/settings-tabs.spec.ts tests/e2e/settings.spec.ts` — 4 passed
- [x] `git diff --check` passes

## Notes
- Left unstaged: rustfmt-only churn in `src-tauri/src/fs_explorer.rs`, `src-tauri/src/persistence.rs`, and `src-tauri/src/pty_env.rs`; these are not included in this PR.
