### PR TITLE
fix(ui): lift toast above status bar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -17,6 +17,10 @@
   --font-mono: "JetBrains Mono", "SF Mono", "Menlo", monospace;
 }
 
+:root {
+  --acorn-status-bar-height: 1.75rem;
+}
+
 .acorn-terminal .xterm-viewport {
   background-color: transparent !important;
 }

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -163,11 +163,12 @@ export function StatusBar() {
   return (
     <>
       {/* `overflow-hidden` + `whitespace-nowrap` on inline children keeps
-          the bar at a strict h-7 even at narrow widths. Without it, the
-          branch text wraps inside its span, the row grows to two lines,
-          and Terminal's ResizeObserver fires SIGWINCH mid-claude-launch —
-          which leaves cursor/cells offset until a tab-switch refit. */}
-      <footer className="flex h-7 shrink-0 items-center gap-3 overflow-hidden border-t border-border bg-bg-sidebar px-3 font-mono text-xs text-fg-muted">
+          the bar at the configured status-bar height even at narrow widths.
+          Without it, the branch text wraps inside its span, the row grows
+          to two lines, and Terminal's ResizeObserver fires SIGWINCH
+          mid-claude-launch — which leaves cursor/cells offset until a
+          tab-switch refit. */}
+      <footer className="flex h-[var(--acorn-status-bar-height)] shrink-0 items-center gap-3 overflow-hidden border-t border-border bg-bg-sidebar px-3 font-mono text-xs text-fg-muted">
         {/* Left: aggregate counters about acorn itself — total sessions and
             the active session's lifecycle status. The IPC and daemon
             buttons sit first so the user can recover from a dead

--- a/src/components/ToastHost.tsx
+++ b/src/components/ToastHost.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 import { useToasts } from "../lib/toasts";
 
 /**
- * Renders the active toast (if any) at the bottom-center of the viewport.
+ * Renders the active toast (if any) above the bottom status bar.
  * Pointer-events disabled so the toast never blocks clicks on the
  * underlying UI. Auto-dismisses via the store's TTL — there is no manual
  * close affordance because every existing trigger is a deliberate user
@@ -12,7 +12,7 @@ export function ToastHost(): ReactElement | null {
   const message = useToasts((s) => s.message);
   if (!message) return null;
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-6 z-50 flex justify-center">
+    <div className="pointer-events-none fixed inset-x-0 bottom-[calc(1.5rem+var(--acorn-status-bar-height))] z-50 flex justify-center">
       <div
         role="status"
         aria-live="polite"


### PR DESCRIPTION
## Summary
This keeps bottom-positioned toast notifications from sitting on top of the bottom status bar.

1. **Shared status bar height** — add `--acorn-status-bar-height` so the status bar and overlays can reference the same vertical offset.
2. **Toast bottom offset** — move `ToastHost` up by the status bar height while preserving the existing 1.5rem bottom gap.
3. **Status bar sizing** — swap the status bar's hardcoded `h-7` class for the shared height variable.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Bottom toast placement | Anchored 1.5rem from the app bottom, overlapping the status bar area | Anchored 1.5rem above the status bar |
| Status bar height | Hardcoded Tailwind `h-7` | Same 1.75rem height via shared CSS variable |

## Design notes
- The toast remains a single global host mounted near the app root; only its fixed bottom offset changes.
- The shared CSS variable keeps future status bar height tweaks from silently desynchronizing toast placement.

## Test plan
- [x] `git diff --check -- src/App.css src/components/StatusBar.tsx src/components/ToastHost.tsx` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` passes; Vite reports the existing dynamic-import/chunk-size warnings

## Notes
- No unrelated local changes were staged.