### PR TITLE
fix(ui): pad right-panel empty states

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -698,7 +698,7 @@ function tabLabelKey(tab: RightTab): RightPanelTranslationKey {
 
 function Empty({ msg }: { msg: string }) {
   return (
-    <div className="flex h-full items-center justify-center text-xs text-fg-muted">
+    <div className="flex h-full w-full items-center justify-center px-4 text-center text-xs leading-5 text-fg-muted">
       {msg}
     </div>
   );


### PR DESCRIPTION
## Summary
Right-panel empty states now keep comfortable horizontal spacing in narrow panels.

1. **Empty-state layout** — add full-width centering, horizontal padding, centered text, and stable line-height to the shared `Empty` component used by Agents History and other right-panel placeholders.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Agents History empty state | Long text could feel pinned to the panel edges | Message wraps with centered text and visible side padding |
| Other right-panel empty states | Same unpadded shared placeholder | Same padded shared placeholder treatment |

## Design notes
- This is intentionally scoped to the existing shared `Empty` component rather than adding a History-specific wrapper, so the panel keeps one consistent placeholder style.
- No data flow, backend command, or translation behavior changed.

## Test plan
- [x] `pnpm exec vitest run src/components/RightPanel.test.tsx` — 15 tests passed
- [x] `pnpm run typecheck` — passed
- [x] Manual screenshot check of Agents → History empty state at `/Users/jthefloor/Desktop/acorn-agents-history-empty.png`

## Notes
- No unrelated workspace files were included in this PR.