### PR TITLE
fix(sessions): restore tab auto-rename by promoting auto-title opt-in on agent detection

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -400,6 +400,21 @@ impl SessionStore {
         Ok(entry.clone())
     }
 
+    /// Flip the explicit auto-title opt-in. Used by the status poll to
+    /// promote a plain terminal session once an agent transcript is bound
+    /// to it. Does not bump `updated_at` — polling must not reshuffle the
+    /// sidebar's most-recent-first ordering. No-op when unchanged.
+    pub fn set_auto_title_enabled(&self, id: &Uuid, enabled: bool) -> SessionResult<Session> {
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        if entry.auto_title_enabled != Some(enabled) {
+            entry.auto_title_enabled = Some(enabled);
+        }
+        Ok(entry.clone())
+    }
+
     /// Attach a daemon session id to an existing session record. The
     /// setter exists so the daemon-routed PTY path can update the row
     /// it created in-app; it is wired up at the same time as that path
@@ -580,6 +595,24 @@ mod tests {
 
         assert_eq!(session.title_source, SessionTitleSource::Default);
         assert_eq!(session.auto_title_enabled, Some(false));
+    }
+
+    #[test]
+    fn set_auto_title_enabled_flips_flag_without_touching_updated_at() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        assert_eq!(session.auto_title_enabled, Some(false));
+
+        let updated = store
+            .set_auto_title_enabled(&session.id, true)
+            .expect("session exists");
+
+        assert_eq!(updated.auto_title_enabled, Some(true));
+        assert_eq!(updated.updated_at, session.updated_at);
+        assert_eq!(
+            store.get(&session.id).expect("session exists").auto_title_enabled,
+            Some(true)
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4060,6 +4060,23 @@ pub struct SessionStatusEntry {
     /// `git checkout` performed inside the session without requiring a
     /// manual refresh.
     pub branch: Option<String>,
+    /// Auto-title opt-in after this poll. Carries the promotion performed
+    /// when an agent transcript is first detected (see
+    /// `auto_title_promotion_needed`) so the frontend planner becomes
+    /// eligible without waiting for the next full session refresh.
+    pub auto_title_enabled: Option<bool>,
+}
+
+/// A session created as a plain terminal starts with
+/// `auto_title_enabled == Some(false)` — at creation time there is no
+/// agent. Once an agent transcript is bound to the session, the user is
+/// running an agent inside it, which is exactly the case auto titles
+/// exist for. Promote the opt-in then; without this flip the per-session
+/// gate permanently overrides the global auto-title setting for every
+/// terminal session. Explicit values (`Some(true)`, legacy `None`) and
+/// transcript-less shells are left untouched.
+fn auto_title_promotion_needed(auto_title_enabled: Option<bool>, has_transcript: bool) -> bool {
+    has_transcript && auto_title_enabled == Some(false)
 }
 
 #[tauri::command]
@@ -4116,7 +4133,8 @@ fn detect_session_statuses_blocking(
             .copied()
     };
 
-    Ok(ids
+    let mut promoted_auto_title = false;
+    let entries: Vec<SessionStatusEntry> = ids
         .into_iter()
         .map(|id| {
             // Hand the detector the in-memory previous status so it can
@@ -4141,6 +4159,7 @@ fn detect_session_statuses_blocking(
                         .as_ref()
                         .and_then(|s| s.agent_transcript_id.clone()),
                     branch,
+                    auto_title_enabled: session.as_ref().and_then(|s| s.auto_title_enabled),
                 };
             }
             // Routing-aware pid lookup. Daemon-managed sessions live
@@ -4208,6 +4227,23 @@ fn detect_session_statuses_blocking(
             let agent_provider = live_agent_kind
                 .or_else(|| transcript.as_ref().map(|(_, kind)| *kind))
                 .map(status_agent_kind_to_provider);
+            let auto_title_enabled = {
+                let current = session.as_ref().and_then(|s| s.auto_title_enabled);
+                match parsed_id {
+                    Some(uuid)
+                        if auto_title_promotion_needed(current, transcript.is_some()) =>
+                    {
+                        promoted_auto_title = true;
+                        state
+                            .sessions
+                            .set_auto_title_enabled(&uuid, true)
+                            .ok()
+                            .and_then(|s| s.auto_title_enabled)
+                            .or(Some(true))
+                    }
+                    _ => current,
+                }
+            };
             let status = session_status::detect(transcript, previous, shell_hint);
             // Branch source priority:
             //  1. deepest PTY descendant cwd — reflects `cd` + `git checkout`
@@ -4234,9 +4270,16 @@ fn detect_session_statuses_blocking(
                 agent_provider,
                 agent_transcript_id,
                 branch,
+                auto_title_enabled,
             }
         })
-        .collect())
+        .collect();
+    // Promotion must survive an app restart — without the save a session
+    // would silently fall back to ineligible until the agent runs again.
+    if promoted_auto_title {
+        persist(&state);
+    }
+    Ok(entries)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -6084,6 +6127,18 @@ mod tests {
             SessionMode::Chat,
             Some(SessionAgentProvider::Codex),
         ));
