### PR TITLE
chore(release): v1.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.13.6",
+  "version": "1.14.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.13.6"
+version = "1.14.0"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.13.6"
+version = "1.14.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.13.6",
+  "version": "1.14.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
This prepares the v1.14.0 release metadata for the feature-bearing release after v1.13.6.

1. **Version metadata:** Bump the app/package versions from 1.13.6 to 1.14.0.
2. **Lockfile alignment:** Update the root Cargo.lock package entry to match the release version.
3. **Release scope:** Include the unreleased feature/fix/build PRs from #393 through #404 in the generated v1.14.0 notes.

## Expected impact
| Area | Impact |
| --- | --- |
| App version | Packaged builds and updater metadata report 1.14.0. |
| Release notes | v1.14.0 notes include project folders, session title regeneration, daemon/session fixes, and release latest-pointer handling. |
| Updater | Stable release tag will publish latest.json through the corrected Latest release pointer from #404. |

## Design notes
This is a minor release because the unreleased changes include user-visible features: project folders for session layouts, hidden project sessions, and transcript-based session title regeneration.

## Follow-up (not in this PR)
None.

## Test plan
- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1`
- [x] `REPO=im-ian/acorn TAG=v1.14.0 OUTPUT=/tmp/acorn-release-notes-v1.14.0.md node scripts/release-notes.mjs`
- [x] `git diff --check`

## Notes
The first typecheck attempt in the temporary release worktree failed because `node_modules` was not installed there; after `pnpm install --frozen-lockfile`, the same typecheck command passed.