### PR TITLE
chore(release): v1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.11.5",
+  "version": "1.12.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.11.5"
+version = "1.12.0"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.11.5"
+version = "1.12.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.11.5",
+  "version": "1.12.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
Minor release bump for the feature and fixes merged after `v1.11.5`.

1. **Version metadata** — bump Acorn from `1.11.5` to `1.12.0` in `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock`.
2. **Included changes** — release PRs #367, #368, and #369. PR #367 is labelled `feat`, so the semver decision is minor.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| App version | `1.11.5` | `1.12.0` |
| Release notes | Latest stable did not include #367, #368, #369 | `v1.12.0` notes include the new project session behavior and title/status fixes |

## Design notes
- This PR only changes release version metadata.
- Changelog entries come from the merged feature/fix PR labels; this release bump PR is labelled `skip-changelog`.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — passes
- [x] `REPO=im-ian/acorn TAG=v1.12.0 OUTPUT=/tmp/acorn-release-notes-v1.12.0.md node scripts/release-notes.mjs` — generated notes include #367, #368, #369
- [x] `git diff --check` — passes
- [x] main CI at `27f7c0d` — CI passes

## Notes
- Semver decision: minor, because #367 adds user-visible project session behavior.
- No unrelated dirty files were included.
