### PR TITLE
feat(sidebar): add instant session workspaces

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,9 +8,9 @@ import {
   FolderPlus,
   GitBranch,
   Home,
+  LayoutPanelLeft,
   MessageSquareText,
   MoreHorizontal,
-  PanelsTopLeft,
   Pencil,
   PencilLine,
   Plus,
@@ -80,6 +80,7 @@ import {
   buildLocalSessions,
 } from "../lib/sessionGrouping";
 import {
+  buildLocalSessionFolderGroups,
   buildProjectFolderGroups,
   defaultProjectFolderId,
   findProjectFolderById,
@@ -90,7 +91,6 @@ import {
 } from "../lib/projectFolders";
 import {
   applySessionCreateRequest,
-  buildLocalSessionCreateRequest,
   buildSessionCreateRequest,
   resolveActiveSessionScope,
   type SessionCreateScope,
@@ -145,6 +145,7 @@ const FOLDER_DRAG_PREFIX = "folder:";
 const SESSION_DRAG_PREFIX = "session:";
 const SESSION_FOLDER_DROP_PREFIX = `${SESSION_DRAG_PREFIX}folder:`;
 const SESSION_PROJECT_DROP_PREFIX = `${SESSION_DRAG_PREFIX}project:`;
+const LOCAL_SESSION_ROOT_DROP_ID = "__local-session-root__";
 const LOCAL_TERMINAL_AREA_SELECTOR = "[data-local-terminal-area='true']";
 
 type SidebarTranslationKey = Extract<TranslationKey, `sidebar.${string}`>;
@@ -257,9 +258,23 @@ export function Sidebar() {
       ),
     [projectFolders, projects, sessionFolderIds, sessions],
   );
+  const localWorkspaceGroups = useMemo(
+    () =>
+      buildLocalSessionFolderGroups(
+        projects,
+        sessions,
+        projectFolders,
+        sessionFolderIds,
+      ),
+    [projectFolders, projects, sessionFolderIds, sessions],
+  );
+  const allWorkspaceGroups = useMemo(
+    () => [...projectGroups, ...localWorkspaceGroups],
+    [localWorkspaceGroups, projectGroups],
+  );
   const pendingRemoveProjectFolderGroup = useMemo(() => {
     if (!pendingRemoveProjectFolderId) return null;
-    for (const project of projectGroups) {
+    for (const project of allWorkspaceGroups) {
       const folderGroup = project.folders.find(
         (candidate) =>
           candidate.folder.id === pendingRemoveProjectFolderId,
@@ -267,7 +282,7 @@ export function Sidebar() {
       if (folderGroup) return folderGroup;
     }
     return null;
-  }, [pendingRemoveProjectFolderId, projectGroups]);
+  }, [allWorkspaceGroups, pendingRemoveProjectFolderId]);
   const localSessions = useMemo(
     () => buildLocalSessions(sessions),
     [sessions],
@@ -352,6 +367,19 @@ export function Sidebar() {
     }
   }
 
+  async function onAddLocalWorkspace() {
+    try {
+      const home = await homeDir();
+      if (!home) return;
+      const folder = createProjectFolder(home);
+      if (!folder) return;
+      setActiveProjectFolder(folder.id);
+    } catch (e) {
+      console.error("create local workspace failed", e);
+      showToast(`${t("toasts.project.createFailed")} ${String(e)}`);
+    }
+  }
+
   async function onAddProjectFolderWorktree(repoPath: string) {
     try {
       const request = buildSessionCreateRequest(
@@ -422,7 +450,7 @@ export function Sidebar() {
   }
 
   function requestRemoveProjectFolder(folderId: string) {
-    const folderGroup = projectGroups
+    const folderGroup = [...projectGroups, ...localWorkspaceGroups]
       .flatMap((project) => project.folders)
       .find((candidate) => candidate.folder.id === folderId);
     if (!folderGroup) return;
@@ -449,7 +477,9 @@ export function Sidebar() {
       mode?: SessionMode,
     ) => Promise<void>
   >(async () => {});
-  const onNewLocalSessionRef = useRef<() => Promise<void>>(async () => {});
+  const onNewLocalSessionRef = useRef<
+    (scopeOverride?: SessionCreateScope) => Promise<void>
+  >(async () => {});
   const onAddProjectRef = useRef<() => Promise<void>>(async () => {});
 
   useEffect(() => {
@@ -469,11 +499,14 @@ export function Sidebar() {
       });
     };
     const newSession = () => {
+      const scope = activeScope();
       if (isLocalTerminalAreaFocused()) {
-        void onNewLocalSessionRef.current();
+        void onNewLocalSessionRef.current(
+          scope?.projectScoped === false ? scope : undefined,
+        );
         return;
       }
-      void onNewSessionRef.current(false, "regular", activeScope() ?? undefined);
+      void onNewSessionRef.current(false, "regular", scope ?? undefined);
     };
     const newIsolated = () => {
       const scope = activeScope();
@@ -580,13 +613,21 @@ export function Sidebar() {
     }
   }
 
-  async function onNewLocalSession() {
+  async function onNewLocalSession(scopeOverride?: SessionCreateScope) {
     try {
-      const home = await homeDir();
-      if (!home) return;
+      const repoPath = scopeOverride?.repoPath ?? (await homeDir());
+      if (!repoPath) return;
       const created = await applySessionCreateRequest(
         createSession,
-        buildLocalSessionCreateRequest({ sessions, projects }, home),
+        buildSessionCreateRequest(
+          { sessions, projects },
+          {
+            repoPath,
+            cwdPath: scopeOverride?.cwdPath,
+            projectScoped: false,
+            projectFolderId: scopeOverride?.projectFolderId,
+          },
+        ),
       );
       const error = useAppStore.getState().consumeError();
       if (!created || error) {
@@ -742,18 +783,19 @@ export function Sidebar() {
     if (activeId.startsWith(SESSION_DRAG_PREFIX)) {
       const activeSid = activeId.slice(SESSION_DRAG_PREFIX.length);
       const activeSession = sessions.find((s) => s.id === activeSid);
-      if (!activeSession || activeSession.project_scoped === false) return;
+      if (!activeSession) return;
       const activeFolderId = projectFolderIdForSession(
-        projectGroups,
+        allWorkspaceGroups,
         activeSid,
       );
       const activeFolder = activeFolderId
-        ? projectFolderById(projectGroups, activeFolderId)
+        ? projectFolderById(allWorkspaceGroups, activeFolderId)
         : null;
 
       if (overId.startsWith(SESSION_FOLDER_DROP_PREFIX)) {
         const folderId = overId.slice(SESSION_FOLDER_DROP_PREFIX.length);
-        const targetFolder = projectFolderById(projectGroups, folderId);
+        const targetFolder = projectFolderById(allWorkspaceGroups, folderId);
+        if (targetFolder?.repoPath !== activeSession.repo_path) return;
         if (
           isSessionDragCrossingLockedWorkspace(
             activeSession,
@@ -770,9 +812,22 @@ export function Sidebar() {
       }
 
       if (overId.startsWith(SESSION_PROJECT_DROP_PREFIX)) {
-        const repoPath = overId.slice(SESSION_PROJECT_DROP_PREFIX.length);
+        const dropRepoPath = overId.slice(SESSION_PROJECT_DROP_PREFIX.length);
+        if (
+          dropRepoPath === LOCAL_SESSION_ROOT_DROP_ID &&
+          activeSession.project_scoped !== false
+        ) {
+          return;
+        }
+        const repoPath =
+          dropRepoPath === LOCAL_SESSION_ROOT_DROP_ID
+            ? activeSession.repo_path
+            : dropRepoPath;
         const targetFolderId = defaultProjectFolderId(repoPath);
-        const targetFolder = projectFolderById(projectGroups, targetFolderId);
+        const targetFolder = projectFolderById(
+          allWorkspaceGroups,
+          targetFolderId,
+        );
         if (
           isSessionDragCrossingLockedWorkspace(
             activeSession,
@@ -808,13 +863,19 @@ export function Sidebar() {
       }
       // Cross-project drops are not supported yet — silently ignore.
       if (activeSession.repo_path !== overSession.repo_path) return;
-      const activeFolderId = projectFolderIdForSession(projectGroups, activeSid);
-      const overFolderId = projectFolderIdForSession(projectGroups, overSid);
+      const activeFolderId = projectFolderIdForSession(
+        allWorkspaceGroups,
+        activeSid,
+      );
+      const overFolderId = projectFolderIdForSession(
+        allWorkspaceGroups,
+        overSid,
+      );
       const activeFolder = activeFolderId
-        ? projectFolderById(projectGroups, activeFolderId)
+        ? projectFolderById(allWorkspaceGroups, activeFolderId)
         : null;
       const overFolder = overFolderId
-        ? projectFolderById(projectGroups, overFolderId)
+        ? projectFolderById(allWorkspaceGroups, overFolderId)
         : null;
       if (
         isSessionDragCrossingLockedWorkspace(
@@ -865,7 +926,6 @@ export function Sidebar() {
         }
       }
       if (
-        activeSession.project_scoped !== false &&
         activeFolderId &&
         overFolderId &&
         activeFolderId !== overFolderId
@@ -1020,12 +1080,28 @@ export function Sidebar() {
             </SortableContext>
           )}
           <LocalTerminalArea
-            sessions={localSessions}
+            groups={localWorkspaceGroups}
             activeSessionId={activeSessionId}
-            onCreate={onNewLocalSession}
+            activeProjectFolderId={activeProjectFolderId}
+            collapsedFolderIds={collapsedFolders}
+            onCreate={() => onNewLocalSession()}
+            onCreateInFolder={(folder) =>
+              onNewLocalSession({
+                repoPath: folder.repoPath,
+                cwdPath: folder.cwdPath,
+                projectScoped: false,
+                projectFolderId: folder.id,
+              })
+            }
+            onCreateWorkspace={onAddLocalWorkspace}
             onFocusArea={focusLocalSessions}
+            onSelectFolder={setActiveProjectFolder}
+            onToggleFolder={toggleProjectFolder}
             onSelectSession={selectSession}
             onRemoveSession={(s) => requestRemoveSession(s.id)}
+            onRenameFolder={renameProjectFolder}
+            onRemoveFolder={requestRemoveProjectFolder}
+            onMoveSessionToFolder={moveSessionToProjectFolder}
           />
           <DragOverlay dropAnimation={null}>
             {activeDragId
@@ -1270,7 +1346,7 @@ function WorkspaceIcon({
   size: number;
   className?: string;
 }) {
-  const Icon = isWorktreeWorkspace(folder) ? GitBranch : PanelsTopLeft;
+  const Icon = isWorktreeWorkspace(folder) ? GitBranch : LayoutPanelLeft;
   return <Icon size={size} className={className} />;
 }
 
@@ -2841,23 +2917,54 @@ function EmptyState({ onOpenProject }: { onOpenProject: () => void }) {
 }
 
 interface LocalTerminalAreaProps {
-  sessions: Session[];
+  groups: ProjectFolderProjectGroup[];
   activeSessionId: string | null;
+  activeProjectFolderId: string | null;
+  collapsedFolderIds: ReadonlySet<string>;
   onCreate: () => void;
+  onCreateInFolder: (folder: ProjectFolder) => void;
+  onCreateWorkspace: () => void;
   onFocusArea: () => void;
+  onSelectFolder: (folderId: string) => void;
+  onToggleFolder: (folderId: string) => void;
   onSelectSession: (id: string) => void;
   onRemoveSession: (session: Session) => void;
+  onRenameFolder: (folderId: string, name: string) => void;
+  onRemoveFolder: (folderId: string) => void;
+  onMoveSessionToFolder: (sessionId: string, folderId: string | null) => void;
 }
 
 function LocalTerminalArea({
-  sessions,
+  groups,
   activeSessionId,
+  activeProjectFolderId,
+  collapsedFolderIds,
   onCreate,
+  onCreateInFolder,
+  onCreateWorkspace,
   onFocusArea,
+  onSelectFolder,
+  onToggleFolder,
   onSelectSession,
   onRemoveSession,
+  onRenameFolder,
+  onRemoveFolder,
+  onMoveSessionToFolder,
 }: LocalTerminalAreaProps) {
   const t = useTranslation();
+  const sessions = useMemo(
+    () => groups.flatMap((group) => group.sessions),
+    [groups],
+  );
+  const hasNamedWorkspaces = groups.some((group) =>
+    group.folders.some((folderGroup) =>
+      !isDefaultProjectFolder(folderGroup.folder),
+    ),
+  );
+  const { setNodeRef: setRootDropNodeRef } = useDroppable({
+    id: sessionProjectDropId(LOCAL_SESSION_ROOT_DROP_ID),
+    disabled: groups.length === 0,
+  });
   const sessionIds = useMemo(
     () => sessions.map((s) => sessionDragId(s.id)),
     [sessions],
@@ -2877,29 +2984,51 @@ function LocalTerminalArea({
         "rounded-md focus:outline-none",
       )}
     >
-      <header className="flex h-9 shrink-0 items-center justify-between gap-2 px-3">
+      <header
+        ref={setRootDropNodeRef}
+        className="flex h-9 shrink-0 items-center justify-between gap-2 px-3"
+      >
         <h2 className="text-xs font-medium text-fg-muted">
           {sidebarText(t, "sidebar.localTerminals.title")}
         </h2>
-        <Tooltip
-          label={sidebarText(t, "sidebar.localTerminals.newSession")}
-          side="bottom"
-        >
-          <button
-            type="button"
-            aria-label={sidebarText(t, "sidebar.localTerminals.newSession")}
-            onClick={(e) => {
-              e.stopPropagation();
-              onCreate();
-            }}
-            onDoubleClick={(e) => e.stopPropagation()}
-            className="rounded-md p-1.5 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+        <div className="flex items-center gap-1">
+          <Tooltip
+            label={sidebarText(t, "sidebar.localTerminals.newSession")}
+            side="bottom"
           >
-            <Plus size={14} />
-          </button>
-        </Tooltip>
+            <button
+              type="button"
+              aria-label={sidebarText(t, "sidebar.localTerminals.newSession")}
+              onClick={(e) => {
+                e.stopPropagation();
+                onCreate();
+              }}
+              onDoubleClick={(e) => e.stopPropagation()}
+              className="rounded-md p-1.5 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+            >
+              <Plus size={14} />
+            </button>
+          </Tooltip>
+          <Tooltip
+            label={sidebarText(t, "sidebar.localTerminals.newWorkspace")}
+            side="bottom"
+          >
+            <button
+              type="button"
+              aria-label={sidebarText(t, "sidebar.localTerminals.newWorkspace")}
+              onClick={(e) => {
+                e.stopPropagation();
+                onCreateWorkspace();
+              }}
+              onDoubleClick={(e) => e.stopPropagation()}
+              className="rounded-md p-1.5 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+            >
+              <LayoutPanelLeft size={13} />
+            </button>
+          </Tooltip>
+        </div>
       </header>
-      {sessions.length > 0 ? (
+      {sessions.length > 0 && !hasNamedWorkspaces ? (
         <div onDoubleClick={(e) => e.stopPropagation()}>
           <SortableContext
             items={sessionIds}
@@ -2919,6 +3048,70 @@ function LocalTerminalArea({
           </SortableContext>
         </div>
       ) : null}
+      {hasNamedWorkspaces ? (
+        <ul className="flex flex-col gap-0.5">
+          {groups.map((group) => {
+            const defaultFolderGroup =
+              group.folders.find((folderGroup) =>
+                isDefaultProjectFolder(folderGroup.folder),
+              ) ?? group.folders[0] ?? null;
+            const namedFolderGroups = group.folders.filter(
+              (folderGroup) => !isDefaultProjectFolder(folderGroup.folder),
+            );
+            return (
+              <li key={group.repoPath} className="flex flex-col gap-0.5">
+                {defaultFolderGroup?.sessions.length ? (
+                  <SortableContext
+                    items={defaultFolderGroup.sessions.map((session) =>
+                      sessionDragId(session.id),
+                    )}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    <ul className="flex flex-col gap-0.5">
+                      {defaultFolderGroup.sessions.map((session) => (
+                        <SessionRow
+                          key={session.id}
+                          session={session}
+                          active={session.id === activeSessionId}
+                          onSelect={() => onSelectSession(session.id)}
+                          onRemove={() => onRemoveSession(session)}
+                          projectFolders={group.folders.map(
+                            (folderGroup) => folderGroup.folder,
+                          )}
+                          currentProjectFolderId={
+                            defaultFolderGroup.folder.id
+                          }
+                          onMoveToProjectFolder={onMoveSessionToFolder}
+                        />
+                      ))}
+                    </ul>
+                  </SortableContext>
+                ) : null}
+                {namedFolderGroups.map((folderGroup) => (
+                  <LocalWorkspaceView
+                    key={folderGroup.folder.id}
+                    folderGroup={folderGroup}
+                    projectFolders={group.folders.map(
+                      (candidate) => candidate.folder,
+                    )}
+                    activeSessionId={activeSessionId}
+                    active={activeProjectFolderId === folderGroup.folder.id}
+                    collapsed={collapsedFolderIds.has(folderGroup.folder.id)}
+                    onToggleFolder={() => onToggleFolder(folderGroup.folder.id)}
+                    onActivate={() => onSelectFolder(folderGroup.folder.id)}
+                    onCreateSession={() => onCreateInFolder(folderGroup.folder)}
+                    onSelectSession={onSelectSession}
+                    onRemoveSession={onRemoveSession}
+                    onRenameFolder={onRenameFolder}
+                    onRemoveFolder={onRemoveFolder}
+                    onMoveSessionToFolder={onMoveSessionToFolder}
+                  />
+                ))}
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
       <div
         role="button"
         tabIndex={0}
@@ -2936,11 +3129,266 @@ function LocalTerminalArea({
         }}
         className="mx-1 mt-1 flex items-center justify-center rounded px-3 py-3 text-center text-[11px] text-fg-muted select-none focus:outline-none focus-visible:ring-1 focus-visible:ring-border"
       >
-        {sessions.length === 0
-          ? sidebarText(t, "sidebar.localTerminals.empty")
-          : null}
+        {sessions.length === 0 && groups.length === 0
+            ? sidebarText(t, "sidebar.localTerminals.empty")
+            : null}
       </div>
     </section>
+  );
+}
+
+interface LocalWorkspaceViewProps {
+  folderGroup: ProjectFolderGroup;
+  projectFolders: ProjectFolder[];
+  activeSessionId: string | null;
+  active: boolean;
+  collapsed: boolean;
+  onToggleFolder: () => void;
+  onActivate: () => void;
+  onCreateSession: () => void;
+  onSelectSession: (sessionId: string) => void;
+  onRemoveSession: (session: Session) => void;
+  onRenameFolder: (folderId: string, name: string) => void;
+  onRemoveFolder: (folderId: string) => void;
+  onMoveSessionToFolder: (sessionId: string, folderId: string | null) => void;
+}
+
+function LocalWorkspaceView({
+  folderGroup,
+  projectFolders,
+  activeSessionId,
+  active,
+  collapsed,
+  onToggleFolder,
+  onActivate,
+  onCreateSession,
+  onSelectSession,
+  onRemoveSession,
+  onRenameFolder,
+  onRemoveFolder,
+  onMoveSessionToFolder,
+}: LocalWorkspaceViewProps) {
+  const t = useTranslation();
+  const [editing, setEditing] = useState(false);
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const folder = folderGroup.folder;
+  const { setNodeRef } = useDroppable({
+    id: sessionFolderDropId(folder.id),
+  });
+  const sessionIds = useMemo(
+    () => folderGroup.sessions.map((session) => sessionDragId(session.id)),
+    [folderGroup.sessions],
+  );
+  const workspaceLabel = workspacePathLabel(folder);
+
+  function submitRename(next: string) {
+    setEditing(false);
+    onRenameFolder(folder.id, next);
+  }
+
+  const menuItems: ContextMenuItem[] = [
+    contextMenuGroupTitle(t, "session"),
+    {
+      label: sidebarText(t, "sidebar.localTerminals.newSession"),
+      icon: <Plus size={12} />,
+      onClick: onCreateSession,
+    },
+    contextMenuGroupTitle(t, "workspace"),
+    {
+      label: sidebarText(t, "sidebar.actions.renameProjectFolder"),
+      icon: <Pencil size={12} />,
+      onClick: () => setEditing(true),
+    },
+    {
+      label: sidebarText(t, "sidebar.actions.revealInFinder"),
+      icon: <FolderOpen size={12} />,
+      onClick: () => {
+        void api.fsReveal(folder.cwdPath);
+      },
+    },
+    {
+      label: sidebarText(t, "sidebar.actions.copyPath"),
+      icon: <Copy size={12} />,
+      onClick: () => {
+        void copyToClipboard(folder.cwdPath);
+      },
+    },
+    contextMenuGroupTitle(t, "danger"),
+    {
+      label: sidebarText(t, "sidebar.actions.removeProjectFolder"),
+      icon: <Trash2 size={12} />,
+      onClick: () => onRemoveFolder(folder.id),
+    },
+  ];
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-sidebar-workspace-id={folder.id}
+      className="flex flex-col gap-0.5"
+    >
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={editing ? undefined : onActivate}
+        onDoubleClick={(e) => {
+          e.stopPropagation();
+          setEditing(true);
+        }}
+        onKeyDown={(e) => {
+          if (editing) return;
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onActivate();
+          } else if (e.key === "F2") {
+            e.preventDefault();
+            setEditing(true);
+          }
+        }}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setMenu({ x: e.clientX, y: e.clientY });
+        }}
+        className={cn(
+          "group/local-workspace flex min-h-7 w-full items-center gap-1 rounded-md px-1.5 py-1 text-left transition",
+          active
+            ? "bg-bg-elevated/50"
+            : "bg-bg-elevated/20 hover:bg-bg-elevated/30",
+        )}
+      >
+        <button
+          type="button"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleFolder();
+          }}
+          aria-label={sidebarText(
+            t,
+            collapsed
+              ? "sidebar.actions.expandProjectFolder"
+              : "sidebar.actions.collapseProjectFolder",
+          )}
+          aria-expanded={!collapsed}
+          className="group/local-workspace-toggle relative flex size-5 shrink-0 self-start items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg focus-visible:bg-bg-elevated focus-visible:text-fg focus-visible:outline-none"
+        >
+          <WorkspaceIcon
+            folder={folder}
+            size={13}
+            className="transition-opacity group-hover/local-workspace:opacity-0 group-focus-visible/local-workspace-toggle:opacity-0"
+          />
+          <ChevronRight
+            size={12}
+            className={cn(
+              "absolute opacity-0 transition-[opacity,transform] group-hover/local-workspace:opacity-100 group-focus-visible/local-workspace-toggle:opacity-100",
+              !collapsed && "rotate-90",
+            )}
+          />
+        </button>
+        <span className="min-w-0 flex-1">
+          {editing ? (
+            <RenameInput
+              initial={folder.name}
+              onSubmit={submitRename}
+              onCancel={() => setEditing(false)}
+            />
+          ) : (
+            <span className="flex min-w-0 flex-col leading-none">
+              <span className="block truncate text-[12px] font-medium leading-4 text-fg">
+                {folder.name}
+              </span>
+              {workspaceLabel ? (
+                <Tooltip
+                  label={folder.cwdPath}
+                  side="right"
+                  className="min-w-0 max-w-full"
+                >
+                  <span className="mt-0.5 flex min-w-0 items-center gap-1 text-[10px] leading-3 text-fg-muted">
+                    <FolderOpen size={10} className="shrink-0" />
+                    <span className="truncate">{workspaceLabel}</span>
+                  </span>
+                </Tooltip>
+              ) : null}
+            </span>
+          )}
+        </span>
+        {!editing ? (
+          <div className="ml-auto flex shrink-0 items-center gap-0.5">
+            <Tooltip
+              label={sidebarText(t, "sidebar.localTerminals.newSession")}
+              side="bottom"
+            >
+              <button
+                type="button"
+                aria-label={sidebarText(t, "sidebar.localTerminals.newSession")}
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCreateSession();
+                }}
+                onKeyDown={(e) => e.stopPropagation()}
+                className="invisible flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover/local-workspace:visible group-focus-within/local-workspace:visible"
+              >
+                <Plus size={12} />
+              </button>
+            </Tooltip>
+            <Tooltip
+              label={sidebarText(t, "sidebar.actions.removeProjectFolder")}
+              side="bottom"
+            >
+              <button
+                type="button"
+                aria-label={sidebarText(t, "sidebar.actions.removeProjectFolder")}
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRemoveFolder(folder.id);
+                }}
+                onKeyDown={(e) => e.stopPropagation()}
+                className="invisible flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger group-hover/local-workspace:visible group-focus-within/local-workspace:visible"
+              >
+                <Trash2 size={12} />
+              </button>
+            </Tooltip>
+          </div>
+        ) : null}
+      </div>
+      <ContextMenu
+        open={menu !== null}
+        x={menu?.x ?? 0}
+        y={menu?.y ?? 0}
+        onClose={() => setMenu(null)}
+        items={menuItems}
+      />
+      {!collapsed ? (
+        <SortableContext
+          items={sessionIds}
+          strategy={verticalListSortingStrategy}
+        >
+          <ul className="ml-4 flex flex-col gap-0.5 border-l border-border pl-1 pt-0.5">
+            {folderGroup.sessions.length === 0 ? (
+              <li className="flex items-center justify-center rounded px-3 py-2 text-center text-[11px] text-fg-muted select-none">
+                {sidebarText(t, "sidebar.emptyProjectFolder.noSessions")}
+              </li>
+            ) : (
+              folderGroup.sessions.map((session) => (
+                <SessionRow
+                  key={session.id}
+                  session={session}
+                  active={session.id === activeSessionId}
+                  onSelect={() => onSelectSession(session.id)}
+                  onRemove={() => onRemoveSession(session)}
+                  projectFolders={projectFolders}
+                  currentProjectFolderId={folder.id}
+                  onMoveToProjectFolder={onMoveSessionToFolder}
+                />
+              ))
+            )}
+          </ul>
+        </SortableContext>
+      ) : null}
+    </div>
   );
 }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2160,6 +2160,7 @@ function ProjectFolderView({
     >
       <div
         ref={setFolderHeaderNodeRef}
+        data-sidebar-workspace-id={folder.id}
         {...attributes}
         role="button"
         tabIndex={0}

--- a/src/lib/projectFolders.test.ts
+++ b/src/lib/projectFolders.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildLocalSessionFolderGroups,
   buildProjectFolderGroups,
   defaultProjectFolderId,
   ensureProjectFolders,
@@ -220,6 +221,51 @@ describe("project folders", () => {
 
     expect(groups).toHaveLength(1);
     expect(groups[0].sessions.map((s) => s.id)).toEqual(["project"]);
+  });
+
+  it("groups local sessions into local workspaces", () => {
+    const repoPath = "/Users/me";
+    const scratch = folder("scratch", repoPath, repoPath, "Scratch");
+    const groups = buildLocalSessionFolderGroups(
+      [],
+      [
+        session("root", repoPath, { project_scoped: false }),
+        session("notes", repoPath, { project_scoped: false }),
+      ],
+      {
+        [repoPath]: [makeDefaultProjectFolder(repoPath), scratch],
+      },
+      { notes: "scratch" },
+    );
+
+    expect(groups.map((group) => group.repoPath)).toEqual([repoPath]);
+    expect(groups[0].folders.map((group) => group.folder.id)).toEqual([
+      repoPath,
+      "scratch",
+    ]);
+    expect(groups[0].folders[0].sessions.map((s) => s.id)).toEqual(["root"]);
+    expect(groups[0].folders[1].sessions.map((s) => s.id)).toEqual(["notes"]);
+  });
+
+  it("keeps empty local workspaces out of project groups", () => {
+    const repoPath = "/Users/me";
+    const scratch = folder("scratch", repoPath, repoPath, "Scratch");
+
+    expect(
+      buildProjectFolderGroups(
+        [],
+        [],
+        { [repoPath]: [makeDefaultProjectFolder(repoPath), scratch] },
+      ),
+    ).toEqual([]);
+
+    expect(
+      buildLocalSessionFolderGroups(
+        [],
+        [],
+        { [repoPath]: [makeDefaultProjectFolder(repoPath), scratch] },
+      )[0].folders.map((group) => group.folder.id),
+    ).toEqual([repoPath, "scratch"]);
   });
 
   it("hides stale empty projects that only mirror local sessions", () => {

--- a/src/lib/projectFolders.ts
+++ b/src/lib/projectFolders.ts
@@ -80,7 +80,7 @@ export function ensureProjectFolders(
   sessions: Session[],
   foldersByRepo: ProjectFoldersByRepo,
 ): ProjectFoldersByRepo {
-  const knownRepos = knownProjectRepos(projects, sessions);
+  const knownRepos = knownWorkspaceRepos(projects, sessions, foldersByRepo);
   const next: ProjectFoldersByRepo = {};
   for (const repoPath of knownRepos) {
     const existing = foldersByRepo[repoPath] ?? [];
@@ -168,6 +168,64 @@ export function buildProjectFolderGroups(
   }
 
   return Array.from(map.values());
+}
+
+export function buildLocalSessionFolderGroups(
+  projects: Project[],
+  sessions: Session[],
+  foldersByRepo: ProjectFoldersByRepo,
+  assignments: SessionFolderAssignments = {},
+): ProjectFolderProjectGroup[] {
+  const projectRepoPaths = new Set(projects.map((project) => project.repo_path));
+  for (const session of sessions) {
+    if (isProjectSession(session)) projectRepoPaths.add(session.repo_path);
+  }
+
+  const localSessions = sessions.filter(isLocalSession);
+  const localSessionPaths = new Set(
+    localSessions.map((session) => session.repo_path),
+  );
+  const repoPaths = new Set(localSessionPaths);
+  for (const [repoPath, folders] of Object.entries(foldersByRepo)) {
+    if (projectRepoPaths.has(repoPath)) continue;
+    if (folders.some((folder) => !isDefaultProjectFolder(folder))) {
+      repoPaths.add(repoPath);
+    }
+  }
+
+  return Array.from(repoPaths)
+    .sort((a, b) => basenamePath(a).localeCompare(basenamePath(b)))
+    .map((repoPath) => {
+      const folders = sortProjectFolders(
+        foldersByRepo[repoPath] ?? [makeDefaultProjectFolder(repoPath)],
+      );
+      const group: ProjectFolderProjectGroup = {
+        repoPath,
+        name: basenamePath(repoPath),
+        folders: folderGroupsForRepo(folders),
+        sessions: [],
+      };
+      for (const session of localSessions) {
+        if (session.repo_path !== repoPath) continue;
+        const folderId = resolveProjectFolderIdForSession(
+          folders,
+          session,
+          assignments,
+        );
+        const folderGroup =
+          group.folders.find((candidate) => candidate.folder.id === folderId) ??
+          group.folders[0];
+        if (!folderGroup) continue;
+        folderGroup.sessions.push(session);
+        group.sessions.push(session);
+      }
+      group.sessions = sortSessions(group.sessions);
+      group.folders = group.folders.map((folderGroup) => ({
+        ...folderGroup,
+        sessions: sortSessions(folderGroup.sessions),
+      }));
+      return group;
+    });
 }
 
 export function resolveProjectFolderIdForSession(
@@ -292,15 +350,24 @@ function folderGroupsForRepo(
   }));
 }
 
-function knownProjectRepos(projects: Project[], sessions: Session[]): string[] {
+function knownWorkspaceRepos(
+  projects: Project[],
+  sessions: Session[],
+  foldersByRepo: ProjectFoldersByRepo,
+): string[] {
   const repos = new Map<string, number>();
   for (const project of projects) {
     repos.set(project.repo_path, project.position ?? Number.MAX_SAFE_INTEGER);
   }
   for (const session of sessions) {
-    if (!isProjectSession(session)) continue;
     if (!repos.has(session.repo_path)) {
       repos.set(session.repo_path, Number.MAX_SAFE_INTEGER);
+    }
+  }
+  for (const [repoPath, folders] of Object.entries(foldersByRepo)) {
+    if (repos.has(repoPath)) continue;
+    if (folders.some((folder) => !isDefaultProjectFolder(folder))) {
+      repos.set(repoPath, Number.MAX_SAFE_INTEGER);
     }
   }
   return Array.from(repos.entries())

--- a/src/lib/sessionCreation.test.ts
+++ b/src/lib/sessionCreation.test.ts
@@ -184,6 +184,31 @@ describe("session creation policy", () => {
     });
   });
 
+  it("preserves the active local workspace when the active session is inside it", () => {
+    const sessions = [
+      session("local", "/Users/me", {
+        project_scoped: false,
+        worktree_path: "/Users/me",
+      }),
+    ];
+
+    expect(
+      resolveActiveSessionScope({
+        sessions,
+        projects: [],
+        activeSessionId: "local",
+        activeWorkspaceRepoPath: "/Users/me",
+        activeWorkspaceCwdPath: "/Users/me/scratch",
+        activeProjectFolderId: "scratch",
+      }),
+    ).toEqual({
+      repoPath: "/Users/me",
+      cwdPath: "/Users/me/scratch",
+      projectScoped: false,
+      projectFolderId: "scratch",
+    });
+  });
+
   it("builds local session requests with local naming", () => {
     const sessions = [
       session("local", "/Users/me", {

--- a/src/lib/sessionCreation.ts
+++ b/src/lib/sessionCreation.ts
@@ -64,7 +64,6 @@ export function resolveActiveSessionScope(
   if (active) {
     const scope = scopeForSession(active);
     if (
-      scope.projectScoped &&
       context.activeProjectFolderId &&
       context.activeWorkspaceRepoPath === active.repo_path
     ) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -852,8 +852,9 @@
       "generatingSessionTitle": "Generating session title"
     },
     "localTerminals": {
-      "title": "Instant sessions",
+      "title": "Instant Sessions",
       "newSession": "New instant session",
+      "newWorkspace": "New workspace",
       "empty": "Double-click to start an instant session."
     },
     "emptyProject": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -854,6 +854,7 @@
     "localTerminals": {
       "title": "인스턴트 세션",
       "newSession": "새 인스턴트 세션",
+      "newWorkspace": "새 작업공간",
       "empty": "더블클릭하면 인스턴트 세션을 시작할 수 있습니다."
     },
     "emptyProject": {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -368,6 +368,88 @@ describe("focusLocalSessions", () => {
   });
 });
 
+describe("local workspaces", () => {
+  it("creates and preserves an empty local workspace", async () => {
+    await seed([], []);
+
+    const folder = useAppStore
+      .getState()
+      .createProjectFolder("/Users/me", "Scratch");
+
+    expect(folder).toMatchObject({
+      repoPath: "/Users/me",
+      name: "Scratch",
+      cwdPath: "/Users/me",
+    });
+    expect(useAppStore.getState().activeProject).toBe("/Users/me");
+    expect(useAppStore.getState().activeProjectFolderId).toBe(folder!.id);
+    expect(useAppStore.getState().workspaces[folder!.id]).toBeDefined();
+
+    mockApi.listProjects.mockResolvedValueOnce([]);
+    mockApi.listSessions.mockResolvedValueOnce([]);
+    await useAppStore.getState().refreshAll();
+
+    const s = useAppStore.getState();
+    expect(s.projectFolders["/Users/me"].map((item) => item.id)).toEqual([
+      "/Users/me",
+      folder!.id,
+    ]);
+    expect(s.workspaces[folder!.id]).toBeDefined();
+    expect(s.activeProjectFolderId).toBe(folder!.id);
+  });
+
+  it("moves local sessions between local workspaces", async () => {
+    const local = session("local", "/Users/me", {
+      project_scoped: false,
+      worktree_path: "/Users/me",
+    });
+    await seed([], [local]);
+    const folder = useAppStore
+      .getState()
+      .createProjectFolder("/Users/me", "Scratch")!;
+
+    useAppStore.getState().moveSessionToProjectFolder("local", folder.id);
+
+    const s = useAppStore.getState();
+    expect(s.sessionFolderIds.local).toBe(folder.id);
+    expect(s.workspaces[folder.id].panes.root.tabIds).toEqual(["local"]);
+    expect(s.workspaces["/Users/me"].panes.root.tabIds).toEqual([]);
+  });
+
+  it("assigns newly created local sessions to the requested local workspace", async () => {
+    await seed([], []);
+    const folder = useAppStore
+      .getState()
+      .createProjectFolder("/Users/me", "Scratch")!;
+    const created = session("local-new", "/Users/me", {
+      project_scoped: false,
+      worktree_path: "/Users/me",
+    });
+    mockApi.createSession.mockResolvedValueOnce(created);
+    mockApi.listProjects.mockResolvedValueOnce([]);
+    mockApi.listSessions.mockResolvedValueOnce([created]);
+
+    await useAppStore
+      .getState()
+      .createSession(
+        "local-new",
+        "/Users/me",
+        false,
+        "regular",
+        null,
+        false,
+        "terminal",
+        folder.id,
+      );
+
+    const s = useAppStore.getState();
+    expect(s.sessionFolderIds["local-new"]).toBe(folder.id);
+    expect(s.activeProject).toBe("/Users/me");
+    expect(s.activeProjectFolderId).toBe(folder.id);
+    expect(s.workspaces[folder.id].panes.root.tabIds).toEqual(["local-new"]);
+  });
+});
+
 describe("setActiveProject", () => {
   it("recreates a missing workspace mirror for a known project", async () => {
     await seed([project(REPO_A, 0)], []);

--- a/src/store.ts
+++ b/src/store.ts
@@ -617,8 +617,17 @@ function reconcileWorkspaces(
   }
   for (const session of sessions) {
     if (session.project_scoped === false) {
-      if (!byFolder[session.repo_path]) byFolder[session.repo_path] = [];
-      byFolder[session.repo_path].push(session);
+      const folders = nextProjectFolders[session.repo_path] ?? [];
+      const folderId =
+        folders.length > 0
+          ? resolveProjectFolderIdForSession(
+              folders,
+              session,
+              nextSessionFolderIds,
+            )
+          : session.repo_path;
+      if (!byFolder[folderId]) byFolder[folderId] = [];
+      byFolder[folderId].push(session);
       continue;
     }
     const folders = nextProjectFolders[session.repo_path] ?? [];
@@ -923,18 +932,16 @@ function applySessionPlacementIntent(
   if (!placement) return s;
   const session = s.sessions.find((candidate) => candidate.id === sessionId);
   if (!session) return s;
-  if (session.project_scoped !== false) {
-    const targetFolderId =
-      placement.projectFolderId === defaultProjectFolderId(session.repo_path)
-        ? null
-        : placement.projectFolderId;
-    if (
-      repoPathForProjectFolderId(s, placement.projectFolderId) !==
-        session.repo_path ||
-      !canAssignSessionToProjectFolder(s, session, targetFolderId)
-    ) {
-      return s;
-    }
+  const targetFolderId =
+    placement.projectFolderId === defaultProjectFolderId(session.repo_path)
+      ? null
+      : placement.projectFolderId;
+  if (
+    repoPathForProjectFolderId(s, placement.projectFolderId) !==
+      session.repo_path ||
+    !canAssignSessionToProjectFolder(s, session, targetFolderId)
+  ) {
+    return s;
   }
 
   const ws = s.workspaces[placement.projectFolderId];
@@ -1547,10 +1554,6 @@ export const useAppStore = create<AppStateModel>()(
   createProjectFolder(repoPath, name, cwdPath) {
     let created: ProjectFolder | null = null;
     set((s) => {
-      const knownRepo =
-        s.projects.some((project) => project.repo_path === repoPath) ||
-        s.sessions.some((session) => session.repo_path === repoPath);
-      if (!knownRepo) return s;
       const current = s.projectFolders[repoPath] ?? [
         {
           id: defaultProjectFolderId(repoPath),
@@ -1685,7 +1688,7 @@ export const useAppStore = create<AppStateModel>()(
   moveSessionToProjectFolder(sessionId, folderId) {
     set((s) => {
       const session = s.sessions.find((candidate) => candidate.id === sessionId);
-      if (!session || session.project_scoped === false) return s;
+      if (!session) return s;
       if (!canAssignSessionToProjectFolder(s, session, folderId)) return s;
       const nextSessionFolderIds = { ...s.sessionFolderIds };
       if (
@@ -2026,7 +2029,7 @@ export const useAppStore = create<AppStateModel>()(
       createdId = created.id;
       const assignedFolderId = placement?.projectFolderId;
       const assignCreatedToFolder = (reconcile: boolean) => {
-        if (!assignedFolderId || projectScoped === false) return;
+        if (!assignedFolderId) return;
         set((s) => {
           const existingSession = s.sessions.find(
             (candidate) => candidate.id === created.id,

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -677,8 +677,7 @@ test.describe("sidebar: project lifecycle", () => {
     await page.getByRole("menuitem", { name: "New workspace", exact: true }).click();
 
     const folderRow = page
-      .locator("aside")
-      .getByRole("button", { name: /New workspace/ })
+      .locator("aside [data-sidebar-workspace-id]")
       .first();
     await expect(folderRow).toBeVisible();
     await expectRootWorkspaceMetadataHidden(folderRow);
@@ -843,6 +842,7 @@ test.describe("sidebar: project lifecycle", () => {
     const folderRow = page
       .locator("aside")
       .getByRole("button", { name: /New workspace/ })
+      .filter({ hasText: "New workspace" })
       .first();
     await expect(folderRow).toBeVisible();
 
@@ -1048,7 +1048,10 @@ test.describe("sidebar: project lifecycle", () => {
     const projectRow = page.getByRole("button", { name: "Project demo" });
     await projectRow.click({ button: "right" });
     await page.getByRole("menuitem", { name: "New workspace", exact: true }).click();
-    const folderRow = sidebar.getByRole("button", { name: /New workspace/ }).first();
+    const folderRow = sidebar
+      .getByRole("button", { name: /New workspace/ })
+      .filter({ hasText: "New workspace" })
+      .first();
     await folderRow.dblclick();
     await sidebar.getByRole("textbox").fill("Frontend");
     await sidebar.getByRole("textbox").press("Enter");
@@ -1238,7 +1241,9 @@ test.describe("sidebar: project lifecycle", () => {
     await projectRow.click({ button: "right" });
     await page.getByRole("menuitem", { name: "New workspace" }).click();
 
-    const folderRows = sidebar.getByRole("button", { name: /New workspace/ });
+    const folderRows = sidebar
+      .getByRole("button", { name: /New workspace/ })
+      .filter({ hasText: "New workspace" });
     await expect(folderRows).toHaveCount(1);
     await folderRows.first().click({ button: "right" });
     await page.getByRole("menuitem", { name: "Remove workspace" }).click();
@@ -1476,6 +1481,7 @@ test.describe("sidebar: project lifecycle", () => {
     const firstFolder = page
       .locator("aside")
       .getByRole("button", { name: /New workspace/ })
+      .filter({ hasText: "New workspace" })
       .first();
     await firstFolder.dblclick();
     await page.locator("aside").getByRole("textbox").fill("Frontend");
@@ -1486,6 +1492,7 @@ test.describe("sidebar: project lifecycle", () => {
     const secondFolder = page
       .locator("aside")
       .getByRole("button", { name: /New workspace/ })
+      .filter({ hasText: "New workspace" })
       .first();
     await secondFolder.dblclick();
     await page.locator("aside").getByRole("textbox").fill("Backend");
@@ -1612,7 +1619,10 @@ test.describe("sidebar: project lifecycle", () => {
     const projectRow = page.getByRole("button", { name: "Project demo" });
     await projectRow.click({ button: "right" });
     await page.getByRole("menuitem", { name: "New workspace", exact: true }).click();
-    const folderRow = sidebar.getByRole("button", { name: /New workspace/ }).first();
+    const folderRow = sidebar
+      .getByRole("button", { name: /New workspace/ })
+      .filter({ hasText: "New workspace" })
+      .first();
     await folderRow.dblclick();
     await sidebar.getByRole("textbox").fill("Frontend");
     await sidebar.getByRole("textbox").press("Enter");
@@ -1725,7 +1735,10 @@ test.describe("sidebar: project lifecycle", () => {
     const projectRow = page.getByRole("button", { name: "Project demo" });
     await projectRow.click({ button: "right" });
     await page.getByRole("menuitem", { name: "New workspace", exact: true }).click();
-    const folderRow = sidebar.getByRole("button", { name: /New workspace/ }).first();
+    const folderRow = sidebar
+      .getByRole("button", { name: /New workspace/ })
+      .filter({ hasText: "New workspace" })
+      .first();
     await folderRow.dblclick();
     await sidebar.getByRole("textbox").fill("Frontend");
     await sidebar.getByRole("textbox").press("Enter");
@@ -1965,6 +1978,7 @@ test.describe("sidebar: project lifecycle", () => {
     const folderRow = page
       .locator("aside")
       .getByRole("button", { name: /New workspace/ })
+      .filter({ hasText: "New workspace" })
       .first();
     await folderRow.dblclick();
     await page.locator("aside").getByRole("textbox").fill("Frontend");
@@ -2107,7 +2121,10 @@ test.describe("sidebar: project lifecycle", () => {
       .getByRole("menuitem", { name: "New workspace", exact: true })
       .click();
     await expect(
-      page.locator("aside").getByRole("button", { name: /New workspace/ }),
+      page
+        .locator("aside")
+        .getByRole("button", { name: /New workspace/ })
+        .filter({ hasText: "New workspace" }),
     ).toBeVisible();
 
     await projectRow.hover();

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -2262,7 +2262,7 @@ test.describe("sidebar: project lifecycle", () => {
     const chats = page.getByRole("region", { name: "Local terminal sessions" });
     await chats.getByRole("button", { name: "New instant session" }).click();
 
-    await expect(page.getByText("Instant sessions")).toBeVisible();
+    await expect(page.getByText("Instant Sessions")).toBeVisible();
     await expect(
       chats.getByRole("button", { name: /^terminal\b/ }),
     ).toBeVisible();
@@ -2321,6 +2321,204 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(
       chats.getByRole("button", { name: /codex/i }),
     ).toBeVisible();
+  });
+
+  test("instant sessions can create workspaces and create sessions inside them", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("plugin:path|resolve_directory", () => "/Users/tester");
+    await tauri.handle("list_projects", () => []);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __localSessionCreated?: boolean };
+      return w.__localSessionCreated
+        ? [
+            {
+              id: "local-1",
+              name: "terminal",
+              repo_path: "/Users/tester",
+              worktree_path: "/Users/tester",
+              branch: "HEAD",
+              isolated: false,
+              project_scoped: false,
+              status: "idle",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:00Z",
+              last_message: null,
+              kind: "regular",
+              owner: { kind: "user" },
+              position: null,
+              in_worktree: false,
+            },
+          ]
+        : [];
+    });
+    await tauri.handle("create_session", (args) => {
+      const w = window as unknown as {
+        __createSessionCalls?: unknown[];
+        __localSessionCreated?: boolean;
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(args);
+      w.__localSessionCreated = true;
+      return {
+        id: "local-1",
+        name: "terminal",
+        repo_path: "/Users/tester",
+        worktree_path: "/Users/tester",
+        branch: "HEAD",
+        isolated: false,
+        project_scoped: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      };
+    });
+
+    await page.goto("/");
+
+    const instant = page.getByRole("region", {
+      name: "Local terminal sessions",
+    });
+    await instant
+      .getByRole("button", { name: "New workspace" })
+      .click();
+    const folderRow = instant
+      .getByRole("button", { name: /New workspace/ })
+      .filter({ hasText: "New workspace" })
+      .first();
+    await expect(folderRow).toBeVisible();
+    await folderRow.dblclick();
+    const input = instant.getByRole("textbox");
+    await input.fill("Scratch");
+    await input.press("Enter");
+
+    const scratch = instant
+      .getByRole("button", { name: /Scratch/ })
+      .first();
+    await expect(scratch).toBeVisible();
+    await scratch.hover();
+    await scratch
+      .getByRole("button", { name: "New instant session" })
+      .click();
+    await expect(
+      instant.getByRole("button", { name: /^terminal\b/ }),
+    ).toBeVisible();
+
+    await scratch
+      .getByRole("button", { name: "Collapse workspace" })
+      .click();
+    await expect(
+      instant.getByRole("button", { name: /^terminal\b/ }),
+    ).toHaveCount(0);
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __createSessionCalls?: unknown[] })
+          .__createSessionCalls,
+    )) as Array<{
+      name: string;
+      repoPath: string;
+      isolated: boolean;
+      kind: string;
+      projectScoped: boolean;
+    }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      name: "terminal",
+      repoPath: "/Users/tester",
+      isolated: false,
+      kind: "regular",
+      projectScoped: false,
+    });
+  });
+
+  test("instant sessions can move into workspaces by drag and drop", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("plugin:path|resolve_directory", () => "/Users/tester");
+    await tauri.handle("list_projects", () => []);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "local-1",
+        name: "terminal",
+        repo_path: "/Users/tester",
+        worktree_path: "/Users/tester",
+        branch: "HEAD",
+        isolated: false,
+        project_scoped: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      },
+    ]);
+
+    await page.goto("/");
+
+    const instant = page.getByRole("region", {
+      name: "Local terminal sessions",
+    });
+    const terminal = instant
+      .getByRole("button", { name: /^terminal\b/ })
+      .first();
+    await expect(terminal).toBeVisible();
+
+    await instant
+      .getByRole("button", { name: "New workspace" })
+      .click();
+    const folderRow = instant
+      .getByRole("button", { name: /New workspace/ })
+      .filter({ hasText: "New workspace" })
+      .first();
+    await expect(folderRow).toBeVisible();
+    await folderRow.dblclick();
+    const input = instant.getByRole("textbox");
+    await input.fill("Scratch");
+    await input.press("Enter");
+
+    const scratch = instant
+      .getByRole("button", { name: /Scratch/ })
+      .first();
+    await expect(scratch).toBeVisible();
+    const scratchWorkspace = instant.locator("[data-sidebar-workspace-id]").first();
+
+    await dragBetween(page, terminal, scratch);
+
+    await expect(scratchWorkspace).toContainText("terminal");
+
+    const terminalBox = await terminal.boundingBox();
+    const instantBox = await instant.boundingBox();
+    if (!terminalBox || !instantBox) {
+      throw new Error("instant session drag target is not visible");
+    }
+    await page.mouse.move(
+      terminalBox.x + Math.min(60, terminalBox.width / 2),
+      terminalBox.y + terminalBox.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(instantBox.x + 18, instantBox.y + 24, { steps: 10 });
+    await page.mouse.up();
+
+    await expect(scratchWorkspace).not.toContainText("terminal");
+    await expect
+      .poll(async () => {
+        const sessionBox = await terminal.boundingBox();
+        const scratchBox = await scratch.boundingBox();
+        if (!sessionBox || !scratchBox) return "missing";
+        return sessionBox.y < scratchBox.y ? "root" : "workspace";
+      })
+      .toBe("root");
   });
 
   test("new-session hotkey preserves local chat scope", async ({


### PR DESCRIPTION
## Summary
This PR adds workspace grouping and drag-and-drop placement for Instant Sessions.

1. **Instant session workspaces** — Instant Sessions can now create named workspaces, create sessions inside them, rename/remove/collapse them, and preserve empty local workspaces across refresh.
2. **Local session placement** — Local sessions reuse the project folder assignment model so Cmd+T, context-menu moves, and drag-and-drop can place them inside or outside instant workspaces.
3. **Sidebar polish** — The section title now reads `Instant Sessions`, the workspace action is labelled `New workspace`, and the workspace icon matches the sidebar workspace treatment.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Instant Sessions organization | Flat local session list only | Named workspaces with collapse/remove/rename and session creation |
| Session placement | Local sessions could not reliably use workspace placement | Local sessions can move into and out of workspaces, including drag-and-drop |
| Persistence | Empty local workspaces were dropped during reconciliation | Empty instant workspaces are preserved |

## Design notes
- Reuses the existing `ProjectFolder` and session folder assignment model for local sessions instead of adding a separate workspace data model.
- Keeps worktree workspace lock rules intact: sessions still cannot be dragged into unrelated worktree-backed workspaces.
- The Instant Sessions header acts as the root drop target for dragging local sessions out of an instant workspace.

## Test plan
- [x] `pnpm exec vitest run src/lib/projectFolders.test.ts src/lib/sessionCreation.test.ts src/store.test.ts` — 134 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "instant sessions can create workspaces|instant sessions can move into workspaces|clicking the instant sessions area|project workspaces can be named"` — 4 tests passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "project workspace remove skips confirmation|project header exposes regular|instant sessions can create workspaces|instant sessions can move into workspaces"` — 4 tests passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts` — 33 tests passed
- [x] `pnpm run build` — passed
