### PR TITLE
fix(terminal): handle pre-keydown IME space echo

### DIFF
--- a/src/lib/terminalInputController.ts
+++ b/src/lib/terminalInputController.ts
@@ -115,7 +115,10 @@ export function attachTerminalInputController({
   let sentPrefix = "";
   let lastKeyCode229 = false;
   let composing = false;
+  let composingText = "";
   let pendingDirectSpaceInputEvents = 0;
+  let suppressNextPlainSpaceKeydown = false;
+  let suppressNextPlainSpaceKeydownTimer: number | null = null;
 
   const readUnsentTail = (ta: HTMLTextAreaElement | null): string =>
     ta && ta.value.length > sentPrefix.length
@@ -126,15 +129,50 @@ export function attachTerminalInputController({
     if (ta) sentPrefix = ta.value;
   };
 
+  const showComposing = (text: string) => {
+    composingText = text;
+    preview.show(text);
+  };
+
+  const hideComposing = () => {
+    composingText = "";
+    preview.hide();
+  };
+
+  const splitTrailingPlainSpace = (text: string) => {
+    const last = text.slice(-1);
+    if (!isPlainSpaceText(last)) {
+      return { beforeSpace: text, hadSpace: false };
+    }
+    return { beforeSpace: text.slice(0, -1), hadSpace: true };
+  };
+
+  const clearSuppressedSpaceKeydown = () => {
+    suppressNextPlainSpaceKeydown = false;
+    if (suppressNextPlainSpaceKeydownTimer !== null) {
+      window.clearTimeout(suppressNextPlainSpaceKeydownTimer);
+      suppressNextPlainSpaceKeydownTimer = null;
+    }
+  };
+
+  const suppressMatchingSpaceKeydown = () => {
+    clearSuppressedSpaceKeydown();
+    suppressNextPlainSpaceKeydown = true;
+    suppressNextPlainSpaceKeydownTimer = window.setTimeout(() => {
+      suppressNextPlainSpaceKeydown = false;
+      suppressNextPlainSpaceKeydownTimer = null;
+    }, 250);
+  };
+
   const commitComposition = (explicit?: string) => {
     if (!composing) return;
     const ta = getHelperTextarea(container);
-    const data = readUnsentTail(ta) || explicit || "";
+    const data = readUnsentTail(ta) || explicit || composingText || "";
     if (data) sendUserInputToPty(data);
     if (ta) ta.value = "";
     sentPrefix = "";
     composing = false;
-    preview.hide();
+    hideComposing();
   };
 
   const consumePendingDirectSpaceInput = (
@@ -155,9 +193,40 @@ export function attachTerminalInputController({
     }
 
     pendingDirectSpaceInputEvents -= 1;
-    preview.hide();
+    hideComposing();
     composing = false;
     syncSentPrefix(ta);
+    ev.stopImmediatePropagation();
+    return true;
+  };
+
+  const consumePreKeydownTerminatorSpaceInput = (
+    ev: InputEvent,
+    ta: HTMLTextAreaElement | null,
+  ): boolean => {
+    if (
+      ev.inputType !== "insertText" ||
+      !lastKeyCode229 ||
+      !composing
+    ) {
+      return false;
+    }
+
+    const tail = readUnsentTail(ta);
+    const { beforeSpace, hadSpace } = splitTrailingPlainSpace(tail);
+    if (!isPlainSpaceText(ev.data ?? "") && !hadSpace) {
+      return false;
+    }
+
+    const composed = beforeSpace || composingText;
+    if (composed) sendUserInputToPty(composed);
+    sendKeyboardInputToPty(" ");
+    if (ta) ta.value = "";
+    sentPrefix = "";
+    lastKeyCode229 = false;
+    composing = false;
+    hideComposing();
+    suppressMatchingSpaceKeydown();
     ev.stopImmediatePropagation();
     return true;
   };
@@ -166,7 +235,7 @@ export function attachTerminalInputController({
     switch (ev.inputType) {
       case "insertCompositionText":
         composing = true;
-        preview.show(ev.data ?? "");
+        showComposing(ev.data ?? "");
         ev.stopImmediatePropagation();
         return;
 
@@ -178,7 +247,7 @@ export function attachTerminalInputController({
         composing = true;
         if (ta) {
           if (!ta.value.startsWith(sentPrefix)) sentPrefix = "";
-          preview.show(ta.value.slice(sentPrefix.length));
+          showComposing(ta.value.slice(sentPrefix.length));
         }
         ev.stopImmediatePropagation();
         return;
@@ -187,7 +256,7 @@ export function attachTerminalInputController({
       case "insertText": {
         const isIme = lastKeyCode229 || isImeTextData(ev.data);
         if (!isIme) {
-          preview.hide();
+          hideComposing();
           composing = false;
           syncSentPrefix(ta);
           return;
@@ -205,7 +274,7 @@ export function attachTerminalInputController({
           sendUserInputToPty(value.slice(sentPrefix.length, committedEnd));
           sentPrefix = value.slice(0, committedEnd);
         }
-        preview.show(value.slice(sentPrefix.length));
+        showComposing(value.slice(sentPrefix.length));
         ev.stopImmediatePropagation();
         return;
       }
@@ -216,7 +285,7 @@ export function attachTerminalInputController({
         return;
 
       default:
-        preview.hide();
+        hideComposing();
         return;
     }
   };
@@ -225,6 +294,7 @@ export function attachTerminalInputController({
     const ev = e as InputEvent;
     const ta = getHelperTextarea(container);
     if (consumePendingDirectSpaceInput(ev, ta)) return;
+    if (consumePreKeydownTerminatorSpaceInput(ev, ta)) return;
     handleInput(ev, ta);
   };
 
@@ -236,7 +306,7 @@ export function attachTerminalInputController({
 
     const hasComposition = !!ta?.value;
     if (ev.key === "Backspace" && hasComposition) {
-      preview.show(ta.value.slice(sentPrefix.length));
+      showComposing(ta.value.slice(sentPrefix.length));
       lastKeyCode229 = true;
       ev.stopImmediatePropagation();
       return true;
@@ -255,6 +325,17 @@ export function attachTerminalInputController({
     const ev = e as KeyboardEvent;
     pendingDirectSpaceInputEvents = 0;
     const ta = getHelperTextarea(container);
+
+    if (suppressNextPlainSpaceKeydown) {
+      if (isPlainSpaceKeydown(ev)) {
+        clearSuppressedSpaceKeydown();
+        syncSentPrefix(ta);
+        ev.preventDefault();
+        ev.stopImmediatePropagation();
+        return;
+      }
+      clearSuppressedSpaceKeydown();
+    }
 
     if (handleImeKeydown(ev, ta)) return;
     if (isModifierOnlyKeydown(ev)) return;
@@ -309,6 +390,7 @@ export function attachTerminalInputController({
       renderDisposable.dispose();
       scrollDisposable.dispose();
       cursorMoveDisposable.dispose();
+      clearSuppressedSpaceKeydown();
     },
   };
 }

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -392,6 +392,37 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     expect(writes.filter((w) => w === " ")).toHaveLength(1);
   });
 
+  test("Korean terminator Space writes one separator when input echo precedes keydown", async ({
+    page,
+    tauri,
+  }) => {
+    await seed(tauri);
+    await activateTerminal(page);
+
+    await runIme(page, [
+      { type: "keydown", key: "Process", keyCode: 229 },
+      { type: "input", inputType: "insertText", data: "한", taValue: "한" },
+      {
+        type: "input",
+        inputType: "insertText",
+        data: " ",
+        taValue: "한 ",
+      },
+      { type: "keydown", key: "Process", code: "Space", keyCode: 229 },
+      {
+        type: "input",
+        inputType: "insertFromComposition",
+        data: "한",
+        taValue: "",
+      },
+    ]);
+
+    const writes = await getWrites(page);
+    const joined = writes.join("");
+    expect(joined).toBe("한 ");
+    expect(writes.filter((w) => w === " ")).toHaveLength(1);
+  });
+
   test("Cmd+ArrowLeft sends \\x01 (start-of-line)", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
This fixes the remaining Korean IME double-space path by handling the event order where WKWebView emits the textarea space echo before the matching Space keydown.

1. **Pre-keydown space echo handling** — when an IME `insertText` space arrives while a composition is active, commit the composed text and one ASCII separator immediately.
2. **Matching keydown suppression** — consume the following Space keydown so xterm/Acorn cannot write a second separator; the suppression expires after 250ms if the matching keydown never arrives.
3. **Regression coverage** — add an E2E case for `insertText(" ") -> keydown(Process/Space)` after Korean composition.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Korean IME Space terminator | Could emit two spaces when WKWebView delivered `input` before `keydown` | Emits one ASCII separator |
| Existing #389 event order | Covered by post-keydown echo suppression | Preserved |
| Non-IME typing | Plain ASCII still delegates to xterm except terminal-owned Space/shortcuts | Unchanged |

## Design notes
- The fix stays inside `terminalInputController`, which already owns IME, Space normalization, and terminal shortcut ordering.
- `composingText` tracks the visible composition preview so the controller can still commit the syllable if the helper textarea tail only contains the early space echo.
- The follow-up keydown suppression is time-bounded to avoid swallowing a later unrelated Space if WKWebView does not deliver the matching keydown.

## Follow-up (not in this PR)
- Add optional dev-only IME event tracing if more WKWebView ordering variants surface.

## Test plan
- [x] `pnpm exec playwright test tests/e2e/terminal-ime.spec.ts` passes — 14 passed
- [x] `pnpm run test -- src/lib/terminalInput.test.ts` passes — 61 files, 586 passed, 1 skipped
- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` passes
- [x] `git diff --check` passes

## Notes
- `pnpm run build` still prints the existing Vite dynamic import and chunk-size warnings. They are not introduced by this PR.