### PR TITLE
fix(ui): improve tooltip readability

### DIFF
--- a/src/components/AuthorAvatar.tsx
+++ b/src/components/AuthorAvatar.tsx
@@ -1,4 +1,5 @@
 import { cn } from "../lib/cn";
+import { Tooltip } from "./Tooltip";
 
 /**
  * Inline GitHub avatar. Uses an API-provided avatar URL when one is available,
@@ -26,19 +27,20 @@ export function AuthorAvatar({
     ? withAvatarSize(avatarUrl, pixelSize)
     : `https://github.com/${encodeURIComponent(slug)}.png?size=${pixelSize}`;
   return (
-    <img
-      src={src}
-      alt=""
-      title={login}
-      width={size}
-      height={size}
-      loading="lazy"
-      style={{ width: size, height: size }}
-      className={cn(
-        "shrink-0 rounded-full bg-bg-elevated align-middle",
-        className,
-      )}
-    />
+    <Tooltip label={login} side="top" className="shrink-0">
+      <img
+        src={src}
+        alt=""
+        width={size}
+        height={size}
+        loading="lazy"
+        style={{ width: size, height: size }}
+        className={cn(
+          "shrink-0 rounded-full bg-bg-elevated align-middle",
+          className,
+        )}
+      />
+    </Tooltip>
   );
 }
 

--- a/src/components/BackgroundSessionsSettings.tsx
+++ b/src/components/BackgroundSessionsSettings.tsx
@@ -1,13 +1,25 @@
 import {
+  Activity,
+  AlertCircle,
   Power,
   RefreshCcw,
   Loader2,
   AlertTriangle,
   Bot,
+  Folder,
+  GitBranch,
+  Hash,
+  MessageSquareText,
   Trash2,
   Undo2,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 
 import { api, type DaemonSessionSummary, type DaemonStatus } from "../lib/api";
 import { cn } from "../lib/cn";
@@ -246,25 +258,29 @@ export function BackgroundSessionsSettings() {
             )}
             <span>{t("backgroundSessions.controls.restart")}</span>
           </button>
-          <button
-            type="button"
-            onClick={() => void handleForgetInactiveSessions()}
-            disabled={
-              !enabled || !running || inactiveSessionCount === 0 || busy !== null
-            }
-            title={t("backgroundSessions.controls.clearInactiveTooltip")}
-            className={cn(
-              "flex items-center gap-1 rounded border border-border bg-bg-elevated px-2.5 py-1 text-xs transition",
-              "hover:bg-bg-elevated/70 disabled:cursor-default disabled:opacity-50",
-            )}
+          <Tooltip
+            label={t("backgroundSessions.controls.clearInactiveTooltip")}
+            side="bottom"
           >
-            {busy === "forget-inactive" ? (
-              <Loader2 size={12} className="animate-spin" />
-            ) : (
-              <Trash2 size={12} />
-            )}
-            <span>{t("backgroundSessions.controls.clearInactive")}</span>
-          </button>
+            <button
+              type="button"
+              onClick={() => void handleForgetInactiveSessions()}
+              disabled={
+                !enabled || !running || inactiveSessionCount === 0 || busy !== null
+              }
+              className={cn(
+                "flex items-center gap-1 rounded border border-border bg-bg-elevated px-2.5 py-1 text-xs transition",
+                "hover:bg-bg-elevated/70 disabled:cursor-default disabled:opacity-50",
+              )}
+            >
+              {busy === "forget-inactive" ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                <Trash2 size={12} />
+              )}
+              <span>{t("backgroundSessions.controls.clearInactive")}</span>
+            </button>
+          </Tooltip>
           {confirmShutdown ? (
             <div className="flex items-center gap-2 rounded border border-danger/40 bg-danger/10 px-2 py-1 text-xs text-danger">
               <span>
@@ -593,27 +609,42 @@ function renderAppMetaTooltip(
   daemon: DaemonSessionSummary,
   t: BackgroundSessionsTranslator,
 ) {
-  const rows: { label: string; value: string }[] = [];
+  const rows: Array<{
+    icon: ReactNode;
+    label: string;
+    value: string;
+    valueClassName?: string;
+  }> = [];
   if (app) {
-    rows.push({ label: t("backgroundSessions.metadata.tab"), value: app.name });
+    rows.push({
+      icon: <MessageSquareText size={12} />,
+      label: t("backgroundSessions.metadata.tab"),
+      value: app.name,
+    });
     if (app.branch) {
       rows.push({
+        icon: <GitBranch size={12} />,
         label: t("backgroundSessions.metadata.branch"),
         value: app.branch,
+        valueClassName: "font-mono",
       });
     }
     rows.push({
+      icon: <Activity size={12} />,
       label: t("backgroundSessions.metadata.status"),
       value: app.status,
     });
     if (app.worktree_path) {
       rows.push({
+        icon: <Folder size={12} />,
         label: t("backgroundSessions.metadata.worktree"),
         value: app.worktree_path,
+        valueClassName: "break-all font-mono",
       });
     }
     if (app.last_message) {
       rows.push({
+        icon: <MessageSquareText size={12} />,
         label: t("backgroundSessions.metadata.last"),
         value: app.last_message,
       });
@@ -621,37 +652,88 @@ function renderAppMetaTooltip(
   } else {
     if (daemon.branch) {
       rows.push({
+        icon: <GitBranch size={12} />,
         label: t("backgroundSessions.metadata.branch"),
         value: daemon.branch,
+        valueClassName: "font-mono",
       });
     }
     if (daemon.repo_path) {
       rows.push({
+        icon: <Folder size={12} />,
         label: t("backgroundSessions.metadata.repo"),
         value: daemon.repo_path,
+        valueClassName: "break-all font-mono",
       });
     }
     if (daemon.cwd) {
       rows.push({
+        icon: <Folder size={12} />,
         label: t("backgroundSessions.metadata.worktree"),
         value: daemon.cwd,
+        valueClassName: "break-all font-mono",
       });
     }
   }
   return (
-    <div className="flex flex-col gap-0.5 text-left">
-      <div className="font-mono text-[10px] text-fg-muted">{daemon.id}</div>
+    <div className="flex w-72 max-w-full flex-col gap-1.5 text-left">
+      <BackgroundSessionTooltipRow
+        icon={<Hash size={12} />}
+        label="ID"
+        value={daemon.id}
+        valueClassName="break-all font-mono text-fg-muted"
+      />
       {!app ? (
-        <div className="text-[10px] italic text-fg-muted">
+        <div className="flex items-center gap-1.5 rounded border border-warning/30 bg-warning/10 px-1.5 py-1 text-[10px] leading-none text-warning">
+          <AlertCircle size={11} aria-hidden="true" className="shrink-0" />
           {t("backgroundSessions.metadata.orphaned")}
         </div>
       ) : null}
       {rows.map((r) => (
-        <div key={r.label} className="flex gap-1.5">
-          <span className="text-fg-muted">{r.label}:</span>
-          <span className="font-mono break-all">{r.value}</span>
-        </div>
+        <BackgroundSessionTooltipRow
+          key={`${r.label}:${r.value}`}
+          icon={r.icon}
+          label={r.label}
+          value={r.value}
+          valueClassName={r.valueClassName}
+        />
       ))}
+    </div>
+  );
+}
+
+function BackgroundSessionTooltipRow({
+  icon,
+  label,
+  value,
+  valueClassName,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  valueClassName?: string;
+}) {
+  return (
+    <div className="flex min-w-0 items-start gap-2">
+      <span
+        aria-hidden="true"
+        className="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded border border-border/70 bg-bg/60 text-fg-muted"
+      >
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-[10px] leading-3 text-fg-muted">
+          {label}
+        </span>
+        <span
+          className={cn(
+            "block min-w-0 break-words text-[11px] leading-snug text-fg",
+            valueClassName,
+          )}
+        >
+          {value}
+        </span>
+      </span>
     </div>
   );
 }

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -1394,22 +1394,26 @@ export function ChatPane({
               {attachments.length > 0 ? (
                 <div className="flex min-w-0 flex-wrap items-center gap-1">
                   {attachments.map((attachment) => (
-                    <span
+                    <Tooltip
                       key={attachment.id}
-                      className="inline-flex max-w-40 items-center gap-1 rounded border border-border bg-bg/70 px-1.5 py-1 text-xs text-fg-muted"
-                      title={attachment.path}
+                      label={attachment.path}
+                      side="top"
+                      multiline
+                      className="max-w-40"
                     >
-                      <span className="truncate">{attachment.name}</span>
-                      <button
-                        aria-label={`Remove attachment ${attachment.name}`}
-                        className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/60"
-                        disabled={sending}
-                        type="button"
-                        onClick={() => removeAttachment(attachment.id)}
-                      >
-                        <X size={11} />
-                      </button>
-                    </span>
+                      <span className="inline-flex max-w-40 items-center gap-1 rounded border border-border bg-bg/70 px-1.5 py-1 text-xs text-fg-muted">
+                        <span className="truncate">{attachment.name}</span>
+                        <button
+                          aria-label={`Remove attachment ${attachment.name}`}
+                          className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/60"
+                          disabled={sending}
+                          type="button"
+                          onClick={() => removeAttachment(attachment.id)}
+                        >
+                          <X size={11} />
+                        </button>
+                      </span>
+                    </Tooltip>
                   ))}
                 </div>
               ) : null}

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -21,6 +21,7 @@ import {
   VirtualizedLineList,
   type VirtualizedLineListHandle,
 } from "./VirtualizedLines";
+import { Tooltip } from "./Tooltip";
 import { Markdown } from "./ui/Markdown";
 import type { CodeWorkspaceTabTarget } from "../lib/workspaceTabs";
 
@@ -482,35 +483,38 @@ export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
                     .replace("{current}", String(activeMatchIndex + 1))
                     .replace("{total}", String(currentMatchCount))}
           </span>
-          <button
-            type="button"
-            onClick={() => stepMatch(-1)}
-            disabled={currentMatchCount === 0}
-            aria-label={t("codeViewer.previousMatch")}
-            title={t("codeViewer.previousMatch")}
-            className="inline-flex size-7 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
-          >
-            <ChevronUp size={14} />
-          </button>
-          <button
-            type="button"
-            onClick={() => stepMatch(1)}
-            disabled={currentMatchCount === 0}
-            aria-label={t("codeViewer.nextMatch")}
-            title={t("codeViewer.nextMatch")}
-            className="inline-flex size-7 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
-          >
-            <ChevronDown size={14} />
-          </button>
-          <button
-            type="button"
-            onClick={closeSearch}
-            aria-label={t("codeViewer.closeFind")}
-            title={t("codeViewer.closeFind")}
-            className="inline-flex size-7 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
-          >
-            <X size={14} />
-          </button>
+          <Tooltip label={t("codeViewer.previousMatch")} side="bottom">
+            <button
+              type="button"
+              onClick={() => stepMatch(-1)}
+              disabled={currentMatchCount === 0}
+              aria-label={t("codeViewer.previousMatch")}
+              className="inline-flex size-7 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+            >
+              <ChevronUp size={14} />
+            </button>
+          </Tooltip>
+          <Tooltip label={t("codeViewer.nextMatch")} side="bottom">
+            <button
+              type="button"
+              onClick={() => stepMatch(1)}
+              disabled={currentMatchCount === 0}
+              aria-label={t("codeViewer.nextMatch")}
+              className="inline-flex size-7 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+            >
+              <ChevronDown size={14} />
+            </button>
+          </Tooltip>
+          <Tooltip label={t("codeViewer.closeFind")} side="bottom">
+            <button
+              type="button"
+              onClick={closeSearch}
+              aria-label={t("codeViewer.closeFind")}
+              className="inline-flex size-7 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
+            >
+              <X size={14} />
+            </button>
+          </Tooltip>
         </div>
       ) : null}
       {canPreviewMarkdown ? (

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -1400,12 +1400,16 @@ function Toolbar(props: ToolbarProps) {
   const rootName = props.rootPath.split("/").filter(Boolean).pop() ?? "/";
   return (
     <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1 text-[11px]">
-      <span
-        className="truncate font-medium text-fg-muted"
-        title={props.rootPath}
+      <Tooltip
+        label={props.rootPath}
+        side="bottom"
+        multiline
+        className="min-w-0"
       >
-        {rootName.toUpperCase()}
-      </span>
+        <span className="truncate font-medium text-fg-muted">
+          {rootName.toUpperCase()}
+        </span>
+      </Tooltip>
       <span className="flex-1" />
       <ToolbarBtn
         label={
@@ -1779,49 +1783,54 @@ function EntryRow({
     !gitStatus && dirtyDescendant ? "text-amber-400/70" : "";
   return (
     <>
-      <button
-        type="button"
-        draggable
-        onDragStart={(e) => {
-          // Set both the OS-friendly text data (terminals + external
-          // apps paste the quoted path) and the in-process Acorn drag
-          // mirror used by Pane/TabStrip drop targets.
-          if (!entry.is_dir) {
-            beginFileDrag(e, { path: entry.path });
-          } else {
-            endAcornDrag();
-          }
-          const quoted = shellQuote(entry.path);
-          try {
-            e.dataTransfer.setData("text/plain", quoted);
-            e.dataTransfer.setData("text/uri-list", `file://${entry.path}`);
-          } catch {
-            // ignore
-          }
-          e.dataTransfer.effectAllowed = "copy";
-        }}
-        onDragEnd={endAcornDrag}
-        onClick={(e) => onEntryClick(entry, e)}
-        onDoubleClick={(e) => {
-          e.preventDefault();
-          onEntryDoubleClick(entry);
-        }}
-        onContextMenu={(e) => {
-          e.stopPropagation();
-          onContextMenu(e, entry);
-        }}
-        className={cn(
-          "flex w-full items-center gap-1 whitespace-nowrap py-0.5 pr-2 text-left transition",
-          isSelected
-            ? "bg-accent/25 text-fg"
-            : isActive
-            ? "bg-accent/15 text-fg"
-            : "text-fg hover:bg-fg-muted/10",
-          entry.gitignored ? "opacity-60" : "",
-        )}
-        style={{ paddingLeft: 8 }}
-        title={entry.path}
+      <Tooltip
+        label={entry.path}
+        side="right"
+        multiline
+        className="w-full"
       >
+        <button
+          type="button"
+          draggable
+          onDragStart={(e) => {
+            // Set both the OS-friendly text data (terminals + external
+            // apps paste the quoted path) and the in-process Acorn drag
+            // mirror used by Pane/TabStrip drop targets.
+            if (!entry.is_dir) {
+              beginFileDrag(e, { path: entry.path });
+            } else {
+              endAcornDrag();
+            }
+            const quoted = shellQuote(entry.path);
+            try {
+              e.dataTransfer.setData("text/plain", quoted);
+              e.dataTransfer.setData("text/uri-list", `file://${entry.path}`);
+            } catch {
+              // ignore
+            }
+            e.dataTransfer.effectAllowed = "copy";
+          }}
+          onDragEnd={endAcornDrag}
+          onClick={(e) => onEntryClick(entry, e)}
+          onDoubleClick={(e) => {
+            e.preventDefault();
+            onEntryDoubleClick(entry);
+          }}
+          onContextMenu={(e) => {
+            e.stopPropagation();
+            onContextMenu(e, entry);
+          }}
+          className={cn(
+            "flex w-full items-center gap-1 whitespace-nowrap py-0.5 pr-2 text-left transition",
+            isSelected
+              ? "bg-accent/25 text-fg"
+              : isActive
+              ? "bg-accent/15 text-fg"
+              : "text-fg hover:bg-fg-muted/10",
+            entry.gitignored ? "opacity-60" : "",
+          )}
+          style={{ paddingLeft: 8 }}
+        >
         {Array.from({ length: depth }).map((_, i) => (
           <span
             key={i}
@@ -1881,7 +1890,8 @@ function EntryRow({
             </span>
           </span>
         ) : null}
-      </button>
+        </button>
+      </Tooltip>
       {children}
     </>
   );

--- a/src/components/PullRequestDetailModal.modal.test.tsx
+++ b/src/components/PullRequestDetailModal.modal.test.tsx
@@ -201,12 +201,13 @@ describe("PullRequestDetailModal — body checkbox toggle", () => {
     });
     await flushPromises();
 
-    const img = document.body.querySelector<HTMLImageElement>(
-      'img[title="linear-code"]',
-    );
-    expect(img?.src).toBe(
-      "https://avatars.githubusercontent.com/in/1658531?s=56&v=4",
-    );
+    const avatarUrl =
+      "https://avatars.githubusercontent.com/in/1658531?s=56&v=4";
+    const img =
+      Array.from(document.body.querySelectorAll<HTMLImageElement>("img")).find(
+        (candidate) => candidate.src === avatarUrl,
+      ) ?? null;
+    expect(img?.src).toBe(avatarUrl);
   });
 
   it("reverts and surfaces an error when updatePullRequestBody rejects", async () => {

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -998,20 +998,25 @@ function ResizableBody({ children }: { children: React.ReactNode }) {
       >
         {children}
       </div>
-      <div
-        role="separator"
-        aria-orientation="horizontal"
-        aria-label={dt(t, "dialogs.pullRequestDetail.resizePrBody")}
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
-        onPointerCancel={onPointerUp}
-        onDoubleClick={() => setHeight(BODY_HEIGHT_DEFAULT)}
-        title={dt(t, "dialogs.pullRequestDetail.resizeHint")}
-        className="group relative flex h-1.5 shrink-0 cursor-row-resize items-center justify-center border-b border-border bg-bg-sidebar/40 transition hover:bg-accent/30"
+      <Tooltip
+        label={dt(t, "dialogs.pullRequestDetail.resizeHint")}
+        side="top"
+        className="flex w-full shrink-0"
       >
-        <span className="h-0.5 w-8 rounded-full bg-fg-muted/0 transition group-hover:bg-fg-muted/40" />
-      </div>
+        <span
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label={dt(t, "dialogs.pullRequestDetail.resizePrBody")}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          onDoubleClick={() => setHeight(BODY_HEIGHT_DEFAULT)}
+          className="group relative flex h-1.5 w-full shrink-0 cursor-row-resize items-center justify-center border-b border-border bg-bg-sidebar/40 transition hover:bg-accent/30"
+        >
+          <span className="h-0.5 w-8 rounded-full bg-fg-muted/0 transition group-hover:bg-fg-muted/40" />
+        </span>
+      </Tooltip>
     </>
   );
 }
@@ -1403,9 +1408,16 @@ function CommitListItem({
             : "text-fg-muted hover:bg-bg-elevated hover:text-fg",
         )}
       >
-        <div className="truncate text-[12px] font-medium text-fg" title={commit.message_headline}>
-          {commit.message_headline || dt(t, "dialogs.pullRequestDetail.noMessage")}
-        </div>
+        <Tooltip
+          label={commit.message_headline || dt(t, "dialogs.pullRequestDetail.noMessage")}
+          side="right"
+          multiline
+          className="min-w-0 w-full"
+        >
+          <div className="w-full truncate text-[12px] font-medium text-fg">
+            {commit.message_headline || dt(t, "dialogs.pullRequestDetail.noMessage")}
+          </div>
+        </Tooltip>
         <div className="mt-1 flex items-center gap-1.5 text-[10.5px] text-fg-muted">
           {primaryAuthor ? (
             <AuthorTag
@@ -1505,12 +1517,16 @@ function CommitDetailView({
       <header className="flex shrink-0 items-start gap-2 border-b border-border bg-bg-sidebar/40 px-4 py-2.5">
         <GitCommit size={14} className="mt-[3px] shrink-0 text-fg-muted" />
         <div className="min-w-0 flex-1">
-          <div
-            className="truncate text-[13px] font-semibold tracking-tight text-fg"
-            title={commit.message_headline}
+          <Tooltip
+            label={commit.message_headline || dt(t, "dialogs.pullRequestDetail.noMessage")}
+            side="bottom"
+            multiline
+            className="min-w-0 w-full"
           >
-            {commit.message_headline || dt(t, "dialogs.pullRequestDetail.noMessage")}
-          </div>
+            <div className="w-full truncate text-[13px] font-semibold tracking-tight text-fg">
+              {commit.message_headline || dt(t, "dialogs.pullRequestDetail.noMessage")}
+            </div>
+          </Tooltip>
           <div className="mt-1 flex items-center gap-1.5 text-[11px] text-fg-muted">
             {primaryAuthor ? (
               <AuthorTag

--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -75,16 +75,6 @@ function exactButtonCount(container: HTMLElement, label: string): number {
   ).length;
 }
 
-function buttonWithTitle(container: HTMLElement, title: string): HTMLButtonElement {
-  const button = Array.from(container.querySelectorAll("button")).find(
-    (button) => button.getAttribute("title") === title,
-  );
-  if (!(button instanceof HTMLButtonElement)) {
-    throw new Error(`button titled "${title}" not found`);
-  }
-  return button;
-}
-
 function buttonContaining(container: HTMLElement, text: string): HTMLButtonElement {
   const button = Array.from(container.querySelectorAll("button")).find(
     (button) => button.textContent?.includes(text),
@@ -732,7 +722,7 @@ describe("RightPanel background tab loading", () => {
     });
     await flushPromises();
 
-    const runButton = buttonWithTitle(container, "Double-click to view details");
+    const runButton = buttonContaining(container, "Run CI");
     expect(runButton.textContent).toContain("Run CI");
     await act(async () => {
       runButton.dispatchEvent(

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -3083,15 +3083,20 @@ function PullRequestsTab({
             {rt(t, prStateLabelKey(opt.value))}
           </button>
         ))}
-        <button
-          type="button"
-          onClick={onOpenSearch}
-          aria-label={rt(t, "rightPanel.search.aria")}
-          title={rt(t, "rightPanel.search.aria")}
-          className="ml-auto rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+        <Tooltip
+          label={rt(t, "rightPanel.search.aria")}
+          side="bottom"
+          className="ml-auto"
         >
-          <Search size={12} />
-        </button>
+          <button
+            type="button"
+            onClick={onOpenSearch}
+            aria-label={rt(t, "rightPanel.search.aria")}
+            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          >
+            <Search size={12} />
+          </button>
+        </Tooltip>
         <RefreshButton
           onClick={() => void fetchActivePrs()}
           loading={loading}
@@ -3339,64 +3344,69 @@ function WorkflowRunRow({
 
   return (
     <li>
-      <button
-        type="button"
-        onDoubleClick={onOpenDetail}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            onOpenDetail();
-          }
-        }}
-        className={cn(
-          "flex w-full items-start gap-2 border-b border-border/40 px-3 py-2 text-left",
-          "transition hover:bg-bg-elevated/60 focus:bg-bg-elevated/60 focus:outline-none",
-        )}
-        title={rt(t, "rightPanel.actions.doubleClickDetails")}
+      <Tooltip
+        label={rt(t, "rightPanel.actions.doubleClickDetails")}
+        side="top"
+        className="w-full"
       >
-        <span className="mt-0.5 flex shrink-0 items-center">
-          <WorkflowRunStatusIcon
-            status={run.status}
-            conclusion={run.conclusion}
-          />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-fg">{title}</div>
-          <div className="mt-0.5 flex items-center gap-1.5 text-[10px] text-fg-muted">
-            <span className="truncate">{run.workflow_name}</span>
-            <span className="opacity-50">·</span>
-            <span className="truncate">{run.event}</span>
-            {branch ? (
-              <>
-                <span className="opacity-50">·</span>
-                <span className="truncate font-mono">{branch}</span>
-              </>
-            ) : null}
-            {run.attempt > 1 ? (
-              <>
-                <span className="opacity-50">·</span>
-                <span>
-                  {rtf(t, "rightPanel.actions.retryAttempt", {
-                    attempt: run.attempt,
-                  })}
-                </span>
-              </>
-            ) : null}
-          </div>
-        </div>
-        {startedRelative ? (
-          <Tooltip label={startedAbsolute}>
-            <span className="mt-0.5 shrink-0 whitespace-nowrap text-[10px] text-fg-muted">
-              {startedRelative}
-            </span>
-          </Tooltip>
-        ) : null}
-        {duration ? (
-          <span className="mt-0.5 shrink-0 whitespace-nowrap font-mono text-[10px] text-fg-muted">
-            {duration}
+        <button
+          type="button"
+          onDoubleClick={onOpenDetail}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              onOpenDetail();
+            }
+          }}
+          className={cn(
+            "flex w-full items-start gap-2 border-b border-border/40 px-3 py-2 text-left",
+            "transition hover:bg-bg-elevated/60 focus:bg-bg-elevated/60 focus:outline-none",
+          )}
+        >
+          <span className="mt-0.5 flex shrink-0 items-center">
+            <WorkflowRunStatusIcon
+              status={run.status}
+              conclusion={run.conclusion}
+            />
           </span>
-        ) : null}
-      </button>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-fg">{title}</div>
+            <div className="mt-0.5 flex items-center gap-1.5 text-[10px] text-fg-muted">
+              <span className="truncate">{run.workflow_name}</span>
+              <span className="opacity-50">·</span>
+              <span className="truncate">{run.event}</span>
+              {branch ? (
+                <>
+                  <span className="opacity-50">·</span>
+                  <span className="truncate font-mono">{branch}</span>
+                </>
+              ) : null}
+              {run.attempt > 1 ? (
+                <>
+                  <span className="opacity-50">·</span>
+                  <span>
+                    {rtf(t, "rightPanel.actions.retryAttempt", {
+                      attempt: run.attempt,
+                    })}
+                  </span>
+                </>
+              ) : null}
+            </div>
+          </div>
+          {startedRelative ? (
+            <Tooltip label={startedAbsolute}>
+              <span className="mt-0.5 shrink-0 whitespace-nowrap text-[10px] text-fg-muted">
+                {startedRelative}
+              </span>
+            </Tooltip>
+          ) : null}
+          {duration ? (
+            <span className="mt-0.5 shrink-0 whitespace-nowrap font-mono text-[10px] text-fg-muted">
+              {duration}
+            </span>
+          ) : null}
+        </button>
+      </Tooltip>
     </li>
   );
 }
@@ -3526,15 +3536,19 @@ function WorkflowRunDetailModal({
         }
         actions={
           detail?.url ? (
-            <button
-              type="button"
-              onClick={() => void openUrl(detail.url)}
-              className="flex items-center gap-1 rounded px-2 py-1 text-[11px] text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
-              title={rt(t, "rightPanel.tooltips.openOnGitHub")}
+            <Tooltip
+              label={rt(t, "rightPanel.tooltips.openOnGitHub")}
+              side="bottom"
             >
-              <ExternalLink size={12} />
-              {rt(t, "rightPanel.actions.github")}
-            </button>
+              <button
+                type="button"
+                onClick={() => void openUrl(detail.url)}
+                className="flex items-center gap-1 rounded px-2 py-1 text-[11px] text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
+              >
+                <ExternalLink size={12} />
+                {rt(t, "rightPanel.actions.github")}
+              </button>
+            </Tooltip>
           ) : null
         }
         onClose={onClose}
@@ -3720,25 +3734,29 @@ function WorkflowJobRow({ job, nowUnix }: { job: WorkflowJob; nowUnix: number })
           <span className="shrink-0 text-[11px] text-fg-muted">{duration}</span>
         ) : null}
         {job.url ? (
-          <span
-            role="link"
-            tabIndex={0}
-            onClick={(e) => {
-              e.stopPropagation();
-              void openUrl(job.url);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
+          <Tooltip
+            label={rt(t, "rightPanel.actions.openJobOnGitHub")}
+            side="top"
+          >
+            <span
+              role="link"
+              tabIndex={0}
+              onClick={(e) => {
                 e.stopPropagation();
                 void openUrl(job.url);
-              }
-            }}
-            className="shrink-0 cursor-pointer rounded p-0.5 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
-            title={rt(t, "rightPanel.actions.openJobOnGitHub")}
-          >
-            <ExternalLink size={11} />
-          </span>
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  void openUrl(job.url);
+                }
+              }}
+              className="shrink-0 cursor-pointer rounded p-0.5 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
+            >
+              <ExternalLink size={11} />
+            </span>
+          </Tooltip>
         ) : null}
       </button>
       {expanded && job.steps.length > 0 ? (

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -43,6 +43,7 @@ import {
 import { useUpdater } from "../lib/updater-store";
 import { BackgroundSessionsSettings } from "./BackgroundSessionsSettings";
 import { WhatsNewModal } from "./WhatsNewModal";
+import { Tooltip } from "./Tooltip";
 import {
   AGENT_OPTIONS,
   DEFAULT_SESSION_TITLE_PROMPT,
@@ -1054,14 +1055,19 @@ function ThemeSection({
             </option>
           ))}
         </Select>
-        <button
-          type="button"
-          onClick={() => void refresh()}
-          className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-bg px-2 text-[11px] text-fg-muted transition hover:text-fg"
-          title={st(t, "settings.appearance.theme.rescanTitle")}
+        <Tooltip
+          label={st(t, "settings.appearance.theme.rescanTitle")}
+          side="bottom"
         >
-          <RefreshCcw size={12} /> {st(t, "settings.appearance.theme.refresh")}
-        </button>
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-bg px-2 text-[11px] text-fg-muted transition hover:text-fg"
+          >
+            <RefreshCcw size={12} />{" "}
+            {st(t, "settings.appearance.theme.refresh")}
+          </button>
+        </Tooltip>
         <button
           type="button"
           onClick={() => void revealThemesFolder()}
@@ -1776,18 +1782,22 @@ function AgentSettings({
               {st(t, "settings.agents.sessionTitles.checkbox")}
             </span>
           </label>
-          <button
-            type="button"
-            aria-haspopup="dialog"
-            aria-expanded={sessionTitlePromptOpen}
-            aria-label={st(t, "settings.agents.sessionTitlePrompt.open")}
-            title={st(t, "settings.agents.sessionTitlePrompt.open")}
-            onClick={() => onSessionTitlePromptOpenChange(true)}
-            className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border bg-bg px-2 text-[11px] font-medium text-fg-muted transition hover:border-accent/60 hover:bg-bg-elevated hover:text-fg"
+          <Tooltip
+            label={st(t, "settings.agents.sessionTitlePrompt.open")}
+            side="bottom"
           >
-            <SettingsIcon size={12} />
-            {st(t, "settings.agents.sessionTitlePrompt.shortButton")}
-          </button>
+            <button
+              type="button"
+              aria-haspopup="dialog"
+              aria-expanded={sessionTitlePromptOpen}
+              aria-label={st(t, "settings.agents.sessionTitlePrompt.open")}
+              onClick={() => onSessionTitlePromptOpenChange(true)}
+              className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border bg-bg px-2 text-[11px] font-medium text-fg-muted transition hover:border-accent/60 hover:bg-bg-elevated hover:text-fg"
+            >
+              <SettingsIcon size={12} />
+              {st(t, "settings.agents.sessionTitlePrompt.shortButton")}
+            </button>
+          </Tooltip>
         </div>
       </Field>
       <SessionTitlePromptModal
@@ -1902,23 +1912,27 @@ function SessionTitlePromptModal({
                   max: SESSION_TITLE_PROMPT_MAX_CHARS,
                 })}
               </span>
-              <button
-                type="button"
-                onClick={() =>
-                  patchAgents({
-                    sessionTitlePrompt: DEFAULT_SESSION_TITLE_PROMPT,
-                  })
-                }
-                disabled={
-                  settings.agents.sessionTitlePrompt ===
-                  DEFAULT_SESSION_TITLE_PROMPT
-                }
-                title={st(t, "settings.agents.sessionTitlePrompt.reset")}
-                className="inline-flex items-center gap-1 rounded-md border border-border bg-bg px-2 py-1 text-[11px] text-fg-muted transition hover:border-accent/60 hover:text-fg disabled:cursor-not-allowed disabled:opacity-45"
+              <Tooltip
+                label={st(t, "settings.agents.sessionTitlePrompt.reset")}
+                side="bottom"
               >
-                <RefreshCcw size={11} />
-                {st(t, "settings.agents.sessionTitlePrompt.reset")}
-              </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    patchAgents({
+                      sessionTitlePrompt: DEFAULT_SESSION_TITLE_PROMPT,
+                    })
+                  }
+                  disabled={
+                    settings.agents.sessionTitlePrompt ===
+                    DEFAULT_SESSION_TITLE_PROMPT
+                  }
+                  className="inline-flex items-center gap-1 rounded-md border border-border bg-bg px-2 py-1 text-[11px] text-fg-muted transition hover:border-accent/60 hover:text-fg disabled:cursor-not-allowed disabled:opacity-45"
+                >
+                  <RefreshCcw size={11} />
+                  {st(t, "settings.agents.sessionTitlePrompt.reset")}
+                </button>
+              </Tooltip>
             </div>
             <div className="rounded-md border border-border bg-bg-sidebar/30 p-2">
               <div className="mb-1 text-[11px] font-medium text-fg-muted">
@@ -2354,57 +2368,67 @@ function ShortcutsSettings() {
                         ? st(t, "settings.shortcuts.recording")
                         : formatHotkey(shortcuts[item.id])}
                     </kbd>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        recordingId === item.id
-                          ? stopRecording()
-                          : startRecording(item.id)
-                      }
-                      aria-label={stf(
+                    <Tooltip
+                      label={stf(
                         t,
                         recordingId === item.id
                           ? "settings.shortcuts.cancelRecording"
                           : "settings.shortcuts.recordShortcut",
                         { command: shortcutLabel(t, item.id) },
                       )}
-                      title={stf(
-                        t,
-                        recordingId === item.id
-                          ? "settings.shortcuts.cancelRecording"
-                          : "settings.shortcuts.recordShortcut",
-                        { command: shortcutLabel(t, item.id) },
-                      )}
-                      className={cn(
-                        "inline-flex h-7 w-[4.75rem] items-center justify-center gap-1 rounded border text-[11px] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
-                        recordingId === item.id
-                          ? "border-danger/50 bg-danger/10 text-danger hover:bg-danger/15"
-                          : "border-border bg-bg text-fg-muted hover:border-accent/60 hover:text-fg",
-                      )}
+                      side="bottom"
                     >
-                      {recordingId === item.id ? (
-                        <X size={11} />
-                      ) : (
-                        <Keyboard size={11} />
-                      )}
-                      {recordingId === item.id
-                        ? st(t, "settings.shortcuts.cancel")
-                        : st(t, "settings.shortcuts.record")}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => resetShortcut(item.id)}
-                      disabled={shortcuts[item.id] === DEFAULT_HOTKEYS[item.id]}
-                      aria-label={stf(t, "settings.shortcuts.resetShortcut", {
+                      <button
+                        type="button"
+                        onClick={() =>
+                          recordingId === item.id
+                            ? stopRecording()
+                            : startRecording(item.id)
+                        }
+                        aria-label={stf(
+                          t,
+                          recordingId === item.id
+                            ? "settings.shortcuts.cancelRecording"
+                            : "settings.shortcuts.recordShortcut",
+                          { command: shortcutLabel(t, item.id) },
+                        )}
+                        className={cn(
+                          "inline-flex h-7 w-[4.75rem] items-center justify-center gap-1 rounded border text-[11px] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+                          recordingId === item.id
+                            ? "border-danger/50 bg-danger/10 text-danger hover:bg-danger/15"
+                            : "border-border bg-bg text-fg-muted hover:border-accent/60 hover:text-fg",
+                        )}
+                      >
+                        {recordingId === item.id ? (
+                          <X size={11} />
+                        ) : (
+                          <Keyboard size={11} />
+                        )}
+                        {recordingId === item.id
+                          ? st(t, "settings.shortcuts.cancel")
+                          : st(t, "settings.shortcuts.record")}
+                      </button>
+                    </Tooltip>
+                    <Tooltip
+                      label={stf(t, "settings.shortcuts.resetShortcut", {
                         command: shortcutLabel(t, item.id),
                       })}
-                      title={stf(t, "settings.shortcuts.resetShortcut", {
-                        command: shortcutLabel(t, item.id),
-                      })}
-                      className="inline-flex h-7 w-7 items-center justify-center rounded border border-border bg-bg text-fg-muted transition hover:border-accent/60 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-default disabled:opacity-40 disabled:hover:border-border disabled:hover:text-fg-muted"
+                      side="bottom"
                     >
-                      <RefreshCcw size={11} />
-                    </button>
+                      <button
+                        type="button"
+                        onClick={() => resetShortcut(item.id)}
+                        disabled={
+                          shortcuts[item.id] === DEFAULT_HOTKEYS[item.id]
+                        }
+                        aria-label={stf(t, "settings.shortcuts.resetShortcut", {
+                          command: shortcutLabel(t, item.id),
+                        })}
+                        className="inline-flex h-7 w-7 items-center justify-center rounded border border-border bg-bg text-fg-muted transition hover:border-accent/60 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-default disabled:opacity-40 disabled:hover:border-border disabled:hover:text-fg-muted"
+                      >
+                        <RefreshCcw size={11} />
+                      </button>
+                    </Tooltip>
                   </div>
                 </div>
               ))}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  Activity,
   Bot,
   ChevronRight,
   CircleX,
@@ -17,11 +18,19 @@ import {
   Settings as SettingsIcon,
   Sparkles,
   SquareX,
+  Tag,
   Trash2,
   X,
 } from "lucide-react";
 import { homeDir } from "@tauri-apps/api/path";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   DndContext,
   DragOverlay,
@@ -2846,32 +2855,113 @@ function composeSessionMetadata(
   return parts.join(" · ");
 }
 
-function buildSessionHoverDetails(t: Translator, session: Session): string {
-  const lines = [
-    `${sidebarText(t, "sidebar.metadata.name")}: ${session.name}`,
-    `${sidebarText(t, "sidebar.metadata.branch")}: ${
-      session.branch || sidebarText(t, "sidebar.metadata.detached")
-    }`,
-    `${sidebarText(t, "sidebar.metadata.workingDirectory")}: ${
-      session.worktree_path
-    }`,
-    `${sidebarText(t, "sidebar.metadata.status")}: ${statusLabel(
-      t,
-      session.status,
-    )}`,
-  ];
-  if (session.kind === "control") {
-    lines.push(
-      `${sidebarText(t, "sidebar.metadata.kind")}: ${sidebarText(
-        t,
-        "sidebar.metadata.controlSession",
-      )}`,
-    );
-  }
-  if (session.isolated) {
-    lines.push(sidebarText(t, "sidebar.metadata.isolatedWorktree"));
-  }
-  return lines.join("\n");
+function buildSessionHoverDetails(t: Translator, session: Session): ReactNode {
+  const branch =
+    session.branch || sidebarText(t, "sidebar.metadata.detached");
+
+  return (
+    <span className="flex w-72 max-w-full flex-col gap-1.5">
+      <SessionHoverDetailRow
+        icon={<Tag size={12} />}
+        label={sidebarText(t, "sidebar.metadata.name")}
+        value={session.name}
+      />
+      <SessionHoverDetailRow
+        icon={<GitBranch size={12} />}
+        label={sidebarText(t, "sidebar.metadata.branch")}
+        value={branch}
+        valueClassName="font-mono"
+      />
+      <SessionHoverDetailRow
+        icon={<Folder size={12} />}
+        label={sidebarText(t, "sidebar.metadata.workingDirectory")}
+        value={session.worktree_path}
+        valueClassName="break-all font-mono"
+      />
+      <SessionHoverDetailRow
+        icon={<Activity size={12} />}
+        iconClassName={STATUS_ICON[session.status]}
+        label={sidebarText(t, "sidebar.metadata.status")}
+        value={statusLabel(t, session.status)}
+        valueClassName={STATUS_ICON[session.status]}
+      />
+      {session.kind === "control" ? (
+        <SessionHoverDetailRow
+          icon={<Bot size={12} />}
+          iconClassName="text-accent"
+          label={sidebarText(t, "sidebar.metadata.kind")}
+          value={sidebarText(t, "sidebar.metadata.controlSession")}
+        />
+      ) : null}
+      {session.isolated ? (
+        <SessionHoverFlag
+          icon={<GitBranch size={12} />}
+          value={sidebarText(t, "sidebar.metadata.isolatedWorktree")}
+        />
+      ) : null}
+    </span>
+  );
+}
+
+function SessionHoverDetailRow({
+  icon,
+  iconClassName,
+  label,
+  value,
+  valueClassName,
+}: {
+  icon: ReactNode;
+  iconClassName?: string;
+  label: string;
+  value: string;
+  valueClassName?: string;
+}) {
+  return (
+    <span className="flex min-w-0 items-start gap-2">
+      <span
+        aria-hidden="true"
+        className={cn(
+          "mt-0.5 flex size-4 shrink-0 items-center justify-center rounded border border-border/70 bg-bg/60 text-fg-muted",
+          iconClassName,
+        )}
+      >
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-[10px] leading-3 text-fg-muted">
+          {label}
+        </span>
+        <span
+          className={cn(
+            "block min-w-0 break-words text-[11px] leading-snug text-fg",
+            valueClassName,
+          )}
+        >
+          {value}
+        </span>
+      </span>
+    </span>
+  );
+}
+
+function SessionHoverFlag({
+  icon,
+  value,
+}: {
+  icon: ReactNode;
+  value: string;
+}) {
+  return (
+    <span className="flex min-w-0 items-center gap-2 rounded border border-border/60 bg-bg/40 px-1.5 py-1 text-[11px] leading-none text-fg">
+      <span
+        aria-hidden="true"
+        className="flex size-4 shrink-0 items-center justify-center rounded bg-bg-elevated/70 text-fg-muted"
+      >
+        {icon}
+      </span>
+      <span className="min-w-0 truncate">{value}</span>
+    </span>
+  );
 }
 
 function loadStringSet(key: string): Set<string> {

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -10,8 +10,10 @@ import { createPortal } from "react-dom";
 import { homeDir } from "@tauri-apps/api/path";
 import {
   Activity,
+  AlertCircle,
   Bell,
   CheckCheck,
+  Clock,
   Gauge,
   Loader2,
   Settings,
@@ -399,7 +401,7 @@ function AgentTokenUsageBadge({
 }) {
   const t = useTranslation();
   const summary = renderAgentTokenSummary(snapshot, provider, t);
-  const tooltip = formatAgentTokenTooltip(snapshot, provider, t);
+  const tooltip = renderAgentTokenTooltip(snapshot, provider, t);
 
   return (
     <Tooltip label={tooltip} side="top" multiline>
@@ -472,36 +474,108 @@ function TokenWindowReadout({
   );
 }
 
-function formatAgentTokenTooltip(
+function renderAgentTokenTooltip(
   snapshot: AgentTokenUsageSnapshot | null,
   provider: AgentTokenProvider,
   t: Translator,
-): string {
-  if (!snapshot) return statusBarText(t, "statusBar.agentTokensUnavailable");
+): ReactNode {
+  if (!snapshot) {
+    return (
+      <span className="flex min-w-40 items-center gap-2">
+        <Loader2
+          size={12}
+          aria-hidden="true"
+          className="shrink-0 animate-spin text-fg-muted"
+        />
+        <span>{statusBarText(t, "statusBar.agentTokensUnavailable")}</span>
+      </span>
+    );
+  }
 
-  const lines = TOKEN_WINDOWS.map((window) => {
-    const metric = tokenMetric(snapshot, provider, window);
-    const windowName = windowDisplayName(window, t);
-    if (!metric || metric.error) {
-      return statusBarFormat(t, "statusBar.agentTokensTooltipError", {
-        window: windowName,
-        error:
-          metric?.error ?? statusBarText(t, "statusBar.agentTokensUnavailable"),
-      });
-    }
-    return statusBarFormat(t, "statusBar.agentTokensTooltipLine", {
-      window: windowName,
-      remaining: formatRemainingPercent(metric) ?? "-",
-      reset: formatResetRemaining(metric.reset_at, snapshot.updated_at, t),
-    });
-  });
-
-  lines.push(
-    statusBarFormat(t, "statusBar.agentTokensUpdated", {
-      time: formatUnixTime(snapshot.updated_at),
-    }),
+  return (
+    <span className="flex w-64 max-w-full flex-col gap-2">
+      {TOKEN_WINDOWS.map((window) => {
+        const metric = tokenMetric(snapshot, provider, window);
+        return (
+          <AgentTokenTooltipWindow
+            key={window}
+            metric={metric}
+            observedAt={snapshot.updated_at}
+            windowName={windowDisplayName(window, t)}
+            t={t}
+          />
+        );
+      })}
+      <span className="flex items-center gap-1.5 border-t border-border/60 pt-1.5 text-[10px] leading-none text-fg-muted">
+        <Clock size={11} aria-hidden="true" className="shrink-0" />
+        <span>
+          {statusBarFormat(t, "statusBar.agentTokensUpdated", {
+            time: formatUnixTime(snapshot.updated_at),
+          })}
+        </span>
+      </span>
+    </span>
   );
-  return lines.join("\n");
+}
+
+function AgentTokenTooltipWindow({
+  metric,
+  observedAt,
+  windowName,
+  t,
+}: {
+  metric: AgentTokenUsageMetric | null;
+  observedAt: number;
+  windowName: string;
+  t: Translator;
+}) {
+  const error =
+    metric?.error ??
+    (!metric ? statusBarText(t, "statusBar.agentTokensUnavailable") : null);
+  const remaining = metric ? (formatRemainingPercent(metric) ?? "-") : "-";
+  const reset = metric
+    ? formatResetRemaining(metric.reset_at, observedAt, t)
+    : statusBarText(t, "statusBar.agentTokensResetUnknown");
+
+  return (
+    <span className="flex min-w-0 items-start gap-2">
+      <span
+        aria-hidden="true"
+        className={cn(
+          "mt-0.5 flex size-4 shrink-0 items-center justify-center rounded border border-border/70 bg-bg/60",
+          error ? "text-danger" : "text-fg-muted",
+        )}
+      >
+        {error ? <AlertCircle size={12} /> : <Gauge size={12} />}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="mb-1 inline-flex rounded border border-fg-muted/25 bg-fg-muted/10 px-1 py-px text-[9px] font-semibold leading-none text-fg-muted">
+          {windowName}
+        </span>
+        {error ? (
+          <span className="block break-words text-[11px] leading-snug text-danger">
+            {error}
+          </span>
+        ) : (
+          <span className="flex flex-col gap-0.5 text-[11px] leading-snug">
+            <span className="font-medium text-fg">
+              {statusBarFormat(t, "statusBar.agentTokensRemaining", {
+                remaining,
+              })}
+            </span>
+            <span className="inline-flex min-w-0 items-center gap-1 text-fg-muted">
+              <Clock size={10} aria-hidden="true" className="shrink-0" />
+              <span className="min-w-0 truncate">
+                {statusBarFormat(t, "statusBar.agentTokensResetIn", {
+                  reset,
+                })}
+              </span>
+            </span>
+          </span>
+        )}
+      </span>
+    </span>
+  );
 }
 
 function tokenMetric(
@@ -992,33 +1066,6 @@ function ServicesStatusButton() {
     return "ok";
   })();
 
-  const tooltip = (() => {
-    const ipcLabel =
-      ipc.running === null
-        ? statusBarText(t, "statusBar.services.tooltip.ipcLoading")
-        : ipc.running
-          ? statusBarText(t, "statusBar.services.tooltip.ipcOn")
-          : statusBarText(t, "statusBar.services.tooltip.ipcOff");
-    const daemonLabel =
-      daemon === null
-        ? statusBarText(t, "statusBar.services.tooltip.daemonLoading")
-        : !daemon.enabled
-          ? statusBarText(t, "statusBar.services.tooltip.daemonDisabled")
-          : daemon.running
-            ? daemon.sessions !== null
-              ? statusBarFormat(
-                  t,
-                  "statusBar.services.tooltip.daemonOnWithSessions",
-                  { count: daemon.sessions },
-                )
-              : statusBarText(t, "statusBar.services.tooltip.daemonOn")
-            : statusBarText(t, "statusBar.services.tooltip.daemonDown");
-    return statusBarFormat(t, "statusBar.services.tooltip.details", {
-      ipc: ipcLabel,
-      daemon: daemonLabel,
-    });
-  })();
-
   const ipcDotState: DotState =
     ipc.running === null ? "muted" : ipc.running ? "ok" : "down";
   const daemonDotState: DotState = (() => {
@@ -1026,6 +1073,13 @@ function ServicesStatusButton() {
     if (!daemon.enabled) return "muted";
     return daemon.running ? "ok" : "down";
   })();
+  const tooltip = renderServicesTooltip(
+    ipc,
+    daemon,
+    ipcDotState,
+    daemonDotState,
+    t,
+  );
 
   return (
     <>
@@ -1064,6 +1118,94 @@ function ServicesStatusButton() {
         />
       ) : null}
     </>
+  );
+}
+
+function renderServicesTooltip(
+  ipc: IpcSnapshot,
+  daemon: DaemonSnapshot | null,
+  ipcDotState: DotState,
+  daemonDotState: DotState,
+  t: Translator,
+): ReactNode {
+  const ipcStatusText =
+    ipc.running === null
+      ? statusBarText(t, "statusBar.services.status.loading")
+      : ipc.running
+        ? statusBarText(t, "statusBar.services.status.running")
+        : statusBarText(t, "statusBar.services.status.down");
+  const daemonStatusText =
+    daemon === null
+      ? statusBarText(t, "statusBar.services.status.loading")
+      : !daemon.enabled
+        ? statusBarText(t, "statusBar.services.status.disabled")
+        : daemon.running
+          ? daemon.sessions !== null
+            ? statusBarFormat(
+                t,
+                "statusBar.services.status.runningSessions",
+                { count: daemon.sessions },
+              )
+            : statusBarText(t, "statusBar.services.status.running")
+          : statusBarText(t, "statusBar.services.status.down");
+
+  return (
+    <span className="flex w-56 max-w-full flex-col gap-1.5">
+      <ServiceTooltipRow
+        icon={<Activity size={12} />}
+        label={statusBarText(t, "statusBar.services.ipc.label")}
+        value={ipcStatusText}
+        dot={ipcDotState}
+      />
+      <ServiceTooltipRow
+        icon={<Gauge size={12} />}
+        label={statusBarText(t, "statusBar.services.daemon.label")}
+        value={daemonStatusText}
+        dot={daemonDotState}
+      />
+      <span className="flex items-center gap-1.5 border-t border-border/60 pt-1.5 text-[10px] leading-none text-fg-muted">
+        <Settings size={11} aria-hidden="true" className="shrink-0" />
+        <span>{statusBarText(t, "statusBar.services.tooltip.detailsHint")}</span>
+      </span>
+    </span>
+  );
+}
+
+function ServiceTooltipRow({
+  icon,
+  label,
+  value,
+  dot,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  dot: DotState;
+}) {
+  return (
+    <span className="flex min-w-0 items-start gap-2">
+      <span
+        aria-hidden="true"
+        className={cn(
+          "mt-0.5 flex size-4 shrink-0 items-center justify-center rounded border border-border/70 bg-bg/60",
+          dot === "ok"
+            ? "text-accent"
+            : dot === "down"
+              ? "text-danger"
+              : "text-fg-muted",
+        )}
+      >
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-[10px] leading-3 text-fg-muted">
+          {label}
+        </span>
+        <span className="block min-w-0 break-words text-[11px] leading-snug text-fg">
+          {value}
+        </span>
+      </span>
+    </span>
   );
 }
 

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -2,6 +2,7 @@ import { Download, X } from "lucide-react";
 import { useState, type ReactElement } from "react";
 import { selectShouldNotify, useUpdater } from "../lib/updater-store";
 import { useTranslation } from "../lib/useTranslation";
+import { Tooltip } from "./Tooltip";
 import { WhatsNewModal } from "./WhatsNewModal";
 
 /**
@@ -58,15 +59,17 @@ export function UpdateBanner(): ReactElement | null {
               ? t("updateBanner.installing")
               : t("updateBanner.installRelaunch")}
           </button>
-          <button
-            type="button"
-            onClick={dismiss}
-            disabled={busy}
-            title={t("updateBanner.hideUntilNextVersion")}
-            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
-          >
-            <X size={14} />
-          </button>
+          <Tooltip label={t("updateBanner.hideUntilNextVersion")} side="bottom">
+            <button
+              type="button"
+              onClick={dismiss}
+              disabled={busy}
+              aria-label={t("updateBanner.hideUntilNextVersion")}
+              className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:opacity-50"
+            >
+              <X size={14} />
+            </button>
+          </Tooltip>
         </div>
         {error ? (
           <div className="flex items-start gap-2 border-t border-danger/30 bg-danger/10 px-4 py-1.5 text-[11px] text-danger">

--- a/src/components/ui/CommandHint.tsx
+++ b/src/components/ui/CommandHint.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactElement } from "react";
 import { CommandRunDialog } from "../CommandRunDialog";
 import { cn } from "../../lib/cn";
 import { useTranslation } from "../../lib/useTranslation";
+import { Tooltip } from "../Tooltip";
 
 interface CommandHintProps {
   /**
@@ -36,17 +37,22 @@ export function CommandHint({
   const [open, setOpen] = useState(false);
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        title={t("ui.commandHint.title")}
-        className={cn(
-          "inline-flex max-w-full items-center rounded border border-border bg-bg-sidebar/70 px-1.5 py-0.5 text-left font-mono text-[11px] text-fg transition hover:border-accent/60 hover:bg-bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
-          className,
-        )}
+      <Tooltip
+        label={t("ui.commandHint.title")}
+        side="top"
+        className="max-w-full"
       >
-        <span className="truncate">{command}</span>
-      </button>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className={cn(
+            "inline-flex max-w-full items-center rounded border border-border bg-bg-sidebar/70 px-1.5 py-0.5 text-left font-mono text-[11px] text-fg transition hover:border-accent/60 hover:bg-bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+            className,
+          )}
+        >
+          <span className="truncate">{command}</span>
+        </button>
+      </Tooltip>
       <CommandRunDialog
         open={open}
         command={command}

--- a/src/components/ui/Markdown.tsx
+++ b/src/components/ui/Markdown.tsx
@@ -6,6 +6,7 @@ import remarkGfm from "remark-gfm";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { cn } from "../../lib/cn";
 import { ImageLightbox } from "../ImageLightbox";
+import { Tooltip } from "../Tooltip";
 
 // Sanitize schema for PR/comment markdown bodies — they routinely embed raw
 // HTML (image uploads, GitHub's `<img width="…">` snippets, details/summary).
@@ -87,8 +88,8 @@ interface MarkdownProps {
 }
 
 const baseComponents: Components = {
-  a({ href, children, ...rest }) {
-    return (
+  a({ href, children, title, ...rest }) {
+    const link = (
       <a
         {...rest}
         href={href}
@@ -100,6 +101,13 @@ const baseComponents: Components = {
       >
         {children}
       </a>
+    );
+    return typeof title === "string" && title.length > 0 ? (
+      <Tooltip label={title} side="top" multiline>
+        {link}
+      </Tooltip>
+    ) : (
+      link
     );
   },
   p({ children }) {
@@ -234,9 +242,9 @@ function MarkdownImpl({ content, className, onTaskToggle }: MarkdownProps) {
   const components = useMemo<Components>(
     () => ({
       ...baseComponents,
-      img({ src, alt, width, height }) {
+      img({ src, alt, title, width, height }) {
         const url = typeof src === "string" ? src : undefined;
-        return (
+        const image = (
           <img
             src={url}
             alt={alt ?? ""}
@@ -249,6 +257,13 @@ function MarkdownImpl({ content, className, onTaskToggle }: MarkdownProps) {
             }}
             className="my-2 max-w-full cursor-zoom-in rounded border border-border transition hover:opacity-90"
           />
+        );
+        return typeof title === "string" && title.length > 0 ? (
+          <Tooltip label={title} side="top" multiline>
+            {image}
+          </Tooltip>
+        ) : (
+          image
         );
       },
       input(props) {

--- a/src/components/ui/RefreshButton.tsx
+++ b/src/components/ui/RefreshButton.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Check, RefreshCw } from "lucide-react";
 import { cn } from "../../lib/cn";
+import { Tooltip } from "../Tooltip";
 
 interface RefreshButtonProps {
   onClick: () => void | Promise<void>;
@@ -60,43 +61,44 @@ export function RefreshButton({
   }, []);
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={loading}
-      title={title}
-      aria-label={ariaLabel ?? title}
-      className={cn(
-        "relative inline-flex items-center justify-center rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-not-allowed disabled:opacity-60",
-        className,
-      )}
-    >
-      {/* Reserve space so the absolute icons don't collapse the button. */}
-      <span
-        aria-hidden
-        className="inline-block"
-        style={{ width: size, height: size }}
-      />
-      <RefreshCw
-        size={size}
-        aria-hidden
+    <Tooltip label={title} side="bottom">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={loading}
+        aria-label={ariaLabel ?? title}
         className={cn(
-          "absolute transition-opacity",
-          loading && "animate-spin",
-          showSuccess ? "opacity-0" : "opacity-100",
+          "relative inline-flex items-center justify-center rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-not-allowed disabled:opacity-60",
+          className,
         )}
