### PR TITLE
fix(sessions): gate title regeneration to agent chat work

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -52,7 +52,7 @@ import {
   resolveSessionTitlePrompt,
 } from "../lib/settings";
 import {
-  canForceGenerateSessionTitle,
+  canRegenerateSessionTitle,
   canRenameSession,
 } from "../lib/sessionTitle";
 import { hasRecordedWorktree } from "../lib/sessionWorktree";
@@ -851,7 +851,7 @@ function TabItem({
     : false;
   const canRegenerateTitle =
     session != null &&
-    canForceGenerateSessionTitle(session) &&
+    canRegenerateSessionTitle(session) &&
     !isGeneratingTitle;
   const showAgentProviderIcons = useSettings(
     (s) => s.settings.sessionDisplay.icons.agentProvider,

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -62,7 +62,7 @@ import {
   type SessionTitleSource,
 } from "../lib/settings";
 import {
-  canForceGenerateSessionTitle,
+  canRegenerateSessionTitle,
   canRenameSession,
 } from "../lib/sessionTitle";
 import { hasRecordedWorktree } from "../lib/sessionWorktree";
@@ -1981,7 +1981,7 @@ function SessionRow({
   );
   const canRename = canRenameSession(session, { isGeneratingTitle });
   const canRegenerateTitle =
-    canForceGenerateSessionTitle(session) && !isGeneratingTitle;
+    canRegenerateSessionTitle(session) && !isGeneratingTitle;
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const {
@@ -2603,7 +2603,7 @@ function LocalSessionRow({
   );
   const canRename = canRenameSession(session, { isGeneratingTitle });
   const canRegenerateTitle =
-    canForceGenerateSessionTitle(session) && !isGeneratingTitle;
+    canRegenerateSessionTitle(session) && !isGeneratingTitle;
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const {

--- a/src/lib/sessionTitle.test.ts
+++ b/src/lib/sessionTitle.test.ts
@@ -5,6 +5,7 @@ import {
   canForceGenerateSessionTitle,
   canGenerateSessionTitle,
   canRenameSession,
+  canRegenerateSessionTitle,
   planAutoGenerateSessionTitles,
 } from "./sessionTitle";
 
@@ -90,7 +91,7 @@ describe("session title helpers", () => {
     expect(canGenerateSessionTitle(session({ agent_provider: null }))).toBe(true);
   });
 
-  it("allows manual title regeneration for user-owned regular sessions", () => {
+  it("allows forced title generation for user-owned regular sessions", () => {
     expect(
       canForceGenerateSessionTitle(session({ title_source: "manual" })),
     ).toBe(true);
@@ -111,6 +112,59 @@ describe("session title helpers", () => {
         session({ owner: { kind: "control", session_id: "control-1" } }),
       ),
     ).toBe(false);
+  });
+
+  it("allows manual title regeneration only for sessions with agent chat work", () => {
+    expect(
+      canRegenerateSessionTitle(
+        session({
+          title_source: "manual",
+          agent_provider: null,
+          agent_transcript_id: null,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      canRegenerateSessionTitle(
+        session({
+          title_source: "manual",
+          agent_provider: null,
+          agent_transcript_id: "codex-1",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      canRegenerateSessionTitle(
+        session({
+          title_source: "generated",
+          generated_title_transcript_id: "codex-1",
+          agent_transcript_id: "codex-1",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      canRegenerateSessionTitle(
+        session({
+          title_source: "manual",
+          mode: "chat",
+          status: "needs_input",
+          agent_provider: null,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      canRegenerateSessionTitle(
+        session({
+          title_source: "manual",
+          mode: "chat",
+          status: "idle",
+          agent_provider: null,
+        }),
+      ),
+    ).toBe(false);
+    expect(canRegenerateSessionTitle(session({ kind: "control" }))).toBe(
+      false,
+    );
   });
 
   it("uses the global automatic title setting for terminal sessions and always allows chat sessions", () => {

--- a/src/lib/sessionTitle.ts
+++ b/src/lib/sessionTitle.ts
@@ -46,11 +46,28 @@ export function canForceGenerateSessionTitle(session: Session): boolean {
   );
 }
 
+export function canRegenerateSessionTitle(session: Session): boolean {
+  return canForceGenerateSessionTitle(session) && hasAgentChatWork(session);
+}
+
 export function autoTitleGenerationEnabledForSession(
   session: Session,
   enabled: boolean,
 ): boolean {
   return enabled || session.mode === "chat";
+}
+
+function hasAgentChatWork(session: Session): boolean {
+  const transcriptId = session.agent_transcript_id?.trim();
+  if (transcriptId) return true;
+
+  const hasWorkStatus =
+    session.status === "running" ||
+    session.status === "needs_input" ||
+    session.status === "failed";
+  if (!hasWorkStatus) return false;
+
+  return session.mode === "chat" || session.agent_provider != null;
 }
 
 function hasSessionTitleAgentSignal(session: Session): boolean {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1427,6 +1427,8 @@ describe("generateSessionTitle", () => {
         session("a1", REPO_A, {
           name: "Manual title",
           title_source: "manual",
+          agent_provider: "codex",
+          agent_transcript_id: "codex-1",
         }),
       ],
     );
@@ -1451,6 +1453,30 @@ describe("generateSessionTitle", () => {
       true,
     );
     expect(useAppStore.getState().sessions[0]?.name).toBe("fresh-title");
+  });
+
+  it("skips forced title generation for sessions without agent chat work", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          name: "Manual title",
+          title_source: "manual",
+          agent_provider: null,
+          agent_transcript_id: null,
+        }),
+      ],
+    );
+
+    const ai = { provider: "codex" as const, ollamaModel: "", llmModel: "" };
+    const status = await useAppStore
+      .getState()
+      .generateSessionTitle("a1", ai, "Title prompt", true);
+
+    expect(status).toBe("skipped");
+    expect(mockApi.generateSessionTitle).not.toHaveBeenCalled();
+    expect(useAppStore.getState().sessions[0]?.name).toBe("Manual title");
+    expect(useAppStore.getState().generatingSessionTitleIds).toEqual({});
   });
 
   it("returns not_ready without replacing the session title", async () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -61,6 +61,7 @@ import {
   type ProjectFoldersByRepo,
   type SessionFolderAssignments,
 } from "./lib/projectFolders";
+import { canRegenerateSessionTitle } from "./lib/sessionTitle";
 
 export type { RightGroup, RightTab };
 
@@ -2013,6 +2014,11 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   async generateSessionTitle(id, ai, prompt, force = false) {
+    if (force) {
+      const session = get().sessions.find((candidate) => candidate.id === id);
+      if (!session || !canRegenerateSessionTitle(session)) return "skipped";
+    }
+
     const startedAt = Date.now();
     let resultStatus: SessionTitleGenerationStatus = "skipped";
     set((s) => ({

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -110,7 +110,7 @@ test.describe("sidebar: project lifecycle", () => {
           branch: "main",
           isolated: false,
           project_scoped: true,
-          status: "idle",
+          status: "needs_input",
           created_at: "2026-01-01T00:00:00Z",
           updated_at: "2026-01-01T00:00:00Z",
           last_message: null,
@@ -140,7 +140,7 @@ test.describe("sidebar: project lifecycle", () => {
         branch: "main",
         isolated: false,
         project_scoped: true,
-        status: "idle",
+        status: "needs_input",
         created_at: "2026-01-01T00:00:00Z",
         updated_at: "2026-01-01T00:00:00Z",
         last_message: null,
@@ -205,7 +205,7 @@ test.describe("sidebar: project lifecycle", () => {
           branch: "main",
           isolated: false,
           project_scoped: true,
-          status: "idle",
+          status: "needs_input",
           created_at: "2026-01-01T00:00:00Z",
           updated_at: "2026-01-01T00:00:00Z",
           last_message: null,
@@ -235,7 +235,7 @@ test.describe("sidebar: project lifecycle", () => {
         branch: "main",
         isolated: false,
         project_scoped: true,
-        status: "idle",
+        status: "needs_input",
         created_at: "2026-01-01T00:00:00Z",
         updated_at: "2026-01-01T00:00:00Z",
         last_message: null,
@@ -271,6 +271,67 @@ test.describe("sidebar: project lifecycle", () => {
     expect(calls[0]).toMatchObject({ id: "session-1", force: true });
   });
 
+  test("ordinary terminal sessions cannot regenerate a session name", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "session-1",
+        name: "plain-terminal",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+        agent_provider: null,
+        agent_transcript_id: null,
+      },
+    ]);
+    await tauri.handle("generate_session_title", (args) => {
+      const w = window as unknown as { __generateTitleCalls?: unknown[] };
+      w.__generateTitleCalls = w.__generateTitleCalls ?? [];
+      w.__generateTitleCalls.push(args);
+      return { status: "skipped", session: null };
+    });
+
+    await page.goto("/");
+
+    await page
+      .locator("aside")
+      .getByRole("button", { name: /plain-terminal/ })
+      .click({ button: "right" });
+    await expect(
+      page.getByRole("menuitem", { name: "Regenerate Name" }),
+    ).toBeDisabled();
+    await expect(
+      page.locator('[data-tab-drag-handle="session-1"]'),
+    ).toContainText("plain-terminal");
+    const calls = await page.evaluate(
+      () =>
+        (window as unknown as { __generateTitleCalls?: unknown[] })
+          .__generateTitleCalls ?? [],
+    );
+    expect(calls).toHaveLength(0);
+  });
+
   test("regenerates a name for sessions backed by real git worktrees", async ({
     page,
     tauri,
@@ -284,7 +345,7 @@ test.describe("sidebar: project lifecycle", () => {
       branch: "feature/alpha",
       isolated: true,
       project_scoped: true,
-      status: "idle",
+      status: "needs_input",
       created_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-01T00:00:00Z",
       last_message: null,
@@ -315,7 +376,7 @@ test.describe("sidebar: project lifecycle", () => {
           branch: "feature/beta",
           isolated: true,
           project_scoped: true,
-          status: "idle",
+          status: "needs_input",
           created_at: "2026-01-01T00:00:00Z",
           updated_at: "2026-01-01T00:00:00Z",
           last_message: null,


### PR DESCRIPTION
## Summary
Restricts manual session name regeneration to sessions that have active agent or native chat work.

1. **Regeneration eligibility** — adds a dedicated frontend helper so `Regenerate Name` requires a user-owned regular session plus agent/chat work signal.
2. **UI and store guard** — applies the same gate to project rows, local rows, tab context menus, and forced store calls so ordinary terminal sessions skip regeneration.
3. **Coverage** — updates helper/store tests and adds E2E coverage proving ordinary terminal sessions cannot trigger regeneration.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Session context menus | Any user-owned regular session could expose manual name regeneration | Only agent/chat work sessions can trigger name regeneration |
| Ordinary terminal sessions | Could call forced title generation from the UI | `Regenerate Name` is disabled and store calls return `skipped` |

## Design notes
- `canForceGenerateSessionTitle` remains the broad backend-compatible ownership check, while `canRegenerateSessionTitle` models the narrower UI action.
- A live transcript id is treated as sufficient evidence of agent work; otherwise the action requires a work-like status on a chat-mode or agent-provider session.
- The store guard keeps forced regeneration consistent even if a future UI path bypasses the context-menu disabled state.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/lib/sessionTitle.test.ts src/store.test.ts` passes — 106 passed, 1 skipped
- [x] `PLAYWRIGHT_PORT=1421 pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "regenerate|ordinary terminal"` passes — 4 passed