### PR TITLE
fix(files): use native macOS trash API

### DIFF
--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
+use crate::fs_explorer::move_to_trash;
 use crate::worktree;
 
 const MAX_SCAN_FILES_PER_PROVIDER: usize = 5_000;
@@ -143,7 +144,7 @@ pub fn trash_agent_history_transcript(
         }
     }
 
-    trash::delete(&path).map_err(|e| AppError::Other(format!("trash failed: {e}")))?;
+    move_to_trash(&path)?;
     Ok(())
 }
 

--- a/src-tauri/src/fs_explorer.rs
+++ b/src-tauri/src/fs_explorer.rs
@@ -366,6 +366,28 @@ fn reject_dangerous(p: &Path) -> AppResult<()> {
     Ok(())
 }
 
+pub(crate) fn move_to_trash(p: &Path) -> AppResult<()> {
+    #[cfg(target_os = "macos")]
+    {
+        use trash::macos::{DeleteMethod, TrashContextExtMacos};
+
+        // Finder-backed AppleScript trashing can reject valid POSIX paths
+        // before Finder moves the file. NSFileManager accepts file URLs
+        // directly and avoids the extra Automation permission hop.
+        let mut ctx = trash::TrashContext::new();
+        ctx.set_delete_method(DeleteMethod::NsFileManager);
+        ctx.delete(p)
+            .map_err(|e| AppError::Other(format!("trash failed: {e}")))?;
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        trash::delete(p).map_err(|e| AppError::Other(format!("trash failed: {e}")))?;
+    }
+
+    Ok(())
+}
+
 #[tauri::command]
 pub fn fs_rename(from: String, to: String) -> AppResult<()> {
     let from_p = PathBuf::from(&from);
@@ -389,7 +411,7 @@ pub fn fs_trash(path: String) -> AppResult<()> {
     if !p.exists() {
         return Err(AppError::InvalidPath(format!("missing: {path}")));
     }
-    trash::delete(&p).map_err(|e| AppError::Other(format!("trash failed: {e}")))?;
+    move_to_trash(&p)?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
This PR fixes macOS Trash actions that could report invalid file paths even when Acorn passed a valid POSIX path.

1. **File Explorer Trash** — routes `fs_trash` through a shared backend helper that uses `NSFileManager` on macOS instead of the `trash` crate's Finder/AppleScript default path.
2. **History transcript Trash** — reuses the same helper for Claude/Codex transcript deletion so the History panel avoids the same macOS failure mode.
3. **Platform fallback** — keeps the existing `trash::delete` behavior for non-macOS platforms.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| File Explorer `Move to Trash` on macOS | Valid paths could fail in Finder/AppleScript with path errors | Valid paths are sent directly to `NSFileManager` |
| History transcript `Move to Trash` on macOS | Shared the same Finder-backed failure mode | Uses the same native macOS trash path |
| Linux/Windows Trash behavior | Existing `trash::delete` path | Unchanged |

## Design notes
- The path validation contract stays in Acorn before deletion: empty, relative, traversal, and missing paths are still rejected before calling the OS trash operation.
- The macOS-specific change only swaps the final trash implementation from Finder AppleScript to `NSFileManager`; it does not broaden the file paths Acorn accepts.
- Transcript deletion continues to validate provider roots, `.jsonl`, and session id matching before the shared trash helper runs.

## Test plan
- [x] `git diff --check` passed
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml fs_file_exists_only_accepts_files` passed

## Notes
- `cargo check` and the focused Rust test both emit the existing `AgentHookServer::start` dead-code warning.
