### PR TITLE
fix(tabs): restore tab drag startup and ghost preview

### DIFF
--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -34,6 +34,7 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
 
 import { Pane } from "./Pane";
 import { useAppStore } from "../store";
+import { clearTabDragPayload, getCurrentTabPayload } from "../lib/dnd";
 import { defaultTabByGroup } from "../lib/rightPanelGroups";
 
 const REPO = "/Users/me/repo";
@@ -141,12 +142,60 @@ function seedInactivePaneWithTab(tab: Session): void {
   }));
 }
 
+function seedActivePaneWithTab(tab: Session): void {
+  const pane = {
+    id: "root",
+    tabIds: [tab.id],
+    activeTabId: tab.id,
+  };
+
+  useAppStore.setState((s) => ({
+    ...s,
+    sessions: [tab],
+    activeProject: REPO,
+    activeSessionId: tab.id,
+    activeTabId: tab.id,
+    workspaces: {
+      ...s.workspaces,
+      [REPO]: {
+        layout: { kind: "pane", id: "root" },
+        panes: { root: pane },
+        focusedPaneId: "root",
+      },
+    },
+    panes: { root: pane },
+    focusedPaneId: "root",
+  }));
+}
+
+function makeDataTransfer(): DataTransfer {
+  return {
+    dropEffect: "none",
+    effectAllowed: "all",
+    setData: vi.fn(),
+    getData: vi.fn(() => ""),
+    clearData: vi.fn(),
+    files: [] as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    types: [],
+    setDragImage: vi.fn(),
+  };
+}
+
+function dispatchDragStart(target: Element, dataTransfer: DataTransfer): Event {
+  const event = new Event("dragstart", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+  target.dispatchEvent(event);
+  return event;
+}
+
 describe("Pane empty state", () => {
   let container: HTMLDivElement;
   let root: Root;
 
   beforeEach(() => {
     resetStore();
+    clearTabDragPayload();
     vi.clearAllMocks();
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -156,6 +205,7 @@ describe("Pane empty state", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    clearTabDragPayload();
   });
 
   it("opens a terminal when Space is pressed twice while an empty pane is focused", async () => {
@@ -407,5 +457,67 @@ describe("Pane empty state", () => {
     });
 
     expect(useAppStore.getState().focusedPaneId).toBe("pane-2");
+  });
+
+  it("starts tab drag from active tab chrome outside the inner handle", () => {
+    const active = session("active-session");
+    seedActivePaneWithTab(active);
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+
+    const dragHandle = container.querySelector(
+      `[data-tab-drag-handle="${active.id}"]`,
+    );
+    const tab = dragHandle?.closest('[role="button"]');
+    expect(tab).toBeInstanceOf(HTMLElement);
+    expect((tab as HTMLElement).getAttribute("draggable")).toBe("true");
+
+    const dataTransfer = makeDataTransfer();
+    act(() => {
+      dispatchDragStart(tab!, dataTransfer);
+    });
+
+    expect(dataTransfer.setDragImage).toHaveBeenCalled();
+    expect(getCurrentTabPayload()).toMatchObject({
+      kind: "tab",
+      tabId: active.id,
+      fromPaneId: "root",
+    });
+  });
+
+  it("does not start tab drag from the close button", () => {
+    const active = session("active-session");
+    seedActivePaneWithTab(active);
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+
+    const closeButton = container.querySelector(
+      `[data-tab-close-button="${active.id}"]`,
+    );
+    const tab = closeButton?.closest('[role="button"]');
+    expect(closeButton).toBeInstanceOf(HTMLElement);
+    expect(tab).toBeInstanceOf(HTMLElement);
+
+    let dragStartDefaultPrevented = false;
+    act(() => {
+      closeButton!.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          button: 0,
+          cancelable: true,
+        }),
+      );
+      dragStartDefaultPrevented = dispatchDragStart(
+        tab!,
+        makeDataTransfer(),
+      ).defaultPrevented;
+    });
+
+    expect(dragStartDefaultPrevented).toBe(true);
+    expect(getCurrentTabPayload()).toBeNull();
   });
 });

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -550,6 +550,39 @@ function isTabStripMouseDownTarget(target: EventTarget | null): boolean {
     : false;
 }
 
