### PR TITLE
feat(terminal): navigate conversation prompts with mod arrows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,10 @@ import {
   shouldUseTinykeysToggleMultiInputFallback,
   useHotkeys,
 } from "./lib/hotkeys";
+import {
+  TERMINAL_CONVERSATION_NAV_EVENT,
+  type ConversationNavigationDirection,
+} from "./lib/terminalConversation";
 import { hasRecordedWorktree } from "./lib/sessionWorktree";
 import {
   EQUALIZE_PANES_EVENT,
@@ -140,6 +144,19 @@ function focusPaneTerminal(paneId: string) {
     (pane?.querySelector(".xterm-helper-textarea") as HTMLElement | null) ??
     (pane?.querySelector(FOCUSABLE_SELECTOR) as HTMLElement | null);
   target?.focus();
+}
+
+function dispatchFocusedTerminalConversationNav(
+  direction: ConversationNavigationDirection,
+): boolean {
+  const sessionId = findFocusedSessionId();
+  if (!sessionId) return false;
+  const event = new CustomEvent(TERMINAL_CONVERSATION_NAV_EVENT, {
+    cancelable: true,
+    detail: { direction, sessionId },
+  });
+  window.dispatchEvent(event);
+  return event.defaultPrevented;
 }
 
 function focusAdjacentPane(direction: "left" | "right" | "up" | "down") {
@@ -1198,6 +1215,16 @@ function App() {
             detail: { sessionId },
           }),
         );
