### PR TITLE
fix(terminal): isolate IME input flow

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -40,8 +40,8 @@ import {
   TERMINAL_CONVERSATION_NAV_EVENT,
   type ConversationNavigationDirection,
 } from "../lib/terminalConversation";
+import { attachTerminalInputController } from "../lib/terminalInputController";
 import { patchTerminalMouseCoordinateScale } from "../lib/terminalMouseScale";
-import { isPlainSpaceKeydown } from "../lib/terminalInput";
 import { UI_SCALE_CHANGED_EVENT } from "../lib/layoutEvents";
 import {
   TERMINAL_PASTE_EVENT,
@@ -1228,329 +1228,13 @@ export function Terminal({
       );
     };
 
-    // CJK IME path. xterm.js's built-in handler only processes plain
-    // `insertText`, so Korean/Japanese/Chinese commits delivered as
-    // W3C composition InputEvents on the helper textarea never reach
-    // the PTY. We intercept those events ourselves and render the
-    // live preview through xterm's hidden `.composition-view` element.
-    const compositionView = container.querySelector<HTMLElement>(
-      ".composition-view",
-    );
-    const getCellDims = (): { width: number; height: number } | null => {
-      // xterm v6 exposes render dimensions only via internals.
-      const core = (term as unknown as { _core?: { _renderService?: { dimensions?: { css?: { cell?: { width: number; height: number } } } } } })
-        ._core;
-      const cell = core?._renderService?.dimensions?.css?.cell;
-      return cell ? { width: cell.width, height: cell.height } : null;
-    };
-    const showComposing = (text: string) => {
-      if (!compositionView) return;
-      if (text.length === 0) {
-        compositionView.classList.remove("active");
-        compositionView.textContent = "";
-        return;
-      }
-      const cell = getCellDims();
-      compositionView.textContent = text;
-      if (cell) {
-        const buf = term.buffer.active;
-        // xterm's visible cursor row = `baseY + cursorY - viewportY`
-        // (mirrors xterm's own `Buffer.ts`: `absoluteY = ybase + y;
-        // relativeY = absoluteY - ydisp`). `cursorY` is the cursor's
-        // offset within the current page (0..rows-1), `baseY` is the
-        // buffer line where that page starts, and `viewportY` is the
-        // buffer line currently shown at the top of the viewport (they
-        // diverge when the user scrolls into scrollback). Subtracting
-        // `viewportY` alone — without adding `baseY` — leaves a session
-        // with non-empty scrollback computing `cursorY - viewportY ≈
-        // -ybase`, parking the overlay thousands of pixels above the
-        // visible terminal so the preview vanishes off-screen.
-        const cursorViewportY = buf.baseY + buf.cursorY - buf.viewportY;
-        compositionView.style.left = `${buf.cursorX * cell.width}px`;
-        compositionView.style.top = `${cursorViewportY * cell.height}px`;
-        compositionView.style.minHeight = `${cell.height}px`;
-        compositionView.style.lineHeight = `${cell.height}px`;
-      }
-      // Sync font with the current xterm options so the preview uses the
-      // user's configured terminal font/size, not the default sans inherited
-      // from the parent.
-      const fontFamily = term.options.fontFamily;
-      const fontSize = term.options.fontSize;
-      const fontWeight = term.options.fontWeight;
-      if (typeof fontFamily === "string") {
-        compositionView.style.fontFamily = fontFamily;
-      }
-      if (typeof fontSize === "number") {
-        compositionView.style.fontSize = `${fontSize}px`;
-      }
-      if (typeof fontWeight === "number" || typeof fontWeight === "string") {
-        compositionView.style.fontWeight = String(fontWeight);
-      }
-      compositionView.classList.add("active");
-    };
-    const hideComposing = () => {
-      if (!compositionView) return;
-      compositionView.classList.remove("active");
-      compositionView.textContent = "";
-    };
-
-    // WKWebView delivers a single Korean syllable across a mix of
-    // input types within one composition:
-    //
-    //   insertCompositionText   preview (ev.data = composed text)
-    //   insertReplacementText   preview when trailing char recomposes
-    //   insertText  (IME flag)  preview + per-syllable diff-commit
-    //   insertFromComposition   final commit (ev.data = full syllable)
-    //
-    // Terminator keys (space/Enter/…) may finalize without firing
-    // `insertFromComposition` at all. To stay correct under any
-    // delivery, one `composing` flag routes every commit
-    // (terminator-keydown OR insertFromComposition) through a single
-    // idempotent `commitComposition()` — a second call for the same
-    // syllable becomes a no-op.
-    let sentPrefix = "";
-    let lastKeyCode229 = false;
-    let composing = false;
-    // Hangul jamo, Hangul syllables, Hiragana, Katakana, CJK ideographs.
-    // Used to recognise IME-driven `insertText` events even when the
-    // accompanying `keydown` (with keyCode 229) hasn't fired yet — on
-    // WKWebView the `input` event sometimes arrives BEFORE its keydown.
-    const CJK_DATA_RE =
-      /[ᄀ-ᇿ㄰-㆏가-힯぀-ゟ゠-ヿ一-鿿]/;
-
-    // Idempotent commit. Sends whatever sits past `sentPrefix` in the
-    // helper textarea (the unflushed trailing syllable), then resets state.
-    // `explicit` overrides the textarea slice — used by
-    // `insertFromComposition` when WKWebView delivers the syllable as
-    // `ev.data` rather than leaving it in the textarea.
-    const commitComposition = (explicit?: string) => {
-      if (!composing) return;
-      const ta = container.querySelector<HTMLTextAreaElement>(
-        ".xterm-helper-textarea",
-      );
-      const tail = ta && ta.value.length > sentPrefix.length
-        ? ta.value.slice(sentPrefix.length)
-        : "";
-      const data = tail || explicit || "";
-      if (data) sendUserInputToPty(data);
-      if (ta) ta.value = "";
-      sentPrefix = "";
-      composing = false;
-      hideComposing();
-    };
-
-    const onInput = (e: Event) => {
-      const ev = e as InputEvent;
-      const ta = container.querySelector<HTMLTextAreaElement>(
-        ".xterm-helper-textarea",
-      );
-      switch (ev.inputType) {
-        case "insertCompositionText":
-          composing = true;
-          showComposing(ev.data ?? "");
-          ev.stopImmediatePropagation();
-          return;
-
-        case "deleteCompositionText":
-          // Preview clear preceding a commit. No-op.
-          ev.stopImmediatePropagation();
-          return;
-
-        case "insertReplacementText": {
-          // Trailing char being recomposed in place. Preview only — never
-          // commit here, the next insertText / insertFromComposition /
-          // terminator-keydown carries the commit.
-          composing = true;
-          if (ta) {
-            // Stale sentPrefix detection: if textarea no longer starts
-            // with the prefix we tracked, a non-IME keystroke (Space,
-            // Ctrl+C, …) reset the textarea between compositions.
-            if (!ta.value.startsWith(sentPrefix)) sentPrefix = "";
-            showComposing(ta.value.slice(sentPrefix.length));
-          }
-          ev.stopImmediatePropagation();
-          return;
-        }
-
-        case "insertText": {
-          // Distinguish plain ASCII from an IME first-jamo: treat as
-          // IME when a keyCode-229 keydown was just observed OR
-          // `ev.data` is a CJK character. The data check covers the
-          // first jamo of a session when WKWebView fires `input`
-          // before the corresponding keydown.
-          const isIme =
-            lastKeyCode229 || (!!ev.data && CJK_DATA_RE.test(ev.data));
-          if (!isIme) {
-            // Plain ASCII. xterm's keypress already emitted it; we
-            // only advance `sentPrefix` so the next IME insertText
-            // diff doesn't re-emit it as part of its committed prefix.
-            hideComposing();
-            composing = false;
-            if (ta) sentPrefix = ta.value;
-            return;
-          }
-          composing = true;
-          if (!ta) return;
-          const value = ta.value;
-          const newCharLen = ev.data?.length ?? 0;
-          // If textarea no longer starts with our tracked prefix, a
-          // non-IME keystroke (Space, Ctrl+C, …) reset the textarea
-          // between compositions. Reset so the slice below doesn't
-          // drop the first jamo of the fresh composition.
-          if (!value.startsWith(sentPrefix)) {
-            sentPrefix = value.slice(0, Math.max(0, value.length - newCharLen));
-          }
-          const committedEnd = value.length - newCharLen;
-          if (committedEnd > sentPrefix.length) {
-            sendUserInputToPty(value.slice(sentPrefix.length, committedEnd));
-            sentPrefix = value.slice(0, committedEnd);
-          }
-          showComposing(value.slice(sentPrefix.length));
-          ev.stopImmediatePropagation();
-          return;
-        }
-
-        case "insertFromComposition":
-          // Final commit from composition-clean IME path. Idempotent —
-          // if a terminator-keydown already flushed this syllable,
-          // `composing` is false and this is a no-op.
-          commitComposition(ev.data ?? undefined);
-          ev.stopImmediatePropagation();
-          return;
-
-        default:
-          hideComposing();
-          return;
-      }
-    };
-
-    const onKeydown = (e: Event) => {
-      const ev = e as KeyboardEvent;
-      // keyCode 229 = IME composing key. xterm's keydown reacts to
-      // 229 with a `_handleAnyTextareaChanges` setTimeout that would
-      // emit duplicate text — swallow at capture, and remember the
-      // flag so a following `insertText` is recognised as an IME
-      // jamo when its CJK-data check is ambiguous.
-      //
-      // macOS reports 229 even for the terminator keystroke that
-      // finalizes the composition (space, Enter, …) when IME state
-      // is uncommitted. Those must NOT take the IME path or the
-      // follow-up `input` event re-emits the terminator on top of
-      // xterm's keypress emit. Detect named non-printable keys +
-      // actual whitespace as terminators and fall through to the
-      // plain path. Letter/digit/punctuation keys keep the IME
-      // path because the Korean 2-set IME reports them with
-      // `ev.key` set to underlying ASCII (e.g. shift+ㅅ → key="T"),
-      // and treating those as terminators flushes mid-syllable.
-      if (ev.keyCode === 229) {
-        const ta229 = container.querySelector<HTMLTextAreaElement>(
-          ".xterm-helper-textarea",
-        );
-        const hasComposition = !!ta229?.value;
-        // Backspace inside active composition is internal IME
-        // editing (e.g. "있" → "이"); the `input` event already
-        // updated the preview. Suppress xterm's \x7f emit so the
-        // committed glyph doesn't race the backspace into the line.
-        // Backspace WITHOUT composition falls through to the plain
-        // path via TERMINATOR_KEYS below.
-        if (ev.key === "Backspace" && hasComposition) {
-          if (ta229) showComposing(ta229.value.slice(sentPrefix.length));
-          lastKeyCode229 = true;
-          ev.stopImmediatePropagation();
-          return;
-        }
-        const TERMINATOR_KEYS = new Set([
-          "Enter", "Tab", "Escape", "Backspace", " ", "Spacebar",
-        ]);
-        const isTerminator = TERMINATOR_KEYS.has(ev.key);
-        if (!isTerminator) {
-          lastKeyCode229 = true;
-          ev.stopImmediatePropagation();
-          return;
-        }
-        // Terminator under IME falls through; the prior syllable
-        // still needs flushing, which happens below because
-        // `lastKeyCode229` remains true from the real IME keydown.
-      }
-      // Modifier-only keystrokes are part of a chord, not a real
-      // key. Must NOT flush mid-composition or clear lastKeyCode229
-      // — Korean 2-set IME emits Shift before the second jamo of
-      // a double consonant, and flushing here would commit the
-      // prior syllable before the second jamo can combine.
-      const MODIFIER_KEYS = new Set([
-        "Shift", "Control", "Alt", "Meta", "CapsLock",
-      ]);
-      if (MODIFIER_KEYS.has(ev.key)) {
-        return;
-      }
-      // Non-IME key after IME activity. Commit any mid-composition
-      // syllable so it lands in the PTY before this key's effect
-      // (space, Enter, English letter, …). Idempotent — a follow-up
-      // `insertFromComposition` for the same syllable hits the
-      // composing===false guard and is a no-op.
-      if (lastKeyCode229 && composing) {
-        commitComposition();
-      }
-      lastKeyCode229 = false;
-      const ta = container.querySelector<HTMLTextAreaElement>(
-        ".xterm-helper-textarea",
-      );
-      if (ta) sentPrefix = ta.value;
-
-      // WKWebView can report an unmodified physical Space as NBSP through
-      // the xterm input path. Shells do not treat NBSP as a separator, so
-      // send ASCII space directly for the plain-space key.
-      if (isPlainSpaceKeydown(ev)) {
-        sendKeyboardInputToPty(" ");
-        ev.preventDefault();
-        ev.stopImmediatePropagation();
-        return;
-      }
-
-      // Shift+Enter: insert newline (LF) instead of submitting (CR). xterm
-      // by default emits \r for both Enter and Shift+Enter, so TUIs like
-      // Claude CLI cannot tell them apart. Send a literal LF and stop the
-      // event so xterm does not emit its own \r on top.
-      if (ev.key === "Enter" && ev.shiftKey && !ev.metaKey && !ev.ctrlKey && !ev.altKey) {
-        sendUserInputToPty("\n");
-        ev.preventDefault();
-        ev.stopImmediatePropagation();
-        return;
-      }
-      // macOS line-navigation conventions. Cmd+Left / Cmd+Right map to the
-      // emacs-style readline shortcuts that nearly every interactive shell
-      // honours: Ctrl+A (start of line) and Ctrl+E (end of line).
-      if (
-        ev.metaKey &&
-        !ev.ctrlKey &&
-        !ev.altKey &&
-        !ev.shiftKey
-      ) {
-        if (ev.key === "ArrowLeft") {
-          sendUserInputToPty("\x01");
-          ev.preventDefault();
-          ev.stopImmediatePropagation();
-          return;
-        }
-        if (ev.key === "ArrowRight") {
-          sendUserInputToPty("\x05");
-          ev.preventDefault();
-          ev.stopImmediatePropagation();
-          return;
-        }
-        if (ev.key === "ArrowDown") {
-          scrollToLiveTail();
-          ev.preventDefault();
-          ev.stopImmediatePropagation();
-          return;
-        }
-      }
-    };
-
-    // Register on `container` (ancestor of helperTextarea) with capture=true
-    // so we run before xterm's textarea-capture listeners.
-    container.addEventListener("input", onInput, true);
-    container.addEventListener("keydown", onKeydown, true);
+    const terminalInputController = attachTerminalInputController({
+      container,
+      term,
+      sendUserInputToPty,
+      sendKeyboardInputToPty,
+      scrollToLiveTail,
+    });
 
     // Own the paste path for text. xterm's built-in listener emits the
     // pasted text but only calls `stopPropagation()` — it never
@@ -1629,19 +1313,6 @@ export function Terminal({
     container.addEventListener("dragover", onDragOver);
     container.addEventListener("drop", onDrop);
 
-    // Swallow xterm's compositionstart/update/end. Its compositionend
-    // handler re-emits the entire textarea contents on top of the
-    // per-syllable PTY writes our `onInput` path already issued,
-    // duplicating the composed phrase. Our `onInput` covers preview,
-    // partial commits, and final commit through `commitComposition()`,
-    // so xterm's path is pure duplication.
-    const swallowComposition = (e: Event) => {
-      e.stopImmediatePropagation();
-    };
-    container.addEventListener("compositionstart", swallowComposition, true);
-    container.addEventListener("compositionupdate", swallowComposition, true);
-    container.addEventListener("compositionend", swallowComposition, true);
-
     let ptyReady = false;
     let lastPtyResize:
       | {
@@ -1699,34 +1370,6 @@ export function Terminal({
         commandSizeSyncScheduler.schedule();
       }
     });
-
-    // Re-anchor the composition preview to the cursor on every xterm render.
-    // The cursor advances asynchronously after a commit (PTY echo → emit →
-    // term.write); without this, the preview stays painted at the previous
-    // cursor cell and visually appears one column to the left of the new
-    // cursor until the user types again.
-    const repositionComposing = () => {
-      if (!compositionView || !compositionView.classList.contains("active")) {
-        return;
-      }
-      const cell = getCellDims();
-      if (!cell) return;
-      const buf = term.buffer.active;
-      // See `showComposing` for the full derivation of this formula.
-      const cursorViewportY = buf.baseY + buf.cursorY - buf.viewportY;
-      compositionView.style.left = `${buf.cursorX * cell.width}px`;
-      compositionView.style.top = `${cursorViewportY * cell.height}px`;
-    };
-    const renderDisposable = term.onRender(repositionComposing);
-    // PTY output that arrives while the user is mid-composition can scroll
-    // the viewport or move the prompt to a new row without producing an
-    // `onRender` event whose painted region overlaps the cursor cell — the
-    // overlay then stays pinned to the old screen coords and visually drifts
-    // away from the live prompt. `onScroll` fires on viewport shifts and
-    // `onCursorMove` fires when the shell redraws its prompt at a new row;
-    // both feed the same recompute so the overlay tracks the cursor.
-    const scrollDisposable = term.onScroll(repositionComposing);
-    const cursorMoveDisposable = term.onCursorMove(repositionComposing);
 
     // Sticky-prompt detection. The banner above the terminal pins the
     // most recent user-prompt line found in xterm's rendered buffer
@@ -2324,20 +1967,13 @@ export function Terminal({
       }
       resizeObserver.disconnect();
       commandSizeSyncScheduler.dispose();
-      container.removeEventListener("input", onInput, true);
-      container.removeEventListener("keydown", onKeydown, true);
+      terminalInputController.dispose();
       container.removeEventListener("paste", onPaste, true);
       window.removeEventListener(TERMINAL_PASTE_EVENT, onTerminalPaste);
       container.removeEventListener("dragover", onDragOver);
       container.removeEventListener("drop", onDrop);
-      container.removeEventListener("compositionstart", swallowComposition, true);
-      container.removeEventListener("compositionupdate", swallowComposition, true);
-      container.removeEventListener("compositionend", swallowComposition, true);
       window.removeEventListener("acorn:terminal-clear", onClearRequested);
       inputDisposable.dispose();
-      renderDisposable.dispose();
-      scrollDisposable.dispose();
-      cursorMoveDisposable.dispose();
       contextScrollDisposable.dispose();
       conversationPositionDisposable.dispose();
       scrollbackStateDisposable.dispose();

--- a/src/lib/terminalInput.test.ts
+++ b/src/lib/terminalInput.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { isPlainSpaceKeydown } from "./terminalInput";
+import {
+  getTerminalShortcutAction,
+  isImeTerminatorKeydown,
+  isImeTextData,
+  isModifierOnlyKeydown,
+  isPlainSpaceKeydown,
+  isPlainSpaceText,
+} from "./terminalInput";
 
 describe("terminal input", () => {
   it("recognises unmodified physical space variants", () => {
@@ -24,5 +31,60 @@ describe("terminal input", () => {
   it("ignores non-space keys", () => {
     expect(isPlainSpaceKeydown({ key: "a", code: "KeyA" })).toBe(false);
     expect(isPlainSpaceKeydown({ key: "Enter", code: "Enter" })).toBe(false);
+  });
+
+  it("recognises plain space input text variants", () => {
+    expect(isPlainSpaceText(" ")).toBe(true);
+    expect(isPlainSpaceText("\u00a0")).toBe(true);
+    expect(isPlainSpaceText("\u3000")).toBe(false);
+    expect(isPlainSpaceText("  ")).toBe(false);
+  });
+
+  it("classifies IME terminator keydowns separately from IME text input", () => {
+    expect(
+      isImeTerminatorKeydown({
+        key: "Process",
+        code: "Space",
+        keyCode: 229,
+      }),
+    ).toBe(true);
+    expect(isImeTerminatorKeydown({ key: " ", keyCode: 229 })).toBe(true);
+    expect(isImeTerminatorKeydown({ key: "Enter", keyCode: 229 })).toBe(true);
+    expect(isImeTerminatorKeydown({ key: "Process", keyCode: 229 })).toBe(
+      false,
+    );
+  });
+
+  it("recognises CJK input text as IME data", () => {
+    expect(isImeTextData("한")).toBe(true);
+    expect(isImeTextData("あ")).toBe(true);
+    expect(isImeTextData("中")).toBe(true);
+    expect(isImeTextData("a")).toBe(false);
+    expect(isImeTextData(null)).toBe(false);
+  });
+
+  it("classifies modifier-only keys", () => {
+    expect(isModifierOnlyKeydown({ key: "Shift" })).toBe(true);
+    expect(isModifierOnlyKeydown({ key: "Control" })).toBe(true);
+    expect(isModifierOnlyKeydown({ key: "a" })).toBe(false);
+  });
+
+  it("maps terminal-owned shortcuts to explicit actions", () => {
+    expect(getTerminalShortcutAction({ key: "Enter", shiftKey: true })).toEqual(
+      { kind: "write", data: "\n" },
+    );
+    expect(getTerminalShortcutAction({ key: "ArrowLeft", metaKey: true }))
+      .toEqual({ kind: "write", data: "\x01" });
+    expect(getTerminalShortcutAction({ key: "ArrowRight", metaKey: true }))
+      .toEqual({ kind: "write", data: "\x05" });
+    expect(getTerminalShortcutAction({ key: "ArrowDown", metaKey: true }))
+      .toEqual({ kind: "scrollToLiveTail" });
+    expect(
+      getTerminalShortcutAction({
+        key: "ArrowLeft",
+        metaKey: true,
+        shiftKey: true,
+      }),
+    ).toBeNull();
   });
 });

--- a/src/lib/terminalInput.ts
+++ b/src/lib/terminalInput.ts
@@ -4,11 +4,74 @@ interface TerminalKeyEventLike {
   altKey?: boolean;
   ctrlKey?: boolean;
   metaKey?: boolean;
+  shiftKey?: boolean;
+  keyCode?: number;
 }
 
+export type TerminalShortcutAction =
+  | { kind: "write"; data: string }
+  | { kind: "scrollToLiveTail" };
+
 const SPACE_KEY_VALUES = new Set([" ", "Spacebar", "\u00a0"]);
+const SPACE_INPUT_VALUES = new Set([" ", "\u00a0"]);
+const IME_TERMINATOR_KEYS = new Set([
+  "Enter", "Tab", "Escape", "Backspace", " ", "Spacebar",
+]);
+const MODIFIER_KEYS = new Set([
+  "Shift", "Control", "Alt", "Meta", "CapsLock",
+]);
+
+// Hangul jamo, Hangul syllables, Hiragana, Katakana, CJK ideographs.
+const CJK_DATA_RE =
+  /[ᄀ-ᇿ㄰-㆏가-힯぀-ゟ゠-ヿ一-鿿]/;
 
 export function isPlainSpaceKeydown(event: TerminalKeyEventLike): boolean {
   if (event.altKey || event.ctrlKey || event.metaKey) return false;
   return event.code === "Space" || SPACE_KEY_VALUES.has(event.key);
+}
+
+export function isPlainSpaceText(text: string): boolean {
+  return SPACE_INPUT_VALUES.has(text);
+}
+
+export function isImeTextData(text: string | null | undefined): boolean {
+  return !!text && CJK_DATA_RE.test(text);
+}
+
+export function isImeTerminatorKeydown(event: TerminalKeyEventLike): boolean {
+  return (
+    event.keyCode === 229 &&
+    (IME_TERMINATOR_KEYS.has(event.key) || isPlainSpaceKeydown(event))
+  );
+}
+
+export function isModifierOnlyKeydown(event: TerminalKeyEventLike): boolean {
+  return MODIFIER_KEYS.has(event.key);
+}
+
+export function getTerminalShortcutAction(
+  event: TerminalKeyEventLike,
+): TerminalShortcutAction | null {
+  if (
+    event.key === "Enter" &&
+    event.shiftKey &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey
+  ) {
+    return { kind: "write", data: "\n" };
+  }
+
+  if (
+    event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.shiftKey
+  ) {
+    if (event.key === "ArrowLeft") return { kind: "write", data: "\x01" };
+    if (event.key === "ArrowRight") return { kind: "write", data: "\x05" };
+    if (event.key === "ArrowDown") return { kind: "scrollToLiveTail" };
+  }
+
+  return null;
 }

--- a/src/lib/terminalInputController.ts
+++ b/src/lib/terminalInputController.ts
@@ -1,0 +1,314 @@
+import type { IDisposable, Terminal as XTerm } from "@xterm/xterm";
+import {
+  getTerminalShortcutAction,
+  isImeTerminatorKeydown,
+  isImeTextData,
+  isModifierOnlyKeydown,
+  isPlainSpaceKeydown,
+  isPlainSpaceText,
+} from "./terminalInput";
+
+interface TerminalInputControllerOptions {
+  container: HTMLElement;
+  term: XTerm;
+  sendUserInputToPty(data: string): void;
+  sendKeyboardInputToPty(data: string): void;
+  scrollToLiveTail(): void;
+}
+
+interface XTermRenderInternals {
+  _core?: {
+    _renderService?: {
+      dimensions?: {
+        css?: {
+          cell?: { width: number; height: number };
+        };
+      };
+    };
+  };
+}
+
+function getHelperTextarea(container: HTMLElement): HTMLTextAreaElement | null {
+  return container.querySelector<HTMLTextAreaElement>(
+    ".xterm-helper-textarea",
+  );
+}
+
+function getCellDims(term: XTerm): { width: number; height: number } | null {
+  // xterm v6 exposes render dimensions only via internals.
+  const core = (term as unknown as XTermRenderInternals)._core;
+  const cell = core?._renderService?.dimensions?.css?.cell;
+  return cell ? { width: cell.width, height: cell.height } : null;
+}
+
+function createCompositionPreview(term: XTerm, view: HTMLElement | null) {
+  const position = () => {
+    if (!view) return;
+    const cell = getCellDims(term);
+    if (!cell) return;
+    const buf = term.buffer.active;
+    // xterm's visible cursor row = `baseY + cursorY - viewportY`.
+    const cursorViewportY = buf.baseY + buf.cursorY - buf.viewportY;
+    view.style.left = `${buf.cursorX * cell.width}px`;
+    view.style.top = `${cursorViewportY * cell.height}px`;
+    view.style.minHeight = `${cell.height}px`;
+    view.style.lineHeight = `${cell.height}px`;
+  };
+
+  const hide = () => {
+    if (!view) return;
+    view.classList.remove("active");
+    view.textContent = "";
+  };
+
+  const show = (text: string) => {
+    if (!view) return;
+    if (text.length === 0) {
+      hide();
+      return;
+    }
+    view.textContent = text;
+    position();
+
+    const fontFamily = term.options.fontFamily;
+    const fontSize = term.options.fontSize;
+    const fontWeight = term.options.fontWeight;
+    if (typeof fontFamily === "string") {
+      view.style.fontFamily = fontFamily;
+    }
+    if (typeof fontSize === "number") {
+      view.style.fontSize = `${fontSize}px`;
+    }
+    if (typeof fontWeight === "number" || typeof fontWeight === "string") {
+      view.style.fontWeight = String(fontWeight);
+    }
+    view.classList.add("active");
+  };
+
+  const reposition = () => {
+    if (!view?.classList.contains("active")) return;
+    position();
+  };
+
+  return { show, hide, reposition };
+}
+
+export function attachTerminalInputController({
+  container,
+  term,
+  sendUserInputToPty,
+  sendKeyboardInputToPty,
+  scrollToLiveTail,
+}: TerminalInputControllerOptions): IDisposable {
+  const preview = createCompositionPreview(
+    term,
+    container.querySelector<HTMLElement>(".composition-view"),
+  );
+
+  // WKWebView delivers a single Korean syllable across a mix of
+  // `inputType`s. This state owns the contract between browser events,
+  // xterm's helper textarea, and PTY writes:
+  //
+  // - preview events update `.composition-view` only
+  // - commit events flush the unsent textarea tail once
+  // - direct keydown writes reserve ownership of the following input echo
+  let sentPrefix = "";
+  let lastKeyCode229 = false;
+  let composing = false;
+  let pendingDirectSpaceInputEvents = 0;
+
+  const readUnsentTail = (ta: HTMLTextAreaElement | null): string =>
+    ta && ta.value.length > sentPrefix.length
+      ? ta.value.slice(sentPrefix.length)
+      : "";
+
+  const syncSentPrefix = (ta: HTMLTextAreaElement | null) => {
+    if (ta) sentPrefix = ta.value;
+  };
+
+  const commitComposition = (explicit?: string) => {
+    if (!composing) return;
+    const ta = getHelperTextarea(container);
+    const data = readUnsentTail(ta) || explicit || "";
+    if (data) sendUserInputToPty(data);
+    if (ta) ta.value = "";
+    sentPrefix = "";
+    composing = false;
+    preview.hide();
+  };
+
+  const consumePendingDirectSpaceInput = (
+    ev: InputEvent,
+    ta: HTMLTextAreaElement | null,
+  ): boolean => {
+    if (
+      pendingDirectSpaceInputEvents <= 0 ||
+      ev.inputType !== "insertText"
+    ) {
+      return false;
+    }
+
+    const insertedText = ev.data ?? readUnsentTail(ta);
+    if (!isPlainSpaceText(insertedText)) {
+      pendingDirectSpaceInputEvents = 0;
+      return false;
+    }
+
+    pendingDirectSpaceInputEvents -= 1;
+    preview.hide();
+    composing = false;
+    syncSentPrefix(ta);
+    ev.stopImmediatePropagation();
+    return true;
+  };
+
+  const handleInput = (ev: InputEvent, ta: HTMLTextAreaElement | null) => {
+    switch (ev.inputType) {
+      case "insertCompositionText":
+        composing = true;
+        preview.show(ev.data ?? "");
+        ev.stopImmediatePropagation();
+        return;
+
+      case "deleteCompositionText":
+        ev.stopImmediatePropagation();
+        return;
+
+      case "insertReplacementText": {
+        composing = true;
+        if (ta) {
+          if (!ta.value.startsWith(sentPrefix)) sentPrefix = "";
+          preview.show(ta.value.slice(sentPrefix.length));
+        }
+        ev.stopImmediatePropagation();
+        return;
+      }
+
+      case "insertText": {
+        const isIme = lastKeyCode229 || isImeTextData(ev.data);
+        if (!isIme) {
+          preview.hide();
+          composing = false;
+          syncSentPrefix(ta);
+          return;
+        }
+
+        composing = true;
+        if (!ta) return;
+        const value = ta.value;
+        const newCharLen = ev.data?.length ?? 0;
+        if (!value.startsWith(sentPrefix)) {
+          sentPrefix = value.slice(0, Math.max(0, value.length - newCharLen));
+        }
+        const committedEnd = value.length - newCharLen;
+        if (committedEnd > sentPrefix.length) {
+          sendUserInputToPty(value.slice(sentPrefix.length, committedEnd));
+          sentPrefix = value.slice(0, committedEnd);
+        }
+        preview.show(value.slice(sentPrefix.length));
+        ev.stopImmediatePropagation();
+        return;
+      }
+
+      case "insertFromComposition":
+        commitComposition(ev.data ?? undefined);
+        ev.stopImmediatePropagation();
+        return;
+
+      default:
+        preview.hide();
+        return;
+    }
+  };
+
+  const onInput = (e: Event) => {
+    const ev = e as InputEvent;
+    const ta = getHelperTextarea(container);
+    if (consumePendingDirectSpaceInput(ev, ta)) return;
+    handleInput(ev, ta);
+  };
+
+  const handleImeKeydown = (
+    ev: KeyboardEvent,
+    ta: HTMLTextAreaElement | null,
+  ): boolean => {
+    if (ev.keyCode !== 229) return false;
+
+    const hasComposition = !!ta?.value;
+    if (ev.key === "Backspace" && hasComposition) {
+      preview.show(ta.value.slice(sentPrefix.length));
+      lastKeyCode229 = true;
+      ev.stopImmediatePropagation();
+      return true;
+    }
+
+    if (!isImeTerminatorKeydown(ev)) {
+      lastKeyCode229 = true;
+      ev.stopImmediatePropagation();
+      return true;
+    }
+
+    return false;
+  };
+
+  const onKeydown = (e: Event) => {
+    const ev = e as KeyboardEvent;
+    pendingDirectSpaceInputEvents = 0;
+    const ta = getHelperTextarea(container);
+
+    if (handleImeKeydown(ev, ta)) return;
+    if (isModifierOnlyKeydown(ev)) return;
+
+    if (lastKeyCode229 && composing) {
+      commitComposition();
+    }
+    lastKeyCode229 = false;
+    syncSentPrefix(ta);
+
+    if (isPlainSpaceKeydown(ev)) {
+      pendingDirectSpaceInputEvents += 1;
+      sendKeyboardInputToPty(" ");
+      ev.preventDefault();
+      ev.stopImmediatePropagation();
+      return;
+    }
+
+    const shortcut = getTerminalShortcutAction(ev);
+    if (!shortcut) return;
+
+    if (shortcut.kind === "write") {
+      sendUserInputToPty(shortcut.data);
+    } else {
+      scrollToLiveTail();
+    }
+    ev.preventDefault();
+    ev.stopImmediatePropagation();
+  };
+
+  const swallowComposition = (e: Event) => {
+    e.stopImmediatePropagation();
+  };
+
+  container.addEventListener("input", onInput, true);
+  container.addEventListener("keydown", onKeydown, true);
+  container.addEventListener("compositionstart", swallowComposition, true);
+  container.addEventListener("compositionupdate", swallowComposition, true);
+  container.addEventListener("compositionend", swallowComposition, true);
+
+  const renderDisposable = term.onRender(() => preview.reposition());
+  const scrollDisposable = term.onScroll(() => preview.reposition());
+  const cursorMoveDisposable = term.onCursorMove(() => preview.reposition());
+
+  return {
+    dispose() {
+      container.removeEventListener("input", onInput, true);
+      container.removeEventListener("keydown", onKeydown, true);
+      container.removeEventListener("compositionstart", swallowComposition, true);
+      container.removeEventListener("compositionupdate", swallowComposition, true);
+      container.removeEventListener("compositionend", swallowComposition, true);
+      renderDisposable.dispose();
+      scrollDisposable.dispose();
+      cursorMoveDisposable.dispose();
+    },
+  };
+}

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -324,6 +324,74 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     expect(writes).not.toContain("\u00a0");
   });
 
+  test("Korean terminator Space writes one ASCII separator when input text follows keydown", async ({
+    page,
+    tauri,
+  }) => {
+    await seed(tauri);
+    await activateTerminal(page);
+
+    await runIme(page, [
+      { type: "keydown", key: "Process", keyCode: 229 },
+      { type: "input", inputType: "insertText", data: "한", taValue: "한" },
+      { type: "keydown", key: "Process", code: "Space", keyCode: 229 },
+      {
+        type: "input",
+        inputType: "insertText",
+        data: "\u00a0",
+        taValue: "\u00a0",
+      },
+      {
+        type: "input",
+        inputType: "insertFromComposition",
+        data: "한",
+        taValue: "",
+      },
+    ]);
+
+    const writes = await getWrites(page);
+    const joined = writes.join("");
+    expect(joined).toBe("한 ");
+    expect(writes.filter((w) => w === " ")).toHaveLength(1);
+    expect(joined).not.toContain("\u00a0");
+  });
+
+  test("Korean terminator Space still suppresses input echo when composition commit arrives first", async ({
+    page,
+    tauri,
+  }) => {
+    await seed(tauri);
+    await activateTerminal(page);
+
+    await runIme(page, [
+      { type: "keydown", key: "Process", keyCode: 229 },
+      {
+        type: "input",
+        inputType: "insertCompositionText",
+        data: "한",
+        taValue: "한",
+      },
+      { type: "keydown", key: " ", code: "Space", keyCode: 229 },
+      {
+        type: "input",
+        inputType: "insertFromComposition",
+        data: "한",
+        taValue: "",
+      },
+      {
+        type: "input",
+        inputType: "insertText",
+        data: " ",
+        taValue: " ",
+      },
+    ]);
+
+    const writes = await getWrites(page);
+    const joined = writes.join("");
+    expect(joined).toBe("한 ");
+    expect(writes.filter((w) => w === " ")).toHaveLength(1);
+  });
+
   test("Cmd+ArrowLeft sends \\x01 (start-of-line)", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
This fixes Korean IME space handling by making terminal input ownership explicit instead of patching one event shape in place.

1. **Input controller extraction** — moved terminal keydown/input/composition ownership out of `Terminal.tsx` into `terminalInputController`, leaving `Terminal.tsx` to attach/dispose the controller and provide PTY/xterm callbacks.
2. **Centralized input classification** — expanded `terminalInput` helpers for plain Space/NBSP, IME terminators, CJK input data, modifier-only keys, and terminal-owned shortcuts.
3. **Space echo suppression** — when WKWebView follows a direct ASCII Space keydown write with a textarea `insertText` Space/NBSP echo, the controller consumes that echo before xterm can write a second separator.
4. **Regression coverage** — added unit coverage for the input classification rules and E2E coverage for both Korean Space event orders, including `key: "Process", code: "Space", keyCode: 229`.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Korean IME Space terminator | Could emit two separators after #386 | Emits one ASCII space |
| Terminal input ownership | IME, Space, shortcuts, and composition listeners lived inside `Terminal.tsx` | Centralized in `terminalInputController` |
| Future IME fixes | Patch local event branches | Extend the controller/classifier flow |

## Design notes
- The controller still intercepts on the terminal container in capture phase so it runs before xterm's helper textarea listeners.
- Plain ASCII input remains delegated to xterm unless Acorn deliberately owns the key, such as Space normalization, Shift+Enter, or Cmd+Arrow navigation.
- `insertFromComposition` and terminator-keydown commits still share the same idempotent composition commit path, preserving the existing duplicate-syllable guard.
- Paste, drag/drop, PTY resize, scrollback, and terminal link behavior stay in `Terminal.tsx` and are intentionally out of scope.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test -- src/lib/terminalInput.test.ts` passes — 61 files, 586 passed, 1 skipped
- [x] `pnpm run test:e2e -- tests/e2e/terminal-ime.spec.ts` passes — 13 passed
- [x] `pnpm run test:e2e -- tests/e2e/terminal.spec.ts` passes — 17 passed
- [x] `pnpm run build` passes
- [x] `git diff --check origin/main...HEAD` passes

## Notes
- `pnpm run build` still prints the existing Vite dynamic import and chunk-size warnings. They are not introduced by this PR.
- One attempted parallel E2E run failed to start because both Playwright commands tried to own port 1420. The IME spec passed when rerun by itself.
