### PR TITLE
fix(terminal): lazy-mount persisted sessions at startup

### DIFF
--- a/src/components/TerminalHost.test.tsx
+++ b/src/components/TerminalHost.test.tsx
@@ -1,0 +1,245 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project, Session } from "../lib/types";
+
+vi.mock("./Terminal", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    Terminal: ({
+      sessionId,
+      isActive,
+    }: {
+      sessionId: string;
+      isActive?: boolean;
+    }) =>
+      React.createElement("div", {
+        "data-testid": "terminal",
+        "data-session-id": sessionId,
+        "data-active": String(Boolean(isActive)),
+      }),
+  };
+});
+
+import { TerminalHost } from "./TerminalHost";
+import { useAppStore } from "../store";
+import { defaultTabByGroup } from "../lib/rightPanelGroups";
+
+const REPO = "/Users/me/repo";
+
+function project(repoPath: string): Project {
+  return {
+    repo_path: repoPath,
+    name: "repo",
+    created_at: "2026-01-01T00:00:00Z",
+    position: 0,
+  };
+}
+
+function session(id: string, overrides: Partial<Session> = {}): Session {
+  return {
+    id,
+    name: id,
+    repo_path: overrides.repo_path ?? REPO,
+    worktree_path:
+      overrides.worktree_path ?? `${overrides.repo_path ?? REPO}/.worktrees/${id}`,
+    branch: `feat/${id}`,
+    isolated: false,
+    status: "idle",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: null,
+    title_source: "default",
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: false,
+    ...overrides,
+  };
+}
+
+function resetStore(): void {
+  const pane = { id: "root", tabIds: [], activeTabId: null };
+  useAppStore.setState(
+    {
+      sessions: [],
+      projects: [project(REPO)],
+      workspaces: {
+        [REPO]: {
+          layout: { kind: "pane", id: "root" },
+          panes: { root: pane },
+          focusedPaneId: "root",
+        },
+      },
+      activeProject: REPO,
+      layout: { kind: "pane", id: "root" },
+      panes: { root: pane },
+      focusedPaneId: "root",
+      activeTabId: null,
+      activeSessionId: null,
+      rightTab: "commits",
+      rightTabByGroup: defaultTabByGroup(),
+      workspaceTabs: {},
+      prAccountByRepo: {},
+      pendingTerminalInput: {},
+      sessionNotifications: [],
+      multiInputEnabled: false,
+      loading: false,
+      error: null,
+      pendingRemoveId: null,
+      pendingRemoveProject: null,
+      sessionsLoadedCleanly: true,
+      liveInWorktree: {},
+      generatingSessionTitleIds: {},
+    },
+    false,
+  );
+}
+
+function terminalRows(): Array<{ id: string; active: boolean }> {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>("[data-testid='terminal']"),
+  )
+    .map((el) => ({
+      id: el.dataset.sessionId ?? "",
+      active: el.dataset.active === "true",
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+describe("TerminalHost", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    localStorage.clear();
+    resetStore();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document
+      .querySelectorAll("[data-acorn-terminal-limbo]")
+      .forEach((el) => el.remove());
+    vi.clearAllMocks();
+  });
+
+  function render() {
+    act(() => {
+      root.render(<TerminalHost />);
+    });
+  }
+
+  it("mounts only terminal sessions visible in the active workspace on first render", () => {
+    const active = session("active");
+    const inactiveTab = session("inactive-tab");
+    const sidePane = session("side-pane");
+    const otherProject = session("other-project", {
+      repo_path: "/Users/me/other",
+      worktree_path: "/Users/me/other",
+    });
+    const chat = session("chat", { mode: "chat" });
+    const layout = {
+      kind: "split" as const,
+      id: "split",
+      direction: "horizontal" as const,
+      a: { kind: "pane" as const, id: "root" },
+      b: { kind: "pane" as const, id: "side" },
+    };
+    const panes = {
+      root: {
+        id: "root",
+        tabIds: [active.id, inactiveTab.id, chat.id],
+        activeTabId: active.id,
+      },
+      side: {
+        id: "side",
+        tabIds: [sidePane.id],
+        activeTabId: sidePane.id,
+      },
+    };
+
+    useAppStore.setState((state) => ({
+      sessions: [active, inactiveTab, sidePane, otherProject, chat],
+      projects: [...state.projects, project("/Users/me/other")],
+      workspaces: {
+        ...state.workspaces,
+        [REPO]: { layout, panes, focusedPaneId: "root" },
+        "/Users/me/other": {
+          layout: { kind: "pane", id: "other-root" },
+          panes: {
+            "other-root": {
+              id: "other-root",
+              tabIds: [otherProject.id],
+              activeTabId: otherProject.id,
+            },
+          },
+          focusedPaneId: "other-root",
+        },
+      },
+      layout,
+      panes,
+      activeTabId: active.id,
+      activeSessionId: active.id,
+    }));
+
+    render();
+
+    expect(terminalRows()).toEqual([
+      { id: "active", active: true },
+      { id: "side-pane", active: true },
+    ]);
+  });
+
+  it("keeps a terminal mounted after it was visible once", () => {
+    const first = session("first");
+    const second = session("second");
+    const pane = {
+      id: "root",
+      tabIds: [first.id, second.id],
+      activeTabId: first.id,
+    };
+    useAppStore.setState((state) => ({
+      sessions: [first, second],
+      workspaces: {
+        ...state.workspaces,
+        [REPO]: {
+          layout: { kind: "pane", id: "root" },
+          panes: { root: pane },
+          focusedPaneId: "root",
+        },
+      },
+      panes: { root: pane },
+      activeTabId: first.id,
+      activeSessionId: first.id,
+    }));
+    render();
+
+    act(() => {
+      useAppStore.setState((state) => {
+        const nextPane = { ...state.panes.root, activeTabId: second.id };
+        return {
+          panes: { ...state.panes, root: nextPane },
+          workspaces: {
+            ...state.workspaces,
+            [REPO]: {
+              ...state.workspaces[REPO],
+              panes: { root: nextPane },
+            },
+          },
+          activeTabId: second.id,
+          activeSessionId: second.id,
+        };
+      });
+    });
+
+    expect(terminalRows()).toEqual([
+      { id: "first", active: false },
+      { id: "second", active: true },
+    ]);
+  });
+});

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { resolveSessionAgentProvider } from "../lib/agentProvider";
 import { getTerminalLimbo } from "../lib/terminalLimbo";
