### PR TITLE
fix(right-panel): prevent opening deleted staged files

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -2557,30 +2557,48 @@ function StagedTab({
     <PanelGroup direction="vertical" autoSaveId="acorn:layout:staged">
       <Panel id="staged-list" order={1} defaultSize={35} minSize={15}>
         <ul className="acorn-no-scrollbar h-full overflow-x-hidden overflow-y-auto">
-          {files.map((f) => (
-            <li
-              key={f.path}
-              onClick={() => setSelectedPath(f.path)}
-              onContextMenu={(e) => {
-                e.preventDefault();
-                setMenu({ x: e.clientX, y: e.clientY, file: f });
-              }}
-              onDoubleClick={() => {
-                openInCodeViewer(f);
-              }}
-              className={cn(
-                "flex cursor-default items-center gap-2 px-3 py-1.5 font-mono text-xs hover:bg-bg-elevated/40",
-                selectedPath === f.path && "bg-bg-elevated",
-              )}
-            >
-              <span className="w-24 shrink-0 truncate text-fg-muted">
-                {f.status}
-              </span>
-              <Tooltip label={f.path} side="top" multiline className="flex! min-w-0 flex-1">
-                <span className="min-w-0 flex-1 truncate text-fg">{f.path}</span>
-              </Tooltip>
-            </li>
-          ))}
+          {files.map((f) => {
+            const canOpen = !isDeleted(f);
+            return (
+              <li
+                key={f.path}
+                aria-disabled={!canOpen}
+                onClick={() => setSelectedPath(f.path)}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  setMenu({ x: e.clientX, y: e.clientY, file: f });
+                }}
+                onDoubleClick={(e) => {
+                  e.preventDefault();
+                  if (!canOpen) return;
+                  openInCodeViewer(f);
+                }}
+                className={cn(
+                  "flex cursor-default items-center gap-2 px-3 py-1.5 font-mono text-xs hover:bg-bg-elevated/40",
+                  selectedPath === f.path && "bg-bg-elevated",
+                )}
+              >
+                <span className="w-24 shrink-0 truncate text-fg-muted">
+                  {f.status}
+                </span>
+                <Tooltip
+                  label={f.path}
+                  side="top"
+                  multiline
+                  className="flex! min-w-0 flex-1"
+                >
+                  <span
+                    className={cn(
+                      "min-w-0 flex-1 truncate",
+                      canOpen ? "text-fg" : "text-fg-muted line-through",
+                    )}
+                  >
+                    {f.path}
+                  </span>
+                </Tooltip>
+              </li>
+            );
+          })}
         </ul>
       </Panel>
       <ResizeHandle direction="vertical" thin />

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -143,6 +143,65 @@ test.describe("right panel: tab switching", () => {
       .toContain("/tmp/demo/.acorn/worktrees/demo-1/src/components/Terminal.tsx");
   });
 
+  test("double-clicking a deleted staged file does not open a code tab", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveWorktreeSession(tauri);
+    await tauri.respond("list_staged", [
+      {
+        path: "src/deleted.ts",
+        status: "staged-deleted",
+      },
+    ]);
+    await tauri.respond("staged_file_diff", {
+      files: [
+        {
+          old_path: "src/deleted.ts",
+          new_path: null,
+          patch: "@@ -1 +0,0 @@\n-export const gone = true;\n",
+          is_image: false,
+        },
+      ],
+    });
+    await tauri.handle("fs_read_file", (args) => {
+      const w = window as unknown as { __readFilePaths?: string[] };
+      w.__readFilePaths = w.__readFilePaths ?? [];
+      w.__readFilePaths.push((args as { path: string }).path);
+      return {
+        content: "",
+        size: 0,
+        truncated: false,
+        binary: false,
+      };
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Staged" }).click();
+    const stagedList = page.locator("#staged-list");
+    await stagedList.getByText("src/deleted.ts").dblclick();
+
+    await expect(stagedList.getByText("src/deleted.ts")).toBeVisible();
+    await expect(page.getByText(/nothing to open/i)).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: /deleted\.ts Close tab/ }),
+    ).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __readFilePaths?: string[] })
+              .__readFilePaths ?? [],
+        ),
+      )
+      .toEqual([]);
+
+    await stagedList.getByText("src/deleted.ts").click({ button: "right" });
+    await expect(
+      page.getByRole("menuitem", { name: "Open in editor" }),
+    ).toBeDisabled();
+  });
+
   test("null read_session_todos does not crash the panel (regression)", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Right panel staged-file rows now treat deleted files as non-openable UI targets.

1. **Staged row double-click guard** — deleted staged/worktree rows stay selectable for diff review, but double-click no longer opens a code viewer tab or replaces the panel with a deleted-file error.
2. **Deleted row affordance** — deleted staged paths render muted with a strike-through and `aria-disabled` so the list communicates that the file cannot be opened.
3. **Regression coverage** — added a Playwright case for `staged-deleted` rows that verifies no code tab opens, no `fs_read_file` call fires, and the context-menu editor action remains disabled.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Code → Staged deleted files | Double-click surfaced `File was deleted; nothing to open.` and displaced the staged diff UI | Double-click is ignored while the deleted-file diff remains visible |
| Existing modified staged files | Double-click opens the code viewer tab | Unchanged |

## Design notes
- The backend already reports staged deletes as `staged-deleted`; `StagedTab.isDeleted` covers both `staged-deleted` and worktree `deleted` statuses via the existing `delete` substring check.
- The context-menu editor path and full diff split view already disabled open actions for deleted files, so this PR keeps the fix scoped to the staged-row double-click path.
- Deleted rows remain clickable for selection so users can still inspect the staged deletion diff.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts` — 17 passed

## Notes
- Playwright emitted existing `NO_COLOR` / `FORCE_COLOR` warnings during local runs; tests still passed.
