### PR TITLE
chore(release): v1.11.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.11.4",
+  "version": "1.11.5",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.11.4"
+version = "1.11.5"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.11.4"
+version = "1.11.5"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
Patch release bump for the fixes merged after `v1.11.4`.

1. **Version metadata** — bump Acorn from `1.11.4` to `1.11.5` in `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock`.
2. **Included fixes** — release PRs #363, #364, and #365. All are labelled `fix`, so the semver decision is patch.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| App version | `1.11.4` | `1.11.5` |
| Release notes | Latest stable did not include #363, #364, #365 | `v1.11.5` notes include those fixes |

## Design notes
- This PR only changes release version metadata.
- Changelog entries come from the merged fix PR labels; this release bump PR is labelled `skip-changelog`.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — passes
- [x] `REPO=im-ian/acorn TAG=v1.11.5 OUTPUT=/tmp/acorn-release-notes-v1.11.5.md node scripts/release-notes.mjs` — generated notes include #363, #364, #365
- [x] `git diff --check` — passes
- [x] main CI at `d8557ca` — Frontend and E2E pass

## Notes
- Semver decision: patch, because all unreleased changes are bug fixes.
- No unrelated dirty files were included.