### PR TITLE
feat(statusbar): show active agent token quota

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ mod shell_util;
 mod staged_rev_reconcile;
 mod state;
 mod todos;
+mod token_usage;
 mod unified_diff;
 mod worktree;
 
@@ -551,6 +552,7 @@ pub fn run() {
             commands::detect_session_statuses,
             commands::detect_session_agent,
             commands::prepare_claude_fork,
+            token_usage::get_agent_token_usage,
             commands::get_memory_usage,
             commands::get_acorn_ipc_status,
             commands::warm_macos_folder_permissions,

--- a/src-tauri/src/token_usage.rs
+++ b/src-tauri/src/token_usage.rs
@@ -1,0 +1,415 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use directories::UserDirs;
+use serde::Serialize;
+use serde_json::Value;
+
+const CODEX_SESSION_SCAN_LIMIT: usize = 20;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentTokenUsageSnapshot {
+    pub metrics: Vec<AgentTokenUsageMetric>,
+    pub updated_at: f64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentTokenUsageMetric {
+    pub provider: AgentTokenProvider,
+    pub window: AgentTokenWindow,
+    pub used_percent: Option<f64>,
+    pub remaining_percent: Option<f64>,
+    pub reset_at: Option<f64>,
+    pub source: String,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTokenProvider {
+    Codex,
+    Claude,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentTokenWindow {
+    FiveHour,
+    Weekly,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct RateLimitWindow {
+    used_percent: f64,
+    reset_at: Option<f64>,
+    source: String,
+}
+
+#[tauri::command]
+pub fn get_agent_token_usage() -> AgentTokenUsageSnapshot {
+    read_agent_token_usage()
+}
+
+fn read_agent_token_usage() -> AgentTokenUsageSnapshot {
+    let updated_at = unix_now();
+    let codex = read_codex_rate_limits();
+    let claude = read_claude_rate_limits();
+
+    let mut metrics = Vec::with_capacity(4);
+    push_metric(
+        &mut metrics,
+        AgentTokenProvider::Codex,
+        AgentTokenWindow::FiveHour,
+        codex.five_hour,
+        "~/.codex/sessions rate_limits",
+        "No Codex 5h rate-limit event found",
+    );
+    push_metric(
+        &mut metrics,
+        AgentTokenProvider::Codex,
+        AgentTokenWindow::Weekly,
+        codex.weekly,
+        "~/.codex/sessions rate_limits",
+        "No Codex weekly rate-limit event found",
+    );
+    push_metric(
+        &mut metrics,
+        AgentTokenProvider::Claude,
+        AgentTokenWindow::FiveHour,
+        claude.five_hour,
+        "~/.claude/token-widget/claude-rate-limits.json",
+        "No Claude 5h statusline rate-limit capture found",
+    );
+    push_metric(
+        &mut metrics,
+        AgentTokenProvider::Claude,
+        AgentTokenWindow::Weekly,
+        claude.weekly,
+        "~/.claude/token-widget/claude-rate-limits.json",
+        "No Claude weekly statusline rate-limit capture found",
+    );
+
+    AgentTokenUsageSnapshot {
+        metrics,
+        updated_at,
+    }
+}
+
+fn push_metric(
+    metrics: &mut Vec<AgentTokenUsageMetric>,
+    provider: AgentTokenProvider,
+    window: AgentTokenWindow,
+    rate_limit: Option<RateLimitWindow>,
+    fallback_source: &str,
+    fallback_error: &str,
+) {
+    if let Some(rate_limit) = rate_limit {
+        let used_percent = clamp_percent(rate_limit.used_percent);
+        metrics.push(AgentTokenUsageMetric {
+            provider,
+            window,
+            used_percent: Some(used_percent),
+            remaining_percent: Some(100.0 - used_percent),
+            reset_at: rate_limit.reset_at,
+            source: rate_limit.source,
+            error: None,
+        });
+        return;
+    }
+
+    metrics.push(AgentTokenUsageMetric {
+        provider,
+        window,
+        used_percent: None,
+        remaining_percent: None,
+        reset_at: None,
+        source: fallback_source.to_string(),
+        error: Some(fallback_error.to_string()),
+    });
+}
+
+#[derive(Debug, Default, PartialEq)]
+struct ProviderRateLimits {
+    five_hour: Option<RateLimitWindow>,
+    weekly: Option<RateLimitWindow>,
+}
+
+fn read_codex_rate_limits() -> ProviderRateLimits {
+    read_codex_rate_limits_from_latest_sessions().unwrap_or_else(read_codex_rate_limits_from_sqlite)
+}
+
+fn read_codex_rate_limits_from_latest_sessions() -> Option<ProviderRateLimits> {
+    let home = home_dir()?;
+    let sessions = home.join(".codex").join("sessions");
+    let files = latest_jsonl_files(&sessions, CODEX_SESSION_SCAN_LIMIT);
+
+    for file in files {
+        let Ok(text) = fs::read_to_string(&file) else {
+            continue;
+        };
+        for line in text.lines().rev() {
+            if !line.contains("\"rate_limits\"") {
+                continue;
+            }
+            let Ok(value) = serde_json::from_str::<Value>(line) else {
+                continue;
+            };
+            let Some(rate_limits) = value
+                .get("payload")
+                .and_then(|payload| payload.get("rate_limits"))
+            else {
+                continue;
+            };
+            let parsed = parse_codex_rate_limits(rate_limits, "~/.codex/sessions rate_limits");
+            if parsed.five_hour.is_some() || parsed.weekly.is_some() {
+                return Some(parsed);
+            }
+        }
+    }
+
+    None
+}
+
+fn read_codex_rate_limits_from_sqlite() -> ProviderRateLimits {
+    let Some(home) = home_dir() else {
+        return ProviderRateLimits::default();
+    };
+    let db = home.join(".codex").join("logs_2.sqlite");
+    if !db.exists() {
+        return ProviderRateLimits::default();
+    }
+
+    let query = r#"
+        select feedback_log_body from logs
+        where feedback_log_body like '%"type":"codex.rate_limits"%'
+        order by ts desc, ts_nanos desc, id desc
+        limit 1;
+    "#;
+    let Ok(output) = Command::new("/usr/bin/sqlite3")
+        .arg(&db)
+        .arg(query)
+        .output()
+    else {
+        return ProviderRateLimits::default();
+    };
+    if !output.status.success() {
+        return ProviderRateLimits::default();
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let Some(json_text) = extract_codex_event_json(&text) else {
+        return ProviderRateLimits::default();
+    };
+    let Ok(value) = serde_json::from_str::<Value>(&json_text) else {
+        return ProviderRateLimits::default();
+    };
+    let Some(rate_limits) = value.get("rate_limits") else {
+        return ProviderRateLimits::default();
+    };
+
+    parse_codex_rate_limits(rate_limits, "~/.codex/logs_2.sqlite rate_limits")
+}
+
+fn parse_codex_rate_limits(value: &Value, source: &str) -> ProviderRateLimits {
+    ProviderRateLimits {
+        five_hour: parse_rate_limit_window(
+            value.get("primary"),
+            &["used_percent"],
+            &["reset_at", "resets_at"],
+            source,
+        ),
+        weekly: parse_rate_limit_window(
+            value.get("secondary"),
+            &["used_percent"],
+            &["reset_at", "resets_at"],
+            source,
+        ),
+    }
+}
+
+fn read_claude_rate_limits() -> ProviderRateLimits {
+    for path in claude_rate_limit_paths() {
+        let Ok(data) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(&data) else {
+            continue;
+        };
+        let Some(rate_limits) = value.get("rate_limits") else {
+            continue;
+        };
+        let source = render_source_path(&path);
+        let parsed = ProviderRateLimits {
+            five_hour: parse_rate_limit_window(
+                rate_limits.get("five_hour"),
+                &["used_percentage"],
+                &["resets_at"],
+                &source,
+            ),
+            weekly: parse_rate_limit_window(
+                rate_limits.get("seven_day"),
+                &["used_percentage"],
+                &["resets_at"],
+                &source,
+            ),
+        };
+        if parsed.five_hour.is_some() || parsed.weekly.is_some() {
+            return parsed;
+        }
+    }
+
+    ProviderRateLimits::default()
+}
+
+fn claude_rate_limit_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(home) = home_dir() {
+        paths.push(
+            home.join(".claude")
+                .join("token-widget")
+                .join("claude-rate-limits.json"),
+        );
+    }
+    paths
+}
+
+fn parse_rate_limit_window(
+    value: Option<&Value>,
+    used_keys: &[&str],
+    reset_keys: &[&str],
+    source: &str,
+) -> Option<RateLimitWindow> {
+    let value = value?;
+    let used_percent = used_keys.iter().find_map(|key| number(value.get(*key)))?;
+    let reset_at = reset_keys.iter().find_map(|key| number(value.get(*key)));
+    Some(RateLimitWindow {
+        used_percent,
+        reset_at,
+        source: source.to_string(),
+    })
+}
+
+fn number(value: Option<&Value>) -> Option<f64> {
+    match value? {
+        Value::Number(n) => n.as_f64(),
+        Value::String(s) => s.parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+fn extract_codex_event_json(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if let Some((_, json)) = trimmed.split_once("websocket event: ") {
+        return Some(json.to_string());
+    }
+    let marker = r#""type":"codex.rate_limits""#;
+    let marker_index = trimmed.find(marker)?;
+    let start = trimmed[..marker_index].rfind('{')?;
+    Some(trimmed[start..].to_string())
+}
+
+fn latest_jsonl_files(root: &Path, limit: usize) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    collect_jsonl_files(root, &mut files);
+    files.sort_by(|a, b| b.1.cmp(&a.1));
+    files
+        .into_iter()
+        .take(limit)
+        .map(|(path, _)| path)
+        .collect()
+}
+
+fn collect_jsonl_files(root: &Path, files: &mut Vec<(PathBuf, SystemTime)>) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        if metadata.is_dir() {
+            collect_jsonl_files(&path, files);
+            continue;
+        }
+        if !metadata.is_file() || path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        files.push((path, metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH)));
+    }
+}
+
+fn render_source_path(path: &Path) -> String {
+    let Some(home) = home_dir() else {
+        return path.display().to_string();
+    };
+    if let Ok(suffix) = path.strip_prefix(&home) {
+        return format!("~/{}", suffix.display());
+    }
+    path.display().to_string()
+}
+
+fn home_dir() -> Option<PathBuf> {
+    UserDirs::new().map(|dirs| dirs.home_dir().to_path_buf())
+}
+
+fn unix_now() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+fn clamp_percent(value: f64) -> f64 {
+    value.clamp(0.0, 100.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_codex_primary_and_secondary_windows() {
+        let value: Value = serde_json::json!({
+            "primary": { "used_percent": 12, "resets_at": 1779860400 },
+            "secondary": { "used_percent": 34.5, "reset_at": 1779930000 }
+        });
+
+        let limits = parse_codex_rate_limits(&value, "codex");
+        let five_hour = limits.five_hour.unwrap();
+        let weekly = limits.weekly.unwrap();
+
+        assert_eq!(five_hour.used_percent, 12.0);
+        assert_eq!(five_hour.reset_at, Some(1779860400.0));
+        assert_eq!(weekly.used_percent, 34.5);
+        assert_eq!(weekly.reset_at, Some(1779930000.0));
+    }
+
+    #[test]
+    fn extracts_codex_event_json_from_logged_websocket_prefix() {
+        let text = r#"websocket event: {"type":"codex.rate_limits","rate_limits":{"primary":{"used_percent":5}}}"#;
+
+        assert_eq!(
+            extract_codex_event_json(text).as_deref(),
+            Some(r#"{"type":"codex.rate_limits","rate_limits":{"primary":{"used_percent":5}}}"#)
+        );
+    }
+
+    #[test]
+    fn parses_string_percentages() {
+        let value: Value = serde_json::json!({
+            "used_percentage": "10.5",
+            "resets_at": "1779860400"
+        });
+
+        let window =
+            parse_rate_limit_window(Some(&value), &["used_percentage"], &["resets_at"], "claude")
+                .unwrap();
+
+        assert_eq!(window.used_percent, 10.5);
+        assert_eq!(window.reset_at, Some(1779860400.0));
+    }
+}

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -333,6 +333,40 @@ describe("SettingsModal font controls", () => {
     });
   });
 
+  it("patches the status bar agent token usage toggle", async () => {
+    const patchStatusBar = vi.fn();
+    useSettings.setState({
+      settings: cloneSettings(),
+      patchStatusBar,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openInterfaceTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const input = Array.from(
+      document.querySelectorAll<HTMLInputElement>("input[type='checkbox']"),
+    ).find((element) => {
+      const label = element.closest("label");
+      return label?.textContent?.includes("Agent token usage");
+    });
+
+    expect(input).toBeInstanceOf(HTMLInputElement);
+    expect(input?.checked).toBe(false);
+
+    act(() => {
+      if (!input) throw new Error("Agent token usage checkbox not found");
+      input.click();
+    });
+
+    expect(patchStatusBar).toHaveBeenCalledWith({ showAgentTokenUsage: true });
+  });
+
   it("renders the Interface language selector in Korean and patches changes", async () => {
     const patchLanguage = vi.fn();
     useSettings.setState({

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1440,6 +1440,15 @@ function StatusBarSection({
           onChange={(v) => patch({ showWorkingDirectory: v })}
         />
         <CheckboxRow
+          label={st(t, "settings.appearance.statusBar.agentTokenUsage.label")}
+          description={st(
+            t,
+            "settings.appearance.statusBar.agentTokenUsage.description",
+          )}
+          checked={statusBar.showAgentTokenUsage}
+          onChange={(v) => patch({ showAgentTokenUsage: v })}
+        />
+        <CheckboxRow
           label={st(t, "settings.appearance.statusBar.memoryUsage.label")}
           description={st(
             t,

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,16 +1,28 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { createPortal } from "react-dom";
 import { homeDir } from "@tauri-apps/api/path";
 import {
   Activity,
   Bell,
   CheckCheck,
+  Gauge,
   Loader2,
   Settings,
   Trash2,
   X,
 } from "lucide-react";
 import { api } from "../lib/api";
+import {
+  AgentProviderIcon,
+  resolveSessionAgentProvider,
+} from "../lib/agentProvider";
 import { cn } from "../lib/cn";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useSettings } from "../lib/settings";
@@ -20,6 +32,10 @@ import type {
   SessionNotification,
   SessionNotificationKind,
   SessionStatus,
+  AgentTokenProvider,
+  AgentTokenUsageMetric,
+  AgentTokenUsageSnapshot,
+  AgentTokenWindow,
 } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
 import { useAppStore } from "../store";
@@ -27,6 +43,7 @@ import { MemoryBreakdownModal } from "./MemoryBreakdownModal";
 import { Tooltip } from "./Tooltip";
 
 const MEMORY_POLL_MS = 2000;
+const TOKEN_USAGE_POLL_MS = 60_000;
 
 type StatusBarTranslationKey = Extract<TranslationKey, `statusBar.${string}`>;
 
@@ -128,6 +145,37 @@ function useMemoryUsage(
   return snapshot;
 }
 
+function useAgentTokenUsage(
+  intervalMs: number,
+  enabled: boolean,
+): AgentTokenUsageSnapshot | null {
+  const [snapshot, setSnapshot] = useState<AgentTokenUsageSnapshot | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setSnapshot(null);
+      return;
+    }
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const usage = await api.getAgentTokenUsage();
+        if (!cancelled) setSnapshot(usage);
+      } catch {
+        if (!cancelled) setSnapshot(null);
+      }
+    };
+    tick();
+    const id = window.setInterval(tick, intervalMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [intervalMs, enabled]);
+
+  return snapshot;
+}
+
 // GitHub octocat mark — lucide-react has no brand glyphs, so inline the
 // official Mark path. `currentColor` lets the surrounding text style it.
 function GitHubMark() {
@@ -165,9 +213,24 @@ export function StatusBar() {
   const showWorkingDirectory = useSettings(
     (s) => s.settings.statusBar.showWorkingDirectory,
   );
+  const showAgentTokenUsage = useSettings(
+    (s) => s.settings.statusBar.showAgentTokenUsage,
+  );
+  const showAgentProviderIcons = useSettings(
+    (s) => s.settings.sessionDisplay.icons.agentProvider,
+  );
   const showMemory = useSettings((s) => s.settings.statusBar.showMemory);
   const active = sessions.find((s) => s.id === activeSessionId);
+  const activeTokenProvider: AgentTokenProvider | null = active
+    ? resolveSessionAgentProvider(active)
+    : null;
+  const showActiveAgentTokenUsage =
+    showAgentTokenUsage && activeTokenProvider !== null;
   const memory = useMemoryUsage(MEMORY_POLL_MS, showMemory);
+  const tokenUsage = useAgentTokenUsage(
+    TOKEN_USAGE_POLL_MS,
+    showActiveAgentTokenUsage,
+  );
   const home = useHomeDir();
   const [breakdownOpen, setBreakdownOpen] = useState(false);
   const displayPath = active ? tildify(active.worktree_path, home) : null;
@@ -274,6 +337,16 @@ export function StatusBar() {
               </Tooltip>
             </>
           ) : null}
+          {showActiveAgentTokenUsage ? (
+            <>
+              <span className="text-fg-muted/50">|</span>
+              <AgentTokenUsageBadge
+                provider={activeTokenProvider}
+                showProviderIcon={showAgentProviderIcons}
+                snapshot={tokenUsage}
+              />
+            </>
+          ) : null}
           {showMemory ? (
             <>
               <span className="text-fg-muted/50">|</span>
@@ -305,6 +378,204 @@ export function StatusBar() {
       />
     </>
   );
+}
+
+const TOKEN_WINDOWS: AgentTokenWindow[] = ["five_hour", "weekly"];
+
+function AgentTokenUsageBadge({
+  provider,
+  showProviderIcon,
+  snapshot,
+}: {
+  provider: AgentTokenProvider;
+  showProviderIcon: boolean;
+  snapshot: AgentTokenUsageSnapshot | null;
+}) {
+  const t = useTranslation();
+  const summary = renderAgentTokenSummary(snapshot, provider, t);
+  const tooltip = formatAgentTokenTooltip(snapshot, provider, t);
+
+  return (
+    <Tooltip label={tooltip} side="top" multiline>
+      <span
+        data-testid="agent-token-usage"
+        className="inline-flex h-5 shrink-0 items-center gap-1 whitespace-nowrap rounded px-1 text-fg-muted"
+      >
+        {showProviderIcon ? (
+          <AgentProviderIcon provider={provider} />
+        ) : (
+          <Gauge size={12} />
+        )}
+        {summary}
+      </span>
+    </Tooltip>
+  );
+}
+
+function renderAgentTokenSummary(
+  snapshot: AgentTokenUsageSnapshot | null,
+  provider: AgentTokenProvider,
+  t: Translator,
+): ReactNode {
+  if (!snapshot) {
+    return statusBarFormat(t, "statusBar.agentTokens", {
+      summary: statusBarText(t, "statusBar.agentTokensUnavailable"),
+    });
+  }
+
+  const fiveHour = tokenMetric(snapshot, provider, "five_hour");
+  const weekly = tokenMetric(snapshot, provider, "weekly");
+  const fiveHourText = formatRemainingPercent(fiveHour);
+  const weeklyText = formatRemainingPercent(weekly);
+  if (!fiveHourText && !weeklyText) {
+    return statusBarFormat(t, "statusBar.agentTokens", {
+      summary: statusBarText(t, "statusBar.agentTokensNoData"),
+    });
+  }
+  return (
+    <>
+      <span>{agentTokensPrefix(t)}</span>
+      <span className="inline-flex items-center gap-2">
+        <TokenWindowReadout label="5h" value={fiveHourText ?? "-"} />
+        <TokenWindowReadout label="w" value={weeklyText ?? "-"} />
+      </span>
+    </>
+  );
+}
+
+function agentTokensPrefix(t: Translator): string {
+  const template = statusBarText(t, "statusBar.agentTokens");
+  const prefix = template.replace(/\s*\{summary\}\s*/g, "").trim();
+  return prefix || "tokens:";
+}
+
+function TokenWindowReadout({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="rounded border border-fg-muted/25 bg-fg-muted/10 px-1 py-px text-[9px] font-semibold leading-none text-fg-muted">
+        {label}
+      </span>
+      <span>{value}</span>
+    </span>
+  );
+}
+
+function formatAgentTokenTooltip(
+  snapshot: AgentTokenUsageSnapshot | null,
+  provider: AgentTokenProvider,
+  t: Translator,
+): string {
+  if (!snapshot) return statusBarText(t, "statusBar.agentTokensUnavailable");
+
+  const lines = TOKEN_WINDOWS.map((window) => {
+    const metric = tokenMetric(snapshot, provider, window);
+    const windowName = windowDisplayName(window, t);
+    if (!metric || metric.error) {
+      return statusBarFormat(t, "statusBar.agentTokensTooltipError", {
+        window: windowName,
+        error:
+          metric?.error ?? statusBarText(t, "statusBar.agentTokensUnavailable"),
+      });
+    }
+    return statusBarFormat(t, "statusBar.agentTokensTooltipLine", {
+      window: windowName,
+      remaining: formatRemainingPercent(metric) ?? "-",
+      reset: formatResetRemaining(metric.reset_at, snapshot.updated_at, t),
+    });
+  });
+
+  lines.push(
+    statusBarFormat(t, "statusBar.agentTokensUpdated", {
+      time: formatUnixTime(snapshot.updated_at),
+    }),
+  );
+  return lines.join("\n");
+}
+
+function tokenMetric(
+  snapshot: AgentTokenUsageSnapshot,
+  provider: AgentTokenProvider,
+  window: AgentTokenWindow,
+): AgentTokenUsageMetric | null {
+  return (
+    snapshot.metrics.find(
+      (metric) => metric.provider === provider && metric.window === window,
+    ) ?? null
+  );
+}
+
+function windowDisplayName(window: AgentTokenWindow, t: Translator): string {
+  return window === "five_hour"
+    ? statusBarText(t, "statusBar.agentTokensWindowFiveHour")
+    : statusBarText(t, "statusBar.agentTokensWindowWeekly");
+}
+
+function formatRemainingPercent(metric: AgentTokenUsageMetric | null): string | null {
+  return metric?.remaining_percent === null || metric?.remaining_percent === undefined
+    ? null
+    : formatPercentValue(metric.remaining_percent);
+}
+
+function formatPercentValue(value: number): string {
+  if (!Number.isFinite(value)) return "-";
+  const clamped = Math.max(0, Math.min(100, value));
+  return Number.isInteger(clamped) ? `${clamped}%` : `${clamped.toFixed(1)}%`;
+}
+
+function formatResetRemaining(
+  resetAt: number | null,
+  observedAt: number,
+  t: Translator,
+): string {
+  if (
+    !resetAt ||
+    !Number.isFinite(resetAt) ||
+    !Number.isFinite(observedAt)
+  ) {
+    return statusBarText(t, "statusBar.agentTokensResetUnknown");
+  }
+  const remainingSeconds = Math.max(0, resetAt - observedAt);
+  return formatDuration(remainingSeconds);
+}
+
+function formatDuration(seconds: number): string {
+  const minutes = Math.ceil(seconds / 60);
+  if (minutes <= 0) return "0m";
+  if (minutes < 60) return `${minutes}m`;
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours < 24) {
+    return remainingMinutes > 0
+      ? `${hours}h ${remainingMinutes}m`
+      : `${hours}h`;
+  }
+
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`;
+}
+
+function formatUnixTime(value: number): string {
+  const date = new Date(value * 1000);
+  if (Number.isNaN(date.getTime())) return "-";
+  const now = new Date();
+  const sameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+  return date.toLocaleString([], {
+    month: sameDay ? undefined : "numeric",
+    day: sameDay ? undefined : "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 // Combined indicator for the in-process IPC server + the out-of-process

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
   AcornIpcStatus,
+  AgentTokenUsageSnapshot,
   AgentHistoryItem,
   CommitInfo,
   DiffPayload,
@@ -294,6 +295,9 @@ export const api = {
   },
   getMemoryUsage(): Promise<MemoryUsage> {
     return invoke<MemoryUsage>("get_memory_usage");
+  },
+  getAgentTokenUsage(): Promise<AgentTokenUsageSnapshot> {
+    return invoke<AgentTokenUsageSnapshot>("get_agent_token_usage");
   },
   /**
    * Inspect the runtime environment for the `acorn-ipc` CLI: bundled binary

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -187,6 +187,10 @@ describe("status bar settings", () => {
     expect(DEFAULT_SETTINGS.statusBar.showSessionActivity).toBe(true);
   });
 
+  it("keeps agent token usage hidden by default", () => {
+    expect(DEFAULT_SETTINGS.statusBar.showAgentTokenUsage).toBe(false);
+  });
+
   it("loads a persisted session activity shortcut preference", async () => {
     localStorage.setItem(
       STORAGE_KEY,
@@ -198,6 +202,20 @@ describe("status bar settings", () => {
 
     expect(useSettings.getState().settings.statusBar.showSessionActivity).toBe(
       false,
+    );
+  });
+
+  it("loads a persisted agent token usage preference", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ statusBar: { showAgentTokenUsage: true } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.statusBar.showAgentTokenUsage).toBe(
+      true,
     );
   });
 });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -277,6 +277,7 @@ export interface AcornSettings {
     showSessionStatus: boolean;
     showGithubAccount: boolean;
     showWorkingDirectory: boolean;
+    showAgentTokenUsage: boolean;
     showMemory: boolean;
   };
   github: {
@@ -418,6 +419,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     showSessionStatus: true,
     showGithubAccount: true,
     showWorkingDirectory: true,
+    showAgentTokenUsage: false,
     showMemory: true,
   },
   github: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -206,6 +206,24 @@ export interface MemoryUsage {
   processes: MemoryProcess[];
 }
 
+export type AgentTokenProvider = "codex" | "claude";
+export type AgentTokenWindow = "five_hour" | "weekly";
+
+export interface AgentTokenUsageMetric {
+  provider: AgentTokenProvider;
+  window: AgentTokenWindow;
+  used_percent: number | null;
+  remaining_percent: number | null;
+  reset_at: number | null;
+  source: string;
+  error: string | null;
+}
+
+export interface AgentTokenUsageSnapshot {
+  metrics: AgentTokenUsageMetric[];
+  updated_at: number;
+}
+
 export interface AcornIpcShim {
   path: string;
   exists: boolean;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -278,6 +278,10 @@
           "label": "Working directory",
           "description": "The active session's worktree path (tildified against $HOME)."
         },
+        "agentTokenUsage": {
+          "label": "Agent token usage",
+          "description": "Codex reads local rate-limit events; Claude reads a token-widget-compatible statusline capture. Polls once per minute when shown."
+        },
         "memoryUsage": {
           "label": "Memory usage",
           "description": "Live memory readout for acorn and its child shells. Disabling also stops the 2-second polling loop, so it costs nothing when hidden."
@@ -579,6 +583,15 @@
     "branch": "branch: {branch}",
     "memoryTooltip": "Click to view per-process breakdown",
     "memory": "memory: {memory}",
+    "agentTokens": "tokens: {summary}",
+    "agentTokensUnavailable": "loading",
+    "agentTokensNoData": "no data",
+    "agentTokensWindowFiveHour": "5h",
+    "agentTokensWindowWeekly": "weekly",
+    "agentTokensResetUnknown": "-",
+    "agentTokensTooltipLine": "{window}: {remaining} left, resets in {reset}",
+    "agentTokensTooltipError": "{window}: {error}",
+    "agentTokensUpdated": "updated {time}",
     "sessionStatus": {
       "idle": "idle",
       "running": "running",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -278,6 +278,10 @@
           "label": "작업 디렉터리",
           "description": "활성 세션의 worktree 경로입니다($HOME 기준으로 ~ 처리됨)."
         },
+        "agentTokenUsage": {
+          "label": "에이전트 토큰 사용량",
+          "description": "Codex는 로컬 rate-limit 이벤트를 읽고, Claude는 token-widget 호환 statusline 캡처를 읽습니다. 표시 중일 때 1분마다 확인합니다."
+        },
         "memoryUsage": {
           "label": "메모리 사용량",
           "description": "acorn과 하위 셸의 실시간 메모리 표시입니다. 끄면 2초 폴링 루프도 중지되어 숨겨진 동안 비용이 들지 않습니다."
@@ -579,6 +583,15 @@
     "branch": "브랜치: {branch}",
     "memoryTooltip": "프로세스별 세부 정보를 보려면 클릭",
     "memory": "메모리: {memory}",
+    "agentTokens": "토큰: {summary}",
+    "agentTokensUnavailable": "불러오는 중",
+    "agentTokensNoData": "데이터 없음",
+    "agentTokensWindowFiveHour": "5시간",
+    "agentTokensWindowWeekly": "주간",
+    "agentTokensResetUnknown": "-",
+    "agentTokensTooltipLine": "{window}: 잔여 {remaining}, 갱신까지 {reset}",
+    "agentTokensTooltipError": "{window}: {error}",
+    "agentTokensUpdated": "확인 시각 {time}",
     "sessionStatus": {
       "idle": "유휴",
       "running": "실행 중",

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -118,6 +118,12 @@ export const tauriMockSource = `
         scrollback_disk_bytes: 0,
       });
     }
+    if (cmd === 'get_agent_token_usage') {
+      return Promise.resolve({
+        metrics: [],
+        updated_at: 0,
+      });
+    }
     if (cmd === 'scrollback_orphan_size') return Promise.resolve(0);
     if (cmd === 'scrollback_orphan_clear') return Promise.resolve(0);
     if (cmd === 'get_acorn_ipc_status') {

--- a/tests/e2e/statusbar.spec.ts
+++ b/tests/e2e/statusbar.spec.ts
@@ -1,0 +1,177 @@
+import { expect, pressHotkey, test } from "./support";
+
+const PROJECT = {
+  repo_path: "/tmp/demo",
+  name: "demo",
+  created_at: "2026-01-01T00:00:00Z",
+  position: 0,
+};
+
+const BASE_SESSION = {
+  id: "s-1",
+  name: "local",
+  repo_path: "/tmp/demo",
+  worktree_path: "/tmp/demo",
+  branch: "main",
+  isolated: false,
+  status: "idle",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:05Z",
+  last_message: null,
+};
+
+const TOKEN_USAGE = {
+  updated_at: 1779860000,
+  metrics: [
+    {
+      provider: "codex",
+      window: "five_hour",
+      used_percent: 12,
+      remaining_percent: 88,
+      reset_at: 1779860400,
+      source: "~/.codex/sessions rate_limits",
+      error: null,
+    },
+    {
+      provider: "codex",
+      window: "weekly",
+      used_percent: 34,
+      remaining_percent: 66,
+      reset_at: 1779930000,
+      source: "~/.codex/sessions rate_limits",
+      error: null,
+    },
+    {
+      provider: "claude",
+      window: "five_hour",
+      used_percent: 45,
+      remaining_percent: 55,
+      reset_at: 1779860400,
+      source: "~/.claude/token-widget/claude-rate-limits.json",
+      error: null,
+    },
+    {
+      provider: "claude",
+      window: "weekly",
+      used_percent: 56,
+      remaining_percent: 44,
+      reset_at: 1779930000,
+      source: "~/.claude/token-widget/claude-rate-limits.json",
+      error: null,
+    },
+  ],
+};
+
+async function enableAgentTokenUsage(
+  page: Parameters<typeof pressHotkey>[0],
+): Promise<void> {
+  await pressHotkey(page, { mod: true, key: "," });
+  const modal = page.getByRole("dialog", { name: "Settings" });
+  await modal.getByRole("checkbox", { name: /Agent token usage/ }).click();
+  await page.keyboard.press("Escape");
+}
+
+test.describe("status bar", () => {
+  test("shows only Codex token usage for an active Codex tab", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      { ...BASE_SESSION, name: "codex", agent_provider: "codex" },
+    ]);
+    await tauri.respond("get_agent_token_usage", TOKEN_USAGE);
+
+    await page.goto("/");
+    await enableAgentTokenUsage(page);
+
+    const footer = page.locator("footer");
+    const tokenBadge = footer.getByTestId("agent-token-usage");
+    await expect(tokenBadge).toBeVisible();
+    await expect(tokenBadge).toContainText("tokens:");
+    await expect(tokenBadge).toContainText("5h");
+    await expect(tokenBadge).toContainText("88%");
+    await expect(tokenBadge).toContainText("w");
+    await expect(tokenBadge).toContainText("66%");
+    await expect(footer.getByRole("img", { name: "Codex" })).toBeVisible();
+    await expect(footer.getByText(/Claude/)).toHaveCount(0);
+    await expect(footer.getByText(/55%/)).toHaveCount(0);
+
+    await tokenBadge.hover();
+    const tooltip = page.getByRole("tooltip");
+    await expect(tooltip).toContainText("5h: 88% left, resets in 7m");
+    await expect(tooltip).toContainText(
+      "weekly: 66% left, resets in 19h 27m",
+    );
+    await expect(tooltip).not.toContainText(/used|12%|34%/);
+  });
+
+  test("shows only Claude token usage for an active Claude tab", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      { ...BASE_SESSION, name: "claude", agent_provider: "claude" },
+    ]);
+    await tauri.respond("get_agent_token_usage", TOKEN_USAGE);
+
+    await page.goto("/");
+    await enableAgentTokenUsage(page);
+
+    const footer = page.locator("footer");
+    const tokenBadge = footer.getByTestId("agent-token-usage");
+    await expect(tokenBadge).toBeVisible();
+    await expect(tokenBadge).toContainText("tokens:");
+    await expect(tokenBadge).toContainText("5h");
+    await expect(tokenBadge).toContainText("55%");
+    await expect(tokenBadge).toContainText("w");
+    await expect(tokenBadge).toContainText("44%");
+    await expect(footer.getByRole("img", { name: "Claude" })).toBeVisible();
+    await expect(footer.getByText(/Codex/)).toHaveCount(0);
+    await expect(footer.getByText(/88%/)).toHaveCount(0);
+  });
+
+  test("hides agent token usage for non-agent tabs", async ({ page, tauri }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [{ ...BASE_SESSION, name: "shell" }]);
+    await tauri.respond("get_agent_token_usage", TOKEN_USAGE);
+
+    await page.goto("/");
+    await enableAgentTokenUsage(page);
+
+    await expect(page.getByText(/^tokens:/)).toHaveCount(0);
+  });
+
+  test("uses a generic token icon when agent provider icons are disabled", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      { ...BASE_SESSION, name: "codex", agent_provider: "codex" },
+    ]);
+    await tauri.respond("get_agent_token_usage", TOKEN_USAGE);
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          statusBar: { showAgentTokenUsage: true },
+          sessionDisplay: { icons: { agentProvider: false } },
+        }),
+      );
+    });
+
+    await page.goto("/");
+
+    const footer = page.locator("footer");
+    const tokenBadge = footer.getByTestId("agent-token-usage");
+    await expect(tokenBadge).toBeVisible();
+    await expect(tokenBadge).toContainText("tokens:");
+    await expect(tokenBadge).toContainText("5h");
+    await expect(tokenBadge).toContainText("88%");
+    await expect(tokenBadge).toContainText("w");
+    await expect(tokenBadge).toContainText("66%");
+    await expect(footer.getByRole("img", { name: "Codex" })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
Adds an opt-in status bar readout for the active agent's local quota state:

1. **Local quota reader** — add a Tauri command that reads Codex rate-limit events from local session/log data and Claude rate limits from the token-widget-compatible statusline capture file.
2. **Status bar setting** — add `Interface → Status bar → Agent token usage`, persisted under `statusBar.showAgentTokenUsage` and defaulted off.
3. **Active-agent display** — show the readout only when the active tab resolves to Codex or Claude; non-agent tabs hide it and stop polling.
4. **Focused UI** — show remaining quota only, with `5h` / `w` labels, optional provider icon support, and tooltip reset times as remaining durations.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Status bar quota visibility | Not available | Opt-in readout for the active Codex/Claude tab |
| Non-agent tabs | No quota UI | Still no quota UI; polling disabled |
| Polling cost | None | 60s local-file poll only while the setting is enabled and an agent tab is active |
| User-facing copy | N/A | English/Korean settings and status bar strings |

## Design notes
- Codex uses the same source shape as token-widget: latest `~/.codex/sessions/**/*.jsonl` rate-limit events first, with a sqlite log fallback.
- Claude reads `~/.claude/token-widget/claude-rate-limits.json`; this PR does not install or override a Claude statusline wrapper.
- The status bar derives the active provider through the existing session provider resolver, so code views and local shell tabs do not show stale quota data.
- The display intentionally shows remaining quota only. Usage percentages are parsed for the remaining calculation but not rendered.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run src/lib/settings.test.ts src/components/SettingsModal.test.tsx`
- [x] `pnpm exec playwright test tests/e2e/statusbar.spec.ts`
- [x] `rustfmt --check src/token_usage.rs && cargo test token_usage --lib`
- [x] `git diff --check`

## Notes
- Claude quota appears only after a compatible statusline capture file exists. Adding an Acorn-managed Claude statusline capture is intentionally left out to avoid overriding user statusline configuration in this PR.