+function isTabDragSuppressedTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement
+    ? target.closest("[data-tab-close-button], [data-tab-rename-input]") !== null
+    : false;
+}
+
+function setTabDragImage(e: React.DragEvent<HTMLElement>): void {
+  const source = e.currentTarget;
+  const rect = source.getBoundingClientRect();
+  const clone = source.cloneNode(true) as HTMLElement;
+  clone.setAttribute("aria-hidden", "true");
+  clone.style.position = "fixed";
+  clone.style.top = "-1000px";
+  clone.style.left = "-1000px";
+  clone.style.width = `${rect.width}px`;
+  clone.style.height = `${rect.height}px`;
+  clone.style.pointerEvents = "none";
+  clone.style.zIndex = "9999";
+  clone.style.transform = "none";
+  clone.style.opacity = "0.95";
+  clone.style.boxShadow = "0 8px 20px rgba(0, 0, 0, 0.32)";
+  document.body.appendChild(clone);
+
+  const offsetX = Math.max(0, Math.min(e.clientX - rect.left, rect.width));
+  const offsetY = Math.max(0, Math.min(e.clientY - rect.top, rect.height));
+  try {
+    e.dataTransfer.setDragImage(clone, offsetX, offsetY);
+  } catch {
+    // Keep drag startup working when a webview rejects a custom drag image.
+  }
+  window.setTimeout(() => clone.remove(), 0);
+}
+
 interface TabStripProps {
   paneId: PaneId;
   tabs: PaneTab[];
@@ -772,6 +805,7 @@ function TabItem({
   const editorConfigured = editorCommand.trim().length > 0;
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [editing, setEditing] = useState(false);
+  const suppressNextDragStartRef = useRef(false);
   // Per-session agent detection result, refreshed each time the context
   // menu opens. Null while loading; the menu rebuilds when this resolves
   // so the Fork item gets the right label / enabled state.
@@ -971,6 +1005,28 @@ function TabItem({
         ref={registerRef}
         role="button"
         tabIndex={0}
+        draggable
+        style={{ WebkitUserDrag: "element" } as CSSProperties}
+        onMouseDownCapture={(e) => {
+          suppressNextDragStartRef.current = isTabDragSuppressedTarget(e.target);
+        }}
+        onDragStart={(e) => {
+          if (
+            suppressNextDragStartRef.current ||
+            isTabDragSuppressedTarget(e.target)
+          ) {
+            e.preventDefault();
+            e.stopPropagation();
+            suppressNextDragStartRef.current = false;
+            return;
+          }
+          if (editing) setEditing(false);
+          setTabDragImage(e);
+          setTabDragPayload(e, { tabId: tab.id, fromPaneId: paneId });
+        }}
+        onDragEnd={() => {
+          suppressNextDragStartRef.current = false;
+        }}
         onClick={editing ? undefined : onSelect}
         onDoubleClick={(e) => {
           e.stopPropagation();
@@ -1006,13 +1062,9 @@ function TabItem({
           data-tab-drag-handle={tab.id}
           draggable
           style={{ WebkitUserDrag: "element" } as CSSProperties}
-          onDragStart={(e) => {
-            if (editing) setEditing(false);
-            setTabDragPayload(e, { tabId: tab.id, fromPaneId: paneId });
-          }}
         >
           {agentProvider ? (
-            <Tooltip label={agentProvider} side="bottom">
+            <Tooltip label={agentProvider} side="bottom" draggable>
               <AgentProviderIcon
                 provider={agentProvider}
                 className={cn(
@@ -1054,6 +1106,7 @@ function TabItem({
           {isGeneratingTitle && !editing ? (
             <SessionTitleGeneratingIndicator
               label={paneT(t, "pane.aria.generatingSessionTitle")}
+              draggable
             />
           ) : null}
           {session &&
@@ -1103,7 +1156,7 @@ function TabItem({
           <X size={11} />
         </button>
         {active ? (
-          <span className="absolute inset-x-0 bottom-0 h-0.5 bg-accent/30" />
+          <span className="pointer-events-none absolute inset-x-0 bottom-0 h-0.5 bg-accent/30" />
         ) : null}
       </div>
       <ContextMenu

--- a/src/components/SessionTitleGeneratingIndicator.tsx
+++ b/src/components/SessionTitleGeneratingIndicator.tsx
@@ -6,19 +6,24 @@ interface SessionTitleGeneratingIndicatorProps {
   label: string;
   side?: "top" | "bottom" | "left" | "right";
   className?: string;
+  draggable?: boolean;
 }
 
 export function SessionTitleGeneratingIndicator({
   label,
   side = "bottom",
   className,
+  draggable = false,
 }: SessionTitleGeneratingIndicatorProps) {
   return (
-    <Tooltip label={label} side={side}>
+    <Tooltip label={label} side={side} draggable={draggable}>
       <span
         role="img"
         aria-label={label}
-        className={cn("acorn-session-title-indicator", className)}
+        className={cn(
+          "pointer-events-none acorn-session-title-indicator",
+          className,
+        )}
       >
         <Sparkles
           size={9}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -4,6 +4,7 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type CSSProperties,
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
@@ -28,6 +29,7 @@ interface TooltipProps {
   multiline?: boolean;
   children: ReactNode;
   className?: string;
+  draggable?: boolean;
 }
 
 export interface TooltipAnchorRect {
@@ -198,6 +200,7 @@ export function Tooltip({
   multiline = false,
   children,
   className,
+  draggable = false,
 }: TooltipProps) {
   const triggerRef = useRef<HTMLSpanElement>(null);
   const showTimer = useRef<number | null>(null);
@@ -239,6 +242,12 @@ export function Tooltip({
         onFocus={show}
         onBlur={hide}
         onClick={hide}
+        draggable={draggable || undefined}
+        style={
+          draggable
+            ? ({ WebkitUserDrag: "element" } as CSSProperties)
+            : undefined
+        }
         className={`inline-flex ${className ?? ""}`}
       >
         {children}


### PR DESCRIPTION
## Summary
This restores reliable workspace tab drag startup and the visible drag preview.

1. **Drag startup** - Make the tab root itself draggable so active tabs can begin drag from the full tab chrome, including wrapped icon/tooltip areas.
2. **Interaction suppression** - Keep close-button and rename-input interactions out of the tab drag path, while preserving existing tab select, rename, and close behavior.
3. **Ghost preview** - Provide an explicit cloned tab drag image so the drag preview remains visible after moving drag handling to the tab root.
4. **Regression coverage** - Add focused Pane tests for active-tab drag startup, custom drag image setup, and close-button suppression.

## Expected impact
| Area | Expected impact |
| --- | --- |
| Workspace tabs | Active tabs start dragging reliably from the tab surface. |
| Drag preview | The visible ghost preview appears during tab drag. |
| Close and rename controls | Close clicks and rename input interactions remain non-drag targets. |

## Design notes
- The drag payload still flows through `src/lib/dnd.ts`; this PR only changes where tab drag starts are captured.
- Tooltip-wrapped tab indicators opt into native dragging so WebKit does not swallow drag startup on nested inline elements.
- The title-generation indicator keeps draggable behavior opt-in, so sidebar usage does not become a new drag source.

## Test plan
- [x] `pnpm exec vitest run src/components/Pane.test.tsx --reporter=dot` - 8 tests passed
- [x] `pnpm exec tsc --noEmit --pretty false` - passed
- [x] `pnpm exec playwright test tests/e2e/panes.spec.ts --grep "tab close button|tab drag remains"` - 2 tests passed
- [x] `git diff --check` - passed

## Notes
- `Pane.test.tsx` still prints existing React act environment warnings during Vitest; the suite passes.