### PR TITLE
fix(session): clear stale agent provider badges

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -400,6 +400,21 @@ impl SessionStore {
         Ok(entry.clone())
     }
 
+    /// Flip the explicit auto-title opt-in. Used by the status poll to
+    /// promote a plain terminal session once an agent transcript is bound
+    /// to it. Does not bump `updated_at` — polling must not reshuffle the
+    /// sidebar's most-recent-first ordering. No-op when unchanged.
+    pub fn set_auto_title_enabled(&self, id: &Uuid, enabled: bool) -> SessionResult<Session> {
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        if entry.auto_title_enabled != Some(enabled) {
+            entry.auto_title_enabled = Some(enabled);
+        }
+        Ok(entry.clone())
+    }
+
     /// Attach a daemon session id to an existing session record. The
     /// setter exists so the daemon-routed PTY path can update the row
     /// it created in-app; it is wired up at the same time as that path
@@ -580,6 +595,24 @@ mod tests {
 
         assert_eq!(session.title_source, SessionTitleSource::Default);
         assert_eq!(session.auto_title_enabled, Some(false));
+    }
+
+    #[test]
+    fn set_auto_title_enabled_flips_flag_without_touching_updated_at() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        assert_eq!(session.auto_title_enabled, Some(false));
+
+        let updated = store
+            .set_auto_title_enabled(&session.id, true)
+            .expect("session exists");
+
+        assert_eq!(updated.auto_title_enabled, Some(true));
+        assert_eq!(updated.updated_at, session.updated_at);
+        assert_eq!(
+            store.get(&session.id).expect("session exists").auto_title_enabled,
+            Some(true)
+        );
     }
 
     #[test]

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -299,13 +299,13 @@ pub struct Session {
     /// worktrees when added.
     #[serde(default, skip_deserializing)]
     pub in_worktree: bool,
-    /// Derived from Acorn's per-session agent-state markers. This reflects
-    /// the most recently associated Claude/Codex/Antigravity transcript and is not
+    /// Derived from status polling. This reflects the currently live
+    /// Claude/Codex/Antigravity process under the session PTY and is not
     /// persisted in sessions.json.
     #[serde(default, skip_deserializing, skip_serializing_if = "Option::is_none")]
     pub agent_provider: Option<SessionAgentProvider>,
-    /// Derived from Acorn's per-session agent-state markers. This is the
-    /// current live transcript id and is not persisted in sessions.json.
+    /// Derived from Acorn's per-session agent-state markers. This is the most
+    /// recently paired transcript id and is not persisted in sessions.json.
     #[serde(default, skip_deserializing, skip_serializing_if = "Option::is_none")]
     pub agent_transcript_id: Option<String>,
 }
@@ -397,6 +397,24 @@ impl SessionStore {
         if entry.status != status {
             entry.status = status;
         }
+        Ok(entry.clone())
+    }
+
+    /// Refresh derived live-agent metadata without bumping `updated_at`.
+    /// Status polling owns these fields because they describe the current PTY
+    /// process tree, not user-authored session data.
+    pub fn refresh_agent_state(
+        &self,
+        id: &Uuid,
+        provider: Option<SessionAgentProvider>,
+        transcript_id: Option<String>,
+    ) -> SessionResult<Session> {
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        entry.agent_provider = provider;
+        entry.agent_transcript_id = transcript_id;
         Ok(entry.clone())
     }
 
@@ -613,6 +631,26 @@ mod tests {
             store.get(&session.id).expect("session exists").auto_title_enabled,
             Some(true)
         );
