### PR TITLE
fix(agents): run title CLIs in cwd and fix agy print prompts

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -33,10 +33,17 @@ pub enum AiProvider {
     Custom,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptTransport {
+    Stdin,
+    Argument,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedAiCommand {
     pub command: &'static str,
     pub args: Vec<String>,
+    pub prompt_transport: PromptTransport,
 }
 
 impl AiExecutionRequest {
@@ -45,20 +52,24 @@ impl AiExecutionRequest {
             AiProvider::Claude => Ok(ResolvedAiCommand {
                 command: "claude",
                 args: vec!["-p".into(), "--output-format".into(), "text".into()],
+                prompt_transport: PromptTransport::Stdin,
             }),
             AiProvider::Antigravity => Ok(ResolvedAiCommand {
                 command: "agy",
                 args: vec!["-p".into()],
+                prompt_transport: PromptTransport::Argument,
             }),
             AiProvider::Codex => Ok(ResolvedAiCommand {
                 command: "codex",
                 args: vec!["exec".into(), "--skip-git-repo-check".into()],
+                prompt_transport: PromptTransport::Stdin,
             }),
             AiProvider::Ollama => {
                 let model = normalize_model_arg(self.ollama_model.as_deref(), "llama3")?;
                 Ok(ResolvedAiCommand {
                     command: "ollama",
                     args: vec!["run".into(), model],
+                    prompt_transport: PromptTransport::Stdin,
                 })
             }
             AiProvider::Llm => {
@@ -70,6 +81,7 @@ impl AiExecutionRequest {
                 Ok(ResolvedAiCommand {
                     command: "llm",
                     args,
+                    prompt_transport: PromptTransport::Stdin,
                 })
             }
             AiProvider::Custom => Err(AppError::Other(
@@ -106,43 +118,67 @@ fn normalize_optional_model_arg(raw: Option<&str>) -> AppResult<Option<String>> 
     Ok(Some(model.to_string()))
 }
 
-pub fn run_oneshot(
-    command: &str,
-    args: &[String],
+pub fn run_resolved_oneshot(
+    resolved: &ResolvedAiCommand,
     prompt: &str,
     settings_label: &str,
 ) -> AppResult<String> {
-    run_oneshot_in_dir(command, args, prompt, settings_label, None)
+    run_resolved_oneshot_in_dir(resolved, prompt, settings_label, None)
 }
 
-pub fn run_oneshot_in_dir(
-    command: &str,
-    args: &[String],
+pub fn run_resolved_oneshot_in_dir(
+    resolved: &ResolvedAiCommand,
     prompt: &str,
     settings_label: &str,
     cwd: Option<&Path>,
 ) -> AppResult<String> {
-    run_oneshot_in_dir_cancellable(command, args, prompt, settings_label, cwd, None)
+    run_resolved_oneshot_in_dir_cancellable(resolved, prompt, settings_label, cwd, None)
 }
 
-pub fn run_oneshot_in_dir_cancellable(
+pub fn run_resolved_oneshot_in_dir_cancellable(
+    resolved: &ResolvedAiCommand,
+    prompt: &str,
+    settings_label: &str,
+    cwd: Option<&Path>,
+    cancellation: Option<ChatCancellation>,
+) -> AppResult<String> {
+    run_oneshot_in_dir_cancellable_with_transport(
+        resolved.command,
+        &resolved.args,
+        prompt,
+        settings_label,
+        cwd,
+        cancellation,
+        resolved.prompt_transport,
+    )
+}
+
+fn run_oneshot_in_dir_cancellable_with_transport(
     command: &str,
     args: &[String],
     prompt: &str,
     settings_label: &str,
     cwd: Option<&Path>,
     cancellation: Option<ChatCancellation>,
+    prompt_transport: PromptTransport,
 ) -> AppResult<String> {
     let resolved = cli_resolver::resolve(command).map_err(|_| {
         AppError::Other(format!(
             "`{command}` not found. Install the configured AI CLI or change the provider in {settings_label}."
         ))
     })?;
+    let mut command_args = args.to_vec();
+    if prompt_transport == PromptTransport::Argument {
+        command_args.push(prompt.to_string());
+    }
     let mut command_builder = Command::new(&resolved);
     crate::shell_env::apply_to_command(&mut command_builder);
     command_builder
-        .args(args)
-        .stdin(Stdio::piped())
+        .args(&command_args)
+        .stdin(match prompt_transport {
+            PromptTransport::Stdin => Stdio::piped(),
+            PromptTransport::Argument => Stdio::null(),
+        })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     if let Some(cwd) = cwd {
@@ -159,12 +195,14 @@ pub fn run_oneshot_in_dir_cancellable(
         }
     })?;
 
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(prompt.as_bytes())
-            .map_err(|e| AppError::Other(format!("failed to write to {command}: {e}")))?;
-    } else {
-        return Err(AppError::Other(format!("{command} stdin missing")));
+    if prompt_transport == PromptTransport::Stdin {
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(prompt.as_bytes())
+                .map_err(|e| AppError::Other(format!("failed to write to {command}: {e}")))?;
+        } else {
+            return Err(AppError::Other(format!("{command} stdin missing")));
+        }
     }
 
     let output = wait_with_timeout(command, child, ONESHOT_TIMEOUT, cancellation)?;
@@ -290,10 +328,26 @@ mod tests {
             req.resolve().unwrap(),
             ResolvedAiCommand {
                 command: "codex",
-                args: vec![
-                    "exec".to_string(),
-                    "--skip-git-repo-check".to_string(),
-                ],
+                args: vec!["exec".to_string(), "--skip-git-repo-check".to_string(),],
+                prompt_transport: PromptTransport::Stdin,
+            }
+        );
+    }
+
+    #[test]
+    fn resolves_antigravity_prompt_as_print_argument() {
+        let req = AiExecutionRequest {
+            provider: AiProvider::Antigravity,
+            ollama_model: None,
+            llm_model: None,
+        };
+
+        assert_eq!(
+            req.resolve().unwrap(),
+            ResolvedAiCommand {
+                command: "agy",
+                args: vec!["-p".to_string()],
+                prompt_transport: PromptTransport::Argument,
             }
         );
     }
@@ -323,12 +377,63 @@ mod tests {
     #[test]
     fn runs_oneshot_in_requested_working_directory() {
         let dir = tempfile::tempdir().unwrap();
-        let output = run_oneshot_in_dir("pwd", &[], "", "test settings", Some(dir.path())).unwrap();
+        let output = run_oneshot_in_dir_cancellable_with_transport(
+            "pwd",
+            &[],
+            "",
+            "test settings",
+            Some(dir.path()),
+            None,
+            PromptTransport::Stdin,
+        )
+        .unwrap();
         let observed = std::path::PathBuf::from(output.trim())
             .canonicalize()
             .unwrap();
         let expected = dir.path().canonicalize().unwrap();
 
         assert_eq!(observed, expected);
+    }
+
+    #[test]
+    fn runs_prompt_as_argument_when_requested() {
+        let args = vec![
+            "-c".to_string(),
+            "printf 'arg=%s stdin=%s' \"$1\" \"$(cat)\"".to_string(),
+            "sh".to_string(),
+        ];
+        let output = run_oneshot_in_dir_cancellable_with_transport(
+            "/bin/sh",
+            &args,
+            "hello",
+            "test settings",
+            None,
+            None,
+            PromptTransport::Argument,
+        )
+        .unwrap();
+
+        assert_eq!(output, "arg=hello stdin=");
+    }
+
+    #[test]
+    fn runs_prompt_through_stdin_when_requested() {
+        let args = vec![
+            "-c".to_string(),
+            "printf 'arg=%s stdin=%s' \"${1-}\" \"$(cat)\"".to_string(),
+            "sh".to_string(),
+        ];
+        let output = run_oneshot_in_dir_cancellable_with_transport(
+            "/bin/sh",
+            &args,
+            "hello",
+            "test settings",
+            None,
+            None,
+            PromptTransport::Stdin,
+        )
+        .unwrap();
+
+        assert_eq!(output, "arg= stdin=hello");
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -404,9 +404,8 @@ impl ChatProviderAdapter for CliChatProviderAdapter {
     fn send_message(&self, input: ChatProviderInput) -> AppResult<ProviderResponse> {
         let invocation = resolve_chat_cli_invocation(&self.ai, &input)?;
         let started_at = SystemTime::now();
-        let raw = crate::ai::run_oneshot_in_dir_cancellable(
-            invocation.command,
-            &invocation.args,
+        let raw = crate::ai::run_resolved_oneshot_in_dir_cancellable(
+            &invocation.cli,
             &invocation.prompt,
             "Settings → Agents",
             Some(&self.cwd),
@@ -429,8 +428,7 @@ impl ChatProviderAdapter for CliChatProviderAdapter {
 
 #[derive(Debug, Clone)]
 struct ChatCliInvocation {
-    command: &'static str,
-    args: Vec<String>,
+    cli: crate::ai::ResolvedAiCommand,
     prompt: String,
     native_thread_id: Option<String>,
     resume_token: Option<String>,
@@ -486,8 +484,11 @@ fn resolve_chat_cli_invocation(
                 }
             };
             Ok(ChatCliInvocation {
-                command: "claude",
-                args,
+                cli: crate::ai::ResolvedAiCommand {
+                    command: "claude",
+                    args,
+                    prompt_transport: crate::ai::PromptTransport::Stdin,
+                },
                 prompt,
                 native_thread_id: Some(thread_id.clone()),
                 resume_token: Some(thread_id),
@@ -497,14 +498,17 @@ fn resolve_chat_cli_invocation(
         crate::ai::AiProvider::Codex => {
             if let Some(cursor) = cursor {
                 Ok(ChatCliInvocation {
-                    command: "codex",
-                    args: vec![
-                        "exec".to_string(),
-                        "--skip-git-repo-check".to_string(),
-                        "resume".to_string(),
-                        cursor.clone(),
-                        "-".to_string(),
-                    ],
+                    cli: crate::ai::ResolvedAiCommand {
+                        command: "codex",
+                        args: vec![
+                            "exec".to_string(),
+                            "--skip-git-repo-check".to_string(),
+                            "resume".to_string(),
+                            cursor.clone(),
+                            "-".to_string(),
+                        ],
+                        prompt_transport: crate::ai::PromptTransport::Stdin,
+                    },
                     prompt,
                     native_thread_id: Some(cursor.clone()),
                     resume_token: Some(cursor),
@@ -513,8 +517,7 @@ fn resolve_chat_cli_invocation(
             } else {
                 let resolved = ai.resolve()?;
                 Ok(ChatCliInvocation {
-                    command: resolved.command,
-                    args: resolved.args,
+                    cli: resolved,
                     prompt,
                     native_thread_id: None,
                     resume_token: None,
@@ -525,12 +528,15 @@ fn resolve_chat_cli_invocation(
         crate::ai::AiProvider::Antigravity => {
             if let Some(cursor) = cursor {
                 Ok(ChatCliInvocation {
-                    command: "agy",
-                    args: vec![
-                        "-p".to_string(),
-                        "--conversation".to_string(),
-                        cursor.clone(),
-                    ],
+                    cli: crate::ai::ResolvedAiCommand {
+                        command: "agy",
+                        args: vec![
+                            "--conversation".to_string(),
+                            cursor.clone(),
+                            "-p".to_string(),
+                        ],
+                        prompt_transport: crate::ai::PromptTransport::Argument,
+                    },
                     prompt,
                     native_thread_id: Some(cursor.clone()),
                     resume_token: Some(cursor),
@@ -539,8 +545,7 @@ fn resolve_chat_cli_invocation(
             } else {
                 let resolved = ai.resolve()?;
                 Ok(ChatCliInvocation {
-                    command: resolved.command,
-                    args: resolved.args,
+                    cli: resolved,
                     prompt,
                     native_thread_id: None,
                     resume_token: None,
@@ -551,8 +556,7 @@ fn resolve_chat_cli_invocation(
         _ => {
             let resolved = ai.resolve()?;
             Ok(ChatCliInvocation {
-                command: resolved.command,
-                args: resolved.args,
+                cli: resolved,
                 prompt,
                 native_thread_id: None,
                 resume_token: None,
@@ -5083,9 +5087,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(invocation.command, "claude");
+        assert_eq!(invocation.cli.command, "claude");
         assert_eq!(
-            invocation.args,
+            invocation.cli.args,
             vec![
                 "-p",
                 "--output-format",
@@ -5093,6 +5097,10 @@ mod tests {
                 "--resume",
                 "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
             ]
+        );
+        assert_eq!(
+            invocation.cli.prompt_transport,
+            crate::ai::PromptTransport::Stdin
         );
         assert_eq!(invocation.prompt, "continue in provider state");
         assert_eq!(
@@ -5136,10 +5144,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(invocation.command, "claude");
-        assert_eq!(invocation.args[0..3], ["-p", "--output-format", "text"]);
-        assert_eq!(invocation.args[3], "--session-id");
-        let seeded_id = invocation.args[4].as_str();
+        assert_eq!(invocation.cli.command, "claude");
+        assert_eq!(invocation.cli.args[0..3], ["-p", "--output-format", "text"]);
+        assert_eq!(invocation.cli.args[3], "--session-id");
+        let seeded_id = invocation.cli.args[4].as_str();
         Uuid::parse_str(seeded_id).expect("seeded Claude id should be a UUID");
         assert_eq!(invocation.prompt, "compiled first message");
         assert_eq!(invocation.native_thread_id.as_deref(), Some(seeded_id));
@@ -5177,9 +5185,9 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(invocation.command, "codex");
+        assert_eq!(invocation.cli.command, "codex");
         assert_eq!(
-            invocation.args,
+            invocation.cli.args,
             vec![
                 "exec",
                 "--skip-git-repo-check",
@@ -5188,7 +5196,86 @@ mod tests {
                 "-"
             ]
         );
+        assert_eq!(
+            invocation.cli.prompt_transport,
+            crate::ai::PromptTransport::Stdin
+        );
         assert_eq!(invocation.prompt, "continue codex");
+    }
+
+    #[test]
+    fn chat_cli_invocation_passes_antigravity_prompt_as_print_argument() {
+        let input = super::ChatProviderInput {
+            thread: None,
+            message: chat_message(
+                "current-user",
+                crate::persistence::ChatRole::User,
+                "run antigravity",
+            ),
+            context: None,
+            model: None,
+        };
+
+        let invocation = super::resolve_chat_cli_invocation(
+            &crate::ai::AiExecutionRequest {
+                provider: crate::ai::AiProvider::Antigravity,
+                ollama_model: None,
+                llm_model: None,
+            },
+            &input,
+        )
+        .unwrap();
+
+        assert_eq!(invocation.cli.command, "agy");
+        assert_eq!(invocation.cli.args, vec!["-p"]);
+        assert_eq!(
+            invocation.cli.prompt_transport,
+            crate::ai::PromptTransport::Argument
+        );
+        assert_eq!(invocation.prompt, "run antigravity");
+    }
+
+    #[test]
+    fn chat_cli_invocation_resumes_antigravity_with_prompt_argument_last() {
+        let input = super::ChatProviderInput {
+            thread: Some(crate::persistence::ProviderThread {
+                session_id: Uuid::new_v4().to_string(),
+                provider: "antigravity".to_string(),
+                model: None,
+                native_thread_id: Some("agy-conversation".to_string()),
+                resume_token: Some("agy-conversation".to_string()),
+                last_response_id: None,
+                updated_at: chrono::Utc::now(),
+            }),
+            message: chat_message(
+                "current-user",
+                crate::persistence::ChatRole::User,
+                "continue antigravity",
+            ),
+            context: None,
+            model: None,
+        };
+
+        let invocation = super::resolve_chat_cli_invocation(
+            &crate::ai::AiExecutionRequest {
+                provider: crate::ai::AiProvider::Antigravity,
+                ollama_model: None,
+                llm_model: None,
+            },
+            &input,
+        )
+        .unwrap();
+
+        assert_eq!(invocation.cli.command, "agy");
+        assert_eq!(
+            invocation.cli.args,
+            vec!["--conversation", "agy-conversation", "-p"]
+        );
+        assert_eq!(
+            invocation.cli.prompt_transport,
+            crate::ai::PromptTransport::Argument
+        );
+        assert_eq!(invocation.prompt, "continue antigravity");
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2814,10 +2814,11 @@ fn generate_session_title_inner(
             session: enrich_session(session),
         });
     };
-    let generated = crate::session_titles::generate_title(
+    let generated = crate::session_titles::generate_title_in_dir(
         &ai,
         prompt.as_deref(),
         &title_input.first_user_message,
+        Some(&session.worktree_path),
     )?;
     let latest = state.sessions.get(&id)?;
     if !crate::session_titles::can_generate_title(&latest, Some(&title_input.transcript_id)) {
@@ -2850,10 +2851,13 @@ fn resolve_title_input_for_session(
 
 #[tauri::command]
 pub async fn preview_session_title(
+    state: State<'_, AppState>,
     ai: crate::ai::AiExecutionRequest,
     prompt: Option<String>,
     first_user_message: String,
+    repo_path: Option<String>,
 ) -> AppResult<String> {
+    let state = state.inner().clone();
     run_blocking("preview_session_title", move || {
         let first_user_message = first_user_message.trim().to_string();
         if first_user_message.is_empty() {
@@ -2861,7 +2865,16 @@ pub async fn preview_session_title(
                 "first user message must not be empty".to_string(),
             ));
         }
-        crate::session_titles::generate_title(&ai, prompt.as_deref(), &first_user_message)
+        let cwd = repo_path
+            .as_deref()
+            .map(|path| authorize_registered_project_root(&state, Path::new(path)))
+            .transpose()?;
+        crate::session_titles::generate_title_in_dir(
+            &ai,
+            prompt.as_deref(),
+            &first_user_message,
+            cwd.as_deref(),
+        )
     })
     .await
 }

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -1705,12 +1705,7 @@ pub fn generate_pr_commit_message(
 
     let (view, diff) = context;
     let prompt = build_commit_message_prompt(method, &prompt, &view, &diff);
-    let raw = crate::ai::run_oneshot(
-        resolved.command,
-        &resolved.args,
-        &prompt,
-        "Settings → Agents",
-    )?;
+    let raw = crate::ai::run_resolved_oneshot(&resolved, &prompt, "Settings → Agents")?;
     Ok(parse_commit_message_response(&raw))
 }
 

--- a/src-tauri/src/session_titles.rs
+++ b/src-tauri/src/session_titles.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use acorn_session::{Session, SessionKind, SessionOwner, SessionTitleSource};
 
@@ -113,21 +113,27 @@ pub fn normalize_generated_title(raw: &str) -> Option<String> {
         .trim()
         .trim_end_matches(['.', '!', '?', ':'])
         .to_string();
-    if out.is_empty() { None } else { Some(out) }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
 }
 
-pub fn generate_title(
+pub fn generate_title_in_dir(
     ai: &AiExecutionRequest,
     prompt: Option<&str>,
     first_user_message: &str,
+    cwd: Option<&Path>,
 ) -> AppResult<String> {
     let resolved = ai.resolve()?;
     let prompt = build_prompt(prompt, first_user_message);
-    let raw = crate::ai::run_oneshot(
+    let raw = crate::ai::run_oneshot_in_dir(
         resolved.command,
         &resolved.args,
         &prompt,
         "Settings → Agents",
+        cwd,
     )?;
     normalize_generated_title(&raw)
         .ok_or_else(|| AppError::Other("AI returned an empty session title.".to_string()))

--- a/src-tauri/src/session_titles.rs
+++ b/src-tauri/src/session_titles.rs
@@ -128,13 +128,7 @@ pub fn generate_title_in_dir(
 ) -> AppResult<String> {
     let resolved = ai.resolve()?;
     let prompt = build_prompt(prompt, first_user_message);
-    let raw = crate::ai::run_oneshot_in_dir(
-        resolved.command,
-        &resolved.args,
-        &prompt,
-        "Settings → Agents",
-        cwd,
-    )?;
+    let raw = crate::ai::run_resolved_oneshot_in_dir(&resolved, &prompt, "Settings → Agents", cwd)?;
     normalize_generated_title(&raw)
         .ok_or_else(|| AppError::Other("AI returned an empty session title.".to_string()))
 }

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
       },
       prompt: string,
       firstUserMessage: string,
+      repoPath?: string | null,
     ) => Promise<string>
   >(),
 }));
@@ -86,6 +87,7 @@ import {
   SESSION_TITLE_PROMPT_PREVIEW_MESSAGE,
   useSettings,
 } from "../lib/settings";
+import { useAppStore } from "../store";
 import { SettingsModal } from "./SettingsModal";
 
 const mockApi = vi.mocked(api);
@@ -241,6 +243,7 @@ describe("SettingsModal font controls", () => {
       patchAppearance: vi.fn(),
       patchTerminal: vi.fn(),
     });
+    useAppStore.setState({ activeProject: null });
     container = document.createElement("div");
     document.body.appendChild(container);
   });
@@ -709,6 +712,7 @@ describe("SettingsModal font controls", () => {
 
   it("generates a session title prompt preview", async () => {
     mockApi.previewSessionTitle.mockResolvedValueOnce("Preview Tab Titles");
+    useAppStore.setState({ activeProject: "/repo/acorn" });
     useSettings.setState({
       settings: cloneSettings(),
       patchAgents: vi.fn(),
@@ -736,6 +740,7 @@ describe("SettingsModal font controls", () => {
       { provider: "claude", ollamaModel: "", llmModel: "" },
       DEFAULT_SETTINGS.agents.sessionTitlePrompt,
       SESSION_TITLE_PROMPT_PREVIEW_MESSAGE,
+      "/repo/acorn",
     );
     expect(document.body.textContent).toContain("Preview Tab Titles");
   });

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -67,6 +67,7 @@ import {
 import { revealThemesFolder, useThemes } from "../lib/themes";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
+import { useAppStore } from "../store";
 import {
   CheckboxRow,
   CommandHint,
@@ -1817,6 +1818,7 @@ function SessionTitlePromptModal({
 }: SessionTitlePromptModalProps) {
   const settings = useSettings((s) => s.settings);
   const patchAgents = useSettings((s) => s.patchAgents);
+  const activeProject = useAppStore((s) => s.activeProject);
   const t = useTranslation();
   const sessionTitlePromptLength = Array.from(
     settings.agents.sessionTitlePrompt,
@@ -1838,6 +1840,7 @@ function SessionTitlePromptModal({
     settings.agents.ollama.model,
     settings.agents.llm.model,
     settings.agents.sessionTitlePrompt,
+    activeProject,
   ]);
 
   async function handlePreviewSessionTitle() {
@@ -1849,6 +1852,7 @@ function SessionTitlePromptModal({
         ai,
         prompt,
         SESSION_TITLE_PROMPT_PREVIEW_MESSAGE,
+        activeProject,
       );
       setTitlePreview({ status: "success", title });
     } catch (error) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -160,11 +160,13 @@ export const api = {
     ai: AiExecutionRequest,
     prompt: string,
     firstUserMessage: string,
+    repoPath?: string | null,
   ): Promise<string> {
     return invoke<string>("preview_session_title", {
       ai,
       prompt,
       firstUserMessage,
+      repoPath,
     });
   },
   loadChatSessionState(sessionId: string): Promise<ChatSessionState> {

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -421,6 +421,12 @@ Rules:
     );
   });
 
+  it("describes the Antigravity print prompt argument in settings", () => {
+    expect(
+      AGENT_OPTIONS.find((o) => o.value === "antigravity")?.oneshotHint,
+    ).toBe("agy -p <prompt>");
+  });
+
   it("shows only the supported built-in agents in Settings order", () => {
     expect(AGENT_OPTIONS.map((o) => [o.value, o.label])).toEqual([
       ["claude", "Claude Code"],

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -55,7 +55,7 @@ export const AGENT_OPTIONS: ReadonlyArray<{
   {
     value: "antigravity",
     label: "Antigravity",
-    oneshotHint: "agy -p",
+    oneshotHint: "agy -p <prompt>",
   },
 ];
 


### PR DESCRIPTION
## Summary
This PR fixes session title one-shots so provider CLIs run in the right repo and Antigravity receives prompts in its print-mode argument form.

1. **Project cwd for titles** — run generated session titles from the session `worktree_path`, and run Settings previews from the active registered project root.
2. **Antigravity print prompts** — teach resolved AI commands whether prompts are sent through stdin or argv, using `agy -p <prompt>` for Antigravity instead of bare `agy -p` plus stdin.
3. **Shared one-shot runner** — route session titles, PR commit-message generation, and ChatPane CLI turns through the resolved command transport so provider-specific invocation rules stay centralized.
4. **Coverage** — add Rust coverage for stdin vs argument prompt transport and Antigravity chat invocation ordering, plus frontend coverage for the updated Settings hint and preview project path.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Codex title preview / generation | Could run from Acorn process cwd and fail repo/trust checks | Runs from the active project or session worktree cwd |
| Antigravity title preview / generation | Could fail with `flag needs an argument: -p` or run outside the workspace context | Runs from the right cwd and passes the prompt as `agy -p <prompt>` |
| Antigravity ChatPane turns | Resume/new turns used stdin with a bare `-p` flag | Uses argument prompt transport; resume orders flags as `--conversation <id> -p <prompt>` |
| Monorepo projects | Depended on app process cwd | Uses the registered project path for preview and session worktree path for live sessions |

## Design notes
- `ResolvedAiCommand` now carries `PromptTransport`, keeping provider-specific prompt placement next to provider command resolution.
- Claude, Codex, Ollama, and `llm` keep the existing stdin behavior; Antigravity uses argument transport and has stdin closed.
- Settings preview path authorization remains strict: only registered project roots can be used as the preview cwd.
- Live automatic title generation does not depend on the active UI project; it uses the target session's persisted `worktree_path`, which handles regular repos, worktrees, and monorepo subdirectory projects consistently.
- After merging current `origin/main`, the broader transcript-context title input from main is preserved while still running the CLI from the target cwd.

## Test plan
- [x] `cargo test -p acorn ai:: --manifest-path src-tauri/Cargo.toml` — 7 passed
- [x] `cargo test -p acorn commands::tests::chat_cli_invocation --manifest-path src-tauri/Cargo.toml` — 5 passed
- [x] `cargo test -p acorn session_titles --manifest-path src-tauri/Cargo.toml` — 10 passed
- [x] `cargo test -p acorn pull_requests::tests --manifest-path src-tauri/Cargo.toml` — 3 passed
- [x] `pnpm exec vitest run src/lib/settings.test.ts src/components/SettingsModal.test.tsx` — 61 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed
- [x] `git diff --check` — passed

## Notes
- `pnpm run build` still emits existing Vite dynamic/static import and chunk-size warnings; the build succeeds and this PR does not introduce those warnings.
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` still reports unrelated formatting drift in existing files (`fs_explorer.rs`, `pty_env.rs`, `pull_requests.rs`). The Rust files changed for this PR were formatted directly where appropriate, and unrelated formatting churn was left out of the diff.
