### PR TITLE
fix(right-panel): scope selected tabs per project

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1855,4 +1855,34 @@ describe("right panel groups", () => {
     useAppStore.getState().setRightGroup("github");
     expect(useAppStore.getState().rightTab).toBe("prs");
   });
+
+  it("keeps the selected tab and sub-tab memory per project", async () => {
+    await seed(
+      [project(REPO_A, 0), project(REPO_B, 1)],
+      [session("a1", REPO_A), session("b1", REPO_B)],
+    );
+
+    useAppStore.getState().setActiveProject(REPO_A);
+    useAppStore.getState().setRightTab("actions");
+    useAppStore.getState().setRightTab("history");
+
+    useAppStore.getState().setActiveProject(REPO_B);
+    expect(useAppStore.getState().rightTab).toBe("commits");
+    useAppStore.getState().setRightTab("prs");
+    useAppStore.getState().setRightTab("todos");
+
+    useAppStore.getState().setActiveProject(REPO_A);
+    let s = useAppStore.getState();
+    expect(s.rightTab).toBe("history");
+    expect(s.rightTabByGroup.github).toBe("actions");
+    s.setRightGroup("github");
+    expect(useAppStore.getState().rightTab).toBe("actions");
+
+    useAppStore.getState().setActiveProject(REPO_B);
+    s = useAppStore.getState();
+    expect(s.rightTab).toBe("todos");
+    expect(s.rightTabByGroup.github).toBe("prs");
+    s.setRightGroup("github");
+    expect(useAppStore.getState().rightTab).toBe("prs");
+  });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -82,6 +82,8 @@ export interface ProjectWorkspace {
   layout: LayoutNode;
   panes: Record<PaneId, PaneState>;
   focusedPaneId: PaneId;
+  rightTab?: RightTab;
+  rightTabByGroup?: Record<RightGroup, RightTab>;
 }
 
 export interface MoveTabArgs {
@@ -363,6 +365,31 @@ function emptyWorkspace(): ProjectWorkspace {
     layout: makePaneNode(ROOT_PANE_ID),
     panes: { [ROOT_PANE_ID]: emptyPane(ROOT_PANE_ID) },
     focusedPaneId: ROOT_PANE_ID,
+    rightTab: "commits",
+    rightTabByGroup: defaultTabByGroup(),
+  };
+}
+
+type PersistedWorkspaceState = Partial<ProjectWorkspace> & {
+  rightTab?: unknown;
+  rightTabByGroup?: Partial<Record<RightGroup, unknown>>;
+};
+
+function normalizeRightPanelState(
+  rightTab: unknown,
+  rightTabByGroup: Partial<Record<RightGroup, unknown>> | undefined,
+): Pick<ProjectWorkspace, "rightTab" | "rightTabByGroup"> {
+  const byGroup = defaultTabByGroup();
+  for (const group of Object.keys(byGroup) as RightGroup[]) {
+    const remembered = rightTabByGroup?.[group];
+    if (isRightTab(remembered) && groupOfTab(remembered) === group) {
+      byGroup[group] = remembered;
+    }
+  }
+  const active = isRightTab(rightTab) ? rightTab : "commits";
+  return {
+    rightTab: active,
+    rightTabByGroup: byGroup,
   };
 }
 
@@ -403,12 +430,14 @@ function mirrorActive(
   const ws = workspaces[activeProject];
   if (!ws) return fallbackEmptyMirror();
   const activeTabId = ws.panes[ws.focusedPaneId]?.activeTabId ?? null;
+  const rightPanel = normalizeRightPanelState(ws.rightTab, ws.rightTabByGroup);
   return {
     layout: ws.layout,
     panes: ws.panes,
     focusedPaneId: ws.focusedPaneId,
     activeTabId,
     activeSessionId: activeSessionIdFromTabId(activeTabId),
+    ...rightPanel,
   };
 }
 
