### PR TITLE
fix(terminal): stop agent output from cancelling Cmd+V image paste

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -400,6 +400,21 @@ impl SessionStore {
         Ok(entry.clone())
     }
 
+    /// Flip the explicit auto-title opt-in. Used by the status poll to
+    /// promote a plain terminal session once an agent transcript is bound
+    /// to it. Does not bump `updated_at` — polling must not reshuffle the
+    /// sidebar's most-recent-first ordering. No-op when unchanged.
+    pub fn set_auto_title_enabled(&self, id: &Uuid, enabled: bool) -> SessionResult<Session> {
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        if entry.auto_title_enabled != Some(enabled) {
+            entry.auto_title_enabled = Some(enabled);
+        }
+        Ok(entry.clone())
+    }
+
     /// Attach a daemon session id to an existing session record. The
     /// setter exists so the daemon-routed PTY path can update the row
     /// it created in-app; it is wired up at the same time as that path
@@ -580,6 +595,24 @@ mod tests {
 
         assert_eq!(session.title_source, SessionTitleSource::Default);
         assert_eq!(session.auto_title_enabled, Some(false));
+    }
+
+    #[test]
+    fn set_auto_title_enabled_flips_flag_without_touching_updated_at() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        assert_eq!(session.auto_title_enabled, Some(false));
+
+        let updated = store
+            .set_auto_title_enabled(&session.id, true)
+            .expect("session exists");
+
+        assert_eq!(updated.auto_title_enabled, Some(true));
+        assert_eq!(updated.updated_at, session.updated_at);
+        assert_eq!(
+            store.get(&session.id).expect("session exists").auto_title_enabled,
+            Some(true)
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4060,6 +4060,23 @@ pub struct SessionStatusEntry {
     /// `git checkout` performed inside the session without requiring a
     /// manual refresh.
     pub branch: Option<String>,
+    /// Auto-title opt-in after this poll. Carries the promotion performed
+    /// when an agent transcript is first detected (see
+    /// `auto_title_promotion_needed`) so the frontend planner becomes
+    /// eligible without waiting for the next full session refresh.
+    pub auto_title_enabled: Option<bool>,
+}
+
+/// A session created as a plain terminal starts with
+/// `auto_title_enabled == Some(false)` — at creation time there is no
+/// agent. Once an agent transcript is bound to the session, the user is
+/// running an agent inside it, which is exactly the case auto titles
+/// exist for. Promote the opt-in then; without this flip the per-session
+/// gate permanently overrides the global auto-title setting for every
+/// terminal session. Explicit values (`Some(true)`, legacy `None`) and
+/// transcript-less shells are left untouched.
+fn auto_title_promotion_needed(auto_title_enabled: Option<bool>, has_transcript: bool) -> bool {
+    has_transcript && auto_title_enabled == Some(false)
 }
 
 #[tauri::command]
@@ -4116,7 +4133,8 @@ fn detect_session_statuses_blocking(
             .copied()
     };
 
-    Ok(ids
+    let mut promoted_auto_title = false;
+    let entries: Vec<SessionStatusEntry> = ids
         .into_iter()
         .map(|id| {
             // Hand the detector the in-memory previous status so it can
@@ -4141,6 +4159,7 @@ fn detect_session_statuses_blocking(
                         .as_ref()
                         .and_then(|s| s.agent_transcript_id.clone()),
                     branch,
+                    auto_title_enabled: session.as_ref().and_then(|s| s.auto_title_enabled),
                 };
             }
             // Routing-aware pid lookup. Daemon-managed sessions live
@@ -4208,6 +4227,23 @@ fn detect_session_statuses_blocking(
             let agent_provider = live_agent_kind
                 .or_else(|| transcript.as_ref().map(|(_, kind)| *kind))
                 .map(status_agent_kind_to_provider);
+            let auto_title_enabled = {
+                let current = session.as_ref().and_then(|s| s.auto_title_enabled);
+                match parsed_id {
+                    Some(uuid)
+                        if auto_title_promotion_needed(current, transcript.is_some()) =>
+                    {
+                        promoted_auto_title = true;
+                        state
+                            .sessions
+                            .set_auto_title_enabled(&uuid, true)
+                            .ok()
+                            .and_then(|s| s.auto_title_enabled)
+                            .or(Some(true))
+                    }
+                    _ => current,
+                }
+            };
             let status = session_status::detect(transcript, previous, shell_hint);
             // Branch source priority:
             //  1. deepest PTY descendant cwd — reflects `cd` + `git checkout`
@@ -4234,9 +4270,16 @@ fn detect_session_statuses_blocking(
                 agent_provider,
                 agent_transcript_id,
                 branch,
+                auto_title_enabled,
             }
         })
-        .collect())
+        .collect();
+    // Promotion must survive an app restart — without the save a session
+    // would silently fall back to ineligible until the agent runs again.
+    if promoted_auto_title {
+        persist(&state);
+    }
+    Ok(entries)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -6084,6 +6127,18 @@ mod tests {
             SessionMode::Chat,
             Some(SessionAgentProvider::Codex),
         ));
