### PR TITLE
fix(sessions): regenerate tab titles after transcript rotation

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -238,6 +238,12 @@ pub struct Session {
     pub last_message: Option<String>,
     #[serde(default = "default_title_source_for_existing_sessions")]
     pub title_source: SessionTitleSource,
+    /// Transcript id used when Acorn last generated this tab title. Manual
+    /// renames clear this value; generated titles keep it so a later agent
+    /// session rotation (for example Claude `/clear`) can generate a fresh
+    /// title without touching user-named tabs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generated_title_transcript_id: Option<String>,
     #[serde(default)]
     pub kind: SessionKind,
     #[serde(default)]
@@ -282,6 +288,10 @@ pub struct Session {
     /// persisted in sessions.json.
     #[serde(default, skip_deserializing, skip_serializing_if = "Option::is_none")]
     pub agent_provider: Option<SessionAgentProvider>,
+    /// Derived from Acorn's per-session agent-state markers. This is the
+    /// current live transcript id and is not persisted in sessions.json.
+    #[serde(default, skip_deserializing, skip_serializing_if = "Option::is_none")]
+    pub agent_transcript_id: Option<String>,
 }
 
 impl Session {
@@ -307,6 +317,7 @@ impl Session {
             updated_at: now,
             last_message: None,
             title_source: SessionTitleSource::Default,
+            generated_title_transcript_id: None,
             kind,
             owner: SessionOwner::User,
             position: None,
@@ -314,6 +325,7 @@ impl Session {
             agent_resume_token: None,
             in_worktree: false,
             agent_provider: None,
+            agent_transcript_id: None,
         }
     }
 }
@@ -424,17 +436,25 @@ impl SessionStore {
             .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
         entry.name = name;
         entry.title_source = SessionTitleSource::Manual;
+        entry.generated_title_transcript_id = None;
         entry.updated_at = Utc::now();
         Ok(entry.clone())
     }
 
-    pub fn set_generated_title(&self, id: &Uuid, name: String) -> SessionResult<Session> {
+    pub fn set_generated_title(
+        &self,
+        id: &Uuid,
+        name: String,
+        transcript_id: Option<String>,
+    ) -> SessionResult<Session> {
         let mut entry = self
             .inner
             .get_mut(id)
             .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
         entry.name = name;
         entry.title_source = SessionTitleSource::Generated;
+        entry.generated_title_transcript_id =
+            transcript_id.filter(|value| !value.trim().is_empty());
         Ok(entry.clone())
     }
 
@@ -561,6 +581,13 @@ mod tests {
     fn manual_rename_marks_title_source_as_manual() {
         let store = SessionStore::new();
         let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        store
+            .set_generated_title(
+                &session.id,
+                "generated title".to_string(),
+                Some("transcript-1".to_string()),
+            )
+            .expect("session exists");
 
         let updated = store
             .rename(&session.id, "manual title".to_string())
@@ -568,6 +595,7 @@ mod tests {
 
         assert_eq!(updated.name, "manual title");
         assert_eq!(updated.title_source, SessionTitleSource::Manual);
+        assert_eq!(updated.generated_title_transcript_id, None);
     }
 
     #[test]
@@ -619,11 +647,19 @@ mod tests {
         let original_updated_at = session.updated_at;
 
         let updated = store
-            .set_generated_title(&session.id, "generated title".to_string())
+            .set_generated_title(
+                &session.id,
+                "generated title".to_string(),
+                Some("transcript-1".to_string()),
+            )
             .expect("session exists");
 
         assert_eq!(updated.name, "generated title");
         assert_eq!(updated.title_source, SessionTitleSource::Generated);
+        assert_eq!(
+            updated.generated_title_transcript_id.as_deref(),
+            Some("transcript-1")
+        );
         assert_eq!(updated.updated_at, original_updated_at);
     }
 

--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -1442,6 +1442,36 @@ mod tests {
     }
 
     #[test]
+    fn transcript_first_user_message_reads_antigravity_user_request() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = dir
+            .path()
+            .join("17f38e8c-3a7e-408b-8c79-aef7432c0fd2/.system_generated/logs/transcript.jsonl");
+        fs::create_dir_all(transcript.parent().unwrap()).unwrap();
+        let mut file = fs::File::create(&transcript).unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "type": "USER_INPUT",
+                "status": "DONE",
+                "content": "<USER_REQUEST>\nCheck whether Antigravity tab rename can miss transcripts\n</USER_REQUEST>",
+            })
+        )
+        .unwrap();
+        drop(file);
+
+        let title =
+            transcript_first_user_message(AgentHistoryProvider::Antigravity, &transcript, 200)
+                .unwrap();
+
+        assert_eq!(
+            title,
+            "Check whether Antigravity tab rename can miss transcripts"
+        );
+    }
+
+    #[test]
     fn unscoped_history_accepts_cwd_inside_unregistered_git_repo() {
         let tmp = tempfile::tempdir().unwrap();
         let repo = tmp.path().join("repo");

--- a/src-tauri/src/agent_resume.rs
+++ b/src-tauri/src/agent_resume.rs
@@ -121,6 +121,7 @@ pub fn antigravity_resume_candidate(session_id: uuid::Uuid) -> io::Result<Option
 /// agent is writing instead of guessing from PTY descendant liveness.
 #[derive(Debug, Clone)]
 pub struct LiveTranscript {
+    pub id: String,
     pub path: PathBuf,
     pub kind: AgentKind,
 }
@@ -173,12 +174,12 @@ fn live_transcript_at(base: &Path, session_id: uuid::Uuid) -> Option<LiveTranscr
             AgentKind::Codex => CODEX_ID_FILE,
             AgentKind::Antigravity => ANTIGRAVITY_ID_FILE,
         };
