### PR TITLE
fix(settings): consolidate menu placement

### DIFF
--- a/docs/CONTROL_SESSIONS.md
+++ b/docs/CONTROL_SESSIONS.md
@@ -33,7 +33,7 @@ Three entry points:
   opening a new tab.
 
 The first time you create one, Acorn shows a one-time guide. You can re-open
-it from Settings → Services → "Control sessions" or by clearing
+it from Settings → Sessions → "Control sessions" or by clearing
 `localStorage["acorn:control-guide-dismissed-v1"]`.
 
 A control session shows a small `Bot` accessory icon next to its name in the
@@ -155,7 +155,7 @@ out of the box.
 You only need a system-wide install when you want to call `acorn-ipc`
 from **outside** an Acorn terminal (debugging from your own shell, an
 external script, a Makefile, …). In that case use the Settings shortcut
-under Services → "Control sessions", which generates a single-line
+under Sessions → "Control sessions", which generates a single-line
 `ln -sf` command pointing at the bundled binary. The Copy button lands
 the command on your clipboard; paste it into a terminal and run it.
 
@@ -181,7 +181,7 @@ to a shared directory outside the worktree, for example
 honours that setting for Cargo's build output while still staging the final
 binaries under `src-tauri/binaries/`, where Tauri expects them.
 
-Settings → Services → "Control sessions" shows the resolved binary path
+Settings → Sessions → "Control sessions" shows the resolved binary path
 Acorn currently sees (it looks for `acorn-ipc` next to the running app
 binary; once the release bundle ships the CLI, that lookup will succeed
 out of the box) and a one-click "Copy install command" for whatever shim

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -70,11 +70,17 @@ const mocks = vi.hoisted(() => ({
       repoPath?: string | null,
     ) => Promise<string>
   >(),
+  getAcornIpcStatus: vi.fn(),
+  daemonStatus: vi.fn(),
+  daemonListSessions: vi.fn(),
 }));
 
 vi.mock("../lib/api", () => ({
   api: {
     previewSessionTitle: mocks.previewSessionTitle,
+    getAcornIpcStatus: mocks.getAcornIpcStatus,
+    daemonStatus: mocks.daemonStatus,
+    daemonListSessions: mocks.daemonListSessions,
   },
 }));
 
@@ -327,6 +333,22 @@ describe("SettingsModal font controls", () => {
       relativePath: "backgrounds/wallpaper.png",
     });
     mocks.removeBackgroundImage.mockResolvedValue(undefined);
+    mocks.getAcornIpcStatus.mockResolvedValue({
+      bundled_path: "/Applications/Acorn.app/Contents/MacOS/acorn-ipc",
+      bundled_exists: true,
+      shim_paths: [],
+    });
+    mocks.daemonStatus.mockResolvedValue({
+      running: false,
+      enabled: true,
+      daemon_version: null,
+      uptime_seconds: null,
+      session_count_total: null,
+      session_count_alive: null,
+      log_path: null,
+      last_error: null,
+    });
+    mocks.daemonListSessions.mockResolvedValue([]);
     useSettings.setState({
       open: true,
       settings: cloneSettings(),
@@ -412,7 +434,7 @@ describe("SettingsModal font controls", () => {
     });
   });
 
