### PR TITLE
fix(actions): correct running job duration display

### DIFF
--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -856,11 +856,11 @@ fn build_detail(number: u64, view: GhPullRequestView, diff_text: String) -> Pull
         .map(|c| PullRequestCheck {
             name: c.name.unwrap_or_else(|| c.context.unwrap_or_default()),
             status: c.status.unwrap_or_default(),
-            conclusion: c.conclusion,
-            started_at: c.started_at,
-            completed_at: c.completed_at,
+            conclusion: normalize_optional_string(c.conclusion),
+            started_at: normalize_github_timestamp(c.started_at),
+            completed_at: normalize_github_timestamp(c.completed_at),
             url: c.details_url.or(c.target_url),
-            workflow_name: c.workflow_name,
+            workflow_name: normalize_optional_string(c.workflow_name),
         })
         .collect();
 
@@ -1794,6 +1794,27 @@ fn default_attempt() -> u32 {
     1
 }
 
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn normalize_github_timestamp(value: Option<String>) -> Option<String> {
+    normalize_optional_string(value).and_then(|value| {
+        if value.starts_with("0001-01-01T00:00:00") {
+            None
+        } else {
+            Some(value)
+        }
+    })
+}
+
 pub fn list_workflow_runs(repo_path: &Path, limit: u32) -> AppResult<WorkflowRunsListing> {
     let Some(slug) = github_owner_repo(repo_path)? else {
         return Ok(WorkflowRunsListing::NotGithub);
@@ -1855,14 +1876,14 @@ fn run_workflow_list(slug: &str, token: &str, limit: u32) -> AppResult<Vec<Workf
                 display_title: r.display_title,
                 workflow_name,
                 status: r.status,
-                conclusion: r.conclusion,
+                conclusion: normalize_optional_string(r.conclusion),
                 event: r.event,
                 head_branch: r.head_branch.filter(|s| !s.is_empty()),
                 head_sha: r.head_sha,
                 url: r.url,
                 created_at: r.created_at,
                 updated_at: r.updated_at,
-                started_at: r.started_at,
+                started_at: normalize_github_timestamp(r.started_at),
                 attempt: r.attempt,
             }
         })
@@ -2048,9 +2069,9 @@ fn run_workflow_view(slug: &str, token: &str, run_id: u64) -> AppResult<Workflow
             id: j.database_id,
             name: j.name,
             status: j.status,
-            conclusion: j.conclusion,
-            started_at: j.started_at,
-            completed_at: j.completed_at,
+            conclusion: normalize_optional_string(j.conclusion),
+            started_at: normalize_github_timestamp(j.started_at),
+            completed_at: normalize_github_timestamp(j.completed_at),
             url: j.url,
             steps: j
                 .steps
@@ -2059,7 +2080,7 @@ fn run_workflow_view(slug: &str, token: &str, run_id: u64) -> AppResult<Workflow
                     name: s.name,
                     number: s.number,
                     status: s.status,
-                    conclusion: s.conclusion,
+                    conclusion: normalize_optional_string(s.conclusion),
                 })
                 .collect(),
         })
@@ -2070,14 +2091,14 @@ fn run_workflow_view(slug: &str, token: &str, run_id: u64) -> AppResult<Workflow
         display_title: raw.display_title,
         workflow_name,
         status: raw.status,
-        conclusion: raw.conclusion,
+        conclusion: normalize_optional_string(raw.conclusion),
         event: raw.event,
         head_branch: raw.head_branch.filter(|s| !s.is_empty()),
         head_sha: raw.head_sha,
         url: raw.url,
         created_at: raw.created_at,
         updated_at: raw.updated_at,
-        started_at: raw.started_at,
+        started_at: normalize_github_timestamp(raw.started_at),
         attempt: raw.attempt,
         jobs,
     })
@@ -2123,5 +2144,19 @@ mod tests {
         );
 
         assert!(prompt.contains("Write a merge commit message."));
+    }
+
+    #[test]
+    fn github_zero_timestamps_are_treated_as_absent() {
+        assert_eq!(normalize_github_timestamp(None), None);
+        assert_eq!(normalize_github_timestamp(Some("".to_string())), None);
+        assert_eq!(
+            normalize_github_timestamp(Some("0001-01-01T00:00:00Z".to_string())),
+            None
+        );
+        assert_eq!(
+            normalize_github_timestamp(Some("2026-05-27T02:42:28Z".to_string())),
+            Some("2026-05-27T02:42:28Z".to_string())
+        );
     }
 }

--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -75,6 +75,26 @@ function exactButtonCount(container: HTMLElement, label: string): number {
   ).length;
 }
 
