### PR TITLE
feat(theme): add high contrast light palette

### DIFF
--- a/src/assets/themes/high-contrast-light.css
+++ b/src/assets/themes/high-contrast-light.css
@@ -1,0 +1,35 @@
+/* @mode light */
+:root[data-acorn-theme="high-contrast-light"] {
+  --color-bg: #ffffff;
+  --color-bg-elevated: #f2f4f7;
+  --color-bg-sidebar: #e8edf3;
+  --color-fg: #05070a;
+  --color-fg-muted: #394150;
+  --color-border: #5c6675;
+  --color-accent: #004ecc;
+  --color-accent-hover: #003a99;
+  --color-danger: #b00020;
+  --color-warning: #7a4d00;
+  --color-terminal-bg: #ffffff;
+  --color-terminal-fg: #05070a;
+  --color-term-selection: rgba(0, 78, 204, 0.26);
+  --color-term-scrollbar: rgba(0, 0, 0, 0.22);
+  --color-term-scrollbar-hover: rgba(0, 0, 0, 0.34);
+  --color-term-scrollbar-active: rgba(0, 0, 0, 0.46);
+  --color-term-black: #05070a;
+  --color-term-red: #b00020;
+  --color-term-green: #006b2f;
+  --color-term-yellow: #7a4d00;
+  --color-term-blue: #004ecc;
+  --color-term-magenta: #6a1bb1;
+  --color-term-cyan: #006d75;
+  --color-term-white: #4a5361;
+  --color-term-bright-black: #2f3744;
+  --color-term-bright-red: #870018;
+  --color-term-bright-green: #005021;
+  --color-term-bright-yellow: #5c3900;
+  --color-term-bright-blue: #003a99;
+  --color-term-bright-magenta: #4f1488;
+  --color-term-bright-cyan: #00525a;
+  --color-term-bright-white: #111827;
+}

--- a/src/lib/themes.test.ts
+++ b/src/lib/themes.test.ts
@@ -33,19 +33,20 @@ describe("BUILT_IN_THEMES", () => {
       "ayu-dark",
       "acorn-light",
       "github-light",
+      "high-contrast-light",
       "flexoki-light",
       "solarized-light",
       "catppuccin-latte",
       "one-light",
       "gruvbox-light",
     ]);
-    expect(BUILT_IN_THEMES).toHaveLength(23);
+    expect(BUILT_IN_THEMES).toHaveLength(24);
     expect(BUILT_IN_THEMES.filter((theme) => theme.mode === "dark")).toHaveLength(
       16,
     );
     expect(
       BUILT_IN_THEMES.filter((theme) => theme.mode === "light"),
-    ).toHaveLength(7);
+    ).toHaveLength(8);
   });
 
   it("every built-in css passes validation", () => {

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -17,6 +17,7 @@ import githubLightCss from "../assets/themes/github-light.css?raw";
 import gruvboxDarkCss from "../assets/themes/gruvbox-dark.css?raw";
 import gruvboxLightCss from "../assets/themes/gruvbox-light.css?raw";
 import highContrastDarkCss from "../assets/themes/high-contrast-dark.css?raw";
+import highContrastLightCss from "../assets/themes/high-contrast-light.css?raw";
 import kanagawaWaveCss from "../assets/themes/kanagawa-wave.css?raw";
 import monokaiProCss from "../assets/themes/monokai-pro.css?raw";
 import nordCss from "../assets/themes/nord.css?raw";
@@ -177,6 +178,13 @@ export const BUILT_IN_THEMES: ReadonlyArray<AcornTheme> = [
     label: "GitHub Light",
     mode: "light",
     css: githubLightCss,
+    source: "builtin",
+  },
+  {
+    id: "high-contrast-light",
+    label: "High Contrast Light",
+    mode: "light",
+    css: highContrastLightCss,
     source: "builtin",
   },
   {


### PR DESCRIPTION
## Summary
Adds a user-visible high contrast light theme to the built-in theme picker.

1. **High Contrast Light palette** — adds a new built-in CSS theme with strong foreground, border, accent, danger, warning, and surface contrast for light-mode users.
2. **Terminal contrast coverage** — defines terminal selection, scrollbar, and ANSI color overrides so shell and agent output stay readable on the white terminal background.
3. **Theme registry coverage** — registers the theme in `BUILT_IN_THEMES` and updates the built-in theme test expectations.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Theme picker | High contrast option only existed for dark mode | Light-mode users can choose `High Contrast Light` |
| Terminal readability | Light themes inherited the generic light terminal palette unless overridden | New high contrast light theme ships explicit ANSI and scrollbar colors |

## Design notes
- The theme follows the existing built-in theme shape: one CSS asset, a raw CSS import, and one `BUILT_IN_THEMES` entry.
- No settings migration is needed because the existing theme picker stores arbitrary theme ids and already falls back safely when ids are missing.
- Syntax highlighting continues to use the existing light-mode high contrast Shiki theme through `resolveThemeMode`.

## Test plan
- [x] `pnpm run test -- src/lib/themes.test.ts src/lib/terminalTheme.test.ts` — 53 files passed, 487 tests passed, 1 skipped
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed; Vite emitted existing dynamic/static import and chunk-size warnings

## Notes
- `pnpm install` was run because this worktree initially had no `node_modules`; the lockfile was already up to date and no package files changed.