### PR TITLE
fix(sessions): gate auto titles to eligible agent sessions

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -248,6 +248,10 @@ pub struct Session {
     pub last_message: Option<String>,
     #[serde(default = "default_title_source_for_existing_sessions")]
     pub title_source: SessionTitleSource,
+    /// Explicit opt-in for automatic title generation. `None` means the row
+    /// predates this field and callers should apply legacy compatibility rules.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_title_enabled: Option<bool>,
     /// Transcript id used when Acorn last generated this tab title. Manual
     /// renames clear this value; generated titles keep it so a later agent
     /// session rotation (for example Claude `/clear`) can generate a fresh
@@ -329,6 +333,7 @@ impl Session {
             updated_at: now,
             last_message: None,
             title_source: SessionTitleSource::Default,
+            auto_title_enabled: Some(false),
             generated_title_transcript_id: None,
             kind,
             mode: SessionMode::Terminal,
@@ -574,6 +579,7 @@ mod tests {
         let session = fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false);
 
         assert_eq!(session.title_source, SessionTitleSource::Default);
+        assert_eq!(session.auto_title_enabled, Some(false));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2238,6 +2238,11 @@ fn create_session_inner(
     let branch = worktree::current_branch(&worktree_path).unwrap_or_else(|_| "HEAD".to_string());
     let mut session = Session::new(name, repo.clone(), worktree_path, branch, isolated, kind);
     session.project_scoped = project_scoped;
+    session.auto_title_enabled = Some(auto_title_enabled_for_new_session(
+        kind,
+        mode,
+        agent_provider,
+    ));
     session.agent_provider = agent_provider;
     session.mode = mode;
     let inserted = state.sessions.insert(session);
@@ -2246,6 +2251,14 @@ fn create_session_inner(
     }
     persist(state);
     Ok(enrich_session(inserted))
+}
+
+fn auto_title_enabled_for_new_session(
+    kind: SessionKind,
+    mode: SessionMode,
+    agent_provider: Option<SessionAgentProvider>,
+) -> bool {
+    kind == SessionKind::Regular && (mode == SessionMode::Chat || agent_provider.is_some())
 }
 
 #[tauri::command]
@@ -4795,14 +4808,15 @@ pub fn acknowledge_staged_rev_mismatch(state: State<'_, AppState>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        collect_memory_usage_from_roots, create_unique_worktree, daemon_spawn_name_for_session,
-        font_name_from_path, infer_acornd_root_from_session_pids, inject_agent_hook_env,
-        memory_root_pids, remove_linked_worktree_at_path, should_remove_local_project_mirror,
+        auto_title_enabled_for_new_session, collect_memory_usage_from_roots,
+        create_unique_worktree, daemon_spawn_name_for_session, font_name_from_path,
+        infer_acornd_root_from_session_pids, inject_agent_hook_env, memory_root_pids,
+        remove_linked_worktree_at_path, should_remove_local_project_mirror,
         validate_editor_command, validate_new_project_name, ChatProviderAdapter,
         ProcessMemorySnapshot,
     };
     use crate::error::{AppError, AppResult};
-    use acorn_session::{Session, SessionAgentProvider, SessionKind};
+    use acorn_session::{Session, SessionAgentProvider, SessionKind, SessionMode};
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
@@ -5997,6 +6011,30 @@ mod tests {
         assert!(!env.contains_key("ACORN_AGENT_HOOK_TOKEN"));
         assert!(!env.contains_key("ACORN_AGENT_HOOK_SESSION_ID"));
         assert!(!env.contains_key("ACORN_AGENT_HOOK_PROVIDER"));
+    }
+
+    #[test]
+    fn auto_title_is_enabled_only_for_new_agent_and_chat_sessions() {
+        assert!(!auto_title_enabled_for_new_session(
+            SessionKind::Regular,
+            SessionMode::Terminal,
+            None,
+        ));
+        assert!(auto_title_enabled_for_new_session(
+            SessionKind::Regular,
+            SessionMode::Terminal,
+            Some(SessionAgentProvider::Codex),
+        ));
+        assert!(auto_title_enabled_for_new_session(
+            SessionKind::Regular,
+            SessionMode::Chat,
+            None,
+        ));
+        assert!(!auto_title_enabled_for_new_session(
+            SessionKind::Control,
+            SessionMode::Chat,
+            Some(SessionAgentProvider::Codex),
+        ));
     }
 
     #[test]

--- a/src-tauri/src/daemon_commands.rs
+++ b/src-tauri/src/daemon_commands.rs
@@ -344,6 +344,7 @@ pub fn daemon_adopt_session(
         updated_at: now,
         last_message: None,
         title_source: acorn_session::SessionTitleSource::Manual,
+        auto_title_enabled: Some(false),
         generated_title_transcript_id: None,
         kind,
         mode: acorn_session::SessionMode::Terminal,

--- a/src-tauri/src/session_titles.rs
+++ b/src-tauri/src/session_titles.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use acorn_session::{Session, SessionKind, SessionOwner, SessionTitleSource};
+use acorn_session::{Session, SessionKind, SessionMode, SessionOwner, SessionTitleSource};
 
 use crate::agent_history::{self, AgentHistoryProvider};
 use crate::agent_resume;
@@ -36,6 +36,9 @@ pub fn can_generate_title(session: &Session, transcript_id: Option<&str>) -> boo
     if !can_force_generate_title(session) {
         return false;
     }
+    if !auto_title_enabled(session) {
+        return false;
+    }
     match session.title_source {
         SessionTitleSource::Default => true,
         SessionTitleSource::Generated => transcript_id
@@ -46,6 +49,27 @@ pub fn can_generate_title(session: &Session, transcript_id: Option<&str>) -> boo
 
 pub fn can_force_generate_title(session: &Session) -> bool {
     session.kind == SessionKind::Regular && matches!(session.owner, SessionOwner::User)
+}
+
+fn auto_title_enabled(session: &Session) -> bool {
+    if let Some(enabled) = session.auto_title_enabled {
+        return enabled;
+    }
+
+    session.mode == SessionMode::Chat
+        || session.title_source == SessionTitleSource::Generated
+        || name_implies_agent_session(&session.name)
+}
+
+fn name_implies_agent_session(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    ["claude", "codex", "antigravity", "agy"]
+        .iter()
+        .any(|needle| {
+            lower
+                .split(|c: char| !c.is_ascii_alphanumeric())
+                .any(|part| part == *needle)
+        })
 }
 
 pub fn build_prompt(prompt: Option<&str>, title_context: &str) -> String {
@@ -373,7 +397,7 @@ mod tests {
     }
 
     #[test]
-    fn generation_is_limited_to_user_owned_default_regular_sessions() {
+    fn generation_is_limited_to_opted_in_user_owned_regular_sessions() {
         let mut session = Session::new(
             "repo".to_string(),
             PathBuf::from("/tmp/repo"),
@@ -382,6 +406,7 @@ mod tests {
             false,
             SessionKind::Regular,
         );
+        session.auto_title_enabled = Some(true);
         assert!(can_generate_title(&session, None));
 
         session.title_source = SessionTitleSource::Manual;
@@ -390,6 +415,51 @@ mod tests {
         session.title_source = SessionTitleSource::Default;
         session.owner = SessionOwner::control(uuid::Uuid::new_v4());
         assert!(!can_generate_title(&session, Some("transcript-1")));
+    }
+
+    #[test]
+    fn generation_requires_auto_title_opt_in() {
+        let mut session = Session::new(
+            "repo".to_string(),
+            PathBuf::from("/tmp/repo"),
+            PathBuf::from("/tmp/repo"),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        session.agent_provider = Some(acorn_session::SessionAgentProvider::Codex);
+
+        assert!(!can_generate_title(&session, Some("transcript-1")));
+
+        session.auto_title_enabled = Some(true);
+        assert!(can_generate_title(&session, Some("transcript-1")));
+    }
+
+    #[test]
+    fn legacy_generated_and_named_agent_sessions_can_auto_title() {
+        let mut generated = Session::new(
+            "generated-title".to_string(),
+            PathBuf::from("/tmp/repo"),
+            PathBuf::from("/tmp/repo"),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        generated.auto_title_enabled = None;
+        generated.title_source = SessionTitleSource::Generated;
+        generated.generated_title_transcript_id = Some("old-transcript".to_string());
+        assert!(can_generate_title(&generated, Some("new-transcript")));
+
+        let mut named = Session::new(
+            "codex resume".to_string(),
+            PathBuf::from("/tmp/repo"),
+            PathBuf::from("/tmp/repo"),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        named.auto_title_enabled = None;
+        assert!(can_generate_title(&named, Some("transcript-1")));
     }
 
     #[test]
@@ -425,6 +495,7 @@ mod tests {
             false,
             SessionKind::Regular,
         );
+        session.auto_title_enabled = Some(true);
         session.title_source = SessionTitleSource::Generated;
         session.generated_title_transcript_id = Some("old-transcript".to_string());
 

--- a/src-tauri/src/session_titles.rs
+++ b/src-tauri/src/session_titles.rs
@@ -436,6 +436,23 @@ mod tests {
     }
 
     #[test]
+    fn legacy_plain_terminals_do_not_auto_title_from_detected_child_agents() {
+        let mut session = Session::new(
+            "repo".to_string(),
+            PathBuf::from("/tmp/repo"),
+            PathBuf::from("/tmp/repo"),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        session.auto_title_enabled = None;
+        session.agent_provider = Some(acorn_session::SessionAgentProvider::Codex);
+        session.agent_transcript_id = Some("transcript-1".to_string());
+
+        assert!(!can_generate_title(&session, Some("transcript-1")));
+    }
+
+    #[test]
     fn legacy_generated_and_named_agent_sessions_can_auto_title() {
         let mut generated = Session::new(
             "generated-title".to_string(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,7 @@ import {
 } from "./lib/settings";
 import {
   autoTitleGenerationEnabledForSession,
+  canAutoGenerateSessionTitle,
   planAutoGenerateSessionTitles,
 } from "./lib/sessionTitle";
 import { applyBackgroundVars, clearBackgroundVars } from "./lib/background";
@@ -820,7 +821,7 @@ function App() {
         .sessions.find((session) => session.id === sessionId);
       return (
         latestSession != null &&
-        autoTitleGenerationEnabledForSession(
+        canAutoGenerateSessionTitle(
           latestSession,
           latestSettings.agents.autoGenerateSessionTitles,
         ) &&

--- a/src/lib/sessionTitle.test.ts
+++ b/src/lib/sessionTitle.test.ts
@@ -225,6 +225,36 @@ describe("session title helpers", () => {
     ).toBe(false);
   });
 
+  it("does not auto-title legacy plain terminals only because a child agent is detected", () => {
+    const legacy = session({
+      agent_provider: "codex",
+      agent_transcript_id: "codex-1",
+      status: "running",
+    });
+    delete legacy.auto_title_enabled;
+
+    expect(canAutoGenerateSessionTitle(legacy, true)).toBe(false);
+  });
+
+  it("keeps legacy generated and named agent sessions eligible", () => {
+    const generated = session({
+      title_source: "generated",
+      generated_title_transcript_id: "codex-1",
+      agent_transcript_id: "codex-2",
+      agent_provider: null,
+    });
+    delete generated.auto_title_enabled;
+
+    const named = session({
+      name: "Codex task",
+      agent_provider: null,
+    });
+    delete named.auto_title_enabled;
+
+    expect(canAutoGenerateSessionTitle(generated, true)).toBe(true);
+    expect(canAutoGenerateSessionTitle(named, true)).toBe(true);
+  });
+
   it("auto-titles explicit agent and chat sessions", () => {
     expect(
       canAutoGenerateSessionTitle(

--- a/src/lib/sessionTitle.test.ts
+++ b/src/lib/sessionTitle.test.ts
@@ -22,6 +22,7 @@ function session(overrides: Partial<Session> = {}): Session {
     updated_at: "2026-01-01T00:00:00Z",
     last_message: null,
     title_source: "default",
+    auto_title_enabled: true,
     kind: "regular",
     owner: { kind: "user" },
     position: null,
@@ -89,6 +90,9 @@ describe("session title helpers", () => {
       ),
     ).toBe(false);
     expect(canGenerateSessionTitle(session({ agent_provider: null }))).toBe(true);
+    expect(
+      canGenerateSessionTitle(session({ auto_title_enabled: false })),
+    ).toBe(false);
   });
 
   it("allows forced title generation for user-owned regular sessions", () => {

--- a/src/lib/sessionTitle.test.ts
+++ b/src/lib/sessionTitle.test.ts
@@ -207,11 +207,56 @@ describe("session title helpers", () => {
     ).toBe(true);
   });
 
+  it("does not auto-title a plain terminal only because a child agent is detected", () => {
+    expect(
+      canAutoGenerateSessionTitle(
+        session({
+          auto_title_enabled: false,
+          agent_provider: "codex",
+          agent_transcript_id: "codex-1",
+          status: "running",
+        }),
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("auto-titles explicit agent and chat sessions", () => {
+    expect(
+      canAutoGenerateSessionTitle(
+        session({
+          auto_title_enabled: true,
+          agent_provider: "codex",
+          agent_transcript_id: "codex-1",
+        }),
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      canAutoGenerateSessionTitle(
+        session({
+          auto_title_enabled: true,
+          agent_provider: null,
+          mode: "chat",
+          status: "needs_input",
+        }),
+        false,
+      ),
+    ).toBe(true);
+  });
+
   it("plans immediate generation for eligible sessions only", () => {
     expect(
       planAutoGenerateSessionTitles({
         sessions: [
           session({ id: "ready" }),
+          session({
+            id: "plain-terminal-with-agent",
+            auto_title_enabled: false,
+            agent_provider: "codex",
+            agent_transcript_id: "codex-1",
+            status: "running",
+          }),
           session({ id: "manual", title_source: "manual" }),
           session({ id: "terminal", agent_provider: null }),
           session({

--- a/src/lib/sessionTitle.ts
+++ b/src/lib/sessionTitle.ts
@@ -31,6 +31,7 @@ export function canGenerateSessionTitle(session: Session): boolean {
   const currentTranscriptId = session.agent_transcript_id?.trim();
   return (
     canForceGenerateSessionTitle(session) &&
+    autoTitleEligibleForSession(session) &&
     (titleSource === "default" ||
       (titleSource === "generated" &&
         currentTranscriptId != null &&
@@ -55,6 +56,18 @@ export function autoTitleGenerationEnabledForSession(
   enabled: boolean,
 ): boolean {
   return enabled || session.mode === "chat";
+}
+
+function autoTitleEligibleForSession(session: Session): boolean {
+  if (typeof session.auto_title_enabled === "boolean") {
+    return session.auto_title_enabled;
+  }
+
+  return (
+    session.mode === "chat" ||
+    session.title_source === "generated" ||
+    inferAgentProvider(session.name) != null
+  );
 }
 
 function hasAgentChatWork(session: Session): boolean {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -118,6 +118,7 @@ export interface Session {
   updated_at: string;
   last_message: string | null;
   title_source: SessionTitleSource;
+  auto_title_enabled?: boolean | null;
   generated_title_transcript_id?: string | null;
   kind: SessionKind;
   mode?: SessionMode;


### PR DESCRIPTION
## Summary
This keeps automatic session titles for explicit agent/chat sessions while preventing plain terminal sessions from being renamed only because a child agent process is detected.

1. **Persist auto-title intent.** Adds `auto_title_enabled` to session rows so new regular terminals opt out, while new chat and explicit agent sessions opt in at creation time.
2. **Gate frontend planning.** Updates the auto-title planner and in-flight freshness check to require eligibility before calling readiness/generation.
3. **Gate backend generation.** Mirrors the same opt-in in the Rust title guard so direct `generate_session_title` calls skip ineligible terminal sessions.
4. **Preserve compatibility.** Keeps legacy generated-title sessions and provider-named sessions eligible so transcript rotation can still refresh titles after upgrade.

## Expected impact

| Area | Impact |
| --- | --- |
| Plain terminal sessions | Running `claude`, `codex`, or `agy` inside an ordinary terminal no longer auto-renames the tab. |
| Explicit agent sessions | Auto-generated titles continue when the session was created as an agent session. |
| Chat sessions | Auto-generated titles continue, including when the global terminal auto-title setting is off. |
| Manual title regeneration | Still available for user-owned regular sessions with agent/chat work. |

## Design notes

- `agent_provider` and `agent_transcript_id` remain useful signals for status, icons, resume/fork, and manual regeneration, but they no longer imply auto-title eligibility by themselves.
- The backend remains authoritative: `session_title_readiness` and `generate_session_title` both go through the Rust `can_generate_title` guard, so frontend-only bypasses do not rename ineligible sessions.
- Existing rows without `auto_title_enabled` use compatibility rules for generated titles and provider-named sessions rather than treating every detected child-agent terminal as eligible.

## Test plan

- [x] `pnpm exec vitest run src/lib/sessionTitle.test.ts` — 1 file passed, 13 tests passed.
- [x] `pnpm run typecheck` — passed.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml session_titles::tests` — 17 tests passed.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml auto_title` — 3 tests passed.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-session new_sessions_start_with_default_title_source` — 1 test passed.
- [x] `pnpm run build:sidecar` — passed.
- [x] `pnpm run build` — passed.
- [x] `git diff --check` — passed.

## Notes

- `pnpm run build` completed with Vite warnings about existing static/dynamic import chunking and large chunks; the command exited successfully.