### PR TITLE
fix(terminal): keep plain space ASCII in WKWebView input

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -41,6 +41,7 @@ import {
   type ConversationNavigationDirection,
 } from "../lib/terminalConversation";
 import { patchTerminalMouseCoordinateScale } from "../lib/terminalMouseScale";
+import { isPlainSpaceKeydown } from "../lib/terminalInput";
 import { UI_SCALE_CHANGED_EVENT } from "../lib/layoutEvents";
 import {
   TERMINAL_PASTE_EVENT,
@@ -1063,6 +1064,10 @@ export function Terminal({
       }
     };
     let terminalActivityVersion = 0;
+    const sendKeyboardInputToPty = (data: string) => {
+      terminalActivityVersion += 1;
+      sendUserInputToPty(data);
+    };
     let imagePasteFallbackTimer: number | null = null;
     let imagePasteFallbackSerial = 0;
     const IMAGE_PASTE_FALLBACK_DELAY_MS = 500;
@@ -1491,6 +1496,16 @@ export function Terminal({
         ".xterm-helper-textarea",
       );
       if (ta) sentPrefix = ta.value;
+
+      // WKWebView can report an unmodified physical Space as NBSP through
+      // the xterm input path. Shells do not treat NBSP as a separator, so
+      // send ASCII space directly for the plain-space key.
+      if (isPlainSpaceKeydown(ev)) {
+        sendKeyboardInputToPty(" ");
+        ev.preventDefault();
+        ev.stopImmediatePropagation();
+        return;
+      }
 
       // Shift+Enter: insert newline (LF) instead of submitting (CR). xterm
       // by default emits \r for both Enter and Shift+Enter, so TUIs like

--- a/src/lib/terminalInput.test.ts
+++ b/src/lib/terminalInput.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isPlainSpaceKeydown } from "./terminalInput";
+
+describe("terminal input", () => {
+  it("recognises unmodified physical space variants", () => {
+    expect(isPlainSpaceKeydown({ key: " ", code: "Space" })).toBe(true);
+    expect(isPlainSpaceKeydown({ key: "Spacebar" })).toBe(true);
+    expect(isPlainSpaceKeydown({ key: "\u00a0", code: "Space" })).toBe(true);
+    expect(isPlainSpaceKeydown({ key: "Process", code: "Space" })).toBe(true);
+  });
+
+  it("leaves modified spaces to xterm", () => {
+    expect(
+      isPlainSpaceKeydown({ key: "\u00a0", code: "Space", altKey: true }),
+    ).toBe(false);
+    expect(
+      isPlainSpaceKeydown({ key: " ", code: "Space", ctrlKey: true }),
+    ).toBe(false);
+    expect(
+      isPlainSpaceKeydown({ key: " ", code: "Space", metaKey: true }),
+    ).toBe(false);
+  });
+
+  it("ignores non-space keys", () => {
+    expect(isPlainSpaceKeydown({ key: "a", code: "KeyA" })).toBe(false);
+    expect(isPlainSpaceKeydown({ key: "Enter", code: "Enter" })).toBe(false);
+  });
+});

--- a/src/lib/terminalInput.ts
+++ b/src/lib/terminalInput.ts
@@ -1,0 +1,14 @@
+interface TerminalKeyEventLike {
+  key: string;
+  code?: string;
+  altKey?: boolean;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+}
+
+const SPACE_KEY_VALUES = new Set([" ", "Spacebar", "\u00a0"]);
+
+export function isPlainSpaceKeydown(event: TerminalKeyEventLike): boolean {
+  if (event.altKey || event.ctrlKey || event.metaKey) return false;
+  return event.code === "Space" || SPACE_KEY_VALUES.has(event.key);
+}

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -21,6 +21,7 @@ import type { TauriMock } from "./support";
 interface ImeKeydown {
   type: "keydown";
   key: string;
+  code?: string;
   keyCode?: number;
   shift?: boolean;
   meta?: boolean;
@@ -106,6 +107,7 @@ async function runIme(page: Page, steps: ImeStep[]): Promise<void> {
         ta.dispatchEvent(
           new KeyboardEvent("keydown", {
             key: ev.key,
+            code: ev.code,
             keyCode: ev.keyCode,
             which: ev.keyCode,
             shiftKey: !!ev.shift,
@@ -304,6 +306,22 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     const writes = await getWrites(page);
     expect(writes).toContain("\n");
     expect(writes.join("")).not.toContain("\r");
+  });
+
+  test("Plain physical Space that surfaces as NBSP sends ASCII space", async ({
+    page,
+    tauri,
+  }) => {
+    await seed(tauri);
+    await activateTerminal(page);
+
+    await runIme(page, [
+      { type: "keydown", key: "\u00a0", code: "Space", keyCode: 32 },
+    ]);
+
+    const writes = await getWrites(page);
+    expect(writes).toContain(" ");
+    expect(writes).not.toContain("\u00a0");
   });
 
   test("Cmd+ArrowLeft sends \\x01 (start-of-line)", async ({


### PR DESCRIPTION
## Summary
This fixes intermittent terminal command failures where an unmodified Space can reach the shell as NBSP instead of an ASCII separator.

1. **Plain-space key path** — detect unmodified physical Space variants and send ASCII space directly before the xterm/WKWebView input path can surface NBSP.
2. **Modifier preservation** — leave Alt/Ctrl/Meta-space chords on the existing xterm path so intentional modified-space behavior is not rewritten.
3. **Regression coverage** — add terminal input helper tests and an IME E2E case that asserts NBSP-shaped plain Space writes ASCII space to the PTY.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal commands containing spaces | Intermittently `cd apps` / `pnpm i` could arrive as one NBSP-joined token and fail with `command not found`. | Plain physical Space is sent as ASCII `0x20`, so shells parse arguments normally. |
| Korean IME terminator space | Space could depend on the xterm/WKWebView input shape after the syllable flush. | The syllable still commits first, then ASCII space is sent explicitly. |
| Modified space and paste input | Existing xterm path. | Existing xterm path preserved for Alt/Ctrl/Meta-space and paste. |

## Design notes
- `isPlainSpaceKeydown` treats `code === "Space"`, legacy `Spacebar`, and NBSP key values as a physical space only when Alt/Ctrl/Meta are not held.
- The terminal keydown handler runs this after pending IME composition commits, so Korean terminator-space ordering stays intact.
- The direct write uses the same `sendUserInputToPty` path as ordinary terminal input, including multi-input fanout, and increments the terminal activity counter used by clipboard image fallback logic.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm run test -- src/lib/terminalInput.test.ts` — 61 files passed; 581 tests passed, 1 skipped
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test:e2e -- tests/e2e/terminal-ime.spec.ts` — 11 passed
- [x] `pnpm run build` passes; Vite reports existing dynamic-import/chunk-size warnings

## Notes
- Local untracked `.codex-worktrees/` and `.codex/` directories were left unstaged.
- The Vite dynamic-import and chunk-size warnings are pre-existing build warnings, not caused by this PR.