### PR TITLE
feat(sessions): warn before closing running sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import "./App.css";
 import { Sidebar } from "./components/Sidebar";
 import { StatusBar } from "./components/StatusBar";
 import { RemoveSessionDialog } from "./components/RemoveSessionDialog";
+import { RunningSessionCloseWarningDialog } from "./components/RunningSessionCloseWarningDialog";
 import { RemoveProjectDialog } from "./components/RemoveProjectDialog";
 import { LayoutRenderer } from "./components/LayoutRenderer";
 import { RightPanel } from "./components/RightPanel";
@@ -290,8 +291,16 @@ function App() {
   const pendingRemoveAutoDeletesWorktree =
     pendingRemove !== null &&
     shouldAutoDeleteSessionWorktree(pendingRemove, projectFolders);
+  const [runningCloseWarningConfirmedId, setRunningCloseWarningConfirmedId] =
+    useState<string | null>(null);
+  const pendingRemoveNeedsRunningWarning =
+    pendingRemove !== null &&
+    pendingRemove.status === "running" &&
+    settings.sessions.warnBeforeClosingRunning &&
+    runningCloseWarningConfirmedId !== pendingRemove.id;
   const pendingRemoveSkipsDialog =
     pendingRemove !== null &&
+    !pendingRemoveNeedsRunningWarning &&
     (pendingRemoveKeepsSharedWorktree ||
       (pendingRemoveAutoDeletesWorktree && autoDeleteWorktrees) ||
       (!pendingRemoveRecordedWorktree && !confirmRemoveSession));
@@ -1063,12 +1072,22 @@ function App() {
     };
   }, [activeSessionId, sessionIdsKey]);
 
+  useEffect(() => {
+    if (
+      runningCloseWarningConfirmedId !== null &&
+      pendingRemove?.id !== runningCloseWarningConfirmedId
+    ) {
+      setRunningCloseWarningConfirmedId(null);
+    }
+  }, [pendingRemove?.id, runningCloseWarningConfirmedId]);
+
   // Skip the confirmation dialog when Settings gives a deterministic removal
   // choice: shared worktree workspace sessions keep the worktree, plain
   // sessions can skip confirmation, and standalone isolated sessions can opt
   // into always deleting their worktree from disk.
   useEffect(() => {
     if (!pendingRemove) return;
+    if (pendingRemoveNeedsRunningWarning) return;
     const recordedWorktree = hasRecordedWorktree(pendingRemove);
     const canDeleteWorktree = canDeleteSessionWorktree(
       pendingRemove,
@@ -1108,6 +1127,7 @@ function App() {
     );
   }, [
     pendingRemove,
+    pendingRemoveNeedsRunningWarning,
     autoDeleteWorktrees,
     clearPendingRemove,
     confirmRemoveSession,
@@ -1692,8 +1712,24 @@ function App() {
           });
         }}
       />
+      <RunningSessionCloseWarningDialog
+        session={pendingRemoveNeedsRunningWarning ? pendingRemove : null}
+        onCancel={() => {
+          setRunningCloseWarningConfirmedId(null);
+          clearPendingRemove();
+        }}
+        onContinue={() => {
+          if (pendingRemove) {
+            setRunningCloseWarningConfirmedId(pendingRemove.id);
+          }
+        }}
+      />
       <RemoveSessionDialog
