### PR TITLE
fix(agents): unblock Codex generated session titles outside repos

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -52,7 +52,7 @@ impl AiExecutionRequest {
             }),
             AiProvider::Codex => Ok(ResolvedAiCommand {
                 command: "codex",
-                args: vec!["exec".into()],
+                args: vec!["exec".into(), "--skip-git-repo-check".into()],
             }),
             AiProvider::Ollama => {
                 let model = normalize_model_arg(self.ollama_model.as_deref(), "llama3")?;
@@ -290,7 +290,10 @@ mod tests {
             req.resolve().unwrap(),
             ResolvedAiCommand {
                 command: "codex",
-                args: vec!["exec".to_string()],
+                args: vec![
+                    "exec".to_string(),
+                    "--skip-git-repo-check".to_string(),
+                ],
             }
         );
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -500,6 +500,7 @@ fn resolve_chat_cli_invocation(
                     command: "codex",
                     args: vec![
                         "exec".to_string(),
+                        "--skip-git-repo-check".to_string(),
                         "resume".to_string(),
                         cursor.clone(),
                         "-".to_string(),
@@ -5168,6 +5169,7 @@ mod tests {
             invocation.args,
             vec![
                 "exec",
+                "--skip-git-repo-check",
                 "resume",
                 "019e2001-3250-76b0-8410-2e073b38a2c1",
                 "-"

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -417,7 +417,7 @@ Rules:
 
   it("describes the Codex one-shot invocation in settings", () => {
     expect(AGENT_OPTIONS.find((o) => o.value === "codex")?.oneshotHint).toBe(
-      "codex exec",
+      "codex exec --skip-git-repo-check",
     );
   });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -50,7 +50,7 @@ export const AGENT_OPTIONS: ReadonlyArray<{
   {
     value: "codex",
     label: "Codex",
-    oneshotHint: "codex exec",
+    oneshotHint: "codex exec --skip-git-repo-check",
   },
   {
     value: "antigravity",


### PR DESCRIPTION
## Summary
Codex-backed one-shot AI calls can now run even when Acorn's app process is not inside a git repository.

1. **Codex one-shot args** — add `--skip-git-repo-check` to the shared Codex `exec` invocation used by generated session titles and other one-shot AI helpers.
2. **Codex chat resume** — pass the same repo-check bypass before the `resume` subcommand so resumed Codex chat turns keep the same execution contract.
3. **Settings hint + tests** — update the Settings → Agents invocation hint and expectations to match the backend command shape.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Auto-generated session titles with Codex selected | Could fail when the Acorn app cwd was not a git repository | Runs `codex exec --skip-git-repo-check` and can name tabs from transcript text |
| Codex chat resume | Could inherit the same repo check sensitivity | Uses the same repo-check bypass before `resume` |
| Claude / Antigravity paths | Unchanged | Unchanged |

## Design notes
- The fix lives in `AiExecutionRequest::resolve()` so all Codex one-shot call sites share one command contract instead of special-casing session title generation.
- The Codex `resume` subcommand path is updated separately because it builds its argv inline around the provider cursor.
- The added flag only changes Codex's repository preflight; Acorn still supplies the prompt over stdin and does not broaden filesystem permissions.

## Test plan
- [x] `pnpm run build:sidecar` — staged `acorn-ipc` and `acornd` sidecars for this worktree
- [x] `cargo test -p acorn ai::tests::resolves_known_ai_provider_commands --manifest-path src-tauri/Cargo.toml` — 1 passed
- [x] `cargo test -p acorn chat_cli_invocation_resumes_codex_thread_from_stdin --manifest-path src-tauri/Cargo.toml` — 1 passed
- [x] `pnpm test -- --run src/lib/settings.test.ts src/lib/sessionTitle.test.ts` — 52 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed
- [x] `git diff --check` — passed
- [x] `codex exec --skip-git-repo-check --help` — accepted option placement
- [x] `codex exec --skip-git-repo-check resume --help` — accepted option placement before `resume`

## Notes
- `pnpm run build` still emits existing Vite dynamic-import and chunk-size warnings. The build completed successfully; these warnings are not introduced by this PR.
