### PR TITLE
fix(terminal): stabilize emoji grapheme rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-serialize": "^0.14.0",
+    "@xterm/addon-unicode-graphemes": "^0.4.0",
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/xterm": "^6.0.0",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@xterm/addon-serialize':
         specifier: ^0.14.0
         version: 0.14.0
+      '@xterm/addon-unicode-graphemes':
+        specifier: ^0.4.0
+        version: 0.4.0
       '@xterm/addon-unicode11':
         specifier: ^0.9.0
         version: 0.9.0
@@ -1205,6 +1208,9 @@ packages:
 
   '@xterm/addon-serialize@0.14.0':
     resolution: {integrity: sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==}
+
+  '@xterm/addon-unicode-graphemes@0.4.0':
+    resolution: {integrity: sha512-9+/CqwbKcnlkJU4d3wIgO+wjsL8f6vyz+UwUWLu6nADQz8Gr8ONqGCJfdDjIdI+yYZLABQqQy47FzEM6AWELjw==}
 
   '@xterm/addon-unicode11@0.9.0':
     resolution: {integrity: sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==}
@@ -3221,6 +3227,8 @@ snapshots:
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-serialize@0.14.0': {}
+
+  '@xterm/addon-unicode-graphemes@0.4.0': {}
 
   '@xterm/addon-unicode11@0.9.0': {}
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -7,6 +7,7 @@ import {
 } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
