### PR TITLE
feat(chat): native chat streaming with smoothed updates

### DIFF
--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -1,6 +1,8 @@
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
+use std::str;
+use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -153,6 +155,29 @@ pub fn run_resolved_oneshot_in_dir_cancellable(
     )
 }
 
+pub fn run_resolved_streaming_in_dir_cancellable<F>(
+    resolved: &ResolvedAiCommand,
+    prompt: &str,
+    settings_label: &str,
+    cwd: Option<&Path>,
+    cancellation: Option<ChatCancellation>,
+    on_stdout_chunk: F,
+) -> AppResult<String>
+where
+    F: FnMut(&str),
+{
+    run_streaming_in_dir_cancellable_with_transport(
+        resolved.command,
+        &resolved.args,
+        prompt,
+        settings_label,
+        cwd,
+        cancellation,
+        resolved.prompt_transport,
+        on_stdout_chunk,
+    )
+}
+
 fn run_oneshot_in_dir_cancellable_with_transport(
     command: &str,
     args: &[String],
@@ -206,6 +231,78 @@ fn run_oneshot_in_dir_cancellable_with_transport(
     }
 
     let output = wait_with_timeout(command, child, ONESHOT_TIMEOUT, cancellation)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("{command} exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn run_streaming_in_dir_cancellable_with_transport<F>(
+    command: &str,
+    args: &[String],
+    prompt: &str,
+    settings_label: &str,
+    cwd: Option<&Path>,
+    cancellation: Option<ChatCancellation>,
+    prompt_transport: PromptTransport,
+    mut on_stdout_chunk: F,
+) -> AppResult<String>
+where
+    F: FnMut(&str),
+{
+    let resolved = cli_resolver::resolve(command).map_err(|_| {
+        AppError::Other(format!(
+            "`{command}` not found. Install the configured AI CLI or change the provider in {settings_label}."
+        ))
+    })?;
+    let mut command_args = args.to_vec();
+    if prompt_transport == PromptTransport::Argument {
+        command_args.push(prompt.to_string());
+    }
+    let mut command_builder = Command::new(&resolved);
+    crate::shell_env::apply_to_command(&mut command_builder);
+    command_builder
+        .args(&command_args)
+        .stdin(match prompt_transport {
+            PromptTransport::Stdin => Stdio::piped(),
+            PromptTransport::Argument => Stdio::null(),
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(cwd) = cwd {
+        command_builder.current_dir(cwd);
+    }
+    let mut child = command_builder.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            cli_resolver::invalidate(command);
+            AppError::Other(format!(
+                "`{command}` not found. Install the configured AI CLI or change the provider in {settings_label}."
+            ))
+        } else {
+            AppError::Other(format!("failed to invoke {command}: {e}"))
+        }
+    })?;
+
+    if prompt_transport == PromptTransport::Stdin {
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(prompt.as_bytes())
+                .map_err(|e| AppError::Other(format!("failed to write to {command}: {e}")))?;
+        } else {
+            return Err(AppError::Other(format!("{command} stdin missing")));
+        }
+    }
+
+    let output =
+        wait_with_timeout_streaming(command, child, None, cancellation, &mut on_stdout_chunk)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -300,6 +397,236 @@ fn wait_with_timeout(
         .join()
         .map_err(|_| AppError::Other(format!("{command} stdout reader failed")))?
         .map_err(|e| AppError::Other(format!("failed reading {command} stdout: {e}")))?;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| AppError::Other(format!("{command} stderr reader failed")))?
