### PR TITLE
feat(sessions): regenerate tab names from transcript context

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm run dev",
+    command: `pnpm run dev -- --port ${PORT}`,
     url: BASE_URL,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -1,5 +1,6 @@
+use std::collections::VecDeque;
 use std::fs;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
@@ -21,6 +22,7 @@ const READ_HEAD_INITIAL_BYTES: u64 = 256 * 1024;
 const READ_HEAD_MAX_BYTES: u64 = 2 * 1024 * 1024;
 const READ_TAIL_BYTES: u64 = 256 * 1024;
 const PREVIEW_CHARS: usize = 160;
+const TITLE_CONTEXT_ENTRY_CHARS: usize = 700;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -388,6 +390,7 @@ fn parse_antigravity_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentH
     })
 }
 
+#[cfg(test)]
 pub fn transcript_first_user_message(
     provider: AgentHistoryProvider,
     path: &Path,
@@ -401,6 +404,29 @@ pub fn transcript_first_user_message(
     state
         .title
         .and_then(|title| truncate_preserving_lines(&title, max_chars))
+}
+
+pub fn transcript_title_context(
+    provider: AgentHistoryProvider,
+    path: &Path,
+    max_chars: usize,
+) -> Option<String> {
+    let file = fs::File::open(path).ok()?;
+    let mut builder = TitleContextBuilder::new(max_chars);
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let line = line.trim();
+        if !line.starts_with('{') {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        let Some(entry) = title_context_entry(&provider, &value) else {
+            continue;
+        };
+        builder.push(entry);
+    }
+    builder.finish()
 }
 
 fn parse_codex_state(path: &Path) -> Option<ParsedAgentFile> {
@@ -499,6 +525,153 @@ fn parse_antigravity_state(path: &Path) -> Option<ParsedAgentFile> {
     }
 
     Some(state)
+}
+
+struct TitleContextEntry {
+    role: &'static str,
+    text: String,
+}
+
+fn title_context_entry(
+    provider: &AgentHistoryProvider,
+    value: &Value,
+) -> Option<TitleContextEntry> {
+    match provider {
+        AgentHistoryProvider::Codex => codex_title_context_entry(value),
+        AgentHistoryProvider::Claude => claude_title_context_entry(value),
+        AgentHistoryProvider::Antigravity => antigravity_title_context_entry(value),
+    }
+}
+
+fn codex_title_context_entry(value: &Value) -> Option<TitleContextEntry> {
+    let payload = value.get("payload");
+    let role = string_at(payload, "role").or_else(|| string_at(Some(value), "role"))?;
+    let texts = value_texts(value);
+    match role.as_str() {
+        "user" => joined_text(&texts).map(|text| TitleContextEntry { role: "User", text }),
+        "assistant" => first_text(&texts)
+            .or_else(|| response_text(value))
+            .map(|text| TitleContextEntry {
+                role: "Assistant",
+                text,
+            }),
+        _ => None,
+    }
+}
+
+fn claude_title_context_entry(value: &Value) -> Option<TitleContextEntry> {
+    if is_claude_meta_event(value) {
+        return None;
+    }
+    let ty = string_at(Some(value), "type")?;
+    let texts = value_texts(value);
+    match ty.as_str() {
+        "user" => {
+            joined_claude_display_text(&texts).map(|text| TitleContextEntry { role: "User", text })
+        }
+        "assistant" => first_claude_display_text(&texts).map(|text| TitleContextEntry {
+            role: "Assistant",
+            text,
+        }),
+        _ => None,
+    }
+}
+
+fn antigravity_title_context_entry(value: &Value) -> Option<TitleContextEntry> {
+    let ty = string_at(Some(value), "type")?;
+    let text = string_at(Some(value), "content").or_else(|| first_text(&value_texts(value)));
+    match ty.as_str() {
+        "USER_INPUT" => text
+            .and_then(|s| extract_antigravity_user_request(&s))
+            .map(|text| TitleContextEntry { role: "User", text }),
+        "PLANNER_RESPONSE" => text.map(|text| TitleContextEntry {
+            role: "Assistant",
+            text,
+        }),
+        _ => None,
+    }
+}
+
+struct TitleContextBuilder {
+    max_chars: usize,
+    head_limit: usize,
+    tail_limit: usize,
+    head: String,
+    head_chars: usize,
+    tail: VecDeque<(String, usize)>,
+    tail_chars: usize,
+    omitted: bool,
+    last_line: Option<String>,
+}
+
+impl TitleContextBuilder {
+    fn new(max_chars: usize) -> Self {
+        let max_chars = max_chars.max(1);
+        let head_limit = (max_chars / 2).max(1);
+        let tail_limit = (max_chars - head_limit).max(1);
+        Self {
+            max_chars,
+            head_limit,
+            tail_limit,
+            head: String::new(),
+            head_chars: 0,
+            tail: VecDeque::new(),
+            tail_chars: 0,
+            omitted: false,
+            last_line: None,
+        }
+    }
+
+    fn push(&mut self, entry: TitleContextEntry) {
+        let Some(text) = collapse_preview(&entry.text, TITLE_CONTEXT_ENTRY_CHARS) else {
+            return;
+        };
+        let line = format!("{}: {}", entry.role, text);
+        if self.last_line.as_deref() == Some(line.as_str()) {
+            return;
+        }
+        self.last_line = Some(line.clone());
+        let line_chars = line.chars().count() + usize::from(!self.head.is_empty());
+        if !self.omitted && self.head_chars + line_chars <= self.head_limit {
+            if !self.head.is_empty() {
+                self.head.push('\n');
+            }
+            self.head.push_str(&line);
+            self.head_chars += line_chars;
+            return;
+        }
+
+        self.omitted = true;
+        let tail_line_chars = line.chars().count() + 1;
+        self.tail.push_back((line, tail_line_chars));
+        self.tail_chars += tail_line_chars;
+        while self.tail_chars > self.tail_limit {
+            let Some((_, chars)) = self.tail.pop_front() else {
+                break;
+            };
+            self.tail_chars = self.tail_chars.saturating_sub(chars);
+        }
+    }
+
+    fn finish(self) -> Option<String> {
+        if self.head.is_empty() && self.tail.is_empty() {
+            return None;
+        }
+        let mut out = self.head;
+        if self.omitted && !self.tail.is_empty() {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str("[...]\n");
+            for (idx, (line, _)) in self.tail.into_iter().enumerate() {
+                if idx > 0 {
+                    out.push('\n');
+                }
+                out.push_str(&line);
+            }
+        }
+        truncate_preserving_lines(&out, self.max_chars)
+    }
 }
 
 fn extract_antigravity_user_request(content: &str) -> Option<String> {
@@ -1525,6 +1698,92 @@ mod tests {
             title,
             "Check whether Antigravity tab rename can miss transcripts"
         );
+    }
+
+    #[test]
+    fn transcript_title_context_includes_later_claude_turns() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = dir
+            .path()
+            .join("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl");
+        let mut file = fs::File::create(&transcript).unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "type": "user",
+                "sessionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "cwd": "/tmp/demo",
+                "message": {
+                    "role": "user",
+                    "content": "Investigate the failing release workflow",
+                },
+            })
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": "The release job is failing before sidecar staging.",
+                },
+            })
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": "Use the final diagnosis to regenerate the tab name.",
+                },
+            })
+        )
+        .unwrap();
+        drop(file);
+
+        let context =
+            transcript_title_context(AgentHistoryProvider::Claude, &transcript, 1_000).unwrap();
+
+        assert!(context.contains("User: Investigate the failing release workflow"));
+        assert!(context.contains("Assistant: The release job is failing"));
+        assert!(context.contains("User: Use the final diagnosis"));
+    }
+
+    #[test]
+    fn transcript_title_context_keeps_tail_when_budget_is_exceeded() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = dir
+            .path()
+            .join("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl");
+        let mut file = fs::File::create(&transcript).unwrap();
+        for idx in 0..20 {
+            writeln!(
+                file,
+                "{}",
+                serde_json::json!({
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": format!("Turn {idx}: investigate release workflow detail {idx}"),
+                    },
+                })
+            )
+            .unwrap();
+        }
+        drop(file);
+
+        let context =
+            transcript_title_context(AgentHistoryProvider::Claude, &transcript, 260).unwrap();
+
+        assert!(context.contains("Turn 0"));
+        assert!(context.contains("[...]"));
+        assert!(context.contains("Turn 19"));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2782,10 +2782,11 @@ pub async fn generate_session_title(
     id: String,
     ai: crate::ai::AiExecutionRequest,
     prompt: Option<String>,
+    force: Option<bool>,
 ) -> AppResult<GenerateSessionTitleResult> {
     let state = state.inner().clone();
     run_blocking("generate_session_title", move || {
-        generate_session_title_inner(state, id, ai, prompt)
+        generate_session_title_inner(state, id, ai, prompt, force.unwrap_or(false))
     })
     .await
 }
