### PR TITLE
fix(dialog): avoid native folder picker hangs

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -139,24 +139,33 @@ fn folder_granted(state: &AppState, path: &Path) -> AppResult<PathBuf> {
     }
 }
 
-fn pick_folder_path<R: Runtime>(
+async fn pick_folder_path<R: Runtime>(
     app: &AppHandle<R>,
     title: Option<String>,
 ) -> AppResult<Option<PathBuf>> {
     let mut dialog = app.dialog().file();
     if let Some(title) = title.and_then(|title| {
         let title = title.trim().to_string();
-        if title.is_empty() { None } else { Some(title) }
+        if title.is_empty() {
+            None
+        } else {
+            Some(title)
+        }
     }) {
         dialog = dialog.set_title(title);
     }
-    dialog
-        .blocking_pick_folder()
-        .map(|path| {
-            path.into_path()
-                .map_err(|err| AppError::Other(err.to_string()))
-        })
-        .transpose()
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    dialog.pick_folder(move |path| {
+        let selected_path = path
+            .map(|path| {
+                path.into_path()
+                    .map_err(|err| AppError::Other(err.to_string()))
+            })
+            .transpose();
+        let _ = tx.send(selected_path);
+    });
+    rx.await
+        .map_err(|_| AppError::Other("folder picker closed before returning".to_string()))?
 }
 
 fn validate_editor_command(command: &str, args: &[String]) -> AppResult<String> {
@@ -1083,7 +1092,7 @@ pub async fn create_session(
 }
 
 #[tauri::command]
-pub fn create_session_from_dialog<R: Runtime>(
+pub async fn create_session_from_dialog<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, AppState>,
     name: String,
@@ -1093,7 +1102,7 @@ pub fn create_session_from_dialog<R: Runtime>(
     project_scoped: Option<bool>,
     title: Option<String>,
 ) -> AppResult<Option<Session>> {
-    let Some(selected_path) = pick_folder_path(&app, title)? else {
+    let Some(selected_path) = pick_folder_path(&app, title).await? else {
         return Ok(None);
     };
     Ok(Some(create_session_inner(
@@ -1161,12 +1170,12 @@ pub fn list_projects(state: State<'_, AppState>) -> Vec<Project> {
 }
 
 #[tauri::command]
-pub fn add_project<R: Runtime>(
+pub async fn add_project<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, AppState>,
     title: Option<String>,
 ) -> AppResult<Option<Project>> {
-    let Some(path) = pick_folder_path(&app, title)? else {
+    let Some(path) = pick_folder_path(&app, title).await? else {
         return Ok(None);
     };
     let path = worktree::project_root_for_path(&path)?;
@@ -1176,12 +1185,12 @@ pub fn add_project<R: Runtime>(
 }
 
 #[tauri::command]
-pub fn select_project_parent_folder<R: Runtime>(
+pub async fn select_project_parent_folder<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, AppState>,
     title: Option<String>,
 ) -> AppResult<Option<String>> {
-    let Some(path) = pick_folder_path(&app, title)? else {
+    let Some(path) = pick_folder_path(&app, title).await? else {
         return Ok(None);
     };
     let path = remember_folder_grant(state.inner(), &path)?;


### PR DESCRIPTION
## Summary
Fixes a native folder picker hang introduced by using Tauri's blocking dialog API from a main-thread command path.

1. **Non-blocking native folder picker** — replace `blocking_pick_folder()` with `pick_folder(...)` bridged through a `tokio::sync::oneshot`, so the command can await the dialog result without parking the AppKit/WebKit main thread.
2. **Async command callers** — convert `create_session_from_dialog`, `add_project`, and `select_project_parent_folder` to async commands while preserving their existing frontend `invoke` payloads and return values.

## Expected impact
| Flow | Before | After |
| --- | --- | --- |
| Add existing project | Could put Acorn into macOS "not responding" while opening the native picker | Native picker result is awaited without blocking the main event loop |
| New session from directory picker | Same blocking-dialog risk | Same backend-owned picker contract without main-thread parking |
| New project parent folder picker | Same blocking-dialog risk | Same folder grant behavior without main-thread parking |

## Design notes
- The backend still owns folder selection, so the project/folder trust boundary from the security hardening remains intact.
- The callback result preserves the previous `Option<PathBuf>` behavior: cancelled dialogs return `Ok(None)`, selected paths are converted through `FilePath::into_path()`, and conversion failures surface as `AppError::Other`.
- No frontend API changes were needed; existing `api.ts` wrappers and E2E mocks still call the same command names.

## Test plan
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` passes
- [x] `pnpm run typecheck` passes
- [x] `git diff --check` passes
- [x] `rg -n "blocking_pick_folder|blocking_pick_file|blocking_save_file|blocking_pick_folders" src-tauri/src src -g '!src-tauri/target/**'` returns no matches
- [x] `env -u ACORN_DATA_DIR -u ACORN_IPC_SOCKET -u ACORN_DAEMON_SOCKET -u ACORN_AGENT_STATE_DIR -u ACORN_AGENT_WRAPPER_DIR -u ACORN_CLI_DIR -u ACORN_RESUME_TOKEN -u ACORN_STAGED_REV -u ACORN_USER_ZDOTDIR ACORN_PROFILE=dev pnpm tauri dev` launches Vite at `http://localhost:1420/`, runs `target/debug/acorn`, and logs IPC under `profiles/dev/ipc.sock`

## Notes
- The original hang report's heaviest stack was `add_project -> pick_folder_path -> blocking_pick_folder -> semaphore_wait_trap`, matching this fix path.