### PR TITLE
fix(sessions): root-launch new sessions from worktrees

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -106,11 +106,11 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       const request = buildSessionCreateRequest(
         { sessions: state.sessions, projects: state.projects },
         {
-          repoPath: scope.repoPath,
-          cwdPath: scope.cwdPath,
-          projectScoped: scope.projectScoped,
+          repoPath: scope.placement.repoPath,
+          launch: scope.launch,
+          projectScoped: scope.placement.projectScoped,
           mode: "chat",
-          projectFolderId: scope.projectFolderId,
+          projectFolderId: scope.placement.projectFolderId,
         },
       );
       const cwdPath =

--- a/src/components/CommandRunDialog.tsx
+++ b/src/components/CommandRunDialog.tsx
@@ -78,26 +78,35 @@ export function CommandRunDialog({
 
   const resolvedScope = repoPath
     ? {
-        repoPath,
-        projectScoped: resolveProjectScopedForRepoPath(
-          { sessions, projects },
+        placement: {
           repoPath,
-        ),
+          projectScoped: resolveProjectScopedForRepoPath(
+            { sessions, projects },
+            repoPath,
+          ),
+        },
+        launch: { kind: "projectRoot" as const },
       }
     : (resolveActiveSessionScope({
         sessions,
         projects,
-      activeSessionId,
-      activeWorkspaceRepoPath: activeProject,
-      activeWorkspaceCwdPath:
-        findProjectFolderById(projectFolders, activeProjectFolderId)?.cwdPath ??
-        null,
-      activeProjectFolderId,
-    }) ??
+        activeSessionId,
+        activeWorkspaceRepoPath: activeProject,
+        activeWorkspaceCwdPath:
+          findProjectFolderById(projectFolders, activeProjectFolderId)?.cwdPath ??
+          null,
+        activeProjectFolderId,
+      }) ??
       (projects[0]
-        ? { repoPath: projects[0].repo_path, projectScoped: true }
+        ? {
+            placement: {
+              repoPath: projects[0].repo_path,
+              projectScoped: true,
+            },
+            launch: { kind: "projectRoot" as const },
+          }
         : null));
-  const resolvedRepoPath = resolvedScope?.repoPath ?? null;
+  const resolvedRepoPath = resolvedScope?.placement.repoPath ?? null;
 
   function close() {
     if (busy) return;

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -49,6 +49,7 @@ import {
   applySessionCreateRequest,
   buildSessionCreateRequestFromScope,
   resolveActiveSessionScope,
+  scopeWithProjectRootLaunch,
 } from "../lib/sessionCreation";
 import { findProjectFolderById } from "../lib/projectFolders";
 
@@ -1051,7 +1052,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
         state.createSession,
         buildSessionCreateRequestFromScope(
           { sessions: state.sessions, projects: state.projects },
-          scope,
+          scopeWithProjectRootLaunch(scope),
           { name },
         ),
       );

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -61,6 +61,7 @@ import {
   buildSessionCreateRequestFromScope,
   resolveProjectScopedForRepoPath,
   scopeForSession,
+  scopeWithProjectRootLaunch,
   type SessionCreateScope,
 } from "../lib/sessionCreation";
 import type { Direction, PaneId } from "../lib/layout";
@@ -248,14 +249,19 @@ export function Pane({ paneId }: PaneProps) {
     );
   }, [paneId]);
 
