### PR TITLE
fix(worktrees): undo disk removal from toast

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2685,10 +2685,12 @@ pub async fn remove_project(
     remove_sessions: Option<bool>,
     remove_worktrees: Option<bool>,
     remove_settings: Option<bool>,
-) -> AppResult<()> {
+) -> AppResult<Vec<worktree::RemovedWorktree>> {
     let path = PathBuf::from(&repo_path);
     let cascade = remove_sessions.unwrap_or(true);
     let drop_worktrees = remove_worktrees.unwrap_or(false);
+    let mut removed_worktrees = Vec::new();
+    let mut staged_worktree_paths = HashSet::new();
     if cascade {
         let session_ids: Vec<_> = state
             .sessions
@@ -2698,8 +2700,12 @@ pub async fn remove_project(
             .collect();
         for session in session_ids {
             terminate_session_pty(state.inner(), &session.id);
-            if drop_worktrees {
-                remove_linked_worktree_at_path(&session.repo_path, &session.worktree_path).ok();
+            if drop_worktrees && staged_worktree_paths.insert(session.worktree_path.clone()) {
+                if let Ok(Some(removed)) =
+                    stage_remove_linked_worktree_at_path(&session.repo_path, &session.worktree_path)
+                {
+                    removed_worktrees.push(removed);
+                }
             }
             state.sessions.remove(&session.id).ok();
         }
@@ -2713,7 +2719,7 @@ pub async fn remove_project(
         }
     }
     persist(&state);
-    Ok(())
+    Ok(removed_worktrees)
 }
 
 #[tauri::command]
@@ -2721,22 +2727,26 @@ pub async fn remove_session(
     state: State<'_, AppState>,
     id: String,
     remove_worktree: Option<bool>,
-) -> AppResult<()> {
+) -> AppResult<Option<worktree::RemovedWorktree>> {
     let id = Uuid::parse_str(&id).map_err(|e| AppError::Other(e.to_string()))?;
     let session = state.sessions.get(&id)?;
     terminate_session_pty(state.inner(), &id);
     if let Ok(dir) = persistence::data_dir() {
         scrollback::delete(&dir, &id.to_string()).ok();
     }
-    if remove_worktree.unwrap_or(false) {
-        remove_linked_worktree_at_path(&session.repo_path, &session.worktree_path).ok();
-    }
+    let removed_worktree = if remove_worktree.unwrap_or(false) {
+        stage_remove_linked_worktree_at_path(&session.repo_path, &session.worktree_path)
+            .ok()
+            .flatten()
+    } else {
+        None
+    };
     state.sessions.remove(&id)?;
     if should_remove_local_project_mirror(&session, &state.sessions.list()) {
         state.projects.remove(&session.repo_path);
     }
     persist(&state);
-    Ok(())
+    Ok(removed_worktree)
 }
 
 #[tauri::command]
@@ -3179,10 +3189,43 @@ pub fn git_worktrees(repo_path: String) -> AppResult<Vec<String>> {
 }
 
 #[tauri::command]
-pub fn remove_worktree(repo_path: String, worktree_path: String) -> AppResult<()> {
+pub fn remove_worktree(
+    repo_path: String,
+    worktree_path: String,
+) -> AppResult<Option<worktree::RemovedWorktree>> {
     let repo_path = PathBuf::from(repo_path);
     let worktree_path = PathBuf::from(worktree_path);
-    remove_linked_worktree_at_path(&repo_path, &worktree_path)
+    stage_remove_linked_worktree_at_path(&repo_path, &worktree_path)
+}
+
+#[tauri::command]
+pub fn restore_removed_worktree(
+    token: String,
+    repo_path: String,
+    worktree_path: String,
+    git_common_dir: String,
+) -> AppResult<()> {
+    worktree::restore_removed_worktree(
+        Path::new(&repo_path),
+        Path::new(&worktree_path),
+        &token,
+        Path::new(&git_common_dir),
+    )
+}
+
+#[tauri::command]
+pub fn discard_removed_worktree(
+    token: String,
+    repo_path: String,
+    worktree_path: String,
+    git_common_dir: String,
+) -> AppResult<()> {
+    worktree::discard_removed_worktree(
+        Path::new(&repo_path),
+        Path::new(&worktree_path),
+        &token,
+        Path::new(&git_common_dir),
+    )
 }
 
 fn parse_id(id: &str) -> AppResult<Uuid> {
@@ -4682,11 +4725,19 @@ pub(crate) fn create_unique_worktree(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn remove_linked_worktree_at_path(
     repo_path: &Path,
     worktree_path: &Path,
 ) -> AppResult<()> {
     worktree::remove_worktree_at_path(repo_path, worktree_path)
+}
+
+pub(crate) fn stage_remove_linked_worktree_at_path(
+    repo_path: &Path,
+    worktree_path: &Path,
+) -> AppResult<Option<worktree::RemovedWorktree>> {
+    worktree::stage_remove_worktree_at_path(repo_path, worktree_path)
 }
 
 /// Surface the "이전 Claude 대화 있음" candidate for a session — used by

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -572,6 +572,8 @@ pub fn run() {
             commands::prepare_chat_session_worktree,
             commands::git_worktrees,
             commands::remove_worktree,
+            commands::restore_removed_worktree,
+            commands::discard_removed_worktree,
             commands::scrollback_save,
             commands::scrollback_load,
             commands::scrollback_delete,

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -1,11 +1,23 @@
 use git2::Repository;
+use serde::Serialize;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
 
 const ACORN_DIR: &str = ".acorn";
 const EXCLUDE_ENTRY: &str = ".acorn/";
+const DELETED_WORKTREES_DIR: &str = ".acorn-deleted-worktrees";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemovedWorktree {
+    pub token: String,
+    pub repo_path: String,
+    pub worktree_path: String,
+    pub git_common_dir: String,
+}
 
 pub fn ensure_repo(path: &Path) -> AppResult<Repository> {
     // `discover` walks up from `path` to find the nearest `.git`, so callers
@@ -119,7 +131,10 @@ pub fn list_worktree_paths(repo_path: &Path) -> AppResult<Vec<std::path::PathBuf
     Ok(paths)
 }
 
-pub fn remove_worktree_at_path(repo_path: &Path, worktree_path: &Path) -> AppResult<()> {
+pub fn stage_remove_worktree_at_path(
+    repo_path: &Path,
+    worktree_path: &Path,
+) -> AppResult<Option<RemovedWorktree>> {
     if worktree_path.exists() && !is_linked_worktree_root(worktree_path) {
         return Err(AppError::InvalidPath(format!(
             "not a linked git worktree: {}",
@@ -132,18 +147,154 @@ pub fn remove_worktree_at_path(repo_path: &Path, worktree_path: &Path) -> AppRes
     for name in names.iter().flatten() {
         let wt = repo.find_worktree(name)?;
         if same_path(wt.path(), worktree_path) {
-            if worktree_path.exists() {
-                std::fs::remove_dir_all(worktree_path).ok();
+            if !worktree_path.exists() {
+                if has_staged_worktree_backup(worktree_path) {
+                    return Ok(None);
+                }
+                wt.prune(None)?;
+                return Ok(None);
             }
-            wt.prune(None)?;
-            return Ok(());
+            let token = Uuid::new_v4().to_string();
+            let backup = removed_worktree_backup_path(worktree_path, &token)?;
+            if let Some(parent) = backup.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::rename(worktree_path, &backup)?;
+            return Ok(Some(RemovedWorktree {
+                token,
+                repo_path: repo_path.to_string_lossy().into_owned(),
+                worktree_path: worktree_path.to_string_lossy().into_owned(),
+                git_common_dir: repo.commondir().to_string_lossy().into_owned(),
+            }));
         }
+    }
+
+    if !worktree_path.exists() {
+        return Ok(None);
     }
 
     Err(AppError::InvalidPath(format!(
         "linked git worktree is not registered: {}",
         worktree_path.display()
     )))
+}
+
+#[cfg(test)]
+pub fn remove_worktree_at_path(repo_path: &Path, worktree_path: &Path) -> AppResult<()> {
+    if let Some(removed) = stage_remove_worktree_at_path(repo_path, worktree_path)? {
+        discard_removed_worktree(
+            Path::new(&removed.repo_path),
+            Path::new(&removed.worktree_path),
+            &removed.token,
+            Path::new(&removed.git_common_dir),
+        )?;
+    }
+    Ok(())
+}
+
+pub fn restore_removed_worktree(
+    _repo_path: &Path,
+    worktree_path: &Path,
+    token: &str,
+    _git_common_dir: &Path,
+) -> AppResult<()> {
+    validate_removal_token(token)?;
+    let backup = removed_worktree_backup_path(worktree_path, token)?;
+    if !backup.exists() {
+        return Err(AppError::InvalidPath(format!(
+            "removed worktree backup is not available: {}",
+            backup.display()
+        )));
+    }
+    if worktree_path.exists() {
+        return Err(AppError::InvalidPath(format!(
+            "worktree path already exists: {}",
+            worktree_path.display()
+        )));
+    }
+    if let Some(parent) = worktree_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::rename(&backup, worktree_path)?;
+    remove_empty_backup_root(worktree_path);
+    Ok(())
+}
+
+pub fn discard_removed_worktree(
+    repo_path: &Path,
+    worktree_path: &Path,
+    token: &str,
+    git_common_dir: &Path,
+) -> AppResult<()> {
+    validate_removal_token(token)?;
+    let backup = removed_worktree_backup_path(worktree_path, token)?;
+    if backup.exists() {
+        std::fs::remove_dir_all(&backup)?;
+    }
+    remove_empty_backup_root(worktree_path);
+    if worktree_path.exists() {
+        return Ok(());
+    }
+    let repo = match Repository::open(git_common_dir) {
+        Ok(repo) => repo,
+        Err(_) => ensure_repo(repo_path)?,
+    };
+    prune_registered_worktree_at_path(&repo, worktree_path)?;
+    Ok(())
+}
+
+fn prune_registered_worktree_at_path(repo: &Repository, worktree_path: &Path) -> AppResult<bool> {
+    let names = repo.worktrees()?;
+    for name in names.iter().flatten() {
+        let wt = repo.find_worktree(name)?;
+        if same_path(wt.path(), worktree_path) {
+            wt.prune(None)?;
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn removed_worktree_backup_path(worktree_path: &Path, token: &str) -> AppResult<PathBuf> {
+    validate_removal_token(token)?;
+    let parent = worktree_path.parent().ok_or_else(|| {
+        AppError::InvalidPath(format!(
+            "worktree path has no parent directory: {}",
+            worktree_path.display()
+        ))
+    })?;
+    Ok(parent.join(DELETED_WORKTREES_DIR).join(token))
+}
+
+fn validate_removal_token(token: &str) -> AppResult<()> {
+    let safe = !token.is_empty()
+        && token
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-');
+    if safe {
+        return Ok(());
+    }
+    Err(AppError::InvalidPath(
+        "invalid worktree removal token".into(),
+    ))
+}
+
+fn remove_empty_backup_root(worktree_path: &Path) {
+    let Some(parent) = worktree_path.parent() else {
+        return;
+    };
+    let root = parent.join(DELETED_WORKTREES_DIR);
+    let _ = std::fs::remove_dir(&root);
+}
+
+fn has_staged_worktree_backup(worktree_path: &Path) -> bool {
+    let Some(parent) = worktree_path.parent() else {
+        return false;
+    };
+    let root = parent.join(DELETED_WORKTREES_DIR);
+    root.read_dir()
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false)
 }
 
 fn same_path(left: &Path, right: &Path) -> bool {
@@ -190,6 +341,122 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).expect("create temp dir");
         dir
+    }
+
+    fn init_repo_with_tracked_file(path: &Path) -> Repository {
+        let repo = Repository::init(path).expect("init repo");
+        std::fs::write(path.join("tracked.txt"), "initial").expect("write tracked file");
+        let sig = git2::Signature::now("acorn-test", "test@acorn").expect("sig");
+        let tree_id = {
+            let mut idx = repo.index().expect("index");
+            idx.add_path(Path::new("tracked.txt"))
+                .expect("add tracked file");
+            idx.write_tree().expect("write tree")
+        };
+        let tree = repo.find_tree(tree_id).expect("find tree");
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .expect("initial commit");
+        drop(tree);
+        repo
+    }
+
+    #[test]
+    fn staged_remove_restore_preserves_uncommitted_files() {
+        let root = unique_temp_dir("restore-uncommitted");
+        let repo = init_repo_with_tracked_file(&root);
+        drop(repo);
+        let worktree_path = create_worktree(&root, "feature").expect("create worktree");
+        std::fs::write(worktree_path.join("tracked.txt"), "modified").expect("modify tracked file");
+        std::fs::write(worktree_path.join("untracked.txt"), "new").expect("write untracked file");
+
+        let removed = stage_remove_worktree_at_path(&root, &worktree_path)
+            .expect("stage remove")
+            .expect("removal token");
+
+        assert!(!worktree_path.exists(), "worktree should move out of place");
+
+        restore_removed_worktree(
+            Path::new(&removed.repo_path),
+            Path::new(&removed.worktree_path),
+            &removed.token,
+            Path::new(&removed.git_common_dir),
+        )
+        .expect("restore worktree");
+
+        assert_eq!(
+            std::fs::read_to_string(worktree_path.join("tracked.txt")).unwrap(),
+            "modified"
+        );
+        assert_eq!(
+            std::fs::read_to_string(worktree_path.join("untracked.txt")).unwrap(),
+            "new"
+        );
+        assert!(is_linked_worktree_root(&worktree_path));
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn discard_removed_worktree_prunes_registration() {
+        let root = unique_temp_dir("discard");
+        let repo = init_repo_with_tracked_file(&root);
+        drop(repo);
+        let worktree_path = create_worktree(&root, "discard-me").expect("create worktree");
+        let removed = stage_remove_worktree_at_path(&root, &worktree_path)
+            .expect("stage remove")
+            .expect("removal token");
+
+        discard_removed_worktree(
+            Path::new(&removed.repo_path),
+            Path::new(&removed.worktree_path),
+            &removed.token,
+            Path::new(&removed.git_common_dir),
+        )
+        .expect("discard worktree");
+
+        assert!(!worktree_path.exists());
+        assert!(
+            !list_worktree_paths(&root)
+                .expect("list worktrees")
+                .iter()
+                .any(|path| same_path(path, &worktree_path)),
+            "discard should prune the linked worktree registration"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn staged_remove_duplicate_call_preserves_registration_for_restore() {
+        let root = unique_temp_dir("duplicate-stage");
+        let repo = init_repo_with_tracked_file(&root);
+        drop(repo);
+        let worktree_path = create_worktree(&root, "duplicate").expect("create worktree");
+        let removed = stage_remove_worktree_at_path(&root, &worktree_path)
+            .expect("stage remove")
+            .expect("removal token");
+
+        let second =
+            stage_remove_worktree_at_path(&root, &worktree_path).expect("second stage remove");
+        assert!(second.is_none());
+
+        restore_removed_worktree(
+            Path::new(&removed.repo_path),
+            Path::new(&removed.worktree_path),
+            &removed.token,
+            Path::new(&removed.git_common_dir),
+        )
+        .expect("restore worktree");
+
+        assert!(
+            list_worktree_paths(&root)
+                .expect("list worktrees")
+                .iter()
+                .any(|path| same_path(path, &worktree_path)),
+            "duplicate stage should not prune a restorable worktree"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,6 +108,7 @@ import { useAppStore } from "./store";
 import type { TranslationKey, Translator } from "./lib/i18n";
 import type { SessionStatus } from "./lib/types";
 import { useTranslation } from "./lib/useTranslation";
+import { showStoreWorktreeRemovalToast } from "./lib/operationToasts";
 
 const FOCUSABLE_SELECTOR =
   "textarea, input:not([type='hidden']), button, [tabindex]:not([tabindex='-1']), a[href]";
@@ -1113,10 +1114,14 @@ function App() {
     );
     if (autoDeleteWorktree && autoDeleteWorktrees) {
       clearPendingRemove();
-      void removeSession(pendingRemove.id, true).then(() =>
-        showStoreOperationToast(
+      void removeSession(pendingRemove.id, true).then((removedWorktree) =>
+        showStoreWorktreeRemovalToast(
+          removedWorktree,
           "toasts.session.worktreeRemoved",
+          "toasts.session.worktreeRemovedUndo",
           "toasts.session.worktreeRemoveFailed",
+          "toasts.session.worktreeRestored",
+          "toasts.session.worktreeRestoreFailed",
         ),
       );
       return;
@@ -1740,15 +1745,20 @@ function App() {
           clearPendingRemove();
           if (!target || choice === "cancel") return;
           void removeSession(target.id, choice === "session_and_worktree").then(
-            () =>
-              showStoreOperationToast(
-                choice === "session_and_worktree"
-                  ? "toasts.session.worktreeRemoved"
-                  : null,
-                choice === "session_and_worktree"
-                  ? "toasts.session.worktreeRemoveFailed"
-                  : "toasts.session.removeFailed",
-              ),
+            (removedWorktree) => {
+              if (choice === "session_and_worktree") {
+                showStoreWorktreeRemovalToast(
+                  removedWorktree,
+                  "toasts.session.worktreeRemoved",
+                  "toasts.session.worktreeRemovedUndo",
+                  "toasts.session.worktreeRemoveFailed",
+                  "toasts.session.worktreeRestored",
+                  "toasts.session.worktreeRestoreFailed",
+                );
+                return;
+              }
+              showStoreOperationToast(null, "toasts.session.removeFailed");
+            },
           );
         }}
       />
@@ -1762,16 +1772,20 @@ function App() {
           void removeProject(
             target.repo_path,
             choice === "project_and_worktrees",
-          ).then(() =>
-            showStoreOperationToast(
-              choice === "project_and_worktrees"
-                ? "toasts.project.worktreesRemoved"
-                : null,
-              choice === "project_and_worktrees"
-                ? "toasts.project.worktreesRemoveFailed"
-                : "toasts.project.removeFailed",
-            ),
-          );
+          ).then((removedWorktrees) => {
+            if (choice === "project_and_worktrees") {
+              showStoreWorktreeRemovalToast(
+                removedWorktrees,
+                "toasts.project.worktreesRemoved",
+                "toasts.project.worktreesRemovedUndo",
+                "toasts.project.worktreesRemoveFailed",
+                "toasts.project.worktreesRestored",
+                "toasts.project.worktreesRestoreFailed",
+              );
+              return;
+            }
+            showStoreOperationToast(null, "toasts.project.removeFailed");
+          });
         }}
       />
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -55,7 +55,7 @@ import {
   AgentProviderIcon,
   resolveSessionAgentProvider,
 } from "../lib/agentProvider";
-import { api } from "../lib/api";
+import { api, type WorktreeRemoval } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
 import type { TranslationKey, Translator } from "../lib/i18n";
@@ -76,6 +76,7 @@ import {
 } from "../lib/sessionWorktree";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
+import { showWorktreeRemovalToast } from "../lib/operationToasts";
 import {
   buildLocalSessions,
 } from "../lib/sessionGrouping";
@@ -419,12 +420,16 @@ export function Sidebar() {
     folderGroup: ProjectFolderGroup,
   ) {
     try {
+      const removedWorktrees: WorktreeRemoval[] = [];
       for (const session of folderGroup.sessions) {
-        await removeSession(
+        const removedWorktree = await removeSession(
           session.id,
           autoDeleteWorktrees &&
             shouldAutoDeleteSessionWorktree(session, projectFolders),
         );
+        if (removedWorktree) {
+          removedWorktrees.push(removedWorktree);
+        }
         const error = useAppStore.getState().consumeError();
         if (error) {
           showToast(`${t("toasts.session.removeFailed")} ${error}`);
@@ -432,6 +437,15 @@ export function Sidebar() {
         }
       }
       removeProjectFolder(folderGroup.folder.id);
+      if (removedWorktrees.length > 0) {
+        showWorktreeRemovalToast(
+          removedWorktrees,
+          "toasts.project.worktreesRemoved",
+          "toasts.project.worktreesRemovedUndo",
+          "toasts.project.worktreesRestored",
+          "toasts.project.worktreesRestoreFailed",
+        );
+      }
     } catch (e) {
       console.error("remove project folder failed", e);
       showToast(`${t("toasts.session.removeFailed")} ${String(e)}`);
@@ -440,9 +454,30 @@ export function Sidebar() {
 
   async function removeProjectFolderAndWorktree(folder: ProjectFolder) {
     try {
-      await api.removeWorktree(folder.repoPath, folder.cwdPath);
+      const removedWorktree = await api.removeWorktree(
+        folder.repoPath,
+        folder.cwdPath,
+      );
       removeProjectFolder(folder.id);
-      showToast(t("toasts.session.worktreeRemoved"));
+      showWorktreeRemovalToast(
+        removedWorktree,
+        "toasts.session.worktreeRemoved",
+        "toasts.session.worktreeRemovedUndo",
+        "toasts.session.worktreeRestored",
+        "toasts.session.worktreeRestoreFailed",
+        {
+          onRestored: () => {
+            const restored = createProjectFolder(
+              folder.repoPath,
+              folder.name,
+              folder.cwdPath,
+            );
+            if (restored) {
+              setActiveProjectFolder(restored.id);
+            }
+          },
+        },
+      );
     } catch (e) {
       console.error("remove project folder worktree failed", e);
       showToast(`${t("toasts.session.worktreeRemoveFailed")} ${String(e)}`);

--- a/src/components/ToastHost.tsx
+++ b/src/components/ToastHost.tsx
@@ -2,7 +2,11 @@ import { useEffect, useState, type CSSProperties, type ReactElement } from "reac
 import { createPortal } from "react-dom";
 import { cn } from "../lib/cn";
 import { useSettings } from "../lib/settings";
-import { useToasts, type ToastItem } from "../lib/toasts";
+import {
+  getToastRemainingMs,
+  useToasts,
+  type ToastItem,
+} from "../lib/toasts";
 
 const TOAST_EXIT_MS = 180;
 
@@ -22,6 +26,7 @@ export function ToastHost(): ReactElement | null {
   const [rendered, setRendered] = useState<RenderedToast[]>([]);
   const [mounted, setMounted] = useState(false);
   const [stackPaused, setStackPaused] = useState(false);
+  const [, setCountdownTick] = useState(0);
 
   useEffect(() => {
     setMounted(true);
@@ -69,6 +74,17 @@ export function ToastHost(): ReactElement | null {
     }
   }, [pause, stackPaused, toasts]);
 
+  useEffect(() => {
+    const hasCountdownToast = rendered.some(
+      (toast) => toast.formatMessage && !toast.exiting,
+    );
+    if (!hasCountdownToast) return;
+    const interval = window.setInterval(() => {
+      setCountdownTick((tick) => tick + 1);
+    }, 1_000);
+    return () => window.clearInterval(interval);
+  }, [rendered]);
+
   if (rendered.length === 0 || !mounted) return null;
   const pauseAll = () => {
     setStackPaused(true);
@@ -84,17 +100,15 @@ export function ToastHost(): ReactElement | null {
   };
   const handleClick = (toast: RenderedToast) => {
     if (toast.exiting) return;
-    try {
-      if (toast.action) {
-        void Promise.resolve(toast.action()).catch((err: unknown) => {
-          console.error("[ToastHost] toast action failed", err);
-        });
-      }
-    } catch (err) {
-      console.error("[ToastHost] toast action failed", err);
-    } finally {
+    if (!toast.action) {
       hide(toast.id);
+      return;
     }
+    hide(toast.id, { skipDismiss: true });
+    void Promise.resolve(toast.action())
+      .catch((err: unknown) => {
+        console.error("[ToastHost] toast action failed", err);
+      });
   };
   return createPortal(
     <div
@@ -121,6 +135,11 @@ export function ToastHost(): ReactElement | null {
           const progressStyle = {
             "--toast-duration": `${toast.durationMs}ms`,
           } as CSSProperties;
+          const message = toast.formatMessage
+            ? toast.formatMessage(
+                Math.max(0, Math.ceil(getToastRemainingMs(toast.id) / 1000)),
+              )
+            : toast.message;
           return (
             <button
               key={toast.id}
@@ -132,7 +151,7 @@ export function ToastHost(): ReactElement | null {
               data-state={toast.exiting ? "exit" : "enter"}
               className="acorn-toast-motion relative cursor-pointer overflow-hidden rounded-full border border-border bg-bg-elevated px-4 py-2 text-xs text-fg shadow-md transition-[background-color,border-color,box-shadow] duration-200 ease-out hover:border-accent/60 hover:bg-bg-elevated/95 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-accent/50"
             >
-              {toast.message}
+              {message}
               <div
                 aria-hidden="true"
                 className="acorn-toast-progress absolute inset-x-0 bottom-0 h-0.5 origin-left bg-accent/80"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -74,6 +74,13 @@ export interface ClipboardSnapshot {
   dataB64: string | null;
 }
 
+export interface WorktreeRemoval {
+  token: string;
+  repoPath: string;
+  worktreePath: string;
+  gitCommonDir: string;
+}
+
 export interface ChatSessionStateChangedPayload {
   session_id: string;
   state: ChatSessionState;
@@ -139,8 +146,11 @@ export const api = {
       mode,
     });
   },
-  removeSession(id: string, removeWorktree = false): Promise<void> {
-    return invoke<void>("remove_session", { id, removeWorktree });
+  removeSession(
+    id: string,
+    removeWorktree = false,
+  ): Promise<WorktreeRemoval | null> {
+    return invoke<WorktreeRemoval | null>("remove_session", { id, removeWorktree });
   },
   setSessionStatus(id: string, status: SessionStatus): Promise<Session> {
     return invoke<Session>("set_session_status", { id, status });
@@ -272,8 +282,8 @@ export const api = {
     removeSessions = true,
     removeWorktrees = false,
     removeSettings = false,
-  ): Promise<void> {
-    return invoke<void>("remove_project", {
+  ): Promise<WorktreeRemoval[]> {
+    return invoke<WorktreeRemoval[]>("remove_project", {
       repoPath,
       removeSessions,
       removeWorktrees,
@@ -647,8 +657,20 @@ export const api = {
   gitWorktrees(repoPath: string): Promise<string[]> {
     return invoke<string[]>("git_worktrees", { repoPath });
   },
-  removeWorktree(repoPath: string, worktreePath: string): Promise<void> {
-    return invoke<void>("remove_worktree", { repoPath, worktreePath });
+  removeWorktree(
+    repoPath: string,
+    worktreePath: string,
+  ): Promise<WorktreeRemoval | null> {
+    return invoke<WorktreeRemoval | null>("remove_worktree", {
+      repoPath,
+      worktreePath,
+    });
+  },
+  restoreRemovedWorktree(removal: WorktreeRemoval): Promise<void> {
+    return invoke<void>("restore_removed_worktree", { ...removal });
+  },
+  discardRemovedWorktree(removal: WorktreeRemoval): Promise<void> {
+    return invoke<void>("discard_removed_worktree", { ...removal });
   },
   /**
    * Probe the `acornd` daemon. Backs the StatusBar daemon indicator and

--- a/src/lib/operationToasts.ts
+++ b/src/lib/operationToasts.ts
@@ -1,7 +1,8 @@
 import { createTranslator, type TranslationKey } from "./i18n";
 import { useSettings } from "./settings";
-import { useToasts } from "./toasts";
+import { TOAST_TTL_MS, useToasts } from "./toasts";
 import { useAppStore } from "../store";
+import { api, type WorktreeRemoval } from "./api";
 
 export function currentText(
   key: TranslationKey,
@@ -44,4 +45,90 @@ export function showStoreResultToast(
   if (successKey) {
     showTranslatedToast(successKey);
   }
+}
+
+function worktreeName(removal: WorktreeRemoval): string {
+  const trimmed = removal.worktreePath.replace(/[\\/]+$/, "");
+  const parts = trimmed.split(/[\\/]/);
+  return parts[parts.length - 1] || trimmed || "worktree";
+}
+
+function worktreeRemovalToastValues(
+  removals: WorktreeRemoval[],
+  remainingSeconds: number,
+): Record<string, string | number> {
+  return {
+    count: removals.length,
+    name: removals.length === 1 ? worktreeName(removals[0]) : removals.length,
+    seconds: remainingSeconds,
+  };
+}
+
+export function showWorktreeRemovalToast(
+  removals: WorktreeRemoval | WorktreeRemoval[] | null | undefined,
+  successKey: TranslationKey,
+  undoKey: TranslationKey,
+  restoredKey: TranslationKey,
+  restoreFailedKey: TranslationKey,
+  options?: { onRestored?: () => void },
+): void {
+  const list = (Array.isArray(removals) ? removals : removals ? [removals] : [])
+    .filter(Boolean);
+  if (list.length === 0) {
+    showTranslatedToast(successKey);
+    return;
+  }
+
+  const initialSeconds = Math.ceil(TOAST_TTL_MS / 1000);
+  useToasts.getState().show(
+    currentText(
+      undoKey,
+      worktreeRemovalToastValues(list, initialSeconds),
+    ),
+    {
+      formatMessage: (remainingSeconds) =>
+        currentText(
+          undoKey,
+          worktreeRemovalToastValues(list, remainingSeconds),
+        ),
+      action: async () => {
+        try {
+          await Promise.all(
+            list.map((removal) => api.restoreRemovedWorktree(removal)),
+          );
+          options?.onRestored?.();
+          showTranslatedToast(restoredKey);
+        } catch (error) {
+          showTranslatedErrorToast(restoreFailedKey, error);
+        }
+      },
+      onDismiss: async () => {
+        await Promise.allSettled(
+          list.map((removal) => api.discardRemovedWorktree(removal)),
+        );
+      },
+    },
+  );
+}
+
+export function showStoreWorktreeRemovalToast(
+  removals: WorktreeRemoval | WorktreeRemoval[] | null | undefined,
+  successKey: TranslationKey,
+  undoKey: TranslationKey,
+  failureKey: TranslationKey,
+  restoredKey: TranslationKey,
+  restoreFailedKey: TranslationKey,
+): void {
+  const error = useAppStore.getState().consumeError();
+  if (error) {
+    showTranslatedErrorToast(failureKey, error);
+    return;
+  }
+  showWorktreeRemovalToast(
+    removals,
+    successKey,
+    undoKey,
+    restoredKey,
+    restoreFailedKey,
+  );
 }

--- a/src/lib/toasts.ts
+++ b/src/lib/toasts.ts
@@ -1,16 +1,25 @@
 import { create } from "zustand";
 
 type ToastAction = () => void | Promise<void>;
+type ToastMessageFormatter = (remainingSeconds: number) => string;
 
 interface ToastOptions {
   action?: ToastAction;
+  onDismiss?: ToastAction;
+  formatMessage?: ToastMessageFormatter;
+}
+
+interface ToastHideOptions {
+  skipDismiss?: boolean;
 }
 
 export interface ToastItem {
   id: number;
   message: string;
+  formatMessage: ToastMessageFormatter | null;
   durationMs: number;
   action: ToastAction | null;
+  onDismiss: ToastAction | null;
   paused: boolean;
 }
 
@@ -22,7 +31,7 @@ export interface ToastItem {
 interface ToastState {
   toasts: ToastItem[];
   show: (message: string, options?: ToastOptions) => void;
-  hide: (id?: number) => void;
+  hide: (id?: number, options?: ToastHideOptions) => void;
   pause: (id: number) => void;
   resume: (id: number) => void;
 }
@@ -43,6 +52,26 @@ function clearDismissTimer(id: number) {
   }
 }
 
+function runDismissAction(toast: ToastItem, skipDismiss?: boolean) {
+  if (skipDismiss || !toast.onDismiss) return;
+  try {
+    void Promise.resolve(toast.onDismiss()).catch((err: unknown) => {
+      console.error("[toasts] dismiss action failed", err);
+    });
+  } catch (err) {
+    console.error("[toasts] dismiss action failed", err);
+  }
+}
+
+export function getToastRemainingMs(id: number): number {
+  const toast = useToasts.getState().toasts.find((item) => item.id === id);
+  if (!toast) return 0;
+  const remaining = remainingMs.get(id) ?? toast.durationMs;
+  if (toast.paused) return remaining;
+  const started = startedAt.get(id) ?? Date.now();
+  return Math.max(0, remaining - (Date.now() - started));
+}
+
 export const useToasts = create<ToastState>((set, get) => ({
   toasts: [],
   show: (message: string, options?: ToastOptions) => {
@@ -55,8 +84,10 @@ export const useToasts = create<ToastState>((set, get) => ({
         {
           id,
           message,
+          formatMessage: options?.formatMessage ?? null,
           durationMs: TOAST_TTL_MS,
           action: options?.action ?? null,
+          onDismiss: options?.onDismiss ?? null,
           paused: false,
         },
       ],
@@ -68,19 +99,24 @@ export const useToasts = create<ToastState>((set, get) => ({
       }, TOAST_TTL_MS),
     );
   },
-  hide: (id?: number) => {
+  hide: (id?: number, options?: ToastHideOptions) => {
     if (id === undefined) {
       for (const toast of get().toasts) {
         clearDismissTimer(toast.id);
         startedAt.delete(toast.id);
         remainingMs.delete(toast.id);
+        runDismissAction(toast, options?.skipDismiss);
       }
       set({ toasts: [] });
       return;
     }
+    const toast = get().toasts.find((item) => item.id === id);
     clearDismissTimer(id);
     startedAt.delete(id);
     remainingMs.delete(id);
+    if (toast) {
+      runDismissAction(toast, options?.skipDismiss);
+    }
     set((state) => ({
       toasts: state.toasts.filter((toast) => toast.id !== id),
     }));

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,9 @@
       "createFailed": "Failed to create session:",
       "removeFailed": "Failed to remove session:",
       "worktreeRemoved": "Worktree deleted from disk.",
+      "worktreeRemovedUndo": "Removing {name} worktree in {seconds}s. Undo",
+      "worktreeRestored": "Worktree restored.",
+      "worktreeRestoreFailed": "Failed to restore worktree:",
       "worktreeRemoveFailed": "Failed to delete worktree:",
       "refreshFailed": "Failed to refresh sessions:",
       "renameFailed": "Failed to rename session:",
@@ -17,6 +20,9 @@
       "createFailed": "Failed to create project:",
       "removeFailed": "Failed to remove project:",
       "worktreesRemoved": "Project worktrees deleted from disk.",
+      "worktreesRemovedUndo": "Removing {count} project worktrees in {seconds}s. Undo",
+      "worktreesRestored": "Project worktrees restored.",
+      "worktreesRestoreFailed": "Failed to restore project worktrees:",
       "worktreesRemoveFailed": "Failed to delete project worktrees:"
     },
     "ipc": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -4,6 +4,9 @@
       "createFailed": "세션을 만들지 못했습니다:",
       "removeFailed": "세션을 제거하지 못했습니다:",
       "worktreeRemoved": "디스크에서 워크트리를 삭제했습니다.",
+      "worktreeRemovedUndo": "{seconds}초 후 {name} 워크트리를 제거합니다. 실행 취소",
+      "worktreeRestored": "워크트리를 복구했습니다.",
+      "worktreeRestoreFailed": "워크트리를 복구하지 못했습니다:",
       "worktreeRemoveFailed": "워크트리를 삭제하지 못했습니다:",
       "refreshFailed": "세션 목록을 새로 고치지 못했습니다:",
       "renameFailed": "세션 이름을 바꾸지 못했습니다:",
@@ -17,6 +20,9 @@
       "createFailed": "프로젝트를 만들지 못했습니다:",
       "removeFailed": "프로젝트를 제거하지 못했습니다:",
       "worktreesRemoved": "디스크에서 프로젝트 워크트리를 삭제했습니다.",
+      "worktreesRemovedUndo": "{seconds}초 후 프로젝트 워크트리 {count}개를 제거합니다. 실행 취소",
+      "worktreesRestored": "프로젝트 워크트리를 복구했습니다.",
+      "worktreesRestoreFailed": "프로젝트 워크트리를 복구하지 못했습니다:",
       "worktreesRemoveFailed": "프로젝트 워크트리를 삭제하지 못했습니다:"
     },
     "ipc": {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -24,7 +24,7 @@ vi.mock("./lib/api", () => {
       ),
       ptyInWorktreeAll: vi.fn(async () => ({} as Record<string, boolean>)),
       createSession: vi.fn(async () => ({}) as Session),
-      removeSession: vi.fn(async () => undefined),
+      removeSession: vi.fn(async () => null),
       renameSession: vi.fn(async () => ({}) as Session),
       generateSessionTitle: vi.fn(
         async () =>
@@ -35,7 +35,7 @@ vi.mock("./lib/api", () => {
       ),
       addProject: vi.fn(async () => ({}) as Project),
       createNewProject: vi.fn(async () => ({}) as Project),
-      removeProject: vi.fn(async () => undefined),
+      removeProject: vi.fn(async () => []),
       reorderProjects: vi.fn(async (paths: string[]) =>
         paths.map<Project>((repo_path, i) => ({
           repo_path,
@@ -187,8 +187,8 @@ beforeEach(() => {
   mockApi.listSessions.mockResolvedValue([]);
   mockApi.listProjects.mockResolvedValue([]);
   mockApi.detectSessionStatuses.mockResolvedValue([]);
-  mockApi.removeSession.mockResolvedValue(undefined);
-  mockApi.removeProject.mockResolvedValue(undefined);
+  mockApi.removeSession.mockResolvedValue(null);
+  mockApi.removeProject.mockResolvedValue([]);
   useSettings.setState({
     settings: structuredClone(DEFAULT_SETTINGS),
     open: false,
@@ -943,7 +943,7 @@ describe("removeSession", () => {
     await seed([project(REPO_A, 0)], [a1, a2]);
     useAppStore.getState().selectSession("a1");
 
-    const pending = deferred<void>();
+    const pending = deferred<null>();
     mockApi.removeSession.mockReturnValueOnce(pending.promise);
     mockApi.listSessions.mockResolvedValue([a2]);
     mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
@@ -954,7 +954,7 @@ describe("removeSession", () => {
     expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual(["a2"]);
     expect(useAppStore.getState().activeSessionId).toBe("a2");
 
-    pending.resolve(undefined);
+    pending.resolve(null);
     await removal;
     expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual(["a2"]);
   });
@@ -970,7 +970,7 @@ describe("removeSession", () => {
       notification("n2", { sessionId: "a2" }),
     );
 
-    const pending = deferred<void>();
+    const pending = deferred<null>();
     mockApi.removeSession.mockReturnValueOnce(pending.promise);
     mockApi.listSessions.mockResolvedValue([a2]);
     mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
@@ -981,7 +981,7 @@ describe("removeSession", () => {
       useAppStore.getState().sessionNotifications.map((item) => item.id),
     ).toEqual(["n2"]);
 
-    pending.resolve(undefined);
+    pending.resolve(null);
     await removal;
   });
 
@@ -1018,7 +1018,7 @@ describe("removeSession", () => {
     });
     expect(useAppStore.getState().layout.kind).toBe("split");
 
-    const pending = deferred<void>();
+    const pending = deferred<null>();
     mockApi.removeSession.mockReturnValueOnce(pending.promise);
     mockApi.listSessions.mockResolvedValue([a1]);
     mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
@@ -1032,7 +1032,7 @@ describe("removeSession", () => {
     expect(mid.panes[mid.focusedPaneId].tabIds).toEqual(["a1"]);
     expect(mid.activeSessionId).toBe("a1");
 
-    pending.resolve(undefined);
+    pending.resolve(null);
     await removal;
 
     const after = useAppStore.getState();
@@ -1907,7 +1907,7 @@ describe("removeProject", () => {
     expect(useAppStore.getState().activeProject).toBe(REPO_B);
 
     // After remove, refreshAll re-pulls projects/sessions; return both stripped of B.
-    mockApi.removeProject.mockResolvedValueOnce(undefined);
+    mockApi.removeProject.mockResolvedValueOnce([]);
     mockApi.listProjects.mockResolvedValueOnce([project(REPO_A, 0)]);
     mockApi.listSessions.mockResolvedValueOnce([]);
 
@@ -1935,7 +1935,7 @@ describe("requestRemoveProject", () => {
 
   it("removes the project directly without a confirmation modal when no sessions remain", async () => {
     await seed([project(REPO_A, 0), project(REPO_B, 1)], []);
-    mockApi.removeProject.mockResolvedValueOnce(undefined);
+    mockApi.removeProject.mockResolvedValueOnce([]);
     mockApi.listProjects.mockResolvedValueOnce([project(REPO_A, 0)]);
     mockApi.listSessions.mockResolvedValueOnce([]);
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
-import { api, type AiExecutionRequest } from "./lib/api";
+import { api, type AiExecutionRequest, type WorktreeRemoval } from "./lib/api";
 import type {
   Project,
   Session,
@@ -233,7 +233,10 @@ interface AppStateModel {
     projectFolderId?: string,
     cwdPath?: string,
   ) => Promise<Session | null>;
-  removeSession: (id: string, removeWorktree?: boolean) => Promise<void>;
+  removeSession: (
+    id: string,
+    removeWorktree?: boolean,
+  ) => Promise<WorktreeRemoval | null>;
   renameSession: (id: string, name: string) => Promise<void>;
   generateSessionTitle: (
     id: string,
@@ -256,7 +259,7 @@ interface AppStateModel {
     repoPath: string,
     removeWorktrees?: boolean,
     removeSettings?: boolean,
-  ) => Promise<void>;
+  ) => Promise<WorktreeRemoval[]>;
   reorderProjects: (orderedRepoPaths: string[]) => Promise<void>;
   reorderProjectFolders: (
     repoPath: string,
@@ -2219,13 +2222,15 @@ export const useAppStore = create<AppStateModel>()(
     }
 
     try {
-      await api.removeSession(id, removeWorktree);
+      const removedWorktree = await api.removeSession(id, removeWorktree);
       await get().refreshAll();
       set({ error: null });
+      return removedWorktree ?? null;
     } catch (e) {
       const message = errorMessage(e);
       await get().refreshAll();
       set({ error: message });
+      return null;
     }
   },
 
@@ -2337,7 +2342,12 @@ export const useAppStore = create<AppStateModel>()(
 
   async removeProject(repoPath, removeWorktrees = false, removeSettings = false) {
     try {
-      await api.removeProject(repoPath, true, removeWorktrees, removeSettings);
+      const removedWorktrees = await api.removeProject(
+        repoPath,
+        true,
+        removeWorktrees,
+        removeSettings,
+      );
       // Drop the project's workspace from local state explicitly — refreshAll
       // also reconciles, but pre-clearing avoids a flash of stale state.
       set((s) => {
@@ -2378,8 +2388,10 @@ export const useAppStore = create<AppStateModel>()(
       });
       await get().refreshAll();
       set({ error: null });
+      return removedWorktrees ?? [];
     } catch (e) {
       set({ error: errorMessage(e) });
+      return [];
     }
   },
 

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -242,6 +242,8 @@ export const tauriMockSource = `
     // session flags (isolated, in_worktree) drive the worktree icon.
     if (cmd === 'pty_in_worktree_all') return Promise.resolve({});
     if (cmd === 'is_path_linked_worktree') return Promise.resolve(false);
+    if (cmd === 'restore_removed_worktree') return Promise.resolve(undefined);
+    if (cmd === 'discard_removed_worktree') return Promise.resolve(undefined);
     // Daemon-mode commands. E2E runs in-browser without a real acornd
     // bound to a socket, so every routed call short-circuits with a
     // realistic "disabled / not-running" response. Tests that need to

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -1406,6 +1406,116 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(folderRow).toHaveCount(0);
   });
 
+  test("project workspace worktree removal toast restores the worktree", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => []);
+    await tauri.respond("remove_worktree", {
+      token: "undo-token",
+      repoPath: "/tmp/demo",
+      worktreePath: "/tmp/demo/.acorn/worktrees/feature-empty",
+      gitCommonDir: "/tmp/demo/.git",
+    });
+    await tauri.handle("restore_removed_worktree", (args) => {
+      const w = window as unknown as { __restoreWorktreeCalls?: unknown[] };
+      w.__restoreWorktreeCalls = w.__restoreWorktreeCalls ?? [];
+      w.__restoreWorktreeCalls.push(args);
+      return null;
+    });
+    await tauri.handle("discard_removed_worktree", (args) => {
+      const w = window as unknown as { __discardWorktreeCalls?: unknown[] };
+      w.__discardWorktreeCalls = w.__discardWorktreeCalls ?? [];
+      w.__discardWorktreeCalls.push(args);
+      return null;
+    });
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn-workspaces",
+        JSON.stringify({
+          state: {
+            projectFolders: {
+              "/tmp/demo": [
+                {
+                  id: "/tmp/demo",
+                  repoPath: "/tmp/demo",
+                  name: "Default",
+                  cwdPath: "/tmp/demo",
+                  position: 0,
+                },
+                {
+                  id: "project-folder:/tmp/demo:feature-empty",
+                  repoPath: "/tmp/demo",
+                  name: "feature-empty",
+                  cwdPath: "/tmp/demo/.acorn/worktrees/feature-empty",
+                  position: 1,
+                },
+              ],
+            },
+            sessionFolderIds: {},
+          },
+          version: 4,
+        }),
+      );
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator("aside");
+    const folderRow = sidebar
+      .getByRole("button", { name: /feature-empty/ })
+      .first();
+    await expect(folderRow).toBeVisible();
+
+    await folderRow.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Remove workspace" }).click();
+    await page
+      .getByRole("dialog", { name: "Remove workspace" })
+      .getByRole("button", { name: "Delete worktree" })
+      .click();
+
+    await expect(folderRow).toHaveCount(0);
+    await page
+      .getByText(/Removing feature-empty worktree in \d+s\. Undo/)
+      .click();
+
+    await expect(
+      sidebar.getByRole("button", { name: /feature-empty/ }).first(),
+    ).toBeVisible();
+    const restoreCalls = (await page.evaluate(
+      () =>
+        (window as unknown as { __restoreWorktreeCalls?: unknown[] })
+          .__restoreWorktreeCalls,
+    )) as Array<{
+      token: string;
+      repoPath: string;
+      worktreePath: string;
+      gitCommonDir: string;
+    }>;
+    expect(restoreCalls).toEqual([
+      {
+        token: "undo-token",
+        repoPath: "/tmp/demo",
+        worktreePath: "/tmp/demo/.acorn/worktrees/feature-empty",
+        gitCommonDir: "/tmp/demo/.git",
+      },
+    ]);
+    const discardCalls = await page.evaluate(
+      () =>
+        (window as unknown as { __discardWorktreeCalls?: unknown[] })
+          .__discardWorktreeCalls,
+    );
+    expect(discardCalls).toBeUndefined();
+  });
+
   test("project workspace remove can auto-delete empty worktree workspaces", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
This makes worktree disk removal reversible from the toast countdown instead of deleting files immediately.

1. **Stage worktree deletion** — move linked worktree directories into a sibling `.acorn-deleted-worktrees/<token>` backup and return a removal token to the frontend.
2. **Restore or discard from toast** — clicking the countdown toast restores the original worktree path; letting it dismiss discards the backup and prunes the git worktree registration.
3. **Preserve uncommitted files** — staged removal keeps tracked modifications and untracked files intact until discard.
4. **Wire removal flows** — session, project, empty worktree workspace, and folder-session cleanup paths now surface undo-capable worktree removal toasts.
5. **Cover the behavior** — add Rust and E2E coverage for preserving/restoring worktree contents and invoking the restore path from the toast.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Worktree disk deletion | Directory removed immediately | Directory staged until toast countdown dismisses |
| Undo behavior | Toast could not restore disk contents | Toast click restores the worktree directory |
| Unstaged/untracked files | Lost when directory was deleted | Preserved during the undo window |

## Design notes
- The backend returns a `RemovedWorktree` token with the repo path, original worktree path, and git common dir so the UI can explicitly restore or discard the staged removal.
- The toast store now supports an `onDismiss` action and countdown-formatted messages. Worktree removal toasts show the remaining seconds and worktree name/count.
- Toast action clicks hide the toast with dismiss skipped before running restore, preventing restore/discard races.
- Duplicate stage calls for the same missing worktree avoid pruning while a staged backup exists, preserving restoreability for shared or repeated cleanup paths.

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml worktree --lib` — 14 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec vitest run src/store.test.ts src/lib/sessionWorktree.test.ts` — 116 passed
- [x] `PLAYWRIGHT_PORT=1421 pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "project workspace worktree removal toast restores the worktree" --workers=1` — 1 passed
- [x] `pnpm run build` — passed with existing Vite chunk/dynamic import warnings
- [x] `git diff --check` and `git diff --cached --check` — passed

## Notes
- `pnpm run build` still reports the existing Vite chunk/dynamic import warnings. This PR does not change that bundling behavior.
