### PR TITLE
chore(release): v1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.15.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.14.0"
+version = "1.15.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
This prepares the v1.15.0 release metadata for the feature-bearing release after v1.14.0.

1. **Version metadata:** Bump the app/package versions from 1.14.0 to 1.15.0.
2. **Lockfile alignment:** Update the root Cargo.lock package entry to match the release version.
3. **Release scope:** Include user-visible features from #399, #412, and #413, plus fixes from #407, #408, #409, #410, #411, #414, and #416. PR #415 is test-only and excluded from changelog via skip-changelog.

## Expected impact
| Area | Impact |
| --- | --- |
| App version | Packaged builds and updater metadata report 1.15.0. |
| Release notes | v1.15.0 notes include terminal idle eviction controls, media previews, mac keep-awake, and the post-v1.14.0 fixes. |
| Updater | Stable release tag will publish latest.json for 1.15.0 through the existing release workflow. |

## Design notes
This is a minor release because the unreleased range includes user-visible features: configurable idle terminal eviction, media file previews with image zoom controls, and the mac keep-awake setting.

This PR intentionally changes only release metadata. The release bump uses skip-changelog so the already-merged feature/fix PRs supply the generated release notes.

Parallel release-content review found no release-blocking issues. Non-blocking follow-ups noted by reviewers are tracked as release caveats below rather than expanding this metadata-only PR.

## Follow-up (not in this PR)
- Consider a small polish fix for native title tooltips on media zoom controls.
- Consider direct backend coverage for fs_prepare_asset asset-scope allow/reject behavior.

## Test plan
- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1`
- [x] `REPO=im-ian/acorn TAG=v1.15.0 OUTPUT=/tmp/acorn-release-notes-v1.15.0.md node scripts/release-notes.mjs`
- [x] `git diff --check`
- [x] Main CI at `a4ba9b9` passed: Frontend and E2E succeeded.

## Notes
- Generated release notes include #399, #412, #413, #407, #408, #409, #410, #411, #414, and #416; #415 is excluded by skip-changelog.
- Parallel review called out that #399 daemon detach/re-attach manual smoke was not marked complete in its original PR, but current main CI is green and no static release blocker was found.
