### PR TITLE
ci(release): mark stable releases as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -404,10 +404,10 @@ jobs:
             bundles/*.app.tar.gz
             bundles/*.app.tar.gz.sig
             latest.json
-          # Defer "Latest" badge + prerelease flag to GitHub's semver
-          # auto-detection so test tags like `v1.1.0-rc1` stay out of the
-          # default release pointer and the updater's latest.json feed.
-          make_latest: legacy
+          # Stable releases must update GitHub's "Latest" pointer because the
+          # app updater resolves latest.json through /releases/latest/download.
+          # Keep prerelease tags out of that pointer.
+          make_latest: ${{ contains(steps.meta.outputs.tag, '-') && 'false' || 'true' }}
           prerelease: ${{ contains(steps.meta.outputs.tag, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
The release workflow currently leaves GitHub's Latest pointer on an older stable release, which can make the updater fetch a stale latest.json manifest.

1. **Stable latest pointer:** Set stable release tags as GitHub Latest explicitly.
2. **Prerelease handling:** Keep prerelease tags out of the Latest pointer using the existing tag suffix check.

## Expected impact
| Area | Impact |
| --- | --- |
| Updater feed | Stable releases update /releases/latest/download/latest.json as expected. |
| Prerelease tags | Prereleases remain excluded from the default updater pointer. |

## Design notes
The app updater is configured against GitHub's /releases/latest/download/latest.json endpoint, so the release job must not rely on legacy auto-detection when GitHub has already left the Latest badge behind on v1.13.3.

## Follow-up (not in this PR)
None.

## Test plan
- [x] `git diff --check`
- [x] Verified `gh release list --json tagName,isLatest` currently reports v1.13.3 as Latest while newer stable releases exist.

## Notes
This is release plumbing needed before the v1.14.0 tag is published.