### PR TITLE
ci(release): tolerate sccache setup download failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
       # builds (when Swatinem/rust-cache misses, e.g. after Cargo.lock
       # bumps). Wraps rustc to memoize per-crate compilation outputs.
       - name: Setup sccache
+        continue-on-error: true
         uses: mozilla-actions/sccache-action@v0.0.6
 
       # Probe the GHA cache backend before trusting sccache. When the


### PR DESCRIPTION
## Summary
The v1.14.0 release workflow failed twice because the sccache setup action could not download its archive from GitHub Releases and returned HTTP 504.

1. **Release resilience:** Allow the sccache setup step to fail without failing the macOS bundle job.
2. **Fallback path:** Preserve the existing probe gate so the build only enables `RUSTC_WRAPPER=sccache` when sccache is actually available.

## Expected impact
| Area | Impact |
| --- | --- |
| Release reliability | Temporary sccache download failures no longer block signed macOS release builds. |
| Build speed | Affected jobs may run slower when sccache is unavailable, but still build normally. |

## Design notes
The workflow already treats the GHA cache backend probe as optional. This extends the same soft-fail behavior to the action download/setup step itself, which is where the current release failed.

## Follow-up (not in this PR)
None.

## Test plan
- [x] `git diff --check`
- [x] Confirmed failed v1.14.0 release logs show repeated HTTP 504 from mozilla-actions/sccache-action setup.

## Notes
The v1.14.0 GitHub Release has not been published yet; after this merges, the failed tag can be recreated at the fixed main commit.