### PR TITLE
fix(terminal): separate dark theme selection colors

### DIFF
--- a/src/assets/themes/acorn-dark.css
+++ b/src/assets/themes/acorn-dark.css
@@ -11,4 +11,5 @@
   --color-warning: oklch(78% 0.16 75);
   --color-terminal-bg: #1f2326;
   --color-terminal-fg: #ededed;
+  --color-term-selection: rgba(115, 210, 142, 0.32);
 }

--- a/src/assets/themes/ayu-dark.css
+++ b/src/assets/themes/ayu-dark.css
@@ -11,4 +11,5 @@
   --color-warning: #ffee99;
   --color-terminal-bg: #0f1419;
   --color-terminal-fg: #e6e1cf;
+  --color-term-selection: rgba(255, 180, 84, 0.28);
 }

--- a/src/assets/themes/catppuccin-mocha.css
+++ b/src/assets/themes/catppuccin-mocha.css
@@ -11,4 +11,5 @@
   --color-warning: #f9e2af;
   --color-terminal-bg: #1e1e2e;
   --color-terminal-fg: #cdd6f4;
+  --color-term-selection: rgba(137, 180, 250, 0.3);
 }

--- a/src/assets/themes/dracula.css
+++ b/src/assets/themes/dracula.css
@@ -11,4 +11,5 @@
   --color-warning: #f1fa8c;
   --color-terminal-bg: #282a36;
   --color-terminal-fg: #f8f8f2;
+  --color-term-selection: rgba(189, 147, 249, 0.32);
 }

--- a/src/assets/themes/gruvbox-dark.css
+++ b/src/assets/themes/gruvbox-dark.css
@@ -11,4 +11,5 @@
   --color-warning: #fabd2f;
   --color-terminal-bg: #282828;
   --color-terminal-fg: #ebdbb2;
+  --color-term-selection: rgba(184, 187, 38, 0.3);
 }

--- a/src/assets/themes/nord.css
+++ b/src/assets/themes/nord.css
@@ -11,4 +11,5 @@
   --color-warning: #ebcb8b;
   --color-terminal-bg: #2e3440;
   --color-terminal-fg: #eceff4;
+  --color-term-selection: rgba(136, 192, 208, 0.3);
 }

--- a/src/assets/themes/one-dark-pro.css
+++ b/src/assets/themes/one-dark-pro.css
@@ -11,4 +11,5 @@
   --color-warning: #e5c07b;
   --color-terminal-bg: #282c34;
   --color-terminal-fg: #abb2bf;
+  --color-term-selection: rgba(97, 175, 239, 0.35);
 }

--- a/src/assets/themes/rose-pine.css
+++ b/src/assets/themes/rose-pine.css
@@ -11,4 +11,5 @@
   --color-warning: #f6c177;
   --color-terminal-bg: #191724;
   --color-terminal-fg: #e0def4;
+  --color-term-selection: rgba(196, 167, 231, 0.32);
 }

--- a/src/assets/themes/tokyo-night.css
+++ b/src/assets/themes/tokyo-night.css
@@ -11,4 +11,5 @@
   --color-warning: #e0af68;
   --color-terminal-bg: #1a1b26;
   --color-terminal-fg: #c0caf5;
+  --color-term-selection: rgba(122, 162, 247, 0.34);
 }

--- a/src/lib/themes.test.ts
+++ b/src/lib/themes.test.ts
@@ -54,6 +54,14 @@ describe("BUILT_IN_THEMES", () => {
       expect(validateThemeCss(theme.css)).toEqual({ ok: true });
     }
   });
+
+  it("gives every built-in dark theme an explicit terminal selection color", () => {
+    for (const theme of BUILT_IN_THEMES.filter(
+      (candidate) => candidate.mode === "dark",
+    )) {
+      expect(theme.css, theme.id).toMatch(/--color-term-selection\s*:/);
+    }
+  });
 });
 
 describe("validateThemeCss", () => {


### PR DESCRIPTION
## Summary
Terminal selection in affected dark themes now uses explicit accent-tinted colors instead of inheriting the neutral dark fallback.

1. **Dark theme selection colors** — add `--color-term-selection` to Acorn Dark and the built-in dark themes that were still inheriting the shared gray fallback.
2. **Regression coverage** — assert every built-in dark theme declares an explicit terminal selection token.

## Expected impact
| Surface | Before | After |
| --- | --- | --- |
| Terminal text selection in affected dark themes | Selection could blend with gray input/prompt surfaces in TUIs such as Codex | Selection uses a theme-specific accent tint and remains visually distinct |
| Custom/user themes | Unchanged | Unchanged; they still inherit the existing palette fallback unless they override it |

## Design notes
- `buildXtermTheme` already reads `--color-term-selection`, so the fix stays in theme data instead of changing terminal rendering or input styles.
- The added colors use each theme's accent family with moderate alpha to keep selected text readable while separating selection from neutral surfaces.
- The validation requirement for user theme CSS is unchanged; this only tightens the built-in dark theme contract in tests.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm test src/lib/themes.test.ts src/lib/terminalTheme.test.ts` — 18 tests passed
- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` passes

## Notes
- `pnpm run build` still reports the existing Vite dynamic-import/chunk-size warnings. This PR does not introduce those warnings.