### PR TITLE
fix(core): daemon bridge races, reachable panics, and async executor stalls

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2105,7 +2105,11 @@ fn collect_memory_usage_from_roots(
 
 #[tauri::command]
 pub fn get_memory_usage(state: State<'_, AppState>) -> MemoryUsage {
-    let mut guard = MEMORY_PROBE.lock().expect("memory probe poisoned");
+    // Recover a poisoned probe rather than panicking the command: the
+    // cached `System` is refreshed from scratch below either way.
+    let mut guard = MEMORY_PROBE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let refresh = ProcessRefreshKind::new()
         .with_memory()
         .with_exe(UpdateKind::Always)
@@ -3254,9 +3258,39 @@ pub async fn pty_spawn<R: Runtime>(
     rows: Option<u16>,
     replay_scrollback: Option<bool>,
 ) -> AppResult<()> {
+    let state = state.inner().clone();
+    // Staging dirs, control markers, and the daemon spawn path (which can
+    // poll the daemon socket for seconds on first spawn) are all blocking —
+    // keep them off the async executor.
+    run_blocking("pty_spawn", move || {
+        pty_spawn_blocking(
+            app,
+            state,
+            session_id,
+            cwd,
+            env,
+            cols,
+            rows,
+            replay_scrollback,
+        )
+    })
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pty_spawn_blocking<R: Runtime>(
+    app: AppHandle<R>,
+    state: AppState,
+    session_id: String,
+    cwd: String,
+    env: Option<HashMap<String, String>>,
+    cols: Option<u16>,
+    rows: Option<u16>,
+    replay_scrollback: Option<bool>,
+) -> AppResult<()> {
     let id = parse_id(&session_id)?;
     let session = state.sessions.get(&id)?;
-    let cwd = authorize_session_cwd(state.inner(), &session, &PathBuf::from(cwd))?;
+    let cwd = authorize_session_cwd(&state, &session, &PathBuf::from(cwd))?;
     // Either an in-process PTY or a daemon-side stream attachment for
     // this session already exists — caller hit `pty_spawn` twice (e.g.
     // StrictMode double mount), nothing to do.
@@ -3498,7 +3532,7 @@ pub async fn pty_spawn<R: Runtime>(
 ///    persist `daemon_session_id` so the next restart hits case 2.
 fn spawn_via_daemon<R: Runtime>(
     app: &AppHandle<R>,
-    state: &State<'_, AppState>,
+    state: &AppState,
     id: uuid::Uuid,
     cwd: &std::path::Path,
     command: &str,
@@ -4031,6 +4065,21 @@ pub struct SessionStatusEntry {
 #[tauri::command]
 pub async fn detect_session_statuses(
     state: State<'_, AppState>,
+    ids: Vec<String>,
+) -> AppResult<Vec<SessionStatusEntry>> {
+    let state = state.inner().clone();
+    // The process-table refresh, per-session branch probes, and the daemon
+    // `list_sessions` RPC (which can sit in the daemon spawn retry loop for
+    // seconds) are all blocking — keep them off the async executor, or the
+    // frontend's status poll stalls every other Tauri command.
+    run_blocking("detect_session_statuses", move || {
+        detect_session_statuses_blocking(state, ids)
+    })
+    .await
+}
+
+fn detect_session_statuses_blocking(
+    state: AppState,
     ids: Vec<String>,
 ) -> AppResult<Vec<SessionStatusEntry>> {
     // One process-table snapshot covers every session in this poll. cwd is

--- a/src-tauri/src/daemon_bridge.rs
+++ b/src-tauri/src/daemon_bridge.rs
@@ -169,15 +169,20 @@ impl DaemonBridge {
         if !self.is_enabled() {
             return Err(BridgeError::Disabled);
         }
-        if self.conn.lock().is_some() {
+        // Hold the lock across the whole probe/spawn/connect sequence.
+        // Releasing it between the `is_some` check and the write let two
+        // concurrent callers both observe `None`, both sit in the spawn
+        // retry loop (up to the socket-wait timeout each), and the loser's
+        // freshly opened connection get silently dropped.
+        let mut conn = self.conn.lock();
+        if conn.is_some() {
             return Ok(());
         }
         // No cached conn — probe; if down, spawn; then connect.
         if client::probe_status()?.is_none() {
             self.spawn_daemon_with_retries()?;
         }
-        let conn = ControlConn::persistent("acorn-app")?;
-        *self.conn.lock() = Some(conn);
+        *conn = Some(ControlConn::persistent("acorn-app")?);
         Ok(())
     }
 
@@ -226,23 +231,37 @@ impl DaemonBridge {
     /// cached connection so the next call re-establishes.
     fn call(&self, payload: ControlPayload) -> BridgeResult<ControlResult> {
         self.ensure_connection()?;
-        // First attempt over the persistent conn.
+        // First attempt over the persistent conn. A concurrent caller's
+        // error path can null the cached conn between `ensure_connection`
+        // and the lock here, so treat a missing conn as a stale-connection
+        // error instead of panicking on it.
         let result = {
             let mut guard = self.conn.lock();
-            let conn = guard.as_mut().expect("ensure_connection set this");
-            conn.call(payload.clone())
+            match guard.as_mut() {
+                Some(conn) => conn.call(payload.clone()),
+                None => Err(io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "daemon connection dropped concurrently",
+                )),
+            }
         };
         match result {
             Ok(resp) => Ok(resp.payload),
             Err(e)
                 if e.kind() == io::ErrorKind::UnexpectedEof
-                    || e.kind() == io::ErrorKind::BrokenPipe =>
+                    || e.kind() == io::ErrorKind::BrokenPipe
+                    || e.kind() == io::ErrorKind::NotConnected =>
             {
                 // Stale connection — drop and reconnect once.
                 *self.conn.lock() = None;
                 self.ensure_connection()?;
                 let mut guard = self.conn.lock();
-                let conn = guard.as_mut().expect("reconnected");
+                let conn = guard.as_mut().ok_or_else(|| {
+                    BridgeError::from(io::Error::new(
+                        io::ErrorKind::NotConnected,
+                        "daemon connection dropped during retry",
+                    ))
+                })?;
                 let resp = conn.call(payload).map_err(BridgeError::from)?;
                 Ok(resp.payload)
             }


### PR DESCRIPTION
## Summary

Stability pass over the Rust backend from a codebase audit. Three independent fixes.

- **`DaemonBridge::ensure_connection` race.** The conn lock was released between the `is_some` check and the write, so two concurrent callers could both observe no connection, both sit in the daemon spawn retry loop (up to the socket-wait timeout each), and the loser's freshly opened connection was silently dropped. The lock is now held across the whole probe/spawn/connect sequence, serializing concurrent ensures.
- **Reachable panics in `DaemonBridge::call`.** Both `expect("ensure_connection set this")` and `expect("reconnected")` assumed no other thread touched the cached conn between `ensure_connection` and the re-lock — but a concurrent caller's error path nulls it, making both expects reachable process-crashing panics under parallel RPC traffic. A missing conn is now treated as a `NotConnected` stale-connection error and routed through the existing reconnect-once path.
- **Blocking work on the async executor.** `detect_session_statuses` (polled on a timer by the frontend) and `pty_spawn` were `async` commands doing purely synchronous work on the tokio runtime: full `sysinfo` process-table refreshes, per-session branch probes, staging-dir setup, and the daemon `list_sessions`/spawn path, which sleeps in a socket-wait loop for up to 5 seconds when the daemon is not up. Both bodies are moved into `run_blocking` (the pattern the other heavy commands already use), so a slow status poll or first spawn no longer stalls every other Tauri command. `spawn_via_daemon` now takes `&AppState` instead of `&State<'_, AppState>` to support the owned-state closure.
- **`get_memory_usage` poison panic.** The `MEMORY_PROBE` mutex used `expect("memory probe poisoned")`, so one panic while holding the lock turned every later call into a crash. The guard is recovered via `into_inner` — the cached `System` is refreshed from scratch on each call anyway.

Known issues intentionally left out of this PR (larger design changes): `ipc_restart`'s fixed 250 ms sleep, the unbounded wait on chat CLI child processes, and the daemon stream pump's blocking `read_line` not honoring `stop()` mid-read.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test --lib` — 263 tests pass
- [ ] Manual: open several sessions at once with the daemon killed and confirm the UI stays responsive while sessions spawn
- [ ] Manual: status polling under daemon restart shows no panic in logs
