### PR TITLE
feat(sidebar): expose project session create actions

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   FolderPlus,
   GitBranch,
   MessageSquareText,
+  MoreHorizontal,
   Pencil,
   PencilLine,
   Plus,
@@ -73,6 +74,7 @@ import {
   type SessionCreateScope,
 } from "../lib/sessionCreation";
 import {
+  PROJECT_SESSION_CREATE_ACTIONS,
   PROJECT_SESSION_CREATE_MENU,
   type ProjectSessionCreateAction,
 } from "../lib/projectSessionCreateActions";
@@ -749,6 +751,25 @@ function projectSessionCreateIcon(id: ProjectSessionCreateAction["id"]) {
   }
 }
 
+const PROJECT_SESSION_PRIMARY_CREATE_ACTION_IDS = new Set<
+  ProjectSessionCreateAction["id"]
+>(["terminal", "isolated"]);
+
+function isPrimaryProjectSessionCreateAction(
+  action: ProjectSessionCreateAction,
+): boolean {
+  return PROJECT_SESSION_PRIMARY_CREATE_ACTION_IDS.has(action.id);
+}
+
+const PROJECT_SESSION_PRIMARY_CREATE_ACTIONS =
+  PROJECT_SESSION_CREATE_ACTIONS.filter(isPrimaryProjectSessionCreateAction);
+
+const PROJECT_SESSION_OVERFLOW_CREATE_MENU = PROJECT_SESSION_CREATE_MENU.filter(
+  (item) =>
+    item.type === "separator" ||
+    !isPrimaryProjectSessionCreateAction(item.action),
+);
+
 interface ProjectGroupViewProps {
   project: ProjectGroup;
   collapsed: boolean;
@@ -813,6 +834,19 @@ function ProjectGroupView({
   const createMenuItems = useMemo<ContextMenuItem[]>(
     () =>
       PROJECT_SESSION_CREATE_MENU.map((item) => {
+        if (item.type === "separator") return { type: "separator" };
+        const action = item.action;
+        return {
+          label: sidebarText(t, action.labelKey),
+          icon: projectSessionCreateIcon(action.id),
+          onClick: () => onAddSession(action.isolated, action.kind, action.mode),
+        };
+      }),
+    [onAddSession, t],
+  );
+  const overflowCreateMenuItems = useMemo<ContextMenuItem[]>(
+    () =>
+      PROJECT_SESSION_OVERFLOW_CREATE_MENU.map((item) => {
         if (item.type === "separator") return { type: "separator" };
         const action = item.action;
         return {
@@ -899,10 +933,29 @@ function ProjectGroupView({
           <span className="truncate text-sm font-medium leading-5 text-fg">
             {project.name}
           </span>
-          <span className="ml-1 flex h-4 shrink-0 items-center rounded bg-bg-elevated/80 px-1 text-[10px] leading-none text-fg-muted">
-            {project.sessions.length}
-          </span>
         </span>
+        {PROJECT_SESSION_PRIMARY_CREATE_ACTIONS.map((action) => (
+          <Tooltip
+            key={action.id}
+            label={sidebarText(t, action.labelKey)}
+            side="bottom"
+          >
+            <button
+              type="button"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                setMenu(null);
+                setCreateMenu(null);
+                onAddSession(action.isolated, action.kind, action.mode);
+              }}
+              className="invisible flex size-5 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
+              aria-label={sidebarText(t, action.ariaKey)}
+            >
+              {projectSessionCreateIcon(action.id)}
+            </button>
+          </Tooltip>
+        ))}
         <button
           type="button"
           onPointerDown={(e) => e.stopPropagation()}
@@ -914,13 +967,12 @@ function ProjectGroupView({
               current === null ? { x: rect.left, y: rect.bottom + 4 } : null,
             );
           }}
-          className="invisible flex h-5 w-7 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
+          className="invisible flex size-5 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
           aria-label={sidebarText(t, "sidebar.aria.newSessionMenuInProject")}
           aria-haspopup="menu"
           aria-expanded={createMenu !== null}
         >
-          <Plus size={12} />
-          <ChevronRight size={10} className="rotate-90" />
+          <MoreHorizontal size={13} />
         </button>
         <Tooltip
           label={sidebarText(t, "sidebar.actions.closeProject")}
@@ -945,7 +997,7 @@ function ProjectGroupView({
         x={createMenu?.x ?? 0}
         y={createMenu?.y ?? 0}
         onClose={() => setCreateMenu(null)}
-        items={createMenuItems}
+        items={overflowCreateMenuItems}
       />
       <ContextMenu
         open={menu !== null}

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -42,10 +42,140 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(
       page.getByRole("listitem").filter({ hasText: "demo" }),
     ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Project demo" }),
+    ).toHaveText("demo");
     await expect(page.getByText(/Click to open a project/i)).toHaveCount(0);
     await expect(
       page.getByRole("button", { name: "Double-click to start a session." }),
     ).toBeVisible();
+  });
+
+  test("project header exposes regular and isolated session buttons outside the menu", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => {
+      return (
+        (window as unknown as { __createdSessions?: unknown[] })
+          .__createdSessions ?? []
+      );
+    });
+    await tauri.handle("create_session", (args) => {
+      const input = (args ?? {}) as {
+        name?: string;
+        repoPath?: string;
+        isolated?: boolean;
+        kind?: string;
+        mode?: string;
+        projectScoped?: boolean;
+      };
+      const w = window as unknown as {
+        __createSessionCalls?: unknown[];
+        __createdSessions?: unknown[];
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createdSessions = w.__createdSessions ?? [];
+      w.__createSessionCalls.push(args);
+      const repoPath = input.repoPath ?? "/tmp/demo";
+      const id = `created-${w.__createdSessions.length + 1}`;
+      const created = {
+        id,
+        name: input.name ?? id,
+        repo_path: repoPath,
+        worktree_path: input.isolated
+          ? `${repoPath}/.acorn/worktrees/${id}`
+          : repoPath,
+        branch: "main",
+        isolated: Boolean(input.isolated),
+        project_scoped: input.projectScoped ?? true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "default",
+        kind: input.kind ?? "regular",
+        mode: input.mode ?? "terminal",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: Boolean(input.isolated),
+      };
+      w.__createdSessions.push(created);
+      return created;
+    });
+
+    await page.goto("/");
+
+    const projectRow = page.getByRole("button", { name: "Project demo" });
+    await projectRow.hover();
+    await expect(
+      page.getByRole("button", { name: "New session in this project" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", {
+        name: "New isolated session in this project",
+      }),
+    ).toBeVisible();
+
+    await page
+      .getByRole("button", { name: "Create session in this project" })
+      .click();
+    await expect(
+      page.getByRole("menuitem", { name: "New session" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("menuitem", { name: /New isolated session/i }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("menuitem", { name: "New chat session" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "New control session" }),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    await projectRow.hover();
+    await page
+      .getByRole("button", { name: "New session in this project" })
+      .click();
+    await projectRow.hover();
+    await page
+      .getByRole("button", {
+        name: "New isolated session in this project",
+      })
+      .click();
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __createSessionCalls?: unknown[] })
+          .__createSessionCalls,
+    )) as Array<{
+      repoPath: string;
+      isolated: boolean;
+      kind: string;
+      mode: string;
+    }>;
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toMatchObject({
+      repoPath: "/tmp/demo",
+      isolated: false,
+      kind: "regular",
+      mode: "terminal",
+    });
+    expect(calls[1]).toMatchObject({
+      repoPath: "/tmp/demo",
+      isolated: true,
+      kind: "regular",
+      mode: "terminal",
+    });
   });
 
   test("instant sessions area stays compact when projects are present", async ({


### PR DESCRIPTION
## Summary
Project rows now expose the two common terminal creation actions directly while keeping less common session types in overflow.

1. **Primary project actions** — add direct header buttons for regular sessions and isolated worktree sessions, reusing the existing project session action metadata and icons.
2. **Overflow menu cleanup** — keep chat and control session creation in a compact `...` overflow button instead of the previous `+` dropdown affordance.
3. **Project header simplification** — remove the session count badge from project headers so the row stays focused on project identity and actions.
4. **E2E coverage** — assert the direct buttons render, the overflow menu excludes the primary actions, and the direct buttons call `create_session` with the expected regular/isolated payloads.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Project session creation | Regular and isolated sessions were inside the project create dropdown | Regular and isolated sessions are one click from the project header |
| Project header density | Header showed project name, session count, and `+` dropdown affordance | Header shows project name, direct primary actions, `...` overflow, and close |
| Less common session types | Chat/control shared the same dropdown with common actions | Chat/control stay in overflow |

## Design notes
- The implementation reuses `PROJECT_SESSION_CREATE_ACTIONS` / `PROJECT_SESSION_CREATE_MENU` so the payload contract stays centralized.
- Right-click project context menus still include the full create action set, preserving the broader project management menu.
- The visible overflow button uses a single `MoreHorizontal` icon and the same `size-5` footprint as nearby project header controls.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts --project=chromium` — 16 passed
- [x] `git diff --check` — no whitespace or conflict-marker issues

## Notes
- The focused Playwright run prints the existing `NO_COLOR` / `FORCE_COLOR` webserver warning, but all sidebar tests pass.
