### PR TITLE
chore(release): v1.13.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.13.3",
+  "version": "1.13.4",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.13.3"
+version = "1.13.4"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.13.3"
+version = "1.13.4"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
Prepare the patch release for the two fixes merged since v1.13.3.

1. **Version bump**: Update package, Tauri, and Cargo release metadata from 1.13.3 to 1.13.4.
2. **Release scope**: Include the WKWebView plain-space input fix (#386) and Codex generated session title fix outside repos (#387).

## Expected impact

| Area | Impact |
| --- | --- |
| Release channel | Publishes patch release v1.13.4 after merge and tag. |
| User-visible behavior | Ships two fixes already merged to main; this PR adds no extra runtime changes. |
| Compatibility | Patch version only; no migration or breaking change expected. |

## Design notes

- Semver: patch because the unreleased changes since v1.13.3 are fixes only.
- Changelog label: skip-changelog because this release bump PR should not add a separate user-facing changelog item.

## Test plan

- [x] `gh run watch 26993208825 --exit-status`
- [x] `rg -n '1\.13\.3|1\.13\.4' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock`
- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1`
- [x] `REPO=im-ian/acorn TAG=v1.13.4 OUTPUT=/tmp/acorn-release-notes-v1.13.4.md node scripts/release-notes.mjs`
- [x] `git diff --check`

## Notes

- Release notes preview includes #386 and #387 under fixes.
- Ignored local build artifacts are not part of this PR.
