### PR TITLE
fix(sidebar): confirm project folder removal choices

### DIFF
--- a/src/components/RemoveProjectFolderDialog.tsx
+++ b/src/components/RemoveProjectFolderDialog.tsx
@@ -1,0 +1,120 @@
+import { AlertTriangle } from "lucide-react";
+import type { ProjectFolder } from "../lib/projectFolders";
+import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import type { Session } from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
+import { Modal, ModalHeader } from "./ui";
+
+type RemoveProjectFolderChoice =
+  | "folder_only"
+  | "folder_and_sessions"
+  | "cancel";
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
+
+interface RemoveProjectFolderDialogProps {
+  folder: ProjectFolder | null;
+  sessions: readonly Session[];
+  onClose: (choice: RemoveProjectFolderChoice) => void;
+}
+
+export function RemoveProjectFolderDialog({
+  folder,
+  sessions,
+  onClose,
+}: RemoveProjectFolderDialogProps) {
+  const t = useTranslation();
+  const sessionCount = sessions.length;
+
+  useDialogShortcuts(folder !== null, {
+    onCancel: () => onClose("cancel"),
+    onConfirm: () =>
+      onClose(sessionCount > 0 ? "folder_only" : "folder_and_sessions"),
+  });
+
+  return (
+    <Modal
+      open={folder !== null}
+      onClose={() => onClose("cancel")}
+      variant="dialog"
+      size="md"
+      ariaLabelledBy="acorn-remove-project-folder-title"
+    >
+      {folder ? (
+        <>
+          <ModalHeader
+            title={dt(t, "dialogs.removeProjectFolder.title")}
+            titleId="acorn-remove-project-folder-title"
+            icon={<AlertTriangle size={16} className="text-warning" />}
+            variant="dialog"
+            onClose={() => onClose("cancel")}
+          />
+          <div className="space-y-3 px-4 py-3 text-sm text-fg">
+            <p>
+              {dt(t, "dialogs.removeProjectFolder.confirmPrefix")}{" "}
+              <span className="font-mono text-accent">{folder.name}</span>?
+            </p>
+            <div className="space-y-1 rounded-md border border-border bg-bg-sidebar/60 p-3 text-xs">
+              {sessionCount > 0 ? (
+                <>
+                  <p className="text-fg-muted">
+                    {sessionCount}{" "}
+                    {sessionCount === 1
+                      ? dt(t, "dialogs.removeProjectFolder.sessionSingular")
+                      : dt(t, "dialogs.removeProjectFolder.sessionPlural")}{" "}
+                    {dt(t, "dialogs.removeProjectFolder.canBeMovedOut")}.
+                  </p>
+                  <p className="text-fg-muted">
+                    {dt(t, "dialogs.removeProjectFolder.removeSessionsHint")}
+                  </p>
+                </>
+              ) : (
+                <p className="text-fg-muted">
+                  {dt(t, "dialogs.removeProjectFolder.emptyFolder")}
+                </p>
+              )}
+              <p className="text-fg-muted">
+                {dt(t, "dialogs.removeProjectFolder.filesWillNotBeTouched")}
+              </p>
+            </div>
+          </div>
+          <footer className="flex items-center justify-end gap-2 border-t border-border bg-bg-sidebar/40 px-4 py-3">
+            <button
+              type="button"
+              onClick={() => onClose("cancel")}
+              className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
+            >
+              {dt(t, "dialogs.common.cancel")}
+            </button>
+            {sessionCount > 0 ? (
+              <button
+                type="button"
+                onClick={() => onClose("folder_only")}
+                className="rounded-md px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
+              >
+                {dt(t, "dialogs.removeProjectFolder.moveSessionsOut")}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={() =>
+                onClose(
+                  sessionCount > 0 ? "folder_and_sessions" : "folder_only",
+                )
+              }
+              className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
+            >
+              {sessionCount > 0
+                ? dt(t, "dialogs.removeProjectFolder.removeWithSessions")
+                : dt(t, "dialogs.removeProjectFolder.removeFolder")}
+            </button>
+          </footer>
+        </>
+      ) : null}
+    </Modal>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -108,6 +108,7 @@ import type {
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { NewProjectDialog } from "./NewProjectDialog";
 import { ProjectSettingsModal } from "./ProjectSettingsModal";
+import { RemoveProjectFolderDialog } from "./RemoveProjectFolderDialog";
 import { SessionTitleGeneratingIndicator } from "./SessionTitleGeneratingIndicator";
 import { Tooltip } from "./Tooltip";
 
@@ -180,6 +181,7 @@ export function Sidebar() {
   const createProjectFolder = useAppStore((s) => s.createProjectFolder);
   const renameProjectFolder = useAppStore((s) => s.renameProjectFolder);
   const removeProjectFolder = useAppStore((s) => s.removeProjectFolder);
+  const removeSession = useAppStore((s) => s.removeSession);
   const moveSessionToProjectFolder = useAppStore(
     (s) => s.moveSessionToProjectFolder,
   );
@@ -205,6 +207,8 @@ export function Sidebar() {
   const [newProjectOpen, setNewProjectOpen] = useState(false);
   const [settingsProject, setSettingsProject] =
     useState<ProjectFolderProjectGroup | null>(null);
+  const [pendingRemoveProjectFolderId, setPendingRemoveProjectFolderId] =
+    useState<string | null>(null);
 
   useEffect(() => {
     saveStringSet(COLLAPSED_KEY, collapsed);
@@ -228,6 +232,17 @@ export function Sidebar() {
       ),
     [projectFolders, projects, sessionFolderIds, sessions],
   );
+  const pendingRemoveProjectFolderGroup = useMemo(() => {
+    if (!pendingRemoveProjectFolderId) return null;
+    for (const project of projectGroups) {
+      const folderGroup = project.folders.find(
+        (candidate) =>
+          candidate.folder.id === pendingRemoveProjectFolderId,
+      );
+      if (folderGroup) return folderGroup;
+    }
+    return null;
+  }, [pendingRemoveProjectFolderId, projectGroups]);
   const localSessions = useMemo(
     () => buildLocalSessions(sessions),
     [sessions],
@@ -309,6 +324,25 @@ export function Sidebar() {
     } catch (e) {
       console.error("create project folder failed", e);
       showToast(`${t("toasts.project.createFailed")} ${String(e)}`);
+    }
+  }
+
+  async function removeProjectFolderAndSessions(
+    folderGroup: ProjectFolderGroup,
+  ) {
+    try {
+      for (const session of folderGroup.sessions) {
+        await removeSession(session.id, false);
+        const error = useAppStore.getState().consumeError();
+        if (error) {
+          showToast(`${t("toasts.session.removeFailed")} ${error}`);
+          return;
+        }
+      }
+      removeProjectFolder(folderGroup.folder.id);
+    } catch (e) {
+      console.error("remove project folder failed", e);
+      showToast(`${t("toasts.session.removeFailed")} ${String(e)}`);
     }
   }
 
@@ -824,7 +858,7 @@ export function Sidebar() {
                       }
                       onAddFolder={() => onAddProjectFolder(project.repoPath)}
                       onRenameFolder={renameProjectFolder}
-                      onRemoveFolder={removeProjectFolder}
+                      onRemoveFolder={setPendingRemoveProjectFolderId}
                       onMoveSessionToFolder={moveSessionToProjectFolder}
                       onRemoveProject={() =>
                         requestRemoveProject(project.repoPath)
@@ -875,6 +909,20 @@ export function Sidebar() {
             : null
         }
         onClose={() => setSettingsProject(null)}
+      />
+      <RemoveProjectFolderDialog
+        folder={pendingRemoveProjectFolderGroup?.folder ?? null}
+        sessions={pendingRemoveProjectFolderGroup?.sessions ?? []}
+        onClose={(choice) => {
+          const target = pendingRemoveProjectFolderGroup;
+          setPendingRemoveProjectFolderId(null);
+          if (!target || choice === "cancel") return;
+          if (choice === "folder_only") {
+            removeProjectFolder(target.folder.id);
+            return;
+          }
+          void removeProjectFolderAndSessions(target);
+        }}
       />
     </aside>
   );
@@ -1268,15 +1316,16 @@ function ProjectGroupView({
     project.folders.find((folderGroup) =>
       isDefaultProjectFolder(folderGroup.folder),
     ) ?? project.folders[0] ?? null;
-  const sessionCreationFolder =
-    folderForActiveSession(project, activeSessionId) ??
-    (activeProjectFolderId
-      ? (project.folders.find(
-          (folderGroup) => folderGroup.folder.id === activeProjectFolderId,
-        )?.folder ?? null)
-      : null) ??
-    defaultFolderGroup?.folder ??
-    null;
+  let sessionCreationFolder = folderForActiveSession(project, activeSessionId);
+  if (!sessionCreationFolder && activeProjectFolderId) {
+    sessionCreationFolder =
+      project.folders.find(
+        (folderGroup) => folderGroup.folder.id === activeProjectFolderId,
+      )?.folder ?? null;
+  }
+  if (!sessionCreationFolder) {
+    sessionCreationFolder = defaultFolderGroup?.folder ?? null;
+  }
 
   const createMenuItems = useMemo<ContextMenuItem[]>(
     () =>
@@ -1636,7 +1685,8 @@ function folderForActiveSession(
 ): ProjectFolder | null {
   if (!activeSessionId) return null;
   const folderGroup = project.folders.find(
-    (candidate) => candidate.sessions.some((session) => session.id === activeSessionId),
+    (candidate) =>
+      candidate.sessions.some((session) => session.id === activeSessionId),
   );
   return folderGroup?.folder ?? null;
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1137,6 +1137,19 @@
       "closeDeleteWorktrees": "Close · delete worktrees",
       "closeProject": "Close project"
     },
+    "removeProjectFolder": {
+      "title": "Remove folder",
+      "confirmPrefix": "Remove folder",
+      "sessionSingular": "session",
+      "sessionPlural": "sessions",
+      "canBeMovedOut": "can be moved out to the project before the folder is removed",
+      "removeSessionsHint": "You can also remove the sessions from Acorn with the folder.",
+      "emptyFolder": "This folder has no sessions.",
+      "filesWillNotBeTouched": "Files and worktrees on disk will not be deleted.",
+      "removeFolder": "Remove folder",
+      "moveSessionsOut": "Move sessions out",
+      "removeWithSessions": "Remove folder and sessions"
+    },
     "projectSettings": {
       "title": "Project Settings",
       "pullRequests": "Pull requests",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1137,6 +1137,19 @@
       "closeDeleteWorktrees": "닫기 · worktree 삭제",
       "closeProject": "프로젝트 닫기"
     },
+    "removeProjectFolder": {
+      "title": "폴더 제거",
+      "confirmPrefix": "폴더 제거",
+      "sessionSingular": "세션",
+      "sessionPlural": "세션",
+      "canBeMovedOut": "폴더를 제거하기 전에 프로젝트 상위 목록으로 이동할 수 있습니다",
+      "removeSessionsHint": "폴더와 함께 세션을 Acorn에서 제거할 수도 있습니다.",
+      "emptyFolder": "이 폴더에는 세션이 없습니다.",
+      "filesWillNotBeTouched": "디스크의 파일과 worktree는 삭제되지 않습니다.",
+      "removeFolder": "폴더 제거",
+      "moveSessionsOut": "세션 밖으로 이동",
+      "removeWithSessions": "폴더와 세션 제거"
+    },
     "projectSettings": {
       "title": "프로젝트 설정",
       "pullRequests": "Pull request",

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -715,6 +715,226 @@ test.describe("sidebar: project lifecycle", () => {
     });
   });
 
+  test("project folder remove asks before removing sessions in the folder", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __sessions?: Array<Record<string, unknown>>;
+        __removedIds?: string[];
+      };
+      w.__sessions = w.__sessions ?? [
+        {
+          id: "root-session",
+          name: "root",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          project_scoped: true,
+          status: "idle",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          title_source: "manual",
+          kind: "regular",
+          owner: { kind: "user" },
+          position: 0,
+          in_worktree: false,
+        },
+        {
+          id: "child-session",
+          name: "child",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          project_scoped: true,
+          status: "idle",
+          created_at: "2026-01-01T00:00:01Z",
+          updated_at: "2026-01-01T00:00:01Z",
+          last_message: null,
+          title_source: "manual",
+          kind: "regular",
+          owner: { kind: "user" },
+          position: 1,
+          in_worktree: false,
+        },
+      ];
+      const removed = new Set(w.__removedIds ?? []);
+      return w.__sessions.filter(
+        (session) => !removed.has(String(session.id)),
+      );
+    });
+    await tauri.handle("remove_session", (args) => {
+      const w = window as unknown as {
+        __removeCalls?: unknown[];
+        __removedIds?: string[];
+      };
+      w.__removeCalls = w.__removeCalls ?? [];
+      w.__removeCalls.push(args);
+      const id = String(args?.id ?? "");
+      w.__removedIds = Array.from(new Set([...(w.__removedIds ?? []), id]));
+      return null;
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator("aside");
+    const projectRow = page.getByRole("button", { name: "Project demo" });
+    await projectRow.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "New project folder" }).click();
+    const folderRow = sidebar.getByRole("button", { name: /New folder/ }).first();
+    await folderRow.dblclick();
+    await sidebar.getByRole("textbox").fill("Frontend");
+    await sidebar.getByRole("textbox").press("Enter");
+
+    const frontend = sidebar.getByRole("button", { name: /Frontend/ }).first();
+    const root = sidebar
+      .getByRole("button", { name: /^root main · Idle/ })
+      .first();
+    const child = sidebar
+      .getByRole("button", { name: /^child main · Idle/ })
+      .first();
+    await child.click({ button: "right" });
+    await page
+      .getByRole("menuitem", { name: "Move to folder: Frontend" })
+      .click();
+
+    await frontend.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Remove folder" }).click();
+    const dialog = page.getByRole("dialog", { name: "Remove folder" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("1 session");
+    await dialog.getByRole("button", { name: "Cancel" }).click();
+    await expect(dialog).toHaveCount(0);
+    await expect(frontend).toBeVisible();
+    await expect(child).toBeVisible();
+
+    await frontend.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Remove folder" }).click();
+    await page
+      .getByRole("dialog", { name: "Remove folder" })
+      .getByRole("button", { name: "Remove folder and sessions" })
+      .click();
+
+    await expect(child).toHaveCount(0);
+    await expect(frontend).toHaveCount(0);
+    await expect(root).toBeVisible();
+
+    const calls = (await page.evaluate(
+      () => (window as unknown as { __removeCalls?: unknown[] }).__removeCalls,
+    )) as Array<{ id: string; removeWorktree: boolean }>;
+    expect(calls).toEqual([{ id: "child-session", removeWorktree: false }]);
+  });
+
+  test("project folder remove can keep sessions and move them out", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "root-session",
+        name: "root",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+      {
+        id: "child-session",
+        name: "child",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:01Z",
+        updated_at: "2026-01-01T00:00:01Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 1,
+        in_worktree: false,
+      },
+    ]);
+    await tauri.handle("remove_session", (args) => {
+      const w = window as unknown as { __removeCalls?: unknown[] };
+      w.__removeCalls = w.__removeCalls ?? [];
+      w.__removeCalls.push(args);
+      return null;
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator("aside");
+    const projectRow = page.getByRole("button", { name: "Project demo" });
+    await projectRow.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "New project folder" }).click();
+    const folderRow = sidebar.getByRole("button", { name: /New folder/ }).first();
+    await folderRow.dblclick();
+    await sidebar.getByRole("textbox").fill("Frontend");
+    await sidebar.getByRole("textbox").press("Enter");
+
+    const frontend = sidebar.getByRole("button", { name: /Frontend/ }).first();
+    const child = sidebar
+      .getByRole("button", { name: /^child main · Idle/ })
+      .first();
+    await child.click({ button: "right" });
+    await page
+      .getByRole("menuitem", { name: "Move to folder: Frontend" })
+      .click();
+
+    await frontend.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Remove folder" }).click();
+    const dialog = page.getByRole("dialog", { name: "Remove folder" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("project before the folder is removed");
+    await dialog.getByRole("button", { name: "Move sessions out" }).click();
+
+    await expect(frontend).toHaveCount(0);
+    await expect(child).toBeVisible();
+    await child.click({ button: "right" });
+    await expect(
+      page.getByRole("menuitem", { name: "Remove from folder" }),
+    ).toHaveCount(0);
+    await page.keyboard.press("Escape");
+
+    const calls = (await page.evaluate(
+      () => (window as unknown as { __removeCalls?: unknown[] }).__removeCalls,
+    )) as unknown[] | undefined;
+    expect(calls ?? []).toEqual([]);
+  });
+
   test("project folders and sessions can move by drag and drop", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Project folder removal now asks the user what should happen to sessions before deleting the folder.

1. **Removal confirmation** — replace the direct `Remove folder` context-menu action with a modal that supports cancel, folder-only removal, and folder-plus-sessions removal.
2. **Session preservation path** — keep sessions by clearing their folder assignment so they move back to the parent project list when only the folder is removed.
3. **Session removal path** — remove sessions from Acorn before deleting the folder, without deleting files or worktrees on disk.
4. **Regression coverage** — add E2E coverage for cancel, remove-with-sessions, and move-sessions-out behavior.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Project folder context menu | `Remove folder` immediately removed the folder and moved sessions out implicitly | User chooses cancel, move sessions out, or remove folder and sessions |
| Session safety | No explicit confirmation for sessions inside the folder | Modal states that disk files/worktrees are untouched and requires an explicit choice |

## Design notes
- The folder-only path reuses the existing `removeProjectFolder` store behavior, which removes folder assignments and reconciles sessions into the parent project list.
- The folder-and-sessions path calls `removeSession(session.id, false)` for each session before removing the folder, so session records are removed from Acorn while worktrees/files remain on disk.
- Enter defaults to the non-destructive folder-only path when the folder contains sessions.

## Follow-up (not in this PR)
- None.

## Test plan
- [x] `pnpm run typecheck`
- [x] `git diff --check`
- [x] `PLAYWRIGHT_PORT=1433 pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "project folder"` — 8 passed
- [x] `pnpm exec vitest run src/lib/projectFolders.test.ts src/store.test.ts` — 2 files passed, 106 tests passed, 1 skipped
- [x] `pnpm run build` — passes

## Notes
- `pnpm run build` still emits the existing Vite dynamic/static import and >500 kB chunk warnings; they are not introduced by this PR.