@@ -501,6 +530,7 @@ function reconcileWorkspace(
   }
 
   return {
+    ...ws,
     layout: newLayout,
     panes: newPanes,
     focusedPaneId: newFocused,
@@ -1660,20 +1690,48 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   setRightTab(tab) {
-    set((s) => ({
-      rightTab: tab,
-      rightTabByGroup: {
+    set((s) => {
+      const rightTabByGroup = {
         ...s.rightTabByGroup,
         [groupOfTab(tab)]: tab,
-      },
-    }));
+      };
+      if (!s.activeProject || !s.workspaces[s.activeProject]) {
+        return { rightTab: tab, rightTabByGroup };
+      }
+      const ws = s.workspaces[s.activeProject];
+      return {
+        rightTab: tab,
+        rightTabByGroup,
+        workspaces: {
+          ...s.workspaces,
+          [s.activeProject]: {
+            ...ws,
+            rightTab: tab,
+            rightTabByGroup,
+          },
+        },
+      };
+    });
   },
 
   setRightGroup(group) {
     set((s) => {
       const remembered = s.rightTabByGroup[group] ?? defaultTabForGroup(group);
       if (s.rightTab === remembered) return s;
-      return { rightTab: remembered };
+      if (!s.activeProject || !s.workspaces[s.activeProject]) {
+        return { rightTab: remembered };
+      }
+      const ws = s.workspaces[s.activeProject];
+      return {
+        rightTab: remembered,
+        workspaces: {
+          ...s.workspaces,
+          [s.activeProject]: {
+            ...ws,
+            rightTab: remembered,
+          },
+        },
+      };
     });
   },
 
@@ -1944,7 +2002,7 @@ export const useAppStore = create<AppStateModel>()(
     {
       name: "acorn-workspaces",
       storage: createJSONStorage(() => localStorage),
-      version: 2,
+      version: 3,
       partialize: (state) => ({
         workspaces: state.workspaces,
         activeProject: state.activeProject,
@@ -1958,11 +2016,6 @@ export const useAppStore = create<AppStateModel>()(
         ),
       }),
       migrate: (persisted, fromVersion) => {
-        // v1 → v2: rightTabByGroup did not exist. Seed it from the persisted
-        // rightTab so the group bar opens to whatever the user last looked at.
-        // An invalid/unknown persisted rightTab leaves rightTabByGroup at the
-        // defaults; the panel-level visibility guard then slides to the
-        // nearest valid tab on first render.
         if (
           persisted &&
           typeof persisted === "object" &&
@@ -1973,7 +2026,35 @@ export const useAppStore = create<AppStateModel>()(
           if (isRightTab(p.rightTab)) {
             seeded[groupOfTab(p.rightTab)] = p.rightTab;
           }
-          return { ...p, rightTabByGroup: seeded } as typeof persisted;
+          persisted = { ...p, rightTabByGroup: seeded };
+        }
+        if (
+          persisted &&
+          typeof persisted === "object" &&
+          fromVersion < 3
+        ) {
+          const p = persisted as {
+            rightTab?: unknown;
+            rightTabByGroup?: Partial<Record<RightGroup, unknown>>;
+            workspaces?: Record<string, PersistedWorkspaceState>;
+          };
+          const rightPanel = normalizeRightPanelState(
+            p.rightTab,
+            p.rightTabByGroup,
+          );
+          const workspaces = Object.fromEntries(
+            Object.entries(p.workspaces ?? {}).map(([repoPath, ws]) => [
+              repoPath,
+              {
+                ...ws,
+                ...normalizeRightPanelState(
+                  ws.rightTab ?? rightPanel.rightTab,
+                  ws.rightTabByGroup ?? rightPanel.rightTabByGroup,
+                ),
+              },
+            ]),
+          );
+          return { ...p, workspaces } as typeof persisted;
         }
         return persisted as typeof persisted;
       },
@@ -2013,7 +2094,15 @@ export const useAppStore = create<AppStateModel>()(
               activationHistory: activationHistoryFor(normalized, ids, active),
             };
           }
-          sanitized[key] = { ...ws, panes: newPanes };
+          sanitized[key] = {
+            ...ws,
+            panes: newPanes,
+            ...normalizeRightPanelState(
+              (ws as PersistedWorkspaceState).rightTab ?? state.rightTab,
+              (ws as PersistedWorkspaceState).rightTabByGroup ??
+                state.rightTabByGroup,
+            ),
+          };
         }
         state.workspaces = sanitized;
         state.workspaceTabs = restoredTabs;


### PR DESCRIPTION
## Summary
Right panel tab selection now follows the active project workspace instead of one global store slot.

1. **Per-project selection state** — stores `rightTab` and `rightTabByGroup` on each `ProjectWorkspace` while keeping the existing root-level fields as active-project mirrors for current consumers.
2. **Scoped tab actions** — updates `setRightTab` and `setRightGroup` so keyboard shortcuts, command palette actions, and panel clicks update the active project workspace.
3. **Persistence migration** — bumps the persisted workspace version and seeds existing workspaces from the previous global Right panel state.
4. **Regression coverage** — adds a store test that switches between two projects and verifies each project keeps its selected tab plus group sub-tab memory independently.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Project switching | Right panel top tab/sub-tab followed the last global selection | Each project restores its own Right panel tab state |
| Existing saved workspace state | One global Right panel state | Migrated into per-project workspace state using the previous selection as the seed |

## Design notes
- `ProjectWorkspace` owns the durable per-project Right panel selection; `mirrorActive` still exposes `rightTab` and `rightTabByGroup` at the store root so existing React consumers do not need call-site changes.
- The workspace fields are optional at the type boundary because old persisted state and test fixtures may only contain layout/pane fields. Hydration and active mirroring normalize missing values to the current defaults.
- `reconcileWorkspace` now preserves workspace-level metadata while reconciling panes against backend sessions.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm exec vitest run src/store.test.ts` — 87 passed, 1 skipped
- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` passes; Vite reported existing chunk-size/dynamic-import warnings

## Notes
- The Vite build warnings are existing bundle-shape warnings and are not caused by this PR.
