### PR TITLE
feat(projects): auto-spawn a terminal session on first project add

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -34,6 +34,7 @@ vi.mock("./lib/api", () => {
           }) as GenerateSessionTitleResult,
       ),
       addProject: vi.fn(async () => ({}) as Project),
+      createNewProject: vi.fn(async () => ({}) as Project),
       removeProject: vi.fn(async () => undefined),
       reorderProjects: vi.fn(async (paths: string[]) =>
         paths.map<Project>((repo_path, i) => ({
@@ -1888,5 +1889,61 @@ describe("right panel groups", () => {
     expect(s.rightTabByGroup.github).toBe("prs");
     s.setRightGroup("github");
     expect(useAppStore.getState().rightTab).toBe("prs");
+  });
+});
+
+describe("auto initial session on first project add", () => {
+  it("spawns one regular session when an existing project is added", async () => {
+    mockApi.addProject.mockResolvedValueOnce(project(REPO_B, 1));
+    mockApi.listProjects.mockResolvedValue([project(REPO_B, 1)]);
+    mockApi.createSession.mockResolvedValueOnce(session("s-new", REPO_B));
+    mockApi.listSessions.mockResolvedValue([session("s-new", REPO_B)]);
+
+    await useAppStore.getState().addProject("Select project");
+
+    expect(mockApi.createSession).toHaveBeenCalledTimes(1);
+    expect(mockApi.createSession).toHaveBeenCalledWith(
+      "repo-b",
+      REPO_B,
+      false,
+      "regular",
+      null,
+    );
+    expect(useAppStore.getState().activeProject).toBe(REPO_B);
+  });
+
+  it("spawns one regular session when a new project is created", async () => {
+    mockApi.createNewProject.mockResolvedValueOnce(project(REPO_B, 1));
+    mockApi.listProjects.mockResolvedValue([project(REPO_B, 1)]);
+    mockApi.createSession.mockResolvedValueOnce(session("s-new", REPO_B));
+    mockApi.listSessions.mockResolvedValue([session("s-new", REPO_B)]);
+
+    await useAppStore.getState().createNewProject("/Users/me", "repo-b");
+
+    expect(mockApi.createSession).toHaveBeenCalledTimes(1);
+    expect(mockApi.createSession).toHaveBeenCalledWith(
+      "repo-b",
+      REPO_B,
+      false,
+      "regular",
+      null,
+    );
+  });
+
+  it("does not spawn a session when the folder picker is cancelled", async () => {
+    mockApi.addProject.mockResolvedValueOnce(null);
+
+    await useAppStore.getState().addProject("Select project");
+
+    expect(mockApi.createSession).not.toHaveBeenCalled();
+  });
+
+  it("does not pile on a session when re-adding a project that already has one", async () => {
+    await seed([project(REPO_A, 0)], [session("s1", REPO_A)]);
+    mockApi.addProject.mockResolvedValueOnce(project(REPO_A, 0));
+
+    await useAppStore.getState().addProject("Select project");
+
+    expect(mockApi.createSession).not.toHaveBeenCalled();
   });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -41,6 +41,10 @@ import {
   type RightTab,
 } from "./lib/rightPanelGroups";
 import { useSettings } from "./lib/settings";
+import {
+  applySessionCreateRequest,
+  buildSessionCreateRequest,
+} from "./lib/sessionCreation";
 
 export type { RightGroup, RightTab };
 
@@ -782,6 +786,26 @@ function applyKnownSessionPlacementIntents(s: AppStateModel): AppStateModel {
     pruneSessionPlacementGroup(placement, next.sessions);
   }
   return next;
+}
+
+// When a project is first registered it starts with no terminal sessions, so
+// the workspace opens on the empty-state prompt. Spawn one regular session so a
+// freshly added project is immediately usable. Guarded on the project still
+// having zero sessions so re-adding a known repo never piles on duplicates.
+async function createInitialProjectSession(
+  get: () => AppStateModel,
+  repoPath: string,
+): Promise<void> {
+  const { sessions, projects } = get();
+  const alreadyHasSession = sessions.some(
+    (session) => session.repo_path === repoPath,
+  );
+  if (alreadyHasSession) return;
+  const request = buildSessionCreateRequest(
+    { sessions, projects },
+    { repoPath },
+  );
+  await applySessionCreateRequest(get().createSession, request);
 }
 
 export const useAppStore = create<AppStateModel>()(
@@ -1591,8 +1615,12 @@ export const useAppStore = create<AppStateModel>()(
 
   async addProject(title) {
     try {
-      await api.addProject(title);
+      const project = await api.addProject(title);
       await get().refreshProjects();
+      if (project) {
+        get().setActiveProject(project.repo_path);
+        await createInitialProjectSession(get, project.repo_path);
+      }
       set({ error: null });
     } catch (e) {
       set({ error: errorMessage(e) });
@@ -1608,6 +1636,7 @@ export const useAppStore = create<AppStateModel>()(
       );
       await get().refreshProjects();
       get().setActiveProject(project.repo_path);
+      await createInitialProjectSession(get, project.repo_path);
       set({ error: null });
       return project;
     } catch (e) {


### PR DESCRIPTION
## Summary

A newly registered project opened on the empty-state prompt with no terminal session, forcing a manual "new session" click before the project was usable. This change spawns one regular terminal session the moment a project is first added, so a freshly added project opens ready to work.

It is wired into both first-add paths in the store — `addProject` (add an existing folder) and `createNewProject` (create a new folder) — via a shared `createInitialProjectSession` helper. The helper reuses the same `buildSessionCreateRequest` / `applySessionCreateRequest` flow the sidebar "+" button uses, so default naming and project-scope resolution stay identical to a manually created session, and focus + active-tab selection are inherited from `createSession` rather than reimplemented.

## Expected impact

- Adding a project (new or existing) immediately shows a focused, ready-to-type terminal — no extra click.
- No change to switching between already-known projects: the spawn only runs at first registration.

## Design notes

- Guarded on the project still having zero sessions, so re-adding a repo that already has sessions never piles on duplicates.
- Skipped entirely when the native folder picker is cancelled (`addProject` resolves to `null`).
- `setActiveProject` is called before the spawn so the placement intent is captured against the new project's own workspace; the session lands in (and is visible in) that workspace rather than leaking into whichever pane was previously active.
- **Behaviour change:** `addProject` now also activates the freshly added project. Previously it registered the project without switching to it. Activation is required for the new session to be placed and visible in the correct workspace, and it matches `createNewProject`, which already activated.

## Follow-up (not in this PR)

- Live end-to-end UX confirmation in the running app (add project → terminal auto-spawns, focused) was not automated here; covered by unit tests at the store level only.

## Test plan

- [x] `bun run typecheck` — clean (`tsc --noEmit`, no errors).
- [x] `npx vitest run src/store.test.ts` — 91 passed, 1 skipped. Adds 4 cases under "auto initial session on first project add": spawns on existing-folder add, spawns on new-project create, no spawn when the picker is cancelled, no spawn when re-adding a project that already has a session.

## Notes

- The new session uses the same default name (`suggestSessionName`, project basename) and `projectScoped` resolution as a manually created session.