@@ -8,8 +8,11 @@ import type { Session } from "../lib/types";
 import { Terminal } from "./Terminal";
 
 /**
- * Renders one `<Terminal>` per session at the App level so the xterm + PTY
- * survive pane and project switches.
+ * Lazily renders terminals at the App level so xterm + PTY state survives
+ * pane and project switches after a session has been shown once. Persisted
+ * sessions that are not visible stay unmounted at boot; mounting every saved
+ * tab would otherwise respawn every shell and restore every scrollback file at
+ * the same time.
  *
  * Each terminal is portaled into a per-session "target div" that we
  * `appendChild`-move between pane bodies (when a pane is showing the
@@ -19,13 +22,73 @@ import { Terminal } from "./Terminal";
  */
 export function TerminalHost() {
   const sessions = useAppStore((s) => s.sessions);
+  const visibleSessionIdKey = useAppStore(visibleTerminalSessionIdKey);
+  const visibleSessionIds = useMemo(
+    () => parseSessionIdKey(visibleSessionIdKey),
+    [visibleSessionIdKey],
+  );
+  const [mountedSessionIds, setMountedSessionIds] = useState<Set<string>>(
+    () => visibleSessionIds,
+  );
+  const terminalSessionIds = useMemo(
+    () =>
+      new Set(sessions.filter((s) => s.mode !== "chat").map((s) => s.id)),
+    [sessions],
+  );
+
+  useEffect(() => {
+    setMountedSessionIds((current) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of current) {
+        if (terminalSessionIds.has(id)) {
+          next.add(id);
+        } else {
+          changed = true;
+        }
+      }
+      for (const id of visibleSessionIds) {
+        if (!terminalSessionIds.has(id)) continue;
+        if (!next.has(id)) changed = true;
+        next.add(id);
+      }
+      return changed || next.size !== current.size ? next : current;
+    });
+  }, [terminalSessionIds, visibleSessionIds]);
+
   return (
     <>
-      {sessions.filter((s) => s.mode !== "chat").map((s) => (
-        <PortaledTerminal key={s.id} session={s} />
-      ))}
+      {sessions
+        .filter(
+          (s) =>
+            s.mode !== "chat" &&
+            (mountedSessionIds.has(s.id) || visibleSessionIds.has(s.id)),
+        )
+        .map((s) => (
+          <PortaledTerminal key={s.id} session={s} />
+        ))}
     </>
   );
