### PR TITLE
fix(chat): propagate shell PATH to native AI CLIs

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -139,6 +139,7 @@ pub fn run_oneshot_in_dir_cancellable(
         ))
     })?;
     let mut command_builder = Command::new(&resolved);
+    crate::shell_env::apply_to_command(&mut command_builder);
     command_builder
         .args(args)
         .stdin(Stdio::piped())

--- a/src-tauri/src/shell_env.rs
+++ b/src-tauri/src/shell_env.rs
@@ -1,7 +1,8 @@
 //! Capture a small whitelist of environment variables out of the user's
-//! login+interactive shell so PTY children we spawn see the same locale,
-//! editor, pager, etc. that the user gets in Terminal.app — without acorn
-//! having to know each shell's rc-file conventions.
+//! login+interactive shell so PTY children and native one-shot CLI runs see
+//! the same PATH, locale, editor, pager, etc. that the user gets in
+//! Terminal.app — without acorn having to know each shell's rc-file
+//! conventions.
 //!
 //! ## Why
 //!
@@ -50,17 +51,21 @@ use base64::Engine;
 use crate::shell_util::shell_quote;
 
 /// Environment variables we propagate from the user's shell into PTY
-/// children. Restricted to a known-safe set so we don't accidentally leak
-/// shell-internal bookkeeping (`SHLVL`, `OLDPWD`, …) or sensitive secrets
-/// the user might keep in their shell.
+/// children and native one-shot CLI runs. Restricted to a known-safe set so
+/// we don't accidentally leak shell-internal bookkeeping (`SHLVL`, `OLDPWD`,
+/// …) or sensitive secrets the user might keep in their shell.
 ///
 /// Categories:
+///   * Command lookup — `PATH`, so npm/Homebrew/asdf/mise CLIs whose
+///     shebangs use `/usr/bin/env node` can find their runtime even when
+///     Acorn was launched by Finder/Dock/Spotlight.
 ///   * Locale family — what zsh's ZLE and tools use to interpret bytes,
 ///     pick message languages, and sort.
 ///   * Tool prefs — what editor / pager / man pager subcommands honor.
 ///   * Misc — `TZ` for time-aware tools, `HISTFILE` so the user's expected
 ///     history file location is honored.
 const CAPTURED_VARS: &[&str] = &[
+    "PATH",
     "LANG",
     "LC_ALL",
     "LC_CTYPE",
@@ -108,6 +113,18 @@ pub fn resolve() -> HashMap<String, String> {
 /// capture.
 pub fn invalidate() {
     *cache().lock().unwrap() = None;
+}
+
+/// Apply the captured login-shell environment to a native command spawn.
+///
+/// This is intentionally narrower than spawning through `$SHELL -l -i -c`:
+/// the target command still executes directly, but child interpreters looked
+/// up via shebangs such as `/usr/bin/env node` see the same PATH the user's
+/// terminal would provide.
+pub fn apply_to_command(cmd: &mut Command) {
+    for (k, v) in resolve() {
+        cmd.env(k, v);
+    }
 }
 
 /// macOS-only: read the system preferred locale and turn it into a `LANG`
@@ -302,9 +319,10 @@ mod tests {
 
     #[test]
     fn build_capture_script_includes_each_var() {
-        let script = build_capture_script(&["LANG", "EDITOR"]);
+        let script = build_capture_script(&["PATH", "LANG", "EDITOR"]);
         assert!(script.contains(ENV_BEGIN));
         assert!(script.contains(ENV_END));
+        assert!(script.contains("PATH"));
         assert!(script.contains("LANG"));
         assert!(script.contains("EDITOR"));
         assert!(script.contains("printenv"));
@@ -319,6 +337,35 @@ mod tests {
 
         let resolved = resolve();
         assert_eq!(resolved.get("LANG").unwrap(), "ko_KR.UTF-8");
+    }
+
+    #[test]
+    fn apply_to_command_layers_cached_path() {
+        let mut seeded = HashMap::new();
+        seeded.insert(
+            "PATH".to_string(),
+            "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin".to_string(),
+        );
+        seeded.insert("LANG".to_string(), "ko_KR.UTF-8".to_string());
+        seed_cache(seeded);
+
+        let mut cmd = Command::new("/bin/sh");
+        apply_to_command(&mut cmd);
+
+        assert_eq!(
+            cmd.get_envs()
+                .find(|(k, _)| k.to_str() == Some("PATH"))
+                .and_then(|(_, v)| v)
+                .and_then(|v| v.to_str()),
+            Some("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"),
+        );
+        assert_eq!(
+            cmd.get_envs()
+                .find(|(k, _)| k.to_str() == Some("LANG"))
+                .and_then(|(_, v)| v)
+                .and_then(|v| v.to_str()),
+            Some("ko_KR.UTF-8"),
+        );
     }
 
     /// End-to-end smoke test: actually invoke the user's shell, capture


### PR DESCRIPTION
## Summary
Native chat CLI launches now inherit the same shell PATH that Acorn already captures for terminal PTYs.

1. **Capture PATH with shell env** — add `PATH` to the login-shell env whitelist so GUI-launched Acorn can preserve Homebrew/npm/asdf/mise runtime locations.
2. **Apply shell env to native AI CLI spawns** — layer the captured env onto `run_oneshot_in_dir_cancellable` before spawning Claude, Codex, Antigravity, Ollama, or llm providers.
3. **Cover the PATH handoff** — add a unit test proving the captured PATH is applied to native `Command` spawns.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Codex native chat launched from Finder/Dock/Spotlight | `env: node: No such file or directory` when `codex` uses `/usr/bin/env node` and Acorn's process PATH lacks Node | `codex` sees the user's login-shell PATH and can resolve `node` |
| Claude native chat | Existing invocation preserved; receives the same shell env layering as Codex | No expected behavior regression |
| Antigravity native chat | Existing `agy` invocation preserved; receives the same shell env layering as Codex | Compatible with PATH-managed runtimes |

## Design notes
- This keeps native CLI execution direct. It does not wrap each chat turn in `$SHELL -l -i -c`, so there is no extra shell quoting surface or per-turn shell startup cost beyond the existing cached shell-env capture.
- The env whitelist remains narrow. `PATH` is added because shebangs such as `/usr/bin/env node` depend on it; broad user secrets remain uncaptured.
- The change is intentionally provider-agnostic because Claude, Codex, and Antigravity all flow through `run_oneshot_in_dir_cancellable` after provider-specific argv construction.

## Test plan
- [x] `pnpm run build:sidecar` — staged `acorn-ipc` and `acornd` sidecars for this worktree
- [x] `rustfmt --edition 2021 --check src/ai.rs src/shell_env.rs`
- [x] `cargo test shell_env --lib` — 10 passed, 1 ignored
- [x] `cargo test ai::tests --lib` — 4 passed
- [x] `cargo test antigravity --lib` — 6 passed
- [x] `cargo test claude --lib` — 12 passed
- [x] `cargo test chat_cli_invocation --lib` — 3 passed
- [x] `pnpm exec vitest run src/lib/settings.test.ts src/lib/agentProvider.test.ts src/components/ChatPane.test.tsx` — 80 passed
- [x] `cargo check --lib` — passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test` — 60 files passed, 575 passed, 1 skipped
- [x] `cargo test --lib -- --test-threads=1` — 239 passed, 1 ignored

## Notes
- `cargo test --lib` with default parallelism hit two `agent_hooks` connection-reset failures once. Both failed tests passed when rerun individually, and the full lib suite passed with `--test-threads=1`. This appears to be pre-existing test timing behavior, not caused by the PATH/env change.