+    }
+
+    #[test]
+    fn refresh_agent_state_updates_live_metadata_without_touching_updated_at() {
+        let store = SessionStore::new();
+        let mut session = fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false);
+        session.agent_provider = Some(SessionAgentProvider::Codex);
+        session.agent_transcript_id = Some("codex-old".to_string());
+        let session = store.insert(session);
+
+        let updated = store
+            .refresh_agent_state(&session.id, None, Some("codex-old".to_string()))
+            .expect("session exists");
+
+        assert_eq!(updated.agent_provider, None);
+        assert_eq!(updated.agent_transcript_id.as_deref(), Some("codex-old"));
+        assert_eq!(updated.updated_at, session.updated_at);
+        let stored = store.get(&session.id).expect("session exists");
+        assert_eq!(stored.agent_provider, None);
+        assert_eq!(stored.agent_transcript_id.as_deref(), Some("codex-old"));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1860,14 +1860,6 @@ fn enrich_session(mut s: Session) -> Session {
     s.in_worktree = worktree::is_linked_worktree_root(&s.worktree_path);
     let live = crate::agent_resume::live_transcript(s.id);
     s.agent_transcript_id = live.as_ref().map(|transcript| transcript.id.clone());
-    let live_provider = live.as_ref().map(|transcript| match transcript.kind {
-        crate::agent_resume::AgentKind::Claude => acorn_session::SessionAgentProvider::Claude,
-        crate::agent_resume::AgentKind::Codex => acorn_session::SessionAgentProvider::Codex,
-        crate::agent_resume::AgentKind::Antigravity => {
-            acorn_session::SessionAgentProvider::Antigravity
-        }
-    });
-    s.agent_provider = live_provider.or(s.agent_provider);
     s
 }
 
@@ -4224,15 +4216,14 @@ fn detect_session_statuses_blocking(
                 transcript.is_some(),
                 live_agent_kind,
             );
