### PR TITLE
fix(workspace): replace native tab drag with pointer sessions

### DIFF
--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -34,8 +34,12 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
 
 import { Pane } from "./Pane";
 import { useAppStore } from "../store";
-import { endAcornDrag, getCurrentTabPayload } from "../lib/dnd";
+import { endAcornDrag } from "../lib/dnd";
 import { defaultTabByGroup } from "../lib/rightPanelGroups";
+import {
+  cancelWorkspaceTabDrag,
+  getWorkspaceTabDragSession,
+} from "../lib/workspaceTabDrag";
 
 const REPO = "/Users/me/repo";
 const HOME = "/Users/me";
@@ -172,29 +176,19 @@ function seedActivePaneWithTabs(tabs: Session[], activeTabId: string): void {
   }));
 }
 
-function makeDataTransfer(): DataTransfer {
-  return {
-    dropEffect: "none",
-    effectAllowed: "all",
-    setData: vi.fn(),
-    getData: vi.fn(() => ""),
-    clearData: vi.fn(),
-    files: [] as unknown as FileList,
-    items: [] as unknown as DataTransferItemList,
-    types: [],
-    setDragImage: vi.fn(),
-  };
-}
-
-function dispatchDragStart(target: Element, dataTransfer: DataTransfer): Event {
-  const event = new Event("dragstart", { bubbles: true, cancelable: true });
-  Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
-  target.dispatchEvent(event);
-  return event;
-}
-
-function dispatchDragEnd(target: Element): Event {
-  const event = new Event("dragend", { bubbles: true, cancelable: true });
+function dispatchPointer(
+  target: Element,
+  type: "pointerdown" | "pointermove" | "pointerup" | "pointercancel",
+  init: { clientX: number; clientY: number; button?: number; pointerId?: number },
+): Event {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    button: init.button ?? 0,
+    clientX: init.clientX,
+    clientY: init.clientY,
+  });
+  Object.defineProperty(event, "pointerId", { value: init.pointerId ?? 1 });
   target.dispatchEvent(event);
   return event;
 }
