### PR TITLE
perf(ui): stable size estimators and lazy total-size scan for virtualized lines

### DIFF
--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -52,6 +52,9 @@ const DIFF_KIND_CLASS: Record<FsLineDiffEntry["kind"], string> = {
 };
 
 const CODE_LINE_HEIGHT = 18;
+// Stable reference so VirtualizedLineList's size memos don't recompute on
+// every CodeViewer render.
+const estimateCodeLineHeight = () => CODE_LINE_HEIGHT;
 const MARKDOWN_EXT_RE = /\.(md|mdown|markdown|mdx)$/i;
 const SEARCH_MARK_CLASS = "rounded-[2px] px-0.5 text-fg";
 const SEARCH_MARK_ACTIVE_CLASS = `${SEARCH_MARK_CLASS} bg-accent/75`;
@@ -434,7 +437,7 @@ export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
           as="pre"
           count={sourceLines.length}
           className="acorn-selectable m-0 flex-1 cursor-text overflow-auto bg-transparent pb-12 font-mono text-[12px] leading-[1.5] text-fg"
-          estimateSize={() => CODE_LINE_HEIGHT}
+          estimateSize={estimateCodeLineHeight}
           getLineText={(index) => sourceLines[index] ?? ""}
           minWidthCh={minWidthCh}
           renderLine={(index) => (

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -1,5 +1,5 @@
 import { ChevronRight, Maximize2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { cn } from "../lib/cn";
 import {
   countStats,
@@ -402,13 +402,19 @@ export function DiffLineList({
     () => estimateMaxLineWidthCh(lineTexts, gutterWidth * 2 + 7),
     [lineTexts, gutterWidth],
   );
+  // Stable reference: an inline arrow here invalidates every size memo in
+  // VirtualizedLineList on each render, re-running O(n) estimate scans.
+  const estimateSize = useCallback(
+    (index: number) => estimateDiffLineHeight(lines[index]),
+    [lines],
+  );
 
   return (
     <VirtualizedLineList
       count={lines.length}
       className={className}
       innerClassName="w-max min-w-full"
-      estimateSize={(index) => estimateDiffLineHeight(lines[index])}
+      estimateSize={estimateSize}
       getLineText={(index) => lineTexts[index] ?? ""}
       minWidthCh={minWidthCh}
       renderLine={(index) => (

--- a/src/components/VirtualizedLines.tsx
+++ b/src/components/VirtualizedLines.tsx
@@ -75,11 +75,6 @@ export const VirtualizedLineList = forwardRef<
     for (let i = 0; i < sample; i++) total += estimateSize(i);
     return Math.max(1, total / sample);
   }, [count, estimateSize]);
-  const estimatedTotalSize = useMemo(() => {
-    let total = 0;
-    for (let i = 0; i < count; i++) total += estimateSize(i);
-    return total;
-  }, [count, estimateSize]);
   const fallbackItems = useMemo(
     () =>
       buildFallbackItems(count, estimateSize, INITIAL_VIEWPORT_ROWS + overscan),
@@ -96,6 +91,16 @@ export const VirtualizedLineList = forwardRef<
       height: averageInitialSize * INITIAL_VIEWPORT_ROWS,
     },
   });
+  // Only needed while the virtualizer has not produced a total yet (no
+  // scroll element measured). Skipping the O(n) scan once measurements
+  // exist keeps large lists from re-summing every line each render.
+  const measuredTotalSize = virtualized ? virtualizer.getTotalSize() : 0;
+  const estimatedTotalSize = useMemo(() => {
+    if (!virtualized || measuredTotalSize > 0) return 0;
+    let total = 0;
+    for (let i = 0; i < count; i++) total += estimateSize(i);
+    return total;
+  }, [virtualized, measuredTotalSize, count, estimateSize]);
   const virtualItems = virtualizer.getVirtualItems();
   const renderedItems: RenderedVirtualItem[] =
     virtualItems.length > 0 ? virtualItems : fallbackItems;
@@ -139,7 +144,7 @@ export const VirtualizedLineList = forwardRef<
     <div
       className={innerClassName}
       style={{
-        height: virtualizer.getTotalSize() || estimatedTotalSize,
+        height: measuredTotalSize || estimatedTotalSize,
         minWidth:
           minWidthCh === undefined ? undefined : `max(100%, ${minWidthCh}ch)`,
         position: "relative",


### PR DESCRIPTION
## Summary

Performance pass over the virtualized line rendering path, found during a codebase audit.

- **Inline `estimateSize` props defeated memoization.** `DiffLineList` (`DiffView.tsx`) and `CodeViewer` passed fresh arrow functions to `VirtualizedLineList` on every render, invalidating its `useMemo`s and re-running full O(n) per-line estimate scans for every render of a large diff or file. They now pass stable references (`useCallback` keyed on `lines` / a module-level constant function).
- **`estimatedTotalSize` scanned all lines unconditionally.** The O(n) total-height loop in `VirtualizedLineList` ran on every memo invalidation even though its result is only used as a fallback before the virtualizer has measured a scroll element. The scan now short-circuits once a measured total exists or when the list is below the virtualization threshold.

No behavior change: fallback height, initial rect, and copy handling are untouched.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 64 files, 651 tests pass (includes `CodeDiffVirtualization.test.tsx`)
- [ ] Manual: open a large diff (1000+ lines) and confirm smooth scrolling and correct total scroll height
