### PR TITLE
fix(terminal): resolve repo-root worktree file links

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -44,7 +44,7 @@ import {
 } from "../lib/terminalPaste";
 import {
   createTerminalFileLinkProvider,
-  resolveTerminalFilePath,
+  resolveTerminalFilePathCandidates,
   type TerminalFileReference,
 } from "../lib/terminalFileLinks";
 import { createTerminalWebLinkProvider } from "../lib/terminalWebLinks";
@@ -71,6 +71,7 @@ import { FloatingTooltip, Tooltip, type TooltipAnchorRect } from "./Tooltip";
 
 interface TerminalProps {
   sessionId: string;
+  repoPath: string;
   cwd: string;
   agentProvider?: SessionAgentProvider | null;
   pasteAgentProvider?: SessionAgentProvider | null;
@@ -512,8 +513,13 @@ function encodeStringToBase64(input: string): string {
   return btoa(binary);
 }
 
+function usesExplicitRelativePath(path: string): boolean {
+  return path.startsWith("./") || path.startsWith("../");
+}
+
 export function Terminal({
   sessionId,
+  repoPath,
   cwd,
   agentProvider = null,
   pasteAgentProvider = null,
@@ -685,21 +691,35 @@ export function Terminal({
         resolveTerminalFileBaseCwd(),
         needsHome ? resolveTerminalFileHomeDir() : Promise.resolve(null),
       ]);
-      const resolved: Array<TerminalFileReference | null> = await Promise.all(
-        references.map(async (reference) => {
-          const absolutePath = resolveTerminalFilePath(
-            baseCwd,
-            reference.path,
+      const resolveExistingFilePath = async (
+        reference: TerminalFileReference,
+      ): Promise<string | null> => {
+        const basePaths = usesExplicitRelativePath(reference.path)
+          ? []
+          : [cwd, repoPath];
+        const candidates = resolveTerminalFilePathCandidates(
+          baseCwd,
+          reference.path,
+          {
             home,
-          );
+            basePaths,
+          },
+        );
+        for (const candidate of candidates) {
           try {
-            if (!(await api.fsFileExists(absolutePath))) {
-              return null;
+            if (await api.fsFileExists(candidate)) {
+              return candidate;
             }
           } catch (err: unknown) {
             console.debug("[Terminal] fs_file_exists for file link failed", err);
-            return null;
           }
+        }
+        return null;
+      };
+      const resolved: Array<TerminalFileReference | null> = await Promise.all(
+        references.map(async (reference) => {
+          const absolutePath = await resolveExistingFilePath(reference);
+          if (!absolutePath) return null;
           return { ...reference, absolutePath };
         }),
       );
@@ -709,23 +729,48 @@ export function Terminal({
     };
     const openTerminalFileReference = (reference: TerminalFileReference) => {
       void (async () => {
-        let path = reference.absolutePath;
-        if (!path) {
+        let path: string | null = reference.absolutePath ?? null;
+        if (path) {
+          try {
+            if (!(await api.fsFileExists(path))) {
+              return;
+            }
+          } catch (err: unknown) {
+            console.debug("[Terminal] fs_file_exists before open failed", err);
+            return;
+          }
+        } else {
           const [baseCwd, home] = await Promise.all([
             resolveTerminalFileBaseCwd(),
             reference.path.startsWith("~/")
               ? resolveTerminalFileHomeDir()
               : Promise.resolve(null),
           ]);
-          path = resolveTerminalFilePath(baseCwd, reference.path, home);
-        }
-        try {
-          if (!(await api.fsFileExists(path))) {
+          const basePaths = usesExplicitRelativePath(reference.path)
+            ? []
+            : [cwd, repoPath];
+          const candidates = resolveTerminalFilePathCandidates(
+            baseCwd,
+            reference.path,
+            {
+              home,
+              basePaths,
+            },
+          );
+          path = null;
+          for (const candidate of candidates) {
+            try {
+              if (await api.fsFileExists(candidate)) {
+                path = candidate;
+                break;
+              }
+            } catch (err: unknown) {
+              console.debug("[Terminal] fs_file_exists before open failed", err);
+            }
+          }
+          if (!path) {
             return;
           }
-        } catch (err: unknown) {
-          console.debug("[Terminal] fs_file_exists before open failed", err);
-          return;
         }
         const target =
           reference.line === undefined
@@ -2163,7 +2208,7 @@ export function Terminal({
       fitRef.current = null;
       fitTerminalRef.current = null;
     };
-  }, [sessionId, cwd]);
+  }, [sessionId, repoPath, cwd]);
 
   useEffect(() => {
     const term = termRef.current;

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -97,6 +97,7 @@ function PortaledTerminal({ session }: { session: Session }) {
   return createPortal(
     <Terminal
       sessionId={session.id}
+      repoPath={session.repo_path}
       cwd={session.worktree_path}
       agentProvider={resolveSessionAgentProvider(session)}
       pasteAgentProvider={session.agent_provider ?? null}

--- a/src/lib/terminalFileLinks.test.ts
+++ b/src/lib/terminalFileLinks.test.ts
@@ -3,6 +3,7 @@ import {
   createTerminalFileLinkProvider,
   findTerminalFileReferences,
   resolveTerminalFilePath,
+  resolveTerminalFilePathCandidates,
 } from "./terminalFileLinks";
 import type {
   IBufferCell,
@@ -92,6 +93,21 @@ describe("terminal file links", () => {
         column: 5,
         text: "~/projects/acorn/src/App.tsx:12:5",
         startIndex: 4,
+      },
+    ]);
+  });
+
+  it("finds Acorn worktree-relative file references", () => {
+    expect(
+      findTerminalFileReferences(
+        ".acorn/worktrees/acorn-worktree-3220b1cc6655/src/components/RightPanel.tsx:3104",
+      ),
+    ).toEqual([
+      {
+        path: ".acorn/worktrees/acorn-worktree-3220b1cc6655/src/components/RightPanel.tsx",
+        line: 3104,
+        text: ".acorn/worktrees/acorn-worktree-3220b1cc6655/src/components/RightPanel.tsx:3104",
+        startIndex: 0,
       },
     ]);
   });
@@ -198,6 +214,22 @@ describe("terminal file links", () => {
     expect(resolveTerminalFilePath("/repo/app", "~/src/App.tsx")).toBe(
       "~/src/App.tsx",
     );
+  });
+
+  it("returns fallback candidates for repo-root-relative paths", () => {
+    expect(
+      resolveTerminalFilePathCandidates(
+        "/repo/app/.acorn/worktrees/current/src",
+        ".acorn/worktrees/other/src/components/RightPanel.tsx",
+        {
+          basePaths: ["/repo/app/.acorn/worktrees/current", "/repo/app"],
+        },
+      ),
+    ).toEqual([
+      "/repo/app/.acorn/worktrees/current/src/.acorn/worktrees/other/src/components/RightPanel.tsx",
+      "/repo/app/.acorn/worktrees/current/.acorn/worktrees/other/src/components/RightPanel.tsx",
+      "/repo/app/.acorn/worktrees/other/src/components/RightPanel.tsx",
+    ]);
   });
 
   it("keeps file link hover decorations from drawing xterm underlines", () => {

--- a/src/lib/terminalFileLinks.ts
+++ b/src/lib/terminalFileLinks.ts
@@ -180,16 +180,32 @@ export function resolveTerminalFilePath(
   referencePath: string,
   home?: string | null,
 ): string {
+  return resolveTerminalFilePathCandidates(cwd, referencePath, {
+    home,
+  })[0];
+}
+
+export function resolveTerminalFilePathCandidates(
+  cwd: string,
+  referencePath: string,
+  options: { home?: string | null; basePaths?: string[] } = {},
+): string[] {
   if (referencePath.startsWith("/")) {
-    return normalizePosixPath(referencePath);
+    return [normalizePosixPath(referencePath)];
   }
   if (referencePath.startsWith("~/")) {
-    if (!home) return referencePath;
-    return normalizePosixPath(
-      `${home.replace(/\/+$/u, "")}/${referencePath.slice(2)}`,
-    );
+    const { home } = options;
+    if (!home) return [referencePath];
+    return [
+      normalizePosixPath(
+        `${home.replace(/\/+$/u, "")}/${referencePath.slice(2)}`,
+      ),
+    ];
   }
-  return normalizePosixPath(`${cwd.replace(/\/+$/u, "")}/${referencePath}`);
+  const candidates = [cwd, ...(options.basePaths ?? [])].map((base) =>
+    normalizePosixPath(`${base.replace(/\/+$/u, "")}/${referencePath}`),
+  );
+  return Array.from(new Set(candidates));
 }
 
 function normalizePosixPath(path: string): string {

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -611,6 +611,121 @@ test.describe("terminal: spawn", () => {
     );
   });
 
+  test("opens repo-root Acorn worktree file links from a worktree cwd", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.acorn/worktrees/current",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle(
+      "pty_cwd",
+      () => "/tmp/demo/.acorn/worktrees/current/src",
+    );
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __repoRootFileLinkChannelId?: number;
+        [key: string]: unknown;
+      };
+      w.__repoRootFileLinkChannelId = channel.id;
+      return 1;
+    });
+    await tauri.handle("fs_file_exists", (args) => {
+      const { path } = args as { path: string };
+      const w = window as unknown as { __fsFileExistsCalls?: string[] };
+      w.__fsFileExistsCalls = [...(w.__fsFileExistsCalls ?? []), path];
+      return (
+        path === "/tmp/demo/.acorn/worktrees/other/src/components/RightPanel.tsx"
+      );
+    });
+    await tauri.handle("fs_read_file", (args) => {
+      const { path } = args as { path: string };
+      if (
+        path !== "/tmp/demo/.acorn/worktrees/other/src/components/RightPanel.tsx"
+      ) {
+        throw new Error(`unexpected path: ${path}`);
+      }
+      return {
+        content: "repo-root worktree link\nresolved target",
+        size: 48,
+        truncated: false,
+        binary: false,
+      };
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __repoRootFileLinkChannelId?: number })
+              .__repoRootFileLinkChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const linkText =
+      ".acorn/worktrees/other/src/components/RightPanel.tsx:2";
+    await emitSubscribedPtyOutput(
+      page,
+      "__repoRootFileLinkChannelId",
+      `${linkText}\r\n`,
+    );
+    await expect(page.locator(".xterm")).toContainText(linkText);
+
+    const screenBox = await page.locator(".xterm-screen").boundingBox();
+    expect(screenBox).not.toBeNull();
+    await page.mouse.move(screenBox!.x + 12, screenBox!.y + 10);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (
+            (window as unknown as { __fsFileExistsCalls?: string[] })
+              .__fsFileExistsCalls ?? []
+          ).includes(
+            "/tmp/demo/.acorn/worktrees/other/src/components/RightPanel.tsx",
+          ),
+        ),
+      )
+      .toBe(true);
+    await page.waitForTimeout(30);
+    await page.mouse.click(screenBox!.x + 12, screenBox!.y + 10);
+
+    await expect(
+      page.getByRole("button", {
+        name: /RightPanel\.tsx Close tab/,
+      }),
+    ).toBeVisible();
+    await expect(page.locator('[data-acorn-target-line="true"]')).toContainText(
+      "resolved target",
+    );
+  });
+
   test("does not underline or open missing file terminal links", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Fix terminal file links that point at Acorn worktree paths from repo-root-relative output.

1. **Path candidate resolution** — keep existing PTY-cwd resolution first, then try the session worktree root and project repo root for bare relative file references.
2. **Worktree file links** — support references like `.acorn/worktrees/<name>/src/components/RightPanel.tsx:3104` even when the terminal's live cwd is inside another worktree subdirectory.
3. **Regression coverage** — add unit coverage for the path parser/candidate resolver and E2E coverage for opening a repo-root worktree link from a worktree cwd.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal file links | Repo-root `.acorn/worktrees/...` links could resolve under the live cwd and fail to open | Links fall back to the session worktree root and project repo root before being discarded |
| Explicit relative links | `./...` and `../...` use the live cwd | Unchanged |

## Design notes
- Absolute paths and `~/...` paths remain single-candidate resolutions.
- Bare relative paths now use ordered candidates: live PTY cwd, recorded session worktree path, then project repo path.
- Explicit `./` and `../` references intentionally skip fallback candidates so command output that is truly cwd-relative does not open a similarly named file elsewhere.

## Test plan
- [x] `pnpm exec vitest run src/lib/terminalFileLinks.test.ts` — 20 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts -g "repo-root Acorn worktree file links|home-relative terminal file links|opens file:line terminal links"` — 3 tests passed
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts -g "repo-root Acorn worktree file links"` — 1 test passed

## Notes
- `pnpm install` was run in this fresh worktree to install local JS tooling before verification; lockfile was already up to date and no tracked dependency files changed.
