### PR TITLE
feat(sidebar): hide sessions from Projects

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -3,6 +3,7 @@ import {
   CircleX,
   Columns2,
   Copy,
+  EyeOff,
   Files,
   FolderOpen,
   FolderPlus,
@@ -44,6 +45,10 @@ import {
   openInConfiguredEditor,
 } from "../lib/editor";
 import { formatHotkey, type HotkeyId } from "../lib/hotkeys";
+import {
+  hideProjectSession,
+  showProjectSession,
+} from "../lib/hiddenProjectSessions";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import { useSettings } from "../lib/settings";
 import { canRenameSession } from "../lib/sessionTitle";
@@ -1010,6 +1015,16 @@ function TabItem({
     window.addEventListener("blur", onWindowBlur);
   }
 
+  function hideFromProjects(): void {
+    if (!session) return;
+    hideProjectSession(session.id);
+    showToast(t("sidebar.toasts.hiddenFromProjects"), {
+      action: () => {
+        showProjectSession(session.id);
+      },
+    });
+  }
+
   const forkItems: ContextMenuItem[] = (() => {
     if (!agent || !onFork) return [];
     const items: ContextMenuItem[] = [];
@@ -1083,6 +1098,15 @@ function TabItem({
       onClick: () => onDuplicate?.(),
       disabled: !onDuplicate,
     },
+    ...(session
+      ? [
+          {
+            label: t("sidebar.actions.hideSessionFromProjects"),
+            icon: <EyeOff size={12} />,
+            onClick: hideFromProjects,
+          },
+        ]
+      : []),
     { type: "separator" },
     ...forkItems,
     {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,6 +4,8 @@ import {
   CircleX,
   Columns2,
   Copy,
+  Eye,
+  EyeOff,
   Files,
   FolderOpen,
   FolderPlus,
@@ -50,6 +52,13 @@ import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { formatHotkey, type HotkeyId } from "../lib/hotkeys";
+import {
+  hideProjectSession,
+  loadHiddenProjectSessionIds,
+  showProjectSession,
+  showProjectSessions,
+  subscribeHiddenProjectSessions,
+} from "../lib/hiddenProjectSessions";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import {
   useSettings,
@@ -160,7 +169,15 @@ export function Sidebar() {
   const createNewProject = useAppStore((s) => s.createNewProject);
   const reorderProjects = useAppStore((s) => s.reorderProjects);
   const reorderSessions = useAppStore((s) => s.reorderSessions);
-  const [collapsed, setCollapsed] = useState<Set<string>>(() => loadCollapsed());
+  const [collapsed, setCollapsed] = useState<Set<string>>(() =>
+    loadStringSet(COLLAPSED_KEY),
+  );
+  const [hiddenSessionIds, setHiddenSessionIds] = useState<Set<string>>(() =>
+    loadHiddenProjectSessionIds(),
+  );
+  const [expandedHiddenProjects, setExpandedHiddenProjects] = useState<
+    Set<string>
+  >(new Set());
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
   const [settingsProject, setSettingsProject] = useState<ProjectGroup | null>(
@@ -168,12 +185,24 @@ export function Sidebar() {
   );
 
   useEffect(() => {
-    saveCollapsed(collapsed);
+    saveStringSet(COLLAPSED_KEY, collapsed);
   }, [collapsed]);
 
-  const projectGroups = useMemo(
+  useEffect(
+    () =>
+      subscribeHiddenProjectSessions(() =>
+        setHiddenSessionIds(loadHiddenProjectSessionIds()),
+      ),
+    [],
+  );
+
+  const allProjectGroups = useMemo(
     () => buildProjectGroups(projects, sessions),
     [projects, sessions],
+  );
+  const projectGroups = useMemo(
+    () => buildProjectGroups(projects, sessions, hiddenSessionIds),
+    [hiddenSessionIds, projects, sessions],
   );
   const localSessions = useMemo(
     () => buildLocalSessions(sessions),
@@ -204,6 +233,40 @@ export function Sidebar() {
       if (prev.has(repoPath)) return prev;
       const next = new Set(prev);
       next.add(repoPath);
+      return next;
+    });
+  }
+
+  function hideSessionInProjects(session: Session) {
+    setHiddenSessionIds(hideProjectSession(session.id));
+    showToast(sidebarText(t, "sidebar.toasts.hiddenFromProjects"), {
+      action: () => showSessionInProjects(session.id),
+    });
+  }
+
+  function showSessionInProjects(sessionId: string) {
+    setHiddenSessionIds(showProjectSession(sessionId));
+  }
+
+  function showHiddenSessionsInProject(repoPath: string) {
+    const project = allProjectGroups.find(
+      (group) => group.repoPath === repoPath,
+    );
+    const hiddenIds = project?.sessions
+      .filter((session) => hiddenSessionIds.has(session.id))
+      .map((session) => session.id);
+    if (!hiddenIds || hiddenIds.length === 0) return;
+    setHiddenSessionIds(showProjectSessions(hiddenIds));
+  }
+
+  function toggleHiddenSessions(repoPath: string) {
+    setExpandedHiddenProjects((prev) => {
+      const next = new Set(prev);
+      if (next.has(repoPath)) {
+        next.delete(repoPath);
+      } else {
+        next.add(repoPath);
+      }
       return next;
     });
   }
@@ -519,59 +582,79 @@ export function Sidebar() {
               strategy={verticalListSortingStrategy}
             >
               <ul className="flex flex-col divide-y divide-border/40 [&>li]:py-1.5 [&>li:first-child]:pt-0.5 [&>li:last-child]:pb-0.5">
-                {projectGroups.map((project) => (
-                  <ProjectGroupView
-                    key={project.repoPath}
-                    project={project}
-                    collapsed={collapsed.has(project.repoPath)}
-                    activeSessionId={activeSessionId}
-                    isActiveProject={activeProject === project.repoPath}
-                    onTitleClick={() =>
-                      applyClickPlan(
-                        planTitleClick({
-                          wasActive: activeProject === project.repoPath,
-                          wasCollapsed: collapsed.has(project.repoPath),
-                        }),
-                        project,
-                      )
-                    }
-                    onChevronClick={() =>
-                      applyClickPlan(
-                        planChevronClick({
-                          wasActive: activeProject === project.repoPath,
-                          wasCollapsed: collapsed.has(project.repoPath),
-                        }),
-                        project,
-                      )
-                    }
-                    onActivate={() => {
-                      setActiveProject(project.repoPath);
-                      expandProject(project.repoPath);
-                      const target = pickSessionToActivate(
-                        project.sessions,
-                        activeSessionId,
-                      );
-                      if (target) selectSession(target);
-                    }}
-                    onSelectSession={selectSession}
-                    onRemoveSession={(s) => requestRemoveSession(s.id)}
-                    onAddSession={(isolated, kind, mode = "terminal") =>
-                      onNewSession(
-                        isolated,
-                        kind,
-                        {
-                          repoPath: project.repoPath,
-                          projectScoped: true,
-                        },
-                        mode,
-                      )
-                    }
-                    onRemoveProject={() =>
-                      requestRemoveProject(project.repoPath)
-                    }
-                    onOpenSettings={() => setSettingsProject(project)}
-                  />
-                ))}
+                {projectGroups.map((project) => {
+                  const hiddenSessions =
+                    allProjectGroups
+                      .find((group) => group.repoPath === project.repoPath)
+                      ?.sessions.filter((session) =>
+                        hiddenSessionIds.has(session.id),
+                      ) ?? [];
+                  return (
+                    <ProjectGroupView
+                      key={project.repoPath}
+                      project={project}
+                      collapsed={collapsed.has(project.repoPath)}
+                      hiddenSessions={hiddenSessions}
+                      hiddenExpanded={expandedHiddenProjects.has(
+                        project.repoPath,
+                      )}
+                      activeSessionId={activeSessionId}
+                      isActiveProject={activeProject === project.repoPath}
+                      onTitleClick={() =>
+                        applyClickPlan(
+                          planTitleClick({
+                            wasActive: activeProject === project.repoPath,
+                            wasCollapsed: collapsed.has(project.repoPath),
+                          }),
+                          project,
+                        )
+                      }
+                      onChevronClick={() =>
+                        applyClickPlan(
+                          planChevronClick({
+                            wasActive: activeProject === project.repoPath,
+                            wasCollapsed: collapsed.has(project.repoPath),
+                          }),
+                          project,
+                        )
+                      }
+                      onActivate={() => {
+                        setActiveProject(project.repoPath);
+                        expandProject(project.repoPath);
+                        const target = pickSessionToActivate(
+                          project.sessions,
+                          activeSessionId,
+                        );
+                        if (target) selectSession(target);
+                      }}
+                      onSelectSession={selectSession}
+                      onRemoveSession={(s) => requestRemoveSession(s.id)}
+                      onAddSession={(isolated, kind, mode = "terminal") =>
+                        onNewSession(
+                          isolated,
+                          kind,
+                          {
+                            repoPath: project.repoPath,
+                            projectScoped: true,
+                          },
+                          mode,
+                        )
+                      }
+                      onRemoveProject={() =>
+                        requestRemoveProject(project.repoPath)
+                      }
+                      onOpenSettings={() => setSettingsProject(project)}
+                      onHideSession={hideSessionInProjects}
+                      onShowSession={showSessionInProjects}
+                      onShowHiddenSessions={() =>
+                        showHiddenSessionsInProject(project.repoPath)
+                      }
+                      onToggleHiddenSessions={() =>
+                        toggleHiddenSessions(project.repoPath)
+                      }
+                    />
+                  );
+                })}
               </ul>
             </SortableContext>
           )}
@@ -773,6 +856,8 @@ const PROJECT_SESSION_OVERFLOW_CREATE_MENU = PROJECT_SESSION_CREATE_MENU.filter(
 interface ProjectGroupViewProps {
   project: ProjectGroup;
   collapsed: boolean;
+  hiddenSessions: Session[];
+  hiddenExpanded: boolean;
   activeSessionId: string | null;
   isActiveProject: boolean;
   /** Title click: activate (preserve collapse if inactive); ensure expanded if already active. */
@@ -790,11 +875,17 @@ interface ProjectGroupViewProps {
   ) => void;
   onRemoveProject: () => void;
   onOpenSettings: () => void;
+  onHideSession: (session: Session) => void;
+  onShowSession: (sessionId: string) => void;
+  onShowHiddenSessions: () => void;
+  onToggleHiddenSessions: () => void;
 }
 
 function ProjectGroupView({
   project,
   collapsed,
+  hiddenSessions,
+  hiddenExpanded,
   activeSessionId,
   isActiveProject,
   onTitleClick,
@@ -805,6 +896,10 @@ function ProjectGroupView({
   onAddSession,
   onRemoveProject,
   onOpenSettings,
+  onHideSession,
+  onShowSession,
+  onShowHiddenSessions,
+  onToggleHiddenSessions,
 }: ProjectGroupViewProps) {
   const t = useTranslation();
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
@@ -1007,6 +1102,16 @@ function ProjectGroupView({
         items={[
           ...createMenuItems,
           { type: "separator" },
+          ...(hiddenSessions.length > 0
+            ? [
+                {
+                  label: sidebarText(t, "sidebar.actions.showHiddenSessions"),
+                  icon: <Eye size={12} />,
+                  onClick: onShowHiddenSessions,
+                },
+                { type: "separator" as const },
+              ]
+            : []),
           {
             label: sidebarText(t, "sidebar.actions.projectSettings"),
             icon: <SettingsIcon size={12} />,
@@ -1040,7 +1145,7 @@ function ProjectGroupView({
           strategy={verticalListSortingStrategy}
         >
           <ul className="ml-3 flex flex-col gap-0.5 border-l border-border pl-1 pt-0.5">
-            {project.sessions.length === 0 ? (
+            {project.sessions.length === 0 && hiddenSessions.length === 0 ? (
               <li
                 role="button"
                 tabIndex={0}
@@ -1065,12 +1170,209 @@ function ProjectGroupView({
                   active={session.id === activeSessionId}
                   onSelect={() => onSelectSession(session.id)}
                   onRemove={() => onRemoveSession(session)}
+                  onHide={() => onHideSession(session)}
                 />
               ))
             )}
+            {hiddenSessions.length > 0 ? (
+              <HiddenSessionsSection
+                sessions={hiddenSessions}
+                expanded={hiddenExpanded}
+                activeSessionId={activeSessionId}
+                onToggle={onToggleHiddenSessions}
+                onSelectSession={onSelectSession}
+                onShowSession={onShowSession}
+                onRemoveSession={onRemoveSession}
+                t={t}
+              />
+            ) : null}
           </ul>
         </SortableContext>
       ) : null}
+    </li>
+  );
+}
+
+function hiddenSessionsLabel(t: Translator, count: number): string {
+  return `${sidebarText(t, "sidebar.hiddenSessions.title")} ${count}${sidebarText(
+    t,
+    "sidebar.hiddenSessions.countSuffix",
+  )}`;
+}
+
+function HiddenSessionsSection({
+  sessions,
+  expanded,
+  activeSessionId,
+  onToggle,
+  onSelectSession,
+  onShowSession,
+  onRemoveSession,
+  t,
+}: {
+  sessions: Session[];
+  expanded: boolean;
+  activeSessionId: string | null;
+  onToggle: () => void;
+  onSelectSession: (id: string) => void;
+  onShowSession: (sessionId: string) => void;
+  onRemoveSession: (session: Session) => void;
+  t: Translator;
+}) {
+  const label = hiddenSessionsLabel(t, sessions.length);
+
+  return (
+    <>
+      <li>
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-label={label}
+          aria-expanded={expanded}
+          className="group mt-0.5 flex min-h-7 w-full items-center gap-1 rounded-md px-2 py-1 text-left text-[11px] text-fg-muted transition hover:bg-bg-elevated/40 hover:text-fg"
+        >
+          <ChevronRight
+            size={12}
+            className={cn(
+              "shrink-0 transition-transform",
+              expanded && "rotate-90",
+            )}
+          />
+          <span className="min-w-0 flex-1 truncate">
+            {sidebarText(t, "sidebar.hiddenSessions.title")}
+          </span>
+          <span className="flex h-4 min-w-4 shrink-0 items-center justify-center rounded bg-bg-elevated/70 px-1 text-[10px] leading-none text-fg-muted">
+            {sessions.length}
+          </span>
+        </button>
+      </li>
+      {expanded
+        ? sessions.map((session) => (
+            <HiddenSessionRow
+              key={session.id}
+              session={session}
+              active={session.id === activeSessionId}
+              onSelect={() => onSelectSession(session.id)}
+              onShow={() => onShowSession(session.id)}
+              onRemove={() => onRemoveSession(session)}
+              t={t}
+            />
+          ))
+        : null}
+    </>
+  );
+}
+
+function HiddenSessionRow({
+  session,
+  active,
+  onSelect,
+  onShow,
+  onRemove,
+  t,
+}: {
+  session: Session;
+  active: boolean;
+  onSelect: () => void;
+  onShow: () => void;
+  onRemove: () => void;
+  t: Translator;
+}) {
+  const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
+  const titleText = resolveSessionTitle(session, sessionDisplay.title);
+  const metadataText = composeSessionMetadata(
+    t,
+    session,
+    sessionDisplay.metadata,
+  );
+  const isGeneratingTitle = useAppStore((s) =>
+    Boolean(s.generatingSessionTitleIds[session.id]),
+  );
+  const agentProvider = sessionDisplay.icons.agentProvider
+    ? resolveSessionAgentProvider(session)
+    : null;
+
+  const row = (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      className={cn(
+        "group flex w-full items-start gap-1.5 rounded-md px-2 py-1 text-left opacity-70 transition hover:bg-bg-elevated/40 hover:opacity-100",
+        active && "bg-bg-elevated/70 opacity-100",
+      )}
+    >
+      {sessionDisplay.icons.statusDot || isGeneratingTitle ? (
+        <SessionStatusMarker
+          session={session}
+          agentProvider={agentProvider}
+          isGeneratingTitle={isGeneratingTitle}
+          generatingLabel={sidebarText(t, "sidebar.aria.generatingSessionTitle")}
+          chatLabel={sidebarText(t, "sidebar.aria.chatSession")}
+        />
+      ) : null}
+      <SessionRowLabel
+        editing={false}
+        session={session}
+        titleText={titleText}
+        metadataText={metadataText}
+        showKindIcons={sessionDisplay.icons.sessionKind}
+        t={t}
+        onSubmitRename={() => undefined}
+        onCancelRename={() => undefined}
+      />
+      <div className="ml-auto flex shrink-0 items-center gap-0.5">
+        <Tooltip label={sidebarText(t, "sidebar.actions.showSessionInProjects")}>
+          <button
+            type="button"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onShow();
+            }}
+            className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+            aria-label={sidebarText(t, "sidebar.actions.showSessionInProjects")}
+          >
+            <Eye size={12} />
+          </button>
+        </Tooltip>
+        <button
+          type="button"
+          aria-label={sidebarText(t, "sidebar.actions.removeSession")}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          onKeyDown={(e) => e.stopPropagation()}
+          className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger"
+        >
+          <Trash2 size={12} />
+        </button>
+      </div>
+    </div>
+  );
+
+  return (
+    <li>
+      {sessionDisplay.showDetailsOnHover ? (
+        <Tooltip
+          label={buildSessionHoverDetails(t, session)}
+          side="right"
+          multiline
+          className="w-full"
+        >
+          {row}
+        </Tooltip>
+      ) : (
+        row
+      )}
     </li>
   );
 }
@@ -1081,6 +1383,7 @@ interface SessionRowProps {
   active: boolean;
   onSelect: () => void;
   onRemove: () => void;
+  onHide: () => void;
 }
 
 function SessionRow({
@@ -1089,6 +1392,7 @@ function SessionRow({
   active,
   onSelect,
   onRemove,
+  onHide,
 }: SessionRowProps) {
   const t = useTranslation();
   const showToast = useToasts((s) => s.show);
@@ -1192,6 +1496,11 @@ function SessionRow({
       label: sidebarText(t, "sidebar.actions.duplicateSession"),
       icon: <Files size={12} />,
       onClick: () => void duplicate(),
+    },
+    {
+      label: sidebarText(t, "sidebar.actions.hideSessionFromProjects"),
+      icon: <EyeOff size={12} />,
+      onClick: onHide,
     },
     { type: "separator" },
     {
@@ -1336,26 +1645,39 @@ function SessionRow({
         }}
         onCancelRename={() => setEditing(false)}
       />
-      <span
-        role="button"
-        aria-label={sidebarText(t, "sidebar.actions.removeSession")}
-        tabIndex={0}
-        onPointerDown={(e) => e.stopPropagation()}
-        onClick={(e) => {
-          e.stopPropagation();
-          onRemove();
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
+      <div className="ml-auto flex shrink-0 items-center gap-0.5">
+        <Tooltip
+          label={sidebarText(t, "sidebar.actions.hideSessionFromProjects")}
+          side="right"
+        >
+          <button
+            type="button"
+            aria-label={sidebarText(t, "sidebar.actions.hideSessionFromProjects")}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onHide();
+            }}
+            onKeyDown={(e) => e.stopPropagation()}
+            className="invisible flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
+          >
+            <EyeOff size={12} />
+          </button>
+        </Tooltip>
+        <button
+          type="button"
+          aria-label={sidebarText(t, "sidebar.actions.removeSession")}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
             e.stopPropagation();
             onRemove();
-          }
-        }}
-        className="invisible rounded p-1 text-fg-muted transition hover:text-danger group-hover:visible"
-      >
-        <Trash2 size={12} />
-      </span>
+          }}
+          onKeyDown={(e) => e.stopPropagation()}
+          className="invisible flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger group-hover:visible"
+        >
+          <Trash2 size={12} />
+        </button>
+      </div>
     </div>
   );
 
@@ -1929,9 +2251,9 @@ function buildSessionHoverDetails(t: Translator, session: Session): string {
   return lines.join("\n");
 }
 
-function loadCollapsed(): Set<string> {
+function loadStringSet(key: string): Set<string> {
   try {
-    const raw = localStorage.getItem(COLLAPSED_KEY);
+    const raw = localStorage.getItem(key);
     if (!raw) return new Set();
     const parsed = JSON.parse(raw);
     if (Array.isArray(parsed)) {
@@ -1943,9 +2265,9 @@ function loadCollapsed(): Set<string> {
   return new Set();
 }
 
-function saveCollapsed(set: Set<string>): void {
+function saveStringSet(key: string, set: Set<string>): void {
   try {
-    localStorage.setItem(COLLAPSED_KEY, JSON.stringify(Array.from(set)));
+    localStorage.setItem(key, JSON.stringify(Array.from(set)));
   } catch {
     // ignore
   }

--- a/src/lib/hiddenProjectSessions.test.ts
+++ b/src/lib/hiddenProjectSessions.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HIDDEN_PROJECT_SESSIONS_STORAGE_KEY,
+  hideProjectSession,
+  loadHiddenProjectSessionIds,
+  showProjectSession,
+  showProjectSessions,
+  subscribeHiddenProjectSessions,
+} from "./hiddenProjectSessions";
+
+describe("hidden project sessions", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("loads only string ids from persisted storage", () => {
+    localStorage.setItem(
+      HIDDEN_PROJECT_SESSIONS_STORAGE_KEY,
+      JSON.stringify(["s-1", 2, null, "s-2"]),
+    );
+
+    expect(Array.from(loadHiddenProjectSessionIds()).sort()).toEqual([
+      "s-1",
+      "s-2",
+    ]);
+  });
+
+  it("hides and shows individual sessions", () => {
+    hideProjectSession("s-1");
+    hideProjectSession("s-2");
+    showProjectSession("s-1");
+
+    expect(Array.from(loadHiddenProjectSessionIds())).toEqual(["s-2"]);
+  });
+
+  it("shows a batch of sessions", () => {
+    hideProjectSession("s-1");
+    hideProjectSession("s-2");
+    hideProjectSession("s-3");
+    showProjectSessions(["s-1", "s-3"]);
+
+    expect(Array.from(loadHiddenProjectSessionIds())).toEqual(["s-2"]);
+  });
+
+  it("notifies same-window subscribers when ids change", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeHiddenProjectSessions(listener);
+
+    hideProjectSession("s-1");
+    showProjectSession("s-1");
+    unsubscribe();
+    hideProjectSession("s-2");
+
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/hiddenProjectSessions.ts
+++ b/src/lib/hiddenProjectSessions.ts
@@ -1,0 +1,103 @@
+export const HIDDEN_PROJECT_SESSIONS_STORAGE_KEY =
+  "acorn:sidebar:hidden-sessions";
+
+const HIDDEN_PROJECT_SESSIONS_CHANGED_EVENT =
+  "acorn:hidden-project-sessions-changed";
+
+export function loadHiddenProjectSessionIds(): Set<string> {
+  try {
+    if (typeof localStorage === "undefined") return new Set();
+    const raw = localStorage.getItem(HIDDEN_PROJECT_SESSIONS_STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return new Set(parsed.filter((x): x is string => typeof x === "string"));
+    }
+  } catch {
+    // ignore
+  }
+  return new Set();
+}
+
+export function hideProjectSession(sessionId: string): Set<string> {
+  return updateHiddenProjectSessionIds((prev) => {
+    if (prev.has(sessionId)) return prev;
+    const next = new Set(prev);
+    next.add(sessionId);
+    return next;
+  });
+}
+
+export function showProjectSession(sessionId: string): Set<string> {
+  return updateHiddenProjectSessionIds((prev) => {
+    if (!prev.has(sessionId)) return prev;
+    const next = new Set(prev);
+    next.delete(sessionId);
+    return next;
+  });
+}
+
+export function showProjectSessions(sessionIds: readonly string[]): Set<string> {
+  return updateHiddenProjectSessionIds((prev) => {
+    let changed = false;
+    const next = new Set(prev);
+    for (const id of sessionIds) {
+      if (next.delete(id)) changed = true;
+    }
+    return changed ? next : prev;
+  });
+}
+
+export function subscribeHiddenProjectSessions(
+  listener: () => void,
+): () => void {
+  if (typeof window === "undefined") return () => undefined;
+
+  const onChanged = () => listener();
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === HIDDEN_PROJECT_SESSIONS_STORAGE_KEY) listener();
+  };
+
+  window.addEventListener(HIDDEN_PROJECT_SESSIONS_CHANGED_EVENT, onChanged);
+  window.addEventListener("storage", onStorage);
+  return () => {
+    window.removeEventListener(HIDDEN_PROJECT_SESSIONS_CHANGED_EVENT, onChanged);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+function updateHiddenProjectSessionIds(
+  update: (prev: Set<string>) => Set<string>,
+): Set<string> {
+  const prev = loadHiddenProjectSessionIds();
+  const next = update(prev);
+  if (setsEqual(prev, next)) return prev;
+  saveHiddenProjectSessionIds(next);
+  notifyHiddenProjectSessionsChanged();
+  return next;
+}
+
+function saveHiddenProjectSessionIds(ids: Set<string>): void {
+  try {
+    if (typeof localStorage === "undefined") return;
+    localStorage.setItem(
+      HIDDEN_PROJECT_SESSIONS_STORAGE_KEY,
+      JSON.stringify(Array.from(ids)),
+    );
+  } catch {
+    // ignore
+  }
+}
+
+function notifyHiddenProjectSessionsChanged(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(HIDDEN_PROJECT_SESSIONS_CHANGED_EVENT));
+}
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const value of a) {
+    if (!b.has(value)) return false;
+  }
+  return true;
+}

--- a/src/lib/sessionGrouping.test.ts
+++ b/src/lib/sessionGrouping.test.ts
@@ -133,6 +133,34 @@ describe("buildProjectGroups", () => {
       "older-created",
     ]);
   });
+
+  it("omits hidden session rows without dropping their project group", () => {
+    const groups = buildProjectGroups(
+      [project("/repo/app", 0)],
+      [session("visible", "/repo/app"), session("hidden", "/repo/app")],
+      new Set(["hidden"]),
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].repoPath).toBe("/repo/app");
+    expect(groups[0].sessions.map((s) => s.id)).toEqual(["visible"]);
+  });
+
+  it("keeps a backfilled hidden-only group available for restoration", () => {
+    const groups = buildProjectGroups(
+      [],
+      [session("hidden", "/repo/missing")],
+      new Set(["hidden"]),
+    );
+
+    expect(groups).toEqual([
+      {
+        repoPath: "/repo/missing",
+        name: "missing",
+        sessions: [],
+      },
+    ]);
+  });
 });
 
 describe("buildLocalSessions", () => {

--- a/src/lib/sessionGrouping.ts
+++ b/src/lib/sessionGrouping.ts
@@ -9,6 +9,7 @@ export interface ProjectGroup {
 export function buildProjectGroups(
   projects: Project[],
   sessions: Session[],
+  hiddenSessionIds: ReadonlySet<string> = new Set(),
 ): ProjectGroup[] {
   const map = new Map<string, ProjectGroup>();
   const projectSessions = sessions.filter(isProjectSession);
@@ -48,6 +49,7 @@ export function buildProjectGroups(
       };
       map.set(session.repo_path, group);
     }
+    if (hiddenSessionIds.has(session.id)) continue;
     group.sessions.push(session);
   }
   for (const group of map.values()) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -763,6 +763,9 @@
       "copyPath": "Copy path",
       "rename": "Rename",
       "duplicateSession": "Duplicate Session",
+      "hideSessionFromProjects": "Hide from Projects",
+      "showSessionInProjects": "Show in Projects",
+      "showHiddenSessions": "Show all hidden sessions",
       "equalizePaneSizes": "Equalize Pane Sizes",
       "openWorktreeInEditor": "Open Worktree in Editor",
       "copyWorktreePath": "Copy Worktree Path",
@@ -793,6 +796,13 @@
       "title": "Instant sessions",
       "newSession": "New instant session",
       "empty": "Double-click to start an instant session."
+    },
+    "hiddenSessions": {
+      "title": "Hidden sessions",
+      "countSuffix": ""
+    },
+    "toasts": {
+      "hiddenFromProjects": "Hidden from Projects. Click to undo."
     },
     "emptyProject": {
       "createSession": "Double-click to start a session."

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -763,6 +763,9 @@
       "copyPath": "경로 복사",
       "rename": "이름 변경",
       "duplicateSession": "세션 복제",
+      "hideSessionFromProjects": "Projects에서 숨기기",
+      "showSessionInProjects": "Projects에 다시 표시",
+      "showHiddenSessions": "숨긴 세션 모두 다시 표시",
       "equalizePaneSizes": "Pane 크기 균등화",
       "openWorktreeInEditor": "편집기에서 worktree 열기",
       "copyWorktreePath": "Worktree 경로 복사",
@@ -793,6 +796,13 @@
       "title": "인스턴트 세션",
       "newSession": "새 인스턴트 세션",
       "empty": "더블클릭하면 인스턴트 세션을 시작할 수 있습니다."
+    },
+    "hiddenSessions": {
+      "title": "숨긴 세션",
+      "countSuffix": "개"
+    },
+    "toasts": {
+      "hiddenFromProjects": "Projects에서 숨겼습니다. 클릭하면 되돌립니다."
     },
     "emptyProject": {
       "createSession": "더블클릭하면 세션을 시작할 수 있습니다."

--- a/src/store.ts
+++ b/src/store.ts
@@ -46,6 +46,7 @@ import {
   applySessionCreateRequest,
   buildSessionCreateRequest,
 } from "./lib/sessionCreation";
+import { showProjectSession } from "./lib/hiddenProjectSessions";
 
 export type { RightGroup, RightTab };
 
@@ -1564,6 +1565,7 @@ export const useAppStore = create<AppStateModel>()(
 
     try {
       await api.removeSession(id, removeWorktree);
+      showProjectSession(id);
       await get().refreshAll();
       set({ error: null });
     } catch (e) {

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -51,6 +51,320 @@ test.describe("sidebar: project lifecycle", () => {
     ).toBeVisible();
   });
 
+  test("project session rows can be hidden from Projects and restored inline", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "work-session",
+        name: "work",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "default",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+      {
+        id: "dev-server-session",
+        name: "npm run dev",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "running",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 1,
+        in_worktree: false,
+      },
+    ]);
+
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-panel-id="sidebar"]');
+    const workRow = sidebar
+      .getByRole("button", { name: /^work main · Idle/ })
+      .first();
+    const devRow = sidebar
+      .getByRole("button", { name: /^npm run dev main · Running/ })
+      .first();
+
+    await expect(workRow).toBeVisible();
+    await expect(devRow).toBeVisible();
+
+    await devRow.hover();
+    await sidebar
+      .getByRole("button", { name: "Hide from Projects", exact: true })
+      .click();
+
+    await expect(workRow).toBeVisible();
+    await expect(devRow).toHaveCount(0);
+    const hiddenToggle = sidebar.getByRole("button", {
+      name: "Hidden sessions 1",
+    });
+    await expect(hiddenToggle).toBeVisible();
+
+    await page.reload();
+
+    await expect(workRow).toBeVisible();
+    await expect(devRow).toHaveCount(0);
+    await expect(hiddenToggle).toBeVisible();
+    await hiddenToggle.click();
+    await expect(devRow).toBeVisible();
+
+    await sidebar
+      .getByRole("button", { name: "Show in Projects", exact: true })
+      .click();
+
+    await expect(devRow).toBeVisible();
+    await expect(hiddenToggle).toHaveCount(0);
+    const hiddenIds = await page.evaluate(() =>
+      JSON.parse(
+        window.localStorage.getItem("acorn:sidebar:hidden-sessions") ?? "[]",
+      ),
+    );
+    expect(hiddenIds).toEqual([]);
+  });
+
+  test("restored project sessions honor persisted hidden Projects state on boot", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:sidebar:hidden-sessions",
+        JSON.stringify(["dev-server-session"]),
+      );
+    });
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "work-session",
+        name: "work",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "default",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+      {
+        id: "dev-server-session",
+        name: "npm run dev",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "running",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 1,
+        in_worktree: false,
+      },
+    ]);
+
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-panel-id="sidebar"]');
+    await expect(
+      sidebar.getByRole("button", { name: /^work main · Idle/ }).first(),
+    ).toBeVisible();
+    await expect(
+      sidebar
+        .getByRole("button", { name: /^npm run dev main · Running/ })
+        .first(),
+    ).toHaveCount(0);
+    await expect(
+      sidebar.getByRole("button", { name: "Hidden sessions 1" }),
+    ).toBeVisible();
+  });
+
+  test("hidden project sessions can be removed from the hidden section", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:sidebar:hidden-sessions",
+        JSON.stringify(["dev-server-session"]),
+      );
+    });
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __sessionRemoved?: boolean };
+      return w.__sessionRemoved
+        ? []
+        : [
+            {
+              id: "dev-server-session",
+              name: "npm run dev",
+              repo_path: "/tmp/demo",
+              worktree_path: "/tmp/demo",
+              branch: "main",
+              isolated: false,
+              status: "running",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:00Z",
+              last_message: null,
+              title_source: "manual",
+              kind: "regular",
+              owner: { kind: "user" },
+              position: 0,
+              in_worktree: false,
+            },
+          ];
+    });
+    await tauri.handle("remove_session", (args) => {
+      const w = window as unknown as {
+        __removeCalls?: unknown[];
+        __sessionRemoved?: boolean;
+      };
+      w.__removeCalls = w.__removeCalls ?? [];
+      w.__removeCalls.push(args);
+      w.__sessionRemoved = true;
+      return null;
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-panel-id="sidebar"]');
+    const hiddenToggle = sidebar.getByRole("button", {
+      name: "Hidden sessions 1",
+    });
+    await hiddenToggle.click();
+
+    await sidebar
+      .getByRole("button", { name: "Remove session", exact: true })
+      .click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(
+      dialog.getByRole("heading", { name: "Remove session" }),
+    ).toBeVisible();
+    await dialog.getByRole("button", { name: /^Remove$/ }).click();
+
+    await expect(hiddenToggle).toHaveCount(0);
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __removeCalls?: unknown[] }).__removeCalls,
+    )) as Array<{ id: string; removeWorktree: boolean }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      id: "dev-server-session",
+      removeWorktree: false,
+    });
+    const hiddenIds = await page.evaluate(() =>
+      JSON.parse(
+        window.localStorage.getItem("acorn:sidebar:hidden-sessions") ?? "[]",
+      ),
+    );
+    expect(hiddenIds).toEqual([]);
+  });
+
+  test("session tab context menu can hide a session from Projects", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "dev-server-session",
+        name: "npm run dev",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "running",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+    ]);
+
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-panel-id="sidebar"]');
+    const devRow = sidebar
+      .getByRole("button", { name: /^npm run dev main · Running/ })
+      .first();
+
+    await devRow.click();
+    await expect(
+      page.locator('[data-tab-drag-handle="dev-server-session"]'),
+    ).toBeVisible();
+
+    await page
+      .locator('[data-tab-drag-handle="dev-server-session"]')
+      .click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Hide from Projects" }).click();
+
+    await expect(devRow).toHaveCount(0);
+    await expect(
+      sidebar.getByRole("button", { name: "Hidden sessions 1" }),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-tab-drag-handle="dev-server-session"]'),
+    ).toBeVisible();
+  });
+
   test("project header exposes regular and isolated session buttons outside the menu", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Adds a Projects-specific hide flow for sessions that should stay available without cluttering the sidebar.

1. **Hidden session state** — persist hidden project-session ids in `localStorage`, keep Sidebar and tab-menu actions synchronized through a small shared utility, and omit hidden sessions from normal project rows without dropping their project group.
2. **Projects sidebar UX** — add `Hide from Projects` controls on visible session rows and context menus, add an inline collapsed `Hidden sessions` section per project, and support restore or remove from expanded hidden rows.
3. **Pane tab integration** — expose `Hide from Projects` from session tab context menus while keeping the tab itself open, preserving the distinction between hiding from Projects and closing/removing a session.
4. **Persistence and cleanup** — honor persisted hidden ids on app boot/session restore and clear stale hidden ids after successful session removal.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Projects sidebar noise | Long-running sessions like dev servers always appeared in project session lists | Users can hide them from Projects while keeping sessions open |
| Hidden session recovery | No hidden state or restore surface | Per-project `Hidden sessions` section supports restore and removal |
| Restart behavior | Not applicable | Hidden state survives app reload/restart when restored session ids match |

## Design notes
- Hidden state is scoped to the Projects surface, not the live tab strip. A hidden session remains open in the pane tab strip so `Hide from Projects` does not look like close/delete.
- The hidden-session storage helper lives in `src/lib/hiddenProjectSessions.ts` so Sidebar and Pane tab menus share one contract and same-window updates are explicit via an `acorn:` event.
- `buildProjectGroups` still backfills hidden-only groups so a project with only hidden sessions can render the restore/delete affordance instead of disappearing.
- Successful `removeSession` now removes the session id from hidden-session storage to avoid stale hidden ids.

## Follow-up (not in this PR)
- Monorepo-oriented named project folders/workspace profiles so the same repo can have multiple named layouts and visibility presets.
- Consider making the hide toast copy more explicit that the tab remains open.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `./node_modules/.bin/vitest run src/lib/hiddenProjectSessions.test.ts src/lib/sessionGrouping.test.ts src/components/Pane.test.tsx src/store.test.ts` — 117 passed, 1 skipped
- [x] `./node_modules/.bin/playwright test tests/e2e/sidebar.spec.ts` — 20 passed
- [x] `git diff --check` passes

## Notes
- The dev app launched for local verification was stopped before PR work.