### PR TITLE
chore(release): v1.13.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.13.4",
+  "version": "1.13.5",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.13.4"
+version = "1.13.5"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.13.4"
+version = "1.13.5"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
Prepare the v1.13.5 patch release after merging the terminal IME input flow fix.

1. **Version metadata** — bump app/package metadata from `1.13.4` to `1.13.5` in `package.json`, `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock`.
2. **Release contents** — generated release notes include PR #389, `fix(terminal): isolate IME input flow`, as the patch-line fix.

## Expected impact
| Area | Impact |
| --- | --- |
| User-visible behavior | Ships the Korean IME Space terminator fix from #389 |
| Version/update metadata | Advances Acorn from `1.13.4` to `1.13.5` |
| Changelog | Release bump PR itself is excluded via `skip-changelog`; #389 supplies the release note |

## Design notes
- Semver decision: patch, because the included change fixes terminal input behavior without adding a new feature or breaking compatibility.
- Only release metadata files are changed in this PR.

## Test plan
- [x] `rg -n '1\.13\.4|1\.13\.5' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock` shows only `1.13.5` in version metadata
- [x] `pnpm run typecheck` passes
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` passes
- [x] `REPO=im-ian/acorn TAG=v1.13.5 OUTPUT=/tmp/acorn-release-notes-v1.13.5.md node scripts/release-notes.mjs` passes
- [x] `git diff --check` passes

## Notes
- #389 was merged with CI bypass at the user's explicit request; local verification for #389 passed before merge.
