### PR TITLE
feat(ui): searchable Select + Storybook component catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+storybook-static
 *.local
 *.local.md
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,47 @@
+import type { StorybookConfig } from "@storybook/react-vite";
+
+const tauriOpenerMock = new URL("./mocks/tauri-opener.ts", import.meta.url)
+  .pathname;
+
+const config: StorybookConfig = {
+  stories: ["../stories/**/*.stories.@(ts|tsx|mdx)"],
+  addons: ["@storybook/addon-docs"],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {},
+  },
+  viteFinal: async (viteConfig) => ({
+    ...viteConfig,
+    plugins: viteConfig.plugins?.filter(
+      (plugin) =>
+        !plugin ||
+        !("name" in plugin) ||
+        plugin.name !== "console-forward",
+    ),
+    resolve: {
+      ...viteConfig.resolve,
+      alias: [
+        {
+          find: "@tauri-apps/plugin-opener",
+          replacement: tauriOpenerMock,
+        },
+        ...(Array.isArray(viteConfig.resolve?.alias)
+          ? viteConfig.resolve.alias
+          : Object.entries(viteConfig.resolve?.alias ?? {}).map(
+              ([find, replacement]) => ({
+                find,
+                replacement: String(replacement),
+              }),
+            )),
+      ],
+    },
+    server: {
+      ...viteConfig.server,
+      port: undefined,
+      strictPort: false,
+      hmr: undefined,
+    },
+  }),
+};
+
+export default config;

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,0 +1,1 @@
+<link rel="icon" href="data:," />

--- a/.storybook/mocks/tauri-opener.ts
+++ b/.storybook/mocks/tauri-opener.ts
@@ -1,0 +1,7 @@
+export async function openUrl(url: string): Promise<void> {
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+export async function openPath(path: string): Promise<void> {
+  console.info("[storybook] openPath", path);
+}

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<link rel="icon" href="data:," />

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,0 +1,8 @@
+.sb-show-main {
+  background: var(--color-bg);
+  color: var(--color-fg);
+}
+
+body {
+  overflow: auto;
+}

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,16 @@
+import type { Preview } from "@storybook/react-vite";
+import "../src/App.css";
+import "./preview.css";
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e:headed": "playwright test --headed",
+    "storybook": "storybook dev -p 6006",
+    "build:storybook": "storybook build"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -56,6 +58,8 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@storybook/addon-docs": "10.4.3",
+    "@storybook/react-vite": "10.4.3",
     "@tailwindcss/vite": "^4.2.4",
     "@tauri-apps/cli": "^2",
     "@types/react": "^19.1.8",
@@ -64,6 +68,7 @@
     "@vitest/ui": "^4.1.5",
     "jsdom": "^29.1.1",
     "postcss": "^8.5.14",
+    "storybook": "10.4.3",
     "tailwindcss": "^4.2.4",
     "typescript": "~5.8.3",
     "vite": "^7.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,11 +106,17 @@ importers:
         version: 3.0.0
       zustand:
         specifier: ^5.0.13
-        version: 5.0.13(@types/react@19.2.14)(react@19.2.6)
+        version: 5.0.13(@types/react@19.2.14)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
     devDependencies:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.60.0
+      '@storybook/addon-docs':
+        specifier: 10.4.3
+        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))
+      '@storybook/react-vite':
+        specifier: 10.4.3
+        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.8.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.3.0(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))
@@ -135,6 +141,9 @@ importers:
       postcss:
         specifier: ^8.5.14
         version: 8.5.14
+      storybook:
+        specifier: 10.4.3
+        version: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwindcss:
         specifier: ^4.2.4
         version: 4.3.0
