### PR TITLE
fix(ui): increase default tooltip hover delay

### DIFF
--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -1,0 +1,94 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Tooltip } from "./Tooltip";
+
+describe("Tooltip", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  function renderTooltip(delay?: number) {
+    act(() => {
+      root.render(
+        <Tooltip label="Tooltip details" delay={delay}>
+          <button type="button">Trigger</button>
+        </Tooltip>,
+      );
+    });
+  }
+
+  function hoverTrigger() {
+    const trigger = container.querySelector("button");
+    if (!trigger) throw new Error("trigger not found");
+    act(() => {
+      trigger.dispatchEvent(
+        new MouseEvent("mouseover", { bubbles: true, cancelable: true }),
+      );
+    });
+  }
+
+  function leaveTrigger() {
+    const trigger = container.querySelector("button");
+    if (!trigger) throw new Error("trigger not found");
+    act(() => {
+      trigger.dispatchEvent(
+        new MouseEvent("mouseout", { bubbles: true, cancelable: true }),
+      );
+    });
+  }
+
+  function tooltip() {
+    return document.body.querySelector('[role="tooltip"]');
+  }
+
+  it("waits one second before showing when no delay is specified", () => {
+    renderTooltip();
+    hoverTrigger();
+
+    act(() => vi.advanceTimersByTime(999));
+    expect(tooltip()).toBeNull();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(tooltip()?.textContent).toBe("Tooltip details");
+  });
+
+  it("uses an explicit delay when provided", () => {
+    renderTooltip(150);
+    hoverTrigger();
+
+    act(() => vi.advanceTimersByTime(149));
+    expect(tooltip()).toBeNull();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(tooltip()?.textContent).toBe("Tooltip details");
+  });
+
+  it("does not show when hover leaves before the delay completes", () => {
+    renderTooltip(500);
+    hoverTrigger();
+
+    act(() => vi.advanceTimersByTime(499));
+    leaveTrigger();
+    act(() => vi.advanceTimersByTime(1));
+
+    expect(tooltip()).toBeNull();
+  });
+});

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -18,7 +18,7 @@ interface TooltipProps {
   label: ReactNode;
   /** Where the tooltip appears relative to the trigger. Default: "bottom". */
   side?: "top" | "bottom" | "left" | "right";
-  /** Delay before showing on hover, in ms. Default: 250. */
+  /** Delay before showing on hover, in ms. Default: 1000. */
   delay?: number;
   /**
    * Allow the tooltip to span multiple lines. The container drops
@@ -196,7 +196,7 @@ export function FloatingTooltip({
 export function Tooltip({
   label,
   side = "bottom",
-  delay = 250,
+  delay = 1000,
   multiline = false,
   children,
   className,


### PR DESCRIPTION
## Summary
Default tooltip hover behavior is now less eager across Acorn.

1. **Default hover delay** — increases the shared `Tooltip` default from 250ms to 1000ms so incidental hovers do not immediately surface path/detail bubbles.
2. **Tooltip timing coverage** — adds unit coverage for the default delay, explicit delay overrides, and cancelled hovers.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Tooltips without an explicit `delay` | Show after 250ms | Show after 1000ms |
| Tooltips with an explicit `delay` prop | Use the call-site value | Unchanged |

## Design notes
- Kept the existing `delay` prop API because it already represents the required hover dwell time.
- Existing `delay={150}` call sites keep their faster behavior.

## Test plan
- [x] `pnpm exec vitest run src/components/Tooltip.test.tsx` — 3 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `git diff --check` — passed

## Notes
- CI was not waited on per request.