### PR TITLE
fix(security): harden markdown links, ssh alias resolution, and IPC socket

### DIFF
--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -141,20 +141,40 @@ fn cached_ssh_hostname(alias: &str) -> Option<String> {
     static CACHE: OnceLock<Mutex<HashMap<String, Option<String>>>> = OnceLock::new();
     let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
 
-    if let Ok(map) = cache.lock() {
+    // A poisoned lock would otherwise silently skip the cache and re-spawn
+    // `ssh -G` on every call; the map itself stays valid, so recover it.
+    {
+        let map = cache.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         if let Some(hit) = map.get(alias) {
             return hit.clone();
         }
     }
 
     let resolved = resolve_ssh_hostname(alias);
-    if let Ok(mut map) = cache.lock() {
-        map.insert(alias.to_string(), resolved.clone());
-    }
+    cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(alias.to_string(), resolved.clone());
     resolved
 }
 
+/// Aliases come from git remote URLs, i.e. repo-controlled data. Only pass
+/// plain host-shaped strings to `ssh -G`: anything with spaces, globs, or an
+/// option-like leading `-` could match an unexpected wildcard `Host` block
+/// (whose `ProxyCommand` OpenSSH would then execute) or be parsed as a flag.
+fn is_plain_hostname(alias: &str) -> bool {
+    !alias.is_empty()
+        && alias.len() <= 255
+        && !alias.starts_with('-')
+        && alias
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_'))
+}
+
 fn resolve_ssh_hostname(alias: &str) -> Option<String> {
+    if !is_plain_hostname(alias) {
+        return None;
+    }
     let out = std::process::Command::new("ssh")
         .args(["-G", alias])
         .output()

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -103,12 +103,18 @@ pub fn start<R: Runtime>(app: AppHandle<R>, state: AppState) -> Option<IpcServer
     // Best-effort cleanup of any previous socket inode. We do not block on
     // failure because the next `bind` will surface the real error.
     let _ = std::fs::remove_file(&path);
-    let listener = match UnixListener::bind(&path) {
+    // Bind at a temporary name, tighten permissions, then rename onto the
+    // advertised path. Binding directly at `path` would leave a window
+    // between bind (umask-derived permissions) and chmod during which any
+    // local user could connect.
+    let staging_path = path.with_extension("sock-staging");
+    let _ = std::fs::remove_file(&staging_path);
+    let listener = match UnixListener::bind(&staging_path) {
         Ok(l) => l,
         Err(err) => {
             tracing::warn!(
                 error = %err,
-                path = %path.display(),
+                path = %staging_path.display(),
                 "ipc: bind failed; server disabled",
             );
             return None;
@@ -124,15 +130,27 @@ pub fn start<R: Runtime>(app: AppHandle<R>, state: AppState) -> Option<IpcServer
         );
         return None;
     }
-    if let Err(err) = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)) {
+    if let Err(err) =
+        std::fs::set_permissions(&staging_path, std::fs::Permissions::from_mode(0o600))
+    {
         // Tighten on best-effort. If chmod fails we keep going — it just
         // means the socket is more permissive than ideal, not that the
         // server is unsafe (the unix peer is still local).
         tracing::warn!(
             error = %err,
-            path = %path.display(),
+            path = %staging_path.display(),
             "ipc: chmod 0600 failed",
         );
+    }
+    if let Err(err) = std::fs::rename(&staging_path, &path) {
+        tracing::warn!(
+            error = %err,
+            from = %staging_path.display(),
+            to = %path.display(),
+            "ipc: socket rename failed; server disabled",
+        );
+        let _ = std::fs::remove_file(&staging_path);
+        return None;
     }
     tracing::info!(path = %path.display(), "ipc: listening");
 
@@ -191,6 +209,11 @@ fn run_listener<R: Runtime>(
     tracing::info!("ipc: listener stopped");
 }
 
+/// Upper bound for a single request line. `read_line` otherwise grows the
+/// buffer without limit, so a misbehaving client writing an endless unbroken
+/// line could exhaust memory. Generous compared to any real `Envelope`.
+const MAX_REQUEST_BYTES: u64 = 1024 * 1024;
+
 fn handle_connection<R: Runtime>(
     stream: UnixStream,
     app: &AppHandle<R>,
@@ -199,7 +222,7 @@ fn handle_connection<R: Runtime>(
     let mut reader = BufReader::new(stream.try_clone()?);
     let mut writer = stream;
     let mut line = String::new();
-    let n = reader.read_line(&mut line)?;
+    let n = std::io::Read::take(&mut reader, MAX_REQUEST_BYTES).read_line(&mut line)?;
     if n == 0 {
         return Ok(());
     }

--- a/src/components/ui/Markdown.tsx
+++ b/src/components/ui/Markdown.tsx
@@ -87,6 +87,12 @@ interface MarkdownProps {
   onTaskToggle?: (index: number, checked: boolean) => void;
 }
 
+// Markdown bodies come from untrusted sources (PR descriptions, comments).
+// rehype-sanitize already strips most schemes from href, but it still admits
+// xmpp/irc and the like — gate what we hand to the OS opener to web links
+// and mailto so a crafted body can't launch arbitrary scheme handlers.
+const SAFE_OPEN_URL_RE = /^(https?:|mailto:)/i;
+
 const baseComponents: Components = {
   a({ href, children, title, ...rest }) {
     const link = (
@@ -95,7 +101,7 @@ const baseComponents: Components = {
         href={href}
         onClick={(e) => {
           e.preventDefault();
-          if (href) void openUrl(href);
+          if (href && SAFE_OPEN_URL_RE.test(href)) void openUrl(href);
         }}
         className="text-accent underline-offset-2 hover:underline"
       >


### PR DESCRIPTION
## Summary

Security hardening pass from a codebase audit. Three independent fixes, none changing intended functionality.

- **Markdown links: scheme allowlist before `openUrl`.** Link clicks in PR/comment markdown (untrusted GitHub data) passed any sanitizer-admitted href to the OS opener. rehype-sanitize strips most schemes but still admits `xmpp:`/`irc:` and the opener capability has no scheme restriction, so a crafted body could launch arbitrary scheme handlers. Now gated to `http(s):` and `mailto:`.
- **`ssh -G` alias validation + poison-safe cache.** Hostnames extracted from git remote URLs (repo-controlled data) were passed to `ssh -G` unvalidated; a crafted alias can match a wildcard `Host` block whose `ProxyCommand` OpenSSH executes. Resolution is now restricted to plain host-shaped strings (alphanumeric plus `.-_`, no leading `-`, max 255 bytes). The lookup cache also silently dropped `PoisonError` on both lock sites — one panic while holding the lock would have disabled caching and re-spawned `ssh` on every later call; the guard is now recovered via `into_inner`.
- **IPC socket: bind-time permission window + unbounded request line.** The unix socket was bound at its advertised path with umask-derived permissions and chmod'd to `0600` afterwards, leaving a window during which any local user could connect. The socket is now bound at a staging name, tightened, then renamed onto the final path. `handle_connection` also read a request line with no length bound (a client writing an endless unbroken line would grow the buffer until OOM); reads are capped at 1 MiB per request — far above any real `Envelope`.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test --lib` — 263 tests pass
- [x] `pnpm typecheck` and `pnpm test` — 651 tests pass
- [ ] Manual: `acorn-ipc status` against a dev profile still connects after the staging-rename change