+}
+
+const SESSION_ID_KEY_SEPARATOR = "\u0000";
+
+type AppStateSnapshot = ReturnType<typeof useAppStore.getState>;
+
+function visibleTerminalSessionIdKey(state: AppStateSnapshot): string {
+  if (!state.activeProject) return "";
+  const ws = state.workspaces[state.activeProject];
+  if (!ws) return "";
+  return Object.values(ws.panes)
+    .map((pane) => pane.activeTabId)
+    .filter((id): id is string => Boolean(id))
+    .sort()
+    .join(SESSION_ID_KEY_SEPARATOR);
+}
+
+function parseSessionIdKey(key: string): Set<string> {
+  if (!key) return new Set();
+  return new Set(key.split(SESSION_ID_KEY_SEPARATOR));
 }
 
 function PortaledTerminal({ session }: { session: Session }) {


### PR DESCRIPTION
## Summary
This PR prevents Acorn from respawning every persisted terminal session during app startup.

1. **Lazy terminal mounting** — mount only terminal sessions that are active in the visible workspace panes on first render, instead of rendering every saved non-chat session immediately.
2. **State preservation after first view** — keep terminals mounted after a session has been shown once, so pane/project switches still preserve xterm and PTY state through the existing limbo portal path.
3. **Regression coverage** — add focused `TerminalHost` tests for first-render filtering and post-activation preservation.

## Expected impact
| Scenario | Before | After |
| --- | --- | --- |
| User has many persisted terminal sessions | Startup can restore scrollback and spawn PTYs for every saved session | Startup only mounts visible terminal sessions |
| Switching back to a session already viewed in this app run | Terminal state preserved | Terminal state preserved |
| Chat-mode sessions | Excluded from terminal mounting | Still excluded |

## Design notes
- `TerminalHost` now tracks a small in-memory set of terminal session ids that have been mounted in the current app run.
- Visible session ids are derived from active panes in the active workspace; code viewer tabs and chat sessions do not cause terminal mounts.
- Removed sessions are pruned from the mounted set so stale portal targets do not linger after backend session cleanup.

## Follow-up (not in this PR)
- Add startup memory/process telemetry if this class of report recurs, so future incidents can distinguish native crash, memory pressure, and persisted-state startup load more directly.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm exec vitest run src/components/TerminalHost.test.tsx` — 2 tests pass
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` — 60 files pass, 575 tests pass, 1 skipped
- [x] `pnpm run build` passes

## Notes
- Local video evidence showed `Acorn.app` briefly appearing in the Dock and then disappearing after launch. No local `Acorn` crash report was present under `~/Library/Logs/DiagnosticReports`, so this PR targets the strongest code-level startup pressure found during investigation rather than a confirmed native crash stack.
- `pnpm run build` emits existing Vite chunk-size/dynamic-import warnings. They are not caused by this PR.
