### PR TITLE
chore(release): v1.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.13.1",
+  "version": "1.13.2",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.13.1"
+version = "1.13.2"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
Patch release bump for the Settings > Agents menu fix shipped after v1.13.1.

1. **Semver decision** — bump `1.13.1` to `1.13.2` as a patch release because the only unreleased change is PR #382, labelled `fix`.
2. **Version metadata** — update `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` to `1.13.2`.
3. **Release notes preview** — generated notes include PR #382 under Fixes.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| App version metadata | 1.13.1 | 1.13.2 |
| Release notes source | No post-1.13.1 release entry | Includes PR #382 as a patch fix |

## Design notes
- This PR is version metadata only; it intentionally uses `skip-changelog` so the merged fix PR supplies the release note entry.
- No source behavior changes are included in the release bump.

## Test plan
- [x] `rg -n '1\.13\.1|1\.13\.2' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock` — version fields point at `1.13.2`
- [x] `pnpm run typecheck` — passed
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — package version reports `1.13.2`
- [x] `REPO=im-ian/acorn TAG=v1.13.2 OUTPUT=/tmp/acorn-release-notes-v1.13.2.md node scripts/release-notes.mjs` — generated notes include PR #382
- [x] `git diff --check` — passed

## Notes
- Included since v1.13.1: #382 `fix(settings): limit agent menu options`.
