### PR TITLE
chore(release): v1.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.11.2",
+  "version": "1.11.3",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.11.2"
+version = "1.11.3"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.11.2"
+version = "1.11.3"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
Prepare the patch release for the terminal emoji rendering fix merged after `v1.11.2`.

1. **Version bump:** Update package, Tauri, and Cargo versions from `1.11.2` to `1.11.3`.
2. **Release scope:** Include PR #358 already merged to `main`.

## Expected impact
| Area | Impact |
| --- | --- |
| Release packaging | `v1.11.3` bundles and updater metadata will carry the matching app version. |
| Changelog | No user-facing release-note entry from this bump PR; PR #358 supplies the changelog item. |

## Design notes
This PR only aligns version metadata before creating the `v1.11.3` tag. Semantic versioning points to a patch bump because only a `fix` change landed after `v1.11.2`; no `feat` or breaking-change PRs are included.

## Test plan
- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` confirmed app version `1.11.3`
- [x] `rg -n '1\\.11\\.2|1\\.11\\.3' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock`
- [x] `REPO=im-ian/acorn TAG=v1.11.3 OUTPUT=/tmp/acorn-release-notes-v1.11.3.md node scripts/release-notes.mjs`
- [x] `git diff --check`
- [ ] CI green
- [ ] Release workflow publishes `v1.11.3` assets and `latest.json`

## Notes
Use `skip-changelog` so this mechanical release bump does not appear in the generated in-app changelog.
