### PR TITLE
fix(viewer): restore syntax highlighting under hardened CSP

### DIFF
--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -1,5 +1,6 @@
 import {
   createHighlighter,
+  createJavaScriptRegexEngine,
   type BundledLanguage,
   type BundledTheme,
   type Highlighter,
@@ -70,6 +71,12 @@ const FILENAME_LANG: Record<string, BundledLanguage> = {
   "CMakeLists.txt": "cmake",
 };
 
+// Use the pure-JS regex engine instead of shiki's default oniguruma WASM
+// engine: the hardened renderer CSP (script-src 'self', no wasm-unsafe-eval)
+// blocks WebAssembly instantiation in the WKWebView, which would otherwise
+// make createHighlighter reject and silently drop all highlighting.
+const jsEngine = createJavaScriptRegexEngine({ forgiving: true });
+
 let highlighterPromise: Promise<Highlighter> | null = null;
 const loadedLangs = new Set<BundledLanguage>();
 const loadingLang = new Map<BundledLanguage, Promise<void>>();
@@ -79,6 +86,7 @@ function getHighlighter(): Promise<Highlighter> {
     highlighterPromise = createHighlighter({
       themes: THEMES,
       langs: [],
+      engine: jsEngine,
     });
   }
   return highlighterPromise;


### PR DESCRIPTION
## Summary

Restore syntax highlighting in the right-panel code viewer, which silently broke in the packaged/dev WKWebView after the renderer CSP was hardened.

## Root cause

`#353` (`security(tauri): harden filesystem and renderer policy`) replaced `csp: null` with a strict policy whose `script-src` allows neither `unsafe-eval` nor `wasm-unsafe-eval` (prod: `script-src 'self'`). Shiki's default `createHighlighter` uses the oniguruma WASM engine, so `WebAssembly` instantiation is blocked in the WKWebView. `createHighlighter` then rejects, `highlightCode` hits its `.catch`, and `CodeViewer` falls back to plain, uncolored text — highlighting disappears while the file still renders.

## Fix

Switch shiki to its pure-JS regex engine (`createJavaScriptRegexEngine({ forgiving: true })`). No WASM is instantiated, so highlighting works under the strict `script-src 'self'` policy and the `#353` hardening stays fully intact (CSP unchanged).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run src/lib/highlight.test.ts` — 2/2 pass
- [x] `pnpm run build` (tsc + vite) succeeds; tsx/ts/js grammar chunks bundle
- [x] `tauri dev` boots on the dev profile (`profiles/dev/ipc.sock`)
- [x] No CSP change — renderer hardening from #353 preserved