-            let agent_provider = live_agent_kind
-                .or_else(|| transcript.as_ref().map(|(_, kind)| *kind))
-                .map(status_agent_kind_to_provider);
+            // Durable transcript markers keep resume/title features working
+            // after exit, but provider badges should reflect only a live
+            // agent process under the PTY.
+            let agent_provider = live_agent_kind.map(status_agent_kind_to_provider);
             let auto_title_enabled = {
                 let current = session.as_ref().and_then(|s| s.auto_title_enabled);
                 match parsed_id {
-                    Some(uuid)
-                        if auto_title_promotion_needed(current, transcript.is_some()) =>
-                    {
+                    Some(uuid) if auto_title_promotion_needed(current, transcript.is_some()) => {
                         promoted_auto_title = true;
                         state
                             .sessions
@@ -4263,6 +4254,11 @@ fn detect_session_statuses_blocking(
             // (e.g. UUID parse failure for a stale id from the frontend).
             if let Some(uuid) = parsed_id {
                 let _ = state.sessions.refresh_status(&uuid, status);
+                let _ = state.sessions.refresh_agent_state(
+                    &uuid,
+                    agent_provider,
+                    agent_transcript_id.clone(),
+                );
             }
             SessionStatusEntry {
                 id,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4060,6 +4060,23 @@ pub struct SessionStatusEntry {
     /// `git checkout` performed inside the session without requiring a
     /// manual refresh.
     pub branch: Option<String>,
+    /// Auto-title opt-in after this poll. Carries the promotion performed
+    /// when an agent transcript is first detected (see
+    /// `auto_title_promotion_needed`) so the frontend planner becomes
+    /// eligible without waiting for the next full session refresh.
+    pub auto_title_enabled: Option<bool>,
+}
+
+/// A session created as a plain terminal starts with
+/// `auto_title_enabled == Some(false)` — at creation time there is no
+/// agent. Once an agent transcript is bound to the session, the user is
+/// running an agent inside it, which is exactly the case auto titles
+/// exist for. Promote the opt-in then; without this flip the per-session
+/// gate permanently overrides the global auto-title setting for every
+/// terminal session. Explicit values (`Some(true)`, legacy `None`) and
+/// transcript-less shells are left untouched.
+fn auto_title_promotion_needed(auto_title_enabled: Option<bool>, has_transcript: bool) -> bool {
+    has_transcript && auto_title_enabled == Some(false)
 }
 
 #[tauri::command]
@@ -4116,7 +4133,8 @@ fn detect_session_statuses_blocking(
             .copied()
     };
 
-    Ok(ids
+    let mut promoted_auto_title = false;
+    let entries: Vec<SessionStatusEntry> = ids
         .into_iter()
         .map(|id| {
             // Hand the detector the in-memory previous status so it can
@@ -4141,6 +4159,7 @@ fn detect_session_statuses_blocking(
                         .as_ref()
                         .and_then(|s| s.agent_transcript_id.clone()),
                     branch,
+                    auto_title_enabled: session.as_ref().and_then(|s| s.auto_title_enabled),
                 };
             }
             // Routing-aware pid lookup. Daemon-managed sessions live
@@ -4208,6 +4227,23 @@ fn detect_session_statuses_blocking(
             let agent_provider = live_agent_kind
                 .or_else(|| transcript.as_ref().map(|(_, kind)| *kind))
                 .map(status_agent_kind_to_provider);
+            let auto_title_enabled = {
+                let current = session.as_ref().and_then(|s| s.auto_title_enabled);
+                match parsed_id {
+                    Some(uuid)
+                        if auto_title_promotion_needed(current, transcript.is_some()) =>
+                    {
+                        promoted_auto_title = true;
+                        state
+                            .sessions
+                            .set_auto_title_enabled(&uuid, true)
+                            .ok()
+                            .and_then(|s| s.auto_title_enabled)
+                            .or(Some(true))
+                    }
+                    _ => current,
+                }
+            };
             let status = session_status::detect(transcript, previous, shell_hint);
             // Branch source priority:
             //  1. deepest PTY descendant cwd — reflects `cd` + `git checkout`
@@ -4234,9 +4270,16 @@ fn detect_session_statuses_blocking(
                 agent_provider,
                 agent_transcript_id,
                 branch,
+                auto_title_enabled,
             }
         })
-        .collect())
+        .collect();
+    // Promotion must survive an app restart — without the save a session
+    // would silently fall back to ineligible until the agent runs again.
+    if promoted_auto_title {
+        persist(&state);
+    }
+    Ok(entries)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -6084,6 +6127,18 @@ mod tests {
             SessionMode::Chat,
             Some(SessionAgentProvider::Codex),
         ));
+    }
+
+    #[test]
+    fn auto_title_promotes_only_opted_out_sessions_with_transcripts() {
+        // Plain terminal that started an agent: promote.
+        assert!(super::auto_title_promotion_needed(Some(false), true));
+        // Plain terminal still shell-only: leave gated.
+        assert!(!super::auto_title_promotion_needed(Some(false), false));
+        // Already opted in: nothing to do.
+        assert!(!super::auto_title_promotion_needed(Some(true), true));
+        // Legacy rows keep using compatibility heuristics.
+        assert!(!super::auto_title_promotion_needed(None, true));
     }
 
     #[test]

--- a/src/lib/agentProvider.test.ts
+++ b/src/lib/agentProvider.test.ts
@@ -126,6 +126,15 @@ describe("agent provider helpers", () => {
     ).toBe("codex");
   });
 
+  it("does not infer live providers from session names", () => {
+    expect(
+      resolveSessionAgentProvider({
+        agent_provider: null,
+        name: "codex shell",
+      }),
+    ).toBeNull();
+  });
+
   it("infers known providers from session names", () => {
     expect(inferAgentProvider("Claude worktree")).toBe("claude");
     expect(inferAgentProvider("resume codex session")).toBe("codex");
@@ -142,6 +151,6 @@ describe("agent provider helpers", () => {
         { agent_provider: null, name: "claude fork" },
         { agent_provider: "codex", name: "second" },
       ]),
-    ).toEqual(["claude", "codex", "antigravity"]);
+    ).toEqual(["codex", "antigravity"]);
   });
 });

