### PR TITLE
chore(release): v1.13.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.13.5",
+  "version": "1.13.6",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.13.5"
+version = "1.13.6"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.13.5",
+  "version": "1.13.6",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
This patch release publishes the Korean IME Space terminator fix merged in #391.

1. **Version bump** — updates Acorn metadata from `1.13.5` to `1.13.6` in `package.json`, `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock`.
2. **Release notes check** — generated notes include #391 under Fixes for `v1.13.6`.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| App version | 1.13.5 | 1.13.6 |
| Changelog source | Latest stable release notes stop at v1.13.5 | v1.13.6 includes #391 IME fix |
| User-visible behavior | Korean IME Space could still double-space in one WKWebView event order | Release includes the remaining double-space fix |

## Design notes
- Semver: patch release, because this ships a focused bug fix with no API, data, or protocol breakage.
- The release bump PR uses `skip-changelog`; the merged fix PR #391 carries the changelog entry.

## Follow-up (not in this PR)
- None.

## Test plan
- [x] `rg -n '1\.13\.5|1\.13\.6' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock` shows only `1.13.6`
- [x] `pnpm run typecheck` passes
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` reports `acorn@1.13.6`
- [x] `REPO=im-ian/acorn TAG=v1.13.6 OUTPUT=/tmp/acorn-release-notes-v1.13.6.md node scripts/release-notes.mjs` generates notes including #391
- [x] `git diff --check` passes

## Notes
- v1.13.6 includes #391: `fix(terminal): handle pre-keydown IME space echo`.