### PR TITLE
fix(code-viewer): live-refresh open file contents

### DIFF
--- a/src/components/CodeDiffVirtualization.test.tsx
+++ b/src/components/CodeDiffVirtualization.test.tsx
@@ -15,16 +15,22 @@ vi.mock("../lib/highlight", () => ({
 }));
 
 vi.mock("../lib/api", () => ({
+  FS_CHANGED_EVENT: "acorn:fs-changed",
   api: {
     fsReadFile: vi.fn<(path: string) => Promise<FsReadFileResult>>(),
     fsGitDiffLines: vi.fn<(path: string) => Promise<FsLineDiffEntry[]>>(),
   },
 }));
 
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: vi.fn(async () => undefined),
 }));
 
+import { listen } from "@tauri-apps/api/event";
 import { api } from "../lib/api";
 import { highlightCode, langFromPath } from "../lib/highlight";
 import { CodeViewer } from "./CodeViewer";
@@ -40,6 +46,23 @@ async function flushPromises() {
   await act(async () => {
     await Promise.resolve();
     await Promise.resolve();
+  });
+}
+
+function emitFsChanged(payload: {
+  paths: string[];
+  root?: string;
+  overflow?: boolean;
+  refresh?: { kind: "root" | "subtree"; path: string } | null;
+  dotgit_changed: boolean;
+}) {
+  const calls = vi.mocked(listen).mock.calls;
+  const listener = calls[calls.length - 1]?.[1];
+  if (!listener) throw new Error("fs listener not registered");
+  listener({
+    event: "acorn:fs-changed",
+    id: 1,
+    payload,
   });
 }
 
