### PR TITLE
fix(sessions): preserve isolated session cwd scope

### DIFF
--- a/src/lib/sessionCreation.test.ts
+++ b/src/lib/sessionCreation.test.ts
@@ -5,6 +5,7 @@ import {
   buildSessionCreateRequestFromScope,
   resolveActiveSessionScope,
   resolveProjectScopedForRepoPath,
+  scopeForSession,
 } from "./sessionCreation";
 import type { Project, Session } from "./types";
 
@@ -80,6 +81,41 @@ describe("session creation policy", () => {
         activeWorkspaceRepoPath: "/repo/app",
       }),
     ).toMatchObject({ repoPath: "/Users/me", projectScoped: false });
+  });
+
+  it("uses the session worktree path for isolated session scope", () => {
+    const isolated = session("isolated", "/repo/app", {
+      isolated: true,
+      project_scoped: true,
+      worktree_path: "/repo/app/.acorn/worktrees/feature",
+    });
+
+    expect(scopeForSession(isolated)).toEqual({
+      repoPath: "/repo/app",
+      cwdPath: "/repo/app/.acorn/worktrees/feature",
+      projectScoped: true,
+    });
+  });
+
+  it("preserves an isolated active session cwd when resolving active scope", () => {
+    const isolated = session("isolated", "/repo/app", {
+      isolated: true,
+      project_scoped: true,
+      worktree_path: "/repo/app/.acorn/worktrees/feature",
+    });
+
+    expect(
+      resolveActiveSessionScope({
+        sessions: [isolated],
+        projects: [project("/repo/app")],
+        activeSessionId: "isolated",
+        activeWorkspaceRepoPath: "/repo/app",
+      }),
+    ).toEqual({
+      repoPath: "/repo/app",
+      cwdPath: "/repo/app/.acorn/worktrees/feature",
+      projectScoped: true,
+    });
   });
 
   it("preserves the active project workspace when the active session is inside it", () => {

--- a/src/lib/sessionCreation.ts
+++ b/src/lib/sessionCreation.ts
@@ -50,7 +50,7 @@ export interface BuildSessionCreateOptions {
 export function scopeForSession(session: Session): SessionCreateScope {
   return {
     repoPath: session.repo_path,
-    cwdPath: session.isolated ? session.repo_path : session.worktree_path,
+    cwdPath: session.worktree_path,
     projectScoped: session.project_scoped !== false,
   };
 }


### PR DESCRIPTION
## Summary
This fixes isolated-session follow-up creation so same-worktree actions keep the isolated worktree as their cwd.

1. **Preserve isolated cwd scope.** `scopeForSession` now uses the session's `worktree_path` for every session instead of falling isolated sessions back to the project root.
2. **Cover the active-scope regression.** Added tests for isolated active sessions so new-session and fork scope resolution keeps the isolated worktree path.

## Expected impact

| Area | Impact |
| --- | --- |
| Session creation | New sessions launched from isolated sessions keep the isolated worktree cwd instead of starting at the project root. |
| Agent fork/resume | Same-cwd forks from isolated sessions keep provider transcript cwd assumptions intact. |
| Daemon-backed terminals | No contract change: daemon spawn still receives app-validated `cwd` separately from `repoPath`, and daemon summaries preserve that cwd for reattach/adopt. |

## Design notes

- `repoPath` remains the registered project root; only `cwdPath` changes to the concrete session worktree.
- Backend `create_session` already accepts separate `repoPath` and `cwdPath`, so this is a frontend scope fix.
- The daemon path stores and round-trips the same separation through `SpawnSpec.cwd`, `SpawnSpec.repo_path`, and `SessionSummary.cwd`.

## Test plan

- [x] `pnpm exec vitest run src/lib/sessionCreation.test.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `git diff --check`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-daemon -- --nocapture`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml commands::tests:: -- --nocapture`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-session -- --nocapture`
- [x] `PLAYWRIGHT_PORT=1421 pnpm exec playwright test tests/e2e/background-sessions.spec.ts tests/e2e/terminal.spec.ts -g "background sessions settings|activating a session calls pty_spawn|reattaching a live daemon session"`

## Notes

- GitHub CI for PR #427 is green: Frontend and E2E completed successfully.