### PR TITLE
fix(terminal): preserve daemon input after resident eviction

### DIFF
--- a/src-tauri/crates/acorn-daemon/src/pty.rs
+++ b/src-tauri/crates/acorn-daemon/src/pty.rs
@@ -31,7 +31,7 @@ use tokio::sync::broadcast;
 use uuid::Uuid;
 
 use super::protocol::{AgentKind, SpawnSpec};
-use super::ring_buffer::RingBuffer;
+use super::ring_buffer::{ByteSpan, RingBuffer, RingSnapshot};
 use super::session::{DaemonSession, SessionRegistry};
 
 const DEFAULT_COLS: u16 = 80;
@@ -71,7 +71,7 @@ struct PtyHandle {
     /// Broadcast channel: every byte chunk read from the PTY goes here
     /// for live consumers. Stored as a `Sender` — drop is the only
     /// teardown signal, no explicit close needed.
-    output_tx: broadcast::Sender<Vec<u8>>,
+    output_tx: broadcast::Sender<OutputChunk>,
     /// Scrollback ring. Same `Arc` as the one in
     /// `DaemonSession::scrollback`; both pointers are clones of the
     /// instance created during `spawn`.
@@ -83,8 +83,25 @@ struct PtyHandle {
 }
 
 pub struct PtySubscription {
-    pub rx: broadcast::Receiver<Vec<u8>>,
+    pub rx: broadcast::Receiver<OutputChunk>,
     pub exit_code: Arc<Mutex<Option<i32>>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OutputChunk {
+    pub bytes: Vec<u8>,
+    pub start_seq: u64,
+    pub end_seq: u64,
+}
+
+impl OutputChunk {
+    fn new(bytes: Vec<u8>, span: ByteSpan) -> Self {
+        Self {
+            bytes,
+            start_seq: span.start_seq,
+            end_seq: span.end_seq,
+        }
+    }
 }
 
 /// Caller-supplied policy for applying environment variables to the
@@ -193,7 +210,7 @@ impl PtyManager {
         let pid = child.process_id();
 
         let scrollback = Arc::new(RingBuffer::new());
-        let (output_tx, _output_rx) = broadcast::channel::<Vec<u8>>(BROADCAST_CAPACITY);
+        let (output_tx, _output_rx) = broadcast::channel::<OutputChunk>(BROADCAST_CAPACITY);
 
         let stop = Arc::new(AtomicBool::new(false));
         let exit_code = Arc::new(Mutex::new(None));
@@ -329,10 +346,10 @@ impl PtyManager {
 
     /// Snapshot the current scrollback ring without subscribing to live
     /// updates. Used in concert with `subscribe` on attach.
-    pub fn scrollback_snapshot(&self, id: &Uuid) -> Option<Vec<u8>> {
+    pub fn scrollback_snapshot(&self, id: &Uuid) -> Option<RingSnapshot> {
         self.handles
             .get(id)
-            .map(|r| r.value().scrollback.snapshot())
+            .map(|r| r.value().scrollback.snapshot_with_seq())
     }
 
     pub fn contains(&self, id: &Uuid) -> bool {
@@ -393,7 +410,7 @@ fn read_loop(
     mut reader: Box<dyn Read + Send>,
     stop: Arc<AtomicBool>,
     scrollback: Arc<RingBuffer>,
-    output_tx: broadcast::Sender<Vec<u8>>,
+    output_tx: broadcast::Sender<OutputChunk>,
 ) {
     let mut buf = [0u8; READ_BUFFER_SIZE];
     loop {
@@ -404,12 +421,14 @@ fn read_loop(
             Ok(0) => break, // EOF
             Ok(n) => {
                 let chunk = &buf[..n];
-                scrollback.push(chunk);
+                let span = scrollback.push_tracked(chunk);
                 // Broadcast is a best-effort delivery; if no clients are
                 // attached, the send fails and we drop the chunk for
                 // them. The scrollback ring is the safety net on
                 // reattach.
-                let _ = output_tx.send(chunk.to_vec());
+                if let Some(span) = span {
+                    let _ = output_tx.send(OutputChunk::new(chunk.to_vec(), span));
+                }
             }
             Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
             Err(_) => break,

--- a/src-tauri/crates/acorn-daemon/src/ring_buffer.rs
+++ b/src-tauri/crates/acorn-daemon/src/ring_buffer.rs
@@ -19,8 +19,10 @@
 //! Both bounds enforced lazily on every append, so the steady-state cost is
 //! one `VecDeque::extend` plus an O(n) drain when the cap is crossed (rare).
 
-use parking_lot::Mutex;
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use parking_lot::Mutex;
 
 /// Maximum line count retained (xterm.js scrollback parity). Lines are
 /// counted by `\n` occurrences in the byte stream; non-terminated trailing
@@ -32,6 +34,18 @@ pub const LINE_CAP: usize = 5_000;
 /// compared to the in-process implementation.
 pub const BYTE_CAP: usize = 4 * 1024 * 1024;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ByteSpan {
+    pub start_seq: u64,
+    pub end_seq: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RingSnapshot {
+    pub bytes: Vec<u8>,
+    pub end_seq: u64,
+}
+
 /// Concurrent-safe ring of PTY output bytes for a single session.
 ///
 /// `Mutex<VecDeque<u8>>` was deliberately picked over a lockless ringbuf:
@@ -42,6 +56,7 @@ pub const BYTE_CAP: usize = 4 * 1024 * 1024;
 pub struct RingBuffer {
     bytes: Mutex<VecDeque<u8>>,
     newlines: Mutex<VecDeque<usize>>,
+    total_written: AtomicU64,
 }
 
 impl Default for RingBuffer {
@@ -57,17 +72,27 @@ impl RingBuffer {
             // burst of PTY output after spawn.
             bytes: Mutex::new(VecDeque::with_capacity(8 * 1024)),
             newlines: Mutex::new(VecDeque::with_capacity(LINE_CAP / 8)),
+            total_written: AtomicU64::new(0),
         }
     }
 
     /// Append a chunk of bytes. Older bytes/lines are evicted from the
     /// front until both `BYTE_CAP` and `LINE_CAP` invariants hold.
     pub fn push(&self, chunk: &[u8]) {
+        let _ = self.push_tracked(chunk);
+    }
+
+    /// Append a chunk and return the absolute byte span it occupied in the
+    /// PTY output stream. Stream attach uses this to avoid a replay gap between
+    /// a scrollback snapshot and live broadcast subscription.
+    pub fn push_tracked(&self, chunk: &[u8]) -> Option<ByteSpan> {
         if chunk.is_empty() {
-            return;
+            return None;
         }
         let mut bytes = self.bytes.lock();
         let mut newlines = self.newlines.lock();
+        let start_seq = self.total_written.load(Ordering::SeqCst);
+        let end_seq = start_seq.saturating_add(chunk.len() as u64);
 
         // 1) Append. Track each new newline by its absolute position
         //    BEFORE eviction (we rebase the indices after byte-eviction
@@ -123,6 +148,8 @@ impl RingBuffer {
                 *n = n.saturating_sub(drop_bytes);
             }
         }
+        self.total_written.store(end_seq, Ordering::SeqCst);
+        Some(ByteSpan { start_seq, end_seq })
     }
 
     /// Snapshot up to `max_bytes` of the freshest bytes. Returns
@@ -141,8 +168,19 @@ impl RingBuffer {
     /// `replay_scrollback = true` so the client sees exactly what the
     /// previous session left on the screen.
     pub fn snapshot(&self) -> Vec<u8> {
+        self.snapshot_with_seq().bytes
+    }
+
+    /// Snapshot the current ring plus the absolute stream sequence at the end
+    /// of that snapshot. If a stream subscriber was already registered before
+    /// this call, any broadcast chunk ending at or before `end_seq` is already
+    /// represented by `bytes` and should be skipped on the live path.
+    pub fn snapshot_with_seq(&self) -> RingSnapshot {
         let buf = self.bytes.lock();
-        buf.iter().copied().collect()
+        RingSnapshot {
+            bytes: buf.iter().copied().collect(),
+            end_seq: self.total_written.load(Ordering::SeqCst),
+        }
     }
 
     /// Current byte length, for status reporting.
@@ -190,6 +228,26 @@ mod tests {
         let (snap, truncated) = r.tail(1024);
         assert_eq!(snap, b"hello\nworld\n");
         assert!(!truncated);
+    }
+
+    #[test]
+    fn tracked_push_reports_absolute_byte_spans() {
+        let r = RingBuffer::new();
+        assert_eq!(
+            r.push_tracked(b"abc"),
+            Some(ByteSpan {
+                start_seq: 0,
+                end_seq: 3,
+            })
+        );
+        assert_eq!(
+            r.push_tracked(b"de"),
+            Some(ByteSpan {
+                start_seq: 3,
+                end_seq: 5,
+            })
+        );
+        assert_eq!(r.snapshot_with_seq().end_seq, 5);
     }
 
     #[test]

--- a/src-tauri/crates/acorn-daemon/src/server.rs
+++ b/src-tauri/crates/acorn-daemon/src/server.rs
@@ -436,19 +436,25 @@ impl Daemon {
             }
         };
 
-        // Snapshot scrollback first (if requested), then subscribe to live.
-        if attach.replay_scrollback {
-            if let Some(snap) = self.pty.scrollback_snapshot(&attach.session_id) {
-                let frame = StreamFrame::Output {
-                    data_b64: base64_encode(&snap),
-                };
-                write_line(reader.get_mut(), &serde_json::to_string(&frame).unwrap())?;
-            }
-        }
         let Some(mut subscription) = self.pty.subscribe(&attach.session_id) else {
             let frame = StreamFrame::Exit { code: None };
             return write_line(reader.get_mut(), &serde_json::to_string(&frame).unwrap());
         };
+        // Subscribe before snapshotting so output produced during attach is
+        // queued on the live receiver. The snapshot carries its end sequence;
+        // the pump below then skips queued chunks already represented by the
+        // replay, avoiding both the old snapshot->subscribe gap and duplicate
+        // bytes.
+        let mut replayed_until = 0;
+        if attach.replay_scrollback {
+            if let Some(snap) = self.pty.scrollback_snapshot(&attach.session_id) {
+                replayed_until = snap.end_seq;
+                let frame = StreamFrame::Output {
+                    data_b64: base64_encode(&snap.bytes),
+                };
+                write_line(reader.get_mut(), &serde_json::to_string(&frame).unwrap())?;
+            }
+        }
 
         // Reader side (client → daemon) runs on a separate thread so
         // the broadcast pump can keep delivering even while the client
@@ -491,8 +497,13 @@ impl Daemon {
         loop {
             match subscription.rx.blocking_recv() {
                 Ok(chunk) => {
+                    let bytes = live_chunk_after_replay(&chunk, replayed_until);
+                    replayed_until = replayed_until.max(chunk.end_seq);
+                    if bytes.is_empty() {
+                        continue;
+                    }
                     let frame = StreamFrame::Output {
-                        data_b64: base64_encode(&chunk),
+                        data_b64: base64_encode(bytes),
                     };
                     if write_line(reader.get_mut(), &serde_json::to_string(&frame).unwrap())
                         .is_err()
@@ -528,6 +539,19 @@ impl Daemon {
         };
         serde_json::to_string(&env).unwrap()
     }
+}
+
+fn live_chunk_after_replay(chunk: &super::pty::OutputChunk, replayed_until: u64) -> &[u8] {
+    if chunk.end_seq <= replayed_until {
+        return &[];
+    }
+    if chunk.start_seq < replayed_until {
+        let offset = usize::try_from(replayed_until - chunk.start_seq)
+            .unwrap_or(usize::MAX)
+            .min(chunk.bytes.len());
+        return &chunk.bytes[offset..];
+    }
+    &chunk.bytes
 }
 
 fn write_line<W: Write>(w: &mut W, line: &str) -> io::Result<()> {
@@ -644,6 +668,21 @@ mod tests {
             let decoded = base64_decode(&encoded).unwrap();
             assert_eq!(&decoded, input);
         }
+    }
+
+    #[test]
+    fn live_chunk_filter_skips_bytes_already_sent_by_replay() {
+        let chunk = super::super::pty::OutputChunk {
+            bytes: b"abcdef".to_vec(),
+            start_seq: 10,
+            end_seq: 16,
+        };
+
+        assert_eq!(live_chunk_after_replay(&chunk, 0), b"abcdef");
+        assert_eq!(live_chunk_after_replay(&chunk, 10), b"abcdef");
+        assert_eq!(live_chunk_after_replay(&chunk, 13), b"def");
+        assert_eq!(live_chunk_after_replay(&chunk, 16), b"");
+        assert_eq!(live_chunk_after_replay(&chunk, 99), b"");
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3249,6 +3249,7 @@ pub async fn pty_spawn<R: Runtime>(
     cols: Option<u16>,
     rows: Option<u16>,
     replay_scrollback: Option<bool>,
+    output_token: Option<u64>,
 ) -> AppResult<()> {
     let state = state.inner().clone();
     // Staging dirs, control markers, and the daemon spawn path (which can
@@ -3264,6 +3265,7 @@ pub async fn pty_spawn<R: Runtime>(
             cols,
             rows,
             replay_scrollback,
+            output_token,
         )
     })
     .await
@@ -3279,14 +3281,20 @@ fn pty_spawn_blocking<R: Runtime>(
     cols: Option<u16>,
     rows: Option<u16>,
     replay_scrollback: Option<bool>,
+    output_token: Option<u64>,
 ) -> AppResult<()> {
     let id = parse_id(&session_id)?;
     let session = state.sessions.get(&id)?;
     let cwd = authorize_session_cwd(&state, &session, &PathBuf::from(cwd))?;
+    let output_token = output_token.or_else(|| state.pty_output.current_token(&id));
     // Either an in-process PTY or a daemon-side stream attachment for
     // this session already exists — caller hit `pty_spawn` twice (e.g.
     // StrictMode double mount), nothing to do.
-    if state.pty.contains(&id) || state.stream_registry.contains(&id) {
+    if state.pty.contains(&id)
+        || state
+            .stream_registry
+            .attachment_matches_output_token(&id, output_token)
+    {
         return Ok(());
     }
     // Sessions always spawn the user's interactive `$SHELL` in login
@@ -3481,6 +3489,7 @@ fn pty_spawn_blocking<R: Runtime>(
             &effective_env,
             cols.unwrap_or(0),
             rows.unwrap_or(0),
+            output_token,
             replay_scrollback.unwrap_or(true),
         ) {
             Ok(()) => return Ok(()),
@@ -3532,12 +3541,13 @@ fn spawn_via_daemon<R: Runtime>(
     env: &HashMap<String, String>,
     cols: u16,
     rows: u16,
+    output_token: Option<u64>,
     replay_scrollback: bool,
 ) -> Result<(), String> {
     let bridge = &state.daemon_bridge;
     let registry = state.stream_registry.clone();
 
-    if registry.contains(&id) {
+    if registry.attachment_matches_output_token(&id, output_token) {
         return Ok(());
     }
 
@@ -3577,6 +3587,7 @@ fn spawn_via_daemon<R: Runtime>(
             state.pty_output.clone(),
             id,
             pid,
+            output_token,
             replay_scrollback,
         )
         .map_err(|e| format!("daemon stream attach failed: {e}"))?;
@@ -3620,6 +3631,7 @@ fn spawn_via_daemon<R: Runtime>(
         state.pty_output.clone(),
         id,
         outcome.pid,
+        output_token,
         replay_scrollback,
     )
     .map_err(|e| format!("daemon stream attach failed: {e}"))
@@ -3685,8 +3697,10 @@ pub fn pty_write(state: State<'_, AppState>, session_id: String, data: String) -
     // Daemon-managed sessions route stdin through the control socket.
     // Keystrokes are small; one RPC round-trip per keystroke is well
     // under the typing-feedback threshold and avoids managing a second
-    // socket on the app side just for input.
-    if state.stream_registry.contains(&id) {
+    // socket on the app side just for input. A stream attachment is the
+    // fast-path signal, but detached/re-attaching sessions can be alive in
+    // the daemon without an app-side output pump for a short window.
+    if daemon_session_alive_or_attached(&state, id) {
         return state
             .daemon_bridge
             .send_input(id, &bytes)
@@ -3706,7 +3720,7 @@ pub fn pty_resize(
     rows: u16,
 ) -> AppResult<()> {
     let id = parse_id(&session_id)?;
-    if state.stream_registry.contains(&id) {
+    if daemon_session_alive_or_attached(&state, id) {
         return state
             .daemon_bridge
             .resize(id, cols, rows)
@@ -3721,7 +3735,8 @@ pub fn pty_resize(
 #[tauri::command]
 pub fn pty_kill(state: State<'_, AppState>, session_id: String) -> AppResult<()> {
     let id = parse_id(&session_id)?;
-    if state.stream_registry.contains(&id) {
+    let stream_attached = state.stream_registry.contains(&id);
+    if stream_attached || state.daemon_bridge.is_alive(id) {
         // Order: tell the daemon to terminate the PTY first, then
         // release the stream attachment. The daemon's wait thread
         // emits an `Exit` frame the stream pump turns into a Tauri
@@ -3733,7 +3748,9 @@ pub fn pty_kill(state: State<'_, AppState>, session_id: String) -> AppResult<()>
             .daemon_bridge
             .kill(id)
             .map_err(|e| AppError::Pty(e.to_string()));
-        state.stream_registry.drop_attachment(&id);
+        if stream_attached {
+            state.stream_registry.drop_attachment(&id);
+        }
         return result;
     }
     state
@@ -3753,14 +3770,44 @@ pub fn pty_kill(state: State<'_, AppState>, session_id: String) -> AppResult<()>
 /// one would leave the user staring at a blank terminal. For an in-process or
 /// unknown session this is a no-op and returns `false` — the caller must keep
 /// such terminals mounted instead of evicting them.
+///
+/// `output_token` is the renderer output subscription being unmounted. If a
+/// newer renderer has already subscribed for the same session, the detach is a
+/// stale cleanup and must not drop the current daemon stream attachment.
 #[tauri::command]
-pub fn pty_detach(state: State<'_, AppState>, session_id: String) -> AppResult<bool> {
+pub fn pty_detach(
+    state: State<'_, AppState>,
+    session_id: String,
+    output_token: Option<u64>,
+) -> AppResult<bool> {
     let id = parse_id(&session_id)?;
-    if state.stream_registry.contains(&id) {
+    let stream_attached = state.stream_registry.contains(&id);
+    if stream_attached {
+        if detach_requested_by_stale_renderer(output_token, state.pty_output.current_token(&id)) {
+            return Ok(true);
+        }
         state.stream_registry.drop_attachment(&id);
         return Ok(true);
     }
+    if state.daemon_bridge.is_alive(id) {
+        return Ok(true);
+    }
     Ok(false)
+}
+
+fn daemon_session_alive_or_attached(state: &AppState, id: Uuid) -> bool {
+    state.stream_registry.contains(&id) || state.daemon_bridge.is_alive(id)
+}
+
+fn detach_requested_by_stale_renderer(
+    detach_output_token: Option<u64>,
+    current_output_token: Option<u64>,
+) -> bool {
+    match (detach_output_token, current_output_token) {
+        (Some(detach_token), Some(current_token)) => detach_token != current_token,
+        (None, Some(_)) => true,
+        _ => false,
+    }
 }
 
 /// Drop the cached snapshot of the user's shell environment. The next PTY
@@ -4897,9 +4944,9 @@ pub fn acknowledge_staged_rev_mismatch(state: State<'_, AppState>) {
 mod tests {
     use super::{
         auto_title_enabled_for_new_session, collect_memory_usage_from_roots,
-        create_unique_worktree, daemon_spawn_name_for_session, font_name_from_path,
-        infer_acornd_root_from_session_pids, inject_agent_hook_env, memory_root_pids,
-        remove_linked_worktree_at_path, should_remove_local_project_mirror,
+        create_unique_worktree, daemon_spawn_name_for_session, detach_requested_by_stale_renderer,
+        font_name_from_path, infer_acornd_root_from_session_pids, inject_agent_hook_env,
+        memory_root_pids, remove_linked_worktree_at_path, should_remove_local_project_mirror,
         validate_editor_command, validate_new_project_name, ChatProviderAdapter,
         ProcessMemorySnapshot,
     };
@@ -5997,6 +6044,15 @@ mod tests {
         let id = Uuid::new_v4();
 
         assert_eq!(daemon_spawn_name_for_session(None, id), id.to_string());
+    }
+
+    #[test]
+    fn detach_token_keeps_newer_renderer_attachment() {
+        assert!(!detach_requested_by_stale_renderer(Some(7), Some(7)));
+        assert!(!detach_requested_by_stale_renderer(Some(7), None));
+
+        assert!(detach_requested_by_stale_renderer(Some(7), Some(8)));
+        assert!(detach_requested_by_stale_renderer(None, Some(8)));
     }
 
     #[test]

--- a/src-tauri/src/daemon_stream.rs
+++ b/src-tauri/src/daemon_stream.rs
@@ -41,6 +41,7 @@ const NEEDS_INPUT_STICKY: std::time::Duration = std::time::Duration::from_secs(5
 /// closes.
 pub struct StreamAttachment {
     stop: Arc<AtomicBool>,
+    output_token: Option<u64>,
     /// OS process id of the daemon-side PTY child captured at spawn /
     /// attach. Used by status polling to walk descendants for
     /// shell-mode classification (Running / NeedsInput / Idle).
@@ -86,6 +87,32 @@ impl StreamRegistry {
         if let Some((_, handle)) = self.inner.remove(id) {
             handle.stop();
         }
+    }
+
+    /// Stop and remove `handle` only if it is still the registered attachment.
+    /// Stream pump threads use this on exit so a stale reader cannot remove a
+    /// newer attachment that re-entered the same session while the old socket
+    /// was shutting down.
+    pub fn drop_attachment_if_current(&self, id: &Uuid, handle: &Arc<StreamAttachment>) {
+        if let Some((_, current)) = self
+            .inner
+            .remove_if(id, |_, current| Arc::ptr_eq(current, handle))
+        {
+            current.stop();
+        }
+    }
+
+    /// Return whether the current attachment belongs to the renderer
+    /// subscription token that is asking to spawn. A missing token keeps the
+    /// older "attached means spawned" behavior for non-eviction callers.
+    pub fn attachment_matches_output_token(&self, id: &Uuid, output_token: Option<u64>) -> bool {
+        let Some(token) = output_token else {
+            return self.contains(id);
+        };
+        self.inner
+            .get(id)
+            .map(|entry| entry.output_token == Some(token))
+            .unwrap_or(false)
     }
 
     /// Look up the immediate PTY child pid for a daemon-managed
@@ -152,6 +179,7 @@ pub fn attach<R: Runtime>(
     output_router: Arc<PtyOutputRouter>,
     session_id: Uuid,
     pid: Option<u32>,
+    output_token: Option<u64>,
     replay_scrollback: bool,
 ) -> std::io::Result<()> {
     let mut conn = socket::connect_stream()?;
@@ -188,13 +216,15 @@ pub fn attach<R: Runtime>(
     let stop = Arc::new(AtomicBool::new(false));
     let handle = Arc::new(StreamAttachment {
         stop: stop.clone(),
+        output_token,
         pid,
         had_child: AtomicBool::new(false),
         needs_input_until: Mutex::new(None),
     });
-    registry.insert(session_id, handle);
+    registry.insert(session_id, Arc::clone(&handle));
 
     let registry_for_thread = Arc::clone(&registry);
+    let handle_for_thread = Arc::clone(&handle);
     std::thread::Builder::new()
         .name(format!("acorn-daemon-stream-{session_id}"))
         .spawn(move || {
@@ -205,6 +235,7 @@ pub fn attach<R: Runtime>(
                 session_id,
                 reader,
                 stop,
+                handle_for_thread,
             );
         })?;
     Ok(())
@@ -217,6 +248,7 @@ fn pump_loop<R: Runtime>(
     session_id: Uuid,
     mut reader: BufReader<Stream>,
     stop: Arc<AtomicBool>,
+    handle: Arc<StreamAttachment>,
 ) {
     let out_event = format!("pty:output:{session_id}");
     let exit_event = format!("pty:exit:{session_id}");
@@ -242,6 +274,16 @@ fn pump_loop<R: Runtime>(
                 let _ = app.emit(&exit_event, ExitPayload { code: None });
                 break;
             }
+        }
+        // A newer renderer generation may have superseded this attachment (via
+        // `StreamRegistry::insert`) while we were parked in `read_line`. The
+        // current attachment's pump is already subscribed to the same broadcast,
+        // so delivering this chunk too would double it. The visible symptom is
+        // the echo of the first keystroke after a fast resident re-attach landing
+        // twice. Bail before delivering; do NOT emit an Exit frame (this is a
+        // supersession, not a PTY exit).
+        if stop.load(Ordering::SeqCst) {
+            break;
         }
         let frame: StreamFrame = match serde_json::from_str(line.trim()) {
             Ok(f) => f,
@@ -275,5 +317,61 @@ fn pump_loop<R: Runtime>(
             | StreamFrame::ClientNote { .. } => {}
         }
     }
-    registry.drop_attachment(&session_id);
+    registry.drop_attachment_if_current(&session_id, &handle);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_attachment() -> Arc<StreamAttachment> {
+        Arc::new(StreamAttachment {
+            stop: Arc::new(AtomicBool::new(false)),
+            output_token: None,
+            pid: None,
+            had_child: AtomicBool::new(false),
+            needs_input_until: Mutex::new(None),
+        })
+    }
+
+    #[test]
+    fn stale_pump_cleanup_does_not_remove_newer_attachment() {
+        let registry = StreamRegistry::new();
+        let id = Uuid::new_v4();
+        let old = test_attachment();
+        let new = test_attachment();
+
+        registry.insert(id, Arc::clone(&old));
+        registry.insert(id, Arc::clone(&new));
+
+        assert!(old.stop.load(Ordering::SeqCst));
+        assert!(registry.contains(&id));
+
+        registry.drop_attachment_if_current(&id, &old);
+        assert!(registry.contains(&id));
+        assert!(!new.stop.load(Ordering::SeqCst));
+
+        registry.drop_attachment_if_current(&id, &new);
+        assert!(!registry.contains(&id));
+        assert!(new.stop.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn attachment_token_distinguishes_renderer_generations() {
+        let registry = StreamRegistry::new();
+        let id = Uuid::new_v4();
+        let old = Arc::new(StreamAttachment {
+            stop: Arc::new(AtomicBool::new(false)),
+            output_token: Some(7),
+            pid: None,
+            had_child: AtomicBool::new(false),
+            needs_input_until: Mutex::new(None),
+        });
+
+        registry.insert(id, old);
+
+        assert!(registry.attachment_matches_output_token(&id, Some(7)));
+        assert!(!registry.attachment_matches_output_token(&id, Some(8)));
+        assert!(registry.attachment_matches_output_token(&id, None));
+    }
 }

--- a/src-tauri/src/pty_output.rs
+++ b/src-tauri/src/pty_output.rs
@@ -42,6 +42,10 @@ impl PtyOutputRouter {
         }
     }
 
+    pub fn current_token(&self, session_id: &Uuid) -> Option<u64> {
+        self.channels.get(session_id).map(|entry| entry.token)
+    }
+
     pub fn send_or_emit<R: Runtime>(
         &self,
         app: &AppHandle<R>,

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -47,10 +47,19 @@ import {
   type TerminalPasteEventDetail,
 } from "../lib/pasteEvents";
 import {
-  prepareScrollbackForSave,
   shouldRestoreScrollback,
   stripRestoreMarkers,
 } from "../lib/terminalScrollback";
+import {
+  clearRememberedTerminalScrollback,
+  rememberedTerminalScrollback,
+  rememberTerminalScrollback,
+} from "../lib/terminalScrollbackHandoff";
+import {
+  cancelPendingTerminalPtyDisposal,
+  scheduleTerminalPtyDisposal,
+} from "../lib/terminalPtyDisposal";
+import { planTerminalRestore } from "../lib/terminalRestorePlan";
 import {
   AGENT_IMAGE_PASTE_CONTROL,
   getClipboardImageFile,
@@ -773,6 +782,7 @@ export function Terminal({
     // terminal column.
     termRef.current = term;
     fitRef.current = fitAddon;
+    cancelPendingTerminalPtyDisposal(sessionId);
 
     // The DOM renderer (default) anchors xterm's hidden textarea at the
     // cursor cell, so IME composition popups (CJK input) render at the
@@ -821,8 +831,8 @@ export function Terminal({
     let observedLinkedWorktreePath: string | null = null;
     let liveCwdProbeTimer: number | null = null;
     let agentProbeTimer: number | null = null;
-    let restoredDiskScrollback = false;
     let daemonSessionAliveAtMount = false;
+    let replayScrollbackOnSpawn = true;
     let agentImagePasteFallbackActive =
       pasteAgentProviderRef.current === "codex" ||
       pasteAgentProviderRef.current === "claude";
@@ -1827,6 +1837,7 @@ export function Terminal({
       const detail = (e as CustomEvent<{ sessionId: string }>).detail;
       if (!detail || detail.sessionId !== sessionId) return;
       term.clear();
+      clearRememberedTerminalScrollback(sessionId);
       // Sticky-prompt banner watches the buffer for `> ` lines; after a
       // clear there are none, so explicitly schedule a dispatch so the
       // banner picks up the now-empty state without waiting for the
@@ -1911,7 +1922,11 @@ export function Terminal({
           env: {},
           cols: spawnCols,
           rows: spawnRows,
-          replayScrollback: daemonSessionAliveAtMount || !restoredDiskScrollback,
+          // Live daemon-backed attaches replay their raw ring as the source of
+          // truth. Local snapshots are only restored for dead daemon sessions,
+          // where there is no live ring to replay.
+          replayScrollback: replayScrollbackOnSpawn,
+          outputToken: outputSubscriptionToken,
         });
         if (disposed) {
           // Cleanup ran mid-spawn — the pty just got created has no UI.
@@ -1990,6 +2005,7 @@ export function Terminal({
       scheduleLiveCwdProbe();
       scheduleAgentDetection();
     };
+    let outputSubscriptionToken: number | null = null;
 
     (async () => {
       let outputChannel: Channel<unknown> | null = null;
@@ -2006,6 +2022,7 @@ export function Terminal({
           sessionId,
           channel: outputChannel,
         });
+        outputSubscriptionToken = outputToken;
         const subscribedOutputChannel = outputChannel;
         if (disposed) {
           invoke("pty_unsubscribe_output", {
@@ -2184,10 +2201,18 @@ export function Terminal({
           sessionId,
         });
         if (disposed) return;
-        restoredDiskScrollback = !daemonSessionAliveAtMount && saved !== null;
-        const restored = saved ? stripRestoreMarkers(saved) : "";
+        const handoff = rememberedTerminalScrollback(sessionId);
+        const restorePlan = planTerminalRestore({
+          daemonAlive: daemonSessionAliveAtMount,
+          handoff,
+          disk: saved,
+        });
+        replayScrollbackOnSpawn = restorePlan.replayScrollback;
+        const restored = restorePlan.snapshot
+          ? stripRestoreMarkers(restorePlan.snapshot)
+          : "";
         if (
-          !daemonSessionAliveAtMount &&
+          restorePlan.source !== null &&
           restored &&
           shouldRestoreScrollback(restored)
         ) {
@@ -2267,19 +2292,20 @@ export function Terminal({
     // ~1s debounce window of unsaved output; that is the cost we accept
     // in exchange for not constantly serialising idle buffers.
     const SCROLLBACK_MAX_ROWS = 2000;
-    const persistScrollbackAsync = async () => {
+    const persistScrollbackAsync = async (options?: { force?: boolean }) => {
       // `savesAllowed` flips true only after the initial scrollback_load
       // settles. Skipping the save until then prevents a still-empty
       // buffer from clobbering the persisted scrollback during the
       // StrictMode mount → cleanup → mount cycle.
-      if (disposed || !savesAllowed) return;
+      if ((!options?.force && disposed) || !savesAllowed) return;
       try {
         const data = serializeAddon.serialize({
           scrollback: SCROLLBACK_MAX_ROWS,
         });
+        const prepared = rememberTerminalScrollback(sessionId, data);
         await invoke("scrollback_save", {
           sessionId,
-          data: prepareScrollbackForSave(data),
+          data: prepared,
         });
       } catch (err) {
         console.warn("[Terminal] scrollback_save failed", err);
@@ -2292,6 +2318,7 @@ export function Terminal({
 
     return () => {
       disposed = true;
+      const detachingForReuse = consumeTerminalDetaching(sessionId);
       unsubSettings();
       hideLinkTooltip(true);
       if (themeFrame !== null) {
@@ -2303,6 +2330,14 @@ export function Terminal({
         window.clearTimeout(scrollbackSaveTimer);
         scrollbackSaveTimer = null;
       }
+      if (detachingForReuse) {
+        // A resident-limit eviction can unmount the terminal less than one
+        // debounce window after the latest output. Persist once from cleanup so
+        // the next mount cannot fall back to an older disk snapshot if daemon
+        // reattach is unavailable or delayed. `savesAllowed` still protects
+        // StrictMode's pre-load cleanup from writing an empty buffer.
+        void persistScrollbackAsync({ force: true });
+      }
       if (viewportRepaintTimer !== null) {
         window.clearTimeout(viewportRepaintTimer);
         viewportRepaintTimer = null;
@@ -2312,14 +2347,6 @@ export function Terminal({
         viewportRepaintFrame = null;
       }
       cancelLinkTooltipHide();
-      // No cleanup-time save: under React.StrictMode the cleanup of the
-      // first dev mount fires while the buffer is still empty (load
-      // hasn't run yet), and a fire-and-forget save here would clobber
-      // the persisted scrollback with 0 bytes. Tab-close / project-switch
-      // unmount instead relies on the most recent debounced output save
-      // (within ~1s of the last activity), which is already on disk; the
-      // App-level `onCloseRequested` handler covers full app quit and
-      // does an awaited flush via `flushAllScrollbacks` before destroy.
       if (resizeTimer !== null) {
         window.clearTimeout(resizeTimer);
         resizeTimer = null;
@@ -2363,24 +2390,29 @@ export function Terminal({
       for (const off of unlistenFns) {
         try { off(); } catch { /* ignore */ }
       }
-      if (consumeTerminalDetaching(sessionId)) {
-        // Evicted for memory, not deleted: detach so the daemon keeps the
-        // shell + scrollback ring alive and a later remount re-attaches and
-        // replays it. If the backend reports the session was not daemon-backed
-        // (and therefore cannot be re-attached), fall back to a kill rather
-        // than strand a headless in-process shell.
-        invoke<boolean>("pty_detach", { sessionId })
-          .then((detached) => {
-            if (!detached) return invoke("pty_kill", { sessionId });
+      scheduleTerminalPtyDisposal(sessionId, () => {
+        if (detachingForReuse) {
+          // Evicted for memory, not deleted: detach so the daemon keeps the
+          // shell + scrollback ring alive and a later remount re-attaches and
+          // replays it. If the backend reports the session was not daemon-backed
+          // (and therefore cannot be re-attached), fall back to a kill rather
+          // than strand a headless in-process shell.
+          invoke<boolean>("pty_detach", {
+            sessionId,
+            outputToken: outputSubscriptionToken,
           })
-          .catch(() => {
-            // best effort
+            .then((detached) => {
+              if (!detached) return invoke("pty_kill", { sessionId });
+            })
+            .catch(() => {
+              // best effort
+            });
+        } else {
+          invoke("pty_kill", { sessionId }).catch(() => {
+            // Backend may not implement pty_kill yet — safe to ignore.
           });
-      } else {
-        invoke("pty_kill", { sessionId }).catch(() => {
-          // Backend may not implement pty_kill yet — safe to ignore.
-        });
-      }
+        }
+      });
       unpatchMouseCoordinateScale();
       try { webLinksDisposable?.dispose(); } catch { /* ignore */ }
       webLinksDisposable = null;

--- a/src/lib/terminalPtyDisposal.test.ts
+++ b/src/lib/terminalPtyDisposal.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cancelPendingTerminalPtyDisposal,
+  hasPendingTerminalPtyDisposal,
+  scheduleTerminalPtyDisposal,
+} from "./terminalPtyDisposal";
+
+describe("terminal PTY disposal scheduler", () => {
+  afterEach(() => {
+    cancelPendingTerminalPtyDisposal("s1");
+    vi.useRealTimers();
+  });
+
+  it("defers disposal so immediate remount can cancel it", () => {
+    vi.useFakeTimers();
+    const disposal = vi.fn();
+
+    scheduleTerminalPtyDisposal("s1", disposal);
+    expect(hasPendingTerminalPtyDisposal("s1")).toBe(true);
+
+    cancelPendingTerminalPtyDisposal("s1");
+    vi.advanceTimersByTime(250);
+
+    expect(disposal).not.toHaveBeenCalled();
+    expect(hasPendingTerminalPtyDisposal("s1")).toBe(false);
+  });
+
+  it("runs disposal after the remount grace window", () => {
+    vi.useFakeTimers();
+    const disposal = vi.fn();
+
+    scheduleTerminalPtyDisposal("s1", disposal);
+    vi.advanceTimersByTime(249);
+    expect(disposal).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(disposal).toHaveBeenCalledTimes(1);
+    expect(hasPendingTerminalPtyDisposal("s1")).toBe(false);
+  });
+});

--- a/src/lib/terminalPtyDisposal.ts
+++ b/src/lib/terminalPtyDisposal.ts
@@ -1,0 +1,26 @@
+type Disposal = () => void;
+
+const pending = new Map<string, number>();
+
+export function cancelPendingTerminalPtyDisposal(sessionId: string): void {
+  const handle = pending.get(sessionId);
+  if (handle === undefined) return;
+  window.clearTimeout(handle);
+  pending.delete(sessionId);
+}
+
+export function scheduleTerminalPtyDisposal(
+  sessionId: string,
+  disposal: Disposal,
+): void {
+  cancelPendingTerminalPtyDisposal(sessionId);
+  const handle = window.setTimeout(() => {
+    pending.delete(sessionId);
+    disposal();
+  }, 250);
+  pending.set(sessionId, handle);
+}
+
+export function hasPendingTerminalPtyDisposal(sessionId: string): boolean {
+  return pending.has(sessionId);
+}

--- a/src/lib/terminalRestorePlan.test.ts
+++ b/src/lib/terminalRestorePlan.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { planTerminalRestore } from "./terminalRestorePlan";
+
+describe("terminal restore plan", () => {
+  it("uses daemon replay when the daemon session is alive", () => {
+    expect(
+      planTerminalRestore({
+        daemonAlive: true,
+        handoff: "latest handoff",
+        disk: "older disk",
+      }),
+    ).toEqual({
+      snapshot: null,
+      source: null,
+      replayScrollback: true,
+    });
+  });
+
+  it("skips disk restore for alive daemon sessions", () => {
+    expect(
+      planTerminalRestore({
+        daemonAlive: true,
+        handoff: null,
+        disk: "older disk",
+      }),
+    ).toEqual({
+      snapshot: null,
+      source: null,
+      replayScrollback: true,
+    });
+  });
+
+  it("uses resident handoff for non-live daemon sessions before disk", () => {
+    expect(
+      planTerminalRestore({
+        daemonAlive: false,
+        handoff: "latest handoff",
+        disk: "saved disk",
+      }),
+    ).toEqual({
+      snapshot: "latest handoff",
+      source: "handoff",
+      replayScrollback: false,
+    });
+  });
+
+  it("uses disk restore for non-live daemon sessions without handoff", () => {
+    expect(
+      planTerminalRestore({
+        daemonAlive: false,
+        handoff: null,
+        disk: "saved disk",
+      }),
+    ).toEqual({
+      snapshot: "saved disk",
+      source: "disk",
+      replayScrollback: false,
+    });
+  });
+
+  it("skips replay when there is no daemon session to replay", () => {
+    expect(
+      planTerminalRestore({
+        daemonAlive: false,
+        handoff: null,
+        disk: null,
+      }),
+    ).toEqual({
+      snapshot: null,
+      source: null,
+      replayScrollback: false,
+    });
+  });
+});

--- a/src/lib/terminalRestorePlan.ts
+++ b/src/lib/terminalRestorePlan.ts
@@ -1,0 +1,44 @@
+export type TerminalRestoreSource = "handoff" | "disk";
+
+export interface TerminalRestorePlan {
+  snapshot: string | null;
+  source: TerminalRestoreSource | null;
+  replayScrollback: boolean;
+}
+
+export function planTerminalRestore({
+  daemonAlive,
+  handoff,
+  disk,
+}: {
+  daemonAlive: boolean;
+  handoff: string | null;
+  disk: string | null;
+}): TerminalRestorePlan {
+  if (daemonAlive) {
+    return {
+      snapshot: null,
+      source: null,
+      replayScrollback: true,
+    };
+  }
+  if (handoff !== null) {
+    return {
+      snapshot: handoff,
+      source: "handoff",
+      replayScrollback: false,
+    };
+  }
+  if (disk !== null) {
+    return {
+      snapshot: disk,
+      source: "disk",
+      replayScrollback: false,
+    };
+  }
+  return {
+    snapshot: null,
+    source: null,
+    replayScrollback: false,
+  };
+}

--- a/src/lib/terminalScrollbackHandoff.test.ts
+++ b/src/lib/terminalScrollbackHandoff.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearRememberedTerminalScrollback,
+  rememberedTerminalScrollback,
+  rememberTerminalScrollback,
+} from "./terminalScrollbackHandoff";
+
+describe("terminal scrollback handoff", () => {
+  it("keeps the latest non-empty serialized scrollback in memory", () => {
+    clearRememberedTerminalScrollback("s1");
+
+    const saved = rememberTerminalScrollback("s1", "before\nlatest\n");
+
+    expect(saved).toBe("before\nlatest\n");
+    expect(rememberedTerminalScrollback("s1")).toBe("before\nlatest\n");
+  });
+
+  it("drops empty or prompt-only snapshots", () => {
+    rememberTerminalScrollback("s2", "real output\n");
+
+    const saved = rememberTerminalScrollback("s2", "% ");
+
+    expect(saved).toBe("");
+    expect(rememberedTerminalScrollback("s2")).toBeNull();
+  });
+
+  it("clears snapshots by session id", () => {
+    rememberTerminalScrollback("s3", "kept\n");
+    clearRememberedTerminalScrollback("s3");
+
+    expect(rememberedTerminalScrollback("s3")).toBeNull();
+  });
+});

--- a/src/lib/terminalScrollbackHandoff.ts
+++ b/src/lib/terminalScrollbackHandoff.ts
@@ -1,0 +1,24 @@
+import { prepareScrollbackForSave } from "./terminalScrollback";
+
+const snapshots = new Map<string, string>();
+
+export function rememberTerminalScrollback(
+  sessionId: string,
+  serialized: string,
+): string {
+  const prepared = prepareScrollbackForSave(serialized);
+  if (prepared) {
+    snapshots.set(sessionId, prepared);
+  } else {
+    snapshots.delete(sessionId);
+  }
+  return prepared;
+}
+
+export function rememberedTerminalScrollback(sessionId: string): string | null {
+  return snapshots.get(sessionId) ?? null;
+}
+
+export function clearRememberedTerminalScrollback(sessionId: string): void {
+  snapshots.delete(sessionId);
+}


### PR DESCRIPTION
## Summary
Fixes resident-terminal eviction races that could leave daemon-backed terminals unable to accept input or restore the newest terminal output after tabs were detached and re-entered.

1. **Renderer generation guard** — pass the renderer output subscription token through `pty_spawn` and `pty_detach` so stale cleanup calls cannot drop or mask a newer renderer attachment.
2. **Daemon input routing** — route `pty_write`, `pty_resize`, and daemon kills by live daemon ownership as well as active stream attachment, so detached sessions do not fall back to missing in-process PTYs.
3. **Sequence-aware daemon replay** — subscribe to live daemon output before snapshot replay and trim queued chunks by byte sequence so attach-time output is neither lost nor duplicated.
4. **Daemon-ring restore policy** — when the daemon session is alive, skip frontend handoff/disk paint and let daemon replay be the source of truth; use resident handoff/disk snapshots only when no live daemon ring exists.
5. **StrictMode-safe PTY disposal** — delay and cancel backend `pty_detach`/`pty_kill` work across immediate remounts so dev StrictMode cleanup cannot briefly restore a terminal and then clear it by disposing the live PTY route.
6. **Superseded pump guard** — stop an old stream pump before it can deliver a chunk after a newer renderer attachment supersedes it, preventing duplicate first-key echoes on fast reattach.
7. **Regression coverage** — add backend tests for stale detach tokens, stale stream pump cleanup, attachment-token generation matching, ring byte spans, replay/live chunk trimming, and frontend restore/handoff/disposal behavior.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Re-entering evicted daemon terminals | A late detach or stale stream could drop or mask the current app-side daemon route, causing input/control failure or stale restore output | New renderer generations reattach and replay correctly while stale cleanup becomes a no-op |
| Latest terminal output before tab switch | Frontend handoff could paint first, then the live daemon PTY redraw could overwrite that local xterm snapshot | Live daemon sessions replay the daemon ring directly, keeping the screen/cursor state aligned with the running PTY |
| Fast resident reattach | A superseded stream pump could still deliver one queued chunk after a newer renderer subscribed | Old pumps stop before delivery once superseded, avoiding duplicate first-key echoes |
| Dev StrictMode remounts | React's mount cleanup probe could call backend detach/kill immediately after the restored terminal appeared | Backend PTY disposal is deferred briefly and canceled by the immediate remount for the same session |
| In-process terminal sessions | Fallback path depended on no daemon attachment | Unchanged for non-daemon sessions except for the same short disposal grace window on immediate remount |

## Design notes
- The input/control race is caused by asynchronous React cleanup: the old terminal can call `pty_detach` or exit its stream pump after a newer mount has already subscribed output for the same session.
- The output subscription token is used as a per-session renderer generation marker. `pty_spawn` only treats an existing stream attachment as current when its stored token matches the new renderer token.
- `stream_registry` is an attachment registry, not a complete daemon-ownership marker. Input and resize now also check whether the daemon still owns a live session.
- Daemon stream replay now uses absolute byte spans from the ring buffer. The server can subscribe first, snapshot second, then skip or slice queued live chunks that are already represented in the replayed snapshot.
- Frontend handoff remains useful only when the daemon session is not alive. For live daemon reattach, painting a serialized xterm snapshot can desynchronize xterm from the running shell's cursor/screen model, so the daemon ring is authoritative.
- PTY detach/kill is scheduled behind a short per-session grace window. A real unmount still disposes the backend PTY, while an immediate remount cancels the stale cleanup before it can clear the restored route.

## Test plan
- [x] `TAURI_SIDECAR_PROFILE=debug ./src-tauri/scripts/build-sidecar.sh`
- [x] `cargo test -p acorn-daemon`
- [x] `cargo test attachment`
- [x] `pnpm test -- --run src/lib/terminalPtyDisposal.test.ts src/lib/terminalRestorePlan.test.ts src/lib/terminalScrollbackHandoff.test.ts src/lib/terminalScrollback.test.ts src/components/TerminalHost.test.tsx`
- [x] `pnpm run typecheck`
- [x] `git diff --check`
- [ ] Manual resident-limit `2` retest after the daemon-ring restore policy update: open tabs 1/2, append output in tab 1, open tab 3, return to tabs 1/2/3, and confirm latest output remains visible and input still works.

## Notes
- The latest update targets the observed pattern where restored content appears briefly and is then cleared by a live PTY redraw. The fix avoids painting a frontend snapshot for live daemon sessions.
