### PR TITLE
fix(diff): reset syntax state across hunks

### DIFF
--- a/src/lib/highlight.test.ts
+++ b/src/lib/highlight.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { highlightThemeForMode } from "./highlight";
+import { parseDiff } from "./diff";
+import { highlightDiff, highlightThemeForMode } from "./highlight";
 
 describe("highlightThemeForMode", () => {
   it("uses a high-contrast light syntax theme for light app themes", () => {
@@ -8,5 +9,27 @@ describe("highlightThemeForMode", () => {
 
   it("keeps the dark syntax theme for dark app themes", () => {
     expect(highlightThemeForMode("dark")).toBe("github-dark");
+  });
+});
+
+describe("highlightDiff", () => {
+  it("does not carry unterminated block comment state across hunk gaps", async () => {
+    const lines = parseDiff(
+      [
+        "@@ -1,2 +1,2 @@",
+        " /**",
+        "  * Starts a doc comment outside the changed range",
+        "@@ -20,2 +20,2 @@",
+        " export function run() {",
+        "   return 1;",
+      ].join("\n"),
+    );
+
+    const highlighted = await highlightDiff(lines, "typescript");
+    const secondHunkCode = highlighted[4] ?? "";
+
+    expect(secondHunkCode).toContain(">export</span>");
+    expect(secondHunkCode).toContain(">function</span>");
+    expect(secondHunkCode).not.toContain(">export function run() {</span>");
   });
 });

--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -176,44 +176,85 @@ export async function highlightCode(
 }
 
 /**
- * Highlight a parsed diff. Splits into the new-side (ctx + add) and old-side
- * (ctx + del) virtual files so the lexer keeps coherent state per side, then
- * maps tokens back to the original line order.
- *
- * Returns one entry per input line. `null` means render plain text (hunk/meta
- * headers, or unsupported languages).
+ * Highlight a parsed diff. Each hunk is tokenized independently because
+ * unified diffs omit unchanged ranges between hunks, so lexer state cannot
+ * safely cross hunk boundaries.
  */
 export async function highlightDiff(
   lines: ParsedLine[],
   lang: BundledLanguage,
   mode: ThemeMode = "dark",
 ): Promise<(string | null)[]> {
-  const newLines: string[] = [];
-  const oldLines: string[] = [];
-  const map: ({ side: "new" | "old"; idx: number } | null)[] = lines.map((l) => {
-    if (l.kind === "add") {
-      newLines.push(l.text);
-      return { side: "new", idx: newLines.length - 1 };
-    }
-    if (l.kind === "del") {
-      oldLines.push(l.text);
-      return { side: "old", idx: oldLines.length - 1 };
-    }
-    if (l.kind === "ctx") {
-      newLines.push(l.text);
-      oldLines.push(l.text);
-      return { side: "new", idx: newLines.length - 1 };
-    }
-    return null;
-  });
+  const html: (string | null)[] = new Array(lines.length).fill(null);
+  const segments: DiffHighlightSegment[] = [];
+  let segment = createDiffHighlightSegment();
 
-  const [newHtml, oldHtml] = await Promise.all([
-    renderLines(newLines, lang, mode),
-    renderLines(oldLines, lang, mode),
-  ]);
+  const flush = () => {
+    if (segment.refs.length > 0) segments.push(segment);
+    segment = createDiffHighlightSegment();
+  };
 
-  return map.map((m) => {
-    if (!m) return null;
-    return (m.side === "new" ? newHtml[m.idx] : oldHtml[m.idx]) ?? null;
+  lines.forEach((line, lineIndex) => {
+    if (line.kind === "hunk" || line.kind === "meta") {
+      flush();
+      return;
+    }
+    if (line.kind === "add") {
+      segment.newLines.push(line.text);
+      segment.refs.push({
+        lineIndex,
+        side: "new",
+        sourceIndex: segment.newLines.length - 1,
+      });
+      return;
+    }
+    if (line.kind === "del") {
+      segment.oldLines.push(line.text);
+      segment.refs.push({
+        lineIndex,
+        side: "old",
+        sourceIndex: segment.oldLines.length - 1,
+      });
+      return;
+    }
+    segment.newLines.push(line.text);
+    segment.oldLines.push(line.text);
+    segment.refs.push({
+      lineIndex,
+      side: "new",
+      sourceIndex: segment.newLines.length - 1,
+    });
   });
+  flush();
+
+  await Promise.all(
+    segments.map(async (part) => {
+      const [newHtml, oldHtml] = await Promise.all([
+        renderLines(part.newLines, lang, mode),
+        renderLines(part.oldLines, lang, mode),
+      ]);
+      for (const ref of part.refs) {
+        const rendered = ref.side === "new" ? newHtml : oldHtml;
+        html[ref.lineIndex] = rendered[ref.sourceIndex] ?? null;
+      }
+    }),
+  );
+
+  return html;
+}
+
+interface DiffHighlightSegment {
+  newLines: string[];
+  oldLines: string[];
+  refs: DiffHighlightRef[];
+}
+
+interface DiffHighlightRef {
+  lineIndex: number;
+  side: "new" | "old";
+  sourceIndex: number;
+}
+
+function createDiffHighlightSegment(): DiffHighlightSegment {
+  return { newLines: [], oldLines: [], refs: [] };
 }


### PR DESCRIPTION
## Summary
This PR fixes diff syntax highlighting when a displayed hunk contains an unterminated block comment.

1. **Hunk-scoped diff highlighting** — tokenize each unified-diff hunk independently so lexer state from a partial code range does not color later hunks as comments.
2. **Regression coverage** — add a TypeScript diff case where an open `/**` in one hunk must not make a later `export function` line render as a single comment token.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Diff/code change view | An open block comment in one displayed hunk could make later hunks look commented out. | Syntax state resets at hunk boundaries, so later hunks highlight as code. |
| Full file code viewer | Unchanged. | Unchanged. |

## Design notes
- The public `highlightDiff` contract stays unchanged: callers still receive one highlighted HTML entry per parsed diff line, with `null` for hunk/meta/plain fallback lines.
- Context/add/delete lines are still split into new-side and old-side virtual sources inside each hunk, preserving side-specific highlighting without trusting lexer state across omitted unchanged ranges.
- The reset happens on `hunk` and `meta` lines because unified diffs do not include the full source between those boundaries.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm exec vitest run src/lib/highlight.test.ts` passes — 1 file / 3 tests
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes — 68 files / 702 tests