### PR TITLE
fix(workspaces): preserve shared worktree removal policy

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3169,6 +3169,13 @@ pub fn git_worktrees(repo_path: String) -> AppResult<Vec<String>> {
         .collect())
 }
 
+#[tauri::command]
+pub fn remove_worktree(repo_path: String, worktree_path: String) -> AppResult<()> {
+    let repo_path = PathBuf::from(repo_path);
+    let worktree_path = PathBuf::from(worktree_path);
+    remove_linked_worktree_at_path(&repo_path, &worktree_path)
+}
+
 fn parse_id(id: &str) -> AppResult<Uuid> {
     Uuid::parse_str(id).map_err(|e| AppError::Other(e.to_string()))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -571,6 +571,7 @@ pub fn run() {
             commands::update_session_worktree,
             commands::prepare_chat_session_worktree,
             commands::git_worktrees,
+            commands::remove_worktree,
             commands::scrollback_save,
             commands::scrollback_load,
             commands::scrollback_delete,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,11 @@ import {
   TERMINAL_CONVERSATION_NAV_EVENT,
   type ConversationNavigationDirection,
 } from "./lib/terminalConversation";
-import { hasRecordedWorktree } from "./lib/sessionWorktree";
+import {
+  canDeleteSessionWorktree,
+  hasRecordedWorktree,
+  shouldAutoDeleteSessionWorktree,
+} from "./lib/sessionWorktree";
 import {
   EQUALIZE_PANES_EVENT,
   EXPAND_PANEL_EVENT,
@@ -251,6 +255,7 @@ function App() {
   const refreshAll = useAppStore((s) => s.refreshAll);
   const sessions = useAppStore((s) => s.sessions);
   const projects = useAppStore((s) => s.projects);
+  const projectFolders = useAppStore((s) => s.projectFolders);
   const layout = useAppStore((s) => s.layout);
   const pendingRemoveId = useAppStore((s) => s.pendingRemoveId);
   const pendingRemoveProject = useAppStore((s) => s.pendingRemoveProject);
@@ -277,9 +282,15 @@ function App() {
     : [];
   const pendingRemoveRecordedWorktree =
     pendingRemove !== null && hasRecordedWorktree(pendingRemove);
+  const pendingRemoveCanDeleteWorktree =
+    pendingRemove !== null &&
+    canDeleteSessionWorktree(pendingRemove, projectFolders);
+  const pendingRemoveAutoDeletesWorktree =
+    pendingRemove !== null &&
+    shouldAutoDeleteSessionWorktree(pendingRemove, projectFolders);
   const pendingRemoveSkipsDialog =
     pendingRemove !== null &&
-    ((pendingRemoveRecordedWorktree && autoDeleteWorktrees) ||
+    ((pendingRemoveAutoDeletesWorktree && autoDeleteWorktrees) ||
       (!pendingRemoveRecordedWorktree && !confirmRemoveSession));
   const sessionIdsKey = useMemo(
     () => sessions.map((session) => session.id).join("\0"),
@@ -1050,12 +1061,16 @@ function App() {
   }, [activeSessionId, sessionIdsKey]);
 
   // Skip the confirmation dialog when Settings gives a deterministic removal
-  // choice: plain sessions can skip confirmation, and worktree-backed sessions
-  // can opt into always deleting the worktree from disk.
+  // choice: plain sessions can skip confirmation, and standalone isolated
+  // sessions can opt into always deleting their worktree from disk.
   useEffect(() => {
     if (!pendingRemove) return;
     const recordedWorktree = hasRecordedWorktree(pendingRemove);
-    if (recordedWorktree && autoDeleteWorktrees) {
+    const autoDeleteWorktree = shouldAutoDeleteSessionWorktree(
+      pendingRemove,
+      projectFolders,
+    );
+    if (autoDeleteWorktree && autoDeleteWorktrees) {
       clearPendingRemove();
       void removeSession(pendingRemove.id, true).then(() =>
         showStoreOperationToast(
@@ -1078,6 +1093,7 @@ function App() {
     autoDeleteWorktrees,
     clearPendingRemove,
     confirmRemoveSession,
+    projectFolders,
     removeSession,
     showStoreOperationToast,
   ]);
@@ -1660,6 +1676,7 @@ function App() {
       />
       <RemoveSessionDialog
         session={pendingRemoveSkipsDialog ? null : pendingRemove}
+        canDeleteWorktree={pendingRemoveCanDeleteWorktree}
         onClose={(choice) => {
           const target = pendingRemove;
           clearPendingRemove();

--- a/src/components/RemoveProjectFolderDialog.tsx
+++ b/src/components/RemoveProjectFolderDialog.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle } from "lucide-react";
 import type { ProjectFolder } from "../lib/projectFolders";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
+import { useSettings } from "../lib/settings";
 import type { Session } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
 import { Modal, ModalHeader } from "./ui";
@@ -9,6 +10,7 @@ import { Modal, ModalHeader } from "./ui";
 type RemoveProjectFolderChoice =
   | "folder_only"
   | "folder_and_sessions"
+  | "folder_and_worktree"
   | "cancel";
 type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
 
@@ -19,21 +21,30 @@ function dt(t: Translator, key: DialogTranslationKey): string {
 interface RemoveProjectFolderDialogProps {
   folder: ProjectFolder | null;
   sessions: readonly Session[];
+  deleteWorktrees?: boolean;
+  worktreeWorkspace?: boolean;
   onClose: (choice: RemoveProjectFolderChoice) => void;
 }
 
 export function RemoveProjectFolderDialog({
   folder,
   sessions,
+  deleteWorktrees = false,
+  worktreeWorkspace = false,
   onClose,
 }: RemoveProjectFolderDialogProps) {
   const t = useTranslation();
+  const autoDeleteEmptyWorktreeWorkspaces = useSettings(
+    (s) => s.settings.sessions.autoDeleteEmptyWorktreeWorkspaces,
+  );
+  const patchSessions = useSettings((s) => s.patchSessions);
   const sessionCount = sessions.length;
+  const canChooseWorktreeRemoval = worktreeWorkspace && sessionCount === 0;
 
   useDialogShortcuts(folder !== null, {
     onCancel: () => onClose("cancel"),
     onConfirm: () =>
-      onClose(sessionCount > 0 ? "folder_only" : "folder_and_sessions"),
+      onClose(sessionCount > 0 ? "folder_and_sessions" : "folder_only"),
   });
 
   return (
@@ -66,10 +77,30 @@ export function RemoveProjectFolderDialog({
                     {sessionCount === 1
                       ? dt(t, "dialogs.removeProjectFolder.sessionSingular")
                       : dt(t, "dialogs.removeProjectFolder.sessionPlural")}{" "}
-                    {dt(t, "dialogs.removeProjectFolder.canBeMovedOut")}.
+                    {dt(t, "dialogs.removeProjectFolder.sessionsWillBeRemoved")}
+                  </p>
+                </>
+              ) : worktreeWorkspace ? (
+                <>
+                  <p className="text-fg-muted">
+                    {dt(t, "dialogs.removeProjectFolder.emptyFolder")}
                   </p>
                   <p className="text-fg-muted">
-                    {dt(t, "dialogs.removeProjectFolder.removeSessionsHint")}
+                    {dt(t, "dialogs.removeProjectFolder.worktreeWorkspacePath")}
+                  </p>
+                  <p className="break-all font-mono text-fg">
+                    {folder.cwdPath}
+                  </p>
+                  <p className="text-fg-muted">
+                    {deleteWorktrees
+                      ? dt(
+                          t,
+                          "dialogs.removeProjectFolder.worktreesWillBeDeleted",
+                        )
+                      : dt(
+                          t,
+                          "dialogs.removeProjectFolder.deleteWorkspaceWorktreeQuestion",
+                        )}
                   </p>
                 </>
               ) : (
@@ -77,10 +108,43 @@ export function RemoveProjectFolderDialog({
                   {dt(t, "dialogs.removeProjectFolder.emptyFolder")}
                 </p>
               )}
-              <p className="text-fg-muted">
-                {dt(t, "dialogs.removeProjectFolder.filesWillNotBeTouched")}
-              </p>
+              {!canChooseWorktreeRemoval ? (
+                <p className="text-fg-muted">
+                  {deleteWorktrees
+                    ? dt(
+                        t,
+                        "dialogs.removeProjectFolder.worktreesWillBeDeleted",
+                      )
+                    : worktreeWorkspace
+                      ? dt(
+                          t,
+                          "dialogs.removeProjectFolder.sharedWorktreeWillBeKept",
+                        )
+                      : dt(
+                          t,
+                          "dialogs.removeProjectFolder.filesWillNotBeTouched",
+                        )}
+                </p>
+              ) : null}
             </div>
+            {canChooseWorktreeRemoval ? (
+              <label className="flex cursor-pointer items-center gap-2 pt-1 text-xs text-fg-muted">
+                <input
+                  type="checkbox"
+                  checked={autoDeleteEmptyWorktreeWorkspaces}
+                  onChange={(e) =>
+                    patchSessions({
+                      autoDeleteEmptyWorktreeWorkspaces: e.target.checked,
+                    })
+                  }
+                  className="accent-[var(--color-accent)]"
+                />
+                {dt(
+                  t,
+                  "dialogs.removeProjectFolder.rememberDeleteWorktree",
+                )}
+              </label>
+            ) : null}
           </div>
           <footer className="flex items-center justify-end gap-2 border-t border-border bg-bg-sidebar/40 px-4 py-3">
             <button
@@ -90,28 +154,38 @@ export function RemoveProjectFolderDialog({
             >
               {dt(t, "dialogs.common.cancel")}
             </button>
-            {sessionCount > 0 ? (
+            {canChooseWorktreeRemoval ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => onClose("folder_only")}
+                  className="rounded-md px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
+                >
+                  {dt(t, "dialogs.removeProjectFolder.keepWorktree")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onClose("folder_and_worktree")}
+                  className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
+                >
+                  {dt(t, "dialogs.removeProjectFolder.deleteWorktree")}
+                </button>
+              </>
+            ) : (
               <button
                 type="button"
-                onClick={() => onClose("folder_only")}
-                className="rounded-md px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
+                onClick={() =>
+                  onClose(
+                    sessionCount > 0 ? "folder_and_sessions" : "folder_only",
+                  )
+                }
+                className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
               >
-                {dt(t, "dialogs.removeProjectFolder.moveSessionsOut")}
+                {sessionCount > 0
+                  ? dt(t, "dialogs.removeProjectFolder.removeWithSessions")
+                  : dt(t, "dialogs.removeProjectFolder.removeFolder")}
               </button>
-            ) : null}
-            <button
-              type="button"
-              onClick={() =>
-                onClose(
-                  sessionCount > 0 ? "folder_and_sessions" : "folder_only",
-                )
-              }
-              className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
-            >
-              {sessionCount > 0
-                ? dt(t, "dialogs.removeProjectFolder.removeWithSessions")
-                : dt(t, "dialogs.removeProjectFolder.removeFolder")}
-            </button>
+            )}
           </footer>
         </>
       ) : null}

--- a/src/components/RemoveSessionDialog.test.tsx
+++ b/src/components/RemoveSessionDialog.test.tsx
@@ -43,10 +43,16 @@ describe("RemoveSessionDialog", () => {
     vi.clearAllMocks();
   });
 
-  function renderDialog(target: Session) {
+  function renderDialog(target: Session, canDeleteWorktree = true) {
     const onClose = vi.fn();
     act(() => {
-      root.render(<RemoveSessionDialog session={target} onClose={onClose} />);
+      root.render(
+        <RemoveSessionDialog
+          session={target}
+          canDeleteWorktree={canDeleteWorktree}
+          onClose={onClose}
+        />,
+      );
     });
     return onClose;
   }
@@ -60,6 +66,17 @@ describe("RemoveSessionDialog", () => {
     expect(document.body.textContent).toContain("Keep worktree");
     expect(document.body.textContent).toContain("Delete worktree");
     expect(document.body.textContent).not.toContain("Don't ask again");
+  });
+
+  it("keeps shared worktree workspace sessions on disk", () => {
+    renderDialog(session({ isolated: true, in_worktree: true }), false);
+
+    expect(document.body.textContent).toContain(
+      "This worktree is shared by a workspace and will be kept on disk.",
+    );
+    expect(document.body.textContent).not.toContain("Keep worktree");
+    expect(document.body.textContent).not.toContain("Delete worktree");
+    expect(document.body.textContent).toContain("Remove");
   });
 
   it("keeps the plain session remove confirmation for non-worktree sessions", () => {

--- a/src/components/RemoveSessionDialog.tsx
+++ b/src/components/RemoveSessionDialog.tsx
@@ -17,13 +17,19 @@ function dt(t: Translator, key: DialogTranslationKey): string {
 
 interface RemoveSessionDialogProps {
   session: Session | null;
+  canDeleteWorktree?: boolean;
   onClose: (choice: RemoveChoice) => void;
 }
 
-export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogProps) {
+export function RemoveSessionDialog({
+  session,
+  canDeleteWorktree = true,
+  onClose,
+}: RemoveSessionDialogProps) {
   const t = useTranslation();
   const isolated = session?.isolated ?? false;
   const recordedWorktree = session ? hasRecordedWorktree(session) : false;
+  const showWorktreeDeleteChoice = recordedWorktree && canDeleteWorktree;
   const patchSessions = useSettings((s) => s.patchSessions);
   const [dontAskAgain, setDontAskAgain] = useState(false);
 
@@ -34,7 +40,7 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
 
   // Keep Enter conservative for non-isolated linked worktrees, which may be
   // user-managed outside Acorn even though the session path is a real worktree.
-  const primaryChoice: RemoveChoice = isolated
+  const primaryChoice: RemoveChoice = isolated && canDeleteWorktree
     ? "session_and_worktree"
     : "session_only";
 
@@ -81,7 +87,9 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
                   {session.worktree_path}
                 </p>
                 <p className="text-xs text-fg-muted">
-                  {dt(t, "dialogs.removeSession.deleteWorktreeQuestion")}
+                  {canDeleteWorktree
+                    ? dt(t, "dialogs.removeSession.deleteWorktreeQuestion")
+                    : dt(t, "dialogs.removeSession.keepSharedWorktree")}
                 </p>
               </div>
             ) : (
@@ -111,7 +119,7 @@ export function RemoveSessionDialog({ session, onClose }: RemoveSessionDialogPro
             >
               {dt(t, "dialogs.common.cancel")}
             </button>
-            {recordedWorktree ? (
+            {showWorktreeDeleteChoice ? (
               <>
                 <button
                   type="button"

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -625,11 +625,11 @@ describe("SettingsModal font controls", () => {
     ).find((input) =>
       input
         .closest("label")
-        ?.textContent?.includes("Always delete worktree-backed sessions"),
+        ?.textContent?.includes("Always delete standalone isolated worktrees"),
     );
 
     expect(document.body.textContent).toContain(
-      "Delete worktrees without asking",
+      "Delete isolated worktrees without asking",
     );
     expect(toggle).toBeInstanceOf(HTMLInputElement);
     expect(toggle?.checked).toBe(false);
@@ -640,6 +640,47 @@ describe("SettingsModal font controls", () => {
 
     expect(patchSessions).toHaveBeenCalledWith({
       autoDeleteWorktrees: true,
+    });
+  });
+
+  it("patches the empty worktree workspace auto-delete toggle", async () => {
+    const patchSessions = vi.fn();
+    useSettings.setState({
+      settings: cloneSettings(),
+      patchSessions,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openSessionsTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const toggle = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    ).find((input) =>
+      input
+        .closest("label")
+        ?.textContent?.includes(
+          "Always delete empty worktree workspace directories",
+        ),
+    );
+
+    expect(document.body.textContent).toContain(
+      "Delete empty worktree workspaces without asking",
+    );
+    expect(toggle).toBeInstanceOf(HTMLInputElement);
+    expect(toggle?.checked).toBe(false);
+
+    act(() => {
+      toggle?.click();
+    });
+
+    expect(patchSessions).toHaveBeenCalledWith({
+      autoDeleteEmptyWorktreeWorkspaces: true,
     });
   });
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -676,6 +676,33 @@ function SessionSettings() {
         </label>
       </Field>
       <Field
+        label={st(
+          t,
+          "settings.sessions.autoDeleteEmptyWorktreeWorkspaces.label",
+        )}
+        hint={st(
+          t,
+          "settings.sessions.autoDeleteEmptyWorktreeWorkspaces.hint",
+        )}
+      >
+        <label className="flex items-center gap-2 text-xs text-fg">
+          <input
+            type="checkbox"
+            checked={settings.sessions.autoDeleteEmptyWorktreeWorkspaces}
+            onChange={(e) =>
+              patchSessions({
+                autoDeleteEmptyWorktreeWorkspaces: e.target.checked,
+              })
+            }
+            className="accent-[var(--color-accent)]"
+          />
+          {st(
+            t,
+            "settings.sessions.autoDeleteEmptyWorktreeWorkspaces.checkbox",
+          )}
+        </label>
+      </Field>
+      <Field
         label={st(t, "settings.sessions.closeOnExit.label")}
         hint={st(t, "settings.sessions.closeOnExit.hint")}
       >

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -70,7 +70,10 @@ import {
   canRegenerateSessionTitle,
   canRenameSession,
 } from "../lib/sessionTitle";
-import { hasRecordedWorktree } from "../lib/sessionWorktree";
+import {
+  hasRecordedWorktree,
+  shouldAutoDeleteSessionWorktree,
+} from "../lib/sessionWorktree";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
 import {
@@ -198,6 +201,12 @@ export function Sidebar() {
   const renameProjectFolder = useAppStore((s) => s.renameProjectFolder);
   const removeProjectFolder = useAppStore((s) => s.removeProjectFolder);
   const removeSession = useAppStore((s) => s.removeSession);
+  const autoDeleteWorktrees = useSettings(
+    (s) => s.settings.sessions.autoDeleteWorktrees,
+  );
+  const autoDeleteEmptyWorktreeWorkspaces = useSettings(
+    (s) => s.settings.sessions.autoDeleteEmptyWorktreeWorkspaces,
+  );
   const moveSessionToProjectFolder = useAppStore(
     (s) => s.moveSessionToProjectFolder,
   );
@@ -383,7 +392,11 @@ export function Sidebar() {
   ) {
     try {
       for (const session of folderGroup.sessions) {
-        await removeSession(session.id, false);
+        await removeSession(
+          session.id,
+          autoDeleteWorktrees &&
+            shouldAutoDeleteSessionWorktree(session, projectFolders),
+        );
         const error = useAppStore.getState().consumeError();
         if (error) {
           showToast(`${t("toasts.session.removeFailed")} ${error}`);
@@ -397,12 +410,31 @@ export function Sidebar() {
     }
   }
 
+  async function removeProjectFolderAndWorktree(folder: ProjectFolder) {
+    try {
+      await api.removeWorktree(folder.repoPath, folder.cwdPath);
+      removeProjectFolder(folder.id);
+      showToast(t("toasts.session.worktreeRemoved"));
+    } catch (e) {
+      console.error("remove project folder worktree failed", e);
+      showToast(`${t("toasts.session.worktreeRemoveFailed")} ${String(e)}`);
+    }
+  }
+
   function requestRemoveProjectFolder(folderId: string) {
     const folderGroup = projectGroups
       .flatMap((project) => project.folders)
       .find((candidate) => candidate.folder.id === folderId);
     if (!folderGroup) return;
     if (folderGroup.sessions.length === 0) {
+      if (isWorktreeWorkspace(folderGroup.folder)) {
+        if (autoDeleteEmptyWorktreeWorkspaces) {
+          void removeProjectFolderAndWorktree(folderGroup.folder);
+        } else {
+          setPendingRemoveProjectFolderId(folderGroup.folder.id);
+        }
+        return;
+      }
       removeProjectFolder(folderGroup.folder.id);
       return;
     }
@@ -1028,10 +1060,24 @@ export function Sidebar() {
       <RemoveProjectFolderDialog
         folder={pendingRemoveProjectFolderGroup?.folder ?? null}
         sessions={pendingRemoveProjectFolderGroup?.sessions ?? []}
+        worktreeWorkspace={Boolean(
+          pendingRemoveProjectFolderGroup &&
+            isWorktreeWorkspace(pendingRemoveProjectFolderGroup.folder),
+        )}
+        deleteWorktrees={Boolean(
+          autoDeleteWorktrees &&
+            pendingRemoveProjectFolderGroup?.sessions.some((session) =>
+              shouldAutoDeleteSessionWorktree(session, projectFolders),
+            ),
+        )}
         onClose={(choice) => {
           const target = pendingRemoveProjectFolderGroup;
           setPendingRemoveProjectFolderId(null);
           if (!target || choice === "cancel") return;
+          if (choice === "folder_and_worktree") {
+            void removeProjectFolderAndWorktree(target.folder);
+            return;
+          }
           if (choice === "folder_only") {
             removeProjectFolder(target.folder.id);
             return;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -645,6 +645,9 @@ export const api = {
   gitWorktrees(repoPath: string): Promise<string[]> {
     return invoke<string[]>("git_worktrees", { repoPath });
   },
+  removeWorktree(repoPath: string, worktreePath: string): Promise<void> {
+    return invoke<void>("remove_worktree", { repoPath, worktreePath });
+  },
   /**
    * Probe the `acornd` daemon. Backs the StatusBar daemon indicator and
    * the Settings → Background sessions panel. Always resolves — when no

--- a/src/lib/sessionWorktree.test.ts
+++ b/src/lib/sessionWorktree.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { Session } from "./types";
-import { hasRecordedWorktree } from "./sessionWorktree";
+import {
+  canDeleteSessionWorktree,
+  hasRecordedWorktree,
+  isSessionInWorktreeWorkspace,
+  shouldAutoDeleteSessionWorktree,
+} from "./sessionWorktree";
 
 function session(overrides: Partial<Session> = {}): Session {
   return {
@@ -34,5 +39,60 @@ describe("hasRecordedWorktree", () => {
 
   it("does not infer a removable worktree for ordinary repo sessions", () => {
     expect(hasRecordedWorktree(session())).toBe(false);
+  });
+});
+
+describe("worktree deletion policy", () => {
+  const foldersByRepo = {
+    "/repo": [
+      {
+        id: "/repo",
+        repoPath: "/repo",
+        name: "Default",
+        cwdPath: "/repo",
+        position: 0,
+      },
+      {
+        id: "project-folder:/repo:shared",
+        repoPath: "/repo",
+        name: "Shared",
+        cwdPath: "/repo/.acorn/worktrees/shared",
+        position: 1,
+      },
+    ],
+  };
+
+  it("auto-deletes standalone isolated sessions", () => {
+    const target = session({
+      isolated: true,
+      worktree_path: "/repo/.acorn/worktrees/solo",
+    });
+
+    expect(isSessionInWorktreeWorkspace(target, foldersByRepo)).toBe(false);
+    expect(canDeleteSessionWorktree(target, foldersByRepo)).toBe(true);
+    expect(shouldAutoDeleteSessionWorktree(target, foldersByRepo)).toBe(true);
+  });
+
+  it("preserves isolated sessions that are backing a worktree workspace", () => {
+    const target = session({
+      isolated: true,
+      worktree_path: "/repo/.acorn/worktrees/shared",
+      in_worktree: true,
+    });
+
+    expect(isSessionInWorktreeWorkspace(target, foldersByRepo)).toBe(true);
+    expect(canDeleteSessionWorktree(target, foldersByRepo)).toBe(false);
+    expect(shouldAutoDeleteSessionWorktree(target, foldersByRepo)).toBe(false);
+  });
+
+  it("does not auto-delete linked worktree sessions", () => {
+    const target = session({
+      isolated: false,
+      in_worktree: true,
+      worktree_path: "/repo/.acorn/worktrees/solo",
+    });
+
+    expect(canDeleteSessionWorktree(target, foldersByRepo)).toBe(true);
+    expect(shouldAutoDeleteSessionWorktree(target, foldersByRepo)).toBe(false);
   });
 });

--- a/src/lib/sessionWorktree.ts
+++ b/src/lib/sessionWorktree.ts
@@ -1,5 +1,42 @@
 import type { Session } from "./types";
+import type { ProjectFoldersByRepo } from "./projectFolders";
 
 export function hasRecordedWorktree(session: Session): boolean {
   return session.isolated || session.in_worktree;
+}
+
+function normalizeWorkspacePath(path: string): string {
+  return path.replace(/[\\/]+$/, "");
+}
+
+function sameWorkspacePath(a: string, b: string): boolean {
+  return normalizeWorkspacePath(a) === normalizeWorkspacePath(b);
+}
+
+export function isSessionInWorktreeWorkspace(
+  session: Session,
+  foldersByRepo: ProjectFoldersByRepo,
+): boolean {
+  return (foldersByRepo[session.repo_path] ?? []).some(
+    (folder) =>
+      !sameWorkspacePath(folder.cwdPath, folder.repoPath) &&
+      sameWorkspacePath(folder.cwdPath, session.worktree_path),
+  );
+}
+
+export function canDeleteSessionWorktree(
+  session: Session,
+  foldersByRepo: ProjectFoldersByRepo,
+): boolean {
+  return (
+    hasRecordedWorktree(session) &&
+    !isSessionInWorktreeWorkspace(session, foldersByRepo)
+  );
+}
+
+export function shouldAutoDeleteSessionWorktree(
+  session: Session,
+  foldersByRepo: ProjectFoldersByRepo,
+): boolean {
+  return session.isolated && canDeleteSessionWorktree(session, foldersByRepo);
 }

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -158,12 +158,20 @@ describe("session removal settings", () => {
 
   it("keeps worktree auto-delete off by default", () => {
     expect(DEFAULT_SETTINGS.sessions.autoDeleteWorktrees).toBe(false);
+    expect(DEFAULT_SETTINGS.sessions.autoDeleteEmptyWorktreeWorkspaces).toBe(
+      false,
+    );
   });
 
   it("loads a persisted worktree auto-delete preference", async () => {
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ sessions: { autoDeleteWorktrees: true } }),
+      JSON.stringify({
+        sessions: {
+          autoDeleteWorktrees: true,
+          autoDeleteEmptyWorktreeWorkspaces: true,
+        },
+      }),
     );
 
     vi.resetModules();
@@ -172,6 +180,10 @@ describe("session removal settings", () => {
     expect(useSettings.getState().settings.sessions.autoDeleteWorktrees).toBe(
       true,
     );
+    expect(
+      useSettings.getState().settings.sessions
+        .autoDeleteEmptyWorktreeWorkspaces,
+    ).toBe(true);
   });
 });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -254,15 +254,23 @@ export interface AcornSettings {
     /**
      * Show the confirmation dialog before removing a non-isolated session.
      * Set false to skip the prompt for plain sessions. Worktree-backed
-     * sessions follow `autoDeleteWorktrees`.
+     * sessions still ask unless they are standalone isolated worktrees covered
+     * by `autoDeleteWorktrees`.
      */
     confirmRemove: boolean;
     /**
-     * Remove worktree-backed sessions without asking whether to keep the
-     * worktree directory. When enabled, the backend receives
-     * `removeWorktree = true` for linked and isolated worktree sessions.
+     * Remove standalone isolated worktree sessions without asking whether to
+     * keep the worktree directory. Shared worktree workspaces and linked
+     * worktree sessions are preserved unless the user explicitly deletes them.
      */
     autoDeleteWorktrees: boolean;
+    /**
+     * Remove the linked worktree directory when deleting an empty worktree
+     * workspace without asking. Worktree workspaces that still contain
+     * sessions always show the workspace removal confirmation and preserve the
+     * directory.
+     */
+    autoDeleteEmptyWorktreeWorkspaces: boolean;
     /**
      * When the session's PTY process exits (e.g. user typed `exit`), close
      * the session tab automatically instead of showing the
@@ -431,6 +439,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   sessions: {
     confirmRemove: true,
     autoDeleteWorktrees: false,
+    autoDeleteEmptyWorktreeWorkspaces: false,
     closeOnExit: false,
   },
   power: {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -97,17 +97,22 @@
     "sessions": {
       "confirmRemove": {
         "label": "Confirm before removing a session",
-        "hint": "Applies to plain sessions. Worktree-backed sessions follow the delete-worktree setting below.",
+        "hint": "Applies to plain sessions. Shared worktree sessions still ask before removal.",
         "checkbox": "Show confirmation dialog"
       },
       "autoDeleteWorktrees": {
-        "label": "Delete worktrees without asking",
-        "hint": "When removing a session that uses an isolated or linked worktree, skip the keep/delete prompt and always delete the worktree from disk.",
-        "checkbox": "Always delete worktree-backed sessions from disk"
+        "label": "Delete isolated worktrees without asking",
+        "hint": "When removing a standalone isolated worktree session, skip the keep/delete prompt and delete its worktree from disk. Shared worktree workspaces are preserved.",
+        "checkbox": "Always delete standalone isolated worktrees from disk"
+      },
+      "autoDeleteEmptyWorktreeWorkspaces": {
+        "label": "Delete empty worktree workspaces without asking",
+        "hint": "When removing a worktree workspace with no sessions, delete its linked worktree from disk without showing the keep/delete prompt.",
+        "checkbox": "Always delete empty worktree workspace directories"
       },
       "closeOnExit": {
         "label": "Close tab when the process exits",
-        "hint": "When the session's shell or agent exits (e.g. you type `exit`), close the tab automatically instead of showing the press-Enter restart prompt. Worktree-backed sessions follow the delete-worktree setting above.",
+        "hint": "When the session's shell or agent exits (e.g. you type `exit`), close the tab automatically instead of showing the press-Enter restart prompt. Standalone isolated sessions follow the delete-worktree setting above.",
         "checkbox": "Auto-close on exit"
       },
       "background": {
@@ -1163,6 +1168,7 @@
       "deleteWorktreeQuestion": "Also delete the worktree from disk?",
       "filesIn": "Files in",
       "willNotBeTouched": "will not be touched.",
+      "keepSharedWorktree": "This worktree is shared by a workspace and will be kept on disk.",
       "dontAskAgain": "Don't ask again (toggle in Settings → Sessions)",
       "keepWorktree": "Keep worktree",
       "deleteWorktree": "Delete worktree",
@@ -1187,13 +1193,18 @@
       "confirmPrefix": "Remove workspace",
       "sessionSingular": "session",
       "sessionPlural": "sessions",
-      "canBeMovedOut": "can be moved out to the project before the workspace is removed",
-      "removeSessionsHint": "You can also remove the sessions from Acorn with the workspace.",
+      "sessionsWillBeRemoved": "will be removed from Acorn with this workspace.",
       "emptyFolder": "This workspace has no sessions.",
       "filesWillNotBeTouched": "Files and worktrees on disk will not be deleted.",
+      "worktreesWillBeDeleted": "Standalone isolated sessions will also delete their worktrees from disk.",
+      "worktreeWorkspacePath": "This workspace uses a linked git worktree:",
+      "deleteWorkspaceWorktreeQuestion": "Also delete this worktree from disk?",
+      "sharedWorktreeWillBeKept": "The workspace worktree will be kept on disk.",
+      "rememberDeleteWorktree": "Always delete empty worktree workspace directories",
       "removeFolder": "Remove workspace",
-      "moveSessionsOut": "Move sessions out",
-      "removeWithSessions": "Remove workspace and sessions"
+      "keepWorktree": "Keep worktree",
+      "deleteWorktree": "Delete worktree",
+      "removeWithSessions": "Remove with sessions"
     },
     "projectSettings": {
       "title": "Project Settings",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -97,17 +97,22 @@
     "sessions": {
       "confirmRemove": {
         "label": "세션 제거 전 확인",
-        "hint": "일반 세션에 적용됩니다. 워크트리가 있는 세션은 아래 워크트리 삭제 설정을 따릅니다.",
+        "hint": "일반 세션에 적용됩니다. 공유 워크트리 세션은 제거 전에 계속 확인합니다.",
         "checkbox": "확인 대화상자 표시"
       },
       "autoDeleteWorktrees": {
-        "label": "묻지 않고 워크트리 삭제",
-        "hint": "격리 또는 연결된 워크트리를 사용하는 세션을 제거할 때 유지/삭제 확인을 건너뛰고 디스크의 워크트리를 항상 삭제합니다.",
-        "checkbox": "워크트리가 있는 세션은 항상 디스크에서도 삭제"
+        "label": "묻지 않고 격리 워크트리 삭제",
+        "hint": "단독 격리 워크트리 세션을 제거할 때 유지/삭제 확인을 건너뛰고 디스크의 워크트리를 삭제합니다. 공유 워크트리 작업공간은 유지됩니다.",
+        "checkbox": "단독 격리 워크트리는 항상 디스크에서도 삭제"
+      },
+      "autoDeleteEmptyWorktreeWorkspaces": {
+        "label": "빈 워크트리 작업공간은 묻지 않고 삭제",
+        "hint": "세션이 없는 워크트리 작업공간을 제거할 때 유지/삭제 확인 없이 디스크의 연결된 워크트리도 삭제합니다.",
+        "checkbox": "빈 워크트리 작업공간 디렉터리 항상 삭제"
       },
       "closeOnExit": {
         "label": "프로세스 종료 시 탭 닫기",
-        "hint": "세션의 셸이나 에이전트가 종료되면(예: `exit` 입력) Enter를 눌러 재시작하라는 프롬프트 대신 탭을 자동으로 닫습니다. 워크트리가 있는 세션은 위 워크트리 삭제 설정을 따릅니다.",
+        "hint": "세션의 셸이나 에이전트가 종료되면(예: `exit` 입력) Enter를 눌러 재시작하라는 프롬프트 대신 탭을 자동으로 닫습니다. 단독 격리 세션은 위 워크트리 삭제 설정을 따릅니다.",
         "checkbox": "종료 시 자동 닫기"
       },
       "background": {
@@ -1163,6 +1168,7 @@
       "deleteWorktreeQuestion": "디스크에서도 워크트리를 삭제할까요?",
       "filesIn": "다음 위치의 파일은",
       "willNotBeTouched": "변경되지 않습니다.",
+      "keepSharedWorktree": "이 워크트리는 작업공간에서 공유 중이므로 디스크에 유지됩니다.",
       "dontAskAgain": "다시 묻지 않기(설정 → 세션에서 변경)",
       "keepWorktree": "워크트리 유지",
       "deleteWorktree": "워크트리 삭제",
@@ -1187,13 +1193,18 @@
       "confirmPrefix": "작업공간 제거",
       "sessionSingular": "세션",
       "sessionPlural": "세션",
-      "canBeMovedOut": "작업공간을 제거하기 전에 프로젝트 상위 목록으로 이동할 수 있습니다",
-      "removeSessionsHint": "작업공간과 함께 세션을 Acorn에서 제거할 수도 있습니다.",
+      "sessionsWillBeRemoved": "이 작업공간과 함께 Acorn에서 제거됩니다.",
       "emptyFolder": "이 작업공간에는 세션이 없습니다.",
       "filesWillNotBeTouched": "디스크의 파일과 워크트리는 삭제되지 않습니다.",
+      "worktreesWillBeDeleted": "단독 격리 세션은 디스크의 워크트리도 함께 삭제됩니다.",
+      "worktreeWorkspacePath": "이 작업공간은 연결된 Git 워크트리를 사용합니다:",
+      "deleteWorkspaceWorktreeQuestion": "이 워크트리도 디스크에서 삭제할까요?",
+      "sharedWorktreeWillBeKept": "작업공간 워크트리는 디스크에 유지됩니다.",
+      "rememberDeleteWorktree": "빈 워크트리 작업공간 디렉터리 항상 삭제",
       "removeFolder": "작업공간 제거",
-      "moveSessionsOut": "세션 밖으로 이동",
-      "removeWithSessions": "작업공간과 세션 제거"
+      "keepWorktree": "워크트리 유지",
+      "deleteWorktree": "워크트리 삭제",
+      "removeWithSessions": "세션까지 제거"
     },
     "projectSettings": {
       "title": "프로젝트 설정",

--- a/tests/e2e/session-lifecycle.spec.ts
+++ b/tests/e2e/session-lifecycle.spec.ts
@@ -189,7 +189,7 @@ test.describe("session lifecycle", () => {
     expect(calls[0].removeWorktree).toBe(false);
   });
 
-  test("worktree auto-delete skips the remove confirmation", async ({
+  test("standalone isolated worktree auto-delete skips the remove confirmation", async ({
     page,
     tauri,
   }) => {
@@ -217,7 +217,7 @@ test.describe("session lifecycle", () => {
               repo_path: "/tmp/demo",
               worktree_path: "/tmp/demo/.acorn/worktrees/alpha",
               branch: "main",
-              isolated: false,
+              isolated: true,
               in_worktree: true,
               status: "idle",
               created_at: "2026-01-01T00:00:00Z",

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -1083,9 +1083,12 @@ test.describe("sidebar: project lifecycle", () => {
       page.getByRole("tooltip", { name: "Remove workspace" }),
     ).toBeVisible();
     await removeFolderButton.click();
-    await page
-      .getByRole("dialog", { name: "Remove workspace" })
-      .getByRole("button", { name: "Remove workspace and sessions" })
+    const removeDialog = page.getByRole("dialog", { name: "Remove workspace" });
+    await expect(
+      removeDialog.getByRole("button", { name: "Move sessions out" }),
+    ).toHaveCount(0);
+    await removeDialog
+      .getByRole("button", { name: "Remove with sessions" })
       .click();
 
     await expect(child).toHaveCount(0);
@@ -1096,6 +1099,119 @@ test.describe("sidebar: project lifecycle", () => {
       () => (window as unknown as { __removeCalls?: unknown[] }).__removeCalls,
     )) as Array<{ id: string; removeWorktree: boolean }>;
     expect(calls).toEqual([{ id: "child-session", removeWorktree: false }]);
+  });
+
+  test("project workspace remove preserves shared worktrees despite auto-delete setting", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          sessions: {
+            confirmRemove: true,
+            autoDeleteWorktrees: true,
+            closeOnExit: false,
+          },
+        }),
+      );
+      localStorage.setItem(
+        "acorn-workspaces",
+        JSON.stringify({
+          state: {
+            projectFolders: {
+              "/tmp/demo": [
+                {
+                  id: "/tmp/demo",
+                  repoPath: "/tmp/demo",
+                  name: "Default",
+                  cwdPath: "/tmp/demo",
+                  position: 0,
+                },
+                {
+                  id: "project-folder:/tmp/demo:feature-worktree",
+                  repoPath: "/tmp/demo",
+                  name: "Feature workspace",
+                  cwdPath: "/tmp/demo/.acorn/worktrees/feature",
+                  position: 1,
+                },
+              ],
+            },
+            sessionFolderIds: {},
+          },
+          version: 4,
+        }),
+      );
+    });
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __removedIds?: string[] };
+      const removed = new Set(w.__removedIds ?? []);
+      return removed.has("worktree-session")
+        ? []
+        : [
+            {
+              id: "worktree-session",
+              name: "alpha",
+              repo_path: "/tmp/demo",
+              worktree_path: "/tmp/demo/.acorn/worktrees/feature",
+              branch: "main",
+              isolated: true,
+              project_scoped: true,
+              status: "idle",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:00Z",
+              last_message: null,
+              title_source: "manual",
+              kind: "regular",
+              owner: { kind: "user" },
+              position: 0,
+              in_worktree: true,
+            },
+          ];
+    });
+    await tauri.handle("remove_session", (args) => {
+      const w = window as unknown as {
+        __removeCalls?: unknown[];
+        __removedIds?: string[];
+      };
+      w.__removeCalls = w.__removeCalls ?? [];
+      w.__removeCalls.push(args);
+      const id = String(args?.id ?? "");
+      w.__removedIds = Array.from(new Set([...(w.__removedIds ?? []), id]));
+      return null;
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator("aside");
+    const workspace = sidebar
+      .getByRole("button", { name: /Feature workspace/ })
+      .first();
+    await expect(workspace).toBeVisible();
+
+    await workspace.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Remove workspace" }).click();
+    const dialog = page.getByRole("dialog", { name: "Remove workspace" });
+    await expect(dialog).toContainText(
+      "The workspace worktree will be kept on disk.",
+    );
+    await dialog.getByRole("button", { name: "Remove with sessions" }).click();
+
+    const calls = (await page.evaluate(
+      () => (window as unknown as { __removeCalls?: unknown[] }).__removeCalls,
+    )) as Array<{ id: string; removeWorktree: boolean }>;
+    expect(calls).toEqual([
+      { id: "worktree-session", removeWorktree: false },
+    ]);
   });
 
   test("project workspace remove skips confirmation for empty workspaces", async ({
@@ -1131,7 +1247,7 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(projectRow).toBeVisible();
   });
 
-  test("project workspace remove can keep sessions and move them out", async ({
+  test("project workspace remove asks before deleting an empty worktree workspace worktree", async ({
     page,
     tauri,
   }) => {
@@ -1143,86 +1259,177 @@ test.describe("sidebar: project lifecycle", () => {
         position: 0,
       },
     ]);
-    await tauri.handle("list_sessions", () => [
-      {
-        id: "root-session",
-        name: "root",
-        repo_path: "/tmp/demo",
-        worktree_path: "/tmp/demo",
-        branch: "main",
-        isolated: false,
-        project_scoped: true,
-        status: "idle",
-        created_at: "2026-01-01T00:00:00Z",
-        updated_at: "2026-01-01T00:00:00Z",
-        last_message: null,
-        title_source: "manual",
-        kind: "regular",
-        owner: { kind: "user" },
-        position: 0,
-        in_worktree: false,
-      },
-      {
-        id: "child-session",
-        name: "child",
-        repo_path: "/tmp/demo",
-        worktree_path: "/tmp/demo",
-        branch: "main",
-        isolated: false,
-        project_scoped: true,
-        status: "idle",
-        created_at: "2026-01-01T00:00:01Z",
-        updated_at: "2026-01-01T00:00:01Z",
-        last_message: null,
-        title_source: "manual",
-        kind: "regular",
-        owner: { kind: "user" },
-        position: 1,
-        in_worktree: false,
-      },
-    ]);
-    await tauri.handle("remove_session", (args) => {
-      const w = window as unknown as { __removeCalls?: unknown[] };
-      w.__removeCalls = w.__removeCalls ?? [];
-      w.__removeCalls.push(args);
+    await tauri.handle("list_sessions", () => []);
+    await tauri.handle("remove_worktree", (args) => {
+      const w = window as unknown as { __removeWorktreeCalls?: unknown[] };
+      w.__removeWorktreeCalls = w.__removeWorktreeCalls ?? [];
+      w.__removeWorktreeCalls.push(args);
       return null;
+    });
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn-workspaces",
+        JSON.stringify({
+          state: {
+            projectFolders: {
+              "/tmp/demo": [
+                {
+                  id: "/tmp/demo",
+                  repoPath: "/tmp/demo",
+                  name: "Default",
+                  cwdPath: "/tmp/demo",
+                  position: 0,
+                },
+                {
+                  id: "project-folder:/tmp/demo:feature-empty",
+                  repoPath: "/tmp/demo",
+                  name: "feature-empty",
+                  cwdPath: "/tmp/demo/.acorn/worktrees/feature-empty",
+                  position: 1,
+                },
+              ],
+            },
+            sessionFolderIds: {},
+          },
+          version: 4,
+        }),
+      );
     });
 
     await page.goto("/");
 
     const sidebar = page.locator("aside");
-    const projectRow = page.getByRole("button", { name: "Project demo" });
-    await projectRow.click({ button: "right" });
-    await page.getByRole("menuitem", { name: "New workspace", exact: true }).click();
-    const folderRow = sidebar.getByRole("button", { name: /New workspace/ }).first();
-    await folderRow.dblclick();
-    await sidebar.getByRole("textbox").fill("Frontend");
-    await sidebar.getByRole("textbox").press("Enter");
-
-    const frontend = sidebar.getByRole("button", { name: /Frontend/ }).first();
-    const child = sidebar
-      .getByRole("button", { name: /^child main · Idle/ })
+    const folderRow = sidebar
+      .getByRole("button", { name: /feature-empty/ })
       .first();
-    await child.click({ button: "right" });
-    await clickMoveToTarget(page, "Frontend");
+    await expect(folderRow).toBeVisible();
 
-    await frontend.click({ button: "right" });
+    await folderRow.click({ button: "right" });
     await page.getByRole("menuitem", { name: "Remove workspace" }).click();
-    const dialog = page.getByRole("dialog", { name: "Remove workspace" });
-    await expect(dialog).toBeVisible();
-    await expect(dialog).toContainText("project before the workspace is removed");
-    await dialog.getByRole("button", { name: "Move sessions out" }).click();
 
-    await expect(frontend).toHaveCount(0);
-    await expect(child).toBeVisible();
-    await child.click({ button: "right" });
-    await expectNoMoveToTarget(page, "Project root");
-    await page.keyboard.press("Escape");
+    const dialog = page.getByRole("dialog", { name: "Remove workspace" });
+    await expect(dialog).toContainText("This workspace has no sessions.");
+    await expect(dialog).toContainText(
+      "/tmp/demo/.acorn/worktrees/feature-empty",
+    );
+    await expect(dialog).toContainText("Also delete this worktree from disk?");
+    const remember = dialog.getByRole("checkbox", {
+      name: "Always delete empty worktree workspace directories",
+    });
+    await expect(remember).not.toBeChecked();
+    await remember.check();
+    await expect
+      .poll(async () =>
+        page.evaluate(() =>
+          Boolean(
+            JSON.parse(localStorage.getItem("acorn:settings:v1") ?? "{}")
+              .sessions?.autoDeleteEmptyWorktreeWorkspaces,
+          ),
+        ),
+      )
+      .toBe(true);
+    await dialog.getByRole("button", { name: "Delete worktree" }).click();
 
     const calls = (await page.evaluate(
-      () => (window as unknown as { __removeCalls?: unknown[] }).__removeCalls,
-    )) as unknown[] | undefined;
-    expect(calls ?? []).toEqual([]);
+      () =>
+        (window as unknown as { __removeWorktreeCalls?: unknown[] })
+          .__removeWorktreeCalls,
+    )) as Array<{ repoPath: string; worktreePath: string }>;
+    expect(calls).toEqual([
+      {
+        repoPath: "/tmp/demo",
+        worktreePath: "/tmp/demo/.acorn/worktrees/feature-empty",
+      },
+    ]);
+    await expect(folderRow).toHaveCount(0);
+  });
+
+  test("project workspace remove can auto-delete empty worktree workspaces", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => []);
+    await tauri.handle("remove_worktree", (args) => {
+      const w = window as unknown as { __removeWorktreeCalls?: unknown[] };
+      w.__removeWorktreeCalls = w.__removeWorktreeCalls ?? [];
+      w.__removeWorktreeCalls.push(args);
+      return null;
+    });
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          sessions: {
+            confirmRemove: true,
+            autoDeleteWorktrees: false,
+            autoDeleteEmptyWorktreeWorkspaces: true,
+            closeOnExit: false,
+          },
+        }),
+      );
+      localStorage.setItem(
+        "acorn-workspaces",
+        JSON.stringify({
+          state: {
+            projectFolders: {
+              "/tmp/demo": [
+                {
+                  id: "/tmp/demo",
+                  repoPath: "/tmp/demo",
+                  name: "Default",
+                  cwdPath: "/tmp/demo",
+                  position: 0,
+                },
+                {
+                  id: "project-folder:/tmp/demo:feature-empty",
+                  repoPath: "/tmp/demo",
+                  name: "feature-empty",
+                  cwdPath: "/tmp/demo/.acorn/worktrees/feature-empty",
+                  position: 1,
+                },
+              ],
+            },
+            sessionFolderIds: {},
+          },
+          version: 4,
+        }),
+      );
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator("aside");
+    const folderRow = sidebar
+      .getByRole("button", { name: /feature-empty/ })
+      .first();
+    await expect(folderRow).toBeVisible();
+
+    await folderRow.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Remove workspace" }).click();
+
+    await expect(
+      page.getByRole("dialog", { name: "Remove workspace" }),
+    ).toHaveCount(0);
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __removeWorktreeCalls?: unknown[] })
+          .__removeWorktreeCalls,
+    )) as Array<{ repoPath: string; worktreePath: string }>;
+    expect(calls).toEqual([
+      {
+        repoPath: "/tmp/demo",
+        worktreePath: "/tmp/demo/.acorn/worktrees/feature-empty",
+      },
+    ]);
+    await expect(folderRow).toHaveCount(0);
   });
 
   test("project workspaces and sessions can move by drag and drop", async ({


### PR DESCRIPTION
## Summary
This keeps worktree-backed workspaces from being deleted through session removal while preserving an explicit delete path for empty worktree workspaces.

1. **Session deletion policy**: restrict automatic worktree deletion to standalone isolated sessions, so sessions inside a worktree workspace only remove the Acorn session record.
2. **Workspace removal UI**: remove the `Move sessions out` action, shorten the destructive workspace action, and add a keep/delete prompt for empty worktree workspaces.
3. **Settings and backend path**: add a setting for auto-deleting empty worktree workspace directories and wire the explicit deletion through a new Rust `remove_worktree` command.
4. **Coverage**: update unit and E2E coverage for shared worktree preservation, empty workspace prompts, and standalone isolated auto-delete behavior.

## Expected impact
| Area | Impact |
| --- | --- |
| Data safety | Shared worktree workspace directories are preserved when removing child sessions or removing a non-empty worktree workspace. |
| User-visible behavior | Workspace removal no longer offers `Move sessions out`; the destructive button is shorter and empty worktree workspaces ask whether to delete the directory. |
| Settings | Users can opt into always deleting empty worktree workspace directories, including directly from the confirmation modal checkbox. |

## Design notes
- `shouldAutoDeleteSessionWorktree` centralizes the auto-delete rule and only returns true for standalone isolated sessions outside any worktree workspace.
- Direct deletion of an empty worktree workspace now calls the Rust backend via `remove_worktree`; removing a workspace that still has sessions removes those sessions from Acorn while preserving the workspace worktree.
- Linked worktree sessions and worktree workspace-backed sessions keep their worktree directories unless the user explicitly deletes an empty worktree workspace.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run src/lib/sessionWorktree.test.ts src/components/RemoveSessionDialog.test.tsx src/components/SettingsModal.test.tsx src/lib/settings.test.ts` - 4 files / 78 tests passed
- [x] `PLAYWRIGHT_PORT=1438 pnpm test:e2e tests/e2e/sidebar.spec.ts tests/e2e/session-lifecycle.spec.ts --grep "project workspace remove|worktree auto-delete|standalone isolated worktree auto-delete"` - 6 tests passed
- [x] `TAURI_SIDECAR_PROFILE=debug ./src-tauri/scripts/build-sidecar.sh`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `git diff --check`
