### PR TITLE
feat(settings): add resident terminal limit toggle

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -540,6 +540,75 @@ describe("SettingsModal font controls", () => {
     expect(patchTerminal).toHaveBeenCalledWith({ maxMountedTerminals: 9 });
   });
 
+  it("patches the resident terminal limit toggle from the Sessions tab", async () => {
+    const patchTerminal = vi.fn();
+    useSettings.setState({
+      settings: cloneSettings(),
+      patchTerminal,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openSessionsTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const toggle = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    ).find((input) =>
+      input
+        .closest("label")
+        ?.textContent?.includes("Detach off-screen terminals over the limit"),
+    );
+
+    expect(toggle).toBeInstanceOf(HTMLInputElement);
+    expect(toggle?.checked).toBe(true);
+
+    act(() => {
+      toggle?.click();
+    });
+
+    expect(patchTerminal).toHaveBeenCalledWith({
+      detachOffscreenTerminals: false,
+    });
+  });
+
+  it("disables the resident terminal limit stepper when the toggle is off", async () => {
+    const settings = cloneSettings();
+    settings.terminal.detachOffscreenTerminals = false;
+    useSettings.setState({
+      settings,
+      patchTerminal: vi.fn(),
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openSessionsTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const label = Array.from(document.querySelectorAll("span")).find(
+      (element) => element.textContent === "Resident terminal limit",
+    );
+    const field = label?.parentElement;
+    const increase = Array.from(field?.querySelectorAll("button") ?? []).find(
+      (element) => element.getAttribute("aria-label") === "Increase",
+    );
+    const valueInput = field?.querySelector<HTMLInputElement>(
+      'input[aria-label="Value"]',
+    );
+
+    expect(valueInput?.disabled).toBe(true);
+    expect(increase).toBeInstanceOf(HTMLButtonElement);
+    expect((increase as HTMLButtonElement | undefined)?.disabled).toBe(true);
+  });
+
   it("maps legacy Services deep links to the Sessions tab", async () => {
     useSettings.setState({
       open: false,

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -805,6 +805,24 @@ function SessionSettings() {
       >
         <div className="space-y-4">
           <Field
+            label={st(t, "settings.terminal.detachOffscreenTerminals.label")}
+            hint={st(t, "settings.terminal.detachOffscreenTerminals.hint")}
+          >
+            <label className="flex items-center gap-2 text-xs text-fg">
+              <input
+                type="checkbox"
+                checked={settings.terminal.detachOffscreenTerminals}
+                onChange={(e) =>
+                  patchTerminal({
+                    detachOffscreenTerminals: e.target.checked,
+                  })
+                }
+                className="accent-[var(--color-accent)]"
+              />
+              {st(t, "settings.terminal.detachOffscreenTerminals.checkbox")}
+            </label>
+          </Field>
+          <Field
             label={st(t, "settings.terminal.maxMountedTerminals.label")}
             hint={st(t, "settings.terminal.maxMountedTerminals.hint")}
           >
@@ -812,6 +830,7 @@ function SessionSettings() {
               value={settings.terminal.maxMountedTerminals}
               min={MOUNTED_TERMINAL_LIMIT_MIN}
               max={MOUNTED_TERMINAL_LIMIT_MAX}
+              disabled={!settings.terminal.detachOffscreenTerminals}
               onChange={(n) => patchTerminal({ maxMountedTerminals: n })}
             />
           </Field>

--- a/src/components/TerminalHost.test.tsx
+++ b/src/components/TerminalHost.test.tsx
@@ -345,4 +345,37 @@ describe("TerminalHost", () => {
       { id: "s4", active: true },
     ]);
   });
+
+  it("keeps off-screen terminals mounted when resident terminal eviction is disabled", async () => {
+    const ids = ["s1", "s2", "s3"];
+    useSettings.setState({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        terminal: {
+          ...DEFAULT_SETTINGS.terminal,
+          maxMountedTerminals: 1,
+          detachOffscreenTerminals: false,
+        },
+      },
+    });
+    mocks.daemonListSessions.mockResolvedValue(
+      ids.map((id) => ({ id, alive: true })),
+    );
+    installWorkspaceSessions(ids);
+    render();
+    await flushEffects();
+
+    for (const id of ids.slice(1)) {
+      await focusSession(id);
+    }
+    await flushEffects();
+
+    expect(mocks.daemonListSessions).not.toHaveBeenCalled();
+    expect(mocks.markTerminalDetaching).not.toHaveBeenCalled();
+    expect(terminalRows()).toEqual([
+      { id: "s1", active: false },
+      { id: "s2", active: false },
+      { id: "s3", active: true },
+    ]);
+  });
 });

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -29,6 +29,9 @@ export function TerminalHost() {
   const maxMountedTerminals = useSettings(
     (s) => s.settings.terminal.maxMountedTerminals,
   );
+  const detachOffscreenTerminals = useSettings(
+    (s) => s.settings.terminal.detachOffscreenTerminals,
+  );
   const visibleSessionIdKey = useAppStore(visibleTerminalSessionIdKey);
   const visibleSessionIds = useMemo(
     () => parseSessionIdKey(visibleSessionIdKey),
@@ -84,6 +87,7 @@ export function TerminalHost() {
   // anything outside it. Runs only while over the cap, so steady state costs
   // nothing.
   useEffect(() => {
+    if (!detachOffscreenTerminals) return;
     const cap = Math.max(maxMountedTerminals, visibleSessionIds.size);
     if (mountedSessionIds.size <= cap) return;
     let cancelled = false;
@@ -123,7 +127,12 @@ export function TerminalHost() {
     return () => {
       cancelled = true;
     };
-  }, [maxMountedTerminals, mountedSessionIds, visibleSessionIds]);
+  }, [
+    detachOffscreenTerminals,
+    maxMountedTerminals,
+    mountedSessionIds,
+    visibleSessionIds,
+  ]);
 
   return (
     <>

--- a/src/components/ui/Stepper.tsx
+++ b/src/components/ui/Stepper.tsx
@@ -1,5 +1,6 @@
 import { Minus, Plus } from "lucide-react";
 import { useEffect, useState } from "react";
+import { cn } from "../../lib/cn";
 import { useTranslation } from "../../lib/useTranslation";
 
 interface StepperProps {
@@ -8,6 +9,7 @@ interface StepperProps {
   max: number;
   step?: number;
   unit?: string;
+  disabled?: boolean;
   /**
    * Optional value formatter for floating-point steppers — keeps the
    * displayed number stable (e.g. 1.05 vs 1.0500000000001) without
@@ -28,6 +30,7 @@ export function Stepper({
   max,
   step = 1,
   unit,
+  disabled = false,
   format,
   onChange,
 }: StepperProps) {
@@ -69,11 +72,16 @@ export function Stepper({
   };
 
   return (
-    <div className="inline-flex h-7 w-fit items-stretch self-start overflow-hidden rounded-md border border-border bg-bg">
+    <div
+      className={cn(
+        "inline-flex h-7 w-fit items-stretch self-start overflow-hidden rounded-md border border-border bg-bg",
+        disabled && "opacity-50",
+      )}
+    >
       <button
         type="button"
         onClick={dec}
-        disabled={value <= min}
+        disabled={disabled || value <= min}
         aria-label={t("ui.stepper.decrease")}
         className="flex w-8 items-center justify-center text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-40"
       >
@@ -82,7 +90,8 @@ export function Stepper({
       <div className="flex min-w-[4.25rem] items-center justify-center border-x border-border px-1.5 font-mono text-xs tabular-nums text-fg focus-within:ring-1 focus-within:ring-inset focus-within:ring-accent">
         <input
           aria-label={t("ui.stepper.value")}
-          className="h-full w-12 bg-transparent text-center font-mono text-xs tabular-nums text-fg outline-none"
+          className="h-full w-12 bg-transparent text-center font-mono text-xs tabular-nums text-fg outline-none disabled:cursor-not-allowed"
+          disabled={disabled}
           inputMode="decimal"
           max={max}
           min={min}
@@ -109,7 +118,7 @@ export function Stepper({
       <button
         type="button"
         onClick={inc}
-        disabled={value >= max}
+        disabled={disabled || value >= max}
         aria-label={t("ui.stepper.increase")}
         className="flex w-8 items-center justify-center text-fg-muted transition hover:bg-bg-sidebar hover:text-fg disabled:cursor-not-allowed disabled:opacity-40"
       >

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -183,6 +183,7 @@ describe("terminal.maxMountedTerminals settings", () => {
     expect(DEFAULT_SETTINGS.terminal.maxMountedTerminals).toBe(
       MOUNTED_TERMINAL_LIMIT_DEFAULT,
     );
+    expect(DEFAULT_SETTINGS.terminal.detachOffscreenTerminals).toBe(true);
   });
 
   it("loads a persisted resident terminal limit and clamps it", async () => {
@@ -196,6 +197,20 @@ describe("terminal.maxMountedTerminals settings", () => {
 
     expect(useSettings.getState().settings.terminal.maxMountedTerminals).toBe(
       MOUNTED_TERMINAL_LIMIT_MAX,
+    );
+  });
+
+  it("loads a persisted resident terminal eviction toggle", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ terminal: { detachOffscreenTerminals: false } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.terminal.detachOffscreenTerminals).toBe(
+      false,
     );
   });
 
@@ -213,6 +228,21 @@ describe("terminal.maxMountedTerminals settings", () => {
     useSettings.getState().patchTerminal({ maxMountedTerminals: 9.6 });
     expect(useSettings.getState().settings.terminal.maxMountedTerminals).toBe(
       10,
+    );
+  });
+
+  it("patches the resident terminal eviction toggle", async () => {
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    useSettings.getState().patchTerminal({ detachOffscreenTerminals: false });
+    expect(useSettings.getState().settings.terminal.detachOffscreenTerminals).toBe(
+      false,
+    );
+
+    useSettings.getState().patchTerminal({ detachOffscreenTerminals: true });
+    expect(useSettings.getState().settings.terminal.detachOffscreenTerminals).toBe(
+      true,
     );
   });
 });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -244,6 +244,11 @@ export interface AcornSettings {
      * sessions that can be re-attached with scrollback replay.
      */
     maxMountedTerminals: number;
+    /**
+     * Detach off-screen daemon-backed terminals when the resident terminal
+     * limit is exceeded. Disable to keep every opened terminal view mounted.
+     */
+    detachOffscreenTerminals: boolean;
   };
   /**
    * The single AI agent acorn uses everywhere AI features fire (currently
@@ -457,6 +462,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     lineHeight: 1.0,
     linkActivation: "click",
     maxMountedTerminals: MOUNTED_TERMINAL_LIMIT_DEFAULT,
+    detachOffscreenTerminals: true,
   },
   agents: {
     selected: "claude",
@@ -900,6 +906,12 @@ function loadSettings(): AcornSettings {
             .maxMountedTerminals,
           DEFAULT_SETTINGS.terminal.maxMountedTerminals,
         ),
+        detachOffscreenTerminals:
+          typeof (terminalRaw as { detachOffscreenTerminals?: unknown })
+            .detachOffscreenTerminals === "boolean"
+            ? (terminalRaw as { detachOffscreenTerminals: boolean })
+                .detachOffscreenTerminals
+            : DEFAULT_SETTINGS.terminal.detachOffscreenTerminals,
       },
       agents: {
         selected,
@@ -1136,6 +1148,12 @@ export const useSettings = create<SettingsState>((set, get) => ({
                   patch.fontSmoothing,
                   s.settings.terminal.fontSmoothing,
                 ),
+          detachOffscreenTerminals:
+            patch.detachOffscreenTerminals === undefined
+              ? s.settings.terminal.detachOffscreenTerminals
+              : typeof patch.detachOffscreenTerminals === "boolean"
+                ? patch.detachOffscreenTerminals
+                : s.settings.terminal.detachOffscreenTerminals,
         },
       };
       persist(next);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -101,6 +101,11 @@
         "label": "Resident terminal limit",
         "hint": "How many off-screen terminal views stay mounted in memory before daemon-backed sessions are detached. Visible terminals are always kept."
       },
+      "detachOffscreenTerminals": {
+        "label": "Enable resident terminal limit",
+        "hint": "Detach daemon-backed off-screen terminal views after the resident limit is exceeded. Turn off to keep every opened terminal view mounted.",
+        "checkbox": "Detach off-screen terminals over the limit"
+      },
       "openLinksOn": {
         "label": "Open links on",
         "hint": "How to follow URLs that xterm detects in terminal output.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -101,6 +101,11 @@
         "label": "메모리에 유지할 터미널 수",
         "hint": "백그라운드 터미널 뷰를 몇 개까지 메모리에 유지할지 정합니다. 초과한 daemon 세션은 detach하며, 현재 보이는 터미널은 항상 유지됩니다."
       },
+      "detachOffscreenTerminals": {
+        "label": "상주 터미널 제한 사용",
+        "hint": "상주 제한을 초과한 daemon 기반 백그라운드 터미널 뷰를 detach합니다. 끄면 열어 본 모든 터미널 뷰를 메모리에 유지합니다.",
+        "checkbox": "제한을 초과한 백그라운드 터미널 detach"
+      },
       "openLinksOn": {
         "label": "링크 열기 방식",
         "hint": "xterm이 터미널 출력에서 감지한 URL을 여는 방식입니다.",


### PR DESCRIPTION
## Summary
Adds an explicit control for disabling Acorn's resident terminal eviction behavior while preserving the existing limit value.

1. **Settings model** — adds `terminal.detachOffscreenTerminals`, defaulting on so existing resident terminal behavior is unchanged after update.
2. **Sessions settings UI** — adds an Enable resident terminal limit checkbox and disables the numeric resident limit stepper when eviction is off.
3. **Terminal host behavior** — skips daemon-backed off-screen terminal detachment entirely when the toggle is disabled.
4. **Verification coverage** — covers persistence, Settings UI patching/disabled state, and TerminalHost no-eviction behavior.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Resident terminal behavior | Off-screen daemon terminals detach after the configured resident limit is exceeded | Same default behavior |
| User control | Users can tune only the resident limit number | Users can disable the eviction feature entirely |
| Memory usage | Capped by resident terminal limit for daemon-backed off-screen sessions | Potentially higher when the toggle is off, by user choice |

## Design notes
- The toggle is modeled as a boolean instead of using `0` as a sentinel so the existing limit clamp, minimum value, and persisted numeric value stay intact.
- `TerminalHost` reads the new setting before calling `daemonListSessions`, so disabling the feature avoids both eviction and the daemon session listing work.
- `Stepper` gained a general `disabled` prop so the Settings UI can lock the numeric limit without adding one-off wrapper logic.

## Test plan
- [x] `pnpm exec vitest run src/lib/settings.test.ts src/components/SettingsModal.test.tsx src/components/TerminalHost.test.tsx` — 3 files / 91 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `git diff --check` — passed

## Notes
- `pnpm install --frozen-lockfile` was run in this fresh worktree because `node_modules` was missing before verification.