### PR TITLE
fix(ui): render context submenu chevron as icon

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { ChevronRight } from "lucide-react";
 import { cn } from "../lib/cn";
 
 interface ContextMenuButton {
@@ -116,7 +117,16 @@ export function ContextMenu({ open, x, y, items, onClose }: ContextMenuProps) {
                   <span className="shrink-0 text-fg-muted">{item.icon}</span>
                 ) : null}
                 <span className="flex-1 truncate">{item.label}</span>
-                {item.shortcut ? (
+                {item.shortcut === ">" ? (
+                  <ChevronRight
+                    size={13}
+                    aria-hidden
+                    className={cn(
+                      "ml-3 shrink-0",
+                      item.disabled ? "text-fg-muted/40" : "text-fg-muted",
+                    )}
+                  />
+                ) : item.shortcut ? (
                   <kbd
                     aria-hidden
                     className={cn(


### PR DESCRIPTION
## Summary
Context menu submenu affordances now render as an icon instead of leaking a literal text marker.

1. **Submenu chevron rendering** — renders `shortcut: ">"` as the shared lucide `ChevronRight` icon in `ContextMenu` instead of a `<kbd>` text glyph.
2. **Shortcut hints preserved** — keeps normal shortcut labels, such as `⌘K`, on the existing `<kbd>` path.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Context menu UI | Submenu affordance could appear as literal `>` text | Submenu affordance appears as a chevron icon |
| Keyboard shortcut hints | Rendered as text hints | Unchanged |

## Design notes
- The existing context menu data contract already uses `shortcut` for the right-side trailing slot. This keeps the change scoped to the shared renderer and avoids touching unrelated menu call sites.
- Only the exact `>` marker is treated as a submenu affordance; all other shortcut strings continue through the normal keyboard hint rendering.

## Test plan
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed; existing Vite chunk-size/dynamic-import warnings only
- [x] Playwright preview render — confirmed submenu marker has no `kbd` text `>` and renders one SVG chevron

## Notes
- Merging after local verification per request, without waiting for CI completion.
