### PR TITLE
fix(terminal): validate file links before opening

### DIFF
--- a/src-tauri/src/fs_explorer.rs
+++ b/src-tauri/src/fs_explorer.rs
@@ -747,6 +747,13 @@ pub struct ReadFileResult {
 const VIEWER_MAX_BYTES: u64 = 2 * 1024 * 1024;
 
 #[tauri::command]
+pub fn fs_file_exists(path: String) -> AppResult<bool> {
+    let p = PathBuf::from(&path);
+    reject_dangerous(&p)?;
+    Ok(p.is_file())
+}
+
+#[tauri::command]
 pub fn fs_read_file(path: String) -> AppResult<ReadFileResult> {
     let p = PathBuf::from(&path);
     reject_dangerous(&p)?;
@@ -1559,6 +1566,21 @@ mod tests {
     fn rename_rejects_traversal_segments() {
         let res = fs_rename("/tmp/../etc/evil".to_string(), "/tmp/x".to_string());
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn fs_file_exists_only_accepts_files() {
+        let d = tmpdir();
+        let file = d.path().join("a.txt");
+        let dir = d.path().join("folder");
+        fs::write(&file, b"hi").unwrap();
+        fs::create_dir(&dir).unwrap();
+
+        assert!(fs_file_exists(file.to_string_lossy().into_owned()).unwrap());
+        assert!(!fs_file_exists(dir.to_string_lossy().into_owned()).unwrap());
+        assert!(
+            !fs_file_exists(d.path().join("missing.txt").to_string_lossy().into_owned()).unwrap()
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -585,6 +585,7 @@ pub fn run() {
             fs_explorer::fs_shell_editor,
             fs_explorer::fs_git_status,
             fs_explorer::fs_git_branch,
+            fs_explorer::fs_file_exists,
             fs_explorer::fs_read_file,
             fs_explorer::fs_git_diff_stats,
             fs_explorer::fs_git_diff_lines,

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -653,15 +653,53 @@ export function Terminal({
         hideLinkTooltip();
       },
     };
+    const resolveTerminalFileBaseCwd = async (): Promise<string> => {
+      let baseCwd = cwd;
+      try {
+        baseCwd = (await api.ptyCwd(sessionId)) ?? cwd;
+      } catch (err: unknown) {
+        console.debug("[Terminal] pty_cwd for file link failed", err);
+      }
+      return baseCwd;
+    };
+    const resolveOpenableTerminalFileReferences = async (
+      references: TerminalFileReference[],
+    ): Promise<TerminalFileReference[]> => {
+      const baseCwd = await resolveTerminalFileBaseCwd();
+      const resolved: Array<TerminalFileReference | null> = await Promise.all(
+        references.map(async (reference) => {
+          const absolutePath = resolveTerminalFilePath(baseCwd, reference.path);
+          try {
+            if (!(await api.fsFileExists(absolutePath))) {
+              return null;
+            }
+          } catch (err: unknown) {
+            console.debug("[Terminal] fs_file_exists for file link failed", err);
+            return null;
+          }
+          return { ...reference, absolutePath };
+        }),
+      );
+      return resolved.filter(
+        (reference): reference is TerminalFileReference => reference !== null,
+      );
+    };
     const openTerminalFileReference = (reference: TerminalFileReference) => {
       void (async () => {
-        let baseCwd = cwd;
+        const path =
+          reference.absolutePath ??
+          resolveTerminalFilePath(
+            await resolveTerminalFileBaseCwd(),
+            reference.path,
+          );
         try {
-          baseCwd = (await api.ptyCwd(sessionId)) ?? cwd;
+          if (!(await api.fsFileExists(path))) {
+            return;
+          }
         } catch (err: unknown) {
-          console.debug("[Terminal] pty_cwd for file link failed", err);
+          console.debug("[Terminal] fs_file_exists before open failed", err);
+          return;
         }
-        const path = resolveTerminalFilePath(baseCwd, reference.path);
         const target =
           reference.line === undefined
             ? undefined
@@ -682,6 +720,7 @@ export function Terminal({
     );
     let fileLinksDisposable: IDisposable | null = term.registerLinkProvider(
       createTerminalFileLinkProvider(term, {
+        resolveReferences: resolveOpenableTerminalFileReferences,
         activate: (event, reference) => {
           event.preventDefault();
           hideLinkTooltip(true);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -657,6 +657,9 @@ export const api = {
   fsGitBranch(repoRoot: string): Promise<string> {
     return invoke<string>("fs_git_branch", { repoRoot });
   },
+  fsFileExists(path: string): Promise<boolean> {
+    return invoke<boolean>("fs_file_exists", { path });
+  },
   fsReadFile(path: string): Promise<FsReadFileResult> {
     return invoke<FsReadFileResult>("fs_read_file", { path });
   },

--- a/src/lib/terminalFileLinks.test.ts
+++ b/src/lib/terminalFileLinks.test.ts
@@ -4,7 +4,12 @@ import {
   findTerminalFileReferences,
   resolveTerminalFilePath,
 } from "./terminalFileLinks";
-import type { IBufferCell, IBufferLine, Terminal as XTerm } from "@xterm/xterm";
+import type {
+  IBufferCell,
+  IBufferLine,
+  ILink,
+  Terminal as XTerm,
+} from "@xterm/xterm";
 
 function makeBufferCell(chars: string, width = 1): IBufferCell {
   return {
@@ -135,6 +140,24 @@ describe("terminal file links", () => {
     expect(findTerminalFileReferences("for example, e.g. this")).toEqual([]);
   });
 
+  it("does not treat property chains as file references", () => {
+    expect(
+      findTerminalFileReferences(
+        "assert_eq!(limits.requests.unwrap().reset_at, Some(1779930000.0));",
+      ),
+    ).toEqual([]);
+  });
+
+  it("accepts sentence-ending periods after file paths", () => {
+    expect(findTerminalFileReferences("Loaded README.md.")).toEqual([
+      {
+        path: "README.md",
+        text: "README.md",
+        startIndex: 7,
+      },
+    ]);
+  });
+
   it("resolves relative paths from the terminal cwd", () => {
     expect(resolveTerminalFilePath("/repo/app", "src/App.tsx")).toBe(
       "/repo/app/src/App.tsx",
@@ -159,6 +182,28 @@ describe("terminal file links", () => {
         underline: false,
       });
     });
+  });
+
+  it("filters links through the reference resolver", async () => {
+    const provider = createTerminalFileLinkProvider(
+      makeTerminalWithLine(makeBufferLine("src/App.tsx missing.tsx")),
+      {
+        activate: () => undefined,
+        resolveReferences: async (references) =>
+          references
+            .filter((reference) => reference.path === "src/App.tsx")
+            .map((reference) => ({
+              ...reference,
+              absolutePath: `/repo/${reference.path}`,
+            })),
+      },
+    );
+
+    const links = await new Promise<ILink[] | undefined>((resolve) => {
+      provider.provideLinks(1, resolve);
+    });
+
+    expect(links?.map((link) => link.text)).toEqual(["src/App.tsx"]);
   });
 
   it("maps file link ranges using terminal cell columns", () => {

--- a/src/lib/terminalFileLinks.ts
+++ b/src/lib/terminalFileLinks.ts
@@ -11,10 +11,14 @@ export interface TerminalFileReference {
   column?: number;
   text: string;
   startIndex: number;
+  absolutePath?: string;
 }
 
 export interface TerminalFileLinkProviderOptions {
   activate: (event: MouseEvent, reference: TerminalFileReference) => void;
+  resolveReferences?: (
+    references: TerminalFileReference[],
+  ) => TerminalFileReference[] | Promise<TerminalFileReference[]>;
   hover?: (
     event: MouseEvent,
     reference: TerminalFileReference,
@@ -24,9 +28,9 @@ export interface TerminalFileLinkProviderOptions {
 }
 
 const FILE_REF_RE =
-  /(^|[\s([{"'`<])((?:\.{1,2}\/|\/)?(?:(?:[A-Za-z0-9._@+-]+\/)+[A-Za-z0-9._@+-]+|[A-Za-z0-9._@+-]*\.[A-Za-z0-9._@+-]+)):(?:(\d{1,7})(?::(\d{1,5}))?)?(?=$|[\s)\]}>,.;!?:])/g;
+  /(^|[\s([{"'`<])((?:\.{1,2}\/|\/)?(?:(?:[A-Za-z0-9._@+-]+\/)+[A-Za-z0-9._@+-]+|[A-Za-z0-9._@+-]*\.[A-Za-z0-9._@+-]+)):(?:(\d{1,7})(?::(\d{1,5}))?)?(?=$|[\s)\]}>,;!?:]|[.](?=$|[\s)\]}>,;!?:]))/g;
 const FILE_PATH_RE =
-  /(^|[\s([{"'`<])((?:\.{1,2}\/|\/)?(?:(?:[A-Za-z0-9._@+-]+\/)+[A-Za-z0-9._@+-]*\.[A-Za-z][A-Za-z0-9_@+-]+|[A-Za-z0-9._@+-]*\.[A-Za-z][A-Za-z0-9_@+-]+))(?=$|[\s)\]}>,.;!?])/g;
+  /(^|[\s([{"'`<])((?:\.{1,2}\/|\/)?(?:(?:[A-Za-z0-9._@+-]+\/)+[A-Za-z0-9._@+-]*\.[A-Za-z][A-Za-z0-9_@+-]+|[A-Za-z0-9._@+-]*\.[A-Za-z][A-Za-z0-9_@+-]+))(?=$|[\s)\]}>,;!?]|[.](?=$|[\s)\]}>,;!?]))/g;
 
 export function createTerminalFileLinkProvider(
   terminal: XTerm,
@@ -45,45 +49,69 @@ export function createTerminalFileLinkProvider(
         callback(undefined);
         return;
       }
-      callback(
-        references.map((reference) => {
-          const startColumn = stringIndexToBufferColumn(
-            line,
-            reference.startIndex,
-          );
-          const endColumn = stringIndexToBufferColumn(
-            line,
-            reference.startIndex + reference.text.length,
-          );
-          const link: ILink = {
-            range: {
-              start: {
-                x: startColumn + 1,
-                y: bufferLineNumber,
-              },
-              end: {
-                x: endColumn,
-                y: bufferLineNumber,
-              },
-            },
-            text: reference.text,
-            decorations: {
-              pointerCursor: true,
-              underline: false,
-            },
-            activate: (event) => options.activate(event, reference),
-          };
-          if (options.hover) {
-            link.hover = (event) => options.hover?.(event, reference, link);
-          }
-          if (options.leave) {
-            link.leave = (event) => options.leave?.(event, reference);
-          }
-          return link;
-        }),
-      );
+      const provide = (resolvedReferences: TerminalFileReference[]) => {
+        if (resolvedReferences.length === 0) {
+          callback(undefined);
+          return;
+        }
+        callback(
+          resolvedReferences.map((reference) =>
+            createTerminalFileLink(
+              line,
+              bufferLineNumber,
+              reference,
+              options,
+            ),
+          ),
+        );
+      };
+      if (!options.resolveReferences) {
+        provide(references);
+        return;
+      }
+      void Promise.resolve(options.resolveReferences(references))
+        .then(provide)
+        .catch(() => callback(undefined));
     },
   };
+}
+
+function createTerminalFileLink(
+  line: IBufferLine,
+  bufferLineNumber: number,
+  reference: TerminalFileReference,
+  options: TerminalFileLinkProviderOptions,
+): ILink {
+  const startColumn = stringIndexToBufferColumn(line, reference.startIndex);
+  const endColumn = stringIndexToBufferColumn(
+    line,
+    reference.startIndex + reference.text.length,
+  );
+  const link: ILink = {
+    range: {
+      start: {
+        x: startColumn + 1,
+        y: bufferLineNumber,
+      },
+      end: {
+        x: endColumn,
+        y: bufferLineNumber,
+      },
+    },
+    text: reference.text,
+    decorations: {
+      pointerCursor: true,
+      underline: false,
+    },
+    activate: (event) => options.activate(event, reference),
+  };
+  if (options.hover) {
+    link.hover = (event) => options.hover?.(event, reference, link);
+  }
+  if (options.leave) {
+    link.leave = (event) => options.leave?.(event, reference);
+  }
+  return link;
 }
 
 export function findTerminalFileReferences(

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -193,6 +193,7 @@ export const tauriMockSource = `
     if (cmd === 'fs_shell_editor') return Promise.resolve('');
     if (cmd === 'fs_git_status') return Promise.resolve({ statuses: {}, huge: false, limit: 10000 });
     if (cmd === 'fs_git_branch') return Promise.resolve('');
+    if (cmd === 'fs_file_exists') return Promise.resolve(false);
     if (cmd === 'fs_read_file') {
       return Promise.resolve({ content: '', size: 0, truncated: false, binary: false });
     }

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -308,6 +308,12 @@ test.describe("terminal: spawn", () => {
       w.__fileLinkChannelId = channel.id;
       return 1;
     });
+    await tauri.handle("fs_file_exists", (args) => {
+      const { path } = args as { path: string };
+      const w = window as unknown as { __fsFileExistsCalls?: string[] };
+      w.__fsFileExistsCalls = [...(w.__fsFileExistsCalls ?? []), path];
+      return path === "/tmp/demo/src/components/FolderPermissionWarmupModal.tsx";
+    });
     await tauri.handle("fs_read_file", (args) => {
       const { path } = args as { path: string };
       if (path !== "/tmp/demo/src/components/FolderPermissionWarmupModal.tsx") {
@@ -361,6 +367,17 @@ test.describe("terminal: spawn", () => {
     const screenBox = await page.locator(".xterm-screen").boundingBox();
     expect(screenBox).not.toBeNull();
     await page.mouse.move(screenBox!.x + 12, screenBox!.y + 10);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (
+            (window as unknown as { __fsFileExistsCalls?: string[] })
+              .__fsFileExistsCalls ?? []
+          ).includes("/tmp/demo/src/components/FolderPermissionWarmupModal.tsx"),
+        ),
+      )
+      .toBe(true);
+    await page.waitForTimeout(30);
     await page.mouse.click(screenBox!.x + 12, screenBox!.y + 10);
 
     await expect(
@@ -410,6 +427,12 @@ test.describe("terminal: spawn", () => {
       w.__fileLinkChannelId = channel.id;
       return 1;
     });
+    await tauri.handle("fs_file_exists", (args) => {
+      const { path } = args as { path: string };
+      const w = window as unknown as { __fsFileExistsCalls?: string[] };
+      w.__fsFileExistsCalls = [...(w.__fsFileExistsCalls ?? []), path];
+      return path === "/tmp/demo/.claude/rules/typescript/coding-style.md";
+    });
     await tauri.handle("fs_read_file", (args) => {
       const { path } = args as { path: string };
       if (path !== "/tmp/demo/.claude/rules/typescript/coding-style.md") {
@@ -458,6 +481,17 @@ test.describe("terminal: spawn", () => {
     const screenBox = await page.locator(".xterm-screen").boundingBox();
     expect(screenBox).not.toBeNull();
     await page.mouse.move(screenBox!.x + 12, screenBox!.y + 10);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (
+            (window as unknown as { __fsFileExistsCalls?: string[] })
+              .__fsFileExistsCalls ?? []
+          ).includes("/tmp/demo/.claude/rules/typescript/coding-style.md"),
+        ),
+      )
+      .toBe(true);
+    await page.waitForTimeout(30);
     await page.mouse.click(screenBox!.x + 12, screenBox!.y + 10);
 
     await expect(
@@ -469,6 +503,115 @@ test.describe("terminal: spawn", () => {
     await expect(page.locator('[data-acorn-target-line="true"]')).toHaveCount(
       0,
     );
+  });
+
+  test("does not underline or open missing file terminal links", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({ terminal: { linkActivation: "modifier-click" } }),
+      );
+    });
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_cwd", () => "/tmp/demo");
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __missingFileLinkChannelId?: number;
+        [key: string]: unknown;
+      };
+      w.__missingFileLinkChannelId = channel.id;
+      return 1;
+    });
+    await tauri.handle("fs_file_exists", (args) => {
+      const { path } = args as { path: string };
+      const w = window as unknown as { __fsFileExistsCalls?: string[] };
+      w.__fsFileExistsCalls = [...(w.__fsFileExistsCalls ?? []), path];
+      return false;
+    });
+    await tauri.handle("fs_read_file", () => {
+      throw new Error("missing file link should not be opened");
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __missingFileLinkChannelId?: number })
+              .__missingFileLinkChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const linkText = "src/missing-file.tsx:10";
+    await emitSubscribedPtyOutput(
+      page,
+      "__missingFileLinkChannelId",
+      `${linkText}\r\n`,
+    );
+    await expect(page.locator(".xterm")).toContainText(linkText);
+
+    const screenBox = await page.locator(".xterm-screen").boundingBox();
+    expect(screenBox).not.toBeNull();
+    await page.mouse.move(screenBox!.x + 12, screenBox!.y + 10);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (
+            (window as unknown as { __fsFileExistsCalls?: string[] })
+              .__fsFileExistsCalls ?? []
+          ).includes("/tmp/demo/src/missing-file.tsx"),
+        ),
+      )
+      .toBe(true);
+    await expect(
+      page.locator('[data-acorn-terminal-link-underline="true"]'),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("tooltip", { name: /to open link/ }),
+    ).toHaveCount(0);
+
+    const modifier = process.platform === "darwin" ? "Meta" : "Control";
+    await page.keyboard.down(modifier);
+    await page.mouse.click(screenBox!.x + 12, screenBox!.y + 10);
+    await page.keyboard.up(modifier);
+    await page.waitForTimeout(150);
+
+    await expect(
+      page.getByRole("button", {
+        name: /missing-file\.tsx Close tab/,
+      }),
+    ).toHaveCount(0);
   });
 
   test("keeps modifier-click link tooltip mounted while output streams", async ({


### PR DESCRIPTION
## Summary

This PR makes terminal file links activate only for real files and avoids property-chain false positives.

1. **Existence-gated file links** — add a `fs_file_exists` backend command and frontend API wrapper, resolve terminal refs from the live PTY cwd, and only provide/open xterm links when the resolved path is a file.
2. **Property-chain filtering** — prevent expressions like `limits.requests.unwrap()` from being parsed as file links while preserving sentence-final paths like `README.md.`.
3. **Coverage** — add Vitest resolver/property-chain coverage and Playwright coverage for existing and missing terminal file links.

## Expected impact

| Area | Impact |
| --- | --- |
| Terminal output | Nonexistent filename-looking tokens no longer show a link affordance or open the code viewer. |
| Code/property chains | Method/property chains such as `limits.requests.unwrap()` no longer false-positive as file paths. |
| Existing file links | Real existing `path[:line[:column]]` refs still open in the code viewer. |

## Design notes

- Validation happens in the terminal link provider layer, so underline/click affordance matches whether the link can actually open.
- `fs_file_exists` returns true only for files, not directories, and still applies the existing dangerous-path rejection.
- The trailing-dot regex handling only treats `.` as punctuation when it ends the token, which keeps sentence-ending file paths without accepting property chains.

## Follow-up (not in this PR)

- Consider a small cache for repeated file-existence probes if profiling shows hover/provider overhead in very noisy terminal output.

## Test plan

- [x] `pnpm run typecheck` — passed.
- [x] `pnpm exec vitest run src/lib/terminalFileLinks.test.ts` — 15 tests passed.
- [x] `cargo test -p acorn fs_file_exists_only_accepts_files` from `src-tauri` — passed.
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts -g "file.*terminal links|missing file terminal links"` — 3 tests passed.
- [x] `git diff --check` — passed.

## Notes

- The focused Rust test emits the existing `AgentHookServer::start` dead-code warning; this PR does not introduce that warning.