### PR TITLE
feat(projects): project-scoped PR generation settings

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,6 +12,7 @@ use crate::agent_resume;
 use crate::error::{AppError, AppResult};
 use crate::git_ops::{self, CommitInfo, DiffPayload, StagedFile};
 use crate::persistence;
+use crate::project_settings::{self, ProjectSettings, ProjectSettingsRecord};
 use crate::pull_requests::{
     self, GeneratedCommitMessage, MergeMethod, PrStateFilter, PullRequestDetailListing,
     PullRequestListing, WorkflowRunDetailListing, WorkflowRunsListing,
@@ -986,6 +987,19 @@ pub fn create_new_project(
     Ok(project)
 }
 
+#[tauri::command]
+pub fn get_project_settings(repo_path: String) -> AppResult<ProjectSettingsRecord> {
+    project_settings::get(&PathBuf::from(repo_path))
+}
+
+#[tauri::command]
+pub fn update_project_settings(
+    repo_path: String,
+    settings: ProjectSettings,
+) -> AppResult<ProjectSettingsRecord> {
+    project_settings::update(&PathBuf::from(repo_path), settings)
+}
+
 fn validate_new_project_name(name: &str, ignore_safe_name: bool) -> AppResult<&str> {
     let trimmed = name.trim();
     if trimmed.is_empty() {
@@ -1061,6 +1075,7 @@ pub async fn remove_project(
     repo_path: String,
     remove_sessions: Option<bool>,
     remove_worktrees: Option<bool>,
+    remove_settings: Option<bool>,
 ) -> AppResult<()> {
     let path = PathBuf::from(&repo_path);
     let cascade = remove_sessions.unwrap_or(true);
@@ -1081,6 +1096,13 @@ pub async fn remove_project(
         }
     }
     state.projects.remove(&path);
+    let drop_settings = remove_settings.unwrap_or(false)
+        || project_settings::should_remove_on_project_close(&path).unwrap_or(false);
+    if drop_settings {
+        if let Err(err) = project_settings::remove(&path) {
+            tracing::warn!(error = %err, path = %path.display(), "failed to remove project settings");
+        }
+    }
     persist(&state);
     Ok(())
 }
@@ -2689,6 +2711,7 @@ pub async fn generate_pr_commit_message(
     method: MergeMethod,
     command: String,
     args: Vec<String>,
+    prompt: String,
 ) -> AppResult<GeneratedCommitMessage> {
     pull_requests::generate_pr_commit_message(
         &PathBuf::from(repo_path),
@@ -2696,6 +2719,7 @@ pub async fn generate_pr_commit_message(
         method,
         command,
         args,
+        prompt,
     )
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod fs_explorer;
 mod git_ops;
 mod ipc;
 mod persistence;
+mod project_settings;
 pub mod pty_env;
 mod pty_output;
 mod pull_requests;
@@ -504,6 +505,8 @@ pub fn run() {
             commands::add_project,
             commands::create_new_project,
             commands::remove_project,
+            commands::get_project_settings,
+            commands::update_project_settings,
             commands::reorder_projects,
             commands::reorder_sessions,
             commands::list_commits,

--- a/src-tauri/src/project_settings.rs
+++ b/src-tauri/src/project_settings.rs
@@ -1,0 +1,246 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, AppResult};
+use crate::{git_ops, persistence};
+
+const PROJECT_SETTINGS_FILE: &str = "project_settings.json";
+const PROJECT_SETTINGS_TMP_FILE: &str = "project_settings.json.tmp";
+pub const PR_GENERATION_PROMPT_MAX_CHARS: usize = 2_000;
+pub const STANDARD_PR_GENERATION_PROMPT: &str = "Use a standard GitHub-style pull request merge message.
+- First line: Conventional Commit subject when the type is clear, e.g. feat(scope): concise summary. Keep it imperative/present tense and <=72 chars.
+- Body: 1-2 concise paragraphs explaining why the change matters, user-visible impact, and key implementation notes when useful.
+- Keep the wording specific to the PR. Avoid boilerplate, markdown headings, labels, and prompt explanations.";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectSettings {
+    #[serde(default = "default_true")]
+    pub remember_after_close: bool,
+    #[serde(default)]
+    pub pull_requests: ProjectPullRequestSettings,
+}
+
+impl Default for ProjectSettings {
+    fn default() -> Self {
+        Self {
+            remember_after_close: true,
+            pull_requests: ProjectPullRequestSettings::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectPullRequestSettings {
+    #[serde(default)]
+    pub generation_prompt: Option<String>,
+}
+
+impl Default for ProjectPullRequestSettings {
+    fn default() -> Self {
+        Self {
+            generation_prompt: Some(STANDARD_PR_GENERATION_PROMPT.to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectSettingsRecord {
+    pub key: String,
+    pub settings: ProjectSettings,
+}
+
+type SettingsMap = BTreeMap<String, ProjectSettings>;
+
+fn default_true() -> bool {
+    true
+}
+
+fn settings_path() -> AppResult<PathBuf> {
+    Ok(persistence::data_dir()?.join(PROJECT_SETTINGS_FILE))
+}
+
+fn settings_tmp_path() -> AppResult<PathBuf> {
+    Ok(persistence::data_dir()?.join(PROJECT_SETTINGS_TMP_FILE))
+}
+
+fn load_all() -> AppResult<SettingsMap> {
+    let path = settings_path()?;
+    if !path.exists() {
+        return Ok(SettingsMap::new());
+    }
+    let bytes = fs::read(&path)?;
+    serde_json::from_slice::<SettingsMap>(&bytes)
+        .map_err(|err| AppError::Other(format!("failed to parse project settings: {err}")))
+}
+
+fn save_all(settings: &SettingsMap) -> AppResult<()> {
+    let final_path = settings_path()?;
+    let tmp_path = settings_tmp_path()?;
+    let payload = serde_json::to_vec_pretty(settings)
+        .map_err(|err| AppError::Other(format!("failed to serialize project settings: {err}")))?;
+    fs::write(&tmp_path, payload)?;
+    fs::rename(&tmp_path, &final_path)?;
+    Ok(())
+}
+
+pub fn key_for_repo(repo_path: &Path) -> String {
+    if let Ok(Some(slug)) = git_ops::github_owner_repo(repo_path) {
+        return format!("github:{}", slug.to_ascii_lowercase());
+    }
+    let path = repo_path
+        .canonicalize()
+        .unwrap_or_else(|_| repo_path.to_path_buf());
+    format!("path:{}", path.display())
+}
+
+pub fn get(repo_path: &Path) -> AppResult<ProjectSettingsRecord> {
+    let key = key_for_repo(repo_path);
+    let settings = load_all()?.get(&key).cloned().unwrap_or_default();
+    Ok(ProjectSettingsRecord { key, settings })
+}
+
+pub fn update(repo_path: &Path, settings: ProjectSettings) -> AppResult<ProjectSettingsRecord> {
+    let key = key_for_repo(repo_path);
+    let settings = normalize_settings(settings);
+    let mut all = load_all()?;
+    all.insert(key.clone(), settings.clone());
+    save_all(&all)?;
+    Ok(ProjectSettingsRecord { key, settings })
+}
+
+pub fn remove(repo_path: &Path) -> AppResult<()> {
+    let key = key_for_repo(repo_path);
+    let mut all = load_all()?;
+    if all.remove(&key).is_some() {
+        save_all(&all)?;
+    }
+    Ok(())
+}
+
+pub fn should_remove_on_project_close(repo_path: &Path) -> AppResult<bool> {
+    let record = get(repo_path)?;
+    Ok(!record.settings.remember_after_close)
+}
+
+fn normalize_settings(mut settings: ProjectSettings) -> ProjectSettings {
+    settings.pull_requests.generation_prompt =
+        settings.pull_requests.generation_prompt.and_then(|prompt| {
+            let trimmed = prompt.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(
+                    prompt
+                        .chars()
+                        .take(PR_GENERATION_PROMPT_MAX_CHARS)
+                        .collect(),
+                )
+            }
+        });
+    settings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_data_dir(test: impl FnOnce(&Path)) {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var(acorn_paths::ENV_DATA_DIR_OVERRIDE, dir.path());
+        }
+        test(dir.path());
+        unsafe {
+            std::env::remove_var(acorn_paths::ENV_DATA_DIR_OVERRIDE);
+        }
+    }
+
+    #[test]
+    fn update_and_get_round_trips_project_settings() {
+        with_data_dir(|_| {
+            let repo = PathBuf::from("/tmp/acorn-settings-repo");
+            let settings = ProjectSettings {
+                remember_after_close: false,
+                pull_requests: ProjectPullRequestSettings {
+                    generation_prompt: Some("Write concise Korean PR messages.".to_string()),
+                },
+            };
+
+            let saved = update(&repo, settings).unwrap();
+            let loaded = get(&repo).unwrap();
+
+            assert_eq!(loaded.key, saved.key);
+            assert_eq!(loaded.settings.remember_after_close, false);
+            assert_eq!(
+                loaded.settings.pull_requests.generation_prompt.as_deref(),
+                Some("Write concise Korean PR messages.")
+            );
+        });
+    }
+
+    #[test]
+    fn default_settings_include_standard_pr_generation_prompt() {
+        with_data_dir(|_| {
+            let repo = PathBuf::from("/tmp/acorn-settings-repo");
+            let loaded = get(&repo).unwrap();
+
+            assert!(loaded
+                .settings
+                .pull_requests
+                .generation_prompt
+                .as_deref()
+                .unwrap_or("")
+                .contains("GitHub-style pull request"));
+        });
+    }
+
+    #[test]
+    fn blank_prompt_normalizes_to_none() {
+        with_data_dir(|_| {
+            let repo = PathBuf::from("/tmp/acorn-settings-repo");
+
+            update(
+                &repo,
+                ProjectSettings {
+                    remember_after_close: true,
+                    pull_requests: ProjectPullRequestSettings {
+                        generation_prompt: Some("   ".to_string()),
+                    },
+                },
+            )
+            .unwrap();
+
+            assert_eq!(
+                get(&repo).unwrap().settings.pull_requests.generation_prompt,
+                None
+            );
+        });
+    }
+
+    #[test]
+    fn remember_after_close_controls_close_cleanup() {
+        with_data_dir(|_| {
+            let repo = PathBuf::from("/tmp/acorn-settings-repo");
+
+            assert_eq!(should_remove_on_project_close(&repo).unwrap(), false);
+
+            update(
+                &repo,
+                ProjectSettings {
+                    remember_after_close: false,
+                    pull_requests: ProjectPullRequestSettings::default(),
+                },
+            )
+            .unwrap();
+
+            assert_eq!(should_remove_on_project_close(&repo).unwrap(), true);
+        });
+    }
+}

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -1615,6 +1615,7 @@ pub fn generate_pr_commit_message(
     method: MergeMethod,
     command: String,
     args: Vec<String>,
+    prompt: String,
 ) -> AppResult<GeneratedCommitMessage> {
     if command.trim().is_empty() {
         return Err(AppError::Other(
@@ -1643,17 +1644,18 @@ pub fn generate_pr_commit_message(
     };
 
     let (view, diff) = context;
-    let prompt = build_commit_message_prompt(method, &view, &diff);
+    let prompt = build_commit_message_prompt(method, &prompt, &view, &diff);
     let raw = crate::ai::run_oneshot(&command, &args, &prompt, "Settings → Agents")?;
     Ok(parse_commit_message_response(&raw))
 }
 
 fn build_commit_message_prompt(
     method: MergeMethod,
+    user_prompt: &str,
     view: &GhPullRequestView,
     diff: &str,
 ) -> String {
-    let style = match method {
+    let fallback_prompt = match method {
         MergeMethod::Squash => {
             "Write a single squash commit message. The first line is a short imperative subject (≤72 chars). \
              Leave one blank line, then a concise body explaining the WHY (not the what)."
@@ -1668,6 +1670,12 @@ fn build_commit_message_prompt(
             "Summarize the change as a single subject line (≤72 chars), no body."
         }
     };
+    let user_prompt = user_prompt.trim();
+    let instructions = if user_prompt.is_empty() {
+        fallback_prompt
+    } else {
+        user_prompt
+    };
 
     // Cap diff size — claude has a context budget and the user can refine
     // afterwards if details are missing.
@@ -1679,15 +1687,20 @@ fn build_commit_message_prompt(
     };
 
     format!(
-        "You are generating a git commit message for merging a pull request.\n\n\
-         {style}\n\n\
-         Output format (strict): the subject line ALONE on the first line, then a blank line, \
-         then the body. Do not wrap the message in code fences or backticks. Do not add \
-         commentary before or after.\n\n\
+        "You are generating the exact git commit message text that Acorn will put into \
+         the pull request merge dialog.\n\n\
+         Style and content instructions:\n{instructions}\n\n\
+         Hard output contract:\n\
+         - Return only the generated commit message text.\n\
+         - First line: subject only, no label, prefix, or heading.\n\
+         - Then one blank line, then the body text. For rebase, leave the body empty.\n\
+         - Do not mention or summarize the prompt, rules, PR, diff, or your reasoning.\n\
+         - Do not include explanations, markdown headings, code fences, quotes, or \
+         labels such as \"Title:\" / \"Comment:\".\n\n\
          PR title: {title}\n\
          PR description:\n{body}\n\n\
          Diff:\n{diff}\n",
-        style = style,
+        instructions = instructions,
         title = view.title.as_deref().unwrap_or(""),
         body = view.body.as_deref().unwrap_or(""),
         diff = trimmed_diff,
@@ -2068,4 +2081,47 @@ fn run_workflow_view(slug: &str, token: &str, run_id: u64) -> AppResult<Workflow
         attempt: raw.attempt,
         jobs,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_view() -> GhPullRequestView {
+        GhPullRequestView {
+            title: Some("Add prompt editing".to_string()),
+            body: Some("Let users steer generated merge messages.".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn commit_message_prompt_uses_custom_user_prompt() {
+        let prompt = build_commit_message_prompt(
+            MergeMethod::Squash,
+            "Write the title and comment in Korean.",
+            &fake_view(),
+            "diff --git a/src/app.tsx b/src/app.tsx",
+        );
+
+        assert!(prompt
+            .contains("Style and content instructions:\nWrite the title and comment in Korean."));
+        assert!(prompt.contains("Return only the generated commit message text."));
+        assert!(prompt.contains("Do not mention or summarize the prompt"));
+        assert!(prompt.contains("labels such as \"Title:\" / \"Comment:\""));
+        assert!(prompt.contains("PR title: Add prompt editing"));
+        assert!(prompt.contains("Diff:\ndiff --git"));
+    }
+
+    #[test]
+    fn commit_message_prompt_falls_back_when_custom_prompt_is_blank() {
+        let prompt = build_commit_message_prompt(
+            MergeMethod::Merge,
+            "  ",
+            &fake_view(),
+            "diff --git a/src/app.tsx b/src/app.tsx",
+        );
+
+        assert!(prompt.contains("Write a merge commit message."));
+    }
 }

--- a/src/components/MergePullRequestDialog.tsx
+++ b/src/components/MergePullRequestDialog.tsx
@@ -1,10 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { AlertTriangle, GitMerge, ShieldAlert, Sparkles } from "lucide-react";
+import {
+  AlertTriangle,
+  GitMerge,
+  MessageSquareText,
+  ShieldAlert,
+  Sparkles,
+} from "lucide-react";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { loadLastMergeMethod, saveLastMergeMethod } from "../lib/merge-prefs";
+import { STANDARD_PR_GENERATION_PROMPT } from "../lib/project-settings";
 import {
   aiCommitProviderLabel,
   resolveAiCommitCommand,
@@ -17,6 +24,7 @@ import type {
   PullRequestDetail,
 } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
+import { ProjectSettingsModal } from "./ProjectSettingsModal";
 import { Tooltip } from "./Tooltip";
 import { Modal, ModalHeader, TextSwap } from "./ui";
 
@@ -25,27 +33,41 @@ const METHOD_OPTIONS: ReadonlyArray<{
   labelKey: DialogTranslationKey;
   hintKey: DialogTranslationKey;
 }> = [
-    {
-      value: "squash",
-      labelKey: "dialogs.mergePullRequest.methodSquash",
-      hintKey: "dialogs.mergePullRequest.methodSquashHint",
-    },
-    {
-      value: "merge",
-      labelKey: "dialogs.mergePullRequest.methodMerge",
-      hintKey: "dialogs.mergePullRequest.methodMergeHint",
-    },
-    {
-      value: "rebase",
-      labelKey: "dialogs.mergePullRequest.methodRebase",
-      hintKey: "dialogs.mergePullRequest.methodRebaseHint",
-    },
-  ];
+  {
+    value: "squash",
+    labelKey: "dialogs.mergePullRequest.methodSquash",
+    hintKey: "dialogs.mergePullRequest.methodSquashHint",
+  },
+  {
+    value: "merge",
+    labelKey: "dialogs.mergePullRequest.methodMerge",
+    hintKey: "dialogs.mergePullRequest.methodMergeHint",
+  },
+  {
+    value: "rebase",
+    labelKey: "dialogs.mergePullRequest.methodRebase",
+    hintKey: "dialogs.mergePullRequest.methodRebaseHint",
+  },
+];
 
 type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
 
 function dt(t: Translator, key: DialogTranslationKey): string {
   return t(key);
+}
+
+function defaultPromptForMethod(method: MergeMethod): string {
+  switch (method) {
+    case "squash":
+    case "merge":
+    case "rebase":
+      return STANDARD_PR_GENERATION_PROMPT;
+  }
+}
+
+function projectNameFromRepoPath(repoPath: string): string {
+  const trimmed = repoPath.replace(/[\\/]+$/, "");
+  return trimmed.split(/[\\/]/).pop() || repoPath;
 }
 
 interface ChecksBlock {
@@ -100,6 +122,8 @@ export function MergePullRequestDialog({
   const [method, setMethod] = useState<MergeMethod>(() => loadLastMergeMethod());
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
+  const [prompt, setPrompt] = useState(() => defaultPromptForMethod(method));
+  const [projectSettingsOpen, setProjectSettingsOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -122,15 +146,34 @@ export function MergePullRequestDialog({
   // method is loaded from prefs so the user's last choice persists across PRs.
   useEffect(() => {
     if (!open || !detail) return;
+    let cancelled = false;
     epochRef.current += 1;
-    setMethod(loadLastMergeMethod());
+    const nextMethod = loadLastMergeMethod();
+    setMethod(nextMethod);
     setTitle(detail.title);
     setBody(detail.body);
+    setPrompt(defaultPromptForMethod(nextMethod));
+    setProjectSettingsOpen(false);
     setError(null);
     setSubmitting(false);
     setGenerating(false);
     setAdminMerge(false);
-  }, [open, detail]);
+    void api
+      .getProjectSettings(repoPath)
+      .then((record) => {
+        if (cancelled) return;
+        const savedPrompt = record.settings.pull_requests.generation_prompt;
+        if (savedPrompt) {
+          setPrompt(savedPrompt);
+        }
+      })
+      .catch(() => {
+        // Project settings are optional; generation still works with defaults.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, detail, repoPath]);
 
   // Close also bumps the epoch — a generate kicked off right before the
   // user dismissed the dialog must be invalidated even if they never
@@ -139,6 +182,7 @@ export function MergePullRequestDialog({
   useEffect(() => {
     if (!open) {
       epochRef.current += 1;
+      setProjectSettingsOpen(false);
     }
   }, [open]);
 
@@ -148,7 +192,7 @@ export function MergePullRequestDialog({
     },
     // Avoid Enter committing a destructive action when the user is composing
     // in the textarea — confirm only via the explicit button.
-    onConfirm: () => { },
+    onConfirm: () => {},
   });
 
   const acceptsMessage = method === "squash" || method === "merge";
@@ -189,6 +233,7 @@ export function MergePullRequestDialog({
         method,
         command,
         args,
+        prompt,
       );
       // Dialog was closed (or reopened against another PR) while the
       // CLI was running — drop the result so it doesn't clobber whatever
@@ -208,18 +253,35 @@ export function MergePullRequestDialog({
   const busy = submitting || generating;
   const mergeBlocked = checksBlock.blocked && !adminMerge;
 
+  function handleMethodSelect(nextMethod: MergeMethod) {
+    setMethod(nextMethod);
+  }
+
+  async function reloadProjectPrompt() {
+    try {
+      const record = await api.getProjectSettings(repoPath);
+      setPrompt(
+        record.settings.pull_requests.generation_prompt ??
+          defaultPromptForMethod(method),
+      );
+    } catch {
+      // Project settings are optional; keep the current prompt fallback.
+    }
+  }
+
   return (
-    <Modal open={open} onClose={onClose} variant="dialog" size="lg">
-      {detail ? (
-        <>
-          <ModalHeader
-            title={`${dt(t, "dialogs.mergePullRequest.titlePrefix")} #${detail.number}`}
-            icon={<GitMerge size={16} className="text-emerald-400" />}
-            variant="dialog"
-            onClose={() => {
-              if (!submitting) onClose();
-            }}
-          />
+    <>
+      <Modal open={open} onClose={onClose} variant="dialog" size="lg">
+        {detail ? (
+          <>
+            <ModalHeader
+              title={`${dt(t, "dialogs.mergePullRequest.titlePrefix")} #${detail.number}`}
+              icon={<GitMerge size={16} className="text-emerald-400" />}
+              variant="dialog"
+              onClose={() => {
+                if (!submitting) onClose();
+              }}
+            />
 
           <div className="space-y-4 px-4 py-3 text-xs text-fg">
             <div>
@@ -231,7 +293,7 @@ export function MergePullRequestDialog({
                   <button
                     key={opt.value}
                     type="button"
-                    onClick={() => setMethod(opt.value)}
+                    onClick={() => handleMethodSelect(opt.value)}
                     className={cn(
                       "rounded-md border px-2.5 py-2 text-left transition",
                       method === opt.value
@@ -257,32 +319,54 @@ export function MergePullRequestDialog({
                   <p className="text-fg-muted">
                     {dt(t, "dialogs.mergePullRequest.commitMessage")}
                   </p>
-                  {generating ? (
-                    <button
-                      key="gen-button-loading"
-                      type="button"
-                      disabled
-                      className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-fg-muted opacity-60"
-                    >
-                      <Sparkles size={11} />
-                      {dt(t, "dialogs.mergePullRequest.generating")}
-                    </button>
-                  ) : (
+                  <div className="flex items-center gap-1">
+                    {generating ? (
+                      <button
+                        key="gen-button-loading"
+                        type="button"
+                        disabled
+                        className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-fg-muted opacity-60"
+                      >
+                        <Sparkles size={11} />
+                        {dt(t, "dialogs.mergePullRequest.generating")}
+                      </button>
+                    ) : (
+                      <Tooltip
+                        label={`${dt(t, "dialogs.mergePullRequest.generateVia")} ${providerLabel}`}
+                        side="top"
+                      >
+                        <button
+                          key="gen-button-idle"
+                          type="button"
+                          onClick={() => void handleGenerate()}
+                          className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+                        >
+                          <Sparkles size={11} />
+                          {dt(t, "dialogs.mergePullRequest.generateWithAi")}
+                        </button>
+                      </Tooltip>
+                    )}
                     <Tooltip
-                      label={`${dt(t, "dialogs.mergePullRequest.generateVia")} ${providerLabel}`}
+                      label={dt(
+                        t,
+                        "dialogs.mergePullRequest.goToProjectSettings",
+                      )}
                       side="top"
                     >
                       <button
-                        key="gen-button-idle"
                         type="button"
-                        onClick={() => void handleGenerate()}
-                        className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+                        aria-label={dt(
+                          t,
+                          "dialogs.mergePullRequest.goToProjectSettings",
+                        )}
+                        onClick={() => setProjectSettingsOpen(true)}
+                        disabled={busy}
+                        className="flex size-6 items-center justify-center rounded-md border border-border bg-bg-sidebar/60 text-fg-muted transition hover:border-accent/50 hover:bg-bg-elevated hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
                       >
-                        <Sparkles size={11} />
-                        {dt(t, "dialogs.mergePullRequest.generateWithAi")}
+                        <MessageSquareText size={13} />
                       </button>
                     </Tooltip>
-                  )}
+                  </div>
                 </div>
                 <input
                   type="text"
@@ -308,9 +392,12 @@ export function MergePullRequestDialog({
             )}
 
             {checksBlock.blocked ? (
-              <div className="space-y-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-200">
+              <div className="space-y-2 rounded-md border border-warning/45 bg-warning/10 px-3 py-2 text-[11px] text-fg">
                 <div className="flex items-start gap-2">
-                  <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                  <AlertTriangle
+                    size={12}
+                    className="mt-0.5 shrink-0 text-warning"
+                  />
                   <div className="space-y-0.5">
                     {checksBlock.failed > 0 ? (
                       <p>
@@ -328,25 +415,25 @@ export function MergePullRequestDialog({
                         )}
                       </p>
                     ) : null}
-                    <p className="text-amber-200/80">
+                    <p className="text-fg-muted">
                       {dt(t, "dialogs.mergePullRequest.checksBlocking")}
                     </p>
                   </div>
                 </div>
-                <label className="flex cursor-pointer items-start gap-2 rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1.5 text-amber-100 transition hover:bg-amber-500/15">
+                <label className="flex cursor-pointer items-start gap-2 rounded border border-warning/40 bg-bg-sidebar/70 px-2 py-1.5 text-fg transition hover:bg-warning/15">
                   <input
                     type="checkbox"
                     checked={adminMerge}
                     onChange={(e) => setAdminMerge(e.target.checked)}
                     disabled={busy}
-                    className="mt-0.5 h-3 w-3 cursor-pointer accent-amber-400"
+                    className="mt-0.5 h-3 w-3 cursor-pointer accent-warning"
                   />
                   <span className="flex flex-col gap-0.5">
                     <span className="flex items-center gap-1 font-medium">
-                      <ShieldAlert size={11} />
+                      <ShieldAlert size={11} className="text-warning" />
                       {dt(t, "dialogs.mergePullRequest.adminMerge")}
                     </span>
-                    <span className="text-[10px] leading-snug text-amber-200/80">
+                    <span className="text-[10px] leading-snug text-fg-muted">
                       {dt(t, "dialogs.mergePullRequest.adminMergeHint")}
                     </span>
                   </span>
@@ -388,8 +475,20 @@ export function MergePullRequestDialog({
               </TextSwap>
             </button>
           </footer>
-        </>
-      ) : null}
-    </Modal>
+          </>
+        ) : null}
+      </Modal>
+      <ProjectSettingsModal
+        project={
+          projectSettingsOpen
+            ? { name: projectNameFromRepoPath(repoPath), repoPath }
+            : null
+        }
+        onClose={() => {
+          setProjectSettingsOpen(false);
+          void reloadProjectPrompt();
+        }}
+      />
+    </>
   );
 }

--- a/src/components/ProjectSettingsModal.test.tsx
+++ b/src/components/ProjectSettingsModal.test.tsx
@@ -1,0 +1,135 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectSettingsRecord } from "../lib/types";
+
+vi.mock("../lib/api", () => ({
+  api: {
+    getProjectSettings: vi.fn<() => Promise<ProjectSettingsRecord>>(),
+    updateProjectSettings: vi.fn<
+      (
+        repoPath: string,
+        settings: ProjectSettingsRecord["settings"],
+      ) => Promise<ProjectSettingsRecord>
+    >(),
+  },
+}));
+
+import { api } from "../lib/api";
+import { ProjectSettingsModal } from "./ProjectSettingsModal";
+
+const mockApi = vi.mocked(api);
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function changeTextareaValue(textarea: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(textarea, value);
+  textarea.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("ProjectSettingsModal", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockApi.getProjectSettings.mockReset();
+    mockApi.updateProjectSettings.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("loads and saves project pull request settings", async () => {
+    mockApi.getProjectSettings.mockResolvedValueOnce({
+      key: "github:im-ian/acorn",
+      settings: {
+        remember_after_close: true,
+        pull_requests: {
+          generation_prompt: "Use concise release-note style.",
+        },
+      },
+    });
+    mockApi.updateProjectSettings.mockImplementation(
+      async (_repoPath, settings) => ({
+        key: "github:im-ian/acorn",
+        settings,
+      }),
+    );
+    const onClose = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <ProjectSettingsModal
+          project={{ name: "acorn", repoPath: "/repo/acorn" }}
+          onClose={onClose}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const prompt = document.body.querySelector<HTMLTextAreaElement>("textarea");
+    expect(prompt?.value).toBe("Use concise release-note style.");
+
+    await act(async () => {
+      changeTextareaValue(prompt!, "Write Korean release notes.");
+    });
+
+    const keepCheckbox = document.body.querySelector<HTMLInputElement>(
+      'input[type="checkbox"]',
+    );
+    expect(keepCheckbox?.checked).toBe(true);
+    await act(async () => {
+      keepCheckbox!.click();
+    });
+
+    const save = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent === "Save");
+    expect(save).toBeDefined();
+
+    await act(async () => {
+      save!.click();
+    });
+    await flushPromises();
+
+    expect(mockApi.updateProjectSettings).toHaveBeenCalledWith("/repo/acorn", {
+      remember_after_close: false,
+      pull_requests: {
+        generation_prompt: "Write Korean release notes.",
+      },
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows the standard PR prompt while project settings are loading", async () => {
+    mockApi.getProjectSettings.mockImplementation(
+      () => new Promise<ProjectSettingsRecord>(() => {}),
+    );
+
+    await act(async () => {
+      root.render(
+        <ProjectSettingsModal
+          project={{ name: "acorn", repoPath: "/repo/acorn" }}
+          onClose={() => {}}
+        />,
+      );
+    });
+
+    const prompt = document.body.querySelector<HTMLTextAreaElement>("textarea");
+    expect(prompt?.value).toContain("GitHub-style pull request");
+  });
+});

--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -1,0 +1,239 @@
+import { Settings } from "lucide-react";
+import { useEffect, useState } from "react";
+import { api } from "../lib/api";
+import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { STANDARD_PR_GENERATION_PROMPT } from "../lib/project-settings";
+import type { ProjectSettings } from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
+import { CheckboxRow, Field, Modal, ModalHeader, TextSwap } from "./ui";
+
+const PROMPT_MAX_CHARS = 2_000;
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
+
+function defaultProjectSettings(): ProjectSettings {
+  return {
+    remember_after_close: true,
+    pull_requests: {
+      generation_prompt: STANDARD_PR_GENERATION_PROMPT,
+    },
+  };
+}
+
+function promptCount(template: string, count: number): string {
+  return template
+    .replace("{count}", String(count))
+    .replace("{max}", String(PROMPT_MAX_CHARS));
+}
+
+interface ProjectSettingsModalProps {
+  project: { name: string; repoPath: string } | null;
+  onClose: () => void;
+}
+
+export function ProjectSettingsModal({
+  project,
+  onClose,
+}: ProjectSettingsModalProps) {
+  const t = useTranslation();
+  const [settings, setSettings] = useState<ProjectSettings>(() =>
+    defaultProjectSettings(),
+  );
+  const [identity, setIdentity] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useDialogShortcuts(project !== null, {
+    onCancel: onClose,
+    onConfirm: () => {},
+  });
+
+  useEffect(() => {
+    if (!project) {
+      setSettings(defaultProjectSettings());
+      setIdentity(null);
+      setLoading(false);
+      setSaving(false);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    api
+      .getProjectSettings(project.repoPath)
+      .then((record) => {
+        if (cancelled) return;
+        setSettings(record.settings);
+        setIdentity(record.key);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setSettings(defaultProjectSettings());
+        setIdentity(null);
+        setError(String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [project]);
+
+  const prompt = settings.pull_requests.generation_prompt ?? "";
+
+  function updatePrompt(value: string) {
+    const next = Array.from(value).slice(0, PROMPT_MAX_CHARS).join("");
+    setSettings((current) => ({
+      ...current,
+      pull_requests: {
+        ...current.pull_requests,
+        generation_prompt: next,
+      },
+    }));
+  }
+
+  function updateRememberAfterClose(value: boolean) {
+    setSettings((current) => ({
+      ...current,
+      remember_after_close: value,
+    }));
+  }
+
+  async function save() {
+    if (!project) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const record = await api.updateProjectSettings(
+        project.repoPath,
+        settings,
+      );
+      setSettings(record.settings);
+      setIdentity(record.key);
+      onClose();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal
+      open={project !== null}
+      onClose={onClose}
+      variant="dialog"
+      size="lg"
+    >
+      {project ? (
+        <>
+          <ModalHeader
+            title={dt(t, "dialogs.projectSettings.title")}
+            subtitle={project.name}
+            icon={
+              <Settings
+                size={16}
+                className="mt-0.5 self-start text-fg-muted"
+              />
+            }
+            variant="dialog"
+            onClose={onClose}
+          />
+          <div className="space-y-4 px-4 py-3 text-xs text-fg">
+            <div className="space-y-1 rounded-md border border-border bg-bg-sidebar/40 px-3 py-2">
+              <p className="break-all font-mono text-[11px] text-fg-muted">
+                {project.repoPath}
+              </p>
+              {identity ? (
+                <p className="break-all font-mono text-[10px] text-fg-muted/80">
+                  {identity}
+                </p>
+              ) : null}
+            </div>
+
+            <section className="space-y-2">
+              <div>
+                <h3 className="text-xs font-medium text-fg">
+                  {dt(t, "dialogs.projectSettings.pullRequests")}
+                </h3>
+                <p className="mt-0.5 text-[11px] text-fg-muted">
+                  {dt(t, "dialogs.projectSettings.pullRequestsHint")}
+                </p>
+              </div>
+              <Field
+                label={dt(t, "dialogs.projectSettings.generationPrompt")}
+                hint={dt(t, "dialogs.projectSettings.generationPromptHint")}
+              >
+                <textarea
+                  value={prompt}
+                  onChange={(e) => updatePrompt(e.target.value)}
+                  disabled={loading || saving}
+                  rows={7}
+                  maxLength={PROMPT_MAX_CHARS}
+                  placeholder={dt(
+                    t,
+                    "dialogs.projectSettings.generationPromptPlaceholder",
+                  )}
+                  className="w-full resize-none rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[11px] leading-relaxed text-fg outline-none transition focus:border-accent disabled:opacity-60"
+                />
+                <p className="text-right text-[10px] tabular-nums text-fg-muted">
+                  {promptCount(
+                    dt(t, "dialogs.projectSettings.promptCount"),
+                    Array.from(prompt).length,
+                  )}
+                </p>
+              </Field>
+            </section>
+
+            <CheckboxRow
+              label={dt(t, "dialogs.projectSettings.rememberAfterClose")}
+              description={dt(
+                t,
+                "dialogs.projectSettings.rememberAfterCloseHint",
+              )}
+              checked={settings.remember_after_close}
+              disabled={loading || saving}
+              onChange={updateRememberAfterClose}
+            />
+
+            {error ? (
+              <p className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-[11px] text-danger">
+                {error}
+              </p>
+            ) : null}
+          </div>
+          <footer className="flex items-center justify-end gap-2 border-t border-border bg-bg-sidebar/40 px-4 py-3">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={saving}
+              className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {dt(t, "dialogs.common.cancel")}
+            </button>
+            <button
+              type="button"
+              onClick={() => void save()}
+              disabled={loading || saving}
+              className="rounded-md bg-accent/20 px-3 py-1.5 text-xs font-medium text-accent transition hover:bg-accent/30 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <TextSwap>
+                {saving
+                  ? dt(t, "dialogs.projectSettings.saving")
+                  : dt(t, "dialogs.projectSettings.save")}
+              </TextSwap>
+            </button>
+          </footer>
+        </>
+      ) : null}
+    </Modal>
+  );
+}

--- a/src/components/PullRequestDetailModal.modal.test.tsx
+++ b/src/components/PullRequestDetailModal.modal.test.tsx
@@ -22,6 +22,11 @@ vi.mock("../lib/api", () => {
       updatePullRequestBody: vi.fn<
         (repoPath: string, n: number, body: string) => Promise<void>
       >(),
+      mergePullRequest: vi.fn(),
+      closePullRequest: vi.fn(),
+      generatePrCommitMessage: vi.fn(),
+      getProjectSettings: vi.fn(),
+      updateProjectSettings: vi.fn(),
     },
   };
 });
@@ -78,6 +83,19 @@ describe("PullRequestDetailModal — body checkbox toggle", () => {
     root = createRoot(container);
     mockApi.getPullRequestDetail.mockReset();
     mockApi.updatePullRequestBody.mockReset();
+    mockApi.mergePullRequest.mockReset();
+    mockApi.closePullRequest.mockReset();
+    mockApi.generatePrCommitMessage.mockReset();
+    mockApi.getProjectSettings.mockReset();
+    mockApi.updateProjectSettings.mockReset();
+    mockApi.getProjectSettings.mockResolvedValue({
+      key: "path:/r",
+      settings: {
+        remember_after_close: true,
+        pull_requests: { generation_prompt: null },
+      },
+    });
+    window.localStorage.clear();
     useSettings.setState({ settings: structuredClone(DEFAULT_SETTINGS) });
   });
 
@@ -344,5 +362,133 @@ describe("PullRequestDetailModal — body checkbox toggle", () => {
 
     expect(mockApi.getPullRequestDetail).toHaveBeenCalledTimes(2);
     expect(document.body.textContent).toContain("6s");
+  });
+
+  it("opens project settings from the hidden GEN prompt button", async () => {
+    mockApi.getPullRequestDetail.mockResolvedValueOnce({
+      kind: "ok",
+      account: "tester",
+      detail: fakeDetail("Describe the change"),
+    });
+
+    await act(async () => {
+      root.render(
+        <PullRequestDetailModal
+          open={{ repoPath: "/r", number: 999 }}
+          onClose={() => {}}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const mergeButton = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent === "Merge");
+    expect(mergeButton).toBeDefined();
+
+    await act(async () => {
+      mergeButton!.click();
+    });
+    await flushPromises();
+
+    const promptBox = document.body.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="GEN prompt"]',
+    );
+    expect(promptBox).toBeNull();
+
+    const settingsButton = document.body.querySelector<HTMLButtonElement>(
+      'button[aria-label="Go to project settings"]',
+    );
+    expect(settingsButton).toBeTruthy();
+    await act(async () => {
+      settingsButton!.click();
+    });
+    await flushPromises();
+
+    expect(document.body.textContent).toContain("Project Settings");
+    expect(document.body.textContent).toContain(
+      "Prompt for generated PR titles, comments, and merge messages",
+    );
+  });
+
+  it("uses the project GEN prompt and applies the generated PR comment", async () => {
+    mockApi.getProjectSettings.mockResolvedValueOnce({
+      key: "github:im-ian/acorn",
+      settings: {
+        remember_after_close: true,
+        pull_requests: {
+          generation_prompt:
+            "프로젝트 규칙대로 PR title과 comment를 한국어 릴리즈 노트 스타일로 작성해.",
+        },
+      },
+    });
+    mockApi.getPullRequestDetail.mockResolvedValueOnce({
+      kind: "ok",
+      account: "tester",
+      detail: fakeDetail("Describe the change"),
+    });
+    mockApi.generatePrCommitMessage.mockResolvedValueOnce({
+      title: "feat(pr): 프로젝트 설정 기반 생성",
+      body: "프로젝트 설정 프롬프트를 반영한 PR 코멘트입니다.",
+    });
+
+    await act(async () => {
+      root.render(
+        <PullRequestDetailModal
+          open={{ repoPath: "/r", number: 999 }}
+          onClose={() => {}}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const mergeButton = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent === "Merge");
+    expect(mergeButton).toBeDefined();
+
+    await act(async () => {
+      mergeButton!.click();
+    });
+    await flushPromises();
+
+    const promptBox = document.body.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="GEN prompt"]',
+    );
+    expect(promptBox).toBeNull();
+
+    const generateButton = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.includes("Generate with AI"));
+    expect(generateButton).toBeDefined();
+
+    await act(async () => {
+      generateButton!.click();
+    });
+    await flushPromises();
+
+    expect(mockApi.generatePrCommitMessage).toHaveBeenCalledWith(
+      "/r",
+      999,
+      "squash",
+      "claude",
+      ["-p", "--output-format", "text"],
+      "프로젝트 규칙대로 PR title과 comment를 한국어 릴리즈 노트 스타일로 작성해.",
+    );
+
+    const generatedTitle = Array.from(
+      document.body.querySelectorAll<HTMLInputElement>('input[type="text"]'),
+    ).find(
+      (input) => input.value === "feat(pr): 프로젝트 설정 기반 생성",
+    );
+    expect(generatedTitle).toBeDefined();
+
+    const generatedComment = Array.from(
+      document.body.querySelectorAll<HTMLTextAreaElement>("textarea"),
+    ).find(
+      (textarea) =>
+        textarea.value === "프로젝트 설정 프롬프트를 반영한 PR 코멘트입니다.",
+    );
+    expect(generatedComment).toBeDefined();
   });
 });

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Pencil,
   PencilLine,
   Plus,
+  Settings as SettingsIcon,
   SquareX,
   Trash2,
   X,
@@ -79,6 +80,7 @@ import {
 import type { Session, SessionKind, SessionStatus } from "../lib/types";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { NewProjectDialog } from "./NewProjectDialog";
+import { ProjectSettingsModal } from "./ProjectSettingsModal";
 import { SessionTitleGeneratingIndicator } from "./SessionTitleGeneratingIndicator";
 import { Tooltip } from "./Tooltip";
 
@@ -142,6 +144,9 @@ export function Sidebar() {
   const [collapsed, setCollapsed] = useState<Set<string>>(() => loadCollapsed());
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
+  const [settingsProject, setSettingsProject] = useState<ProjectGroup | null>(
+    null,
+  );
 
   useEffect(() => {
     saveCollapsed(collapsed);
@@ -524,6 +529,7 @@ export function Sidebar() {
                     onRemoveProject={() =>
                       requestRemoveProject(project.repoPath)
                     }
+                    onOpenSettings={() => setSettingsProject(project)}
                   />
                 ))}
               </ul>
@@ -555,6 +561,17 @@ export function Sidebar() {
             throw e;
           }
         }}
+      />
+      <ProjectSettingsModal
+        project={
+          settingsProject
+            ? {
+                name: settingsProject.name,
+                repoPath: settingsProject.repoPath,
+              }
+            : null
+        }
+        onClose={() => setSettingsProject(null)}
       />
     </aside>
   );
@@ -707,6 +724,7 @@ interface ProjectGroupViewProps {
   onRemoveSession: (s: Session) => void;
   onAddSession: (isolated: boolean, kind: SessionKind) => void;
   onRemoveProject: () => void;
+  onOpenSettings: () => void;
 }
 
 function ProjectGroupView({
@@ -721,6 +739,7 @@ function ProjectGroupView({
   onRemoveSession,
   onAddSession,
   onRemoveProject,
+  onOpenSettings,
 }: ProjectGroupViewProps) {
   const t = useTranslation();
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
@@ -919,6 +938,11 @@ function ProjectGroupView({
             onClick: () => onAddSession(false, "control"),
           },
           { type: "separator" },
+          {
+            label: sidebarText(t, "sidebar.actions.projectSettings"),
+            icon: <SettingsIcon size={12} />,
+            onClick: onOpenSettings,
+          },
           {
             label: sidebarText(t, "sidebar.actions.revealInFinder"),
             icon: <FolderOpen size={12} />,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,8 @@ import type {
   MemoryUsage,
   MergeMethod,
   Project,
+  ProjectSettings,
+  ProjectSettingsRecord,
   PrStateFilter,
   PullRequestDetailListing,
   PullRequestListing,
@@ -122,11 +124,25 @@ export const api = {
     repoPath: string,
     removeSessions = true,
     removeWorktrees = false,
+    removeSettings = false,
   ): Promise<void> {
     return invoke<void>("remove_project", {
       repoPath,
       removeSessions,
       removeWorktrees,
+      removeSettings,
+    });
+  },
+  getProjectSettings(repoPath: string): Promise<ProjectSettingsRecord> {
+    return invoke<ProjectSettingsRecord>("get_project_settings", { repoPath });
+  },
+  updateProjectSettings(
+    repoPath: string,
+    settings: ProjectSettings,
+  ): Promise<ProjectSettingsRecord> {
+    return invoke<ProjectSettingsRecord>("update_project_settings", {
+      repoPath,
+      settings,
     });
   },
   reorderProjects(order: string[]): Promise<Project[]> {
@@ -247,6 +263,7 @@ export const api = {
     method: MergeMethod,
     command: string,
     args: string[],
+    prompt: string,
   ): Promise<GeneratedCommitMessage> {
     return invoke<GeneratedCommitMessage>("generate_pr_commit_message", {
       repoPath,
@@ -254,6 +271,7 @@ export const api = {
       method,
       command,
       args,
+      prompt,
     });
   },
   listWorkflowRuns(

--- a/src/lib/project-settings.ts
+++ b/src/lib/project-settings.ts
@@ -1,0 +1,4 @@
+export const STANDARD_PR_GENERATION_PROMPT = `Use a standard GitHub-style pull request merge message.
+- First line: Conventional Commit subject when the type is clear, e.g. feat(scope): concise summary. Keep it imperative/present tense and <=72 chars.
+- Body: 1-2 concise paragraphs explaining why the change matters, user-visible impact, and key implementation notes when useful.
+- Keep the wording specific to the PR. Avoid boilerplate, markdown headings, labels, and prompt explanations.`;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -128,6 +128,20 @@ export interface Project {
   position: number;
 }
 
+export interface ProjectPullRequestSettings {
+  generation_prompt: string | null;
+}
+
+export interface ProjectSettings {
+  remember_after_close: boolean;
+  pull_requests: ProjectPullRequestSettings;
+}
+
+export interface ProjectSettingsRecord {
+  key: string;
+  settings: ProjectSettings;
+}
+
 export type AgentHistoryProvider = "claude" | "codex";
 
 export interface AgentHistoryWorktree {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -718,6 +718,7 @@
       "newIsolatedSession": "New isolated session",
       "newIsolatedSessionWorktree": "New isolated session (worktree)",
       "newControlSession": "New control session",
+      "projectSettings": "Project Settings",
       "closeProject": "Close project",
       "revealInFinder": "Reveal in Finder",
       "copyPath": "Copy path",
@@ -1069,6 +1070,19 @@
       "closeDeleteWorktrees": "Close · delete worktrees",
       "closeProject": "Close project"
     },
+    "projectSettings": {
+      "title": "Project Settings",
+      "pullRequests": "Pull requests",
+      "pullRequestsHint": "Project-specific defaults for pull request workflows.",
+      "generationPrompt": "Prompt for generated PR titles, comments, and merge messages",
+      "generationPromptHint": "Used when Acorn asks the selected AI CLI to generate this project's pull request title, review comment, or merge message.",
+      "generationPromptPlaceholder": "Example: Use a standard GitHub-style pull request merge message with a Conventional Commit subject and a concise impact-focused body.",
+      "promptCount": "{count} / {max}",
+      "rememberAfterClose": "Keep project settings after closing this project",
+      "rememberAfterCloseHint": "When disabled, Acorn deletes this project's saved settings when you close the project.",
+      "saving": "Saving...",
+      "save": "Save"
+    },
     "newProject": {
       "title": "New project",
       "subtitle": "Create a git repository and add it to Acorn",
@@ -1179,6 +1193,7 @@
       "generating": "Generating...",
       "generateVia": "Generate via",
       "generateWithAi": "Generate with AI",
+      "goToProjectSettings": "Go to project settings",
       "subjectPlaceholder": "Subject",
       "bodyPlaceholder": "Body (optional)",
       "rebaseMessageLocked": "Rebase replays the original commits onto the base branch - the commit messages are not customizable here.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -718,6 +718,7 @@
       "newIsolatedSession": "새 격리 세션",
       "newIsolatedSessionWorktree": "새 격리 세션 (worktree)",
       "newControlSession": "새 컨트롤 세션",
+      "projectSettings": "프로젝트 설정",
       "closeProject": "프로젝트 닫기",
       "revealInFinder": "Finder에서 보기",
       "copyPath": "경로 복사",
@@ -1069,6 +1070,19 @@
       "closeDeleteWorktrees": "닫기 · worktree 삭제",
       "closeProject": "프로젝트 닫기"
     },
+    "projectSettings": {
+      "title": "프로젝트 설정",
+      "pullRequests": "Pull request",
+      "pullRequestsHint": "이 프로젝트의 pull request 작업에만 적용되는 기본값입니다.",
+      "generationPrompt": "PR 제목, 코멘트, 머지 메시지 생성 프롬프트",
+      "generationPromptHint": "Acorn이 선택된 AI CLI로 이 프로젝트의 pull request 제목, 리뷰 코멘트, 머지 메시지를 생성할 때 사용합니다.",
+      "generationPromptPlaceholder": "예: Conventional Commit 제목과 영향 중심 본문을 사용하는 표준 GitHub 스타일 pull request merge message로 작성하세요.",
+      "promptCount": "{count} / {max}",
+      "rememberAfterClose": "프로젝트를 닫은 뒤에도 설정 유지",
+      "rememberAfterCloseHint": "끄면 이 프로젝트를 닫을 때 저장된 프로젝트 설정을 삭제합니다.",
+      "saving": "저장 중...",
+      "save": "저장"
+    },
     "newProject": {
       "title": "새 프로젝트",
       "subtitle": "Git 저장소를 만들고 Acorn에 추가합니다",
@@ -1179,6 +1193,7 @@
       "generating": "생성 중...",
       "generateVia": "다음으로 생성:",
       "generateWithAi": "AI로 생성",
+      "goToProjectSettings": "프로젝트 설정으로 이동",
       "subjectPlaceholder": "제목",
       "bodyPlaceholder": "본문(선택 사항)",
       "rebaseMessageLocked": "Rebase는 원래 커밋을 기본 브랜치 위에 다시 적용하므로 여기서 커밋 메시지를 변경할 수 없습니다.",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1402,7 +1402,12 @@ describe("requestRemoveProject", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(useAppStore.getState().pendingRemoveProject).toBeNull();
-    expect(mockApi.removeProject).toHaveBeenCalledWith(REPO_B, true, false);
+    expect(mockApi.removeProject).toHaveBeenCalledWith(
+      REPO_B,
+      true,
+      false,
+      false,
+    );
     expect(useAppStore.getState().workspaces[REPO_B]).toBeUndefined();
   });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -209,7 +209,11 @@ interface AppStateModel {
     name: string,
     ignoreSafeName?: boolean,
   ) => Promise<Project>;
-  removeProject: (repoPath: string, removeWorktrees?: boolean) => Promise<void>;
+  removeProject: (
+    repoPath: string,
+    removeWorktrees?: boolean,
+    removeSettings?: boolean,
+  ) => Promise<void>;
   reorderProjects: (orderedRepoPaths: string[]) => Promise<void>;
   reorderSessions: (repoPath: string, orderedIds: string[]) => Promise<void>;
   requestRemoveProject: (repoPath: string) => void;
@@ -1581,9 +1585,9 @@ export const useAppStore = create<AppStateModel>()(
     }
   },
 
-  async removeProject(repoPath, removeWorktrees = false) {
+  async removeProject(repoPath, removeWorktrees = false, removeSettings = false) {
     try {
-      await api.removeProject(repoPath, true, removeWorktrees);
+      await api.removeProject(repoPath, true, removeWorktrees, removeSettings);
       // Drop the project's workspace from local state explicitly — refreshAll
       // also reconciles, but pre-clearing avoids a flash of stale state.
       set((s) => {

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -11,6 +11,7 @@ export const tauriMockSource = `
 
   const handlers = window.__ACORN_MOCK_HANDLERS__ || {};
   let nextCallbackId = 0;
+  const standardPrGenerationPrompt = 'Use a standard GitHub-style pull request merge message.\\n- First line: Conventional Commit subject when the type is clear, e.g. feat(scope): concise summary. Keep it imperative/present tense and <=72 chars.\\n- Body: 1-2 concise paragraphs explaining why the change matters, user-visible impact, and key implementation notes when useful.\\n- Keep the wording specific to the PR. Avoid boilerplate, markdown headings, labels, and prompt explanations.';
 
   function pluginDefault(cmd, args) {
     if (cmd === 'plugin:event|listen') return Promise.resolve(nextCallbackId++);
@@ -43,6 +44,24 @@ export const tauriMockSource = `
     }
     if (cmd === 'list_sessions') return Promise.resolve([]);
     if (cmd === 'list_projects') return Promise.resolve([]);
+    if (cmd === 'get_project_settings') {
+      return Promise.resolve({
+        key: 'path:' + (args?.repoPath || '/tmp/project'),
+        settings: {
+          remember_after_close: true,
+          pull_requests: { generation_prompt: standardPrGenerationPrompt },
+        },
+      });
+    }
+    if (cmd === 'update_project_settings') {
+      return Promise.resolve({
+        key: 'path:' + (args?.repoPath || '/tmp/project'),
+        settings: args?.settings || {
+          remember_after_close: true,
+          pull_requests: { generation_prompt: standardPrGenerationPrompt },
+        },
+      });
+    }
     if (cmd === 'create_new_project') {
       const name = args && typeof args.name === 'string' ? args.name : 'new-project';
       const parentPath = args && typeof args.parentPath === 'string' ? args.parentPath : '/tmp';


### PR DESCRIPTION
## Summary
This adds project-scoped settings for AI-generated pull request merge text so each repository can keep its own generation style.

1. **Project settings storage**: Add `project_settings.json` backed by stable project keys (`github:owner/repo` when available, path fallback) with a `remember_after_close` setting.
2. **PR generation prompt**: Store a per-project prompt for generated PR titles, comments, and merge messages, and pass it into the existing PR merge-message generation flow.
3. **Settings UI**: Add a Project Settings modal reachable from the sidebar project menu and from the PR merge dialog, with explicit copy explaining where the prompt is used.
4. **Merge dialog contrast**: Use theme tokens for the blocked-checks/admin-merge warning block so it remains legible in light themes.
5. **Tests and mocks**: Cover settings persistence, prompt normalization/fallback, modal behavior, PR generation calls, and the updated Tauri mock contract.

## Expected impact
| Area | Impact |
| --- | --- |
| Pull request workflow | Users can tune generated PR merge text per project instead of relying on one fixed prompt. |
| Project lifecycle | Settings persist across close/reopen by default, and can be configured to delete when the project is closed. |
| Existing projects | Existing projects get the standard default prompt until a project setting is saved. |
| Light theme usability | The blocked-checks/admin-merge warning remains readable instead of using low-contrast fixed amber text. |

## Design notes
- Settings are stored outside `projects.json` to avoid coupling heavier, growing project preferences to the open-project list.
- GitHub remotes use a repo identity key so reopening the same repo from another path can reuse settings; non-GitHub projects fall back to canonical path identity.
- The merge dialog keeps the generated title/body fields local, but resolves the prompt from Project Settings before invoking the AI CLI.
- The backend still enforces a strict output contract around the user prompt so generated output remains usable as merge dialog text.
- The blocked-checks/admin-merge panel now uses existing theme tokens (`warning`, `fg`, `fg-muted`, `bg-sidebar`) rather than hard-coded amber text colors.

## Follow-up (not in this PR)
- Consider adding more project-level settings once there are multiple categories worth grouping in this modal.
- Consider adding a close-project dialog option for deleting saved settings explicitly, separate from the persistent project setting.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run src/components/ProjectSettingsModal.test.tsx src/components/PullRequestDetailModal.modal.test.tsx src/store.test.ts`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml project_settings`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml commit_message_prompt`
- [x] `git diff --check`
- [x] GitHub Actions `Frontend`
- [x] GitHub Actions `E2E`

## Notes
- The targeted Rust tests emit the existing `AgentHookServer::start` dead-code warning; it is not introduced by this PR.
