### PR TITLE
fix(tabs): clear stale drag state after cancelled drags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,7 @@ import { planAutoGenerateSessionTitles } from "./lib/sessionTitle";
 import { applyBackgroundVars, clearBackgroundVars } from "./lib/background";
 import { applyTheme, useThemes } from "./lib/themes";
 import { extractTabFromEvent } from "./lib/settings-events";
+import { useAcornDragGlobalCleanup } from "./lib/dnd";
 import {
   nextSessionStatusPollDelayMs,
   selectDueSessionStatusPollIds,
@@ -150,6 +151,7 @@ function focusAdjacentPane(direction: "left" | "right" | "up" | "down") {
 
 function App() {
   const t = useTranslation();
+  useAcornDragGlobalCleanup();
   const refreshAll = useAppStore((s) => s.refreshAll);
   const sessions = useAppStore((s) => s.sessions);
   const projects = useAppStore((s) => s.projects);

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -34,7 +34,7 @@ import { planGitRefresh } from "../lib/git-refresh-scheduler";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { rightPanelCache } from "../lib/right-panel-cache";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
-import { setFileDragPayload } from "../lib/dnd";
+import { beginFileDrag, endAcornDrag } from "../lib/dnd";
 import { Tooltip } from "./Tooltip";
 import { IconInput, TextInput } from "./ui";
 import { useToasts } from "../lib/toasts";
@@ -1745,7 +1745,9 @@ function EntryRow({
           // apps paste the quoted path) and the in-process Acorn drag
           // mirror used by Pane/TabStrip drop targets.
           if (!entry.is_dir) {
-            setFileDragPayload(e, { path: entry.path });
+            beginFileDrag(e, { path: entry.path });
+          } else {
+            endAcornDrag();
           }
           const quoted = shellQuote(entry.path);
           try {
@@ -1756,6 +1758,7 @@ function EntryRow({
           }
           e.dataTransfer.effectAllowed = "copy";
         }}
+        onDragEnd={endAcornDrag}
         onClick={(e) => onEntryClick(entry, e)}
         onDoubleClick={(e) => {
           e.preventDefault();

--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -34,7 +34,7 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
 
 import { Pane } from "./Pane";
 import { useAppStore } from "../store";
-import { clearTabDragPayload, getCurrentTabPayload } from "../lib/dnd";
+import { endAcornDrag, getCurrentTabPayload } from "../lib/dnd";
 import { defaultTabByGroup } from "../lib/rightPanelGroups";
 
 const REPO = "/Users/me/repo";
@@ -143,18 +143,22 @@ function seedInactivePaneWithTab(tab: Session): void {
 }
 
 function seedActivePaneWithTab(tab: Session): void {
+  seedActivePaneWithTabs([tab], tab.id);
+}
+
+function seedActivePaneWithTabs(tabs: Session[], activeTabId: string): void {
   const pane = {
     id: "root",
-    tabIds: [tab.id],
-    activeTabId: tab.id,
+    tabIds: tabs.map((tab) => tab.id),
+    activeTabId,
   };
 
   useAppStore.setState((s) => ({
     ...s,
-    sessions: [tab],
+    sessions: tabs,
     activeProject: REPO,
-    activeSessionId: tab.id,
-    activeTabId: tab.id,
+    activeSessionId: activeTabId,
+    activeTabId,
     workspaces: {
       ...s.workspaces,
       [REPO]: {
@@ -189,13 +193,19 @@ function dispatchDragStart(target: Element, dataTransfer: DataTransfer): Event {
   return event;
 }
 
+function dispatchDragEnd(target: Element): Event {
+  const event = new Event("dragend", { bubbles: true, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
+}
+
 describe("Pane empty state", () => {
   let container: HTMLDivElement;
   let root: Root;
 
   beforeEach(() => {
     resetStore();
-    clearTabDragPayload();
+    endAcornDrag();
     vi.clearAllMocks();
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -205,7 +215,7 @@ describe("Pane empty state", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
-    clearTabDragPayload();
+    endAcornDrag();
   });
 
   it("opens a terminal when Space is pressed twice while an empty pane is focused", async () => {
@@ -483,6 +493,54 @@ describe("Pane empty state", () => {
     expect(getCurrentTabPayload()).toMatchObject({
       kind: "tab",
       tabId: active.id,
+      fromPaneId: "root",
+    });
+  });
+
+  it("clears a tab drag payload when the source drag ends", () => {
+    const first = session("first-session");
+    const second = session("second-session");
+    seedActivePaneWithTabs([first, second], first.id);
+    const addWindowListener = window.addEventListener.bind(window);
+    const addWindowListenerSpy = vi
+      .spyOn(window, "addEventListener")
+      .mockImplementation((type, listener, options) => {
+        if (type === "dragend" || type === "drop") return;
+        addWindowListener(type, listener, options);
+      });
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+    addWindowListenerSpy.mockRestore();
+
+    const firstTab = container
+      .querySelector(`[data-tab-drag-handle="${first.id}"]`)
+      ?.closest('[role="button"]');
+    const secondTab = container
+      .querySelector(`[data-tab-drag-handle="${second.id}"]`)
+      ?.closest('[role="button"]');
+    expect(firstTab).toBeInstanceOf(HTMLElement);
+    expect(secondTab).toBeInstanceOf(HTMLElement);
+
+    act(() => {
+      dispatchDragStart(firstTab!, makeDataTransfer());
+    });
+    expect(getCurrentTabPayload()).toMatchObject({
+      tabId: first.id,
+      fromPaneId: "root",
+    });
+
+    act(() => {
+      dispatchDragEnd(firstTab!);
+    });
+    expect(getCurrentTabPayload()).toBeNull();
+
+    act(() => {
+      dispatchDragStart(secondTab!, makeDataTransfer());
+    });
+    expect(getCurrentTabPayload()).toMatchObject({
+      tabId: second.id,
       fromPaneId: "root",
     });
   });

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -36,11 +36,12 @@ import {
 import { cn } from "../lib/cn";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import {
+  beginTabDrag,
+  endAcornDrag,
   getCurrentFilePayload,
   getCurrentTabPayload,
   isAcornDrag,
   isTabDrag,
-  setTabDragPayload,
 } from "../lib/dnd";
 import {
   hasConfiguredEditor,
@@ -660,22 +661,26 @@ function TabStrip({
       onDrop={(e) => {
         if (!isAcornDrag(e)) return;
         e.preventDefault();
-        const idx = computeInsertIndex(e.clientX);
-        setInsertIndex(null);
-        const filePayload = getCurrentFilePayload();
-        if (filePayload) {
-          useAppStore.getState().setFocusedPane(paneId);
-          useAppStore.getState().openCodeViewerTab(filePayload.path);
-          return;
+        try {
+          const idx = computeInsertIndex(e.clientX);
+          setInsertIndex(null);
+          const filePayload = getCurrentFilePayload();
+          if (filePayload) {
+            useAppStore.getState().setFocusedPane(paneId);
+            useAppStore.getState().openCodeViewerTab(filePayload.path);
+            return;
+          }
+          const payload = getCurrentTabPayload();
+          if (!payload) return;
+          // No-op: dropping onto the same pane at the same position.
+          if (payload.fromPaneId === paneId) {
+            const currentIdx = tabs.findIndex((t) => t.id === payload.tabId);
+            if (currentIdx === idx || currentIdx + 1 === idx) return;
+          }
+          onDropReorder(payload, idx);
+        } finally {
+          endAcornDrag();
         }
-        const payload = getCurrentTabPayload();
-        if (!payload) return;
-        // No-op: dropping onto the same pane at the same position.
-        if (payload.fromPaneId === paneId) {
-          const currentIdx = tabs.findIndex((t) => t.id === payload.tabId);
-          if (currentIdx === idx || currentIdx + 1 === idx) return;
-        }
-        onDropReorder(payload, idx);
       }}
     >
       {tabs.map((tab, i) => (
@@ -1018,14 +1023,16 @@ function TabItem({
             e.preventDefault();
             e.stopPropagation();
             suppressNextDragStartRef.current = false;
+            endAcornDrag();
             return;
           }
           if (editing) setEditing(false);
           setTabDragImage(e);
-          setTabDragPayload(e, { tabId: tab.id, fromPaneId: paneId });
+          beginTabDrag(e, { tabId: tab.id, fromPaneId: paneId });
         }}
         onDragEnd={() => {
           suppressNextDragStartRef.current = false;
+          endAcornDrag();
         }}
         onClick={editing ? undefined : onSelect}
         onDoubleClick={(e) => {

--- a/src/components/PaneDropOverlay.test.tsx
+++ b/src/components/PaneDropOverlay.test.tsx
@@ -15,8 +15,9 @@ vi.mock("../lib/api", () => ({
 }));
 
 import {
-  clearTabDragPayload,
-  setFileDragPayload,
+  beginFileDrag,
+  beginTabDrag,
+  endAcornDrag,
 } from "../lib/dnd";
 import { makePaneNode } from "../lib/layout";
 import { defaultTabByGroup } from "../lib/rightPanelGroups";
@@ -99,7 +100,7 @@ describe("PaneDropOverlay", () => {
 
   beforeEach(() => {
     resetStore();
-    clearTabDragPayload();
+    endAcornDrag();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -108,12 +109,12 @@ describe("PaneDropOverlay", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
-    clearTabDragPayload();
+    endAcornDrag();
   });
 
   it("opens a code viewer tab when a file is dropped on an empty pane", () => {
     const dataTransfer = makeDataTransfer();
-    setFileDragPayload(
+    beginFileDrag(
       { dataTransfer } as unknown as React.DragEvent,
       { path: FILE },
     );
@@ -142,7 +143,7 @@ describe("PaneDropOverlay", () => {
 
   it("does not intercept file drops when the pane reserves them for the terminal", () => {
     const dataTransfer = makeDataTransfer();
-    setFileDragPayload(
+    beginFileDrag(
       { dataTransfer } as unknown as React.DragEvent,
       { path: FILE },
     );
@@ -162,5 +163,31 @@ describe("PaneDropOverlay", () => {
     const state = useAppStore.getState();
     expect(state.panes.root.tabIds).toEqual([]);
     expect(state.workspaceTabs).toEqual({});
+  });
+
+  it("updates the overlay when a new drag starts before the previous payload is cleared", () => {
+    const fileTransfer = makeDataTransfer();
+    beginFileDrag(
+      { dataTransfer: fileTransfer } as unknown as React.DragEvent,
+      { path: FILE },
+    );
+
+    act(() => {
+      root.render(<PaneDropOverlay paneId="root" acceptFileDrops={false} />);
+    });
+
+    const overlay = container.firstElementChild;
+    if (!overlay) throw new Error("overlay did not render");
+    expect(overlay.className).toContain("pointer-events-none");
+
+    const tabTransfer = makeDataTransfer();
+    act(() => {
+      beginTabDrag(
+        { dataTransfer: tabTransfer } as unknown as React.DragEvent,
+        { tabId: "session-1", fromPaneId: "root" },
+      );
+    });
+
+    expect(overlay.className).not.toContain("pointer-events-none");
   });
 });

--- a/src/components/PaneDropOverlay.tsx
+++ b/src/components/PaneDropOverlay.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { cn } from "../lib/cn";
 import {
   classifyDropZone,
+  endAcornDrag,
   type DropZone,
   getCurrentDragPayload,
   getCurrentFilePayload,
@@ -92,39 +93,43 @@ export function PaneDropOverlay({
       onDrop={(e) => {
         if (!acceptsDrag) return;
         e.preventDefault();
-        setZone(null);
-        const filePayload = getCurrentFilePayload();
-        if (filePayload) {
-          useAppStore.getState().setFocusedPane(paneId);
-          useAppStore.getState().openCodeViewerTab(filePayload.path);
-          return;
-        }
-        const target = computeZone(e);
-        if (!target) return;
-        const payload = getCurrentTabPayload();
-        if (!payload) return;
-        if (target.kind === "center") {
-          if (payload.fromPaneId === paneId) return;
+        try {
+          setZone(null);
+          const filePayload = getCurrentFilePayload();
+          if (filePayload) {
+            useAppStore.getState().setFocusedPane(paneId);
+            useAppStore.getState().openCodeViewerTab(filePayload.path);
+            return;
+          }
+          const target = computeZone(e);
+          if (!target) return;
+          const payload = getCurrentTabPayload();
+          if (!payload) return;
+          if (target.kind === "center") {
+            if (payload.fromPaneId === paneId) return;
+            moveTab({
+              tabId: payload.tabId,
+              fromPaneId: payload.fromPaneId,
+              toPaneId: paneId,
+            });
+            return;
+          }
+          // Edge drop. Avoid the no-op of splitting a pane that holds only the
+          // dragged tab — the source would immediately collapse.
+          if (payload.fromPaneId === paneId) {
+            const fromPane = useAppStore.getState().panes[paneId];
+            if (fromPane && fromPane.tabIds.length <= 1) return;
+          }
           moveTab({
             tabId: payload.tabId,
             fromPaneId: payload.fromPaneId,
             toPaneId: paneId,
+            splitDirection: target.direction,
+            splitSide: target.side,
           });
-          return;
+        } finally {
+          endAcornDrag();
         }
-        // Edge drop. Avoid the no-op of splitting a pane that holds only the
-        // dragged tab — the source would immediately collapse.
-        if (payload.fromPaneId === paneId) {
-          const fromPane = useAppStore.getState().panes[paneId];
-          if (fromPane && fromPane.tabIds.length <= 1) return;
-        }
-        moveTab({
-          tabId: payload.tabId,
-          fromPaneId: payload.fromPaneId,
-          toPaneId: paneId,
-          splitDirection: target.direction,
-          splitSide: target.side,
-        });
       }}
     >
       <ZoneHighlight zone={zone} />

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -18,7 +18,7 @@ import "@xterm/xterm/css/xterm.css";
 import { api } from "../lib/api";
 import type { BackgroundState } from "../lib/background";
 import { visibleMultiInputSessionIds } from "../lib/multiInput";
-import { getCurrentFilePayload } from "../lib/dnd";
+import { endAcornDrag, getCurrentFilePayload } from "../lib/dnd";
 import { formatTerminalFileMention } from "../lib/fileMention";
 import { registerScrollbackFlusher } from "../lib/scrollback-coordinator";
 import {
@@ -1415,8 +1415,12 @@ export function Terminal({
       const payload = getCurrentFilePayload();
       if (!payload) return;
       e.preventDefault();
-      sendUserInputToPty(formatTerminalFileMention(payload.path, cwd));
-      term.focus();
+      try {
+        sendUserInputToPty(formatTerminalFileMention(payload.path, cwd));
+        term.focus();
+      } finally {
+        endAcornDrag();
+      }
     };
     container.addEventListener("dragover", onDragOver);
     container.addEventListener("drop", onDrop);

--- a/src/lib/dnd.ts
+++ b/src/lib/dnd.ts
@@ -1,14 +1,14 @@
 /**
- * Drag-and-drop helpers for moving workspace tabs between panes.
+ * Drag-and-drop session helpers for Acorn-owned tab and file payloads.
  *
  * The browser's `DataTransfer` is unreliable for custom MIME types in some
  * webviews (notably WKWebView used by Tauri on macOS): the `types` list and
  * `getData()` are restricted in "protected mode" during dragenter/dragover.
  * To work around this we mirror the payload to a module-level variable that
- * lives for the duration of the drag, and use `text/plain` on the
- * `DataTransfer` only as a fallback / OS preview affordance.
+ * lives for the duration of the drag, while `DataTransfer` keeps its native
+ * OS preview and drop affordances.
  */
-import { useEffect, useState } from "react";
+import { useEffect, useState, type DragEvent } from "react";
 import type { Direction, PaneId, SplitSide } from "./layout";
 
 export interface TabDragPayload {
@@ -25,32 +25,53 @@ export interface FileDragPayload {
 export type DragPayload = TabDragPayload | FileDragPayload;
 
 let currentDrag: DragPayload | null = null;
+let dragRevision = 0;
 const listeners = new Set<() => void>();
 
 function notify(): void {
+  dragRevision += 1;
   for (const fn of listeners) fn();
 }
 
-export function setTabDragPayload(
-  e: React.DragEvent,
+export function beginTabDrag(
+  e: DragEvent,
   payload: { tabId: string; fromPaneId: PaneId },
 ): void {
-  currentDrag = { kind: "tab", ...payload };
-  try {
-    e.dataTransfer.setData("text/plain", payload.tabId);
-  } catch {
-    // ignore
+  beginAcornDrag(e, { kind: "tab", ...payload }, {
+    effectAllowed: "move",
+    text: payload.tabId,
+  });
+}
+
+export function beginFileDrag(
+  e: DragEvent,
+  payload: { path: string },
+): void {
+  beginAcornDrag(e, { kind: "file", path: payload.path }, {
+    effectAllowed: "copy",
+  });
+}
+
+function beginAcornDrag(
+  e: DragEvent,
+  payload: DragPayload,
+  options: { effectAllowed: DataTransfer["effectAllowed"]; text?: string },
+): void {
+  currentDrag = payload;
+  if (options.text !== undefined) {
+    try {
+      e.dataTransfer.setData("text/plain", options.text);
+    } catch {
+      // ignore
+    }
   }
-  e.dataTransfer.effectAllowed = "move";
+  e.dataTransfer.effectAllowed = options.effectAllowed;
   notify();
 }
 
-export function setFileDragPayload(
-  e: React.DragEvent,
-  payload: { path: string },
-): void {
-  currentDrag = { kind: "file", path: payload.path };
-  e.dataTransfer.effectAllowed = "copy";
+export function endAcornDrag(): void {
+  if (currentDrag === null) return;
+  currentDrag = null;
   notify();
 }
 
@@ -66,76 +87,44 @@ export function getCurrentFilePayload(): FileDragPayload | null {
   return currentDrag?.kind === "file" ? currentDrag : null;
 }
 
-export function clearTabDragPayload(): void {
-  if (currentDrag === null) return;
-  currentDrag = null;
-  notify();
-}
-
-export function isTabDrag(_e: React.DragEvent): boolean {
+export function isTabDrag(_e: DragEvent): boolean {
   return currentDrag?.kind === "tab";
 }
 
-export function isFileDrag(_e: React.DragEvent): boolean {
-  return currentDrag?.kind === "file";
-}
-
-export function isAcornDrag(_e: React.DragEvent): boolean {
+export function isAcornDrag(_e: DragEvent): boolean {
   return currentDrag !== null;
 }
 
-/**
- * Tracks whether a tab drag is currently in progress anywhere on the page.
- * Used by drop overlays to render and intercept pointer events only during
- * an active drag. Backed by a module-level signal updated synchronously
- * inside `setTabDragPayload` and on window-level dragend / drop.
- */
-export function useAcornDragInProgress(): boolean {
-  const [active, setActive] = useState<boolean>(() => currentDrag !== null);
-
+export function useAcornDragGlobalCleanup(): void {
   useEffect(() => {
-    function onChange() {
-      setActive(currentDrag !== null);
-    }
-    listeners.add(onChange);
-    function onEnd() {
-      clearTabDragPayload();
-    }
-    window.addEventListener("dragend", onEnd);
-    window.addEventListener("drop", onEnd);
+    window.addEventListener("dragend", endAcornDrag);
+    window.addEventListener("drop", endAcornDrag);
     return () => {
-      listeners.delete(onChange);
-      window.removeEventListener("dragend", onEnd);
-      window.removeEventListener("drop", onEnd);
+      window.removeEventListener("dragend", endAcornDrag);
+      window.removeEventListener("drop", endAcornDrag);
     };
   }, []);
-
-  return active;
 }
 
-export function useTabDragInProgress(): boolean {
-  const [active, setActive] = useState<boolean>(
-    () => currentDrag?.kind === "tab",
-  );
+/**
+ * Tracks whether an Acorn-owned drag is currently in progress. The hook only
+ * subscribes to the drag session; sources and drop targets own lifecycle
+ * cleanup directly.
+ */
+export function useAcornDragInProgress(): boolean {
+  const [, setRevision] = useState(dragRevision);
 
   useEffect(() => {
     function onChange() {
-      setActive(currentDrag?.kind === "tab");
+      setRevision(dragRevision);
     }
     listeners.add(onChange);
-    function onEnd() {
-      clearTabDragPayload();
-    }
-    window.addEventListener("dragend", onEnd);
-    window.addEventListener("drop", onEnd);
     return () => {
       listeners.delete(onChange);
-      window.removeEventListener("dragend", onEnd);
-      window.removeEventListener("drop", onEnd);
     };
   }, []);
 
-  return active;
+  return currentDrag !== null;
 }
 
 /**


### PR DESCRIPTION
## Summary
This fixes stale Acorn drag state after a tab drag is cancelled.

1. **Drag session lifecycle** — replace the tab-only payload setter/clearer with `beginTabDrag`, `beginFileDrag`, and `endAcornDrag`, so drag sources and drop targets share one explicit lifecycle.
2. **Source-owned cleanup** — clear the payload from the tab drag source on suppressed drag starts and `dragend`, instead of relying only on window-level cleanup.
3. **Drop-target cleanup** — clear the same drag session after tab-strip, pane-overlay, and terminal file drops so cancelled or completed drags cannot leak into the next drag.
4. **Regression coverage** — add focused tests for cancelled tab drags and stale payload replacement when a new drag starts before old state clears.

## Expected impact
| Area | Expected impact |
| --- | --- |
| Workspace tabs | Cancelling one tab drag no longer prevents dragging another tab. |
| File and tab drops | Drag payload cleanup is consistent across tab strip, pane body, file explorer, and terminal drops. |
| Drag overlays | Overlay state refreshes when a new Acorn drag replaces an older payload. |

## Design notes
- The module-level payload mirror remains in `src/lib/dnd.ts` because WKWebView can hide custom `DataTransfer` data during protected drag phases.
- `useAcornDragInProgress` now subscribes to drag-session revisions only; `App` owns the global `dragend` / `drop` fallback cleanup once.
- Drag sources and successful drop targets call `endAcornDrag()` directly, so source-level cancellation works even if a WebView skips the window fallback event.

## Test plan
- [x] `pnpm exec vitest run src/components/Pane.test.tsx src/components/PaneDropOverlay.test.tsx --reporter=dot` — 12 tests passed
- [x] `pnpm exec tsc --noEmit --pretty false` — passed
- [x] `pnpm exec playwright test tests/e2e/panes.spec.ts --grep "tab close button|tab drag remains"` — 2 tests passed
- [x] `git diff --check` — passed

## Notes
- `Pane.test.tsx` and `PaneDropOverlay.test.tsx` still print the existing React `act(...)` environment warnings under Vitest; the suites pass.
