### PR TITLE
fix(ui): align modal header icons

### DIFF
--- a/src/components/AgentResumeModal.tsx
+++ b/src/components/AgentResumeModal.tsx
@@ -150,11 +150,7 @@ export function AgentResumeModal({
         title={dt(t, "dialogs.agentResume.title")}
         subtitle={lastActivityLabel}
         titleId={copy.ariaLabelledBy}
-        icon={
-          <span className="self-start pt-0.5">
-            <History size={14} className="text-accent" />
-          </span>
-        }
+        icon={<History size={14} className="text-accent" />}
         variant="dialog"
         onClose={dismiss}
       />

--- a/src/components/FolderPermissionWarmupModal.tsx
+++ b/src/components/FolderPermissionWarmupModal.tsx
@@ -138,11 +138,7 @@ export function FolderPermissionWarmupModal({
         title={dt(t, "dialogs.folderPermissionWarmup.title")}
         subtitle={dt(t, "dialogs.folderPermissionWarmup.subtitle")}
         titleId="acorn-folder-permission-warmup-title"
-        icon={
-          <span className="self-start pt-0.5">
-            <FolderCheck size={14} className="text-accent" />
-          </span>
-        }
+        icon={<FolderCheck size={14} className="text-accent" />}
         variant="dialog"
         onClose={onClose}
       />

--- a/src/components/ui/ModalHeader.tsx
+++ b/src/components/ui/ModalHeader.tsx
@@ -39,9 +39,11 @@ export function ModalHeader({
   const hoverBg =
     variant === "dialog" ? "hover:bg-bg-sidebar" : "hover:bg-bg-elevated";
   return (
-    <header className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
-      <div className="flex min-w-0 items-center gap-2">
-        {icon}
+    <header className="flex shrink-0 items-start justify-between gap-3 border-b border-border px-4 py-3">
+      <div className="flex min-w-0 items-start gap-2">
+        {icon ? (
+          <span className="mt-0.5 flex shrink-0 items-center">{icon}</span>
+        ) : null}
         <div className="min-w-0">
           <h3
             id={titleId}


### PR DESCRIPTION
## Summary
This fixes modal header icon placement for headers with subtitle text.

1. **Shared header alignment** — update `ModalHeader` so optional icons align to the top of the title block instead of centering against multi-line header copy.
2. **Call-site cleanup** — remove now-redundant per-modal icon wrappers from the agent resume and folder permission warmup dialogs.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Modal headers with subtitles | Icons could sit vertically centered between title and subtitle | Icons align with the title line consistently |
| Existing modal call sites | Some modals needed manual wrapper offsets | `ModalHeader` owns the alignment behavior |

## Design notes
- Kept the change inside the existing `ModalHeader` abstraction rather than introducing a new component. The header already centralizes modal title, subtitle, icon, action, and close-button layout.
- Existing manual top-offset wrappers became redundant once `ModalHeader` handled the icon container, so they were removed from matching call sites.

## Test plan
- [x] `git diff --check` — passes
- [x] `pnpm typecheck` — passes
- [x] `pnpm test:e2e -- settings.spec.ts --project=chromium` — 3 passed
- [x] Opened the Session title prompt modal under the Playwright/Tauri mock path and verified the icon aligns with the title row.

## Notes
- No unrelated dirty files were included.