### PR TITLE
fix(github): keep right panel rooted per project

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -222,25 +222,37 @@ export function RightPanel() {
   // `claude --worktree`, which silently moves the running session into a
   // freshly created worktree. `useLiveRepoPath` asks the backend on demand
   // and falls back to the recorded path when there's no live PTY.
-  const fallbackPath =
+  const fallbackWorktreePath =
     active?.worktree_path ?? activeWorkspaceTab?.repoPath ?? activeProject ?? null;
-  const repoPath = useLiveRepoPath(active?.id ?? null, fallbackPath);
+  const liveRepoPath = useLiveRepoPath(
+    active?.id ?? null,
+    fallbackWorktreePath,
+  );
   const activeIsLocalChat = active?.project_scoped === false;
   const agentHistoryScope =
     activeIsLocalChat || (!active && activeProject === null)
       ? "unscoped"
       : "project";
-  const projectPanelRepoPath = activeIsLocalChat ? null : repoPath;
-  const agentHistoryPath = agentHistoryScope === "project" ? repoPath : null;
+  // Code tabs follow the active worktree; GitHub/history stay anchored to the
+  // project root so same-project pane focus changes do not remount them.
+  const codePanelRepoPath = activeIsLocalChat ? null : liveRepoPath;
+  const projectRootFallbackPath =
+    active?.repo_path ??
+    activeProject ??
+    activeWorkspaceTab?.repoPath ??
+    liveRepoPath;
+  const projectRootRepoPath = activeIsLocalChat ? null : projectRootFallbackPath;
+  const agentHistoryPath =
+    agentHistoryScope === "project" ? projectRootRepoPath : null;
   const localSessionHostPath =
     sessions.find((session) => session.project_scoped === false)?.repo_path ??
     null;
   const sessionHostRepoPath =
     active?.repo_path ??
-    activeWorkspaceTab?.repoPath ??
     activeProject ??
+    activeWorkspaceTab?.repoPath ??
     localSessionHostPath ??
-    repoPath;
+    liveRepoPath;
   const sessionHostProjectScoped = active
     ? scopeForSession(active).placement.projectScoped
     : agentHistoryScope === "unscoped"
@@ -253,12 +265,17 @@ export function RightPanel() {
       : true;
   const [gitRepoProbeVersion, setGitRepoProbeVersion] = useState(0);
   const invalidateGitProbe = useCallback(() => {
-    if (!projectPanelRepoPath) return;
-    invalidateGitRepositoryStatus(projectPanelRepoPath);
+    const paths = new Set(
+      [codePanelRepoPath, projectRootRepoPath].filter(
+        (path): path is string => path !== null,
+      ),
+    );
+    if (paths.size === 0) return;
+    for (const path of paths) invalidateGitRepositoryStatus(path);
     setGitRepoProbeVersion((version) => version + 1);
-  }, [projectPanelRepoPath]);
+  }, [codePanelRepoPath, projectRootRepoPath]);
   const invalidations = useRightPanelInvalidations(
-    projectPanelRepoPath,
+    codePanelRepoPath,
     invalidateGitProbe,
   );
   const [expanded, setExpanded] = useState<ExpandedDiff | null>(null);
@@ -282,24 +299,24 @@ export function RightPanel() {
     active?.worktree_path ?? null,
   );
   const showTodos = todosState.todos.length > 0;
