### PR TITLE
fix(terminal): support home-relative file links

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -11,6 +11,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { Channel, invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { homeDir } from "@tauri-apps/api/path";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { ArrowDownToLine } from "lucide-react";
 import { createPortal } from "react-dom";
@@ -662,13 +663,35 @@ export function Terminal({
       }
       return baseCwd;
     };
+    let terminalFileHomeDirPromise: Promise<string | null> | null = null;
+    const resolveTerminalFileHomeDir = (): Promise<string | null> => {
+      if (!terminalFileHomeDirPromise) {
+        terminalFileHomeDirPromise = homeDir()
+          .then((home) => home?.replace(/\/+$/u, "") ?? null)
+          .catch((err: unknown) => {
+            console.debug("[Terminal] home_dir for file link failed", err);
+            return null;
+          });
+      }
+      return terminalFileHomeDirPromise;
+    };
     const resolveOpenableTerminalFileReferences = async (
       references: TerminalFileReference[],
     ): Promise<TerminalFileReference[]> => {
-      const baseCwd = await resolveTerminalFileBaseCwd();
+      const needsHome = references.some((reference) =>
+        reference.path.startsWith("~/"),
+      );
+      const [baseCwd, home] = await Promise.all([
+        resolveTerminalFileBaseCwd(),
+        needsHome ? resolveTerminalFileHomeDir() : Promise.resolve(null),
+      ]);
       const resolved: Array<TerminalFileReference | null> = await Promise.all(
         references.map(async (reference) => {
-          const absolutePath = resolveTerminalFilePath(baseCwd, reference.path);
+          const absolutePath = resolveTerminalFilePath(
+            baseCwd,
+            reference.path,
+            home,
+          );
           try {
             if (!(await api.fsFileExists(absolutePath))) {
               return null;
@@ -686,12 +709,16 @@ export function Terminal({
     };
     const openTerminalFileReference = (reference: TerminalFileReference) => {
       void (async () => {
-        const path =
-          reference.absolutePath ??
-          resolveTerminalFilePath(
-            await resolveTerminalFileBaseCwd(),
-            reference.path,
-          );
+        let path = reference.absolutePath;
+        if (!path) {
+          const [baseCwd, home] = await Promise.all([
+            resolveTerminalFileBaseCwd(),
+            reference.path.startsWith("~/")
+              ? resolveTerminalFileHomeDir()
+              : Promise.resolve(null),
+          ]);
+          path = resolveTerminalFilePath(baseCwd, reference.path, home);
+        }
         try {
           if (!(await api.fsFileExists(path))) {
             return;

--- a/src/lib/terminalFileLinks.test.ts
+++ b/src/lib/terminalFileLinks.test.ts
@@ -82,6 +82,20 @@ describe("terminal file links", () => {
     ]);
   });
 
+  it("finds home-relative file references", () => {
+    expect(
+      findTerminalFileReferences("see ~/projects/acorn/src/App.tsx:12:5"),
+    ).toEqual([
+      {
+        path: "~/projects/acorn/src/App.tsx",
+        line: 12,
+        column: 5,
+        text: "~/projects/acorn/src/App.tsx:12:5",
+        startIndex: 4,
+      },
+    ]);
+  });
+
   it("finds file references with a trailing colon and no line number", () => {
     expect(
       findTerminalFileReferences(
@@ -167,6 +181,22 @@ describe("terminal file links", () => {
     );
     expect(resolveTerminalFilePath("/repo/app", "/tmp/file.ts")).toBe(
       "/tmp/file.ts",
+    );
+  });
+
+  it("resolves home-relative paths when a home directory is available", () => {
+    expect(
+      resolveTerminalFilePath(
+        "/repo/app",
+        "~/projects/acorn/src/App.tsx",
+        "/Users/me",
+      ),
+    ).toBe("/Users/me/projects/acorn/src/App.tsx");
+  });
+
+  it("leaves home-relative paths untouched without a home directory", () => {
+    expect(resolveTerminalFilePath("/repo/app", "~/src/App.tsx")).toBe(
+      "~/src/App.tsx",
     );
   });
 

--- a/src/lib/terminalFileLinks.ts
+++ b/src/lib/terminalFileLinks.ts
@@ -28,9 +28,9 @@ export interface TerminalFileLinkProviderOptions {
 }
 
 const FILE_REF_RE =
-  /(^|[\s([{"'`<])((?:\.{1,2}\/|\/)?(?:(?:[A-Za-z0-9._@+-]+\/)+[A-Za-z0-9._@+-]+|[A-Za-z0-9._@+-]*\.[A-Za-z0-9._@+-]+)):(?:(\d{1,7})(?::(\d{1,5}))?)?(?=$|[\s)\]}>,;!?:]|[.](?=$|[\s)\]}>,;!?:]))/g;
+  /(^|[\s([{"'`<])((?:~\/|\.{1,2}\/|\/)?(?:(?:[A-Za-z0-9._@+-]+\/)+[A-Za-z0-9._@+-]+|[A-Za-z0-9._@+-]*\.[A-Za-z0-9._@+-]+)):(?:(\d{1,7})(?::(\d{1,5}))?)?(?=$|[\s)\]}>,;!?:]|[.](?=$|[\s)\]}>,;!?:]))/g;
 const FILE_PATH_RE =
-  /(^|[\s([{"'`<])((?:\.{1,2}\/|\/)?(?:(?:[A-Za-z0-9._@+-]+\/)+[A-Za-z0-9._@+-]*\.[A-Za-z][A-Za-z0-9_@+-]+|[A-Za-z0-9._@+-]*\.[A-Za-z][A-Za-z0-9_@+-]+))(?=$|[\s)\]}>,;!?]|[.](?=$|[\s)\]}>,;!?]))/g;
+  /(^|[\s([{"'`<])((?:~\/|\.{1,2}\/|\/)?(?:(?:[A-Za-z0-9._@+-]+\/)+[A-Za-z0-9._@+-]*\.[A-Za-z][A-Za-z0-9_@+-]+|[A-Za-z0-9._@+-]*\.[A-Za-z][A-Za-z0-9_@+-]+))(?=$|[\s)\]}>,;!?]|[.](?=$|[\s)\]}>,;!?]))/g;
 
 export function createTerminalFileLinkProvider(
   terminal: XTerm,
@@ -178,9 +178,16 @@ function stringIndexToBufferColumn(
 export function resolveTerminalFilePath(
   cwd: string,
   referencePath: string,
+  home?: string | null,
 ): string {
   if (referencePath.startsWith("/")) {
     return normalizePosixPath(referencePath);
+  }
+  if (referencePath.startsWith("~/")) {
+    if (!home) return referencePath;
+    return normalizePosixPath(
+      `${home.replace(/\/+$/u, "")}/${referencePath.slice(2)}`,
+    );
   }
   return normalizePosixPath(`${cwd.replace(/\/+$/u, "")}/${referencePath}`);
 }

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -505,6 +505,112 @@ test.describe("terminal: spawn", () => {
     );
   });
 
+  test("opens home-relative terminal file links in the code viewer", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("plugin:path|resolve_directory", () => "/Users/tester");
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_cwd", () => "/tmp/demo");
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __homeFileLinkChannelId?: number;
+        [key: string]: unknown;
+      };
+      w.__homeFileLinkChannelId = channel.id;
+      return 1;
+    });
+    await tauri.handle("fs_file_exists", (args) => {
+      const { path } = args as { path: string };
+      const w = window as unknown as { __fsFileExistsCalls?: string[] };
+      w.__fsFileExistsCalls = [...(w.__fsFileExistsCalls ?? []), path];
+      return path === "/Users/tester/projects/acorn/src/App.tsx";
+    });
+    await tauri.handle("fs_read_file", (args) => {
+      const { path } = args as { path: string };
+      if (path !== "/Users/tester/projects/acorn/src/App.tsx") {
+        throw new Error(`unexpected path: ${path}`);
+      }
+      return {
+        content: "home-relative file link\nresolved target",
+        size: 48,
+        truncated: false,
+        binary: false,
+      };
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __homeFileLinkChannelId?: number })
+              .__homeFileLinkChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const linkText = "~/projects/acorn/src/App.tsx:2";
+    await emitSubscribedPtyOutput(
+      page,
+      "__homeFileLinkChannelId",
+      `${linkText}\r\n`,
+    );
+    await expect(page.locator(".xterm")).toContainText(linkText);
+
+    const screenBox = await page.locator(".xterm-screen").boundingBox();
+    expect(screenBox).not.toBeNull();
+    await page.mouse.move(screenBox!.x + 36, screenBox!.y + 10);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (
+            (window as unknown as { __fsFileExistsCalls?: string[] })
+              .__fsFileExistsCalls ?? []
+          ).includes("/Users/tester/projects/acorn/src/App.tsx"),
+        ),
+      )
+      .toBe(true);
+    await page.waitForTimeout(30);
+    await page.mouse.click(screenBox!.x + 36, screenBox!.y + 10);
+
+    await expect(
+      page.getByRole("button", {
+        name: /App\.tsx Close tab/,
+      }),
+    ).toBeVisible();
+    await expect(page.locator('[data-acorn-target-line="true"]')).toContainText(
+      "resolved target",
+    );
+  });
+
   test("does not underline or open missing file terminal links", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Terminal file links now support home-relative `~/...` paths in the same flow as absolute and cwd-relative paths.

1. **Path detection** — include `~/` as an accepted file-reference prefix for both `file:line[:column]` links and file-only links.
2. **Path resolution** — expand `~/...` through Tauri's `homeDir()` before validating and opening the file, while avoiding the extra home lookup for ordinary relative paths.
3. **Regression coverage** — add Vitest coverage for parsing/resolving home-relative references and Playwright coverage for opening a `~/...` terminal link in the code viewer.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal file links | `~/path/file.ts:12` was not opened as a valid file link | `~/path/file.ts:12` resolves against the user's home directory and opens when the file exists |
| Existing absolute / relative links | Supported | Still supported, covered by existing E2E cases |

## Design notes
- `resolveTerminalFilePath` now accepts an optional home directory so the pure parser stays testable and the Tauri-specific home lookup remains at the `Terminal.tsx` integration edge.
- `Terminal.tsx` only calls `homeDir()` when at least one detected reference starts with `~/`, keeping the common cwd-relative path path unchanged.

## Test plan
- [x] `pnpm exec vitest run src/lib/terminalFileLinks.test.ts` — 18 tests passed
- [x] `pnpm exec tsc --noEmit` — passed
- [x] `PLAYWRIGHT_PORT=1437 pnpm exec playwright test tests/e2e/terminal.spec.ts -g "opens file:line terminal links|opens file-only terminal links|opens home-relative terminal file links|does not underline or open missing file terminal links"` — 4 tests passed

## Notes
- Local Playwright was run against a temporary Vite server on port 1437 because port 1420 was already occupied by another Acorn worktree's dev server.