-  it("patches the resident terminal limit from the Terminal tab", async () => {
+  it("patches the resident terminal limit from the Sessions tab", async () => {
     const patchTerminal = vi.fn();
     useSettings.setState({
       settings: cloneSettings(),
@@ -423,7 +445,7 @@ describe("SettingsModal font controls", () => {
       root = createRoot(container);
       root.render(<SettingsModal />);
     });
-    openTerminalTab();
+    openSessionsTab();
     await act(async () => {
       await Promise.resolve();
     });
@@ -444,6 +466,26 @@ describe("SettingsModal font controls", () => {
     });
 
     expect(patchTerminal).toHaveBeenCalledWith({ maxMountedTerminals: 9 });
+  });
+
+  it("maps legacy Services deep links to the Sessions tab", async () => {
+    useSettings.setState({
+      open: false,
+      settings: cloneSettings(),
+    });
+    useSettings.getState().openTab("services");
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(document.body.textContent).toContain("Session lifecycle");
+    expect(document.body.textContent).toContain("Session runtime");
+    expect(document.body.textContent).not.toContain("Language");
   });
 
   it("does not render the Appearance font dropdown controls", async () => {
@@ -554,7 +596,7 @@ describe("SettingsModal font controls", () => {
       root = createRoot(container);
       root.render(<SettingsModal />);
     });
-    openInterfaceTab();
+    openAppearanceTab();
     await act(async () => {
       await Promise.resolve();
     });
@@ -630,7 +672,6 @@ describe("SettingsModal font controls", () => {
       "터미널",
       "에이전트",
       "세션",
-      "서비스",
       "GitHub",
       "편집기",
       "알림",

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -93,9 +93,8 @@ type Tab =
   | "interface"
   | "appearance"
   | "terminal"
-  | "agents"
   | "sessions"
-  | "services"
+  | "agents"
   | "github"
   | "editor"
   | "notifications"
@@ -108,9 +107,8 @@ const TABS: Array<{ id: Tab; labelKey: TranslationKey }> = [
   { id: "interface", labelKey: "settings.tabs.interface" },
   { id: "appearance", labelKey: "settings.tabs.appearance" },
   { id: "terminal", labelKey: "settings.tabs.terminal" },
-  { id: "agents", labelKey: "settings.tabs.agents" },
   { id: "sessions", labelKey: "settings.tabs.sessions" },
-  { id: "services", labelKey: "settings.tabs.services" },
+  { id: "agents", labelKey: "settings.tabs.agents" },
   { id: "github", labelKey: "settings.tabs.github" },
   { id: "editor", labelKey: "settings.tabs.editor" },
   { id: "notifications", labelKey: "settings.tabs.notifications" },
@@ -121,6 +119,9 @@ const TABS: Array<{ id: Tab; labelKey: TranslationKey }> = [
 ];
 
 const TAB_IDS = new Set<string>(TABS.map((t) => t.id));
+const TAB_ALIASES: Record<string, Tab> = {
+  services: "sessions",
+};
 type SettingsTranslator = Translator;
 
 type ShortcutItem = {
@@ -357,7 +358,7 @@ export function SettingsModal() {
   const t = useTranslation();
 
   // When the store reports a pending tab (e.g. StatusBar daemon button
-  // dispatched `acorn:open-settings` with `tab: "services"`),
+  // dispatched `acorn:open-settings` with `tab: "sessions"`),
   // jump there on the next render and clear the flag so subsequent
   // opens restore the user's manual tab choice. Subscribing to
   // `pendingTab` (not just `open`) makes the deep-link work even when
@@ -366,8 +367,9 @@ export function SettingsModal() {
   useEffect(() => {
     if (!open || pendingTab === null) return;
     const pending = consumePendingTab();
-    if (pending && TAB_IDS.has(pending)) {
-      setTab(pending as Tab);
+    const nextTab = pending ? (TAB_ALIASES[pending] ?? pending) : null;
+    if (nextTab && TAB_IDS.has(nextTab)) {
+      setTab(nextTab as Tab);
     }
   }, [open, pendingTab, consumePendingTab]);
 
@@ -432,15 +434,13 @@ export function SettingsModal() {
             <AppearanceSettings />
           ) : tab === "terminal" ? (
             <TerminalSettings />
+          ) : tab === "sessions" ? (
+            <SessionSettings />
           ) : tab === "agents" ? (
             <AgentSettings
               sessionTitlePromptOpen={sessionTitlePromptOpen}
               onSessionTitlePromptOpenChange={setSessionTitlePromptOpen}
             />
-          ) : tab === "sessions" ? (
-            <SessionSettings />
-          ) : tab === "services" ? (
-            <ServicesSettings />
           ) : tab === "github" ? (
             <GithubSettings />
           ) : tab === "editor" ? (
@@ -519,17 +519,6 @@ function TerminalSettings() {
           step={0.05}
           format={(n) => n.toFixed(2)}
           onChange={(n) => patchTerminal({ lineHeight: n })}
-        />
-      </Field>
-      <Field
-        label={st(t, "settings.terminal.maxMountedTerminals.label")}
-        hint={st(t, "settings.terminal.maxMountedTerminals.hint")}
-      >
-        <Stepper
-          value={settings.terminal.maxMountedTerminals}
-          min={MOUNTED_TERMINAL_LIMIT_MIN}
-          max={MOUNTED_TERMINAL_LIMIT_MAX}
-          onChange={(n) => patchTerminal({ maxMountedTerminals: n })}
         />
       </Field>
       <Field
@@ -645,113 +634,127 @@ function WeightSelect({ value, onChange }: WeightSelectProps) {
 function SessionSettings() {
   const settings = useSettings((s) => s.settings);
   const patchSessions = useSettings((s) => s.patchSessions);
-  const t = useTranslation();
-
-  return (
-    <section className="space-y-4">
-      <Field
-        label={st(t, "settings.sessions.confirmRemove.label")}
-        hint={st(t, "settings.sessions.confirmRemove.hint")}
-      >
-        <label className="flex items-center gap-2 text-xs text-fg">
-          <input
-            type="checkbox"
-            checked={settings.sessions.confirmRemove}
-            onChange={(e) =>
-              patchSessions({ confirmRemove: e.target.checked })
-            }
-            className="accent-[var(--color-accent)]"
-          />
-          {st(t, "settings.sessions.confirmRemove.checkbox")}
-        </label>
-      </Field>
-      <Field
-        label={st(t, "settings.sessions.warnBeforeClosingRunning.label")}
-        hint={st(t, "settings.sessions.warnBeforeClosingRunning.hint")}
-      >
-        <label className="flex items-center gap-2 text-xs text-fg">
-          <input
-            type="checkbox"
-            checked={settings.sessions.warnBeforeClosingRunning}
-            onChange={(e) =>
-              patchSessions({ warnBeforeClosingRunning: e.target.checked })
-            }
-            className="accent-[var(--color-accent)]"
-          />
-          {st(t, "settings.sessions.warnBeforeClosingRunning.checkbox")}
-        </label>
-      </Field>
-      <Field
-        label={st(t, "settings.sessions.autoDeleteWorktrees.label")}
-        hint={st(t, "settings.sessions.autoDeleteWorktrees.hint")}
-      >
-        <label className="flex items-center gap-2 text-xs text-fg">
-          <input
-            type="checkbox"
-            checked={settings.sessions.autoDeleteWorktrees}
-            onChange={(e) =>
-              patchSessions({ autoDeleteWorktrees: e.target.checked })
-            }
-            className="accent-[var(--color-accent)]"
-          />
-          {st(t, "settings.sessions.autoDeleteWorktrees.checkbox")}
-        </label>
-      </Field>
-      <Field
-        label={st(
-          t,
-          "settings.sessions.autoDeleteEmptyWorktreeWorkspaces.label",
-        )}
-        hint={st(
-          t,
-          "settings.sessions.autoDeleteEmptyWorktreeWorkspaces.hint",
-        )}
-      >
-        <label className="flex items-center gap-2 text-xs text-fg">
-          <input
-            type="checkbox"
-            checked={settings.sessions.autoDeleteEmptyWorktreeWorkspaces}
-            onChange={(e) =>
-              patchSessions({
-                autoDeleteEmptyWorktreeWorkspaces: e.target.checked,
-              })
-            }
-            className="accent-[var(--color-accent)]"
-          />
-          {st(
-            t,
-            "settings.sessions.autoDeleteEmptyWorktreeWorkspaces.checkbox",
-          )}
-        </label>
-      </Field>
-      <Field
-        label={st(t, "settings.sessions.closeOnExit.label")}
-        hint={st(t, "settings.sessions.closeOnExit.hint")}
-      >
-        <label className="flex items-center gap-2 text-xs text-fg">
-          <input
-            type="checkbox"
-            checked={settings.sessions.closeOnExit}
-            onChange={(e) => patchSessions({ closeOnExit: e.target.checked })}
-            className="accent-[var(--color-accent)]"
-          />
-          {st(t, "settings.sessions.closeOnExit.checkbox")}
-        </label>
-      </Field>
-    </section>
-  );
-}
-
-function ServicesSettings() {
+  const patchTerminal = useSettings((s) => s.patchTerminal);
   const t = useTranslation();
 
   return (
     <section className="space-y-6">
       <SettingsGroup
-        title={st(t, "settings.power.title")}
-        description={st(t, "settings.power.description")}
+        title={st(t, "settings.sessions.lifecycle.title")}
+        description={st(t, "settings.sessions.lifecycle.description")}
       >
-        <PowerSettings />
+        <div className="space-y-4">
+          <Field
+            label={st(t, "settings.sessions.confirmRemove.label")}
+            hint={st(t, "settings.sessions.confirmRemove.hint")}
+          >
+            <label className="flex items-center gap-2 text-xs text-fg">
+              <input
+                type="checkbox"
+                checked={settings.sessions.confirmRemove}
+                onChange={(e) =>
+                  patchSessions({ confirmRemove: e.target.checked })
+                }
+                className="accent-[var(--color-accent)]"
+              />
+              {st(t, "settings.sessions.confirmRemove.checkbox")}
+            </label>
+          </Field>
+          <Field
+            label={st(t, "settings.sessions.warnBeforeClosingRunning.label")}
+            hint={st(t, "settings.sessions.warnBeforeClosingRunning.hint")}
+          >
+            <label className="flex items-center gap-2 text-xs text-fg">
+              <input
+                type="checkbox"
+                checked={settings.sessions.warnBeforeClosingRunning}
+                onChange={(e) =>
+                  patchSessions({ warnBeforeClosingRunning: e.target.checked })
+                }
+                className="accent-[var(--color-accent)]"
+              />
+              {st(t, "settings.sessions.warnBeforeClosingRunning.checkbox")}
+            </label>
+          </Field>
+          <Field
+            label={st(t, "settings.sessions.autoDeleteWorktrees.label")}
+            hint={st(t, "settings.sessions.autoDeleteWorktrees.hint")}
+          >
+            <label className="flex items-center gap-2 text-xs text-fg">
+              <input
+                type="checkbox"
+                checked={settings.sessions.autoDeleteWorktrees}
+                onChange={(e) =>
+                  patchSessions({ autoDeleteWorktrees: e.target.checked })
+                }
+                className="accent-[var(--color-accent)]"
+              />
+              {st(t, "settings.sessions.autoDeleteWorktrees.checkbox")}
+            </label>
+          </Field>
+          <Field
+            label={st(
+              t,
+              "settings.sessions.autoDeleteEmptyWorktreeWorkspaces.label",
+            )}
+            hint={st(
+              t,
+              "settings.sessions.autoDeleteEmptyWorktreeWorkspaces.hint",
+            )}
+          >
+            <label className="flex items-center gap-2 text-xs text-fg">
+              <input
+                type="checkbox"
+                checked={settings.sessions.autoDeleteEmptyWorktreeWorkspaces}
+                onChange={(e) =>
+                  patchSessions({
+                    autoDeleteEmptyWorktreeWorkspaces: e.target.checked,
+                  })
+                }
+                className="accent-[var(--color-accent)]"
+              />
+              {st(
+                t,
+                "settings.sessions.autoDeleteEmptyWorktreeWorkspaces.checkbox",
+              )}
+            </label>
+          </Field>
+          <Field
+            label={st(t, "settings.sessions.closeOnExit.label")}
+            hint={st(t, "settings.sessions.closeOnExit.hint")}
+          >
+            <label className="flex items-center gap-2 text-xs text-fg">
+              <input
+                type="checkbox"
+                checked={settings.sessions.closeOnExit}
+                onChange={(e) =>
+                  patchSessions({ closeOnExit: e.target.checked })
+                }
+                className="accent-[var(--color-accent)]"
+              />
+              {st(t, "settings.sessions.closeOnExit.checkbox")}
+            </label>
+          </Field>
+        </div>
+      </SettingsGroup>
+      <SettingsGroup
+        title={st(t, "settings.sessions.runtime.title")}
+        description={st(t, "settings.sessions.runtime.description")}
+      >
+        <div className="space-y-4">
+          <Field
+            label={st(t, "settings.terminal.maxMountedTerminals.label")}
+            hint={st(t, "settings.terminal.maxMountedTerminals.hint")}
+          >
+            <Stepper
+              value={settings.terminal.maxMountedTerminals}
+              min={MOUNTED_TERMINAL_LIMIT_MIN}
+              max={MOUNTED_TERMINAL_LIMIT_MAX}
+              onChange={(n) => patchTerminal({ maxMountedTerminals: n })}
+            />
+          </Field>
+          <PowerSettings />
+        </div>
       </SettingsGroup>
       <ControlSessionInstallSection />
       <SettingsGroup
@@ -985,13 +988,10 @@ function GithubSettings() {
 function InterfaceSettings({ t }: { t: SettingsTranslator }) {
   const settings = useSettings((s) => s.settings);
   const patchLanguage = useSettings((s) => s.patchLanguage);
-  const patchStatusBar = useSettings((s) => s.patchStatusBar);
-  const patchSessionDisplay = useSettings((s) => s.patchSessionDisplay);
   const patchAppearance = useSettings((s) => s.patchAppearance);
-  const sessionDisplay = settings.sessionDisplay;
 
   return (
-    <section className="space-y-6">
+    <section className="space-y-4">
       <LanguageSection
         language={settings.language}
         onChange={patchLanguage}
@@ -1001,27 +1001,30 @@ function InterfaceSettings({ t }: { t: SettingsTranslator }) {
         value={settings.appearance.uiScalePercent}
         onChange={(uiScalePercent) => patchAppearance({ uiScalePercent })}
       />
-      <SessionDisplaySection
-        sessionDisplay={sessionDisplay}
-        patch={patchSessionDisplay}
-      />
-      <StatusBarSection
-        statusBar={settings.statusBar}
-        patch={patchStatusBar}
-      />
     </section>
   );
 }
 
 function AppearanceSettings() {
-  const appearance = useSettings((s) => s.settings.appearance);
+  const settings = useSettings((s) => s.settings);
   const patchAppearance = useSettings((s) => s.patchAppearance);
+  const patchSessionDisplay = useSettings((s) => s.patchSessionDisplay);
+  const patchStatusBar = useSettings((s) => s.patchStatusBar);
+  const appearance = settings.appearance;
 
   return (
     <section className="space-y-6">
       <ThemeSection
         themeId={appearance.themeId}
         onChange={(themeId) => patchAppearance({ themeId })}
+      />
+      <SessionDisplaySection
+        sessionDisplay={settings.sessionDisplay}
+        patch={patchSessionDisplay}
+      />
+      <StatusBarSection
+        statusBar={settings.statusBar}
+        patch={patchStatusBar}
       />
       <ToastPositionSection
         value={appearance.toastPosition}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1051,7 +1051,7 @@ function ServicesStatusButton() {
 
   const openDaemonSettings = useCallback(() => {
     window.dispatchEvent(
-      new CustomEvent("acorn:open-settings", { detail: { tab: "services" } }),
+      new CustomEvent("acorn:open-settings", { detail: { tab: "sessions" } }),
     );
     setOpen(false);
   }, []);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -456,7 +456,7 @@ export const api = {
    * Inspect the runtime environment for the `acorn-ipc` CLI: bundled binary
    * location and presence, the IPC socket path, and which of the common
    * `$PATH` shim locations already have a copy/symlink installed. Used by
-   * the Services → Control sessions settings section.
+   * the Sessions → Control sessions settings section.
    */
   getAcornIpcStatus(): Promise<AcornIpcStatus> {
     return invoke<AcornIpcStatus>("get_acorn_ipc_status");

--- a/src/lib/settings-events.ts
+++ b/src/lib/settings-events.ts
@@ -8,8 +8,8 @@
 
 /**
  * Pluck a tab id out of an open-settings event payload. Accepts:
- * * A bare string ("services").
- * * An object with a `tab` string property (`{ tab: "services" }`).
+ * * A bare string ("sessions").
+ * * An object with a `tab` string property (`{ tab: "sessions" }`).
  *
  * Returns `null` when no useable tab id can be extracted so the caller
  * falls back to a default `setOpen(true)` that preserves the user's

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -44,7 +44,6 @@
       "terminal": "Terminal",
       "agents": "Agents",
       "sessions": "Sessions",
-      "services": "Services",
       "github": "GitHub",
       "editor": "Editor",
       "notifications": "Notifications",
@@ -95,6 +94,14 @@
       }
     },
     "sessions": {
+      "lifecycle": {
+        "title": "Session lifecycle",
+        "description": "Confirmation and cleanup behavior for closing sessions and worktree-backed workspaces."
+      },
+      "runtime": {
+        "title": "Session runtime",
+        "description": "Runtime behavior that keeps long-running terminals usable while Acorn is open or restarting."
+      },
       "confirmRemove": {
         "label": "Confirm before removing a session",
         "hint": "Applies to plain sessions. Shared worktree sessions still ask before removal.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -44,7 +44,6 @@
       "terminal": "터미널",
       "agents": "에이전트",
       "sessions": "세션",
-      "services": "서비스",
       "github": "GitHub",
       "editor": "편집기",
       "notifications": "알림",
@@ -95,6 +94,14 @@
       }
     },
     "sessions": {
+      "lifecycle": {
+        "title": "세션 생명주기",
+        "description": "세션과 워크트리 기반 작업공간을 닫을 때의 확인 및 정리 동작입니다."
+      },
+      "runtime": {
+        "title": "세션 런타임",
+        "description": "Acorn이 열려 있거나 재시작되는 동안 장시간 실행되는 터미널을 유지하는 동작입니다."
+      },
       "confirmRemove": {
         "label": "세션 제거 전 확인",
         "hint": "일반 세션에 적용됩니다. 공유 워크트리 세션은 제거 전에 계속 확인합니다.",

--- a/tests/e2e/background-sessions.spec.ts
+++ b/tests/e2e/background-sessions.spec.ts
@@ -39,12 +39,12 @@ const DAEMON_RUNNING = {
   last_error: null,
 };
 
-async function openServicesSettings(page: import("./support").Page) {
+async function openSessionsSettings(page: import("./support").Page) {
   await page.goto("/");
   await pressHotkey(page, { mod: true, key: "," });
   const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
   await expect(modal).toBeVisible();
-  await modal.getByRole("button", { name: "Services", exact: true }).click();
+  await modal.getByRole("button", { name: "Sessions", exact: true }).click();
   return modal;
 }
 
@@ -69,7 +69,7 @@ test.describe("background sessions settings", () => {
       },
     ]);
 
-    const modal = await openServicesSettings(page);
+    const modal = await openSessionsSettings(page);
 
     await expect(modal.getByText("alpha", { exact: true })).toBeVisible();
     await expect(modal.getByText("s-1", { exact: true })).toHaveCount(0);
@@ -146,7 +146,7 @@ test.describe("background sessions settings", () => {
       return undefined;
     });
 
-    const modal = await openServicesSettings(page);
+    const modal = await openSessionsSettings(page);
     await modal.getByRole("button", { name: "Restore session" }).click();
 
     await expect(
@@ -221,7 +221,7 @@ test.describe("background sessions settings", () => {
       return 1;
     });
 
-    const modal = await openServicesSettings(page);
+    const modal = await openSessionsSettings(page);
 
     await expect(modal.getByText("live session", { exact: true })).toBeVisible();
     await expect(

--- a/tests/e2e/control-session-install.spec.ts
+++ b/tests/e2e/control-session-install.spec.ts
@@ -19,7 +19,7 @@ test.describe("control session: settings install section", () => {
     await pressHotkey(page, { mod: true, key: "," });
     const modal = page.getByRole("dialog", { name: /Settings/i });
     await expect(modal).toBeVisible();
-    await modal.getByRole("button", { name: "Services", exact: true }).click();
+    await modal.getByRole("button", { name: "Sessions", exact: true }).click();
 
     // The section heading is the visible label of the Field wrapping the
     // install card. Matching on the field label keeps us decoupled from
@@ -70,7 +70,7 @@ test.describe("control session: settings install section", () => {
     await page.goto("/");
     await pressHotkey(page, { mod: true, key: "," });
     const modal = page.getByRole("dialog", { name: /Settings/i });
-    await modal.getByRole("button", { name: "Services", exact: true }).click();
+    await modal.getByRole("button", { name: "Sessions", exact: true }).click();
 
     // Match the badge text exactly so we don't collide with the
     // "Installed shim" label that lives in the same card.
@@ -96,7 +96,7 @@ test.describe("control session: settings install section", () => {
     await page.goto("/");
     await pressHotkey(page, { mod: true, key: "," });
     const modal = page.getByRole("dialog", { name: /Settings/i });
-    await modal.getByRole("button", { name: "Services", exact: true }).click();
+    await modal.getByRole("button", { name: "Sessions", exact: true }).click();
 
     await expect(modal.getByText("missing", { exact: true })).toBeVisible();
     // No install command should render when the binary is absent — there

--- a/tests/e2e/settings-tabs.spec.ts
+++ b/tests/e2e/settings-tabs.spec.ts
@@ -37,7 +37,7 @@ const TAB_MARKERS: Array<{
     label: "Terminal",
     marker: {
       kind: "text",
-      pattern: /Resident terminal limit|메모리에 유지할 터미널 수/i,
+      pattern: /Open links on|링크 열기 방식/i,
     },
   },
   {
@@ -51,14 +51,6 @@ const TAB_MARKERS: Array<{
     marker: {
       kind: "text",
       pattern: /Confirm before removing|세션 제거 전 확인/i,
-    },
-  },
-  {
-    tab: /^(Services|서비스)$/,
-    label: "Services",
-    marker: {
-      kind: "text",
-      pattern: /Bundled binary|번들 바이너리/i,
     },
   },
   {
@@ -144,9 +136,8 @@ test.describe("settings modal: tab content", () => {
       "인터페이스",
       "모양",
       "터미널",
-      "에이전트",
       "세션",
-      "서비스",
+      "에이전트",
       "GitHub",
       "편집기",
       "알림",
@@ -174,6 +165,6 @@ test.describe("settings modal: tab content", () => {
 
     await modal.getByRole("button", { name: "터미널", exact: true }).click();
     await expect(modal.getByText("글꼴 패밀리")).toBeVisible();
-    await expect(modal.getByText("메모리에 유지할 터미널 수")).toBeVisible();
+    await expect(modal.getByText("링크 열기 방식")).toBeVisible();
   });
 });

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -114,7 +114,7 @@ test.describe("settings modal", () => {
 
     await pressHotkey(page, { mod: true, key: "," });
     const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
-    await modal.getByRole("button", { name: /^(Services|서비스)$/ }).click();
+    await modal.getByRole("button", { name: /^(Sessions|세션)$/ }).click();
 
     const checkbox = modal.getByRole("checkbox", {
       name: /Keep this Mac awake|이 Mac 잠자기 방지/,

--- a/tests/e2e/statusbar.spec.ts
+++ b/tests/e2e/statusbar.spec.ts
@@ -67,6 +67,7 @@ async function enableAgentTokenUsage(
 ): Promise<void> {
   await pressHotkey(page, { mod: true, key: "," });
   const modal = page.getByRole("dialog", { name: "Settings" });
+  await modal.getByRole("button", { name: "Appearance", exact: true }).click();
   await modal.getByRole("checkbox", { name: /Agent token usage/ }).click();
   await page.keyboard.press("Escape");
 }


### PR DESCRIPTION
## Summary
This PR reorganizes Settings so session runtime controls and display controls live under the tabs users expect.

1. **Session controls** — removes the separate Services settings tab, moves background sessions, control sessions, keep-awake, and resident terminal limit into Sessions, and keeps old `services` deep links aliased to Sessions.
2. **Display controls** — moves session row and status bar visibility controls from Interface to Appearance while leaving language/UI scale in Interface and terminal font/link settings in Terminal.
3. **Tests and docs** — updates locale strings, Settings unit/E2E coverage, and control-session docs to match the new Settings paths.

## Expected impact
| Area | Impact |
| --- | --- |
| Settings navigation | Session runtime controls are grouped in Sessions; display controls are grouped in Appearance. |
| Existing settings events | `{ tab: "services" }` still lands on Sessions through a compatibility alias. |
| Persisted settings | No storage schema changes; existing settings keys and patch functions are unchanged. |

## Design notes
- This is a render/navigation change only: the controls still write through the same `patchSessions`, `patchTerminal`, `patchPower`, `patchStatusBar`, and `patchSessionDisplay` paths.
- The StatusBar service-health menu now opens Sessions directly, while old `services` payloads remain supported for any stale callers.
- Terminal keeps terminal-specific presentation/input controls; Sessions owns long-running terminal runtime behavior.

## Test plan
- [x] `pnpm exec tsc --noEmit --pretty false` passes
- [x] `pnpm exec vitest run src/components/SettingsModal.test.tsx src/lib/settings-events.test.ts src/lib/settings.test.ts` passes — 80 tests
- [x] `pnpm exec playwright test tests/e2e/settings-tabs.spec.ts tests/e2e/settings.spec.ts tests/e2e/control-session-install.spec.ts tests/e2e/background-sessions.spec.ts tests/e2e/statusbar.spec.ts` passes — 18 tests
- [x] `pnpm run typecheck` passes
- [x] `git diff --check` passes

## Notes
- Playwright printed the existing `FORCE_COLOR` / `NO_COLOR` warning during local runs; the tests still passed.
