### PR TITLE
feat(github): add issues panel and detail modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Acorn은 여러 AI 코딩 에이전트(Claude Code / Codex / Antigravity / Ollam
 세 그룹으로 묶인 탭:
 
 - **Code** — Files / Staged / Commits. 파일 트리·검색·Git 상태, 스테이징 변경, 커밋 + Diff 모달
-- **GitHub** — PRs / Actions. PR 리스트(라벨/체크/CI 시간), 상세 모달(Conversation·Commits·Checks·Files), 본문 task 토글, 머지 메시지 AI 자동 생성. GitHub Actions 실행 + workflow 필터
+- **GitHub** — PRs / Issues / Actions. PR 리스트(라벨/체크/CI 시간), Issues 목록/검색/상세 모달, PR 상세 모달(Conversation·Commits·Checks·Files), 본문 task 토글, 머지 메시지 AI 자동 생성. GitHub Actions 실행 + workflow 필터
 - **Agents** — Activity / History / Todos. 세션별 알림, transcript 히스토리, Claude Code todo (`TodoWrite` 이벤트)
 
 ### 🔍 Code / Diff 뷰어

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -110,7 +110,9 @@ The mock returns safe values for the boot path so empty UIs render without crash
 | `detect_session_statuses`                  | `[]`                                             |
 | `read_session_todos`                       | `[]`                                             |
 | `list_commits`, `list_staged`              | `[]`                                             |
-| `list_pull_requests`                       | `{ items: [], account: null, error: null }`      |
+| `list_pull_requests`                       | `{ kind: "ok", items: [], account: "test" }`     |
+| `list_issues`                              | `{ kind: "ok", items: [], account: "test" }`     |
+| `get_issue_detail`                         | `{ kind: "not_github" }`                         |
 | `staged_diff`, `commit_diff`               | `{ files: [] }`                                  |
 | `scrollback_load`                          | `null`                                           |
 | `scrollback_orphan_size` / `_clear`        | `0`                                              |
@@ -151,7 +153,11 @@ If you only need a constant return value (no per-call logic), use `respond` inst
 import { makeProject } from "./fixtures/factories";
 
 await tauri.respond("list_projects", [makeProject({ name: "demo" })]);
-await tauri.respond("list_pull_requests", { items: [], account: null, error: null });
+await tauri.respond("list_pull_requests", {
+  kind: "ok",
+  items: [],
+  account: "test",
+});
 ```
 
 Use `handle` when the response depends on the call args, when it needs to mutate state on `window`, or when later actions in the same test should change what the next call returns.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15,8 +15,9 @@ use crate::git_ops::{self, CommitInfo, DiffPayload, StagedFile};
 use crate::persistence;
 use crate::project_settings::{self, ProjectSettings, ProjectSettingsRecord};
 use crate::pull_requests::{
-    self, GeneratedCommitMessage, MergeMethod, PrStateFilter, PullRequestDetailListing,
-    PullRequestDiffListing, PullRequestListing, WorkflowRunDetailListing, WorkflowRunsListing,
+    self, GeneratedCommitMessage, IssueDetailListing, IssueListing, IssueStateFilter, MergeMethod,
+    PrStateFilter, PullRequestDetailListing, PullRequestDiffListing, PullRequestListing,
+    WorkflowRunDetailListing, WorkflowRunsListing,
 };
 use crate::state::AppState;
 use crate::todos::{self, TodoItem};
@@ -4722,6 +4723,32 @@ pub async fn list_pull_requests(
             limit.unwrap_or(50),
             query.as_deref().map(str::trim).filter(|s| !s.is_empty()),
         )
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn list_issues(
+    repo_path: String,
+    state: Option<IssueStateFilter>,
+    limit: Option<u32>,
+    query: Option<String>,
+) -> AppResult<IssueListing> {
+    run_blocking("list_issues", move || {
+        pull_requests::list_issues(
+            &PathBuf::from(repo_path),
+            state.unwrap_or(IssueStateFilter::Open),
+            limit.unwrap_or(50),
+            query.as_deref().map(str::trim).filter(|s| !s.is_empty()),
+        )
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn get_issue_detail(repo_path: String, number: u64) -> AppResult<IssueDetailListing> {
+    run_blocking("get_issue_detail", move || {
+        pull_requests::get_issue_detail(&PathBuf::from(repo_path), number)
     })
     .await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -545,6 +545,8 @@ pub fn run() {
             commands::staged_diff,
             commands::staged_file_diff,
             commands::list_pull_requests,
+            commands::list_issues,
+            commands::get_issue_detail,
             commands::get_pull_request_detail,
             commands::get_pull_request_diff,
             commands::get_pull_request_commit_diff,

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -1,4 +1,4 @@
-//! GitHub pull request listing via the `gh` CLI.
+//! GitHub pull request and issue data via the `gh` CLI.
 //!
 //! We shell out to `gh pr list --json ...` rather than calling GitHub's REST
 //! API directly so that the user's existing `gh` auth (keychain, OAuth
@@ -56,6 +56,24 @@ impl PrStateFilter {
             PrStateFilter::Closed => "closed",
             PrStateFilter::Merged => "merged",
             PrStateFilter::All => "all",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IssueStateFilter {
+    Open,
+    Closed,
+    All,
+}
+
+impl IssueStateFilter {
+    fn as_gh_arg(self) -> &'static str {
+        match self {
+            IssueStateFilter::Open => "open",
+            IssueStateFilter::Closed => "closed",
+            IssueStateFilter::All => "all",
         }
     }
 }
@@ -165,6 +183,120 @@ pub enum PullRequestListing {
     },
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct IssueInfo {
+    pub number: u64,
+    pub title: String,
+    /// Lifecycle state from gh: "OPEN" / "CLOSED".
+    pub state: String,
+    pub author: String,
+    pub url: String,
+    pub created_at: String,
+    pub updated_at: String,
+    /// GitHub close reason such as "COMPLETED" / "NOT_PLANNED".
+    pub state_reason: Option<String>,
+    pub comments: u32,
+    pub labels: Vec<PullRequestLabel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhIssue {
+    number: u64,
+    title: String,
+    state: String,
+    #[serde(default)]
+    author: GhAuthor,
+    url: String,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+    #[serde(rename = "stateReason", default)]
+    state_reason: Option<String>,
+    #[serde(default)]
+    comments: GhIssueComments,
+    #[serde(default)]
+    labels: Vec<GhLabel>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum GhIssueComments {
+    Count(u32),
+    Items(Vec<serde_json::Value>),
+}
+
+impl Default for GhIssueComments {
+    fn default() -> Self {
+        GhIssueComments::Count(0)
+    }
+}
+
+impl GhIssueComments {
+    fn count(&self) -> u32 {
+        match self {
+            GhIssueComments::Count(count) => *count,
+            GhIssueComments::Items(items) => items.len().try_into().unwrap_or(u32::MAX),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum IssueListing {
+    Ok {
+        items: Vec<IssueInfo>,
+        account: String,
+    },
+    NotGithub,
+    NoAccess {
+        slug: String,
+        accounts: Vec<AccountSummary>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct IssueComment {
+    pub author: String,
+    pub author_avatar_url: Option<String>,
+    pub body: String,
+    pub created_at: String,
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct IssueDetail {
+    pub number: u64,
+    pub title: String,
+    pub body: String,
+    /// Lifecycle state from gh: "OPEN" / "CLOSED".
+    pub state: String,
+    pub author: String,
+    pub url: String,
+    pub created_at: String,
+    pub updated_at: String,
+    /// GitHub close reason such as "COMPLETED" / "NOT_PLANNED".
+    pub state_reason: Option<String>,
+    pub labels: Vec<PullRequestLabel>,
+    pub comments: Vec<IssueComment>,
+    pub assignees: Vec<String>,
+    pub milestone: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum IssueDetailListing {
+    Ok {
+        account: String,
+        detail: IssueDetail,
+    },
+    NotGithub,
+    NoAccess {
+        slug: String,
+        accounts: Vec<AccountSummary>,
+    },
+}
+
 const GH_HOST: &str = "github.com";
 
 /// How long a successful (login, repo) resolution stays trusted before we
@@ -243,6 +375,46 @@ pub fn list_pull_requests(
         }),
         AccountOutcome::NoAccess { accounts } => {
             Ok(PullRequestListing::NoAccess { slug, accounts })
+        }
+    }
+}
+
+pub fn list_issues(
+    repo_path: &Path,
+    state: IssueStateFilter,
+    limit: u32,
+    query: Option<&str>,
+) -> AppResult<IssueListing> {
+    let Some(slug) = github_owner_repo(repo_path)? else {
+        return Ok(IssueListing::NotGithub);
+    };
+
+    match try_with_account(repo_path, &slug, |token| {
+        run_issue_list(&slug, token, state, limit, query)
+    })? {
+        AccountOutcome::Ok { account, value } => Ok(IssueListing::Ok {
+            items: value,
+            account,
+        }),
+        AccountOutcome::NoAccess { accounts } => Ok(IssueListing::NoAccess { slug, accounts }),
+    }
+}
+
+pub fn get_issue_detail(repo_path: &Path, number: u64) -> AppResult<IssueDetailListing> {
+    let Some(slug) = github_owner_repo(repo_path)? else {
+        return Ok(IssueDetailListing::NotGithub);
+    };
+
+    match try_with_account(repo_path, &slug, |token| {
+        let view = run_issue_view(&slug, number, token)?;
+        Ok(build_issue_detail(number, view))
+    })? {
+        AccountOutcome::Ok {
+            account,
+            value: detail,
+        } => Ok(IssueDetailListing::Ok { account, detail }),
+        AccountOutcome::NoAccess { accounts } => {
+            Ok(IssueDetailListing::NoAccess { slug, accounts })
         }
     }
 }
@@ -376,6 +548,159 @@ fn run_pr_list(
             }
         })
         .collect())
+}
+
+fn run_issue_list(
+    slug: &str,
+    token: &str,
+    state: IssueStateFilter,
+    limit: u32,
+    query: Option<&str>,
+) -> AppResult<Vec<IssueInfo>> {
+    let limit = limit.clamp(1, 1000);
+    let limit_s = limit.to_string();
+    let output = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token).env("GH_HOST", GH_HOST).args([
+            "issue",
+            "list",
+            "--repo",
+            slug,
+            "--state",
+            state.as_gh_arg(),
+            "--limit",
+            &limit_s,
+            "--json",
+            "number,title,state,author,url,createdAt,updatedAt,stateReason,comments,labels",
+        ]);
+        if let Some(q) = query {
+            cmd.args(["--search", q]);
+        }
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("gh exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+
+    let raw: Vec<GhIssue> = serde_json::from_slice(&output.stdout)
+        .map_err(|e| AppError::Other(format!("failed to parse gh output: {e}")))?;
+
+    Ok(raw
+        .into_iter()
+        .map(|issue| IssueInfo {
+            number: issue.number,
+            title: issue.title,
+            state: issue.state,
+            author: issue.author.login.unwrap_or_else(|| "unknown".to_string()),
+            url: issue.url,
+            created_at: issue.created_at,
+            updated_at: issue.updated_at,
+            state_reason: normalize_optional_string(issue.state_reason),
+            comments: issue.comments.count(),
+            labels: issue
+                .labels
+                .into_iter()
+                .map(|l| PullRequestLabel {
+                    name: l.name,
+                    color: l.color,
+                })
+                .collect(),
+        })
+        .collect())
+}
+
+fn build_issue_detail(number: u64, view: GhIssueView) -> IssueDetail {
+    let actor_avatars = view
+        .actor_avatars
+        .as_ref()
+        .map(|avatars| avatars.by_login.clone())
+        .unwrap_or_default();
+    let comments = view
+        .comments
+        .unwrap_or_default()
+        .into_iter()
+        .map(|comment| {
+            let author = comment
+                .author
+                .login
+                .unwrap_or_else(|| "unknown".to_string());
+            IssueComment {
+                author_avatar_url: actor_avatars.get(&author).cloned(),
+                author,
+                body: comment.body.unwrap_or_default(),
+                created_at: comment.created_at.unwrap_or_default(),
+                url: comment.url,
+            }
+        })
+        .collect();
+
+    IssueDetail {
+        number,
+        title: view.title.unwrap_or_default(),
+        body: view.body.unwrap_or_default(),
+        state: view.state.unwrap_or_default(),
+        author: view
+            .author
+            .unwrap_or_default()
+            .login
+            .unwrap_or_else(|| "unknown".to_string()),
+        url: view.url.unwrap_or_default(),
+        created_at: view.created_at.unwrap_or_default(),
+        updated_at: view.updated_at.unwrap_or_default(),
+        state_reason: normalize_optional_string(view.state_reason),
+        labels: view
+            .labels
+            .into_iter()
+            .map(|label| PullRequestLabel {
+                name: label.name,
+                color: label.color,
+            })
+            .collect(),
+        comments,
+        assignees: view
+            .assignees
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|assignee| assignee.login)
+            .collect(),
+        milestone: view.milestone.and_then(|milestone| milestone.title),
+    }
+}
+
+fn run_issue_view(slug: &str, number: u64, token: &str) -> AppResult<GhIssueView> {
+    let number_s = number.to_string();
+    let output = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token).env("GH_HOST", GH_HOST).args([
+            "issue",
+            "view",
+            &number_s,
+            "--repo",
+            slug,
+            "--json",
+            "number,title,body,state,author,url,createdAt,updatedAt,stateReason,\
+             comments,labels,assignees,milestone",
+        ]);
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("gh exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+
+    let mut view: GhIssueView = serde_json::from_slice(&output.stdout)
+        .map_err(|e| AppError::Other(format!("failed to parse gh output: {e}")))?;
+    view.actor_avatars = Some(resolve_issue_actor_avatars(&view, token));
+    Ok(view)
 }
 
 /// Aggregate `statusCheckRollup` entries into pass/fail/pending counts.
@@ -744,7 +1069,10 @@ pub enum PullRequestDetailListing {
 #[derive(Debug, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum PullRequestDiffListing {
-    Ok { account: String, diff: DiffPayload },
+    Ok {
+        account: String,
+        diff: DiffPayload,
+    },
     NotGithub,
     NoAccess {
         slug: String,
@@ -774,10 +1102,7 @@ pub fn get_pull_request_detail(
     }
 }
 
-pub fn get_pull_request_diff(
-    repo_path: &Path,
-    number: u64,
-) -> AppResult<PullRequestDiffListing> {
+pub fn get_pull_request_diff(repo_path: &Path, number: u64) -> AppResult<PullRequestDiffListing> {
     let Some(slug) = github_owner_repo(repo_path)? else {
         return Ok(PullRequestDiffListing::NotGithub);
     };
@@ -1031,6 +1356,25 @@ fn resolve_pr_actor_avatars(view: &GhPullRequestView, token: &str) -> PrActorAva
     }
     for review in view.reviews.as_deref().unwrap_or(&[]) {
         if let Some(login) = review.author.login.as_deref() {
+            logins.push(login.to_string());
+        }
+    }
+    logins.sort();
+    logins.dedup();
+
+    let mut by_login = HashMap::new();
+    for login in logins {
+        if let Some(url) = resolve_actor_avatar_url(&login, token) {
+            by_login.insert(login, url);
+        }
+    }
+    PrActorAvatars { by_login }
+}
+
+fn resolve_issue_actor_avatars(view: &GhIssueView, token: &str) -> PrActorAvatars {
+    let mut logins = Vec::new();
+    for comment in view.comments.as_deref().unwrap_or(&[]) {
+        if let Some(login) = comment.author.login.as_deref() {
             logins.push(login.to_string());
         }
     }
@@ -1362,6 +1706,43 @@ struct GhPullRequestView {
     commits: Option<Vec<GhCommit>>,
     #[serde(skip)]
     actor_avatars: Option<PrActorAvatars>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GhIssueView {
+    title: Option<String>,
+    body: Option<String>,
+    state: Option<String>,
+    author: Option<GhAuthor>,
+    url: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: Option<String>,
+    #[serde(rename = "updatedAt")]
+    updated_at: Option<String>,
+    #[serde(rename = "stateReason")]
+    state_reason: Option<String>,
+    #[serde(default)]
+    labels: Vec<GhLabel>,
+    comments: Option<Vec<GhIssueComment>>,
+    assignees: Option<Vec<GhAuthor>>,
+    milestone: Option<GhMilestone>,
+    #[serde(skip)]
+    actor_avatars: Option<PrActorAvatars>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhIssueComment {
+    #[serde(default)]
+    author: GhAuthor,
+    body: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: Option<String>,
+    url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhMilestone {
+    title: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2218,5 +2599,77 @@ mod tests {
             normalize_github_timestamp(Some("2026-05-27T02:42:28Z".to_string())),
             Some("2026-05-27T02:42:28Z".to_string())
         );
+    }
+
+    #[test]
+    fn issue_comments_accept_count_or_comment_array() {
+        let with_array: GhIssue = serde_json::from_str(
+            r##"{
+                "number": 1,
+                "title": "Track issues",
+                "state": "OPEN",
+                "url": "https://github.com/acme/widgets/issues/1",
+                "createdAt": "2026-06-01T00:00:00Z",
+                "updatedAt": "2026-06-02T00:00:00Z",
+                "comments": [{"id": "1"}, {"id": "2"}],
+                "labels": [{"name": "bug", "color": "d73a4a"}]
+            }"##,
+        )
+        .expect("issue with comment array should parse");
+        assert_eq!(with_array.comments.count(), 2);
+
+        let with_count: GhIssue = serde_json::from_str(
+            r##"{
+                "number": 2,
+                "title": "Track issue counts",
+                "state": "CLOSED",
+                "url": "https://github.com/acme/widgets/issues/2",
+                "createdAt": "2026-06-01T00:00:00Z",
+                "updatedAt": "2026-06-02T00:00:00Z",
+                "comments": 4,
+                "labels": []
+            }"##,
+        )
+        .expect("issue with comment count should parse");
+        assert_eq!(with_count.comments.count(), 4);
+    }
+
+    #[test]
+    fn issue_view_builds_detail_with_comments_and_metadata() {
+        let view: GhIssueView = serde_json::from_str(
+            r##"{
+                "number": 7,
+                "title": "Render issue detail",
+                "body": "Issue body",
+                "state": "CLOSED",
+                "author": { "login": "alice" },
+                "url": "https://github.com/acme/widgets/issues/7",
+                "createdAt": "2026-06-01T00:00:00Z",
+                "updatedAt": "2026-06-02T00:00:00Z",
+                "stateReason": "COMPLETED",
+                "labels": [{ "name": "enhancement", "color": "a2eeef" }],
+                "comments": [
+                    {
+                        "author": { "login": "bob" },
+                        "body": "Looks good",
+                        "createdAt": "2026-06-02T01:00:00Z",
+                        "url": "https://github.com/acme/widgets/issues/7#issuecomment-1"
+                    }
+                ],
+                "assignees": [{ "login": "carol" }],
+                "milestone": { "title": "v1" }
+            }"##,
+        )
+        .expect("issue view should parse");
+
+        let detail = build_issue_detail(7, view);
+        assert_eq!(detail.number, 7);
+        assert_eq!(detail.title, "Render issue detail");
+        assert_eq!(detail.state_reason.as_deref(), Some("COMPLETED"));
+        assert_eq!(detail.labels[0].name, "enhancement");
+        assert_eq!(detail.comments[0].author, "bob");
+        assert_eq!(detail.comments[0].body, "Looks good");
+        assert_eq!(detail.assignees, vec!["carol".to_string()]);
+        assert_eq!(detail.milestone.as_deref(), Some("v1"));
     }
 }

--- a/src/components/IssueDetailModal.tsx
+++ b/src/components/IssueDetailModal.tsx
@@ -1,0 +1,440 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  CircleCheck,
+  CircleDot,
+  CircleX,
+  ExternalLink,
+  MessageSquare,
+} from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { api } from "../lib/api";
+import { cn } from "../lib/cn";
+import { useDialogShortcuts } from "../lib/dialog";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import type {
+  IssueComment,
+  IssueDetail,
+  IssueDetailListing,
+  PullRequestLabel,
+} from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
+import { AuthorTag } from "./AuthorTag";
+import { Tooltip } from "./Tooltip";
+import { Markdown, Modal, ModalHeader, RefreshButton } from "./ui";
+
+type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
+
+function dt(t: Translator, key: DialogTranslationKey): string {
+  return t(key);
+}
+
+interface IssueDetailModalProps {
+  open: { repoPath: string; number: number } | null;
+  onClose: () => void;
+}
+
+export function IssueDetailModal({ open, onClose }: IssueDetailModalProps) {
+  const t = useTranslation();
+  const [listing, setListing] = useState<IssueDetailListing | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useDialogShortcuts(open !== null, { onCancel: onClose });
+
+  useEffect(() => {
+    if (!open) {
+      setListing(null);
+      setError(null);
+      setReloadKey(0);
+      setRefreshing(false);
+      return;
+    }
+    setListing(null);
+    setError(null);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setRefreshing(true);
+    api
+      .getIssueDetail(open.repoPath, open.number)
+      .then((result) => {
+        if (cancelled) return;
+        setListing(result);
+        setError(null);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setRefreshing(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, reloadKey]);
+
+  const handleRefresh = useCallback(() => {
+    setReloadKey((key) => key + 1);
+  }, []);
+
+  return (
+    <Modal open={open !== null} onClose={onClose} variant="panel" size="3xl">
+      {open ? (
+        error ? (
+          <IssueModalShell
+            title={`#${open.number}`}
+            onClose={onClose}
+            onRefresh={handleRefresh}
+            refreshing={refreshing}
+          >
+            <div className="p-4 text-xs text-danger">{error}</div>
+          </IssueModalShell>
+        ) : !listing ? (
+          <IssueDetailSkeleton
+            number={open.number}
+            onClose={onClose}
+            onRefresh={handleRefresh}
+            refreshing={refreshing}
+          />
+        ) : listing.kind === "not_github" ? (
+          <IssueModalShell
+            title={`#${open.number}`}
+            onClose={onClose}
+            onRefresh={handleRefresh}
+            refreshing={refreshing}
+          >
+            <div className="p-4 text-xs text-fg-muted">
+              {dt(t, "dialogs.issueDetail.notGithub")}
+            </div>
+          </IssueModalShell>
+        ) : listing.kind === "no_access" ? (
+          <IssueModalShell
+            title={`#${open.number}`}
+            onClose={onClose}
+            onRefresh={handleRefresh}
+            refreshing={refreshing}
+          >
+            <div className="p-4 text-xs text-fg-muted">
+              {dt(t, "dialogs.issueDetail.noAccessPrefix")}{" "}
+              <code className="font-mono">gh</code>{" "}
+              {dt(t, "dialogs.issueDetail.noAccessSuffix")} {listing.slug}.
+            </div>
+          </IssueModalShell>
+        ) : (
+          <IssueDetailBody
+            detail={listing.detail}
+            onClose={onClose}
+            onRefresh={handleRefresh}
+            refreshing={refreshing}
+          />
+        )
+      ) : null}
+    </Modal>
+  );
+}
+
+function IssueModalShell({
+  title,
+  onClose,
+  onRefresh,
+  refreshing,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  onRefresh: () => void;
+  refreshing: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <ModalHeader
+        title={title}
+        actions={<RefreshButton onClick={onRefresh} loading={refreshing} size={14} />}
+        onClose={onClose}
+      />
+      <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
+    </>
+  );
+}
+
+function IssueDetailBody({
+  detail,
+  onClose,
+  onRefresh,
+  refreshing,
+}: {
+  detail: IssueDetail;
+  onClose: () => void;
+  onRefresh: () => void;
+  refreshing: boolean;
+}) {
+  const t = useTranslation();
+  const created = toUnixSeconds(detail.created_at);
+  const updated = toUnixSeconds(detail.updated_at);
+  const subtitle = (
+    <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1">
+      <AuthorTag
+        login={detail.author}
+        size={16}
+        nameClass="text-[11px] text-fg-muted"
+      />
+      <span className="opacity-50">·</span>
+      <span>{dt(t, "dialogs.issueDetail.created")} {absoluteTime(created)}</span>
+      <span className="opacity-50">·</span>
+      <span>{dt(t, "dialogs.issueDetail.updated")} {absoluteTime(updated)}</span>
+    </span>
+  );
+
+  return (
+    <>
+      <ModalHeader
+        title={`#${detail.number} ${detail.title}`}
+        subtitle={subtitle}
+        icon={<IssueStateGlyph state={detail.state} reason={detail.state_reason} />}
+        actions={
+          <>
+            <RefreshButton onClick={onRefresh} loading={refreshing} size={14} />
+            <Tooltip
+              label={dt(t, "dialogs.issueDetail.openOnGithub")}
+              side="bottom"
+            >
+              <button
+                type="button"
+                onClick={() => void openUrl(detail.url)}
+                className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+              >
+                <ExternalLink size={14} />
+              </button>
+            </Tooltip>
+          </>
+        }
+        onClose={onClose}
+      />
+      <div className="acorn-no-scrollbar min-h-0 flex-1 overflow-y-auto">
+        <div className="space-y-4 px-4 py-3">
+          <IssueMeta detail={detail} />
+          {detail.body.trim().length > 0 ? (
+            <section className="rounded border border-border bg-bg-elevated/30 px-3 py-2">
+              <Markdown content={detail.body} />
+            </section>
+          ) : (
+            <div className="rounded border border-border bg-bg-elevated/30 px-3 py-2 text-xs text-fg-muted">
+              {dt(t, "dialogs.issueDetail.noBody")}
+            </div>
+          )}
+          <section>
+            <div className="mb-2 flex items-center gap-2 text-[11px] font-medium uppercase tracking-wide text-fg-muted">
+              <MessageSquare size={12} />
+              {dt(t, "dialogs.issueDetail.comments")} ({detail.comments.length})
+            </div>
+            {detail.comments.length === 0 ? (
+              <div className="rounded border border-border/60 px-3 py-2 text-xs text-fg-muted">
+                {dt(t, "dialogs.issueDetail.noComments")}
+              </div>
+            ) : (
+              <ul className="space-y-2">
+                {detail.comments.map((comment, index) => (
+                  <IssueCommentBlock
+                    key={`${comment.created_at}:${comment.author}:${index}`}
+                    comment={comment}
+                  />
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function IssueMeta({ detail }: { detail: IssueDetail }) {
+  const t = useTranslation();
+  const state = detail.state.toUpperCase();
+  const reason = detail.state_reason?.toUpperCase() ?? null;
+  const stateText =
+    state === "OPEN"
+      ? dt(t, "dialogs.issueDetail.stateOpen")
+      : issueClosedReasonLabel(reason, t);
+  const assignees = detail.assignees.join(", ");
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-fg-muted">
+      <span
+        className={cn(
+          "rounded px-1.5 py-0.5 font-medium",
+          state === "OPEN"
+            ? "bg-emerald-500/10 text-emerald-300"
+            : reason === "NOT_PLANNED"
+              ? "bg-fg-muted/15 text-fg-muted"
+              : "bg-purple-500/10 text-purple-300",
+        )}
+      >
+        {stateText}
+      </span>
+      {detail.labels.map((label) => (
+        <IssueLabelChip key={label.name} label={label} />
+      ))}
+      {detail.milestone ? (
+        <>
+          <span className="opacity-50">·</span>
+          <span>
+            {dt(t, "dialogs.issueDetail.milestone")} {detail.milestone}
+          </span>
+        </>
+      ) : null}
+      {assignees ? (
+        <>
+          <span className="opacity-50">·</span>
+          <span>
+            {dt(t, "dialogs.issueDetail.assignees")} {assignees}
+          </span>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function IssueCommentBlock({ comment }: { comment: IssueComment }) {
+  const t = useTranslation();
+  const created = toUnixSeconds(comment.created_at);
+  const content =
+    comment.body.trim().length > 0
+      ? comment.body
+      : dt(t, "dialogs.issueDetail.empty");
+  return (
+    <li className="rounded border border-border bg-bg-elevated/30">
+      <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2 text-[11px] text-fg-muted">
+        <AuthorTag
+          login={comment.author}
+          avatarUrl={comment.author_avatar_url}
+          size={18}
+          nameClass="text-[11px] text-fg"
+        />
+        <span className="opacity-50">·</span>
+        <span>{absoluteTime(created)}</span>
+        {comment.url ? (
+          <Tooltip
+            label={dt(t, "dialogs.issueDetail.openCommentOnGithub")}
+            side="top"
+            className="ml-auto"
+          >
+            <button
+              type="button"
+              onClick={() => void openUrl(comment.url ?? "")}
+              className="rounded p-0.5 text-fg-muted transition hover:bg-bg hover:text-fg"
+            >
+              <ExternalLink size={12} />
+            </button>
+          </Tooltip>
+        ) : null}
+      </div>
+      <div className="px-3 py-2">
+        <Markdown content={content} />
+      </div>
+    </li>
+  );
+}
+
+function IssueLabelChip({ label }: { label: PullRequestLabel }) {
+  return (
+    <Tooltip label={label.name} side="top">
+      <span
+        className="shrink-0 rounded px-1.5 py-0.5 text-[9px] font-medium uppercase"
+        style={{
+          backgroundColor: `#${label.color.replace(/^#/, "")}26`,
+          color: `#${label.color.replace(/^#/, "")}`,
+        }}
+      >
+        {label.name}
+      </span>
+    </Tooltip>
+  );
+}
+
+function IssueStateGlyph({
+  state,
+  reason,
+}: {
+  state: string;
+  reason: string | null;
+}) {
+  if (state.toUpperCase() === "OPEN") {
+    return <CircleDot size={14} className="text-emerald-400" />;
+  }
+  if (reason?.toUpperCase() === "NOT_PLANNED") {
+    return <CircleX size={14} className="text-fg-muted" />;
+  }
+  return <CircleCheck size={14} className="text-purple-400" />;
+}
+
+function issueClosedReasonLabel(
+  reason: string | null,
+  t: Translator,
+): string {
+  if (reason === "NOT_PLANNED") {
+    return dt(t, "dialogs.issueDetail.stateNotPlanned");
+  }
+  return dt(t, "dialogs.issueDetail.stateCompleted");
+}
+
+function IssueDetailSkeleton({
+  number,
+  onClose,
+  onRefresh,
+  refreshing,
+}: {
+  number: number;
+  onClose: () => void;
+  onRefresh: () => void;
+  refreshing: boolean;
+}) {
+  return (
+    <>
+      <ModalHeader
+        title={`#${number}`}
+        icon={<CircleDot size={14} className="text-fg-muted" />}
+        actions={<RefreshButton onClick={onRefresh} loading={refreshing} size={14} />}
+        onClose={onClose}
+      />
+      <div className="space-y-3 px-4 py-3 animate-pulse">
+        <span className="block h-3 w-36 rounded bg-fg-muted/15" />
+        <div className="rounded border border-border bg-bg-elevated/30 p-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <span
+              key={index}
+              className="mb-2 block h-3 rounded bg-fg-muted/10"
+              style={{ width: `${42 + ((index * 17) % 45)}%` }}
+            />
+          ))}
+        </div>
+        <span className="block h-3 w-24 rounded bg-fg-muted/15" />
+        <div className="space-y-2">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <div
+              key={index}
+              className="rounded border border-border bg-bg-elevated/30 p-3"
+            >
+              <span className="mb-2 block h-3 w-28 rounded bg-fg-muted/15" />
+              <span className="block h-3 w-4/5 rounded bg-fg-muted/10" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function toUnixSeconds(iso: string): number {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return Math.floor(Date.now() / 1000);
+  return Math.floor(ms / 1000);
+}
+
+function absoluteTime(unixSeconds: number): string {
+  return new Date(unixSeconds * 1000).toLocaleString();
+}

--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -10,6 +10,8 @@ import {
 } from "vitest";
 import type {
   AgentHistoryItem,
+  IssueDetailListing,
+  IssueListing,
   PullRequestListing,
   WorkflowRunsListing,
 } from "../lib/types";
@@ -30,6 +32,18 @@ vi.mock("../lib/api", () => ({
           state: string,
           limit: number,
         ) => Promise<PullRequestListing>
+      >(),
+    listIssues:
+      vi.fn<
+        (
+          repoPath: string,
+          state: string,
+          limit: number,
+        ) => Promise<IssueListing>
+      >(),
+    getIssueDetail:
+      vi.fn<
+        (repoPath: string, number: number) => Promise<IssueDetailListing>
       >(),
     listWorkflowRuns:
       vi.fn<(repoPath: string, limit: number) => Promise<WorkflowRunsListing>>(),
@@ -85,6 +99,16 @@ function buttonContaining(container: HTMLElement, text: string): HTMLButtonEleme
   return button;
 }
 
+function roleButtonContaining(container: HTMLElement, text: string): HTMLElement {
+  const element = Array.from(container.querySelectorAll('[role="button"]')).find(
+    (candidate) => candidate.textContent?.includes(text),
+  );
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`role button containing "${text}" not found`);
+  }
+  return element;
+}
+
 function comboboxWithAria(
   container: HTMLElement,
   label: string,
@@ -137,6 +161,35 @@ const detailedPullRequest = {
   checks: { passed: 1, failed: 0, pending: 1 },
 };
 
+const listedIssue = {
+  number: 301,
+  title: "Render issues in app",
+  state: "OPEN",
+  author: "im-ian",
+  url: "https://github.com/im-ian/acorn/issues/301",
+  created_at: "2026-05-18T00:00:00Z",
+  updated_at: "2026-05-19T00:00:00Z",
+  state_reason: null,
+  comments: 1,
+  labels: [{ name: "enhancement", color: "A2EEEF" }],
+};
+
+const detailedIssue = {
+  ...listedIssue,
+  body: "Detailed issue body",
+  comments: [
+    {
+      author: "im-ian",
+      author_avatar_url: null,
+      body: "First issue comment",
+      created_at: "2026-05-19T01:00:00Z",
+      url: "https://github.com/im-ian/acorn/issues/301#issuecomment-1",
+    },
+  ],
+  assignees: ["im-ian"],
+  milestone: "v1",
+};
+
 async function flushPromises() {
   await act(async () => {
     await Promise.resolve();
@@ -178,6 +231,14 @@ describe("RightPanel background tab loading", () => {
       kind: "ok",
       items: [],
       account: "tester",
+    });
+    mockApi.listIssues.mockResolvedValue({
+      kind: "ok",
+      items: [],
+      account: "tester",
+    });
+    mockApi.getIssueDetail.mockResolvedValue({
+      kind: "not_github",
     });
     mockApi.listWorkflowRuns.mockResolvedValue({
       kind: "ok",
@@ -257,6 +318,29 @@ describe("RightPanel background tab loading", () => {
     expect(container.textContent).not.toContain("No project selected");
     expect(mockApi.githubOriginSlug).toHaveBeenCalledWith(REPO);
     expect(mockApi.listPullRequests).toHaveBeenCalledWith(REPO, "open", 50);
+    expect(mockApi.listIssues).toHaveBeenCalledWith(REPO, "open", 50);
+  });
+
+  it("orders GitHub sub-tabs as PRs, Issues, Actions", async () => {
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+
+    const labels = Array.from(
+      container.querySelectorAll('nav[aria-label="Right panel sub-tab"] button'),
+    ).map((button) => button.textContent?.trim());
+    expect(labels).toEqual(["Files", "Staged", "Commits"]);
+
+    await act(async () => {
+      buttonContaining(container, "GitHub").click();
+    });
+    await flushPromises();
+
+    const githubLabels = Array.from(
+      container.querySelectorAll('nav[aria-label="Right panel sub-tab"] button'),
+    ).map((button) => button.textContent?.trim());
+    expect(githubLabels).toEqual(["PRs", "Issues", "Actions"]);
   });
 
   it("prefetches other open projects once after startup", async () => {
@@ -305,6 +389,9 @@ describe("RightPanel background tab loading", () => {
     expect(mockApi.listPullRequests).toHaveBeenCalledWith(REPO_B, "merged", 50);
     expect(mockApi.listPullRequests).toHaveBeenCalledWith(REPO_B, "closed", 50);
     expect(mockApi.listPullRequests).toHaveBeenCalledWith(REPO_B, "all", 50);
+    expect(mockApi.listIssues).toHaveBeenCalledWith(REPO_B, "open", 50);
+    expect(mockApi.listIssues).toHaveBeenCalledWith(REPO_B, "closed", 50);
+    expect(mockApi.listIssues).toHaveBeenCalledWith(REPO_B, "all", 50);
     expect(mockApi.listWorkflowRuns).toHaveBeenCalledWith(REPO_B, 50);
   });
 
@@ -322,6 +409,7 @@ describe("RightPanel background tab loading", () => {
     expect(container.textContent).not.toContain("GitHub");
     expect(mockApi.githubOriginSlug).not.toHaveBeenCalled();
     expect(mockApi.listPullRequests).not.toHaveBeenCalled();
+    expect(mockApi.listIssues).not.toHaveBeenCalled();
     expect(mockApi.listWorkflowRuns).not.toHaveBeenCalled();
   });
 
@@ -339,6 +427,7 @@ describe("RightPanel background tab loading", () => {
     expect(container.textContent).not.toContain("GitHub");
     expect(mockApi.githubOriginSlug).toHaveBeenCalledWith(REPO);
     expect(mockApi.listPullRequests).not.toHaveBeenCalled();
+    expect(mockApi.listIssues).not.toHaveBeenCalled();
     expect(mockApi.listWorkflowRuns).not.toHaveBeenCalled();
   });
 
@@ -629,6 +718,42 @@ describe("RightPanel background tab loading", () => {
 
     expect(container.textContent).toContain("Add PR row display options");
     expect(container.textContent).not.toContain("1/2");
+  });
+
+  it("opens issue detail in app from the Issues tab", async () => {
+    useAppStore.setState({ rightTab: "issues" });
+    mockApi.listIssues.mockResolvedValue({
+      kind: "ok",
+      items: [listedIssue],
+      account: "tester",
+    });
+    mockApi.getIssueDetail.mockResolvedValue({
+      kind: "ok",
+      account: "tester",
+      detail: detailedIssue,
+    });
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+
+    const issueRow = roleButtonContaining(container, "Render issues in app");
+    await act(async () => {
+      issueRow.dispatchEvent(
+        new MouseEvent("dblclick", {
+          bubbles: true,
+          cancelable: true,
+          detail: 2,
+        }),
+      );
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(mockApi.getIssueDetail).toHaveBeenCalledWith(REPO, 301);
+    expect(document.body.textContent).toContain("Detailed issue body");
+    expect(document.body.textContent).toContain("First issue comment");
   });
 
   it("updates running Actions run durations every second without refetching", async () => {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -15,6 +15,7 @@ import {
   Code2,
   CircleCheck,
   CircleDashed,
+  CircleDot,
   CircleX,
   Copy,
   ExternalLink,
@@ -30,6 +31,7 @@ import {
   Loader2,
   ListTodo,
   Maximize2,
+  MessageSquare,
   MinusCircle,
   Play,
   Search,
@@ -68,6 +70,9 @@ import type {
   AgentHistoryProvider,
   CommitInfo,
   DiffPayload,
+  IssueInfo,
+  IssueListing,
+  IssueStateFilter,
   PrStateFilter,
   PullRequestChecksSummary,
   PullRequestDetail,
@@ -93,6 +98,7 @@ import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { DiffView } from "./DiffView";
 import { DiffViewerModal } from "./DiffViewerModal";
 import { FileExplorer } from "./FileExplorer";
+import { IssueDetailModal } from "./IssueDetailModal";
 import { MergePullRequestDialog } from "./MergePullRequestDialog";
 import { PullRequestDetailModal } from "./PullRequestDetailModal";
 import { ResizeHandle } from "./ResizeHandle";
@@ -132,7 +138,12 @@ interface ExpandedDiff {
 
 const COMMITS_PAGE_SIZE = 50;
 const COMMIT_ROW_HEIGHT = 48;
-const BACKGROUND_LOADED_TABS = new Set<RightTab>(["prs", "actions", "history"]);
+const BACKGROUND_LOADED_TABS = new Set<RightTab>([
+  "prs",
+  "issues",
+  "actions",
+  "history",
+]);
 const PROJECT_PREFETCH_START_DELAY_MS = 1_000;
 const PROJECT_PREFETCH_GAP_MS = 250;
 
@@ -180,6 +191,10 @@ async function prefetchProjectPanelData(repoPath: string): Promise<void> {
   await rightPanelCache.fetchPullRequests(repoPath, "open", PR_PAGE_SIZE);
   for (const filter of PR_BACKGROUND_PREFETCH_STATES) {
     await rightPanelCache.fetchPullRequests(repoPath, filter, PR_PAGE_SIZE);
+  }
+  await rightPanelCache.fetchIssues(repoPath, "open", ISSUE_PAGE_SIZE);
+  for (const filter of ISSUE_BACKGROUND_PREFETCH_STATES) {
+    await rightPanelCache.fetchIssues(repoPath, filter, ISSUE_PAGE_SIZE);
   }
   await rightPanelCache.fetchWorkflowRuns(repoPath, WORKFLOW_RUNS_LIMIT);
 }
@@ -508,6 +523,12 @@ export function RightPanel() {
                 refreshKey={prListVersion}
               />
             </BackgroundLoadedTab>
+            <BackgroundLoadedTab active={rightTab === "issues"}>
+              <IssuesTab
+                key={`issues:${projectPanelRepoPath}`}
+                repoPath={projectPanelRepoPath}
+              />
+            </BackgroundLoadedTab>
             <BackgroundLoadedTab active={rightTab === "actions"}>
               <ActionsTab
                 key={`actions:${projectPanelRepoPath}`}
@@ -681,6 +702,8 @@ function tabIcon(tab: RightTab): ReactNode {
       return <GitCommit size={12} />;
     case "prs":
       return <GitPullRequest size={12} />;
+    case "issues":
+      return <CircleDot size={12} />;
     case "actions":
       return <Activity size={12} />;
     case "activity":
@@ -3179,6 +3202,385 @@ function PullRequestsTab({
   );
 }
 
+const ISSUE_STATE_OPTIONS: { value: IssueStateFilter }[] = [
+  { value: "open" },
+  { value: "closed" },
+  { value: "all" },
+];
+const ISSUE_BACKGROUND_PREFETCH_STATES: ReadonlyArray<IssueStateFilter> = [
+  "closed",
+  "all",
+];
+
+function issueStateLabelKey(value: IssueStateFilter): RightPanelTranslationKey {
+  return `rightPanel.issueStates.${value}`;
+}
+
+const ISSUE_PAGE_SIZE = 50;
+const ISSUE_PAGE_MAX = 1000;
+
+interface IssueListState {
+  listing: IssueListing | null;
+  error: string | null;
+  limit: number;
+}
+
+function cachedIssueListing(
+  repoPath: string,
+  filter: IssueStateFilter,
+  limit = ISSUE_PAGE_SIZE,
+): IssueListing | null {
+  return rightPanelCache.getIssues(repoPath, filter, limit);
+}
+
+function fetchIssuesCached(
+  repoPath: string,
+  filter: IssueStateFilter,
+  limit: number,
+  options: { force?: boolean } = {},
+): Promise<IssueListing> {
+  return rightPanelCache.fetchIssues(repoPath, filter, limit, options);
+}
+
+function emptyIssueListState(): IssueListState {
+  return { listing: null, error: null, limit: ISSUE_PAGE_SIZE };
+}
+
+function initialIssueListStates(
+  repoPath?: string,
+): Record<IssueStateFilter, IssueListState> {
+  return {
+    open: issueListStateFromCache(repoPath, "open"),
+    closed: issueListStateFromCache(repoPath, "closed"),
+    all: issueListStateFromCache(repoPath, "all"),
+  };
+}
+
+function issueListStateFromCache(
+  repoPath: string | undefined,
+  filter: IssueStateFilter,
+): IssueListState {
+  if (!repoPath) return emptyIssueListState();
+  return {
+    listing: cachedIssueListing(repoPath, filter),
+    error: null,
+    limit: ISSUE_PAGE_SIZE,
+  };
+}
+
+function useIssueRowActions(onOpenDetail: (number: number) => void) {
+  const t = useTranslation();
+  const [menu, setMenu] = useState<{
+    x: number;
+    y: number;
+    issue: IssueInfo;
+  } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function copyText(text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function openIssueInBrowser(issue: IssueInfo) {
+    try {
+      await openUrl(issue.url);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  function openContextMenu(
+    e: React.MouseEvent<HTMLLIElement>,
+    issue: IssueInfo,
+  ) {
+    e.preventDefault();
+    setMenu({ x: e.clientX, y: e.clientY, issue });
+  }
+
+  const overlays = (
+    <ContextMenu
+      open={menu !== null}
+      x={menu?.x ?? 0}
+      y={menu?.y ?? 0}
+      items={
+        menu
+          ? ([
+              {
+                label: rt(t, "rightPanel.menu.openDetail"),
+                icon: <Maximize2 size={12} />,
+                onClick: () => onOpenDetail(menu.issue.number),
+              },
+              {
+                label: rt(t, "rightPanel.menu.openInBrowser"),
+                icon: <ExternalLink size={12} />,
+                onClick: () => void openIssueInBrowser(menu.issue),
+              },
+              { type: "separator" },
+              {
+                label: rt(t, "rightPanel.menu.copyIssueNumber"),
+                icon: <Copy size={12} />,
+                onClick: () => void copyText(`#${menu.issue.number}`),
+              },
+              {
+                label: rt(t, "rightPanel.menu.copyUrl"),
+                icon: <Copy size={12} />,
+                onClick: () => void copyText(menu.issue.url),
+              },
+            ] satisfies ContextMenuItem[])
+          : []
+      }
+      onClose={() => setMenu(null)}
+    />
+  );
+
+  return { openContextMenu, overlays, error };
+}
+
+function IssuesTab({ repoPath }: { repoPath: string }) {
+  const t = useTranslation();
+  const refreshIntervalMs = useSettings(
+    (s) => s.settings.github.refreshIntervalMs,
+  );
+  const showAvatars = useSettings((s) => s.settings.github.showAvatars);
+  const showLabels = useSettings((s) => s.settings.github.showLabels);
+  const [stateFilter, setStateFilter] = useState<IssueStateFilter>("open");
+  const [listsByState, setListsByState] = useState(() =>
+    initialIssueListStates(repoPath),
+  );
+  const [loadingKeys, setLoadingKeys] = useState<string[]>([]);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [issueDetail, setIssueDetail] = useState<{
+    repoPath: string;
+    number: number;
+  } | null>(null);
+  const activeList = listsByState[stateFilter] ?? emptyIssueListState();
+  const listing = activeList.listing;
+  const error = activeList.error;
+  const limit = activeList.limit;
+  const loading = loadingKeys.some((key) =>
+    key.startsWith(`${repoPath}:${stateFilter}:`),
+  );
+
+  const fetchIssues = useCallback(
+    async (
+      filter: IssueStateFilter,
+      requestedLimit: number,
+      signal?: { cancelled: boolean },
+    ) => {
+      const key = `${repoPath}:${filter}:${requestedLimit}`;
+      setLoadingKeys((prev) => (prev.includes(key) ? prev : [...prev, key]));
+      try {
+        const result = await fetchIssuesCached(
+          repoPath,
+          filter,
+          requestedLimit,
+          { force: true },
+        );
+        if (signal?.cancelled) return;
+        setListsByState((prev) => ({
+          ...prev,
+          [filter]: {
+            listing: result,
+            error: null,
+            limit: requestedLimit,
+          },
+        }));
+      } catch (e) {
+        if (signal?.cancelled) return;
+        setListsByState((prev) => ({
+          ...prev,
+          [filter]: {
+            ...(prev[filter] ?? emptyIssueListState()),
+            error: String(e),
+            limit: requestedLimit,
+          },
+        }));
+      } finally {
+        setLoadingKeys((prev) => prev.filter((candidate) => candidate !== key));
+      }
+    },
+    [repoPath],
+  );
+  const fetchActiveIssues = useCallback(
+    (signal?: { cancelled: boolean }) =>
+      fetchIssues(stateFilter, limit, signal),
+    [fetchIssues, stateFilter, limit],
+  );
+
+  useEffect(() => {
+    setLoadingKeys([]);
+    setListsByState(initialIssueListStates(repoPath));
+  }, [repoPath]);
+
+  useEffect(() => {
+    const signal = { cancelled: false };
+    void fetchActiveIssues(signal);
+    const handle = setInterval(() => {
+      void fetchActiveIssues(signal);
+    }, refreshIntervalMs);
+    return () => {
+      signal.cancelled = true;
+      clearInterval(handle);
+    };
+  }, [fetchActiveIssues, refreshIntervalMs]);
+
+  useEffect(() => {
+    const signal = { cancelled: false };
+    const handle = window.setTimeout(() => {
+      void (async () => {
+        for (const filter of ISSUE_BACKGROUND_PREFETCH_STATES) {
+          if (signal.cancelled) return;
+          await fetchIssues(filter, ISSUE_PAGE_SIZE, signal);
+        }
+      })();
+    }, PR_BACKGROUND_PREFETCH_DELAY_MS);
+    return () => {
+      signal.cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [repoPath, fetchIssues]);
+
+  const openIssueDetail = useCallback(
+    (number: number) => setIssueDetail({ repoPath, number }),
+    [repoPath],
+  );
+  const rowActions = useIssueRowActions(openIssueDetail);
+
+  function handleScroll(e: React.UIEvent<HTMLDivElement>) {
+    if (loading) return;
+    if (!listing || listing.kind !== "ok") return;
+    if (listing.items.length < limit) return;
+    if (limit >= ISSUE_PAGE_MAX) return;
+    const el = e.currentTarget;
+    if (el.scrollHeight - el.scrollTop - el.clientHeight < 200) {
+      setListsByState((prev) => {
+        const current = prev[stateFilter] ?? emptyIssueListState();
+        const nextLimit = Math.min(
+          current.limit + ISSUE_PAGE_SIZE,
+          ISSUE_PAGE_MAX,
+        );
+        if (nextLimit === current.limit) return prev;
+        return {
+          ...prev,
+          [stateFilter]: { ...current, limit: nextLimit },
+        };
+      });
+    }
+  }
+
+  const reachedMax =
+    listing?.kind === "ok" &&
+    listing.items.length >= limit &&
+    limit >= ISSUE_PAGE_MAX;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1.5">
+        {ISSUE_STATE_OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => setStateFilter(opt.value)}
+            className={cn(
+              "rounded px-2 py-0.5 text-[11px] transition",
+              stateFilter === opt.value
+                ? "bg-bg-elevated text-fg"
+                : "text-fg-muted hover:text-fg",
+            )}
+          >
+            {rt(t, issueStateLabelKey(opt.value))}
+          </button>
+        ))}
+        <Tooltip
+          label={rt(t, "rightPanel.issueSearch.aria")}
+          side="bottom"
+          className="ml-auto"
+        >
+          <button
+            type="button"
+            onClick={() => setSearchOpen(true)}
+            aria-label={rt(t, "rightPanel.issueSearch.aria")}
+            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          >
+            <Search size={12} />
+          </button>
+        </Tooltip>
+        <RefreshButton
+          onClick={() => void fetchActiveIssues()}
+          loading={loading}
+          size={12}
+        />
+      </div>
+      <div
+        className="acorn-no-scrollbar flex-1 overflow-x-hidden overflow-y-auto"
+        onScroll={handleScroll}
+      >
+        {error || rowActions.error ? (
+          <div className="p-3 text-xs text-danger">
+            {error ?? rowActions.error}
+          </div>
+        ) : !listing ? (
+          <PrSkeletonList count={10} />
+        ) : listing.kind === "not_github" ? (
+          <Empty msg={rt(t, "rightPanel.errors.originNotGitHub")} />
+        ) : listing.kind === "no_access" ? (
+          <NoAccessBanner
+            slug={listing.slug}
+            accounts={listing.accounts}
+            repoPath={repoPath}
+          />
+        ) : listing.items.length === 0 ? (
+          <Empty
+            msg={rtf(t, "rightPanel.issues.emptyByState", {
+              state: rt(t, issueStateLabelKey(stateFilter)).toLowerCase(),
+            })}
+          />
+        ) : (
+          <ul className="text-xs">
+            {listing.items.map((issue) => (
+              <IssueRow
+                key={issue.number}
+                issue={issue}
+                showAvatar={showAvatars}
+                showLabels={showLabels}
+                onOpen={() => openIssueDetail(issue.number)}
+                onContextMenu={(e) => rowActions.openContextMenu(e, issue)}
+              />
+            ))}
+            {loading && listing.items.length >= limit ? (
+              <li className="px-3 py-2 text-[10px] text-fg-muted">
+                {rt(t, "rightPanel.loading.more")}
+              </li>
+            ) : null}
+            {reachedMax ? (
+              <li className="px-3 py-2 text-[10px] text-fg-muted">
+                {rtf(t, "rightPanel.issues.reachedMax", {
+                  count: ISSUE_PAGE_MAX,
+                })}
+              </li>
+            ) : null}
+          </ul>
+        )}
+      </div>
+      {rowActions.overlays}
+      <IssueSearchModal
+        open={searchOpen ? { repoPath } : null}
+        detailOpen={issueDetail !== null}
+        onClose={() => setSearchOpen(false)}
+        onOpenDetail={openIssueDetail}
+      />
+      <IssueDetailModal
+        open={issueDetail}
+        onClose={() => setIssueDetail(null)}
+      />
+    </div>
+  );
+}
+
 const WORKFLOW_RUNS_LIMIT = 50;
 const ALL_WORKFLOWS = "__all__";
 
@@ -3936,7 +4338,7 @@ function NoAccessBanner({
   );
 }
 
-function PrLabelChip({ label }: { label: PullRequestLabel }) {
+function GitHubLabelChip({ label }: { label: PullRequestLabel }) {
   return (
     <Tooltip label={label.name} side="top">
       <span
@@ -3949,6 +4351,116 @@ function PrLabelChip({ label }: { label: PullRequestLabel }) {
         {label.name}
       </span>
     </Tooltip>
+  );
+}
+
+type GitHubRowSurface = "panel" | "dialog";
+
+function GitHubListRow({
+  number,
+  title,
+  author,
+  updatedAt,
+  labels,
+  numberClassName,
+  meta,
+  onOpen,
+  onContextMenu,
+  surface = "panel",
+  showAvatar = false,
+  showLabels = true,
+}: {
+  number: number;
+  title: string;
+  author: string;
+  updatedAt: string;
+  labels: PullRequestLabel[];
+  numberClassName: string;
+  meta?: ReactNode;
+  onOpen: () => void;
+  onContextMenu?: (e: React.MouseEvent<HTMLLIElement>) => void;
+  surface?: GitHubRowSurface;
+  showAvatar?: boolean;
+  showLabels?: boolean;
+}) {
+  const t = useTranslation();
+  const hoverBg =
+    surface === "dialog"
+      ? "hover:bg-bg-sidebar focus-visible:bg-bg-sidebar"
+      : "hover:bg-bg-elevated/50 focus-visible:bg-bg-elevated/60";
+  const titleSize = showAvatar ? "text-[13px]" : "text-xs";
+  const metaSize = showAvatar ? "text-[11px]" : "text-[10px]";
+
+  return (
+    <li
+      role="button"
+      tabIndex={0}
+      onDoubleClick={onOpen}
+      onContextMenu={onContextMenu}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className={cn(
+        "flex w-full flex-col items-start gap-0.5 border-b border-border/40 px-3 py-2 text-left transition focus-visible:outline-none",
+        hoverBg,
+      )}
+    >
+      <span className={cn("flex w-full min-w-0 items-center gap-2", titleSize)}>
+        <span className={cn("shrink-0 font-mono", numberClassName)}>
+          #{number}
+        </span>
+        <Tooltip
+          label={title}
+          side="top"
+          multiline
+          className="flex! min-w-0 flex-1"
+        >
+          <span className="min-w-0 flex-1 truncate text-fg">{title}</span>
+        </Tooltip>
+        {showLabels && labels.length > 0 ? (
+          <span className="flex shrink-0 items-center gap-1">
+            {labels.slice(0, 3).map((label) => (
+              <GitHubLabelChip key={label.name} label={label} />
+            ))}
+            {labels.length > 3 ? (
+              <span className="text-[9px] text-fg-muted">
+                +{labels.length - 3}
+              </span>
+            ) : null}
+          </span>
+        ) : null}
+      </span>
+      <span
+        className={cn(
+          "flex w-full min-w-0 items-center gap-2 text-fg-muted",
+          metaSize,
+        )}
+      >
+        <span className="flex min-w-0 shrink-0 items-center gap-1.5">
+          {showAvatar ? <AuthorAvatar login={author} size={14} /> : null}
+          <span className="truncate">{author}</span>
+        </span>
+        {meta ? (
+          <>
+            <span className="shrink-0 opacity-50">·</span>
+            {meta}
+          </>
+        ) : null}
+        <span className="shrink-0 opacity-50">·</span>
+        <Tooltip
+          label={absoluteTime(toUnixSeconds(updatedAt))}
+          side="top"
+          className="shrink-0"
+        >
+          <span className="whitespace-nowrap font-mono">
+            {relativeTime(toUnixSeconds(updatedAt), t)}
+          </span>
+        </Tooltip>
+      </span>
+    </li>
   );
 }
 
@@ -4009,6 +4521,47 @@ function PrChecksBadge({
   );
 }
 
+function IssueRow({
+  issue,
+  onOpen,
+  onContextMenu,
+  surface = "panel",
+  showAvatar = false,
+  showLabels = true,
+}: {
+  issue: IssueInfo;
+  onOpen: () => void;
+  onContextMenu?: (e: React.MouseEvent<HTMLLIElement>) => void;
+  surface?: GitHubRowSurface;
+  showAvatar?: boolean;
+  showLabels?: boolean;
+}) {
+  const upper = issue.state.toUpperCase();
+  const numberColor = upper === "OPEN" ? "text-emerald-400" : "text-purple-400";
+  return (
+    <GitHubListRow
+      number={issue.number}
+      title={issue.title}
+      author={issue.author}
+      updatedAt={issue.updated_at}
+      labels={issue.labels}
+      numberClassName={numberColor}
+      surface={surface}
+      showAvatar={showAvatar}
+      showLabels={showLabels}
+      onOpen={onOpen}
+      onContextMenu={onContextMenu}
+      meta={
+        issue.comments > 0 ? (
+          <span className="flex shrink-0 items-center gap-1 font-mono tabular-nums">
+            <MessageSquare size={10} />
+            {issue.comments}
+          </span>
+        ) : undefined
+      }
+    />
+  );
+}
 
 function toUnixSeconds(iso: string): number {
   const ms = Date.parse(iso);
@@ -4039,7 +4592,7 @@ function PrRow({
    * (`bg-bg`), `dialog` is the modal surface (`bg-bg-elevated`) — each
    * needs a different hover color to actually feel interactive.
    */
-  surface?: "panel" | "dialog";
+  surface?: GitHubRowSurface;
   /**
    * Render the author's GitHub avatar to the left of the row. Bumps the
    * row's vertical footprint slightly in exchange for at-a-glance author
@@ -4053,15 +4606,6 @@ function PrRow({
   /** Render CI/check status in the metadata row. */
   showChecks?: boolean;
 }) {
-  const t = useTranslation();
-  const hoverBg =
-    surface === "dialog"
-      ? "hover:bg-bg-sidebar focus-visible:bg-bg-sidebar"
-      : "hover:bg-bg-elevated/50 focus-visible:bg-bg-elevated/60";
-  // Avatar rows get a touch more leading + larger text so the avatar
-  // doesn't dominate visually. Plain rows stay compact at the prior size.
-  const titleSize = showAvatar ? "text-[13px]" : "text-xs";
-  const metaSize = showAvatar ? "text-[11px]" : "text-[10px]";
   const upper = pr.state.toUpperCase();
   const isDraft = pr.is_draft && upper === "OPEN";
   const numberColor = isDraft
@@ -4071,93 +4615,42 @@ function PrRow({
       : upper === "MERGED"
         ? "text-purple-400"
         : "text-rose-400";
-  return (
-    <li
-      role="button"
-      tabIndex={0}
-      onDoubleClick={onOpen}
-      onContextMenu={onContextMenu}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") {
-          e.preventDefault();
-          onOpen();
-        }
-      }}
-      className={cn(
-        "flex w-full flex-col items-start gap-0.5 border-b border-border/40 px-3 py-2 text-left transition focus-visible:outline-none",
-        hoverBg,
-      )}
-    >
-      <span
-        className={cn(
-          "flex w-full min-w-0 items-center gap-2",
-          titleSize,
-        )}
-      >
-        <span className={cn("shrink-0 font-mono", numberColor)}>#{pr.number}</span>
-        <Tooltip
-          label={pr.title}
-          side="top"
-          multiline
-          className="flex! min-w-0 flex-1"
-        >
-          <span className="min-w-0 flex-1 truncate text-fg">{pr.title}</span>
-        </Tooltip>
-        {showLabels && pr.labels.length > 0 ? (
-          <span className="flex shrink-0 items-center gap-1">
-            {pr.labels.slice(0, 3).map((label) => (
-              <PrLabelChip key={label.name} label={label} />
-            ))}
-            {pr.labels.length > 3 ? (
-              <span className="text-[9px] text-fg-muted">+{pr.labels.length - 3}</span>
-            ) : null}
-          </span>
-        ) : null}
-      </span>
-      <span
-        className={cn(
-          "flex w-full min-w-0 items-center gap-2 text-fg-muted",
-          metaSize,
-        )}
-      >
-        <span className="flex min-w-0 shrink-0 items-center gap-1.5">
-          {showAvatar ? <AuthorAvatar login={pr.author} size={14} /> : null}
-          <span className="truncate">{pr.author}</span>
-        </span>
-        {showBranches || showChecks ? (
-          <>
-            <span className="opacity-50">·</span>
-            <span className="flex min-w-0 items-center gap-1">
-              {showBranches ? (
-                <Tooltip
-                  label={`${pr.head_branch} → ${pr.base_branch}`}
-                  side="top"
-                  multiline
-                  className="min-w-0"
-                >
-                  <span className="flex min-w-0 items-center gap-1 font-mono">
-                    <span className="truncate">{pr.head_branch}</span>
-                    <span className="shrink-0">→</span>
-                    <span className="truncate">{pr.base_branch}</span>
-                  </span>
-                </Tooltip>
-              ) : null}
-              {showChecks ? <PrChecksBadge checks={pr.checks} /> : null}
+  const meta =
+    showBranches || showChecks ? (
+      <span className="flex min-w-0 items-center gap-1">
+        {showBranches ? (
+          <Tooltip
+            label={`${pr.head_branch} → ${pr.base_branch}`}
+            side="top"
+            multiline
+            className="min-w-0"
+          >
+            <span className="flex min-w-0 items-center gap-1 font-mono">
+              <span className="truncate">{pr.head_branch}</span>
+              <span className="shrink-0">→</span>
+              <span className="truncate">{pr.base_branch}</span>
             </span>
-          </>
+          </Tooltip>
         ) : null}
-        <span className="shrink-0 opacity-50">·</span>
-        <Tooltip
-          label={absoluteTime(toUnixSeconds(pr.updated_at))}
-          side="top"
-          className="shrink-0"
-        >
-          <span className="whitespace-nowrap font-mono">
-            {relativeTime(toUnixSeconds(pr.updated_at), t)}
-          </span>
-        </Tooltip>
+        {showChecks ? <PrChecksBadge checks={pr.checks} /> : null}
       </span>
-    </li>
+    ) : undefined;
+
+  return (
+    <GitHubListRow
+      number={pr.number}
+      title={pr.title}
+      author={pr.author}
+      updatedAt={pr.updated_at}
+      labels={pr.labels}
+      numberClassName={numberColor}
+      meta={meta}
+      surface={surface}
+      showAvatar={showAvatar}
+      showLabels={showLabels}
+      onOpen={onOpen}
+      onContextMenu={onContextMenu}
+    />
   );
 }
 
@@ -4382,6 +4875,204 @@ function PullRequestSearchModal({
               <li className="px-3 py-2 text-[10px] text-fg-muted">
                 {rtf(t, "rightPanel.search.reachedMax", {
                   count: PR_PAGE_MAX,
+                })}
+              </li>
+            ) : null}
+          </ul>
+        )}
+      </div>
+      {rowActions.overlays}
+    </Modal>
+  );
+}
+
+function IssueSearchModal({
+  open,
+  detailOpen,
+  onClose,
+  onOpenDetail,
+}: {
+  open: { repoPath: string } | null;
+  detailOpen: boolean;
+  onClose: () => void;
+  onOpenDetail: (number: number) => void;
+}) {
+  const t = useTranslation();
+  const repoPath = open?.repoPath ?? null;
+  const showAvatars = useSettings((s) => s.settings.github.showAvatars);
+  const showLabels = useSettings((s) => s.settings.github.showLabels);
+  const [rawQuery, setRawQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [stateFilter, setStateFilter] = useState<IssueStateFilter>("all");
+  const [listing, setListing] = useState<IssueListing | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [limit, setLimit] = useState(ISSUE_PAGE_SIZE);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const rowActions = useIssueRowActions(onOpenDetail);
+
+  useDialogShortcuts(open !== null && !detailOpen, { onCancel: onClose });
+
+  useEffect(() => {
+    if (!open) return;
+    setRawQuery("");
+    setDebouncedQuery("");
+    setStateFilter("all");
+    setListing(null);
+    setError(null);
+    setLimit(ISSUE_PAGE_SIZE);
+    queueMicrotask(() => inputRef.current?.focus());
+  }, [open]);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(rawQuery.trim()), 250);
+    return () => clearTimeout(t);
+  }, [rawQuery]);
+
+  useEffect(() => {
+    setLimit(ISSUE_PAGE_SIZE);
+    setListing(null);
+  }, [debouncedQuery, stateFilter]);
+
+  useEffect(() => {
+    if (!open || !repoPath) return;
+    if (!debouncedQuery) {
+      setListing(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    const signal = { cancelled: false };
+    setLoading(true);
+    api
+      .listIssues(repoPath, stateFilter, limit, debouncedQuery)
+      .then((result) => {
+        if (signal.cancelled) return;
+        setListing(result);
+        setError(null);
+      })
+      .catch((e) => {
+        if (signal.cancelled) return;
+        setError(String(e));
+      })
+      .finally(() => {
+        if (!signal.cancelled) setLoading(false);
+      });
+    return () => {
+      signal.cancelled = true;
+    };
+  }, [open, repoPath, debouncedQuery, stateFilter, limit]);
+
+  function handleScroll(e: React.UIEvent<HTMLDivElement>) {
+    if (loading) return;
+    if (!listing || listing.kind !== "ok") return;
+    if (listing.items.length < limit) return;
+    if (limit >= ISSUE_PAGE_MAX) return;
+    const el = e.currentTarget;
+    if (el.scrollHeight - el.scrollTop - el.clientHeight < 200) {
+      setLimit((prev) => Math.min(prev + ISSUE_PAGE_SIZE, ISSUE_PAGE_MAX));
+    }
+  }
+
+  const reachedMax =
+    listing?.kind === "ok" &&
+    listing.items.length >= limit &&
+    limit >= ISSUE_PAGE_MAX;
+
+  return (
+    <Modal
+      open={open !== null}
+      onClose={onClose}
+      variant="dialog"
+      size="2xl"
+      ariaLabel={rt(t, "rightPanel.issueSearch.aria")}
+    >
+      <ModalHeader
+        title={rt(t, "rightPanel.issueSearch.aria")}
+        icon={<Search size={14} className="text-fg-muted" />}
+        variant="dialog"
+        onClose={onClose}
+      />
+      <div className="flex shrink-0 flex-col gap-2 border-b border-border px-4 py-3">
+        <TextInput
+          ref={inputRef}
+          value={rawQuery}
+          onChange={(e) => setRawQuery(e.currentTarget.value)}
+          placeholder={rt(t, "rightPanel.issueSearch.placeholder")}
+          autoFocus
+        />
+        <div className="flex items-center gap-1 text-[11px]">
+          {ISSUE_STATE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setStateFilter(opt.value)}
+              className={cn(
+                "rounded px-2 py-0.5 transition",
+                stateFilter === opt.value
+                  ? "bg-bg text-fg"
+                  : "text-fg-muted hover:text-fg",
+              )}
+            >
+              {rt(t, issueStateLabelKey(opt.value))}
+            </button>
+          ))}
+          {loading ? (
+            <span className="ml-auto text-fg-muted">
+              {rt(t, "rightPanel.issueSearch.searching")}
+            </span>
+          ) : listing?.kind === "ok" ? (
+            <span className="ml-auto font-mono text-fg-muted">
+              {listing.items.length}
+              {listing.items.length >= limit && limit < ISSUE_PAGE_MAX
+                ? "+"
+                : ""}
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <div
+        className="acorn-no-scrollbar h-[60vh] overflow-y-auto"
+        onScroll={handleScroll}
+      >
+        {!debouncedQuery ? (
+          <Empty msg={rt(t, "rightPanel.issueSearch.typeToSearch")} />
+        ) : error || rowActions.error ? (
+          <div className="p-3 text-xs text-danger">
+            {error ?? rowActions.error}
+          </div>
+        ) : !listing ? (
+          <PrSkeletonList count={6} />
+        ) : listing.kind === "not_github" ? (
+          <Empty msg={rt(t, "rightPanel.errors.originNotGitHub")} />
+        ) : listing.kind === "no_access" ? (
+          <div className="p-3 text-xs text-fg-muted">
+            {rt(t, "rightPanel.issueSearch.noGhAccessThisRepo")}
+          </div>
+        ) : listing.items.length === 0 ? (
+          <Empty msg={rt(t, "rightPanel.issueSearch.noMatches")} />
+        ) : (
+          <ul className="text-xs">
+            {listing.items.map((issue) => (
+              <IssueRow
+                key={issue.number}
+                issue={issue}
+                surface="dialog"
+                showAvatar={showAvatars}
+                showLabels={showLabels}
+                onOpen={() => onOpenDetail(issue.number)}
+                onContextMenu={(e) => rowActions.openContextMenu(e, issue)}
+              />
+            ))}
+            {loading && listing.items.length >= limit ? (
+              <li className="px-3 py-2 text-[10px] text-fg-muted">
+                {rt(t, "rightPanel.loading.more")}
+              </li>
+            ) : null}
+            {reachedMax ? (
+              <li className="px-3 py-2 text-[10px] text-fg-muted">
+                {rtf(t, "rightPanel.issueSearch.reachedMax", {
+                  count: ISSUE_PAGE_MAX,
                 })}
               </li>
             ) : null}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,6 +10,9 @@ import type {
   DiffPayload,
   GenerateSessionTitleResult,
   GeneratedCommitMessage,
+  IssueDetailListing,
+  IssueListing,
+  IssueStateFilter,
   MemoryUsage,
   MergeMethod,
   Project,
@@ -353,6 +356,28 @@ export const api = {
       state,
       limit,
       query,
+    });
+  },
+  listIssues(
+    repoPath: string,
+    state: IssueStateFilter = "open",
+    limit = 50,
+    query: string | null = null,
+  ): Promise<IssueListing> {
+    return invoke<IssueListing>("list_issues", {
+      repoPath,
+      state,
+      limit,
+      query,
+    });
+  },
+  getIssueDetail(
+    repoPath: string,
+    number: number,
+  ): Promise<IssueDetailListing> {
+    return invoke<IssueDetailListing>("get_issue_detail", {
+      repoPath,
+      number,
     });
   },
   getPullRequestDetail(

--- a/src/lib/right-panel-cache.test.ts
+++ b/src/lib/right-panel-cache.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentHistoryItem,
+  IssueListing,
   PullRequestListing,
   WorkflowRunsListing,
 } from "./types";
@@ -18,6 +19,14 @@ vi.mock("./api", () => ({
           state: string,
           limit: number,
         ) => Promise<PullRequestListing>
+      >(),
+    listIssues:
+      vi.fn<
+        (
+          repoPath: string,
+          state: string,
+          limit: number,
+        ) => Promise<IssueListing>
       >(),
     listWorkflowRuns:
       vi.fn<(repoPath: string, limit: number) => Promise<WorkflowRunsListing>>(),
@@ -67,6 +76,28 @@ describe("rightPanelCache", () => {
     expect(mockApi.listPullRequests).toHaveBeenCalledTimes(1);
   });
 
+  it("dedupes in-flight issue fetches and reuses cached results", async () => {
+    const listing: IssueListing = {
+      kind: "ok",
+      items: [],
+      account: "tester",
+    };
+    const pending = deferred<IssueListing>();
+    mockApi.listIssues.mockReturnValueOnce(pending.promise);
+
+    const first = rightPanelCache.fetchIssues(REPO, "closed", 50);
+    const second = rightPanelCache.fetchIssues(REPO, "closed", 50);
+    expect(first).toBe(second);
+    expect(mockApi.listIssues).toHaveBeenCalledTimes(1);
+
+    pending.resolve(listing);
+    await expect(first).resolves.toBe(listing);
+    await expect(
+      rightPanelCache.fetchIssues(REPO, "closed", 50),
+    ).resolves.toBe(listing);
+    expect(mockApi.listIssues).toHaveBeenCalledTimes(1);
+  });
+
   it("tracks project prefetch once until the repo is pruned", () => {
     expect(rightPanelCache.claimProjectPrefetch(REPO)).toBe(true);
     expect(rightPanelCache.claimProjectPrefetch(REPO)).toBe(false);
@@ -84,15 +115,23 @@ describe("rightPanelCache", () => {
     };
     mockApi.listAgentHistory.mockResolvedValue(history);
     mockApi.listWorkflowRuns.mockResolvedValue(workflows);
+    mockApi.listIssues.mockResolvedValue({
+      kind: "ok",
+      items: [],
+      account: "tester",
+    });
 
     await rightPanelCache.fetchAgentHistory(REPO);
     await rightPanelCache.fetchWorkflowRuns(REPO, 50);
+    await rightPanelCache.fetchIssues(REPO, "open", 50);
     expect(rightPanelCache.getAgentHistory(REPO)).toBe(history);
     expect(rightPanelCache.getWorkflowRuns(REPO, 50)).toBe(workflows);
+    expect(rightPanelCache.getIssues(REPO, "open", 50)).not.toBeNull();
 
     rightPanelCache.retainRepos([OTHER_REPO]);
     expect(rightPanelCache.getAgentHistory(REPO)).toBeNull();
     expect(rightPanelCache.getWorkflowRuns(REPO, 50)).toBeNull();
+    expect(rightPanelCache.getIssues(REPO, "open", 50)).toBeNull();
   });
 
   it("preserves file explorer expansion by repo until the repo is pruned", () => {
@@ -140,5 +179,22 @@ describe("rightPanelCache", () => {
     await expect(request).resolves.toBe(listing);
 
     expect(rightPanelCache.getPullRequests(REPO, "open", 50)).toBeNull();
+  });
+
+  it("does not repopulate pruned issue data from a stale in-flight request", async () => {
+    const listing: IssueListing = {
+      kind: "ok",
+      items: [],
+      account: "tester",
+    };
+    const pending = deferred<IssueListing>();
+    mockApi.listIssues.mockReturnValueOnce(pending.promise);
+
+    const request = rightPanelCache.fetchIssues(REPO, "open", 50);
+    rightPanelCache.retainRepos([OTHER_REPO]);
+    pending.resolve(listing);
+    await expect(request).resolves.toBe(listing);
+
+    expect(rightPanelCache.getIssues(REPO, "open", 50)).toBeNull();
   });
 });

--- a/src/lib/right-panel-cache.ts
+++ b/src/lib/right-panel-cache.ts
@@ -3,6 +3,8 @@ import type {
   AgentHistoryItem,
   CommitInfo,
   DiffPayload,
+  IssueListing,
+  IssueStateFilter,
   PrStateFilter,
   PullRequestListing,
   StagedFile,
@@ -36,6 +38,8 @@ class RightPanelCacheManager {
   private fileExplorerExpanded = new Map<string, Set<string>>();
   private prListCache = new Map<string, PullRequestListing>();
   private prListInFlight = new Map<string, Promise<PullRequestListing>>();
+  private issueListCache = new Map<string, IssueListing>();
+  private issueListInFlight = new Map<string, Promise<IssueListing>>();
   private workflowRunsCache = new Map<string, WorkflowRunsListing>();
   private workflowRunsInFlight = new Map<string, Promise<WorkflowRunsListing>>();
 
@@ -61,6 +65,8 @@ class RightPanelCacheManager {
     this.collectRemovedStringValues(this.prefetchedProjectRepos, next, removed);
     this.collectRemovedJsonKeys(this.prListCache, next, removed);
     this.collectRemovedJsonKeys(this.prListInFlight, next, removed);
+    this.collectRemovedJsonKeys(this.issueListCache, next, removed);
+    this.collectRemovedJsonKeys(this.issueListInFlight, next, removed);
     this.collectRemovedJsonKeys(this.workflowRunsCache, next, removed);
     this.collectRemovedJsonKeys(this.workflowRunsInFlight, next, removed);
     for (const repoPath of removed) this.bumpRepoVersion(repoPath);
@@ -74,6 +80,8 @@ class RightPanelCacheManager {
     this.pruneStringKeyedSet(this.prefetchedProjectRepos, next);
     this.pruneJsonKeyedMap(this.prListCache, next);
     this.pruneJsonKeyedMap(this.prListInFlight, next);
+    this.pruneJsonKeyedMap(this.issueListCache, next);
+    this.pruneJsonKeyedMap(this.issueListInFlight, next);
     this.pruneJsonKeyedMap(this.workflowRunsCache, next);
     this.pruneJsonKeyedMap(this.workflowRunsInFlight, next);
   }
@@ -202,6 +210,41 @@ class RightPanelCacheManager {
     return promise;
   }
 
+  getIssues(
+    repoPath: string,
+    filter: IssueStateFilter,
+    limit: number,
+  ): IssueListing | null {
+    return this.issueListCache.get(this.issueListKey(repoPath, filter, limit)) ?? null;
+  }
+
+  fetchIssues(
+    repoPath: string,
+    filter: IssueStateFilter,
+    limit: number,
+    options: FetchOptions = {},
+  ): Promise<IssueListing> {
+    const key = this.issueListKey(repoPath, filter, limit);
+    const cached = this.issueListCache.get(key);
+    if (cached && !options.force) return Promise.resolve(cached);
+    const existing = this.issueListInFlight.get(key);
+    if (existing) return existing;
+    const version = this.repoVersion(repoPath);
+    const promise = api
+      .listIssues(repoPath, filter, limit)
+      .then((result) => {
+        if (this.isCurrentRepoVersion(repoPath, version)) {
+          this.issueListCache.set(key, result);
+        }
+        return result;
+      })
+      .finally(() => {
+        this.issueListInFlight.delete(key);
+      });
+    this.issueListInFlight.set(key, promise);
+    return promise;
+  }
+
   getWorkflowRuns(repoPath: string, limit: number): WorkflowRunsListing | null {
     return this.workflowRunsCache.get(this.workflowRunsKey(repoPath, limit)) ?? null;
   }
@@ -245,6 +288,8 @@ class RightPanelCacheManager {
     this.fileExplorerExpanded.clear();
     this.prListCache.clear();
     this.prListInFlight.clear();
+    this.issueListCache.clear();
+    this.issueListInFlight.clear();
     this.workflowRunsCache.clear();
     this.workflowRunsInFlight.clear();
   }
@@ -268,6 +313,14 @@ class RightPanelCacheManager {
   private prListKey(
     repoPath: string,
     filter: PrStateFilter,
+    limit: number,
+  ): string {
+    return JSON.stringify([repoPath, filter, limit]);
+  }
+
+  private issueListKey(
+    repoPath: string,
+    filter: IssueStateFilter,
     limit: number,
   ): string {
     return JSON.stringify([repoPath, filter, limit]);

--- a/src/lib/rightPanelGroups.ts
+++ b/src/lib/rightPanelGroups.ts
@@ -5,6 +5,7 @@ export type RightTab =
   | "staged"
   | "commits"
   | "prs"
+  | "issues"
   | "actions"
   | "activity"
   | "todos"
@@ -14,7 +15,7 @@ export const RIGHT_GROUPS: ReadonlyArray<RightGroup> = ["code", "github", "agent
 
 const TABS_BY_GROUP: Record<RightGroup, ReadonlyArray<RightTab>> = {
   code: ["files", "staged", "commits"],
-  github: ["prs", "actions"],
+  github: ["prs", "issues", "actions"],
   agents: ["activity", "history", "todos"],
 };
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -351,15 +351,14 @@ export interface AcornSettings {
     showMemory: boolean;
   };
   github: {
-    /** Auto-refresh cadence for the PRs and Actions tabs in milliseconds. */
+    /** Auto-refresh cadence for the PRs, Issues, and Actions tabs in milliseconds. */
     refreshIntervalMs: number;
     /**
-     * Show the author's GitHub avatar on PR rows. Trades a thicker row
-     * for at-a-glance author recognition, mirroring the PR detail modal
-     * which already shows avatars in its header / conversation.
+     * Show the author's GitHub avatar on PR and issue rows. Trades a thicker
+     * row for at-a-glance author recognition.
      */
     showAvatars: boolean;
-    /** Show GitHub labels next to each PR row title. */
+    /** Show GitHub labels next to each PR or issue row title. */
     showLabels: boolean;
     /** Show source and target branches on each PR row. */
     showBranches: boolean;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -371,6 +371,7 @@ export interface TodoItem {
 }
 
 export type PrStateFilter = "open" | "closed" | "merged" | "all";
+export type IssueStateFilter = "open" | "closed" | "all";
 
 export interface PullRequestLabel {
   name: string;
@@ -406,6 +407,53 @@ export interface AccountSummary {
 
 export type PullRequestListing =
   | { kind: "ok"; items: PullRequestInfo[]; account: string }
+  | { kind: "not_github" }
+  | { kind: "no_access"; slug: string; accounts: AccountSummary[] };
+
+export interface IssueInfo {
+  number: number;
+  title: string;
+  state: string;
+  author: string;
+  url: string;
+  created_at: string;
+  updated_at: string;
+  state_reason: string | null;
+  comments: number;
+  labels: PullRequestLabel[];
+}
+
+export type IssueListing =
+  | { kind: "ok"; items: IssueInfo[]; account: string }
+  | { kind: "not_github" }
+  | { kind: "no_access"; slug: string; accounts: AccountSummary[] };
+
+export interface IssueComment {
+  author: string;
+  author_avatar_url: string | null;
+  body: string;
+  created_at: string;
+  url: string | null;
+}
+
+export interface IssueDetail {
+  number: number;
+  title: string;
+  body: string;
+  state: string;
+  author: string;
+  url: string;
+  created_at: string;
+  updated_at: string;
+  state_reason: string | null;
+  labels: PullRequestLabel[];
+  comments: IssueComment[];
+  assignees: string[];
+  milestone: string | null;
+}
+
+export type IssueDetailListing =
+  | { kind: "ok"; account: string; detail: IssueDetail }
   | { kind: "not_github" }
   | { kind: "no_access"; slug: string; accounts: AccountSummary[] };
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -181,20 +181,20 @@
     "github": {
       "refreshInterval": {
         "label": "Refresh interval",
-        "hint": "How often the PRs and Actions tabs auto-refetch from gh. Lower values feel snappier but spend more API budget."
+        "hint": "How often the PRs, Issues, and Actions tabs auto-refetch from gh. Lower values feel snappier but spend more API budget."
       },
       "manualRefresh": "Manual refresh (the icon in each tab) always works regardless of this interval.",
       "listDensity": {
         "label": "List density",
-        "hint": "Choose which optional details appear in each PR row."
+        "hint": "Choose which optional details appear in each PR or issue row."
       },
       "showAuthorAvatars": {
         "label": "Show author avatars",
-        "description": "Render the GitHub avatar next to each PR row."
+        "description": "Render the GitHub avatar next to each PR or issue row."
       },
       "showLabels": {
         "label": "Show labels",
-        "description": "Render GitHub labels next to each PR row title."
+        "description": "Render GitHub labels next to each PR or issue row title."
       },
       "showBranches": {
         "label": "Show branches",
@@ -334,7 +334,7 @@
         },
         "githubAccount": {
           "label": "GitHub account",
-          "description": "The `gh` account used to list pull requests for the active repo."
+          "description": "The `gh` account used to list GitHub data for the active repo."
         },
         "workingDirectory": {
           "label": "Working directory",
@@ -976,6 +976,7 @@
       "commits": "Commits",
       "staged": "Staged",
       "prs": "PRs",
+      "issues": "Issues",
       "activity": "Activity",
       "history": "History",
       "actions": "Actions"
@@ -1067,6 +1068,7 @@
       "openDetail": "Open detail",
       "openInBrowser": "Open in browser",
       "copyPrNumber": "Copy PR number",
+      "copyIssueNumber": "Copy issue number",
       "copyUrl": "Copy URL",
       "copyBranchWithValue": "Copy branch ({branch})",
       "merge": "Merge…",
@@ -1079,9 +1081,18 @@
       "all": "All",
       "draft": "DRAFT"
     },
+    "issueStates": {
+      "open": "Open",
+      "closed": "Closed",
+      "all": "All"
+    },
     "prs": {
       "emptyByState": "No {state} pull requests.",
       "reachedMax": "Showing first {count}. Use search to find older PRs."
+    },
+    "issues": {
+      "emptyByState": "No {state} issues.",
+      "reachedMax": "Showing first {count}. Use search to find older issues."
     },
     "search": {
       "aria": "Search pull requests",
@@ -1091,6 +1102,15 @@
       "noGhAccessThisRepo": "No logged-in gh account can access this repo.",
       "noMatches": "No matching pull requests.",
       "reachedMax": "Showing first {count}. Refine the query for older PRs."
+    },
+    "issueSearch": {
+      "aria": "Search issues",
+      "placeholder": "Search title, author, label…",
+      "searching": "Searching…",
+      "typeToSearch": "Type to search issues.",
+      "noGhAccessThisRepo": "No logged-in gh account can access this repo.",
+      "noMatches": "No matching issues.",
+      "reachedMax": "Showing first {count}. Refine the query for older issues."
     },
     "actions": {
       "filterByWorkflow": "Filter by workflow",
@@ -1508,6 +1528,24 @@
       "checkNeutral": "neutral",
       "checkSkipped": "skipped",
       "checkCompleted": "completed"
+    },
+    "issueDetail": {
+      "notGithub": "Origin remote is not a GitHub repository.",
+      "noAccessPrefix": "No logged-in",
+      "noAccessSuffix": "account can access",
+      "openOnGithub": "Open on GitHub",
+      "openCommentOnGithub": "Open comment on GitHub",
+      "created": "Created",
+      "updated": "Updated",
+      "comments": "Comments",
+      "noComments": "No comments yet.",
+      "noBody": "No issue description.",
+      "empty": "(empty)",
+      "stateOpen": "Open",
+      "stateCompleted": "Completed",
+      "stateNotPlanned": "Not planned",
+      "assignees": "Assignees:",
+      "milestone": "Milestone:"
     }
   },
   "commandPalette": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -181,20 +181,20 @@
     "github": {
       "refreshInterval": {
         "label": "새로고침 간격",
-        "hint": "PR 및 Actions 탭이 gh에서 자동으로 다시 가져오는 빈도입니다. 값이 낮을수록 더 빠르게 느껴지지만 API 예산을 더 사용합니다."
+        "hint": "PR, Issues 및 Actions 탭이 gh에서 자동으로 다시 가져오는 빈도입니다. 값이 낮을수록 더 빠르게 느껴지지만 API 예산을 더 사용합니다."
       },
       "manualRefresh": "수동 새로고침(각 탭의 아이콘)은 이 간격과 관계없이 항상 작동합니다.",
       "listDensity": {
         "label": "목록 밀도",
-        "hint": "각 PR 행에 표시할 선택 정보를 고릅니다."
+        "hint": "각 PR 또는 이슈 행에 표시할 선택 정보를 고릅니다."
       },
       "showAuthorAvatars": {
         "label": "작성자 아바타 표시",
-        "description": "각 PR 행 옆에 GitHub 아바타를 표시합니다."
+        "description": "각 PR 또는 이슈 행 옆에 GitHub 아바타를 표시합니다."
       },
       "showLabels": {
         "label": "라벨 표시",
-        "description": "각 PR 행 제목 옆에 GitHub 라벨을 표시합니다."
+        "description": "각 PR 또는 이슈 행 제목 옆에 GitHub 라벨을 표시합니다."
       },
       "showBranches": {
         "label": "브랜치 표시",
@@ -334,7 +334,7 @@
         },
         "githubAccount": {
           "label": "GitHub 계정",
-          "description": "활성 저장소의 pull request 목록을 가져오는 데 사용하는 `gh` 계정입니다."
+          "description": "활성 저장소의 GitHub 데이터를 가져오는 데 사용하는 `gh` 계정입니다."
         },
         "workingDirectory": {
           "label": "작업 디렉터리",
@@ -976,6 +976,7 @@
       "commits": "커밋",
       "staged": "스테이징",
       "prs": "PR",
+      "issues": "이슈",
       "activity": "활동",
       "history": "기록",
       "actions": "작업"
@@ -1067,6 +1068,7 @@
       "openDetail": "상세 열기",
       "openInBrowser": "브라우저에서 열기",
       "copyPrNumber": "PR 번호 복사",
+      "copyIssueNumber": "이슈 번호 복사",
       "copyUrl": "URL 복사",
       "copyBranchWithValue": "브랜치 복사({branch})",
       "merge": "병합…",
@@ -1079,9 +1081,18 @@
       "all": "전체",
       "draft": "초안"
     },
+    "issueStates": {
+      "open": "열림",
+      "closed": "닫힘",
+      "all": "전체"
+    },
     "prs": {
       "emptyByState": "{state} PR이 없습니다.",
       "reachedMax": "처음 {count}개를 표시합니다. 더 오래된 PR은 검색으로 찾으세요."
+    },
+    "issues": {
+      "emptyByState": "{state} 이슈가 없습니다.",
+      "reachedMax": "처음 {count}개를 표시합니다. 더 오래된 이슈는 검색으로 찾으세요."
     },
     "search": {
       "aria": "PR 검색",
@@ -1091,6 +1102,15 @@
       "noGhAccessThisRepo": "로그인된 gh 계정으로 이 저장소에 접근할 수 없습니다.",
       "noMatches": "일치하는 PR이 없습니다.",
       "reachedMax": "처음 {count}개를 표시합니다. 더 오래된 PR은 검색어를 좁혀 찾으세요."
+    },
+    "issueSearch": {
+      "aria": "이슈 검색",
+      "placeholder": "제목, 작성자, 라벨 검색…",
+      "searching": "검색 중…",
+      "typeToSearch": "이슈를 검색하려면 입력하세요.",
+      "noGhAccessThisRepo": "로그인된 gh 계정으로 이 저장소에 접근할 수 없습니다.",
+      "noMatches": "일치하는 이슈가 없습니다.",
+      "reachedMax": "처음 {count}개를 표시합니다. 더 오래된 이슈는 검색어를 좁혀 찾으세요."
     },
     "actions": {
       "filterByWorkflow": "워크플로로 필터링",
@@ -1508,6 +1528,24 @@
       "checkNeutral": "중립",
       "checkSkipped": "건너뜀",
       "checkCompleted": "완료"
+    },
+    "issueDetail": {
+      "notGithub": "origin 원격 저장소가 GitHub 저장소가 아닙니다.",
+      "noAccessPrefix": "로그인된",
+      "noAccessSuffix": "계정으로 접근할 수 없습니다:",
+      "openOnGithub": "GitHub에서 열기",
+      "openCommentOnGithub": "GitHub에서 댓글 열기",
+      "created": "생성",
+      "updated": "업데이트",
+      "comments": "댓글",
+      "noComments": "아직 댓글이 없습니다.",
+      "noBody": "이슈 설명이 없습니다.",
+      "empty": "(비어 있음)",
+      "stateOpen": "열림",
+      "stateCompleted": "완료됨",
+      "stateNotPlanned": "계획 없음",
+      "assignees": "담당자:",
+      "milestone": "마일스톤:"
     }
   },
   "commandPalette": {

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -184,7 +184,13 @@ export const tauriMockSource = `
     if (cmd === 'list_staged') return Promise.resolve([]);
     if (cmd === 'list_unscoped_agent_history') return Promise.resolve([]);
     if (cmd === 'list_pull_requests') {
-      return Promise.resolve({ items: [], account: null, error: null });
+      return Promise.resolve({ kind: 'ok', items: [], account: 'test' });
+    }
+    if (cmd === 'list_issues') {
+      return Promise.resolve({ kind: 'ok', items: [], account: 'test' });
+    }
+    if (cmd === 'get_issue_detail') {
+      return Promise.resolve({ kind: 'not_github' });
     }
     if (cmd === 'get_pull_request_diff') {
       return Promise.resolve({ kind: 'ok', account: 'test', diff: { files: [] } });

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -86,6 +86,66 @@ test.describe("right panel: tab switching", () => {
     await expect(page.getByText(/Select a commit to see diff/i)).toBeVisible();
   });
 
+  test("double-clicking an issue opens its in-app detail modal", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    await tauri.respond("list_issues", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 42,
+          title: "Render issue detail in app",
+          state: "OPEN",
+          author: "im-ian",
+          url: "https://github.com/im-ian/acorn/issues/42",
+          created_at: "2026-05-18T00:00:00Z",
+          updated_at: "2026-05-19T00:00:00Z",
+          state_reason: null,
+          comments: 1,
+          labels: [{ name: "enhancement", color: "a2eeef" }],
+        },
+      ],
+    });
+    await tauri.respond("get_issue_detail", {
+      kind: "ok",
+      account: "test-account",
+      detail: {
+        number: 42,
+        title: "Render issue detail in app",
+        body: "Loaded issue body from gh.",
+        state: "OPEN",
+        author: "im-ian",
+        url: "https://github.com/im-ian/acorn/issues/42",
+        created_at: "2026-05-18T00:00:00Z",
+        updated_at: "2026-05-19T00:00:00Z",
+        state_reason: null,
+        labels: [{ name: "enhancement", color: "a2eeef" }],
+        comments: [
+          {
+            author: "im-ian",
+            author_avatar_url: null,
+            body: "First in-app issue comment.",
+            created_at: "2026-05-19T01:00:00Z",
+            url: "https://github.com/im-ian/acorn/issues/42#issuecomment-1",
+          },
+        ],
+        assignees: ["im-ian"],
+        milestone: "v1",
+      },
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await page.getByRole("button", { name: "Issues" }).click();
+    await page.getByText("Render issue detail in app").dblclick();
+
+    await expect(page.getByText("Loaded issue body from gh.")).toBeVisible();
+    await expect(page.getByText("First in-app issue comment.")).toBeVisible();
+  });
+
   test("hotkey $mod+Shift+S routes to Staged tab", async ({ page, tauri }) => {
     await seedActiveSession(tauri);
 


### PR DESCRIPTION
## Summary
Adds Issues as a first-class GitHub panel next to PRs and Actions.

1. **Issues tab** — adds the GitHub sub-tab order `PRs | Issues | Actions`, with open/closed/all filters, refresh, pagination, search, labels, avatars, comment counts, and browser/copy context actions.
2. **In-app issue detail** — adds a read-only issue detail modal with body markdown, comments, labels, assignees, milestone, state reason, refresh, and GitHub deep links.
3. **Shared GitHub row surface** — extracts the common PR/Issue list row shell while keeping PR-specific and Issue-specific metadata separate.
4. **Backend + cache contract** — adds `list_issues` and `get_issue_detail` Tauri commands backed by `gh issue list/view`, using the same GitHub account routing and no-access handling as PRs.
5. **Docs and tests** — updates E2E mocks/docs, README copy, i18n strings, cache tests, RightPanel unit tests, and Playwright coverage.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| GitHub panel navigation | `PRs | Actions` | `PRs | Issues | Actions` |
| Issues workflow | Users leave Acorn or use external GitHub views | Users can browse, search, and inspect issues in-app |
| PR list UI | PR row shell was PR-only | PR rows keep behavior while sharing the neutral row surface with issues |
| GitHub auth behavior | PRs and Actions use routed `gh` accounts | Issues use the same routed account/no-access behavior |

## Design notes
- The shared abstraction is intentionally limited to the repeated GitHub list-row surface. PR and Issue tabs, search state, and detail modals stay separate because their data contracts and actions differ.
- Issue list caching mirrors PR list caching with repo-version pruning and in-flight dedupe. Search calls `api.listIssues` directly because query-specific results should not pollute the background tab cache.
- `gh issue list --json comments` can return either a count or an array depending on gh output shape, so the Rust parser accepts both.
- Issue detail comment avatar resolution reuses the existing GitHub REST avatar helper pattern used by PR conversation comments.

## Follow-up (not in this PR)
- Issue editing, commenting, closing/reopening, and task toggles are intentionally out of scope.
- Deeper PR/Issue modal consolidation can wait until the issue modal needs PR-like actions; doing that now would add configuration without removing much complexity.

## Test plan
- [x] `pnpm run typecheck` passed
- [x] `pnpm exec vitest run src/components/RightPanel.test.tsx src/lib/right-panel-cache.test.ts` passed, 25 tests
- [x] `cargo test --manifest-path src-tauri/Cargo.toml issue_ -- --nocapture` passed, 2 tests
- [x] `PLAYWRIGHT_PORT=1438 pnpm exec playwright test tests/e2e/right-panel.spec.ts -g "double-clicking an issue"` passed, 1 test
- [x] `pnpm run build` passed with existing Vite dynamic import/chunk-size warnings
- [x] `git diff --check` and `git diff --cached --check` passed

## Notes
- A first local Playwright attempt without `PLAYWRIGHT_PORT` reused an existing Vite server from another worktree on port 1420 and saw the old `PRs | Actions` UI. Rerunning on a fresh port against this worktree passed. Not caused by this PR.