+import { UnicodeGraphemesAddon } from "@xterm/addon-unicode-graphemes";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { Channel, invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
@@ -25,6 +26,10 @@ import {
   patchTerminalCellMeasurements,
   unpatchTerminalCellMeasurements,
 } from "../lib/terminal-cjk-cell-width-addon";
+import {
+  patchTerminalEmojiWidthMeasurements,
+  unpatchTerminalEmojiWidthMeasurements,
+} from "../lib/terminal-emoji-width-addon";
 import {
   createTerminalRepaintScheduler,
   repaintTerminalViewport,
@@ -727,14 +732,16 @@ export function Terminal({
     );
     const serializeAddon = new SerializeAddon();
     const unicode11Addon = new Unicode11Addon();
+    const unicodeGraphemesAddon = new UnicodeGraphemesAddon();
     term.loadAddon(fitAddon);
     term.loadAddon(serializeAddon);
     term.loadAddon(unicode11Addon);
-    // xterm.js defaults to Unicode 6 width tables that treat most emoji as
-    // width 1. The glyph then overflows its cell and adjacent cells overwrite
-    // it, producing the half-rendered / crammed look. Unicode 11 tables mark
-    // modern emoji as width 2 so cell allocation matches the glyph footprint.
-    term.unicode.activeVersion = "11";
+    term.loadAddon(unicodeGraphemesAddon);
+    // xterm.js defaults to Unicode 6 width tables and plain codepoint
+    // accounting. The grapheme provider uses newer width data and keeps
+    // variation-selector, skin-tone, regional-flag, and ZWJ emoji clusters in
+    // a single rendered cell group so following text starts on the right
+    // terminal column.
     termRef.current = term;
     fitRef.current = fitAddon;
 
@@ -744,6 +751,7 @@ export function Terminal({
     // PTY mid-composition. The canvas/webgl addons are faster but mis-handle
     // composition events on macOS/Linux IMEs — we pick correctness over fps.
     term.open(container);
+    patchTerminalEmojiWidthMeasurements(term);
     const unpatchMouseCoordinateScale = patchTerminalMouseCoordinateScale(term);
     const fitWithCellMeasurements = () => {
       const cjkEnabled =
@@ -2176,6 +2184,7 @@ export function Terminal({
       invoke("pty_kill", { sessionId }).catch(() => {
         // Backend may not implement pty_kill yet — safe to ignore.
       });
+      unpatchTerminalEmojiWidthMeasurements(term);
       unpatchMouseCoordinateScale();
       try { webLinksDisposable?.dispose(); } catch { /* ignore */ }
       webLinksDisposable = null;

--- a/src/lib/terminal-emoji-width-addon.test.ts
+++ b/src/lib/terminal-emoji-width-addon.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  patchTerminalEmojiWidthMeasurements,
+  unpatchTerminalEmojiWidthMeasurements,
+} from "./terminal-emoji-width-addon";
+
+describe("terminal emoji width patch", () => {
+  function makeTerminal(measure: (chars: string) => number) {
+    const renderer = {
+      _widthCache: {
+        clear: () => undefined,
+        get: (
+          chars: string,
+          _bold: boolean | number,
+          _italic: boolean | number,
+        ) => measure(chars),
+      },
+      dimensions: { css: { cell: { width: 7.25 } } },
+    };
+    const terminal = {
+      _core: {
+        _renderService: { _renderer: { value: renderer } },
+        unicodeService: {
+          getStringCellWidth: (text: string) =>
+            text === "W" || text === "가" ? 1 : 2,
+        },
+      },
+    };
+    return { renderer, terminal };
+  }
+
+  it("clamps emoji measurements to their terminal grid width", () => {
+    const { renderer, terminal } = makeTerminal((chars) =>
+      chars === "🦊" ? 18 : 7.25,
+    );
+
+    patchTerminalEmojiWidthMeasurements(terminal);
+
+    expect(renderer._widthCache.get("🦊", false, false)).toBe(14.5);
+  });
+
+  it("leaves emoji measurements below the terminal grid width unchanged", () => {
+    const { renderer, terminal } = makeTerminal((chars) =>
+      chars === "🦊" ? 12 : 7.25,
+    );
+
+    patchTerminalEmojiWidthMeasurements(terminal);
+
+    expect(renderer._widthCache.get("🦊", false, false)).toBe(12);
+  });
+
+  it("does not clamp non-emoji wide glyph measurements", () => {
+    const { renderer, terminal } = makeTerminal((chars) =>
+      chars === "가" ? 18 : 7.25,
+    );
+
+    patchTerminalEmojiWidthMeasurements(terminal);
+
+    expect(renderer._widthCache.get("가", false, false)).toBe(18);
+  });
+
+  it("restores the original width cache getter", () => {
+    const { renderer, terminal } = makeTerminal((chars) =>
+      chars === "🚀" ? 20 : 7.25,
+    );
+    const originalGet = renderer._widthCache.get;
+
+    patchTerminalEmojiWidthMeasurements(terminal);
+    expect(renderer._widthCache.get("🚀", false, false)).toBe(14.5);
+
+    unpatchTerminalEmojiWidthMeasurements(terminal);
+
+    expect(renderer._widthCache.get).toBe(originalGet);
+    expect(renderer._widthCache.get("🚀", false, false)).toBe(20);
+  });
+});

--- a/src/lib/terminal-emoji-width-addon.ts
+++ b/src/lib/terminal-emoji-width-addon.ts
@@ -1,0 +1,111 @@
+interface WidthCache {
+  get(chars: string, bold: boolean | number, italic: boolean | number): number;
+  clear?: () => void;
+  __acornEmojiWidthPatch?: {
+    originalGet: WidthCache["get"];
+  };
+}
+
+interface DomRenderer {
+  _widthCache?: WidthCache;
+  dimensions?: {
+    css?: {
+      cell?: {
+        width?: number;
+      };
+    };
+  };
+}
+
+interface TerminalInternals {
+  cols?: number;
+  rows?: number;
+  refresh?: (start: number, end: number) => void;
+  _core?: {
+    _renderService?: {
+      _renderer?: {
+        value?: DomRenderer;
+      };
+    };
+    unicodeService?: {
+      getStringCellWidth?: (text: string) => number;
+    };
+    _unicodeService?: {
+      getStringCellWidth?: (text: string) => number;
+    };
+  };
+}
+
+export function patchTerminalEmojiWidthMeasurements(
+  term: TerminalInternals,
+): void {
+  const renderer = term._core?._renderService?._renderer?.value;
+  const widthCache = renderer?._widthCache;
+  const unicodeService = term._core?.unicodeService ?? term._core?._unicodeService;
+  if (
+    !renderer ||
+    !widthCache ||
+    typeof widthCache.get !== "function" ||
+    widthCache.__acornEmojiWidthPatch
+  ) {
+    return;
+  }
+
+  const patch = { originalGet: widthCache.get };
+  widthCache.__acornEmojiWidthPatch = patch;
+  widthCache.get = (chars, bold, italic) => {
+    const measuredWidth = patch.originalGet.call(widthCache, chars, bold, italic);
+    if (!isEmojiLikeTerminalCluster(chars) || measuredWidth <= 0) {
+      return measuredWidth;
+    }
+
+    const cellWidth = renderer.dimensions?.css?.cell?.width;
+    const cellCount = unicodeService?.getStringCellWidth?.(chars);
+    if (
+      typeof cellWidth !== "number" ||
+      !Number.isFinite(cellWidth) ||
+      cellWidth <= 0 ||
+      typeof cellCount !== "number" ||
+      !Number.isFinite(cellCount) ||
+      cellCount < 2
+    ) {
+      return measuredWidth;
+    }
+
+    const gridWidth = cellWidth * cellCount;
+    return Number.isFinite(gridWidth) && gridWidth > 0
+      ? Math.min(measuredWidth, gridWidth)
+      : measuredWidth;
+  };
+  widthCache.clear?.();
+}
+
+export function unpatchTerminalEmojiWidthMeasurements(
+  term: TerminalInternals,
+): void {
+  const widthCache =
+    term._core?._renderService?._renderer?.value?._widthCache;
+  const patch = widthCache?.__acornEmojiWidthPatch;
+  if (!widthCache || !patch) return;
+
+  widthCache.get = patch.originalGet;
+  delete widthCache.__acornEmojiWidthPatch;
+  widthCache.clear?.();
+}
+
+function isEmojiLikeTerminalCluster(chars: string): boolean {
+  for (const char of chars) {
+    const codePoint = char.codePointAt(0);
+    if (codePoint === undefined) continue;
+    if (
+      codePoint === 0x200d ||
+      codePoint === 0x20e3 ||
+      codePoint === 0xfe0f ||
+      (codePoint >= 0x2600 && codePoint <= 0x27bf) ||
+      (codePoint >= 0x1f000 && codePoint <= 0x1faff)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -139,6 +139,105 @@ async function terminalTextAndUnderlineRects(
   }, text);
 }
 
+async function terminalEmojiTrailingOffsets(page: Page): Promise<{
+  cellWidth: number;
+  offsets: Record<string, number>;
+  emojiLetterSpacing: number[];
+}> {
+  return page.evaluate(() => {
+    const rows = Array.from(
+      document.querySelectorAll<HTMLElement>(".xterm-rows > div"),
+    );
+    const rowFor = (marker: string) => {
+      const row = rows.find((candidate) =>
+        (candidate.textContent ?? "").includes(marker),
+      );
+      if (!row) throw new Error(`missing terminal row: ${marker}`);
+      return row;
+    };
+    const rangeRect = (
+      row: HTMLElement,
+      start: number,
+      end: number,
+    ): DOMRect => {
+      const walker = document.createTreeWalker(row, NodeFilter.SHOW_TEXT);
+      const range = document.createRange();
+      let offset = 0;
+      let startSet = false;
+      let endSet = false;
+
+      for (
+        let node = walker.nextNode() as Text | null;
+        node;
+        node = walker.nextNode() as Text | null
+      ) {
+        const textLength = node.textContent?.length ?? 0;
+        const nextOffset = offset + textLength;
+        if (!startSet && start <= nextOffset) {
+          range.setStart(node, Math.max(0, start - offset));
+          startSet = true;
+        }
+        if (startSet && end <= nextOffset) {
+          range.setEnd(node, Math.max(0, end - offset));
+          endSet = true;
+          break;
+        }
+        offset = nextOffset;
+      }
+
+      if (!startSet || !endSet) {
+        range.detach();
+        throw new Error("missing terminal text range");
+      }
+      const rect = range.getBoundingClientRect();
+      range.detach();
+      return rect;
+    };
+    const characterRect = (row: HTMLElement, index: number) =>
+      rangeRect(row, index, index + 1);
+    const trailingOffset = (marker: string): number => {
+      const row = rowFor(marker);
+      const text = row.textContent ?? "";
+      const markerStart = text.indexOf(marker);
+      const aStart = markerStart + marker.length;
+      const bStart = text.indexOf("B", aStart + 1);
+      if (markerStart < 0 || bStart < 0) {
+        throw new Error(`missing A/B cells for ${marker}`);
+      }
+      return characterRect(row, bStart).left - characterRect(row, aStart).left;
+    };
+    const emojiLikePattern =
+      /[\u200d\u20e3\ufe0f\u2600-\u27bf\u{1f000}-\u{1faff}]/u;
+    const emojiLetterSpacing = rows.flatMap((row) =>
+      Array.from(row.querySelectorAll<HTMLElement>("span"))
+        .filter((span) => emojiLikePattern.test(span.textContent ?? ""))
+        .map((span) => {
+          const parsed = Number.parseFloat(
+            window.getComputedStyle(span).letterSpacing,
+          );
+          return Number.isFinite(parsed) ? parsed : 0;
+        }),
+    );
+
+    const refRow = rowFor("R: AB");
+    const refText = refRow.textContent ?? "";
+    const refA = refText.indexOf("A");
+    const refB = refText.indexOf("B", refA + 1);
+    if (refA < 0 || refB < 0) throw new Error("missing reference cells");
+
+    return {
+      cellWidth:
+        characterRect(refRow, refB).left - characterRect(refRow, refA).left,
+      offsets: {
+        heart: trailingOffset("H: "),
+        skinTone: trailingOffset("S: "),
+        zwj: trailingOffset("Z: "),
+      },
+      emojiLetterSpacing,
+    };
+  });
+}
+
 async function gotoWithAccent(page: Page): Promise<void> {
   await page.goto("/");
   await page.addStyleTag({
@@ -269,6 +368,81 @@ test.describe("terminal: spawn", () => {
     expect(first.cwd).toBe("/tmp/demo");
     expect(first.parentPane).not.toBeNull();
     expect(first.parentLimbo).toBeNull();
+  });
+
+  test("renders emoji grapheme clusters as two-cell terminal glyphs", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __emojiWidthChannelId?: number;
+      };
+      w.__emojiWidthChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __emojiWidthChannelId?: number })
+              .__emojiWidthChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    await emitSubscribedPtyOutput(
+      page,
+      "__emojiWidthChannelId",
+      [
+        "R: AB",
+        'Q: "🦊🌪️⚡🎸🚀🐙🧻🎲🦕"Z',
+        "H: A\u2764\uFE0FB",
+        "S: A\u{1F44D}\u{1F3FD}B",
+        "Z: A\u{1F9D1}\u200D\u{1F4BB}B",
+      ].join("\r\n") + "\r\n",
+    );
+    await expect(page.locator(".xterm-rows")).toContainText("Z: A");
+
+    const { cellWidth, offsets, emojiLetterSpacing } =
+      await terminalEmojiTrailingOffsets(page);
+    const expected = cellWidth * 3;
+    for (const offset of Object.values(offsets)) {
+      expect(Math.abs(offset - expected)).toBeLessThan(cellWidth * 0.35);
+    }
+    expect(emojiLetterSpacing.length).toBeGreaterThan(0);
+    for (const spacing of emojiLetterSpacing) {
+      expect(spacing).toBeGreaterThanOrEqual(0);
+    }
   });
 
   test("opens file:line terminal links in the code viewer", async ({


### PR DESCRIPTION
## Summary
This fixes emoji rendering in the terminal by handling modern grapheme clusters and preventing xterm's DOM renderer from visually compressing emoji glyphs.

1. **Grapheme-aware emoji width** — load `@xterm/addon-unicode-graphemes` so variation selectors, skin-tone modifiers, regional indicators, and ZWJ emoji clusters are treated as one terminal glyph group.
2. **DOM width-cache clamp** — wrap xterm's DOM width cache for emoji-like clusters so measured glyph width cannot create negative renderer spacing below the terminal grid width.
3. **Regression coverage** — add Vitest coverage for the width-cache wrapper and Playwright coverage for emoji cluster offsets plus nonnegative emoji span spacing.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal emoji input/output | Emoji clusters could appear cramped or overlapped, and following text could look mispositioned | Emoji grapheme clusters keep their intended two-cell placement without negative renderer compression |
| Non-emoji terminal text | Unchanged | Unchanged |
| CJK terminal width handling | Existing local patch remains separate | Emoji clamping is scoped to emoji-like clusters and leaves non-emoji/CJK measurements untouched |

## Design notes
- The DOM renderer stays in use because Acorn's current terminal path depends on its IME behavior.
- The new width-cache patch follows the existing internal-renderer patching pattern used by `terminal-cjk-cell-width-addon`; it is scoped to emoji-like clusters and restores the original getter on terminal cleanup.
- Upstream xterm.js has a related DOM renderer emoji layout issue: https://github.com/xtermjs/xterm.js/issues/5893. This PR keeps Acorn's workaround local and narrow for the current `@xterm/xterm@6.0.0` integration.

## Follow-up (not in this PR)
- Revisit the local width-cache clamp after xterm.js ships a stable upstream fix for DOM renderer emoji/grapheme layout.

## Test plan
- [x] `pnpm exec vitest run src/lib/terminal-emoji-width-addon.test.ts src/lib/terminal-cjk-cell-width-addon.test.ts` — 2 files, 17 tests passed
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts` — 14 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed

## Notes
- `pnpm run build` still reports pre-existing Vite warnings for modules that are both statically and dynamically imported, plus chunk-size warnings. No new build failure.
