### PR TITLE
feat(settings): mac keep-awake toggle

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "clap",
+ "core-foundation",
  "dashmap",
  "directories",
  "git2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -148,6 +148,7 @@ tempfile = { workspace = true }
 nix = { version = "0.31", default-features = false, features = ["process", "signal"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.10.1"
 objc2 = { version = "0.6.4", default-features = false, features = ["std"] }
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSBitmapImageRep", "NSImageRep", "NSPasteboard"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSArray", "NSData", "NSDictionary", "NSObject", "NSString"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod fs_explorer;
 mod git_ops;
 mod ipc;
 mod persistence;
+mod power_assertion;
 mod project_settings;
 pub mod pty_env;
 mod pty_output;
@@ -598,6 +599,8 @@ pub fn run() {
             commands::acknowledge_antigravity_resume,
             commands::staged_rev_mismatch_status,
             commands::acknowledge_staged_rev_mismatch,
+            power_assertion::prevent_sleep_status,
+            power_assertion::set_prevent_sleep,
             daemon_commands::daemon_status,
             daemon_commands::daemon_set_enabled,
             daemon_commands::daemon_restart,

--- a/src-tauri/src/power_assertion.rs
+++ b/src-tauri/src/power_assertion.rs
@@ -1,0 +1,174 @@
+use serde::Serialize;
+use tauri::State;
+
+use crate::error::{AppError, AppResult};
+use crate::state::AppState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreventSleepStatus {
+    pub supported: bool,
+    pub enabled: bool,
+}
+
+#[derive(Default)]
+pub struct PowerAssertionState {
+    assertion: Option<platform::PowerAssertion>,
+}
+
+impl PowerAssertionState {
+    pub fn new() -> Self {
+        Self { assertion: None }
+    }
+
+    pub fn status(&self) -> PreventSleepStatus {
+        PreventSleepStatus {
+            supported: platform::SUPPORTED,
+            enabled: self.assertion.is_some(),
+        }
+    }
+
+    pub fn set_prevent_sleep(&mut self, enabled: bool) -> AppResult<PreventSleepStatus> {
+        if !enabled {
+            self.assertion.take();
+            return Ok(self.status());
+        }
+
+        if !platform::SUPPORTED {
+            return Ok(self.status());
+        }
+
+        if self.assertion.is_none() {
+            self.assertion = Some(platform::PowerAssertion::new().map_err(AppError::Other)?);
+        }
+        Ok(self.status())
+    }
+}
+
+#[tauri::command]
+pub fn prevent_sleep_status(state: State<'_, AppState>) -> PreventSleepStatus {
+    state.power_assertion.lock().status()
+}
+
+#[tauri::command]
+pub fn set_prevent_sleep(
+    enabled: bool,
+    state: State<'_, AppState>,
+) -> AppResult<PreventSleepStatus> {
+    state.power_assertion.lock().set_prevent_sleep(enabled)
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use core_foundation::base::TCFType;
+    use core_foundation::string::{CFString, CFStringRef};
+
+    pub const SUPPORTED: bool = true;
+
+    type IOPMAssertionID = u32;
+    type IOReturn = i32;
+    type CFTimeInterval = f64;
+
+    const K_IO_RETURN_SUCCESS: IOReturn = 0;
+    const ASSERTION_TYPE_PREVENT_USER_IDLE_SYSTEM_SLEEP: &str = "PreventUserIdleSystemSleep";
+    const ASSERTION_NAME: &str = "Acorn keep awake";
+    const ASSERTION_DETAILS: &str =
+        "Acorn is preventing idle system sleep while the keep-awake setting is enabled.";
+
+    #[link(name = "IOKit", kind = "framework")]
+    unsafe extern "C" {
+        fn IOPMAssertionCreateWithDescription(
+            assertion_type: CFStringRef,
+            name: CFStringRef,
+            details: CFStringRef,
+            human_readable_reason: CFStringRef,
+            localization_bundle_path: CFStringRef,
+            timeout: CFTimeInterval,
+            timeout_action: CFStringRef,
+            assertion_id: *mut IOPMAssertionID,
+        ) -> IOReturn;
+
+        fn IOPMAssertionRelease(assertion_id: IOPMAssertionID) -> IOReturn;
+    }
+
+    pub struct PowerAssertion {
+        id: IOPMAssertionID,
+    }
+
+    impl PowerAssertion {
+        pub fn new() -> Result<Self, String> {
+            let assertion_type = CFString::new(ASSERTION_TYPE_PREVENT_USER_IDLE_SYSTEM_SLEEP);
+            let name = CFString::new(ASSERTION_NAME);
+            let details = CFString::new(ASSERTION_DETAILS);
+            let mut id = 0;
+
+            let result = unsafe {
+                IOPMAssertionCreateWithDescription(
+                    assertion_type.as_concrete_TypeRef(),
+                    name.as_concrete_TypeRef(),
+                    details.as_concrete_TypeRef(),
+                    std::ptr::null(),
+                    std::ptr::null(),
+                    0.0,
+                    std::ptr::null(),
+                    &mut id,
+                )
+            };
+
+            if result == K_IO_RETURN_SUCCESS {
+                Ok(Self { id })
+            } else {
+                Err(format!(
+                    "IOPMAssertionCreateWithDescription failed with IOReturn {result}"
+                ))
+            }
+        }
+    }
+
+    impl Drop for PowerAssertion {
+        fn drop(&mut self) {
+            let result = unsafe { IOPMAssertionRelease(self.id) };
+            if result != K_IO_RETURN_SUCCESS {
+                tracing::warn!(
+                    assertion_id = self.id,
+                    ioreturn = result,
+                    "failed to release prevent-sleep assertion",
+                );
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+mod platform {
+    pub const SUPPORTED: bool = false;
+
+    pub struct PowerAssertion;
+
+    impl PowerAssertion {
+        pub fn new() -> Result<Self, String> {
+            Err("prevent sleep is only supported on macOS".to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PowerAssertionState;
+
+    #[test]
+    fn defaults_to_supported_platform_status_and_disabled() {
+        let state = PowerAssertionState::new();
+
+        assert!(!state.status().enabled);
+    }
+
+    #[test]
+    fn disabling_without_assertion_is_idempotent() {
+        let mut state = PowerAssertionState::new();
+
+        let status = state.set_prevent_sleep(false).unwrap();
+
+        assert!(!status.enabled);
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8,6 +8,7 @@ use crate::daemon_bridge::DaemonBridge;
 use crate::daemon_stream::StreamRegistry;
 use crate::fs_explorer::WatcherState;
 use crate::ipc::server::IpcServerHandle;
+use crate::power_assertion::PowerAssertionState;
 use crate::pty_output::PtyOutputRouter;
 use crate::staged_rev_reconcile::StagedRevMismatch;
 use acorn_pty::PtyManager;
@@ -69,6 +70,9 @@ pub struct AppState {
     /// The cancel command uses this to kill the one-shot provider child and
     /// let the running turn settle as cancelled.
     pub chat_runs: Arc<crate::chat_runs::ChatRunRegistry>,
+    /// macOS idle-sleep assertion owned while Settings keeps Acorn awake.
+    /// Dropping the inner assertion releases the OS power-management hold.
+    pub power_assertion: Arc<Mutex<PowerAssertionState>>,
 }
 
 impl AppState {
@@ -89,6 +93,7 @@ impl AppState {
             folder_grants: Arc::new(Mutex::new(Vec::new())),
             external_file_grants: Arc::new(Mutex::new(Vec::new())),
             chat_runs: crate::chat_runs::ChatRunRegistry::new(),
+            power_assertion: Arc::new(Mutex::new(PowerAssertionState::new())),
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,6 +115,8 @@ const RIGHT_PANEL_MIN_SIZE = 16;
 
 type AppTranslationKey = Extract<TranslationKey, `app.${string}`>;
 
+let lastPreventSleepSync: boolean | null = null;
+
 function appText(t: Translator, key: AppTranslationKey): string {
   return t(key);
 }
@@ -266,6 +268,7 @@ function App() {
   );
   const settings = useSettings((s) => s.settings);
   const shortcuts = settings.shortcuts;
+  const preventSleep = settings.power.preventSleep;
   const pendingRemove = sessions.find((s) => s.id === pendingRemoveId) ?? null;
   const pendingProject =
     projects.find((p) => p.repo_path === pendingRemoveProject) ?? null;
@@ -689,6 +692,15 @@ function App() {
       });
     });
   }, []);
+
+  useEffect(() => {
+    if (lastPreventSleepSync === preventSleep) return;
+    lastPreventSleepSync = preventSleep;
+    void api.setPreventSleep(preventSleep).catch((err) => {
+      lastPreventSleepSync = null;
+      console.warn("[App] prevent-sleep sync failed", err);
+    });
+  }, [preventSleep]);
 
   // Auto-update: check once on startup, then every 24h. Both calls are
   // best-effort and non-blocking — surfaced via the App-level

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -698,6 +698,12 @@ function ServicesSettings() {
 
   return (
     <section className="space-y-6">
+      <SettingsGroup
+        title={st(t, "settings.power.title")}
+        description={st(t, "settings.power.description")}
+      >
+        <PowerSettings />
+      </SettingsGroup>
       <ControlSessionInstallSection />
       <SettingsGroup
         title={st(t, "settings.sessions.background.title")}
@@ -706,6 +712,21 @@ function ServicesSettings() {
         <BackgroundSessionsSettings />
       </SettingsGroup>
     </section>
+  );
+}
+
+function PowerSettings() {
+  const preventSleep = useSettings((s) => s.settings.power.preventSleep);
+  const patchPower = useSettings((s) => s.patchPower);
+  const t = useTranslation();
+
+  return (
+    <CheckboxRow
+      label={st(t, "settings.power.preventSleep.label")}
+      description={st(t, "settings.power.preventSleep.description")}
+      checked={preventSleep}
+      onChange={(v) => patchPower({ preventSleep: v })}
+    />
   );
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -52,6 +52,11 @@ export interface LoadStatus {
   projectsClean: boolean;
 }
 
+export interface PreventSleepStatus {
+  supported: boolean;
+  enabled: boolean;
+}
+
 export interface AiExecutionRequest {
   provider: "claude" | "antigravity" | "codex" | "ollama" | "llm" | "custom";
   ollamaModel?: string | null;
@@ -665,6 +670,12 @@ export const api = {
    */
   acknowledgeStagedRevMismatch(): Promise<void> {
     return invoke<void>("acknowledge_staged_rev_mismatch");
+  },
+  preventSleepStatus(): Promise<PreventSleepStatus> {
+    return invoke<PreventSleepStatus>("prevent_sleep_status");
+  },
+  setPreventSleep(enabled: boolean): Promise<PreventSleepStatus> {
+    return invoke<PreventSleepStatus>("set_prevent_sleep", { enabled });
   },
   /**
    * Flip the daemon killswitch. Persistence (so the setting survives a

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -175,6 +175,60 @@ describe("session removal settings", () => {
   });
 });
 
+describe("power settings", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("defaults to allowing normal idle sleep", () => {
+    expect(DEFAULT_SETTINGS.power.preventSleep).toBe(false);
+  });
+
+  it("loads a persisted prevent-sleep preference", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ power: { preventSleep: true } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.power.preventSleep).toBe(true);
+  });
+
+  it("persists patched prevent-sleep changes", async () => {
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    useSettings.getState().patchPower({ preventSleep: true });
+
+    expect(useSettings.getState().settings.power.preventSleep).toBe(true);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}").power).toEqual(
+      { preventSleep: true },
+    );
+  });
+});
+
 describe("notification settings", () => {
   const STORAGE_KEY = "acorn:settings:v1";
   let storage: Map<string, string>;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -271,6 +271,14 @@ export interface AcornSettings {
      */
     closeOnExit: boolean;
   };
+  power: {
+    /**
+     * Hold a macOS PreventUserIdleSystemSleep assertion while Acorn is
+     * running. The display may still sleep; this only keeps idle system
+     * sleep from suspending long-running sessions.
+     */
+    preventSleep: boolean;
+  };
   editor: {
     /**
      * External command used by the "Open in editor" action.
@@ -424,6 +432,9 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     confirmRemove: true,
     autoDeleteWorktrees: false,
     closeOnExit: false,
+  },
+  power: {
+    preventSleep: false,
   },
   editor: {
     command: "",
@@ -838,6 +849,12 @@ function loadSettings(): AcornSettings {
         ...DEFAULT_SETTINGS.sessions,
         ...(parsed.sessions ?? {}),
       },
+      power: {
+        preventSleep:
+          typeof parsed.power?.preventSleep === "boolean"
+            ? parsed.power.preventSleep
+            : DEFAULT_SETTINGS.power.preventSleep,
+      },
       editor: {
         ...DEFAULT_SETTINGS.editor,
         ...(parsed.editor ?? {}),
@@ -975,6 +992,7 @@ interface SettingsState {
     }>,
   ) => void;
   patchSessions: (patch: Partial<AcornSettings["sessions"]>) => void;
+  patchPower: (patch: Partial<AcornSettings["power"]>) => void;
   patchEditor: (patch: Partial<AcornSettings["editor"]>) => void;
   patchNotifications: (
     patch: Partial<Omit<AcornSettings["notifications"], "events">> & {
@@ -1072,6 +1090,15 @@ export const useSettings = create<SettingsState>((set, get) => ({
       const next: AcornSettings = {
         ...s.settings,
         sessions: { ...s.settings.sessions, ...patch },
+      };
+      persist(next);
+      return { settings: next };
+    }),
+  patchPower: (patch) =>
+    set((s) => {
+      const next: AcornSettings = {
+        ...s.settings,
+        power: { ...s.settings.power, ...patch },
       };
       persist(next);
       return { settings: next };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -129,6 +129,14 @@
         "recheck": "Re-check"
       }
     },
+    "power": {
+      "title": "Power",
+      "description": "Controls how Acorn interacts with macOS sleep while it is running.",
+      "preventSleep": {
+        "label": "Keep this Mac awake",
+        "description": "Prevent idle system sleep while Acorn is open. The display may still turn off, and manual sleep or lid close still wins."
+      }
+    },
     "github": {
       "refreshInterval": {
         "label": "Refresh interval",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -129,6 +129,14 @@
         "recheck": "다시 확인"
       }
     },
+    "power": {
+      "title": "전원",
+      "description": "Acorn이 실행 중일 때 macOS 잠자기 동작을 제어합니다.",
+      "preventSleep": {
+        "label": "이 Mac 잠자기 방지",
+        "description": "Acorn이 열려 있는 동안 유휴 상태로 시스템이 잠자기에 들어가지 않도록 합니다. 디스플레이는 꺼질 수 있으며, 수동 잠자기나 덮개 닫기가 우선합니다."
+      }
+    },
     "github": {
       "refreshInterval": {
         "label": "새로고침 간격",

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -286,6 +286,12 @@ export const tauriMockSource = `
     if (cmd === 'staged_rev_mismatch_status') return Promise.resolve(null);
     if (cmd === 'acknowledge_staged_rev_mismatch')
       return Promise.resolve(undefined);
+    if (cmd === 'prevent_sleep_status') {
+      return Promise.resolve({ supported: true, enabled: false });
+    }
+    if (cmd === 'set_prevent_sleep') {
+      return Promise.resolve({ supported: true, enabled: !!args?.enabled });
+    }
     if (cmd === 'pty_write') return Promise.resolve(undefined);
     // File explorer. No real fs in E2E — default to an empty listing so
     // the panel renders without errors. Tests that need real entries

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -71,4 +71,74 @@ test.describe("settings modal", () => {
       .click();
     await expect(modal.getByText(/⌘=|Ctrl\+=/).first()).toBeVisible();
   });
+
+  test("syncs the keep-awake toggle with the backend and local settings", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({ power: { preventSleep: true } }),
+      );
+      (window as typeof window & { __ACORN_PREVENT_SLEEP_CALLS__?: boolean[] })
+        .__ACORN_PREVENT_SLEEP_CALLS__ = [];
+    });
+    await tauri.handle("set_prevent_sleep", (args) => {
+      const win = window as typeof window & {
+        __ACORN_PREVENT_SLEEP_CALLS__?: boolean[];
+      };
+      const enabled =
+        !!args &&
+        typeof args === "object" &&
+        "enabled" in args &&
+        !!args.enabled;
+      win.__ACORN_PREVENT_SLEEP_CALLS__ =
+        win.__ACORN_PREVENT_SLEEP_CALLS__ || [];
+      win.__ACORN_PREVENT_SLEEP_CALLS__.push(enabled);
+      return { supported: true, enabled };
+    });
+
+    await page.goto("/");
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as typeof window & {
+              __ACORN_PREVENT_SLEEP_CALLS__?: boolean[];
+            }).__ACORN_PREVENT_SLEEP_CALLS__ ?? [],
+        ),
+      )
+      .toEqual([true]);
+
+    await pressHotkey(page, { mod: true, key: "," });
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
+    await modal.getByRole("button", { name: /^(Services|서비스)$/ }).click();
+
+    const checkbox = modal.getByRole("checkbox", {
+      name: /Keep this Mac awake|이 Mac 잠자기 방지/,
+    });
+    await expect(checkbox).toBeChecked();
+    await checkbox.click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as typeof window & {
+              __ACORN_PREVENT_SLEEP_CALLS__?: boolean[];
+            }).__ACORN_PREVENT_SLEEP_CALLS__ ?? [],
+        ),
+      )
+      .toEqual([true, false]);
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("acorn:settings:v1");
+          return raw ? JSON.parse(raw).power?.preventSleep : null;
+        }),
+      )
+      .toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
Adds an opt-in macOS keep-awake setting so Acorn can keep long-running sessions active while the app is open.

1. **macOS power assertion** — add a Tauri backend command backed by `IOPMAssertionCreateWithDescription` / `PreventUserIdleSystemSleep`, with RAII release when disabled or dropped.
2. **Settings integration** — add `power.preventSleep` to the persisted settings store and surface it under Settings → Services → Power.
3. **Renderer sync** — push the persisted setting into the backend on boot and whenever the toggle changes, including E2E mock coverage for the boot-time invoke.
4. **Tests and localization** — cover settings persistence, backend idempotence, Settings UI sync, and English/Korean copy.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Long-running Acorn sessions on macOS | Mac could enter idle system sleep while Acorn is open | Users can opt in to prevent idle system sleep while Acorn is open |
| Display sleep / manual sleep | Normal macOS behavior | Unchanged: display may still sleep; lid close, manual Sleep, low battery, and thermal sleep still win |
| Default power behavior | Normal idle sleep | Unchanged until the user enables the setting |

## Design notes
- The backend uses a small Acorn-owned wrapper instead of adding a Tauri keep-awake plugin, keeping command registration, AppState ownership, and E2E mocks aligned with existing project patterns.
- The assertion type is `PreventUserIdleSystemSleep`, not display sleep, so this avoids forcing the screen to stay on while still protecting background session work from idle suspension.
- Non-macOS builds report unsupported and keep the assertion disabled; the UI copy is macOS-specific because this feature targets the Mac behavior shown in the request.
- React StrictMode can mount effects twice in dev; the renderer sync is guarded so the backend receives one state transition per setting value.

## Follow-up (not in this PR)
- Add an optional display-awake mode only if users explicitly need the screen to remain lit; it has a higher battery/thermal cost and is intentionally out of scope here.
- Surface backend unsupported/error state in Settings if Acorn starts targeting non-macOS desktop builds with this same UI enabled.

## Test plan
- [x] `pnpm exec vitest run src/lib/settings.test.ts` — 52 passed
- [x] `pnpm run typecheck` — passed
- [x] `cargo test -p acorn power_assertion` — 2 passed
- [x] `pnpm exec playwright test tests/e2e/settings.spec.ts tests/e2e/settings-tabs.spec.ts` — 6 passed
- [x] `cargo check -p acorn` — passed
- [x] `git diff --check` — passed

## Notes
- Playwright emitted the existing `NO_COLOR` / `FORCE_COLOR` warning from the dev server environment; tests still passed.
