### PR TITLE
feat(viewer): media file previews and image zoom controls

### DIFF
--- a/src-tauri/src/fs_explorer.rs
+++ b/src-tauri/src/fs_explorer.rs
@@ -11,7 +11,7 @@ use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Emitter, Runtime, State};
+use tauri::{AppHandle, Emitter, Manager, Runtime, State};
 
 use crate::error::{AppError, AppResult};
 use crate::state::AppState;
@@ -1011,6 +1011,11 @@ pub struct ReadFileResult {
     pub binary: bool,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct PrepareAssetResult {
+    pub size: u64,
+}
+
 const VIEWER_MAX_BYTES: u64 = 2 * 1024 * 1024;
 
 #[tauri::command]
@@ -1044,6 +1049,33 @@ fn fs_file_exists_scoped(scope: &FsScope, path: String) -> AppResult<bool> {
 pub fn fs_read_file(state: State<'_, AppState>, path: String) -> AppResult<ReadFileResult> {
     let scope = FsScope::from_state(state.inner());
     fs_read_file_scoped(&scope, path)
+}
+
+#[tauri::command]
+pub fn fs_prepare_asset<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, AppState>,
+    path: String,
+) -> AppResult<PrepareAssetResult> {
+    let scope = FsScope::from_state(state.inner());
+    fs_prepare_asset_scoped(&scope, app, path)
+}
+
+fn fs_prepare_asset_scoped<R: Runtime>(
+    scope: &FsScope,
+    app: AppHandle<R>,
+    path: String,
+) -> AppResult<PrepareAssetResult> {
+    let p = PathBuf::from(&path);
+    let scoped = scope.authorize_existing(&p)?;
+    if !scoped.resolved.is_file() {
+        return Err(AppError::InvalidPath(format!("not a file: {path}")));
+    }
+    let meta = std::fs::metadata(&scoped.resolved)?;
+    app.asset_protocol_scope()
+        .allow_file(&scoped.resolved)
+        .map_err(|e| AppError::Other(format!("asset scope failed: {e}")))?;
+    Ok(PrepareAssetResult { size: meta.len() })
 }
 
 fn fs_read_file_scoped(scope: &FsScope, path: String) -> AppResult<ReadFileResult> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -621,6 +621,7 @@ pub fn run() {
             fs_explorer::fs_grant_external_file,
             fs_explorer::fs_file_exists,
             fs_explorer::fs_read_file,
+            fs_explorer::fs_prepare_asset,
             fs_explorer::fs_git_diff_stats,
             fs_explorer::fs_git_diff_lines,
             fs_explorer::fs_watch_set_root,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,8 +22,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost data: https:; connect-src 'self' ipc: http://ipc.localhost https://api.github.com; font-src 'self'; object-src 'none'; base-uri 'none'; frame-src 'none'",
-      "devCsp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost data: https: http://localhost:* http://127.0.0.1:*; connect-src 'self' ipc: http://ipc.localhost https://api.github.com http://localhost:* ws://localhost:* http://127.0.0.1:* ws://127.0.0.1:*; font-src 'self'; object-src 'none'; base-uri 'none'; frame-src 'none'",
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost data: https:; media-src 'self' asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost https://api.github.com; font-src 'self'; object-src 'none'; base-uri 'none'; frame-src asset: http://asset.localhost",
+      "devCsp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost data: https: http://localhost:* http://127.0.0.1:*; media-src 'self' asset: http://asset.localhost http://localhost:* http://127.0.0.1:*; connect-src 'self' ipc: http://ipc.localhost https://api.github.com http://localhost:* ws://localhost:* http://127.0.0.1:* ws://127.0.0.1:*; font-src 'self'; object-src 'none'; base-uri 'none'; frame-src asset: http://asset.localhost http://localhost:* http://127.0.0.1:*",
       "assetProtocol": {
         "enable": true,
         "scope": ["$APPLOCALDATA/backgrounds/**/*"]

--- a/src/components/FileViewer.test.tsx
+++ b/src/components/FileViewer.test.tsx
@@ -1,0 +1,112 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  FsLineDiffEntry,
+  FsPrepareAssetResult,
+  FsReadFileResult,
+} from "../lib/api";
+import { DEFAULT_SETTINGS, useSettings } from "../lib/settings";
+
+vi.mock("../lib/highlight", () => ({
+  langFromPath: vi.fn(() => null),
+  highlightCode: vi.fn(async (content: string) =>
+    content.split("\n").map(() => null),
+  ),
+}));
+
+vi.mock("../lib/api", () => ({
+  FS_CHANGED_EVENT: "acorn:fs-changed",
+  api: {
+    fsPrepareAsset: vi.fn<(path: string) => Promise<FsPrepareAssetResult>>(),
+    fsReadFile: vi.fn<(path: string) => Promise<FsReadFileResult>>(),
+    fsGitDiffLines: vi.fn<(path: string) => Promise<FsLineDiffEntry[]>>(),
+  },
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: vi.fn((path: string) => `asset://localhost/${encodeURIComponent(path)}`),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+import { api } from "../lib/api";
+import { FileViewer } from "./FileViewer";
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("FileViewer", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.mocked(api.fsPrepareAsset).mockReset();
+    vi.mocked(api.fsReadFile).mockReset();
+    vi.mocked(api.fsGitDiffLines).mockReset();
+    useSettings.setState({ settings: structuredClone(DEFAULT_SETTINGS) });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("opens image files in the media viewer without reading them as text", async () => {
+    vi.mocked(api.fsPrepareAsset).mockResolvedValueOnce({ size: 1024 });
+
+    await act(async () => {
+      root.render(<FileViewer path="/repo/assets/logo.png" isActive />);
+    });
+    await flushPromises();
+
+    const image = container.querySelector<HTMLImageElement>('img[alt="logo.png"]');
+    expect(image).not.toBeNull();
+    expect(image?.src).toContain(encodeURIComponent("/repo/assets/logo.png"));
+    expect(api.fsPrepareAsset).toHaveBeenCalledWith("/repo/assets/logo.png");
+    expect(api.fsReadFile).not.toHaveBeenCalled();
+  });
+
+  it("opens pdf files in the media viewer", async () => {
+    vi.mocked(api.fsPrepareAsset).mockResolvedValueOnce({ size: 2048 });
+
+    await act(async () => {
+      root.render(<FileViewer path="/repo/docs/spec.pdf" isActive />);
+    });
+    await flushPromises();
+
+    const frame = container.querySelector<HTMLIFrameElement>(
+      'iframe[title="spec.pdf"]',
+    );
+    expect(frame).not.toBeNull();
+    expect(frame?.src).toContain(encodeURIComponent("/repo/docs/spec.pdf"));
+    expect(api.fsReadFile).not.toHaveBeenCalled();
+  });
+
+  it("keeps text files on the code viewer path", async () => {
+    vi.mocked(api.fsReadFile).mockResolvedValueOnce({
+      content: "hello from source",
+      size: 17,
+      truncated: false,
+      binary: false,
+    });
+    vi.mocked(api.fsGitDiffLines).mockResolvedValueOnce([]);
+
+    await act(async () => {
+      root.render(<FileViewer path="/repo/README.md" isActive />);
+    });
+    await flushPromises();
+
+    expect(container.textContent).toContain("hello from source");
+    expect(api.fsPrepareAsset).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/FileViewer.test.tsx
+++ b/src/components/FileViewer.test.tsx
@@ -76,6 +76,51 @@ describe("FileViewer", () => {
     expect(api.fsReadFile).not.toHaveBeenCalled();
   });
 
+  it("lets image media zoom in, zoom out, and reset", async () => {
+    vi.mocked(api.fsPrepareAsset).mockResolvedValueOnce({ size: 1536 });
+
+    await act(async () => {
+      root.render(<FileViewer path="/repo/assets/icon.svg" isActive />);
+    });
+    await flushPromises();
+
+    const image = container.querySelector<HTMLImageElement>('img[alt="icon.svg"]');
+    const zoomIn = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Zoom in"]',
+    );
+    const zoomOut = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Zoom out"]',
+    );
+    const reset = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Reset zoom"]',
+    );
+
+    expect(image).not.toBeNull();
+    expect(zoomIn).not.toBeNull();
+    expect(zoomOut).not.toBeNull();
+    expect(reset).not.toBeNull();
+    expect(image?.style.transform).toBe("scale(1)");
+    expect(
+      container.querySelector('[data-acorn-media-zoom="1"]'),
+    ).not.toBeNull();
+
+    await act(async () => zoomIn!.click());
+
+    expect(image?.style.transform).toBe("scale(1.25)");
+    expect(
+      container.querySelector('[data-acorn-media-zoom="1.25"]'),
+    ).not.toBeNull();
+
+    await act(async () => zoomOut!.click());
+    await act(async () => zoomOut!.click());
+
+    expect(image?.style.transform).toBe("scale(0.75)");
+
+    await act(async () => reset!.click());
+
+    expect(image?.style.transform).toBe("scale(1)");
+  });
+
   it("opens pdf files in the media viewer", async () => {
     vi.mocked(api.fsPrepareAsset).mockResolvedValueOnce({ size: 2048 });
 
@@ -89,6 +134,9 @@ describe("FileViewer", () => {
     );
     expect(frame).not.toBeNull();
     expect(frame?.src).toContain(encodeURIComponent("/repo/docs/spec.pdf"));
+    expect(
+      container.querySelector<HTMLButtonElement>('button[aria-label="Zoom in"]'),
+    ).toBeNull();
     expect(api.fsReadFile).not.toHaveBeenCalled();
   });
 

--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -1,0 +1,18 @@
+import type { CodeWorkspaceTabTarget } from "../lib/workspaceTabs";
+import { mediaKindFromPath } from "../lib/mediaFiles";
+import { CodeViewer } from "./CodeViewer";
+import { MediaViewer } from "./MediaViewer";
+
+interface FileViewerProps {
+  path: string;
+  isActive: boolean;
+  target?: CodeWorkspaceTabTarget;
+}
+
+export function FileViewer({ path, isActive, target }: FileViewerProps) {
+  const mediaKind = mediaKindFromPath(path);
+  if (mediaKind) {
+    return <MediaViewer path={path} kind={mediaKind} isActive={isActive} />;
+  }
+  return <CodeViewer path={path} target={target} isActive={isActive} />;
+}

--- a/src/components/MediaViewer.tsx
+++ b/src/components/MediaViewer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
 import {
   api,
   FS_CHANGED_EVENT,
@@ -10,6 +11,7 @@ import {
 import { basenameFromPath, type MediaFileKind } from "../lib/mediaFiles";
 import { cn } from "../lib/cn";
 import { useTranslation } from "../lib/useTranslation";
+import { Tooltip } from "./Tooltip";
 
 interface MediaViewerProps {
   path: string;
@@ -31,9 +33,14 @@ const EMPTY_STATE: MediaState = {
   loading: true,
 };
 
+const IMAGE_ZOOM_MIN = 0.25;
+const IMAGE_ZOOM_MAX = 5;
+const IMAGE_ZOOM_STEP = 0.25;
+
 export function MediaViewer({ path, kind, isActive }: MediaViewerProps) {
   const t = useTranslation();
   const [state, setState] = useState<MediaState>(EMPTY_STATE);
+  const [imageZoom, setImageZoom] = useState(1);
   const loadSeqRef = useRef(0);
   const title = basenameFromPath(path);
 
@@ -71,6 +78,10 @@ export function MediaViewer({ path, kind, isActive }: MediaViewerProps) {
       loadSeqRef.current += 1;
     };
   }, [refreshAsset]);
+
+  useEffect(() => {
+    setImageZoom(1);
+  }, [path, kind]);
 
   useEffect(() => {
     let unlisten: UnlistenFn | null = null;
@@ -116,26 +127,52 @@ export function MediaViewer({ path, kind, isActive }: MediaViewerProps) {
   return (
     <div
       className={cn(
-        "flex h-full w-full items-center justify-center overflow-hidden bg-bg",
+        "relative flex h-full w-full items-center justify-center overflow-hidden bg-bg",
         isActive ? "" : "pointer-events-none",
       )}
       data-acorn-media-viewer={kind}
       data-acorn-media-size={state.asset?.size ?? undefined}
+      data-acorn-media-zoom={kind === "image" ? imageZoom : undefined}
     >
-      {renderMedia(kind, state.src, title)}
+      {kind === "image" ? (
+        <>
+          <ImageZoomControls
+            zoom={imageZoom}
+            onZoomIn={() => setImageZoom((value) => nextImageZoom(value, 1))}
+            onZoomOut={() => setImageZoom((value) => nextImageZoom(value, -1))}
+            onReset={() => setImageZoom(1)}
+          />
+          {renderMedia(kind, state.src, title, imageZoom)}
+        </>
+      ) : (
+        renderMedia(kind, state.src, title)
+      )}
     </div>
   );
 }
 
-function renderMedia(kind: MediaFileKind, src: string, title: string) {
+function renderMedia(
+  kind: MediaFileKind,
+  src: string,
+  title: string,
+  imageZoom = 1,
+) {
   if (kind === "image") {
     return (
-      <img
-        src={src}
-        alt={title}
-        className="max-h-full max-w-full object-contain"
-        draggable={false}
-      />
+      <div className="h-full w-full overflow-auto">
+        <div className="flex min-h-full min-w-full items-center justify-center p-6">
+          <img
+            src={src}
+            alt={title}
+            className="max-h-full max-w-full object-contain will-change-transform"
+            style={{
+              transform: `scale(${imageZoom})`,
+              transformOrigin: "center center",
+            }}
+            draggable={false}
+          />
+        </div>
+      </div>
     );
   }
   if (kind === "video") {
@@ -163,6 +200,86 @@ function renderMedia(kind: MediaFileKind, src: string, title: string) {
       className="h-full w-full border-0 bg-white"
     />
   );
+}
+
+interface ImageZoomControlsProps {
+  zoom: number;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onReset: () => void;
+}
+
+function ImageZoomControls({
+  zoom,
+  onZoomIn,
+  onZoomOut,
+  onReset,
+}: ImageZoomControlsProps) {
+  const t = useTranslation();
+  const zoomInLabel = t("mediaViewer.zoomIn");
+  const zoomOutLabel = t("mediaViewer.zoomOut");
+  const resetLabel = t("mediaViewer.resetZoom");
+
+  return (
+    <div className="absolute right-3 top-3 z-20 flex max-w-[calc(100%-1.5rem)] items-center gap-1 rounded-md border border-border bg-bg-elevated/95 p-1 shadow-lg backdrop-blur">
+      <Tooltip label={zoomOutLabel} side="bottom">
+        <button
+          type="button"
+          aria-label={zoomOutLabel}
+          title={zoomOutLabel}
+          onClick={onZoomOut}
+          disabled={zoom <= IMAGE_ZOOM_MIN}
+          className="inline-flex size-7 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+        >
+          <ZoomOut size={14} />
+        </button>
+      </Tooltip>
+      <span className="flex h-7 w-12 shrink-0 items-center justify-center font-mono text-[11px] tabular-nums text-fg-muted">
+        {formatImageZoom(zoom)}
+      </span>
+      <Tooltip label={zoomInLabel} side="bottom">
+        <button
+          type="button"
+          aria-label={zoomInLabel}
+          title={zoomInLabel}
+          onClick={onZoomIn}
+          disabled={zoom >= IMAGE_ZOOM_MAX}
+          className="inline-flex size-7 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+        >
+          <ZoomIn size={14} />
+        </button>
+      </Tooltip>
+      <Tooltip label={resetLabel} side="bottom">
+        <button
+          type="button"
+          aria-label={resetLabel}
+          title={resetLabel}
+          onClick={onReset}
+          disabled={zoom === 1}
+          className="inline-flex size-7 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+        >
+          <RotateCcw size={14} />
+        </button>
+      </Tooltip>
+    </div>
+  );
+}
+
+function nextImageZoom(value: number, direction: 1 | -1): number {
+  const next = value + direction * IMAGE_ZOOM_STEP;
+  return clampImageZoom(roundZoom(next));
+}
+
+function clampImageZoom(value: number): number {
+  return Math.min(IMAGE_ZOOM_MAX, Math.max(IMAGE_ZOOM_MIN, value));
+}
+
+function roundZoom(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function formatImageZoom(value: number): string {
+  return `${Math.round(value * 100)}%`;
 }
 
 function mediaFileChanged(filePath: string, payload: FsChangePayload): boolean {

--- a/src/components/MediaViewer.tsx
+++ b/src/components/MediaViewer.tsx
@@ -1,0 +1,196 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { convertFileSrc } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import {
+  api,
+  FS_CHANGED_EVENT,
+  type FsChangePayload,
+  type FsPrepareAssetResult,
+} from "../lib/api";
+import { basenameFromPath, type MediaFileKind } from "../lib/mediaFiles";
+import { cn } from "../lib/cn";
+import { useTranslation } from "../lib/useTranslation";
+
+interface MediaViewerProps {
+  path: string;
+  kind: MediaFileKind;
+  isActive: boolean;
+}
+
+interface MediaState {
+  src: string | null;
+  asset: FsPrepareAssetResult | null;
+  error: string | null;
+  loading: boolean;
+}
+
+const EMPTY_STATE: MediaState = {
+  src: null,
+  asset: null,
+  error: null,
+  loading: true,
+};
+
+export function MediaViewer({ path, kind, isActive }: MediaViewerProps) {
+  const t = useTranslation();
+  const [state, setState] = useState<MediaState>(EMPTY_STATE);
+  const loadSeqRef = useRef(0);
+  const title = basenameFromPath(path);
+
+  const refreshAsset = useCallback(
+    async ({ reset = false }: { reset?: boolean } = {}) => {
+      const seq = ++loadSeqRef.current;
+      if (reset) setState(EMPTY_STATE);
+      try {
+        const asset = await api.fsPrepareAsset(path);
+        if (seq !== loadSeqRef.current) return;
+        const baseSrc = convertFileSrc(path);
+        const separator = baseSrc.includes("?") ? "&" : "?";
+        setState({
+          src: `${baseSrc}${separator}v=${seq}`,
+          asset,
+          error: null,
+          loading: false,
+        });
+      } catch (err: unknown) {
+        if (seq !== loadSeqRef.current) return;
+        setState({
+          src: null,
+          asset: null,
+          error: err instanceof Error ? err.message : String(err),
+          loading: false,
+        });
+      }
+    },
+    [path],
+  );
+
+  useEffect(() => {
+    void refreshAsset({ reset: true });
+    return () => {
+      loadSeqRef.current += 1;
+    };
+  }, [refreshAsset]);
+
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+
+    void listen<FsChangePayload>(FS_CHANGED_EVENT, (event) => {
+      if (cancelled) return;
+      if (mediaFileChanged(path, event.payload)) {
+        void refreshAsset();
+      }
+    }).then((cancel) => {
+      if (cancelled) {
+        cancel();
+        return;
+      }
+      unlisten = cancel;
+    });
+
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, [path, refreshAsset]);
+
+  if (state.loading) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-fg-muted">
+        {t("codeViewer.loading")}
+      </div>
+    );
+  }
+
+  if (state.error) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-xs text-fg-muted">
+        {state.error}
+      </div>
+    );
+  }
+
+  if (!state.src) return null;
+
+  return (
+    <div
+      className={cn(
+        "flex h-full w-full items-center justify-center overflow-hidden bg-bg",
+        isActive ? "" : "pointer-events-none",
+      )}
+      data-acorn-media-viewer={kind}
+      data-acorn-media-size={state.asset?.size ?? undefined}
+    >
+      {renderMedia(kind, state.src, title)}
+    </div>
+  );
+}
+
+function renderMedia(kind: MediaFileKind, src: string, title: string) {
+  if (kind === "image") {
+    return (
+      <img
+        src={src}
+        alt={title}
+        className="max-h-full max-w-full object-contain"
+        draggable={false}
+      />
+    );
+  }
+  if (kind === "video") {
+    return (
+      <video
+        key={src}
+        src={src}
+        controls
+        className="max-h-full max-w-full bg-black"
+      />
+    );
+  }
+  if (kind === "audio") {
+    return (
+      <div className="w-full max-w-xl px-6">
+        <audio key={src} src={src} controls className="w-full" />
+      </div>
+    );
+  }
+  return (
+    <iframe
+      key={src}
+      src={src}
+      title={title}
+      className="h-full w-full border-0 bg-white"
+    />
+  );
+}
+
+function mediaFileChanged(filePath: string, payload: FsChangePayload): boolean {
+  if (
+    payload.paths.some((changedPath) => pathsOverlap(changedPath, filePath))
+  ) {
+    return true;
+  }
+  if (!payload.overflow) return false;
+  if (!payload.refresh) return true;
+  return isSameOrInside(payload.refresh.path, filePath);
+}
+
+function normalizeFsPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized === "" ? "/" : normalized;
+}
+
+function isSameOrInside(parent: string, child: string): boolean {
+  const normalizedParent = normalizeFsPath(parent);
+  const normalizedChild = normalizeFsPath(child);
+  if (normalizedParent === "/") return normalizedChild.startsWith("/");
+  return (
+    normalizedChild === normalizedParent ||
+    normalizedChild.startsWith(`${normalizedParent}/`)
+  );
+}
+
+function pathsOverlap(a: string, b: string): boolean {
+  return isSameOrInside(a, b) || isSameOrInside(b, a);
+}

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -28,7 +28,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { selectSessionsById, useAppStore } from "../store";
-import { CodeViewer } from "./CodeViewer";
+import { FileViewer } from "./FileViewer";
 import { ChatPane } from "./ChatPane";
 import { api } from "../lib/api";
 import {
@@ -489,8 +489,8 @@ export function Pane({ paneId }: PaneProps) {
           at App level. It is portaled into a per-session target div which
           gets `appendChild`-moved into this pane body when this session is
           active. We render only an EmptyPane fallback here for the
-          no-active-session case — or a CodeViewer when the active tab is
-          a frontend-owned code tab instead of a PTY session.
+          no-active-session case — or a FileViewer when the active tab is
+          a frontend-owned file tab instead of a PTY session.
         */}
         {activeSession?.mode === "chat" ? (
           <ChatPane
@@ -501,7 +501,7 @@ export function Pane({ paneId }: PaneProps) {
           />
         ) : null}
         {active?.kind === "code" ? (
-          <CodeViewer
+          <FileViewer
             path={active.path}
             target={active.target}
             isActive={isFocused}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -855,6 +855,9 @@ export const api = {
   fsReadFile(path: string): Promise<FsReadFileResult> {
     return invoke<FsReadFileResult>("fs_read_file", { path });
   },
+  fsPrepareAsset(path: string): Promise<FsPrepareAssetResult> {
+    return invoke<FsPrepareAssetResult>("fs_prepare_asset", { path });
+  },
   fsGitDiffLines(path: string): Promise<FsLineDiffEntry[]> {
     return invoke<FsLineDiffEntry[]>("fs_git_diff_lines", { path });
   },
@@ -936,6 +939,11 @@ export interface FsReadFileResult {
   size: number;
   truncated: boolean;
   binary: boolean;
+}
+
+/** Mirror of `crate::fs_explorer::PrepareAssetResult`. */
+export interface FsPrepareAssetResult {
+  size: number;
 }
 
 /** Mirror of `crate::fs_explorer::LineDiffEntry`. */

--- a/src/lib/mediaFiles.ts
+++ b/src/lib/mediaFiles.ts
@@ -1,0 +1,58 @@
+export type MediaFileKind = "image" | "video" | "audio" | "pdf";
+
+const IMAGE_EXTENSIONS = new Set([
+  "apng",
+  "avif",
+  "bmp",
+  "gif",
+  "ico",
+  "jpg",
+  "jpeg",
+  "png",
+  "svg",
+  "webp",
+]);
+
+const VIDEO_EXTENSIONS = new Set([
+  "m4v",
+  "mov",
+  "mp4",
+  "mpeg",
+  "mpg",
+  "ogv",
+  "webm",
+]);
+
+const AUDIO_EXTENSIONS = new Set([
+  "aac",
+  "flac",
+  "m4a",
+  "mp3",
+  "oga",
+  "ogg",
+  "opus",
+  "wav",
+  "weba",
+]);
+
+export function mediaKindFromPath(path: string): MediaFileKind | null {
+  const ext = extensionFromPath(path);
+  if (!ext) return null;
+  if (IMAGE_EXTENSIONS.has(ext)) return "image";
+  if (VIDEO_EXTENSIONS.has(ext)) return "video";
+  if (AUDIO_EXTENSIONS.has(ext)) return "audio";
+  if (ext === "pdf") return "pdf";
+  return null;
+}
+
+export function basenameFromPath(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] ?? path;
+}
+
+function extensionFromPath(path: string): string | null {
+  const base = basenameFromPath(path).toLowerCase();
+  const idx = base.lastIndexOf(".");
+  if (idx <= 0 || idx === base.length - 1) return null;
+  return base.slice(idx + 1);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -692,6 +692,11 @@
     "openInBrowser": "Open in browser",
     "close": "Close"
   },
+  "mediaViewer": {
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "resetZoom": "Reset zoom"
+  },
   "codeViewer": {
     "loading": "Loading...",
     "binaryFile": "Binary file",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -692,6 +692,11 @@
     "openInBrowser": "브라우저에서 열기",
     "close": "닫기"
   },
+  "mediaViewer": {
+    "zoomIn": "확대",
+    "zoomOut": "축소",
+    "resetZoom": "확대/축소 초기화"
+  },
   "codeViewer": {
     "loading": "불러오는 중...",
     "binaryFile": "바이너리 파일",

--- a/tests/e2e/file-explorer.spec.ts
+++ b/tests/e2e/file-explorer.spec.ts
@@ -643,6 +643,91 @@ test.describe("file explorer", () => {
     ).toBeVisible();
   });
 
+  test("opens media files from the file explorer in a media viewer", async ({
+    page,
+    tauri,
+  }) => {
+    const repo = "/tmp/demo";
+
+    await tauri.respond("list_projects", [
+      {
+        repo_path: repo,
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", []);
+    await tauri.handle("fs_list_dir", (args) => {
+      const { path } = args as { path: string };
+      if (path !== "/tmp/demo") {
+        return { repo_root: "/tmp/demo", entries: [] };
+      }
+      return {
+        repo_root: "/tmp/demo",
+        entries: [
+          {
+            name: "logo.png",
+            path: "/tmp/demo/logo.png",
+            is_dir: false,
+            is_symlink: false,
+            size: 512,
+            modified_ms: 0,
+            gitignored: false,
+          },
+          {
+            name: "spec.pdf",
+            path: "/tmp/demo/spec.pdf",
+            is_dir: false,
+            is_symlink: false,
+            size: 1024,
+            modified_ms: 0,
+            gitignored: false,
+          },
+        ],
+      };
+    });
+    await tauri.handle("fs_prepare_asset", (args) => {
+      const { path } = args as { path: string };
+      if (path === "/tmp/demo/logo.png") return { size: 512 };
+      if (path === "/tmp/demo/spec.pdf") return { size: 1024 };
+      throw new Error(`unexpected media path: ${path}`);
+    });
+    await tauri.handle("fs_read_file", () => {
+      throw new Error("media files should not be read as text");
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Code" }).click();
+    await page.getByRole("button", { name: "Files", exact: true }).click();
+
+    await page.getByRole("button", { name: "logo.png" }).dblclick();
+
+    await expect(
+      page.getByRole("button", { name: /logo\.png Close tab/ }),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-acorn-media-viewer="image"]'),
+    ).toBeVisible();
+    await expect(page.locator('img[alt="logo.png"]')).toHaveAttribute(
+      "src",
+      /%2Ftmp%2Fdemo%2Flogo\.png/,
+    );
+
+    await page.getByRole("button", { name: "spec.pdf" }).dblclick();
+
+    await expect(
+      page.getByRole("button", { name: /spec\.pdf Close tab/ }),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-acorn-media-viewer="pdf"]'),
+    ).toBeVisible();
+    await expect(page.locator('iframe[title="spec.pdf"]')).toHaveAttribute(
+      "src",
+      /%2Ftmp%2Fdemo%2Fspec\.pdf/,
+    );
+  });
+
   test("finds matches inside a code viewer tab", async ({ page, tauri }) => {
     const repo = "/tmp/demo";
 

--- a/tests/e2e/file-explorer.spec.ts
+++ b/tests/e2e/file-explorer.spec.ts
@@ -713,6 +713,25 @@ test.describe("file explorer", () => {
       "src",
       /%2Ftmp%2Fdemo%2Flogo\.png/,
     );
+    await expect(
+      page.locator('[data-acorn-media-viewer="image"]'),
+    ).toHaveAttribute("data-acorn-media-zoom", "1");
+
+    await page.getByRole("button", { name: "Zoom in" }).click();
+
+    await expect(
+      page.locator('[data-acorn-media-viewer="image"]'),
+    ).toHaveAttribute("data-acorn-media-zoom", "1.25");
+    await expect(page.locator('img[alt="logo.png"]')).toHaveAttribute(
+      "style",
+      /scale\(1\.25\)/,
+    );
+
+    await page.getByRole("button", { name: "Reset zoom" }).click();
+
+    await expect(
+      page.locator('[data-acorn-media-viewer="image"]'),
+    ).toHaveAttribute("data-acorn-media-zoom", "1");
 
     await page.getByRole("button", { name: "spec.pdf" }).dblclick();
 

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -305,6 +305,7 @@ export const tauriMockSource = `
     if (cmd === 'fs_read_file') {
       return Promise.resolve({ content: '', size: 0, truncated: false, binary: false });
     }
+    if (cmd === 'fs_prepare_asset') return Promise.resolve({ size: 0 });
     if (cmd === 'fs_git_diff_lines') return Promise.resolve([]);
     if (cmd === 'fs_watch_set_root') return Promise.resolve(undefined);
     if (cmd && cmd.startsWith('list_')) return Promise.resolve([]);
@@ -329,6 +330,17 @@ export const tauriMockSource = `
     },
     unregisterCallback: (id) => {
       try { delete window['_' + id]; } catch (_) { window['_' + id] = undefined; }
+    },
+    convertFileSrc: (filePath, protocol = 'asset') => {
+      const path = encodeURIComponent(filePath);
+      if (protocol === 'asset') {
+        const lower = String(filePath).toLowerCase();
+        if (/\.(apng|avif|bmp|gif|ico|jpe?g|png|svg|webp)$/.test(lower)) {
+          return 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==#' + path;
+        }
+        return 'about:blank#' + path;
+      }
+      return protocol + '://localhost/' + path;
     },
     invoke: async (cmd, args) => {
       const handler = handlers[cmd];


### PR DESCRIPTION
## Summary
Media file tabs now use a dedicated media viewer instead of routing every file through the readonly code viewer.

1. **Media routing** — add `FileViewer` so image, video, audio, and PDF extensions open in `MediaViewer` while text/code files keep the existing `CodeViewer` path.
2. **Scoped asset access** — add `fs_prepare_asset` to validate the requested path through the existing filesystem scope, allow it through Tauri's asset protocol, and avoid loading large media through `fs_read_file`.
3. **Image zoom controls** — add zoom in, zoom out, and reset controls for image media, including SVG and GIF, without changing PDF/video/audio controls.
4. **Regression coverage** — cover media routing, image zoom, PDF rendering, and file-explorer media opens in Vitest and Playwright.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Image / GIF / SVG file tabs | Readonly code viewer showed binary-file messaging for binary assets | Inline image preview with zoom controls |
| Video / audio / PDF file tabs | Media files were not previewed as media | Native browser media controls or PDF iframe preview |
| Large media files | Could not be viewed through the readonly text path | Served through Tauri's scoped asset protocol after path authorization |

## Design notes
- `FileViewer` is the tab-level router; it keeps the existing `CodeViewer` behavior untouched for non-media files.
- `MediaViewer` prepares the asset via a backend command before calling `convertFileSrc`, so frontend previews stay within the same `FsScope` authorization model as file reads.
- The media viewer listens to `acorn:fs-changed` and refreshes the asset URL with a cache-busting sequence when the opened file changes.
- Image zoom state is local to the media tab and resets when the file path or media kind changes.

## Test plan
- [x] `pnpm exec vitest run src/components/FileViewer.test.tsx` — 4 passed
- [x] `pnpm exec playwright test tests/e2e/file-explorer.spec.ts -g "opens media files"` — 1 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test` — 63 files passed, 614 passed / 1 skipped
- [x] `pnpm run build` — passed with existing Vite dynamic-import/chunk-size warnings
- [x] `pnpm run test:e2e` — 148 passed
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — passed
- [x] `git diff --check origin/main...HEAD` — passed
- [ ] CI green on this PR

## Notes
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` reports pre-existing formatting diffs in `src-tauri/src/pty_env.rs` and `src-tauri/src/pull_requests.rs`; neither file is modified by this PR, and CI does not currently gate on rustfmt.
