### PR TITLE
fix(files): preserve File Explorer expansion across tab switches

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1011,6 +1011,22 @@ function useRightPanelInvalidations(
 }
 
 /**
+ * Strip a trailing slash so a backend-resolved repo path byte-matches the
+ * slash-free paths Acorn records (project `repo_path`, session
+ * `worktree_path`). `pty_repo_root` returns libgit2's `Repository::workdir()`,
+ * which always carries a trailing slash (e.g. `/repo/.acorn/worktrees/wt/`).
+ * If that slashed form reaches the right panel as `repoPath`, it never matches
+ * a retained repo path, so `rightPanelCache.canStore` silently drops File
+ * Explorer expansion writes — collapsing every expanded folder on the next
+ * remount (tab switch). Preserve a bare root `/`.
+ */
+function normalizeRepoPath(path: string | null): string | null {
+  if (path === null) return null;
+  const trimmed = path.replace(/\/+$/, "");
+  return trimmed === "" ? "/" : trimmed;
+}
+
+/**
  * Resolve the live working directory of a session's PTY tree to the git
  * repo it sits inside, with the recorded `fallback` path as the immediate
  * (and final) fallback. Backed by `pty_repo_root`, which does the
@@ -1037,7 +1053,13 @@ function useLiveRepoPath(
     api
       .ptyRepoRoot(sessionId)
       .then((repoPath) => {
-        if (!cancelled) setLiveRepo({ sessionId, fallbackPath, repoPath });
+        if (!cancelled) {
+          setLiveRepo({
+            sessionId,
+            fallbackPath,
+            repoPath: normalizeRepoPath(repoPath),
+          });
+        }
       })
       .catch((err: unknown) => {
         // Don't blow away a previously resolved path on a transient backend

--- a/tests/e2e/file-explorer.spec.ts
+++ b/tests/e2e/file-explorer.spec.ts
@@ -125,6 +125,127 @@ test.describe("file explorer", () => {
     ).toBeVisible();
   });
 
+  test("keeps expanded folders when the live repo root carries a trailing slash", async ({
+    page,
+    tauri,
+  }) => {
+    // libgit2's `Repository::workdir()` — what `pty_repo_root` returns — always
+    // carries a trailing slash. Recorded paths (project/session) never do. If
+    // the slashed form reaches the panel it fails to match any retained repo
+    // path, so the expansion cache silently drops writes and folders collapse
+    // on the next remount. This drives a project switch (which remounts the
+    // File Explorer) to prove the expansion survives.
+    const repoA = "/tmp/alpha";
+    const repoB = "/tmp/beta";
+    const worktreeA = "/tmp/alpha/.worktrees/a-session";
+    const worktreeB = "/tmp/beta/.worktrees/b-session";
+
+    await tauri.respond("list_projects", [
+      {
+        repo_path: repoA,
+        name: "alpha",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+      {
+        repo_path: repoB,
+        name: "beta",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 1,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "a-session",
+        name: "a-session",
+        repo_path: repoA,
+        worktree_path: worktreeA,
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+      {
+        id: "b-session",
+        name: "b-session",
+        repo_path: repoB,
+        worktree_path: worktreeB,
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    // Mirror real libgit2 behavior: hand the frontend a trailing-slash workdir.
+    await tauri.handle("pty_repo_root", (args) => {
+      const { sessionId } = args as { sessionId: string };
+      if (sessionId === "a-session") return "/tmp/alpha/.worktrees/a-session/";
+      if (sessionId === "b-session") return "/tmp/beta/.worktrees/b-session/";
+      return null;
+    });
+    await tauri.handle("fs_list_dir", (args) => {
+      // The backend tolerates either form; normalize so the tree still renders
+      // pre-fix (the bug is purely about persistence, not initial listing).
+      const { path } = args as { path: string };
+      const normalized = path.replace(/\/+$/, "");
+      const wt = "/tmp/alpha/.worktrees/a-session";
+      const src = `${wt}/src`;
+      if (normalized === wt) {
+        return {
+          repo_root: wt,
+          entries: [
+            {
+              name: "src",
+              path: src,
+              is_dir: true,
+              is_symlink: false,
+              size: 0,
+              modified_ms: 0,
+              gitignored: false,
+            },
+          ],
+        };
+      }
+      if (normalized === src) {
+        return {
+          repo_root: wt,
+          entries: [
+            {
+              name: "App.tsx",
+              path: `${src}/App.tsx`,
+              is_dir: false,
+              is_symlink: false,
+              size: 42,
+              modified_ms: 0,
+              gitignored: false,
+            },
+          ],
+        };
+      }
+      return { repo_root: normalized, entries: [] };
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Code" }).click();
+    await page.getByRole("button", { name: "Files", exact: true }).click();
+
+    await page.getByRole("button", { name: "src" }).click();
+    await expect(page.getByRole("button", { name: "App.tsx" })).toBeVisible();
+
+    // Switch to the other project and back — this remounts the File Explorer.
+    await page.getByRole("button", { name: "Project beta" }).click();
+    await page.getByRole("button", { name: "Project alpha" }).click();
+
+    // The expansion must survive the remount.
+    await expect(
+      page.getByRole("button", { name: "App.tsx", exact: true }),
+    ).toBeVisible();
+  });
+
   test("previews markdown files from a code viewer tab", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

The right-panel File Explorer collapsed every expanded folder whenever you switched to another tab and back. Expansion state *is* persisted per repo in `rightPanelCache`, but the writes were being silently dropped.

`pty_repo_root` resolves the live repo via libgit2's `Repository::workdir()`, which always returns the working directory with a trailing slash (e.g. `/repo/.acorn/worktrees/wt/`). Every path Acorn records — project `repo_path`, session `worktree_path` — is slash-free, so the slashed live path never matched any entry in the retained-repo set. `rightPanelCache.canStore` then rejected every File Explorer expansion write, and on the next remount (tab or sub-tab switch) the cache read back empty and the tree rendered fully collapsed.

## Fix

Normalize the resolved live repo path at the single boundary where it enters the panel — `useLiveRepoPath` in `RightPanel.tsx` — with a new `normalizeRepoPath` helper that trims the trailing slash (preserving a bare root `/`). The live path now byte-matches the recorded paths, `canStore` accepts the write, and the expansion restores across remounts.

## Test plan

- [x] `bun run typecheck`
- [x] New e2e regression test in `tests/e2e/file-explorer.spec.ts` — verified RED without the fix, GREEN with it
- [x] `bun run test:e2e file-explorer` — 5 passed
- [x] `bun run test src/lib/right-panel-cache.test.ts` — 6 passed
- [x] Manual `tauri dev` on the dev profile — expand folders, switch tabs, folders persist

## Notes

The existing e2e mocked a slash-free `pty_repo_root`, which masked the bug. The new test hands the panel a trailing-slash workdir (real libgit2 behavior) and asserts the expansion survives a project switch that remounts the File Explorer.
