### PR TITLE
feat(settings): record custom keyboard shortcuts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,9 +36,11 @@ import {
   type StagedRevMismatch,
 } from "./lib/api";
 import {
-  Hotkeys,
+  DEFAULT_HOTKEYS,
+  hotkeyBindingsFor,
   shouldUseTinykeysToggleMultiInputFallback,
   useHotkeys,
+  type HotkeyBindings,
 } from "./lib/hotkeys";
 import { hasRecordedWorktree } from "./lib/sessionWorktree";
 import {
@@ -171,6 +173,7 @@ function App() {
     (s) => s.settings.sessions.autoDeleteWorktrees,
   );
   const settings = useSettings((s) => s.settings);
+  const shortcuts = settings.shortcuts;
   const pendingRemove = sessions.find((s) => s.id === pendingRemoveId) ?? null;
   const pendingProject =
     projects.find((p) => p.repo_path === pendingRemoveProject) ?? null;
@@ -1114,57 +1117,76 @@ function App() {
     };
   }, []);
 
-  const bindings = useMemo(
-    () => ({
-      [Hotkeys.openPalette]: (e: KeyboardEvent) => {
+  const bindings = useMemo<HotkeyBindings>(() => {
+    const uiScaleDownHandler = (e: KeyboardEvent) => {
+      e.preventDefault();
+      updateUiScalePercent(-UI_SCALE_PERCENT_STEP);
+    };
+    const uiScaleUpHandler = (e: KeyboardEvent) => {
+      e.preventDefault();
+      updateUiScalePercent(UI_SCALE_PERCENT_STEP);
+    };
+    const toggleMultiInputHandler = (e: KeyboardEvent) => {
+      e.preventDefault();
+      if (
+        shortcuts.toggleMultiInput === DEFAULT_HOTKEYS.toggleMultiInput &&
+        !shouldUseTinykeysToggleMultiInputFallback()
+      ) {
+        return;
+      }
+      toggleMultiInput();
+    };
+
+    const next: HotkeyBindings = {
+      [shortcuts.openPalette]: (e: KeyboardEvent) => {
         e.preventDefault();
         setPaletteOpen((v) => !v);
       },
-      [Hotkeys.newSession]: (e: KeyboardEvent) => {
+      [shortcuts.newSession]: (e: KeyboardEvent) => {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent("acorn:new-session"));
       },
-      [Hotkeys.newIsolatedSession]: (e: KeyboardEvent) => {
+      [shortcuts.newIsolatedSession]: (e: KeyboardEvent) => {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent("acorn:new-isolated-session"));
       },
-      [Hotkeys.newControlSession]: (e: KeyboardEvent) => {
+      [shortcuts.newControlSession]: (e: KeyboardEvent) => {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent("acorn:new-control-session"));
       },
-      [Hotkeys.addProject]: (e: KeyboardEvent) => {
+      [shortcuts.addProject]: (e: KeyboardEvent) => {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent("acorn:add-project"));
       },
-      [Hotkeys.focusSidebar]: (e: KeyboardEvent) => {
+      [shortcuts.focusSidebar]: (e: KeyboardEvent) => {
         e.preventDefault();
         sidebarPanelRef.current?.expand();
         focusPanel("sidebar");
       },
-      [Hotkeys.focusMain]: (e: KeyboardEvent) => {
+      [shortcuts.focusMain]: (e: KeyboardEvent) => {
         e.preventDefault();
         focusPanel("main");
       },
-      [Hotkeys.focusRight]: (e: KeyboardEvent) => {
+      [shortcuts.focusRight]: (e: KeyboardEvent) => {
         e.preventDefault();
         rightPanelRef.current?.expand();
         focusPanel("right");
       },
-      [Hotkeys.toggleSidebar]: (e: KeyboardEvent) => {
+      [shortcuts.toggleSidebar]: (e: KeyboardEvent) => {
         e.preventDefault();
         const panel = sidebarPanelRef.current;
         if (!panel) return;
         if (panel.isCollapsed()) panel.expand();
         else panel.collapse();
       },
-      [Hotkeys.toggleRightPanel]: (e: KeyboardEvent) => {
+      [shortcuts.toggleRightPanel]: (e: KeyboardEvent) => {
         e.preventDefault();
         const panel = rightPanelRef.current;
         if (!panel) return;
         if (panel.isCollapsed()) panel.expand();
         else panel.collapse();
       },
-      [Hotkeys.clearTerminal]: (e: KeyboardEvent) => {
+      [shortcuts.clearTerminal]: (e: KeyboardEvent) => {
         // Prefer the terminal whose helper textarea currently owns DOM
         // focus over `state.activeSessionId`. The app-level `focusin`
         // listener keeps `focusedPaneId` synced for clicks, but a hotkey
@@ -1199,23 +1221,23 @@ function App() {
           }),
         );
       },
-      [Hotkeys.toggleTodos]: (e: KeyboardEvent) => {
+      [shortcuts.toggleTodos]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().setRightTab("todos");
       },
-      [Hotkeys.toggleCommits]: (e: KeyboardEvent) => {
+      [shortcuts.toggleCommits]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().setRightTab("commits");
       },
-      [Hotkeys.toggleStaged]: (e: KeyboardEvent) => {
+      [shortcuts.toggleStaged]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().setRightTab("staged");
       },
-      [Hotkeys.togglePrs]: (e: KeyboardEvent) => {
+      [shortcuts.togglePrs]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().setRightTab("prs");
       },
-      [Hotkeys.toggleFiles]: (e: KeyboardEvent) => {
+      [shortcuts.toggleFiles]: (e: KeyboardEvent) => {
         e.preventDefault();
         const panel = rightPanelRef.current;
         const state = useAppStore.getState();
@@ -1232,84 +1254,66 @@ function App() {
           state.setRightTab("files");
         }
       },
-      [Hotkeys.uiScaleDown]: (e: KeyboardEvent) => {
-        e.preventDefault();
-        updateUiScalePercent(-UI_SCALE_PERCENT_STEP);
-      },
-      [Hotkeys.uiScaleDownShift]: (e: KeyboardEvent) => {
-        e.preventDefault();
-        updateUiScalePercent(-UI_SCALE_PERCENT_STEP);
-      },
-      [Hotkeys.uiScaleUp]: (e: KeyboardEvent) => {
-        e.preventDefault();
-        updateUiScalePercent(UI_SCALE_PERCENT_STEP);
-      },
-      [Hotkeys.uiScaleUpShift]: (e: KeyboardEvent) => {
-        e.preventDefault();
-        updateUiScalePercent(UI_SCALE_PERCENT_STEP);
-      },
-      [Hotkeys.uiScaleReset]: (e: KeyboardEvent) => {
+      [shortcuts.uiScaleDown]: uiScaleDownHandler,
+      [shortcuts.uiScaleUp]: uiScaleUpHandler,
+      [shortcuts.uiScaleReset]: (e: KeyboardEvent) => {
         e.preventDefault();
         useSettings.getState().patchAppearance({ uiScalePercent: 100 });
       },
-      [Hotkeys.toggleMultiInput]: (e: KeyboardEvent) => {
-        e.preventDefault();
-        if (!shouldUseTinykeysToggleMultiInputFallback()) return;
-        toggleMultiInput();
-      },
-      [Hotkeys.focusPaneLeft]: (e: KeyboardEvent) => {
+      [shortcuts.toggleMultiInput]: toggleMultiInputHandler,
+      [shortcuts.focusPaneLeft]: (e: KeyboardEvent) => {
         e.preventDefault();
         focusAdjacentPane("left");
       },
-      [Hotkeys.focusPaneRight]: (e: KeyboardEvent) => {
+      [shortcuts.focusPaneRight]: (e: KeyboardEvent) => {
         e.preventDefault();
         focusAdjacentPane("right");
       },
-      [Hotkeys.focusPaneUp]: (e: KeyboardEvent) => {
+      [shortcuts.focusPaneUp]: (e: KeyboardEvent) => {
         e.preventDefault();
         focusAdjacentPane("up");
       },
-      [Hotkeys.focusPaneDown]: (e: KeyboardEvent) => {
+      [shortcuts.focusPaneDown]: (e: KeyboardEvent) => {
         e.preventDefault();
         focusAdjacentPane("down");
       },
-      [Hotkeys.splitVertical]: (e: KeyboardEvent) => {
+      [shortcuts.splitVertical]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().splitFocusedPane("horizontal");
       },
-      [Hotkeys.splitHorizontal]: (e: KeyboardEvent) => {
+      [shortcuts.splitHorizontal]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().splitFocusedPane("vertical");
       },
-      [Hotkeys.equalizePanes]: (e: KeyboardEvent) => {
+      [shortcuts.equalizePanes]: (e: KeyboardEvent) => {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
       },
-      [Hotkeys.closeTab]: (e: KeyboardEvent) => {
+      [shortcuts.closeTab]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().closeFocusedTab();
       },
-      [Hotkeys.nextTab]: (e: KeyboardEvent) => {
+      [shortcuts.nextTab]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().cycleTab(1);
       },
-      [Hotkeys.prevTab]: (e: KeyboardEvent) => {
+      [shortcuts.prevTab]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().cycleTab(-1);
       },
-      [Hotkeys.nextProject]: (e: KeyboardEvent) => {
+      [shortcuts.nextProject]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().cycleProject(1);
       },
-      [Hotkeys.prevProject]: (e: KeyboardEvent) => {
+      [shortcuts.prevProject]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().cycleProject(-1);
       },
-      [Hotkeys.openSettings]: (e: KeyboardEvent) => {
+      [shortcuts.openSettings]: (e: KeyboardEvent) => {
         e.preventDefault();
         useSettings.getState().setOpen(true);
       },
-      [Hotkeys.reloadShellEnv]: (e: KeyboardEvent) => {
+      [shortcuts.reloadShellEnv]: (e: KeyboardEvent) => {
         e.preventDefault();
         const show = useToasts.getState().show;
         api
@@ -1335,7 +1339,7 @@ function App() {
             );
           });
       },
-      [Hotkeys.closeEmptyPane]: (e: KeyboardEvent) => {
+      [shortcuts.closeEmptyPane]: (e: KeyboardEvent) => {
         // Only collapse the focused pane when it's empty, so Escape stays
         // available for inputs, dialogs, and the command palette.
         const { focusedPaneId, panes } = useAppStore.getState();
@@ -1346,9 +1350,17 @@ function App() {
         e.preventDefault();
         useAppStore.getState().closePane(focusedPaneId);
       },
-    }),
-    [t, toggleMultiInput],
-  );
+    };
+
+    for (const alias of hotkeyBindingsFor(shortcuts, "uiScaleDown").slice(1)) {
+      next[alias] = uiScaleDownHandler;
+    }
+    for (const alias of hotkeyBindingsFor(shortcuts, "uiScaleUp").slice(1)) {
+      next[alias] = uiScaleUpHandler;
+    }
+
+    return next;
+  }, [shortcuts, t, toggleMultiInput]);
 
   useHotkeys(bindings);
 

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -47,7 +47,7 @@ import {
   hasConfiguredEditor,
   openInConfiguredEditor,
 } from "../lib/editor";
-import { formatHotkey, Hotkeys } from "../lib/hotkeys";
+import { formatHotkey, type HotkeyId } from "../lib/hotkeys";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import { useSettings } from "../lib/settings";
 import { canRenameSession } from "../lib/sessionTitle";
@@ -101,6 +101,13 @@ function paneT(t: Translator, key: PaneTranslationKey): string {
   return t(key);
 }
 
+function shortcutLabel(
+  shortcuts: Record<HotkeyId, string>,
+  id: HotkeyId,
+): string {
+  return formatHotkey(shortcuts[id]);
+}
+
 interface PaneProps {
   paneId: PaneId;
 }
@@ -134,6 +141,7 @@ export function Pane({ paneId }: PaneProps) {
   const splitFocusedPane = useAppStore((s) => s.splitFocusedPane);
   const closePane = useAppStore((s) => s.closePane);
   const sessionsById = useAppStore(selectSessionsById);
+  const shortcuts = useSettings((s) => s.settings.shortcuts);
   const [paneMenu, setPaneMenu] = useState<{ x: number; y: number } | null>(
     null,
   );
@@ -485,6 +493,7 @@ export function Pane({ paneId }: PaneProps) {
           onSplit: splitFocusedPane,
           onClose: () => closePane(paneId),
           activeProjectFallback: useAppStore.getState().activeProject,
+          shortcuts,
         })}
       />
     </div>
@@ -807,6 +816,7 @@ function TabItem({
   const editorCommand = useSettings(
     (s) => s.settings.editor.command,
   );
+  const shortcuts = useSettings((s) => s.settings.shortcuts);
   const editorConfigured = editorCommand.trim().length > 0;
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [editing, setEditing] = useState(false);
@@ -925,21 +935,21 @@ function TabItem({
     {
       label: paneT(t, "pane.menu.splitRight"),
       icon: <SplitSquareHorizontal size={12} />,
-      shortcut: formatHotkey(Hotkeys.splitVertical),
+      shortcut: shortcutLabel(shortcuts, "splitVertical"),
       onClick: () => onSplitTab("horizontal"),
       disabled: siblingCount <= 1,
     },
     {
       label: paneT(t, "pane.menu.splitDown"),
       icon: <SplitSquareVertical size={12} />,
-      shortcut: formatHotkey(Hotkeys.splitHorizontal),
+      shortcut: shortcutLabel(shortcuts, "splitHorizontal"),
       onClick: () => onSplitTab("vertical"),
       disabled: siblingCount <= 1,
     },
     {
       label: paneT(t, "pane.menu.equalizePaneSizes"),
       icon: <Columns2 size={12} />,
-      shortcut: formatHotkey(Hotkeys.equalizePanes),
+      shortcut: shortcutLabel(shortcuts, "equalizePanes"),
       onClick: () => {
         window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
       },
@@ -1007,7 +1017,7 @@ function TabItem({
     {
       label: paneT(t, "pane.menu.close"),
       icon: <X size={12} />,
-      shortcut: formatHotkey(Hotkeys.closeTab),
+      shortcut: shortcutLabel(shortcuts, "closeTab"),
       onClick: onClose,
     },
     {
@@ -1253,6 +1263,7 @@ function buildPaneMenuItems({
   onSplit,
   onClose,
   activeProjectFallback,
+  shortcuts,
 }: {
   t: Translator;
   activeSession: Session | null;
@@ -1262,6 +1273,7 @@ function buildPaneMenuItems({
   onSplit: (direction: Direction) => void;
   onClose: () => void;
   activeProjectFallback: string | null;
+  shortcuts: Record<HotkeyId, string>;
 }): ContextMenuItem[] {
   const editorReady = hasConfiguredEditor();
   const worktreeItems: ContextMenuItem[] = activeSession
@@ -1309,7 +1321,7 @@ function buildPaneMenuItems({
     {
       label: paneT(t, "pane.menu.newSessionInThisPane"),
       icon: <TerminalIcon size={12} />,
-      shortcut: formatHotkey(Hotkeys.newSession),
+      shortcut: shortcutLabel(shortcuts, "newSession"),
       onClick: onNewTab,
       disabled: !activeSession && activeProjectFallback === null,
     },
@@ -1317,19 +1329,19 @@ function buildPaneMenuItems({
     {
       label: paneT(t, "pane.menu.splitRight"),
       icon: <SplitSquareHorizontal size={12} />,
-      shortcut: formatHotkey(Hotkeys.splitVertical),
+      shortcut: shortcutLabel(shortcuts, "splitVertical"),
       onClick: () => onSplit("horizontal"),
     },
     {
       label: paneT(t, "pane.menu.splitDown"),
       icon: <SplitSquareVertical size={12} />,
-      shortcut: formatHotkey(Hotkeys.splitHorizontal),
+      shortcut: shortcutLabel(shortcuts, "splitHorizontal"),
       onClick: () => onSplit("vertical"),
     },
     {
       label: paneT(t, "pane.menu.equalizePaneSizes"),
       icon: <Columns2 size={12} />,
-      shortcut: formatHotkey(Hotkeys.equalizePanes),
+      shortcut: shortcutLabel(shortcuts, "equalizePanes"),
       onClick: () => {
         window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
       },
@@ -1340,7 +1352,7 @@ function buildPaneMenuItems({
     {
       label: paneT(t, "pane.menu.closePane"),
       icon: <X size={12} />,
-      shortcut: formatHotkey(Hotkeys.closeEmptyPane),
+      shortcut: shortcutLabel(shortcuts, "closeEmptyPane"),
       onClick: onClose,
       disabled: totalPanes <= 1,
     },

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -445,7 +445,7 @@ describe("SettingsModal font controls", () => {
     expect(document.body.textContent).toContain("언어");
   });
 
-  it("renders shortcut hints with the edit-coming-soon notice", async () => {
+  it("renders shortcut hints with editing controls", async () => {
     await act(async () => {
       root = createRoot(container);
       root.render(<SettingsModal />);
@@ -457,11 +457,82 @@ describe("SettingsModal font controls", () => {
 
     const bodyText = document.body.textContent ?? "";
 
-    expect(bodyText).toContain("Shortcut editing is coming soon.");
+    expect(bodyText).toContain("Reset all shortcuts");
     expect(bodyText).toContain("Open command palette");
     expect(bodyText).toContain("New control session");
     expect(bodyText).toContain("Right panel");
+    expect(bodyText).toContain("Record");
     expect(bodyText).toMatch(/⌘P|Ctrl\+P/);
+  });
+
+  it("records and resets a shortcut binding", async () => {
+    const originalPlatform = navigator.platform;
+    Object.defineProperty(navigator, "platform", {
+      value: "MacIntel",
+      configurable: true,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openShortcutsTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const record = Array.from(document.querySelectorAll("button")).find(
+      (element) =>
+        element.getAttribute("aria-label") ===
+        "Record shortcut for Open command palette",
+    );
+    expect(record).toBeInstanceOf(HTMLButtonElement);
+
+    await act(async () => {
+      record?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(document.body.textContent).toContain("Press keys");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "O",
+          code: "KeyO",
+          metaKey: true,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(useSettings.getState().settings.shortcuts.openPalette).toBe(
+      "$mod+Shift+o",
+    );
+    expect(document.body.textContent).toContain("⇧⌘O");
+
+    const reset = Array.from(document.querySelectorAll("button")).find(
+      (element) =>
+        element.getAttribute("aria-label") ===
+        "Reset shortcut for Open command palette",
+    );
+    expect(reset).toBeInstanceOf(HTMLButtonElement);
+
+    await act(async () => {
+      reset?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(useSettings.getState().settings.shortcuts.openPalette).toBe(
+      "$mod+p",
+    );
+
+    Object.defineProperty(navigator, "platform", {
+      value: originalPlatform,
+      configurable: true,
+    });
   });
 
   it("patches the worktree auto-delete session toggle", async () => {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -8,6 +8,7 @@ import {
   Settings as SettingsIcon,
   Sparkles,
   Trash2,
+  X,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../lib/api";
@@ -18,7 +19,15 @@ import {
 } from "../lib/background";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
-import { formatHotkey, Hotkeys, type HotkeyId } from "../lib/hotkeys";
+import {
+  DEFAULT_HOTKEYS,
+  formatHotkey,
+  hotkeyBindingsFor,
+  recordHotkeyFromEvent,
+  setShortcutRecordingActive,
+  type HotkeyConfig,
+  type HotkeyId,
+} from "../lib/hotkeys";
 import {
   LANGUAGE_OPTIONS,
   type Language,
@@ -272,6 +281,30 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
     ],
   },
 ];
+
+function shortcutLabel(t: SettingsTranslator, id: HotkeyId): string {
+  for (const group of SHORTCUT_GROUPS) {
+    const item = group.items.find((candidate) => candidate.id === id);
+    if (item) return st(t, item.labelKey);
+  }
+  return id;
+}
+
+function findShortcutConflict(
+  shortcuts: HotkeyConfig,
+  currentId: HotkeyId,
+  binding: string,
+): HotkeyId | null {
+  for (const group of SHORTCUT_GROUPS) {
+    for (const item of group.items) {
+      if (item.id === currentId) continue;
+      if (hotkeyBindingsFor(shortcuts, item.id).includes(binding)) {
+        return item.id;
+      }
+    }
+  }
+  return null;
+}
 
 function st(t: SettingsTranslator, key: TranslationKey): string {
   return t(key);
@@ -2219,14 +2252,88 @@ function ExperimentsSettings() {
 }
 
 function ShortcutsSettings() {
+  const shortcuts = useSettings((s) => s.settings.shortcuts);
+  const patchShortcut = useSettings((s) => s.patchShortcut);
+  const resetShortcut = useSettings((s) => s.resetShortcut);
+  const resetShortcuts = useSettings((s) => s.resetShortcuts);
+  const [recordingId, setRecordingId] = useState<HotkeyId | null>(null);
+  const [recordingError, setRecordingError] = useState<string | null>(null);
   const t = useTranslation();
+
+  useEffect(() => {
+    setShortcutRecordingActive(recordingId !== null);
+    return () => setShortcutRecordingActive(false);
+  }, [recordingId]);
+
+  const stopRecording = useCallback(() => {
+    setShortcutRecordingActive(false);
+    setRecordingId(null);
+    setRecordingError(null);
+  }, []);
+
+  const startRecording = useCallback((id: HotkeyId) => {
+    setShortcutRecordingActive(true);
+    setRecordingId(id);
+    setRecordingError(null);
+  }, []);
+
+  useEffect(() => {
+    if (recordingId === null) return;
+
+    const handler = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+
+      const binding = recordHotkeyFromEvent(event);
+      if (!binding) {
+        setRecordingError(st(t, "settings.shortcuts.errors.modifierOnly"));
+        return;
+      }
+
+      const conflictId = findShortcutConflict(shortcuts, recordingId, binding);
+      if (conflictId) {
+        setRecordingError(
+          stf(t, "settings.shortcuts.errors.conflict", {
+            shortcut: formatHotkey(binding),
+            command: shortcutLabel(t, conflictId),
+          }),
+        );
+        return;
+      }
+
+      patchShortcut(recordingId, binding);
+      stopRecording();
+    };
+
+    window.addEventListener("keydown", handler, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", handler, { capture: true });
+  }, [patchShortcut, recordingId, shortcuts, stopRecording, t]);
 
   return (
     <section className="space-y-4">
-      <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] leading-snug text-fg-muted">
-        <Sparkles size={11} className="mr-1 inline align-text-bottom text-warning" />
-        {st(t, "settings.shortcuts.editingSoon")}
+      <div className="flex items-center justify-end">
+        <button
+          type="button"
+          onClick={() => {
+            resetShortcuts();
+            stopRecording();
+          }}
+          className="inline-flex h-7 items-center gap-1.5 rounded border border-border bg-bg px-2 text-[11px] text-fg-muted transition hover:border-accent/60 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          <RefreshCcw size={11} />
+          {st(t, "settings.shortcuts.resetAll")}
+        </button>
       </div>
+      {recordingError ? (
+        <div
+          role="alert"
+          className="rounded-md border border-danger/30 bg-danger/10 px-3 py-2 text-[11px] leading-snug text-danger"
+        >
+          {recordingError}
+        </div>
+      ) : null}
       <div className="space-y-3">
         {SHORTCUT_GROUPS.map((group) => (
           <section
@@ -2241,7 +2348,10 @@ function ShortcutsSettings() {
               {group.items.map((item) => (
                 <div
                   key={item.id}
-                  className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2"
+                  className={cn(
+                    "grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2",
+                    recordingId === item.id ? "bg-accent/10" : null,
+                  )}
                 >
                   <div className="min-w-0">
                     <div className="text-xs font-medium text-fg">
@@ -2253,9 +2363,64 @@ function ShortcutsSettings() {
                       </div>
                     ) : null}
                   </div>
-                  <kbd className="rounded border border-border bg-bg-elevated px-1.5 py-0.5 font-mono text-[11px] leading-5 text-fg">
-                    {formatHotkey(Hotkeys[item.id])}
-                  </kbd>
+                  <div className="flex items-center gap-1.5">
+                    <kbd className="min-w-16 rounded border border-border bg-bg-elevated px-1.5 py-0.5 text-center font-mono text-[11px] leading-5 text-fg">
+                      {recordingId === item.id
+                        ? st(t, "settings.shortcuts.recording")
+                        : formatHotkey(shortcuts[item.id])}
+                    </kbd>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        recordingId === item.id
+                          ? stopRecording()
+                          : startRecording(item.id)
+                      }
+                      aria-label={stf(
+                        t,
+                        recordingId === item.id
+                          ? "settings.shortcuts.cancelRecording"
+                          : "settings.shortcuts.recordShortcut",
+                        { command: shortcutLabel(t, item.id) },
+                      )}
+                      title={stf(
+                        t,
+                        recordingId === item.id
+                          ? "settings.shortcuts.cancelRecording"
+                          : "settings.shortcuts.recordShortcut",
+                        { command: shortcutLabel(t, item.id) },
+                      )}
+                      className={cn(
+                        "inline-flex h-7 w-[4.75rem] items-center justify-center gap-1 rounded border text-[11px] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+                        recordingId === item.id
+                          ? "border-danger/50 bg-danger/10 text-danger hover:bg-danger/15"
+                          : "border-border bg-bg text-fg-muted hover:border-accent/60 hover:text-fg",
+                      )}
+                    >
+                      {recordingId === item.id ? (
+                        <X size={11} />
+                      ) : (
+                        <Keyboard size={11} />
+                      )}
+                      {recordingId === item.id
+                        ? st(t, "settings.shortcuts.cancel")
+                        : st(t, "settings.shortcuts.record")}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => resetShortcut(item.id)}
+                      disabled={shortcuts[item.id] === DEFAULT_HOTKEYS[item.id]}
+                      aria-label={stf(t, "settings.shortcuts.resetShortcut", {
+                        command: shortcutLabel(t, item.id),
+                      })}
+                      title={stf(t, "settings.shortcuts.resetShortcut", {
+                        command: shortcutLabel(t, item.id),
+                      })}
+                      className="inline-flex h-7 w-7 items-center justify-center rounded border border-border bg-bg text-fg-muted transition hover:border-accent/60 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-default disabled:opacity-40 disabled:hover:border-border disabled:hover:text-fg-muted"
+                    >
+                      <RefreshCcw size={11} />
+                    </button>
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -48,7 +48,7 @@ import {
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
 import type { TranslationKey, Translator } from "../lib/i18n";
-import { formatHotkey, Hotkeys } from "../lib/hotkeys";
+import { formatHotkey, type HotkeyId } from "../lib/hotkeys";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import {
   useSettings,
@@ -110,6 +110,13 @@ type SidebarTranslationKey = Extract<TranslationKey, `sidebar.${string}`>;
 
 function sidebarText(t: Translator, key: SidebarTranslationKey): string {
   return t(key);
+}
+
+function shortcutLabel(
+  shortcuts: Record<HotkeyId, string>,
+  id: HotkeyId,
+): string {
+  return formatHotkey(shortcuts[id]);
 }
 
 function statusLabel(t: Translator, status: SessionStatus): string {
@@ -1026,6 +1033,7 @@ function SessionRow({
   const renameSession = useAppStore((s) => s.renameSession);
   const editorCommand = useSettings((s) => s.settings.editor.command);
   const editorConfigured = editorCommand.trim().length > 0;
+  const shortcuts = useSettings((s) => s.settings.shortcuts);
   const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
   const showAgentProviderIcons = sessionDisplay.icons.agentProvider;
   const titleText = resolveSessionTitle(session, sessionDisplay.title);
@@ -1127,7 +1135,7 @@ function SessionRow({
     {
       label: sidebarText(t, "sidebar.actions.equalizePaneSizes"),
       icon: <Columns2 size={12} />,
-      shortcut: formatHotkey(Hotkeys.equalizePanes),
+      shortcut: shortcutLabel(shortcuts, "equalizePanes"),
       onClick: () => {
         window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
       },

--- a/src/lib/hotkeys.test.ts
+++ b/src/lib/hotkeys.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  DEFAULT_HOTKEYS,
   formatHotkey,
+  recordHotkeyFromEvent,
+  resolveHotkeys,
   shouldUseTinykeysToggleMultiInputFallback,
 } from "./hotkeys";
 
@@ -84,5 +87,107 @@ describe("formatHotkey", () => {
       expect(formatHotkey("$mod+Alt+KeyT")).toBe("Ctrl+Alt+T");
       expect(formatHotkey("$mod+Digit3")).toBe("Ctrl+3");
     });
+  });
+});
+
+describe("recordHotkeyFromEvent", () => {
+  const originalPlatform = navigator.platform;
+
+  function setPlatform(value: string) {
+    Object.defineProperty(navigator, "platform", {
+      value,
+      configurable: true,
+    });
+  }
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  it("records the platform primary modifier as $mod", () => {
+    setPlatform("MacIntel");
+
+    const binding = recordHotkeyFromEvent(
+      new KeyboardEvent("keydown", {
+        key: "p",
+        code: "KeyP",
+        metaKey: true,
+      }),
+    );
+
+    expect(binding).toBe("$mod+p");
+  });
+
+  it("uses code tokens for Alt-modified letters", () => {
+    setPlatform("MacIntel");
+
+    const binding = recordHotkeyFromEvent(
+      new KeyboardEvent("keydown", {
+        key: "†",
+        code: "KeyT",
+        metaKey: true,
+        altKey: true,
+      }),
+    );
+
+    expect(binding).toBe("$mod+Alt+KeyT");
+  });
+
+  it("ignores modifier-only events", () => {
+    setPlatform("Win32");
+
+    expect(
+      recordHotkeyFromEvent(
+        new KeyboardEvent("keydown", {
+          key: "Shift",
+          code: "ShiftLeft",
+          shiftKey: true,
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("resolveHotkeys", () => {
+  it("merges custom bindings with defaults", () => {
+    expect(resolveHotkeys({ openPalette: "$mod+Shift+o" })).toMatchObject({
+      ...DEFAULT_HOTKEYS,
+      openPalette: "$mod+Shift+o",
+    });
+  });
+
+  it("falls back when a persisted binding is invalid", () => {
+    expect(resolveHotkeys({ openPalette: "Shift" }).openPalette).toBe(
+      DEFAULT_HOTKEYS.openPalette,
+    );
+  });
+
+  it("drops persisted bindings that collide with another command", () => {
+    const hotkeys = resolveHotkeys({
+      openPalette: DEFAULT_HOTKEYS.newSession,
+    });
+
+    expect(hotkeys.openPalette).toBe(DEFAULT_HOTKEYS.openPalette);
+    expect(hotkeys.newSession).toBe(DEFAULT_HOTKEYS.newSession);
+  });
+
+  it("allows a default binding after its owning command is customized", () => {
+    const hotkeys = resolveHotkeys({
+      openPalette: DEFAULT_HOTKEYS.newSession,
+      newSession: "$mod+Alt+KeyU",
+    });
+
+    expect(hotkeys.openPalette).toBe(DEFAULT_HOTKEYS.newSession);
+    expect(hotkeys.newSession).toBe("$mod+Alt+KeyU");
+  });
+
+  it("drops duplicate custom bindings from persisted settings", () => {
+    const hotkeys = resolveHotkeys({
+      openPalette: "$mod+Alt+KeyU",
+      newSession: "$mod+Alt+KeyU",
+    });
+
+    expect(hotkeys.openPalette).toBe(DEFAULT_HOTKEYS.openPalette);
+    expect(hotkeys.newSession).toBe(DEFAULT_HOTKEYS.newSession);
   });
 });

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -23,10 +23,10 @@ type Tinykeys = (
 const tinykeys = tinykeysRaw as Tinykeys;
 
 /**
- * Named keybinding constants used across the app. `$mod` resolves to
+ * Named keybinding defaults used across the app. `$mod` resolves to
  * the platform-appropriate primary modifier (Cmd on macOS, Ctrl elsewhere).
  */
-export const Hotkeys = {
+export const DEFAULT_HOTKEYS = {
   openPalette: "$mod+p",
   clearTerminal: "$mod+k",
   newSession: "$mod+t",
@@ -51,9 +51,7 @@ export const Hotkeys = {
   togglePrs: "$mod+Shift+p",
   toggleFiles: "$mod+Shift+e",
   uiScaleDown: "$mod+-",
-  uiScaleDownShift: "$mod+Shift+Minus",
   uiScaleUp: "$mod+=",
-  uiScaleUpShift: "$mod+Shift+Equal",
   uiScaleReset: "$mod+0",
   toggleMultiInput: "$mod+Alt+KeyI",
   focusPaneLeft: "$mod+Alt+ArrowLeft",
@@ -79,7 +77,21 @@ export const Hotkeys = {
   prevProject: "Control+Alt+Shift+Tab",
 } as const;
 
-export type HotkeyId = keyof typeof Hotkeys;
+export type HotkeyId = keyof typeof DEFAULT_HOTKEYS;
+export type HotkeyConfig = Record<HotkeyId, string>;
+
+export const HOTKEY_IDS = Object.keys(DEFAULT_HOTKEYS) as HotkeyId[];
+
+const HOTKEY_ALIASES: Partial<Record<HotkeyId, string[]>> = {
+  uiScaleDown: ["$mod+Shift+Minus"],
+  uiScaleUp: ["$mod+Shift+Equal"],
+};
+
+export const Hotkeys = {
+  ...DEFAULT_HOTKEYS,
+  uiScaleDownShift: "$mod+Shift+Minus",
+  uiScaleUpShift: "$mod+Shift+Equal",
+} as const;
 
 export type HotkeyHandler = (event: KeyboardEvent) => void;
 
@@ -96,6 +108,81 @@ const MODIFIER_TOKENS = new Set([
   "Option",
   "Shift",
 ]);
+
+const MODIFIER_ALIASES: Record<string, string> = {
+  $mod: "$mod",
+  Meta: "Meta",
+  Cmd: "$mod",
+  Command: "$mod",
+  Control: "Control",
+  Ctrl: "Control",
+  Alt: "Alt",
+  Option: "Alt",
+  Shift: "Shift",
+};
+
+const BINDING_MODIFIER_ORDER = ["$mod", "Control", "Alt", "Shift", "Meta"];
+
+const NAMED_KEY_TOKENS = new Set([
+  "Enter",
+  "Return",
+  "Escape",
+  "Esc",
+  "Backspace",
+  "Delete",
+  "Tab",
+  "Space",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Minus",
+  "Equal",
+  "Comma",
+  "Period",
+  "Slash",
+  "Backslash",
+  "Semicolon",
+  "Quote",
+  "BracketLeft",
+  "BracketRight",
+  "Backquote",
+]);
+
+const EVENT_CODE_KEY_TOKENS: Record<string, string> = {
+  Enter: "Enter",
+  Return: "Return",
+  Escape: "Escape",
+  Backspace: "Backspace",
+  Delete: "Delete",
+  Tab: "Tab",
+  Space: "Space",
+  ArrowLeft: "ArrowLeft",
+  ArrowRight: "ArrowRight",
+  ArrowUp: "ArrowUp",
+  ArrowDown: "ArrowDown",
+  Minus: "Minus",
+  Equal: "Equal",
+  Comma: "Comma",
+  Period: "Period",
+  Slash: "Slash",
+  Backslash: "Backslash",
+  Semicolon: "Semicolon",
+  Quote: "Quote",
+  BracketLeft: "BracketLeft",
+  BracketRight: "BracketRight",
+  Backquote: "Backquote",
+};
+
+const MODIFIER_EVENT_KEYS = new Set([
+  "Shift",
+  "Control",
+  "Alt",
+  "Meta",
+  "OS",
+]);
+
+let shortcutRecordingActive = false;
 
 type TauriRuntimeWindow = Window & { __TAURI_INTERNALS__?: unknown };
 
@@ -115,6 +202,175 @@ function isMacPlatform(): boolean {
     typeof navigator !== "undefined" &&
     /Mac|iP(hone|od|ad)/.test(navigator.platform)
   );
+}
+
+function normalizeModifierToken(token: string): string | null {
+  return MODIFIER_ALIASES[token] ?? null;
+}
+
+function normalizeKeyToken(token: string): string | null {
+  if (/^[a-zA-Z]$/.test(token)) return token.toLowerCase();
+  if (/^[0-9]$/.test(token)) return token;
+  const keyMatch = /^Key([A-Z])$/.exec(token);
+  if (keyMatch) return token;
+  const digitMatch = /^Digit([0-9])$/.exec(token);
+  if (digitMatch) return token;
+  if (/^F([1-9]|1[0-9]|2[0-4])$/.test(token)) return token;
+  if (NAMED_KEY_TOKENS.has(token)) {
+    if (token === "Esc") return "Escape";
+    if (token === "Return") return "Enter";
+    return token;
+  }
+  if (token === " ") return "Space";
+  return null;
+}
+
+function canonicalizeHotkeyBinding(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || /\s/.test(trimmed)) return null;
+
+  const rawParts = trimmed.split("+");
+  if (rawParts.length === 0 || rawParts.some((part) => part.trim() === "")) {
+    return null;
+  }
+
+  const key = normalizeKeyToken(rawParts[rawParts.length - 1].trim());
+  if (!key || normalizeModifierToken(key)) return null;
+
+  const modifiers = new Set<string>();
+  for (const rawPart of rawParts.slice(0, -1)) {
+    const modifier = normalizeModifierToken(rawPart.trim());
+    if (!modifier || modifiers.has(modifier)) return null;
+    modifiers.add(modifier);
+  }
+
+  const orderedModifiers = BINDING_MODIFIER_ORDER.filter((modifier) =>
+    modifiers.has(modifier),
+  );
+  return [...orderedModifiers, key].join("+");
+}
+
+export function normalizeHotkeyBinding(
+  value: unknown,
+  fallback: string,
+): string {
+  return canonicalizeHotkeyBinding(value) ?? fallback;
+}
+
+export function resolveHotkeys(
+  value?: Partial<Record<HotkeyId, unknown>> | null,
+): HotkeyConfig {
+  const custom = new Map<HotkeyId, string>();
+  const defaultOwnerByBinding = new Map<string, HotkeyId>();
+
+  for (const id of HOTKEY_IDS) {
+    defaultOwnerByBinding.set(DEFAULT_HOTKEYS[id], id);
+  }
+
+  for (const id of HOTKEY_IDS) {
+    const candidate = canonicalizeHotkeyBinding(value?.[id]);
+    if (candidate && candidate !== DEFAULT_HOTKEYS[id]) {
+      custom.set(id, candidate);
+    }
+  }
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+
+    const duplicateBindings = new Set<string>();
+    const seenBindings = new Set<string>();
+    for (const binding of custom.values()) {
+      if (seenBindings.has(binding)) {
+        duplicateBindings.add(binding);
+      } else {
+        seenBindings.add(binding);
+      }
+    }
+
+    if (duplicateBindings.size > 0) {
+      for (const [id, binding] of custom) {
+        if (duplicateBindings.has(binding)) {
+          custom.delete(id);
+          changed = true;
+        }
+      }
+    }
+
+    for (const [id, binding] of custom) {
+      const defaultOwner = defaultOwnerByBinding.get(binding);
+      if (defaultOwner && defaultOwner !== id && !custom.has(defaultOwner)) {
+        custom.delete(id);
+        changed = true;
+      }
+    }
+  }
+
+  const resolved = { ...DEFAULT_HOTKEYS } as HotkeyConfig;
+  for (const [id, binding] of custom) {
+    resolved[id] = binding;
+  }
+
+  return resolved;
+}
+
+export function hotkeyBindingsFor(
+  hotkeys: HotkeyConfig,
+  id: HotkeyId,
+): string[] {
+  const bindings = [hotkeys[id]];
+  if (hotkeys[id] === DEFAULT_HOTKEYS[id]) {
+    bindings.push(...(HOTKEY_ALIASES[id] ?? []));
+  }
+  return Array.from(new Set(bindings));
+}
+
+function keyTokenFromEvent(event: KeyboardEvent): string | null {
+  if (
+    event.isComposing ||
+    MODIFIER_EVENT_KEYS.has(event.key) ||
+    event.key === "Dead"
+  ) {
+    return null;
+  }
+
+  if (/^Key[A-Z]$/.test(event.code)) {
+    if (event.altKey || !/^[a-zA-Z]$/.test(event.key)) return event.code;
+    return event.key.toLowerCase();
+  }
+  if (/^Digit[0-9]$/.test(event.code)) {
+    if (event.altKey || !/^[0-9]$/.test(event.key)) return event.code;
+    return event.key;
+  }
+  if (EVENT_CODE_KEY_TOKENS[event.code]) {
+    return EVENT_CODE_KEY_TOKENS[event.code];
+  }
+  if (/^F([1-9]|1[0-9]|2[0-4])$/.test(event.key)) return event.key;
+  if (event.key === " ") return "Space";
+  return normalizeKeyToken(event.key);
+}
+
+export function recordHotkeyFromEvent(event: KeyboardEvent): string | null {
+  const key = keyTokenFromEvent(event);
+  if (!key) return null;
+
+  const mac = isMacPlatform();
+  const modifiers: string[] = [];
+  if (event.metaKey) modifiers.push(mac ? "$mod" : "Meta");
+  if (event.ctrlKey) modifiers.push(mac ? "Control" : "$mod");
+  if (event.altKey) modifiers.push("Alt");
+  if (event.shiftKey) modifiers.push("Shift");
+
+  return canonicalizeHotkeyBinding([...modifiers, key].join("+"));
+}
+
+export function setShortcutRecordingActive(active: boolean): void {
+  shortcutRecordingActive = active;
+}
+
+export function isShortcutRecordingActive(): boolean {
+  return shortcutRecordingActive;
 }
 
 const MAC_KEY_SYMBOL: Record<string, string> = {
@@ -143,6 +399,13 @@ const MAC_KEY_SYMBOL: Record<string, string> = {
   Equal: "=",
   Comma: ",",
   Period: ".",
+  Slash: "/",
+  Backslash: "\\",
+  Semicolon: ";",
+  Quote: "'",
+  BracketLeft: "[",
+  BracketRight: "]",
+  Backquote: "`",
 };
 
 const NON_MAC_KEY_LABEL: Record<string, string> = {
@@ -166,6 +429,13 @@ const NON_MAC_KEY_LABEL: Record<string, string> = {
   Equal: "=",
   Comma: ",",
   Period: ".",
+  Slash: "/",
+  Backslash: "\\",
+  Semicolon: ";",
+  Quote: "'",
+  BracketLeft: "[",
+  BracketRight: "]",
+  Backquote: "`",
   ArrowLeft: "←",
   ArrowRight: "→",
   ArrowUp: "↑",
@@ -214,12 +484,25 @@ function stopPropagationAfterHandling(
     Object.entries(bindings).map(([binding, handler]) => [
       binding,
       (event: KeyboardEvent) => {
+        if (isShortcutRecordingActive()) return;
         handler(event);
         // App-level shortcuts that handled the key must own it before focused
         // surfaces like xterm also interpret the same chord.
         if (event.defaultPrevented) {
           event.stopImmediatePropagation();
         }
+      },
+    ]),
+  );
+}
+
+function skipWhileRecording(bindings: HotkeyBindings): HotkeyBindings {
+  return Object.fromEntries(
+    Object.entries(bindings).map(([binding, handler]) => [
+      binding,
+      (event: KeyboardEvent) => {
+        if (isShortcutRecordingActive()) return;
+        handler(event);
       },
     ]),
   );
@@ -273,7 +556,7 @@ export function useHotkeys(bindings: HotkeyBindings): void {
       );
     }
     if (Object.keys(bubbleBindings).length > 0) {
-      unsubscribes.push(tinykeys(window, bubbleBindings));
+      unsubscribes.push(tinykeys(window, skipWhileRecording(bubbleBindings)));
     }
 
     return () => {

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -9,6 +9,7 @@ import {
   resolveSessionTitlePrompt,
   SESSION_TITLE_PROMPT_MAX_CHARS,
 } from "./settings";
+import { DEFAULT_HOTKEYS } from "./hotkeys";
 
 describe("language settings", () => {
   const STORAGE_KEY = "acorn:settings:v1";
@@ -216,6 +217,64 @@ describe("status bar settings", () => {
 
     expect(useSettings.getState().settings.statusBar.showAgentTokenUsage).toBe(
       true,
+    );
+  });
+});
+
+describe("shortcut settings", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("loads persisted shortcut overrides", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ shortcuts: { openPalette: "$mod+Shift+o" } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.shortcuts.openPalette).toBe(
+      "$mod+Shift+o",
+    );
+    expect(useSettings.getState().settings.shortcuts.newSession).toBe(
+      DEFAULT_HOTKEYS.newSession,
+    );
+  });
+
+  it("patches and resets a shortcut", async () => {
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    useSettings.getState().patchShortcut("openPalette", "$mod+Shift+o");
+    expect(useSettings.getState().settings.shortcuts.openPalette).toBe(
+      "$mod+Shift+o",
+    );
+
+    useSettings.getState().resetShortcut("openPalette");
+    expect(useSettings.getState().settings.shortcuts.openPalette).toBe(
+      DEFAULT_HOTKEYS.openPalette,
     );
   });
 });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -5,6 +5,12 @@ import {
   sanitizeFontFamilyName,
   type CuratedMonospaceFont,
 } from "./fonts";
+import {
+  DEFAULT_HOTKEYS,
+  resolveHotkeys,
+  type HotkeyConfig,
+  type HotkeyId,
+} from "./hotkeys";
 import { isLanguage, type Language } from "./i18n";
 
 const STORAGE_KEY = "acorn:settings:v1";
@@ -344,6 +350,7 @@ export interface AcornSettings {
     uiScalePercent: number;
     toastPosition: ToastPosition;
   };
+  shortcuts: HotkeyConfig;
   /**
    * Opt-in toggles for unfinished features. Anything under here is
    * unstable on purpose — the contract is "we keep the toggle, the
@@ -463,6 +470,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     uiScalePercent: 100,
     toastPosition: "top",
   },
+  shortcuts: { ...DEFAULT_HOTKEYS },
   experiments: {
     stickyPrompt: false,
     cjkCellWidthHeuristic: false,
@@ -876,6 +884,9 @@ function loadSettings(): AcornSettings {
             : DEFAULT_SETTINGS.sessionDisplay.showDetailsOnHover,
       },
       appearance,
+      shortcuts: resolveHotkeys(
+        (parsed.shortcuts ?? {}) as Partial<Record<HotkeyId, unknown>>,
+      ),
       experiments: {
         ...DEFAULT_SETTINGS.experiments,
         ...(parsed.experiments ?? {}),
@@ -956,6 +967,9 @@ interface SettingsState {
       fontSlots?: AcornSettings["appearance"]["fontSlots"];
     },
   ) => void;
+  patchShortcut: (id: HotkeyId, binding: string) => void;
+  resetShortcut: (id: HotkeyId) => void;
+  resetShortcuts: () => void;
   patchExperiments: (patch: Partial<AcornSettings["experiments"]>) => void;
   patchLanguage: (language: Language) => void;
   reset: () => void;
@@ -1111,6 +1125,41 @@ export const useSettings = create<SettingsState>((set, get) => ({
       const next: AcornSettings = {
         ...s.settings,
         appearance,
+      };
+      persist(next);
+      return { settings: next };
+    }),
+  patchShortcut: (id, binding) =>
+    set((s) => {
+      const shortcuts = resolveHotkeys({
+        ...s.settings.shortcuts,
+        [id]: binding,
+      });
+      const next: AcornSettings = {
+        ...s.settings,
+        shortcuts,
+      };
+      persist(next);
+      return { settings: next };
+    }),
+  resetShortcut: (id) =>
+    set((s) => {
+      const shortcuts = resolveHotkeys({
+        ...s.settings.shortcuts,
+        [id]: DEFAULT_HOTKEYS[id],
+      });
+      const next: AcornSettings = {
+        ...s.settings,
+        shortcuts,
+      };
+      persist(next);
+      return { settings: next };
+    }),
+  resetShortcuts: () =>
+    set((s) => {
+      const next: AcornSettings = {
+        ...s.settings,
+        shortcuts: { ...DEFAULT_HOTKEYS },
       };
       persist(next);
       return { settings: next };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -340,7 +340,17 @@
       "permissionHint": "macOS may ask once for permission the first time a notification fires."
     },
     "shortcuts": {
-      "editingSoon": "Shortcut editing is coming soon.",
+      "record": "Record",
+      "cancel": "Cancel",
+      "recording": "Press keys",
+      "recordShortcut": "Record shortcut for {command}",
+      "cancelRecording": "Cancel recording for {command}",
+      "resetShortcut": "Reset shortcut for {command}",
+      "resetAll": "Reset all shortcuts",
+      "errors": {
+        "modifierOnly": "Press a non-modifier key.",
+        "conflict": "{shortcut} is already used by {command}."
+      },
       "groups": {
         "general": "General",
         "navigation": "Navigation",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -340,7 +340,17 @@
       "permissionHint": "처음 알림이 발생할 때 macOS가 한 번 권한을 요청할 수 있습니다."
     },
     "shortcuts": {
-      "editingSoon": "단축키 편집 기능은 준비 중이다.",
+      "record": "기록",
+      "cancel": "취소",
+      "recording": "키 입력 중",
+      "recordShortcut": "{command} 단축키 기록",
+      "cancelRecording": "{command} 단축키 기록 취소",
+      "resetShortcut": "{command} 단축키 초기화",
+      "resetAll": "모든 단축키 초기화",
+      "errors": {
+        "modifierOnly": "수정 키가 아닌 키를 누르세요.",
+        "conflict": "{shortcut} 단축키는 이미 {command}에 사용 중입니다."
+      },
       "groups": {
         "general": "일반",
         "navigation": "이동",

--- a/tests/e2e/settings-tabs.spec.ts
+++ b/tests/e2e/settings-tabs.spec.ts
@@ -86,6 +86,14 @@ const TAB_MARKERS: Array<{
     },
   },
   {
+    tab: /^(Shortcuts|단축키)$/,
+    label: "Shortcuts",
+    marker: {
+      kind: "text",
+      pattern: /Reset all shortcuts|모든 단축키 초기화/i,
+    },
+  },
+  {
     tab: /^(Storage|저장 공간)$/,
     label: "Storage",
     marker: {
@@ -142,6 +150,7 @@ test.describe("settings modal: tab content", () => {
       "GitHub",
       "편집기",
       "알림",
+      "단축키",
       "저장 공간",
       "실험 기능",
       "정보",

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -32,4 +32,43 @@ test.describe("settings modal", () => {
     await modal.getByRole("button", { name: /close/i }).first().click();
     await expect(modal).toHaveCount(0);
   });
+
+  test("records a custom shortcut and reset all restores defaults", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "," });
+
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
+    await modal.getByRole("button", { name: /^(Shortcuts|단축키)$/ }).click();
+
+    await modal
+      .getByRole("button", {
+        name: "Record shortcut for Increase UI scale",
+      })
+      .click();
+    await expect(modal.getByText("Press keys")).toBeVisible();
+
+    await pressHotkey(page, { mod: true, alt: true, key: "u" });
+    await expect(modal.getByText(/⌥⌘U|Ctrl\+Alt\+U/)).toBeVisible();
+
+    await modal.getByRole("button", { name: /close/i }).first().click();
+    await expect(modal).toHaveCount(0);
+
+    await pressHotkey(page, { mod: true, alt: true, key: "u" });
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          document.documentElement.style.getPropertyValue("--acorn-ui-scale"),
+        ),
+      )
+      .toBe("1.05");
+
+    await pressHotkey(page, { mod: true, key: "," });
+    await modal.getByRole("button", { name: /^(Shortcuts|단축키)$/ }).click();
+    await modal
+      .getByRole("button", { name: "Reset all shortcuts" })
+      .click();
+    await expect(modal.getByText(/⌘=|Ctrl\+=/).first()).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
This completes Settings -> Shortcuts editing so users can record and reset custom keyboard shortcuts.

1. **Shortcut persistence** — add normalized shortcut settings with per-shortcut and full reset actions.
2. **Recording UI** — replace the placeholder Shortcuts tab with record/cancel/reset controls, conflict handling, and localized labels.
3. **Runtime bindings** — route app hotkeys and context-menu hints through saved settings while preserving default UI-scale aliases.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Settings -> Shortcuts | Static read-only list | Record custom bindings, reset one, or reset all |
| App hotkeys | Hardcoded defaults | Saved bindings apply to global shortcuts and visible hints |
| Invalid persisted data | Could be accepted as-is | Invalid or conflicting values fall back to defaults |

## Design notes
- Recording is captured at window level and temporarily suppresses global hotkeys so the chord being recorded does not trigger the app command underneath it.
- `recordHotkeyFromEvent` stores `$mod` for the platform-primary modifier and uses `KeyboardEvent.code` for Alt-modified letter/digit chords so macOS Option dead keys remain recordable.
- Default UI-scale Shift aliases remain available only while their primary binding is still default; once customized, the old alias is not kept active.
- Tauri native menu accelerators for Settings and multi-input still act as platform menu shortcuts; custom webview bindings are added on top of those native defaults.

## Test plan
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec vitest run src/lib/hotkeys.test.ts src/lib/hotkeys.react.test.tsx src/lib/settings.test.ts src/components/SettingsModal.test.tsx` — 4 files, 75 tests passed
- [x] `PLAYWRIGHT_PORT=1421 pnpm exec playwright test tests/e2e/settings.spec.ts tests/e2e/settings-tabs.spec.ts` — 5 tests passed against this worktree's Vite server on 1421 because local port 1420 was already occupied by another Acorn worktree
- [x] `pnpm run build` — passed; Vite reports pre-existing dynamic-import and large-chunk warnings

## Notes
- The initial local E2E run reused an existing dev server from a different Acorn worktree on port 1420 and served the old Shortcuts placeholder UI. Rerunning against this worktree's own Vite server on 1421 passed.