-  const isGitRepo = useIsGitRepository(
-    projectPanelRepoPath,
+  const isCodeGitRepo = useIsGitRepository(
+    codePanelRepoPath,
     gitRepoProbeVersion,
   );
   const isGitHubRepo = useIsGitHubRepo(
-    projectPanelRepoPath,
+    projectRootRepoPath,
     gitRepoProbeVersion,
   );
   const githubVisible = isGitHubRepo === true;
   const gitBackedTabsVisible =
-    projectPanelRepoPath !== null && isGitRepo !== false;
+    codePanelRepoPath !== null && isCodeGitRepo !== false;
 
   const visibleTabsByGroup = useMemo<
     Record<RightGroup, ReadonlyArray<RightTab>>
   >(
     () => ({
       code:
-        projectPanelRepoPath === null
+        codePanelRepoPath === null
           ? []
           : gitBackedTabsVisible
             ? tabsForGroup("code")
@@ -309,7 +326,7 @@ export function RightPanel() {
         ? tabsForGroup("agents")
         : tabsForGroup("agents").filter((tab) => tab !== "todos"),
     }),
-    [gitBackedTabsVisible, githubVisible, projectPanelRepoPath, showTodos],
+    [codePanelRepoPath, gitBackedTabsVisible, githubVisible, showTodos],
   );
   const visibleGroups = useMemo(
     () => RIGHT_GROUPS.filter((g) => visibleTabsByGroup[g].length > 0),
@@ -320,7 +337,7 @@ export function RightPanel() {
     : (visibleGroups[0] ?? "code");
   const visibleTabs = visibleTabsByGroup[activeGroup];
   const shouldLoadGitHubTabs =
-    projectPanelRepoPath !== null && isGitHubRepo === true;
+    projectRootRepoPath !== null && isGitHubRepo === true;
   const projectKey = useMemo(
     () => projects.map((project) => project.repo_path).join("\0"),
     [projects],
@@ -343,7 +360,7 @@ export function RightPanel() {
   // rather than render the panel against a stale selection.
   useEffect(() => {
     if (
-      projectPanelRepoPath === null &&
+      codePanelRepoPath === null &&
       activeProject === null &&
       !active &&
       projects.length === 0 &&
@@ -354,15 +371,15 @@ export function RightPanel() {
     if (visibleTabs.length === 0) return;
     if (!visibleTabs.includes(rightTab)) {
       if (
-        projectPanelRepoPath !== null &&
-        isGitRepo === null &&
+        codePanelRepoPath !== null &&
+        isCodeGitRepo === null &&
         groupOfTab(rightTab) === "code" &&
         rightTab !== "files"
       ) {
         return;
       }
       if (
-        projectPanelRepoPath !== null &&
+        projectRootRepoPath !== null &&
         isGitHubRepo === null &&
         groupOfTab(rightTab) === "github"
       ) {
@@ -372,10 +389,11 @@ export function RightPanel() {
     }
   }, [
     isGitHubRepo,
-    isGitRepo,
+    isCodeGitRepo,
     active,
     activeProject,
-    projectPanelRepoPath,
+    codePanelRepoPath,
+    projectRootRepoPath,
     projects.length,
     rightTab,
     sessions.length,
@@ -464,13 +482,13 @@ export function RightPanel() {
             <Empty msg={rt(t, "rightPanel.empty.noTodos")} />
           )
         ) : rightTab === "commits" ? (
-          projectPanelRepoPath ? (
+          codePanelRepoPath ? (
             // `key` forces a full remount on project switch so any in-flight
             // git request from the previous repo cannot land its `setState`
             // into the new repo's component (cross-project data leak).
             <CommitsTab
-              key={projectPanelRepoPath}
-              repoPath={projectPanelRepoPath}
+              key={codePanelRepoPath}
+              repoPath={codePanelRepoPath}
               invalidateKey={invalidations.commits}
               onExpand={setExpanded}
             />
@@ -478,10 +496,10 @@ export function RightPanel() {
             <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : rightTab === "staged" ? (
-          projectPanelRepoPath ? (
+          codePanelRepoPath ? (
             <StagedTab
-              key={projectPanelRepoPath}
-              repoPath={projectPanelRepoPath}
+              key={codePanelRepoPath}
+              repoPath={codePanelRepoPath}
               invalidateKey={invalidations.staged}
               onExpand={setExpanded}
             />
@@ -489,10 +507,10 @@ export function RightPanel() {
             <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : rightTab === "files" ? (
-          projectPanelRepoPath ? (
+          codePanelRepoPath ? (
             <FileExplorer
-              key={projectPanelRepoPath}
-              rootPath={projectPanelRepoPath}
+              key={codePanelRepoPath}
+              rootPath={codePanelRepoPath}
             />
           ) : (
             <Empty msg={rt(t, "rightPanel.empty.noProject")} />
@@ -502,37 +520,37 @@ export function RightPanel() {
             agentHistoryScope === "unscoped" || agentHistoryPath ? null : (
               <Empty msg={rt(t, "rightPanel.empty.noProject")} />
             )
-          ) : projectPanelRepoPath ? null : (
+          ) : projectRootRepoPath ? null : (
             <Empty msg={rt(t, "rightPanel.empty.noProject")} />
           )
         ) : (
           <Empty msg={rt(t, "rightPanel.empty.noProject")} />
         )}
-        {projectPanelRepoPath && shouldLoadGitHubTabs ? (
+        {projectRootRepoPath && shouldLoadGitHubTabs ? (
           <>
             <BackgroundLoadedTab active={rightTab === "prs"}>
               <PullRequestsTab
-                key={`prs:${projectPanelRepoPath}`}
-                repoPath={projectPanelRepoPath}
+                key={`prs:${projectRootRepoPath}`}
+                repoPath={projectRootRepoPath}
                 onOpenDetail={(number) =>
-                  setPrDetail({ repoPath: projectPanelRepoPath, number })
+                  setPrDetail({ repoPath: projectRootRepoPath, number })
                 }
                 onOpenSearch={() =>
-                  setPrSearch({ repoPath: projectPanelRepoPath })
+                  setPrSearch({ repoPath: projectRootRepoPath })
                 }
                 refreshKey={prListVersion}
               />
             </BackgroundLoadedTab>
             <BackgroundLoadedTab active={rightTab === "issues"}>
               <IssuesTab
-                key={`issues:${projectPanelRepoPath}`}
-                repoPath={projectPanelRepoPath}
+                key={`issues:${projectRootRepoPath}`}
+                repoPath={projectRootRepoPath}
               />
             </BackgroundLoadedTab>
             <BackgroundLoadedTab active={rightTab === "actions"}>
               <ActionsTab
-                key={`actions:${projectPanelRepoPath}`}
-                repoPath={projectPanelRepoPath}
+                key={`actions:${projectRootRepoPath}`}
+                repoPath={projectRootRepoPath}
               />
             </BackgroundLoadedTab>
           </>
@@ -559,7 +577,7 @@ export function RightPanel() {
         subtitle={expanded?.subtitle}
         headerActions={expanded?.headerActions}
         body={expanded?.body}
-        cwd={projectPanelRepoPath ?? undefined}
+        cwd={codePanelRepoPath ?? undefined}
         onClose={() => setExpanded(null)}
       />
       <PullRequestSearchModal
@@ -573,7 +591,7 @@ export function RightPanel() {
       />
       <PullRequestDetailModal
         open={prDetail}
-        cwd={projectPanelRepoPath ?? undefined}
+        cwd={projectRootRepoPath ?? undefined}
         onClose={() => setPrDetail(null)}
         onMutated={() => setPrListVersion((v) => v + 1)}
       />

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -407,6 +407,156 @@ test.describe("right panel: tab switching", () => {
     // Regression: A's page-1 marker must never appear in B's panel.
     await expect(page.getByText(/leak-marker-AAA/)).toHaveCount(0);
   });
+
+  test("same-project worktree pane focus keeps GitHub tabs mounted", async ({
+    page,
+    tauri,
+  }) => {
+    const repoPath = "/tmp/demo";
+    const worktreeA = "/tmp/demo/.acorn/worktrees/alpha";
+    const worktreeB = "/tmp/demo/.acorn/worktrees/beta";
+
+    await tauri.respond("list_projects", [
+      {
+        repo_path: repoPath,
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-alpha",
+        name: "alpha",
+        repo_path: repoPath,
+        worktree_path: worktreeA,
+        branch: "alpha",
+        isolated: true,
+        in_worktree: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+      {
+        id: "s-beta",
+        name: "beta",
+        repo_path: repoPath,
+        worktree_path: worktreeB,
+        branch: "beta",
+        isolated: true,
+        in_worktree: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_repo_root", (args) => {
+      const sessionId = (args as { sessionId?: string }).sessionId;
+      if (sessionId === "s-alpha") return "/tmp/demo/.acorn/worktrees/alpha/";
+      if (sessionId === "s-beta") return "/tmp/demo/.acorn/worktrees/beta/";
+      return null;
+    });
+    await tauri.handle("list_pull_requests", (args) => {
+      const w = window as unknown as { __prRepoPaths?: string[] };
+      w.__prRepoPaths = w.__prRepoPaths ?? [];
+      w.__prRepoPaths.push((args as { repoPath: string }).repoPath);
+      return { kind: "ok", items: [], account: null };
+    });
+    await tauri.handle("list_issues", (args) => {
+      const w = window as unknown as { __issueRepoPaths?: string[] };
+      w.__issueRepoPaths = w.__issueRepoPaths ?? [];
+      w.__issueRepoPaths.push((args as { repoPath: string }).repoPath);
+      return { kind: "ok", items: [], account: null };
+    });
+    await tauri.handle("list_workflow_runs", (args) => {
+      const w = window as unknown as { __workflowRepoPaths?: string[] };
+      w.__workflowRepoPaths = w.__workflowRepoPaths ?? [];
+      w.__workflowRepoPaths.push((args as { repoPath: string }).repoPath);
+      return { kind: "ok", items: [], account: null };
+    });
+
+    await page.goto("/");
+    await page
+      .locator('[data-panel-id="sidebar"]')
+      .getByRole("button", { name: /^alpha worktree alpha · Idle$/ })
+      .click();
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await expect(page.getByText(/No open pull requests/i)).toBeVisible();
+
+    const indicator = page.locator("[data-active-pane-indicator]");
+    const alphaPaneId = await indicator.getAttribute(
+      "data-active-pane-indicator",
+    );
+    expect(alphaPaneId).not.toBeNull();
+
+    await pressHotkey(page, { mod: true, key: "d" });
+    await page
+      .locator('[data-panel-id="sidebar"]')
+      .getByRole("button", { name: /^beta worktree beta · Idle$/ })
+      .click();
+    await expect(page.locator("[data-pane-body]")).toHaveCount(2);
+    await expect(page.getByText(/No open pull requests/i)).toBeVisible();
+    await page.getByRole("button", { name: "Closed" }).click();
+    await expect(page.getByText(/No closed pull requests/i)).toBeVisible();
+
+    // Let initial PR/Issues/Actions effects and background prefetch settle,
+    // then prove same-project pane focus does not remount GitHub tabs.
+    await page.waitForTimeout(1_500);
+    const initialCalls = await page.evaluate(() => {
+      const w = window as unknown as {
+        __prRepoPaths?: string[];
+        __issueRepoPaths?: string[];
+        __workflowRepoPaths?: string[];
+      };
+      return [
+        ...(w.__prRepoPaths ?? []),
+        ...(w.__issueRepoPaths ?? []),
+        ...(w.__workflowRepoPaths ?? []),
+      ];
+    });
+    const unexpectedInitialPaths = initialCalls.filter(
+      (path) => path !== repoPath,
+    );
+    expect(initialCalls).toContain(repoPath);
+    expect(unexpectedInitialPaths).toEqual([]);
+
+    await page.evaluate(() => {
+      const w = window as unknown as {
+        __prRepoPaths?: string[];
+        __issueRepoPaths?: string[];
+        __workflowRepoPaths?: string[];
+      };
+      w.__prRepoPaths = [];
+      w.__issueRepoPaths = [];
+      w.__workflowRepoPaths = [];
+    });
+
+    await page
+      .locator(`[data-pane-body="${alphaPaneId}"]`)
+      .click({ position: { x: 12, y: 12 } });
+    await expect(page.getByText(/No closed pull requests/i)).toBeVisible();
+    await page.waitForTimeout(300);
+
+    const calls = await page.evaluate(() => {
+      const w = window as unknown as {
+        __prRepoPaths?: string[];
+        __issueRepoPaths?: string[];
+        __workflowRepoPaths?: string[];
+      };
+      return {
+        prs: w.__prRepoPaths ?? [],
+        issues: w.__issueRepoPaths ?? [],
+        workflows: w.__workflowRepoPaths ?? [],
+      };
+    });
+    expect(
+      [...calls.prs, ...calls.issues, ...calls.workflows].filter(
+        (path) => path !== repoPath,
+      ),
+    ).toEqual([]);
+  });
 });
 
 test.describe("right panel: groups", () => {


### PR DESCRIPTION
## Summary
This fixes right-panel reloads when switching panes inside the same project by separating worktree-scoped code tabs from project-scoped GitHub/history tabs.

1. **Split panel repo scope** — keep Files/Staged/Commits tied to the active live worktree, while PRs/Issues/Actions/History stay keyed to the project root.
2. **Preserve GitHub tab mounts** — use the stable project root for GitHub status probes, tab keys, PR/issue/action fetches, and PR modal cwd.
3. **Add pane-focus regression coverage** — verify same-project worktree pane focus does not remount GitHub tabs or refetch against worktree paths.

## Expected impact
| Flow | Before | After |
| --- | --- | --- |
| Same-project pane focus between worktrees | GitHub right-panel tabs could feel like they reloaded and lose tab-local state | GitHub tabs remain rooted to the project and stay mounted |
| Files/Staged/Commits in a worktree session | Followed the active worktree | Still follows the active worktree |
| PRs/Issues/Actions requests | Could use the active worktree path | Use the project root path |

## Design notes
- `RightPanel` now derives two paths: `codePanelRepoPath` for code/git working tree surfaces and `projectRootRepoPath` for project-level GitHub/history surfaces.
- Git repository invalidation still covers both paths, but file/status invalidation remains tied to the active worktree.
- The E2E test captures `list_pull_requests`, `list_issues`, and `list_workflow_runs` invoke arguments to prevent regressions across all GitHub tabs.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/components/RightPanel.test.tsx` — 17 passed
- [x] `PLAYWRIGHT_PORT=1464 pnpm exec playwright test tests/e2e/right-panel.spec.ts -g "same-project worktree pane focus"` — 1 passed
- [x] `PLAYWRIGHT_PORT=1465 pnpm exec playwright test tests/e2e/right-panel.spec.ts` — 19 passed
- [x] `git diff --check` passes

## Notes
- #462 is already merged into `main`; this PR applies the pane-focus fix on top of that latest Issues-tab implementation.