@@ -2795,6 +2796,7 @@ fn generate_session_title_inner(
     id: String,
     ai: crate::ai::AiExecutionRequest,
     prompt: Option<String>,
+    force: bool,
 ) -> AppResult<GenerateSessionTitleResult> {
     let id = parse_id(&id)?;
     let session = state.sessions.get(&id)?;
@@ -2802,7 +2804,12 @@ fn generate_session_title_inner(
     let transcript_id = title_input
         .as_ref()
         .map(|input| input.transcript_id.as_str());
-    if !crate::session_titles::can_generate_title(&session, transcript_id) {
+    let can_generate = if force {
+        crate::session_titles::can_force_generate_title(&session)
+    } else {
+        crate::session_titles::can_generate_title(&session, transcript_id)
+    };
+    if !can_generate {
         return Ok(GenerateSessionTitleResult {
             status: GenerateSessionTitleStatus::Skipped,
             session: enrich_session(session),
@@ -2814,13 +2821,15 @@ fn generate_session_title_inner(
             session: enrich_session(session),
         });
     };
-    let generated = crate::session_titles::generate_title(
-        &ai,
-        prompt.as_deref(),
-        &title_input.first_user_message,
-    )?;
+    let generated =
+        crate::session_titles::generate_title(&ai, prompt.as_deref(), &title_input.title_context)?;
     let latest = state.sessions.get(&id)?;
-    if !crate::session_titles::can_generate_title(&latest, Some(&title_input.transcript_id)) {
+    let can_store = if force {
+        crate::session_titles::can_force_generate_title(&latest)
+    } else {
+        crate::session_titles::can_generate_title(&latest, Some(&title_input.transcript_id))
+    };
+    if !can_store {
         return Ok(GenerateSessionTitleResult {
             status: GenerateSessionTitleStatus::Skipped,
             session: enrich_session(latest),

--- a/src-tauri/src/session_titles.rs
+++ b/src-tauri/src/session_titles.rs
@@ -8,12 +8,12 @@ use crate::ai::AiExecutionRequest;
 use crate::error::{AppError, AppResult};
 use crate::todos;
 
-const TITLE_INPUT_CHARS: usize = 2_000;
+const TITLE_CONTEXT_CHARS: usize = 8_000;
 const GENERATED_TITLE_CHARS: usize = 29;
 const SESSION_TITLE_PROMPT_CHARS: usize = 1_000;
 
 pub const DEFAULT_SESSION_TITLE_PROMPT: &str = "\
-You are naming an Acorn session tab from the user's first prompt.
+You are naming an Acorn session tab from the conversation transcript.
 
 Return only a concise title for the tab.
 Rules:
@@ -28,11 +28,11 @@ Rules:
 
 pub struct ResolvedTitleInput {
     pub transcript_id: String,
-    pub first_user_message: String,
+    pub title_context: String,
 }
 
 pub fn can_generate_title(session: &Session, transcript_id: Option<&str>) -> bool {
-    if session.kind != SessionKind::Regular || !matches!(session.owner, SessionOwner::User) {
+    if !can_force_generate_title(session) {
         return false;
     }
     match session.title_source {
@@ -43,9 +43,13 @@ pub fn can_generate_title(session: &Session, transcript_id: Option<&str>) -> boo
     }
 }
 
-pub fn build_prompt(prompt: Option<&str>, first_user_message: &str) -> String {
+pub fn can_force_generate_title(session: &Session) -> bool {
+    session.kind == SessionKind::Regular && matches!(session.owner, SessionOwner::User)
+}
+
+pub fn build_prompt(prompt: Option<&str>, title_context: &str) -> String {
     let header = effective_prompt(prompt);
-    format!("{header}\nFirst user prompt:\n{first_user_message}\n")
+    format!("{header}\nConversation transcript context:\n{title_context}\n")
 }
 
 fn effective_prompt(prompt: Option<&str>) -> String {
@@ -60,11 +64,11 @@ fn effective_prompt(prompt: Option<&str>) -> String {
 
 pub fn resolve_title_input(session_id: uuid::Uuid) -> Option<ResolvedTitleInput> {
     let (path, provider, transcript_id) = resolve_transcript(session_id)?;
-    let first_user_message =
-        agent_history::transcript_first_user_message(provider, &path, TITLE_INPUT_CHARS)?;
+    let title_context =
+        agent_history::transcript_title_context(provider, &path, TITLE_CONTEXT_CHARS)?;
     Some(ResolvedTitleInput {
         transcript_id,
-        first_user_message,
+        title_context,
     })
 }
 
@@ -76,17 +80,43 @@ pub fn resolve_chat_title_input(session_id: uuid::Uuid) -> Option<ResolvedTitleI
 pub fn chat_title_input_from_state(
     state: &crate::persistence::ChatSessionState,
 ) -> Option<ResolvedTitleInput> {
-    let first_user_message = state.messages.iter().find(|message| {
+    let first_user_index = state.messages.iter().position(|message| {
         message.role == crate::persistence::ChatRole::User && !message.content.trim().is_empty()
     })?;
+    let first_user_message = &state.messages[first_user_index];
+    let title_context = state
+        .messages
+        .iter()
+        .skip(first_user_index)
+        .filter_map(|message| {
+            let content = truncate_chat_message_for_title(&message.content)?;
+            let role = match message.role {
+                crate::persistence::ChatRole::User => "User",
+                crate::persistence::ChatRole::Assistant => "Assistant",
+                crate::persistence::ChatRole::System => "System",
+                crate::persistence::ChatRole::Tool => "Tool",
+            };
+            Some(format!("{role}: {content}"))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
     Some(ResolvedTitleInput {
         transcript_id: format!("chat:{}", first_user_message.id),
-        first_user_message: first_user_message
-            .content
-            .chars()
-            .take(TITLE_INPUT_CHARS)
-            .collect(),
+        title_context: title_context.chars().take(TITLE_CONTEXT_CHARS).collect(),
     })
+}
+
+fn truncate_chat_message_for_title(content: &str) -> Option<String> {
+    let collapsed = content.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() {
+        return None;
+    }
+    let max_chars = 700;
+    let mut out = collapsed.chars().take(max_chars).collect::<String>();
+    if collapsed.chars().count() > max_chars {
+        out.push('…');
+    }
+    Some(out)
 }
 
 pub fn normalize_generated_title(raw: &str) -> Option<String> {
@@ -113,16 +143,20 @@ pub fn normalize_generated_title(raw: &str) -> Option<String> {
         .trim()
         .trim_end_matches(['.', '!', '?', ':'])
         .to_string();
-    if out.is_empty() { None } else { Some(out) }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
 }
 
 pub fn generate_title(
     ai: &AiExecutionRequest,
     prompt: Option<&str>,
-    first_user_message: &str,
+    title_context: &str,
 ) -> AppResult<String> {
     let resolved = ai.resolve()?;
-    let prompt = build_prompt(prompt, first_user_message);
+    let prompt = build_prompt(prompt, title_context);
     let raw = crate::ai::run_oneshot(
         resolved.command,
         &resolved.args,
@@ -155,13 +189,14 @@ mod tests {
     use acorn_session::{Session, SessionKind};
 
     #[test]
-    fn prompt_contains_first_user_message_and_rules() {
+    fn prompt_contains_transcript_context_and_rules() {
         let prompt = build_prompt(None, "Fix the release workflow failure");
 
         assert!(prompt.contains("2 to 5 words"));
         assert!(prompt.contains("Separate each word with hyphens"));
         assert!(prompt.contains("Use lowercase words only"));
         assert!(prompt.contains("overall intent of the full request"));
+        assert!(prompt.contains("Conversation transcript context:"));
         assert!(prompt.contains("Fix the release workflow failure"));
     }
 
@@ -225,6 +260,29 @@ mod tests {
     }
 
     #[test]
+    fn forced_generation_allows_manual_and_same_transcript_titles() {
+        let mut session = Session::new(
+            "repo".to_string(),
+            PathBuf::from("/tmp/repo"),
+            PathBuf::from("/tmp/repo"),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        session.title_source = SessionTitleSource::Manual;
+        assert!(!can_generate_title(&session, Some("transcript-1")));
+        assert!(can_force_generate_title(&session));
+
+        session.title_source = SessionTitleSource::Generated;
+        session.generated_title_transcript_id = Some("transcript-1".to_string());
+        assert!(!can_generate_title(&session, Some("transcript-1")));
+        assert!(can_force_generate_title(&session));
+
+        session.kind = SessionKind::Control;
+        assert!(!can_force_generate_title(&session));
+    }
+
+    #[test]
     fn generated_titles_can_regenerate_after_transcript_rotation() {
         let mut session = Session::new(
             "repo".to_string(),
@@ -284,6 +342,63 @@ mod tests {
         let input = chat_title_input_from_state(&state).unwrap();
 
         assert_eq!(input.transcript_id, "chat:user-first");
-        assert_eq!(input.first_user_message, "Build Acorn native chat history");
+        assert_eq!(input.title_context, "User: Build Acorn native chat history");
+    }
+
+    #[test]
+    fn chat_title_input_uses_full_chat_context() {
+        let now = chrono::Utc::now();
+        let state = crate::persistence::ChatSessionState {
+            schema_version: crate::persistence::CHAT_SESSION_SCHEMA_VERSION,
+            session_id: uuid::Uuid::new_v4().to_string(),
+            session: crate::persistence::ChatSession::default(),
+            provider: Some("claude".to_string()),
+            model: None,
+            messages: vec![
+                crate::persistence::ChatMessage {
+                    id: "user-first".to_string(),
+                    session_id: None,
+                    turn_id: None,
+                    role: crate::persistence::ChatRole::User,
+                    content: "Investigate the release failure".to_string(),
+                    created_at: now,
+                    status: Some(crate::persistence::ChatMessageStatus::Complete),
+                    metadata: None,
+                },
+                crate::persistence::ChatMessage {
+                    id: "assistant-first".to_string(),
+                    session_id: None,
+                    turn_id: None,
+                    role: crate::persistence::ChatRole::Assistant,
+                    content: "The failing job is release-ci.".to_string(),
+                    created_at: now,
+                    status: Some(crate::persistence::ChatMessageStatus::Complete),
+                    metadata: None,
+                },
+                crate::persistence::ChatMessage {
+                    id: "user-second".to_string(),
+                    session_id: None,
+                    turn_id: None,
+                    role: crate::persistence::ChatRole::User,
+                    content: "Rename the tab from the final diagnosis.".to_string(),
+                    created_at: now,
+                    status: Some(crate::persistence::ChatMessageStatus::Complete),
+                    metadata: None,
+                },
+            ],
+            turns: Vec::new(),
+            provider_threads: Vec::new(),
+            context_snapshots: Vec::new(),
+            memory: crate::persistence::SessionMemory::default(),
+            created_at: now,
+            updated_at: now,
+        };
+
+        let input = chat_title_input_from_state(&state).unwrap();
+
+        assert_eq!(
+            input.title_context,
+            "User: Investigate the release failure\nAssistant: The failing job is release-ci.\nUser: Rename the tab from the final diagnosis."
+        );
     }
 }

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -11,6 +11,7 @@ import {
   MessageSquareText,
   Pencil,
   PencilLine,
+  Sparkles,
   SplitSquareHorizontal,
   SplitSquareVertical,
   SquareX,
@@ -45,8 +46,15 @@ import {
 } from "../lib/editor";
 import { formatHotkey, type HotkeyId } from "../lib/hotkeys";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
-import { useSettings } from "../lib/settings";
-import { canRenameSession } from "../lib/sessionTitle";
+import {
+  useSettings,
+  resolveAiExecutionRequest,
+  resolveSessionTitlePrompt,
+} from "../lib/settings";
+import {
+  canForceGenerateSessionTitle,
+  canRenameSession,
+} from "../lib/sessionTitle";
 import { hasRecordedWorktree } from "../lib/sessionWorktree";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
@@ -821,6 +829,7 @@ function TabItem({
   const t = useTranslation();
   const showToast = useToasts((s) => s.show);
   const renameSession = useAppStore((s) => s.renameSession);
+  const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
   const session = tab.kind === "session" ? tab.session : null;
   const isGeneratingTitle = useAppStore((s) =>
     session ? Boolean(s.generatingSessionTitleIds[session.id]) : false,
@@ -828,6 +837,10 @@ function TabItem({
   const canRename = session
     ? canRenameSession(session, { isGeneratingTitle })
     : false;
+  const canRegenerateTitle =
+    session != null &&
+    canForceGenerateSessionTitle(session) &&
+    !isGeneratingTitle;
   const showAgentProviderIcons = useSettings(
     (s) => s.settings.sessionDisplay.icons.agentProvider,
   );
@@ -897,6 +910,22 @@ function TabItem({
       pendingDragCleanupRef.current = null;
     };
   }, []);
+
+  async function regenerateTitle() {
+    if (!session) return;
+    const settings = useSettings.getState().settings;
+    const status = await generateSessionTitle(
+      session.id,
+      resolveAiExecutionRequest(settings),
+      resolveSessionTitlePrompt(settings),
+      true,
+    );
+    if (status === "not_ready") {
+      showToast(t("toasts.session.titleNotReady"));
+    } else if (status !== "generated") {
+      showToast(t("toasts.session.titleRegenerateSkipped"));
+    }
+  }
 
   function onTabPointerDown(e: ReactPointerEvent<HTMLDivElement>): void {
     if (
@@ -1076,6 +1105,12 @@ function TabItem({
       icon: <Pencil size={12} />,
       onClick: () => setEditing(true),
       disabled: !canRename,
+    },
+    {
+      label: paneT(t, "pane.menu.regenerateName"),
+      icon: <Sparkles size={12} />,
+      onClick: () => void regenerateTitle(),
+      disabled: !canRegenerateTitle,
     },
     {
       label: paneT(t, "pane.menu.duplicateSession"),

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   PencilLine,
   Plus,
   Settings as SettingsIcon,
+  Sparkles,
   SquareX,
   Trash2,
   X,
@@ -53,10 +54,15 @@ import { formatHotkey, type HotkeyId } from "../lib/hotkeys";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import {
   useSettings,
+  resolveAiExecutionRequest,
+  resolveSessionTitlePrompt,
   type AcornSettings,
   type SessionTitleSource,
 } from "../lib/settings";
-import { canRenameSession } from "../lib/sessionTitle";
+import {
+  canForceGenerateSessionTitle,
+  canRenameSession,
+} from "../lib/sessionTitle";
 import { hasRecordedWorktree } from "../lib/sessionWorktree";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
@@ -1093,6 +1099,7 @@ function SessionRow({
   const t = useTranslation();
   const showToast = useToasts((s) => s.show);
   const renameSession = useAppStore((s) => s.renameSession);
+  const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
   const editorCommand = useSettings((s) => s.settings.editor.command);
   const editorConfigured = editorCommand.trim().length > 0;
   const shortcuts = useSettings((s) => s.settings.shortcuts);
@@ -1111,6 +1118,8 @@ function SessionRow({
     Boolean(s.generatingSessionTitleIds[session.id]),
   );
   const canRename = canRenameSession(session, { isGeneratingTitle });
+  const canRegenerateTitle =
+    canForceGenerateSessionTitle(session) && !isGeneratingTitle;
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const {
@@ -1173,6 +1182,21 @@ function SessionRow({
     }
   }
 
+  async function regenerateTitle() {
+    const settings = useSettings.getState().settings;
+    const status = await generateSessionTitle(
+      session.id,
+      resolveAiExecutionRequest(settings),
+      resolveSessionTitlePrompt(settings),
+      true,
+    );
+    if (status === "not_ready") {
+      showToast(t("toasts.session.titleNotReady"));
+    } else if (status !== "generated") {
+      showToast(t("toasts.session.titleRegenerateSkipped"));
+    }
+  }
+
   const otherSiblings = useMemo(
     () => projectSessions.filter((s) => s.id !== session.id),
     [projectSessions, session.id],
@@ -1187,6 +1211,12 @@ function SessionRow({
       icon: <Pencil size={12} />,
       onClick: () => setEditing(true),
       disabled: !canRename,
+    },
+    {
+      label: sidebarText(t, "sidebar.actions.regenerateName"),
+      icon: <Sparkles size={12} />,
+      onClick: () => void regenerateTitle(),
+      disabled: !canRegenerateTitle,
     },
     {
       label: sidebarText(t, "sidebar.actions.duplicateSession"),
@@ -1663,6 +1693,7 @@ function LocalSessionRow({
   const t = useTranslation();
   const showToast = useToasts((s) => s.show);
   const renameSession = useAppStore((s) => s.renameSession);
+  const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
   const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
   const titleText = resolveSessionTitle(session, sessionDisplay.title);
   const metadataText = composeSessionMetadata(
@@ -1680,6 +1711,8 @@ function LocalSessionRow({
     Boolean(s.generatingSessionTitleIds[session.id]),
   );
   const canRename = canRenameSession(session, { isGeneratingTitle });
+  const canRegenerateTitle =
+    canForceGenerateSessionTitle(session) && !isGeneratingTitle;
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const {
@@ -1725,12 +1758,33 @@ function LocalSessionRow({
     }
   }
 
+  async function regenerateTitle() {
+    const settings = useSettings.getState().settings;
+    const status = await generateSessionTitle(
+      session.id,
+      resolveAiExecutionRequest(settings),
+      resolveSessionTitlePrompt(settings),
+      true,
+    );
+    if (status === "not_ready") {
+      showToast(t("toasts.session.titleNotReady"));
+    } else if (status !== "generated") {
+      showToast(t("toasts.session.titleRegenerateSkipped"));
+    }
+  }
+
   const menuItems: ContextMenuItem[] = [
     {
       label: sidebarText(t, "sidebar.actions.rename"),
       icon: <Pencil size={12} />,
       onClick: () => setEditing(true),
       disabled: !canRename,
+    },
+    {
+      label: sidebarText(t, "sidebar.actions.regenerateName"),
+      icon: <Sparkles size={12} />,
+      onClick: () => void regenerateTitle(),
+      disabled: !canRegenerateTitle,
     },
     {
       label: sidebarText(t, "sidebar.actions.duplicateSession"),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -149,11 +149,13 @@ export const api = {
     id: string,
     ai: AiExecutionRequest,
     prompt: string,
+    force = false,
   ): Promise<GenerateSessionTitleResult> {
     return invoke<GenerateSessionTitleResult>("generate_session_title", {
       id,
       ai,
       prompt,
+      force,
     });
   },
   previewSessionTitle(

--- a/src/lib/sessionTitle.test.ts
+++ b/src/lib/sessionTitle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { Session } from "./types";
 import {
   canAutoGenerateSessionTitle,
+  canForceGenerateSessionTitle,
   canGenerateSessionTitle,
   canRenameSession,
   planAutoGenerateSessionTitles,
@@ -87,6 +88,29 @@ describe("session title helpers", () => {
       ),
     ).toBe(false);
     expect(canGenerateSessionTitle(session({ agent_provider: null }))).toBe(true);
+  });
+
+  it("allows manual title regeneration for user-owned regular sessions", () => {
+    expect(
+      canForceGenerateSessionTitle(session({ title_source: "manual" })),
+    ).toBe(true);
+    expect(
+      canForceGenerateSessionTitle(
+        session({
+          title_source: "generated",
+          generated_title_transcript_id: "claude-1",
+          agent_transcript_id: "claude-1",
+        }),
+      ),
+    ).toBe(true);
+    expect(canForceGenerateSessionTitle(session({ kind: "control" }))).toBe(
+      false,
+    );
+    expect(
+      canForceGenerateSessionTitle(
+        session({ owner: { kind: "control", session_id: "control-1" } }),
+      ),
+    ).toBe(false);
   });
 
   it("uses the global automatic title setting for terminal sessions and always allows chat sessions", () => {

--- a/src/lib/sessionTitle.ts
+++ b/src/lib/sessionTitle.ts
@@ -30,13 +30,19 @@ export function canGenerateSessionTitle(session: Session): boolean {
   const titleSource = session.title_source ?? "manual";
   const currentTranscriptId = session.agent_transcript_id?.trim();
   return (
-    (session.kind ?? "regular") === "regular" &&
-    (session.owner?.kind ?? "user") === "user" &&
+    canForceGenerateSessionTitle(session) &&
     (titleSource === "default" ||
       (titleSource === "generated" &&
         currentTranscriptId != null &&
         currentTranscriptId.length > 0 &&
         session.generated_title_transcript_id !== currentTranscriptId))
+  );
+}
+
+export function canForceGenerateSessionTitle(session: Session): boolean {
+  return (
+    (session.kind ?? "regular") === "regular" &&
+    (session.owner?.kind ?? "user") === "user"
   );
 }
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -79,7 +79,7 @@ Rules:
 - No quotes, Markdown, trailing punctuation, or extra commentary.
 - Prefer the concrete task over generic words like "help" or "question".`;
 
-export const DEFAULT_SESSION_TITLE_PROMPT = `You are naming an Acorn terminal tab from the user's entire first agent prompt.
+export const DEFAULT_SESSION_TITLE_PROMPT = `You are naming an Acorn terminal tab from the conversation transcript.
 
 Return only a concise title for the tab.
 Rules:
@@ -224,12 +224,12 @@ export interface AcornSettings {
     selected: SelectedAgent;
     /**
      * When enabled, new user-owned agent sessions can have their default tab
-     * name replaced by an AI-generated title from the entire first user prompt.
+     * name replaced by an AI-generated title from transcript context.
      * Default off: this can send prompt text to the configured AI CLI.
      */
     autoGenerateSessionTitles: boolean;
     /**
-     * Instructions prepended to the entire first user prompt when Acorn asks the
+     * Instructions prepended to transcript context when Acorn asks the
      * selected AI CLI to name a new session tab.
      */
     sessionTitlePrompt: string;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,6 +8,8 @@
       "worktreeRemoveFailed": "Failed to delete worktree:",
       "refreshFailed": "Failed to refresh sessions:",
       "renameFailed": "Failed to rename session:",
+      "titleNotReady": "No transcript is available for this session yet.",
+      "titleRegenerateSkipped": "Session name was not regenerated.",
       "worktreeAdopted": "Adopted new worktree: {name}",
       "worktreeAdoptFailed": "Failed to adopt worktree:"
     },
@@ -490,12 +492,12 @@
       },
       "sessionTitles": {
         "label": "Session titles",
-        "hint": "When enabled, acorn sends the entire first user prompt in a new agent session to the selected AI CLI and replaces the default tab name with a concise title.",
+        "hint": "When enabled, acorn sends transcript context from a new agent session to the selected AI CLI and replaces the default tab name with a concise title.",
         "checkbox": "Auto-generate session titles"
       },
       "sessionTitlePrompt": {
         "label": "Session title prompt",
-        "hint": "Instructions sent before the entire first user prompt. Leave blank to use the default prompt.",
+        "hint": "Instructions sent before the transcript context. Leave blank to use the default prompt.",
         "open": "Configure title prompt",
         "shortButton": "Prompt",
         "editorLabel": "Prompt",
@@ -762,6 +764,7 @@
       "revealInFinder": "Reveal in Finder",
       "copyPath": "Copy path",
       "rename": "Rename",
+      "regenerateName": "Regenerate Name",
       "duplicateSession": "Duplicate Session",
       "equalizePaneSizes": "Equalize Pane Sizes",
       "openWorktreeInEditor": "Open Worktree in Editor",
@@ -826,6 +829,7 @@
     },
     "menu": {
       "rename": "Rename",
+      "regenerateName": "Regenerate Name",
       "duplicateSession": "Duplicate Session",
       "forkClaudeSession": "Fork Claude Session",
       "forkSession": "Fork Session",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -8,6 +8,8 @@
       "worktreeRemoveFailed": "worktree를 삭제하지 못했습니다:",
       "refreshFailed": "세션을 새로고침하지 못했습니다:",
       "renameFailed": "세션 이름을 변경하지 못했습니다:",
+      "titleNotReady": "아직 이 세션에서 사용할 transcript가 없습니다.",
+      "titleRegenerateSkipped": "세션 이름을 다시 생성하지 못했습니다.",
       "worktreeAdopted": "새 worktree를 가져왔습니다: {name}",
       "worktreeAdoptFailed": "worktree를 가져오지 못했습니다:"
     },
@@ -490,12 +492,12 @@
       },
       "sessionTitles": {
         "label": "세션 제목",
-        "hint": "켜면 새 에이전트 세션의 첫 사용자 프롬프트 전체를 선택한 AI CLI로 보내고 기본 탭 이름을 간결한 제목으로 바꿉니다.",
+        "hint": "켜면 새 에이전트 세션의 transcript context를 선택한 AI CLI로 보내고 기본 탭 이름을 간결한 제목으로 바꿉니다.",
         "checkbox": "세션 제목 자동 생성"
       },
       "sessionTitlePrompt": {
         "label": "세션 제목 프롬프트",
-        "hint": "첫 사용자 프롬프트 전체 앞에 함께 보낼 지시문입니다. 비워 두면 기본 프롬프트를 사용합니다.",
+        "hint": "transcript context 앞에 함께 보낼 지시문입니다. 비워 두면 기본 프롬프트를 사용합니다.",
         "open": "제목 프롬프트 설정",
         "shortButton": "프롬프트",
         "editorLabel": "프롬프트",
@@ -762,6 +764,7 @@
       "revealInFinder": "Finder에서 보기",
       "copyPath": "경로 복사",
       "rename": "이름 변경",
+      "regenerateName": "이름 다시 생성",
       "duplicateSession": "세션 복제",
       "equalizePaneSizes": "Pane 크기 균등화",
       "openWorktreeInEditor": "편집기에서 worktree 열기",
@@ -826,6 +829,7 @@
     },
     "menu": {
       "rename": "이름 변경",
+      "regenerateName": "이름 다시 생성",
       "duplicateSession": "세션 복제",
       "forkClaudeSession": "Claude 세션 포크",
       "forkSession": "세션 포크",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1318,12 +1318,46 @@ describe("generateSessionTitle", () => {
       "a1",
       ai,
       "Title prompt",
+      false,
     );
     expect(mockApi.listSessions).toHaveBeenCalledTimes(1);
     expect(useAppStore.getState().sessions[0]?.name).toBe(
       "Fix Release Workflow",
     );
     expect(useAppStore.getState().sessions[0]?.title_source).toBe("generated");
+  });
+
+  it("passes force when manually regenerating a generated session title", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          name: "Manual title",
+          title_source: "manual",
+        }),
+      ],
+    );
+    mockApi.generateSessionTitle.mockResolvedValueOnce({
+      status: "generated",
+      session: session("a1", REPO_A, {
+        name: "fresh-title",
+        title_source: "generated",
+      }),
+    });
+
+    const ai = { provider: "codex" as const, ollamaModel: "", llmModel: "" };
+    const status = await useAppStore
+      .getState()
+      .generateSessionTitle("a1", ai, "Title prompt", true);
+
+    expect(status).toBe("generated");
+    expect(mockApi.generateSessionTitle).toHaveBeenCalledWith(
+      "a1",
+      ai,
+      "Title prompt",
+      true,
+    );
+    expect(useAppStore.getState().sessions[0]?.name).toBe("fresh-title");
   });
 
   it("returns not_ready without replacing the session title", async () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -205,6 +205,7 @@ interface AppStateModel {
     id: string,
     ai: AiExecutionRequest,
     prompt: string,
+    force?: boolean,
   ) => Promise<SessionTitleGenerationStatus>;
   adoptSessionWorktree: (id: string, worktreePath: string) => Promise<void>;
   requestRemoveSession: (id: string) => void;
@@ -1585,7 +1586,7 @@ export const useAppStore = create<AppStateModel>()(
     }
   },
 
-  async generateSessionTitle(id, ai, prompt) {
+  async generateSessionTitle(id, ai, prompt, force = false) {
     const startedAt = Date.now();
     let resultStatus: SessionTitleGenerationStatus = "skipped";
     set((s) => ({
@@ -1595,7 +1596,7 @@ export const useAppStore = create<AppStateModel>()(
       },
     }));
     try {
-      const result = await api.generateSessionTitle(id, ai, prompt);
+      const result = await api.generateSessionTitle(id, ai, prompt, force);
       resultStatus = result.status;
       const updated = result.session;
       if (result.status === "generated" && updated?.id) {

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -1,6 +1,342 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test, expect, pressHotkey, seedSettingsLanguage } from "./support";
 
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function createLinkedWorktreeFixture(): {
+  root: string;
+  repo: string;
+  alpha: string;
+  beta: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), "acorn-title-worktrees-"));
+  const repo = join(root, "repo");
+  const alpha = join(root, "wt-alpha");
+  const beta = join(root, "wt-beta");
+  mkdirSync(repo, { recursive: true });
+  git(["init"], repo);
+  git(["config", "user.email", "acorn-test@example.com"], repo);
+  git(["config", "user.name", "Acorn Test"], repo);
+  writeFileSync(join(repo, "README.md"), "# worktree title test\n");
+  git(["add", "README.md"], repo);
+  git(["commit", "-m", "initial"], repo);
+  git(["worktree", "add", "-b", "feature/alpha", alpha], repo);
+  git(["worktree", "add", "-b", "feature/beta", beta], repo);
+
+  const realRepo = realpathSync(repo);
+  const realAlpha = realpathSync(alpha);
+  const realBeta = realpathSync(beta);
+  const list = git(["worktree", "list", "--porcelain"], repo);
+  expect(list).toContain(`worktree ${realAlpha}`);
+  expect(list).toContain(`worktree ${realBeta}`);
+
+  return {
+    root,
+    repo: realRepo,
+    alpha: realAlpha,
+    beta: realBeta,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
 test.describe("sidebar: project lifecycle", () => {
+  test("session context menu can regenerate a session name", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __sessions?: unknown[];
+      };
+      w.__sessions = w.__sessions ?? [
+        {
+          id: "session-1",
+          name: "demo-session",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          project_scoped: true,
+          status: "idle",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          title_source: "manual",
+          kind: "regular",
+          owner: { kind: "user" },
+          position: 0,
+          in_worktree: false,
+          agent_provider: "codex",
+          agent_transcript_id: "codex-1",
+        },
+      ];
+      return w.__sessions;
+    });
+    await tauri.handle("generate_session_title", (args) => {
+      const w = window as unknown as {
+        __generateTitleCalls?: unknown[];
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__generateTitleCalls = w.__generateTitleCalls ?? [];
+      w.__generateTitleCalls.push(args);
+      const updated = {
+        id: "session-1",
+        name: "fresh-title",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "generated",
+        generated_title_transcript_id: "codex-1",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+        agent_provider: "codex",
+        agent_transcript_id: "codex-1",
+      };
+      w.__sessions = [updated];
+      return { status: "generated", session: updated };
+    });
+
+    await page.goto("/");
+
+    await page.locator("aside").getByRole("button", { name: /demo-session/ }).click({
+      button: "right",
+    });
+    await page.getByRole("menuitem", { name: "Regenerate Name" }).click();
+
+    await expect(
+      page.locator("aside").getByRole("button", { name: /fresh-title/ }),
+    ).toBeVisible();
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __generateTitleCalls?: unknown[] })
+          .__generateTitleCalls,
+    )) as Array<{ id: string; force: boolean; ai: { provider: string } }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      id: "session-1",
+      force: true,
+      ai: { provider: "claude" },
+    });
+  });
+
+  test("tab context menu can regenerate a session name", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __sessions?: unknown[];
+      };
+      w.__sessions = w.__sessions ?? [
+        {
+          id: "session-1",
+          name: "demo-session",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          project_scoped: true,
+          status: "idle",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          title_source: "manual",
+          kind: "regular",
+          owner: { kind: "user" },
+          position: 0,
+          in_worktree: false,
+          agent_provider: "codex",
+          agent_transcript_id: "codex-1",
+        },
+      ];
+      return w.__sessions;
+    });
+    await tauri.handle("generate_session_title", (args) => {
+      const w = window as unknown as {
+        __generateTitleCalls?: unknown[];
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__generateTitleCalls = w.__generateTitleCalls ?? [];
+      w.__generateTitleCalls.push(args);
+      const updated = {
+        id: "session-1",
+        name: "tab-title",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "generated",
+        generated_title_transcript_id: "codex-1",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+        agent_provider: "codex",
+        agent_transcript_id: "codex-1",
+      };
+      w.__sessions = [updated];
+      return { status: "generated", session: updated };
+    });
+
+    await page.goto("/");
+
+    await page.locator('[data-tab-drag-handle="session-1"]').click({
+      button: "right",
+    });
+    await page.getByRole("menuitem", { name: "Regenerate Name" }).click();
+
+    await expect(page.locator('[data-tab-drag-handle="session-1"]')).toContainText(
+      "tab-title",
+    );
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __generateTitleCalls?: unknown[] })
+          .__generateTitleCalls,
+    )) as Array<{ id: string; force: boolean }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ id: "session-1", force: true });
+  });
+
+  test("regenerates a name for sessions backed by real git worktrees", async ({
+    page,
+    tauri,
+  }) => {
+    const fixture = createLinkedWorktreeFixture();
+    const alphaSession = {
+      id: "wt-alpha",
+      name: "alpha-session",
+      repo_path: fixture.repo,
+      worktree_path: fixture.alpha,
+      branch: "feature/alpha",
+      isolated: true,
+      project_scoped: true,
+      status: "idle",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      last_message: null,
+      title_source: "manual",
+      kind: "regular",
+      owner: { kind: "user" },
+      position: 0,
+      in_worktree: true,
+      agent_provider: "codex",
+      agent_transcript_id: "codex-alpha",
+    };
+    try {
+      await tauri.respond("list_projects", [
+        {
+          repo_path: fixture.repo,
+          name: "repo",
+          created_at: "2026-01-01T00:00:00Z",
+          position: 0,
+        },
+      ]);
+      await tauri.respond("list_sessions", [
+        alphaSession,
+        {
+          id: "wt-beta",
+          name: "beta-session",
+          repo_path: fixture.repo,
+          worktree_path: fixture.beta,
+          branch: "feature/beta",
+          isolated: true,
+          project_scoped: true,
+          status: "idle",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          title_source: "manual",
+          kind: "regular",
+          owner: { kind: "user" },
+          position: 1,
+          in_worktree: true,
+          agent_provider: "codex",
+          agent_transcript_id: "codex-beta",
+        },
+      ]);
+      await tauri.respond("generate_session_title", {
+        status: "generated",
+        session: {
+          ...alphaSession,
+          name: "linked-worktree-title",
+          title_source: "generated",
+          generated_title_transcript_id: "codex-alpha",
+        },
+      });
+
+      await page.goto("/");
+
+      await expect(
+        page.locator("aside").getByRole("button", { name: /alpha-session/ }),
+      ).toBeVisible();
+      await expect(
+        page.locator("aside").getByRole("button", { name: /beta-session/ }),
+      ).toBeVisible();
+
+      await page
+        .locator("aside")
+        .getByRole("button", { name: /alpha-session/ })
+        .click({ button: "right" });
+      await page.getByRole("menuitem", { name: "Regenerate Name" }).click();
+
+      await expect(
+        page
+          .locator("aside")
+          .getByRole("button", { name: /linked-worktree-title/ }),
+      ).toBeVisible();
+      await expect(page.locator('[data-tab-drag-handle="wt-alpha"]')).toContainText(
+        "linked-worktree-title",
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   test("Korean mode localizes project chrome and empty state", async ({
     page,
   }) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,8 @@ import { consoleForwardPlugin } from "vite-console-forward-plugin";
 const host = process.env.TAURI_DEV_HOST;
 // @ts-expect-error process is a nodejs global
 const projectRoot: string = process.cwd();
+// @ts-expect-error process is a nodejs global
+const port = Number(process.env.PLAYWRIGHT_PORT ?? 1420);
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
@@ -29,7 +31,7 @@ export default defineConfig(async () => ({
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
-    port: 1420,
+    port,
     strictPort: true,
     host: host || false,
     hmr: host


### PR DESCRIPTION
## Summary
Adds user-triggered session title regeneration from transcript context.

1. **Context menu regeneration** — adds `Regenerate Name` to Projects session rows, local session rows, and session tabs, then routes the action through the existing store/API/backend title-generation path with an explicit force flag.
2. **Transcript-context titles** — replaces first-prompt-only title input with bounded transcript context for Codex, Claude, Antigravity, and chat sessions so regenerated names can reflect the full conversation.
3. **Coverage and worktree validation** — adds unit/store coverage plus Playwright coverage for sidebar and tab context menus, including a fixture that creates real linked git worktrees before exercising the action.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Session/tab naming | Generated or manual names could not be regenerated directly from the UI | User-owned regular sessions can regenerate their name from session row or tab context menus |
| Title quality | Session titles were based on the first user prompt only | Title generation receives bounded transcript context from the conversation head and tail |
| E2E stability across worktrees | Playwright could reuse a stale Vite server on the default port | Playwright/Vite can target a selected `PLAYWRIGHT_PORT` for isolated worktree runs |

## Design notes
- Forced generation bypasses the title-source/transcript-id skip policy only for regular user-owned sessions. It still requires resolvable transcript input and rechecks session eligibility before storing the generated name.
- Transcript context is read from JSONL line-by-line and capped to avoid loading unbounded prompt text. The context keeps the beginning and the latest tail with an omission marker when needed.
- Existing automatic title generation keeps its conservative skip behavior; the new force path is only used by explicit context-menu regeneration.

## Test plan
- [x] `rustfmt --edition 2021 --check src-tauri/src/agent_history.rs src-tauri/src/session_titles.rs src-tauri/src/commands.rs` passes
- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm exec vitest run src/lib/settings.test.ts src/lib/sessionTitle.test.ts src/store.test.ts` passes — 146 passed, 1 skipped
- [x] `cargo test --manifest-path src-tauri/Cargo.toml session_titles -- --nocapture` passes — 10 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml transcript_title_context -- --nocapture` passes — 2 passed
- [x] `PLAYWRIGHT_PORT=1421 pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "regenerate|real git worktrees"` passes — 3 passed, including real linked git worktree fixture coverage
- [x] `pnpm run build` passes
- [x] `git diff --check` / `git diff --cached --check` pass

## Notes
- `pnpm run build` still emits the existing Vite dynamic/static import and chunk-size warnings, but exits successfully.