### PR TITLE
feat(theme): add Acorn Light Pink palette

### DIFF
--- a/src/assets/themes/acorn-light-pink.css
+++ b/src/assets/themes/acorn-light-pink.css
@@ -1,0 +1,15 @@
+/* @mode light */
+:root[data-acorn-theme="acorn-light-pink"] {
+  --color-bg: #ffffff;
+  --color-bg-elevated: #f5f6f7;
+  --color-bg-sidebar: #f0f1f3;
+  --color-fg: #1a1d20;
+  --color-fg-muted: oklch(45% 0.01 250);
+  --color-border: #d8dade;
+  --color-accent: oklch(50% 0.18 345);
+  --color-accent-hover: oklch(45% 0.18 345);
+  --color-danger: oklch(55% 0.22 25);
+  --color-warning: oklch(65% 0.16 75);
+  --color-terminal-bg: #ffffff;
+  --color-terminal-fg: #1a1d20;
+}

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -28,7 +28,14 @@ const mocks = vi.hoisted(() => ({
     {
       css: "",
       id: "acorn-light",
-      label: "Acorn Light",
+      label: "Acorn Light Green",
+      mode: "light" as const,
+      source: "builtin" as const,
+    },
+    {
+      css: "",
+      id: "acorn-light-pink",
+      label: "Acorn Light Pink",
       mode: "light" as const,
       source: "builtin" as const,
     },
@@ -488,7 +495,8 @@ describe("SettingsModal font controls", () => {
     expect(optionLabels()).toEqual([
       "Acorn Dark Green",
       "Acorn Dark Pink",
-      "Acorn Light",
+      "Acorn Light Green",
+      "Acorn Light Pink",
       "One Dark Pro",
       "GitHub Light",
       "Solarized Local (custom)",

--- a/src/lib/themes.test.ts
+++ b/src/lib/themes.test.ts
@@ -33,6 +33,7 @@ describe("BUILT_IN_THEMES", () => {
       "rose-pine",
       "ayu-dark",
       "acorn-light",
+      "acorn-light-pink",
       "github-light",
       "high-contrast-light",
       "flexoki-light",
@@ -41,13 +42,13 @@ describe("BUILT_IN_THEMES", () => {
       "one-light",
       "gruvbox-light",
     ]);
-    expect(BUILT_IN_THEMES).toHaveLength(25);
+    expect(BUILT_IN_THEMES).toHaveLength(26);
     expect(BUILT_IN_THEMES.filter((theme) => theme.mode === "dark")).toHaveLength(
       17,
     );
     expect(
       BUILT_IN_THEMES.filter((theme) => theme.mode === "light"),
-    ).toHaveLength(8);
+    ).toHaveLength(9);
   });
 
   it("keeps Acorn built-in theme ids and labels stable", () => {
@@ -59,6 +60,19 @@ describe("BUILT_IN_THEMES", () => {
     ).toEqual([
       { id: "acorn-dark", label: "Acorn Dark Green" },
       { id: "acorn-pink", label: "Acorn Dark Pink" },
+    ]);
+    expect(
+      BUILT_IN_THEMES.filter((theme) => theme.id.startsWith("acorn-")).map(
+        (theme) => ({
+          id: theme.id,
+          label: theme.label,
+        }),
+      ),
+    ).toEqual([
+      { id: "acorn-dark", label: "Acorn Dark Green" },
+      { id: "acorn-pink", label: "Acorn Dark Pink" },
+      { id: "acorn-light", label: "Acorn Light Green" },
+      { id: "acorn-light-pink", label: "Acorn Light Pink" },
     ]);
   });
 
@@ -123,7 +137,10 @@ describe("applyTheme", () => {
 
   it("replaces the previous theme on a second call", () => {
     applyTheme("acorn-dark", BUILT_IN_THEMES[0].css);
-    applyTheme("acorn-light", BUILT_IN_THEMES[3].css);
+    applyTheme(
+      "acorn-light",
+      BUILT_IN_THEMES.find((theme) => theme.id === "acorn-light")?.css ?? "",
+    );
 
     expect(document.querySelectorAll("style#acorn-theme")).toHaveLength(1);
     expect(document.documentElement.getAttribute("data-acorn-theme")).toBe(

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -5,6 +5,7 @@ import { create } from "zustand";
 
 import acornDarkCss from "../assets/themes/acorn-dark.css?raw";
 import acornLightCss from "../assets/themes/acorn-light.css?raw";
+import acornLightPinkCss from "../assets/themes/acorn-light-pink.css?raw";
 import acornPinkCss from "../assets/themes/acorn-pink.css?raw";
 import ayuDarkCss from "../assets/themes/ayu-dark.css?raw";
 import catppuccinLatteCss from "../assets/themes/catppuccin-latte.css?raw";
@@ -176,9 +177,16 @@ export const BUILT_IN_THEMES: ReadonlyArray<AcornTheme> = [
   },
   {
     id: "acorn-light",
-    label: "Acorn Light",
+    label: "Acorn Light Green",
     mode: "light",
     css: acornLightCss,
+    source: "builtin",
+  },
+  {
+    id: "acorn-light-pink",
+    label: "Acorn Light Pink",
+    mode: "light",
+    css: acornLightPinkCss,
     source: "builtin",
   },
   {

--- a/stories/ui/select.stories.tsx
+++ b/stories/ui/select.stories.tsx
@@ -30,7 +30,8 @@ const themeGroups: SelectOptionGroup[] = [
     options: [
       { value: "acorn-dark", label: "Acorn Dark Green" },
       { value: "acorn-pink", label: "Acorn Dark Pink" },
-      { value: "acorn-light", label: "Acorn Light" },
+      { value: "acorn-light", label: "Acorn Light Green" },
+      { value: "acorn-light-pink", label: "Acorn Light Pink" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
Adds a second light Acorn palette so the built-in Acorn theme family is named consistently across color variants.

1. **Theme naming** — renames the existing `Acorn Light` label to `Acorn Light Green` while keeping the stable `acorn-light` id.
2. **Light pink palette** — adds `Acorn Light Pink` as a built-in light theme using the existing light surfaces with a pink accent.
3. **Selector coverage** — updates Settings theme selector tests and Storybook select examples so the new Acorn theme appears in the Acorn themes group.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Appearance theme list | `Acorn Light` did not name its green accent | `Acorn Light Green` and `Acorn Light Pink` are both available |
| Saved settings | Existing `acorn-light` selections remain valid | No migration required; the id is unchanged |

## Design notes
- The existing `acorn-light` id is intentionally unchanged to preserve persisted appearance settings.
- `Acorn Light Pink` uses the same neutral light surface values as `Acorn Light Green`; only the accent and hover accent differ.
- The new theme id starts with `acorn-`, so the existing Settings grouping logic keeps it under `Acorn themes`.

## Test plan
- [x] `pnpm exec vitest run src/lib/themes.test.ts src/components/SettingsModal.test.tsx src/components/ui/Select.test.tsx` — 3 files, 35 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed
- [x] `git diff --check` — passed

## Notes
- `pnpm run build` still prints existing Vite dynamic/static import and chunk-size warnings. The build completed successfully, and these warnings are not introduced by this PR.
