### PR TITLE
feat(context-menu): add non-actionable group titles

### DIFF
--- a/src/components/ContextMenu.test.tsx
+++ b/src/components/ContextMenu.test.tsx
@@ -1,0 +1,68 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
+
+describe("ContextMenu", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(items: ContextMenuItem[]) {
+    const onClose = vi.fn();
+    act(() => {
+      root.render(
+        <ContextMenu open x={20} y={30} items={items} onClose={onClose} />,
+      );
+    });
+    return onClose;
+  }
+
+  it("renders group titles without making them actionable menu items", () => {
+    render([
+      { type: "group-title", label: "Session" },
+      { label: "Rename", onClick: vi.fn() },
+      { type: "separator" },
+      { type: "group-title", label: "Danger zone" },
+      { label: "Remove", onClick: vi.fn(), disabled: true },
+    ]);
+
+    const menu = document.querySelector('[role="menu"]');
+    expect(menu?.textContent).toContain("Session");
+    expect(menu?.textContent).toContain("Danger zone");
+    expect(document.querySelectorAll('[role="separator"]')).toHaveLength(1);
+    expect(
+      Array.from(document.querySelectorAll('[role="menuitem"]')).map((node) =>
+        node.textContent?.trim(),
+      ),
+    ).toEqual(["Rename", "Remove"]);
+  });
+
+  it("keeps button click behavior unchanged", () => {
+    const onClick = vi.fn();
+    const onClose = render([
+      { type: "group-title", label: "Actions" },
+      { label: "Rename", onClick },
+    ]);
+
+    const rename = document.querySelector('[role="menuitem"]');
+    if (!rename) throw new Error("missing menu item");
+
+    act(() => {
+      (rename as HTMLButtonElement).click();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -15,7 +15,15 @@ interface ContextMenuSeparator {
   type: "separator";
 }
 
-export type ContextMenuItem = ContextMenuButton | ContextMenuSeparator;
+interface ContextMenuGroupTitle {
+  type: "group-title";
+  label: string;
+}
+
+export type ContextMenuItem =
+  | ContextMenuButton
+  | ContextMenuSeparator
+  | ContextMenuGroupTitle;
 
 interface ContextMenuProps {
   open: boolean;
@@ -92,6 +100,20 @@ export function ContextMenu({ open, x, y, items, onClose }: ContextMenuProps) {
                 aria-orientation="horizontal"
                 className="my-1 h-px bg-border"
               />
+            );
+          }
+          if (item.type === "group-title") {
+            return (
+              <li
+                key={i}
+                role="presentation"
+                className={cn(
+                  "px-2.5 pb-1 text-[10px] font-semibold text-fg-muted/70",
+                  i === 0 ? "pt-1" : "pt-2",
+                )}
+              >
+                <span className="block truncate">{item.label}</span>
+              </li>
             );
           }
           return (


### PR DESCRIPTION
## Summary
Adds a shared context menu item type for rendering group titles without changing existing menu button behavior.

1. **Group title item** — extends `ContextMenuItem` with `{ type: "group-title", label }` so callers can separate menu sections with non-actionable headings.
2. **Menu rendering** — renders group titles as muted, truncated labels while preserving separators and clickable `menuitem` buttons.
3. **Component coverage** — adds focused React/Vitest coverage for group title rendering and unchanged button click behavior.

## Expected impact
| Area | Expected impact |
| --- | --- |
| Existing context menus | No behavior change unless callers opt into `group-title` items. |
| New grouped menus | Callers can show section labels that are not focusable/clickable menu actions. |
| Accessibility | Clickable actions remain the only `role="menuitem"` nodes; titles render as presentation-only labels. |

## Design notes
- The type is a narrow extension of the existing `ContextMenuItem` union, keeping current button and separator call sites valid.
- Group titles are intentionally rendered outside the button path so they cannot trigger `onClose` or user actions.
- Styling follows the existing menu scale: compact muted text with extra top padding after the first row.

## Test plan
- [x] `pnpm exec vitest run src/components/ContextMenu.test.tsx` — 1 file / 2 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed; Vite reported existing chunk/dynamic-import warnings only

## Notes
- Per maintainer request, CI wait is intentionally skipped for this PR.
- This PR adds the shared capability only; individual menus can opt into group titles in follow-up UI changes.
