### PR TITLE
chore(release): v1.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.17.0",
+  "version": "1.17.1",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.17.0"
+version = "1.17.1"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
This release bumps Acorn from `1.17.0` to `1.17.1` for the next stable macOS updater release.

1. **Version metadata.** Updates `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` to `1.17.1`.
2. **Semver selection.** Uses a patch bump because the unreleased set contains fixes, security hardening, and performance work without a breaking or feature change.
3. **Included changes.** Releases #438, #439, #440, #441, and #442.

## Expected impact

| Area | Impact |
| --- | --- |
| App updater | Publishes the next stable version as `1.17.1` once the release tag is pushed. |
| Release notes | Uses the existing merged PR labels for Fixes and Performance sections, with cumulative `1.17.x` notes for updater jumps. |
| Runtime behavior | No code behavior changes in this PR; it only updates release metadata. |

## Design notes

- This is a release bump PR only; fix, security, and performance changelog entries come from the merged PRs listed above.
- `skip-changelog` is intentional so the release bump itself does not appear as an app-facing changelog entry.
- Latest stable release is `v1.17.0`; generated notes compare `v1.17.0...v1.17.1` and include cumulative `1.17.x` notes.

## Test plan

- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1`
- [x] `GH_TOKEN=<im-ian token> REPO=im-ian/acorn TAG=v1.17.1 OUTPUT=/tmp/acorn-release-notes-v1.17.1-after-442.md node scripts/release-notes.mjs`
- [x] `git diff --check`
- [x] main CI is green at `acd52ac560e2f70ac0cebc36b12282d9b1d8f6c6`

## Notes

- Semver reason: patch release due to fixes #438, #440, #441, #442 and performance PR #439.