### PR TITLE
fix(ui): reuse status icon slot for title generation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -104,8 +104,8 @@
 .acorn-session-title-indicator {
   position: relative;
   display: inline-flex;
-  width: 0.875rem;
-  height: 0.875rem;
+  width: 0.75rem;
+  height: 0.75rem;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;

--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -362,9 +362,23 @@ describe("Pane empty state", () => {
       root.render(<Pane paneId="root" />);
     });
 
+    const dragHandle = container.querySelector(
+      `[data-tab-drag-handle="${active.id}"]`,
+    );
+    const indicator = container.querySelector(
+      '[aria-label="Generating session title"]',
+    );
+    const title = Array.from(dragHandle?.querySelectorAll("span") ?? []).find(
+      (el) => el.textContent === active.name,
+    );
+
+    expect(indicator).toBeInstanceOf(HTMLElement);
+    expect(title).toBeInstanceOf(HTMLElement);
+    expect(dragHandle?.firstElementChild?.contains(indicator)).toBe(true);
     expect(
-      container.querySelector('[aria-label="Generating session title"]'),
-    ).toBeInstanceOf(HTMLElement);
+      indicator!.compareDocumentPosition(title!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
   });
 
   it("does not enter tab rename while title generation is active", async () => {

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -10,7 +10,6 @@ import {
   GitFork,
   Pencil,
   PencilLine,
-  Sparkles,
   SplitSquareHorizontal,
   SplitSquareVertical,
   SquareX,
@@ -1234,7 +1233,11 @@ function TabItem({
           className="flex min-w-0 flex-1 items-center gap-1.5 self-stretch pl-3"
           data-tab-drag-handle={tab.id}
         >
-          {agentProvider ? (
+          {isGeneratingTitle ? (
+            <SessionTitleGeneratingIndicator
+              label={paneT(t, "pane.aria.generatingSessionTitle")}
+            />
+          ) : agentProvider ? (
             <Tooltip label={agentProvider} side="bottom">
               <AgentProviderIcon
                 provider={agentProvider}
@@ -1274,11 +1277,6 @@ function TabItem({
               {tab.title}
             </span>
           )}
-          {isGeneratingTitle && !editing ? (
-            <SessionTitleGeneratingIndicator
-              label={paneT(t, "pane.aria.generatingSessionTitle")}
-            />
-          ) : null}
           {showWorktreeIcon ? (
             <GitBranch
               size={10}
@@ -1337,6 +1335,7 @@ function TabItem({
             session={session}
             agentProvider={agentProvider}
             isGeneratingTitle={isGeneratingTitle}
+            generatingLabel={paneT(t, "pane.aria.generatingSessionTitle")}
             showWorktreeIcon={showWorktreeIcon}
           />
         ) : null}
@@ -1358,6 +1357,7 @@ function WorkspaceTabDragGhost({
   session,
   agentProvider,
   isGeneratingTitle,
+  generatingLabel,
   showWorktreeIcon,
 }: {
   drag: WorkspaceTabDragSession;
@@ -1365,6 +1365,7 @@ function WorkspaceTabDragGhost({
   session: Session | null;
   agentProvider: SessionAgentProvider | null;
   isGeneratingTitle: boolean;
+  generatingLabel: string;
   showWorktreeIcon: boolean;
 }) {
   return createPortal(
@@ -1378,7 +1379,9 @@ function WorkspaceTabDragGhost({
         height: drag.sourceRect.height,
       }}
     >
-      {agentProvider ? (
+      {isGeneratingTitle ? (
+        <SessionTitleGeneratingIndicator label={generatingLabel} />
+      ) : agentProvider ? (
         <AgentProviderIcon
           provider={agentProvider}
           className={cn(
@@ -1400,12 +1403,6 @@ function WorkspaceTabDragGhost({
         />
       )}
       <span className="min-w-0 truncate">{drag.title}</span>
-      {isGeneratingTitle ? (
-        <Sparkles
-          size={9}
-          className="pointer-events-none shrink-0 text-accent"
-        />
-      ) : null}
       {showWorktreeIcon ? (
         <GitBranch
           size={10}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -76,7 +76,12 @@ import {
   planTitleClick,
   type ProjectClickPlan,
 } from "../lib/sidebar-actions";
-import type { Session, SessionKind, SessionStatus } from "../lib/types";
+import type {
+  Session,
+  SessionAgentProvider,
+  SessionKind,
+  SessionStatus,
+} from "../lib/types";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { NewProjectDialog } from "./NewProjectDialog";
 import { ProjectSettingsModal } from "./ProjectSettingsModal";
@@ -660,23 +665,12 @@ function SessionRowPreview({
   return (
     <div className="flex w-full items-start gap-1.5 rounded-md bg-bg-elevated/95 px-2 py-1 shadow-lg ring-1 ring-border/60">
       {sessionDisplay.icons.statusDot ? (
-        <span className="flex h-5 w-3 shrink-0 items-center justify-center">
-          {agentProvider ? (
-            <Tooltip label={agentProvider} side="right">
-              <AgentProviderIcon
-                provider={agentProvider}
-                className={cn("size-3", STATUS_ICON[session.status])}
-              />
-            </Tooltip>
-          ) : (
-            <span
-              className={cn(
-                "size-1.5 rounded-full",
-                STATUS_DOT[session.status],
-              )}
-            />
-          )}
-        </span>
+        <SessionStatusMarker
+          session={session}
+          agentProvider={agentProvider}
+          isGeneratingTitle={false}
+          generatingLabel={sidebarText(t, "sidebar.aria.generatingSessionTitle")}
+        />
       ) : null}
       <SessionRowLabel
         editing={false}
@@ -684,7 +678,6 @@ function SessionRowPreview({
         titleText={titleText}
         metadataText={metadataText}
         showKindIcons={sessionDisplay.icons.sessionKind}
-        isGeneratingTitle={false}
         t={t}
         onSubmitRename={() => undefined}
         onCancelRename={() => undefined}
@@ -1253,24 +1246,13 @@ function SessionRow({
         isDragging && "opacity-40",
       )}
     >
-      {sessionDisplay.icons.statusDot ? (
-        <span className="flex h-5 w-3 shrink-0 items-center justify-center">
-          {agentProvider ? (
-            <Tooltip label={agentProvider} side="right">
-              <AgentProviderIcon
-                provider={agentProvider}
-                className={cn("size-3", STATUS_ICON[session.status])}
-              />
-            </Tooltip>
-          ) : (
-            <span
-              className={cn(
-                "size-1.5 rounded-full",
-                STATUS_DOT[session.status],
-              )}
-            />
-          )}
-        </span>
+      {sessionDisplay.icons.statusDot || isGeneratingTitle ? (
+        <SessionStatusMarker
+          session={session}
+          agentProvider={agentProvider}
+          isGeneratingTitle={isGeneratingTitle}
+          generatingLabel={sidebarText(t, "sidebar.aria.generatingSessionTitle")}
+        />
       ) : null}
       <SessionRowLabel
         editing={editing}
@@ -1278,7 +1260,6 @@ function SessionRow({
         titleText={titleText}
         metadataText={metadataText}
         showKindIcons={sessionDisplay.icons.sessionKind}
-        isGeneratingTitle={isGeneratingTitle}
         t={t}
         onSubmitRename={async (next) => {
           setEditing(false);
@@ -1339,7 +1320,6 @@ interface SessionRowLabelProps {
   titleText: string;
   metadataText: string;
   showKindIcons: boolean;
-  isGeneratingTitle: boolean;
   t: Translator;
   onSubmitRename: (value: string) => void | Promise<void>;
   onCancelRename: () => void;
@@ -1351,7 +1331,6 @@ function SessionRowLabel({
   titleText,
   metadataText,
   showKindIcons,
-  isGeneratingTitle,
   t,
   onSubmitRename,
   onCancelRename,
@@ -1376,12 +1355,6 @@ function SessionRowLabel({
             {titleText}
           </span>
         )}
-        {isGeneratingTitle && !editing ? (
-          <SessionTitleGeneratingIndicator
-            label={sidebarText(t, "sidebar.aria.generatingSessionTitle")}
-            side="right"
-          />
-        ) : null}
         {showKindIcons && inWorktree ? (
           <GitBranch
             size={10}
@@ -1406,6 +1379,37 @@ function SessionRowLabel({
   );
 
   return body;
+}
+
+function SessionStatusMarker({
+  session,
+  agentProvider,
+  isGeneratingTitle,
+  generatingLabel,
+}: {
+  session: Session;
+  agentProvider: SessionAgentProvider | null;
+  isGeneratingTitle: boolean;
+  generatingLabel: string;
+}) {
+  return (
+    <span className="flex h-5 w-3 shrink-0 items-center justify-center">
+      {isGeneratingTitle ? (
+        <SessionTitleGeneratingIndicator label={generatingLabel} side="right" />
+      ) : agentProvider ? (
+        <Tooltip label={agentProvider} side="right">
+          <AgentProviderIcon
+            provider={agentProvider}
+            className={cn("size-3", STATUS_ICON[session.status])}
+          />
+        </Tooltip>
+      ) : (
+        <span
+          className={cn("size-1.5 rounded-full", STATUS_DOT[session.status])}
+        />
+      )}
+    </span>
+  );
 }
 
 async function copyToClipboard(text: string): Promise<void> {
@@ -1720,24 +1724,13 @@ function LocalSessionRow({
         isDragging && "opacity-40",
       )}
     >
-      {sessionDisplay.icons.statusDot ? (
-        <span className="flex h-5 w-3 shrink-0 items-center justify-center">
-          {agentProvider ? (
-            <Tooltip label={agentProvider} side="right">
-              <AgentProviderIcon
-                provider={agentProvider}
-                className={cn("size-3", STATUS_ICON[session.status])}
-              />
-            </Tooltip>
-          ) : (
-            <span
-              className={cn(
-                "size-1.5 rounded-full",
-                STATUS_DOT[session.status],
-              )}
-            />
-          )}
-        </span>
+      {sessionDisplay.icons.statusDot || isGeneratingTitle ? (
+        <SessionStatusMarker
+          session={session}
+          agentProvider={agentProvider}
+          isGeneratingTitle={isGeneratingTitle}
+          generatingLabel={sidebarText(t, "sidebar.aria.generatingSessionTitle")}
+        />
       ) : null}
       <SessionRowLabel
         editing={editing}
@@ -1745,7 +1738,6 @@ function LocalSessionRow({
         titleText={titleText}
         metadataText={metadataText}
         showKindIcons={sessionDisplay.icons.sessionKind}
-        isGeneratingTitle={isGeneratingTitle}
         t={t}
         onSubmitRename={async (next) => {
           setEditing(false);


### PR DESCRIPTION
## Summary
This PR keeps automatic session-title generation from adding extra horizontal chrome to tabs and sidebar rows.

1. **Tab indicator placement** — title-generation activity now temporarily replaces the existing tab status/agent icon instead of rendering another icon after the title.
2. **Sidebar indicator placement** — project and local session rows share the same behavior through a single status marker helper.
3. **Compact indicator sizing** — the generation indicator is trimmed to fit the existing icon slot more closely.
4. **Regression coverage** — the Pane test now asserts the generation indicator appears before the tab title rather than after it.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Auto-renaming tabs | Status/agent icon plus title-generation icon consumed extra width | Title-generation indicator reuses the status/agent icon slot |
| Sidebar session rows | Title-generation icon appeared after the session name | Title-generation indicator temporarily replaces the row status/agent marker |

## Design notes
- `SessionTitleGeneratingIndicator` remains the shared visual affordance; only its placement changed.
- Sidebar rows use `SessionStatusMarker` so project rows, local rows, and drag previews keep the same status/agent/title-generation precedence.
- The tab drag ghost mirrors the visible tab ordering so drag feedback does not reintroduce the extra trailing icon.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes — 56 files, 529 passed, 1 skipped
- [x] `pnpm run build` passes; Vite reports pre-existing chunking warnings

## Notes
- `pnpm run build` still reports existing Vite dynamic/static import and large chunk warnings. This PR does not change bundling behavior.
