### PR TITLE
fix(terminal): link Next.js route file references

### DIFF
--- a/src/lib/terminalFileLinks.test.ts
+++ b/src/lib/terminalFileLinks.test.ts
@@ -126,6 +126,36 @@ describe("terminal file links", () => {
     ]);
   });
 
+  it("finds Next.js route segment file references", () => {
+    expect(
+      findTerminalFileReferences(
+        "apps/web/src/app/[locale]/(authenticated)/settings/page.tsx:321",
+      ),
+    ).toEqual([
+      {
+        path: "apps/web/src/app/[locale]/(authenticated)/settings/page.tsx",
+        line: 321,
+        text: "apps/web/src/app/[locale]/(authenticated)/settings/page.tsx:321",
+        startIndex: 0,
+      },
+    ]);
+  });
+
+  it("uses the first line from range file references", () => {
+    expect(
+      findTerminalFileReferences(
+        "apps/web/src/app/[locale]/(authenticated)/settings/page.tsx:321-324",
+      ),
+    ).toEqual([
+      {
+        path: "apps/web/src/app/[locale]/(authenticated)/settings/page.tsx",
+        line: 321,
+        text: "apps/web/src/app/[locale]/(authenticated)/settings/page.tsx:321-324",
+        startIndex: 0,
+      },
+    ]);
+  });
+
   it("finds file references with a trailing colon and no line number", () => {
     expect(
       findTerminalFileReferences(

--- a/src/lib/terminalFileLinks.ts
+++ b/src/lib/terminalFileLinks.ts
@@ -27,10 +27,27 @@ export interface TerminalFileLinkProviderOptions {
   leave?: (event: MouseEvent, reference: TerminalFileReference) => void;
 }
 
-const FILE_REF_RE =
-  /(^|[\s([{"'`<])((?:~\/|\.{1,2}\/|\/)?(?:(?:[\p{L}\p{N}._@+-]+\/)+[\p{L}\p{N}._@+-]+|[\p{L}\p{N}._@+-]*\.[\p{L}\p{N}._@+-]+)):(?:(\d{1,7})(?::(\d{1,5}))?)?(?=$|[\s)\]}>,;!?:]|[.](?=$|[\s)\]}>,;!?:]))/gu;
-const FILE_PATH_RE =
-  /(^|[\s([{"'`<])((?:~\/|\.{1,2}\/|\/)?(?:(?:[\p{L}\p{N}._@+-]+\/)+[\p{L}\p{N}._@+-]*\.[\p{L}][\p{L}\p{N}_@+-]+|[\p{L}\p{N}._@+-]*\.[\p{L}][\p{L}\p{N}_@+-]+))(?=$|[\s)\]}>,;!?]|[.](?=$|[\s)\]}>,;!?]))/gu;
+const LINK_PREFIX_RE = String.raw`(^|[\s([{"'\x60<])`;
+const OPTIONAL_PATH_ROOT_RE = String.raw`(?:~\/|\.{1,2}\/|\/)?`;
+// Next.js route groups need parentheses in directory segments, but the final
+// file segment excludes them so code like `unwrap().reset_at` is not linked.
+const DIRECTORY_SEGMENT_RE = String.raw`[\p{L}\p{N}._@+\[\]()-]+`;
+const FILE_SEGMENT_RE = String.raw`[\p{L}\p{N}._@+\[\]-]+`;
+const FILE_STEM_RE = String.raw`[\p{L}\p{N}._@+\[\]-]*`;
+const FILE_REF_PATH_RE = String.raw`${OPTIONAL_PATH_ROOT_RE}(?:(?:${DIRECTORY_SEGMENT_RE}\/)+${FILE_SEGMENT_RE}|${FILE_STEM_RE}\.${FILE_SEGMENT_RE})`;
+const FILE_EXTENSION_RE = String.raw`[\p{L}][\p{L}\p{N}_@+\[\]-]+`;
+const FILE_PATH_REQUIRING_EXTENSION_RE = String.raw`${OPTIONAL_PATH_ROOT_RE}(?:(?:${DIRECTORY_SEGMENT_RE}\/)+${FILE_STEM_RE}\.${FILE_EXTENSION_RE}|${FILE_STEM_RE}\.${FILE_EXTENSION_RE})`;
+const FILE_REF_LOCATION_RE = String.raw`:(?:(\d{1,7})(?:-\d{1,7})?(?::(\d{1,5}))?)?`;
+const FILE_REF_TRAILER_RE = String.raw`(?=$|[\s)\]}>,;!?:]|[.](?=$|[\s)\]}>,;!?:]))`;
+const FILE_PATH_TRAILER_RE = String.raw`(?=$|[\s)\]}>,;!?]|[.](?=$|[\s)\]}>,;!?]))`;
+const FILE_REF_RE = new RegExp(
+  `${LINK_PREFIX_RE}(${FILE_REF_PATH_RE})${FILE_REF_LOCATION_RE}${FILE_REF_TRAILER_RE}`,
+  "gu",
+);
+const FILE_PATH_RE = new RegExp(
+  `${LINK_PREFIX_RE}(${FILE_PATH_REQUIRING_EXTENSION_RE})${FILE_PATH_TRAILER_RE}`,
+  "gu",
+);
 
 export function createTerminalFileLinkProvider(
   terminal: XTerm,


### PR DESCRIPTION
## Summary
Terminal file links now recognize common Next.js app-router path shapes and line ranges printed by tools.

1. **Route segment paths** — allow bracketed and parenthesized directory segments such as `[locale]` and `(authenticated)` in terminal file references.
2. **Line ranges** — treat `file.tsx:321-324` as an openable link targeting the starting line, `321`.
3. **Parser readability** — split the terminal file-link regular expressions into named fragments while preserving existing false-positive guards.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal file links | `apps/web/src/app/[locale]/(authenticated)/settings/page.tsx:321-324` did not link | Path is detected and opens at line 321 |
| False-positive handling | Code-like property chains such as `unwrap().reset_at` were ignored | Existing guard remains covered by tests |

## Design notes
- Parentheses are allowed only in directory segments, not the final file segment, so Next.js route groups work without making code property chains look like file paths.
- Line ranges are parsed conservatively: the full range remains the link text, but the code viewer target uses only the starting line.
- The regexes still back the xterm link provider directly; this PR only makes their path and location fragments easier to audit.

## Test plan
- [x] `pnpm exec vitest run src/lib/terminalFileLinks.test.ts` — 25 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test` — 62 files passed; 610 passed, 1 skipped

## Notes
- No follow-up work is required for the current terminal link behavior.
