### PR TITLE
feat(terminal): anti-aliasing setting for terminal text

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -41,6 +41,30 @@
   border-radius: 4px;
 }
 
+.acorn-terminal[data-acorn-font-smoothing="system"],
+.acorn-terminal[data-acorn-font-smoothing="system"] * {
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+}
+
+.acorn-terminal[data-acorn-font-smoothing="grayscale"],
+.acorn-terminal[data-acorn-font-smoothing="grayscale"] * {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.acorn-terminal[data-acorn-font-smoothing="subpixel"],
+.acorn-terminal[data-acorn-font-smoothing="subpixel"] * {
+  -webkit-font-smoothing: subpixel-antialiased;
+  -moz-osx-font-smoothing: auto;
+}
+
+.acorn-terminal[data-acorn-font-smoothing="none"],
+.acorn-terminal[data-acorn-font-smoothing="none"] * {
+  -webkit-font-smoothing: none;
+  -moz-osx-font-smoothing: auto;
+}
+
 .acorn-no-scrollbar {
   scrollbar-width: none;
   -ms-overflow-style: none;

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -478,6 +478,31 @@ describe("SettingsModal font controls", () => {
     expect(patchTerminal).toHaveBeenCalledWith({ letterSpacing: 0.75 });
   });
 
+  it("patches terminal anti-aliasing from the Terminal tab", async () => {
+    const patchTerminal = vi.fn();
+    useSettings.setState({
+      settings: cloneSettings(),
+      patchTerminal,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openTerminalTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const select = getComboboxByLabel("Anti-aliasing");
+    expect(select.textContent).toContain("Grayscale");
+
+    clickElement(select);
+    clickOption("Subpixel");
+
+    expect(patchTerminal).toHaveBeenCalledWith({ fontSmoothing: "subpixel" });
+  });
+
   it("patches the resident terminal limit from the Sessions tab", async () => {
     const patchTerminal = vi.fn();
     useSettings.setState({

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -64,9 +64,11 @@ import {
   type SelectedAgent,
   type SessionTitleSource,
   type AcornSettings,
+  type TerminalFontSmoothing,
   type TerminalFontWeight,
   type TerminalLinkActivation,
   type ToastPosition,
+  TERMINAL_FONT_SMOOTHING_VALUES,
   TERMINAL_FONT_WEIGHTS,
   useSettings,
 } from "../lib/settings";
@@ -471,6 +473,22 @@ function formatTerminalLetterSpacing(value: number): string {
     : value.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
 }
 
+function terminalFontSmoothingLabel(
+  t: SettingsTranslator,
+  value: TerminalFontSmoothing,
+): string {
+  switch (value) {
+    case "grayscale":
+      return st(t, "settings.terminal.fontSmoothing.options.grayscale");
+    case "subpixel":
+      return st(t, "settings.terminal.fontSmoothing.options.subpixel");
+    case "system":
+      return st(t, "settings.terminal.fontSmoothing.options.system");
+    case "none":
+      return st(t, "settings.terminal.fontSmoothing.options.none");
+  }
+}
+
 function TerminalSettings() {
   const settings = useSettings((s) => s.settings);
   const patchTerminal = useSettings((s) => s.patchTerminal);
@@ -512,6 +530,27 @@ function TerminalSettings() {
           format={formatTerminalLetterSpacing}
           onChange={(n) => patchTerminal({ letterSpacing: n })}
         />
+      </Field>
+      <Field
+        label={st(t, "settings.terminal.fontSmoothing.label")}
+        hint={st(t, "settings.terminal.fontSmoothing.hint")}
+      >
+        <Select
+          value={settings.terminal.fontSmoothing}
+          onChange={(e) =>
+            patchTerminal({
+              fontSmoothing: e.target.value as TerminalFontSmoothing,
+            })
+          }
+          className="w-48"
+          aria-label={st(t, "settings.terminal.fontSmoothing.label")}
+        >
+          {TERMINAL_FONT_SMOOTHING_VALUES.map((value) => (
+            <option key={value} value={value}>
+              {terminalFontSmoothingLabel(t, value)}
+            </option>
+          ))}
+        </Select>
       </Field>
       <Field
         label={st(t, "settings.terminal.fontWeight.label")}

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -492,6 +492,9 @@ export function Terminal({
     linkKey: string;
   } | null>(null);
   const [isScrolledBack, setIsScrolledBack] = useState(false);
+  const fontSmoothing = useSettings(
+    (s) => s.settings.terminal.fontSmoothing,
+  );
 
   useEffect(() => {
     pasteAgentProviderRef.current = pasteAgentProvider;
@@ -2550,6 +2553,7 @@ export function Terminal({
         className={`acorn-terminal relative z-10 h-full w-full ${
           isFocusedPane ? "" : "acorn-terminal-inactive"
         }`}
+        data-acorn-font-smoothing={fontSmoothing}
       />
       {isScrolledBack ? (
         <Tooltip label="Scroll terminal to bottom" side="top" delay={150}>

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -7,6 +7,7 @@ import {
   MOUNTED_TERMINAL_LIMIT_MAX,
   MOUNTED_TERMINAL_LIMIT_MIN,
   NOTIFICATION_HISTORY_LIMIT_MAX,
+  TERMINAL_FONT_SMOOTHING_VALUES,
   TERMINAL_LETTER_SPACING_MAX,
   TERMINAL_LETTER_SPACING_MIN,
   TERMINAL_LETTER_SPACING_STEP,
@@ -68,6 +69,88 @@ describe("language settings", () => {
 describe("terminal.linkActivation default", () => {
   it("defaults to plain click so xterm's stock behaviour is preserved", () => {
     expect(DEFAULT_SETTINGS.terminal.linkActivation).toBe("click");
+  });
+});
+
+describe("terminal.fontSmoothing settings", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("defaults to grayscale font smoothing", () => {
+    expect(DEFAULT_SETTINGS.terminal.fontSmoothing).toBe("grayscale");
+  });
+
+  it("lists the supported terminal font smoothing modes", () => {
+    expect(TERMINAL_FONT_SMOOTHING_VALUES).toEqual([
+      "grayscale",
+      "subpixel",
+      "system",
+      "none",
+    ]);
+  });
+
+  it("loads a persisted terminal font smoothing mode", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ terminal: { fontSmoothing: "subpixel" } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.terminal.fontSmoothing).toBe(
+      "subpixel",
+    );
+  });
+
+  it("falls back to the default for unsupported stored terminal font smoothing", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ terminal: { fontSmoothing: "sharp" } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.terminal.fontSmoothing).toBe(
+      "grayscale",
+    );
+  });
+
+  it("patches terminal font smoothing and preserves the previous value for invalid patches", async () => {
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    useSettings.getState().patchTerminal({ fontSmoothing: "none" });
+    expect(useSettings.getState().settings.terminal.fontSmoothing).toBe("none");
+
+    const invalidFontSmoothing =
+      "sharp" as unknown as typeof DEFAULT_SETTINGS.terminal.fontSmoothing;
+    useSettings.getState().patchTerminal({
+      fontSmoothing: invalidFontSmoothing,
+    });
+    expect(useSettings.getState().settings.terminal.fontSmoothing).toBe("none");
   });
 });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -155,6 +155,13 @@ export type TerminalFontWeight =
  * focus to the browser.
  */
 export type TerminalLinkActivation = "click" | "modifier-click";
+export type TerminalFontSmoothing =
+  | "grayscale"
+  | "subpixel"
+  | "system"
+  | "none";
+export const TERMINAL_FONT_SMOOTHING_VALUES: ReadonlyArray<TerminalFontSmoothing> =
+  ["grayscale", "subpixel", "system", "none"];
 
 /**
  * Which field acorn shows as the primary line of a sidebar session row.
@@ -211,6 +218,12 @@ export interface AcornSettings {
      * horizontal room.
      */
     letterSpacing: number;
+    /**
+     * CSS font-smoothing mode applied to terminal text only. xterm.js does
+     * not expose this as a terminal option, so Acorn applies it on the
+     * terminal DOM renderer container.
+     */
+    fontSmoothing: TerminalFontSmoothing;
     fontWeight: TerminalFontWeight;
     fontWeightBold: TerminalFontWeight;
     /**
@@ -438,6 +451,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     ),
     fontSize: 12,
     letterSpacing: 0,
+    fontSmoothing: "grayscale",
     fontWeight: 400,
     fontWeightBold: 700,
     lineHeight: 1.0,
@@ -616,6 +630,16 @@ function normalizeLinkActivation(
 ): TerminalLinkActivation {
   if (v === "click" || v === "modifier-click") return v;
   return fallback;
+}
+
+function normalizeTerminalFontSmoothing(
+  v: unknown,
+  fallback: TerminalFontSmoothing,
+): TerminalFontSmoothing {
+  return typeof v === "string" &&
+    TERMINAL_FONT_SMOOTHING_VALUES.includes(v as TerminalFontSmoothing)
+    ? (v as TerminalFontSmoothing)
+    : fallback;
 }
 
 function normalizeLineHeight(v: unknown, fallback: number): number {
@@ -859,6 +883,10 @@ function loadSettings(): AcornSettings {
           (terminalRaw as { letterSpacing?: unknown }).letterSpacing,
           DEFAULT_SETTINGS.terminal.letterSpacing,
         ),
+        fontSmoothing: normalizeTerminalFontSmoothing(
+          (terminalRaw as { fontSmoothing?: unknown }).fontSmoothing,
+          DEFAULT_SETTINGS.terminal.fontSmoothing,
+        ),
         lineHeight: normalizeLineHeight(
           (terminalRaw as { lineHeight?: unknown }).lineHeight,
           DEFAULT_SETTINGS.terminal.lineHeight,
@@ -1100,6 +1128,13 @@ export const useSettings = create<SettingsState>((set, get) => ({
               : normalizeTerminalLetterSpacing(
                   patch.letterSpacing,
                   s.settings.terminal.letterSpacing,
+                ),
+          fontSmoothing:
+            patch.fontSmoothing === undefined
+              ? s.settings.terminal.fontSmoothing
+              : normalizeTerminalFontSmoothing(
+                  patch.fontSmoothing,
+                  s.settings.terminal.fontSmoothing,
                 ),
         },
       };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -75,6 +75,16 @@
         "label": "Letter spacing",
         "hint": "Horizontal spacing between terminal cells, in pixels. Supports 0.25px steps. Range -2 to 6."
       },
+      "fontSmoothing": {
+        "label": "Anti-aliasing",
+        "hint": "Controls terminal font smoothing only. Grayscale matches Acorn's current rendering.",
+        "options": {
+          "grayscale": "Grayscale",
+          "subpixel": "Subpixel",
+          "system": "System",
+          "none": "None"
+        }
+      },
       "fontWeight": {
         "label": "Font weight",
         "hint": "Weight for normal text. Effective values depend on the chosen font's available weights."

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -75,6 +75,16 @@
         "label": "글자 간격",
         "hint": "터미널 셀 사이의 가로 간격입니다. 0.25px 단위를 지원하며 범위는 -2~6입니다."
       },
+      "fontSmoothing": {
+        "label": "안티앨리어싱",
+        "hint": "터미널 글꼴 smoothing만 조절합니다. Grayscale은 현재 Acorn 렌더링과 같습니다.",
+        "options": {
+          "grayscale": "Grayscale",
+          "subpixel": "Subpixel",
+          "system": "시스템",
+          "none": "없음"
+        }
+      },
       "fontWeight": {
         "label": "글꼴 두께",
         "hint": "일반 텍스트의 두께입니다. 실제 적용 값은 선택한 글꼴이 제공하는 두께에 따라 달라집니다."

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -61,6 +61,32 @@ test.describe("settings modal", () => {
       .toBe(0.75);
   });
 
+  test("changes terminal anti-aliasing and persists it", async ({ page }) => {
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "," });
+
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
+    await modal.getByRole("button", { name: /^(Terminal|터미널)$/ }).click();
+
+    const select = modal.getByRole("combobox", {
+      name: /^(Anti-aliasing|안티앨리어싱)$/,
+    });
+    await expect(select).toContainText("Grayscale");
+
+    await select.click();
+    await page.getByRole("option", { name: "Subpixel" }).click();
+
+    await expect(select).toContainText("Subpixel");
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("acorn:settings:v1");
+          return raw ? JSON.parse(raw).terminal?.fontSmoothing : null;
+        }),
+      )
+      .toBe("subpixel");
+  });
+
   test("records a custom shortcut and reset all restores defaults", async ({
     page,
   }) => {

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -509,6 +509,39 @@ test.describe("terminal: spawn", () => {
     expect(first.parentLimbo).toBeNull();
   });
 
+  test("applies terminal font smoothing setting to the terminal renderer", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({ terminal: { fontSmoothing: "subpixel" } }),
+      );
+    });
+    await seedWritableTerminal(tauri);
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+
+    const terminal = page.locator("[data-pane-body] .acorn-terminal");
+    await expect(terminal).toHaveAttribute(
+      "data-acorn-font-smoothing",
+      "subpixel",
+    );
+    await expect
+      .poll(() =>
+        terminal.evaluate((element) =>
+          window
+            .getComputedStyle(element)
+            .getPropertyValue("-webkit-font-smoothing"),
+        ),
+      )
+      .toBe("subpixel-antialiased");
+  });
+
   test("drops desktop file paths into the focused terminal", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Adds a terminal-only anti-aliasing control so users can tune how Acorn smooths terminal text.

1. **Terminal setting** — add `terminal.fontSmoothing` with `grayscale`, `subpixel`, `system`, and `none` modes, normalized on load and patch.
2. **Settings UI** — expose the option in Settings → Terminal with localized English/Korean labels and persistence.
3. **Renderer application** — apply the selected smoothing mode through terminal-scoped CSS on the xterm DOM container.
4. **Regression coverage** — cover settings normalization, Settings modal selection, persisted e2e selection, and terminal renderer CSS application.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal text rendering | Fixed app default smoothing | User can choose grayscale, subpixel, system, or none |
| Existing users | Existing rendering by default | Default remains `grayscale`, matching current behavior |
| Non-terminal UI | Uses app-wide smoothing | Unchanged |

## Design notes
- xterm.js does not expose a font anti-aliasing option in the local v6 type surface, so this PR keeps the behavior scoped to CSS on `.acorn-terminal` rather than extending xterm options.
- The CSS selector also targets terminal descendants so the terminal setting overrides Acorn's app-wide body smoothing without changing the rest of the UI.
- Invalid persisted or patched values fall back to the default/current value, matching the defensive normalization pattern used by nearby terminal settings.

## Test plan
- [x] `git diff --check` passed
- [x] `pnpm run typecheck` passed
- [x] `pnpm exec vitest run src/lib/settings.test.ts src/components/SettingsModal.test.tsx --reporter=verbose` passed — 83 tests
- [x] `pnpm exec playwright test tests/e2e/settings.spec.ts tests/e2e/terminal.spec.ts -g "letter spacing|anti-aliasing|font smoothing" --workers=1` passed — 3 tests
- [x] `pnpm run build` passed

## Notes
- `pnpm run build` still prints the existing Vite dynamic-import/chunk-size warnings for `src/lib/api.ts`, `src/store.ts`, and large generated chunks. The build completes successfully; these warnings are not introduced by this PR.