+    }
+
+    #[test]
+    fn auto_title_promotes_only_opted_out_sessions_with_transcripts() {
+        // Plain terminal that started an agent: promote.
+        assert!(super::auto_title_promotion_needed(Some(false), true));
+        // Plain terminal still shell-only: leave gated.
+        assert!(!super::auto_title_promotion_needed(Some(false), false));
+        // Already opted in: nothing to do.
+        assert!(!super::auto_title_promotion_needed(Some(true), true));
+        // Legacy rows keep using compatibility heuristics.
+        assert!(!super::auto_title_promotion_needed(None, true));
     }
 
     #[test]

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1067,7 +1067,13 @@ export function Terminal({
         writeToPty(targetId, data);
       }
     };
-    let terminalActivityVersion = 0;
+    // Counts USER INPUT only (xterm onData). The image-paste fallback
+    // cancels itself when this advances, meaning "the paste already
+    // reached the PTY as input". PTY *output* must not bump this:
+    // a busy agent (spinner, streaming) emits output continuously, and
+    // counting it cancelled every deferred image paste while an agent
+    // was running.
+    let terminalInputVersion = 0;
     let imagePasteFallbackTimer: number | null = null;
     let imagePasteFallbackSerial = 0;
     const IMAGE_PASTE_FALLBACK_DELAY_MS = 500;