-  function scopeForTab(tab: PaneTab): SessionCreateScope {
-    if (tab.kind === "session") return scopeForSession(tab.session);
+  function rootScopeForTab(tab: PaneTab): SessionCreateScope {
+    if (tab.kind === "session") {
+      return scopeWithProjectRootLaunch(scopeForSession(tab.session));
+    }
     return {
-      repoPath: tab.repoPath,
-      projectScoped: resolveProjectScopedForRepoPath(
-        { sessions, projects },
-        tab.repoPath,
-      ),
+      placement: {
+        repoPath: tab.repoPath,
+        projectScoped: resolveProjectScopedForRepoPath(
+          { sessions, projects },
+          tab.repoPath,
+        ),
+      },
+      launch: { kind: "projectRoot" },
     };
   }
 
@@ -268,11 +274,14 @@ export function Pane({ paneId }: PaneProps) {
     repoPath: string,
     kind: SessionKind = "regular",
     scope: SessionCreateScope = {
-      repoPath,
-      projectScoped: resolveProjectScopedForRepoPath(
-        { sessions, projects },
+      placement: {
         repoPath,
-      ),
+        projectScoped: resolveProjectScopedForRepoPath(
+          { sessions, projects },
+          repoPath,
+        ),
+      },
+      launch: { kind: "projectRoot" },
     },
   ) {
     setFocusedPane(paneId);
@@ -373,7 +382,7 @@ export function Pane({ paneId }: PaneProps) {
   async function handleNewTabFromStrip() {
     if (tabs.length === 0) return;
     const anchor = active ?? tabs[0];
-    await spawnSession(anchor.repoPath, "regular", scopeForTab(anchor));
+    await spawnSession(anchor.repoPath, "regular", rootScopeForTab(anchor));
   }
 
   async function handleNewTabFromEmpty() {
@@ -392,15 +401,19 @@ export function Pane({ paneId }: PaneProps) {
       repoPath,
       "regular",
       anchor
-        ? scopeForTab(anchor)
+        ? rootScopeForTab(anchor)
         : {
-            repoPath,
-            cwdPath: activeFolder?.cwdPath ?? repoPath,
-            projectScoped: resolveProjectScopedForRepoPath(
-              { sessions, projects },
+            placement: {
               repoPath,
-            ),
-            projectFolderId: activeFolder?.id,
+              projectScoped: resolveProjectScopedForRepoPath(
+                { sessions, projects },
+                repoPath,
+              ),
+              projectFolderId: activeFolder?.id,
+            },
+            launch: activeFolder
+              ? { kind: "workspaceCwd", cwdPath: activeFolder.cwdPath }
+              : { kind: "projectRoot" },
           },
     );
   }

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -227,7 +227,7 @@ export function RightPanel() {
     localSessionHostPath ??
     repoPath;
   const sessionHostProjectScoped = active
-    ? scopeForSession(active).projectScoped
+    ? scopeForSession(active).placement.projectScoped
     : agentHistoryScope === "unscoped"
       ? false
     : sessionHostRepoPath

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -94,6 +94,7 @@ import {
   applySessionCreateRequest,
   buildSessionCreateRequest,
   resolveActiveSessionScope,
+  scopeWithProjectRootLaunch,
   type SessionCreateScope,
 } from "../lib/sessionCreation";
 import {
@@ -387,7 +388,6 @@ export function Sidebar() {
         { sessions, projects },
         {
           repoPath,
-          cwdPath: repoPath,
           isolated: true,
           kind: "regular",
           mode: "terminal",
@@ -537,30 +537,45 @@ export function Sidebar() {
       const scope = activeScope();
       if (isLocalTerminalAreaFocused()) {
         void onNewLocalSessionRef.current(
-          scope?.projectScoped === false ? scope : undefined,
+          scope?.placement.projectScoped === false ? scope : undefined,
         );
         return;
       }
-      void onNewSessionRef.current(false, "regular", scope ?? undefined);
+      void onNewSessionRef.current(
+        false,
+        "regular",
+        scope ? scopeWithProjectRootLaunch(scope) : undefined,
+      );
     };
     const newIsolated = () => {
       const scope = activeScope();
+      const scopedProject =
+        scope && scope.placement.projectScoped !== false ? scope : undefined;
       void onNewSessionRef.current(
         true,
         "regular",
-        scope?.projectScoped === false ? undefined : (scope ?? undefined),
+        scopedProject,
       );
     };
     const newControl = () => {
       const scope = activeScope();
+      const scopedProject =
+        scope && scope.placement.projectScoped !== false
+          ? scopeWithProjectRootLaunch(scope)
+          : undefined;
       void onNewSessionRef.current(
         false,
         "control",
-        scope?.projectScoped === false ? undefined : (scope ?? undefined),
+        scopedProject,
       );
     };
     const newChat = () => {
-      void onNewSessionRef.current(false, "regular", activeScope() ?? undefined, "chat");
+      void onNewSessionRef.current(
+        false,
+        "regular",
+        activeScope() ?? undefined,
+        "chat",
+      );
     };
     const newProject = () => {
       setNewProjectOpen(true);
@@ -620,15 +635,13 @@ export function Sidebar() {
       const request = buildSessionCreateRequest(
         { sessions, projects },
         {
-          repoPath: scopeOverride.repoPath,
-          cwdPath: scopeOverride.cwdPath,
+          repoPath: scopeOverride.placement.repoPath,
+          launch: scopeOverride.launch,
           isolated,
           kind,
           mode,
-          projectScoped:
-            scopeOverride.projectScoped ??
-            (isolated || kind === "control" ? true : undefined),
-          projectFolderId: scopeOverride.projectFolderId,
+          projectScoped: scopeOverride.placement.projectScoped,
+          projectFolderId: scopeOverride.placement.projectFolderId,
         },
       );
       const created = await applySessionCreateRequest(createSession, request);
@@ -650,7 +663,7 @@ export function Sidebar() {
 
   async function onNewLocalSession(scopeOverride?: SessionCreateScope) {
     try {
-      const repoPath = scopeOverride?.repoPath ?? (await homeDir());
+      const repoPath = scopeOverride?.placement.repoPath ?? (await homeDir());
       if (!repoPath) return;
       const created = await applySessionCreateRequest(
         createSession,
@@ -658,9 +671,9 @@ export function Sidebar() {
           { sessions, projects },
           {
             repoPath,
-            cwdPath: scopeOverride?.cwdPath,
+            launch: scopeOverride?.launch,
             projectScoped: false,
-            projectFolderId: scopeOverride?.projectFolderId,
+            projectFolderId: scopeOverride?.placement.projectFolderId,
           },
         ),
       );
@@ -1087,10 +1100,15 @@ export function Sidebar() {
                           isolated,
                           kind,
                           {
-                            repoPath: project.repoPath,
-                            cwdPath: folder.cwdPath,
-                            projectScoped: true,
-                            projectFolderId: folder.id,
+                            placement: {
+                              repoPath: project.repoPath,
+                              projectScoped: true,
+                              projectFolderId: folder.id,
+                            },
+                            launch: {
+                              kind: "workspaceCwd",
+                              cwdPath: folder.cwdPath,
+                            },
                           },
                           mode,
                         )
@@ -1122,10 +1140,15 @@ export function Sidebar() {
             onCreate={() => onNewLocalSession()}
             onCreateInFolder={(folder) =>
               onNewLocalSession({
-                repoPath: folder.repoPath,
-                cwdPath: folder.cwdPath,
-                projectScoped: false,
-                projectFolderId: folder.id,
+                placement: {
+                  repoPath: folder.repoPath,
+                  projectScoped: false,
+                  projectFolderId: folder.id,
+                },
+                launch: {
+                  kind: "workspaceCwd",
+                  cwdPath: folder.cwdPath,
+                },
               })
             }
             onCreateWorkspace={onAddLocalWorkspace}

--- a/src/lib/sessionCreation.test.ts
+++ b/src/lib/sessionCreation.test.ts
@@ -6,6 +6,7 @@ import {
   resolveActiveSessionScope,
   resolveProjectScopedForRepoPath,
   scopeForSession,
+  scopeWithProjectRootLaunch,
 } from "./sessionCreation";
 import type { Project, Session } from "./types";
 
@@ -80,7 +81,9 @@ describe("session creation policy", () => {
         activeSessionId: "local",
         activeWorkspaceRepoPath: "/repo/app",
       }),
-    ).toMatchObject({ repoPath: "/Users/me", projectScoped: false });
+    ).toMatchObject({
+      placement: { repoPath: "/Users/me", projectScoped: false },
+    });
   });
 
   it("uses the session worktree path for isolated session scope", () => {
@@ -91,9 +94,14 @@ describe("session creation policy", () => {
     });
 
     expect(scopeForSession(isolated)).toEqual({
-      repoPath: "/repo/app",
-      cwdPath: "/repo/app/.acorn/worktrees/feature",
-      projectScoped: true,
+      placement: {
+        repoPath: "/repo/app",
+        projectScoped: true,
+      },
+      launch: {
+        kind: "workspaceCwd",
+        cwdPath: "/repo/app/.acorn/worktrees/feature",
+      },
     });
   });
 
@@ -112,8 +120,42 @@ describe("session creation policy", () => {
         activeWorkspaceRepoPath: "/repo/app",
       }),
     ).toEqual({
+      placement: {
+        repoPath: "/repo/app",
+        projectScoped: true,
+      },
+      launch: {
+        kind: "workspaceCwd",
+        cwdPath: "/repo/app/.acorn/worktrees/feature",
+      },
+    });
+  });
+
+  it("can root-launch a generic new session from an active worktree scope", () => {
+    const isolated = session("isolated", "/repo/app", {
+      isolated: true,
+      project_scoped: true,
+      worktree_path: "/repo/app/.acorn/worktrees/feature",
+    });
+    const scope = resolveActiveSessionScope({
+      sessions: [isolated],
+      projects: [project("/repo/app")],
+      activeSessionId: "isolated",
+      activeWorkspaceRepoPath: "/repo/app",
+    });
+
+    expect(scope).not.toBeNull();
+    const request = buildSessionCreateRequestFromScope(
+      { sessions: [isolated], projects: [project("/repo/app")] },
+      scopeWithProjectRootLaunch(scope!),
+      { name: "worker" },
+    );
+
+    expect(request).toMatchObject({
+      name: "worker",
       repoPath: "/repo/app",
-      cwdPath: "/repo/app/.acorn/worktrees/feature",
+      cwdPath: "/repo/app",
+      isolated: false,
       projectScoped: true,
     });
   });
@@ -136,10 +178,15 @@ describe("session creation policy", () => {
         activeProjectFolderId: "frontend",
       }),
     ).toEqual({
-      repoPath: "/repo/app",
-      cwdPath: "/repo/app/apps/web",
-      projectScoped: true,
-      projectFolderId: "frontend",
+      placement: {
+        repoPath: "/repo/app",
+        projectScoped: true,
+        projectFolderId: "frontend",
+      },
+      launch: {
+        kind: "workspaceCwd",
+        cwdPath: "/repo/app/apps/web",
+      },
     });
   });
 
@@ -161,9 +208,14 @@ describe("session creation policy", () => {
         activeProjectFolderId: "/repo/app",
       }),
     ).toEqual({
-      repoPath: "/repo/app",
-      cwdPath: "/repo/app",
-      projectScoped: true,
+      placement: {
+        repoPath: "/repo/app",
+        projectScoped: true,
+      },
+      launch: {
+        kind: "workspaceCwd",
+        cwdPath: "/repo/app",
+      },
     });
   });
 
