### PR TITLE
feat(settings): readable daemon sessions + project-tab restore

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1861,7 +1861,7 @@ fn spawn_via_daemon<R: Runtime>(
     let outcome = bridge
         .spawn(
             id,
-            id.to_string(),
+            daemon_spawn_name_for_session(session.as_ref(), id),
             cwd.to_path_buf(),
             command.to_string(),
             args.to_vec(),
@@ -1893,6 +1893,16 @@ fn spawn_via_daemon<R: Runtime>(
         replay_scrollback,
     )
     .map_err(|e| format!("daemon stream attach failed: {e}"))
+}
+
+fn daemon_spawn_name_for_session(session: Option<&Session>, id: Uuid) -> String {
+    if let Some(name) = session
+        .map(|session| session.name.trim())
+        .filter(|name| !name.is_empty())
+    {
+        return name.to_string();
+    }
+    id.to_string()
 }
 
 /// Drop a `<cwd>/.acorn-control.md` marker every time a control session
@@ -2980,10 +2990,10 @@ pub fn acknowledge_staged_rev_mismatch(state: State<'_, AppState>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        collect_memory_usage_from_roots, create_unique_worktree, font_name_from_path,
-        infer_acornd_root_from_session_pids, inject_agent_hook_env, memory_root_pids,
-        remove_linked_worktree_at_path, should_remove_local_project_mirror,
-        validate_new_project_name, ProcessMemorySnapshot,
+        collect_memory_usage_from_roots, create_unique_worktree, daemon_spawn_name_for_session,
+        font_name_from_path, infer_acornd_root_from_session_pids, inject_agent_hook_env,
+        memory_root_pids, remove_linked_worktree_at_path,
+        should_remove_local_project_mirror, validate_new_project_name, ProcessMemorySnapshot,
     };
     use acorn_session::{Session, SessionAgentProvider, SessionKind};
     use std::collections::HashMap;
@@ -3100,6 +3110,31 @@ mod tests {
                 error: None,
             },
         );
