### PR TITLE
fix(ui): collapse resize handle layout gaps

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1372,11 +1372,11 @@ function App() {
           >
             <Sidebar />
           </Panel>
-          <ResizeHandle />
+          <ResizeHandle thin />
           <Panel id="main" order={2} defaultSize={56} minSize={30}>
             <LayoutRenderer node={layout} />
           </Panel>
-          <ResizeHandle />
+          <ResizeHandle thin />
           <Panel
             ref={rightPanelRef}
             id="right"

--- a/src/components/DiffSplitView.tsx
+++ b/src/components/DiffSplitView.tsx
@@ -177,7 +177,7 @@ export function DiffSplitView({ payload, cwd }: DiffSplitViewProps) {
           </ul>
         </aside>
       </Panel>
-      <ResizeHandle />
+      <ResizeHandle thin />
       <Panel id="content" order={2} defaultSize={72} minSize={40}>
         <section className="flex h-full flex-col bg-bg">
           <header className="flex shrink-0 items-center justify-between gap-2 border-b border-border bg-bg-elevated px-3 py-2 font-mono text-xs">

--- a/src/components/DiffViewerModal.tsx
+++ b/src/components/DiffViewerModal.tsx
@@ -72,7 +72,7 @@ export function DiffViewerModal({
                     <Markdown content={body!} />
                   </div>
                 </Panel>
-                <ResizeHandle direction="vertical" />
+                <ResizeHandle direction="vertical" thin />
                 <Panel id="diff" order={2} defaultSize={75} minSize={20}>
                   <DiffSplitView payload={payload} cwd={cwd} />
                 </Panel>

--- a/src/components/LayoutRenderer.tsx
+++ b/src/components/LayoutRenderer.tsx
@@ -74,7 +74,7 @@ export function LayoutRenderer({ node }: LayoutRendererProps) {
       <Panel id={`${node.id}:a`} order={1} defaultSize={leftPct} minSize={10}>
         <LayoutRenderer node={node.a} />
       </Panel>
-      <ResizeHandle direction={handleDirection} />
+      <ResizeHandle direction={handleDirection} showDivider thin />
       <Panel id={`${node.id}:b`} order={2} defaultSize={rightPct} minSize={10}>
         <LayoutRenderer node={node.b} />
       </Panel>

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -1227,7 +1227,7 @@ function CommitsPane({
           </ul>
         </aside>
       </Panel>
-      <ResizeHandle />
+      <ResizeHandle thin />
       <Panel id="detail" order={2} defaultSize={72} minSize={40}>
         <div className="flex h-full min-w-0 flex-col">
           {selected ? (
@@ -1466,7 +1466,7 @@ function CommitDetailView({
             <Panel id="body" order={1} defaultSize={20} minSize={8} maxSize={70}>
               {bodySection}
             </Panel>
-            <ResizeHandle direction="vertical" />
+            <ResizeHandle direction="vertical" thin />
             <Panel id="diff" order={2} defaultSize={80} minSize={20}>
               {diffSection}
             </Panel>

--- a/src/components/ResizeHandle.tsx
+++ b/src/components/ResizeHandle.tsx
@@ -9,15 +9,17 @@ import {
 
 interface ResizeHandleProps {
   direction?: "horizontal" | "vertical";
+  showDivider?: boolean;
+  thin?: boolean;
 }
 
 /**
  * Resize handle behaviour:
  *
- * 1. Open state: the 12px bar is fully invisible at rest. The cursor
- *    flips to col/row resize on hover, and a 1px accent line appears
- *    centred during drag — visually equivalent to the original 1px
- *    border between panels.
+ * 1. Open state: the handle is visually quiet at rest unless its caller
+ *    opts into a divider. Thin handles render as 1px while
+ *    `hitAreaMargins` preserves a forgiving resize target. The cursor flips
+ *    to col/row resize on hover, and a 1px accent line appears during drag.
  * 2. Closed state (an adjacent collapsible panel is collapsed): the bar
  *    fades to a faint white tint on hover and shows a fixed-size white
  *    grip pill so the user knows where to grab to re-expand.
@@ -31,7 +33,11 @@ interface ResizeHandleProps {
 const TOOLTIP_DELAY_MS = 250;
 const TOOLTIP_TEXT = "Double-click to expand";
 
-export function ResizeHandle({ direction = "horizontal" }: ResizeHandleProps) {
+export function ResizeHandle({
+  direction = "horizontal",
+  showDivider = false,
+  thin = false,
+}: ResizeHandleProps) {
   const isHorizontal = direction === "horizontal";
   const handleId = useId();
   const [dragging, setDragging] = useState(false);
@@ -128,7 +134,7 @@ export function ResizeHandle({ direction = "horizontal" }: ResizeHandleProps) {
     <>
       <PanelResizeHandle
         id={handleId}
-        hitAreaMargins={{ coarse: 0, fine: 0 }}
+        hitAreaMargins={thin ? { coarse: 12, fine: 6 } : { coarse: 0, fine: 0 }}
         onDragging={setDragging}
         onDoubleClick={handleDoubleClick}
         className={cn(
@@ -139,16 +145,21 @@ export function ResizeHandle({ direction = "horizontal" }: ResizeHandleProps) {
           showHandleVisual && hovered && !dragging
             ? "bg-white/5"
             : "bg-transparent",
-          isHorizontal ? "w-3 cursor-col-resize" : "h-3 cursor-row-resize",
+          isHorizontal
+            ? thin
+              ? "w-px cursor-col-resize"
+              : "w-3 cursor-col-resize"
+            : thin
+              ? "h-px cursor-row-resize"
+              : "h-3 cursor-row-resize",
         )}
       >
-        {/* Open-state drag indicator: 1px accent line in the centre of
-            the hit area, mimicking the original border-style separator. */}
-        {dragging && !showHandleVisual ? (
+        {showDivider || (dragging && !showHandleVisual) ? (
           <span
             aria-hidden="true"
             className={cn(
-              "pointer-events-none absolute bg-accent",
+              "pointer-events-none absolute transition-colors duration-150",
+              dragging && !showHandleVisual ? "bg-accent" : "bg-border/80",
               isHorizontal ? "h-full w-px" : "h-px w-full",
             )}
           />

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -2104,7 +2104,7 @@ function CommitsTab({
             <SkeletonList count={8} />
           </div>
         </Panel>
-        <ResizeHandle direction="vertical" />
+        <ResizeHandle direction="vertical" thin />
         <Panel id="commits-diff" order={2} defaultSize={50} minSize={15}>
           <div className="acorn-no-scrollbar h-full overflow-y-auto p-3">
             <div className="h-3 w-1/2 animate-pulse rounded bg-fg-muted/15" />
@@ -2212,7 +2212,7 @@ function CommitsTab({
         </div>
         </div>
       </Panel>
-      <ResizeHandle direction="vertical" />
+      <ResizeHandle direction="vertical" thin />
       <Panel id="commits-diff" order={2} defaultSize={50} minSize={15}>
         <div className="acorn-no-scrollbar h-full overflow-y-auto">
           {selected && diff ? (
@@ -2510,7 +2510,7 @@ function StagedTab({
           ))}
         </ul>
       </Panel>
-      <ResizeHandle direction="vertical" />
+      <ResizeHandle direction="vertical" thin />
       <Panel id="staged-diff" order={2} defaultSize={65} minSize={15}>
         <div className="acorn-no-scrollbar h-full overflow-y-auto">
           {selectedDiff ? (


### PR DESCRIPTION
## Summary
This fixes resize splitters that were visually reserving a wide empty gutter between adjacent panes.

1. **Thin resize handles** — add a `thin` mode to `ResizeHandle` so splitters render as a 1px layout boundary while preserving a forgiving resize target through `hitAreaMargins`.
2. **Workspace and panel cleanup** — apply thin handles across the app shell, workspace pane splits, right-panel splits, diff viewer, and PR detail diff views.
3. **Pane divider scope** — keep the always-visible divider only for workspace pane splits via `showDivider`.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| App shell / right panel / diff splitters | 12px visible gutter between panels | 1px visual boundary with same practical resize affordance |
| Workspace pane splits | Divider could still sit inside a wider gutter | Divider sits on a 1px boundary |
| Collapsed panel resize affordance | Grip appears on hover | Preserved |

## Design notes
- `ResizeHandle` keeps the existing default behavior available, but all current call sites now opt into `thin` to avoid visual layout gaps.
- Thin mode changes the element's layout size, not the resize usability: `react-resizable-panels` receives expanded `hitAreaMargins` for pointer targeting.
- `showDivider` remains explicit so regular splitters stay visually quiet unless a pane boundary wants a persistent separator.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test -- src/lib/layout.test.ts` passes — 16 tests
- [x] `pnpm run build` passes

## Notes
- `pnpm run build` still reports existing Vite dynamic-import and large-chunk warnings; the build exits successfully and these warnings are not caused by this PR.
