### PR TITLE
fix(terminal): stabilize link hover tooltip and underline

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-serialize": "^0.14.0",
     "@xterm/addon-unicode11": "^0.9.0",
-    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       '@xterm/addon-unicode11':
         specifier: ^0.9.0
         version: 0.9.0
-      '@xterm/addon-web-links':
-        specifier: ^0.12.0
-        version: 0.12.0
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
@@ -1211,9 +1208,6 @@ packages:
 
   '@xterm/addon-unicode11@0.9.0':
     resolution: {integrity: sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==}
-
-  '@xterm/addon-web-links@0.12.0':
-    resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
@@ -3229,8 +3223,6 @@ snapshots:
   '@xterm/addon-serialize@0.14.0': {}
 
   '@xterm/addon-unicode11@0.9.0': {}
-
-  '@xterm/addon-web-links@0.12.0': {}
 
   '@xterm/xterm@6.0.0': {}
 

--- a/src/App.css
+++ b/src/App.css
@@ -94,6 +94,13 @@
   background: var(--color-terminal-bg, #1f2326);
 }
 
+.acorn-terminal-shell[data-acorn-link-hover="true"]
+  .xterm-rows
+  span[style*="underline"] {
+  text-decoration: none !important;
+  text-decoration-line: none !important;
+}
+
 .acorn-session-title-indicator {
   position: relative;
   display: inline-flex;

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -9,11 +9,11 @@ import {
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
-import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Channel, invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { ArrowDownToLine } from "lucide-react";
+import { createPortal } from "react-dom";
 import "@xterm/xterm/css/xterm.css";
 import { api } from "../lib/api";
 import type { BackgroundState } from "../lib/background";
@@ -46,6 +46,7 @@ import {
   resolveTerminalFilePath,
   type TerminalFileReference,
 } from "../lib/terminalFileLinks";
+import { createTerminalWebLinkProvider } from "../lib/terminalWebLinks";
 import {
   useSettings,
   type TerminalLinkActivation,
@@ -140,6 +141,8 @@ const ANSI_RED = "\x1b[31m";
 const ANSI_RESET = "\x1b[0m";
 const ANSI_DIM = "\x1b[2m";
 const SCROLL_TO_BOTTOM_VISIBLE_ROWS = 10;
+// xterm briefly leaves and re-enters hovered links when refreshed rows repaint.
+const LINK_TOOLTIP_HIDE_GRACE_MS = 80;
 
 // Custom event the sticky-prompt banner listens to. Fired whenever the user
 // scrolls the terminal so the banner can swap to the prompt "in scope" at
@@ -252,6 +255,15 @@ const MODIFIER_LINK_LABEL = IS_MAC ? "Command-click" : "Ctrl-click";
 
 interface TerminalRenderInternals {
   _core?: {
+    linkifier?: {
+      currentLink?: {
+        link?: {
+          decorations?: {
+            underline?: boolean;
+          };
+        };
+      };
+    };
     _renderService?: {
       dimensions?: {
         css?: {
@@ -273,6 +285,14 @@ function terminalCellDims(term: XTerm): { width: number; height: number } | null
   const core = (term as unknown as TerminalRenderInternals)._core;
   const cell = core?._renderService?.dimensions?.css?.cell;
   return cell ? { width: cell.width, height: cell.height } : null;
+}
+
+function suppressCurrentXtermLinkUnderline(term: XTerm): void {
+  const link = (term as unknown as TerminalRenderInternals)._core?.linkifier
+    ?.currentLink?.link;
+  if (link?.decorations && link.decorations.underline !== false) {
+    link.decorations.underline = false;
+  }
 }
 
 function textRangeRectForColumns(
@@ -317,7 +337,18 @@ function textRangeRectForColumns(
   return rect;
 }
 
-function unionRects(rects: DOMRect[]): TooltipAnchorRect | null {
+function rectToTooltipAnchorRect(rect: DOMRect): TooltipAnchorRect {
+  return {
+    top: rect.top,
+    bottom: rect.bottom,
+    left: rect.left,
+    right: rect.right,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function unionRects(rects: TooltipAnchorRect[]): TooltipAnchorRect | null {
   if (rects.length === 0) return null;
   const left = Math.min(...rects.map((r) => r.left));
   const top = Math.min(...rects.map((r) => r.top));
@@ -333,76 +364,99 @@ function unionRects(rects: DOMRect[]): TooltipAnchorRect | null {
   };
 }
 
-function hoveredLinkAnchorRect(container: HTMLElement): TooltipAnchorRect | null {
-  const rects = Array.from(
-    container.querySelectorAll<HTMLElement>(".xterm-rows span"),
-  )
-    .filter((el) => {
-      const style = getComputedStyle(el);
-      return style.textDecorationLine.includes("underline");
-    })
-    .map((el) => el.getBoundingClientRect())
-    .filter((rect) => rect.width > 0 && rect.height > 0);
-  return unionRects(rects);
+function terminalLinkTooltipKey(text: string, range: IViewportRange): string {
+  return [
+    text,
+    range.start.x,
+    range.start.y,
+    range.end.x,
+    range.end.y,
+  ].join("\u0000");
 }
 
-function linkRangeAnchorRect(
+function FloatingTerminalLinkUnderlines({
+  linkKey,
+  rects,
+}: {
+  linkKey: string;
+  rects: TooltipAnchorRect[];
+}): ReactElement | null {
+  if (rects.length === 0) return null;
+
+  return createPortal(
+    <>
+      {rects.map((rect, index) => (
+        <span
+          key={`${linkKey}:${index}`}
+          aria-hidden="true"
+          data-acorn-terminal-link-underline="true"
+          className="xterm-hover pointer-events-none fixed bg-fg"
+          style={{
+            top: rect.bottom - 1,
+            left: rect.left,
+            width: rect.width,
+            height: 1,
+            zIndex: 9998,
+          }}
+        />
+      ))}
+    </>,
+    document.body,
+  );
+}
+
+function linkRangeAnchorRects(
   container: HTMLElement,
   term: XTerm,
   range: IViewportRange,
-): TooltipAnchorRect | null {
+): TooltipAnchorRect[] {
   const cell = terminalCellDims(term);
-  if (!cell) return null;
+  if (!cell) return [];
   const viewportY = term.buffer.active.viewportY;
 
   const startViewportY = range.start.y - viewportY - 1;
   const endViewportY = range.end.y - viewportY - 1;
-  if (endViewportY < 0 || startViewportY >= term.rows) return null;
+  if (endViewportY < 0 || startViewportY >= term.rows) return [];
 
-  const row = Math.max(0, Math.min(term.rows - 1, startViewportY));
   const rowElements = Array.from(
     container.querySelectorAll<HTMLElement>(".xterm-rows > div"),
   );
-  const textRects: DOMRect[] = [];
+  const rects: TooltipAnchorRect[] = [];
   const firstVisibleRow = Math.max(0, startViewportY);
   const lastVisibleRow = Math.min(term.rows - 1, endViewportY);
   for (let y = firstVisibleRow; y <= lastVisibleRow; y++) {
     const rowElement = rowElements[y];
-    if (!rowElement) continue;
+    const rowRect =
+      rowElement?.getBoundingClientRect() ??
+      (
+        container.querySelector<HTMLElement>(".xterm-screen") ?? container
+      ).getBoundingClientRect();
     const startCol = y === startViewportY ? Math.max(0, range.start.x - 1) : 0;
     const endCol =
       y === endViewportY
         ? Math.max(startCol + 1, Math.min(term.cols, range.end.x))
         : term.cols;
-    const rect = textRangeRectForColumns(rowElement, startCol, endCol);
-    if (rect) textRects.push(rect);
+    const textRect = rowElement
+      ? textRangeRectForColumns(rowElement, startCol, endCol)
+      : null;
+    if (textRect) {
+      rects.push(rectToTooltipAnchorRect(textRect));
+      continue;
+    }
+    const left = rowRect.left + startCol * cell.width;
+    const top = rowElement ? rowRect.top : rowRect.top + y * cell.height;
+    const right = rowRect.left + endCol * cell.width;
+    const bottom = rowElement ? rowRect.bottom : top + cell.height;
+    rects.push({
+      top,
+      bottom,
+      left,
+      right,
+      width: right - left,
+      height: bottom - top,
+    });
   }
-  const textRect = unionRects(textRects);
-  if (textRect) return textRect;
-
-  const rowElement = rowElements[row];
-  const rowRect =
-    rowElement?.getBoundingClientRect() ??
-    (
-      container.querySelector<HTMLElement>(".xterm-screen") ?? container
-    ).getBoundingClientRect();
-  const startX = startViewportY < 0 ? 0 : Math.max(0, range.start.x - 1);
-  const endX =
-    row === endViewportY
-      ? Math.max(startX + 1, Math.min(term.cols, range.end.x))
-      : term.cols;
-  const left = rowRect.left + startX * cell.width;
-  const top = rowElement ? rowRect.top : rowRect.top + row * cell.height;
-  const right = rowRect.left + endX * cell.width;
-  const bottom = rowElement ? rowRect.bottom : top + cell.height;
-  return {
-    top,
-    bottom,
-    left,
-    right,
-    width: right - left,
-    height: bottom - top,
-  };
+  return rects.filter((rect) => rect.width > 0 && rect.height > 0);
 }
 
 function decodeBase64ToBytes(b64: string): Uint8Array {
@@ -473,6 +527,8 @@ export function Terminal({
     useRef<SessionAgentProvider | null>(pasteAgentProvider);
   const [linkTooltip, setLinkTooltip] = useState<{
     anchorRect: TooltipAnchorRect;
+    underlineRects: TooltipAnchorRect[];
+    linkKey: string;
   } | null>(null);
   const [isScrolledBack, setIsScrolledBack] = useState(false);
 
@@ -525,26 +581,77 @@ export function Terminal({
     // opts into modifier-click activation, plain clicks are swallowed so a
     // stray click on a URL in shell output doesn't steal focus.
     let linkTooltipFrame: number | null = null;
-    const showLinkTooltip = (range: IViewportRange) => {
+    let linkTooltipHideTimer: number | null = null;
+    const cancelLinkTooltipHide = () => {
+      if (linkTooltipHideTimer !== null) {
+        window.clearTimeout(linkTooltipHideTimer);
+        linkTooltipHideTimer = null;
+      }
+    };
+    const showLinkTooltip = (text: string, range: IViewportRange) => {
+      cancelLinkTooltipHide();
       if (linkTooltipFrame !== null) {
         cancelAnimationFrame(linkTooltipFrame);
       }
+      const linkKey = terminalLinkTooltipKey(text, range);
       linkTooltipFrame = requestAnimationFrame(() => {
         linkTooltipFrame = null;
         if (linkActivation !== "modifier-click") return;
-        const anchorRect =
-          hoveredLinkAnchorRect(container) ??
-          linkRangeAnchorRect(container, term, range);
+        const underlineRects = linkRangeAnchorRects(container, term, range);
+        const anchorRect = unionRects(underlineRects);
         if (!anchorRect) return;
-        setLinkTooltip({ anchorRect });
+        setLinkTooltip((current) => {
+          if (current?.linkKey === linkKey) {
+            return current;
+          }
+          return { anchorRect, underlineRects, linkKey };
+        });
       });
     };
-    const hideLinkTooltip = () => {
+    const hideLinkTooltip = (immediate = false) => {
       if (linkTooltipFrame !== null) {
         cancelAnimationFrame(linkTooltipFrame);
         linkTooltipFrame = null;
       }
-      setLinkTooltip(null);
+      cancelLinkTooltipHide();
+      if (immediate) {
+        setLinkTooltip(null);
+        return;
+      }
+      linkTooltipHideTimer = window.setTimeout(() => {
+        linkTooltipHideTimer = null;
+        setLinkTooltip(null);
+      }, LINK_TOOLTIP_HIDE_GRACE_MS);
+    };
+    const activateExternalLink = (event: MouseEvent, uri: string) => {
+      event.preventDefault();
+      hideLinkTooltip(true);
+      if (linkActivation === "modifier-click" && !modifierHeld(event)) {
+        return;
+      }
+      void openUrl(uri).catch((err: unknown) => {
+        console.error("failed to open terminal link", uri, err);
+      });
+    };
+    const hoverExternalLink = (uri: string, range: IViewportRange) => {
+      if (linkActivation !== "modifier-click") return;
+      suppressCurrentXtermLinkUnderline(term);
+      queueMicrotask(() => {
+        try { suppressCurrentXtermLinkUnderline(term); } catch { /* ignore */ }
+      });
+      requestAnimationFrame(() => {
+        try { suppressCurrentXtermLinkUnderline(term); } catch { /* ignore */ }
+      });
+      showLinkTooltip(uri, range);
+    };
+    term.options.linkHandler = {
+      activate: activateExternalLink,
+      hover: (_event, uri, range) => {
+        hoverExternalLink(uri, range as IViewportRange);
+      },
+      leave: () => {
+        hideLinkTooltip();
+      },
     };
     const openTerminalFileReference = (reference: TerminalFileReference) => {
       void (async () => {
@@ -562,30 +669,22 @@ export function Terminal({
         useAppStore.getState().openCodeViewerTab(path, cwd, target);
       })();
     };
-    const webLinksAddon = new WebLinksAddon(
-      (event, uri) => {
-        event.preventDefault();
-        hideLinkTooltip();
-        if (linkActivation === "modifier-click" && !modifierHeld(event)) return;
-        void openUrl(uri).catch((err: unknown) => {
-          console.error("failed to open terminal link", uri, err);
-        });
-      },
-      {
-        hover: (_event, _uri, range) => {
-          if (linkActivation !== "modifier-click") return;
-          showLinkTooltip(range);
+    let webLinksDisposable: IDisposable | null = term.registerLinkProvider(
+      createTerminalWebLinkProvider(term, {
+        activate: activateExternalLink,
+        hover: (_event, uri, link) => {
+          hoverExternalLink(uri, link.range);
         },
         leave: () => {
           hideLinkTooltip();
         },
-      },
+      }),
     );
     let fileLinksDisposable: IDisposable | null = term.registerLinkProvider(
       createTerminalFileLinkProvider(term, {
         activate: (event, reference) => {
           event.preventDefault();
-          hideLinkTooltip();
+          hideLinkTooltip(true);
           if (linkActivation === "modifier-click" && !modifierHeld(event)) {
             return;
           }
@@ -593,7 +692,7 @@ export function Terminal({
         },
         hover: (_event, _reference, link) => {
           if (linkActivation !== "modifier-click") return;
-          showLinkTooltip(link.range);
+          showLinkTooltip(link.text, link.range);
         },
         leave: () => {
           hideLinkTooltip();
@@ -603,7 +702,6 @@ export function Terminal({
     const serializeAddon = new SerializeAddon();
     const unicode11Addon = new Unicode11Addon();
     term.loadAddon(fitAddon);
-    term.loadAddon(webLinksAddon);
     term.loadAddon(serializeAddon);
     term.loadAddon(unicode11Addon);
     // xterm.js defaults to Unicode 6 width tables that treat most emoji as
@@ -772,7 +870,7 @@ export function Terminal({
       if (next.linkActivation !== previous.linkActivation) {
         linkActivation = next.linkActivation;
         if (next.linkActivation !== "modifier-click") {
-          setLinkTooltip(null);
+          hideLinkTooltip(true);
         }
       }
       if (state.settings.appearance.themeId !== prev.settings.appearance.themeId) {
@@ -1920,7 +2018,7 @@ export function Terminal({
     return () => {
       disposed = true;
       unsubSettings();
-      hideLinkTooltip();
+      hideLinkTooltip(true);
       if (themeFrame !== null) {
         cancelAnimationFrame(themeFrame);
         themeFrame = null;
@@ -1938,6 +2036,7 @@ export function Terminal({
         cancelAnimationFrame(viewportRepaintFrame);
         viewportRepaintFrame = null;
       }
+      cancelLinkTooltipHide();
       // No cleanup-time save: under React.StrictMode the cleanup of the
       // first dev mount fires while the buffer is still empty (load
       // hasn't run yet), and a fire-and-forget save here would clobber
@@ -1983,10 +2082,11 @@ export function Terminal({
         // Backend may not implement pty_kill yet — safe to ignore.
       });
       unpatchMouseCoordinateScale();
+      try { webLinksDisposable?.dispose(); } catch { /* ignore */ }
+      webLinksDisposable = null;
       try { fileLinksDisposable?.dispose(); } catch { /* ignore */ }
       fileLinksDisposable = null;
       try { fitAddon.dispose(); } catch { /* ignore */ }
-      try { webLinksAddon.dispose(); } catch { /* ignore */ }
       try { serializeAddon.dispose(); } catch { /* ignore */ }
       term.dispose();
       termRef.current = null;
@@ -2071,13 +2171,17 @@ export function Terminal({
       if (document.visibilityState === "hidden") return;
       scheduler.schedule();
     };
+    const onUiScaleChanged = () => {
+      setLinkTooltip(null);
+      scheduler.schedule();
+    };
 
     window.addEventListener("focus", scheduler.schedule);
-    window.addEventListener(UI_SCALE_CHANGED_EVENT, scheduler.schedule);
+    window.addEventListener(UI_SCALE_CHANGED_EVENT, onUiScaleChanged);
     document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
       window.removeEventListener("focus", scheduler.schedule);
-      window.removeEventListener(UI_SCALE_CHANGED_EVENT, scheduler.schedule);
+      window.removeEventListener(UI_SCALE_CHANGED_EVENT, onUiScaleChanged);
       document.removeEventListener("visibilitychange", onVisibilityChange);
       scheduler.dispose();
     };
@@ -2093,6 +2197,7 @@ export function Terminal({
   return (
     <div
       className="acorn-terminal-shell relative h-full w-full"
+      data-acorn-link-hover={linkTooltip ? "true" : undefined}
       style={{
         padding: "16px 8px",
         overflow: "hidden",
@@ -2126,6 +2231,12 @@ export function Terminal({
             <ArrowDownToLine size={15} aria-hidden="true" />
           </button>
         </Tooltip>
+      ) : null}
+      {linkTooltip ? (
+        <FloatingTerminalLinkUnderlines
+          linkKey={linkTooltip.linkKey}
+          rects={linkTooltip.underlineRects}
+        />
       ) : null}
       <FloatingTooltip
         label={`${MODIFIER_LINK_LABEL} to open link`}

--- a/src/lib/terminalWebLinks.test.ts
+++ b/src/lib/terminalWebLinks.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { IBufferCell, IBufferLine, Terminal as XTerm } from "@xterm/xterm";
+import { createTerminalWebLinkProvider } from "./terminalWebLinks";
+
+interface MutableBufferCell extends IBufferCell {
+  chars: string;
+  width: number;
+}
+
+function makeBufferCell(chars: string, width = 1): IBufferCell {
+  return {
+    getChars: () => chars,
+    getWidth: () => width,
+  } as unknown as IBufferCell;
+}
+
+function makeMutableCell(): MutableBufferCell {
+  return {
+    chars: "",
+    width: 1,
+    getChars() {
+      return this.chars;
+    },
+    getWidth() {
+      return this.width;
+    },
+  } as MutableBufferCell;
+}
+
+function makeBufferLine(
+  text: string,
+  cells = Array.from(text, (char) => makeBufferCell(char)),
+  isWrapped = false,
+): IBufferLine {
+  return {
+    isWrapped,
+    length: cells.length,
+    getCell: (index: number, reusable?: IBufferCell) => {
+      const source = cells[index];
+      if (!source) return undefined;
+      if (reusable) {
+        const mutable = reusable as MutableBufferCell;
+        mutable.chars = source.getChars();
+        mutable.width = source.getWidth();
+        return reusable;
+      }
+      return source;
+    },
+    translateToString: () => text,
+  } as unknown as IBufferLine;
+}
+
+function makeTerminalWithLines(lines: IBufferLine[]): XTerm {
+  return {
+    buffer: {
+      active: {
+        getLine: (index: number) => lines[index],
+        getNullCell: () => makeMutableCell(),
+      },
+    },
+  } as unknown as XTerm;
+}
+
+describe("terminal web links", () => {
+  it("provides URL links without xterm hover underlines", () => {
+    const provider = createTerminalWebLinkProvider(
+      makeTerminalWithLines([makeBufferLine("open https://example.test/docs")]),
+      { activate: () => undefined },
+    );
+
+    provider.provideLinks(1, (links) => {
+      expect(links?.[0]?.text).toBe("https://example.test/docs");
+      expect(links?.[0]?.range).toEqual({
+        start: { x: 6, y: 1 },
+        end: { x: 30, y: 1 },
+      });
+      expect(links?.[0]?.decorations).toEqual({
+        pointerCursor: true,
+        underline: false,
+      });
+    });
+  });
+
+  it("skips URL-shaped text that cannot parse as a URL", () => {
+    const provider = createTerminalWebLinkProvider(
+      makeTerminalWithLines([makeBufferLine("open https://")]),
+      { activate: () => undefined },
+    );
+
+    provider.provideLinks(1, (links) => {
+      expect(links).toBeUndefined();
+    });
+  });
+});

--- a/src/lib/terminalWebLinks.ts
+++ b/src/lib/terminalWebLinks.ts
@@ -1,0 +1,186 @@
+import type {
+  ILink,
+  ILinkProvider,
+  Terminal as XTerm,
+} from "@xterm/xterm";
+
+export interface TerminalWebLinkProviderOptions {
+  activate: (event: MouseEvent, uri: string) => void;
+  hover?: (event: MouseEvent, uri: string, link: ILink) => void;
+  leave?: (event: MouseEvent, uri: string) => void;
+  urlRegex?: RegExp;
+}
+
+const STRICT_URL_RE =
+  /(https?|HTTPS?):[/]{2}[^\s"'!*(){}|\\\^<>`]*[^\s"':,.!?{}|\\\^~\[\]`()<>]/;
+
+export function createTerminalWebLinkProvider(
+  terminal: XTerm,
+  options: TerminalWebLinkProviderOptions,
+): ILinkProvider {
+  return {
+    provideLinks(bufferLineNumber, callback) {
+      const links = computeWebLinks(
+        bufferLineNumber,
+        options.urlRegex ?? STRICT_URL_RE,
+        terminal,
+        options,
+      );
+      callback(links.length === 0 ? undefined : links);
+    },
+  };
+}
+
+function computeWebLinks(
+  bufferLineNumber: number,
+  pattern: RegExp,
+  terminal: XTerm,
+  options: TerminalWebLinkProviderOptions,
+): ILink[] {
+  const flags = new Set(pattern.flags.split(""));
+  flags.add("g");
+  const regex = new RegExp(pattern.source, [...flags].join(""));
+  const [lines, startLineIndex] = getWindowedLineStrings(
+    bufferLineNumber - 1,
+    terminal,
+  );
+  const line = lines.join("");
+  const links: ILink[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(line)) !== null) {
+    const text = match[0];
+    if (!isUrl(text)) continue;
+
+    const [startY, startX] = mapStringIndex(
+      terminal,
+      startLineIndex,
+      0,
+      match.index,
+    );
+    const [endY, endX] = mapStringIndex(
+      terminal,
+      startY,
+      startX,
+      text.length,
+    );
+    if (startY === -1 || startX === -1 || endY === -1 || endX === -1) {
+      continue;
+    }
+
+    const link: ILink = {
+      range: {
+        start: { x: startX + 1, y: startY + 1 },
+        end: { x: endX, y: endY + 1 },
+      },
+      text,
+      decorations: {
+        pointerCursor: true,
+        underline: false,
+      },
+      activate: (event) => options.activate(event, text),
+    };
+    if (options.hover) {
+      link.hover = (event) => options.hover?.(event, text, link);
+    }
+    if (options.leave) {
+      link.leave = (event) => options.leave?.(event, text);
+    }
+    links.push(link);
+  }
+
+  return links;
+}
+
+function getWindowedLineStrings(
+  lineIndex: number,
+  terminal: XTerm,
+): [string[], number] {
+  let line = terminal.buffer.active.getLine(lineIndex);
+  let topIndex = lineIndex;
+  let bottomIndex = lineIndex;
+  let length = 0;
+  const lines: string[] = [];
+
+  if (!line) return [lines, topIndex];
+
+  const current = line.translateToString(true);
+  if (line.isWrapped && current[0] !== " ") {
+    while (
+      (line = terminal.buffer.active.getLine(--topIndex)) &&
+      length < 2048
+    ) {
+      const content = line.translateToString(true);
+      length += content.length;
+      lines.push(content);
+      if (!line.isWrapped || content.includes(" ")) break;
+    }
+    lines.reverse();
+  }
+
+  lines.push(current);
+  length = 0;
+  while (
+    (line = terminal.buffer.active.getLine(++bottomIndex)) &&
+    line.isWrapped &&
+    length < 2048
+  ) {
+    const content = line.translateToString(true);
+    length += content.length;
+    lines.push(content);
+    if (content.includes(" ")) break;
+  }
+
+  return [lines, topIndex];
+}
+
+function mapStringIndex(
+  terminal: XTerm,
+  y: number,
+  startX: number,
+  length: number,
+): [number, number] {
+  const buffer = terminal.buffer.active;
+  const cell = buffer.getNullCell();
+  let x = startX;
+
+  while (length) {
+    const line = buffer.getLine(y);
+    if (!line) return [-1, -1];
+    for (let currentX = x; currentX < line.length; currentX += 1) {
+      line.getCell(currentX, cell);
+      const chars = cell.getChars();
+      if (cell.getWidth()) {
+        length -= chars.length || 1;
+        if (currentX === line.length - 1 && chars === "") {
+          const nextLine = buffer.getLine(y + 1);
+          if (nextLine?.isWrapped) {
+            nextLine.getCell(0, cell);
+            if (cell.getWidth() === 2) length += 1;
+          }
+        }
+      }
+      if (length === 0) return [y, currentX + 1];
+      if (length < 0) return [y, currentX];
+    }
+    y += 1;
+    x = 0;
+  }
+
+  return [y, x];
+}
+
+function isUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    const parsedBase =
+      url.password && url.username
+        ? `${url.protocol}//${url.username}:${url.password}@${url.host}`
+        : url.username
+          ? `${url.protocol}//${url.username}@${url.host}`
+          : `${url.protocol}//${url.host}`;
+    return value.toLowerCase().startsWith(parsedBase.toLowerCase());
+  } catch {
+    return false;
+  }
+}

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -43,6 +43,102 @@ async function seedAlphaBetaTerminals(tauri: TauriMock): Promise<void> {
   await tauri.handle("pty_spawn", () => null);
 }
 
+async function emitSubscribedPtyOutput(
+  page: Page,
+  channelIdKey: string,
+  text: string,
+): Promise<void> {
+  await page.evaluate(
+    ({ channelIdKey, text }) => {
+      const w = window as unknown as {
+        [key: string]: unknown;
+      };
+      const id = w[channelIdKey];
+      if (typeof id !== "number") {
+        throw new Error(`missing terminal output channel: ${channelIdKey}`);
+      }
+      const callback = w[`_${id}`] as
+        | ((payload: { index: number; message: number[] }) => void)
+        | undefined;
+      if (!callback) throw new Error("missing terminal output callback");
+      callback({
+        index: 0,
+        message: Array.from(new TextEncoder().encode(text)),
+      });
+    },
+    { channelIdKey, text },
+  );
+}
+
+async function terminalTextAndUnderlineRects(
+  page: Page,
+  text: string,
+): Promise<{
+  text: { top: number; bottom: number; left: number; width: number };
+  underline: { top: number; bottom: number; left: number; width: number };
+} | null> {
+  return page.evaluate((target) => {
+    const toPlainRect = (rect: DOMRect) => ({
+      top: rect.top,
+      bottom: rect.bottom,
+      left: rect.left,
+      width: rect.width,
+    });
+    const underline = document.querySelector<HTMLElement>(
+      '[data-acorn-terminal-link-underline="true"]',
+    );
+    if (!underline) return null;
+
+    for (const row of Array.from(
+      document.querySelectorAll<HTMLElement>(".xterm-rows > div"),
+    )) {
+      const rowText = row.textContent ?? "";
+      const start = rowText.indexOf(target);
+      if (start < 0) continue;
+
+      const end = start + target.length;
+      const walker = document.createTreeWalker(row, NodeFilter.SHOW_TEXT);
+      const range = document.createRange();
+      let offset = 0;
+      let startSet = false;
+      let endSet = false;
+
+      for (
+        let node = walker.nextNode() as Text | null;
+        node;
+        node = walker.nextNode() as Text | null
+      ) {
+        const textLength = node.textContent?.length ?? 0;
+        const nextOffset = offset + textLength;
+        if (!startSet && start <= nextOffset) {
+          range.setStart(node, Math.max(0, start - offset));
+          startSet = true;
+        }
+        if (startSet && end <= nextOffset) {
+          range.setEnd(node, Math.max(0, end - offset));
+          endSet = true;
+          break;
+        }
+        offset = nextOffset;
+      }
+
+      if (!startSet || !endSet) {
+        range.detach();
+        return null;
+      }
+
+      const textRect = range.getBoundingClientRect();
+      range.detach();
+      return {
+        text: toPlainRect(textRect),
+        underline: toPlainRect(underline.getBoundingClientRect()),
+      };
+    }
+
+    return null;
+  }, text);
+}
+
 async function gotoWithAccent(page: Page): Promise<void> {
   await page.goto("/");
   await page.addStyleTag({
@@ -373,6 +469,357 @@ test.describe("terminal: spawn", () => {
     await expect(page.locator('[data-acorn-target-line="true"]')).toHaveCount(
       0,
     );
+  });
+
+  test("keeps modifier-click link tooltip mounted while output streams", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({ terminal: { linkActivation: "modifier-click" } }),
+      );
+    });
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __linkTooltipChannelId?: number;
+      };
+      w.__linkTooltipChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __linkTooltipChannelId?: number })
+              .__linkTooltipChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const url = "https://example.test/docs";
+    await emitSubscribedPtyOutput(
+      page,
+      "__linkTooltipChannelId",
+      `${url}\r\n`,
+    );
+    await expect(page.locator(".xterm")).toContainText(url);
+
+    const screenBox = await page.locator(".xterm-screen").boundingBox();
+    expect(screenBox).not.toBeNull();
+    await page.mouse.move(screenBox!.x + 12, screenBox!.y + 10);
+
+    const tooltip = page.getByRole("tooltip", { name: /to open link/ });
+    await expect(tooltip).toBeVisible();
+    const underline = page.locator(
+      '[data-acorn-terminal-link-underline="true"]',
+    );
+    await expect(underline).toHaveCount(1);
+    await expect(underline.first()).toBeVisible();
+    const countXtermUnderlines = () =>
+      page.evaluate(
+        () =>
+          Array.from(
+            document.querySelectorAll<HTMLElement>(".xterm-rows span"),
+          ).filter((el) =>
+            getComputedStyle(el).textDecorationLine.includes("underline"),
+          ).length,
+      );
+    await expect.poll(countXtermUnderlines).toBe(0);
+    const initialTooltipPosition = await tooltip.evaluate((el) => ({
+      top: (el as HTMLElement).style.top,
+      left: (el as HTMLElement).style.left,
+    }));
+    const initialUnderlinePosition = await underline.first().evaluate((el) => ({
+      top: (el as HTMLElement).style.top,
+      left: (el as HTMLElement).style.left,
+      width: (el as HTMLElement).style.width,
+    }));
+
+    await page.evaluate(() => {
+      const w = window as unknown as {
+        __tooltipRemovalCount?: number;
+        __tooltipObserver?: MutationObserver;
+      };
+      w.__tooltipRemovalCount = 0;
+      w.__tooltipObserver?.disconnect();
+      w.__tooltipObserver = new MutationObserver((records) => {
+        for (const record of records) {
+          for (const node of Array.from(record.removedNodes)) {
+            if (
+              node instanceof HTMLElement &&
+              node.getAttribute("role") === "tooltip"
+            ) {
+              w.__tooltipRemovalCount = (w.__tooltipRemovalCount ?? 0) + 1;
+            }
+          }
+        }
+      });
+      w.__tooltipObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+      });
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      await emitSubscribedPtyOutput(page, "__linkTooltipChannelId", ".");
+      await page.waitForTimeout(30);
+      await expect(tooltip).toBeVisible();
+      await expect(underline).toHaveCount(1);
+      await expect(underline.first()).toBeVisible();
+      await expect
+        .poll(() =>
+          tooltip.evaluate((el) => ({
+            top: (el as HTMLElement).style.top,
+            left: (el as HTMLElement).style.left,
+          })),
+        )
+        .toEqual(initialTooltipPosition);
+      await expect
+        .poll(() =>
+          underline.first().evaluate((el) => ({
+            top: (el as HTMLElement).style.top,
+            left: (el as HTMLElement).style.left,
+            width: (el as HTMLElement).style.width,
+          })),
+        )
+        .toEqual(initialUnderlinePosition);
+      await expect.poll(countXtermUnderlines).toBe(0);
+    }
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __tooltipRemovalCount?: number })
+              .__tooltipRemovalCount ?? 0,
+        ),
+      )
+      .toBe(0);
+    await page.evaluate(() => {
+      (window as unknown as { __tooltipObserver?: MutationObserver })
+        .__tooltipObserver?.disconnect();
+    });
+  });
+
+  test("shows stable hover underline for OSC URI terminal links", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({ terminal: { linkActivation: "modifier-click" } }),
+      );
+    });
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __oscLinkChannelId?: number;
+      };
+      w.__oscLinkChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __oscLinkChannelId?: number })
+              .__oscLinkChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const label = "OSC URI";
+    await emitSubscribedPtyOutput(
+      page,
+      "__oscLinkChannelId",
+      `\x1b]8;;https://example.test/osc\x1b\\${label}\x1b]8;;\x1b\\\r\n`,
+    );
+    await expect(page.locator(".xterm")).toContainText(label);
+
+    const screenBox = await page.locator(".xterm-screen").boundingBox();
+    expect(screenBox).not.toBeNull();
+    await page.mouse.move(screenBox!.x + 12, screenBox!.y + 10);
+
+    await expect(
+      page.getByRole("tooltip", { name: /to open link/ }),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-acorn-terminal-link-underline="true"]'),
+    ).toHaveCount(1);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            Array.from(
+              document.querySelectorAll<HTMLElement>(".xterm-rows span"),
+            ).filter((el) =>
+              getComputedStyle(el).textDecorationLine.includes("underline"),
+            ).length,
+        ),
+      )
+      .toBeGreaterThanOrEqual(1);
+  });
+
+  test("positions link hover underline with app UI scale", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          appearance: { uiScalePercent: 125 },
+          terminal: { linkActivation: "modifier-click" },
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __scaledLinkChannelId?: number;
+      };
+      w.__scaledLinkChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          document.documentElement.style.getPropertyValue("--acorn-ui-scale"),
+        ),
+      )
+      .toBe("1.25");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __scaledLinkChannelId?: number })
+              .__scaledLinkChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const url = "https://example.test/scaled";
+    await emitSubscribedPtyOutput(
+      page,
+      "__scaledLinkChannelId",
+      `${url}\r\n`,
+    );
+    await expect(page.locator(".xterm")).toContainText(url);
+
+    const screenBox = await page.locator(".xterm-screen").boundingBox();
+    expect(screenBox).not.toBeNull();
+    await page.mouse.move(screenBox!.x + 12, screenBox!.y + 10);
+
+    const underline = page.locator(
+      '[data-acorn-terminal-link-underline="true"]',
+    );
+    await expect(underline).toHaveCount(1);
+    await expect(underline.first()).toBeVisible();
+    await expect
+      .poll(() =>
+        underline.first().evaluate((el) => el.parentElement === document.body),
+      )
+      .toBe(true);
+
+    const rects = await terminalTextAndUnderlineRects(page, url);
+    expect(rects).not.toBeNull();
+    expect(Math.abs(rects!.underline.left - rects!.text.left)).toBeLessThan(2);
+    expect(Math.abs(rects!.underline.width - rects!.text.width)).toBeLessThan(
+      2,
+    );
+    expect(
+      Math.abs(rects!.underline.top - (rects!.text.bottom - 1)),
+    ).toBeLessThan(2);
   });
 
   test("submitting a command resyncs the PTY size for agent TUIs", async ({


### PR DESCRIPTION
## Summary
This fixes terminal link hover affordances that could flicker or drift while the terminal repaints or the app UI scale changes.

1. **Stable web-link provider** — replaces `@xterm/addon-web-links` with an Acorn link provider that keeps pointer cursor behavior but disables xterm's hover underline for plain URL links.
2. **Tooltip/underline stability** — keeps the modifier-click tooltip mounted across brief xterm hover leave/re-enter cycles during terminal output, and draws Acorn-owned underline overlays for URL and OSC URI links.
3. **UI scale coordinate fix** — renders hover underlines through a `document.body` portal so viewport rects from `getBoundingClientRect()` are not double-scaled by `.acorn-app-shell` transforms.
4. **Focused coverage** — adds unit coverage for the custom URL link provider and e2e coverage for streamed terminal output, OSC URI links, and 125% UI scale positioning.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Modifier-click URL hover while output streams | Tooltip/underline could blink as xterm repainted rows | Tooltip and Acorn underline remain mounted and stable |
| App UI scale changes | Hover underline could use the wrong coordinate space | Underline is positioned in viewport space like the tooltip |
| Terminal URL dependency | WebLinksAddon dependency required | Custom provider owns the needed behavior; unused dependency removed |

## Design notes
- The existing terminal mouse scale patch maps pointer events back into xterm's unscaled coordinate space. The hover underline problem is the inverse display-space issue, so the implementation avoids the transformed app subtree instead of reusing the mouse-event helper directly.
- Plain URL links use the custom provider with `decorations.underline = false`; OSC URI links still come from xterm's native link handler, so the Acorn underline is layered on top while persistent OSC text underline behavior remains intact.
- UI scale changes clear the active hover affordance and schedule the existing terminal viewport repaint path.

## Test plan
- [x] `pnpm exec tsc --noEmit --pretty false` passes
- [x] `pnpm exec vitest run src/lib/terminalWebLinks.test.ts src/lib/terminalFileLinks.test.ts src/lib/terminalMouseScale.test.ts` — 3 files, 22 tests passed
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts` — 9 tests passed
- [x] `pnpm run build` passes
- [x] `git diff --check` passes

## Notes
- `pnpm run build` still emits existing Vite dynamic-import/chunk-size warnings; the build completes successfully.
