### PR TITLE
fix(settings): align session lifecycle prompt toggles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -271,9 +271,11 @@ function App() {
   const confirmRemoveSession = useSettings(
     (s) => s.settings.sessions.confirmRemove,
   );
-  const autoDeleteWorktrees = useSettings(
-    (s) => s.settings.sessions.autoDeleteWorktrees,
+  const confirmDeleteIsolatedWorktrees = useSettings(
+    (s) => s.settings.sessions.confirmDeleteIsolatedWorktrees,
   );
+  const deleteIsolatedWorktreesWithoutPrompt =
+    !confirmDeleteIsolatedWorktrees;
   const settings = useSettings((s) => s.settings);
   const shortcuts = settings.shortcuts;
   const preventSleep = settings.power.preventSleep;
@@ -304,7 +306,8 @@ function App() {
     pendingRemove !== null &&
     !pendingRemoveNeedsRunningWarning &&
     (pendingRemoveKeepsSharedWorktree ||
-      (pendingRemoveAutoDeletesWorktree && autoDeleteWorktrees) ||
+      (pendingRemoveAutoDeletesWorktree &&
+        deleteIsolatedWorktreesWithoutPrompt) ||
       (!pendingRemoveRecordedWorktree && !confirmRemoveSession));
   const sessionIdsKey = useMemo(
     () => sessions.map((session) => session.id).join("\0"),
@@ -1086,10 +1089,10 @@ function App() {
     }
   }, [pendingRemove?.id, runningCloseWarningConfirmedId]);
 
-  // Skip the confirmation dialog when Settings gives a deterministic removal
-  // choice: shared worktree workspace sessions keep the worktree, plain
-  // sessions can skip confirmation, and standalone isolated sessions can opt
-  // into always deleting their worktree from disk.
+  // Skip the confirmation dialog when Settings gives a deterministic removal:
+  // shared worktree workspace sessions keep the worktree, plain sessions can
+  // skip confirmation, and standalone isolated sessions can delete their
+  // worktree automatically when the cleanup prompt is disabled.
   useEffect(() => {
     if (!pendingRemove) return;
     if (pendingRemoveNeedsRunningWarning) return;
@@ -1112,7 +1115,7 @@ function App() {
       pendingRemove,
       projectFolders,
     );
-    if (autoDeleteWorktree && autoDeleteWorktrees) {
+    if (autoDeleteWorktree && deleteIsolatedWorktreesWithoutPrompt) {
       clearPendingRemove();
       void removeSession(pendingRemove.id, true).then((removedWorktree) =>
         showStoreWorktreeRemovalToast(
@@ -1137,7 +1140,7 @@ function App() {
   }, [
     pendingRemove,
     pendingRemoveNeedsRunningWarning,
-    autoDeleteWorktrees,
+    deleteIsolatedWorktreesWithoutPrompt,
     clearPendingRemove,
     confirmRemoveSession,
     projectFolders,

--- a/src/components/RemoveProjectFolderDialog.tsx
+++ b/src/components/RemoveProjectFolderDialog.tsx
@@ -34,8 +34,8 @@ export function RemoveProjectFolderDialog({
   onClose,
 }: RemoveProjectFolderDialogProps) {
   const t = useTranslation();
-  const autoDeleteEmptyWorktreeWorkspaces = useSettings(
-    (s) => s.settings.sessions.autoDeleteEmptyWorktreeWorkspaces,
+  const confirmDeleteEmptyWorktreeWorkspaces = useSettings(
+    (s) => s.settings.sessions.confirmDeleteEmptyWorktreeWorkspaces,
   );
   const patchSessions = useSettings((s) => s.patchSessions);
   const sessionCount = sessions.length;
@@ -139,10 +139,10 @@ export function RemoveProjectFolderDialog({
               <label className="flex cursor-pointer items-center gap-2 pt-1 text-xs text-fg-muted">
                 <input
                   type="checkbox"
-                  checked={autoDeleteEmptyWorktreeWorkspaces}
+                  checked={confirmDeleteEmptyWorktreeWorkspaces}
                   onChange={(e) =>
                     patchSessions({
-                      autoDeleteEmptyWorktreeWorkspaces: e.target.checked,
+                      confirmDeleteEmptyWorktreeWorkspaces: e.target.checked,
                     })
                   }
                   className="accent-[var(--color-accent)]"

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -853,46 +853,7 @@ describe("SettingsModal font controls", () => {
     });
   });
 
-  it("patches the worktree auto-delete session toggle", async () => {
-    const patchSessions = vi.fn();
-    useSettings.setState({
-      settings: cloneSettings(),
-      patchSessions,
-    });
-
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<SettingsModal />);
-    });
-    openSessionsTab();
-    await act(async () => {
-      await Promise.resolve();
-    });
-
-    const toggle = Array.from(
-      document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
-    ).find((input) =>
-      input
-        .closest("label")
-        ?.textContent?.includes("Always delete standalone isolated worktrees"),
-    );
-
-    expect(document.body.textContent).toContain(
-      "Delete isolated worktrees without asking",
-    );
-    expect(toggle).toBeInstanceOf(HTMLInputElement);
-    expect(toggle?.checked).toBe(false);
-
-    act(() => {
-      toggle?.click();
-    });
-
-    expect(patchSessions).toHaveBeenCalledWith({
-      autoDeleteWorktrees: true,
-    });
-  });
-
-  it("patches the empty worktree workspace auto-delete toggle", async () => {
+  it("patches the isolated worktree cleanup prompt toggle", async () => {
     const patchSessions = vi.fn();
     useSettings.setState({
       settings: cloneSettings(),
@@ -914,22 +875,100 @@ describe("SettingsModal font controls", () => {
       input
         .closest("label")
         ?.textContent?.includes(
-          "Always delete empty worktree workspace directories",
+          "Ask before deleting standalone isolated worktrees",
         ),
     );
 
     expect(document.body.textContent).toContain(
-      "Delete empty worktree workspaces without asking",
+      "Isolated worktree cleanup prompt",
     );
     expect(toggle).toBeInstanceOf(HTMLInputElement);
-    expect(toggle?.checked).toBe(false);
+    expect(toggle?.checked).toBe(true);
 
     act(() => {
       toggle?.click();
     });
 
     expect(patchSessions).toHaveBeenCalledWith({
-      autoDeleteEmptyWorktreeWorkspaces: true,
+      confirmDeleteIsolatedWorktrees: false,
+    });
+  });
+
+  it("patches the empty worktree workspace cleanup prompt toggle", async () => {
+    const patchSessions = vi.fn();
+    useSettings.setState({
+      settings: cloneSettings(),
+      patchSessions,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openSessionsTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const toggle = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    ).find((input) =>
+      input
+        .closest("label")
+        ?.textContent?.includes(
+          "Ask before deleting empty worktree workspace directories",
+        ),
+    );
+
+    expect(document.body.textContent).toContain(
+      "Empty worktree workspace cleanup prompt",
+    );
+    expect(toggle).toBeInstanceOf(HTMLInputElement);
+    expect(toggle?.checked).toBe(true);
+
+    act(() => {
+      toggle?.click();
+    });
+
+    expect(patchSessions).toHaveBeenCalledWith({
+      confirmDeleteEmptyWorktreeWorkspaces: false,
+    });
+  });
+
+  it("patches the process-exit restart prompt toggle", async () => {
+    const patchSessions = vi.fn();
+    useSettings.setState({
+      settings: cloneSettings(),
+      patchSessions,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openSessionsTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const toggle = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    ).find((input) =>
+      input
+        .closest("label")
+        ?.textContent?.includes("Show restart prompt after the process exits"),
+    );
+
+    expect(document.body.textContent).toContain("Process-exit restart prompt");
+    expect(toggle).toBeInstanceOf(HTMLInputElement);
+    expect(toggle?.checked).toBe(true);
+
+    act(() => {
+      toggle?.click();
+    });
+
+    expect(patchSessions).toHaveBeenCalledWith({
+      showRestartPromptOnExit: false,
     });
   });
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -739,62 +739,75 @@ function SessionSettings() {
             </label>
           </Field>
           <Field
-            label={st(t, "settings.sessions.autoDeleteWorktrees.label")}
-            hint={st(t, "settings.sessions.autoDeleteWorktrees.hint")}
-          >
-            <label className="flex items-center gap-2 text-xs text-fg">
-              <input
-                type="checkbox"
-                checked={settings.sessions.autoDeleteWorktrees}
-                onChange={(e) =>
-                  patchSessions({ autoDeleteWorktrees: e.target.checked })
-                }
-                className="accent-[var(--color-accent)]"
-              />
-              {st(t, "settings.sessions.autoDeleteWorktrees.checkbox")}
-            </label>
-          </Field>
-          <Field
             label={st(
               t,
-              "settings.sessions.autoDeleteEmptyWorktreeWorkspaces.label",
+              "settings.sessions.confirmDeleteIsolatedWorktrees.label",
             )}
             hint={st(
               t,
-              "settings.sessions.autoDeleteEmptyWorktreeWorkspaces.hint",
+              "settings.sessions.confirmDeleteIsolatedWorktrees.hint",
             )}
           >
             <label className="flex items-center gap-2 text-xs text-fg">
               <input
                 type="checkbox"
-                checked={settings.sessions.autoDeleteEmptyWorktreeWorkspaces}
+                checked={settings.sessions.confirmDeleteIsolatedWorktrees}
                 onChange={(e) =>
                   patchSessions({
-                    autoDeleteEmptyWorktreeWorkspaces: e.target.checked,
+                    confirmDeleteIsolatedWorktrees: e.target.checked,
                   })
                 }
                 className="accent-[var(--color-accent)]"
               />
               {st(
                 t,
-                "settings.sessions.autoDeleteEmptyWorktreeWorkspaces.checkbox",
+                "settings.sessions.confirmDeleteIsolatedWorktrees.checkbox",
               )}
             </label>
           </Field>
           <Field
-            label={st(t, "settings.sessions.closeOnExit.label")}
-            hint={st(t, "settings.sessions.closeOnExit.hint")}
+            label={st(
+              t,
+              "settings.sessions.confirmDeleteEmptyWorktreeWorkspaces.label",
+            )}
+            hint={st(
+              t,
+              "settings.sessions.confirmDeleteEmptyWorktreeWorkspaces.hint",
+            )}
           >
             <label className="flex items-center gap-2 text-xs text-fg">
               <input
                 type="checkbox"
-                checked={settings.sessions.closeOnExit}
+                checked={
+                  settings.sessions.confirmDeleteEmptyWorktreeWorkspaces
+                }
                 onChange={(e) =>
-                  patchSessions({ closeOnExit: e.target.checked })
+                  patchSessions({
+                    confirmDeleteEmptyWorktreeWorkspaces: e.target.checked,
+                  })
                 }
                 className="accent-[var(--color-accent)]"
               />
-              {st(t, "settings.sessions.closeOnExit.checkbox")}
+              {st(
+                t,
+                "settings.sessions.confirmDeleteEmptyWorktreeWorkspaces.checkbox",
+              )}
+            </label>
+          </Field>
+          <Field
+            label={st(t, "settings.sessions.showRestartPromptOnExit.label")}
+            hint={st(t, "settings.sessions.showRestartPromptOnExit.hint")}
+          >
+            <label className="flex items-center gap-2 text-xs text-fg">
+              <input
+                type="checkbox"
+                checked={settings.sessions.showRestartPromptOnExit}
+                onChange={(e) =>
+                  patchSessions({ showRestartPromptOnExit: e.target.checked })
+                }
+                className="accent-[var(--color-accent)]"
+              />
+              {st(t, "settings.sessions.showRestartPromptOnExit.checkbox")}
             </label>
           </Field>
         </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -204,12 +204,16 @@ export function Sidebar() {
   const renameProjectFolder = useAppStore((s) => s.renameProjectFolder);
   const removeProjectFolder = useAppStore((s) => s.removeProjectFolder);
   const removeSession = useAppStore((s) => s.removeSession);
-  const autoDeleteWorktrees = useSettings(
-    (s) => s.settings.sessions.autoDeleteWorktrees,
+  const confirmDeleteIsolatedWorktrees = useSettings(
+    (s) => s.settings.sessions.confirmDeleteIsolatedWorktrees,
   );
-  const autoDeleteEmptyWorktreeWorkspaces = useSettings(
-    (s) => s.settings.sessions.autoDeleteEmptyWorktreeWorkspaces,
+  const confirmDeleteEmptyWorktreeWorkspaces = useSettings(
+    (s) => s.settings.sessions.confirmDeleteEmptyWorktreeWorkspaces,
   );
+  const deleteIsolatedWorktreesWithoutPrompt =
+    !confirmDeleteIsolatedWorktrees;
+  const deleteEmptyWorktreeWorkspacesWithoutPrompt =
+    !confirmDeleteEmptyWorktreeWorkspaces;
   const moveSessionToProjectFolder = useAppStore(
     (s) => s.moveSessionToProjectFolder,
   );
@@ -424,7 +428,7 @@ export function Sidebar() {
       for (const session of folderGroup.sessions) {
         const removedWorktree = await removeSession(
           session.id,
-          autoDeleteWorktrees &&
+          deleteIsolatedWorktreesWithoutPrompt &&
             shouldAutoDeleteSessionWorktree(session, projectFolders),
         );
         if (removedWorktree) {
@@ -491,7 +495,7 @@ export function Sidebar() {
     if (!folderGroup) return;
     if (folderGroup.sessions.length === 0) {
       if (isWorktreeWorkspace(folderGroup.folder)) {
-        if (autoDeleteEmptyWorktreeWorkspaces) {
+        if (deleteEmptyWorktreeWorkspacesWithoutPrompt) {
           void removeProjectFolderAndWorktree(folderGroup.folder);
         } else {
           setPendingRemoveProjectFolderId(folderGroup.folder.id);
@@ -1199,7 +1203,7 @@ export function Sidebar() {
             isWorktreeWorkspace(pendingRemoveProjectFolderGroup.folder),
         )}
         deleteWorktrees={Boolean(
-          autoDeleteWorktrees &&
+          deleteIsolatedWorktreesWithoutPrompt &&
             pendingRemoveProjectFolderGroup?.sessions.some((session) =>
               shouldAutoDeleteSessionWorktree(session, projectFolders),
             ),

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -2127,10 +2127,12 @@ export function Terminal({
               // briefly flash on the way out.
               return;
             }
-            // User opted into auto-close: drop ordinary sessions immediately,
-            // but route worktree-backed sessions through the same removal
-            // policy as tab close.
-            if (useSettings.getState().settings.sessions.closeOnExit) {
+            // When the restart prompt is disabled, drop ordinary sessions
+            // immediately, but route worktree-backed sessions through the same
+            // removal policy as tab close.
+            if (
+              !useSettings.getState().settings.sessions.showRestartPromptOnExit
+            ) {
               exited = true;
               const store = useAppStore.getState();
               const session =

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -317,12 +317,15 @@ describe("session removal settings", () => {
     });
   });
 
-  it("keeps worktree auto-delete off by default", () => {
+  it("shows removal and cleanup prompts by default", () => {
     expect(DEFAULT_SETTINGS.sessions.warnBeforeClosingRunning).toBe(true);
-    expect(DEFAULT_SETTINGS.sessions.autoDeleteWorktrees).toBe(false);
-    expect(DEFAULT_SETTINGS.sessions.autoDeleteEmptyWorktreeWorkspaces).toBe(
-      false,
+    expect(DEFAULT_SETTINGS.sessions.confirmDeleteIsolatedWorktrees).toBe(
+      true,
     );
+    expect(DEFAULT_SETTINGS.sessions.confirmDeleteEmptyWorktreeWorkspaces).toBe(
+      true,
+    );
+    expect(DEFAULT_SETTINGS.sessions.showRestartPromptOnExit).toBe(true);
   });
 
   it("loads persisted session removal preferences", async () => {
@@ -331,8 +334,9 @@ describe("session removal settings", () => {
       JSON.stringify({
         sessions: {
           warnBeforeClosingRunning: false,
-          autoDeleteWorktrees: true,
-          autoDeleteEmptyWorktreeWorkspaces: true,
+          confirmDeleteIsolatedWorktrees: false,
+          confirmDeleteEmptyWorktreeWorkspaces: false,
+          showRestartPromptOnExit: false,
         },
       }),
     );
@@ -340,15 +344,79 @@ describe("session removal settings", () => {
     vi.resetModules();
     const { useSettings } = await import("./settings");
 
-    expect(useSettings.getState().settings.sessions.autoDeleteWorktrees).toBe(
-      true,
-    );
+    expect(
+      useSettings.getState().settings.sessions.confirmDeleteIsolatedWorktrees,
+    ).toBe(false);
     expect(
       useSettings.getState().settings.sessions.warnBeforeClosingRunning,
     ).toBe(false);
     expect(
       useSettings.getState().settings.sessions
-        .autoDeleteEmptyWorktreeWorkspaces,
+        .confirmDeleteEmptyWorktreeWorkspaces,
+    ).toBe(false);
+    expect(
+      useSettings.getState().settings.sessions.showRestartPromptOnExit,
+    ).toBe(false);
+  });
+
+  it("migrates persisted automatic cleanup preferences", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        sessions: {
+          warnBeforeClosingRunning: false,
+          autoDeleteWorktrees: true,
+          autoDeleteEmptyWorktreeWorkspaces: true,
+          closeOnExit: true,
+        },
+      }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(
+      useSettings.getState().settings.sessions.confirmDeleteIsolatedWorktrees,
+    ).toBe(false);
+    expect(
+      useSettings.getState().settings.sessions.warnBeforeClosingRunning,
+    ).toBe(false);
+    expect(
+      useSettings.getState().settings.sessions
+        .confirmDeleteEmptyWorktreeWorkspaces,
+    ).toBe(false);
+    expect(
+      useSettings.getState().settings.sessions.showRestartPromptOnExit,
+    ).toBe(false);
+  });
+
+  it("prefers current cleanup prompt preferences over automatic cleanup keys", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        sessions: {
+          confirmDeleteIsolatedWorktrees: true,
+          autoDeleteWorktrees: true,
+          confirmDeleteEmptyWorktreeWorkspaces: true,
+          autoDeleteEmptyWorktreeWorkspaces: true,
+          showRestartPromptOnExit: true,
+          closeOnExit: true,
+        },
+      }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(
+      useSettings.getState().settings.sessions.confirmDeleteIsolatedWorktrees,
+    ).toBe(true);
+    expect(
+      useSettings.getState().settings.sessions
+        .confirmDeleteEmptyWorktreeWorkspaces,
+    ).toBe(true);
+    expect(
+      useSettings.getState().settings.sessions.showRestartPromptOnExit,
     ).toBe(true);
   });
 });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -276,8 +276,7 @@ export interface AcornSettings {
     /**
      * Show the confirmation dialog before removing a non-isolated session.
      * Set false to skip the prompt for plain sessions. Worktree-backed
-     * sessions still ask unless they are standalone isolated worktrees covered
-     * by `autoDeleteWorktrees`.
+     * sessions still ask unless their cleanup prompt is disabled below.
      */
     confirmRemove: boolean;
     /**
@@ -287,25 +286,24 @@ export interface AcornSettings {
      */
     warnBeforeClosingRunning: boolean;
     /**
-     * Remove standalone isolated worktree sessions without asking whether to
-     * keep the worktree directory. Shared worktree workspaces and linked
-     * worktree sessions are preserved unless the user explicitly deletes them.
+     * Ask before deleting a standalone isolated worktree directory when its
+     * session is removed. Shared worktree workspaces and linked worktree
+     * sessions are preserved unless the user explicitly deletes them.
      */
-    autoDeleteWorktrees: boolean;
+    confirmDeleteIsolatedWorktrees: boolean;
     /**
-     * Remove the linked worktree directory when deleting an empty worktree
-     * workspace without asking. Worktree workspaces that still contain
-     * sessions always show the workspace removal confirmation and preserve the
-     * directory.
+     * Ask before deleting the linked worktree directory when removing an
+     * empty worktree workspace. Worktree workspaces that still contain
+     * sessions always show the workspace removal confirmation.
      */
-    autoDeleteEmptyWorktreeWorkspaces: boolean;
+    confirmDeleteEmptyWorktreeWorkspaces: boolean;
     /**
-     * When the session's PTY process exits (e.g. user typed `exit`), close
-     * the session tab automatically instead of showing the
-     * "[process exited — press Enter to restart]" prompt. The worktree is
-     * preserved either way; only the in-app tab is affected.
+     * Show the "[process exited — press Enter to restart]" prompt when the
+     * session's PTY process exits. When false, Acorn closes the session tab
+     * automatically; worktree-backed sessions still pass through the normal
+     * worktree cleanup policy.
      */
-    closeOnExit: boolean;
+    showRestartPromptOnExit: boolean;
   };
   power: {
     /**
@@ -469,9 +467,9 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   sessions: {
     confirmRemove: true,
     warnBeforeClosingRunning: true,
-    autoDeleteWorktrees: false,
-    autoDeleteEmptyWorktreeWorkspaces: false,
-    closeOnExit: false,
+    confirmDeleteIsolatedWorktrees: true,
+    confirmDeleteEmptyWorktreeWorkspaces: true,
+    showRestartPromptOnExit: true,
   },
   power: {
     preventSleep: false,
@@ -769,6 +767,13 @@ interface LegacyPullRequests {
   showChecks?: boolean;
 }
 
+interface PersistedSessionSettings
+  extends Partial<AcornSettings["sessions"]> {
+  autoDeleteWorktrees?: boolean;
+  autoDeleteEmptyWorktreeWorkspaces?: boolean;
+  closeOnExit?: boolean;
+}
+
 function loadSettings(): AcornSettings {
   if (typeof localStorage === "undefined") return DEFAULT_SETTINGS;
   try {
@@ -782,6 +787,7 @@ function loadSettings(): AcornSettings {
       | null;
     if (!parsed || typeof parsed !== "object") return DEFAULT_SETTINGS;
     const terminalRaw: Partial<AcornSettings["terminal"]> = parsed.terminal ?? {};
+    const sessionsRaw = (parsed.sessions ?? {}) as PersistedSessionSettings;
 
     // Prefer the `agents` block; fall back to values stored under the older
     // `commitMessage` shape, then to the Claude default.
@@ -916,8 +922,33 @@ function loadSettings(): AcornSettings {
         llm: { model: llmModel },
       },
       sessions: {
-        ...DEFAULT_SETTINGS.sessions,
-        ...(parsed.sessions ?? {}),
+        confirmRemove:
+          typeof sessionsRaw.confirmRemove === "boolean"
+            ? sessionsRaw.confirmRemove
+            : DEFAULT_SETTINGS.sessions.confirmRemove,
+        warnBeforeClosingRunning:
+          typeof sessionsRaw.warnBeforeClosingRunning === "boolean"
+            ? sessionsRaw.warnBeforeClosingRunning
+            : DEFAULT_SETTINGS.sessions.warnBeforeClosingRunning,
+        confirmDeleteIsolatedWorktrees:
+          typeof sessionsRaw.confirmDeleteIsolatedWorktrees === "boolean"
+            ? sessionsRaw.confirmDeleteIsolatedWorktrees
+            : typeof sessionsRaw.autoDeleteWorktrees === "boolean"
+              ? !sessionsRaw.autoDeleteWorktrees
+              : DEFAULT_SETTINGS.sessions.confirmDeleteIsolatedWorktrees,
+        confirmDeleteEmptyWorktreeWorkspaces:
+          typeof sessionsRaw.confirmDeleteEmptyWorktreeWorkspaces === "boolean"
+            ? sessionsRaw.confirmDeleteEmptyWorktreeWorkspaces
+            : typeof sessionsRaw.autoDeleteEmptyWorktreeWorkspaces ===
+                "boolean"
+              ? !sessionsRaw.autoDeleteEmptyWorktreeWorkspaces
+              : DEFAULT_SETTINGS.sessions.confirmDeleteEmptyWorktreeWorkspaces,
+        showRestartPromptOnExit:
+          typeof sessionsRaw.showRestartPromptOnExit === "boolean"
+            ? sessionsRaw.showRestartPromptOnExit
+            : typeof sessionsRaw.closeOnExit === "boolean"
+              ? !sessionsRaw.closeOnExit
+              : DEFAULT_SETTINGS.sessions.showRestartPromptOnExit,
       },
       power: {
         preventSleep:

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -123,29 +123,29 @@
         "description": "Runtime behavior that keeps long-running terminals usable while Acorn is open or restarting."
       },
       "confirmRemove": {
-        "label": "Confirm before removing a session",
+        "label": "Session removal confirmation",
         "hint": "Applies to plain sessions. Shared worktree sessions still ask before removal.",
-        "checkbox": "Show confirmation dialog"
+        "checkbox": "Show confirmation before removing plain sessions"
       },
       "warnBeforeClosingRunning": {
-        "label": "Warn before closing a running session",
+        "label": "Running-session close warning",
         "hint": "Show a warning before closing a session that is still running. Closing a running session terminates its active shell or agent process.",
-        "checkbox": "Show running-session warning"
+        "checkbox": "Show warning before closing running sessions"
       },
-      "autoDeleteWorktrees": {
-        "label": "Delete isolated worktrees without asking",
-        "hint": "When removing a standalone isolated worktree session, skip the keep/delete prompt and delete its worktree from disk. Shared worktree workspaces are preserved.",
-        "checkbox": "Always delete standalone isolated worktrees from disk"
+      "confirmDeleteIsolatedWorktrees": {
+        "label": "Isolated worktree cleanup prompt",
+        "hint": "Turn this off to delete standalone isolated worktrees from disk without the keep/delete prompt. Shared worktree workspaces are preserved.",
+        "checkbox": "Ask before deleting standalone isolated worktrees"
       },
-      "autoDeleteEmptyWorktreeWorkspaces": {
-        "label": "Delete empty worktree workspaces without asking",
-        "hint": "When removing a worktree workspace with no sessions, delete its linked worktree from disk without showing the keep/delete prompt.",
-        "checkbox": "Always delete empty worktree workspace directories"
+      "confirmDeleteEmptyWorktreeWorkspaces": {
+        "label": "Empty worktree workspace cleanup prompt",
+        "hint": "Turn this off to delete an empty worktree workspace directory from disk without the keep/delete prompt.",
+        "checkbox": "Ask before deleting empty worktree workspace directories"
       },
-      "closeOnExit": {
-        "label": "Close tab when the process exits",
-        "hint": "When the session's shell or agent exits (e.g. you type `exit`), close the tab automatically instead of showing the press-Enter restart prompt. Standalone isolated sessions follow the delete-worktree setting above.",
-        "checkbox": "Auto-close on exit"
+      "showRestartPromptOnExit": {
+        "label": "Process-exit restart prompt",
+        "hint": "Turn this off to close the tab automatically when its shell or agent exits. Worktree-backed tabs then follow the cleanup prompt settings above.",
+        "checkbox": "Show restart prompt after the process exits"
       },
       "background": {
         "title": "Background sessions",
@@ -1249,7 +1249,7 @@
       "worktreeWorkspacePath": "This workspace uses a linked git worktree:",
       "deleteWorkspaceWorktreeQuestion": "Also delete this worktree from disk?",
       "sharedWorktreeWillBeKept": "The workspace worktree will be kept on disk.",
-      "rememberDeleteWorktree": "Always delete empty worktree workspace directories",
+      "rememberDeleteWorktree": "Ask before deleting empty worktree workspace directories",
       "removeFolder": "Remove workspace",
       "keepWorktree": "Keep worktree",
       "deleteWorktree": "Delete worktree",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -123,29 +123,29 @@
         "description": "Acorn이 열려 있거나 재시작되는 동안 장시간 실행되는 터미널을 유지하는 동작입니다."
       },
       "confirmRemove": {
-        "label": "세션 제거 전 확인",
+        "label": "세션 제거 확인",
         "hint": "일반 세션에 적용됩니다. 공유 워크트리 세션은 제거 전에 계속 확인합니다.",
-        "checkbox": "확인 대화상자 표시"
+        "checkbox": "일반 세션을 제거하기 전에 확인 표시"
       },
       "warnBeforeClosingRunning": {
-        "label": "실행 중인 세션을 닫기 전 경고",
+        "label": "실행 중 세션 닫기 경고",
         "hint": "아직 실행 중인 세션을 닫기 전에 경고를 표시합니다. 실행 중인 세션을 닫으면 활성 셸이나 에이전트 프로세스가 종료됩니다.",
-        "checkbox": "실행 중 세션 경고 표시"
+        "checkbox": "실행 중인 세션을 닫기 전에 경고 표시"
       },
-      "autoDeleteWorktrees": {
-        "label": "묻지 않고 격리 워크트리 삭제",
-        "hint": "단독 격리 워크트리 세션을 제거할 때 유지/삭제 확인을 건너뛰고 디스크의 워크트리를 삭제합니다. 공유 워크트리 작업공간은 유지됩니다.",
-        "checkbox": "단독 격리 워크트리는 항상 디스크에서도 삭제"
+      "confirmDeleteIsolatedWorktrees": {
+        "label": "격리 워크트리 정리 확인",
+        "hint": "끄면 단독 격리 워크트리를 유지/삭제 확인 없이 디스크에서 삭제합니다. 공유 워크트리 작업공간은 유지됩니다.",
+        "checkbox": "단독 격리 워크트리를 삭제하기 전에 확인 표시"
       },
-      "autoDeleteEmptyWorktreeWorkspaces": {
-        "label": "빈 워크트리 작업공간은 묻지 않고 삭제",
-        "hint": "세션이 없는 워크트리 작업공간을 제거할 때 유지/삭제 확인 없이 디스크의 연결된 워크트리도 삭제합니다.",
-        "checkbox": "빈 워크트리 작업공간 디렉터리 항상 삭제"
+      "confirmDeleteEmptyWorktreeWorkspaces": {
+        "label": "빈 워크트리 작업공간 정리 확인",
+        "hint": "끄면 세션이 없는 워크트리 작업공간 디렉터리를 유지/삭제 확인 없이 디스크에서 삭제합니다.",
+        "checkbox": "빈 워크트리 작업공간 디렉터리를 삭제하기 전에 확인 표시"
       },
-      "closeOnExit": {
-        "label": "프로세스 종료 시 탭 닫기",
-        "hint": "세션의 셸이나 에이전트가 종료되면(예: `exit` 입력) Enter를 눌러 재시작하라는 프롬프트 대신 탭을 자동으로 닫습니다. 단독 격리 세션은 위 워크트리 삭제 설정을 따릅니다.",
-        "checkbox": "종료 시 자동 닫기"
+      "showRestartPromptOnExit": {
+        "label": "프로세스 종료 후 재시작 안내",
+        "hint": "끄면 세션의 셸이나 에이전트가 종료될 때 탭을 자동으로 닫습니다. 워크트리 기반 탭은 위 정리 확인 설정을 따릅니다.",
+        "checkbox": "프로세스가 종료되면 재시작 안내 표시"
       },
       "background": {
         "title": "백그라운드 세션",
@@ -1249,7 +1249,7 @@
       "worktreeWorkspacePath": "이 작업공간은 연결된 Git 워크트리를 사용합니다:",
       "deleteWorkspaceWorktreeQuestion": "이 워크트리도 디스크에서 삭제할까요?",
       "sharedWorktreeWillBeKept": "작업공간 워크트리는 디스크에 유지됩니다.",
-      "rememberDeleteWorktree": "빈 워크트리 작업공간 디렉터리 항상 삭제",
+      "rememberDeleteWorktree": "빈 워크트리 작업공간 디렉터리를 삭제하기 전에 확인 표시",
       "removeFolder": "작업공간 제거",
       "keepWorktree": "워크트리 유지",
       "deleteWorktree": "워크트리 삭제",

--- a/tests/e2e/session-lifecycle.spec.ts
+++ b/tests/e2e/session-lifecycle.spec.ts
@@ -299,8 +299,8 @@ test.describe("session lifecycle", () => {
         JSON.stringify({
           sessions: {
             confirmRemove: true,
-            autoDeleteWorktrees: true,
-            closeOnExit: false,
+            confirmDeleteIsolatedWorktrees: false,
+            showRestartPromptOnExit: true,
           },
         }),
       );
@@ -373,8 +373,8 @@ test.describe("session lifecycle", () => {
         JSON.stringify({
           sessions: {
             confirmRemove: true,
-            autoDeleteWorktrees: true,
-            closeOnExit: false,
+            confirmDeleteIsolatedWorktrees: false,
+            showRestartPromptOnExit: true,
           },
         }),
       );

--- a/tests/e2e/settings-tabs.spec.ts
+++ b/tests/e2e/settings-tabs.spec.ts
@@ -50,7 +50,7 @@ const TAB_MARKERS: Array<{
     label: "Sessions",
     marker: {
       kind: "text",
-      pattern: /Confirm before removing|세션 제거 전 확인/i,
+      pattern: /Session removal confirmation|세션 제거 확인/i,
     },
   },
   {

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -206,7 +206,7 @@ test.describe("settings modal", () => {
     await modal.getByRole("button", { name: /^(Sessions|세션)$/ }).click();
 
     const checkbox = modal.getByRole("checkbox", {
-      name: /Show running-session warning|실행 중 세션 경고 표시/,
+      name: /Show warning before closing running sessions|실행 중인 세션을 닫기 전에 경고 표시/,
     });
     await expect(checkbox).toBeChecked();
     await checkbox.click();

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -1168,8 +1168,8 @@ test.describe("sidebar: project lifecycle", () => {
         JSON.stringify({
           sessions: {
             confirmRemove: true,
-            autoDeleteWorktrees: true,
-            closeOnExit: false,
+            confirmDeleteIsolatedWorktrees: false,
+            showRestartPromptOnExit: true,
           },
         }),
       );
@@ -1376,20 +1376,18 @@ test.describe("sidebar: project lifecycle", () => {
     );
     await expect(dialog).toContainText("Also delete this worktree from disk?");
     const remember = dialog.getByRole("checkbox", {
-      name: "Always delete empty worktree workspace directories",
+      name: "Ask before deleting empty worktree workspace directories",
     });
-    await expect(remember).not.toBeChecked();
-    await remember.check();
+    await expect(remember).toBeChecked();
+    await remember.uncheck();
     await expect
       .poll(async () =>
         page.evaluate(() =>
-          Boolean(
-            JSON.parse(localStorage.getItem("acorn:settings:v1") ?? "{}")
-              .sessions?.autoDeleteEmptyWorktreeWorkspaces,
-          ),
+          JSON.parse(localStorage.getItem("acorn:settings:v1") ?? "{}")
+            .sessions?.confirmDeleteEmptyWorktreeWorkspaces,
         ),
       )
-      .toBe(true);
+      .toBe(false);
     await dialog.getByRole("button", { name: "Delete worktree" }).click();
 
     const calls = (await page.evaluate(
@@ -1541,9 +1539,9 @@ test.describe("sidebar: project lifecycle", () => {
         JSON.stringify({
           sessions: {
             confirmRemove: true,
-            autoDeleteWorktrees: false,
-            autoDeleteEmptyWorktreeWorkspaces: true,
-            closeOnExit: false,
+            confirmDeleteIsolatedWorktrees: true,
+            confirmDeleteEmptyWorktreeWorkspaces: false,
+            showRestartPromptOnExit: true,
           },
         }),
       );


### PR DESCRIPTION
## Summary
This fixes the Session lifecycle settings so checked toggles consistently mean Acorn will show a confirmation, warning, or prompt.

1. **Positive setting keys** — replace the inverted cleanup keys with `confirmDeleteIsolatedWorktrees`, `confirmDeleteEmptyWorktreeWorkspaces`, and `showRestartPromptOnExit` so UI checkboxes bind directly to the stored boolean.
2. **Legacy settings migration** — read existing `autoDeleteWorktrees`, `autoDeleteEmptyWorktreeWorkspaces`, and `closeOnExit` values and invert them into the new positive keys at load time.
3. **Lifecycle copy alignment** — update English and Korean Session lifecycle labels so every checkbox uses the same “show/ask before” mental model.
4. **Call-site updates** — route session removal, empty worktree workspace cleanup, and process-exit behavior through derived “without prompt” variables where automatic behavior is still required.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Session lifecycle settings | Some checked toggles meant “show prompt”; others meant “skip prompt and auto-delete/auto-close” | Checked toggles consistently mean “show confirmation/warning/prompt” |
| Settings implementation | UI had to invert stored booleans for cleanup and process-exit controls | Stored booleans match the visible checkbox meaning |
| Existing user settings | Legacy automatic cleanup keys existed in localStorage | Legacy keys migrate to the equivalent new prompt settings on load |

## Design notes
- Existing automatic behavior is preserved by deriving `deleteIsolatedWorktreesWithoutPrompt` and `deleteEmptyWorktreeWorkspacesWithoutPrompt` from the new positive settings at call sites.
- Current keys take precedence over legacy keys when both are present, so a user who has already saved the new shape does not get overwritten by stale fields.
- The empty-worktree workspace removal dialog now uses the same “ask before deleting” preference as the Settings modal.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/lib/settings.test.ts` — 64 passed
- [x] `pnpm exec vitest run src/components/SettingsModal.test.tsx` — 22 passed
- [x] `pnpm exec playwright test tests/e2e/settings.spec.ts tests/e2e/settings-tabs.spec.ts tests/e2e/session-lifecycle.spec.ts tests/e2e/sidebar.spec.ts` — 51 passed
- [x] `pnpm run build` passes
- [x] `git diff --check` passes

## Notes
- `pnpm run build` still emits existing Vite chunking/dynamic-import warnings for `api.ts`, `store.ts`, and large Shiki-related chunks. The build completes successfully; these warnings are not caused by this PR.