-        session={pendingRemoveSkipsDialog ? null : pendingRemove}
+        session={
+          pendingRemoveSkipsDialog || pendingRemoveNeedsRunningWarning
+            ? null
+            : pendingRemove
+        }
         canDeleteWorktree={pendingRemoveCanDeleteWorktree}
         onClose={(choice) => {
           const target = pendingRemove;

--- a/src/components/RunningSessionCloseWarningDialog.tsx
+++ b/src/components/RunningSessionCloseWarningDialog.tsx
@@ -1,0 +1,106 @@
+import { AlertTriangle } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import { useSettings } from "../lib/settings";
+import type { Session } from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
+import { Modal, ModalHeader } from "./ui";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+const TITLE_ID = "running-session-close-warning-title";
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
+
+interface RunningSessionCloseWarningDialogProps {
+  session: Session | null;
+  onCancel: () => void;
+  onContinue: () => void;
+}
+
+export function RunningSessionCloseWarningDialog({
+  session,
+  onCancel,
+  onContinue,
+}: RunningSessionCloseWarningDialogProps) {
+  const t = useTranslation();
+  const patchSessions = useSettings((s) => s.patchSessions);
+  const [dontWarnAgain, setDontWarnAgain] = useState(false);
+
+  useEffect(() => {
+    if (session) setDontWarnAgain(false);
+  }, [session?.id]);
+
+  function commitContinue() {
+    if (dontWarnAgain) {
+      patchSessions({ warnBeforeClosingRunning: false });
+    }
+    onContinue();
+  }
+
+  useDialogShortcuts(session !== null, {
+    onCancel,
+    onConfirm: commitContinue,
+  });
+
+  return (
+    <Modal
+      open={session !== null}
+      onClose={onCancel}
+      variant="dialog"
+      size="md"
+      ariaLabelledBy={TITLE_ID}
+    >
+      {session ? (
+        <>
+          <ModalHeader
+            title={dt(t, "dialogs.runningSessionClose.title")}
+            titleId={TITLE_ID}
+            icon={<AlertTriangle size={16} className="text-warning" />}
+            variant="dialog"
+            onClose={onCancel}
+          />
+          <div className="space-y-3 px-4 py-3 text-sm text-fg">
+            <p>{dt(t, "dialogs.runningSessionClose.message")}</p>
+            <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2">
+              <div className="text-[11px] uppercase tracking-wide text-fg-muted">
+                {dt(t, "dialogs.runningSessionClose.sessionLabel")}
+              </div>
+              <div className="mt-1 truncate font-mono text-xs text-accent">
+                {session.name}
+              </div>
+            </div>
+            <label className="flex cursor-pointer items-center gap-2 pt-1 text-xs text-fg-muted">
+              <input
+                type="checkbox"
+                checked={dontWarnAgain}
+                onChange={(e) => setDontWarnAgain(e.target.checked)}
+                className="accent-[var(--color-accent)]"
+              />
+              {dt(t, "dialogs.runningSessionClose.dontWarnAgain")}
+            </label>
+          </div>
+          <footer className="flex items-center justify-end gap-2 border-t border-border bg-bg-sidebar/40 px-4 py-3">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
+            >
+              {dt(t, "dialogs.common.cancel")}
+            </button>
+            <button
+              type="button"
+              onClick={commitContinue}
+              className="rounded-md bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition hover:bg-danger/25"
+            >
+              {dt(t, "dialogs.runningSessionClose.continue")}
+            </button>
+          </footer>
+        </>
+      ) : null}
+    </Modal>
+  );
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -660,6 +660,22 @@ function SessionSettings() {
         </label>
       </Field>
       <Field
+        label={st(t, "settings.sessions.warnBeforeClosingRunning.label")}
+        hint={st(t, "settings.sessions.warnBeforeClosingRunning.hint")}
+      >
+        <label className="flex items-center gap-2 text-xs text-fg">
+          <input
+            type="checkbox"
+            checked={settings.sessions.warnBeforeClosingRunning}
+            onChange={(e) =>
+              patchSessions({ warnBeforeClosingRunning: e.target.checked })
+            }
+            className="accent-[var(--color-accent)]"
+          />
+          {st(t, "settings.sessions.warnBeforeClosingRunning.checkbox")}
+        </label>
+      </Field>
+      <Field
         label={st(t, "settings.sessions.autoDeleteWorktrees.label")}
         hint={st(t, "settings.sessions.autoDeleteWorktrees.hint")}
       >

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -157,17 +157,19 @@ describe("session removal settings", () => {
   });
 
   it("keeps worktree auto-delete off by default", () => {
+    expect(DEFAULT_SETTINGS.sessions.warnBeforeClosingRunning).toBe(true);
     expect(DEFAULT_SETTINGS.sessions.autoDeleteWorktrees).toBe(false);
     expect(DEFAULT_SETTINGS.sessions.autoDeleteEmptyWorktreeWorkspaces).toBe(
       false,
     );
   });
 
-  it("loads a persisted worktree auto-delete preference", async () => {
+  it("loads persisted session removal preferences", async () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
         sessions: {
+          warnBeforeClosingRunning: false,
           autoDeleteWorktrees: true,
           autoDeleteEmptyWorktreeWorkspaces: true,
         },
@@ -180,6 +182,9 @@ describe("session removal settings", () => {
     expect(useSettings.getState().settings.sessions.autoDeleteWorktrees).toBe(
       true,
     );
+    expect(
+      useSettings.getState().settings.sessions.warnBeforeClosingRunning,
+    ).toBe(false);
     expect(
       useSettings.getState().settings.sessions
         .autoDeleteEmptyWorktreeWorkspaces,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -259,6 +259,12 @@ export interface AcornSettings {
      */
     confirmRemove: boolean;
     /**
+     * Warn before closing a session that Acorn currently marks as running.
+     * This sits ahead of the normal removal confirmation so users get an
+     * explicit chance to avoid killing active shell or agent work.
+     */
+    warnBeforeClosingRunning: boolean;
+    /**
      * Remove standalone isolated worktree sessions without asking whether to
      * keep the worktree directory. Shared worktree workspaces and linked
      * worktree sessions are preserved unless the user explicitly deletes them.
@@ -438,6 +444,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   },
   sessions: {
     confirmRemove: true,
+    warnBeforeClosingRunning: true,
     autoDeleteWorktrees: false,
     autoDeleteEmptyWorktreeWorkspaces: false,
     closeOnExit: false,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -100,6 +100,11 @@
         "hint": "Applies to plain sessions. Shared worktree sessions still ask before removal.",
         "checkbox": "Show confirmation dialog"
       },
+      "warnBeforeClosingRunning": {
+        "label": "Warn before closing a running session",
+        "hint": "Show a warning before closing a session that is still running. Closing a running session terminates its active shell or agent process.",
+        "checkbox": "Show running-session warning"
+      },
       "autoDeleteWorktrees": {
         "label": "Delete isolated worktrees without asking",
         "hint": "When removing a standalone isolated worktree session, skip the keep/delete prompt and delete its worktree from disk. Shared worktree workspaces are preserved.",
@@ -1173,6 +1178,13 @@
       "keepWorktree": "Keep worktree",
       "deleteWorktree": "Delete worktree",
       "remove": "Remove"
+    },
+    "runningSessionClose": {
+      "title": "Close running session?",
+      "message": "This session is still running. Closing it will terminate the active shell or agent process.",
+      "sessionLabel": "Session",
+      "dontWarnAgain": "Don't warn again (toggle in Settings → Sessions)",
+      "continue": "Close session"
     },
     "removeProject": {
       "title": "Close project",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -100,6 +100,11 @@
         "hint": "일반 세션에 적용됩니다. 공유 워크트리 세션은 제거 전에 계속 확인합니다.",
         "checkbox": "확인 대화상자 표시"
       },
+      "warnBeforeClosingRunning": {
+        "label": "실행 중인 세션을 닫기 전 경고",
+        "hint": "아직 실행 중인 세션을 닫기 전에 경고를 표시합니다. 실행 중인 세션을 닫으면 활성 셸이나 에이전트 프로세스가 종료됩니다.",
+        "checkbox": "실행 중 세션 경고 표시"
+      },
       "autoDeleteWorktrees": {
         "label": "묻지 않고 격리 워크트리 삭제",
         "hint": "단독 격리 워크트리 세션을 제거할 때 유지/삭제 확인을 건너뛰고 디스크의 워크트리를 삭제합니다. 공유 워크트리 작업공간은 유지됩니다.",
@@ -1173,6 +1178,13 @@
       "keepWorktree": "워크트리 유지",
       "deleteWorktree": "워크트리 삭제",
       "remove": "제거"
+    },
+    "runningSessionClose": {
+      "title": "실행 중인 세션을 닫을까요?",
+      "message": "이 세션은 아직 실행 중입니다. 닫으면 활성 셸이나 에이전트 프로세스가 종료됩니다.",
+      "sessionLabel": "세션",
+      "dontWarnAgain": "다시 경고하지 않기(설정 → 세션에서 변경)",
+      "continue": "세션 닫기"
     },
     "removeProject": {
       "title": "프로젝트 닫기",

--- a/tests/e2e/session-lifecycle.spec.ts
+++ b/tests/e2e/session-lifecycle.spec.ts
@@ -189,6 +189,106 @@ test.describe("session lifecycle", () => {
     expect(calls[0].removeWorktree).toBe(false);
   });
 
+  test("closing a running session shows a warning before removal", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          sessions: {
+            confirmRemove: false,
+            warnBeforeClosingRunning: true,
+          },
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __sessionRemoved?: boolean };
+      return w.__sessionRemoved
+        ? []
+        : [
+            {
+              id: "s-1",
+              name: "alpha",
+              repo_path: "/tmp/demo",
+              worktree_path: "/tmp/demo",
+              branch: "main",
+              isolated: false,
+              status: "running",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:05Z",
+              last_message: null,
+            },
+          ];
+    });
+    await tauri.handle("remove_session", (args) => {
+      const w = window as unknown as {
+        __removeCalls?: unknown[];
+        __sessionRemoved?: boolean;
+      };
+      w.__removeCalls = w.__removeCalls ?? [];
+      w.__removeCalls.push(args);
+      w.__sessionRemoved = true;
+      return null;
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-panel-id="sidebar"]');
+    const row = sidebar
+      .getByRole("button", { name: /^alpha main · Running/ })
+      .first();
+    await expect(row).toBeVisible();
+
+    await row.hover();
+    await sidebar
+      .getByRole("button", { name: "Remove session", exact: true })
+      .click();
+
+    const warning = page.getByRole("dialog", {
+      name: "Close running session?",
+    });
+    await expect(warning).toBeVisible();
+    await expect(warning).toContainText(
+      "Closing it will terminate the active shell or agent process.",
+    );
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __removeCalls?: unknown[] }).__removeCalls
+              ?.length ?? 0,
+        ),
+      )
+      .toBe(0);
+
+    await warning
+      .getByRole("checkbox", { name: /Don't warn again/ })
+      .click();
+    await warning.getByRole("button", { name: "Close session" }).click();
+
+    await expect(
+      sidebar.getByRole("button", { name: /^alpha main · Running/ }),
+    ).toHaveCount(0);
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __removeCalls?: unknown[] }).__removeCalls,
+    )) as Array<{ id: string; removeWorktree: boolean }>;
+    expect(calls).toEqual([{ id: "s-1", removeWorktree: false }]);
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("acorn:settings:v1");
+          return raw ? JSON.parse(raw).sessions?.warnBeforeClosingRunning : null;
+        }),
+      )
+      .toBe(false);
+  });
+
   test("standalone isolated worktree auto-delete skips the remove confirmation", async ({
     page,
     tauri,

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -141,4 +141,29 @@ test.describe("settings modal", () => {
       )
       .toBe(false);
   });
+
+  test("toggles the running-session close warning from Sessions settings", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "," });
+
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
+    await modal.getByRole("button", { name: /^(Sessions|세션)$/ }).click();
+
+    const checkbox = modal.getByRole("checkbox", {
+      name: /Show running-session warning|실행 중 세션 경고 표시/,
+    });
+    await expect(checkbox).toBeChecked();
+    await checkbox.click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("acorn:settings:v1");
+          return raw ? JSON.parse(raw).sessions?.warnBeforeClosingRunning : null;
+        }),
+      )
+      .toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
Adds a user-configurable guardrail before closing sessions that Acorn still marks as running.

1. **Running-session close warning** — show a confirmation modal before removing a running session, ahead of the existing remove/worktree prompts and auto-remove paths.
2. **Settings integration** — add `Settings → Sessions` control for the warning, with matching in-modal “don't warn again” behavior that updates the same setting.
3. **Regression coverage** — cover the warning flow, the Settings toggle, and settings persistence defaults.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Closing a running session | Could immediately remove the session and terminate its active shell/agent when other remove prompts were disabled or auto-skipped. | Shows a warning first, unless the user disables the warning. |
| Settings | No separate control for running-session close warnings. | Users can toggle the warning in `Settings → Sessions` or from the warning modal. |

## Design notes
- The warning is hosted in `App.tsx` at the existing `pendingRemoveId` boundary so sidebar buttons, tab close actions, and shortcut-driven session close paths share the same behavior.
- The new `sessions.warnBeforeClosingRunning` setting defaults to enabled and is persisted with the existing `acorn:settings:v1` settings store.
- The warning sits before the existing `RemoveSessionDialog` and before deterministic auto-removal branches, preserving the existing worktree deletion behavior after the user continues.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test -- src/lib/settings.test.ts src/components/SettingsModal.test.tsx src/components/RemoveSessionDialog.test.tsx` passes — Vitest ran 63 files / 631 tests
- [x] `pnpm run test:e2e -- tests/e2e/settings.spec.ts tests/e2e/session-lifecycle.spec.ts` passes — 11 Playwright tests
- [x] `pnpm run build` passes
- [x] `git diff --check` passes

## Notes
- `pnpm run build` still reports the existing Vite dynamic/static import and large chunk warnings for `api.ts`, `store.ts`, and the main bundle. This PR does not add new dynamic imports or change chunking.