@@ -177,10 +229,15 @@ describe("session creation policy", () => {
         activeProjectFolderId: "frontend",
       }),
     ).toEqual({
-      repoPath: "/repo/app",
-      cwdPath: "/repo/app/apps/web",
-      projectScoped: true,
-      projectFolderId: "frontend",
+      placement: {
+        repoPath: "/repo/app",
+        projectScoped: true,
+        projectFolderId: "frontend",
+      },
+      launch: {
+        kind: "workspaceCwd",
+        cwdPath: "/repo/app/apps/web",
+      },
     });
   });
 
@@ -202,10 +259,15 @@ describe("session creation policy", () => {
         activeProjectFolderId: "scratch",
       }),
     ).toEqual({
-      repoPath: "/Users/me",
-      cwdPath: "/Users/me/scratch",
-      projectScoped: false,
-      projectFolderId: "scratch",
+      placement: {
+        repoPath: "/Users/me",
+        projectScoped: false,
+        projectFolderId: "scratch",
+      },
+      launch: {
+        kind: "workspaceCwd",
+        cwdPath: "/Users/me/scratch",
+      },
     });
   });
 
@@ -234,7 +296,10 @@ describe("session creation policy", () => {
     expect(
       buildSessionCreateRequestFromScope(
         { sessions: [], projects: [] },
-        { repoPath: "/Users/me", projectScoped: false },
+        {
+          placement: { repoPath: "/Users/me", projectScoped: false },
+          launch: { kind: "projectRoot" },
+        },
         { name: "codex-copy", agentProvider: "codex" },
       ),
     ).toMatchObject({

--- a/src/lib/sessionCreation.ts
+++ b/src/lib/sessionCreation.ts
@@ -16,11 +16,19 @@ export interface SessionCreationContext {
   activeProjectFolderId?: string | null;
 }
 
-export interface SessionCreateScope {
+export interface SessionCreatePlacement {
   repoPath: string;
-  cwdPath?: string;
   projectScoped: boolean;
   projectFolderId?: string;
+}
+
+export type SessionLaunchCwd =
+  | { kind: "projectRoot" }
+  | { kind: "workspaceCwd"; cwdPath: string };
+
+export interface SessionCreateScope {
+  placement: SessionCreatePlacement;
+  launch: SessionLaunchCwd;
 }
 
 export interface SessionCreateRequest {
@@ -37,7 +45,7 @@ export interface SessionCreateRequest {
 
 export interface BuildSessionCreateOptions {
   repoPath: string;
-  cwdPath?: string;
+  launch?: SessionLaunchCwd;
   isolated?: boolean;
   kind?: SessionKind;
   agentProvider?: SessionAgentProvider | null;
@@ -47,11 +55,34 @@ export interface BuildSessionCreateOptions {
   projectFolderId?: string;
 }
 
+function projectRootLaunch(): SessionLaunchCwd {
+  return { kind: "projectRoot" };
+}
+
+function workspaceLaunch(cwdPath: string): SessionLaunchCwd {
+  return { kind: "workspaceCwd", cwdPath };
+}
+
+function cwdPathForLaunch(repoPath: string, launch: SessionLaunchCwd): string {
+  return launch.kind === "workspaceCwd" ? launch.cwdPath : repoPath;
+}
+
+export function scopeWithProjectRootLaunch(
+  scope: SessionCreateScope,
+): SessionCreateScope {
+  return {
+    placement: scope.placement,
+    launch: projectRootLaunch(),
+  };
+}
+
 export function scopeForSession(session: Session): SessionCreateScope {
   return {
-    repoPath: session.repo_path,
-    cwdPath: session.worktree_path,
-    projectScoped: session.project_scoped !== false,
+    placement: {
+      repoPath: session.repo_path,
+      projectScoped: session.project_scoped !== false,
+    },
+    launch: workspaceLaunch(session.worktree_path),
   };
 }
 
@@ -72,22 +103,31 @@ export function resolveActiveSessionScope(
           ? context.activeProjectFolderId
           : undefined;
       return {
-        ...scope,
-        cwdPath: context.activeWorkspaceCwdPath ?? scope.cwdPath,
-        ...(projectFolderId ? { projectFolderId } : {}),
+        placement: {
+          ...scope.placement,
+          ...(projectFolderId ? { projectFolderId } : {}),
+        },
+        launch: workspaceLaunch(
+          context.activeWorkspaceCwdPath ??
+            cwdPathForLaunch(active.repo_path, scope.launch),
+        ),
       };
     }
     return scope;
   }
   if (!context.activeWorkspaceRepoPath) return null;
   return {
-    repoPath: context.activeWorkspaceRepoPath,
-    cwdPath: context.activeWorkspaceCwdPath ?? context.activeWorkspaceRepoPath,
-    projectScoped: resolveProjectScopedForRepoPath(
-      context,
-      context.activeWorkspaceRepoPath,
+    placement: {
+      repoPath: context.activeWorkspaceRepoPath,
+      projectScoped: resolveProjectScopedForRepoPath(
+        context,
+        context.activeWorkspaceRepoPath,
+      ),
+      projectFolderId: context.activeProjectFolderId ?? undefined,
+    },
+    launch: workspaceLaunch(
+      context.activeWorkspaceCwdPath ?? context.activeWorkspaceRepoPath,
     ),
-    projectFolderId: context.activeProjectFolderId ?? undefined,
   };
 }
 
@@ -116,7 +156,10 @@ export function buildSessionCreateRequest(
   const projectScoped =
     options.projectScoped ??
     resolveProjectScopedForRepoPath(context, options.repoPath);
-  const cwdPath = options.cwdPath ?? options.repoPath;
+  const launch = isolated
+    ? projectRootLaunch()
+    : (options.launch ?? projectRootLaunch());
+  const cwdPath = cwdPathForLaunch(options.repoPath, launch);
   const name =
     options.name ??
     (projectScoped
@@ -155,10 +198,10 @@ export function buildSessionCreateRequestFromScope(
 ): SessionCreateRequest {
   return buildSessionCreateRequest(context, {
     ...options,
-    repoPath: scope.repoPath,
-    cwdPath: options.cwdPath ?? scope.cwdPath,
-    projectScoped: scope.projectScoped,
-    projectFolderId: options.projectFolderId ?? scope.projectFolderId,
+    repoPath: scope.placement.repoPath,
+    launch: options.launch ?? scope.launch,
+    projectScoped: scope.placement.projectScoped,
+    projectFolderId: options.projectFolderId ?? scope.placement.projectFolderId,
   });
 }
 

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -2786,6 +2786,108 @@ test.describe("sidebar: project lifecycle", () => {
     });
   });
 
+  test("new-session hotkey from a worktree session starts at the project root", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __createdRootSession?: boolean };
+      const baseSession = {
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+      };
+      const rootSession = {
+        ...baseSession,
+        id: "root",
+        name: "root",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        in_worktree: false,
+      };
+      const worktreeSession = {
+        ...baseSession,
+        id: "worker",
+        name: "worker",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.acorn/worktrees/main-copy",
+        in_worktree: true,
+      };
+      const createdSession = {
+        ...baseSession,
+        id: "created-root",
+        name: "demo",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        in_worktree: false,
+      };
+      return w.__createdRootSession
+        ? [rootSession, worktreeSession, createdSession]
+        : [rootSession, worktreeSession];
+    });
+    await tauri.handle("create_session", (args) => {
+      const w = window as unknown as {
+        __createdRootSession?: boolean;
+        __createSessionCalls?: unknown[];
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(args);
+      w.__createdRootSession = true;
+      return {
+        id: "created-root",
+        name: "demo",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      };
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^worker worktree main · Idle/ })
+      .click();
+    await pressHotkey(page, { mod: true, key: "t" });
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __createSessionCalls?: unknown[] })
+          .__createSessionCalls,
+    )) as Array<{
+      repoPath: string;
+      cwdPath?: string;
+      isolated: boolean;
+    }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      repoPath: "/tmp/demo",
+      isolated: false,
+    });
+    expect(calls[0].cwdPath).toBeUndefined();
+  });
+
   test("clicking the instant sessions area makes new-session hotkey create a local session", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
This fixes regular new-session creation so active worktree context no longer silently becomes the new terminal cwd.

1. **Split creation intent** — separate session placement (`repoPath`, project scope, folder id) from launch cwd (`projectRoot` vs explicit workspace cwd) in `sessionCreation`.
2. **Root-launch generic sessions** — make global New Session, control sessions, pane tab-strip creation, and file-explorer spawned sessions default to the project root while keeping explicit workspace/folder creation and fork flows on workspace cwd.
3. **Lock regression coverage** — add unit coverage for root-launching from an active worktree scope and Playwright coverage for `Cmd+T` from a linked-worktree session.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| New Session from active worktree | Could inherit the worktree cwd and appear as a worktree-backed session | Starts at the registered project root |
| Explicit workspace/folder session creation | Uses that workspace cwd | Unchanged |
| Fork/chat flows with explicit context | Can inherit the intended cwd | Unchanged where explicitly passed |

## Design notes
- `SessionCreateScope` now carries `placement` separately from `launch`, so callers must choose whether they want project-root launch or workspace-cwd launch.
- `buildSessionCreateRequest` no longer accepts top-level `cwdPath`; the only way to send a non-root cwd is an explicit `launch: { kind: "workspaceCwd", cwdPath }`.
- Isolated session creation forces project-root launch intent because the backend creates a fresh worktree and ignores inherited cwd.

## Test plan
- [x] `git diff --check`
- [x] `pnpm exec tsc --noEmit --pretty false`
- [x] `pnpm run test` — 67 files, 676 tests passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts tests/e2e/command-palette.spec.ts` — 40 passed
- [x] `pnpm run build` — passed; existing Vite chunk/dynamic import warnings only

## Notes
- `pnpm exec tsc --noEmit -p tests/e2e/tsconfig.json --pretty false` still fails on existing E2E type debt unrelated to this PR, including missing Node test types, old `{}` mock arg typings, and unused vars.