+    }
+
+    #[test]
+    fn auto_title_promotes_only_opted_out_sessions_with_transcripts() {
+        // Plain terminal that started an agent: promote.
+        assert!(super::auto_title_promotion_needed(Some(false), true));
+        // Plain terminal still shell-only: leave gated.
+        assert!(!super::auto_title_promotion_needed(Some(false), false));
+        // Already opted in: nothing to do.
+        assert!(!super::auto_title_promotion_needed(Some(true), true));
+        // Legacy rows keep using compatibility heuristics.
+        assert!(!super::auto_title_promotion_needed(None, true));
     }
 
     #[test]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -514,6 +514,7 @@ export const api = {
       agent_provider?: SessionAgentProvider | null;
       agent_transcript_id?: string | null;
       branch: string | null;
+      auto_title_enabled?: boolean | null;
     }[]
   > {
     return invoke<
@@ -523,6 +524,7 @@ export const api = {
         agent_provider?: SessionAgentProvider | null;
         agent_transcript_id?: string | null;
         branch: string | null;
+        auto_title_enabled?: boolean | null;
       }[]
     >("detect_session_statuses", { ids });
   },

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1572,6 +1572,25 @@ describe("pollSessionStatuses", () => {
     expect(mockApi.detectSessionStatuses).not.toHaveBeenCalled();
   });
 
+  it("merges the backend auto-title promotion from status polling", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A, { auto_title_enabled: false })],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "running",
+        branch: null,
+        auto_title_enabled: true,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.auto_title_enabled).toBe(true);
+  });
+
   it("serializes overlapping polls and runs queued subsets afterward", async () => {
     await seed(
       [project(REPO_A, 0)],

--- a/src/store.ts
+++ b/src/store.ts
@@ -1332,11 +1332,18 @@ export const useAppStore = create<AppStateModel>()(
                 )
                   ? (update.agent_transcript_id ?? null)
                   : (sess.agent_transcript_id ?? null);
+                // Carries the backend's auto-title promotion (terminal
+                // session that started an agent) so the title planner sees
+                // eligibility on the next poll instead of waiting for a
+                // full session refresh.
+                const nextAutoTitleEnabled =
+                  update.auto_title_enabled ?? sess.auto_title_enabled ?? null;
                 if (
                   nextStatus !== sess.status ||
                   nextBranch !== sess.branch ||
                   nextAgentProvider !== (sess.agent_provider ?? null) ||
-                  nextAgentTranscriptId !== (sess.agent_transcript_id ?? null)
+                  nextAgentTranscriptId !== (sess.agent_transcript_id ?? null) ||
+                  nextAutoTitleEnabled !== (sess.auto_title_enabled ?? null)
                 ) {
                   changed = true;
                   return {
@@ -1345,6 +1352,7 @@ export const useAppStore = create<AppStateModel>()(
                     branch: nextBranch,
                     agent_provider: nextAgentProvider,
                     agent_transcript_id: nextAgentTranscriptId,
+                    auto_title_enabled: nextAutoTitleEnabled,
                   };
                 }
                 return sess;


### PR DESCRIPTION
## Summary

Fixes session tab auto-rename being dead for all new terminal sessions since #431 (v1.17.0).

**Root cause.** #431 stamps `auto_title_enabled = Some(false)` on every new regular terminal session at creation, gating both the frontend planner and the Rust title guard. The gate was meant to keep "explicit agent sessions" eligible, but no general UI creation path actually passes an agent provider at creation (only fork and history-resume do — Sidebar new session, Pane new tab, CommandRunDialog, and CommandPalette all pass `null`), and nothing ever flipped the flag afterwards. Net effect: running `claude`/`codex` inside any newly created terminal never auto-renamed the tab, and the per-session gate permanently overrode the global `autoGenerateSessionTitles` setting. Confirmed in live data: post-upgrade rows sit at `auto_title: false / title_src: default` while pre-upgrade rows (`auto_title: None`) still carry `generated` titles.

**Fix.** The status poll now promotes `Some(false)` → `Some(true)` the first time an agent transcript is bound to the session — an agent running inside the shell is exactly the case auto titles exist for, while transcript-less plain shells stay gated as #431 intended. Specifically:

- `SessionStore::set_auto_title_enabled` — flips the flag without bumping `updated_at`, so polling does not reshuffle the sidebar ordering.
- `detect_session_statuses` — promotes when `auto_title_promotion_needed(current, has_transcript)` holds (`Some(false)` + transcript present; `Some(true)` and legacy `None` rows are untouched), persists the store when any session was promoted so the opt-in survives restarts, and returns `auto_title_enabled` on each `SessionStatusEntry`.
- `pollSessionStatuses` (frontend) — merges the promoted flag into the session row, so the auto-title planner becomes eligible on the same poll instead of waiting for the next full `list_sessions` refresh.

Manual renames stay respected — the `title_source == Manual` guard is untouched, the promotion only changes the eligibility class.

## Test plan

- [x] `cargo test --lib` — 264 tests pass (new: `auto_title_promotes_only_opted_out_sessions_with_transcripts`)
- [x] `cargo test -p acorn-session` — 42 tests pass (new: `set_auto_title_enabled_flips_flag_without_touching_updated_at`)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 652 tests pass (new: store merge test for the promoted flag)
- [ ] Manual: create a new terminal session, run `claude`, send a prompt, and confirm the tab auto-renames within a poll cycle while a plain shell session keeps its name

Refs #431