@@ -1111,21 +1117,29 @@ export function Terminal({
         }
       };
     const pasteNativeClipboard = async () => {
-      const observedActivityVersion = terminalActivityVersion;
+      const observedInputVersion = terminalInputVersion;
       const snapshot = await api.clipboardSnapshot();
       logNativeClipboardSnapshot(snapshot);
       const imageFile = nativeClipboardImageFile(snapshot);
-      if (imageFile) {
-        scheduleClipboardImageFallback(imageFile, observedActivityVersion);
+      // Same precedence as the DOM paste path (`terminalPasteAction`):
+      // text wins over an image flavor. Apps like Word/Excel put both a
+      // string and a bitmap on the pasteboard; preferring the image here
+      // made Cmd+V silently attach a picture instead of pasting the text.
+      const action = terminalPasteAction({
+        text: snapshot.text ?? "",
+        hasImagePayload: Boolean(imageFile),
+      });
+      if (action.kind === "pasteText") {
+        term.paste(action.text);
         return;
       }
-      if (snapshot.text) {
-        term.paste(snapshot.text);
+      if (action.kind === "deferImageAttachment") {
+        scheduleClipboardImageFallback(imageFile, observedInputVersion);
       }
     };
     const scheduleClipboardImageFallback = (
       imageFile: ClipboardImageFile | null,
-      observedActivityVersion: number,
+      observedInputVersion: number,
     ) => {
       if (imagePasteFallbackTimer !== null) {
         window.clearTimeout(imagePasteFallbackTimer);
@@ -1137,7 +1151,7 @@ export function Terminal({
         if (
           disposed ||
           serial !== imagePasteFallbackSerial ||
-          terminalActivityVersion !== observedActivityVersion
+          terminalInputVersion !== observedInputVersion
         ) {
           return;
         }
@@ -1150,7 +1164,7 @@ export function Terminal({
             if (
               disposed ||
               serial !== imagePasteFallbackSerial ||
-              terminalActivityVersion !== observedActivityVersion
+              terminalInputVersion !== observedInputVersion
             ) {
               return;
             }
@@ -1161,7 +1175,7 @@ export function Terminal({
           if (
             disposed ||
             serial !== imagePasteFallbackSerial ||
-            terminalActivityVersion !== observedActivityVersion
+            terminalInputVersion !== observedInputVersion
           ) {
             return;
           }
@@ -1562,8 +1576,9 @@ export function Terminal({
     // blocks xterm's listener so the data emits exactly once.
     //
     // Image-only payloads first stay on the native path. If the paste
-    // produces no terminal input or output, run the provider-specific
-    // compatibility path.
+    // produces no terminal *input*, run the provider-specific
+    // compatibility path. (Unrelated PTY output — agent spinners,
+    // streaming — must not cancel the fallback.)
     const onPaste = (e: Event) => {
       const ev = e as ClipboardEvent;
       const cd = ev.clipboardData;
@@ -1575,11 +1590,11 @@ export function Terminal({
         hasImagePayload: Boolean(imageFile) || hasClipboardImagePayload(cd),
       });
       if (action.kind === "deferImageAttachment") {
-        scheduleClipboardImageFallback(imageFile, terminalActivityVersion);
+        scheduleClipboardImageFallback(imageFile, terminalInputVersion);
         return;
       }
       if (action.kind === "native") {
-        scheduleClipboardImageFallback(null, terminalActivityVersion);
+        scheduleClipboardImageFallback(null, terminalInputVersion);
         return;
       }
       if (action.kind === "pasteText") term.paste(action.text);
@@ -1688,7 +1703,7 @@ export function Terminal({
     );
 
     const inputDisposable = term.onData((data: string) => {
-      terminalActivityVersion += 1;
+      terminalInputVersion += 1;
       sendUserInputToPty(data);
       if (data.includes("\r") || data.includes("\n")) {
         commandSizeSyncScheduler.schedule();
@@ -1952,7 +1967,6 @@ export function Terminal({
     // PTY to also exit (zsh prints "Saving session..." twice). Guard every
     // await resumption point so a disposed mount short-circuits cleanly.
     const handlePtyOutput = (bytes: Uint8Array) => {
-      terminalActivityVersion += 1;
       term.write(bytes, () => {
         if (disposed) return;
         // The parser has drained this chunk. Force a frame-bound

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -514,6 +514,7 @@ export const api = {
       agent_provider?: SessionAgentProvider | null;
       agent_transcript_id?: string | null;
       branch: string | null;
+      auto_title_enabled?: boolean | null;
     }[]
   > {
     return invoke<
@@ -523,6 +524,7 @@ export const api = {
         agent_provider?: SessionAgentProvider | null;
         agent_transcript_id?: string | null;
         branch: string | null;
+        auto_title_enabled?: boolean | null;
       }[]
     >("detect_session_statuses", { ids });
   },

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1572,6 +1572,25 @@ describe("pollSessionStatuses", () => {
     expect(mockApi.detectSessionStatuses).not.toHaveBeenCalled();
   });
 
+  it("merges the backend auto-title promotion from status polling", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A, { auto_title_enabled: false })],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "running",
+        branch: null,
+        auto_title_enabled: true,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.auto_title_enabled).toBe(true);
+  });
+
   it("serializes overlapping polls and runs queued subsets afterward", async () => {
     await seed(
       [project(REPO_A, 0)],

--- a/src/store.ts
+++ b/src/store.ts
@@ -1332,11 +1332,18 @@ export const useAppStore = create<AppStateModel>()(
                 )
                   ? (update.agent_transcript_id ?? null)
                   : (sess.agent_transcript_id ?? null);
+                // Carries the backend's auto-title promotion (terminal
+                // session that started an agent) so the title planner sees
+                // eligibility on the next poll instead of waiting for a
+                // full session refresh.
+                const nextAutoTitleEnabled =
+                  update.auto_title_enabled ?? sess.auto_title_enabled ?? null;
                 if (
                   nextStatus !== sess.status ||
                   nextBranch !== sess.branch ||
                   nextAgentProvider !== (sess.agent_provider ?? null) ||
-                  nextAgentTranscriptId !== (sess.agent_transcript_id ?? null)
+                  nextAgentTranscriptId !== (sess.agent_transcript_id ?? null) ||
+                  nextAutoTitleEnabled !== (sess.auto_title_enabled ?? null)
                 ) {
                   changed = true;
                   return {
@@ -1345,6 +1352,7 @@ export const useAppStore = create<AppStateModel>()(
                     branch: nextBranch,
                     agent_provider: nextAgentProvider,
                     agent_transcript_id: nextAgentTranscriptId,
+                    auto_title_enabled: nextAutoTitleEnabled,
                   };
                 }
                 return sess;


### PR DESCRIPTION
## Summary

Cmd+V paste into the terminal failed intermittently. Two root causes, both in the image-paste compatibility path added in #360:

1. **Agent output cancelled the deferred image paste.** The 500ms image-paste fallback aborts when `terminalActivityVersion` advances, but that counter incremented on every PTY output chunk. While Claude/Codex is busy (spinner, streaming output) the version always changes inside the defer window, so the paste was silently dropped. The guard now tracks user input only (xterm `onData`), which is the actual "the paste already reached the PTY" signal — unrelated output no longer cancels it.

2. **Menu-accelerator path preferred image over text.** The macOS `acorn:paste` path (`pasteNativeClipboard`) checked the clipboard image flavor before text — the opposite of the DOM paste path. Copying from apps that put both a string and a bitmap on the pasteboard (Word, Excel, etc.) attached an image instead of pasting the text. The menu path now routes through the shared `terminalPasteAction`, matching the tested text-first precedence.

## Changes

- `src/components/Terminal.tsx`
  - Rename `terminalActivityVersion` → `terminalInputVersion`; stop incrementing it in `handlePtyOutput` so only `term.onData` advances it.
  - Route `pasteNativeClipboard` through `terminalPasteAction` for text-over-image ordering shared with the DOM paste handler.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 652 tests pass (text-first precedence covered by existing `terminalPaste.test.ts` case "pastes text through xterm even when files are also present")
- [ ] Manual: with an agent actively streaming output, Cmd+V a screenshot — image attach goes through instead of silently dropping
