### PR TITLE
feat(agents): filter history by provider

### DIFF
--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -95,6 +95,14 @@ function buttonContaining(container: HTMLElement, text: string): HTMLButtonEleme
   return button;
 }
 
+function selectWithAria(container: HTMLElement, label: string): HTMLSelectElement {
+  const select = container.querySelector(`select[aria-label="${label}"]`);
+  if (!(select instanceof HTMLSelectElement)) {
+    throw new Error(`select labelled "${label}" not found`);
+  }
+  return select;
+}
+
 const labeledPullRequest = {
   number: 247,
   title: "Hide git tabs outside repositories",
@@ -380,6 +388,59 @@ describe("RightPanel background tab loading", () => {
     expect(mockApi.githubOriginSlug).not.toHaveBeenCalled();
     expect(mockApi.listAgentHistory).not.toHaveBeenCalled();
     expect(mockApi.listUnscopedAgentHistory).toHaveBeenCalledWith(100);
+  });
+
+  it("filters agent history by provider", async () => {
+    useAppStore.setState({ rightTab: "history" });
+    mockApi.listAgentHistory.mockResolvedValue([
+      {
+        provider: "codex",
+        id: "codex-session",
+        title: "Codex patch",
+        preview: null,
+        cwd: REPO,
+        worktree: null,
+        transcript_path: "/tmp/codex-session.jsonl",
+        updated_at: 1770000000,
+        resume_command: "codex resume codex-session",
+      },
+      {
+        provider: "claude",
+        id: "claude-session",
+        title: "Claude plan",
+        preview: null,
+        cwd: REPO,
+        worktree: null,
+        transcript_path: "/tmp/claude-session.jsonl",
+        updated_at: 1770000001,
+        resume_command: "claude --resume claude-session",
+      },
+    ]);
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+
+    expect(container.textContent).toContain("Codex patch");
+    expect(container.textContent).toContain("Claude plan");
+
+    const select = selectWithAria(container, "Filter by agent");
+    await act(async () => {
+      select.value = "codex";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Codex patch");
+    expect(container.textContent).not.toContain("Claude plan");
+
+    await act(async () => {
+      select.value = "claude";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expect(container.textContent).not.toContain("Codex patch");
+    expect(container.textContent).toContain("Claude plan");
   });
 
   it("reprobes GitHub visibility when git metadata changes", async () => {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -65,6 +65,7 @@ import {
 import type {
   AccountSummary,
   AgentHistoryItem,
+  AgentHistoryProvider,
   CommitInfo,
   DiffPayload,
   PrStateFilter,
@@ -1379,6 +1380,11 @@ function formatActivityTime(value: string): string {
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
+const ALL_AGENT_HISTORY_PROVIDERS = "__all__";
+type AgentHistoryProviderFilter =
+  | typeof ALL_AGENT_HISTORY_PROVIDERS
+  | AgentHistoryProvider;
+
 function AgentHistoryTab({
   scope,
   repoPath,
@@ -1410,6 +1416,8 @@ function AgentHistoryTab({
         ? rightPanelCache.getUnscopedAgentHistory(historyLimit)
       : null,
   );
+  const [providerFilter, setProviderFilter] =
+    useState<AgentHistoryProviderFilter>(ALL_AGENT_HISTORY_PROVIDERS);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [menu, setMenu] = useState<{
@@ -1460,6 +1468,13 @@ function AgentHistoryTab({
   useEffect(() => {
     void fetchHistory();
   }, [fetchHistory]);
+
+  const visibleItems = useMemo(() => {
+    if (!items) return [];
+    return providerFilter === ALL_AGENT_HISTORY_PROVIDERS
+      ? items
+      : items.filter((item) => item.provider === providerFilter);
+  }, [items, providerFilter]);
 
   async function copy(text: string) {
     try {
@@ -1565,12 +1580,22 @@ function AgentHistoryTab({
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex shrink-0 items-center gap-2 border-b border-border px-2 py-1.5">
-        <div className="min-w-0 flex-1 truncate text-[11px] text-fg-muted">
-          {items
-            ? rtf(t, "rightPanel.history.count", { count: items.length })
-            : rt(t, "rightPanel.history.loading")}
-        </div>
+      <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1.5">
+        <Select
+          value={providerFilter}
+          onChange={(e) =>
+            setProviderFilter(e.target.value as AgentHistoryProviderFilter)
+          }
+          aria-label={rt(t, "rightPanel.history.filterByAgent")}
+          disabled={!items || items.length === 0}
+          className="min-w-0 max-w-full flex-1 truncate"
+        >
+          <option value={ALL_AGENT_HISTORY_PROVIDERS}>
+            {rt(t, "rightPanel.history.allAgents")}
+          </option>
+          <option value="codex">{rt(t, "rightPanel.history.codex")}</option>
+          <option value="claude">{rt(t, "rightPanel.history.claude")}</option>
+        </Select>
         <RefreshButton
           onClick={() => void fetchHistory({ force: true })}
           loading={loading}
@@ -1596,9 +1621,11 @@ function AgentHistoryTab({
           </div>
         ) : items.length === 0 ? (
           <Empty msg={rt(t, "rightPanel.history.empty")} />
+        ) : visibleItems.length === 0 ? (
+          <Empty msg={rt(t, "rightPanel.history.emptyForFilter")} />
         ) : (
           <div className="divide-y divide-border/50">
-            {items.map((item) => {
+            {visibleItems.map((item) => {
               const providerTone =
                 item.provider === "codex"
                   ? "bg-[#3867ff]/15 text-[#5f7dff]"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -875,7 +875,12 @@
     "history": {
       "loading": "Scanning agent sessions…",
       "count": "{count} agent sessions",
+      "filterByAgent": "Filter by agent",
+      "allAgents": "All agents",
+      "codex": "Codex",
+      "claude": "Claude",
       "empty": "No Claude or Codex sessions found for this project",
+      "emptyForFilter": "No sessions match this filter.",
       "runSession": "Run in new terminal",
       "runInWorktree": "Run in worktree",
       "copyResume": "Copy resume command",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -875,7 +875,12 @@
     "history": {
       "loading": "agent 세션을 스캔하는 중…",
       "count": "agent 세션 {count}개",
+      "filterByAgent": "에이전트로 필터링",
+      "allAgents": "모든 에이전트",
+      "codex": "Codex",
+      "claude": "Claude",
       "empty": "이 프로젝트의 Claude 또는 Codex 세션을 찾지 못했습니다",
+      "emptyForFilter": "이 필터와 일치하는 세션이 없습니다.",
       "runSession": "새 터미널에서 실행",
       "runInWorktree": "워크트리에서 실행",
       "copyResume": "resume 명령 복사",

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -498,6 +498,54 @@ test.describe("right panel: groups", () => {
     ).toHaveCount(0);
   });
 
+  test("History provider filter scopes visible rows", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    await tauri.respond("list_agent_history", [
+      {
+        provider: "codex",
+        id: "codex-filter",
+        title: "Codex refactor",
+        preview: null,
+        cwd: "/tmp/demo",
+        worktree: null,
+        transcript_path: "/tmp/codex-filter.jsonl",
+        updated_at: 1770000000,
+        resume_command: "codex resume codex-filter",
+      },
+      {
+        provider: "claude",
+        id: "claude-filter",
+        title: "Claude outline",
+        preview: null,
+        cwd: "/tmp/demo",
+        worktree: null,
+        transcript_path: "/tmp/claude-filter.jsonl",
+        updated_at: 1770000001,
+        resume_command: "claude --resume claude-filter",
+      },
+    ]);
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Agents" }).click();
+    await page.getByRole("button", { name: "History" }).click();
+
+    const filter = page.getByLabel("Filter by agent");
+    await expect(filter).toHaveValue("__all__");
+    await expect(page.getByText("Codex refactor")).toBeVisible();
+    await expect(page.getByText("Claude outline")).toBeVisible();
+
+    await filter.selectOption("codex");
+    await expect(page.getByText("Codex refactor")).toBeVisible();
+    await expect(page.getByText("Claude outline")).toHaveCount(0);
+
+    await filter.selectOption("claude");
+    await expect(page.getByText("Codex refactor")).toHaveCount(0);
+    await expect(page.getByText("Claude outline")).toBeVisible();
+  });
+
   test("History resume adopts the source worktree for the new terminal", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Adds an agent provider filter to Agents History so mixed Claude/Codex session lists can be narrowed in place.

1. **History filter UI** — replace the History header count with the shared `Select` pattern used by GitHub Actions, with All agents, Codex, and Claude options.
2. **Provider-scoped rendering** — derive visible History rows from the selected provider while preserving existing refresh, empty, context-menu, resume, and trash flows.
3. **Localization and coverage** — add English/Korean labels plus focused Vitest and Playwright coverage for provider filtering.

## Expected impact
| Area | Impact |
| --- | --- |
| Agents History usability | Users can quickly isolate Codex or Claude sessions without changing the underlying history scan. |
| Existing resume/trash actions | No contract change; actions continue to operate on the rendered history item. |
| Backend/API behavior | No change; filtering is client-side over existing `AgentHistoryItem.provider` data. |

## Design notes
- The filter intentionally mirrors GitHub Actions' compact header `Select` so the control placement and sizing stay consistent across right-panel tabs.
- Filtering remains local UI state in `AgentHistoryTab`; cache contents and refresh behavior stay provider-agnostic.
- The provider type reuses the existing `AgentHistoryProvider` union, avoiding a parallel string contract.

## Test plan
- [x] `pnpm run typecheck` — passed
- [x] `pnpm vitest run src/components/RightPanel.test.tsx` — 14 tests passed
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts` — 16 tests passed
