### PR TITLE
fix(terminal): remove scrollback restore banner

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -48,7 +48,6 @@ import {
 } from "../lib/pasteEvents";
 import {
   prepareScrollbackForSave,
-  RESTORE_MARKER_TEXT,
   shouldRestoreScrollback,
   stripRestoreMarkers,
 } from "../lib/terminalScrollback";
@@ -2192,16 +2191,10 @@ export function Terminal({
           restored &&
           shouldRestoreScrollback(restored)
         ) {
-          // Each step is awaited individually. Previously the mode
-          // resets and marker were fired without awaiting and `spawnPty`
-          // was called immediately after, so the new shell's first
-          // prompt could arrive via the pty:output listener while our
-          // own writes were still sitting in xterm's parser queue.
-          // Interleaving with the shell's prompt-redraw escape sequences
-          // intermittently parked the cursor at column 0 of the new
-          // prompt line and left input invisible (the user typed but
-          // echo landed off-screen). Strict serial drain makes the
-          // post-restore cursor position deterministic.
+          // Each step is awaited individually so the restored snapshot,
+          // terminal-mode resets, and the new shell's first prompt cannot
+          // interleave inside xterm's parser queue. Strict serial drain
+          // keeps the post-restore cursor position deterministic.
           const writeAndDrain = (data: string): Promise<void> =>
             new Promise<void>((resolve) => term.write(data, resolve));
 
@@ -2238,9 +2231,9 @@ export function Terminal({
             "\r"; //          park cursor at column 0
           await writeAndDrain(RESETS);
           if (disposed) return;
-          await writeAndDrain(
-            `\r\n${ANSI_DIM}${RESTORE_MARKER_TEXT}${ANSI_RESET}\r\n`,
-          );
+          // Leave room for the new shell prompt without adding a visible
+          // restore banner to the terminal history.
+          await writeAndDrain("\r\n");
           if (disposed) return;
         }
       } catch (err) {

--- a/src/lib/terminalScrollback.test.ts
+++ b/src/lib/terminalScrollback.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   prepareScrollbackForSave,
-  RESTORE_MARKER_TEXT,
   shouldRestoreScrollback,
 } from "./terminalScrollback";
 
 describe("terminal scrollback restore hygiene", () => {
+  const legacyRestoreMarkerText = "— restored from previous session —";
+
   it("does not restore whitespace-only scrollback", () => {
     expect(shouldRestoreScrollback("\r\n\n   \x1b[0m\r\n")).toBe(false);
   });
@@ -18,12 +19,12 @@ describe("terminal scrollback restore hygiene", () => {
     ).toBe(false);
   });
 
-  it("removes Acorn restore markers before saving", () => {
+  it("removes legacy Acorn restore markers before saving", () => {
     const saved = prepareScrollbackForSave(
-      `build ok\r\n\x1b[2m${RESTORE_MARKER_TEXT}\x1b[0m\r\nnext prompt % `,
+      `build ok\r\n\x1b[2m${legacyRestoreMarkerText}\x1b[0m\r\nnext prompt % `,
     );
 
-    expect(saved).not.toContain(RESTORE_MARKER_TEXT);
+    expect(saved).not.toContain(legacyRestoreMarkerText);
     expect(saved).toContain("build ok");
   });
 

--- a/src/lib/terminalScrollback.ts
+++ b/src/lib/terminalScrollback.ts
@@ -1,4 +1,4 @@
-export const RESTORE_MARKER_TEXT = "— restored from previous session —";
+const LEGACY_RESTORE_MARKER_TEXT = "— restored from previous session —";
 
 const ANSI_ESCAPE_RE =
   // OSC, CSI, and common one-character escape sequences.
@@ -30,7 +30,7 @@ export function stripRestoreMarkers(input: string): string {
   return chunks
     .filter((chunk) => {
       if (chunk.length === 0) return false;
-      return !stripAnsi(chunk).includes(RESTORE_MARKER_TEXT);
+      return !stripAnsi(chunk).includes(LEGACY_RESTORE_MARKER_TEXT);
     })
     .join("");
 }


### PR DESCRIPTION
## Summary
Remove the visible terminal restore banner while keeping scrollback replay behavior intact.

1. **No visible restore marker** — stop writing `— restored from previous session —` into terminal history after disk scrollback replay.
2. **Prompt spacing preserved** — keep a trailing newline so the newly spawned shell prompt does not overwrite the restored screen's final row.
3. **Legacy cleanup retained** — continue stripping previously saved restore markers from old scrollback snapshots before reuse or save.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal restart UX | Replayed scrollback ended with a visible restore message | Replayed scrollback returns silently with normal prompt spacing |
| Existing saved scrollback | Old restore marker lines could be present on disk | Old marker lines are still filtered out on load/save |

## Design notes
- The restore marker constant is no longer exported because the UI no longer writes the banner.
- `stripRestoreMarkers` still recognizes the old marker text so existing user data is cleaned opportunistically without a migration.
- The terminal replay path still serial-drains the restored bytes and reset sequences before spawning the PTY, preserving the cursor/input safety behavior around restored snapshots.

## Test plan
- [x] `git diff --check origin/main...HEAD` passes
- [x] `pnpm run test -- src/lib/terminalScrollback.test.ts` passes — 64 files, 654 tests
- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` passes; Vite reports existing chunk/dynamic-import warnings

## Notes
- PR #447 was closed and replaced because it was accidentally based on a prior worktree commit. This PR is based directly on `main` and contains only the terminal restore-banner change.
