### PR TITLE
fix(pane): root-launch new tabs from worktree sessions

### DIFF
--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -63,6 +63,7 @@ import {
 
 const REPO = "/Users/me/repo";
 const HOME = "/Users/me";
+const WORKTREE = `${REPO}/.acorn/worktrees/feature`;
 
 function project(repoPath: string): Project {
   return {
@@ -330,6 +331,120 @@ describe("Pane empty state", () => {
           bubbles: true,
           cancelable: true,
         }),
+      );
+    });
+
+    expect(mocks.createSession).toHaveBeenCalledTimes(1);
+    expect(mocks.createSession).toHaveBeenCalledWith(
+      "repo",
+      REPO,
+      false,
+      "regular",
+      null,
+    );
+  });
+
+  it("starts empty-pane project sessions at the project root from an active worktree workspace", async () => {
+    const folderId = `project-folder:${REPO}:feature`;
+    const created = session("new-session", {
+      name: "repo",
+      worktree_path: REPO,
+      branch: "main",
+      in_worktree: false,
+    });
+    mocks.createSession.mockResolvedValueOnce(created);
+    mocks.listSessions.mockResolvedValueOnce([created]);
+    mocks.listProjects.mockResolvedValueOnce([project(REPO)]);
+    useAppStore.setState((s) => ({
+      ...s,
+      projectFolders: {
+        [REPO]: [
+          {
+            id: REPO,
+            repoPath: REPO,
+            name: "Default",
+            cwdPath: REPO,
+            position: 0,
+          },
+          {
+            id: folderId,
+            repoPath: REPO,
+            name: "Feature",
+            cwdPath: WORKTREE,
+            position: 1,
+          },
+        ],
+      },
+      activeProject: REPO,
+      activeProjectFolderId: folderId,
+      workspaces: {
+        ...s.workspaces,
+        [folderId]: {
+          layout: { kind: "pane", id: "root" },
+          panes: { root: { id: "root", tabIds: [], activeTabId: null } },
+          focusedPaneId: "root",
+        },
+      },
+      layout: { kind: "pane", id: "root" },
+      panes: { root: { id: "root", tabIds: [], activeTabId: null } },
+      focusedPaneId: "root",
+      activeTabId: null,
+      activeSessionId: null,
+    }));
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+
+    const emptyPane = container.querySelector('[role="button"]');
+    expect(emptyPane).not.toBeNull();
+
+    await act(async () => {
+      emptyPane?.dispatchEvent(
+        new MouseEvent("dblclick", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(mocks.createSession).toHaveBeenCalledTimes(1);
+    expect(mocks.createSession).toHaveBeenCalledWith(
+      "repo",
+      REPO,
+      false,
+      "regular",
+      null,
+    );
+  });
+
+  it("starts tab-strip sessions at the project root when the active tab is a worktree session", async () => {
+    const worker = session("worker", {
+      name: "worker",
+      repo_path: REPO,
+      worktree_path: WORKTREE,
+      branch: "feature",
+      in_worktree: true,
+    });
+    const created = session("new-session", {
+      name: "repo",
+      repo_path: REPO,
+      worktree_path: REPO,
+      branch: "main",
+      in_worktree: false,
+    });
+    mocks.createSession.mockResolvedValueOnce(created);
+    mocks.listSessions.mockResolvedValueOnce([worker, created]);
+    mocks.listProjects.mockResolvedValueOnce([project(REPO)]);
+    seedActivePaneWithTab(worker);
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+
+    const filler = container.querySelector('[data-pane-tab-filler="root"]');
+    expect(filler).not.toBeNull();
+
+    await act(async () => {
+      filler?.dispatchEvent(
+        new MouseEvent("dblclick", { bubbles: true, cancelable: true }),
       );
     });
 

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -58,10 +58,13 @@ import { hasRecordedWorktree } from "../lib/sessionWorktree";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
 import {
+  defaultProjectFolderId,
+  isPathInsideOrEqual,
+} from "../lib/projectFolders";
+import {
   buildSessionCreateRequestFromScope,
   resolveProjectScopedForRepoPath,
   scopeForSession,
-  scopeWithProjectRootLaunch,
   type SessionCreateScope,
 } from "../lib/sessionCreation";
 import type { Direction, PaneId } from "../lib/layout";
@@ -74,6 +77,7 @@ import { PaneDropOverlay } from "./PaneDropOverlay";
 import { SessionTitleGeneratingIndicator } from "./SessionTitleGeneratingIndicator";
 import { Tooltip } from "./Tooltip";
 import type {
+  Project,
   Session,
   SessionAgentProvider,
   SessionKind,
@@ -251,15 +255,38 @@ export function Pane({ paneId }: PaneProps) {
 
   function rootScopeForTab(tab: PaneTab): SessionCreateScope {
     if (tab.kind === "session") {
-      return scopeWithProjectRootLaunch(scopeForSession(tab.session));
+      const projectScoped = tab.session.project_scoped !== false;
+      const repoPath = repoPathForSessionRootLaunch(tab.session, projects);
+      if (!projectScoped) {
+        return {
+          placement: {
+            repoPath,
+            projectScoped: false,
+          },
+          launch: { kind: "projectRoot" },
+        };
+      }
+      return {
+        placement: {
+          repoPath,
+          projectScoped,
+          projectFolderId: defaultProjectFolderId(repoPath),
+        },
+        launch: { kind: "projectRoot" },
+      };
     }
+    const repoPath = repoPathForCodeTabSession(tab, sessions);
+    const projectScoped = resolveProjectScopedForRepoPath(
+      { sessions, projects },
+      repoPath,
+    );
     return {
       placement: {
-        repoPath: tab.repoPath,
-        projectScoped: resolveProjectScopedForRepoPath(
-          { sessions, projects },
-          tab.repoPath,
-        ),
+        repoPath,
+        projectScoped,
+        ...(projectScoped
+          ? { projectFolderId: defaultProjectFolderId(repoPath) }
+          : {}),
       },
       launch: { kind: "projectRoot" },
     };
@@ -397,6 +424,20 @@ export function Pane({ paneId }: PaneProps) {
           .flat()
           .find((folder) => folder.id === state.activeProjectFolderId)
       : null;
+    const projectScoped = resolveProjectScopedForRepoPath(
+      { sessions, projects },
+      repoPath,
+    );
+    const activeFolderUsesProjectRoot =
+      activeFolder &&
+      sameWorkspacePath(activeFolder.cwdPath, activeFolder.repoPath);
+    const activeFolderIsProjectWorktree =
+      projectScoped &&
+      activeFolder &&
+      !activeFolderUsesProjectRoot;
+    const projectFolderId = activeFolderIsProjectWorktree
+      ? defaultProjectFolderId(repoPath)
+      : activeFolder?.id;
     await spawnSession(
       repoPath,
       "regular",
@@ -405,15 +446,13 @@ export function Pane({ paneId }: PaneProps) {
         : {
             placement: {
               repoPath,
-              projectScoped: resolveProjectScopedForRepoPath(
-                { sessions, projects },
-                repoPath,
-              ),
-              projectFolderId: activeFolder?.id,
+              projectScoped,
+              projectFolderId,
             },
-            launch: activeFolder
-              ? { kind: "workspaceCwd", cwdPath: activeFolder.cwdPath }
-              : { kind: "projectRoot" },
+            launch:
+              activeFolder && !activeFolderIsProjectWorktree
+                ? { kind: "workspaceCwd", cwdPath: activeFolder.cwdPath }
+                : { kind: "projectRoot" },
           },
     );
   }
@@ -631,6 +670,60 @@ function isNonTerminalTextEditingTarget(target: EventTarget | null): boolean {
   const tag = target.tagName;
   if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
   return target.isContentEditable;
+}
+
+function normalizeWorkspacePath(path: string): string {
+  return path.replace(/[\\/]+$/, "");
+}
+
+function sameWorkspacePath(a: string, b: string): boolean {
+  return normalizeWorkspacePath(a) === normalizeWorkspacePath(b);
+}
+
+function repoPathForSessionRootLaunch(
+  session: Session,
+  projects: readonly Project[],
+): string {
+  if (session.project_scoped === false) return session.repo_path;
+  const state = useAppStore.getState();
+  const workspaceFolder = Object.values(state.projectFolders)
+    .flat()
+    .find(
+      (folder) =>
+        !sameWorkspacePath(folder.cwdPath, folder.repoPath) &&
+        sameWorkspacePath(folder.cwdPath, session.worktree_path),
+    );
+  if (workspaceFolder) return workspaceFolder.repoPath;
+
+  const containingProject = [...projects]
+    .filter((project) =>
+      isPathInsideOrEqual(session.worktree_path, project.repo_path),
+    )
+    .sort(
+      (a, b) =>
+        normalizeWorkspacePath(b.repo_path).length -
+        normalizeWorkspacePath(a.repo_path).length,
+    )[0];
+  return containingProject?.repo_path ?? session.repo_path;
+}
+
+function repoPathForCodeTabSession(
+  tab: CodeWorkspaceTab,
+  sessions: readonly Session[],
+): string {
+  const exactSession = sessions.find((session) =>
+    sameWorkspacePath(session.worktree_path, tab.repoPath),
+  );
+  if (exactSession) return exactSession.repo_path;
+
+  const containingSession = [...sessions]
+    .filter((session) => isPathInsideOrEqual(tab.path, session.worktree_path))
+    .sort(
+      (a, b) =>
+        normalizeWorkspacePath(b.worktree_path).length -
+        normalizeWorkspacePath(a.worktree_path).length,
+    )[0];
+  return containingSession?.repo_path ?? tab.repoPath;
 }
 
 function isTabStripMouseDownTarget(target: EventTarget | null): boolean {

--- a/tests/e2e/panes.spec.ts
+++ b/tests/e2e/panes.spec.ts
@@ -38,6 +38,212 @@ test.describe("pane / sidebar shortcuts", () => {
     ).toBeVisible();
   });
 
+  test("double-clicking an empty worktree workspace pane creates a project-root session", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn-workspaces",
+        JSON.stringify({
+          state: {
+            activeProject: "/tmp/demo",
+            activeProjectFolderId: "project-folder:/tmp/demo:feature",
+            projectFolders: {
+              "/tmp/demo": [
+                {
+                  id: "/tmp/demo",
+                  repoPath: "/tmp/demo",
+                  name: "Default",
+                  cwdPath: "/tmp/demo",
+                  position: 0,
+                },
+                {
+                  id: "project-folder:/tmp/demo:feature",
+                  repoPath: "/tmp/demo",
+                  name: "Feature",
+                  cwdPath: "/tmp/demo/.acorn/worktrees/feature",
+                  position: 1,
+                },
+              ],
+            },
+            sessionFolderIds: {},
+          },
+          version: 4,
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __createdRootSession?: boolean };
+      return w.__createdRootSession
+        ? [
+            {
+              id: "created-root",
+              name: "demo",
+              repo_path: "/tmp/demo",
+              worktree_path: "/tmp/demo",
+              branch: "main",
+              isolated: false,
+              status: "idle",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:00Z",
+              last_message: null,
+              kind: "regular",
+              owner: { kind: "user" },
+              position: null,
+              in_worktree: false,
+            },
+          ]
+        : [];
+    });
+    await tauri.handle("create_session", (args) => {
+      const w = window as unknown as {
+        __createdRootSession?: boolean;
+        __createSessionCalls?: unknown[];
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(args);
+      w.__createdRootSession = true;
+      return {
+        id: "created-root",
+        name: "demo",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      };
+    });
+
+    await page.goto("/");
+    await expect(
+      page.locator("aside").getByRole("button", { name: /Feature/ }),
+    ).toBeVisible();
+
+    const emptyPane = page.getByText(/Drop a tab here or double-click/i);
+    await expect(emptyPane).toBeVisible();
+    await emptyPane.dblclick();
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __createSessionCalls?: unknown[] })
+          .__createSessionCalls,
+    )) as Array<{
+      repoPath: string;
+      cwdPath?: string;
+      isolated: boolean;
+    }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      repoPath: "/tmp/demo",
+      isolated: false,
+    });
+    expect(calls[0].cwdPath).toBeUndefined();
+    await expect(
+      page.locator("aside").getByRole("button", { name: /^demo main · Idle/ }),
+    ).toBeVisible();
+  });
+
+  test("double-clicking a tab strip beside a worktree session creates a project-root session", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __createdRootSession?: boolean };
+      const worker = {
+        id: "worker",
+        name: "worker",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.acorn/worktrees/feature",
+        branch: "feature",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: true,
+      };
+      const created = {
+        id: "created-root",
+        name: "demo",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:01Z",
+        updated_at: "2026-01-01T00:00:01Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      };
+      return w.__createdRootSession ? [worker, created] : [worker];
+    });
+    await tauri.handle("create_session", (args) => {
+      const w = window as unknown as {
+        __createdRootSession?: boolean;
+        __createSessionCalls?: unknown[];
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(args);
+      w.__createdRootSession = true;
+      return {
+        id: "created-root",
+        name: (args as { name?: string })?.name ?? "demo",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:01Z",
+        updated_at: "2026-01-01T00:00:01Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      };
+    });
+
+    await page.goto("/");
+    await page
+      .locator("aside")
+      .getByRole("button", { name: /^worker worktree feature · Idle/ })
+      .click();
+
+    await page.locator('[data-pane-tab-filler="root"]').dblclick();
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __createSessionCalls?: unknown[] })
+          .__createSessionCalls,
+    )) as Array<{
+      repoPath: string;
+      cwdPath?: string;
+      isolated: boolean;
+    }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      repoPath: "/tmp/demo",
+      isolated: false,
+    });
+    expect(calls[0].cwdPath).toBeUndefined();
+  });
+
   // react-resizable-panels publishes the current size on `data-panel-size`
   // (string, e.g. "18.0" for the default 18%). Collapsed panels get "0.0".
   test("$mod+B collapses then re-expands the sidebar", async ({ page }) => {


### PR DESCRIPTION
## Summary
This fixes regular session creation from pane tab affordances so worktree context does not leak into the new session cwd.

1. **Tab strip root launch** — double-clicking beside a worktree session now resolves the owning project root and creates the new regular session there.
2. **Empty worktree workspace launch** — double-clicking an empty pane in a worktree workspace now launches at the default project folder/root instead of the worktree cwd.
3. **Regression coverage** — added component and E2E coverage for both pane creation paths.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Tab-strip double-click beside a worktree session | New regular session could reuse the worktree root/cwd | New regular session opens at the project root/default folder |
| Empty pane double-click in a worktree workspace | New regular session could inherit the worktree cwd | New regular session opens at the project root/default folder |
| Local terminal scope | Local-only tab creation needed to stay local | Local `project_scoped: false` scope is preserved |

## Design notes
- `rootScopeForTab` now builds root-launch scopes directly instead of using `scopeForSession` plus `scopeWithProjectRootLaunch`. `scopeForSession` still preserves `worktree_path` for session-scoped operations, but generic tab-strip new-session creation should reset to the project root.
- Worktree-scoped code tabs map back through the owning session/worktree path before deciding the repo path for the new session.
- Empty pane creation detects non-default project workspace folders and sends new regular sessions to the default project folder instead of using the active worktree cwd.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm exec vitest run src/components/Pane.test.tsx src/lib/sessionCreation.test.ts` — 31 tests pass
- [x] `pnpm exec playwright test tests/e2e/panes.spec.ts --grep "worktree session"` — passes
- [x] `pnpm exec playwright test tests/e2e/panes.spec.ts` — 12 tests pass
- [x] `git diff --check` — passes
- [x] `pnpm run build` — passes

## Notes
- `pnpm run build` still emits the existing Vite dynamic/static import and large chunk warnings. The build completes successfully, and those warnings are not caused by this PR.