### PR TITLE
chore(release): v1.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.13.1",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.13.0"
+version = "1.13.1"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
Patch release bump for the native chat CLI PATH fix merged after `v1.13.0`.

1. **Version metadata** — bump Acorn from `1.13.0` to `1.13.1` in `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock`.
2. **SemVer decision** — patch release because the only unreleased change is a user-visible bug fix: #380.

## Expected impact
| Area | Impact |
| --- | --- |
| Updater metadata | Publishes `v1.13.1` as the next stable Acorn release |
| Release notes | Includes the #380 native chat CLI PATH fix under Fixes |
| App behavior | No behavior change beyond the already-merged fix |

## Design notes
- This PR intentionally changes release metadata only.
- `v1.13.1` release notes were generated locally and include #380 as the only entry since `v1.13.0`.

## Test plan
- [x] `rg -n '1\\.13\\.0|1\\.13\\.1' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock` — only `1.13.1` remains in release metadata
- [x] `pnpm run typecheck` — passed
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — reports `acorn` version `1.13.1`
- [x] `REPO=im-ian/acorn TAG=v1.13.1 OUTPUT=/tmp/acorn-release-notes-v1.13.1.md node scripts/release-notes.mjs` — generated notes with #380 under Fixes
- [x] `git diff --check` — passed

## Notes
- The release branch leaves unrelated local `.codex*` directories unstaged.