+function buttonWithTitle(container: HTMLElement, title: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (button) => button.getAttribute("title") === title,
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`button titled "${title}" not found`);
+  }
+  return button;
+}
+
+function buttonContaining(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (button) => button.textContent?.includes(text),
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`button containing "${text}" not found`);
+  }
+  return button;
+}
+
 const labeledPullRequest = {
   number: 247,
   title: "Hide git tabs outside repositories",
@@ -540,5 +560,95 @@ describe("RightPanel background tab loading", () => {
 
     expect(container.textContent).toContain("6s");
     expect(mockApi.listWorkflowRuns).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores GitHub zero completedAt sentinels for running Actions jobs", async () => {
+    vi.setSystemTime(new Date("2026-05-19T12:00:05Z"));
+    useAppStore.setState({ rightTab: "actions" });
+    mockApi.listWorkflowRuns.mockResolvedValue({
+      kind: "ok",
+      account: "tester",
+      items: [
+        {
+          id: 42,
+          display_title: "Run CI",
+          workflow_name: "CI",
+          status: "in_progress",
+          conclusion: null,
+          event: "push",
+          head_branch: "main",
+          head_sha: "abc1234",
+          url: "https://github.com/im-ian/acorn/actions/runs/42",
+          created_at: "2026-05-19T11:59:50Z",
+          updated_at: "2026-05-19T12:00:05Z",
+          started_at: "2026-05-19T12:00:00Z",
+          attempt: 1,
+        },
+      ],
+    });
+    mockApi.getWorkflowRunDetail.mockResolvedValue({
+      kind: "ok",
+      account: "tester",
+      detail: {
+        id: 42,
+        display_title: "Run CI",
+        workflow_name: "CI",
+        status: "in_progress",
+        conclusion: null,
+        event: "push",
+        head_branch: "main",
+        head_sha: "abc1234",
+        url: "https://github.com/im-ian/acorn/actions/runs/42",
+        created_at: "2026-05-19T11:59:50Z",
+        updated_at: "2026-05-19T12:00:05Z",
+        started_at: "2026-05-19T12:00:00Z",
+        attempt: 1,
+        jobs: [
+          {
+            id: 99,
+            name: "macOS bundle",
+            status: "in_progress",
+            conclusion: null,
+            started_at: "2026-05-19T12:00:00Z",
+            completed_at: "0001-01-01T00:00:00Z",
+            url: "",
+            steps: [],
+          },
+        ],
+      },
+    });
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+
+    const runButton = buttonWithTitle(container, "Double-click to view details");
+    expect(runButton.textContent).toContain("Run CI");
+    await act(async () => {
+      runButton.dispatchEvent(
+        new MouseEvent("dblclick", {
+          bubbles: true,
+          cancelable: true,
+          detail: 2,
+        }),
+      );
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(mockApi.getWorkflowRunDetail).toHaveBeenCalledWith(REPO, 42);
+    expect(buttonContaining(document.body, "macOS bundle").textContent).toContain(
+      "5s",
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_000);
+    });
+    await flushPromises();
+
+    expect(buttonContaining(document.body, "macOS bundle").textContent).toContain(
+      "6s",
+    );
   });
 });

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -3618,7 +3618,13 @@ function WorkflowRunDetailBody({ detail }: { detail: WorkflowRunDetail }) {
 function WorkflowJobRow({ job, nowUnix }: { job: WorkflowJob; nowUnix: number }) {
   const t = useTranslation();
   const [expanded, setExpanded] = useState(false);
-  const duration = formatJobDuration(job.started_at, job.completed_at, t, nowUnix);
+  const duration = formatJobDuration(
+    job.started_at,
+    job.completed_at,
+    job.status,
+    t,
+    nowUnix,
+  );
   return (
     <li className="bg-bg/40">
       <button
@@ -3733,13 +3739,15 @@ function formatDurationSeconds(seconds: number, t: Translator): string {
 function formatJobDuration(
   startedAt: string | null,
   completedAt: string | null,
+  status: string,
   t: Translator,
   nowUnix = Math.floor(Date.now() / 1000),
 ): string {
   if (!startedAt) return "";
   const start = toUnixSeconds(startedAt);
   if (start <= 0) return "";
-  const end = completedAt ? toUnixSeconds(completedAt) : nowUnix;
+  const completed = status.toLowerCase() === "completed";
+  const end = completed && completedAt ? toUnixSeconds(completedAt) : nowUnix;
   return formatDurationSeconds(Math.max(0, end - start), t);
 }
 


### PR DESCRIPTION
## Summary
Fix the Actions run detail modal duration display when GitHub reports in-progress jobs with zero-time sentinel completion values.

1. **Normalize GitHub timestamps** — convert empty strings and `0001-01-01T00:00:00Z` timestamps from `gh` into absent values at the Rust API boundary.
2. **Harden job duration rendering** — only use `completed_at` for jobs whose status is actually `completed`, so running jobs keep counting from `started_at`.
3. **Cover the regression** — add a RightPanel test that reproduces the sentinel `completedAt` response and verifies the duration advances from `5s` to `6s`.

## Expected impact
| Surface | Before | After |
| --- | --- | --- |
| Actions run detail modal | Running jobs could stay at `0s` when GitHub returned a zero completion timestamp | Running jobs show live elapsed time until completion |
| PR/check duration data | Empty or sentinel GitHub values could leak through as real timestamps | The frontend receives nullable timestamps for absent values |

## Design notes
- The backend normalization is shared by workflow runs, workflow job detail, and PR check detail so the UI does not need to know about GitHub CLI sentinel values.
- The frontend still guards duration calculation by job status because a `completed_at` field is only meaningful for completed jobs.

## Test plan
- [x] `pnpm exec vitest run src/components/RightPanel.test.tsx` — 13 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml github_zero_timestamps_are_treated_as_absent` — passed
- [x] `pnpm run build` — passed

## Notes
- `pnpm run build` still emits existing Vite dynamic-import/chunk-size warnings. Not caused by this PR.
- The focused Rust test still emits the existing `AgentHookServer::start` dead-code warning. Not caused by this PR.