### PR TITLE
chore(release): v1.17.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.17.2",
+  "version": "1.17.3",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.17.2"
+version = "1.17.3"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
This prepares the v1.17.3 patch release after the fixes merged since v1.17.2.

1. **Version metadata** - bump Acorn from `1.17.2` to `1.17.3` in `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock`.
2. **Semver decision** - use a patch release because all unreleased changes are bug fixes.
3. **Included PRs** - release notes include #448, #449, #450, #451, and #452.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| App version | `1.17.2` | `1.17.3` |
| Release channel | Latest stable remains v1.17.2 | Tagging this merge will publish v1.17.3 |

## Design notes
- This PR intentionally changes release version metadata only.
- Changelog entries come from the already-merged fix PRs; this release PR is labelled `skip-changelog`.

## Follow-up (not in this PR)
- Tag `v1.17.3` after this PR merges and `origin/main` points at the release bump commit.

## Test plan
- [x] `rg -n '1\\.17\\.2|1\\.17\\.3' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock`
- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1`
- [x] `REPO=im-ian/acorn TAG=v1.17.3 OUTPUT=/tmp/acorn-release-notes-v1.17.3.md node scripts/release-notes.mjs`
- [x] `git diff --check`

## Notes
- Latest stable release before this PR is `v1.17.2`.