+    }
+
+    #[test]
+    fn daemon_spawn_name_prefers_session_name_over_uuid() {
+        let id = Uuid::new_v4();
+        let session = Session::new(
+            "Readable tab".to_string(),
+            PathBuf::from("/tmp/repo"),
+            PathBuf::from("/tmp/repo"),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+
+        assert_eq!(
+            daemon_spawn_name_for_session(Some(&session), id),
+            "Readable tab"
+        );
+    }
+
+    #[test]
+    fn daemon_spawn_name_falls_back_to_uuid_without_session() {
+        let id = Uuid::new_v4();
+
+        assert_eq!(daemon_spawn_name_for_session(None, id), id.to_string());
     }
 
     #[test]

--- a/src/components/BackgroundSessionsSettings.tsx
+++ b/src/components/BackgroundSessionsSettings.tsx
@@ -297,6 +297,8 @@ function SessionsList({
   const [rowBusy, setRowBusy] = useState<string | null>(null);
   const [rowError, setRowError] = useState<string | null>(null);
   const showToast = useToasts((s) => s.show);
+  const refreshAll = useAppStore((s) => s.refreshAll);
+  const selectSession = useAppStore((s) => s.selectSession);
   const appById = useMemo(() => {
     const m = new Map<string, Session>();
     for (const s of appSessions) m.set(s.id, s);
@@ -314,12 +316,49 @@ function SessionsList({
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         setRowError(message);
-        showToast(`${t("backgroundSessions.toasts.sessionActionFailed")} ${message}`);
+        showToast(
+          `${t("backgroundSessions.toasts.sessionActionFailed")} ${message}`,
+        );
       } finally {
         setRowBusy(null);
       }
     },
     [onRefresh, showToast, t],
+  );
+
+  const restoreSessionToTab = useCallback(
+    async (daemonSession: DaemonSessionSummary) => {
+      const appSession = appById.get(daemonSession.id);
+      setRowBusy(daemonSession.id);
+      setRowError(null);
+      try {
+        if (!appSession) {
+          await api.daemonAdoptSession(daemonSession.id);
+        }
+        await refreshAll();
+        selectSession(daemonSession.id);
+        if (typeof window !== "undefined") {
+          requestAnimationFrame(() => {
+            window.dispatchEvent(
+              new CustomEvent("acorn:focus-session", {
+                detail: { sessionId: daemonSession.id },
+              }),
+            );
+          });
+        }
+        await onRefresh();
+        showToast(t("backgroundSessions.toasts.sessionRestored"));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setRowError(message);
+        showToast(
+          `${t("backgroundSessions.toasts.sessionActionFailed")} ${message}`,
+        );
+      } finally {
+        setRowBusy(null);
+      }
+    },
+    [appById, onRefresh, refreshAll, selectSession, showToast, t],
   );
 
   if (!enabled) {
@@ -355,6 +394,9 @@ function SessionsList({
       <ul className="divide-y divide-border rounded border border-border bg-bg-elevated text-xs">
         {sessions.map((s) => {
           const busy = rowBusy === s.id;
+          const app = appById.get(s.id);
+          const displayName = sessionDisplayName(app, s);
+          const ts = app ? Date.parse(app.updated_at) : Number.NaN;
           return (
             <li key={s.id} className="flex items-center gap-2 px-3 py-1.5">
               <span
@@ -365,30 +407,24 @@ function SessionsList({
               >
                 {s.alive ? "●" : "○"}
               </span>
-              <span className="flex flex-1 items-center gap-1.5 truncate font-mono">
+              <span className="flex flex-1 items-center gap-1.5 truncate">
                 <Tooltip
-                  label={renderAppMetaTooltip(appById.get(s.id), s, t)}
+                  label={renderAppMetaTooltip(app, s, t)}
                   side="top"
                   multiline
                 >
-                  <span className="truncate cursor-help">{s.name}</span>
+                  <span className="truncate cursor-help">{displayName}</span>
                 </Tooltip>
-                {(() => {
-                  const app = appById.get(s.id);
-                  if (!app) return null;
-                  const ts = Date.parse(app.updated_at);
-                  if (Number.isNaN(ts)) return null;
-                  return (
-                    <Tooltip label={new Date(ts).toLocaleString()} side="top">
-                      <span className="shrink-0 cursor-help text-[10px] text-fg-muted">
-                        {formatRelativeTime(
-                          ts,
-                          t("backgroundSessions.relativeTime.ago"),
-                        )}
-                      </span>
-                    </Tooltip>
-                  );
-                })()}
+                {!Number.isNaN(ts) ? (
+                  <Tooltip label={new Date(ts).toLocaleString()} side="top">
+                    <span className="shrink-0 cursor-help text-[10px] text-fg-muted">
+                      {formatRelativeTime(
+                        ts,
+                        t("backgroundSessions.relativeTime.ago"),
+                      )}
+                    </span>
+                  </Tooltip>
+                ) : null}
                 {s.kind === "control" ? (
                   <Tooltip
                     label={t("backgroundSessions.sessions.controlSession")}
@@ -410,6 +446,22 @@ function SessionsList({
                 </span>
               ) : null}
               <div className="flex items-center gap-1">
+                <Tooltip
+                  label={
+                    app
+                      ? t("backgroundSessions.actions.openTooltip")
+                      : t("backgroundSessions.actions.restoreTooltip")
+                  }
+                  side="top"
+                >
+                  <RowButton
+                    busy={busy}
+                    onClick={() => void restoreSessionToTab(s)}
+                    aria-label={t("backgroundSessions.actions.restore")}
+                  >
+                    <Undo2 size={12} />
+                  </RowButton>
+                </Tooltip>
                 {s.alive ? (
                   <Tooltip
                     label={t("backgroundSessions.actions.killPty")}
@@ -430,26 +482,7 @@ function SessionsList({
                       <Power size={12} />
                     </RowButton>
                   </Tooltip>
-                ) : (
-                  <Tooltip
-                    label={t("backgroundSessions.actions.restoreTooltip")}
-                    side="top"
-                  >
-                    <RowButton
-                      busy={busy}
-                      onClick={() =>
-                        void runRowAction(
-                          s.id,
-                          () => api.daemonAdoptSession(s.id),
-                          t("backgroundSessions.toasts.sessionRestored"),
-                        )
-                      }
-                      aria-label={t("backgroundSessions.actions.restore")}
-                    >
-                      <Undo2 size={12} />
-                    </RowButton>
-                  </Tooltip>
-                )}
+                ) : null}
                 <Tooltip
                   label={
                     s.alive
@@ -501,6 +534,35 @@ function formatRelativeTime(timestampMs: number, ago: string): string {
   if (mo < 12) return `${mo}mo ${ago}`;
   const yr = Math.round(diffSec / (86400 * 365));
   return `${yr}y ${ago}`;
+}
+
+function sessionDisplayName(
+  app: Session | undefined,
+  daemon: DaemonSessionSummary,
+): string {
+  const appName = app?.name.trim();
+  if (appName) return appName;
+
+  const daemonName = daemon.name.trim();
+  if (daemonName && daemonName !== daemon.id && !isUuidLike(daemonName)) {
+    return daemonName;
+  }
+
+  const pathName = basenamePath(daemon.cwd ?? daemon.repo_path ?? "");
+  if (pathName && daemon.branch) return `${pathName} · ${daemon.branch}`;
+  if (pathName) return pathName;
+  return daemonName || daemon.id;
+}
+
+function basenamePath(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] ?? "";
+}
+
+function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
 }
 
 function renderAppMetaTooltip(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1374,6 +1374,7 @@
     },
     "actions": {
       "killPty": "Kill PTY",
+      "openTooltip": "Open this session in its project tab",
       "restoreTooltip": "Adopt this session back into Acorn's sidebar",
       "restore": "Restore session",
       "forgetDisabledTooltip": "Kill first, then forget",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1374,6 +1374,7 @@
     },
     "actions": {
       "killPty": "PTY 종료",
+      "openTooltip": "이 세션을 원래 프로젝트 탭에서 열기",
       "restoreTooltip": "이 세션을 Acorn 사이드바로 다시 가져오기",
       "restore": "세션 복원",
       "forgetDisabledTooltip": "먼저 종료한 뒤 잊기",

--- a/tests/e2e/background-sessions.spec.ts
+++ b/tests/e2e/background-sessions.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect, pressHotkey } from "./support";
+
+const SETTINGS_DIALOG_NAME = /^(Settings|설정)$/;
+
+const PROJECT = {
+  repo_path: "/tmp/demo",
+  name: "demo",
+  created_at: "2026-01-01T00:00:00Z",
+  position: 0,
+};
+
+const SESSION = {
+  id: "s-1",
+  name: "alpha",
+  repo_path: "/tmp/demo",
+  worktree_path: "/tmp/demo",
+  branch: "main",
+  isolated: false,
+  status: "idle",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:05Z",
+  last_message: null,
+  title_source: "manual",
+  kind: "regular",
+  owner: { kind: "user" },
+  position: null,
+  in_worktree: false,
+  agent_provider: null,
+};
+
+const DAEMON_RUNNING = {
+  running: true,
+  enabled: true,
+  daemon_version: "test",
+  uptime_seconds: 60,
+  session_count_total: 1,
+  session_count_alive: 1,
+  log_path: "/tmp/acorn/daemon.log",
+  last_error: null,
+};
+
+async function openServicesSettings(page: import("./support").Page) {
+  await page.goto("/");
+  await pressHotkey(page, { mod: true, key: "," });
+  const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
+  await expect(modal).toBeVisible();
+  await modal.getByRole("button", { name: "Services", exact: true }).click();
+  return modal;
+}
+
+test.describe("background sessions settings", () => {
+  test("shows the app tab name when daemon metadata still has the UUID name", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [SESSION]);
+    await tauri.respond("daemon_status", DAEMON_RUNNING);
+    await tauri.respond("daemon_list_sessions", [
+      {
+        id: "s-1",
+        name: "s-1",
+        kind: "regular",
+        alive: true,
+        cwd: "/tmp/demo",
+        repo_path: "/tmp/demo",
+        branch: "main",
+        agent_kind: null,
+      },
+    ]);
+
+    const modal = await openServicesSettings(page);
+
+    await expect(modal.getByText("alpha", { exact: true })).toBeVisible();
+    await expect(modal.getByText("s-1", { exact: true })).toHaveCount(0);
+    await expect(
+      modal.getByRole("button", { name: "Restore session" }),
+    ).toBeVisible();
+  });
+
+  test("restore adopts an orphaned daemon session and opens its project tab", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __adopted?: boolean };
+      return w.__adopted
+        ? [
+            {
+              id: "550e8400-e29b-41d4-a716-446655440000",
+              name: "orphan restored",
+              repo_path: "/tmp/demo",
+              worktree_path: "/tmp/demo",
+              branch: "main",
+              isolated: false,
+              status: "idle",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:05Z",
+              last_message: null,
+              title_source: "manual",
+              kind: "regular",
+              owner: { kind: "user" },
+              position: null,
+              in_worktree: false,
+              agent_provider: null,
+            },
+          ]
+        : [];
+    });
+    await tauri.respond("daemon_status", DAEMON_RUNNING);
+    await tauri.respond("daemon_list_sessions", [
+      {
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        name: "550e8400-e29b-41d4-a716-446655440000",
+        kind: "regular",
+        alive: false,
+        cwd: "/tmp/demo",
+        repo_path: "/tmp/demo",
+        branch: "main",
+        agent_kind: null,
+      },
+    ]);
+    await tauri.handle("daemon_adopt_session", (args) => {
+      const w = window as unknown as {
+        __adopted?: boolean;
+        __adoptCalls?: unknown[];
+      };
+      w.__adoptCalls = w.__adoptCalls ?? [];
+      w.__adoptCalls.push(args);
+      w.__adopted = true;
+      return undefined;
+    });
+
+    const modal = await openServicesSettings(page);
+    await modal.getByRole("button", { name: "Restore session" }).click();
+
+    await expect(
+      page.locator(
+        '[data-tab-drag-handle="550e8400-e29b-41d4-a716-446655440000"]',
+      ),
+    ).toBeVisible();
+    await expect(
+      modal.getByText("orphan restored", { exact: true }),
+    ).toBeVisible();
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __adoptCalls?: unknown[] }).__adoptCalls,
+    )) as Array<{ targetSessionId: string }>;
+    expect(calls).toEqual([
+      { targetSessionId: "550e8400-e29b-41d4-a716-446655440000" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Settings → Services now shows daemon sessions as user-readable tabs and can restore them directly into their project workspace.

1. **Readable daemon rows:** prefer the app-side tab name for daemon sessions, with path/branch fallback for daemon-only rows instead of surfacing UUIDs as the primary label.
2. **Restore-to-tab action:** make the restore action available for daemon rows, adopting orphaned daemon sessions when needed and then selecting/focusing the restored project tab.
3. **Daemon metadata naming:** store the frontend session name in new daemon spawns so future daemon registry rows are readable by default.
4. **Coverage:** add E2E coverage for readable Services rows and orphan restore-to-tab behavior, plus Rust unit coverage for daemon spawn naming.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Settings → Services | Daemon sessions are easier to identify because the row label uses the tab name when available. |
| Session recovery | Users can restore/open daemon-tracked sessions directly into the original project tab from Services. |
| Existing sessions | Existing daemon rows whose daemon name is a UUID are displayed with app metadata or path fallback where possible. |
| New daemon sessions | New daemon registry metadata stores the session name instead of the UUID as the row name. |

## Design notes

- The daemon session id remains available in the row tooltip for precise debugging and support.
- Restore is idempotent for app-known sessions: it refreshes state and selects the existing tab without re-adopting.
- Orphan restore still uses the existing `daemon_adopt_session` backend command, then refreshes store state before selecting the tab.
- UUID-like daemon names are treated as non-user-facing labels and fall back to cwd/repo basename when no app session exists.

## Test plan

- [x] `./src-tauri/scripts/build-sidecar.sh` — staged the required sidecar binaries for this worktree.
- [x] `cargo test -p acorn daemon_spawn_name` — 2 Rust naming tests passed.
- [x] `pnpm run typecheck` — TypeScript passed.
- [x] `pnpm exec playwright test tests/e2e/background-sessions.spec.ts` — 2 Services background-session E2E tests passed.

## Notes

- This is intentionally a feature PR, not a patch-fix PR. Hold merge until the pending SemVer patch release is out.