@@ -206,6 +200,7 @@ describe("Pane empty state", () => {
   beforeEach(() => {
     resetStore();
     endAcornDrag();
+    cancelWorkspaceTabDrag();
     vi.clearAllMocks();
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -216,6 +211,7 @@ describe("Pane empty state", () => {
     act(() => root.unmount());
     container.remove();
     endAcornDrag();
+    cancelWorkspaceTabDrag();
   });
 
   it("opens a terminal when Space is pressed twice while an empty pane is focused", async () => {
@@ -469,7 +465,7 @@ describe("Pane empty state", () => {
     expect(useAppStore.getState().focusedPaneId).toBe("pane-2");
   });
 
-  it("starts tab drag from active tab chrome outside the inner handle", () => {
+  it("starts tab drag from active tab chrome after pointer movement", () => {
     const active = session("active-session");
     seedActivePaneWithTab(active);
 
@@ -482,37 +478,92 @@ describe("Pane empty state", () => {
     );
     const tab = dragHandle?.closest('[role="button"]');
     expect(tab).toBeInstanceOf(HTMLElement);
-    expect((tab as HTMLElement).getAttribute("draggable")).toBe("true");
 
-    const dataTransfer = makeDataTransfer();
     act(() => {
-      dispatchDragStart(tab!, dataTransfer);
+      dispatchPointer(tab!, "pointerdown", { clientX: 32, clientY: 12 });
+      dispatchPointer(window as unknown as Element, "pointermove", {
+        clientX: 48,
+        clientY: 12,
+      });
     });
 
-    expect(dataTransfer.setDragImage).toHaveBeenCalled();
-    expect(getCurrentTabPayload()).toMatchObject({
-      kind: "tab",
+    expect(getWorkspaceTabDragSession()?.payload).toMatchObject({
       tabId: active.id,
       fromPaneId: "root",
     });
   });
 
-  it("clears a tab drag payload when the source drag ends", () => {
+  it("keeps small pointer movement on the click path selecting the tab", () => {
     const first = session("first-session");
     const second = session("second-session");
     seedActivePaneWithTabs([first, second], first.id);
-    const addWindowListener = window.addEventListener.bind(window);
-    const addWindowListenerSpy = vi
-      .spyOn(window, "addEventListener")
-      .mockImplementation((type, listener, options) => {
-        if (type === "dragend" || type === "drop") return;
-        addWindowListener(type, listener, options);
-      });
 
     act(() => {
       root.render(<Pane paneId="root" />);
     });
-    addWindowListenerSpy.mockRestore();
+
+    const secondTab = container
+      .querySelector(`[data-tab-drag-handle="${second.id}"]`)
+      ?.closest('[role="button"]');
+    expect(secondTab).toBeInstanceOf(HTMLElement);
+
+    act(() => {
+      dispatchPointer(secondTab!, "pointerdown", { clientX: 32, clientY: 12 });
+      dispatchPointer(window as unknown as Element, "pointermove", {
+        clientX: 34,
+        clientY: 12,
+      });
+      dispatchPointer(window as unknown as Element, "pointerup", {
+        clientX: 34,
+        clientY: 12,
+      });
+      secondTab!.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(getWorkspaceTabDragSession()).toBeNull();
+    expect(useAppStore.getState().activeTabId).toBe(second.id);
+  });
+
+  it("starts tab drag from the title text area without native draggable", () => {
+    const active = session("active-session");
+    seedActivePaneWithTab(active);
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+
+    const dragHandle = container.querySelector(
+      `[data-tab-drag-handle="${active.id}"]`,
+    );
+    const tab = dragHandle?.closest('[role="button"]');
+    expect(tab).toBeInstanceOf(HTMLElement);
+    expect((tab as HTMLElement).hasAttribute("draggable")).toBe(false);
+    expect((dragHandle as HTMLElement).hasAttribute("draggable")).toBe(false);
+
+    act(() => {
+      dispatchPointer(tab!, "pointerdown", { clientX: 32, clientY: 12 });
+      dispatchPointer(window as unknown as Element, "pointermove", {
+        clientX: 44,
+        clientY: 12,
+      });
+    });
+
+    expect(getWorkspaceTabDragSession()?.payload).toMatchObject({
+      tabId: active.id,
+      fromPaneId: "root",
+    });
+  });
+
+  it("clears a tab drag payload when the source pointer ends", () => {
+    const first = session("first-session");
+    const second = session("second-session");
+    seedActivePaneWithTabs([first, second], first.id);
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
 
     const firstTab = container
       .querySelector(`[data-tab-drag-handle="${first.id}"]`)
@@ -524,22 +575,33 @@ describe("Pane empty state", () => {
     expect(secondTab).toBeInstanceOf(HTMLElement);
 
     act(() => {
-      dispatchDragStart(firstTab!, makeDataTransfer());
+      dispatchPointer(firstTab!, "pointerdown", { clientX: 32, clientY: 12 });
+      dispatchPointer(window as unknown as Element, "pointermove", {
+        clientX: 48,
+        clientY: 12,
+      });
     });
-    expect(getCurrentTabPayload()).toMatchObject({
+    expect(getWorkspaceTabDragSession()?.payload).toMatchObject({
       tabId: first.id,
       fromPaneId: "root",
     });
 
     act(() => {
-      dispatchDragEnd(firstTab!);
+      dispatchPointer(window as unknown as Element, "pointerup", {
+        clientX: 48,
+        clientY: 12,
+      });
     });
-    expect(getCurrentTabPayload()).toBeNull();
+    expect(getWorkspaceTabDragSession()).toBeNull();
 
     act(() => {
-      dispatchDragStart(secondTab!, makeDataTransfer());
+      dispatchPointer(secondTab!, "pointerdown", { clientX: 32, clientY: 12 });
+      dispatchPointer(window as unknown as Element, "pointermove", {
+        clientX: 48,
+        clientY: 12,
+      });
     });
-    expect(getCurrentTabPayload()).toMatchObject({
+    expect(getWorkspaceTabDragSession()?.payload).toMatchObject({
       tabId: second.id,
       fromPaneId: "root",
     });
@@ -560,22 +622,14 @@ describe("Pane empty state", () => {
     expect(closeButton).toBeInstanceOf(HTMLElement);
     expect(tab).toBeInstanceOf(HTMLElement);
 
-    let dragStartDefaultPrevented = false;
     act(() => {
-      closeButton!.dispatchEvent(
-        new MouseEvent("mousedown", {
-          bubbles: true,
-          button: 0,
-          cancelable: true,
-        }),
-      );
-      dragStartDefaultPrevented = dispatchDragStart(
-        tab!,
-        makeDataTransfer(),
-      ).defaultPrevented;
+      dispatchPointer(closeButton!, "pointerdown", { clientX: 110, clientY: 12 });
+      dispatchPointer(window as unknown as Element, "pointermove", {
+        clientX: 140,
+        clientY: 12,
+      });
     });
 
-    expect(dragStartDefaultPrevented).toBe(true);
-    expect(getCurrentTabPayload()).toBeNull();
+    expect(getWorkspaceTabDragSession()).toBeNull();
   });
 });

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -10,6 +10,7 @@ import {
   GitFork,
   Pencil,
   PencilLine,
+  Sparkles,
   SplitSquareHorizontal,
   SplitSquareVertical,
   SquareX,
@@ -17,12 +18,14 @@ import {
   X,
 } from "lucide-react";
 import {
+  useCallback,
   useMemo,
   useRef,
   useState,
   useEffect,
-  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
 } from "react";
+import { createPortal } from "react-dom";
 import { openPath } from "@tauri-apps/plugin-opener";
 import { selectSessionsById, useAppStore } from "../store";
 import { CodeViewer } from "./CodeViewer";
@@ -35,14 +38,7 @@ import {
 } from "../lib/agentProvider";
 import { cn } from "../lib/cn";
 import type { TranslationKey, Translator } from "../lib/i18n";
-import {
-  beginTabDrag,
-  endAcornDrag,
-  getCurrentFilePayload,
-  getCurrentTabPayload,
-  isAcornDrag,
-  isTabDrag,
-} from "../lib/dnd";
+import { endAcornDrag, getCurrentFilePayload } from "../lib/dnd";
 import {
   hasConfiguredEditor,
   openInConfiguredEditor,
@@ -76,6 +72,15 @@ import {
   type CodeWorkspaceTab,
   type SessionWorkspaceTab,
 } from "../lib/workspaceTabs";
+import {
+  beginWorkspaceTabDrag,
+  cancelWorkspaceTabDrag,
+  finishWorkspaceTabDrag,
+  registerWorkspaceTabDropTarget,
+  updateWorkspaceTabDrag,
+  useWorkspaceTabDragSession,
+  type WorkspaceTabDragSession,
+} from "../lib/workspaceTabDrag";
 
 const STATUS_DOT: Record<SessionStatus, string> = {
   idle: "bg-fg-muted",
@@ -94,6 +99,7 @@ const STATUS_ICON: Record<SessionStatus, string> = {
 };
 
 const EMPTY_PANE_DOUBLE_SPACE_MS = 500;
+const TAB_DRAG_START_THRESHOLD_PX = 6;
 
 type PaneTranslationKey = Extract<TranslationKey, `pane.${string}`>;
 
@@ -118,8 +124,8 @@ type PaneTab =
 
 /**
  * A single workspace pane. Hosts a tab strip and a body with the active
- * session's Terminal mounted. Tabs are draggable and the body is a drop
- * target for tab drags (via {@link PaneDropOverlay}).
+ * session's Terminal mounted. Tabs use pointer-based drag and the body is a
+ * drop target for tab drags (via {@link PaneDropOverlay}).
  *
  * State (tab list, active session) lives in the global store keyed by
  * `paneId`. The pane itself only renders.
@@ -566,31 +572,24 @@ function isTabDragSuppressedTarget(target: EventTarget | null): boolean {
     : false;
 }
 
-function setTabDragImage(e: React.DragEvent<HTMLElement>): void {
-  const source = e.currentTarget;
-  const rect = source.getBoundingClientRect();
-  const clone = source.cloneNode(true) as HTMLElement;
-  clone.setAttribute("aria-hidden", "true");
-  clone.style.position = "fixed";
-  clone.style.top = "-1000px";
-  clone.style.left = "-1000px";
-  clone.style.width = `${rect.width}px`;
-  clone.style.height = `${rect.height}px`;
-  clone.style.pointerEvents = "none";
-  clone.style.zIndex = "9999";
-  clone.style.transform = "none";
-  clone.style.opacity = "0.95";
-  clone.style.boxShadow = "0 8px 20px rgba(0, 0, 0, 0.32)";
-  document.body.appendChild(clone);
+interface PointerPoint {
+  x: number;
+  y: number;
+}
 
-  const offsetX = Math.max(0, Math.min(e.clientX - rect.left, rect.width));
-  const offsetY = Math.max(0, Math.min(e.clientY - rect.top, rect.height));
-  try {
-    e.dataTransfer.setDragImage(clone, offsetX, offsetY);
-  } catch {
-    // Keep drag startup working when a webview rejects a custom drag image.
-  }
-  window.setTimeout(() => clone.remove(), 0);
+function distanceSquared(a: PointerPoint, b: PointerPoint): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return dx * dx + dy * dy;
+}
+
+function rectContainsPoint(rect: DOMRect, point: PointerPoint): boolean {
+  return (
+    point.x >= rect.left &&
+    point.x <= rect.right &&
+    point.y >= rect.top &&
+    point.y <= rect.bottom
+  );
 }
 
 interface TabStripProps {
@@ -633,8 +632,9 @@ function TabStrip({
   const [insertIndex, setInsertIndex] = useState<number | null>(null);
   const stripRef = useRef<HTMLDivElement | null>(null);
   const tabRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const tabDrag = useWorkspaceTabDragSession();
 
-  function computeInsertIndex(clientX: number): number {
+  const computeInsertIndex = useCallback((clientX: number): number => {
     let idx = tabs.length;
     for (let i = 0; i < tabs.length; i++) {
       const el = tabRefs.current.get(tabs[i].id);
@@ -646,7 +646,37 @@ function TabStrip({
       }
     }
     return idx;
-  }
+  }, [tabs]);
+
+  useEffect(() => {
+    return registerWorkspaceTabDropTarget({
+      id: `tab-strip:${paneId}`,
+      priority: 20,
+      getRect: () => stripRef.current?.getBoundingClientRect() ?? null,
+      onDrop: (payload, point) => {
+        const idx = computeInsertIndex(point.x);
+        if (payload.fromPaneId === paneId) {
+          const currentIdx = tabs.findIndex((t) => t.id === payload.tabId);
+          if (currentIdx === idx || currentIdx + 1 === idx) return;
+        }
+        onDropReorder(payload, idx);
+      },
+    });
+  }, [computeInsertIndex, onDropReorder, paneId, tabs]);
+
+  useEffect(() => {
+    if (!tabDrag) {
+      if (insertIndex !== null) setInsertIndex(null);
+      return;
+    }
+    const rect = stripRef.current?.getBoundingClientRect();
+    if (!rect || !rectContainsPoint(rect, tabDrag.pointer)) {
+      if (insertIndex !== null) setInsertIndex(null);
+      return;
+    }
+    const next = computeInsertIndex(tabDrag.pointer.x);
+    if (next !== insertIndex) setInsertIndex(next);
+  }, [computeInsertIndex, insertIndex, tabDrag]);
 
   return (
     <div
@@ -654,24 +684,21 @@ function TabStrip({
       data-pane-tab-strip={paneId}
       className="acorn-no-scrollbar relative flex h-9 shrink-0 items-stretch overflow-x-auto border-b border-border"
       onDragEnter={(e) => {
-        if (!isAcornDrag(e)) return;
+        if (!getCurrentFilePayload()) return;
         e.preventDefault();
-        setInsertIndex(computeInsertIndex(e.clientX));
       }}
       onDragOver={(e) => {
-        if (!isAcornDrag(e)) return;
+        if (!getCurrentFilePayload()) return;
         e.preventDefault();
-        e.dataTransfer.dropEffect = isTabDrag(e) ? "move" : "copy";
-        setInsertIndex(computeInsertIndex(e.clientX));
+        e.dataTransfer.dropEffect = "copy";
       }}
       onDragLeave={(e) => {
         if (e.currentTarget === e.target) setInsertIndex(null);
       }}
       onDrop={(e) => {
-        if (!isAcornDrag(e)) return;
+        if (!getCurrentFilePayload()) return;
         e.preventDefault();
         try {
-          const idx = computeInsertIndex(e.clientX);
           setInsertIndex(null);
           const filePayload = getCurrentFilePayload();
           if (filePayload) {
@@ -679,14 +706,6 @@ function TabStrip({
             useAppStore.getState().openCodeViewerTab(filePayload.path);
             return;
           }
-          const payload = getCurrentTabPayload();
-          if (!payload) return;
-          // No-op: dropping onto the same pane at the same position.
-          if (payload.fromPaneId === paneId) {
-            const currentIdx = tabs.findIndex((t) => t.id === payload.tabId);
-            if (currentIdx === idx || currentIdx + 1 === idx) return;
-          }
-          onDropReorder(payload, idx);
         } finally {
           endAcornDrag();
         }
@@ -811,6 +830,9 @@ function TabItem({
   const liveInWorktree = useAppStore((s) =>
     session ? s.liveInWorktree[session.id] : false,
   );
+  const showWorktreeIcon = session
+    ? Boolean(liveInWorktree ?? hasRecordedWorktree(session))
+    : false;
   // Subscribe to the editor command so the menu's enabled/disabled state
   // updates immediately when the user configures an editor in Settings.
   const editorCommand = useSettings(
@@ -820,7 +842,10 @@ function TabItem({
   const editorConfigured = editorCommand.trim().length > 0;
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [editing, setEditing] = useState(false);
-  const suppressNextDragStartRef = useRef(false);
+  const pendingDragCleanupRef = useRef<(() => void) | null>(null);
+  const suppressNextClickRef = useRef(false);
+  const tabDrag = useWorkspaceTabDragSession();
+  const isDraggingThisTab = tabDrag?.payload.tabId === tab.id;
   // Per-session agent detection result, refreshed each time the context
   // menu opens. Null while loading; the menu rebuilds when this resolves
   // so the Fork item gets the right label / enabled state.
@@ -856,6 +881,125 @@ function TabItem({
   useEffect(() => {
     if (isGeneratingTitle && editing) setEditing(false);
   }, [editing, isGeneratingTitle]);
+
+  useEffect(() => {
+    return () => {
+      pendingDragCleanupRef.current?.();
+      pendingDragCleanupRef.current = null;
+    };
+  }, []);
+
+  function onTabPointerDown(e: ReactPointerEvent<HTMLDivElement>): void {
+    if (
+      e.button !== 0 ||
+      isTabDragSuppressedTarget(e.target)
+    ) {
+      return;
+    }
+
+    pendingDragCleanupRef.current?.();
+    const source = e.currentTarget;
+    const rect = source.getBoundingClientRect();
+    const start = { x: e.clientX, y: e.clientY };
+    const offset = {
+      x: Math.max(0, Math.min(e.clientX - rect.left, rect.width)),
+      y: Math.max(0, Math.min(e.clientY - rect.top, rect.height)),
+    };
+    const pointerId = e.pointerId;
+    let dragging = false;
+
+    const cleanup = () => {
+      try {
+        source.releasePointerCapture?.(pointerId);
+      } catch {
+        // The pointer may already be released if the tab moved or unmounted.
+      }
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp, true);
+      window.removeEventListener("pointercancel", onPointerCancel, true);
+      window.removeEventListener("blur", onWindowBlur);
+      if (pendingDragCleanupRef.current === cleanup) {
+        pendingDragCleanupRef.current = null;
+      }
+    };
+
+    const clearClickSuppressionSoon = () => {
+      window.setTimeout(() => {
+        suppressNextClickRef.current = false;
+      }, 0);
+    };
+
+    const startDragging = (point: PointerPoint) => {
+      dragging = true;
+      suppressNextClickRef.current = true;
+      if (editing) setEditing(false);
+      beginWorkspaceTabDrag({
+        payload: { tabId: tab.id, fromPaneId: paneId },
+        title: tab.title,
+        pointer: point,
+        offset,
+        sourceRect: { width: rect.width, height: rect.height },
+      });
+    };
+
+    function onPointerMove(event: PointerEvent): void {
+      if (event.pointerId !== pointerId) return;
+      const point = { x: event.clientX, y: event.clientY };
+      if (!dragging) {
+        if (
+          distanceSquared(point, start) <
+          TAB_DRAG_START_THRESHOLD_PX ** 2
+        ) {
+          return;
+        }
+        startDragging(point);
+      } else {
+        updateWorkspaceTabDrag(point);
+      }
+      event.preventDefault();
+    }
+
+    function onPointerUp(event: PointerEvent): void {
+      if (event.pointerId !== pointerId) return;
+      cleanup();
+      if (dragging) {
+        event.preventDefault();
+        event.stopPropagation();
+        finishWorkspaceTabDrag({ x: event.clientX, y: event.clientY });
+        clearClickSuppressionSoon();
+      }
+    }
+
+    function onPointerCancel(event: PointerEvent): void {
+      if (event.pointerId !== pointerId) return;
+      cleanup();
+      if (dragging) {
+        event.preventDefault();
+        cancelWorkspaceTabDrag();
+        clearClickSuppressionSoon();
+      }
+    }
+
+    function onWindowBlur(): void {
+      cleanup();
+      if (dragging) {
+        cancelWorkspaceTabDrag();
+        clearClickSuppressionSoon();
+      }
+    }
+
+    pendingDragCleanupRef.current = cleanup;
+    try {
+      source.setPointerCapture?.(pointerId);
+    } catch {
+      // Synthetic events and some webviews can reject capture; window
+      // listeners still cover normal in-window dragging.
+    }
+    window.addEventListener("pointermove", onPointerMove, { passive: false });
+    window.addEventListener("pointerup", onPointerUp, true);
+    window.addEventListener("pointercancel", onPointerCancel, true);
+    window.addEventListener("blur", onWindowBlur);
+  }
 
   const forkItems: ContextMenuItem[] = (() => {
     if (!agent || !onFork) return [];
@@ -1042,29 +1186,19 @@ function TabItem({
         ref={registerRef}
         role="button"
         tabIndex={0}
-        draggable
-        style={{ WebkitUserDrag: "element" } as CSSProperties}
-        onMouseDownCapture={(e) => {
-          suppressNextDragStartRef.current = isTabDragSuppressedTarget(e.target);
-        }}
+        onPointerDown={onTabPointerDown}
         onDragStart={(e) => {
-          if (
-            suppressNextDragStartRef.current ||
-            isTabDragSuppressedTarget(e.target)
-          ) {
+          if (!getCurrentFilePayload()) {
             e.preventDefault();
             e.stopPropagation();
-            suppressNextDragStartRef.current = false;
-            endAcornDrag();
-            return;
           }
-          if (editing) setEditing(false);
-          setTabDragImage(e);
-          beginTabDrag(e, { tabId: tab.id, fromPaneId: paneId });
         }}
-        onDragEnd={() => {
-          suppressNextDragStartRef.current = false;
-          endAcornDrag();
+        onClickCapture={(e) => {
+          if (suppressNextClickRef.current) {
+            suppressNextClickRef.current = false;
+            e.preventDefault();
+            e.stopPropagation();
+          }
         }}
         onClick={editing ? undefined : onSelect}
         onDoubleClick={(e) => {
@@ -1091,6 +1225,7 @@ function TabItem({
         }}
         className={cn(
           "group relative flex min-w-[96px] shrink-0 cursor-pointer select-none items-center border-r border-border pr-1 text-[13px] leading-5 transition",
+          isDraggingThisTab && "opacity-40",
           active
             ? "bg-bg text-fg"
             : "bg-bg-elevated/40 text-fg-muted hover:bg-bg-elevated/70 hover:text-fg",
@@ -1099,11 +1234,9 @@ function TabItem({
         <div
           className="flex min-w-0 flex-1 items-center gap-1.5 self-stretch pl-3"
           data-tab-drag-handle={tab.id}
-          draggable
-          style={{ WebkitUserDrag: "element" } as CSSProperties}
         >
           {agentProvider ? (
-            <Tooltip label={agentProvider} side="bottom" draggable>
+            <Tooltip label={agentProvider} side="bottom">
               <AgentProviderIcon
                 provider={agentProvider}
                 className={cn(
@@ -1145,11 +1278,9 @@ function TabItem({
           {isGeneratingTitle && !editing ? (
             <SessionTitleGeneratingIndicator
               label={paneT(t, "pane.aria.generatingSessionTitle")}
-              draggable
             />
           ) : null}
-          {session &&
-          (liveInWorktree ?? hasRecordedWorktree(session)) ? (
+          {showWorktreeIcon ? (
             <GitBranch
               size={10}
               className="pointer-events-none shrink-0 text-fg-muted"
@@ -1197,6 +1328,16 @@ function TabItem({
         {active ? (
           <span className="pointer-events-none absolute inset-x-0 bottom-0 h-0.5 bg-accent/30" />
         ) : null}
+        {isDraggingThisTab ? (
+          <WorkspaceTabDragGhost
+            drag={tabDrag}
+            tab={tab}
+            session={session}
+            agentProvider={agentProvider}
+            isGeneratingTitle={isGeneratingTitle}
+            showWorktreeIcon={showWorktreeIcon}
+          />
+        ) : null}
       </div>
       <ContextMenu
         open={menu !== null}
@@ -1206,6 +1347,77 @@ function TabItem({
         items={menuItems}
       />
     </>
+  );
+}
+
+function WorkspaceTabDragGhost({
+  drag,
+  tab,
+  session,
+  agentProvider,
+  isGeneratingTitle,
+  showWorktreeIcon,
+}: {
+  drag: WorkspaceTabDragSession;
+  tab: PaneTab;
+  session: Session | null;
+  agentProvider: SessionAgentProvider | null;
+  isGeneratingTitle: boolean;
+  showWorktreeIcon: boolean;
+}) {
+  return createPortal(
+    <div
+      aria-hidden
+      className="pointer-events-none fixed z-[9999] flex items-center gap-1.5 border border-border bg-bg-elevated px-3 text-[13px] leading-5 text-fg opacity-95 shadow-2xl"
+      style={{
+        left: drag.pointer.x - drag.offset.x,
+        top: drag.pointer.y - drag.offset.y,
+        width: drag.sourceRect.width,
+        height: drag.sourceRect.height,
+      }}
+    >
+      {agentProvider ? (
+        <AgentProviderIcon
+          provider={agentProvider}
+          className={cn(
+            "pointer-events-none size-2.5",
+            session && STATUS_ICON[session.status],
+          )}
+        />
+      ) : tab.kind === "code" ? (
+        <Files
+          size={11}
+          className="pointer-events-none shrink-0 text-fg-muted"
+        />
+      ) : (
+        <span
+          className={cn(
+            "pointer-events-none size-1.5 shrink-0 rounded-full",
+            session ? STATUS_DOT[session.status] : "bg-fg-muted/50",
+          )}
+        />
+      )}
+      <span className="min-w-0 truncate">{drag.title}</span>
+      {isGeneratingTitle ? (
+        <Sparkles
+          size={9}
+          className="pointer-events-none shrink-0 text-accent"
+        />
+      ) : null}
+      {showWorktreeIcon ? (
+        <GitBranch
+          size={10}
+          className="pointer-events-none shrink-0 text-fg-muted"
+        />
+      ) : null}
+      {session?.kind === "control" ? (
+        <Bot
+          size={10}
+          className="pointer-events-none shrink-0 text-accent"
+        />
+      ) : null}
+    </div>,
+    document.body,
   );
 }
 

--- a/src/components/PaneDropOverlay.test.tsx
+++ b/src/components/PaneDropOverlay.test.tsx
@@ -16,12 +16,16 @@ vi.mock("../lib/api", () => ({
 
 import {
   beginFileDrag,
-  beginTabDrag,
   endAcornDrag,
 } from "../lib/dnd";
 import { makePaneNode } from "../lib/layout";
 import { defaultTabByGroup } from "../lib/rightPanelGroups";
 import { useAppStore } from "../store";
+import {
+  beginWorkspaceTabDrag,
+  cancelWorkspaceTabDrag,
+  finishWorkspaceTabDrag,
+} from "../lib/workspaceTabDrag";
 import { PaneDropOverlay } from "./PaneDropOverlay";
 
 const REPO = "/tmp/acorn-repo";
@@ -72,6 +76,39 @@ function resetStore(): void {
   );
 }
 
+function seedTwoPaneWorkspace(): void {
+  const panes = {
+    root: {
+      id: "root",
+      tabIds: ["session-1", "session-2"],
+      activeTabId: "session-1",
+    },
+    "pane-2": { id: "pane-2", tabIds: [], activeTabId: null },
+  };
+  const layout = {
+    kind: "split" as const,
+    id: "split-test",
+    direction: "horizontal" as const,
+    a: makePaneNode("root"),
+    b: makePaneNode("pane-2"),
+  };
+
+  useAppStore.setState((s) => ({
+    ...s,
+    workspaces: {
+      [REPO]: {
+        layout,
+        panes,
+        focusedPaneId: "root",
+      },
+    },
+    layout,
+    panes,
+    activeTabId: "session-1",
+    activeSessionId: "session-1",
+  }));
+}
+
 function makeDataTransfer(): DataTransfer {
   return {
     dropEffect: "none",
@@ -101,6 +138,7 @@ describe("PaneDropOverlay", () => {
   beforeEach(() => {
     resetStore();
     endAcornDrag();
+    cancelWorkspaceTabDrag();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -110,6 +148,7 @@ describe("PaneDropOverlay", () => {
     act(() => root.unmount());
     container.remove();
     endAcornDrag();
+    cancelWorkspaceTabDrag();
   });
 
   it("opens a code viewer tab when a file is dropped on an empty pane", () => {
@@ -165,29 +204,41 @@ describe("PaneDropOverlay", () => {
     expect(state.workspaceTabs).toEqual({});
   });
 
-  it("updates the overlay when a new drag starts before the previous payload is cleared", () => {
-    const fileTransfer = makeDataTransfer();
-    beginFileDrag(
-      { dataTransfer: fileTransfer } as unknown as React.DragEvent,
-      { path: FILE },
-    );
+  it("moves a pointer-dragged tab onto a pane body center", () => {
+    seedTwoPaneWorkspace();
 
     act(() => {
-      root.render(<PaneDropOverlay paneId="root" acceptFileDrops={false} />);
+      root.render(<PaneDropOverlay paneId="pane-2" acceptFileDrops={false} />);
     });
 
     const overlay = container.firstElementChild;
     if (!overlay) throw new Error("overlay did not render");
-    expect(overlay.className).toContain("pointer-events-none");
-
-    const tabTransfer = makeDataTransfer();
-    act(() => {
-      beginTabDrag(
-        { dataTransfer: tabTransfer } as unknown as React.DragEvent,
-        { tabId: "session-1", fromPaneId: "root" },
-      );
+    vi.spyOn(overlay, "getBoundingClientRect").mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 100,
+      width: 100,
+      height: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
     });
 
-    expect(overlay.className).not.toContain("pointer-events-none");
+    act(() => {
+      beginWorkspaceTabDrag({
+        payload: { tabId: "session-1", fromPaneId: "root" },
+        title: "session-1",
+        pointer: { x: 50, y: 50 },
+        offset: { x: 8, y: 8 },
+        sourceRect: { width: 100, height: 32 },
+      });
+      finishWorkspaceTabDrag({ x: 50, y: 50 });
+    });
+
+    const state = useAppStore.getState();
+    expect(state.panes.root.tabIds).toEqual(["session-2"]);
+    expect(state.panes["pane-2"].tabIds).toEqual(["session-1"]);
+    expect(state.panes["pane-2"].activeTabId).toBe("session-1");
   });
 });

--- a/src/components/PaneDropOverlay.tsx
+++ b/src/components/PaneDropOverlay.tsx
@@ -1,16 +1,19 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "../lib/cn";
 import {
   classifyDropZone,
   endAcornDrag,
   type DropZone,
-  getCurrentDragPayload,
   getCurrentFilePayload,
-  getCurrentTabPayload,
   useAcornDragInProgress,
 } from "../lib/dnd";
 import { useAppStore } from "../store";
 import type { PaneId } from "../lib/layout";
+import {
+  registerWorkspaceTabDropTarget,
+  useWorkspaceTabDragSession,
+  type WorkspaceTabDragPoint,
+} from "../lib/workspaceTabDrag";
 
 interface PaneDropOverlayProps {
   paneId: PaneId;
@@ -27,30 +30,87 @@ export function PaneDropOverlay({
   paneId,
   acceptFileDrops = true,
 }: PaneDropOverlayProps) {
-  const dragging = useAcornDragInProgress();
-  const dragPayload = dragging ? getCurrentDragPayload() : null;
-  const acceptsDrag =
-    dragPayload?.kind === "tab" ||
-    (acceptFileDrops && dragPayload?.kind === "file");
+  const fileDragging = useAcornDragInProgress();
+  const filePayload = fileDragging ? getCurrentFilePayload() : null;
+  const tabDrag = useWorkspaceTabDragSession();
+  const acceptsFileDrop = acceptFileDrops && filePayload !== null;
   const moveTab = useAppStore((s) => s.moveTab);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [zone, setZone] = useState<DropZone | null>(null);
 
-  // Clear any lingering highlight when the drag ends without a dragleave
-  // event firing on this overlay (e.g., dropped on a sibling pane).
-  useEffect(() => {
-    if (!dragging && zone) setZone(null);
-  }, [dragging, zone]);
+  const computeTabZone = useCallback(
+    (point: WorkspaceTabDragPoint): DropZone | null => {
+      const el = containerRef.current;
+      if (!el) return null;
+      const rect = el.getBoundingClientRect();
+      if (
+        point.x < rect.left ||
+        point.x > rect.right ||
+        point.y < rect.top ||
+        point.y > rect.bottom
+      ) {
+        return null;
+      }
+      return classifyDropZone(point, rect);
+    },
+    [],
+  );
 
-  function computeZone(e: React.DragEvent): DropZone | null {
-    if (getCurrentFilePayload()) return { kind: "center" };
-    const el = containerRef.current;
-    if (!el) return null;
-    const rect = el.getBoundingClientRect();
-    return classifyDropZone(
-      { x: e.clientX, y: e.clientY },
-      rect,
-    );
+  useEffect(() => {
+    return registerWorkspaceTabDropTarget({
+      id: `pane-body:${paneId}`,
+      priority: 10,
+      getRect: () => containerRef.current?.getBoundingClientRect() ?? null,
+      onDrop: (payload, point) => {
+        const target = computeTabZone(point);
+        if (!target) return;
+        if (target.kind === "center") {
+          if (payload.fromPaneId === paneId) return;
+          moveTab({
+            tabId: payload.tabId,
+            fromPaneId: payload.fromPaneId,
+            toPaneId: paneId,
+          });
+          return;
+        }
+        if (payload.fromPaneId === paneId) {
+          const fromPane = useAppStore.getState().panes[paneId];
+          if (fromPane && fromPane.tabIds.length <= 1) return;
+        }
+        moveTab({
+          tabId: payload.tabId,
+          fromPaneId: payload.fromPaneId,
+          toPaneId: paneId,
+          splitDirection: target.direction,
+          splitSide: target.side,
+        });
+      },
+    });
+  }, [computeTabZone, moveTab, paneId]);
+
+  // Clear or update highlights when pointer tab drags or native file drags end
+  // without firing a dragleave on this overlay.
+  useEffect(() => {
+    if (tabDrag) {
+      const next = computeTabZone(tabDrag.pointer);
+      if (
+        !zone ||
+        !next ||
+        zone.kind !== next.kind ||
+        (zone.kind === "edge" &&
+          next.kind === "edge" &&
+          (zone.direction !== next.direction || zone.side !== next.side))
+      ) {
+        setZone(next);
+      }
+      return;
+    }
+    if (!filePayload && zone) setZone(null);
+  }, [computeTabZone, filePayload, tabDrag, zone]);
+
+  function computeZone(): DropZone | null {
+    if (!getCurrentFilePayload()) return null;
+    return { kind: "center" };
   }
 
   // Always mount so the very first dragenter into a pane body is captured;
@@ -60,21 +120,20 @@ export function PaneDropOverlay({
     <div
       ref={containerRef}
       className={
-        acceptsDrag
+        acceptsFileDrop
           ? "absolute inset-0 z-20"
           : "pointer-events-none absolute inset-0 z-20"
       }
       onDragEnter={(e) => {
-        if (!acceptsDrag) return;
+        if (!acceptsFileDrop) return;
         e.preventDefault();
-        setZone(computeZone(e));
+        setZone(computeZone());
       }}
       onDragOver={(e) => {
-        if (!acceptsDrag) return;
+        if (!acceptsFileDrop) return;
         e.preventDefault();
-        e.dataTransfer.dropEffect =
-          getCurrentTabPayload() !== null ? "move" : "copy";
-        const next = computeZone(e);
+        e.dataTransfer.dropEffect = "copy";
+        const next = computeZone();
         if (
           !zone ||
           !next ||
@@ -91,7 +150,7 @@ export function PaneDropOverlay({
         if (e.currentTarget === e.target) setZone(null);
       }}
       onDrop={(e) => {
-        if (!acceptsDrag) return;
+        if (!acceptsFileDrop) return;
         e.preventDefault();
         try {
           setZone(null);
@@ -101,32 +160,6 @@ export function PaneDropOverlay({
             useAppStore.getState().openCodeViewerTab(filePayload.path);
             return;
           }
-          const target = computeZone(e);
-          if (!target) return;
-          const payload = getCurrentTabPayload();
-          if (!payload) return;
-          if (target.kind === "center") {
-            if (payload.fromPaneId === paneId) return;
-            moveTab({
-              tabId: payload.tabId,
-              fromPaneId: payload.fromPaneId,
-              toPaneId: paneId,
-            });
-            return;
-          }
-          // Edge drop. Avoid the no-op of splitting a pane that holds only the
-          // dragged tab — the source would immediately collapse.
-          if (payload.fromPaneId === paneId) {
-            const fromPane = useAppStore.getState().panes[paneId];
-            if (fromPane && fromPane.tabIds.length <= 1) return;
-          }
-          moveTab({
-            tabId: payload.tabId,
-            fromPaneId: payload.fromPaneId,
-            toPaneId: paneId,
-            splitDirection: target.direction,
-            splitSide: target.side,
-          });
         } finally {
           endAcornDrag();
         }

--- a/src/lib/dnd.ts
+++ b/src/lib/dnd.ts
@@ -1,5 +1,5 @@
 /**
- * Drag-and-drop session helpers for Acorn-owned tab and file payloads.
+ * Drag-and-drop session helpers for Acorn-owned file payloads.
  *
  * The browser's `DataTransfer` is unreliable for custom MIME types in some
  * webviews (notably WKWebView used by Tauri on macOS): the `types` list and
@@ -9,38 +9,20 @@
  * OS preview and drop affordances.
  */
 import { useEffect, useState, type DragEvent } from "react";
-import type { Direction, PaneId, SplitSide } from "./layout";
-
-export interface TabDragPayload {
-  kind: "tab";
-  tabId: string;
-  fromPaneId: PaneId;
-}
+import type { Direction, SplitSide } from "./layout";
 
 export interface FileDragPayload {
   kind: "file";
   path: string;
 }
 
-export type DragPayload = TabDragPayload | FileDragPayload;
-
-let currentDrag: DragPayload | null = null;
+let currentDrag: FileDragPayload | null = null;
 let dragRevision = 0;
 const listeners = new Set<() => void>();
 
 function notify(): void {
   dragRevision += 1;
   for (const fn of listeners) fn();
-}
-
-export function beginTabDrag(
-  e: DragEvent,
-  payload: { tabId: string; fromPaneId: PaneId },
-): void {
-  beginAcornDrag(e, { kind: "tab", ...payload }, {
-    effectAllowed: "move",
-    text: payload.tabId,
-  });
 }
 
 export function beginFileDrag(
@@ -54,7 +36,7 @@ export function beginFileDrag(
 
 function beginAcornDrag(
   e: DragEvent,
-  payload: DragPayload,
+  payload: FileDragPayload,
   options: { effectAllowed: DataTransfer["effectAllowed"]; text?: string },
 ): void {
   currentDrag = payload;
@@ -75,24 +57,8 @@ export function endAcornDrag(): void {
   notify();
 }
 
-export function getCurrentDragPayload(): DragPayload | null {
-  return currentDrag;
-}
-
-export function getCurrentTabPayload(): TabDragPayload | null {
-  return currentDrag?.kind === "tab" ? currentDrag : null;
-}
-
 export function getCurrentFilePayload(): FileDragPayload | null {
   return currentDrag?.kind === "file" ? currentDrag : null;
-}
-
-export function isTabDrag(_e: DragEvent): boolean {
-  return currentDrag?.kind === "tab";
-}
-
-export function isAcornDrag(_e: DragEvent): boolean {
-  return currentDrag !== null;
 }
 
 export function useAcornDragGlobalCleanup(): void {

--- a/src/lib/workspaceTabDrag.ts
+++ b/src/lib/workspaceTabDrag.ts
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+import type { PaneId } from "./layout";
+
+export interface WorkspaceTabDragPayload {
+  tabId: string;
+  fromPaneId: PaneId;
+}
+
+export interface WorkspaceTabDragPoint {
+  x: number;
+  y: number;
+}
+
+export interface WorkspaceTabDragRect {
+  width: number;
+  height: number;
+}
+
+export interface WorkspaceTabDragSession {
+  payload: WorkspaceTabDragPayload;
+  title: string;
+  pointer: WorkspaceTabDragPoint;
+  offset: WorkspaceTabDragPoint;
+  sourceRect: WorkspaceTabDragRect;
+}
+
+interface WorkspaceTabDropTarget {
+  id: string;
+  priority: number;
+  getRect: () => DOMRect | null;
+  onDrop: (
+    payload: WorkspaceTabDragPayload,
+    point: WorkspaceTabDragPoint,
+  ) => void;
+}
+
+let currentDrag: WorkspaceTabDragSession | null = null;
+let dragRevision = 0;
+const listeners = new Set<() => void>();
+const dropTargets = new Map<string, WorkspaceTabDropTarget>();
+
+function notify(): void {
+  dragRevision += 1;
+  for (const fn of listeners) fn();
+}
+
+function containsPoint(rect: DOMRect, point: WorkspaceTabDragPoint): boolean {
+  return (
+    point.x >= rect.left &&
+    point.x <= rect.right &&
+    point.y >= rect.top &&
+    point.y <= rect.bottom
+  );
+}
+
+export function beginWorkspaceTabDrag(session: WorkspaceTabDragSession): void {
+  currentDrag = session;
+  notify();
+}
+
+export function updateWorkspaceTabDrag(point: WorkspaceTabDragPoint): void {
+  if (!currentDrag) return;
+  if (currentDrag.pointer.x === point.x && currentDrag.pointer.y === point.y) {
+    return;
+  }
+  currentDrag = { ...currentDrag, pointer: point };
+  notify();
+}
+
+export function cancelWorkspaceTabDrag(): void {
+  if (!currentDrag) return;
+  currentDrag = null;
+  notify();
+}
+
+export function finishWorkspaceTabDrag(point?: WorkspaceTabDragPoint): void {
+  const session = currentDrag;
+  if (!session) return;
+  const dropPoint = point ?? session.pointer;
+  const targets = [...dropTargets.values()].sort(
+    (a, b) => b.priority - a.priority,
+  );
+
+  currentDrag = null;
+  notify();
+
+  for (const target of targets) {
+    const rect = target.getRect();
+    if (!rect || !containsPoint(rect, dropPoint)) continue;
+    target.onDrop(session.payload, dropPoint);
+    return;
+  }
+}
+
+export function getWorkspaceTabDragSession(): WorkspaceTabDragSession | null {
+  return currentDrag;
+}
+
+export function registerWorkspaceTabDropTarget(
+  target: WorkspaceTabDropTarget,
+): () => void {
+  dropTargets.set(target.id, target);
+  return () => {
+    const current = dropTargets.get(target.id);
+    if (current === target) dropTargets.delete(target.id);
+  };
+}
+
+export function useWorkspaceTabDragSession(): WorkspaceTabDragSession | null {
+  const [, setRevision] = useState(dragRevision);
+
+  useEffect(() => {
+    function onChange() {
+      setRevision(dragRevision);
+    }
+    listeners.add(onChange);
+    return () => {
+      listeners.delete(onChange);
+    };
+  }, []);
+
+  return currentDrag;
+}

--- a/tests/e2e/panes.spec.ts
+++ b/tests/e2e/panes.spec.ts
@@ -158,7 +158,7 @@ test.describe("pane / sidebar shortcuts", () => {
     await expect(dragHandle).toBeVisible();
 
     await expect(closeButton).toHaveAttribute("draggable", "false");
-    await expect(dragHandle).toHaveAttribute("draggable", "true");
+    await expect(dragHandle).not.toHaveAttribute("draggable", "true");
 
     const geometry = await page.evaluate(() => {
       const close = document.querySelector(
@@ -212,19 +212,39 @@ test.describe("pane / sidebar shortcuts", () => {
     const renameInput = page.locator("[data-tab-rename-input]");
     await expect(renameInput).toBeFocused();
     await expect(renameInput).toHaveAttribute("draggable", "false");
-    await expect(dragHandle).toHaveAttribute("draggable", "true");
+    await expect(dragHandle).not.toHaveAttribute("draggable", "true");
 
     await page.evaluate(() => {
       const handle = document.querySelector(
         '[data-tab-drag-handle="s-1"]',
       );
       if (!handle) throw new Error("missing tab drag handle");
-      const event = new DragEvent("dragstart", {
+      const rect = handle.getBoundingClientRect();
+      const pointerId = 1;
+      handle.dispatchEvent(new PointerEvent("pointerdown", {
         bubbles: true,
         cancelable: true,
-        dataTransfer: new DataTransfer(),
-      });
-      handle.dispatchEvent(event);
+        pointerId,
+        button: 0,
+        clientX: rect.left + 4,
+        clientY: rect.top + rect.height / 2,
+      }));
+      window.dispatchEvent(new PointerEvent("pointermove", {
+        bubbles: true,
+        cancelable: true,
+        pointerId,
+        button: 0,
+        clientX: rect.left + 24,
+        clientY: rect.top + rect.height / 2,
+      }));
+      window.dispatchEvent(new PointerEvent("pointerup", {
+        bubbles: true,
+        cancelable: true,
+        pointerId,
+        button: 0,
+        clientX: rect.left + 24,
+        clientY: rect.top + rect.height / 2,
+      }));
     });
 
     await expect(renameInput).toHaveCount(0);


### PR DESCRIPTION
## Summary
This replaces workspace tab dragging with an internal pointer lifecycle so ordinary tab clicks, close hits, and rename input interactions no longer fall into native drag mode.

1. **Pointer tab drag lifecycle** — add a dedicated `workspaceTabDrag` session helper with pointer updates, cancellation, finish handling, and priority-based drop targets.
2. **Tab click/drag separation** — remove native `draggable` from workspace tabs, require pointer movement past a 6px threshold before a drag begins, and suppress only the click that follows a real drag.
3. **Drop target split** — keep native `DataTransfer` drag-and-drop for files only, while tab strip reorder and pane-body move/split use the pointer session registry.
4. **Drag ghost parity** — render a React portal ghost that follows the pointer and preserves tab context icons such as provider/status, code tab, worktree, control-session, and title-generation indicators.
5. **Regression coverage** — update unit and E2E coverage around click-path selection, close-button hit area, rename-mode drag, pointer cleanup, and pane-body tab drops.

## Expected impact
| User interaction | Before | After |
| --- | --- | --- |
| Click a tab | Could be intercepted by native drag startup in the webview | Stays on the click path unless pointer movement exceeds 6px |
| Click the close button | Close hit area competed with tab-level `draggable` behavior | Close button is excluded from tab drag startup |
| Drag from tab title/chrome | Depended on native HTML5 drag event timing | Uses Acorn-owned pointer state and cleanup |
| Drag over pane body | Native tab payload was mixed with file drag payloads | Center move / edge split are computed from pointer drop targets |
| File drag/drop | Shared helper with tab drag payloads | Keeps the existing native file drag path |

## Design notes
- `src/lib/dnd.ts` now mirrors only Acorn-owned file payloads for native `DataTransfer`; tab drag state moved to `src/lib/workspaceTabDrag.ts`.
- Tab strip and pane body register independent pointer drop targets. The tab strip has higher priority so dropping over the tab bar reorders before pane-body split handling can run.
- `pointerup`, `pointercancel`, window `blur`, and pointer capture release all clear the active tab drag session to avoid stale drag state.
- The ghost is rendered via `createPortal(document.body)` instead of `DataTransfer.setDragImage`, avoiding WKWebView native drag image behavior for tabs.

## Test plan
- [x] `git diff --check HEAD~1..HEAD` — passes
- [x] `pnpm exec tsc --noEmit --pretty false` — passes
- [x] `pnpm exec vitest run src/components/Pane.test.tsx src/components/PaneDropOverlay.test.tsx src/lib/dnd.test.ts --reporter=dot` — 3 files / 22 tests passed
- [x] `pnpm exec playwright test tests/e2e/panes.spec.ts` — 10 tests passed
- [x] `pnpm run build` — passes; Vite emits existing chunk/dynamic-import warnings

## Notes
- Vitest still prints the existing React `act(...)` environment warning in these component tests; the tests pass and this PR does not introduce that warning.
