### PR TITLE
refactor(ui): separate context submenu affordance

### DIFF
--- a/src/components/ContextMenu.test.tsx
+++ b/src/components/ContextMenu.test.tsx
@@ -66,6 +66,23 @@ describe("ContextMenu", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it("renders submenu affordances separately from shortcut text", () => {
+    render([
+      {
+        type: "submenu",
+        label: "Copy",
+        children: [{ label: "Path", onClick: vi.fn() }],
+      },
+      { label: "Command palette", shortcut: "⌘K", onClick: vi.fn() },
+    ]);
+
+    const [copy, commandPalette] = document.querySelectorAll('[role="menuitem"]');
+    expect(copy?.textContent?.trim()).toBe("Copy");
+    expect(copy?.querySelector("svg")).not.toBeNull();
+    expect(commandPalette?.textContent?.trim()).toBe("Command palette⌘K");
+    expect(commandPalette?.querySelector("kbd")?.textContent).toBe("⌘K");
+  });
+
   it("opens nested submenu items without a depth limit in the item model", () => {
     const onClick = vi.fn();
     const onClose = render([

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -106,6 +106,86 @@ interface ContextMenuPanelProps {
   panelRef?: React.Ref<HTMLDivElement>;
 }
 
+interface ContextMenuItemButtonProps {
+  label: string;
+  icon?: React.ReactNode;
+  disabled?: boolean;
+  trailing?: React.ReactNode;
+  ariaHasPopup?: "menu";
+  ariaExpanded?: boolean;
+  onClick?: () => void;
+  onMouseEnter?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onFocus?: (event: React.FocusEvent<HTMLButtonElement>) => void;
+}
+
+function ContextMenuItemButton({
+  label,
+  icon,
+  disabled,
+  trailing,
+  ariaHasPopup,
+  ariaExpanded,
+  onClick,
+  onMouseEnter,
+  onFocus,
+}: ContextMenuItemButtonProps) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      aria-haspopup={ariaHasPopup}
+      aria-expanded={ariaExpanded}
+      disabled={disabled}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onFocus={onFocus}
+      className={cn(
+        "flex w-full items-center gap-1.5 px-2.5 py-1 text-left transition",
+        disabled
+          ? "cursor-not-allowed text-fg-muted/50"
+          : "text-fg hover:bg-bg-sidebar",
+      )}
+    >
+      {icon ? <span className="shrink-0 text-fg-muted">{icon}</span> : null}
+      <span className="flex-1 truncate">{label}</span>
+      {trailing}
+    </button>
+  );
+}
+
+function ContextMenuShortcut({
+  shortcut,
+  disabled,
+}: {
+  shortcut: string;
+  disabled?: boolean;
+}) {
+  return (
+    <kbd
+      aria-hidden
+      className={cn(
+        "shrink-0 pl-3 font-sans text-[11px] tabular-nums tracking-wide",
+        disabled ? "text-fg-muted/40" : "text-fg-muted",
+      )}
+    >
+      {shortcut}
+    </kbd>
+  );
+}
+
+function ContextMenuSubmenuChevron({ disabled }: { disabled?: boolean }) {
+  return (
+    <ChevronRight
+      size={13}
+      aria-hidden
+      className={cn(
+        "ml-3 shrink-0",
+        disabled ? "text-fg-muted/40" : "text-fg-muted",
+      )}
+    />
+  );
+}
+
 function ContextMenuPanel({
   items,
   position,
@@ -182,12 +262,13 @@ function ContextMenuPanel({
             const disabled = item.disabled || item.children.length === 0;
             return (
               <li key={i}>
-                <button
-                  type="button"
-                  role="menuitem"
-                  aria-haspopup="menu"
-                  aria-expanded={activeSubmenu?.index === i}
+                <ContextMenuItemButton
+                  label={item.label}
+                  icon={item.icon}
                   disabled={disabled}
+                  ariaHasPopup="menu"
+                  ariaExpanded={activeSubmenu?.index === i}
+                  trailing={<ContextMenuSubmenuChevron disabled={disabled} />}
                   onMouseEnter={(event) => {
                     if (disabled) return;
                     const rect = event.currentTarget.getBoundingClientRect();
@@ -204,27 +285,7 @@ function ContextMenuPanel({
                       position: { left: rect.right - 1, top: rect.top },
                     });
                   }}
-                  className={cn(
-                    "flex w-full items-center gap-1.5 px-2.5 py-1 text-left transition",
-                    disabled
-                      ? "cursor-not-allowed text-fg-muted/50"
-                      : "text-fg hover:bg-bg-sidebar",
-                  )}
-                >
-                  {item.icon ? (
-                    <span className="shrink-0 text-fg-muted">{item.icon}</span>
-                  ) : null}
-                  <span className="flex-1 truncate">{item.label}</span>
-                  <span
-                    aria-hidden
-                    className={cn(
-                      "shrink-0 pl-3 font-sans text-[11px]",
-                      disabled ? "text-fg-muted/40" : "text-fg-muted",
-                    )}
-                  >
-                    &gt;
-                  </span>
-                </button>
+                />
                 {activeSubmenu?.index === i ? (
                   <ContextMenuPanel
                     items={item.children}
@@ -237,10 +298,18 @@ function ContextMenuPanel({
           }
           return (
             <li key={i}>
-              <button
-                type="button"
-                role="menuitem"
+              <ContextMenuItemButton
+                label={item.label}
+                icon={item.icon}
                 disabled={item.disabled}
+                trailing={
+                  item.shortcut ? (
+                    <ContextMenuShortcut
+                      shortcut={item.shortcut}
+                      disabled={item.disabled}
+                    />
+                  ) : null
+                }
                 onMouseEnter={() => setActiveSubmenu(null)}
                 onFocus={() => setActiveSubmenu(null)}
                 onClick={() => {
@@ -248,38 +317,7 @@ function ContextMenuPanel({
                   onClose();
                   item.onClick();
                 }}
-                className={cn(
-                  "flex w-full items-center gap-1.5 px-2.5 py-1 text-left transition",
-                  item.disabled
-                    ? "cursor-not-allowed text-fg-muted/50"
-                    : "text-fg hover:bg-bg-sidebar",
-                )}
-              >
-                {item.icon ? (
-                  <span className="shrink-0 text-fg-muted">{item.icon}</span>
-                ) : null}
-                <span className="flex-1 truncate">{item.label}</span>
-                {item.shortcut === ">" ? (
-                  <ChevronRight
-                    size={13}
-                    aria-hidden
-                    className={cn(
-                      "ml-3 shrink-0",
-                      item.disabled ? "text-fg-muted/40" : "text-fg-muted",
-                    )}
-                  />
-                ) : item.shortcut ? (
-                  <kbd
-                    aria-hidden
-                    className={cn(
-                      "shrink-0 pl-3 font-sans text-[11px] tabular-nums tracking-wide",
-                      item.disabled ? "text-fg-muted/40" : "text-fg-muted",
-                    )}
-                  >
-                    {item.shortcut}
-                  </kbd>
-                ) : null}
-              </button>
+              />
             </li>
           );
         })}


### PR DESCRIPTION
## Summary
Context menu trailing content now separates keyboard shortcut text from submenu affordances.

1. **Shared row renderer** — factors the common context-menu button row into a single internal renderer so button and submenu rows keep consistent spacing, hover, disabled, and accessibility behavior.
2. **Explicit trailing affordances** — renders submenu chevrons from the `type: "submenu"` path and leaves `shortcut` as keyboard hint text only.
3. **Regression coverage** — adds a focused ContextMenu test that locks submenu chevrons and shortcut hints onto separate rendering paths.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Context menu model | Submenu affordance could be treated as special shortcut text | Submenu affordance is tied to `type: "submenu"` |
| Shortcut hints | Normal `<kbd>` hints rendered for shortcut strings | Unchanged for real shortcut strings |
| Menu row styling | Button and submenu rows duplicated similar JSX | Shared row renderer keeps row behavior aligned |

## Design notes
- This keeps the existing `ContextMenuItem` public shape intact: buttons use `shortcut?: string`; submenus use `children`.
- The renderer now has explicit `ContextMenuShortcut` and `ContextMenuSubmenuChevron` trailing components, which makes it harder to reintroduce sentinel shortcut values for non-shortcut UI.
- Existing submenu call sites in `Pane` and `Sidebar` already use `type: "submenu"`, so no caller migration is needed.

## Test plan
- [x] `pnpm exec vitest run src/components/ContextMenu.test.tsx` — passed, 4 tests
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed; existing Vite dynamic-import/chunk-size warnings only

## Notes
- This PR intentionally follows up #422 by removing the `shortcut === ">"` special case rather than adding another call-site convention.