@@ -81,6 +104,8 @@ describe("virtualized code and diff rendering", () => {
     root = createRoot(container);
     vi.mocked(api.fsReadFile).mockReset();
     vi.mocked(api.fsGitDiffLines).mockReset();
+    vi.mocked(listen).mockClear();
+    vi.mocked(listen).mockResolvedValue(() => {});
     vi.mocked(highlightCode).mockClear();
     vi.mocked(langFromPath).mockReturnValue(null);
     useSettings.setState({ settings: structuredClone(DEFAULT_SETTINGS) });
@@ -247,6 +272,91 @@ describe("virtualized code and diff rendering", () => {
       1,
     );
     expect(container.textContent).toContain("1/1");
+  });
+
+  it("refreshes an open code viewer when its file changes", async () => {
+    vi.mocked(api.fsReadFile)
+      .mockResolvedValueOnce({
+        content: "old content",
+        size: "old content".length,
+        truncated: false,
+        binary: false,
+      })
+      .mockResolvedValueOnce({
+        content: "new content",
+        size: "new content".length,
+        truncated: false,
+        binary: false,
+      });
+    vi.mocked(api.fsGitDiffLines)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ line: 1, kind: "modified" }]);
+
+    await act(async () => {
+      root.render(<CodeViewer path="/repo/src/live.ts" isActive />);
+    });
+    await flushPromises();
+
+    expect(container.textContent).toContain("old content");
+
+    await act(async () => {
+      emitFsChanged({
+        root: "/repo",
+        paths: ["/repo/src/live.ts"],
+        dotgit_changed: false,
+      });
+    });
+    await flushPromises();
+
+    expect(api.fsReadFile).toHaveBeenCalledTimes(2);
+    expect(api.fsGitDiffLines).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain("new content");
+  });
+
+  it("keeps markdown preview mode live across file changes", async () => {
+    vi.mocked(api.fsReadFile)
+      .mockResolvedValueOnce({
+        content: "# Old title",
+        size: "# Old title".length,
+        truncated: false,
+        binary: false,
+      })
+      .mockResolvedValueOnce({
+        content: "# New title",
+        size: "# New title".length,
+        truncated: false,
+        binary: false,
+      });
+    vi.mocked(api.fsGitDiffLines).mockResolvedValue([]);
+
+    await act(async () => {
+      root.render(<CodeViewer path="/repo/README.md" isActive />);
+    });
+    await flushPromises();
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[aria-pressed="false"]',
+    );
+    await act(async () => {
+      toggle?.click();
+    });
+
+    expect(container.querySelector("h1")?.textContent).toBe("Old title");
+
+    await act(async () => {
+      emitFsChanged({
+        root: "/repo",
+        paths: ["/repo/README.md"],
+        dotgit_changed: false,
+      });
+    });
+    await flushPromises();
+
+    expect(container.querySelector("h1")?.textContent).toBe("New title");
+    expect(container.querySelector("pre")).toBeNull();
+    expect(
+      container.querySelector<HTMLButtonElement>('button[aria-pressed="true"]'),
+    ).not.toBeNull();
   });
 
   it("copies selected text by source line in virtualized lists", () => {

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { ChevronDown, ChevronUp, Code2, Eye, Search, X } from "lucide-react";
 import {
   api,
+  FS_CHANGED_EVENT,
+  type FsChangePayload,
   type FsLineDiffEntry,
   type FsReadFileResult,
 } from "../lib/api";
@@ -74,6 +77,49 @@ function isMarkdownPath(path: string): boolean {
   return MARKDOWN_EXT_RE.test(path);
 }
 
+function classifyCodeViewerFsChange(
+  filePath: string,
+  payload: FsChangePayload,
+): { content: boolean; diff: boolean } {
+  const sameRoot =
+    !payload.root ||
+    isSameOrInside(payload.root, filePath) ||
+    isSameOrInside(filePath, payload.root);
+  if (!sameRoot) return { content: false, diff: false };
+
+  const content =
+    payload.paths.some((changedPath) => pathsOverlap(changedPath, filePath)) ||
+    (payload.overflow
+      ? payload.refresh
+        ? isSameOrInside(payload.refresh.path, filePath)
+        : true
+      : false);
+
+  return {
+    content,
+    diff: content || payload.dotgit_changed,
+  };
+}
+
+function normalizeFsPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized === "" ? "/" : normalized;
+}
+
+function isSameOrInside(parent: string, child: string): boolean {
+  const normalizedParent = normalizeFsPath(parent);
+  const normalizedChild = normalizeFsPath(child);
+  if (normalizedParent === "/") return normalizedChild.startsWith("/");
+  return (
+    normalizedChild === normalizedParent ||
+    normalizedChild.startsWith(`${normalizedParent}/`)
+  );
+}
+
+function pathsOverlap(a: string, b: string): boolean {
+  return isSameOrInside(a, b) || isSameOrInside(b, a);
+}
+
 export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
   const t = useTranslation();
   const themeId = useSettings((s) => s.settings.appearance.themeId);
@@ -88,9 +134,36 @@ export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
   const lineListRef = useRef<VirtualizedLineListHandle | null>(null);
   const previewRef = useRef<HTMLDivElement | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const loadSeqRef = useRef(0);
   const themeMode = useMemo(
     () => resolveThemeMode(themeId, themes),
     [themeId, themes],
+  );
+
+  const refreshFile = useCallback(
+    async ({ reset = false }: { reset?: boolean } = {}) => {
+      const seq = ++loadSeqRef.current;
+      if (reset) setState(EMPTY_STATE);
+      try {
+        const data = await api.fsReadFile(path);
+        if (seq !== loadSeqRef.current) return;
+        setState({
+          data,
+          highlightedLines: null,
+          error: null,
+          loading: false,
+        });
+      } catch (err: unknown) {
+        if (seq !== loadSeqRef.current) return;
+        setState({
+          data: null,
+          highlightedLines: null,
+          error: err instanceof Error ? err.message : String(err),
+          loading: false,
+        });
+      }
+    },
+    [path],
   );
 
   const refreshDiff = useCallback(async () => {
@@ -103,37 +176,16 @@ export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
   }, [path]);
 
   useEffect(() => {
-    let cancelled = false;
-    setState(EMPTY_STATE);
     setPreviewMarkdown(false);
     setSearchOpen(false);
     setSearchQuery("");
     setActiveMatchIndex(0);
     setPreviewMatchCount(0);
-    api
-      .fsReadFile(path)
-      .then((data) => {
-        if (cancelled) return;
-        setState({
-          data,
-          highlightedLines: null,
-          error: null,
-          loading: false,
-        });
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setState({
-          data: null,
-          highlightedLines: null,
-          error: err instanceof Error ? err.message : String(err),
-          loading: false,
-        });
-      });
+    void refreshFile({ reset: true });
     return () => {
-      cancelled = true;
+      loadSeqRef.current += 1;
     };
-  }, [path]);
+  }, [path, refreshFile]);
 
   useEffect(() => {
     const data = state.data;
@@ -169,6 +221,33 @@ export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
   useEffect(() => {
     void refreshDiff();
   }, [refreshDiff]);
+
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+
+    void listen<FsChangePayload>(FS_CHANGED_EVENT, (event) => {
+      if (cancelled) return;
+      const change = classifyCodeViewerFsChange(path, event.payload);
+      if (change.content) {
+        void refreshFile();
+      }
+      if (change.content || change.diff) {
+        void refreshDiff();
+      }
+    }).then((cancel) => {
+      if (cancelled) {
+        cancel();
+        return;
+      }
+      unlisten = cancel;
+    });
+
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, [path, refreshDiff, refreshFile]);
 
   const diffByLine = useMemo(() => {
     const map = new Map<number, FsLineDiffEntry["kind"]>();


### PR DESCRIPTION
## Summary
Code viewer tabs now stay in sync with disk changes while they are open:

1. **Live file refresh** — subscribe `CodeViewer` to the existing `acorn:fs-changed` batches and reload the active file when the changed path, overflow hint, or subtree refresh overlaps the viewer path.
2. **Preview continuity** — preserve markdown preview mode across content refreshes so rendered previews update in place instead of forcing the user back to source view.
3. **Regression coverage** — extend the virtualized code viewer test suite with file-change and markdown-preview refresh cases.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Readonly file viewer | File contents stayed stale until the tab was reopened | Open viewer tabs update after filesystem watcher events |
| Markdown preview | Preview rendered the initially loaded content | Preview re-renders with fresh file content and stays in preview mode |

## Design notes
- Reuses the existing repo-root filesystem watcher event surface instead of adding a new backend command or watcher.
- Uses a sequence guard around async file reads so slower stale reads cannot overwrite newer refreshes.
- Refreshes git diff line markers when the file content changes or git metadata changes.

## Test plan
- [x] `pnpm exec vitest run src/components/CodeDiffVirtualization.test.tsx` — 10 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test` — 53 files passed, 485 tests passed, 1 skipped
- [x] `pnpm run build` — passed

## Notes
- `pnpm run build` emitted existing Vite chunking/dynamic-import warnings, but completed successfully.