@@ -152,6 +161,9 @@ importers:
         version: 4.1.6(@vitest/ui@4.1.6)(jsdom@29.1.1)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -316,6 +328,21 @@ packages:
     resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
     peerDependencies:
       react: '>=16.8.0'
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -526,6 +553,15 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
+    resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -541,6 +577,235 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    resolution: {integrity: sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    resolution: {integrity: sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    resolution: {integrity: sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    resolution: {integrity: sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    resolution: {integrity: sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    resolution: {integrity: sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    resolution: {integrity: sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    resolution: {integrity: sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    resolution: {integrity: sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    resolution: {integrity: sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    resolution: {integrity: sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.20.0':
+    resolution: {integrity: sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.20.0':
+    resolution: {integrity: sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.20.0':
+    resolution: {integrity: sha512-MUcavykj2ewlR+kc5arpg4tC2RvzJkUxWtNv74pf7lcNk00GpIpN43vXMj+j6r4eMmfZhlb8hueKoIb8e9kAGQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.20.0':
+    resolution: {integrity: sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.20.0':
+    resolution: {integrity: sha512-JZgtePaqj3qmD5XFHJaSLWzHRxQu0LaPkdoM1KJXYADvAaa83ijXHclV3ej3CueeW0wxfIAbGCZVP45J0CA7uQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
+    resolution: {integrity: sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
+    resolution: {integrity: sha512-2ArPksaw0AqeuGBfoS715VF+JvJQAhD2niWgjE5hVO+L+nAfikVQopvngCMX9x4BD8itWoQ3dnikrQyl5Ho5Jg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
+    resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
+    resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
+    resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
+    resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
+    resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
+    resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
+    resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.20.0':
+    resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.20.0':
+    resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.20.0':
+    resolution: {integrity: sha512-Tn0y1XOFYHNfK1wp1Z5QK8Rcld/bsOwRISQXfqAZ5IBpv8Gz1IvV39fUWNprqNdRizgcvFhOzWwFun2zkJsyBg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
+    resolution: {integrity: sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
+    resolution: {integrity: sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==}
+    cpu: [x64]
+    os: [win32]
 
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
@@ -746,6 +1011,15 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.60.4':
     resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
     cpu: [arm]
@@ -904,6 +1178,87 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@storybook/addon-docs@10.4.3':
+    resolution: {integrity: sha512-CJGEXSo0zpIy7gvEeeUi09ZbjQUSNDi4YipAeb+lZGGEn8ShZUr2Pk330yd2ZO+ngNWJXD4ZxOb0e3/aIlxb3Q==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@storybook/builder-vite@10.4.3':
+    resolution: {integrity: sha512-gvXVJvcsqFuSO5PLhS5+BdoYbQDxbkVVrW2cHrf4g089bXVTImZrOSzTO7SEOTs4I9acJqv4nK22WEeJpY+VZw==}
+    peerDependencies:
+      storybook: ^10.4.3
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/csf-plugin@10.4.3':
+    resolution: {integrity: sha512-D+XF5CVhZmIOI0uhfTKxlQr+gR1z8X9djPy9phiA1USLPAOHagBAucp/PhLwlFVUxrKzEIf8yImrvkCv50IcDg==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.4.3
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@2.0.2':
+    resolution: {integrity: sha512-KZBCpXsshAIjczYNXR/rlxEtCUX/eAbpFNwKi8bcOomrLA4t/SyPz5RF+lVPO2oZBUE4sAkt43mfJUevQDSEEw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@storybook/react-dom-shim@10.4.3':
+    resolution: {integrity: sha512-aPZ+Afd+zdoSygISOVCJIYdiqWJM6uRZFw0zhsONwNcn3kU1TNce6iAoBCY8cpEhDAu61M1QjeIHM3LPy/ieog==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@storybook/react-vite@10.4.3':
+    resolution: {integrity: sha512-Pk/hi10JFuwJ5sj/HAapWrgaa9Z83oT4MJPbHqeKzMt3A3jkIru4L9ibnt82bzV3crOaiErprvOlAFDsjxhrrQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.3
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/react@10.4.3':
+    resolution: {integrity: sha512-Td+Zoi8ylJTPC1jg5vHw8OK7U2kJgqc5kuAn92UvD4IbAkcpMTBRPHDziK1piv6q7r8yNLVah+ku6IKHpTLeXA==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.4.3
+      typescript: '>= 4.9.x'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+      typescript:
+        optional: true
 
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
@@ -1099,6 +1454,26 @@ packages:
   '@tauri-apps/plugin-updater@2.10.1':
     resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1120,6 +1495,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/doctrine@0.0.9':
+    resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -1135,6 +1513,9 @@ packages:
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
+  '@types/mdx@2.0.14':
+    resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -1148,6 +1529,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/resolve@1.20.6':
+    resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1164,6 +1548,9 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/expect@4.1.6':
     resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
 
@@ -1178,6 +1565,9 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/pretty-format@4.1.6':
     resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
 
@@ -1187,6 +1577,9 @@ packages:
   '@vitest/snapshot@4.1.6':
     resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/spy@4.1.6':
     resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
 
@@ -1195,8 +1588,14 @@ packages:
     peerDependencies:
       vitest: 4.1.6
 
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
+
+  '@webcontainer/env@1.1.1':
+    resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
   '@xterm/addon-canvas@0.7.0':
     resolution: {integrity: sha512-LF5LYcfvefJuJ7QotNRdRSPc9YASAVDeoT5uyXS/nZshZXjYplGXRECBGiznwvhNL2I8bq1Lf5MzRwstsYQ2Iw==}
@@ -1218,6 +1617,19 @@ packages:
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1225,9 +1637,20 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
 
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
@@ -1235,6 +1658,10 @@ packages:
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   baseline-browser-mapping@2.10.30:
     resolution: {integrity: sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==}
@@ -1244,10 +1671,18 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1258,6 +1693,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1274,6 +1713,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
@@ -1305,6 +1748,9 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -1327,6 +1773,22 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1345,8 +1807,22 @@ packages:
     resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   electron-to-chromium@1.5.357:
     resolution: {integrity: sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==}
+
+  empathic@2.0.1:
+    resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
+    engines: {node: '>=14'}
 
   enhanced-resolve@5.21.3:
     resolution: {integrity: sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==}
@@ -1387,11 +1863,23 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1438,6 +1926,10 @@ packages:
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1490,6 +1982,10 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
@@ -1509,8 +2005,18 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -1518,6 +2024,10 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -1628,6 +2138,9 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
@@ -1639,6 +2152,10 @@ packages:
     resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1781,6 +2298,21 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -1805,6 +2337,17 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
+  oxc-parser@0.127.0:
+    resolution: {integrity: sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.20.0:
+    resolution: {integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1825,12 +2368,20 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1853,6 +2404,10 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -1867,6 +2422,15 @@ packages:
       react: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  react-docgen-typescript@2.4.0:
+    resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+
+  react-docgen@8.0.3:
+    resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
+    engines: {node: ^20.9.0 || >=22}
+
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
@@ -1874,6 +2438,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -1925,6 +2492,14 @@ packages:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
 
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -1970,6 +2545,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -1979,6 +2558,11 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   shiki@4.0.2:
@@ -2000,6 +2584,10 @@ packages:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
@@ -2009,8 +2597,35 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  storybook@10.4.3:
+    resolution: {integrity: sha512-oTfNXtS/K4PmASbcD+RyW7kxWGt3tknJL3RZodCMh+nnp3X4ng8vYg8yvIhTG/q0dqBxw7Ba8dHsfsEy4631vg==}
+    hasBin: true
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      prettier: ^2 || ^3
+      vite-plus: ^0.1.15
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      prettier:
+        optional: true
+      vite-plus:
+        optional: true
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  strip-indent@4.1.1:
+    resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
+    engines: {node: '>=12'}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -2038,6 +2653,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -2052,8 +2670,16 @@ packages:
   tinykeys@3.0.0:
     resolution: {integrity: sha512-nazawuGv5zx6MuDfDY0rmfXjuOGhD5XU2z0GLURQ1nzl0RUe9OuCJq+0u8xxJZINHe+mr7nw8PWYYZ9WhMFujw==}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.30:
@@ -2080,6 +2706,14 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2111,6 +2745,10 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -2136,6 +2774,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -2243,6 +2886,9 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
@@ -2255,6 +2901,22 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -2292,6 +2954,8 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@adobe/css-tools@4.5.0': {}
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -2480,6 +3144,33 @@ snapshots:
       react: 19.2.6
       tslib: 2.8.1
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.28.6
@@ -2634,6 +3325,14 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.8.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      glob: 13.0.6
+      react-docgen-typescript: 2.4.0(typescript@5.8.3)
+      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)
+    optionalDependencies:
+      typescript: 5.8.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2652,6 +3351,153 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@types/mdx': 2.0.14
+      '@types/react': 19.2.14
+      react: 19.2.6
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.20.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
+    optional: true
 
   '@playwright/test@1.60.0':
     dependencies:
@@ -2820,6 +3666,14 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
+  '@rollup/pluginutils@5.4.0(rollup@4.60.4)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.4
+
   '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true
 
@@ -2936,6 +3790,101 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@storybook/addon-docs@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@storybook/csf-plugin': 10.4.3(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))
+      '@storybook/icons': 2.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      ts-dedent: 2.3.0
+    optionalDependencies:
+      '@types/react': 19.2.14
+    transitivePeerDependencies:
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
+  '@storybook/builder-vite@10.4.3(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@storybook/csf-plugin': 10.4.3(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))
+      storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      ts-dedent: 2.3.0
+      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/csf-plugin@10.4.3(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.7
+      rollup: 4.60.4
+      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@2.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@storybook/react-dom-shim@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@storybook/react-vite@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.8.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.8.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))
+      '@rollup/pluginutils': 5.4.0(rollup@4.60.4)
+      '@storybook/builder-vite': 10.4.3(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))
+      '@storybook/react': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.8.3)
+      empathic: 2.0.1
+      magic-string: 0.30.21
+      react: 19.2.6
+      react-docgen: 8.0.3
+      react-dom: 19.2.6(react@19.2.6)
+      resolve: 1.22.12
+      storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      tsconfig-paths: 4.2.0
+      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - supports-color
+      - typescript
+      - webpack
+
+  '@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.8.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      react: 19.2.6
+      react-docgen: 8.0.3
+      react-docgen-typescript: 2.4.0(typescript@5.8.3)
+      react-dom: 19.2.6(react@19.2.6)
+      storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@tailwindcss/node@4.3.0':
     dependencies:
@@ -3090,6 +4039,37 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.0
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.3
@@ -3122,6 +4102,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/doctrine@0.0.9': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.9
@@ -3138,6 +4120,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/mdx@2.0.14': {}
+
   '@types/ms@2.1.0': {}
 
   '@types/parse-json@4.0.2': {}
@@ -3149,6 +4133,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/resolve@1.20.6': {}
 
   '@types/unist@2.0.11': {}
 
@@ -3168,6 +4154,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@4.1.6':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -3185,6 +4179,10 @@ snapshots:
     optionalDependencies:
       vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)
 
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.1.6':
     dependencies:
       tinyrainbow: 3.1.0
@@ -3201,6 +4199,10 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.1.6': {}
 
   '@vitest/ui@4.1.6(vitest@4.1.6)':
@@ -3214,11 +4216,19 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.6(@vitest/ui@4.1.6)(jsdom@29.1.1)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0))
 
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   '@vitest/utils@4.1.6':
     dependencies:
       '@vitest/pretty-format': 4.1.6
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@webcontainer/env@1.1.1': {}
 
   '@xterm/addon-canvas@0.7.0(@xterm/xterm@6.0.0)':
     dependencies:
@@ -3234,13 +4244,29 @@ snapshots:
 
   '@xterm/xterm@6.0.0': {}
 
+  acorn@8.16.0: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
   assertion-error@2.0.1: {}
+
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
 
   babel-plugin-macros@3.1.0:
     dependencies:
@@ -3250,11 +4276,17 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.10.30: {}
 
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   browserslist@4.28.2:
     dependencies:
@@ -3264,11 +4296,23 @@ snapshots:
       node-releases: 2.0.44
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001793: {}
 
   ccount@2.0.1: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
 
   chai@6.2.2: {}
 
@@ -3279,6 +4323,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.3: {}
 
   classnames@2.5.1: {}
 
@@ -3315,6 +4361,8 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
 
   data-urls@7.0.0:
@@ -3334,6 +4382,17 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@5.0.2: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -3346,7 +4405,17 @@ snapshots:
 
   diff@9.0.0: {}
 
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   electron-to-chromium@1.5.357: {}
+
+  empathic@2.0.1: {}
 
   enhanced-resolve@5.21.3:
     dependencies:
@@ -3400,11 +4469,17 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  esprima@4.0.1: {}
+
   estree-util-is-identifier-name@3.0.0: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
 
   expect-type@1.3.0: {}
 
@@ -3431,6 +4506,12 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-nonce@1.0.1: {}
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   graceful-fs@4.2.11: {}
 
@@ -3550,6 +4631,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  indent-string@4.0.0: {}
+
   inline-style-parser@0.2.7: {}
 
   is-alphabetical@2.0.1: {}
@@ -3567,11 +4650,21 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-docker@3.0.0: {}
+
   is-hexadecimal@2.0.1: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   jiti@2.7.0: {}
 
@@ -3666,6 +4759,8 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  loupe@3.2.1: {}
+
   lru-cache@11.3.6: {}
 
   lru-cache@5.1.1:
@@ -3675,6 +4770,8 @@ snapshots:
   lucide-react@1.16.0(react@19.2.6):
     dependencies:
       react: 19.2.6
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -4030,6 +5127,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  min-indent@1.0.1: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -4047,6 +5154,60 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
+  oxc-parser@0.127.0:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.127.0
+      '@oxc-parser/binding-android-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-x64': 0.127.0
+      '@oxc-parser/binding-freebsd-x64': 0.127.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.127.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.127.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-musl': 0.127.0
+      '@oxc-parser/binding-openharmony-arm64': 0.127.0
+      '@oxc-parser/binding-wasm32-wasi': 0.127.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.127.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.127.0
+
+  oxc-resolver@11.20.0:
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.20.0
+      '@oxc-resolver/binding-android-arm64': 11.20.0
+      '@oxc-resolver/binding-darwin-arm64': 11.20.0
+      '@oxc-resolver/binding-darwin-x64': 11.20.0
+      '@oxc-resolver/binding-freebsd-x64': 11.20.0
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.20.0
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.20.0
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-arm64-musl': 11.20.0
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.20.0
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-x64-gnu': 11.20.0
+      '@oxc-resolver/binding-linux-x64-musl': 11.20.0
+      '@oxc-resolver/binding-openharmony-arm64': 11.20.0
+      '@oxc-resolver/binding-wasm32-wasi': 11.20.0
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
+      '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
 
   parent-module@1.0.1:
     dependencies:
@@ -4079,9 +5240,16 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.6
+      minipass: 7.1.3
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -4101,6 +5269,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   property-information@7.1.0: {}
 
   punycode@2.3.1: {}
@@ -4119,12 +5293,33 @@ snapshots:
       - '@types/react'
       - supports-color
 
+  react-docgen-typescript@2.4.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
+  react-docgen@8.0.3:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+      '@types/doctrine': 0.0.9
+      '@types/resolve': 1.20.6
+      doctrine: 3.0.0
+      resolve: 1.22.12
+      strip-indent: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   react-dom@19.2.6(react@19.2.6):
     dependencies:
       react: 19.2.6
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.6):
     dependencies:
@@ -4179,6 +5374,19 @@ snapshots:
       '@types/react': 19.2.14
 
   react@19.2.6: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   regex-recursion@6.0.2:
     dependencies:
@@ -4277,6 +5485,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
+  run-applescript@7.1.0: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -4284,6 +5494,8 @@ snapshots:
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
+
+  semver@7.8.4: {}
 
   shiki@4.0.2:
     dependencies:
@@ -4308,16 +5520,52 @@ snapshots:
 
   source-map@0.5.7: {}
 
+  source-map@0.6.1: {}
+
   space-separated-tokens@2.0.2: {}
 
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
 
+  storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
+      esbuild: 0.27.7
+      open: 10.2.0
+      oxc-parser: 0.127.0
+      oxc-resolver: 11.20.0
+      recast: 0.23.11
+      semver: 7.8.4
+      use-sync-external-store: 1.6.0(react@19.2.6)
+      ws: 8.21.0
+    optionalDependencies:
+      '@types/react': 19.2.14
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - react
+      - react-dom
+      - utf-8-validate
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-bom@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  strip-indent@4.1.1: {}
 
   style-to-js@1.1.21:
     dependencies:
@@ -4339,6 +5587,8 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.2: {}
@@ -4350,7 +5600,11 @@ snapshots:
 
   tinykeys@3.0.0: {}
 
+  tinyrainbow@2.0.0: {}
+
   tinyrainbow@3.1.0: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@7.0.30: {}
 
@@ -4371,6 +5625,14 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-dedent@2.3.0: {}
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
 
   tslib@2.8.1: {}
 
@@ -4411,6 +5673,13 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -4431,6 +5700,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  use-sync-external-store@1.6.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
 
   vfile-location@5.0.3:
     dependencies:
@@ -4500,6 +5773,8 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
+  webpack-virtual-modules@0.6.2: {}
+
   whatwg-mimetype@5.0.0: {}
 
   whatwg-url@16.0.1:
@@ -4515,6 +5790,12 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  ws@8.21.0: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
@@ -4523,9 +5804,10 @@ snapshots:
 
   yaml@1.10.3: {}
 
-  zustand@5.0.13(@types/react@19.2.14)(react@19.2.6):
+  zustand@5.0.13(@types/react@19.2.14)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)
 
   zwitch@2.0.4: {}

--- a/src/assets/themes/acorn-pink.css
+++ b/src/assets/themes/acorn-pink.css
@@ -1,0 +1,14 @@
+:root[data-acorn-theme="acorn-pink"] {
+  --color-bg: #1f2326;
+  --color-bg-elevated: #272b2f;
+  --color-bg-sidebar: #1a1d20;
+  --color-fg: #ededed;
+  --color-fg-muted: oklch(64% 0.01 250);
+  --color-border: #2f3338;
+  --color-accent: oklch(72% 0.18 345);
+  --color-accent-hover: oklch(78% 0.18 345);
+  --color-danger: oklch(62% 0.22 25);
+  --color-warning: oklch(78% 0.16 75);
+  --color-terminal-bg: #1f2326;
+  --color-terminal-fg: #ededed;
+}

--- a/src/assets/themes/acorn-pink.css
+++ b/src/assets/themes/acorn-pink.css
@@ -11,4 +11,5 @@
   --color-warning: oklch(78% 0.16 75);
   --color-terminal-bg: #1f2326;
   --color-terminal-fg: #ededed;
+  --color-term-selection: rgba(240, 112, 190, 0.32);
 }

--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -85,12 +85,30 @@ function buttonContaining(container: HTMLElement, text: string): HTMLButtonEleme
   return button;
 }
 
-function selectWithAria(container: HTMLElement, label: string): HTMLSelectElement {
-  const select = container.querySelector(`select[aria-label="${label}"]`);
-  if (!(select instanceof HTMLSelectElement)) {
-    throw new Error(`select labelled "${label}" not found`);
+function comboboxWithAria(
+  container: HTMLElement,
+  label: string,
+): HTMLButtonElement {
+  const button = container.querySelector(
+    `button[role="combobox"][aria-label="${label}"]`,
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`combobox labelled "${label}" not found`);
   }
-  return select;
+  return button;
+}
+
+function selectOption(label: string) {
+  const optionLabel = Array.from(
+    document.querySelectorAll("[data-select-option-label]"),
+  ).find((element) => element.textContent?.trim() === label);
+  const option = optionLabel?.closest('[role="option"]');
+  if (!(option instanceof HTMLElement)) {
+    throw new Error(`option "${label}" not found`);
+  }
+  act(() => {
+    option.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
 }
 
 const labeledPullRequest = {
@@ -415,19 +433,22 @@ describe("RightPanel background tab loading", () => {
     expect(container.textContent).toContain("Codex patch");
     expect(container.textContent).toContain("Claude plan");
 
-    const select = selectWithAria(container, "Filter by agent");
-    await act(async () => {
-      select.value = "codex";
-      select.dispatchEvent(new Event("change", { bubbles: true }));
+    act(() => {
+      comboboxWithAria(container, "Filter by agent").dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
     });
+    selectOption("Codex");
 
     expect(container.textContent).toContain("Codex patch");
     expect(container.textContent).not.toContain("Claude plan");
 
-    await act(async () => {
-      select.value = "claude";
-      select.dispatchEvent(new Event("change", { bubbles: true }));
+    act(() => {
+      comboboxWithAria(container, "Filter by agent").dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
     });
+    selectOption("Claude");
 
     expect(container.textContent).not.toContain("Codex patch");
     expect(container.textContent).toContain("Claude plan");
@@ -471,14 +492,6 @@ describe("RightPanel background tab loading", () => {
     expect(container.textContent).not.toContain("Exploring chat runtime");
     expect(container.textContent).not.toContain("Acorn chat");
     expect(container.textContent).toContain("No Claude, Codex, or Antigravity sessions found");
-
-    const select = selectWithAria(container, "Filter by agent");
-    await act(async () => {
-      select.value = "codex";
-      select.dispatchEvent(new Event("change", { bubbles: true }));
-    });
-
-    expect(container.textContent).not.toContain("Exploring chat runtime");
   });
 
   it("reprobes GitHub visibility when git metadata changes", async () => {

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -243,23 +243,40 @@ function setInputValue(input: HTMLInputElement, value: string) {
   });
 }
 
-function getComboboxByLabel(label: string): HTMLInputElement {
-  const input = document.querySelector<HTMLInputElement>(
-    `input[role="combobox"][aria-label="${label}"]`,
+function getComboboxByLabel(label: string): HTMLButtonElement {
+  const button = document.querySelector<HTMLButtonElement>(
+    `button[role="combobox"][aria-label="${label}"]`,
   );
-  if (!input) throw new Error(`Combobox not found: ${label}`);
-  return input;
+  if (!button) throw new Error(`Combobox not found: ${label}`);
+  return button;
 }
 
-function focusInput(input: HTMLInputElement) {
+function clickElement(element: HTMLElement) {
   act(() => {
-    input.focus();
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   });
 }
 
-function pressKey(input: HTMLInputElement, key: string) {
+function getSelectSearchInput(): HTMLInputElement {
+  const input = document.querySelector<HTMLInputElement>("[data-select-search]");
+  if (!input) throw new Error("Select search input not found");
+  return input;
+}
+
+function clickOption(label: string) {
+  const optionLabel = Array.from(
+    document.querySelectorAll("[data-select-option-label]"),
+  ).find((element) => element.textContent?.trim() === label);
+  const option = optionLabel?.closest('[role="option"]');
+  if (!(option instanceof HTMLElement)) {
+    throw new Error(`Select option not found: ${label}`);
+  }
+  clickElement(option);
+}
+
+function pressKey(element: HTMLElement, key: string) {
   act(() => {
-    input.dispatchEvent(
+    element.dispatchEvent(
       new KeyboardEvent("keydown", {
         bubbles: true,
         cancelable: true,
@@ -270,9 +287,9 @@ function pressKey(input: HTMLInputElement, key: string) {
 }
 
 function optionLabels(): string[] {
-  return Array.from(document.querySelectorAll('[role="option"]')).map(
-    (option) => option.textContent?.trim() ?? "",
-  );
+  return Array.from(
+    document.querySelectorAll("[data-select-option-label]"),
+  ).map((option) => option.textContent?.trim() ?? "");
 }
 
 function blurInput(input: HTMLInputElement) {
@@ -442,9 +459,10 @@ describe("SettingsModal font controls", () => {
     });
 
     const themeSelect = getComboboxByLabel("Theme");
-    expect(themeSelect.value).toBe("Acorn Dark Green");
+    expect(themeSelect.textContent).toContain("Acorn Dark Green");
+    expect(document.querySelector("[data-select-search]")).toBeNull();
 
-    focusInput(themeSelect);
+    clickElement(themeSelect);
 
     expect(
       Array.from(document.querySelectorAll("[data-select-group-label]")).map(
@@ -465,11 +483,13 @@ describe("SettingsModal font controls", () => {
       "Solarized Local (custom)",
     ]);
 
-    setInputValue(themeSelect, "local");
+    const searchInput = getSelectSearchInput();
+    expect(searchInput.getAttribute("placeholder")).toBe("Search themes");
+    setInputValue(searchInput, "local");
 
     expect(optionLabels()).toEqual(["Solarized Local (custom)"]);
 
-    pressKey(themeSelect, "Enter");
+    pressKey(searchInput, "Enter");
 
     expect(useSettings.getState().patchAppearance).toHaveBeenCalledWith({
       themeId: "solarized-local",
@@ -492,11 +512,11 @@ describe("SettingsModal font controls", () => {
     expect(
       document.querySelector('input[aria-label="Custom UI scale percentage"]'),
     ).toBeNull();
-    expect(scaleSelect.value).toBe("100%");
+    expect(scaleSelect.textContent).toContain("100%");
 
-    focusInput(scaleSelect);
-    setInputValue(scaleSelect, "125");
-    pressKey(scaleSelect, "Enter");
+    clickElement(scaleSelect);
+    expect(document.querySelector("[data-select-search]")).toBeNull();
+    clickOption("125%");
 
     expect(useSettings.getState().patchAppearance).toHaveBeenCalledWith({
       uiScalePercent: 125,
@@ -562,12 +582,11 @@ describe("SettingsModal font controls", () => {
 
     const languageSelect = getComboboxByLabel("언어");
 
-    expect(languageSelect).toBeInstanceOf(HTMLInputElement);
-    expect(languageSelect.value).toBe("한국어");
+    expect(languageSelect).toBeInstanceOf(HTMLButtonElement);
+    expect(languageSelect.textContent).toContain("한국어");
 
-    focusInput(languageSelect);
-    setInputValue(languageSelect, "English");
-    pressKey(languageSelect, "Enter");
+    clickElement(languageSelect);
+    clickOption("English");
 
     expect(patchLanguage).toHaveBeenCalledWith("en");
   });

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -292,6 +292,12 @@ function optionLabels(): string[] {
   ).map((option) => option.textContent?.trim() ?? "");
 }
 
+function separatorLabels(): string[] {
+  return Array.from(
+    document.querySelectorAll("[data-select-separator]"),
+  ).map((separator) => separator.textContent?.trim() ?? "");
+}
+
 function blurInput(input: HTMLInputElement) {
   act(() => {
     input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
@@ -448,7 +454,7 @@ describe("SettingsModal font controls", () => {
     expect(document.querySelector('[role="listbox"]')).toBeNull();
   });
 
-  it("renders searchable grouped theme options including user themes", async () => {
+  it("renders searchable theme sections with separators including user themes", async () => {
     await act(async () => {
       root = createRoot(container);
       root.render(<SettingsModal />);
@@ -464,11 +470,8 @@ describe("SettingsModal font controls", () => {
 
     clickElement(themeSelect);
 
-    expect(
-      Array.from(document.querySelectorAll("[data-select-group-label]")).map(
-        (element) => element.textContent?.trim(),
-      ),
-    ).toEqual([
+    expect(document.querySelector("[data-select-group-label]")).toBeNull();
+    expect(separatorLabels()).toEqual([
       "Acorn themes",
       "Built-in dark",
       "Built-in light",
@@ -488,6 +491,7 @@ describe("SettingsModal font controls", () => {
     setInputValue(searchInput, "local");
 
     expect(optionLabels()).toEqual(["Solarized Local (custom)"]);
+    expect(separatorLabels()).toEqual([]);
 
     pressKey(searchInput, "Enter");
 

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -454,7 +454,7 @@ describe("SettingsModal font controls", () => {
     expect(document.querySelector('[role="listbox"]')).toBeNull();
   });
 
-  it("renders searchable theme sections with separators including user themes", async () => {
+  it("renders searchable grouped theme options with separators including user themes", async () => {
     await act(async () => {
       root = createRoot(container);
       root.render(<SettingsModal />);
@@ -470,12 +470,20 @@ describe("SettingsModal font controls", () => {
 
     clickElement(themeSelect);
 
-    expect(document.querySelector("[data-select-group-label]")).toBeNull();
-    expect(separatorLabels()).toEqual([
+    expect(
+      Array.from(document.querySelectorAll("[data-select-group-label]")).map(
+        (element) => element.textContent?.trim(),
+      ),
+    ).toEqual([
       "Acorn themes",
       "Built-in dark",
       "Built-in light",
       "Custom themes",
+    ]);
+    expect(separatorLabels()).toEqual([
+      "",
+      "",
+      "",
     ]);
     expect(optionLabels()).toEqual([
       "Acorn Dark Green",

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -3,6 +3,50 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  themes: [
+    {
+      css: "",
+      id: "acorn-dark",
+      label: "Acorn Dark Green",
+      mode: "dark" as const,
+      source: "builtin" as const,
+    },
+    {
+      css: "",
+      id: "acorn-pink",
+      label: "Acorn Dark Pink",
+      mode: "dark" as const,
+      source: "builtin" as const,
+    },
+    {
+      css: "",
+      id: "one-dark-pro",
+      label: "One Dark Pro",
+      mode: "dark" as const,
+      source: "builtin" as const,
+    },
+    {
+      css: "",
+      id: "acorn-light",
+      label: "Acorn Light",
+      mode: "light" as const,
+      source: "builtin" as const,
+    },
+    {
+      css: "",
+      id: "github-light",
+      label: "GitHub Light",
+      mode: "light" as const,
+      source: "builtin" as const,
+    },
+    {
+      css: "",
+      id: "solarized-local",
+      label: "Solarized Local",
+      mode: "dark" as const,
+      source: "user" as const,
+    },
+  ],
   importBackgroundImage: vi.fn<
     (name: string, bytes: Uint8Array) => Promise<{ relativePath: string; fileName: string }>
   >(),
@@ -42,28 +86,12 @@ vi.mock("../lib/releases", () => ({
 }));
 
 vi.mock("../lib/themes", () => ({
-  BUILT_IN_THEMES: [
-    {
-      css: "",
-      id: "acorn-dark",
-      label: "Acorn Dark",
-      mode: "dark",
-      source: "builtin",
-    },
-  ],
+  BUILT_IN_THEMES: mocks.themes.filter((theme) => theme.source === "builtin"),
   revealThemesFolder: vi.fn(),
   useThemes: (selector: (state: unknown) => unknown) =>
     selector({
       refresh: vi.fn(),
-      themes: [
-        {
-          css: "",
-          id: "acorn-dark",
-          label: "Acorn Dark",
-          mode: "dark",
-          source: "builtin",
-        },
-      ],
+      themes: mocks.themes,
     }),
 }));
 
@@ -213,6 +241,38 @@ function setInputValue(input: HTMLInputElement, value: string) {
     setter.call(input, value);
     input.dispatchEvent(new Event("input", { bubbles: true }));
   });
+}
+
+function getComboboxByLabel(label: string): HTMLInputElement {
+  const input = document.querySelector<HTMLInputElement>(
+    `input[role="combobox"][aria-label="${label}"]`,
+  );
+  if (!input) throw new Error(`Combobox not found: ${label}`);
+  return input;
+}
+
+function focusInput(input: HTMLInputElement) {
+  act(() => {
+    input.focus();
+  });
+}
+
+function pressKey(input: HTMLInputElement, key: string) {
+  act(() => {
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key,
+      }),
+    );
+  });
+}
+
+function optionLabels(): string[] {
+  return Array.from(document.querySelectorAll('[role="option"]')).map(
+    (option) => option.textContent?.trim() ?? "",
+  );
 }
 
 function blurInput(input: HTMLInputElement) {
@@ -371,6 +431,51 @@ describe("SettingsModal font controls", () => {
     expect(document.querySelector('[role="listbox"]')).toBeNull();
   });
 
+  it("renders searchable grouped theme options including user themes", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openAppearanceTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const themeSelect = getComboboxByLabel("Theme");
+    expect(themeSelect.value).toBe("Acorn Dark Green");
+
+    focusInput(themeSelect);
+
+    expect(
+      Array.from(document.querySelectorAll("[data-select-group-label]")).map(
+        (element) => element.textContent?.trim(),
+      ),
+    ).toEqual([
+      "Acorn themes",
+      "Built-in dark",
+      "Built-in light",
+      "Custom themes",
+    ]);
+    expect(optionLabels()).toEqual([
+      "Acorn Dark Green",
+      "Acorn Dark Pink",
+      "Acorn Light",
+      "One Dark Pro",
+      "GitHub Light",
+      "Solarized Local (custom)",
+    ]);
+
+    setInputValue(themeSelect, "local");
+
+    expect(optionLabels()).toEqual(["Solarized Local (custom)"]);
+
+    pressKey(themeSelect, "Enter");
+
+    expect(useSettings.getState().patchAppearance).toHaveBeenCalledWith({
+      themeId: "solarized-local",
+    });
+  });
+
   it("edits Interface UI scale with presets only", async () => {
     await act(async () => {
       root = createRoot(container);
@@ -381,21 +486,17 @@ describe("SettingsModal font controls", () => {
       await Promise.resolve();
     });
 
-    const scaleSelect = Array.from(
-      document.querySelectorAll<HTMLSelectElement>("select"),
-    ).find((element) => element.value === "100");
+    const scaleSelect = getComboboxByLabel("UI scale");
 
     expect(document.body.textContent).toContain("UI scale");
     expect(
       document.querySelector('input[aria-label="Custom UI scale percentage"]'),
     ).toBeNull();
-    expect(scaleSelect?.value).toBe("100");
+    expect(scaleSelect.value).toBe("100%");
 
-    act(() => {
-      if (!scaleSelect) throw new Error("UI scale select not found");
-      scaleSelect.value = "125";
-      scaleSelect.dispatchEvent(new Event("change", { bubbles: true }));
-    });
+    focusInput(scaleSelect);
+    setInputValue(scaleSelect, "125");
+    pressKey(scaleSelect, "Enter");
 
     expect(useSettings.getState().patchAppearance).toHaveBeenCalledWith({
       uiScalePercent: 125,
@@ -459,18 +560,14 @@ describe("SettingsModal font controls", () => {
     expect(document.body.textContent).toContain("인터페이스");
     expect(document.body.textContent).toContain("언어");
 
-    const languageSelect = Array.from(
-      document.querySelectorAll<HTMLSelectElement>("select"),
-    ).find((element) => element.value === "ko");
+    const languageSelect = getComboboxByLabel("언어");
 
-    expect(languageSelect).toBeInstanceOf(HTMLSelectElement);
-    expect(languageSelect?.textContent).toContain("한국어");
+    expect(languageSelect).toBeInstanceOf(HTMLInputElement);
+    expect(languageSelect.value).toBe("한국어");
 
-    act(() => {
-      if (!languageSelect) throw new Error("Language select not found");
-      languageSelect.value = "en";
-      languageSelect.dispatchEvent(new Event("change", { bubbles: true }));
-    });
+    focusInput(languageSelect);
+    setInputValue(languageSelect, "English");
+    pressKey(languageSelect, "Enter");
 
     expect(patchLanguage).toHaveBeenCalledWith("en");
   });

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1172,6 +1172,11 @@ function ThemeSection({
           value={themeId}
           onValueChange={onChange}
           options={themeOptions}
+          searchable
+          searchPlaceholder={st(
+            t,
+            "settings.appearance.theme.searchPlaceholder",
+          )}
           className="min-w-[14rem]"
           aria-label={st(t, "settings.appearance.theme.label")}
         />

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -86,6 +86,7 @@ import {
   Stepper,
   TextInput,
   type SelectItem,
+  type SelectOptionGroup,
 } from "./ui";
 
 type Tab =
@@ -1095,7 +1096,7 @@ function UiScaleSection({
 function buildThemeSelectItems(
   themes: ReadonlyArray<AcornTheme>,
   t: SettingsTranslator,
-): SelectItem[] {
+): Array<SelectItem | SelectOptionGroup> {
   const customLabel = st(t, "settings.appearance.theme.custom");
   const acornBuiltIns = themes.filter(isAcornBuiltInTheme);
   const otherBuiltInDark = themes.filter(
@@ -1112,7 +1113,7 @@ function buildThemeSelectItems(
   );
   const userThemes = themes.filter((theme) => theme.source === "user");
 
-  const sections = [
+  const sections: SelectOptionGroup[] = [
     {
       label: st(t, "settings.appearance.theme.groups.acorn"),
       options: acornBuiltIns.map((theme) => themeToSelectOption(theme)),
@@ -1131,12 +1132,14 @@ function buildThemeSelectItems(
         themeToSelectOption(theme, customLabel),
       ),
     },
-  ];
+  ].filter((section) => section.options.length > 0);
 
-  const items: SelectItem[] = [];
-  for (const section of sections) {
-    if (section.options.length === 0) continue;
-    items.push({ type: "separator", label: section.label }, ...section.options);
+  const items: Array<SelectItem | SelectOptionGroup> = [];
+  for (const [index, section] of sections.entries()) {
+    if (index > 0) {
+      items.push({ type: "separator" });
+    }
+    items.push(section);
   }
   return items;
 }

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -85,7 +85,7 @@ import {
   Select,
   Stepper,
   TextInput,
-  type SelectOptionGroup,
+  type SelectItem,
 } from "./ui";
 
 type Tab =
@@ -1092,10 +1092,10 @@ function UiScaleSection({
   );
 }
 
-function buildThemeSelectGroups(
+function buildThemeSelectItems(
   themes: ReadonlyArray<AcornTheme>,
   t: SettingsTranslator,
-): SelectOptionGroup[] {
+): SelectItem[] {
   const customLabel = st(t, "settings.appearance.theme.custom");
   const acornBuiltIns = themes.filter(isAcornBuiltInTheme);
   const otherBuiltInDark = themes.filter(
@@ -1112,7 +1112,7 @@ function buildThemeSelectGroups(
   );
   const userThemes = themes.filter((theme) => theme.source === "user");
 
-  return [
+  const sections = [
     {
       label: st(t, "settings.appearance.theme.groups.acorn"),
       options: acornBuiltIns.map((theme) => themeToSelectOption(theme)),
@@ -1131,7 +1131,14 @@ function buildThemeSelectGroups(
         themeToSelectOption(theme, customLabel),
       ),
     },
-  ].filter((group) => group.options.length > 0);
+  ];
+
+  const items: SelectItem[] = [];
+  for (const section of sections) {
+    if (section.options.length === 0) continue;
+    items.push({ type: "separator", label: section.label }, ...section.options);
+  }
+  return items;
 }
 
 function isAcornBuiltInTheme(theme: AcornTheme): boolean {
@@ -1160,7 +1167,7 @@ function ThemeSection({
   const themes = useThemes((s) => s.themes);
   const refresh = useThemes((s) => s.refresh);
   const t = useTranslation();
-  const themeOptions = buildThemeSelectGroups(themes, t);
+  const themeOptions = buildThemeSelectItems(themes, t);
 
   return (
     <Field

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -67,7 +67,11 @@ import {
   TERMINAL_FONT_WEIGHTS,
   useSettings,
 } from "../lib/settings";
-import { revealThemesFolder, useThemes } from "../lib/themes";
+import {
+  revealThemesFolder,
+  useThemes,
+  type AcornTheme,
+} from "../lib/themes";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
 import { useAppStore } from "../store";
@@ -81,6 +85,7 @@ import {
   Select,
   Stepper,
   TextInput,
+  type SelectOptionGroup,
 } from "./ui";
 
 type Tab =
@@ -915,6 +920,7 @@ function GithubSettings() {
             })
           }
           className="w-48"
+          aria-label={st(t, "settings.github.refreshInterval.label")}
         >
           {PR_REFRESH_INTERVAL_OPTIONS.map((opt) => (
             <option key={opt.value} value={opt.value}>
@@ -1073,6 +1079,7 @@ function UiScaleSection({
           value={String(value)}
           onChange={(e) => commitValue(Number(e.target.value))}
           className="w-32"
+          aria-label={st(t, "settings.appearance.uiScale.label")}
         >
           {presets.map((preset) => (
             <option key={preset} value={preset}>
@@ -1085,6 +1092,64 @@ function UiScaleSection({
   );
 }
 
+function buildThemeSelectGroups(
+  themes: ReadonlyArray<AcornTheme>,
+  t: SettingsTranslator,
+): SelectOptionGroup[] {
+  const customLabel = st(t, "settings.appearance.theme.custom");
+  const acornBuiltIns = themes.filter(isAcornBuiltInTheme);
+  const otherBuiltInDark = themes.filter(
+    (theme) =>
+      theme.source === "builtin" &&
+      theme.mode === "dark" &&
+      !isAcornBuiltInTheme(theme),
+  );
+  const otherBuiltInLight = themes.filter(
+    (theme) =>
+      theme.source === "builtin" &&
+      theme.mode === "light" &&
+      !isAcornBuiltInTheme(theme),
+  );
+  const userThemes = themes.filter((theme) => theme.source === "user");
+
+  return [
+    {
+      label: st(t, "settings.appearance.theme.groups.acorn"),
+      options: acornBuiltIns.map((theme) => themeToSelectOption(theme)),
+    },
+    {
+      label: st(t, "settings.appearance.theme.groups.dark"),
+      options: otherBuiltInDark.map((theme) => themeToSelectOption(theme)),
+    },
+    {
+      label: st(t, "settings.appearance.theme.groups.light"),
+      options: otherBuiltInLight.map((theme) => themeToSelectOption(theme)),
+    },
+    {
+      label: st(t, "settings.appearance.theme.groups.custom"),
+      options: userThemes.map((theme) =>
+        themeToSelectOption(theme, customLabel),
+      ),
+    },
+  ].filter((group) => group.options.length > 0);
+}
+
+function isAcornBuiltInTheme(theme: AcornTheme): boolean {
+  return (
+    theme.source === "builtin" &&
+    (theme.id.startsWith("acorn-") || theme.label.startsWith("Acorn "))
+  );
+}
+
+function themeToSelectOption(theme: AcornTheme, suffix?: string) {
+  const label = suffix ? `${theme.label} ${suffix}` : theme.label;
+  return {
+    value: theme.id,
+    label,
+    searchText: [theme.id, theme.label, suffix].filter(Boolean).join(" "),
+  };
+}
+
 function ThemeSection({
   themeId,
   onChange,
@@ -1095,6 +1160,7 @@ function ThemeSection({
   const themes = useThemes((s) => s.themes);
   const refresh = useThemes((s) => s.refresh);
   const t = useTranslation();
+  const themeOptions = buildThemeSelectGroups(themes, t);
 
   return (
     <Field
@@ -1104,18 +1170,11 @@ function ThemeSection({
       <div className="flex flex-wrap items-center gap-2">
         <Select
           value={themeId}
-          onChange={(e) => onChange(e.target.value)}
+          onValueChange={onChange}
+          options={themeOptions}
           className="min-w-[14rem]"
-        >
-          {themes.map((theme) => (
-            <option key={theme.id} value={theme.id}>
-              {theme.label}
-              {theme.source === "user"
-                ? ` ${st(t, "settings.appearance.theme.custom")}`
-                : ""}
-            </option>
-          ))}
-        </Select>
+          aria-label={st(t, "settings.appearance.theme.label")}
+        />
         <Tooltip
           label={st(t, "settings.appearance.theme.rescanTitle")}
           side="bottom"

--- a/src/components/ui/Select.test.tsx
+++ b/src/components/ui/Select.test.tsx
@@ -1,7 +1,12 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { Select, type SelectItem, type SelectOption } from "./Select";
+import {
+  Select,
+  type SelectItem,
+  type SelectOption,
+  type SelectOptionGroup,
+} from "./Select";
 
 const THEME_OPTIONS: SelectOption[] = [
   { value: "acorn-dark", label: "Acorn Dark Green" },
@@ -63,6 +68,18 @@ function optionLabels(): string[] {
 function separators(): HTMLElement[] {
   return Array.from(
     document.querySelectorAll<HTMLElement>("[data-select-separator]"),
+  );
+}
+
+function sectionMarkers(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(
+      "[data-select-group-label], [data-select-separator]",
+    ),
+  ).map((element) =>
+    element.hasAttribute("data-select-separator")
+      ? "separator"
+      : (element.textContent?.trim() ?? ""),
   );
 }
 
@@ -269,6 +286,39 @@ describe("Select", () => {
     pressKey(getSearchInput(), "Enter");
 
     expect(onValueChange).toHaveBeenCalledWith("enterprise");
+  });
+
+  it("preserves separators between explicit option groups", () => {
+    const options: Array<SelectItem | SelectOptionGroup> = [
+      {
+        label: "Acorn themes",
+        options: [{ value: "acorn-dark", label: "Acorn Dark Green" }],
+      },
+      { type: "separator" },
+      {
+        label: "Built-in dark",
+        options: [{ value: "github-dark", label: "GitHub Dark" }],
+      },
+    ];
+
+    act(() => {
+      root = createRoot(container);
+      root.render(<Select searchable value="acorn-dark" options={options} />);
+    });
+
+    clickElement(getCombobox());
+
+    expect(sectionMarkers()).toEqual([
+      "Acorn themes",
+      "separator",
+      "Built-in dark",
+    ]);
+    expect(optionLabels()).toEqual(["Acorn Dark Green", "GitHub Dark"]);
+
+    setInputValue(getSearchInput(), "github");
+
+    expect(sectionMarkers()).toEqual(["Built-in dark"]);
+    expect(optionLabels()).toEqual(["GitHub Dark"]);
   });
 
   it("opens non-searchable selects without rendering a search input", () => {

--- a/src/components/ui/Select.test.tsx
+++ b/src/components/ui/Select.test.tsx
@@ -9,16 +9,24 @@ const THEME_OPTIONS: SelectOption[] = [
   { value: "solarized-dark", label: "Solarized Dark" },
 ];
 
-function getCombobox(): HTMLInputElement {
-  const input = document.querySelector<HTMLInputElement>('[role="combobox"]');
-  if (!input) throw new Error("Combobox not found");
-  return input;
+function getCombobox(): HTMLButtonElement {
+  const button = document.querySelector<HTMLButtonElement>(
+    'button[role="combobox"]',
+  );
+  if (!button) throw new Error("Combobox not found");
+  return button;
 }
 
-function focusInput(input: HTMLInputElement) {
+function clickElement(element: HTMLElement) {
   act(() => {
-    input.focus();
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   });
+}
+
+function getSearchInput(): HTMLInputElement {
+  const input = document.querySelector<HTMLInputElement>("[data-select-search]");
+  if (!input) throw new Error("Search input not found");
+  return input;
 }
 
 function setInputValue(input: HTMLInputElement, value: string) {
@@ -34,9 +42,9 @@ function setInputValue(input: HTMLInputElement, value: string) {
   });
 }
 
-function pressKey(input: HTMLInputElement, key: string) {
+function pressKey(element: HTMLElement, key: string) {
   act(() => {
-    input.dispatchEvent(
+    element.dispatchEvent(
       new KeyboardEvent("keydown", {
         bubbles: true,
         cancelable: true,
@@ -47,9 +55,9 @@ function pressKey(input: HTMLInputElement, key: string) {
 }
 
 function optionLabels(): string[] {
-  return Array.from(document.querySelectorAll('[role="option"]')).map(
-    (option) => option.textContent?.trim() ?? "",
-  );
+  return Array.from(
+    document.querySelectorAll("[data-select-option-label]"),
+  ).map((option) => option.textContent?.trim() ?? "");
 }
 
 describe("Select", () => {
@@ -75,11 +83,11 @@ describe("Select", () => {
     vi.clearAllMocks();
   });
 
-  it("filters option children by typed keywords", () => {
+  it("opens a searchable popover from a button trigger", () => {
     act(() => {
       root = createRoot(container);
       root.render(
-        <Select defaultValue="acorn-dark">
+        <Select searchable defaultValue="acorn-dark">
           <option value="acorn-dark">Acorn Dark Green</option>
           <option value="acorn-pink">Acorn Dark Pink</option>
           <option value="solarized-dark">Solarized Dark</option>
@@ -87,10 +95,12 @@ describe("Select", () => {
       );
     });
 
-    const input = getCombobox();
-    expect(input.value).toBe("Acorn Dark Green");
+    const trigger = getCombobox();
+    expect(trigger.textContent).toContain("Acorn Dark Green");
+    expect(document.querySelector("[data-select-search]")).toBeNull();
 
-    focusInput(input);
+    clickElement(trigger);
+    const input = getSearchInput();
     setInputValue(input, "pink");
 
     expect(optionLabels()).toEqual(["Acorn Dark Pink"]);
@@ -104,6 +114,7 @@ describe("Select", () => {
       root = createRoot(container);
       root.render(
         <Select
+          searchable
           value="acorn-dark"
           options={THEME_OPTIONS}
           onValueChange={onValueChange}
@@ -112,8 +123,8 @@ describe("Select", () => {
       );
     });
 
-    const input = getCombobox();
-    focusInput(input);
+    clickElement(getCombobox());
+    const input = getSearchInput();
     setInputValue(input, "pink");
     pressKey(input, "Enter");
 
@@ -134,6 +145,7 @@ describe("Select", () => {
       root.render(
         <Select
           multiple
+          searchable
           value={["acorn-dark"]}
           options={THEME_OPTIONS}
           onValuesChange={onValuesChange}
@@ -142,8 +154,8 @@ describe("Select", () => {
       );
     });
 
-    const input = getCombobox();
-    focusInput(input);
+    clickElement(getCombobox());
+    const input = getSearchInput();
     setInputValue(input, "pink");
     pressKey(input, "Enter");
 
@@ -159,5 +171,85 @@ describe("Select", () => {
         }),
       }),
     );
+  });
+
+  it("renders option descriptions and includes them in search", () => {
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <Select
+          searchable
+          value="pro"
+          options={[
+            {
+              value: "basic",
+              label: "Basic Plan",
+              description: "$9/month - Perfect for small projects",
+            },
+            {
+              value: "pro",
+              label: "Pro Plan",
+              description: "$29/month - Advanced features",
+            },
+            {
+              value: "enterprise",
+              label: "Enterprise Plan",
+              description: "Custom pricing - Tailored solutions",
+            },
+          ]}
+        />,
+      );
+    });
+
+    clickElement(getCombobox());
+
+    expect(optionLabels()).toEqual([
+      "Basic Plan",
+      "Pro Plan",
+      "Enterprise Plan",
+    ]);
+    expect(
+      Array.from(
+        document.querySelectorAll("[data-select-option-description]"),
+      ).map((option) => option.textContent?.trim() ?? ""),
+    ).toEqual([
+      "$9/month - Perfect for small projects",
+      "$29/month - Advanced features",
+      "Custom pricing - Tailored solutions",
+    ]);
+
+    setInputValue(getSearchInput(), "tailored");
+
+    expect(optionLabels()).toEqual(["Enterprise Plan"]);
+  });
+
+  it("opens non-searchable selects without rendering a search input", () => {
+    const onValueChange = vi.fn();
+
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <Select
+          value="acorn-dark"
+          options={THEME_OPTIONS}
+          onValueChange={onValueChange}
+        />,
+      );
+    });
+
+    const trigger = getCombobox();
+    clickElement(trigger);
+
+    expect(document.querySelector("[data-select-search]")).toBeNull();
+    expect(optionLabels()).toEqual([
+      "Acorn Dark Green",
+      "Acorn Dark Pink",
+      "Solarized Dark",
+    ]);
+
+    pressKey(trigger, "ArrowDown");
+    pressKey(trigger, "Enter");
+
+    expect(onValueChange).toHaveBeenCalledWith("acorn-pink");
   });
 });

--- a/src/components/ui/Select.test.tsx
+++ b/src/components/ui/Select.test.tsx
@@ -1,0 +1,163 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Select, type SelectOption } from "./Select";
+
+const THEME_OPTIONS: SelectOption[] = [
+  { value: "acorn-dark", label: "Acorn Dark Green" },
+  { value: "acorn-pink", label: "Acorn Dark Pink" },
+  { value: "solarized-dark", label: "Solarized Dark" },
+];
+
+function getCombobox(): HTMLInputElement {
+  const input = document.querySelector<HTMLInputElement>('[role="combobox"]');
+  if (!input) throw new Error("Combobox not found");
+  return input;
+}
+
+function focusInput(input: HTMLInputElement) {
+  act(() => {
+    input.focus();
+  });
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  if (!setter) throw new Error("Input value setter not found");
+
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function pressKey(input: HTMLInputElement, key: string) {
+  act(() => {
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key,
+      }),
+    );
+  });
+}
+
+function optionLabels(): string[] {
+  return Array.from(document.querySelectorAll('[role="option"]')).map(
+    (option) => option.textContent?.trim() ?? "",
+  );
+}
+
+describe("Select", () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+    }
+    root = null;
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("filters option children by typed keywords", () => {
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <Select defaultValue="acorn-dark">
+          <option value="acorn-dark">Acorn Dark Green</option>
+          <option value="acorn-pink">Acorn Dark Pink</option>
+          <option value="solarized-dark">Solarized Dark</option>
+        </Select>,
+      );
+    });
+
+    const input = getCombobox();
+    expect(input.value).toBe("Acorn Dark Green");
+
+    focusInput(input);
+    setInputValue(input, "pink");
+
+    expect(optionLabels()).toEqual(["Acorn Dark Pink"]);
+  });
+
+  it("selects the filtered active option with Enter", () => {
+    const onValueChange = vi.fn();
+    const onChange = vi.fn();
+
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <Select
+          value="acorn-dark"
+          options={THEME_OPTIONS}
+          onValueChange={onValueChange}
+          onChange={onChange}
+        />,
+      );
+    });
+
+    const input = getCombobox();
+    focusInput(input);
+    setInputValue(input, "pink");
+    pressKey(input, "Enter");
+
+    expect(onValueChange).toHaveBeenCalledWith("acorn-pink");
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ value: "acorn-pink" }),
+      }),
+    );
+  });
+
+  it("adds a filtered option through the multi-select API", () => {
+    const onValuesChange = vi.fn();
+    const onChange = vi.fn();
+
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <Select
+          multiple
+          value={["acorn-dark"]}
+          options={THEME_OPTIONS}
+          onValuesChange={onValuesChange}
+          onChange={onChange}
+        />,
+      );
+    });
+
+    const input = getCombobox();
+    focusInput(input);
+    setInputValue(input, "pink");
+    pressKey(input, "Enter");
+
+    expect(onValuesChange).toHaveBeenCalledWith([
+      "acorn-dark",
+      "acorn-pink",
+    ]);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({
+          value: "acorn-dark",
+          values: ["acorn-dark", "acorn-pink"],
+        }),
+      }),
+    );
+  });
+});

--- a/src/components/ui/Select.test.tsx
+++ b/src/components/ui/Select.test.tsx
@@ -1,7 +1,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { Select, type SelectOption } from "./Select";
+import { Select, type SelectItem, type SelectOption } from "./Select";
 
 const THEME_OPTIONS: SelectOption[] = [
   { value: "acorn-dark", label: "Acorn Dark Green" },
@@ -58,6 +58,12 @@ function optionLabels(): string[] {
   return Array.from(
     document.querySelectorAll("[data-select-option-label]"),
   ).map((option) => option.textContent?.trim() ?? "");
+}
+
+function separators(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>("[data-select-separator]"),
+  );
 }
 
 describe("Select", () => {
@@ -221,6 +227,48 @@ describe("Select", () => {
     setInputValue(getSearchInput(), "tailored");
 
     expect(optionLabels()).toEqual(["Enterprise Plan"]);
+  });
+
+  it("renders separators without making them selectable", () => {
+    const onValueChange = vi.fn();
+    const options: SelectItem[] = [
+      { value: "basic", label: "Basic Plan" },
+      { type: "separator" },
+      { value: "pro", label: "Pro Plan" },
+      { type: "separator", label: "Enterprise" },
+      { value: "enterprise", label: "Enterprise Plan" },
+    ];
+
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <Select
+          searchable
+          value="basic"
+          options={options}
+          onValueChange={onValueChange}
+        />,
+      );
+    });
+
+    clickElement(getCombobox());
+
+    expect(optionLabels()).toEqual([
+      "Basic Plan",
+      "Pro Plan",
+      "Enterprise Plan",
+    ]);
+    expect(separators()).toHaveLength(2);
+    expect(separators()[1]?.getAttribute("aria-label")).toBe("Enterprise");
+
+    setInputValue(getSearchInput(), "enterprise");
+
+    expect(optionLabels()).toEqual(["Enterprise Plan"]);
+    expect(separators()).toHaveLength(0);
+
+    pressKey(getSearchInput(), "Enter");
+
+    expect(onValueChange).toHaveBeenCalledWith("enterprise");
   });
 
   it("opens non-searchable selects without rendering a search input", () => {

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,17 +1,638 @@
-import { forwardRef, type SelectHTMLAttributes } from "react";
+import { Check, ChevronDown } from "lucide-react";
+import {
+  Children,
+  forwardRef,
+  isValidElement,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
 import { cn } from "../../lib/cn";
 
-type SelectProps = SelectHTMLAttributes<HTMLSelectElement>;
+type SelectValue = string | number;
+
+export interface SelectOption {
+  value: SelectValue;
+  label: string;
+  disabled?: boolean;
+  searchText?: string;
+}
+
+export interface SelectOptionGroup {
+  label: string;
+  options: ReadonlyArray<SelectOption>;
+}
+
+export interface SelectChangeEvent {
+  target: {
+    value: string;
+    values: string[];
+    name?: string;
+  };
+  currentTarget: {
+    value: string;
+    values: string[];
+    name?: string;
+  };
+}
+
+type BaseSelectProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "children" | "defaultValue" | "onChange" | "onKeyDown"
+> & {
+  children?: ReactNode;
+  options?: ReadonlyArray<SelectOption | SelectOptionGroup>;
+  disabled?: boolean;
+  emptyMessage?: string;
+  name?: string;
+  placeholder?: string;
+};
+
+type SingleSelectProps = BaseSelectProps & {
+  multiple?: false;
+  value?: SelectValue;
+  defaultValue?: SelectValue;
+  onChange?: (event: SelectChangeEvent) => void;
+  onValueChange?: (value: string) => void;
+  onValuesChange?: never;
+};
+
+type MultiSelectProps = BaseSelectProps & {
+  multiple: true;
+  value?: ReadonlyArray<SelectValue>;
+  defaultValue?: ReadonlyArray<SelectValue>;
+  onChange?: (event: SelectChangeEvent) => void;
+  onValueChange?: never;
+  onValuesChange?: (values: string[]) => void;
+};
+
+export type SelectProps = SingleSelectProps | MultiSelectProps;
+
+interface NormalizedOption {
+  value: string;
+  label: string;
+  disabled: boolean;
+  group?: string;
+  searchText: string;
+}
+
+interface NormalizedOptionGroup {
+  label?: string;
+  options: NormalizedOption[];
+}
+
+interface ChildOptionProps {
+  children?: ReactNode;
+  disabled?: boolean;
+  label?: string;
+  value?: SelectValue;
+}
+
+interface ChildOptionGroupProps {
+  children?: ReactNode;
+  label?: string;
+}
 
 export const SELECT_CLASS =
-  "h-7 rounded-md border border-border bg-bg px-2 font-mono text-xs text-fg outline-none focus:border-accent";
+  "flex h-7 w-full items-center rounded-md border border-border bg-bg font-mono text-xs text-fg outline-none transition focus-within:border-accent";
 
-export const Select = forwardRef<HTMLSelectElement, SelectProps>(
-  function Select({ className, children, ...rest }, ref) {
+const SELECT_ROOT_CLASS = "relative inline-block min-w-0 text-xs";
+
+export const Select = forwardRef<HTMLInputElement, SelectProps>(
+  function Select(props, ref) {
+    const {
+      children,
+      className,
+      disabled = false,
+      emptyMessage = "No options",
+      name,
+      options,
+      placeholder = "",
+      onChange,
+      value: _value,
+      defaultValue: _defaultValue,
+      multiple: _multiple,
+      onValueChange: _onValueChange,
+      onValuesChange: _onValuesChange,
+      ...rest
+    } = props;
+    const rootRef = useRef<HTMLDivElement | null>(null);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const reactId = useId();
+    const listboxId = `${reactId}-listbox`;
+    const multiple = props.multiple === true;
+    const optionGroups = useMemo(
+      () => normalizeOptionGroups(options, children),
+      [children, options],
+    );
+    const allOptions = useMemo(
+      () => optionGroups.flatMap((group) => group.options),
+      [optionGroups],
+    );
+    const [internalValues, setInternalValues] = useState<string[]>(() => {
+      if (props.multiple) {
+        return normalizeValues(props.defaultValue ?? []);
+      }
+      return normalizeValue(props.defaultValue);
+    });
+    const controlledValues = useMemo(() => {
+      if (props.value === undefined) return null;
+      return props.multiple
+        ? normalizeValues(props.value)
+        : normalizeValue(props.value);
+    }, [props.multiple, props.value]);
+    const selectedValues = controlledValues ?? internalValues;
+    const selectedSet = useMemo(
+      () => new Set(selectedValues),
+      [selectedValues],
+    );
+    const selectedLabels = useMemo(() => {
+      const byValue = new Map(allOptions.map((option) => [option.value, option]));
+      return selectedValues.map((value) => byValue.get(value)?.label ?? value);
+    }, [allOptions, selectedValues]);
+    const [isOpen, setIsOpen] = useState(false);
+    const [listboxRect, setListboxRect] = useState<{
+      left: number;
+      top: number;
+      width: number;
+    } | null>(null);
+    const [query, setQuery] = useState("");
+    const [activeIndex, setActiveIndex] = useState(-1);
+    const visibleGroups = useMemo(
+      () => filterGroups(optionGroups, query),
+      [optionGroups, query],
+    );
+    const visibleOptions = useMemo(
+      () => visibleGroups.flatMap((group) => group.options),
+      [visibleGroups],
+    );
+    const inputValue = isOpen ? query : selectedLabels.join(", ");
+    const activeOption =
+      activeIndex >= 0 ? visibleOptions[activeIndex] : undefined;
+    const activeOptionId = activeOption
+      ? optionId(listboxId, activeIndex)
+      : undefined;
+
+    useEffect(() => {
+      if (!isOpen) return;
+      setActiveIndex((current) => {
+        if (
+          current >= 0 &&
+          current < visibleOptions.length &&
+          !visibleOptions[current]?.disabled
+        ) {
+          return current;
+        }
+
+        const selectedIndex = visibleOptions.findIndex(
+          (option) => selectedSet.has(option.value) && !option.disabled,
+        );
+        if (selectedIndex >= 0) return selectedIndex;
+
+        return firstEnabledIndex(visibleOptions);
+      });
+    }, [isOpen, selectedSet, visibleOptions]);
+
+    useLayoutEffect(() => {
+      if (!isOpen) return;
+
+      const updateListboxRect = () => {
+        const rect = rootRef.current?.getBoundingClientRect();
+        if (!rect) return;
+        setListboxRect({
+          left: rect.left,
+          top: rect.bottom + 4,
+          width: rect.width,
+        });
+      };
+
+      updateListboxRect();
+      window.addEventListener("resize", updateListboxRect);
+      window.addEventListener("scroll", updateListboxRect, true);
+      return () => {
+        window.removeEventListener("resize", updateListboxRect);
+        window.removeEventListener("scroll", updateListboxRect, true);
+      };
+    }, [isOpen]);
+
+    const assignInputRef = (node: HTMLInputElement | null) => {
+      inputRef.current = node;
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    };
+
+    const openList = () => {
+      if (disabled) return;
+      setIsOpen(true);
+    };
+
+    const closeList = () => {
+      setIsOpen(false);
+      setListboxRect(null);
+      setQuery("");
+      setActiveIndex(-1);
+    };
+
+    const commitValues = (nextValues: string[]) => {
+      if (props.value === undefined) {
+        setInternalValues(nextValues);
+      }
+
+      if (props.multiple) {
+        props.onValuesChange?.(nextValues);
+      } else {
+        props.onValueChange?.(nextValues[0] ?? "");
+      }
+
+      const target = {
+        value: nextValues[0] ?? "",
+        values: nextValues,
+        name,
+      };
+      onChange?.({ target, currentTarget: target });
+    };
+
+    const selectOption = (option: NormalizedOption) => {
+      if (option.disabled) return;
+      if (props.multiple) {
+        const nextValues = selectedSet.has(option.value)
+          ? selectedValues.filter((value) => value !== option.value)
+          : [...selectedValues, option.value];
+        commitValues(nextValues);
+        setQuery("");
+        setIsOpen(true);
+      } else {
+        commitValues([option.value]);
+        closeList();
+        inputRef.current?.focus();
+      }
+    };
+
+    const moveActive = (delta: 1 | -1) => {
+      const enabledIndexes = visibleOptions
+        .map((option, index) => (option.disabled ? -1 : index))
+        .filter((index) => index >= 0);
+      if (enabledIndexes.length === 0) {
+        setActiveIndex(-1);
+        return;
+      }
+
+      setActiveIndex((current) => {
+        const currentPosition = enabledIndexes.indexOf(current);
+        if (currentPosition === -1) {
+          return delta > 0
+            ? enabledIndexes[0]
+            : enabledIndexes[enabledIndexes.length - 1];
+        }
+        const nextPosition =
+          (currentPosition + delta + enabledIndexes.length) %
+          enabledIndexes.length;
+        return enabledIndexes[nextPosition];
+      });
+    };
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          event.stopPropagation();
+          openList();
+          moveActive(1);
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          event.stopPropagation();
+          openList();
+          moveActive(-1);
+          break;
+        case "Enter": {
+          if (!isOpen) {
+            event.preventDefault();
+            event.stopPropagation();
+            openList();
+            break;
+          }
+          const option =
+            visibleOptions[activeIndex] ??
+            visibleOptions.find((candidate) => !candidate.disabled);
+          if (option && !option.disabled) {
+            event.preventDefault();
+            event.stopPropagation();
+            selectOption(option);
+          }
+          break;
+        }
+        case "Escape":
+          if (isOpen) {
+            event.preventDefault();
+            event.stopPropagation();
+            closeList();
+          }
+          break;
+        case "Tab":
+          closeList();
+          break;
+      }
+    };
+
+    const listbox =
+      isOpen && listboxRect
+        ? createPortal(
+            <div
+              id={listboxId}
+              role="listbox"
+              aria-multiselectable={multiple || undefined}
+              className="fixed z-[60] max-h-56 overflow-y-auto rounded-md border border-border bg-bg-elevated py-1 font-mono text-xs text-fg shadow-xl"
+              style={{
+                left: listboxRect.left,
+                minWidth: listboxRect.width,
+                top: listboxRect.top,
+              }}
+            >
+              {visibleGroups.length > 0 ? (
+                visibleGroups.map((group, groupIndex) => (
+                  <div key={`${group.label ?? "group"}-${groupIndex}`}>
+                    {group.label ? (
+                      <div
+                        data-select-group-label
+                        className="px-2 py-1 text-[10px] font-semibold uppercase tracking-normal text-fg-muted"
+                      >
+                        {group.label}
+                      </div>
+                    ) : null}
+                    {group.options.map((option) => {
+                      const optionIndex = visibleOptions.indexOf(option);
+                      const selected = selectedSet.has(option.value);
+                      const active = optionIndex === activeIndex;
+                      return (
+                        <div
+                          id={optionId(listboxId, optionIndex)}
+                          key={`${option.group ?? "option"}-${option.value}`}
+                          role="option"
+                          aria-disabled={option.disabled || undefined}
+                          aria-selected={selected}
+                          className={cn(
+                            "flex min-h-7 cursor-default items-center gap-2 px-2 py-1.5",
+                            option.disabled && "opacity-50",
+                            active && "bg-accent/15 text-fg",
+                            !active && "text-fg",
+                          )}
+                          onMouseDown={(event) => event.preventDefault()}
+                          onMouseEnter={() => {
+                            if (!option.disabled) setActiveIndex(optionIndex);
+                          }}
+                          onClick={() => selectOption(option)}
+                        >
+                          <span className="min-w-0 flex-1 truncate">
+                            {option.label}
+                          </span>
+                          {selected ? (
+                            <Check
+                              aria-hidden="true"
+                              size={13}
+                              className="shrink-0 text-accent"
+                            />
+                          ) : null}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))
+              ) : (
+                <div className="px-2 py-2 text-fg-muted">{emptyMessage}</div>
+              )}
+            </div>,
+            document.body,
+          )
+        : null;
+
     return (
-      <select ref={ref} className={cn(SELECT_CLASS, className)} {...rest}>
-        {children}
-      </select>
+      <div
+        ref={rootRef}
+        {...rest}
+        className={cn(SELECT_ROOT_CLASS, className)}
+        onBlur={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+            closeList();
+          }
+        }}
+      >
+        <div
+          className={cn(
+            SELECT_CLASS,
+            disabled && "cursor-not-allowed opacity-60",
+            isOpen && "border-accent",
+          )}
+          onMouseDown={(event) => {
+            if (disabled) return;
+            if (event.target !== inputRef.current) {
+              event.preventDefault();
+              inputRef.current?.focus();
+            }
+            openList();
+          }}
+        >
+          <input
+            ref={assignInputRef}
+            role="combobox"
+            aria-activedescendant={activeOptionId}
+            aria-autocomplete="list"
+            aria-controls={isOpen ? listboxId : undefined}
+            aria-expanded={isOpen}
+            aria-haspopup="listbox"
+            aria-label={props["aria-label"]}
+            aria-labelledby={props["aria-labelledby"]}
+            aria-describedby={props["aria-describedby"]}
+            autoComplete="off"
+            className="h-full min-w-0 flex-1 bg-transparent px-2 text-xs text-fg outline-none placeholder:text-fg-muted disabled:cursor-not-allowed"
+            disabled={disabled}
+            name={name}
+            placeholder={placeholder}
+            value={inputValue}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              openList();
+            }}
+            onFocus={() => {
+              setQuery("");
+              openList();
+            }}
+            onKeyDown={handleKeyDown}
+          />
+          <ChevronDown
+            aria-hidden="true"
+            size={14}
+            className={cn(
+              "mr-1.5 shrink-0 text-fg-muted transition",
+              isOpen && "rotate-180 text-fg",
+            )}
+          />
+        </div>
+
+        {listbox}
+      </div>
     );
   },
 );
+
+function normalizeValue(value: SelectValue | undefined): string[] {
+  return value === undefined ? [] : [String(value)];
+}
+
+function normalizeValues(values: ReadonlyArray<SelectValue>): string[] {
+  return values.map((value) => String(value));
+}
+
+function normalizeOptionGroups(
+  options: ReadonlyArray<SelectOption | SelectOptionGroup> | undefined,
+  children: ReactNode,
+): NormalizedOptionGroup[] {
+  if (options) {
+    return normalizeExplicitOptions(options);
+  }
+
+  const groups: NormalizedOptionGroup[] = [];
+  const ungrouped: NormalizedOption[] = [];
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child) || typeof child.type !== "string") return;
+
+    if (child.type === "option") {
+      ungrouped.push(normalizeChildOption(child.props as ChildOptionProps));
+      return;
+    }
+
+    if (child.type === "optgroup") {
+      const optgroupProps = child.props as ChildOptionGroupProps;
+      const label =
+        typeof optgroupProps.label === "string"
+          ? optgroupProps.label
+          : undefined;
+      const groupOptions: NormalizedOption[] = [];
+      Children.forEach(optgroupProps.children, (optionChild) => {
+        if (
+          isValidElement(optionChild) &&
+          typeof optionChild.type === "string" &&
+          optionChild.type === "option"
+        ) {
+          groupOptions.push(
+            normalizeChildOption(optionChild.props as ChildOptionProps, label),
+          );
+        }
+      });
+      groups.push({ label, options: groupOptions });
+    }
+  });
+
+  if (ungrouped.length > 0) {
+    groups.unshift({ options: ungrouped });
+  }
+
+  return groups;
+}
+
+function normalizeExplicitOptions(
+  options: ReadonlyArray<SelectOption | SelectOptionGroup>,
+): NormalizedOptionGroup[] {
+  const groups: NormalizedOptionGroup[] = [];
+  const ungrouped: NormalizedOption[] = [];
+
+  for (const item of options) {
+    if ("options" in item) {
+      groups.push({
+        label: item.label,
+        options: item.options.map((option) =>
+          normalizeOption(option, item.label),
+        ),
+      });
+    } else {
+      ungrouped.push(normalizeOption(item));
+    }
+  }
+
+  if (ungrouped.length > 0) {
+    groups.unshift({ options: ungrouped });
+  }
+
+  return groups;
+}
+
+function normalizeChildOption(
+  props: ChildOptionProps,
+  group?: string,
+): NormalizedOption {
+  const label = props.label ?? textFromReactNode(props.children);
+  return normalizeOption(
+    {
+      value: props.value ?? label,
+      label,
+      disabled: props.disabled,
+    },
+    group,
+  );
+}
+
+function normalizeOption(
+  option: SelectOption,
+  group?: string,
+): NormalizedOption {
+  const value = String(option.value);
+  const label = option.label;
+  return {
+    value,
+    label,
+    disabled: option.disabled === true,
+    group,
+    searchText: [label, value, group, option.searchText]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase(),
+  };
+}
+
+function filterGroups(
+  groups: NormalizedOptionGroup[],
+  query: string,
+): NormalizedOptionGroup[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return groups;
+
+  return groups
+    .map((group) => ({
+      ...group,
+      options: group.options.filter((option) =>
+        option.searchText.includes(normalizedQuery),
+      ),
+    }))
+    .filter((group) => group.options.length > 0);
+}
+
+function firstEnabledIndex(options: ReadonlyArray<NormalizedOption>): number {
+  return options.findIndex((option) => !option.disabled);
+}
+
+function optionId(listboxId: string, index: number): string {
+  return `${listboxId}-option-${index}`;
+}
+
+function textFromReactNode(node: ReactNode): string {
+  return Children.toArray(node)
+    .map((child) => {
+      if (typeof child === "string" || typeof child === "number") {
+        return String(child);
+      }
+      return "";
+    })
+    .join("")
+    .trim();
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -679,6 +679,11 @@ function normalizeOptionGroups(
 
   const groups: NormalizedOptionGroup[] = [];
   const ungrouped: NormalizedSelectItem[] = [];
+  const flushUngrouped = () => {
+    if (ungrouped.length === 0) return;
+    groups.push({ items: [...ungrouped] });
+    ungrouped.length = 0;
+  };
 
   Children.forEach(children, (child) => {
     if (!isValidElement(child) || typeof child.type !== "string") return;
@@ -696,6 +701,7 @@ function normalizeOptionGroups(
     }
 
     if (child.type === "optgroup") {
+      flushUngrouped();
       const optgroupProps = child.props as ChildOptionGroupProps;
       const label =
         typeof optgroupProps.label === "string"
@@ -724,9 +730,7 @@ function normalizeOptionGroups(
     }
   });
 
-  if (ungrouped.length > 0) {
-    groups.unshift({ items: ungrouped });
-  }
+  flushUngrouped();
 
   return groups;
 }
@@ -736,9 +740,15 @@ function normalizeExplicitOptions(
 ): NormalizedOptionGroup[] {
   const groups: NormalizedOptionGroup[] = [];
   const ungrouped: NormalizedSelectItem[] = [];
+  const flushUngrouped = () => {
+    if (ungrouped.length === 0) return;
+    groups.push({ items: [...ungrouped] });
+    ungrouped.length = 0;
+  };
 
   for (const item of options) {
     if ("options" in item) {
+      flushUngrouped();
       groups.push({
         label: item.label,
         items: item.options.map((option) => normalizeItem(option, item.label)),
@@ -748,9 +758,7 @@ function normalizeExplicitOptions(
     }
   }
 
-  if (ungrouped.length > 0) {
-    groups.unshift({ items: ungrouped });
-  }
+  flushUngrouped();
 
   return groups;
 }

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -151,6 +151,9 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
       multiple: _multiple,
       onValueChange: _onValueChange,
       onValuesChange: _onValuesChange,
+      "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabelledBy,
+      "aria-describedby": ariaDescribedBy,
       ...rest
     } = props;
     const rootRef = useRef<HTMLDivElement | null>(null);
@@ -599,9 +602,9 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
           aria-controls={isOpen ? listboxId : undefined}
           aria-expanded={isOpen}
           aria-haspopup="listbox"
-          aria-label={props["aria-label"]}
-          aria-labelledby={props["aria-labelledby"]}
-          aria-describedby={props["aria-describedby"]}
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
+          aria-describedby={ariaDescribedBy}
           disabled={disabled}
           className={cn(
             SELECT_CLASS,

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, Search } from "lucide-react";
 import {
   Children,
   forwardRef,
@@ -11,6 +11,7 @@ import {
   useState,
   type HTMLAttributes,
   type KeyboardEvent,
+  type MouseEvent,
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
@@ -21,6 +22,7 @@ type SelectValue = string | number;
 export interface SelectOption {
   value: SelectValue;
   label: string;
+  description?: string;
   disabled?: boolean;
   searchText?: string;
 }
@@ -53,6 +55,8 @@ type BaseSelectProps = Omit<
   emptyMessage?: string;
   name?: string;
   placeholder?: string;
+  searchable?: boolean;
+  searchPlaceholder?: string;
 };
 
 type SingleSelectProps = BaseSelectProps & {
@@ -78,6 +82,7 @@ export type SelectProps = SingleSelectProps | MultiSelectProps;
 interface NormalizedOption {
   value: string;
   label: string;
+  description?: string;
   disabled: boolean;
   group?: string;
   searchText: string;
@@ -93,6 +98,7 @@ interface ChildOptionProps {
   disabled?: boolean;
   label?: string;
   value?: SelectValue;
+  "data-description"?: string;
 }
 
 interface ChildOptionGroupProps {
@@ -101,11 +107,11 @@ interface ChildOptionGroupProps {
 }
 
 export const SELECT_CLASS =
-  "flex h-7 w-full items-center rounded-md border border-border bg-bg font-mono text-xs text-fg outline-none transition focus-within:border-accent";
+  "flex h-7 w-full items-center rounded-md border border-border bg-bg font-mono text-xs text-fg outline-none transition focus-visible:border-accent";
 
 const SELECT_ROOT_CLASS = "relative inline-block min-w-0 text-xs";
 
-export const Select = forwardRef<HTMLInputElement, SelectProps>(
+export const Select = forwardRef<HTMLButtonElement, SelectProps>(
   function Select(props, ref) {
     const {
       children,
@@ -115,6 +121,8 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       name,
       options,
       placeholder = "",
+      searchable = false,
+      searchPlaceholder = "Search options",
       onChange,
       value: _value,
       defaultValue: _defaultValue,
@@ -124,7 +132,9 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       ...rest
     } = props;
     const rootRef = useRef<HTMLDivElement | null>(null);
-    const inputRef = useRef<HTMLInputElement | null>(null);
+    const listboxRef = useRef<HTMLDivElement | null>(null);
+    const searchInputRef = useRef<HTMLInputElement | null>(null);
+    const triggerRef = useRef<HTMLButtonElement | null>(null);
     const reactId = useId();
     const listboxId = `${reactId}-listbox`;
     const multiple = props.multiple === true;
@@ -166,19 +176,33 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
     const [query, setQuery] = useState("");
     const [activeIndex, setActiveIndex] = useState(-1);
     const visibleGroups = useMemo(
-      () => filterGroups(optionGroups, query),
-      [optionGroups, query],
+      () => filterGroups(optionGroups, searchable ? query : ""),
+      [optionGroups, query, searchable],
     );
     const visibleOptions = useMemo(
       () => visibleGroups.flatMap((group) => group.options),
       [visibleGroups],
     );
-    const inputValue = isOpen ? query : selectedLabels.join(", ");
+    const displayValue = selectedLabels.join(", ");
+    const hasDisplayValue = displayValue.length > 0;
     const activeOption =
       activeIndex >= 0 ? visibleOptions[activeIndex] : undefined;
     const activeOptionId = activeOption
       ? optionId(listboxId, activeIndex)
       : undefined;
+
+    const openList = () => {
+      if (disabled) return;
+      setQuery("");
+      setIsOpen(true);
+    };
+
+    const closeList = () => {
+      setIsOpen(false);
+      setListboxRect(null);
+      setQuery("");
+      setActiveIndex(-1);
+    };
 
     useEffect(() => {
       if (!isOpen) return;
@@ -199,6 +223,23 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
         return firstEnabledIndex(visibleOptions);
       });
     }, [isOpen, selectedSet, visibleOptions]);
+
+    useEffect(() => {
+      if (!isOpen) return;
+
+      const handlePointerDown = (event: PointerEvent) => {
+        const target = event.target;
+        if (!(target instanceof Node)) return;
+        if (rootRef.current?.contains(target)) return;
+        if (listboxRef.current?.contains(target)) return;
+        closeList();
+      };
+
+      document.addEventListener("pointerdown", handlePointerDown);
+      return () => {
+        document.removeEventListener("pointerdown", handlePointerDown);
+      };
+    }, [isOpen]);
 
     useLayoutEffect(() => {
       if (!isOpen) return;
@@ -222,25 +263,18 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       };
     }, [isOpen]);
 
-    const assignInputRef = (node: HTMLInputElement | null) => {
-      inputRef.current = node;
+    useLayoutEffect(() => {
+      if (!isOpen || !searchable || !listboxRect) return;
+      searchInputRef.current?.focus();
+    }, [isOpen, listboxRect, searchable]);
+
+    const assignTriggerRef = (node: HTMLButtonElement | null) => {
+      triggerRef.current = node;
       if (typeof ref === "function") {
         ref(node);
       } else if (ref) {
         ref.current = node;
       }
-    };
-
-    const openList = () => {
-      if (disabled) return;
-      setIsOpen(true);
-    };
-
-    const closeList = () => {
-      setIsOpen(false);
-      setListboxRect(null);
-      setQuery("");
-      setActiveIndex(-1);
     };
 
     const commitValues = (nextValues: string[]) => {
@@ -274,7 +308,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       } else {
         commitValues([option.value]);
         closeList();
-        inputRef.current?.focus();
+        triggerRef.current?.focus();
       }
     };
 
@@ -301,7 +335,18 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       });
     };
 
-    const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    const chooseActiveOption = () => {
+      const option =
+        visibleOptions[activeIndex] ??
+        visibleOptions.find((candidate) => !candidate.disabled);
+      if (option && !option.disabled) {
+        selectOption(option);
+        return true;
+      }
+      return false;
+    };
+
+    const handleTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
       switch (event.key) {
         case "ArrowDown":
           event.preventDefault();
@@ -315,23 +360,25 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
           openList();
           moveActive(-1);
           break;
-        case "Enter": {
+        case "Enter":
           if (!isOpen) {
             event.preventDefault();
             event.stopPropagation();
             openList();
             break;
           }
-          const option =
-            visibleOptions[activeIndex] ??
-            visibleOptions.find((candidate) => !candidate.disabled);
-          if (option && !option.disabled) {
+          if (chooseActiveOption()) {
             event.preventDefault();
             event.stopPropagation();
-            selectOption(option);
           }
           break;
-        }
+        case " ":
+          if (!isOpen) {
+            event.preventDefault();
+            event.stopPropagation();
+            openList();
+          }
+          break;
         case "Escape":
           if (isOpen) {
             event.preventDefault();
@@ -345,130 +392,196 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
       }
     };
 
+    const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          event.stopPropagation();
+          moveActive(1);
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          event.stopPropagation();
+          moveActive(-1);
+          break;
+        case "Enter":
+          if (chooseActiveOption()) {
+            event.preventDefault();
+            event.stopPropagation();
+          }
+          break;
+        case "Escape":
+          event.preventDefault();
+          event.stopPropagation();
+          closeList();
+          triggerRef.current?.focus();
+          break;
+        case "Tab":
+          closeList();
+          break;
+      }
+    };
+
+    const handleTriggerClick = (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      if (disabled) return;
+      if (isOpen) {
+        closeList();
+      } else {
+        openList();
+      }
+    };
+
     const listbox =
       isOpen && listboxRect
         ? createPortal(
             <div
-              id={listboxId}
-              role="listbox"
-              aria-multiselectable={multiple || undefined}
-              className="fixed z-[60] max-h-56 overflow-y-auto rounded-md border border-border bg-bg-elevated py-1 font-mono text-xs text-fg shadow-xl"
+              ref={listboxRef}
+              className="fixed z-[60] overflow-hidden rounded-md border border-border bg-bg-elevated font-mono text-xs text-fg shadow-xl"
               style={{
                 left: listboxRect.left,
                 minWidth: listboxRect.width,
                 top: listboxRect.top,
               }}
             >
-              {visibleGroups.length > 0 ? (
-                visibleGroups.map((group, groupIndex) => (
-                  <div key={`${group.label ?? "group"}-${groupIndex}`}>
-                    {group.label ? (
-                      <div
-                        data-select-group-label
-                        className="px-2 py-1 text-[10px] font-semibold uppercase tracking-normal text-fg-muted"
-                      >
-                        {group.label}
-                      </div>
-                    ) : null}
-                    {group.options.map((option) => {
-                      const optionIndex = visibleOptions.indexOf(option);
-                      const selected = selectedSet.has(option.value);
-                      const active = optionIndex === activeIndex;
-                      return (
-                        <div
-                          id={optionId(listboxId, optionIndex)}
-                          key={`${option.group ?? "option"}-${option.value}`}
-                          role="option"
-                          aria-disabled={option.disabled || undefined}
-                          aria-selected={selected}
-                          className={cn(
-                            "flex min-h-7 cursor-default items-center gap-2 px-2 py-1.5",
-                            option.disabled && "opacity-50",
-                            active && "bg-accent/15 text-fg",
-                            !active && "text-fg",
-                          )}
-                          onMouseDown={(event) => event.preventDefault()}
-                          onMouseEnter={() => {
-                            if (!option.disabled) setActiveIndex(optionIndex);
-                          }}
-                          onClick={() => selectOption(option)}
-                        >
-                          <span className="min-w-0 flex-1 truncate">
-                            {option.label}
-                          </span>
-                          {selected ? (
-                            <Check
-                              aria-hidden="true"
-                              size={13}
-                              className="shrink-0 text-accent"
-                            />
-                          ) : null}
-                        </div>
-                      );
-                    })}
+              {searchable ? (
+                <div className="border-b border-border p-1.5">
+                  <div className="flex h-7 items-center rounded-md border border-border bg-bg px-2 focus-within:border-accent">
+                    <Search
+                      aria-hidden="true"
+                      size={13}
+                      className="mr-1.5 shrink-0 text-fg-muted"
+                    />
+                    <input
+                      ref={searchInputRef}
+                      data-select-search
+                      aria-activedescendant={activeOptionId}
+                      aria-controls={listboxId}
+                      aria-label={searchPlaceholder}
+                      autoComplete="off"
+                      className="h-full min-w-0 flex-1 bg-transparent text-xs text-fg outline-none placeholder:text-fg-muted"
+                      placeholder={searchPlaceholder}
+                      value={query}
+                      onChange={(event) => setQuery(event.target.value)}
+                      onKeyDown={handleSearchKeyDown}
+                    />
                   </div>
-                ))
-              ) : (
-                <div className="px-2 py-2 text-fg-muted">{emptyMessage}</div>
-              )}
+                </div>
+              ) : null}
+              <div
+                id={listboxId}
+                role="listbox"
+                aria-multiselectable={multiple || undefined}
+                className="max-h-56 overflow-y-auto py-1"
+              >
+                {visibleGroups.length > 0 ? (
+                  visibleGroups.map((group, groupIndex) => (
+                    <div key={`${group.label ?? "group"}-${groupIndex}`}>
+                      {group.label ? (
+                        <div
+                          data-select-group-label
+                          className="px-2 py-1 text-[10px] font-semibold uppercase tracking-normal text-fg-muted"
+                        >
+                          {group.label}
+                        </div>
+                      ) : null}
+                      {group.options.map((option) => {
+                        const optionIndex = visibleOptions.indexOf(option);
+                        const selected = selectedSet.has(option.value);
+                        const active = optionIndex === activeIndex;
+                        return (
+                          <div
+                            id={optionId(listboxId, optionIndex)}
+                            key={`${option.group ?? "option"}-${option.value}`}
+                            role="option"
+                            aria-disabled={option.disabled || undefined}
+                            aria-selected={selected}
+                            className={cn(
+                              "flex min-h-7 cursor-default items-center gap-2 px-2 py-1.5",
+                              option.disabled && "opacity-50",
+                              active && "bg-accent/15 text-fg",
+                              !active && "text-fg",
+                            )}
+                            onMouseDown={(event) => event.preventDefault()}
+                            onMouseEnter={() => {
+                              if (!option.disabled) setActiveIndex(optionIndex);
+                            }}
+                            onClick={() => selectOption(option)}
+                          >
+                            <span className="min-w-0 flex-1">
+                              <span
+                                data-select-option-label
+                                className="block truncate"
+                              >
+                                {option.label}
+                              </span>
+                              {option.description ? (
+                                <span
+                                  data-select-option-description
+                                  className="block truncate text-[11px] text-fg-muted"
+                                >
+                                  {option.description}
+                                </span>
+                              ) : null}
+                            </span>
+                            {selected ? (
+                              <Check
+                                aria-hidden="true"
+                                size={13}
+                                className="shrink-0 text-accent"
+                              />
+                            ) : null}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ))
+                ) : (
+                  <div className="px-2 py-2 text-fg-muted">{emptyMessage}</div>
+                )}
+              </div>
             </div>,
             document.body,
           )
         : null;
 
     return (
-      <div
-        ref={rootRef}
-        {...rest}
-        className={cn(SELECT_ROOT_CLASS, className)}
-        onBlur={(event) => {
-          if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
-            closeList();
-          }
-        }}
-      >
-        <div
+      <div ref={rootRef} {...rest} className={cn(SELECT_ROOT_CLASS, className)}>
+        {name
+          ? selectedValues.map((value) => (
+              <input key={value} type="hidden" name={name} value={value} />
+            ))
+          : null}
+        <button
+          ref={assignTriggerRef}
+          type="button"
+          role="combobox"
+          aria-activedescendant={!searchable ? activeOptionId : undefined}
+          aria-autocomplete={searchable ? "list" : "none"}
+          aria-controls={isOpen ? listboxId : undefined}
+          aria-expanded={isOpen}
+          aria-haspopup="listbox"
+          aria-label={props["aria-label"]}
+          aria-labelledby={props["aria-labelledby"]}
+          aria-describedby={props["aria-describedby"]}
+          disabled={disabled}
           className={cn(
             SELECT_CLASS,
+            "justify-between text-left",
             disabled && "cursor-not-allowed opacity-60",
             isOpen && "border-accent",
           )}
-          onMouseDown={(event) => {
-            if (disabled) return;
-            if (event.target !== inputRef.current) {
-              event.preventDefault();
-              inputRef.current?.focus();
-            }
-            openList();
-          }}
+          onClick={handleTriggerClick}
+          onKeyDown={handleTriggerKeyDown}
         >
-          <input
-            ref={assignInputRef}
-            role="combobox"
-            aria-activedescendant={activeOptionId}
-            aria-autocomplete="list"
-            aria-controls={isOpen ? listboxId : undefined}
-            aria-expanded={isOpen}
-            aria-haspopup="listbox"
-            aria-label={props["aria-label"]}
-            aria-labelledby={props["aria-labelledby"]}
-            aria-describedby={props["aria-describedby"]}
-            autoComplete="off"
-            className="h-full min-w-0 flex-1 bg-transparent px-2 text-xs text-fg outline-none placeholder:text-fg-muted disabled:cursor-not-allowed"
-            disabled={disabled}
-            name={name}
-            placeholder={placeholder}
-            value={inputValue}
-            onChange={(event) => {
-              setQuery(event.target.value);
-              openList();
-            }}
-            onFocus={() => {
-              setQuery("");
-              openList();
-            }}
-            onKeyDown={handleKeyDown}
-          />
+          <span
+            className={cn(
+              "min-w-0 flex-1 truncate px-2",
+              !hasDisplayValue && "text-fg-muted",
+            )}
+          >
+            {hasDisplayValue ? displayValue : placeholder}
+          </span>
           <ChevronDown
             aria-hidden="true"
             size={14}
@@ -477,7 +590,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(
               isOpen && "rotate-180 text-fg",
             )}
           />
-        </div>
+        </button>
 
         {listbox}
       </div>
@@ -576,6 +689,7 @@ function normalizeChildOption(
     {
       value: props.value ?? label,
       label,
+      description: props["data-description"],
       disabled: props.disabled,
     },
     group,
@@ -588,12 +702,14 @@ function normalizeOption(
 ): NormalizedOption {
   const value = String(option.value);
   const label = option.label;
+  const description = option.description;
   return {
     value,
     label,
+    description,
     disabled: option.disabled === true,
     group,
-    searchText: [label, value, group, option.searchText]
+    searchText: [label, description, value, group, option.searchText]
       .filter(Boolean)
       .join(" ")
       .toLowerCase(),

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -27,9 +27,16 @@ export interface SelectOption {
   searchText?: string;
 }
 
+export interface SelectSeparator {
+  type: "separator";
+  label?: string;
+}
+
+export type SelectItem = SelectOption | SelectSeparator;
+
 export interface SelectOptionGroup {
   label: string;
-  options: ReadonlyArray<SelectOption>;
+  options: ReadonlyArray<SelectItem>;
 }
 
 export interface SelectChangeEvent {
@@ -50,7 +57,7 @@ type BaseSelectProps = Omit<
   "children" | "defaultValue" | "onChange" | "onKeyDown"
 > & {
   children?: ReactNode;
-  options?: ReadonlyArray<SelectOption | SelectOptionGroup>;
+  options?: ReadonlyArray<SelectItem | SelectOptionGroup>;
   disabled?: boolean;
   emptyMessage?: string;
   name?: string;
@@ -80,6 +87,7 @@ type MultiSelectProps = BaseSelectProps & {
 export type SelectProps = SingleSelectProps | MultiSelectProps;
 
 interface NormalizedOption {
+  kind: "option";
   value: string;
   label: string;
   description?: string;
@@ -88,9 +96,17 @@ interface NormalizedOption {
   searchText: string;
 }
 
+interface NormalizedSeparator {
+  kind: "separator";
+  label?: string;
+  group?: string;
+}
+
+type NormalizedSelectItem = NormalizedOption | NormalizedSeparator;
+
 interface NormalizedOptionGroup {
   label?: string;
-  options: NormalizedOption[];
+  items: NormalizedSelectItem[];
 }
 
 interface ChildOptionProps {
@@ -104,6 +120,12 @@ interface ChildOptionProps {
 interface ChildOptionGroupProps {
   children?: ReactNode;
   label?: string;
+}
+
+interface ChildSeparatorProps {
+  "aria-label"?: string;
+  "data-label"?: string;
+  title?: string;
 }
 
 export const SELECT_CLASS =
@@ -143,7 +165,10 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
       [children, options],
     );
     const allOptions = useMemo(
-      () => optionGroups.flatMap((group) => group.options),
+      () =>
+        optionGroups.flatMap((group) =>
+          group.items.filter(isNormalizedOption),
+        ),
       [optionGroups],
     );
     const [internalValues, setInternalValues] = useState<string[]>(() => {
@@ -180,7 +205,10 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
       [optionGroups, query, searchable],
     );
     const visibleOptions = useMemo(
-      () => visibleGroups.flatMap((group) => group.options),
+      () =>
+        visibleGroups.flatMap((group) =>
+          group.items.filter(isNormalizedOption),
+        ),
       [visibleGroups],
     );
     const displayValue = selectedLabels.join(", ");
@@ -485,7 +513,17 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
                           {group.label}
                         </div>
                       ) : null}
-                      {group.options.map((option) => {
+                      {group.items.map((item, itemIndex) => {
+                        if (item.kind === "separator") {
+                          return (
+                            <SelectSeparatorRow
+                              key={`${group.label ?? "group"}-separator-${itemIndex}`}
+                              label={item.label}
+                            />
+                          );
+                        }
+
+                        const option = item;
                         const optionIndex = visibleOptions.indexOf(option);
                         const selected = selectedSet.has(option.value);
                         const active = optionIndex === activeIndex;
@@ -598,6 +636,31 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
   },
 );
 
+function SelectSeparatorRow({ label }: { label?: string }) {
+  if (!label) {
+    return (
+      <div
+        role="separator"
+        data-select-separator
+        className="my-1 border-t border-border"
+      />
+    );
+  }
+
+  return (
+    <div
+      role="separator"
+      aria-label={label}
+      data-select-separator
+      className="my-1 flex items-center gap-2 px-2 text-[10px] font-semibold uppercase tracking-normal text-fg-muted"
+    >
+      <span aria-hidden="true" className="h-px flex-1 bg-border" />
+      <span className="min-w-0 truncate">{label}</span>
+      <span aria-hidden="true" className="h-px flex-1 bg-border" />
+    </div>
+  );
+}
+
 function normalizeValue(value: SelectValue | undefined): string[] {
   return value === undefined ? [] : [String(value)];
 }
@@ -607,7 +670,7 @@ function normalizeValues(values: ReadonlyArray<SelectValue>): string[] {
 }
 
 function normalizeOptionGroups(
-  options: ReadonlyArray<SelectOption | SelectOptionGroup> | undefined,
+  options: ReadonlyArray<SelectItem | SelectOptionGroup> | undefined,
   children: ReactNode,
 ): NormalizedOptionGroup[] {
   if (options) {
@@ -615,7 +678,7 @@ function normalizeOptionGroups(
   }
 
   const groups: NormalizedOptionGroup[] = [];
-  const ungrouped: NormalizedOption[] = [];
+  const ungrouped: NormalizedSelectItem[] = [];
 
   Children.forEach(children, (child) => {
     if (!isValidElement(child) || typeof child.type !== "string") return;
@@ -625,56 +688,68 @@ function normalizeOptionGroups(
       return;
     }
 
+    if (child.type === "hr") {
+      ungrouped.push(
+        normalizeSeparator(child.props as ChildSeparatorProps),
+      );
+      return;
+    }
+
     if (child.type === "optgroup") {
       const optgroupProps = child.props as ChildOptionGroupProps;
       const label =
         typeof optgroupProps.label === "string"
           ? optgroupProps.label
           : undefined;
-      const groupOptions: NormalizedOption[] = [];
+      const groupItems: NormalizedSelectItem[] = [];
       Children.forEach(optgroupProps.children, (optionChild) => {
-        if (
-          isValidElement(optionChild) &&
-          typeof optionChild.type === "string" &&
-          optionChild.type === "option"
-        ) {
-          groupOptions.push(
+        if (!isValidElement(optionChild) || typeof optionChild.type !== "string") {
+          return;
+        }
+
+        if (optionChild.type === "option") {
+          groupItems.push(
             normalizeChildOption(optionChild.props as ChildOptionProps, label),
+          );
+          return;
+        }
+
+        if (optionChild.type === "hr") {
+          groupItems.push(
+            normalizeSeparator(optionChild.props as ChildSeparatorProps, label),
           );
         }
       });
-      groups.push({ label, options: groupOptions });
+      groups.push({ label, items: groupItems });
     }
   });
 
   if (ungrouped.length > 0) {
-    groups.unshift({ options: ungrouped });
+    groups.unshift({ items: ungrouped });
   }
 
   return groups;
 }
 
 function normalizeExplicitOptions(
-  options: ReadonlyArray<SelectOption | SelectOptionGroup>,
+  options: ReadonlyArray<SelectItem | SelectOptionGroup>,
 ): NormalizedOptionGroup[] {
   const groups: NormalizedOptionGroup[] = [];
-  const ungrouped: NormalizedOption[] = [];
+  const ungrouped: NormalizedSelectItem[] = [];
 
   for (const item of options) {
     if ("options" in item) {
       groups.push({
         label: item.label,
-        options: item.options.map((option) =>
-          normalizeOption(option, item.label),
-        ),
+        items: item.options.map((option) => normalizeItem(option, item.label)),
       });
     } else {
-      ungrouped.push(normalizeOption(item));
+      ungrouped.push(normalizeItem(item));
     }
   }
 
   if (ungrouped.length > 0) {
-    groups.unshift({ options: ungrouped });
+    groups.unshift({ items: ungrouped });
   }
 
   return groups;
@@ -696,6 +771,12 @@ function normalizeChildOption(
   );
 }
 
+function normalizeItem(item: SelectItem, group?: string): NormalizedSelectItem {
+  return isSelectSeparator(item)
+    ? normalizeSeparator(item, group)
+    : normalizeOption(item, group);
+}
+
 function normalizeOption(
   option: SelectOption,
   group?: string,
@@ -704,6 +785,7 @@ function normalizeOption(
   const label = option.label;
   const description = option.description;
   return {
+    kind: "option",
     value,
     label,
     description,
@@ -713,6 +795,20 @@ function normalizeOption(
       .filter(Boolean)
       .join(" ")
       .toLowerCase(),
+  };
+}
+
+function normalizeSeparator(
+  separator: SelectSeparator | ChildSeparatorProps,
+  group?: string,
+): NormalizedSeparator {
+  const label = isSelectSeparatorProps(separator)
+    ? separator.label
+    : separator["data-label"] ?? separator["aria-label"] ?? separator.title;
+  return {
+    kind: "separator",
+    group,
+    label: typeof label === "string" && label.trim() ? label.trim() : undefined,
   };
 }
 
@@ -726,15 +822,80 @@ function filterGroups(
   return groups
     .map((group) => ({
       ...group,
-      options: group.options.filter((option) =>
-        option.searchText.includes(normalizedQuery),
+      items: compactSeparators(
+        group.items.filter(
+          (item, index, items) =>
+            (isNormalizedOption(item) &&
+              item.searchText.includes(normalizedQuery)) ||
+            (item.kind === "separator" &&
+              hasMatchingOption(items, index, -1, normalizedQuery) &&
+              hasMatchingOption(items, index, 1, normalizedQuery)),
+        ),
       ),
     }))
-    .filter((group) => group.options.length > 0);
+    .filter((group) => group.items.some(isNormalizedOption));
 }
 
 function firstEnabledIndex(options: ReadonlyArray<NormalizedOption>): number {
   return options.findIndex((option) => !option.disabled);
+}
+
+function compactSeparators(
+  items: ReadonlyArray<NormalizedSelectItem>,
+): NormalizedSelectItem[] {
+  const compacted: NormalizedSelectItem[] = [];
+
+  for (const item of items) {
+    if (
+      item.kind === "separator" &&
+      (compacted.length === 0 ||
+        compacted[compacted.length - 1]?.kind === "separator")
+    ) {
+      continue;
+    }
+    compacted.push(item);
+  }
+
+  while (compacted[compacted.length - 1]?.kind === "separator") {
+    compacted.pop();
+  }
+
+  return compacted;
+}
+
+function hasMatchingOption(
+  items: ReadonlyArray<NormalizedSelectItem>,
+  fromIndex: number,
+  direction: 1 | -1,
+  query: string,
+): boolean {
+  for (
+    let index = fromIndex + direction;
+    index >= 0 && index < items.length;
+    index += direction
+  ) {
+    const item = items[index];
+    if (isNormalizedOption(item) && item.searchText.includes(query)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isSelectSeparator(item: SelectItem): item is SelectSeparator {
+  return "type" in item && item.type === "separator";
+}
+
+function isSelectSeparatorProps(
+  separator: SelectSeparator | ChildSeparatorProps,
+): separator is SelectSeparator {
+  return "type" in separator && separator.type === "separator";
+}
+
+function isNormalizedOption(
+  item: NormalizedSelectItem,
+): item is NormalizedOption {
+  return item.kind === "option";
 }
 
 function optionId(listboxId: string, index: number): string {

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -6,8 +6,10 @@ export { IconInput } from "./IconInput";
 export {
   Select,
   SELECT_CLASS,
+  type SelectItem,
   type SelectOption,
   type SelectOptionGroup,
+  type SelectSeparator,
 } from "./Select";
 export { Stepper } from "./Stepper";
 export { CheckboxRow } from "./CheckboxRow";

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -3,7 +3,12 @@ export { ModalHeader } from "./ModalHeader";
 export { Field } from "./Field";
 export { TextInput, TEXT_INPUT_CLASS } from "./TextInput";
 export { IconInput } from "./IconInput";
-export { Select, SELECT_CLASS } from "./Select";
+export {
+  Select,
+  SELECT_CLASS,
+  type SelectOption,
+  type SelectOptionGroup,
+} from "./Select";
 export { Stepper } from "./Stepper";
 export { CheckboxRow } from "./CheckboxRow";
 export { RadioCard } from "./RadioCard";

--- a/src/lib/sessionCreation.test.ts
+++ b/src/lib/sessionCreation.test.ts
@@ -5,6 +5,7 @@ import {
   buildSessionCreateRequestFromScope,
   resolveActiveSessionScope,
   resolveProjectScopedForRepoPath,
+  scopeForSession,
 } from "./sessionCreation";
 import type { Project, Session } from "./types";
 
@@ -80,6 +81,41 @@ describe("session creation policy", () => {
         activeWorkspaceRepoPath: "/repo/app",
       }),
     ).toMatchObject({ repoPath: "/Users/me", projectScoped: false });
+  });
+
+  it("uses the session worktree path for isolated session scope", () => {
+    const isolated = session("isolated", "/repo/app", {
+      isolated: true,
+      project_scoped: true,
+      worktree_path: "/repo/app/.acorn/worktrees/feature",
+    });
+
+    expect(scopeForSession(isolated)).toEqual({
+      repoPath: "/repo/app",
+      cwdPath: "/repo/app/.acorn/worktrees/feature",
+      projectScoped: true,
+    });
+  });
+
+  it("preserves an isolated active session cwd when resolving active scope", () => {
+    const isolated = session("isolated", "/repo/app", {
+      isolated: true,
+      project_scoped: true,
+      worktree_path: "/repo/app/.acorn/worktrees/feature",
+    });
+
+    expect(
+      resolveActiveSessionScope({
+        sessions: [isolated],
+        projects: [project("/repo/app")],
+        activeSessionId: "isolated",
+        activeWorkspaceRepoPath: "/repo/app",
+      }),
+    ).toEqual({
+      repoPath: "/repo/app",
+      cwdPath: "/repo/app/.acorn/worktrees/feature",
+      projectScoped: true,
+    });
   });
 
   it("preserves the active project workspace when the active session is inside it", () => {

--- a/src/lib/sessionCreation.ts
+++ b/src/lib/sessionCreation.ts
@@ -50,7 +50,7 @@ export interface BuildSessionCreateOptions {
 export function scopeForSession(session: Session): SessionCreateScope {
   return {
     repoPath: session.repo_path,
-    cwdPath: session.isolated ? session.repo_path : session.worktree_path,
+    cwdPath: session.worktree_path,
     projectScoped: session.project_scoped !== false,
   };
 }

--- a/src/lib/terminalTheme.ts
+++ b/src/lib/terminalTheme.ts
@@ -31,7 +31,7 @@ export interface TerminalPalette {
 }
 
 // Default xterm ANSI palette for dark themes. Mirrors the One Dark family the
-// stock Acorn Dark theme is tuned for, so a stream of ANSI-coloured output
+// stock Acorn Dark Green theme is tuned for, so a stream of ANSI-coloured output
 // from agent TUIs and shells stays readable on the default background.
 export const DARK_PALETTE: TerminalPalette = {
   background: "#1f2326",

--- a/src/lib/themes.test.ts
+++ b/src/lib/themes.test.ts
@@ -16,6 +16,7 @@ describe("BUILT_IN_THEMES", () => {
   it("ships an expanded set of built-in themes", () => {
     expect(BUILT_IN_THEMES.map((theme) => theme.id)).toEqual([
       "acorn-dark",
+      "acorn-pink",
       "one-dark-pro",
       "monokai-pro",
       "kanagawa-wave",
@@ -40,13 +41,25 @@ describe("BUILT_IN_THEMES", () => {
       "one-light",
       "gruvbox-light",
     ]);
-    expect(BUILT_IN_THEMES).toHaveLength(24);
+    expect(BUILT_IN_THEMES).toHaveLength(25);
     expect(BUILT_IN_THEMES.filter((theme) => theme.mode === "dark")).toHaveLength(
-      16,
+      17,
     );
     expect(
       BUILT_IN_THEMES.filter((theme) => theme.mode === "light"),
     ).toHaveLength(8);
+  });
+
+  it("keeps Acorn built-in theme ids and labels stable", () => {
+    expect(
+      BUILT_IN_THEMES.slice(0, 2).map((theme) => ({
+        id: theme.id,
+        label: theme.label,
+      })),
+    ).toEqual([
+      { id: "acorn-dark", label: "Acorn Dark Green" },
+      { id: "acorn-pink", label: "Acorn Dark Pink" },
+    ]);
   });
 
   it("every built-in css passes validation", () => {

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -5,6 +5,7 @@ import { create } from "zustand";
 
 import acornDarkCss from "../assets/themes/acorn-dark.css?raw";
 import acornLightCss from "../assets/themes/acorn-light.css?raw";
+import acornPinkCss from "../assets/themes/acorn-pink.css?raw";
 import ayuDarkCss from "../assets/themes/ayu-dark.css?raw";
 import catppuccinLatteCss from "../assets/themes/catppuccin-latte.css?raw";
 import catppuccinMochaCss from "../assets/themes/catppuccin-mocha.css?raw";
@@ -56,9 +57,16 @@ export const THEME_CSS_VARS = [
 export const BUILT_IN_THEMES: ReadonlyArray<AcornTheme> = [
   {
     id: "acorn-dark",
-    label: "Acorn Dark",
+    label: "Acorn Dark Green",
     mode: "dark",
     css: acornDarkCss,
+    source: "builtin",
+  },
+  {
+    id: "acorn-pink",
+    label: "Acorn Dark Pink",
+    mode: "dark",
+    css: acornPinkCss,
     source: "builtin",
   },
   {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -177,6 +177,12 @@
         "label": "Theme",
         "hint": "Built-in palettes and valid CSS files from the themes folder.",
         "custom": "(custom)",
+        "groups": {
+          "acorn": "Acorn themes",
+          "dark": "Built-in dark",
+          "light": "Built-in light",
+          "custom": "Custom themes"
+        },
         "rescanTitle": "Rescan themes folder",
         "refresh": "Refresh",
         "revealFolder": "Reveal folder"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -177,6 +177,7 @@
         "label": "Theme",
         "hint": "Built-in palettes and valid CSS files from the themes folder.",
         "custom": "(custom)",
+        "searchPlaceholder": "Search themes",
         "groups": {
           "acorn": "Acorn themes",
           "dark": "Built-in dark",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -177,6 +177,7 @@
         "label": "테마",
         "hint": "내장 팔레트와 themes 폴더의 유효한 CSS 파일입니다.",
         "custom": "(사용자 지정)",
+        "searchPlaceholder": "테마 검색",
         "groups": {
           "acorn": "Acorn 테마",
           "dark": "내장 다크",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -177,6 +177,12 @@
         "label": "테마",
         "hint": "내장 팔레트와 themes 폴더의 유효한 CSS 파일입니다.",
         "custom": "(사용자 지정)",
+        "groups": {
+          "acorn": "Acorn 테마",
+          "dark": "내장 다크",
+          "light": "내장 라이트",
+          "custom": "사용자 지정 테마"
+        },
         "rescanTitle": "테마 폴더 다시 스캔",
         "refresh": "새로고침",
         "revealFolder": "폴더 보기"

--- a/stories/chat.stories.tsx
+++ b/stories/chat.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ChatCodeBlock } from "../src/components/chat/ChatCodeBlock";
+import { ChatMessageBody } from "../src/components/chat/ChatMessageBody";
+
+const meta = {
+  title: "Components/Chat",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[720px] rounded-lg border border-border bg-bg-elevated p-4 text-fg shadow-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const MessageBody: Story = {
+  render: () => (
+    <ChatMessageBody
+      content={[
+        "I added a compact Storybook setup and kept it separate from the app build.",
+        "",
+        "```tsx",
+        "export function Example() {",
+        "  return <button type=\"button\">Run</button>;",
+        "}",
+        "```",
+        "",
+        "- Existing Vite build remains unchanged",
+        "- Stories render Acorn UI components in isolation",
+      ].join("\n")}
+    />
+  ),
+};
+
+export const CodeBlock: Story = {
+  render: () => (
+    <ChatCodeBlock
+      language="tsx"
+      code={[
+        "import { TextInput } from './TextInput';",
+        "",
+        "export function SearchField() {",
+        "  return <TextInput placeholder=\"Search\" />;",
+        "}",
+      ].join("\n")}
+    />
+  ),
+};
+
+export const DiffBlock: Story = {
+  render: () => (
+    <ChatCodeBlock
+      language="diff"
+      code={[
+        "diff --git a/package.json b/package.json",
+        "@@ -1,4 +1,5 @@",
+        " {",
+        "+  \"storybook\": \"storybook dev -p 6006\",",
+        "   \"build\": \"tsc && vite build\"",
+        " }",
+      ].join("\n")}
+    />
+  ),
+};

--- a/stories/dialogs.stories.tsx
+++ b/stories/dialogs.stories.tsx
@@ -1,0 +1,154 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryBreakdownModal } from "../src/components/MemoryBreakdownModal";
+import { RemoveProjectDialog } from "../src/components/RemoveProjectDialog";
+import { RemoveProjectFolderDialog } from "../src/components/RemoveProjectFolderDialog";
+import { RemoveSessionDialog } from "../src/components/RemoveSessionDialog";
+import { WhatsNewModal } from "../src/components/WhatsNewModal";
+import type { ProjectFolder } from "../src/lib/projectFolders";
+import type { MemoryProcess, Project, Session } from "../src/lib/types";
+
+const meta = {
+  title: "Components/Dialogs",
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-screen bg-bg p-8 text-fg">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const project: Project = {
+  repo_path: "/Users/acorn/workspace",
+  name: "Acorn",
+  created_at: "2026-06-11T00:00:00Z",
+  position: 0,
+};
+
+const baseSession: Session = {
+  id: "session-1",
+  name: "storybook-setup",
+  repo_path: project.repo_path,
+  worktree_path: "/Users/acorn/workspace/.acorn/worktrees/storybook-setup",
+  branch: "storybook/setup",
+  isolated: true,
+  project_scoped: true,
+  status: "running",
+  created_at: "2026-06-11T00:00:00Z",
+  updated_at: "2026-06-11T00:00:00Z",
+  last_message: "Adding component stories",
+  title_source: "manual",
+  kind: "regular",
+  mode: "terminal",
+  owner: { kind: "user" },
+  position: 0,
+  in_worktree: true,
+  agent_provider: "codex",
+  agent_transcript_id: null,
+};
+
+const folder: ProjectFolder = {
+  id: "folder-1",
+  repoPath: project.repo_path,
+  name: "Storybook work",
+  cwdPath: "/Users/acorn/workspace",
+  position: 0,
+};
+
+const processes: MemoryProcess[] = [
+  {
+    pid: 1000,
+    parent_pid: null,
+    name: "Acorn",
+    command_line: "/Applications/Acorn.app/Contents/MacOS/acorn",
+    bytes: 180_000_000,
+    depth: 0,
+  },
+  {
+    pid: 1001,
+    parent_pid: 1000,
+    name: "node",
+    command_line: "node ./node_modules/.bin/vite",
+    bytes: 92_000_000,
+    depth: 1,
+  },
+  {
+    pid: 1002,
+    parent_pid: 1000,
+    name: "acornd",
+    command_line: "acornd --profile dev",
+    bytes: 48_000_000,
+    depth: 1,
+  },
+];
+
+export const RemoveSession: Story = {
+  render: () => (
+    <RemoveSessionDialog
+      session={baseSession}
+      canDeleteWorktree
+      onClose={() => undefined}
+    />
+  ),
+};
+
+export const RemoveProject: Story = {
+  render: () => (
+    <RemoveProjectDialog
+      project={project}
+      sessions={[baseSession, { ...baseSession, id: "session-2", isolated: false }]}
+      onClose={() => undefined}
+    />
+  ),
+};
+
+export const RemoveProjectFolder: Story = {
+  render: () => (
+    <RemoveProjectFolderDialog
+      folder={folder}
+      sessions={[baseSession]}
+      onClose={() => undefined}
+    />
+  ),
+};
+
+export const MemoryBreakdown: Story = {
+  render: () => (
+    <MemoryBreakdownModal
+      open
+      totalBytes={processes.reduce((sum, process) => sum + process.bytes, 0)}
+      processes={processes}
+      onClose={() => undefined}
+    />
+  ),
+};
+
+export const WhatsNew: Story = {
+  render: () => (
+    <WhatsNewModal
+      open
+      version="1.15.0"
+      currentVersion="1.14.0"
+      body={[
+        "## Summary",
+        "",
+        "- Added Storybook for component review.",
+        "- Kept the production app build path unchanged.",
+        "",
+        "```sh",
+        "pnpm run storybook",
+        "```",
+      ].join("\n")}
+      showInstall
+      onClose={() => undefined}
+      onInstall={() => undefined}
+    />
+  ),
+};

--- a/stories/feedback.stories.tsx
+++ b/stories/feedback.stories.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Copy, FolderOpen, RefreshCw, Settings, Trash2 } from "lucide-react";
+import { ContextMenu, type ContextMenuItem } from "../src/components/ContextMenu";
+import { FileDropHoverOverlay } from "../src/components/FileDropHoverOverlay";
+import { SessionTitleGeneratingIndicator } from "../src/components/SessionTitleGeneratingIndicator";
+import { StickyUserPrompt } from "../src/components/StickyUserPrompt";
+import { Tooltip } from "../src/components/Tooltip";
+
+const meta = {
+  title: "Components/Feedback",
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const menuItems: ContextMenuItem[] = [
+  { type: "group-title", label: "Session" },
+  { label: "Copy command", icon: <Copy size={12} />, onClick: () => undefined },
+  {
+    type: "submenu",
+    label: "Move to",
+    icon: <FolderOpen size={12} />,
+    children: [
+      { label: "Default", onClick: () => undefined },
+      { label: "Feature worktree", onClick: () => undefined },
+    ],
+  },
+  { type: "separator" },
+  {
+    label: "Remove session",
+    icon: <Trash2 size={12} />,
+    shortcut: "Del",
+    onClick: () => undefined,
+  },
+];
+
+export const TooltipPlacements: Story = {
+  render: () => (
+    <div className="grid grid-cols-2 gap-5 rounded-lg border border-border bg-bg-elevated p-6 text-xs text-fg">
+      <Tooltip label="Appears above" side="top" delay={150}>
+        <button className="rounded border border-border px-3 py-2">Top</button>
+      </Tooltip>
+      <Tooltip label="Appears below" side="bottom" delay={150}>
+        <button className="rounded border border-border px-3 py-2">Bottom</button>
+      </Tooltip>
+      <Tooltip label="Appears left" side="left" delay={150}>
+        <button className="rounded border border-border px-3 py-2">Left</button>
+      </Tooltip>
+      <Tooltip label="Appears right" side="right" delay={150}>
+        <button className="rounded border border-border px-3 py-2">Right</button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const OpenContextMenu: Story = {
+  parameters: {
+    layout: "fullscreen",
+  },
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <div className="h-screen bg-bg p-8 text-fg">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-md border border-border bg-bg-elevated px-3 py-1.5 text-xs"
+        >
+          Show menu
+        </button>
+        <ContextMenu
+          open={open}
+          x={72}
+          y={72}
+          items={menuItems}
+          onClose={() => setOpen(false)}
+        />
+      </div>
+    );
+  },
+};
+
+export const Indicators: Story = {
+  render: () => (
+    <div className="flex items-center gap-4 rounded-lg border border-border bg-bg-elevated p-5 text-xs text-fg">
+      <SessionTitleGeneratingIndicator label="Generating title" />
+      <span className="text-fg-muted">Generating session title</span>
+      <RefreshCw size={14} className="animate-spin text-accent" />
+      <Settings size={14} className="text-fg-muted" />
+    </div>
+  ),
+};
+
+export const DropOverlays: Story = {
+  parameters: {
+    layout: "fullscreen",
+  },
+  render: () => (
+    <div className="grid h-screen grid-cols-3 gap-4 bg-bg p-6 text-fg">
+      <div className="relative rounded-lg border border-border bg-bg-elevated">
+        <FileDropHoverOverlay purpose="preview" path="/tmp/design.png" />
+      </div>
+      <div className="relative rounded-lg border border-border bg-bg-elevated">
+        <FileDropHoverOverlay purpose="terminal" path="/tmp/script.sh" />
+      </div>
+      <div className="relative rounded-lg border border-border bg-bg-elevated">
+        <FileDropHoverOverlay purpose="tab" path="/tmp/session.log" />
+      </div>
+    </div>
+  ),
+};
+
+export const PinnedPrompt: Story = {
+  parameters: {
+    layout: "fullscreen",
+  },
+  render: () => {
+    useEffect(() => {
+      window.dispatchEvent(
+        new CustomEvent("acorn:context-prompt", {
+          detail: {
+            sessionId: "storybook-session",
+            prompt:
+              "Please add Storybook stories for the existing components.\\nKeep the app build isolated from Storybook config.",
+          },
+        }),
+      );
+    }, []);
+
+    return (
+      <div className="relative h-screen overflow-hidden bg-bg p-6 text-fg">
+        <StickyUserPrompt
+          sessionId="storybook-session"
+          agentProvider="codex"
+        />
+        <div className="mt-12 rounded-lg border border-border bg-bg-elevated p-4 text-xs text-fg-muted">
+          Terminal content sits under the pinned prompt banner.
+        </div>
+      </div>
+    );
+  },
+};

--- a/stories/identity.stories.tsx
+++ b/stories/identity.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AuthorAvatar } from "../src/components/AuthorAvatar";
+import { AuthorTag } from "../src/components/AuthorTag";
+
+const meta = {
+  title: "Components/Identity",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[360px] rounded-lg border border-border bg-bg-elevated p-4 text-fg shadow-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Authors: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 text-xs">
+      <div className="flex items-center gap-2">
+        <AuthorAvatar login="octocat" size={28} />
+        <AuthorTag login="octocat" size={28} />
+      </div>
+      <div className="flex items-center gap-2">
+        <AuthorTag login="dependabot[bot]" size={24} />
+      </div>
+      <div className="flex items-center gap-2">
+        <AuthorTag login={null} fallbackName="Local Author" />
+      </div>
+    </div>
+  ),
+};
+
+export const AvatarOnly: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <AuthorTag login="octocat" avatarOnly />
+      <AuthorTag login="github-actions[bot]" avatarOnly />
+      <AuthorAvatar login="im-ian" size={32} />
+    </div>
+  ),
+};

--- a/stories/media.stories.tsx
+++ b/stories/media.stories.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AcornRain } from "../src/components/AcornRain";
+import { ImageLightbox } from "../src/components/ImageLightbox";
+
+const meta = {
+  title: "Components/Media",
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Lightbox: Story = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <div className="h-screen bg-bg p-8 text-fg">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-md border border-border bg-bg-elevated px-3 py-1.5 text-xs"
+        >
+          Open lightbox
+        </button>
+        <ImageLightbox
+          image={
+            open
+              ? {
+                  src: "https://images.unsplash.com/photo-1515879218367-8466d910aaa4?w=1200&auto=format&fit=crop",
+                  alt: "Code on a laptop",
+                }
+              : null
+          }
+          onClose={() => setOpen(false)}
+        />
+      </div>
+    );
+  },
+};
+
+export const TreeShake: Story = {
+  render: () => (
+    <div className="h-screen bg-bg p-8 text-fg">
+      <button
+        type="button"
+        onClick={() => window.dispatchEvent(new Event("acorn:shake-tree"))}
+        className="rounded-md border border-border bg-bg-elevated px-3 py-1.5 text-xs"
+      >
+        Shake tree
+      </button>
+      <AcornRain />
+    </div>
+  ),
+};

--- a/stories/ui.stories.tsx
+++ b/stories/ui.stories.tsx
@@ -1,0 +1,218 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Bot,
+  CheckCircle2,
+  Eye,
+  Search,
+  Terminal,
+  XCircle,
+} from "lucide-react";
+import { CheckboxRow } from "../src/components/ui/CheckboxRow";
+import { Field } from "../src/components/ui/Field";
+import { IconInput } from "../src/components/ui/IconInput";
+import { Markdown } from "../src/components/ui/Markdown";
+import { Modal } from "../src/components/ui/Modal";
+import { ModalHeader } from "../src/components/ui/ModalHeader";
+import { RadioCard } from "../src/components/ui/RadioCard";
+import { RefreshButton } from "../src/components/ui/RefreshButton";
+import { Select } from "../src/components/ui/Select";
+import { Stepper } from "../src/components/ui/Stepper";
+import { TextInput } from "../src/components/ui/TextInput";
+
+const meta = {
+  title: "UI",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px] rounded-lg border border-border bg-bg-elevated p-4 text-fg shadow-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function FormControlsExample() {
+  const [backgroundSessions, setBackgroundSessions] = useState(true);
+  const [mode, setMode] = useState<"auto" | "manual">("auto");
+  const [scale, setScale] = useState(100);
+  const [refreshing, setRefreshing] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Field label="Project path" hint="Shown with the same compact field styling as Acorn dialogs.">
+        <TextInput defaultValue="/Users/acorn/workspace" />
+      </Field>
+
+      <Field label="Default agent">
+        <Select defaultValue="codex" className="w-full">
+          <option value="codex">Codex</option>
+          <option value="claude">Claude</option>
+          <option value="antigravity">Antigravity</option>
+        </Select>
+      </Field>
+
+      <Field label="Search">
+        <IconInput
+          leading={<Search size={13} />}
+          trailing={<Eye size={13} />}
+          placeholder="Filter sessions"
+        />
+      </Field>
+
+      <div className="flex items-center justify-between gap-3">
+        <Field label="UI scale">
+          <Stepper
+            value={scale}
+            min={75}
+            max={150}
+            step={5}
+            unit="%"
+            onChange={setScale}
+          />
+        </Field>
+        <RefreshButton
+          loading={refreshing}
+          onClick={() => {
+            setRefreshing(true);
+            window.setTimeout(() => setRefreshing(false), 700);
+          }}
+        />
+      </div>
+
+      <CheckboxRow
+        label="Keep sessions running in the background"
+        description="Session output and notifications continue while panes are hidden."
+        checked={backgroundSessions}
+        onChange={setBackgroundSessions}
+      />
+
+      <div className="grid gap-2">
+        <RadioCard
+          name="session-mode"
+          value="auto"
+          current={mode}
+          label="Automatic"
+          description="Let Acorn pick the best session behavior."
+          onSelect={setMode}
+        />
+        <RadioCard
+          name="session-mode"
+          value="manual"
+          current={mode}
+          label="Manual"
+          description="Choose session behavior per project."
+          onSelect={setMode}
+        />
+      </div>
+    </div>
+  );
+}
+
+export const FormControls: Story = {
+  render: () => <FormControlsExample />,
+};
+
+export const ValidationStates: Story = {
+  render: () => (
+    <div className="grid gap-3">
+      <IconInput
+        leading={<CheckCircle2 size={13} />}
+        defaultValue="acorn-worktree"
+      />
+      <IconInput
+        leading={<XCircle size={13} />}
+        defaultValue="missing path"
+        invalid
+      />
+      <TextInput defaultValue="readonly value" readOnly />
+    </div>
+  ),
+};
+
+export const MarkdownContent: Story = {
+  render: () => (
+    <Markdown
+      content={[
+        "### Pull request summary",
+        "",
+        "- [x] Build Storybook with Vite",
+        "- [ ] Add component fixtures",
+        "",
+        "| Area | Status |",
+        "| --- | --- |",
+        "| UI | Ready |",
+        "| Docs | Draft |",
+        "",
+        "> Markdown uses the same compact rendering as Acorn review panels.",
+        "",
+        "`pnpm run build:storybook`",
+      ].join("\n")}
+      onTaskToggle={() => undefined}
+    />
+  ),
+};
+
+export const DialogShell: Story = {
+  parameters: {
+    layout: "fullscreen",
+  },
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <div className="h-screen bg-bg p-8 text-fg">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-md border border-border bg-bg-elevated px-3 py-1.5 text-xs text-fg"
+        >
+          Open modal
+        </button>
+        <Modal
+          open={open}
+          onClose={() => setOpen(false)}
+          variant="dialog"
+          size="md"
+        >
+          <ModalHeader
+            title="Run command"
+            subtitle="Preview of the shared modal shell"
+            icon={<Terminal size={15} className="text-accent" />}
+            variant="dialog"
+            onClose={() => setOpen(false)}
+          />
+          <div className="space-y-3 px-4 py-4 text-sm">
+            <p className="text-fg-muted">
+              This story renders the shared Modal and ModalHeader components.
+            </p>
+            <div className="rounded-md border border-border bg-bg-sidebar p-3 font-mono text-xs">
+              pnpm run storybook
+            </div>
+          </div>
+          <footer className="flex justify-end gap-2 border-t border-border px-4 py-3">
+            <button
+              type="button"
+              className="rounded px-3 py-1 text-xs text-fg-muted hover:bg-bg-sidebar"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 rounded bg-accent px-3 py-1 text-xs font-medium text-white"
+            >
+              <Bot size={12} />
+              Run
+            </button>
+          </footer>
+        </Modal>
+      </div>
+    );
+  },
+};

--- a/stories/ui/button.stories.tsx
+++ b/stories/ui/button.stories.tsx
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Check,
+  Copy,
+  Download,
+  ExternalLink,
+  Play,
+  RefreshCw,
+  Settings,
+  Trash2,
+  X,
+} from "lucide-react";
+import { cn } from "../../src/lib/cn";
+
+type ButtonTone = "primary" | "secondary" | "ghost" | "danger";
+type ButtonSize = "sm" | "md" | "icon";
+
+interface ButtonExampleProps {
+  tone?: ButtonTone;
+  size?: ButtonSize;
+  disabled?: boolean;
+  children?: React.ReactNode;
+  icon?: React.ReactNode;
+}
+
+const toneClass: Record<ButtonTone, string> = {
+  primary:
+    "bg-accent px-3 py-1.5 font-medium text-bg hover:opacity-90 focus-visible:ring-accent/60",
+  secondary:
+    "border border-border bg-bg-elevated px-3 py-1.5 text-fg hover:bg-bg-sidebar focus-visible:ring-accent/50",
+  ghost:
+    "px-3 py-1.5 text-fg-muted hover:bg-bg-sidebar hover:text-fg focus-visible:ring-accent/50",
+  danger:
+    "bg-danger/15 px-3 py-1.5 font-medium text-danger hover:bg-danger/25 focus-visible:ring-danger/50",
+};
+
+const sizeClass: Record<ButtonSize, string> = {
+  sm: "h-7 rounded-md text-xs",
+  md: "h-8 rounded-md text-sm",
+  icon: "size-7 rounded",
+};
+
+function ButtonExample({
+  tone = "secondary",
+  size = "sm",
+  disabled = false,
+  children,
+  icon,
+}: ButtonExampleProps) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center gap-1.5 transition focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50",
+        toneClass[tone],
+        sizeClass[size],
+      )}
+    >
+      {icon}
+      {size === "icon" ? null : children}
+    </button>
+  );
+}
+
+const meta = {
+  title: "UI/Button",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[520px] rounded-lg border border-border bg-bg-elevated p-5 text-fg shadow-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-3">
+      <ButtonExample tone="primary" icon={<Play size={13} />}>
+        Run
+      </ButtonExample>
+      <ButtonExample tone="secondary" icon={<Download size={13} />}>
+        Export
+      </ButtonExample>
+      <ButtonExample tone="ghost" icon={<ExternalLink size={13} />}>
+        Open
+      </ButtonExample>
+      <ButtonExample tone="danger" icon={<Trash2 size={13} />}>
+        Remove
+      </ButtonExample>
+    </div>
+  ),
+};
+
+export const IconButtons: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <ButtonExample size="icon" tone="ghost" icon={<Settings size={14} />} />
+      <ButtonExample size="icon" tone="secondary" icon={<RefreshCw size={14} />} />
+      <ButtonExample size="icon" tone="secondary" icon={<Copy size={14} />} />
+      <ButtonExample size="icon" tone="danger" icon={<X size={14} />} />
+    </div>
+  ),
+};
+
+export const States: Story = {
+  render: () => (
+    <div className="grid gap-3">
+      <div className="flex items-center gap-3">
+        <ButtonExample tone="primary" icon={<Check size={13} />}>
+          Ready
+        </ButtonExample>
+        <ButtonExample tone="primary" disabled icon={<Play size={13} />}>
+          Disabled
+        </ButtonExample>
+      </div>
+      <div className="flex items-center gap-3">
+        <ButtonExample tone="secondary" icon={<RefreshCw size={13} />}>
+          Refresh
+        </ButtonExample>
+        <ButtonExample tone="secondary" disabled icon={<RefreshCw size={13} />}>
+          Refreshing
+        </ButtonExample>
+      </div>
+      <div className="flex items-center gap-3">
+        <ButtonExample tone="danger" icon={<Trash2 size={13} />}>
+          Delete
+        </ButtonExample>
+        <ButtonExample tone="danger" disabled icon={<Trash2 size={13} />}>
+          Locked
+        </ButtonExample>
+      </div>
+    </div>
+  ),
+};

--- a/stories/ui/checkbox-row.stories.tsx
+++ b/stories/ui/checkbox-row.stories.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CheckboxRow } from "../../src/components/ui/CheckboxRow";
+
+const meta = {
+  title: "UI/CheckboxRow",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px] rounded-lg border border-border bg-bg-elevated p-5 text-fg shadow-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => {
+    const [checked, setChecked] = useState(true);
+    return (
+      <CheckboxRow
+        label="Keep sessions running in the background"
+        description="Session output and notifications continue while panes are hidden."
+        checked={checked}
+        onChange={setChecked}
+      />
+    );
+  },
+};
+
+export const States: Story = {
+  render: () => (
+    <div className="grid gap-3">
+      <CheckboxRow
+        label="Enabled"
+        description="The option can be toggled."
+        checked
+        onChange={() => undefined}
+      />
+      <CheckboxRow
+        label="Unchecked"
+        description="A regular inactive state."
+        checked={false}
+        onChange={() => undefined}
+      />
+      <CheckboxRow
+        label="Disabled"
+        description="Unavailable options stay visible but muted."
+        checked={false}
+        disabled
+        onChange={() => undefined}
+      />
+    </div>
+  ),
+};

--- a/stories/ui/command-hint.stories.tsx
+++ b/stories/ui/command-hint.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CommandHint } from "../../src/components/ui/CommandHint";
+
+const meta = {
+  title: "UI/CommandHint",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[520px] rounded-lg border border-border bg-bg-elevated p-5 text-fg shadow-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="text-xs text-fg-muted">
+      Run <CommandHint command="gh auth login" repoPath={null} /> before
+      refreshing pull requests.
+    </div>
+  ),
+};
+
+export const LongCommand: Story = {
+  render: () => (
+    <CommandHint
+      command="pnpm exec vitest run src/components/ui/Select.test.tsx src/components/SettingsModal.test.tsx"
+      repoPath="/Users/acorn/workspace"
+      className="w-full"
+    />
+  ),
+};

--- a/stories/ui/field.stories.tsx
+++ b/stories/ui/field.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Search } from "lucide-react";
+import { Field } from "../../src/components/ui/Field";
+import { IconInput } from "../../src/components/ui/IconInput";
+import { TextInput } from "../../src/components/ui/TextInput";
+
+const meta = {
+  title: "UI/Field",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px] rounded-lg border border-border bg-bg-elevated p-5 text-fg shadow-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithHint: Story = {
+  render: () => (
+    <Field label="Project path" hint="Shown with Acorn's compact form spacing.">
+      <TextInput defaultValue="/Users/acorn/workspace" />
+    </Field>
+  ),
+};
+
+export const Stacked: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <Field label="Repository">
+        <TextInput defaultValue="im-ian/acorn" />
+      </Field>
+      <Field label="Filter" hint="Use the same wrapper for icon inputs.">
+        <IconInput leading={<Search size={13} />} placeholder="Changed files" />
+      </Field>
+    </div>
+  ),
+};

--- a/stories/ui/input.stories.tsx
+++ b/stories/ui/input.stories.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Eye, FolderOpen, Search, X } from "lucide-react";
+import { Field } from "../../src/components/ui/Field";
+import { IconInput } from "../../src/components/ui/IconInput";
+import { TextInput } from "../../src/components/ui/TextInput";
+
+const meta = {
+  title: "UI/Input",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px] rounded-lg border border-border bg-bg-elevated p-5 text-fg shadow-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const TextInputs: Story = {
+  render: () => (
+    <div className="grid gap-4">
+      <Field label="Project path" hint="Compact mono input used in dialogs.">
+        <TextInput defaultValue="/Users/acorn/workspace" />
+      </Field>
+      <Field label="Session title">
+        <TextInput placeholder="New session name" />
+      </Field>
+      <Field label="Readonly">
+        <TextInput readOnly defaultValue="generated-title" />
+      </Field>
+      <Field label="Disabled">
+        <TextInput disabled defaultValue="disabled value" />
+      </Field>
+    </div>
+  ),
+};
+
+export const IconInputs: Story = {
+  render: () => {
+    const [query, setQuery] = useState("storybook");
+    return (
+      <div className="grid gap-4">
+        <Field label="Search">
+          <IconInput
+            leading={<Search size={13} />}
+            trailing={
+              query ? (
+                <button
+                  type="button"
+                  aria-label="Clear search"
+                  onClick={() => setQuery("")}
+                  className="rounded p-0.5 text-fg-muted hover:bg-bg-sidebar hover:text-fg"
+                >
+                  <X size={12} />
+                </button>
+              ) : null
+            }
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+            placeholder="Filter sessions"
+          />
+        </Field>
+        <Field label="Location">
+          <IconInput
+            leading={<FolderOpen size={13} />}
+            trailing={<Eye size={13} />}
+            defaultValue="/Users/acorn/workspace"
+          />
+        </Field>
+        <Field label="Invalid">
+          <IconInput
+            leading={<Search size={13} />}
+            invalid
+            defaultValue="missing path"
+          />
+        </Field>
+      </div>
+    );
+  },
+};
+
+export const DenseForm: Story = {
+  render: () => (
+    <div className="grid gap-3">
+      <Field label="Repository">
+        <TextInput defaultValue="im-ian/acorn" />
+      </Field>
+      <Field label="Branch">
+        <TextInput defaultValue="feat/storybook-components" />
+      </Field>
+      <Field label="Filter">
+        <IconInput leading={<Search size={13} />} placeholder="Changed files" />
+      </Field>
+    </div>
+  ),
+};

--- a/stories/ui/markdown.stories.tsx
+++ b/stories/ui/markdown.stories.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Markdown } from "../../src/components/ui/Markdown";
+
+const sampleMarkdown = [
+  "### Pull request summary",
+  "",
+  "- [x] Add Storybook",
+  "- [ ] Review component coverage",
+  "",
+  "| Area | Status |",
+  "| --- | --- |",
+  "| UI | Ready |",
+  "| Build | Verified |",
+  "",
+  "> Markdown uses the same compact rendering as Acorn review panels.",
+  "",
+  "`pnpm run build:storybook`",
+].join("\n");
+
+const meta = {
+  title: "UI/Markdown",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[520px] rounded-lg border border-border bg-bg-elevated p-5 text-fg shadow-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Content: Story = {
+  render: () => <Markdown content={sampleMarkdown} />,
+};
+
+export const TaskList: Story = {
+  render: () => {
+    const [content, setContent] = useState(sampleMarkdown);
+    return (
+      <Markdown
+        content={content}
+        onTaskToggle={(index, checked) => {
+          let current = -1;
+          setContent((value) =>
+            value.replace(/- \[[ x]\]/g, (match) => {
+              current += 1;
+              if (current !== index) return match;
+              return checked ? "- [x]" : "- [ ]";
+            }),
+          );
+        }}
+      />
+    );
+  },
+};

--- a/stories/ui/modal.stories.tsx
+++ b/stories/ui/modal.stories.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ExternalLink, Terminal } from "lucide-react";
+import { Modal } from "../../src/components/ui/Modal";
+import { ModalHeader } from "../../src/components/ui/ModalHeader";
+
+const meta = {
+  title: "UI/Modal",
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Dialog: Story = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <div className="h-screen bg-bg p-8 text-fg">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-md border border-border bg-bg-elevated px-3 py-1.5 text-xs text-fg"
+        >
+          Open dialog
+        </button>
+        <Modal open={open} onClose={() => setOpen(false)} variant="dialog" size="md">
+          <ModalHeader
+            title="Run command"
+            subtitle="Preview of the shared dialog shell"
+            icon={<Terminal size={15} className="text-accent" />}
+            variant="dialog"
+            onClose={() => setOpen(false)}
+          />
+          <div className="space-y-3 px-4 py-4 text-sm">
+            <p className="text-fg-muted">
+              Dialog modals use the elevated surface and compact header.
+            </p>
+            <div className="rounded-md border border-border bg-bg-sidebar p-3 font-mono text-xs">
+              pnpm run storybook
+            </div>
+          </div>
+          <footer className="flex justify-end gap-2 border-t border-border px-4 py-3">
+            <button
+              type="button"
+              className="rounded px-3 py-1 text-xs text-fg-muted hover:bg-bg-sidebar"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="rounded bg-accent px-3 py-1 text-xs font-medium text-white"
+            >
+              Run
+            </button>
+          </footer>
+        </Modal>
+      </div>
+    );
+  },
+};
+
+export const Panel: Story = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <div className="h-screen bg-bg p-8 text-fg">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-md border border-border bg-bg-elevated px-3 py-1.5 text-xs text-fg"
+        >
+          Open panel
+        </button>
+        <Modal open={open} onClose={() => setOpen(false)} variant="panel" size="3xl">
+          <ModalHeader
+            title="Pull request details"
+            subtitle="Panel variant for larger workflows"
+            icon={<ExternalLink size={15} className="text-accent" />}
+            onClose={() => setOpen(false)}
+          />
+          <div className="grid flex-1 grid-cols-[220px_1fr] gap-4 overflow-hidden p-4 text-xs">
+            <aside className="rounded-md border border-border bg-bg-sidebar p-3 text-fg-muted">
+              Changed files
+            </aside>
+            <main className="rounded-md border border-border bg-bg-elevated p-3 text-fg">
+              Review content
+            </main>
+          </div>
+        </Modal>
+      </div>
+    );
+  },
+};

--- a/stories/ui/radio-card.stories.tsx
+++ b/stories/ui/radio-card.stories.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RadioCard } from "../../src/components/ui/RadioCard";
+
+const meta = {
+  title: "UI/RadioCard",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px] rounded-lg border border-border bg-bg-elevated p-5 text-fg shadow-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Group: Story = {
+  render: () => {
+    const [mode, setMode] = useState<"auto" | "manual" | "off">("auto");
+    return (
+      <div className="grid gap-2">
+        <RadioCard
+          name="session-mode"
+          value="auto"
+          current={mode}
+          label="Automatic"
+          description="Let Acorn pick the best session behavior."
+          onSelect={setMode}
+        />
+        <RadioCard
+          name="session-mode"
+          value="manual"
+          current={mode}
+          label="Manual"
+          description="Choose session behavior per project."
+          onSelect={setMode}
+        />
+        <RadioCard
+          name="session-mode"
+          value="off"
+          current={mode}
+          label="Off"
+          description="Disable this behavior for now."
+          onSelect={setMode}
+        />
+      </div>
+    );
+  },
+};

--- a/stories/ui/refresh-button.stories.tsx
+++ b/stories/ui/refresh-button.stories.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RefreshButton } from "../../src/components/ui/RefreshButton";
+
+const meta = {
+  title: "UI/RefreshButton",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="rounded-lg border border-border bg-bg-elevated p-5 text-fg shadow-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => {
+    const [loading, setLoading] = useState(false);
+    return (
+      <RefreshButton
+        loading={loading}
+        title="Refresh pull requests"
+        onClick={() => {
+          setLoading(true);
+          window.setTimeout(() => setLoading(false), 900);
+        }}
+      />
+    );
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <RefreshButton loading={false} size={12} onClick={() => undefined} />
+      <RefreshButton loading={false} size={14} onClick={() => undefined} />
+      <RefreshButton loading={false} size={18} onClick={() => undefined} />
+      <RefreshButton loading size={14} onClick={() => undefined} />
+    </div>
+  ),
+};

--- a/stories/ui/select.stories.tsx
+++ b/stories/ui/select.stories.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Field } from "../../src/components/ui/Field";
+import {
+  Select,
+  type SelectOptionGroup,
+} from "../../src/components/ui/Select";
+
+const agentOptions = [
+  {
+    value: "codex",
+    label: "Codex",
+    description: "Default coding agent",
+  },
+  {
+    value: "claude",
+    label: "Claude Code",
+    description: "Alternative terminal agent",
+  },
+  {
+    value: "antigravity",
+    label: "Antigravity",
+    description: "Experimental agent",
+  },
+];
+
+const themeGroups: SelectOptionGroup[] = [
+  {
+    label: "Acorn themes",
+    options: [
+      { value: "acorn-dark", label: "Acorn Dark Green" },
+      { value: "acorn-pink", label: "Acorn Dark Pink" },
+      { value: "acorn-light", label: "Acorn Light" },
+    ],
+  },
+  {
+    label: "Built-in dark",
+    options: [
+      { value: "one-dark-pro", label: "One Dark Pro" },
+      { value: "tokyo-night", label: "Tokyo Night" },
+      { value: "catppuccin-mocha", label: "Catppuccin Mocha" },
+    ],
+  },
+  {
+    label: "Built-in light",
+    options: [
+      { value: "github-light", label: "GitHub Light" },
+      { value: "one-light", label: "One Light" },
+      { value: "gruvbox-light", label: "Gruvbox Light" },
+    ],
+  },
+];
+
+const meta = {
+  title: "UI/Select",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px] rounded-lg border border-border bg-bg-elevated p-5 text-fg shadow-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: () => {
+    const [agent, setAgent] = useState("codex");
+    return (
+      <Field label="Default agent">
+        <Select
+          value={agent}
+          options={agentOptions}
+          onValueChange={setAgent}
+        />
+      </Field>
+    );
+  },
+};
+
+export const SearchableGroups: Story = {
+  render: () => {
+    const [theme, setTheme] = useState("acorn-dark");
+    return (
+      <Field label="Theme" hint="Searchable grouped select from #430.">
+        <Select
+          value={theme}
+          options={themeGroups}
+          searchable
+          searchPlaceholder="Search themes"
+          onValueChange={setTheme}
+        />
+      </Field>
+    );
+  },
+};
+
+export const Multiple: Story = {
+  render: () => {
+    const [metadata, setMetadata] = useState(["branch", "status"]);
+    return (
+      <Field label="Session metadata">
+        <Select
+          multiple
+          value={metadata}
+          options={[
+            { value: "branch", label: "Branch" },
+            { value: "status", label: "Status" },
+            { value: "agent", label: "Agent" },
+            { value: "worktree", label: "Worktree" },
+          ]}
+          onValuesChange={setMetadata}
+        />
+      </Field>
+    );
+  },
+};
+
+export const SeparatorsAndDisabled: Story = {
+  render: () => {
+    const [value, setValue] = useState("run");
+    return (
+      <Field label="Command">
+        <Select
+          value={value}
+          options={[
+            { type: "separator", label: "Common" },
+            { value: "run", label: "Run command" },
+            { value: "copy", label: "Copy command" },
+            { type: "separator", label: "Danger" },
+            { value: "delete", label: "Delete session", disabled: true },
+          ]}
+          onValueChange={setValue}
+        />
+      </Field>
+    );
+  },
+};

--- a/stories/ui/stepper.stories.tsx
+++ b/stories/ui/stepper.stories.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Field } from "../../src/components/ui/Field";
+import { Stepper } from "../../src/components/ui/Stepper";
+
+const meta = {
+  title: "UI/Stepper",
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[320px] rounded-lg border border-border bg-bg-elevated p-5 text-fg shadow-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Percent: Story = {
+  render: () => {
+    const [scale, setScale] = useState(100);
+    return (
+      <Field label="UI scale">
+        <Stepper
+          value={scale}
+          min={75}
+          max={150}
+          step={5}
+          unit="%"
+          onChange={setScale}
+        />
+      </Field>
+    );
+  },
+};
+
+export const Fractional: Story = {
+  render: () => {
+    const [opacity, setOpacity] = useState(0.8);
+    return (
+      <Field label="Opacity">
+        <Stepper
+          value={opacity}
+          min={0}
+          max={1}
+          step={0.05}
+          format={(value) => value.toFixed(2)}
+          onChange={setOpacity}
+        />
+      </Field>
+    );
+  },
+};

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -591,16 +591,18 @@ test.describe("right panel: groups", () => {
     await page.getByRole("button", { name: "Agents" }).click();
     await page.getByRole("button", { name: "History" }).click();
 
-    const filter = page.getByLabel("Filter by agent");
-    await expect(filter).toHaveValue("__all__");
+    const filter = page.getByRole("combobox", { name: "Filter by agent" });
+    await expect(filter).toContainText("All agents");
     await expect(page.getByText("Codex refactor")).toBeVisible();
     await expect(page.getByText("Claude outline")).toBeVisible();
 
-    await filter.selectOption("codex");
+    await filter.click();
+    await page.getByRole("option", { name: "Codex" }).click();
     await expect(page.getByText("Codex refactor")).toBeVisible();
     await expect(page.getByText("Claude outline")).toHaveCount(0);
 
-    await filter.selectOption("claude");
+    await filter.click();
+    await page.getByRole("option", { name: "Claude" }).click();
     await expect(page.getByText("Codex refactor")).toHaveCount(0);
     await expect(page.getByText("Claude outline")).toBeVisible();
   });

--- a/tests/e2e/settings-tabs.spec.ts
+++ b/tests/e2e/settings-tabs.spec.ts
@@ -162,8 +162,8 @@ test.describe("settings modal: tab content", () => {
 
     await modal.getByRole("button", { name: "인터페이스", exact: true }).click();
     await expect(modal.getByText("언어", { exact: true })).toBeVisible();
-    await expect(modal.getByRole("combobox", { name: "언어" })).toHaveValue(
-      "ko",
+    await expect(modal.getByRole("combobox", { name: "언어" })).toContainText(
+      "한국어",
     );
     await expect(
       modal.getByRole("button", { name: "기본값으로 재설정" }),


### PR DESCRIPTION
## Summary
This expands the shared UI surface with a searchable Select, grouped theme picker, and an isolated Storybook component catalog.

1. **Custom Select:** Replaced the native-only wrapper with a button-triggered combobox/listbox Select. Searchable callers opt in with `searchable`; the control supports search input, keyboard navigation, grouped options, separators, option descriptions, legacy `<option>` children, and a multi-select API.
2. **Theme picker:** Switched Settings > Appearance to searchable grouped theme options ordered as Acorn themes, other built-in dark themes, built-in light themes, then custom/user themes, with visual separators between groups.
3. **Storybook setup:** Added React/Vite Storybook as dev-only tooling with a Storybook-only Tauri opener mock, `storybook` / `build:storybook` scripts, ignored static output, and no production app entrypoint changes.
4. **Component catalog:** Added stories for existing app components and individual UI controls, including Button style patterns, Field, Input, Select, Stepper, CheckboxRow, RadioCard, RefreshButton, CommandHint, Modal, Markdown, feedback, identity, chat, media, and dialogs.
5. **Coverage:** Added focused Select tests and updated Settings/theme/session coverage for filtering, keyboard selection, multi-select behavior, option descriptions, separators, grouped theme ordering, and user themes.

## Expected impact
| Area | Impact |
| --- | --- |
| Settings > Appearance | Theme selection is searchable, keeps group headers, and adds visual dividers between groups without making the closed Select look like a text input. |
| Shared Select | Existing single-select callers keep `<option>` compatibility while future callers can use grouped options, descriptions, separators, searchable mode, or multi-select. |
| Storybook | Developers can inspect current components and UI primitives in isolation via `pnpm run storybook` or `pnpm run build:storybook`. |
| App build/runtime | Storybook dependencies and Tauri mocks are dev-only; `pnpm run build` still uses the existing app build path. |

## Design notes
- `Select` now owns trigger/search/listbox interaction instead of delegating to native `<select>`.
- Separators can be passed in options as `{ type: "separator" }` or `{ type: "separator", label: "..." }`; they render with `role="separator"` and are skipped by keyboard selection.
- Theme grouping stays at the Settings consumer edge so the underlying theme registry ids/order remain stable for existing code.
- Storybook aliases `@tauri-apps/plugin-opener` only inside `.storybook/main.ts`, so the production Vite config and app bundle are not affected.
- Button is documented as a Storybook style catalog for now because the app does not yet expose a shared Button component.

## Follow-up (not in this PR)
- Extract a shared Button component once production button call sites converge on a stable API.
- Add a production multi-select consumer when a settings surface needs one.
- Consider visual regression coverage for Storybook if the component catalog becomes part of the release gate.

## Test plan
- [x] `pnpm exec vitest run src/components/ui/Select.test.tsx src/components/SettingsModal.test.tsx src/lib/themes.test.ts src/lib/sessionCreation.test.ts` -> 4 files / 45 tests passed.
- [x] `pnpm run build:storybook` -> passed; Vite emitted chunk-size warnings.
- [x] `pnpm run build` -> passed; Vite emitted existing dynamic-import/chunk-size warnings.
- [x] `git diff --check` -> passed.

## Notes
- The Vite dynamic-import and chunk-size warnings are not introduced by the Storybook setup; they also appear in the existing app build path.
