### PR TITLE
fix(ui): preserve workspace state across pane operations and fix focus sync

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -603,7 +603,10 @@ function App() {
       if (!sid) return;
       const state = useAppStore.getState();
       if (!state.activeProject) return;
-      const ws = state.workspaces[state.activeProject];
+      // Workspaces are keyed by project-folder id when a named folder is
+      // active; the repo path only keys the default workspace.
+      const ws =
+        state.workspaces[state.activeProjectFolderId ?? state.activeProject];
       if (!ws) return;
       for (const [pid, pane] of Object.entries(ws.panes)) {
         if (pane.tabIds.includes(sid)) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1777,6 +1777,7 @@ export const useAppStore = create<AppStateModel>()(
           nextSplitId(),
         );
         return {
+          ...ws,
           layout: newLayout,
           panes: { ...ws.panes, [newPaneId]: emptyPane(newPaneId) },
           focusedPaneId: newPaneId,
@@ -1856,13 +1857,26 @@ export const useAppStore = create<AppStateModel>()(
         const fallback = surviving[0] ?? ROOT_PANE_ID;
         if (newPanes[fallback] && pane.tabIds.length > 0) {
           const target = newPanes[fallback];
+          const mergedTabIds = [...target.tabIds, ...pane.tabIds];
+          const mergedActive = target.activeTabId ?? pane.activeTabId;
           newPanes[fallback] = {
             ...target,
-            tabIds: [...target.tabIds, ...pane.tabIds],
-            activeTabId: target.activeTabId ?? pane.activeTabId,
+            tabIds: mergedTabIds,
+            activeTabId: mergedActive,
+            activationHistory: activationHistoryFor(
+              {
+                activationHistory: [
+                  ...(pane.activationHistory ?? []),
+                  ...(target.activationHistory ?? []),
+                ],
+              },
+              mergedTabIds,
+              mergedActive,
+            ),
           };
         }
         return {
+          ...ws,
           layout: collapsed,
           panes: newPanes,
           focusedPaneId: fallback,
@@ -1951,6 +1965,7 @@ export const useAppStore = create<AppStateModel>()(
         }
 
         return {
+          ...ws,
           layout: newLayout,
           panes: newPanes,
           focusedPaneId: toPaneId,


### PR DESCRIPTION
## Summary

Fixes three state-management bugs found during a codebase audit of the pane/workspace layer.

- **Pane operations erased right-panel state.** `splitFocusedPane`, `closePane`, and `moveTab` returned bare `{ layout, panes, focusedPaneId }` objects from the `updateActiveWorkspace` updater, which stores the return value as the complete replacement workspace. The optional `rightTab` / `rightTabByGroup` fields were dropped on every split, pane close, or tab drag, resetting the right panel to its default tab. Each updater now spreads the original workspace first.
- **`closePane` lost MRU ordering of absorbed tabs.** When a closed pane's tabs were merged into the surviving pane, the closed pane's `activationHistory` was discarded, so the next auto-activated tab fell back to array order instead of the user's most-recently-used tab. Both histories are now merged through `activationHistoryFor`.
- **`focusin` syncer broke under named project folders.** The handler looked up `workspaces[activeProject]`, but workspaces are keyed by project-folder id when a named folder is active, so the lookup silently failed and `setFocusedPane` never ran — focus-dependent hotkeys (Cmd+T, Cmd+W, Cmd+Shift+D) kept targeting the previously focused pane. The lookup now uses `activeProjectFolderId ?? activeProject`, matching `activeWorkspaceId`.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 64 files, 651 tests pass
- [ ] Manual: split a pane with a non-default right-panel tab open and confirm the tab selection survives
- [ ] Manual: in a named project folder, click into a terminal in a split layout and confirm Cmd+W targets that pane