--- a/src/lib/agentProvider.tsx
+++ b/src/lib/agentProvider.tsx
@@ -3,7 +3,6 @@ import { cn } from "./cn";
 import {
   AGENT_PROVIDER_ORDER,
   getAgentProviderDefinition,
-  inferAgentProvider,
 } from "./agentProviderRegistry";
 import type { Session, SessionAgentProvider } from "./types";
 
@@ -23,8 +22,7 @@ export {
 export function resolveSessionAgentProvider(
   session: Pick<Session, "agent_provider" | "name">,
 ): SessionAgentProvider | null {
-  if (session.agent_provider) return session.agent_provider;
-  return inferAgentProvider(session.name);
+  return session.agent_provider ?? null;
 }
 
 export function collectSessionAgentProviders(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -514,6 +514,7 @@ export const api = {
       agent_provider?: SessionAgentProvider | null;
       agent_transcript_id?: string | null;
       branch: string | null;
+      auto_title_enabled?: boolean | null;
     }[]
   > {
     return invoke<
@@ -523,6 +524,7 @@ export const api = {
         agent_provider?: SessionAgentProvider | null;
         agent_transcript_id?: string | null;
         branch: string | null;
+        auto_title_enabled?: boolean | null;
       }[]
     >("detect_session_statuses", { ids });
   },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -128,9 +128,9 @@ export interface Session {
    * worktree marker). Surfaces the worktree icon regardless of whether Acorn,
    * `claude -w`, or the user originally created the worktree. */
   in_worktree: boolean;
-  /** Most recently associated agent transcript for this Acorn session. */
+  /** Current live agent provider, if a known agent process is under the PTY. */
   agent_provider?: SessionAgentProvider | null;
-  /** Current live agent transcript id, if Acorn has paired this tab to one. */
+  /** Most recently paired agent transcript id, if Acorn has paired this tab to one. */
   agent_transcript_id?: string | null;
 }
 

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1572,6 +1572,25 @@ describe("pollSessionStatuses", () => {
     expect(mockApi.detectSessionStatuses).not.toHaveBeenCalled();
   });
 
+  it("merges the backend auto-title promotion from status polling", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A, { auto_title_enabled: false })],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "running",
+        branch: null,
+        auto_title_enabled: true,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.auto_title_enabled).toBe(true);
+  });
+
   it("serializes overlapping polls and runs queued subsets afterward", async () => {
     await seed(
       [project(REPO_A, 0)],

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1564,6 +1564,34 @@ describe("pollSessionStatuses", () => {
     );
   });
 
+  it("clears the live agent provider when status polling reports null", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          agent_provider: "codex",
+          agent_transcript_id: "codex-old",
+        }),
+      ],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "idle",
+        agent_provider: null,
+        agent_transcript_id: "codex-old",
+        branch: null,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.agent_provider).toBeNull();
+    expect(useAppStore.getState().sessions[0]?.agent_transcript_id).toBe(
+      "codex-old",
+    );
+  });
+
   it("does not call the backend when the requested ids are absent", async () => {
     await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1325,7 +1325,9 @@ export const useAppStore = create<AppStateModel>()(
                 const nextStatus = update.status;
                 const nextBranch = update.branch ?? sess.branch;
                 const nextAgentProvider =
-                  update.agent_provider ?? sess.agent_provider ?? null;
+                  Object.prototype.hasOwnProperty.call(update, "agent_provider")
+                    ? (update.agent_provider ?? null)
+                    : (sess.agent_provider ?? null);
                 const nextAgentTranscriptId = Object.prototype.hasOwnProperty.call(
                   update,
                   "agent_transcript_id",

--- a/src/store.ts
+++ b/src/store.ts
@@ -1332,11 +1332,18 @@ export const useAppStore = create<AppStateModel>()(
                 )
                   ? (update.agent_transcript_id ?? null)
                   : (sess.agent_transcript_id ?? null);
+                // Carries the backend's auto-title promotion (terminal
+                // session that started an agent) so the title planner sees
+                // eligibility on the next poll instead of waiting for a
+                // full session refresh.
+                const nextAutoTitleEnabled =
+                  update.auto_title_enabled ?? sess.auto_title_enabled ?? null;
                 if (
                   nextStatus !== sess.status ||
                   nextBranch !== sess.branch ||
                   nextAgentProvider !== (sess.agent_provider ?? null) ||
-                  nextAgentTranscriptId !== (sess.agent_transcript_id ?? null)
+                  nextAgentTranscriptId !== (sess.agent_transcript_id ?? null) ||
+                  nextAutoTitleEnabled !== (sess.auto_title_enabled ?? null)
                 ) {
                   changed = true;
                   return {
@@ -1345,6 +1352,7 @@ export const useAppStore = create<AppStateModel>()(
                     branch: nextBranch,
                     agent_provider: nextAgentProvider,
                     agent_transcript_id: nextAgentTranscriptId,
+                    auto_title_enabled: nextAutoTitleEnabled,
                   };
                 }
                 return sess;

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -459,6 +459,60 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(tooltip.locator("svg")).toHaveCount(6);
   });
 
+  test("clears agent provider icon after the agent process exits", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "session-1",
+        name: "codex",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "needs_input",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        mode: "terminal",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+        agent_provider: "codex",
+        agent_transcript_id: "codex-1",
+      },
+    ]);
+    await tauri.handle("detect_session_statuses", () => [
+      {
+        id: "session-1",
+        status: "idle",
+        branch: null,
+        agent_provider: null,
+        agent_transcript_id: "codex-1",
+      },
+    ]);
+
+    await page.goto("/");
+
+    await expect(page.locator("aside").getByRole("img", { name: "Codex" }))
+      .toHaveCount(0);
+    await expect(
+      page.locator("aside").getByRole("button", { name: /codex/ }),
+    ).toBeVisible();
+  });
+
   test("regenerates a name for sessions backed by real git worktrees", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Fixes stale agent-provider UI after a terminal exits Codex, Claude, or Antigravity and returns to an ordinary shell.

1. **Live provider semantics** — make `agent_provider` represent only a currently live known agent process under the PTY, while keeping `agent_transcript_id` available for resume/title flows.
2. **Frontend clearing path** — treat `agent_provider: null` from status polling as an explicit clear instead of preserving the previous provider.
3. **Name fallback removal** — stop provider badges/token usage/file mention behavior from inferring a live provider from session names such as `codex` or `claude`.
4. **Regression coverage** — add unit and E2E coverage for clearing the provider badge after agent exit.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Sidebar/tab provider badge | Could remain Codex/Claude/Antigravity after the agent process exited | Clears once status polling observes no live agent child process |
| Agent token usage status bar | Could remain visible from stale provider inference | Hidden for ordinary shell sessions after exit |
| Resume/title metadata | Shared the same provider signal as live UI state | Transcript id remains available without forcing a live provider badge |

## Design notes
- `agent_provider` is now updated by status polling from the live PTY descendant process tree only.
- Durable transcript markers still feed `agent_transcript_id`; this preserves resume/title behavior without making the UI think an agent is still running.
- `resolveSessionAgentProvider()` no longer falls back to `inferAgentProvider(session.name)`. Name inference remains available directly for title-generation compatibility paths that intentionally use it.

## Test plan
- [x] `pnpm exec vitest run src/lib/agentProvider.test.ts src/store.test.ts` — 119 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "clears agent provider icon"` — 1 passed
- [x] `cargo test -p acorn-session refresh_agent_state` — 1 passed
- [x] `cargo test -p acorn status_hint_tests` — 3 passed
- [x] `pnpm run test` — 654 passed
- [x] `pnpm run build` — passed; Vite emitted existing dynamic-import/chunk-size warnings
- [x] `cargo check -p acorn` — passed
- [x] `git diff --check` — passed

## Notes
- `pnpm run build:sidecar` was run once in this fresh worktree to stage the required Tauri sidecars before Rust checks.
