### PR TITLE
perf(pr): lazy-load pull request diffs

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15,7 +15,7 @@ use crate::persistence;
 use crate::project_settings::{self, ProjectSettings, ProjectSettingsRecord};
 use crate::pull_requests::{
     self, GeneratedCommitMessage, MergeMethod, PrStateFilter, PullRequestDetailListing,
-    PullRequestListing, WorkflowRunDetailListing, WorkflowRunsListing,
+    PullRequestDiffListing, PullRequestListing, WorkflowRunDetailListing, WorkflowRunsListing,
 };
 use crate::state::AppState;
 use crate::todos::{self, TodoItem};
@@ -2714,7 +2714,21 @@ pub async fn get_pull_request_detail(
     repo_path: String,
     number: u64,
 ) -> AppResult<PullRequestDetailListing> {
-    pull_requests::get_pull_request_detail(&PathBuf::from(repo_path), number)
+    run_blocking("get_pull_request_detail", move || {
+        pull_requests::get_pull_request_detail(&PathBuf::from(repo_path), number)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn get_pull_request_diff(
+    repo_path: String,
+    number: u64,
+) -> AppResult<PullRequestDiffListing> {
+    run_blocking("get_pull_request_diff", move || {
+        pull_requests::get_pull_request_diff(&PathBuf::from(repo_path), number)
+    })
+    .await
 }
 
 #[tauri::command]
@@ -2722,7 +2736,10 @@ pub async fn get_pull_request_commit_diff(
     repo_path: String,
     sha: String,
 ) -> AppResult<DiffPayload> {
-    pull_requests::get_pull_request_commit_diff(&PathBuf::from(repo_path), &sha)
+    run_blocking("get_pull_request_commit_diff", move || {
+        pull_requests::get_pull_request_commit_diff(&PathBuf::from(repo_path), &sha)
+    })
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -521,6 +521,7 @@ pub fn run() {
             commands::staged_file_diff,
             commands::list_pull_requests,
             commands::get_pull_request_detail,
+            commands::get_pull_request_diff,
             commands::get_pull_request_commit_diff,
             commands::resolve_commit_logins,
             commands::merge_pull_request,

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -725,7 +725,6 @@ pub struct PullRequestDetail {
     pub reviews: Vec<PullRequestReview>,
     pub checks: Vec<PullRequestCheck>,
     pub commits: Vec<PullRequestCommit>,
-    pub diff: DiffPayload,
 }
 
 #[derive(Debug, Serialize)]
@@ -735,6 +734,17 @@ pub enum PullRequestDetailListing {
         account: String,
         detail: PullRequestDetail,
     },
+    NotGithub,
+    NoAccess {
+        slug: String,
+        accounts: Vec<AccountSummary>,
+    },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PullRequestDiffListing {
+    Ok { account: String, diff: DiffPayload },
     NotGithub,
     NoAccess {
         slug: String,
@@ -752,16 +762,7 @@ pub fn get_pull_request_detail(
 
     match try_with_account(repo_path, &slug, |token| {
         let view = run_pr_view(&slug, number, token)?;
-        let diff_text = run_pr_diff(&slug, number, token)?;
-        let mut detail = build_detail(number, view, diff_text);
-        // The unified diff `gh pr diff` returns reduces binary changes to a
-        // "Binary files ... differ" line. Enrich image entries with actual
-        // bytes fetched from the head/base refs so the renderer can show
-        // before/after previews instead of that placeholder text.
-        let head = detail.head_branch.clone();
-        let base = detail.base_branch.clone();
-        enrich_image_previews_against_refs(&slug, &head, &base, token, &mut detail.diff);
-        Ok(detail)
+        Ok(build_detail(number, view))
     })? {
         AccountOutcome::Ok {
             account,
@@ -769,6 +770,39 @@ pub fn get_pull_request_detail(
         } => Ok(PullRequestDetailListing::Ok { account, detail }),
         AccountOutcome::NoAccess { accounts } => {
             Ok(PullRequestDetailListing::NoAccess { slug, accounts })
+        }
+    }
+}
+
+pub fn get_pull_request_diff(
+    repo_path: &Path,
+    number: u64,
+) -> AppResult<PullRequestDiffListing> {
+    let Some(slug) = github_owner_repo(repo_path)? else {
+        return Ok(PullRequestDiffListing::NotGithub);
+    };
+
+    match try_with_account(repo_path, &slug, |token| {
+        let diff_text = run_pr_diff(&slug, number, token)?;
+        let mut diff = crate::unified_diff::parse_unified_diff(&diff_text);
+        if diff.files.iter().any(|file| file.is_image) {
+            let refs = run_pr_refs(&slug, number, token)?;
+            enrich_image_previews_against_refs(
+                &slug,
+                &refs.head_ref_name,
+                &refs.base_ref_name,
+                token,
+                &mut diff,
+            );
+        }
+        Ok(diff)
+    })? {
+        AccountOutcome::Ok {
+            account,
+            value: diff,
+        } => Ok(PullRequestDiffListing::Ok { account, diff }),
+        AccountOutcome::NoAccess { accounts } => {
+            Ok(PullRequestDiffListing::NoAccess { slug, accounts })
         }
     }
 }
@@ -802,7 +836,7 @@ fn enrich_image_previews_against_refs(
     }
 }
 
-fn build_detail(number: u64, view: GhPullRequestView, diff_text: String) -> PullRequestDetail {
+fn build_detail(number: u64, view: GhPullRequestView) -> PullRequestDetail {
     let actor_avatars = view
         .actor_avatars
         .as_ref()
@@ -919,7 +953,6 @@ fn build_detail(number: u64, view: GhPullRequestView, diff_text: String) -> Pull
         reviews,
         checks,
         commits,
-        diff: crate::unified_diff::parse_unified_diff(&diff_text),
     }
 }
 
@@ -952,6 +985,35 @@ fn run_pr_view(slug: &str, number: u64, token: &str) -> AppResult<GhPullRequestV
     let mut view: GhPullRequestView = serde_json::from_slice(&output.stdout)
         .map_err(|e| AppError::Other(format!("failed to parse gh output: {e}")))?;
     view.actor_avatars = Some(resolve_pr_actor_avatars(&view, token));
+    Ok(view)
+}
+
+fn run_pr_refs(slug: &str, number: u64, token: &str) -> AppResult<GhPullRequestRefs> {
+    let number_s = number.to_string();
+    let output = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token).env("GH_HOST", GH_HOST).args([
+            "pr",
+            "view",
+            &number_s,
+            "--repo",
+            slug,
+            "--json",
+            "headRefName,baseRefName",
+        ]);
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("gh exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+
+    let view: GhPullRequestRefs = serde_json::from_slice(&output.stdout)
+        .map_err(|e| AppError::Other(format!("failed to parse gh output: {e}")))?;
     Ok(view)
 }
 
@@ -1257,6 +1319,14 @@ fn run_pr_diff(slug: &str, number: u64, token: &str) -> AppResult<String> {
     // mojibake) — those segments are non-renderable anyway and the parser
     // ultimately routes them into the binary-placeholder branch.
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GhPullRequestRefs {
+    #[serde(rename = "headRefName")]
+    head_ref_name: String,
+    #[serde(rename = "baseRefName")]
+    base_ref_name: String,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/src/components/PullRequestDetailModal.modal.test.tsx
+++ b/src/components/PullRequestDetailModal.modal.test.tsx
@@ -9,8 +9,10 @@ import {
   vi,
 } from "vitest";
 import type {
+  DiffPayload,
   PullRequestDetail,
   PullRequestDetailListing,
+  PullRequestDiffListing,
 } from "../lib/types";
 
 vi.mock("../lib/api", () => {
@@ -18,6 +20,9 @@ vi.mock("../lib/api", () => {
     api: {
       getPullRequestDetail: vi.fn<
         (repoPath: string, n: number) => Promise<PullRequestDetailListing>
+      >(),
+      getPullRequestDiff: vi.fn<
+        (repoPath: string, n: number) => Promise<PullRequestDiffListing>
       >(),
       updatePullRequestBody: vi.fn<
         (repoPath: string, n: number, body: string) => Promise<void>
@@ -62,7 +67,19 @@ function fakeDetail(body: string): PullRequestDetail {
     reviews: [],
     checks: [],
     commits: [],
-    diff: { files: [] },
+  };
+}
+
+function fakeDiffPayload(): DiffPayload {
+  return {
+    files: [
+      {
+        old_path: "src/example.ts",
+        new_path: "src/example.ts",
+        patch: "@@ -1,1 +1,1 @@\n-old\n+new\n",
+        is_image: false,
+      },
+    ],
   };
 }
 
@@ -82,6 +99,7 @@ describe("PullRequestDetailModal — body checkbox toggle", () => {
     document.body.appendChild(container);
     root = createRoot(container);
     mockApi.getPullRequestDetail.mockReset();
+    mockApi.getPullRequestDiff.mockReset();
     mockApi.updatePullRequestBody.mockReset();
     mockApi.mergePullRequest.mockReset();
     mockApi.closePullRequest.mockReset();
@@ -362,6 +380,45 @@ describe("PullRequestDetailModal — body checkbox toggle", () => {
 
     expect(mockApi.getPullRequestDetail).toHaveBeenCalledTimes(2);
     expect(document.body.textContent).toContain("6s");
+  });
+
+  it("loads the PR diff only after the Files tab is selected", async () => {
+    mockApi.getPullRequestDetail.mockResolvedValueOnce({
+      kind: "ok",
+      account: "tester",
+      detail: { ...fakeDetail(""), changed_files: 1 },
+    });
+    mockApi.getPullRequestDiff.mockResolvedValueOnce({
+      kind: "ok",
+      account: "tester",
+      diff: fakeDiffPayload(),
+    });
+
+    await act(async () => {
+      root.render(
+        <PullRequestDetailModal
+          open={{ repoPath: "/r", number: 999 }}
+          onClose={() => {}}
+        />,
+      );
+    });
+    await flushPromises();
+
+    expect(mockApi.getPullRequestDetail).toHaveBeenCalledWith("/r", 999);
+    expect(mockApi.getPullRequestDiff).not.toHaveBeenCalled();
+
+    const filesTab = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.includes("Files"));
+    expect(filesTab).toBeDefined();
+
+    await act(async () => {
+      filesTab!.click();
+    });
+    await flushPromises();
+
+    expect(mockApi.getPullRequestDiff).toHaveBeenCalledWith("/r", 999);
+    expect(document.body.textContent).toContain("src/example.ts");
   });
 
   it("opens project settings from the hidden GEN prompt button", async () => {

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -293,6 +293,7 @@ export function PullRequestDetailModal({
             onClose={onClose}
             onRefresh={handleRefresh}
             refreshing={refreshing}
+            diffReloadKey={reloadKey}
             onOpenMerge={() => setMergeDialogOpen(true)}
             onOpenClose={() => setCloseDialogOpen(true)}
           />
@@ -356,6 +357,7 @@ function DetailBody({
   onClose,
   onRefresh,
   refreshing,
+  diffReloadKey,
   onOpenMerge,
   onOpenClose,
 }: {
@@ -371,6 +373,7 @@ function DetailBody({
   onClose: () => void;
   onRefresh: () => void;
   refreshing: boolean;
+  diffReloadKey: number;
   onOpenMerge: () => void;
   onOpenClose: () => void;
 }) {
@@ -389,7 +392,7 @@ function DetailBody({
   const checksPartial =
     effectiveChecks > 0 && !allChecksPassed && !allChecksFailed;
   const totalChecks = effectiveChecks;
-  const fileCount = detail.diff.files.length;
+  const fileCount = detail.changed_files;
   const commitCount = detail.commits.length;
 
   return (
@@ -566,11 +569,109 @@ function DetailBody({
         ) : tab === "checks" ? (
           <ChecksPane checks={detail.checks} />
         ) : (
-          <DiffSplitView payload={detail.diff} cwd={cwd} />
+          <PullRequestFilesPane
+            active={tab === "files"}
+            repoPath={repoPath}
+            number={detail.number}
+            cwd={cwd}
+            reloadKey={diffReloadKey}
+          />
         )}
       </div>
     </>
   );
+}
+
+function PullRequestFilesPane({
+  active,
+  repoPath,
+  number,
+  cwd,
+  reloadKey,
+}: {
+  active: boolean;
+  repoPath: string;
+  number: number;
+  cwd?: string;
+  reloadKey: number;
+}) {
+  const t = useTranslation();
+  const [diff, setDiff] = useState<DiffPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const loadedKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    setDiff(null);
+    setError(null);
+    setLoading(false);
+    loadedKeyRef.current = null;
+  }, [repoPath, number]);
+
+  useEffect(() => {
+    if (!active) return;
+    const requestKey = `${repoPath}#${number}:${reloadKey}`;
+    if (loadedKeyRef.current === requestKey) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    api
+      .getPullRequestDiff(repoPath, number)
+      .then((result) => {
+        if (cancelled) return;
+        if (result.kind === "ok") {
+          loadedKeyRef.current = requestKey;
+          setDiff(result.diff);
+          setError(null);
+        } else if (result.kind === "not_github") {
+          setDiff(null);
+          setError(dt(t, "dialogs.pullRequestDetail.notGithub"));
+        } else {
+          setDiff(null);
+          setError(
+            `${dt(t, "dialogs.pullRequestDetail.noAccessPrefix")} gh ${dt(
+              t,
+              "dialogs.pullRequestDetail.noAccessSuffix",
+            )} ${result.slug}.`,
+          );
+        }
+        setLoading(false);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(String(e));
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [active, repoPath, number, reloadKey, t]);
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-xs text-danger">
+        {error}
+      </div>
+    );
+  }
+  if (loading && !diff) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-fg-muted">
+        {dt(t, "dialogs.pullRequestDetail.loadingDiff")}
+      </div>
+    );
+  }
+  if (!diff) {
+    return null;
+  }
+  if (diff.files.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-fg-muted">
+        {t("diffView.noChanges")}
+      </div>
+    );
+  }
+  return <DiffSplitView payload={diff} cwd={cwd} />;
 }
 
 /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -14,6 +14,7 @@ import type {
   ProjectSettingsRecord,
   PrStateFilter,
   PullRequestDetailListing,
+  PullRequestDiffListing,
   PullRequestListing,
   Session,
   SessionAgentProvider,
@@ -200,6 +201,15 @@ export const api = {
     number: number,
   ): Promise<PullRequestDetailListing> {
     return invoke<PullRequestDetailListing>("get_pull_request_detail", {
+      repoPath,
+      number,
+    });
+  },
+  getPullRequestDiff(
+    repoPath: string,
+    number: number,
+  ): Promise<PullRequestDiffListing> {
+    return invoke<PullRequestDiffListing>("get_pull_request_diff", {
       repoPath,
       number,
     });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -357,11 +357,15 @@ export interface PullRequestDetail {
   reviews: PullRequestReview[];
   checks: PullRequestCheck[];
   commits: PullRequestCommit[];
-  diff: DiffPayload;
 }
 
 export type PullRequestDetailListing =
   | { kind: "ok"; account: string; detail: PullRequestDetail }
+  | { kind: "not_github" }
+  | { kind: "no_access"; slug: string; accounts: AccountSummary[] };
+
+export type PullRequestDiffListing =
+  | { kind: "ok"; account: string; diff: DiffPayload }
   | { kind: "not_github" }
   | { kind: "no_access"; slug: string; accounts: AccountSummary[] };
 

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -91,6 +91,9 @@ export const tauriMockSource = `
     if (cmd === 'list_pull_requests') {
       return Promise.resolve({ items: [], account: null, error: null });
     }
+    if (cmd === 'get_pull_request_diff') {
+      return Promise.resolve({ kind: 'ok', account: 'test', diff: { files: [] } });
+    }
     if (cmd === 'list_workflow_runs') {
       return Promise.resolve({ kind: 'not_github' });
     }

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -1246,7 +1246,7 @@ test.describe("terminal: spawn", () => {
       .toBeGreaterThanOrEqual(1);
   });
 
-  test("Cmd+Left and Cmd+Right move through terminal conversation prompts", async ({
+  test("conversation shortcuts move through terminal conversation prompts", async ({
     page,
     tauri,
   }) => {
@@ -1314,16 +1314,16 @@ test.describe("terminal: spawn", () => {
     await expect(page.locator(".xterm-rows")).toContainText("tail 35");
 
     await page.locator(".xterm-helper-textarea").focus();
-    await pressHotkey(page, { mod: true, key: "ArrowLeft" });
+    await pressHotkey(page, { mod: true, alt: true, key: "ArrowUp" });
     await expect(page.locator(".xterm-rows")).toContainText("third prompt");
 
-    await pressHotkey(page, { mod: true, key: "ArrowLeft" });
+    await pressHotkey(page, { mod: true, alt: true, key: "ArrowUp" });
     await expect(page.locator(".xterm-rows")).toContainText("second prompt");
 
-    await pressHotkey(page, { mod: true, key: "ArrowRight" });
+    await pressHotkey(page, { mod: true, alt: true, key: "ArrowDown" });
     await expect(page.locator(".xterm-rows")).toContainText("third prompt");
 
-    await pressHotkey(page, { mod: true, key: "ArrowRight" });
+    await pressHotkey(page, { mod: true, alt: true, key: "ArrowDown" });
     await expect(page.locator(".xterm-rows")).toContainText("tail 35");
   });
 


### PR DESCRIPTION
## Summary
PR detail opens faster by decoupling heavy diff and image work from the initial modal load.

1. **Split PR detail and diff payloads** — remove `diff` from `PullRequestDetail` and add a dedicated `get_pull_request_diff` / `getPullRequestDiff` API for the Files tab.
2. **Lazy-load Files tab content** — keep title, body, conversation, commits, and checks renderable after the lightweight detail call; fetch the full diff only when the user opens Files.
3. **Avoid unnecessary image ref lookup** — only resolve head/base refs and enrich image previews when the parsed PR diff actually contains image files.
4. **Keep blocking GitHub/diff work off the async runtime** — run PR detail, PR diff, and PR commit diff commands through `run_blocking`.
5. **Align terminal navigation E2E coverage** — update the conversation-navigation E2E to use the current default shortcuts (`$mod+Alt+ArrowUp/Down`) instead of the retired legacy left/right binding.

## Expected impact
| PR pattern | Before | After |
| --- | --- | --- |
| Large text-only PR opened for review context | Modal waits on full `gh pr diff` + parse before rendering | Summary/conversation/checks render after `gh pr view`; diff waits until Files tab |
| PR with many image changes | Initial modal waits on image blob fetch + base64 payload | Image work moves behind Files tab and only runs for image diffs |
| Running-check refresh | Polling re-fetches full detail including diff/image work | Polling re-fetches lightweight detail only |

## Design notes
- `PullRequestDetail` now carries the metadata and review data needed by the header, body, conversation, commits, checks, merge, and close flows. The diff moved to `PullRequestDiffListing` so the frontend can fetch it independently.
- `PullRequestFilesPane` caches the loaded diff per PR/reload key, so switching tabs does not repeatedly call `gh pr diff` unless the user refreshes or opens another PR.
- The Files tab badge now uses `changed_files` from `gh pr view`, which is already part of the lightweight detail payload.
- PR diff image previews still use the existing before/after renderer; this PR moves that cost later rather than changing preview behavior.

## Follow-up (not in this PR)
- Apply the same payload split to per-commit PR diffs if users hit slow image-heavy commit views.
- Make image previews per-file lazy instead of enriching every image in a loaded diff payload.
- Defer `DiffSplitView` line parsing to the selected file so large multi-file diffs spend less CPU building the file list.
- Consider checks-only polling so running check refreshes avoid re-fetching conversation and commits.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm exec vitest run src/components/PullRequestDetailModal.modal.test.tsx` — 8 passed
- [x] `pnpm exec vitest run src/components/CodeDiffVirtualization.test.tsx` — 10 passed
- [x] `pnpm exec vitest run src/components/PullRequestDetailModal.modal.test.tsx src/components/CodeDiffVirtualization.test.tsx` — 18 passed
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts -g "conversation shortcuts move through terminal conversation prompts"` — 1 passed
- [x] `pnpm run typecheck` passes
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` passes
- [x] `pnpm run test` — 54 files passed, 508 passed, 1 skipped
- [x] `pnpm run build` passes; Vite reports existing chunk-size/dynamic-import warnings

## Notes
- Initial CI E2E failed on `terminal.spec.ts` because the test still sent the retired `$mod+ArrowLeft/Right` shortcut while current defaults are `$mod+Alt+ArrowUp/Down`. The app code path is unrelated to PR diff loading; the test was updated to use the current binding.
