### PR TITLE
chore(release): v1.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.16.0",
+  "version": "1.17.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.16.0"
+version = "1.17.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
This release bumps Acorn from `1.16.0` to `1.17.0` for the next stable macOS updater release.

1. **Version metadata.** Updates `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` to `1.17.0`.
2. **Semver selection.** Uses a minor bump because the unreleased set includes user-visible session, UI, theme, and sidebar workspace features, alongside fixes.
3. **Included changes.** Releases #429, #430, #431, #432, #433, #434, #435, and #436.

## Expected impact

| Area | Impact |
| --- | --- |
| App updater | Publishes the next stable version as `1.17.0` once the release tag is pushed. |
| Release notes | Uses the existing merged PR labels for Features and Fixes sections. |
| Runtime behavior | No code behavior changes in this PR; it only updates release metadata. |

## Design notes

- This is a release bump PR only; feature and fix changelog entries come from the merged PRs listed above.
- `skip-changelog` is intentional so the release bump itself does not appear as an app-facing changelog entry.
- Latest stable release is `v1.16.0`; generated notes compare `v1.16.0...v1.17.0`.

## Test plan

- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1`
- [x] `REPO=im-ian/acorn TAG=v1.17.0 OUTPUT=/tmp/acorn-release-notes-v1.17.0.md node scripts/release-notes.mjs`
- [x] `git diff --check`
- [x] main CI is green at `be44c92af8f5cee3958562262f4ade4722362b8b`

## Notes

- Semver reason: minor release due to feature PRs #430, #432, #433, and #435.