-        let uuid = fs::read_to_string(dir.join(file)).ok()?.trim().to_string();
-        if uuid.is_empty() {
+        let id = fs::read_to_string(dir.join(file)).ok()?.trim().to_string();
+        if id.is_empty() {
             return None;
         }
-        let path = locate_transcript(kind, &uuid)?;
-        Some(LiveTranscript { path, kind })
+        let path = locate_transcript(kind, &id)?;
+        Some(LiveTranscript { id, path, kind })
     };
     markers.into_iter().find_map(|(kind, _)| resolve(kind))
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -797,14 +797,15 @@ fn enrich_session(mut s: Session) -> Session {
         s.branch = branch;
     }
     s.in_worktree = worktree::is_linked_worktree_root(&s.worktree_path);
-    let live_provider =
-        crate::agent_resume::live_transcript(s.id).map(|transcript| match transcript.kind {
-            crate::agent_resume::AgentKind::Claude => acorn_session::SessionAgentProvider::Claude,
-            crate::agent_resume::AgentKind::Codex => acorn_session::SessionAgentProvider::Codex,
-            crate::agent_resume::AgentKind::Antigravity => {
-                acorn_session::SessionAgentProvider::Antigravity
-            }
-        });
+    let live = crate::agent_resume::live_transcript(s.id);
+    s.agent_transcript_id = live.as_ref().map(|transcript| transcript.id.clone());
+    let live_provider = live.as_ref().map(|transcript| match transcript.kind {
+        crate::agent_resume::AgentKind::Claude => acorn_session::SessionAgentProvider::Claude,
+        crate::agent_resume::AgentKind::Codex => acorn_session::SessionAgentProvider::Codex,
+        crate::agent_resume::AgentKind::Antigravity => {
+            acorn_session::SessionAgentProvider::Antigravity
+        }
+    });
     s.agent_provider = live_provider.or(s.agent_provider);
     s
 }