-        style={{ transitionDuration: `${FADE_MS}ms` }}
-      />
-      <Check
-        size={size}
-        strokeWidth={3}
-        aria-hidden
-        className={cn(
-          "absolute text-emerald-400 transition-opacity",
-          showSuccess ? "opacity-100" : "opacity-0",
-        )}
-        style={{ transitionDuration: `${FADE_MS}ms` }}
-      />
-    </button>
+      >
+        {/* Reserve space so the absolute icons don't collapse the button. */}
+        <span
+          aria-hidden
+          className="inline-block"
+          style={{ width: size, height: size }}
+        />
+        <RefreshCw
+          size={size}
+          aria-hidden
+          className={cn(
+            "absolute transition-opacity",
+            loading && "animate-spin",
+            showSuccess ? "opacity-0" : "opacity-100",
+          )}
+          style={{ transitionDuration: `${FADE_MS}ms` }}
+        />
+        <Check
+          size={size}
+          strokeWidth={3}
+          aria-hidden
+          className={cn(
+            "absolute text-emerald-400 transition-opacity",
+            showSuccess ? "opacity-100" : "opacity-0",
+          )}
+          style={{ transitionDuration: `${FADE_MS}ms` }}
+        />
+      </button>
+    </Tooltip>
   );
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -607,8 +607,8 @@
     "agentTokensWindowFiveHour": "5h",
     "agentTokensWindowWeekly": "weekly",
     "agentTokensResetUnknown": "-",
