### PR TITLE
fix(settings): limit agent menu options

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -245,6 +245,35 @@ describe("SettingsModal font controls", () => {
     document.body.appendChild(container);
   });
 
+  it("shows only supported agents in the requested order", async () => {
+    useSettings.setState({
+      open: true,
+      settings: cloneSettings(),
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openAgentsTab();
+
+    const radios = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[name="acorn-agent"]'),
+    );
+    expect(radios.map((radio) => radio.value)).toEqual([
+      "claude",
+      "codex",
+      "antigravity",
+      "custom",
+    ]);
+    expect(document.body.textContent).toContain("Claude Code");
+    expect(document.body.textContent).toContain("Codex");
+    expect(document.body.textContent).toContain("Antigravity");
+    expect(document.body.textContent).toContain("Custom Command");
+    expect(document.body.textContent).not.toContain("Ollama");
+    expect(document.body.textContent).not.toContain("llm CLI");
+  });
+
   afterEach(() => {
     if (root) {
       act(() => root?.unmount());

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1743,32 +1743,6 @@ function AgentSettings({
           />
         </div>
       </Field>
-      {selected === "ollama" ? (
-        <Field
-          label={st(t, "settings.agents.ollamaModel.label")}
-          hint={st(t, "settings.agents.ollamaModel.hint")}
-        >
-          <TextInput
-            value={settings.agents.ollama.model}
-            onChange={(e) =>
-              patchAgents({ ollama: { model: e.target.value } })
-            }
-            placeholder="e.g. llama3:8b"
-          />
-        </Field>
-      ) : null}
-      {selected === "llm" ? (
-        <Field
-          label={st(t, "settings.agents.llmModel.label")}
-          hint={st(t, "settings.agents.llmModel.hint")}
-        >
-          <TextInput
-            value={settings.agents.llm.model}
-            onChange={(e) => patchAgents({ llm: { model: e.target.value } })}
-            placeholder="e.g. gpt-4o-mini"
-          />
-        </Field>
-      ) : null}
       {selected === "custom" ? (
         <Field
           label={st(t, "settings.agents.customCommand.label")}

--- a/src/components/ui/RadioCard.tsx
+++ b/src/components/ui/RadioCard.tsx
@@ -30,6 +30,7 @@ export function RadioCard<T extends string>({
       <input
         type="radio"
         name={name}
+        value={value}
         checked={active}
         onChange={() => onSelect(value)}
         className="mt-0.5 accent-[var(--color-accent)]"

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -421,6 +421,26 @@ Rules:
     );
   });
 
+  it("shows only the supported built-in agents in Settings order", () => {
+    expect(AGENT_OPTIONS.map((o) => [o.value, o.label])).toEqual([
+      ["claude", "Claude Code"],
+      ["codex", "Codex"],
+      ["antigravity", "Antigravity"],
+    ]);
+  });
+
+  it("falls back from persisted hidden agents to the default agent", async () => {
+    localStorage.setItem(
+      "acorn:settings:v1",
+      JSON.stringify({ agents: { selected: "ollama" } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.agents.selected).toBe("claude");
+  });
+
   it("runs Antigravity through the AGY CLI one-shot mode", () => {
     expect(
       resolveAiExecutionRequest({

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -48,24 +48,14 @@ export const AGENT_OPTIONS: ReadonlyArray<{
     oneshotHint: "claude -p --output-format text",
   },
   {
-    value: "antigravity",
-    label: "Antigravity CLI",
-    oneshotHint: "agy -p",
-  },
-  {
-    value: "ollama",
-    label: "Ollama (local)",
-    oneshotHint: "ollama run <model>",
-  },
-  {
-    value: "llm",
-    label: "llm CLI",
-    oneshotHint: "llm [-m <model>]",
-  },
-  {
     value: "codex",
-    label: "OpenAI Codex CLI",
+    label: "Codex",
     oneshotHint: "codex exec",
+  },
+  {
+    value: "antigravity",
+    label: "Antigravity",
+    oneshotHint: "agy -p",
   },
 ];
 
@@ -498,8 +488,6 @@ const VALID_WEIGHTS = new Set<TerminalFontWeight>([
 const VALID_AGENTS = new Set<AgentProvider>([
   "claude",
   "antigravity",
-  "ollama",
-  "llm",
   "codex",
 ]);
 
@@ -1236,7 +1224,7 @@ export const resolveAiCommitRequest = resolveAiExecutionRequest;
  * Generate.
  */
 export function selectedAgentLabel(s: AcornSettings): string {
-  if (s.agents.selected === "custom") return "Custom command";
+  if (s.agents.selected === "custom") return "Custom Command";
   return (
     AGENT_OPTIONS.find((o) => o.value === s.agents.selected)?.label ?? "AI"
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -473,7 +473,7 @@
         "hint": "Choose which AI CLI acorn uses."
       },
       "customOption": {
-        "label": "Custom command",
+        "label": "Custom Command",
         "description": "Legacy option. Native AI generation now requires a built-in provider."
       },
       "ollamaModel": {
@@ -485,7 +485,7 @@
         "hint": "Passed via `llm -m <model>` (and `llm chat -m <model>` for sessions). Blank uses the llm-configured default."
       },
       "customCommand": {
-        "label": "Custom command",
+        "label": "Custom Command",
         "hint": "Kept for existing settings. Built-in providers are required for native AI generation."
       },
       "sessionTitles": {


### PR DESCRIPTION
## Summary
Settings > Agents now only exposes the supported agent choices requested for the menu.

1. **Agent menu options** — limit the Settings agent picker to Claude Code, Codex, Antigravity, and Custom Command in that order.
2. **Persisted hidden selections** — normalize previously stored Ollama/llm selections back to the default Claude Code selection so the UI cannot stay on a hidden provider.
3. **UI test coverage** — lock the Settings agent order in both settings model and rendered modal tests, and give RadioCard inputs explicit DOM values.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Settings > Agents menu | Included Ollama and llm provider choices | Shows Claude Code, Codex, Antigravity, Custom Command only |
| Existing hidden provider selection | Could load into a provider no longer shown by the menu | Falls back to Claude Code |

## Design notes
- Provider model fields for Ollama/llm remain in the settings type for compatibility with older stored settings and existing execution request shape; they are no longer valid picker options.
- The Custom Command option stays separate from `AGENT_OPTIONS`, matching the existing renderer structure and preserving its legacy copy.
- `RadioCard` now writes the provided value to the radio input, aligning DOM state with the typed selection used by React.

## Test plan
- [x] `pnpm exec vitest run src/lib/settings.test.ts src/components/SettingsModal.test.tsx` — 60 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec playwright test tests/e2e/settings-tabs.spec.ts --project=chromium` — 2 passed