@@ -1452,13 +1453,17 @@ fn session_title_readiness_inner(
 ) -> AppResult<SessionTitleReadinessResult> {
     let id = parse_id(&id)?;
     let session = state.sessions.get(&id)?;
-    if !crate::session_titles::can_generate_title(&session) {
+    let title_input = crate::session_titles::resolve_title_input(id);
+    let transcript_id = title_input
+        .as_ref()
+        .map(|input| input.transcript_id.as_str());
+    if !crate::session_titles::can_generate_title(&session, transcript_id) {
         return Ok(SessionTitleReadinessResult {
             status: SessionTitleReadinessStatus::Skipped,
             session: enrich_session(session),
         });
     }
-    if crate::session_titles::resolve_first_user_message(id).is_none() {
+    if title_input.is_none() {
         return Ok(SessionTitleReadinessResult {
             status: SessionTitleReadinessStatus::NotReady,
             session: enrich_session(session),
@@ -1492,28 +1497,38 @@ fn generate_session_title_inner(
 ) -> AppResult<GenerateSessionTitleResult> {
     let id = parse_id(&id)?;
     let session = state.sessions.get(&id)?;
-    if !crate::session_titles::can_generate_title(&session) {
+    let title_input = crate::session_titles::resolve_title_input(id);
+    let transcript_id = title_input
+        .as_ref()
+        .map(|input| input.transcript_id.as_str());
+    if !crate::session_titles::can_generate_title(&session, transcript_id) {
         return Ok(GenerateSessionTitleResult {
             status: GenerateSessionTitleStatus::Skipped,
             session: enrich_session(session),
         });
     }
-    let Some(first_user_message) = crate::session_titles::resolve_first_user_message(id) else {
+    let Some(title_input) = title_input else {
         return Ok(GenerateSessionTitleResult {
             status: GenerateSessionTitleStatus::NotReady,
             session: enrich_session(session),
         });
     };
-    let generated =
-        crate::session_titles::generate_title(&ai, prompt.as_deref(), &first_user_message)?;
+    let generated = crate::session_titles::generate_title(
+        &ai,
+        prompt.as_deref(),
+        &title_input.first_user_message,
+    )?;
     let latest = state.sessions.get(&id)?;
-    if !crate::session_titles::can_generate_title(&latest) {
+    if !crate::session_titles::can_generate_title(&latest, Some(&title_input.transcript_id)) {
         return Ok(GenerateSessionTitleResult {
             status: GenerateSessionTitleStatus::Skipped,
             session: enrich_session(latest),
         });
     }
-    let updated = state.sessions.set_generated_title(&id, generated)?;
+    let transcript_id = title_input.transcript_id;
+    let updated = state
+        .sessions
+        .set_generated_title(&id, generated, Some(transcript_id))?;
     persist(&state);
     Ok(GenerateSessionTitleResult {
         status: GenerateSessionTitleStatus::Generated,
@@ -2525,6 +2540,7 @@ pub struct SessionStatusEntry {
     pub id: String,
     pub status: SessionStatus,
     pub agent_provider: Option<SessionAgentProvider>,
+    pub agent_transcript_id: Option<String>,
     /// Current branch read live from the session's worktree on each poll.
     /// `None` when the worktree has no readable HEAD (e.g. detached, or
     /// path was deleted out from under acorn). Lets the frontend reflect
@@ -2621,7 +2637,8 @@ pub async fn detect_session_statuses(
             // to the legacy Acorn-UUID-named JSONL so any direct claude
             // session-id caller keeps working.
             let live = parsed_id.and_then(agent_resume::live_transcript);
-            let transcript = match live {
+            let agent_transcript_id = live.as_ref().map(|t| t.id.clone());
+            let transcript = match live.as_ref() {
                 Some(t) => {
                     let kind = match t.kind {
                         agent_resume::AgentKind::Claude => acorn_session::status::AgentKind::Claude,
@@ -2630,7 +2647,7 @@ pub async fn detect_session_statuses(
                             acorn_session::status::AgentKind::Antigravity
                         }
                     };
-                    Some((t.path, kind))
+                    Some((t.path.clone(), kind))
                 }
                 None => todos::locate_transcript_for(&id)
                     .ok()
@@ -2673,6 +2690,7 @@ pub async fn detect_session_statuses(
                 id,
                 status,
                 agent_provider,
+                agent_transcript_id,
                 branch,
             }
         })

--- a/src-tauri/src/daemon_commands.rs
+++ b/src-tauri/src/daemon_commands.rs
@@ -317,6 +317,7 @@ pub fn daemon_adopt_session(
         updated_at: now,
         last_message: None,
         title_source: acorn_session::SessionTitleSource::Manual,
+        generated_title_transcript_id: None,
         kind,
         owner: acorn_session::SessionOwner::User,
         position: None,
@@ -324,6 +325,7 @@ pub fn daemon_adopt_session(
         agent_resume_token: Some(id.to_string()),
         in_worktree: false,
         agent_provider: None,
+        agent_transcript_id: None,
     };
     state.sessions.insert(session);
 

--- a/src-tauri/src/session_titles.rs
+++ b/src-tauri/src/session_titles.rs
@@ -26,10 +26,21 @@ Rules:
 - Prefer the main user goal over setup steps and generic words like \"help\" or \"question\".
 ";
 
-pub fn can_generate_title(session: &Session) -> bool {
-    session.kind == SessionKind::Regular
-        && matches!(session.owner, SessionOwner::User)
-        && session.title_source == SessionTitleSource::Default
+pub struct ResolvedTitleInput {
+    pub transcript_id: String,
+    pub first_user_message: String,
+}
+
+pub fn can_generate_title(session: &Session, transcript_id: Option<&str>) -> bool {
+    if session.kind != SessionKind::Regular || !matches!(session.owner, SessionOwner::User) {
+        return false;
+    }
+    match session.title_source {
+        SessionTitleSource::Default => true,
+        SessionTitleSource::Generated => transcript_id
+            .is_some_and(|id| session.generated_title_transcript_id.as_deref() != Some(id)),
+        SessionTitleSource::Manual => false,
+    }
 }
 
 pub fn build_prompt(prompt: Option<&str>, first_user_message: &str) -> String {
@@ -47,9 +58,14 @@ fn effective_prompt(prompt: Option<&str>) -> String {
     prompt.chars().take(SESSION_TITLE_PROMPT_CHARS).collect()
 }
 
-pub fn resolve_first_user_message(session_id: uuid::Uuid) -> Option<String> {
-    let (path, provider) = resolve_transcript(session_id)?;
-    agent_history::transcript_first_user_message(provider, &path, TITLE_INPUT_CHARS)
+pub fn resolve_title_input(session_id: uuid::Uuid) -> Option<ResolvedTitleInput> {
+    let (path, provider, transcript_id) = resolve_transcript(session_id)?;
+    let first_user_message =
+        agent_history::transcript_first_user_message(provider, &path, TITLE_INPUT_CHARS)?;
+    Some(ResolvedTitleInput {
+        transcript_id,
+        first_user_message,
+    })
 }
 
 pub fn normalize_generated_title(raw: &str) -> Option<String> {
@@ -100,20 +116,20 @@ pub fn generate_title(
         .ok_or_else(|| AppError::Other("AI returned an empty session title.".to_string()))
 }
 
-fn resolve_transcript(session_id: uuid::Uuid) -> Option<(PathBuf, AgentHistoryProvider)> {
+fn resolve_transcript(session_id: uuid::Uuid) -> Option<(PathBuf, AgentHistoryProvider, String)> {
     if let Some(live) = agent_resume::live_transcript(session_id) {
         let provider = match live.kind {
             agent_resume::AgentKind::Claude => AgentHistoryProvider::Claude,
             agent_resume::AgentKind::Codex => AgentHistoryProvider::Codex,
             agent_resume::AgentKind::Antigravity => AgentHistoryProvider::Antigravity,
         };
-        return Some((live.path, provider));
+        return Some((live.path, provider, live.id));
     }
 
     todos::locate_transcript_for(&session_id.to_string())
         .ok()
         .flatten()
-        .map(|path| (path, AgentHistoryProvider::Claude))
+        .map(|path| (path, AgentHistoryProvider::Claude, session_id.to_string()))
 }
 
 #[cfg(test)]
@@ -181,13 +197,31 @@ mod tests {
             false,
             SessionKind::Regular,
         );
-        assert!(can_generate_title(&session));
+        assert!(can_generate_title(&session, None));
 
         session.title_source = SessionTitleSource::Manual;
-        assert!(!can_generate_title(&session));
+        assert!(!can_generate_title(&session, Some("transcript-1")));
 
         session.title_source = SessionTitleSource::Default;
         session.owner = SessionOwner::control(uuid::Uuid::new_v4());
-        assert!(!can_generate_title(&session));
+        assert!(!can_generate_title(&session, Some("transcript-1")));
+    }
+
+    #[test]
+    fn generated_titles_can_regenerate_after_transcript_rotation() {
+        let mut session = Session::new(
+            "repo".to_string(),
+            PathBuf::from("/tmp/repo"),
+            PathBuf::from("/tmp/repo"),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        session.title_source = SessionTitleSource::Generated;
+        session.generated_title_transcript_id = Some("old-transcript".to_string());
+
+        assert!(!can_generate_title(&session, Some("old-transcript")));
+        assert!(can_generate_title(&session, Some("new-transcript")));
+        assert!(!can_generate_title(&session, None));
     }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -400,6 +400,7 @@ export const api = {
       id: string;
       status: SessionStatus;
       agent_provider?: SessionAgentProvider | null;
+      agent_transcript_id?: string | null;
       branch: string | null;
     }[]
   > {
@@ -408,6 +409,7 @@ export const api = {
         id: string;
         status: SessionStatus;
         agent_provider?: SessionAgentProvider | null;
+        agent_transcript_id?: string | null;
         branch: string | null;
       }[]
     >("detect_session_statuses", { ids });

--- a/src/lib/sessionTitle.test.ts
+++ b/src/lib/sessionTitle.test.ts
@@ -45,7 +45,7 @@ describe("session title helpers", () => {
     ).toBe(false);
   });
 
-  it("generates titles only for default user-owned agent sessions", () => {
+  it("generates titles only for default user-owned regular sessions", () => {
     expect(canGenerateSessionTitle(session())).toBe(true);
     const legacy = { ...session() } as Partial<Session>;
     delete legacy.title_source;
@@ -53,20 +53,60 @@ describe("session title helpers", () => {
     expect(canGenerateSessionTitle(session({ title_source: "manual" }))).toBe(
       false,
     );
+    expect(
+      canGenerateSessionTitle(
+        session({
+          title_source: "generated",
+          generated_title_transcript_id: "claude-1",
+          agent_transcript_id: "claude-1",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      canGenerateSessionTitle(
+        session({
+          title_source: "generated",
+          generated_title_transcript_id: "claude-1",
+          agent_transcript_id: "claude-2",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      canGenerateSessionTitle(
+        session({
+          title_source: "generated",
+          generated_title_transcript_id: null,
+          agent_transcript_id: "claude-2",
+        }),
+      ),
+    ).toBe(true);
     expect(canGenerateSessionTitle(session({ kind: "control" }))).toBe(false);
     expect(
       canGenerateSessionTitle(
         session({ owner: { kind: "control", session_id: "control-1" } }),
       ),
     ).toBe(false);
-    expect(canGenerateSessionTitle(session({ agent_provider: null }))).toBe(
-      false,
-    );
+    expect(canGenerateSessionTitle(session({ agent_provider: null }))).toBe(true);
   });
 
-  it("requires the global automatic title setting for background generation", () => {
+  it("requires the global automatic title setting and an agent signal for background generation", () => {
     expect(canAutoGenerateSessionTitle(session(), false)).toBe(false);
     expect(canAutoGenerateSessionTitle(session(), true)).toBe(true);
+    expect(
+      canAutoGenerateSessionTitle(session({ agent_provider: null }), true),
+    ).toBe(false);
+    expect(
+      canAutoGenerateSessionTitle(
+        session({ agent_provider: null, status: "running" }),
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      canAutoGenerateSessionTitle(
+        session({ agent_provider: null, name: "Claude task" }),
+        true,
+      ),
+    ).toBe(true);
   });
 
   it("plans immediate generation for eligible sessions only", () => {
@@ -76,6 +116,29 @@ describe("session title helpers", () => {
           session({ id: "ready" }),
           session({ id: "manual", title_source: "manual" }),
           session({ id: "terminal", agent_provider: null }),
+          session({
+            id: "detected-running",
+            agent_provider: null,
+            status: "running",
+          }),
+          session({
+            id: "named-antigravity",
+            agent_provider: null,
+            name: "Antigravity task",
+          }),
+          session({
+            id: "rotated-claude",
+            title_source: "generated",
+            generated_title_transcript_id: "claude-1",
+            agent_transcript_id: "claude-2",
+            agent_provider: null,
+          }),
+          session({
+            id: "same-claude",
+            title_source: "generated",
+            generated_title_transcript_id: "claude-1",
+            agent_transcript_id: "claude-1",
+          }),
         ],
         enabled: true,
         inFlightIds: new Set(),
@@ -83,7 +146,15 @@ describe("session title helpers", () => {
         now: 1_000,
         retryMs: 30_000,
       }),
-    ).toEqual({ sessionIds: ["ready"], retryDelayMs: null });
+    ).toEqual({
+      sessionIds: [
+        "ready",
+        "detected-running",
+        "named-antigravity",
+        "rotated-claude",
+      ],
+      retryDelayMs: null,
+    });
   });
 
   it("returns the next retry delay for recently attempted sessions", () => {

--- a/src/lib/sessionTitle.ts
+++ b/src/lib/sessionTitle.ts
@@ -1,4 +1,5 @@
 import type { Session } from "./types";
+import { inferAgentProvider } from "./agentProviderRegistry";
 
 export interface AutoSessionTitlePlanOptions {
   sessions: readonly Session[];
@@ -26,11 +27,26 @@ export function canRenameSession(
 }
 
 export function canGenerateSessionTitle(session: Session): boolean {
+  const titleSource = session.title_source ?? "manual";
+  const currentTranscriptId = session.agent_transcript_id?.trim();
   return (
     (session.kind ?? "regular") === "regular" &&
     (session.owner?.kind ?? "user") === "user" &&
-    (session.title_source ?? "manual") === "default" &&
-    session.agent_provider != null
+    (titleSource === "default" ||
+      (titleSource === "generated" &&
+        currentTranscriptId != null &&
+        currentTranscriptId.length > 0 &&
+        session.generated_title_transcript_id !== currentTranscriptId))
+  );
+}
+
+function hasSessionTitleAgentSignal(session: Session): boolean {
+  return (
+    session.agent_transcript_id != null ||
+    session.agent_provider != null ||
+    inferAgentProvider(session.name) != null ||
+    session.status === "running" ||
+    session.status === "needs_input"
   );
 }
 
@@ -38,7 +54,9 @@ export function canAutoGenerateSessionTitle(
   session: Session,
   enabled: boolean,
 ): boolean {
-  return enabled && canGenerateSessionTitle(session);
+  return (
+    enabled && canGenerateSessionTitle(session) && hasSessionTitleAgentSignal(session)
+  );
 }
 
 export function planAutoGenerateSessionTitles({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -116,6 +116,7 @@ export interface Session {
   updated_at: string;
   last_message: string | null;
   title_source: SessionTitleSource;
+  generated_title_transcript_id?: string | null;
   kind: SessionKind;
   owner: SessionOwner;
   position: number | null;
@@ -125,6 +126,8 @@ export interface Session {
   in_worktree: boolean;
   /** Most recently associated agent transcript for this Acorn session. */
   agent_provider?: SessionAgentProvider | null;
+  /** Current live agent transcript id, if Acorn has paired this tab to one. */
+  agent_transcript_id?: string | null;
 }
 
 export interface Project {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1140,6 +1140,33 @@ describe("pollSessionStatuses", () => {
     expect(sessions.find((s) => s.id === "a2")?.branch).toBe("feat/a2-live");
   });
 
+  it("merges live agent transcript ids from status polling", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          agent_provider: "claude",
+          agent_transcript_id: "claude-old",
+        }),
+      ],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "running",
+        agent_provider: "claude",
+        agent_transcript_id: "claude-new",
+        branch: null,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.agent_transcript_id).toBe(
+      "claude-new",
+    );
+  });
+
   it("does not call the backend when the requested ids are absent", async () => {
     await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -979,10 +979,17 @@ export const useAppStore = create<AppStateModel>()(
                 const nextBranch = update.branch ?? sess.branch;
                 const nextAgentProvider =
                   update.agent_provider ?? sess.agent_provider ?? null;
+                const nextAgentTranscriptId = Object.prototype.hasOwnProperty.call(
+                  update,
+                  "agent_transcript_id",
+                )
+                  ? (update.agent_transcript_id ?? null)
+                  : (sess.agent_transcript_id ?? null);
                 if (
                   nextStatus !== sess.status ||
                   nextBranch !== sess.branch ||
-                  nextAgentProvider !== (sess.agent_provider ?? null)
+                  nextAgentProvider !== (sess.agent_provider ?? null) ||
+                  nextAgentTranscriptId !== (sess.agent_transcript_id ?? null)
                 ) {
                   changed = true;
                   return {
@@ -990,6 +997,7 @@ export const useAppStore = create<AppStateModel>()(
                     status: nextStatus,
                     branch: nextBranch,
                     agent_provider: nextAgentProvider,
+                    agent_transcript_id: nextAgentTranscriptId,
                   };
                 }
                 return sess;


### PR DESCRIPTION
## Summary
Acorn now treats a new agent transcript in the same tab as a fresh automatic title-generation opportunity while preserving manually named tabs.

1. **Track generated title origin** — persist the transcript id used for the last generated title and clear it when the user manually renames a tab.
2. **Expose current transcript id** — carry `agent_transcript_id` through session enrichment and status polling so the frontend can detect Claude `/clear` or other session rotations.
3. **Regenerate only on rotation** — allow `generated` titles to run again only when the current transcript id differs from the id that produced the current title.
4. **Cover Antigravity input parsing** — add regression coverage for Antigravity `<USER_REQUEST>` transcript input used by the title generator.

## Expected impact
| Scenario | Before | After |
| --- | --- | --- |
| Claude `/clear` in an already titled Acorn tab | Tab title stayed tied to the previous transcript | New transcript id can trigger a fresh generated title |
| Starting a new agent conversation in the same Acorn tab | Generated title was treated as final | Generated title can update for the new conversation |
| Manual tab rename | Protected from auto-generation | Still protected |
| Antigravity transcript input | Parser behavior lacked targeted title-regression coverage | First user request path is covered |

## Design notes
- `SessionTitleSource::Manual` remains a hard stop. Only `Generated` titles can regenerate, and only when `agent_transcript_id != generated_title_transcript_id`.
- `LiveTranscript` now carries the marker id alongside provider kind and path, so backend title readiness/generation and frontend polling use the same transcript identity.
- Status polling merges `agent_transcript_id` into the store without requiring a full session refresh, matching the existing `agent_provider` update path.
- Legacy generated titles without a stored transcript id can regenerate once when a current live transcript id is known.

## Test plan
- [x] `pnpm test -- src/lib/sessionTitle.test.ts src/store.test.ts` — 94 passed, 1 skipped
- [x] `pnpm typecheck` — passed
- [x] `cargo test -p acorn-session` — 40 passed
- [x] `cargo test -p acorn --lib session_titles::tests` — 7 passed
- [x] `cargo test -p acorn --lib agent_resume::tests` — 10 passed
- [x] `cargo test -p acorn --lib agent_history::tests::transcript_first_user_message_reads_antigravity_user_request` — 1 passed
- [x] `git diff --check` — clean

## Notes
- Full Rust formatting still has pre-existing drift outside this PR's behavioral change; this PR leaves unrelated formatting untouched.