### PR TITLE
fix(terminal): route native file drops into terminal mentions

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,7 @@
         "height": 800,
         "minWidth": 900,
         "minHeight": 600,
-        "dragDropEnabled": false,
+        "dragDropEnabled": true,
         "devtools": false
       }
     ],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,6 +83,7 @@ import { applyBackgroundVars, clearBackgroundVars } from "./lib/background";
 import { applyTheme, useThemes } from "./lib/themes";
 import { extractTabFromEvent } from "./lib/settings-events";
 import { useAcornDragGlobalCleanup } from "./lib/dnd";
+import { useNativeFileDropTerminalBridge } from "./lib/nativeFileDrop";
 import {
   nextSessionStatusPollDelayMs,
   selectDueSessionStatusPollIds,
@@ -171,6 +172,7 @@ function focusAdjacentPane(direction: "left" | "right" | "up" | "down") {
 function App() {
   const t = useTranslation();
   useAcornDragGlobalCleanup();
+  useNativeFileDropTerminalBridge();
   const refreshAll = useAppStore((s) => s.refreshAll);
   const sessions = useAppStore((s) => s.sessions);
   const projects = useAppStore((s) => s.projects);

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -20,6 +20,10 @@ import { api } from "../lib/api";
 import type { BackgroundState } from "../lib/background";
 import { visibleMultiInputSessionIds } from "../lib/multiInput";
 import { endAcornDrag, getCurrentFilePayload } from "../lib/dnd";
+import {
+  extractNativeFileDropPaths,
+  hasNativeFileDropData,
+} from "../lib/fileDrop";
 import { formatTerminalFileMention } from "../lib/fileMention";
 import { registerScrollbackFlusher } from "../lib/scrollback-coordinator";
 import {
@@ -1433,16 +1437,23 @@ export function Terminal({
     container.addEventListener("paste", onPaste, true);
 
     const onDragOver = (e: DragEvent) => {
-      if (!getCurrentFilePayload()) return;
+      if (!getCurrentFilePayload() && !hasNativeFileDropData(e.dataTransfer)) {
+        return;
+      }
       e.preventDefault();
       if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
     };
     const onDrop = (e: DragEvent) => {
       const payload = getCurrentFilePayload();
-      if (!payload) return;
+      const paths = payload
+        ? [payload.path]
+        : extractNativeFileDropPaths(e.dataTransfer);
+      if (paths.length === 0) return;
       e.preventDefault();
       try {
-        sendUserInputToPty(formatTerminalFileMention(payload.path, cwd));
+        sendUserInputToPty(
+          paths.map((path) => formatTerminalFileMention(path, cwd)).join(""),
+        );
         term.focus();
       } finally {
         endAcornDrag();

--- a/src/lib/fileDrop.test.ts
+++ b/src/lib/fileDrop.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractNativeFileDropPaths,
+  hasNativeFileDropData,
+} from "./fileDrop";
+
+interface FakeTransfer {
+  types?: string[];
+  items?: Array<{ kind: string }>;
+  files?: Array<{ path?: string }>;
+  data?: Record<string, string>;
+}
+
+function transfer({
+  types = [],
+  items = [],
+  files = [],
+  data = {},
+}: FakeTransfer) {
+  return {
+    types,
+    items,
+    files,
+    getData(type: string) {
+      return data[type] ?? "";
+    },
+  };
+}
+
+describe("hasNativeFileDropData", () => {
+  it("detects OS file drags by standard Files type", () => {
+    expect(hasNativeFileDropData(transfer({ types: ["Files"] }))).toBe(true);
+  });
+
+  it("detects WebKit file URL pasteboard drags", () => {
+    expect(hasNativeFileDropData(transfer({ types: ["public.file-url"] }))).toBe(
+      true,
+    );
+  });
+
+  it("detects browser DataTransfer file lists", () => {
+    expect(
+      hasNativeFileDropData(transfer({ files: [{ path: undefined }] })),
+    ).toBe(true);
+  });
+
+  it("ignores Acorn-owned text drags without native file markers", () => {
+    expect(
+      hasNativeFileDropData(
+        transfer({ types: ["text/plain", "text/uri-list"] }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("extractNativeFileDropPaths", () => {
+  it("decodes file URLs from text/uri-list", () => {
+    expect(
+      extractNativeFileDropPaths(
+        transfer({
+          types: ["Files", "text/uri-list"],
+          data: {
+            "text/uri-list":
+              "# comment\r\nfile:///Users/me/Desktop/PR%20notes.md\r\nhttps://example.com",
+          },
+        }),
+      ),
+    ).toEqual(["/Users/me/Desktop/PR notes.md"]);
+  });
+
+  it("uses public.file-url when WebKit exposes that pasteboard type", () => {
+    expect(
+      extractNativeFileDropPaths(
+        transfer({
+          types: ["public.file-url"],
+          data: {
+            "public.file-url": "file:///Users/me/Desktop/screenshot.png",
+          },
+        }),
+      ),
+    ).toEqual(["/Users/me/Desktop/screenshot.png"]);
+  });
+
+  it("uses non-standard File.path values when a webview provides them", () => {
+    expect(
+      extractNativeFileDropPaths(
+        transfer({
+          types: ["Files"],
+          files: [{ path: "/Users/me/Desktop/raw.log" }],
+        }),
+      ),
+    ).toEqual(["/Users/me/Desktop/raw.log"]);
+  });
+
+  it("keeps Windows drive paths from file URLs usable", () => {
+    expect(
+      extractNativeFileDropPaths(
+        transfer({
+          types: ["Files"],
+          data: { "text/uri-list": "file:///C:/Users/me/Desktop/a.txt" },
+        }),
+      ),
+    ).toEqual(["C:/Users/me/Desktop/a.txt"]);
+  });
+
+  it("does not extract paths from text-only drags", () => {
+    expect(
+      extractNativeFileDropPaths(
+        transfer({
+          types: ["text/plain"],
+          data: { "text/plain": "/Users/me/Desktop/a.txt" },
+        }),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/src/lib/fileDrop.ts
+++ b/src/lib/fileDrop.ts
@@ -1,0 +1,129 @@
+interface DataTransferItemLike {
+  kind: string;
+}
+
+interface FileLike {
+  name?: unknown;
+  path?: unknown;
+}
+
+interface FileDropDataTransferLike {
+  types?: ArrayLike<string> | Iterable<string>;
+  items?: ArrayLike<DataTransferItemLike> | null;
+  files?: ArrayLike<FileLike> | null;
+  getData(type: string): string;
+}
+
+const NATIVE_FILE_TYPES = new Set(["Files", "public.file-url"]);
+const FILE_URL_DATA_TYPES = ["text/uri-list", "public.file-url", "URL"];
+
+function arrayFromList<T>(
+  value: ArrayLike<T> | Iterable<T> | null | undefined,
+): T[] {
+  if (!value) return [];
+  return Array.from(value);
+}
+
+function getTransferTypes(dataTransfer: FileDropDataTransferLike): string[] {
+  return arrayFromList(dataTransfer.types).filter(
+    (type): type is string => typeof type === "string",
+  );
+}
+
+function getTransferData(
+  dataTransfer: FileDropDataTransferLike,
+  type: string,
+): string {
+  try {
+    return dataTransfer.getData(type);
+  } catch {
+    return "";
+  }
+}
+
+function fileUrlToPath(value: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "file:") return null;
+
+  let path = decodeURIComponent(url.pathname);
+  if (/^\/[a-zA-Z]:\//u.test(path)) {
+    path = path.slice(1);
+  }
+  if (url.hostname && url.hostname !== "localhost") {
+    return `//${url.hostname}${path}`;
+  }
+  return path;
+}
+
+function collectUriListPaths(value: string, paths: string[]): void {
+  for (const rawLine of value.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const path = fileUrlToPath(line);
+    if (path) paths.push(path);
+  }
+}
+
+function collectPlainTextPaths(value: string, paths: string[]): void {
+  for (const rawLine of value.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith("file:")) {
+      const path = fileUrlToPath(line);
+      if (path) paths.push(path);
+      continue;
+    }
+    if (line.startsWith("/") || /^[a-zA-Z]:[\\/]/u.test(line)) {
+      paths.push(line);
+    }
+  }
+}
+
+function uniqueNonEmpty(paths: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const path of paths) {
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    result.push(path);
+  }
+  return result;
+}
+
+export function hasNativeFileDropData(
+  dataTransfer: FileDropDataTransferLike | null | undefined,
+): boolean {
+  if (!dataTransfer) return false;
+  if (arrayFromList(dataTransfer.files).length > 0) return true;
+  if (
+    getTransferTypes(dataTransfer).some((type) => NATIVE_FILE_TYPES.has(type))
+  ) {
+    return true;
+  }
+  return arrayFromList(dataTransfer.items).some((item) => item.kind === "file");
+}
+
+export function extractNativeFileDropPaths(
+  dataTransfer: FileDropDataTransferLike | null | undefined,
+): string[] {
+  if (!dataTransfer || !hasNativeFileDropData(dataTransfer)) return [];
+
+  const paths: string[] = [];
+  for (const file of arrayFromList(dataTransfer.files)) {
+    if (typeof file.path === "string" && file.path.length > 0) {
+      paths.push(file.path);
+    }
+  }
+
+  for (const type of FILE_URL_DATA_TYPES) {
+    collectUriListPaths(getTransferData(dataTransfer, type), paths);
+  }
+  collectPlainTextPaths(getTransferData(dataTransfer, "text/plain"), paths);
+
+  return uniqueNonEmpty(paths);
+}

--- a/src/lib/nativeFileDrop.ts
+++ b/src/lib/nativeFileDrop.ts
@@ -1,0 +1,121 @@
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useEffect } from "react";
+import { api } from "./api";
+import { formatTerminalFileMention } from "./fileMention";
+import { visibleMultiInputSessionIds } from "./multiInput";
+import { useAppStore } from "../store";
+
+interface DropPoint {
+  x: number;
+  y: number;
+}
+
+interface NativeDropPosition extends DropPoint {
+  toLogical?: (scaleFactor: number) => DropPoint;
+}
+
+interface TerminalDropTarget {
+  sessionId: string;
+  cwd: string;
+}
+
+function toLogicalPoint(
+  position: NativeDropPosition,
+  scaleFactor: number,
+): DropPoint {
+  if (typeof position.toLogical === "function") {
+    return position.toLogical(scaleFactor);
+  }
+  return {
+    x: position.x / scaleFactor,
+    y: position.y / scaleFactor,
+  };
+}
+
+export function terminalDropTargetAtPoint(
+  point: DropPoint,
+): TerminalDropTarget | null {
+  const element = document.elementFromPoint(
+    point.x,
+    point.y,
+  ) as HTMLElement | null;
+  const slot = element?.closest<HTMLElement>("[data-acorn-terminal-slot]");
+  if (!slot?.dataset.acornTerminalSlot) return null;
+  if (!slot.closest("[data-pane-body]")) return null;
+
+  const sessionId = slot.dataset.acornTerminalSlot;
+  const session = useAppStore
+    .getState()
+    .sessions.find((candidate) => candidate.id === sessionId);
+  if (!session) return null;
+  return { sessionId, cwd: session.worktree_path };
+}
+
+function ptyWriteTargets(primarySessionId: string): string[] {
+  const state = useAppStore.getState();
+  const targets = state.multiInputEnabled
+    ? visibleMultiInputSessionIds(state.panes)
+    : [primarySessionId];
+  return targets.length > 0 ? targets : [primarySessionId];
+}
+
+function writePathsToTerminal(target: TerminalDropTarget, paths: string[]): void {
+  if (paths.length === 0) return;
+  const data = paths
+    .map((path) => formatTerminalFileMention(path, target.cwd))
+    .join("");
+  for (const sessionId of ptyWriteTargets(target.sessionId)) {
+    void api.ptyWrite(sessionId, data).catch((err: unknown) => {
+      console.error("[nativeFileDrop] pty_write failed", err);
+    });
+  }
+}
+
+export function useNativeFileDropTerminalBridge(): void {
+  useEffect(() => {
+    if (!("__TAURI_INTERNALS__" in window)) return;
+
+    let disposed = false;
+    let scaleFactor = window.devicePixelRatio || 1;
+    let unlisten: (() => void) | null = null;
+
+    void getCurrentWindow()
+      .scaleFactor()
+      .then((factor) => {
+        if (!disposed && Number.isFinite(factor) && factor > 0) {
+          scaleFactor = factor;
+        }
+      })
+      .catch((err: unknown) => {
+        console.debug("[nativeFileDrop] scale factor probe failed", err);
+      });
+
+    void getCurrentWebview()
+      .onDragDropEvent((event) => {
+        if (disposed || event.payload.type !== "drop") return;
+        const point = toLogicalPoint(
+          event.payload.position as NativeDropPosition,
+          scaleFactor,
+        );
+        const target = terminalDropTargetAtPoint(point);
+        if (!target) return;
+        writePathsToTerminal(target, event.payload.paths);
+      })
+      .then((off) => {
+        if (disposed) {
+          off();
+          return;
+        }
+        unlisten = off;
+      })
+      .catch((err: unknown) => {
+        console.error("[nativeFileDrop] listener setup failed", err);
+      });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
+}

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -25,6 +25,7 @@ export const tauriMockSource = `
     if (cmd === 'plugin:notification|notify') return Promise.resolve(undefined);
     if (cmd === 'plugin:window|destroy') return Promise.resolve(undefined);
     if (cmd === 'plugin:window|close') return Promise.resolve(undefined);
+    if (cmd === 'plugin:window|scale_factor') return Promise.resolve(1);
     if (cmd === 'plugin:path|resolve_directory') return Promise.resolve('/Users/tester');
     if (cmd === 'plugin:path|app_local_data_dir') return Promise.resolve('/tmp/acorn-e2e');
     if (cmd === 'plugin:path|join') {

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -43,6 +43,42 @@ async function seedAlphaBetaTerminals(tauri: TauriMock): Promise<void> {
   await tauri.handle("pty_spawn", () => null);
 }
 
+async function seedWritableTerminal(tauri: TauriMock): Promise<void> {
+  await tauri.handle("list_projects", () => [
+    {
+      repo_path: "/tmp/demo",
+      name: "demo",
+      created_at: "2026-01-01T00:00:00Z",
+      position: 0,
+    },
+  ]);
+  await tauri.handle("list_sessions", () => [
+    {
+      id: "s-term",
+      name: "shell",
+      repo_path: "/tmp/demo",
+      worktree_path: "/tmp/demo",
+      branch: "main",
+      isolated: false,
+      status: "idle",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:05Z",
+      last_message: null,
+    },
+  ]);
+  await tauri.handle("pty_spawn", () => null);
+  await tauri.handle("pty_write", (args: unknown) => {
+    const w = window as unknown as { __ptyWrites?: string[] };
+    w.__ptyWrites = w.__ptyWrites ?? [];
+    const { data } = args as { data: string };
+    const binary = atob(data);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    w.__ptyWrites.push(new TextDecoder().decode(bytes));
+    return null;
+  });
+}
+
 async function emitSubscribedPtyOutput(
   page: Page,
   channelIdKey: string,
@@ -413,6 +449,91 @@ test.describe("terminal: spawn", () => {
     expect(first.cwd).toBe("/tmp/demo");
     expect(first.parentPane).not.toBeNull();
     expect(first.parentLimbo).toBeNull();
+  });
+
+  test("drops desktop file paths into the focused terminal", async ({
+    page,
+    tauri,
+  }) => {
+    await seedWritableTerminal(tauri);
+    await tauri.handle("plugin:event|listen", (args: unknown) => {
+      const { event, handler } = args as { event: string; handler: number };
+      const w = window as unknown as {
+        __tauriEventHandlers?: Record<string, number>;
+      };
+      w.__tauriEventHandlers = w.__tauriEventHandlers ?? {};
+      w.__tauriEventHandlers[event] = handler;
+      return handler;
+    });
+    await tauri.handle("plugin:event|unlisten", () => undefined);
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await page.waitForTimeout(150);
+    await page.evaluate(() => {
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+    });
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __tauriEventHandlers?: Record<string, number>;
+              }
+            ).__tauriEventHandlers?.["tauri://drag-drop"] ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const terminalBox = await page
+      .locator("[data-pane-body] .acorn-terminal")
+      .boundingBox();
+    expect(terminalBox).not.toBeNull();
+
+    await page.evaluate((box) => {
+      if (!box) throw new Error("missing terminal box");
+      const w = window as unknown as {
+        __tauriEventHandlers?: Record<string, number>;
+        [key: string]: unknown;
+      };
+      const id = w.__tauriEventHandlers?.["tauri://drag-drop"];
+      if (typeof id !== "number") throw new Error("missing drag-drop handler");
+      const callback = w[`_${id}`] as
+        | ((payload: {
+            event: string;
+            id: number;
+            payload: {
+              paths: string[];
+              position: { x: number; y: number };
+            };
+          }) => void)
+        | undefined;
+      if (!callback) throw new Error("missing drag-drop callback");
+      callback({
+        event: "tauri://drag-drop",
+        id,
+        payload: {
+          paths: ["/Users/tester/Desktop/PR notes.md"],
+          position: {
+            x: box.x + box.width / 2,
+            y: box.y + box.height / 2,
+          },
+        },
+      });
+    }, terminalBox);
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as unknown as { __ptyWrites?: string[] }).__ptyWrites,
+        ),
+      )
+      .toEqual(["@/Users/tester/Desktop/PR\\ notes.md "]);
   });
 
   test("renders emoji grapheme clusters as two-cell terminal glyphs", async ({


### PR DESCRIPTION
## Summary
Native OS file drops now land in Acorn terminals as path mentions instead of letting the WebView navigate to the dropped file.

1. **Tauri file-drop ownership** — enable Tauri drag/drop events and bridge native drops to the terminal under the drop point.
2. **Terminal mention behavior** — format dropped paths with the existing terminal mention helper and preserve multi-input fanout.
3. **Regression coverage** — add DOM file-drop parsing tests plus a Playwright regression for desktop file drops into a focused terminal.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Native file drop into terminal | Dropping files such as PDFs could navigate the WebView to the file | The target terminal receives an `@path ` mention |
| File Explorer drag into terminal | Existing Acorn-owned drag payload inserted a path mention | Behavior remains covered through the same mention formatter |
| Multi-input mode | Regular terminal input fans out to visible terminals | Dropped file mentions follow the same fanout behavior |

## Design notes
- The native bridge is App-level and no-ops outside Tauri, so browser-only E2E boot remains stable.
- Tauri emits physical drop coordinates; the bridge converts them to logical coordinates before resolving the stable terminal portal slot.
- The existing Terminal drop handler still owns Acorn file-explorer payloads, while the new parser handles browser/WebKit file URL data when available.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/lib/fileDrop.test.ts src/lib/fileMention.test.ts src/lib/dnd.test.ts src/components/PaneDropOverlay.test.tsx` — 26 tests pass
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts -g "drops desktop file paths"` — 1 test passes
- [x] `pnpm run build` passes

## Notes
- `pnpm run build` emits non-fatal Vite warnings about mixed static/dynamic imports and large chunks; the command exits successfully.