### PR TITLE
chore(release): v1.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.13.2",
+  "version": "1.13.3",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.13.2"
+version = "1.13.3"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
This prepares the `v1.13.3` patch release for the post-`v1.13.2` terminal responsiveness fix.

1. **Version metadata.** Bumps Acorn from `1.13.2` to `1.13.3` in `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock`.
2. **SemVer decision.** Uses a patch bump because the only unreleased user-visible change since `v1.13.2` is fix PR #384.
3. **Release notes scope.** Generated release notes include #384 under Fixes; this bump PR is labeled `skip-changelog` so the release notes come from the shipped fix PR.

## Expected impact
| Area | Impact |
| --- | --- |
| Version metadata | App/package metadata reports `1.13.3`. |
| Release channel | Publishes a patch update containing #384 once tagged. |
| Changelog | Keeps this mechanical release PR out of user-facing notes. |

## Design notes
- Latest stable release is `v1.13.2`, published at `2026-06-04T07:52:09Z`.
- Unreleased PR scan found #384: `fix(terminal): keep process probes off the main thread`.
- Patch is the correct SemVer level because #384 is a bug fix with no new feature or breaking behavior.

## Test plan
- [x] `git diff --check`
- [x] `rg -n '1\.13\.2|1\.13\.3' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock`
- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1`
- [x] `REPO=im-ian/acorn TAG=v1.13.3 OUTPUT=/tmp/acorn-release-notes-v1.13.3.md node scripts/release-notes.mjs`

## Notes
- `Cargo.lock` still contains dependency version `unicode-segmentation = 1.13.2`; the Acorn package entry is updated to `1.13.3`.
