### PR TITLE
fix(session): hide internal title-generation prompts from History

### DIFF
--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -293,6 +293,9 @@ fn parse_file_budget(limit: usize) -> usize {
 
 fn parse_codex_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistoryItem> {
     let state = parse_codex_state(path)?;
+    if state.internal_title_generation {
+        return None;
+    }
     let cwd = state.cwd.clone()?;
     if !scope.accepts_cwd(&cwd) {
         return None;
@@ -321,6 +324,9 @@ fn parse_codex_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistory
 
 fn parse_claude_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistoryItem> {
     let state = parse_claude_state(path)?;
+    if state.internal_title_generation {
+        return None;
+    }
     let cwd = state.cwd.clone()?;
     if !scope.accepts_cwd(&cwd) {
         return None;
@@ -353,6 +359,9 @@ fn parse_claude_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistor
 
 fn parse_antigravity_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistoryItem> {
     let state = parse_antigravity_state(path)?;
+    if state.internal_title_generation {
+        return None;
+    }
     let id = state.id.or_else(|| antigravity_id_from_path(path))?;
     let mut cwd_candidates = Vec::new();
     if let Some(cwd) = state.cwd.clone() {
@@ -451,8 +460,15 @@ fn parse_codex_state(path: &Path) -> Option<ParsedAgentFile> {
         let role = string_at(payload, "role");
         let texts = value_texts(&value);
         let text = first_text(&texts);
-        if state.title.is_none() && role.as_deref() == Some("user") {
-            state.title = joined_text(&texts);
+        if role.as_deref() == Some("user") {
+            if let Some(user_text) = joined_text(&texts) {
+                if looks_like_acorn_title_generation_prompt(&user_text) {
+                    state.internal_title_generation = true;
+                }
+                if state.title.is_none() {
+                    state.title = Some(user_text);
+                }
+            }
         }
         if role.as_deref() == Some("assistant") {
             state.preview = text.clone().or(state.preview);
@@ -484,8 +500,15 @@ fn parse_claude_state(path: &Path) -> Option<ParsedAgentFile> {
         let ty = string_at(Some(&value), "type");
         let texts = value_texts(&value);
         let text = first_claude_display_text(&texts);
-        if state.title.is_none() && ty.as_deref() == Some("user") {
-            state.title = joined_claude_display_text(&texts);
+        if ty.as_deref() == Some("user") {
+            if let Some(user_text) = joined_claude_display_text(&texts) {
+                if looks_like_acorn_title_generation_prompt(&user_text) {
+                    state.internal_title_generation = true;
+                }
+                if state.title.is_none() {
+                    state.title = Some(user_text);
+                }
+            }
         }
         if ty.as_deref() == Some("assistant") {
             state.preview = text.clone().or(state.preview);
@@ -513,8 +536,13 @@ fn parse_antigravity_state(path: &Path) -> Option<ParsedAgentFile> {
         }
         match ty.as_deref() {
             Some("USER_INPUT") => {
-                if state.title.is_none() {
-                    state.title = text.and_then(|s| extract_antigravity_user_request(&s));
+                if let Some(user_text) = text.and_then(|s| extract_antigravity_user_request(&s)) {
+                    if looks_like_acorn_title_generation_prompt(&user_text) {
+                        state.internal_title_generation = true;
+                    }
+                    if state.title.is_none() {
+                        state.title = Some(user_text);
+                    }
                 }
             }
             Some("PLANNER_RESPONSE") => {
@@ -703,6 +731,15 @@ struct ParsedAgentFile {
     title: Option<String>,
     preview: Option<String>,
     cwd: Option<String>,
+    internal_title_generation: bool,
+}
+
+fn looks_like_acorn_title_generation_prompt(text: &str) -> bool {
+    text.contains(crate::session_titles::INTERNAL_TITLE_PROMPT_MARKER)
+        || (text.contains("Conversation transcript context:")
+            && (text.contains("You are naming an Acorn session tab")
+                || text.contains("Return only a concise title for the tab")
+                || text.contains("Fewer than 30 characters.")))
 }
 
 fn sample_lines(path: &Path) -> std::io::Result<Vec<String>> {
@@ -1427,6 +1464,110 @@ mod tests {
         assert_eq!(
             item.resume_command.as_deref(),
             Some("agy --conversation 17f38e8c-3a7e-408b-8c79-aef7432c0fd2")
+        );
+    }
+
+    #[test]
+    fn codex_history_skips_marked_acorn_title_generation_prompt() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let transcript = dir
+            .path()
+            .join("rollout-2026-06-08T00-00-00-019e4818-7c15-7e60-9b3b-898a1c7803d6.jsonl");
+        let mut file = fs::File::create(&transcript).unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "payload": {
+                    "id": "019e4818-7c15-7e60-9b3b-898a1c7803d6",
+                    "cwd": repo.display().to_string(),
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": crate::session_titles::build_prompt(None, "User: Fix release workflow"),
+                        },
+                    ],
+                },
+            })
+        )
+        .unwrap();
+        drop(file);
+
+        assert!(
+            parse_codex_file(&transcript, HistoryScope::Project(&repo)).is_none(),
+            "Acorn-generated title prompts should not appear as History rows"
+        );
+    }
+
+    #[test]
+    fn claude_history_skips_unmarked_acorn_title_generation_prompt() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let transcript = dir
+            .path()
+            .join("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl");
+        let mut file = fs::File::create(&transcript).unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "type": "user",
+                "sessionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "cwd": repo.display().to_string(),
+                "message": {
+                    "role": "user",
+                    "content": "\
+            You are naming an Acorn session tab from the conversation transcript.\n\
+            \n\
+            Return only a concise title for the tab.\n\
+            Conversation transcript context:\n\
+            User: Fix release workflow\n",
+                },
+            })
+        )
+        .unwrap();
+        drop(file);
+
+        assert!(
+            parse_claude_file(&transcript, HistoryScope::Project(&repo)).is_none(),
+            "unmarked title prompts should be hidden"
+        );
+    }
+
+    #[test]
+    fn antigravity_history_skips_marked_acorn_title_generation_prompt() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let transcript = dir
+            .path()
+            .join("17f38e8c-3a7e-408b-8c79-aef7432c0fd2/.system_generated/logs/transcript.jsonl");
+        fs::create_dir_all(transcript.parent().unwrap()).unwrap();
+        let prompt = crate::session_titles::build_prompt(
+            Some("Name this tab in Korean. Return only the title."),
+            "User: Fix release workflow",
+        );
+        let mut file = fs::File::create(&transcript).unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "type": "USER_INPUT",
+                "status": "DONE",
+                "workspacePaths": [repo.display().to_string()],
+                "content": format!("<USER_REQUEST>\n{prompt}\n</USER_REQUEST>"),
+            })
+        )
+        .unwrap();
+        drop(file);
+
+        assert!(
+            parse_antigravity_file(&transcript, HistoryScope::Project(&repo)).is_none(),
+            "Antigravity title prompts should not appear as History rows"
         );
     }
 

--- a/src-tauri/src/session_titles.rs
+++ b/src-tauri/src/session_titles.rs
@@ -157,11 +157,34 @@ pub fn generate_title_in_dir(
     title_context: &str,
     cwd: Option<&Path>,
 ) -> AppResult<String> {
-    let resolved = title_generation_command(ai.resolve()?);
+    let base = ai.resolve()?;
     let prompt = build_prompt(prompt, title_context);
-    let raw = crate::ai::run_resolved_oneshot_in_dir(&resolved, &prompt, "Settings → Agents", cwd)?;
+    let raw = run_title_generation(&base, |resolved| {
+        crate::ai::run_resolved_oneshot_in_dir(resolved, &prompt, "Settings → Agents", cwd)
+    })?;
     normalize_generated_title(&raw)
         .ok_or_else(|| AppError::Other("AI returned an empty session title.".to_string()))
+}
+
+/// Run title generation with the provider's non-persistence flag, falling back to
+/// the unflagged command when the flagged invocation fails.
+///
+/// Older `claude` / `codex` CLIs may reject `--no-session-persistence` / `--ephemeral`
+/// and exit non-zero, which would otherwise break title generation entirely. The
+/// internal prompt marker keeps any transcript persisted by the fallback out of
+/// Agents → History, so degrading to the unflagged command stays safe.
+fn run_title_generation(
+    base: &ResolvedAiCommand,
+    run: impl Fn(&ResolvedAiCommand) -> AppResult<String>,
+) -> AppResult<String> {
+    let flagged = title_generation_command(base.clone());
+    if flagged == *base {
+        return run(base);
+    }
+    match run(&flagged) {
+        Ok(raw) => Ok(raw),
+        Err(_) => run(base),
+    }
 }
 
 fn title_generation_command(mut resolved: ResolvedAiCommand) -> ResolvedAiCommand {
@@ -271,6 +294,82 @@ mod tests {
             .unwrap(),
         );
         assert!(codex.args.contains(&"--ephemeral".to_string()));
+    }
+
+    #[test]
+    fn title_generation_falls_back_to_unflagged_command_when_flag_rejected() {
+        use std::cell::Cell;
+
+        let base = AiExecutionRequest {
+            provider: crate::ai::AiProvider::Codex,
+            ollama_model: None,
+            llm_model: None,
+        }
+        .resolve()
+        .unwrap();
+
+        let calls = Cell::new(0);
+        let result = run_title_generation(&base, |resolved| {
+            calls.set(calls.get() + 1);
+            if resolved.args.contains(&"--ephemeral".to_string()) {
+                Err(AppError::Other(
+                    "error: unexpected argument '--ephemeral' found".to_string(),
+                ))
+            } else {
+                Ok("release-workflow-fix".to_string())
+            }
+        });
+
+        assert_eq!(result.unwrap(), "release-workflow-fix");
+        assert_eq!(calls.get(), 2, "should retry once without the flag");
+    }
+
+    #[test]
+    fn title_generation_runs_once_when_flag_supported() {
+        use std::cell::Cell;
+
+        let base = AiExecutionRequest {
+            provider: crate::ai::AiProvider::Claude,
+            ollama_model: None,
+            llm_model: None,
+        }
+        .resolve()
+        .unwrap();
+
+        let calls = Cell::new(0);
+        let result = run_title_generation(&base, |_| {
+            calls.set(calls.get() + 1);
+            Ok("release-workflow-fix".to_string())
+        });
+
+        assert_eq!(result.unwrap(), "release-workflow-fix");
+        assert_eq!(calls.get(), 1, "no retry when the flagged command succeeds");
+    }
+
+    #[test]
+    fn title_generation_does_not_retry_for_providers_without_flag() {
+        use std::cell::Cell;
+
+        let base = AiExecutionRequest {
+            provider: crate::ai::AiProvider::Ollama,
+            ollama_model: Some("llama3".to_string()),
+            llm_model: None,
+        }
+        .resolve()
+        .unwrap();
+
+        let calls = Cell::new(0);
+        let result = run_title_generation(&base, |_| {
+            calls.set(calls.get() + 1);
+            Err(AppError::Other("model run failed".to_string()))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            calls.get(),
+            1,
+            "providers without a non-persistence flag must not double-run on failure"
+        );
     }
 
     #[test]

--- a/src-tauri/src/session_titles.rs
+++ b/src-tauri/src/session_titles.rs
@@ -4,13 +4,14 @@ use acorn_session::{Session, SessionKind, SessionOwner, SessionTitleSource};
 
 use crate::agent_history::{self, AgentHistoryProvider};
 use crate::agent_resume;
-use crate::ai::AiExecutionRequest;
+use crate::ai::{AiExecutionRequest, ResolvedAiCommand};
 use crate::error::{AppError, AppResult};
 use crate::todos;
 
 const TITLE_CONTEXT_CHARS: usize = 8_000;
 const GENERATED_TITLE_CHARS: usize = 29;
 const SESSION_TITLE_PROMPT_CHARS: usize = 1_000;
+pub const INTERNAL_TITLE_PROMPT_MARKER: &str = "<ACORN_INTERNAL_SESSION_TITLE_GENERATION>";
 
 pub const DEFAULT_SESSION_TITLE_PROMPT: &str = "\
 You are naming an Acorn session tab from the conversation transcript.
@@ -49,7 +50,7 @@ pub fn can_force_generate_title(session: &Session) -> bool {
 
 pub fn build_prompt(prompt: Option<&str>, title_context: &str) -> String {
     let header = effective_prompt(prompt);
-    format!("{header}\nConversation transcript context:\n{title_context}\n")
+    format!("{header}\n{INTERNAL_TITLE_PROMPT_MARKER}\nConversation transcript context:\n{title_context}\n")
 }
 
 fn effective_prompt(prompt: Option<&str>) -> String {
@@ -156,11 +157,20 @@ pub fn generate_title_in_dir(
     title_context: &str,
     cwd: Option<&Path>,
 ) -> AppResult<String> {
-    let resolved = ai.resolve()?;
+    let resolved = title_generation_command(ai.resolve()?);
     let prompt = build_prompt(prompt, title_context);
     let raw = crate::ai::run_resolved_oneshot_in_dir(&resolved, &prompt, "Settings → Agents", cwd)?;
     normalize_generated_title(&raw)
         .ok_or_else(|| AppError::Other("AI returned an empty session title.".to_string()))
+}
+
+fn title_generation_command(mut resolved: ResolvedAiCommand) -> ResolvedAiCommand {
+    match resolved.command {
+        "claude" => resolved.args.push("--no-session-persistence".to_string()),
+        "codex" => resolved.args.push("--ephemeral".to_string()),
+        _ => {}
+    }
+    resolved
 }
 
 fn resolve_transcript(session_id: uuid::Uuid) -> Option<(PathBuf, AgentHistoryProvider, String)> {
@@ -192,6 +202,7 @@ mod tests {
         assert!(prompt.contains("Separate each word with hyphens"));
         assert!(prompt.contains("Use lowercase words only"));
         assert!(prompt.contains("overall intent of the full request"));
+        assert!(prompt.contains(INTERNAL_TITLE_PROMPT_MARKER));
         assert!(prompt.contains("Conversation transcript context:"));
         assert!(prompt.contains("Fix the release workflow failure"));
     }
@@ -233,6 +244,33 @@ mod tests {
             normalize_generated_title("### Investigate Codex Resume\nextra").as_deref(),
             Some("Investigate Codex Resume")
         );
+    }
+
+    #[test]
+    fn title_generation_uses_non_persistent_provider_flags() {
+        let claude = title_generation_command(
+            (AiExecutionRequest {
+                provider: crate::ai::AiProvider::Claude,
+                ollama_model: None,
+                llm_model: None,
+            })
+            .resolve()
+            .unwrap(),
+        );
+        assert!(claude
+            .args
+            .contains(&"--no-session-persistence".to_string()));
+
+        let codex = title_generation_command(
+            (AiExecutionRequest {
+                provider: crate::ai::AiProvider::Codex,
+                ollama_model: None,
+                llm_model: None,
+            })
+            .resolve()
+            .unwrap(),
+        );
+        assert!(codex.args.contains(&"--ephemeral".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Acorn no longer exposes its own tab-title generation traffic as normal rows in Agents -> History.

1. **Title generation path** now tags Acorn's internal prompt and runs supported CLIs with their non-persistent flags where available: Codex uses `--ephemeral`, Claude uses `--no-session-persistence`.
2. **History parsing** now drops internal title-generation transcripts for Codex, Claude, and Antigravity so the rename workflow stays out of the normal session list.
3. **Graceful fallback** retries title generation with the unflagged command when the non-persistent flag is rejected, so older CLIs keep working while the prompt marker still hides any persisted transcript from History.
4. **Regression coverage** was added for prompt formatting, provider flags, the flag-rejection fallback, and History suppression across the supported agent paths.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Agents -> History | Internal rename/title-generation prompts could show up as normal history rows | Those internal prompts are hidden |
| Title generation runtime | Codex / Claude could persist their title-generation sessions | Title generation runs with non-persistent flags on supported CLIs |
| Older CLI without the flag | Would have broken once a non-persistent flag was always appended | Falls back to the unflagged command; transcript still hidden via the marker |

## Design notes
- The implementation uses a stable internal prompt marker instead of trying to guess from prompt text alone.
- Codex and Claude have CLI-level non-persistence flags, so the generator can avoid writing session transcripts there.
- The flagged invocation falls back to the unflagged command on failure, so a CLI version that does not recognize the flag degrades gracefully instead of breaking title generation; the marker keeps the fallback transcript out of History.
- Antigravity does not expose an equivalent no-persistence flag in the CLI path we verified locally, so History filtering remains the containment point for that provider.

## Test plan
- [x] `cargo test -p acorn session_titles --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test -p acorn agent_history --manifest-path src-tauri/Cargo.toml`
- [x] `git diff --check`
- [x] Local CLI verification for Codex and Claude: no new session-history files were created during title-generation runs
- [x] Fallback unit tests cover flag rejection (retry once unflagged), flag success (single run), and flag-less providers (no double-run on failure)

## Notes
- Antigravity still persists its own transcript files when run directly, based on local CLI verification. The PR hides the internal title-generation prompt from History rather than relying on a persistence-off flag there.
