### PR TITLE
fix(projects): delete empty project folders without modal

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -346,6 +346,18 @@ export function Sidebar() {
     }
   }
 
+  function requestRemoveProjectFolder(folderId: string) {
+    const folderGroup = projectGroups
+      .flatMap((project) => project.folders)
+      .find((candidate) => candidate.folder.id === folderId);
+    if (!folderGroup) return;
+    if (folderGroup.sessions.length === 0) {
+      removeProjectFolder(folderGroup.folder.id);
+      return;
+    }
+    setPendingRemoveProjectFolderId(folderGroup.folder.id);
+  }
+
   const onNewSessionRef = useRef<
     (
       isolated: boolean,
@@ -858,7 +870,7 @@ export function Sidebar() {
                       }
                       onAddFolder={() => onAddProjectFolder(project.repoPath)}
                       onRenameFolder={renameProjectFolder}
-                      onRemoveFolder={setPendingRemoveProjectFolderId}
+                      onRemoveFolder={requestRemoveProjectFolder}
                       onMoveSessionToFolder={moveSessionToProjectFolder}
                       onRemoveProject={() =>
                         requestRemoveProject(project.repoPath)

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -898,6 +898,39 @@ test.describe("sidebar: project lifecycle", () => {
     expect(calls).toEqual([{ id: "child-session", removeWorktree: false }]);
   });
 
+  test("project folder remove skips confirmation for empty folders", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => []);
+
+    await page.goto("/");
+
+    const sidebar = page.locator("aside");
+    const projectRow = page.getByRole("button", { name: "Project demo" });
+    await projectRow.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "New project folder" }).click();
+
+    const folderRows = sidebar.getByRole("button", { name: /New folder/ });
+    await expect(folderRows).toHaveCount(1);
+    await folderRows.first().click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Remove folder" }).click();
+
+    await expect(page.getByRole("dialog", { name: "Remove folder" })).toHaveCount(
+      0,
+    );
+    await expect(folderRows).toHaveCount(0);
+    await expect(projectRow).toBeVisible();
+  });
+
   test("project folder remove can keep sessions and move them out", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Project folder deletion now skips the confirmation modal when the folder has no sessions to protect.

1. **Empty folder deletion** — route project folder remove requests through a sidebar handler that removes empty folders immediately and only opens the confirmation modal for folders containing sessions.
2. **Regression coverage** — add a Playwright sidebar flow covering empty folder removal without a `Remove folder` dialog.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Empty project folder deletion | Shows a confirmation modal | Deletes immediately from the folder context menu |
| Project folders with sessions | Confirmation modal offers move/delete choices | Unchanged |

## Design notes
- The store-level `removeProjectFolder` behavior is unchanged; the decision to skip confirmation stays at the UI request boundary where the current folder session count is already available.
- `RemoveProjectFolderDialog` remains responsible for non-empty folders, including the existing choices to move sessions out or remove the folder with its sessions.

## Test plan
- [x] `pnpm install --frozen-lockfile` installed workspace dependencies without lockfile changes
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "project folder remove"` — 3 passed
- [x] `pnpm run typecheck` — passes

## Notes
- The focused Playwright run emitted existing `NO_COLOR` / `FORCE_COLOR` warnings from the test environment; the tests still passed.
