### PR TITLE
fix(sessions): skip shared worktree removal prompt

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -285,12 +285,15 @@ function App() {
   const pendingRemoveCanDeleteWorktree =
     pendingRemove !== null &&
     canDeleteSessionWorktree(pendingRemove, projectFolders);
+  const pendingRemoveKeepsSharedWorktree =
+    pendingRemoveRecordedWorktree && !pendingRemoveCanDeleteWorktree;
   const pendingRemoveAutoDeletesWorktree =
     pendingRemove !== null &&
     shouldAutoDeleteSessionWorktree(pendingRemove, projectFolders);
   const pendingRemoveSkipsDialog =
     pendingRemove !== null &&
-    ((pendingRemoveAutoDeletesWorktree && autoDeleteWorktrees) ||
+    (pendingRemoveKeepsSharedWorktree ||
+      (pendingRemoveAutoDeletesWorktree && autoDeleteWorktrees) ||
       (!pendingRemoveRecordedWorktree && !confirmRemoveSession));
   const sessionIdsKey = useMemo(
     () => sessions.map((session) => session.id).join("\0"),
@@ -1061,11 +1064,26 @@ function App() {
   }, [activeSessionId, sessionIdsKey]);
 
   // Skip the confirmation dialog when Settings gives a deterministic removal
-  // choice: plain sessions can skip confirmation, and standalone isolated
-  // sessions can opt into always deleting their worktree from disk.
+  // choice: shared worktree workspace sessions keep the worktree, plain
+  // sessions can skip confirmation, and standalone isolated sessions can opt
+  // into always deleting their worktree from disk.
   useEffect(() => {
     if (!pendingRemove) return;
     const recordedWorktree = hasRecordedWorktree(pendingRemove);
+    const canDeleteWorktree = canDeleteSessionWorktree(
+      pendingRemove,
+      projectFolders,
+    );
+    if (recordedWorktree && !canDeleteWorktree) {
+      clearPendingRemove();
+      void removeSession(pendingRemove.id, false).then(() =>
+        showStoreOperationToast(
+          null,
+          "toasts.session.removeFailed",
+        ),
+      );
+      return;
+    }
     const autoDeleteWorktree = shouldAutoDeleteSessionWorktree(
       pendingRemove,
       projectFolders,

--- a/src/components/RemoveProjectFolderDialog.tsx
+++ b/src/components/RemoveProjectFolderDialog.tsx
@@ -79,6 +79,14 @@ export function RemoveProjectFolderDialog({
                       : dt(t, "dialogs.removeProjectFolder.sessionPlural")}{" "}
                     {dt(t, "dialogs.removeProjectFolder.sessionsWillBeRemoved")}
                   </p>
+                  {worktreeWorkspace ? (
+                    <p className="text-fg-muted">
+                      {dt(
+                        t,
+                        "dialogs.removeProjectFolder.worktreeSessionsWillBeRemovedOnly",
+                      )}
+                    </p>
+                  ) : null}
                 </>
               ) : worktreeWorkspace ? (
                 <>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1194,6 +1194,7 @@
       "sessionSingular": "session",
       "sessionPlural": "sessions",
       "sessionsWillBeRemoved": "will be removed from Acorn with this workspace.",
+      "worktreeSessionsWillBeRemovedOnly": "Worktree workspace sessions will be removed from Acorn only.",
       "emptyFolder": "This workspace has no sessions.",
       "filesWillNotBeTouched": "Files and worktrees on disk will not be deleted.",
       "worktreesWillBeDeleted": "Standalone isolated sessions will also delete their worktrees from disk.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1194,6 +1194,7 @@
       "sessionSingular": "세션",
       "sessionPlural": "세션",
       "sessionsWillBeRemoved": "이 작업공간과 함께 Acorn에서 제거됩니다.",
+      "worktreeSessionsWillBeRemovedOnly": "워크트리 작업공간 세션은 Acorn에서만 제거됩니다.",
       "emptyFolder": "이 작업공간에는 세션이 없습니다.",
       "filesWillNotBeTouched": "디스크의 파일과 워크트리는 삭제되지 않습니다.",
       "worktreesWillBeDeleted": "단독 격리 세션은 디스크의 워크트리도 함께 삭제됩니다.",

--- a/tests/e2e/session-lifecycle.spec.ts
+++ b/tests/e2e/session-lifecycle.spec.ts
@@ -262,4 +262,105 @@ test.describe("session lifecycle", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]).toEqual({ id: "s-1", removeWorktree: true });
   });
+
+  test("shared worktree workspace session removal skips the confirmation", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          sessions: {
+            confirmRemove: true,
+            autoDeleteWorktrees: true,
+            closeOnExit: false,
+          },
+        }),
+      );
+      window.localStorage.setItem(
+        "acorn-workspaces",
+        JSON.stringify({
+          state: {
+            projectFolders: {
+              "/tmp/demo": [
+                {
+                  id: "/tmp/demo",
+                  repoPath: "/tmp/demo",
+                  name: "Default",
+                  cwdPath: "/tmp/demo",
+                  position: 0,
+                },
+                {
+                  id: "project-folder:/tmp/demo:feature-worktree",
+                  repoPath: "/tmp/demo",
+                  name: "Feature workspace",
+                  cwdPath: "/tmp/demo/.acorn/worktrees/feature",
+                  position: 1,
+                },
+              ],
+            },
+            sessionFolderIds: {},
+          },
+          version: 4,
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __sessionRemoved?: boolean };
+      return w.__sessionRemoved
+        ? []
+        : [
+            {
+              id: "s-1",
+              name: "alpha",
+              repo_path: "/tmp/demo",
+              worktree_path: "/tmp/demo/.acorn/worktrees/feature",
+              branch: "main",
+              isolated: true,
+              in_worktree: true,
+              status: "idle",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:05Z",
+              last_message: null,
+            },
+          ];
+    });
+    await tauri.handle("remove_session", (args) => {
+      const w = window as unknown as {
+        __removeCalls?: unknown[];
+        __sessionRemoved?: boolean;
+      };
+      w.__removeCalls = w.__removeCalls ?? [];
+      w.__removeCalls.push(args);
+      w.__sessionRemoved = true;
+      return null;
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-panel-id="sidebar"]');
+    const row = sidebar
+      .getByRole("button", { name: /^alpha main · Idle/ })
+      .first();
+    await expect(row).toBeVisible();
+
+    await row.hover();
+    await sidebar
+      .getByRole("button", { name: "Remove session", exact: true })
+      .click();
+
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expect(
+      sidebar.getByRole("button", { name: /^alpha main · Idle/ }),
+    ).toHaveCount(0);
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __removeCalls?: unknown[] }).__removeCalls,
+    )) as Array<{ id: string; removeWorktree: boolean }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ id: "s-1", removeWorktree: false });
+  });
 });

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -1202,6 +1202,9 @@ test.describe("sidebar: project lifecycle", () => {
     await page.getByRole("menuitem", { name: "Remove workspace" }).click();
     const dialog = page.getByRole("dialog", { name: "Remove workspace" });
     await expect(dialog).toContainText(
+      "Worktree workspace sessions will be removed from Acorn only.",
+    );
+    await expect(dialog).toContainText(
       "The workspace worktree will be kept on disk.",
     );
     await dialog.getByRole("button", { name: "Remove with sessions" }).click();


### PR DESCRIPTION
## Summary
This removes an unnecessary confirmation step when deleting a session that belongs to a shared worktree workspace.

1. **Session removal**: skip the Remove Session modal for worktree workspace-backed sessions because the only valid action is removing the Acorn session while keeping the shared worktree on disk.
2. **Workspace removal copy**: add explicit modal copy that worktree workspace sessions are removed from Acorn only, while the workspace worktree remains on disk.
3. **Coverage**: add E2E coverage for shared worktree session deletion without a prompt and extend the workspace removal modal assertion.

## Expected impact
| Area | Impact |
| --- | --- |
| User flow | Removing a session inside a worktree workspace no longer shows a redundant modal. |
| Data safety | Shared worktree directories continue to be preserved; the backend receives `removeWorktree: false`. |
| Modal clarity | Removing a non-empty worktree workspace now explicitly states that its sessions are removed from Acorn only. |

## Design notes
- The skip path uses the existing `canDeleteSessionWorktree` policy, so standalone isolated worktree sessions and linked worktree sessions keep their existing behavior.
- The workspace removal dialog only shows the new worktree-session copy for worktree workspaces with sessions.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run src/lib/sessionWorktree.test.ts src/components/RemoveSessionDialog.test.tsx` - 2 files / 9 tests passed
- [x] `PLAYWRIGHT_PORT=1445 pnpm test:e2e tests/e2e/session-lifecycle.spec.ts tests/e2e/sidebar.spec.ts --grep "F2|double-clicking|Remove session button|shared worktree|standalone isolated worktree auto-delete|project workspace remove preserves"` - 6 tests passed
- [x] `git diff --check`