-    "agentTokensTooltipLine": "{window}: {remaining} left, resets in {reset}",
-    "agentTokensTooltipError": "{window}: {error}",
+    "agentTokensRemaining": "{remaining} left",
+    "agentTokensResetIn": "resets in {reset}",
     "agentTokensUpdated": "updated {time}",
     "sessionStatus": {
       "idle": "idle",
@@ -648,7 +648,7 @@
         "daemonOn": "daemon: on",
         "daemonOnWithSessions": "daemon: on ({count})",
         "daemonDown": "daemon: down",
-        "details": "{ipc} · {daemon} - click for details"
+        "detailsHint": "Click for details"
       },
       "status": {
         "loading": "loading",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -607,8 +607,8 @@
     "agentTokensWindowFiveHour": "5시간",
     "agentTokensWindowWeekly": "주간",
     "agentTokensResetUnknown": "-",
-    "agentTokensTooltipLine": "{window}: 잔여 {remaining}, 갱신까지 {reset}",
-    "agentTokensTooltipError": "{window}: {error}",
+    "agentTokensRemaining": "잔여 {remaining}",
+    "agentTokensResetIn": "갱신까지 {reset}",
     "agentTokensUpdated": "확인 시각 {time}",
     "sessionStatus": {
       "idle": "유휴",
@@ -648,7 +648,7 @@
         "daemonOn": "데몬: 켜짐",
         "daemonOnWithSessions": "데몬: 켜짐 ({count})",
         "daemonDown": "데몬: 중단됨",
-        "details": "{ipc} · {daemon} - 자세히 보려면 클릭"
+        "detailsHint": "자세히 보려면 클릭"
       },
       "status": {
         "loading": "불러오는 중",

--- a/tests/e2e/background-sessions.spec.ts
+++ b/tests/e2e/background-sessions.spec.ts
@@ -76,6 +76,20 @@ test.describe("background sessions settings", () => {
     await expect(
       modal.getByRole("button", { name: "Restore session" }),
     ).toBeVisible();
+
+    await modal.getByText("alpha", { exact: true }).hover();
+    const tooltip = page.getByRole("tooltip");
+    await expect(tooltip).toContainText("ID");
+    await expect(tooltip).toContainText("s-1");
+    await expect(tooltip).toContainText("Tab");
+    await expect(tooltip).toContainText("alpha");
+    await expect(tooltip).toContainText("Branch");
+    await expect(tooltip).toContainText("main");
+    await expect(tooltip).toContainText("Status");
+    await expect(tooltip).toContainText("idle");
+    await expect(tooltip).toContainText("Worktree");
+    await expect(tooltip).toContainText("/tmp/demo");
+    await expect(tooltip.locator("svg")).toHaveCount(5);
   });
 
   test("restore adopts an orphaned daemon session and opens its project tab", async ({

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -332,6 +332,64 @@ test.describe("sidebar: project lifecycle", () => {
     expect(calls).toHaveLength(0);
   });
 
+  test("session hover details render as icon rows", async ({ page, tauri }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "session-1",
+        name: "detail-session",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.acorn/worktrees/detail-session",
+        branch: "feature/readable-tooltip",
+        isolated: true,
+        project_scoped: true,
+        status: "needs_input",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "control",
+        mode: "terminal",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: true,
+        agent_provider: null,
+        agent_transcript_id: null,
+      },
+    ]);
+
+    await page.goto("/");
+
+    await page
+      .locator("aside")
+      .getByRole("button", { name: /detail-session/ })
+      .hover();
+
+    const tooltip = page.getByRole("tooltip");
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toContainText("Name");
+    await expect(tooltip).toContainText("detail-session");
+    await expect(tooltip).toContainText("Branch");
+    await expect(tooltip).toContainText("feature/readable-tooltip");
+    await expect(tooltip).toContainText("Working directory");
+    await expect(tooltip).toContainText(
+      "/tmp/demo/.acorn/worktrees/detail-session",
+    );
+    await expect(tooltip).toContainText("Status");
+    await expect(tooltip).toContainText("Needs input");
+    await expect(tooltip).toContainText("Kind");
+    await expect(tooltip).toContainText("Control session");
+    await expect(tooltip).toContainText("Isolated worktree");
+    await expect(tooltip.locator("svg")).toHaveCount(6);
+  });
+
   test("regenerates a name for sessions backed by real git worktrees", async ({
     page,
     tauri,

--- a/tests/e2e/statusbar.spec.ts
+++ b/tests/e2e/statusbar.spec.ts
@@ -72,6 +72,43 @@ async function enableAgentTokenUsage(
 }
 
 test.describe("status bar", () => {
+  test("service status tooltip renders service rows with icons", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("get_acorn_ipc_status", {
+      bundled_path: "/tmp/acorn-ipc",
+      bundled_exists: true,
+      socket_path: "/tmp/acorn-dev/ipc.sock",
+      server_running: true,
+      shim_paths: [],
+    });
+    await tauri.respond("daemon_status", {
+      running: true,
+      enabled: true,
+      daemon_version: "test",
+      uptime_seconds: 60,
+      session_count_total: 2,
+      session_count_alive: 2,
+      log_path: "/tmp/acorn/daemon.log",
+      last_error: null,
+    });
+
+    await page.goto("/");
+
+    const serviceButton = page.getByRole("button", { name: "Service status" });
+    await expect(serviceButton).toBeVisible();
+    await serviceButton.hover();
+
+    const tooltip = page.getByRole("tooltip");
+    await expect(tooltip).toContainText("IPC server");
+    await expect(tooltip).toContainText("running");
+    await expect(tooltip).toContainText("acornd daemon");
+    await expect(tooltip).toContainText("running · 2 sessions");
+    await expect(tooltip).toContainText("Click for details");
+    await expect(tooltip.locator("svg")).toHaveCount(3);
+  });
+
   test("shows only Codex token usage for an active Codex tab", async ({
     page,
     tauri,
@@ -99,10 +136,13 @@ test.describe("status bar", () => {
 
     await tokenBadge.hover();
     const tooltip = page.getByRole("tooltip");
-    await expect(tooltip).toContainText("5h: 88% left, resets in 7m");
-    await expect(tooltip).toContainText(
-      "weekly: 66% left, resets in 19h 27m",
-    );
+    await expect(tooltip).toContainText("5h");
+    await expect(tooltip).toContainText("88% left");
+    await expect(tooltip).toContainText("resets in 7m");
+    await expect(tooltip).toContainText("weekly");
+    await expect(tooltip).toContainText("66% left");
+    await expect(tooltip).toContainText("resets in 19h 27m");
+    await expect(tooltip.locator("svg")).toHaveCount(5);
     await expect(tooltip).not.toContainText(/used|12%|34%/);
   });
 


### PR DESCRIPTION
## Summary
This fixes hard-to-scan tooltip content by replacing dense native/title hovers with structured Acorn tooltips.

1. **Structured tooltip rows** — convert session, status bar, service, token usage, and background-session metadata hovers into icon-backed rows with clearer labels and wrapping for long paths.
2. **Native title migration** — replace DOM `title` hovers across file paths, attachments, workflow/PR controls, avatars, refresh buttons, command hints, update dismiss actions, and markdown link/image titles with the shared `Tooltip` component.
3. **Regression coverage** — update tooltip assertions and remove test selectors that depended on native `title` attributes.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Session/status tooltips | Dense text strings and line breaks | Icon rows with explicit labels and readable wrapping |
| Native browser hovers | Mixed `title` and Acorn tooltip behavior | Consistent Acorn tooltip behavior |
| Long paths / commit text | Native hover only, inconsistent wrapping | Shared multiline tooltip styling |

## Design notes
- Existing `Tooltip` behavior is reused instead of adding another hover primitive.
- Icon rows use existing lucide icons and keep accessible button labels via `aria-label` where native `title` previously carried the label.
- Remaining `title=` JSX occurrences are component props such as `ModalHeader`/`ModalShell` titles, not DOM native tooltip attributes.
- Markdown still accepts sanitized `title` attributes from GitHub content, but the React renderers consume them into `Tooltip` instead of spreading them to DOM nodes.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes — 61 files, 591 passed, 1 skipped
- [x] `pnpm run build` passes — Vite build completed; existing chunk-size/dynamic-import warnings only
- [x] `pnpm exec vitest run src/components/RightPanel.test.tsx` passes — 15 tests
- [x] `pnpm exec vitest run src/components/SettingsModal.test.tsx src/components/PullRequestDetailModal.modal.test.tsx` passes — 23 tests
- [x] `pnpm exec vitest run src/components/ui/Markdown.test.tsx` passes — 3 tests
- [x] `pnpm exec playwright test tests/e2e/statusbar.spec.ts tests/e2e/sidebar.spec.ts tests/e2e/background-sessions.spec.ts tests/e2e/command-hint.spec.ts -g "shows only Codex token usage|service status tooltip|session hover details render as icon rows|shows the app tab name|CommandHint"` passes — 6 tests
- [x] `git diff --check` passes
- [ ] CI green on this PR

## Notes
- `pnpm run build` reports pre-existing Vite warnings about large chunks and modules that are both statically and dynamically imported; no build failure and not introduced by this PR's tooltip changes.
