### PR TITLE
fix(terminal): keep process probes off the main thread

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3040,10 +3040,18 @@ pub fn prepare_claude_fork(parent_uuid: String, new_cwd: String) -> AppResult<()
 /// the user right-clicks but absent from the last cache, or vice-versa.
 /// An on-demand scan locks the answer to "what's true right now."
 #[tauri::command]
-pub fn detect_session_agent(
+pub async fn detect_session_agent(
     state: State<'_, AppState>,
     session_id: String,
 ) -> AppResult<AgentDetection> {
+    let state = state.inner().clone();
+    run_blocking("detect_session_agent", move || {
+        detect_session_agent_inner(state, session_id)
+    })
+    .await
+}
+
+fn detect_session_agent_inner(state: AppState, session_id: String) -> AppResult<AgentDetection> {
     let parsed = parse_id(&session_id)?;
     let session_pids = crate::agent_resume_persister::collect_session_pids(&state);
     let mappings = acorn_transcript::collect_live_mappings(&session_pids);
@@ -3630,7 +3638,12 @@ pub fn pty_reload_shell_env() {
 /// already exited). The frontend then falls back to the session's recorded
 /// `worktree_path`.
 #[tauri::command]
-pub fn pty_cwd(state: State<'_, AppState>, session_id: String) -> AppResult<Option<String>> {
+pub async fn pty_cwd(state: State<'_, AppState>, session_id: String) -> AppResult<Option<String>> {
+    let state = state.inner().clone();
+    run_blocking("pty_cwd", move || pty_cwd_inner(state, session_id)).await
+}
+
+fn pty_cwd_inner(state: AppState, session_id: String) -> AppResult<Option<String>> {
     let id = parse_id(&session_id)?;
     let Some(root_pid) = session_root_pid(&state, &id) else {
         return Ok(None);
@@ -3650,7 +3663,7 @@ pub fn pty_cwd(state: State<'_, AppState>, session_id: String) -> AppResult<Opti
     Ok(deepest_descendant_cwd(&sys, Pid::from_u32(root_pid)))
 }
 
-fn session_root_pid(state: &State<'_, AppState>, id: &Uuid) -> Option<u32> {
+fn session_root_pid(state: &AppState, id: &Uuid) -> Option<u32> {
     state
         .stream_registry
         .pid(id)
@@ -3675,7 +3688,7 @@ pub async fn pty_repo_root(
     session_id: String,
 ) -> AppResult<Option<String>> {
     let id = parse_id(&session_id)?;
-    let Some(root_pid) = session_root_pid(&state, &id) else {
+    let Some(root_pid) = session_root_pid(state.inner(), &id) else {
         return Ok(None);
     };
     tauri::async_runtime::spawn_blocking(move || {
@@ -3767,7 +3780,15 @@ pub fn linked_worktree_root(path: String) -> Option<String> {
 /// signal override the fresh live one (e.g. user `cd`s out of an adopted
 /// worktree).
 #[tauri::command]
-pub fn pty_in_worktree_all(state: State<'_, AppState>) -> HashMap<String, bool> {
+pub async fn pty_in_worktree_all(state: State<'_, AppState>) -> AppResult<HashMap<String, bool>> {
+    let state = state.inner().clone();
+    run_blocking("pty_in_worktree_all", move || {
+        Ok(pty_in_worktree_all_inner(state))
+    })
+    .await
+}
+
+fn pty_in_worktree_all_inner(state: AppState) -> HashMap<String, bool> {
     let sessions = state.sessions.list();
     let pids: Vec<(Uuid, u32)> = sessions
         .iter()

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -581,20 +581,16 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
   useEffect(() => {
     let cancelled = false;
     let unsub: (() => void) | null = null;
+    let lastSyncedSessionId: string | null | undefined = undefined;
     void import("../store").then(({ useAppStore }) => {
       if (cancelled) return;
       const sync = (sid: string | null) => {
+        if (sid === lastSyncedSessionId) return;
+        lastSyncedSessionId = sid;
         setActiveSessionIdLocal(sid);
         if (!sid) {
           setAgent({ claude: null, codex: null, antigravity: null });
-          return;
         }
-        api
-          .detectSessionAgent(sid)
-          .then((res) => {
-            if (!cancelled) setAgent(res);
-          })
-          .catch(() => {});
       };
       sync(useAppStore.getState().activeSessionId);
       unsub = useAppStore.subscribe((s) => {
@@ -606,6 +602,29 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       if (unsub) unsub();
     };
   }, []);
+
+  useEffect(() => {
+    if (!menu) return;
+    if (!activeSessionId) {
+      setAgent({ claude: null, codex: null, antigravity: null });
+      return;
+    }
+    setAgent({ claude: null, codex: null, antigravity: null });
+    let cancelled = false;
+    api
+      .detectSessionAgent(activeSessionId)
+      .then((res) => {
+        if (!cancelled) setAgent(res);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAgent({ claude: null, codex: null, antigravity: null });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSessionId, menu]);
 
   useEffect(() => {
     setLocalBool(SHOW_HIDDEN_KEY, showHidden);


### PR DESCRIPTION
## Summary
This keeps live terminal process probes from tying up the Tauri IPC path when Acorn resumes focus with active agent sessions.

1. **Offload live process probes.** Converts `detect_session_agent`, `pty_cwd`, and `pty_in_worktree_all` to async Tauri commands and runs their process-table work through `run_blocking`.
2. **Reduce FileExplorer probe fanout.** Stops running `detect_session_agent` on every app-store mutation while still refreshing the agent state when the file context menu opens.
3. **Preserve caller behavior.** Keeps frontend API contracts unchanged for the affected callers; the batched worktree probe still resolves to the same map shape after Tauri unwraps the command result.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| UI responsiveness | Focus/menu/output paths could synchronously scan the process table on the Tauri IPC path. | Process scans run on the blocking pool, reducing resume/focus stalls after remote or locked-screen work. |
| FileExplorer agent probes | Active-session agent detection ran on unrelated store updates. | FileExplorer tracks active-session changes and probes live agents on context-menu open. |
| Agent action freshness | On-demand detection stayed fresh but could block the app path. | Detection remains on-demand for menus while the blocking work is off the app path. |

## Design notes
- The agent detection path intentionally remains an on-demand live scan instead of using the watcher cache, because Fork/attach menu actions need a current process snapshot.
- `pty_repo_root` already used blocking work; this PR keeps that shape and only updates the shared `session_root_pid` helper to accept `AppState` directly.
- `pty_in_worktree_all` now returns `AppResult<HashMap<_, _>>` so it can use the same `run_blocking` helper as other fallible Tauri commands. Frontend callers still receive `Record<string, boolean>` on success.

## Test plan
- [x] `git diff --check`
- [x] `rustfmt --edition 2021 --check src/commands.rs`
- [x] `cargo check`
- [x] `cargo test -p acorn --lib` — 239 passed, 1 ignored
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 60 files passed, 578 tests passed, 1 skipped
- [x] `pnpm run build`
- [x] `pnpm run build:sidecar`

## Notes
- `pnpm run build` still emits existing Vite dynamic-import/chunk-size warnings, but exits successfully.