+      },
+      [Hotkeys.previousConversation]: (e: KeyboardEvent) => {
+        if (dispatchFocusedTerminalConversationNav("previous")) {
+          e.preventDefault();
+        }
+      },
+      [Hotkeys.nextConversation]: (e: KeyboardEvent) => {
+        if (dispatchFocusedTerminalConversationNav("next")) {
+          e.preventDefault();
+        }
       },
       [Hotkeys.toggleTodos]: (e: KeyboardEvent) => {
         e.preventDefault();

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -245,6 +245,14 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
         labelKey: "settings.shortcuts.items.clearTerminal.label",
       },
       {
+        id: "previousConversation",
+        labelKey: "settings.shortcuts.items.previousConversation.label",
+      },
+      {
+        id: "nextConversation",
+        labelKey: "settings.shortcuts.items.nextConversation.label",
+      },
+      {
         id: "toggleMultiInput",
         labelKey: "settings.shortcuts.items.toggleMultiInput.label",
       },

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState, type ReactElement } from "react";
 import {
   Terminal as XTerm,
-  type IBuffer,
   type IDisposable,
   type ITheme,
   type IViewportRange,
@@ -30,6 +29,12 @@ import {
   createTerminalRepaintScheduler,
   repaintTerminalViewport,
 } from "../lib/terminalRepaint";
+import {
+  findConversationPromptTarget,
+  scanForContextPrompt,
+  TERMINAL_CONVERSATION_NAV_EVENT,
+  type ConversationNavigationDirection,
+} from "../lib/terminalConversation";
 import { patchTerminalMouseCoordinateScale } from "../lib/terminalMouseScale";
 import { UI_SCALE_CHANGED_EVENT } from "../lib/layoutEvents";
 import {
@@ -155,96 +160,6 @@ interface ContextPromptDetail {
   sessionId: string;
   /** Prompt text to pin, or `null` to revert to JSONL-latest. */
   prompt: string | null;
-}
-
-// Markers Claude TUI uses to introduce a user turn. v2.1.x renders `›`
-// (U+203A); older versions used `>`; `❯` shows up in some shell-prompt
-// theming. Matching any of these lets the scroll-aware banner cope with
-// claude version churn without code changes.
-const PROMPT_MARKER_RE = /^[›>❯]\s+/u;
-// Lines that look like the *start* of an assistant turn or another
-// claude UI element — used to bound the continuation walk so a long
-// stream of assistant output doesn't get spliced into the pinned prompt.
-const TURN_BOUNDARY_RE = /^[●○*✱⏺·]\s/u;
-const BOX_DRAWING_RE = /^[\s│╭╮╰╯─┃┏┓┗┛━]+/u;
-
-/**
- * Walk xterm buffer rows upwards from `startY` to find the nearest
- * user-prompt marker line, then walk down to collect the rest of the
- * prompt body (continuation rows are either xterm wrap-continuations
- * or indented rows beneath the marker). The result is the full prompt
- * text the user typed, joined with `\n` between hard-wrapped rows so
- * the banner's `whitespace-pre-wrap` styling preserves line breaks.
- *
- * Returns `null` when no prompt line is reachable above the start row —
- * e.g. user scrolled past the top of scrollback, or the buffer contains
- * raw shell output rather than a claude conversation.
- */
-function scanForContextPrompt(buf: IBuffer, startY: number): string | null {
-  // Max walk distance. Bounded so a terminal with a massive scrollback
-  // (claude conversations easily push tens of thousands of rows) doesn't
-  // freeze the UI on every scroll event. 5000 rows ≈ the default xterm
-  // scrollback limit (`scrollback: 5000` in this file).
-  const MAX_WALK = 5000;
-  const MAX_CONTINUATION = 200;
-  const limit = Math.max(0, startY - MAX_WALK);
-  for (let y = startY; y >= limit; y--) {
-    const line = buf.getLine(y);
-    if (!line) continue;
-    const raw = line.translateToString(true);
-    const stripped = raw.replace(BOX_DRAWING_RE, "");
-    const match = stripped.match(PROMPT_MARKER_RE);
-    if (!match) continue;
-    const headBody = stripped
-      .slice(match[0].length)
-      .replace(/\s*[│┃]?\s*$/u, "")
-      .trim();
-    if (headBody.length === 0) continue;
-    const parts: string[] = [headBody];
-    for (let yy = y + 1; yy <= y + MAX_CONTINUATION; yy++) {
-      const cont = buf.getLine(yy);
-      if (!cont) break;
-      const contRaw = cont.translateToString(true);
-      // Use the raw line (not the box-stripped form) to detect "blank-ish"
-      // continuation gutters that still belong to the same turn.
-      const trimmedTail = contRaw.replace(/\s+$/u, "");
-      const contStripped = trimmedTail.replace(BOX_DRAWING_RE, "");
-      // Hit the next prompt marker → previous user turn ended.
-      if (PROMPT_MARKER_RE.test(contStripped)) break;
-      // Hit an assistant or other turn-class marker.
-      if (TURN_BOUNDARY_RE.test(contStripped)) break;
-      // An xterm wrap-continuation row is unambiguously the same logical
-      // line, so always accept it.
-      if (cont.isWrapped) {
-        const wrapBody = contStripped.replace(/\s*[│┃]?\s*$/u, "");
-        if (wrapBody.length > 0) parts.push(wrapBody);
-        continue;
-      }
-      // Hard-wrapped continuation rows in claude's TUI keep a leading
-      // indent (so the body lines up under the `> ` marker). Accept
-      // rows whose first non-whitespace column matches the marker's,
-      // and bail on anything that looks like a new gutter / divider.
-      if (trimmedTail.length === 0) {
-        // Single blank row inside a long pasted prompt is part of the
-        // same turn (the user pressed Enter twice). Treat as line
-        // break, keep collecting.
-        parts.push("");
-        continue;
-      }
-      if (/^\s{2,}/u.test(contRaw) && contStripped.length > 0) {
-        parts.push(contStripped.replace(/\s*[│┃]?\s*$/u, ""));
-        continue;
-      }
-      break;
-    }
-    // Strip trailing blank-string entries the loop may have collected
-    // before hitting the boundary.
-    while (parts.length > 0 && parts[parts.length - 1] === "") {
-      parts.pop();
-    }
-    return parts.join("\n");
-  }
-  return null;
 }
 
 // macOS uses Cmd (metaKey); other platforms use Ctrl. Matches the
@@ -1074,6 +989,33 @@ export function Terminal({
       }
       term.focus();
     };
+    const scrollToBufferLine = (line: number) => {
+      const buffer = term.buffer.active;
+      const target = Math.max(0, Math.min(line, buffer.baseY));
+      try {
+        term.scrollToLine(target);
+        setIsScrolledBack(target < buffer.baseY);
+        term.focus();
+        return true;
+      } catch {
+        return false;
+      }
+    };
+    const scrollToConversationPrompt = (
+      direction: ConversationNavigationDirection,
+    ) => {
+      const buffer = term.buffer.active;
+      if (buffer.type !== "normal") return false;
+      const target = findConversationPromptTarget(buffer, direction);
+      if (target) {
+        return scrollToBufferLine(target.markerRow);
+      }
+      if (direction === "next" && buffer.viewportY < buffer.baseY) {
+        scrollToLiveTail();
+        return true;
+      }
+      return false;
+    };
     const syncScrolledBackState = () => {
       setIsScrolledBack(
         isTerminalScrolledBack(term) ||
@@ -1573,7 +1515,10 @@ export function Terminal({
       const enabled =
         useSettings.getState().settings.experiments.stickyPrompt;
       const next = enabled
-        ? scanForContextPrompt(term.buffer.active, term.buffer.active.viewportY)
+        ? scanForContextPrompt(
+            term.buffer.active,
+            term.buffer.active.viewportY,
+          )?.prompt ?? null
         : null;
       if (next === lastDispatchedContext) return;
       lastDispatchedContext = next;
@@ -1607,6 +1552,24 @@ export function Terminal({
         scheduleContextDispatch();
       }
     });
+
+    const onConversationNavRequested = (e: Event) => {
+      const detail = (
+        e as CustomEvent<{
+          direction: ConversationNavigationDirection;
+          sessionId: string;
+        }>
+      ).detail;
+      if (!detail || detail.sessionId !== sessionId) return;
+      if (!scrollToConversationPrompt(detail.direction)) return;
+      e.preventDefault();
+      scheduleContextDispatch();
+      syncScrolledBackState();
+    };
+    window.addEventListener(
+      TERMINAL_CONVERSATION_NAV_EVENT,
+      onConversationNavRequested,
+    );
 
     // Custom event hook so a global hotkey (Cmd+K) can clear THIS terminal
     // without needing a cross-component ref registry. The dispatcher passes
@@ -2138,6 +2101,10 @@ export function Terminal({
       scrollbackStateDisposable.dispose();
       viewportElement?.removeEventListener("scroll", syncScrolledBackState);
       unsubStickyToggle();
+      window.removeEventListener(
+        TERMINAL_CONVERSATION_NAV_EVENT,
+        onConversationNavRequested,
+      );
       resizeDisposable.dispose();
       if (liveCwdProbeTimer !== null) {
         window.clearTimeout(liveCwdProbeTimer);

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -55,6 +55,8 @@ export const Hotkeys = {
   uiScaleUp: "$mod+=",
   uiScaleUpShift: "$mod+Shift+Equal",
   uiScaleReset: "$mod+0",
+  previousConversation: "$mod+ArrowLeft",
+  nextConversation: "$mod+ArrowRight",
   toggleMultiInput: "$mod+Alt+KeyI",
   focusPaneLeft: "$mod+Alt+ArrowLeft",
   focusPaneRight: "$mod+Alt+ArrowRight",

--- a/src/lib/terminalConversation.test.ts
+++ b/src/lib/terminalConversation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  findConversationPromptTarget,
+  scanForContextPrompt,
+  type TerminalBufferLike,
+} from "./terminalConversation";
+
+type LineInput = string | { text: string; wrapped?: boolean };
+
+function makeBuffer(lines: LineInput[], viewportY = 0): TerminalBufferLike {
+  return {
+    baseY: Math.max(0, lines.length - 24),
+    length: lines.length,
+    viewportY,
+    getLine(index) {
+      const input = lines[index];
+      if (input === undefined) return undefined;
+      const text = typeof input === "string" ? input : input.text;
+      const isWrapped = typeof input === "string" ? false : !!input.wrapped;
+      return {
+        isWrapped,
+        translateToString: () => text,
+      };
+    },
+  };
+}
+
+describe("terminal conversation prompt scanning", () => {
+  it("scans upward for the prompt currently in viewport context", () => {
+    const buf = makeBuffer([
+      "shell output",
+      "› first prompt",
+      "  pasted continuation",
+      "● assistant reply",
+      "› second prompt",
+      { text: "wrapped continuation", wrapped: true },
+      "plain reply text",
+    ]);
+
+    expect(scanForContextPrompt(buf, 6)).toEqual({
+      markerRow: 4,
+      prompt: "second prompt\nwrapped continuation",
+    });
+  });
+
+  it("finds previous and next prompt anchors relative to viewport top", () => {
+    const buf = makeBuffer(
+      [
+        "intro",
+        "› first prompt",
+        "first answer",
+        "› second prompt",
+        "second answer",
+        "› third prompt",
+        "third answer",
+      ],
+      5,
+    );
+
+    expect(findConversationPromptTarget(buf, "previous")).toEqual({
+      markerRow: 3,
+      prompt: "second prompt",
+    });
+    expect(findConversationPromptTarget(buf, "next")).toBeNull();
+    expect(findConversationPromptTarget(buf, "previous", 7)).toEqual({
+      markerRow: 5,
+      prompt: "third prompt",
+    });
+    expect(findConversationPromptTarget(buf, "next", 3)).toEqual({
+      markerRow: 5,
+      prompt: "third prompt",
+    });
+  });
+
+  it("treats a prompt at the top as the current anchor", () => {
+    const buf = makeBuffer([
+      "› first prompt",
+      "first answer",
+      "› second prompt",
+      "second answer",
+    ]);
+
+    expect(findConversationPromptTarget(buf, "previous", 2)).toEqual({
+      markerRow: 0,
+      prompt: "first prompt",
+    });
+    expect(findConversationPromptTarget(buf, "next", 2)).toBeNull();
+  });
+});

--- a/src/lib/terminalConversation.ts
+++ b/src/lib/terminalConversation.ts
@@ -1,0 +1,118 @@
+export type ConversationNavigationDirection = "previous" | "next";
+
+export const TERMINAL_CONVERSATION_NAV_EVENT =
+  "acorn:terminal-conversation-nav";
+
+export interface TerminalBufferLineLike {
+  isWrapped: boolean;
+  translateToString(trimRight?: boolean): string;
+}
+
+export interface TerminalBufferLike {
+  baseY: number;
+  length: number;
+  viewportY: number;
+  getLine(index: number): TerminalBufferLineLike | undefined;
+}
+
+export interface ContextPrompt {
+  markerRow: number;
+  prompt: string;
+}
+
+// Markers Claude TUI uses to introduce a user turn. v2.1.x renders `›`
+// (U+203A); older versions used `>`; `❯` shows up in some shell-prompt
+// theming. Matching any of these lets prompt navigation cope with
+// claude version churn without code changes.
+const PROMPT_MARKER_RE = /^[›>❯]\s+/u;
+const TURN_BOUNDARY_RE = /^[●○*✱⏺·]\s/u;
+const BOX_DRAWING_RE = /^[\s│╭╮╰╯─┃┏┓┗┛━]+/u;
+const MAX_CONTEXT_WALK = 5000;
+const MAX_NAVIGATION_WALK = 5000;
+const MAX_CONTINUATION = 200;
+
+function promptAtRow(buf: TerminalBufferLike, y: number): ContextPrompt | null {
+  const line = buf.getLine(y);
+  if (!line) return null;
+  const raw = line.translateToString(true);
+  const stripped = raw.replace(BOX_DRAWING_RE, "");
+  const match = stripped.match(PROMPT_MARKER_RE);
+  if (!match) return null;
+  const headBody = stripped
+    .slice(match[0].length)
+    .replace(/\s*[│┃]?\s*$/u, "")
+    .trim();
+  if (headBody.length === 0) return null;
+  const parts: string[] = [headBody];
+  for (let yy = y + 1; yy <= y + MAX_CONTINUATION; yy++) {
+    const cont = buf.getLine(yy);
+    if (!cont) break;
+    const contRaw = cont.translateToString(true);
+    const trimmedTail = contRaw.replace(/\s+$/u, "");
+    const contStripped = trimmedTail.replace(BOX_DRAWING_RE, "");
+    if (PROMPT_MARKER_RE.test(contStripped)) break;
+    if (TURN_BOUNDARY_RE.test(contStripped)) break;
+    if (cont.isWrapped) {
+      const wrapBody = contStripped.replace(/\s*[│┃]?\s*$/u, "");
+      if (wrapBody.length > 0) parts.push(wrapBody);
+      continue;
+    }
+    if (trimmedTail.length === 0) {
+      parts.push("");
+      continue;
+    }
+    if (/^\s{2,}/u.test(contRaw) && contStripped.length > 0) {
+      parts.push(contStripped.replace(/\s*[│┃]?\s*$/u, ""));
+      continue;
+    }
+    break;
+  }
+  while (parts.length > 0 && parts[parts.length - 1] === "") {
+    parts.pop();
+  }
+  return { markerRow: y, prompt: parts.join("\n") };
+}
+
+/**
+ * Walk xterm buffer rows upwards from `startY` to find the nearest
+ * user-prompt marker, then collect continuation rows that belong to it.
+ */
+export function scanForContextPrompt(
+  buf: TerminalBufferLike,
+  startY: number,
+): ContextPrompt | null {
+  const from = Math.min(Math.max(0, Math.floor(startY)), buf.length - 1);
+  const limit = Math.max(0, from - MAX_CONTEXT_WALK);
+  for (let y = from; y >= limit; y--) {
+    const prompt = promptAtRow(buf, y);
+    if (prompt) return prompt;
+  }
+  return null;
+}
+
+/**
+ * Finds the prompt marker that should anchor previous/next conversation
+ * navigation relative to the current viewport's top buffer row.
+ */
+export function findConversationPromptTarget(
+  buf: TerminalBufferLike,
+  direction: ConversationNavigationDirection,
+  fromY = buf.viewportY,
+): ContextPrompt | null {
+  const from = Math.min(Math.max(0, Math.floor(fromY)), buf.length - 1);
+  if (direction === "previous") {
+    const limit = Math.max(0, from - MAX_NAVIGATION_WALK);
+    for (let y = from - 1; y >= limit; y--) {
+      const prompt = promptAtRow(buf, y);
+      if (prompt) return prompt;
+    }
+    return null;
+  }
+
+  const limit = Math.min(buf.length - 1, from + MAX_NAVIGATION_WALK);
+  for (let y = from + 1; y <= limit; y++) {
+    const prompt = promptAtRow(buf, y);
+    if (prompt) return prompt;
+  }
+  return null;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -429,6 +429,12 @@
         "clearTerminal": {
           "label": "Clear terminal"
         },
+        "previousConversation": {
+          "label": "Previous conversation"
+        },
+        "nextConversation": {
+          "label": "Next conversation"
+        },
         "toggleMultiInput": {
           "label": "Toggle multi-input"
         },

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -429,6 +429,12 @@
         "clearTerminal": {
           "label": "터미널 지우기"
         },
+        "previousConversation": {
+          "label": "이전 대화로 이동"
+        },
+        "nextConversation": {
+          "label": "다음 대화로 이동"
+        },
         "toggleMultiInput": {
           "label": "다중 입력 켜기/끄기"
         },

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "./support";
+import { test, expect, pressHotkey, type Page } from "./support";
 import type { TauriMock } from "./support";
 
 // Tauri handler callbacks run in the page context and must not close over
@@ -1129,6 +1129,87 @@ test.describe("terminal: spawn", () => {
         { timeout: 1_000 },
       )
       .toBeGreaterThanOrEqual(1);
+  });
+
+  test("Cmd+Left and Cmd+Right move through terminal conversation prompts", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __conversationNavChannelId?: number;
+        [key: string]: unknown;
+      };
+      w.__conversationNavChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __conversationNavChannelId?: number })
+              .__conversationNavChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const lines: string[] = [];
+    for (let i = 0; i < 10; i++) lines.push(`intro ${i}`);
+    lines.push("> first prompt");
+    for (let i = 0; i < 18; i++) lines.push(`first answer ${i}`);
+    lines.push("> second prompt");
+    for (let i = 0; i < 18; i++) lines.push(`second answer ${i}`);
+    lines.push("> third prompt");
+    for (let i = 0; i < 36; i++) lines.push(`tail ${i}`);
+    await emitSubscribedPtyOutput(
+      page,
+      "__conversationNavChannelId",
+      lines.join("\r\n") + "\r\n",
+    );
+    await expect(page.locator(".xterm-rows")).toContainText("tail 35");
+
+    await page.locator(".xterm-helper-textarea").focus();
+    await pressHotkey(page, { mod: true, key: "ArrowLeft" });
+    await expect(page.locator(".xterm-rows")).toContainText("third prompt");
+
+    await pressHotkey(page, { mod: true, key: "ArrowLeft" });
+    await expect(page.locator(".xterm-rows")).toContainText("second prompt");
+
+    await pressHotkey(page, { mod: true, key: "ArrowRight" });
+    await expect(page.locator(".xterm-rows")).toContainText("third prompt");
+
+    await pressHotkey(page, { mod: true, key: "ArrowRight" });
+    await expect(page.locator(".xterm-rows")).toContainText("tail 35");
   });
 
   test("global modifier shortcuts are claimed before terminal key listeners", async ({


### PR DESCRIPTION
## Summary
Adds keyboard navigation between prompt anchors in terminal scrollback.

1. **Conversation prompt scanner** - extracts sticky-prompt buffer scanning into `src/lib/terminalConversation.ts` and adds previous/next prompt target lookup.
2. **Terminal shortcut routing** - wires `$mod+ArrowLeft` / `$mod+ArrowRight` through a cancellable `acorn:terminal-conversation-nav` event so focused xterms scroll to adjacent prompt anchors, while existing line start/end fallback remains when no prompt target is handled.
3. **Shortcut docs and coverage** - adds shortcut labels plus Vitest and Playwright coverage for prompt navigation and the existing Cmd+Arrow fallback path.

## Expected impact
| Area | Impact |
| --- | --- |
| Terminal navigation | Users can jump between Claude-style prompt turns in scrollback with Cmd/Ctrl+Left and Cmd/Ctrl+Right. |
| Existing terminal input | If no conversation prompt target is available, the existing Cmd+Arrow start/end-line behavior continues. |

## Design notes
- Reuses the same prompt marker heuristics as the pinned prompt overlay (`›`, `>`, `❯`) and keeps scans bounded to the configured scrollback scale.
- App-level hotkeys dispatch a cancellable custom event to the focused terminal; the original key event is prevented only when a terminal actually handles conversation navigation.
- `Cmd+Right` from the latest prompt returns to the live tail when there is no newer prompt target.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm exec vitest run src/lib/hotkeys.test.ts src/lib/hotkeys.react.test.tsx src/lib/terminalConversation.test.ts` passes
- [x] `pnpm exec playwright test tests/e2e/terminal-ime.spec.ts -g "Cmd\\+Arrow"` passes
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts` passes

## Notes
- `pnpm tauri dev` was launched briefly under `ACORN_PROFILE=dev` for manual smoke startup and then stopped before merge work.