### PR TITLE
fix(daemon): kill daemon session PTY and stream pump on removal

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2619,6 +2619,23 @@ pub fn reorder_sessions(
         .collect())
 }
 
+/// Best-effort terminate a session's PTY regardless of where it is hosted.
+///
+/// In-process PTYs live in `state.pty`; daemon-managed sessions live behind
+/// `stream_registry` + `daemon_bridge`. The session/project removal paths must
+/// route the kill the same way [`pty_kill`] does — otherwise removing a
+/// daemon-backed session is a no-op against `state.pty`, leaving its child
+/// process and stream pump thread running and leaking its `stream_registry`
+/// entry.
+fn terminate_session_pty(state: &AppState, id: &Uuid) {
+    if state.stream_registry.contains(id) {
+        state.daemon_bridge.kill(*id).ok();
+        state.stream_registry.drop_attachment(id);
+    } else {
+        state.pty.kill(id).ok();
+    }
+}
+
 #[tauri::command]
 pub async fn remove_project(
     state: State<'_, AppState>,
@@ -2638,7 +2655,7 @@ pub async fn remove_project(
             .filter(|s| s.repo_path == path)
             .collect();
         for session in session_ids {
-            state.pty.kill(&session.id).ok();
+            terminate_session_pty(state.inner(), &session.id);
             if drop_worktrees {
                 remove_linked_worktree_at_path(&session.repo_path, &session.worktree_path).ok();
             }
@@ -2665,7 +2682,7 @@ pub async fn remove_session(
 ) -> AppResult<()> {
     let id = Uuid::parse_str(&id).map_err(|e| AppError::Other(e.to_string()))?;
     let session = state.sessions.get(&id)?;
-    state.pty.kill(&id).ok();
+    terminate_session_pty(state.inner(), &id);
     if let Ok(dir) = persistence::data_dir() {
         scrollback::delete(&dir, &id.to_string()).ok();
     }


### PR DESCRIPTION
## Summary

Removing a daemon-managed session left an orphaned daemon child process, a running `acorn-daemon-stream-*` pump thread, and a leaked `stream_registry` entry behind. These accumulate one-per-removed-session over the app's lifetime and are a likely contributor to the "Acorn gets slow over time" reports.

## Root cause

`remove_session` and `remove_project` terminated sessions with only `state.pty.kill(&id)`. That call targets the **in-process** PTY manager. Daemon-managed sessions are not held there — they live behind `stream_registry` + `daemon_bridge` — so the kill silently no-ops (the `Err` is swallowed by `.ok()`). As a result:

- the daemon child process is never told to exit and keeps running;
- the stream pump thread keeps draining the daemon socket forever, because its `stop` flag is only set by `drop_attachment`, which was never called;
- the `stream_registry` entry is retained.

The correct routing already exists in `pty_kill` (kill via `daemon_bridge`, then `drop_attachment`); the removal paths simply never adopted it.

## Fix

Introduce a shared `terminate_session_pty` helper that mirrors `pty_kill`, and route both `remove_session` and the `remove_project` cascade through it:

- daemon session (present in `stream_registry`) → `daemon_bridge.kill` + `drop_attachment` (stops the pump thread, frees the registry entry);
- otherwise → in-process `state.pty.kill`.

Best-effort by design: a kill failure must not block session/project deletion.

## Test plan

- [x] `cargo check -p acorn` passes
- [ ] Create a background (daemon) session, remove it, confirm via Activity Monitor / `ps` that the daemon child process exits and no `acorn-daemon-stream-*` thread lingers
- [ ] Remove a project that cascades several daemon sessions; confirm all child processes and pump threads are released
- [ ] Regression: removing a normal in-process session still tears its PTY down as before