+        .map_err(|e| AppError::Other(format!("failed reading {command} stderr: {e}")))?;
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+struct Utf8ChunkDecoder {
+    pending: Vec<u8>,
+}
+
+impl Utf8ChunkDecoder {
+    fn new() -> Self {
+        Self {
+            pending: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, bytes: &[u8]) -> String {
+        self.pending.extend_from_slice(bytes);
+        let mut out = String::new();
+        loop {
+            match str::from_utf8(&self.pending) {
+                Ok(valid) => {
+                    out.push_str(valid);
+                    self.pending.clear();
+                    break;
+                }
+                Err(err) => {
+                    let valid_up_to = err.valid_up_to();
+                    if valid_up_to > 0 {
+                        let valid = str::from_utf8(&self.pending[..valid_up_to])
+                            .expect("valid_up_to must end at a utf8 boundary");
+                        out.push_str(valid);
+                        self.pending.drain(..valid_up_to);
+                    }
+                    if let Some(error_len) = err.error_len() {
+                        out.push_str(&String::from_utf8_lossy(&self.pending[..error_len]));
+                        self.pending.drain(..error_len);
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    fn finish(&mut self) -> String {
+        if self.pending.is_empty() {
+            return String::new();
+        }
+        let trailing = String::from_utf8_lossy(&self.pending).to_string();
+        self.pending.clear();
+        trailing
+    }
+}
+
+fn process_stdout_chunk<F>(
+    command: &str,
+    chunk: io::Result<Vec<u8>>,
+    stdout: &mut Vec<u8>,
+    decoder: &mut Utf8ChunkDecoder,
+    on_stdout_chunk: &mut F,
+) -> AppResult<()>
+where
+    F: FnMut(&str),
+{
+    let chunk =
+        chunk.map_err(|e| AppError::Other(format!("failed reading {command} stdout: {e}")))?;
+    if chunk.is_empty() {
+        return Ok(());
+    }
+    stdout.extend_from_slice(&chunk);
+    let text = decoder.push(&chunk);
+    if !text.is_empty() {
+        on_stdout_chunk(&text);
+    }
+    Ok(())
+}
+
+fn drain_stdout_chunks<F>(
+    command: &str,
+    stdout_rx: &Receiver<io::Result<Vec<u8>>>,
+    stdout: &mut Vec<u8>,
+    decoder: &mut Utf8ChunkDecoder,
+    on_stdout_chunk: &mut F,
+) -> AppResult<()>
+where
+    F: FnMut(&str),
+{
+    loop {
+        match stdout_rx.try_recv() {
+            Ok(chunk) => process_stdout_chunk(command, chunk, stdout, decoder, on_stdout_chunk)?,
+            Err(TryRecvError::Empty | TryRecvError::Disconnected) => return Ok(()),
+        }
+    }
+}
+
+fn wait_with_timeout_streaming<F>(
+    command: &str,
+    mut child: std::process::Child,
+    timeout: Option<Duration>,
+    cancellation: Option<ChatCancellation>,
+    on_stdout_chunk: &mut F,
+) -> AppResult<Output>
+where
+    F: FnMut(&str),
+{
+    let stdout_pipe = child
+        .stdout
+        .take()
+        .ok_or_else(|| AppError::Other(format!("{command} stdout missing")))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| AppError::Other(format!("{command} stderr missing")))?;
+
+    let (stdout_tx, stdout_rx) = mpsc::channel();
+    let stdout_reader = thread::spawn(move || {
+        let mut reader = stdout_pipe;
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if stdout_tx.send(Ok(buf[..n].to_vec())).is_err() {
+                        break;
+                    }
+                }
+                Err(err) => {
+                    let _ = stdout_tx.send(Err(err));
+                    break;
+                }
+            }
+        }
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut reader = stderr;
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf).map(|_| buf)
+    });
+
+    let mut stdout = Vec::new();
+    let mut decoder = Utf8ChunkDecoder::new();
+    let started = Instant::now();
+    let status = if let Some(cancellation) = cancellation {
+        cancellation.set_child(child);
+        let status = loop {
+            drain_stdout_chunks(
+                command,
+                &stdout_rx,
+                &mut stdout,
+                &mut decoder,
+                on_stdout_chunk,
+            )?;
+            if cancellation.is_cancelled() {
+                cancellation.kill_and_wait();
+                let _ = stdout_reader.join();
+                let _ = stderr_reader.join();
+                cancellation.clear_child();
+                return Err(AppError::Other(format!("{command} cancelled")));
+            }
+            match cancellation.try_wait(command)? {
+                Some(status) => break status,
+                None if timeout.is_some_and(|timeout| started.elapsed() >= timeout) => {
+                    cancellation.kill_and_wait();
+                    let _ = stdout_reader.join();
+                    let _ = stderr_reader.join();
+                    cancellation.clear_child();
+                    let timeout = timeout.expect("timeout checked as some");
+                    return Err(AppError::Other(format!(
+                        "{command} timed out after {} seconds",
+                        timeout.as_secs()
+                    )));
+                }
+                None => thread::sleep(Duration::from_millis(25)),
+            }
+        };
+        cancellation.clear_child();
+        status
+    } else {
+        loop {
+            drain_stdout_chunks(
+                command,
+                &stdout_rx,
+                &mut stdout,
+                &mut decoder,
+                on_stdout_chunk,
+            )?;
+            match child
+                .try_wait()
+                .map_err(|e| AppError::Other(format!("failed waiting for {command}: {e}")))?
+            {
+                Some(status) => break status,
+                None if timeout.is_some_and(|timeout| started.elapsed() >= timeout) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = stdout_reader.join();
+                    let _ = stderr_reader.join();
+                    let timeout = timeout.expect("timeout checked as some");
+                    return Err(AppError::Other(format!(
+                        "{command} timed out after {} seconds",
+                        timeout.as_secs()
+                    )));
+                }
+                None => thread::sleep(Duration::from_millis(25)),
+            }
+        }
+    };
+
+    stdout_reader
+        .join()
+        .map_err(|_| AppError::Other(format!("{command} stdout reader failed")))?;
+    drain_stdout_chunks(
+        command,
+        &stdout_rx,
+        &mut stdout,
+        &mut decoder,
+        on_stdout_chunk,
+    )?;
+    let trailing = decoder.finish();
+    if !trailing.is_empty() {
+        on_stdout_chunk(&trailing);
+    }
     let stderr = stderr_reader
         .join()
         .map_err(|_| AppError::Other(format!("{command} stderr reader failed")))?
@@ -435,5 +762,29 @@ mod tests {
         .unwrap();
 
         assert_eq!(output, "arg= stdin=hello");
+    }
+
+    #[test]
+    fn streams_stdout_chunks_before_returning() {
+        let args = vec![
+            "-c".to_string(),
+            "printf one; sleep 0.05; printf two".to_string(),
+        ];
+        let mut chunks = Vec::new();
+        let output = run_streaming_in_dir_cancellable_with_transport(
+            "/bin/sh",
+            &args,
+            "",
+            "test settings",
+            None,
+            None,
+            PromptTransport::Stdin,
+            |chunk| chunks.push(chunk.to_string()),
+        )
+        .unwrap();
+
+        assert_eq!(output, "onetwo");
+        assert_eq!(chunks.concat(), "onetwo");
+        assert!(!chunks.is_empty());
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -451,6 +451,278 @@ pub(crate) struct ProviderResponse {
 pub(crate) trait ChatProviderAdapter {
     fn capabilities(&self) -> ChatProviderCapabilities;
     fn send_message(&self, input: ChatProviderInput) -> AppResult<ProviderResponse>;
+    fn send_message_streaming(
+        &self,
+        input: ChatProviderInput,
+        on_chunk: &mut dyn FnMut(&str),
+    ) -> AppResult<ProviderResponse> {
+        let _ = on_chunk;
+        self.send_message(input)
+    }
+}
+
+fn ignore_chat_streaming_chunk(_: &str) {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChatCliOutputMode {
+    Text,
+    ClaudeStreamJson,
+    CodexJson,
+}
+
+struct ChatCliOutputParser {
+    mode: ChatCliOutputMode,
+    pending_line: String,
+    emitted_text: String,
+    final_text: Option<String>,
+}
+
+impl ChatCliOutputParser {
+    fn new(mode: ChatCliOutputMode) -> Self {
+        Self {
+            mode,
+            pending_line: String::new(),
+            emitted_text: String::new(),
+            final_text: None,
+        }
+    }
+
+    fn push_chunk(&mut self, chunk: &str, on_chunk: &mut dyn FnMut(&str)) {
+        match self.mode {
+            ChatCliOutputMode::Text => self.emit_delta(chunk, on_chunk),
+            ChatCliOutputMode::ClaudeStreamJson | ChatCliOutputMode::CodexJson => {
+                self.pending_line.push_str(chunk);
+                while let Some(newline) = self.pending_line.find('\n') {
+                    let line = self.pending_line[..newline].to_string();
+                    self.pending_line.drain(..=newline);
+                    self.process_json_line(&line, on_chunk);
+                }
+            }
+        }
+    }
+
+    fn finish(&mut self, raw: &str) -> String {
+        if self.mode == ChatCliOutputMode::Text {
+            return raw.trim().to_string();
+        }
+        if !self.pending_line.trim().is_empty() {
+            let line = std::mem::take(&mut self.pending_line);
+            let mut ignore_chunk = ignore_chat_streaming_chunk;
+            self.process_json_line(&line, &mut ignore_chunk);
+        }
+        self.final_text
+            .as_deref()
+            .unwrap_or(self.emitted_text.as_str())
+            .trim()
+            .to_string()
+    }
+
+    fn process_json_line(&mut self, line: &str, on_chunk: &mut dyn FnMut(&str)) {
+        let line = line.trim();
+        if line.is_empty() {
+            return;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            return;
+        };
+        let Some(event) = extract_chat_stream_text(self.mode, &value) else {
+            return;
+        };
+        if event.is_final {
+            self.final_text = Some(event.text.clone());
+        }
+        self.emit_text_candidate(&event, on_chunk);
+    }
+
+    fn emit_text_candidate(
+        &mut self,
+        event: &ChatStreamTextEvent,
+        on_chunk: &mut dyn FnMut(&str),
+    ) {
+        let text = event.text.as_str();
+        if text.is_empty() {
+            return;
+        }
+        if let Some(delta) = text.strip_prefix(&self.emitted_text) {
+            self.emit_delta(delta, on_chunk);
+        } else if event.is_final {
+            // Persist normalized final text from finish() without briefly
+            // appending a divergent duplicate to the live stream.
+        } else if event.boundary != ChatStreamTextBoundary::Delta {
+            let separator = message_boundary_separator(&self.emitted_text, text);
+            if !separator.is_empty() {
+                self.emit_delta(separator, on_chunk);
+            }
+            self.emit_delta(text, on_chunk);
+        } else {
+            self.emit_delta(text, on_chunk);
+        }
+    }
+
+    fn emit_delta(&mut self, delta: &str, on_chunk: &mut dyn FnMut(&str)) {
+        if delta.is_empty() {
+            return;
+        }
+        self.emitted_text.push_str(delta);
+        on_chunk(delta);
+    }
+}
+
+struct ChatStreamTextEvent {
+    text: String,
+    boundary: ChatStreamTextBoundary,
+    is_final: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChatStreamTextBoundary {
+    Delta,
+    Snapshot,
+    Message,
+}
+
+fn message_boundary_separator(previous: &str, next: &str) -> &'static str {
+    if previous.is_empty()
+        || previous.ends_with('\n')
+        || next.starts_with('\n')
+        || previous.ends_with(' ')
+        || next.starts_with(' ')
+    {
+        ""
+    } else {
+        "\n\n"
+    }
+}
+
+fn extract_chat_stream_text(
+    mode: ChatCliOutputMode,
+    value: &serde_json::Value,
+) -> Option<ChatStreamTextEvent> {
+    match mode {
+        ChatCliOutputMode::Text => None,
+        ChatCliOutputMode::ClaudeStreamJson => extract_claude_stream_text(value),
+        ChatCliOutputMode::CodexJson => extract_codex_stream_text(value),
+    }
+}
+
+fn extract_claude_stream_text(value: &serde_json::Value) -> Option<ChatStreamTextEvent> {
+    let event_type = value.get("type").and_then(serde_json::Value::as_str);
+    match event_type {
+        Some("assistant") => {
+            assistant_message_text(value.get("message")?).map(|text| ChatStreamTextEvent {
+                text,
+                boundary: ChatStreamTextBoundary::Snapshot,
+                is_final: false,
+            })
+        }
+        Some("result") => string_field(value, &["result"])
+            .or_else(|| string_field(value, &["message"]))
+            .map(|text| ChatStreamTextEvent {
+                text,
+                boundary: ChatStreamTextBoundary::Snapshot,
+                is_final: true,
+            }),
+        Some("content_block_delta") | Some("text_delta") | Some("partial") => {
+            json_delta_text(value).map(|text| ChatStreamTextEvent {
+                text,
+                boundary: ChatStreamTextBoundary::Delta,
+                is_final: false,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn extract_codex_stream_text(value: &serde_json::Value) -> Option<ChatStreamTextEvent> {
+    if let Some(event) = extract_codex_event_text(value) {
+        return Some(event);
+    }
+    value
+        .get("msg")
+        .and_then(extract_codex_event_text)
+        .or_else(|| value.get("payload").and_then(extract_codex_event_text))
+}
+
+fn extract_codex_event_text(value: &serde_json::Value) -> Option<ChatStreamTextEvent> {
+    let event_type = value.get("type").and_then(serde_json::Value::as_str);
+    match event_type {
+        Some("agent_message_content_delta") => {
+            json_delta_text(value).map(|text| ChatStreamTextEvent {
+                text,
+                boundary: ChatStreamTextBoundary::Delta,
+                is_final: false,
+            })
+        }
+        Some("agent_message") => string_field(value, &["message"])
+            .or_else(|| string_field(value, &["text"]))
+            .or_else(|| assistant_message_text(value))
+            .map(|text| ChatStreamTextEvent {
+                text,
+                boundary: ChatStreamTextBoundary::Message,
+                is_final: false,
+            }),
+        Some("response_item") | Some("raw_response_item") => value
+            .get("payload")
+            .and_then(assistant_message_text)
+            .map(|text| ChatStreamTextEvent {
+                text,
+                boundary: ChatStreamTextBoundary::Message,
+                is_final: false,
+            }),
+        Some("turn_complete") | Some("task_complete") => {
+            string_field(value, &["last_agent_message"]).map(|text| ChatStreamTextEvent {
+                text,
+                boundary: ChatStreamTextBoundary::Snapshot,
+                is_final: true,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn json_delta_text(value: &serde_json::Value) -> Option<String> {
+    string_field(value, &["delta"])
+        .or_else(|| string_field(value, &["delta", "text"]))
+        .or_else(|| string_field(value, &["delta", "content"]))
+        .or_else(|| string_field(value, &["text"]))
+        .or_else(|| string_field(value, &["content"]))
+}
+
+fn assistant_message_text(value: &serde_json::Value) -> Option<String> {
+    if value
+        .get("role")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|role| role != "assistant")
+    {
+        return None;
+    }
+    if let Some(text) = value.get("content").and_then(serde_json::Value::as_str) {
+        return Some(text.to_string());
+    }
+    let content = value.get("content")?.as_array()?;
+    let text = content
+        .iter()
+        .filter_map(chat_content_part_text)
+        .collect::<String>();
+    if text.is_empty() { None } else { Some(text) }
+}
+
+fn chat_content_part_text(value: &serde_json::Value) -> Option<&str> {
+    let part_type = value.get("type").and_then(serde_json::Value::as_str);
+    match part_type {
+        Some("text") | Some("output_text") | Some("message") | None => {
+            value.get("text").and_then(serde_json::Value::as_str)
+        }
+        _ => None,
+    }
+}
+
+fn string_field(value: &serde_json::Value, path: &[&str]) -> Option<String> {
+    let mut cursor = value;
+    for key in path {
+        cursor = cursor.get(*key)?;
+    }
+    cursor.as_str().map(str::to_string)
 }
 
 struct CliChatProviderAdapter {
@@ -468,28 +740,40 @@ impl ChatProviderAdapter for CliChatProviderAdapter {
                     | crate::ai::AiProvider::Codex
                     | crate::ai::AiProvider::Antigravity
             ),
-            streaming: false,
+            streaming: true,
             attachments: false,
         }
     }
 
     fn send_message(&self, input: ChatProviderInput) -> AppResult<ProviderResponse> {
+        let mut ignore_chunk: fn(&str) = ignore_chat_streaming_chunk;
+        self.send_message_streaming(input, &mut ignore_chunk)
+    }
+
+    fn send_message_streaming(
+        &self,
+        input: ChatProviderInput,
+        on_chunk: &mut dyn FnMut(&str),
+    ) -> AppResult<ProviderResponse> {
         let invocation = resolve_chat_cli_invocation(&self.ai, &input)?;
         let started_at = SystemTime::now();
-        let raw = crate::ai::run_resolved_oneshot_in_dir_cancellable(
+        let mut output_parser = ChatCliOutputParser::new(invocation.output_mode);
+        let raw = crate::ai::run_resolved_streaming_in_dir_cancellable(
             &invocation.cli,
             &invocation.prompt,
             "Settings → Agents",
             Some(&self.cwd),
             self.cancellation.clone(),
+            |chunk| output_parser.push_chunk(chunk, on_chunk),
         )?;
+        let content = output_parser.finish(&raw);
         let discovered_thread_id = invocation.transcript_discovery.and_then(|kind| {
             acorn_transcript::find_completed_agent_run(&self.cwd, kind, started_at)
         });
         let native_thread_id = invocation.native_thread_id.or(discovered_thread_id);
         let resume_token = invocation.resume_token.or_else(|| native_thread_id.clone());
         Ok(ProviderResponse {
-            content: raw.trim().to_string(),
+            content,
             native_thread_id,
             resume_token,
             last_response_id: None,
@@ -505,6 +789,7 @@ struct ChatCliInvocation {
     native_thread_id: Option<String>,
     resume_token: Option<String>,
     transcript_discovery: Option<acorn_transcript::AgentKind>,
+    output_mode: ChatCliOutputMode,
 }
 
 fn provider_thread_resume_cursor(thread: Option<&persistence::ProviderThread>) -> Option<String> {
@@ -540,7 +825,9 @@ fn resolve_chat_cli_invocation(
             let mut args = vec![
                 "-p".to_string(),
                 "--output-format".to_string(),
-                "text".to_string(),
+                "stream-json".to_string(),
+                "--verbose".to_string(),
+                "--include-partial-messages".to_string(),
             ];
             let thread_id = match cursor {
                 Some(cursor) => {
@@ -565,6 +852,7 @@ fn resolve_chat_cli_invocation(
                 native_thread_id: Some(thread_id.clone()),
                 resume_token: Some(thread_id),
                 transcript_discovery: None,
+                output_mode: ChatCliOutputMode::ClaudeStreamJson,
             })
         }
         crate::ai::AiProvider::Codex => {
@@ -575,6 +863,7 @@ fn resolve_chat_cli_invocation(
                         args: vec![
                             "exec".to_string(),
                             "--skip-git-repo-check".to_string(),
+                            "--json".to_string(),
                             "resume".to_string(),
                             cursor.clone(),
                             "-".to_string(),
@@ -585,15 +874,24 @@ fn resolve_chat_cli_invocation(
                     native_thread_id: Some(cursor.clone()),
                     resume_token: Some(cursor),
                     transcript_discovery: None,
+                    output_mode: ChatCliOutputMode::CodexJson,
                 })
             } else {
-                let resolved = ai.resolve()?;
                 Ok(ChatCliInvocation {
-                    cli: resolved,
+                    cli: crate::ai::ResolvedAiCommand {
+                        command: "codex",
+                        args: vec![
+                            "exec".to_string(),
+                            "--skip-git-repo-check".to_string(),
+                            "--json".to_string(),
+                        ],
+                        prompt_transport: crate::ai::PromptTransport::Stdin,
+                    },
                     prompt,
                     native_thread_id: None,
                     resume_token: None,
                     transcript_discovery: Some(acorn_transcript::AgentKind::Codex),
+                    output_mode: ChatCliOutputMode::CodexJson,
                 })
             }
         }
@@ -613,6 +911,7 @@ fn resolve_chat_cli_invocation(
                     native_thread_id: Some(cursor.clone()),
                     resume_token: Some(cursor),
                     transcript_discovery: None,
+                    output_mode: ChatCliOutputMode::Text,
                 })
             } else {
                 let resolved = ai.resolve()?;
@@ -622,6 +921,7 @@ fn resolve_chat_cli_invocation(
                     native_thread_id: None,
                     resume_token: None,
                     transcript_discovery: Some(acorn_transcript::AgentKind::Antigravity),
+                    output_mode: ChatCliOutputMode::Text,
                 })
             }
         }
@@ -633,6 +933,7 @@ fn resolve_chat_cli_invocation(
                 native_thread_id: None,
                 resume_token: None,
                 transcript_discovery: None,
+                output_mode: ChatCliOutputMode::Text,
             })
         }
     }
@@ -1067,6 +1368,38 @@ fn finish_chat_turn(
     started.state.session.updated_at = completed_at;
     started.state.updated_at = completed_at;
     started.state
+}
+
+fn append_streaming_chat_chunk(
+    chat_state: &mut persistence::ChatSessionState,
+    assistant_message_id: &str,
+    chunk: &str,
+) -> bool {
+    if chunk.is_empty() {
+        return false;
+    }
+    let Some(message) = chat_state
+        .messages
+        .iter_mut()
+        .find(|message| message.id == assistant_message_id)
+    else {
+        return false;
+    };
+    if message.role != persistence::ChatRole::Assistant {
+        return false;
+    }
+    message.content.push_str(chunk);
+    if matches!(
+        message.status,
+        Some(persistence::ChatMessageStatus::Pending)
+            | Some(persistence::ChatMessageStatus::Streaming)
+    ) {
+        message.status = Some(persistence::ChatMessageStatus::Streaming);
+    }
+    let now = chrono::Utc::now();
+    chat_state.session.updated_at = now;
+    chat_state.updated_at = now;
+    true
 }
 
 fn chat_turn_finish_from_result(
@@ -2436,7 +2769,18 @@ fn send_chat_message_from_state_inner<R: Runtime>(
     persist(state);
     emit_chat_session_state_changed(app, &started.state);
 
-    let provider_result = adapter.send_message(started.input.clone());
+    let provider_input = started.input.clone();
+    let assistant_message_id = started.assistant_message_id.clone();
+    let provider_result = if adapter.capabilities().streaming {
+        let mut on_chunk = |chunk: &str| {
+            if append_streaming_chat_chunk(&mut started.state, &assistant_message_id, chunk) {
+                emit_chat_session_state_changed(app, &started.state);
+            }
+        };
+        adapter.send_message_streaming(provider_input, &mut on_chunk)
+    } else {
+        adapter.send_message(provider_input)
+    };
     let was_cancelled = cancellation.is_cancelled();
     state.chat_runs.finish(&session.id, &started.turn_id);
     let final_session_status = chat_session_status_for_message_status(if was_cancelled {
@@ -5292,6 +5636,171 @@ mod tests {
     }
 
     #[test]
+    fn streaming_chunk_appends_to_pending_assistant_message() {
+        let now = chrono::Utc::now();
+        let mut state = chat_state_for_runtime(vec![
+            chat_message("u1", crate::persistence::ChatRole::User, "hello"),
+            crate::persistence::ChatMessage {
+                id: "a1".to_string(),
+                session_id: None,
+                turn_id: Some("turn-1".to_string()),
+                role: crate::persistence::ChatRole::Assistant,
+                content: String::new(),
+                created_at: now,
+                status: Some(crate::persistence::ChatMessageStatus::Pending),
+                metadata: None,
+            },
+        ]);
+
+        assert!(super::append_streaming_chat_chunk(&mut state, "a1", "hel"));
+        assert!(super::append_streaming_chat_chunk(&mut state, "a1", "lo"));
+
+        let assistant = state.messages.last().unwrap();
+        assert_eq!(assistant.content, "hello");
+        assert_eq!(
+            assistant.status,
+            Some(crate::persistence::ChatMessageStatus::Streaming)
+        );
+        assert!(super::chat_state_has_running_message(&state));
+    }
+
+    #[test]
+    fn chat_stream_parser_extracts_claude_partial_jsonl_without_duplicates() {
+        let mut parser =
+            super::ChatCliOutputParser::new(super::ChatCliOutputMode::ClaudeStreamJson);
+        let mut chunks = Vec::new();
+
+        {
+            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            parser.push_chunk(
+                r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hel"}]}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+            parser.push_chunk(
+                r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+            parser.push_chunk(r#"{"type":"result","result":"hello"}"#, &mut on_chunk);
+            parser.push_chunk("\n", &mut on_chunk);
+        }
+
+        assert_eq!(chunks, vec!["hel", "lo"]);
+        assert_eq!(parser.finish(""), "hello");
+    }
+
+    #[test]
+    fn chat_stream_parser_separates_non_prefix_claude_assistant_messages() {
+        let mut parser =
+            super::ChatCliOutputParser::new(super::ChatCliOutputMode::ClaudeStreamJson);
+        let mut chunks = Vec::new();
+
+        {
+            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            parser.push_chunk(
+                r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"핵심 파일 확인."}]}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+            parser.push_chunk(
+                r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"경로 문제. 절대경로로 다시."}]}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+        }
+
+        assert_eq!(
+            chunks.concat(),
+            "핵심 파일 확인.\n\n경로 문제. 절대경로로 다시."
+        );
+        assert_eq!(
+            parser.finish(""),
+            "핵심 파일 확인.\n\n경로 문제. 절대경로로 다시."
+        );
+    }
+
+    #[test]
+    fn chat_stream_parser_extracts_codex_delta_jsonl_and_final_message() {
+        let mut parser = super::ChatCliOutputParser::new(super::ChatCliOutputMode::CodexJson);
+        let mut chunks = Vec::new();
+
+        {
+            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            parser.push_chunk(
+                r#"{"msg":{"type":"agent_message_content_delta","delta":"hel"}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+            parser.push_chunk(
+                r#"{"msg":{"type":"agent_message_content_delta","delta":"lo"}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+            parser.push_chunk(
+                r#"{"msg":{"type":"turn_complete","last_agent_message":"hello"}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+        }
+
+        assert_eq!(chunks.concat(), "hello");
+        assert_eq!(parser.finish(""), "hello");
+    }
+
+    #[test]
+    fn chat_stream_parser_separates_complete_codex_agent_messages() {
+        let mut parser = super::ChatCliOutputParser::new(super::ChatCliOutputMode::CodexJson);
+        let mut chunks = Vec::new();
+
+        {
+            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            parser.push_chunk(
+                r#"{"msg":{"type":"agent_message","message":"디렉토리 + 타입 정의 핵심 파일 확인."}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+            parser.push_chunk(
+                r#"{"msg":{"type":"agent_message","message":"경로 문제. 절대경로로 다시."}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+        }
+
+        assert_eq!(
+            chunks.concat(),
+            "디렉토리 + 타입 정의 핵심 파일 확인.\n\n경로 문제. 절대경로로 다시."
+        );
+        assert_eq!(
+            parser.finish(""),
+            "디렉토리 + 타입 정의 핵심 파일 확인.\n\n경로 문제. 절대경로로 다시."
+        );
+    }
+
+    #[test]
+    fn chat_stream_parser_extracts_codex_response_item_output_text() {
+        let mut parser = super::ChatCliOutputParser::new(super::ChatCliOutputMode::CodexJson);
+        let mut chunks = Vec::new();
+
+        {
+            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            parser.push_chunk(
+                r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+            parser.push_chunk(
+                r#"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"ignored"}]}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+        }
+
+        assert_eq!(chunks.concat(), "hello");
+        assert_eq!(parser.finish(""), "hello");
+    }
+
+    #[test]
     fn compiled_context_omits_full_transcript_once_over_threshold() {
         let messages = vec![
             chat_message(
@@ -5336,13 +5845,17 @@ mod tests {
         assert!(context.prompt.contains("Earlier summary"));
         assert!(context.prompt.contains("Use adapters"));
         assert!(context.prompt.contains("current question"));
-        assert!(context
-            .included_message_ids
-            .contains(&"current-user".to_string()));
+        assert!(
+            context
+                .included_message_ids
+                .contains(&"current-user".to_string())
+        );
         assert!(!context.prompt.contains("old user content"));
-        assert!(!context
-            .included_message_ids
-            .contains(&"old-user".to_string()));
+        assert!(
+            !context
+                .included_message_ids
+                .contains(&"old-user".to_string())
+        );
     }
 
     #[test]
@@ -5465,6 +5978,10 @@ mod tests {
                 adapter.capabilities().native_thread,
                 "{provider:?} should support provider-native chat continuation"
             );
+            assert!(
+                adapter.capabilities().streaming,
+                "{provider:?} should stream stdout chunks"
+            );
         }
     }
 
@@ -5505,7 +6022,9 @@ mod tests {
             vec![
                 "-p",
                 "--output-format",
-                "text",
+                "stream-json",
+                "--verbose",
+                "--include-partial-messages",
                 "--resume",
                 "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
             ]
@@ -5518,6 +6037,10 @@ mod tests {
         assert_eq!(
             invocation.native_thread_id.as_deref(),
             Some("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        );
+        assert_eq!(
+            invocation.output_mode,
+            super::ChatCliOutputMode::ClaudeStreamJson
         );
     }
 
@@ -5557,13 +6080,26 @@ mod tests {
         .unwrap();
 
         assert_eq!(invocation.cli.command, "claude");
-        assert_eq!(invocation.cli.args[0..3], ["-p", "--output-format", "text"]);
-        assert_eq!(invocation.cli.args[3], "--session-id");
-        let seeded_id = invocation.cli.args[4].as_str();
+        assert_eq!(
+            invocation.cli.args[0..5],
+            [
+                "-p",
+                "--output-format",
+                "stream-json",
+                "--verbose",
+                "--include-partial-messages"
+            ]
+        );
+        assert_eq!(invocation.cli.args[5], "--session-id");
+        let seeded_id = invocation.cli.args[6].as_str();
         Uuid::parse_str(seeded_id).expect("seeded Claude id should be a UUID");
         assert_eq!(invocation.prompt, "compiled first message");
         assert_eq!(invocation.native_thread_id.as_deref(), Some(seeded_id));
         assert_eq!(invocation.resume_token.as_deref(), Some(seeded_id));
+        assert_eq!(
+            invocation.output_mode,
+            super::ChatCliOutputMode::ClaudeStreamJson
+        );
     }
 
     #[test]
@@ -5603,6 +6139,7 @@ mod tests {
             vec![
                 "exec",
                 "--skip-git-repo-check",
+                "--json",
                 "resume",
                 "019e2001-3250-76b0-8410-2e073b38a2c1",
                 "-"
@@ -5613,6 +6150,7 @@ mod tests {
             crate::ai::PromptTransport::Stdin
         );
         assert_eq!(invocation.prompt, "continue codex");
+        assert_eq!(invocation.output_mode, super::ChatCliOutputMode::CodexJson);
     }
 
     #[test]
@@ -5734,22 +6272,28 @@ mod tests {
         let inputs = adapter.inputs.lock().unwrap();
 
         assert!(inputs[0].context.is_some());
-        assert!(inputs[0]
-            .thread
-            .as_ref()
-            .unwrap()
-            .native_thread_id
-            .is_none());
-        assert!(result
-            .final_state
-            .provider_threads
-            .iter()
-            .any(|thread| thread.provider == "codex"));
-        assert!(result
-            .final_state
-            .provider_threads
-            .iter()
-            .any(|thread| thread.provider == "claude"));
+        assert!(
+            inputs[0]
+                .thread
+                .as_ref()
+                .unwrap()
+                .native_thread_id
+                .is_none()
+        );
+        assert!(
+            result
+                .final_state
+                .provider_threads
+                .iter()
+                .any(|thread| thread.provider == "codex")
+        );
+        assert!(
+            result
+                .final_state
+                .provider_threads
+                .iter()
+                .any(|thread| thread.provider == "claude")
+        );
         assert_eq!(
             result.final_state.context_snapshots[0].mode,
             crate::persistence::ContextSnapshotMode::CompiledContext

--- a/src/components/ChatPane.test.tsx
+++ b/src/components/ChatPane.test.tsx
@@ -123,6 +123,12 @@ async function nextAnimationFrame() {
   });
 }
 
+async function advanceAnimationFrames(count: number) {
+  for (let i = 0; i < count; i += 1) {
+    await nextAnimationFrame();
+  }
+}
+
 function mockScrollRegion(
   element: HTMLElement,
   {
@@ -779,6 +785,10 @@ describe("ChatPane", () => {
     await settle();
 
     expect(container.textContent).toContain("Running Claude");
+    const runningLabel = container.querySelector("[data-chat-running-label]");
+    expect(runningLabel?.textContent).toContain("Running Claude");
+    expect(runningLabel?.className).toContain("animate-pulse");
+    expect(container.querySelector("[data-chat-streaming-spinner]")).toBeNull();
 
     await act(async () => {
       emitChatState(
@@ -804,6 +814,157 @@ describe("ChatPane", () => {
     });
 
     expect(container.textContent).toContain("response after tab switch");
+  });
+
+  it("renders streaming assistant chunks from chat state updates", async () => {
+    mocks.loadChatSessionState.mockResolvedValueOnce(
+      chatState(
+        "s1",
+        [
+          {
+            id: "u1",
+            role: "user",
+            content: "hello",
+            created_at: "2026-01-01T00:00:00Z",
+            status: "complete",
+            metadata: null,
+          },
+          {
+            id: "a1",
+            role: "assistant",
+            content: "",
+            created_at: "2026-01-01T00:00:00Z",
+            status: "pending",
+            metadata: { provider: "claude" },
+          },
+        ],
+        "claude",
+      ),
+    );
+
+    await act(async () => {
+      root.render(<ChatPane sessionId="s1" />);
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Running Claude");
+
+    await act(async () => {
+      emitChatState(
+        chatState(
+          "s1",
+          [
+            {
+              id: "u1",
+              role: "user",
+              content: "hello",
+              created_at: "2026-01-01T00:00:00Z",
+              status: "complete",
+              metadata: null,
+            },
+            {
+              id: "a1",
+              role: "assistant",
+              content: "partial response",
+              created_at: "2026-01-01T00:00:00Z",
+              status: "streaming",
+              metadata: { provider: "claude" },
+            },
+          ],
+          "claude",
+        ),
+      );
+    });
+
+    expect(container.textContent).toContain("par");
+    expect(container.textContent).not.toContain("partial response");
+    expect(container.textContent).toContain("Claude - streaming");
+    expect(
+      container.querySelector("[data-chat-streaming-spinner]"),
+    ).toBeTruthy();
+    expect(
+      container.querySelector('button[aria-label="Copy Claude message"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('button[aria-label="Regenerate Claude message"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('button[aria-label="Stop response"]'),
+    ).toBeTruthy();
+
+    await advanceAnimationFrames(6);
+
+    expect(container.textContent).toContain("partial response");
+  });
+
+  it("does not force-scroll when streaming chunks arrive while scrolled back", async () => {
+    const initial = chatState(
+      "s1",
+      [
+        {
+          id: "u1",
+          role: "user",
+          content: "hello",
+          created_at: "2026-01-01T00:00:00Z",
+          status: "complete",
+          metadata: null,
+        },
+        {
+          id: "a1",
+          role: "assistant",
+          content: "partial",
+          created_at: "2026-01-01T00:00:00Z",
+          status: "streaming",
+          metadata: { provider: "claude" },
+        },
+      ],
+      "claude",
+    );
+    mocks.loadChatSessionState.mockResolvedValueOnce(initial);
+
+    await act(async () => {
+      root.render(<ChatPane sessionId="s1" />);
+    });
+    await settle();
+
+    const scrollRegion = container.querySelector<HTMLElement>(
+      "[data-chat-scroll-region]",
+    );
+    expect(scrollRegion).toBeTruthy();
+    const scroll = mockScrollRegion(scrollRegion!, {
+      clientHeight: 100,
+      scrollHeight: 420,
+      scrollTop: 0,
+    });
+
+    await act(async () => {
+      scrollRegion!.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    scroll.scrollTo.mockClear();
+
+    const updated = chatState(
+      "s1",
+      [
+        initial.messages[0],
+        {
+          ...initial.messages[1],
+          content: "partial response chunk",
+        } as ChatMessage,
+      ],
+      "claude",
+    );
+    updated.updated_at = "2026-01-01T00:00:01Z";
+    updated.session.updated_at = updated.updated_at;
+
+    await act(async () => {
+      emitChatState(updated);
+    });
+
+    await advanceAnimationFrames(8);
+
+    expect(container.textContent).toContain("partial response chunk");
+    expect(scroll.scrollTop).toBe(0);
+    expect(scroll.scrollTo).not.toHaveBeenCalled();
   });
 
   it("ignores stale pending chat state updates after a completed response", async () => {

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -63,6 +63,8 @@ interface ChatAttachment {
 }
 
 const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 48;
+const STREAM_SMOOTH_BASE_CHARS = 3;
+const STREAM_SMOOTH_MAX_CHARS = 48;
 const FORKED_CHAT_DEFAULT_TITLE = "Forked chat";
 const EMPTY_COMPOSER_TITLES = [
   "어떤 작업을 진행할까요?",
@@ -341,6 +343,126 @@ function chatStateUpdatedAtMs(state: ChatSessionState): number | null {
     if (Number.isFinite(parsed)) return parsed;
   }
   return null;
+}
+
+function streamingDisplayStep(backlog: number): number {
+  if (backlog <= 0) return 0;
+  if (backlog > 600) {
+    return Math.min(STREAM_SMOOTH_MAX_CHARS, Math.ceil(backlog / 8));
+  }
+  if (backlog > 160) return 18;
+  if (backlog > 60) return 9;
+  return STREAM_SMOOTH_BASE_CHARS;
+}
+
+function requestDisplayFrame(callback: FrameRequestCallback): number {
+  if (typeof window === "undefined" || !window.requestAnimationFrame) {
+    return setTimeout(() => callback(performance.now()), 16);
+  }
+  return window.requestAnimationFrame(callback);
+}
+
+function cancelDisplayFrame(frame: number) {
+  if (typeof window === "undefined" || !window.cancelAnimationFrame) {
+    clearTimeout(frame);
+    return;
+  }
+  window.cancelAnimationFrame(frame);
+}
+
+function useSmoothedStreamingContent(
+  content: string,
+  isStreaming: boolean,
+): string {
+  const initialContent = isStreaming
+    ? content.slice(0, streamingDisplayStep(content.length))
+    : content;
+  const [visibleContent, setVisibleContent] = useState(initialContent);
+  const visibleRef = useRef(initialContent);
+  const targetRef = useRef(content);
+  const frameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (frameRef.current !== null) {
+        cancelDisplayFrame(frameRef.current);
+        frameRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    targetRef.current = content;
+
+    const flush = (next: string) => {
+      if (frameRef.current !== null) {
+        cancelDisplayFrame(frameRef.current);
+        frameRef.current = null;
+      }
+      visibleRef.current = next;
+      setVisibleContent(next);
+    };
+
+    if (!isStreaming) {
+      flush(content);
+      return;
+    }
+
+    if (
+      visibleRef.current.length > content.length ||
+      !content.startsWith(visibleRef.current)
+    ) {
+      flush(content);
+      return;
+    }
+
+    const tick = () => {
+      frameRef.current = null;
+      const target = targetRef.current;
+      const visible = visibleRef.current;
+      if (visible.length >= target.length) return;
+      if (!target.startsWith(visible)) {
+        flush(target);
+        return;
+      }
+      const backlog = target.length - visible.length;
+      const nextLength = visible.length + streamingDisplayStep(backlog);
+      const next = target.slice(0, Math.min(target.length, nextLength));
+      visibleRef.current = next;
+      setVisibleContent(next);
+      if (next.length < targetRef.current.length) {
+        frameRef.current = requestDisplayFrame(tick);
+      }
+    };
+
+    if (
+      visibleRef.current.length < content.length &&
+      frameRef.current === null
+    ) {
+      frameRef.current = requestDisplayFrame(tick);
+    }
+  }, [content, isStreaming]);
+
+  return visibleContent;
+}
+
+function StreamingChatMessageBody({
+  content,
+  repoPath,
+  isStreaming,
+}: {
+  content: string;
+  repoPath?: string;
+  isStreaming: boolean;
+}) {
+  const displayContent = useSmoothedStreamingContent(content, isStreaming);
+  return (
+    <ChatMessageBody
+      content={displayContent}
+      repoPath={repoPath}
+      isStreaming={isStreaming}
+    />
+  );
 }
 
 function providerLabel(provider: string | null | undefined): string {
@@ -1000,9 +1122,14 @@ export function ChatPane({
               const isSystem = message.role === "system";
               const isError = message.status === "error";
               const isPending = message.status === "pending";
+              const isStreaming = message.status === "streaming";
+              const isRunningMessage = isPending || isStreaming;
               const isCancelled = message.status === "cancelled";
               const canForkBeforeMessage =
-                !isPending && !isUser && index > 0 && Boolean(sourceRepoPath);
+                !isRunningMessage &&
+                !isUser &&
+                index > 0 &&
+                Boolean(sourceRepoPath);
               const headerLabel = messageHeaderLabel(message, stateProvider);
               const messageProvider = providerFromMetadata(message.metadata);
               const agentProvider =
@@ -1028,14 +1155,18 @@ export function ChatPane({
                 cancelling ||
                 hasRunningMessages ||
                 messageActionBusyId !== null;
-              const canEditMessage = isUser && !isPending && isLastMessage;
+              const canEditMessage =
+                isUser && !isRunningMessage && isLastMessage;
               const canRegenerateMessage =
-                message.role === "assistant" && !isPending && isLastMessage;
-              const canDeleteMessage = !isSystem && !isPending && isLastMessage;
+                message.role === "assistant" &&
+                !isRunningMessage &&
+                isLastMessage;
+              const canDeleteMessage =
+                !isSystem && !isRunningMessage && isLastMessage;
               const showMessageMeta =
                 !isSystem &&
-                ((isPending && Boolean(durationLabel)) ||
-                  (!isPending && message.content.trim().length > 0));
+                ((isRunningMessage && Boolean(durationLabel)) ||
+                  (!isRunningMessage && message.content.trim().length > 0));
               const actionLabel = headerLabel ?? message.role;
               const bubbleClass = isUser
                 ? "bg-accent/18 text-fg ring-accent/35"
@@ -1077,9 +1208,17 @@ export function ChatPane({
                         <span>
                           {headerLabel}
                           {isPending ? " - pending" : ""}
+                          {isStreaming ? " - streaming" : ""}
                           {isError ? " - error" : ""}
                           {isCancelled ? " - cancelled" : ""}
                         </span>
+                        {isStreaming ? (
+                          <LoaderCircle
+                            size={11}
+                            className="animate-spin text-fg-muted/75"
+                            data-chat-streaming-spinner
+                          />
+                        ) : null}
                       </div>
                     ) : null}
                     <div
@@ -1089,10 +1228,12 @@ export function ChatPane({
                           : ""
                       }`}
                     >
-                      {isPending ? (
-                        <div className="flex items-center gap-2 text-fg-muted">
-                          <LoaderCircle size={14} className="animate-spin" />
-                          <span>
+                      {isPending || (isStreaming && !message.content) ? (
+                        <div className="flex items-center text-fg-muted">
+                          <span
+                            className="animate-pulse"
+                            data-chat-running-label
+                          >
                             Running {providerLabel(
                               messageProvider ?? stateProvider ?? provider,
                             )}
@@ -1145,10 +1286,10 @@ export function ChatPane({
                           </div>
                         </div>
                       ) : (
-                        <ChatMessageBody
+                        <StreamingChatMessageBody
                           content={message.content}
                           repoPath={repoPath}
-                          isStreaming={message.status === "streaming"}
+                          isStreaming={isStreaming}
                         />
                       )}
                     </div>
@@ -1159,7 +1300,7 @@ export function ChatPane({
                           isUser ? "justify-end" : "justify-start"
                         }`}
                       >
-                        {isPending && durationLabel ? (
+                        {isRunningMessage && durationLabel ? (
                           <span
                             className="self-center font-mono text-[11px] text-fg-muted/75"
                             data-chat-running-duration
@@ -1167,7 +1308,7 @@ export function ChatPane({
                             {durationLabel}
                           </span>
                         ) : null}
-                        {!isPending && timestampLabel ? (
+                        {!isRunningMessage && timestampLabel ? (
                           <>
                             <Tooltip
                               label={timestampTitle ?? timestampLabel}
@@ -1188,7 +1329,7 @@ export function ChatPane({
                             />
                           </>
                         ) : null}
-                        {!isPending && durationLabel ? (
+                        {!isRunningMessage && durationLabel ? (
                           <>
                             <span
                               className="self-center font-mono text-[11px] text-fg-muted/75"
@@ -1203,7 +1344,7 @@ export function ChatPane({
                             />
                           </>
                         ) : null}
-                        {!isPending ? (
+                        {!isRunningMessage ? (
                           <>
                             <Tooltip label="Copy message" side="bottom">
                               <button


### PR DESCRIPTION
## Summary
Native chat responses now stream into the chat pane instead of appearing only after the provider process exits:

1. **Process streaming** - add a cancellable stdout streaming runner for AI CLIs; one-shot calls keep the 60-second timeout, while native chat streaming is no longer cut off by that wall-clock limit.
2. **Provider JSONL parsing** - run Claude with `stream-json` partial messages and Codex with `--json`, then normalize deltas, snapshots, final messages, and non-prefix message boundaries so adjacent chunks do not collapse together.
3. **Streaming UI** - append assistant chunks into chat state, show a small spinner beside the streaming header, switch `Running {Agent}` to a Tailwind pulse, and smooth visible text reveal without changing persisted content.
4. **Coverage** - add process streaming, provider invocation, JSONL parser, ChatPane streaming, message action, and scrollback coverage.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Long native chat requests | Could fail around 60 seconds before the assistant response completed | Streaming native chat can run past 60 seconds while still supporting cancellation |
| Response visibility | Claude/Codex native chat often appeared as one final block | Partial assistant text is emitted while the CLI is still running |
| JSONL output | Provider event lines could leak formatting issues or collapse adjacent messages | Claude/Codex JSONL is parsed into assistant text with explicit message boundaries |
| Streaming presentation | Pending state used a spinner in the message body | Running label pulses; streaming header carries the spinner; chunks reveal progressively |

## Design notes
- `src-tauri/src/ai.rs` stays responsible for process execution, cancellation, stdout/stderr collection, and UTF-8 chunk decoding.
- Provider-specific JSONL normalization lives in `commands.rs`, next to native chat invocation construction, so the frontend receives ordinary chat state updates.
- The streaming callback emits full `acorn:chat-session-state-changed` state snapshots, keeping the frontend merge path the same as existing chat updates.
- The smoothing buffer is render-only. Final saved assistant content still comes from the backend parser and flushes immediately when the message leaves `streaming` state.

## Follow-up (not in this PR)
- Add provider-native Antigravity JSONL/partial parsing if its CLI exposes a streaming machine-readable mode.
- Tune the text reveal step sizes from real usage if the current smoothing feels too fast or too slow.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test -- src/components/ChatPane.test.tsx` passes; current pnpm/Vitest argument behavior ran 67 files / 692 tests
- [x] `cd src-tauri && cargo test` passes; 284 passed, 1 ignored
- [x] `PLAYWRIGHT_PORT=1421 pnpm exec playwright test tests/e2e/chat-message-actions.spec.ts` passes; 2 tests

## Notes
- Antigravity remains text stdout best-effort because its current prompt CLI path does not expose the same JSONL partial output mode used by Claude and Codex.
