### PR TITLE
feat(sessions): inline worktree cleanup preference and summary launch fix

### DIFF
--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -503,6 +503,173 @@ describe("Pane empty state", () => {
     );
   });
 
+  it("starts tab-strip sessions at the linked session root when the active tab is a work summary", async () => {
+    const worker = session("worker", {
+      name: "worker",
+      repo_path: REPO,
+      worktree_path: WORKTREE,
+      branch: "feature",
+      in_worktree: true,
+    });
+    const summaryTab = makeWorkSummaryWorkspaceTab({
+      repoPath: WORKTREE,
+      cwdPath: WORKTREE,
+      sessionId: worker.id,
+      title: "Worker Summary",
+    });
+    const created = session("new-session", {
+      name: "repo",
+      repo_path: REPO,
+      worktree_path: REPO,
+      branch: "main",
+      in_worktree: false,
+    });
+    mocks.createSession.mockResolvedValueOnce(created);
+    mocks.listSessions.mockResolvedValueOnce([worker, created]);
+    mocks.listProjects.mockResolvedValueOnce([project(REPO)]);
+    useAppStore.setState((s) => ({
+      ...s,
+      sessions: [worker],
+      activeProject: REPO,
+      activeProjectFolderId: REPO,
+      activeSessionId: null,
+      activeTabId: summaryTab.id,
+      workspaceTabs: { [summaryTab.id]: summaryTab },
+      workspaces: {
+        ...s.workspaces,
+        [REPO]: {
+          layout: { kind: "pane", id: "root" },
+          panes: {
+            root: {
+              id: "root",
+              tabIds: [summaryTab.id],
+              activeTabId: summaryTab.id,
+            },
+          },
+          focusedPaneId: "root",
+        },
+      },
+      panes: {
+        root: {
+          id: "root",
+          tabIds: [summaryTab.id],
+          activeTabId: summaryTab.id,
+        },
+      },
+      focusedPaneId: "root",
+    }));
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+
+    const filler = container.querySelector('[data-pane-tab-filler="root"]');
+    expect(filler).not.toBeNull();
+
+    await act(async () => {
+      filler?.dispatchEvent(
+        new MouseEvent("dblclick", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(mocks.createSession).toHaveBeenCalledTimes(1);
+    expect(mocks.createSession).toHaveBeenCalledWith(
+      "repo",
+      REPO,
+      false,
+      "regular",
+      null,
+    );
+  });
+
+  it("keeps tab-strip double-click creation in linked work summary local scope", async () => {
+    const local = session("local-session", {
+      name: "terminal",
+      repo_path: HOME,
+      worktree_path: HOME,
+      project_scoped: false,
+    });
+    const projectScopedSibling = session("project-session", {
+      name: "project",
+      repo_path: HOME,
+      worktree_path: `${HOME}/.worktrees/project-session`,
+      project_scoped: true,
+    });
+    const summaryTab = makeWorkSummaryWorkspaceTab({
+      repoPath: HOME,
+      cwdPath: HOME,
+      sessionId: local.id,
+      title: "Local Summary",
+    });
+    const created = session("local-session-2", {
+      name: "terminal-2",
+      repo_path: HOME,
+      worktree_path: HOME,
+      project_scoped: false,
+    });
+    mocks.createSession.mockResolvedValueOnce(created);
+    mocks.listSessions.mockResolvedValueOnce([
+      local,
+      projectScopedSibling,
+      created,
+    ]);
+    mocks.listProjects.mockResolvedValueOnce([project(REPO)]);
+    useAppStore.setState((s) => ({
+      ...s,
+      sessions: [local, projectScopedSibling],
+      activeProject: HOME,
+      activeSessionId: null,
+      activeTabId: summaryTab.id,
+      workspaceTabs: { [summaryTab.id]: summaryTab },
+      workspaces: {
+        ...s.workspaces,
+        [HOME]: {
+          layout: { kind: "pane", id: "root" },
+          panes: {
+            root: {
+              id: "root",
+              tabIds: [summaryTab.id],
+              activeTabId: summaryTab.id,
+            },
+          },
+          focusedPaneId: "root",
+        },
+      },
+      layout: { kind: "pane", id: "root" },
+      panes: {
+        root: {
+          id: "root",
+          tabIds: [summaryTab.id],
+          activeTabId: summaryTab.id,
+        },
+      },
+      focusedPaneId: "root",
+    }));
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+
+    const filler = container.querySelector('[data-pane-tab-filler="root"]');
+    expect(filler).not.toBeNull();
+
+    await act(async () => {
+      filler?.dispatchEvent(
+        new MouseEvent("dblclick", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(mocks.createSession).toHaveBeenCalledTimes(1);
+    expect(mocks.createSession).toHaveBeenCalledWith(
+      "terminal-2",
+      HOME,
+      false,
+      "regular",
+      null,
+      false,
+    );
+  });
+
   it("keeps tab-strip double-click creation in local chat scope", async () => {
     const local = session("local-session", {
       name: "terminal",

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -273,27 +273,16 @@ export function Pane({ paneId }: PaneProps) {
 
   function rootScopeForTab(tab: PaneTab): SessionCreateScope {
     if (tab.kind === "session") {
-      const projectScoped = tab.session.project_scoped !== false;
-      const repoPath = repoPathForSessionRootLaunch(tab.session, projects);
-      if (!projectScoped) {
-        return {
-          placement: {
-            repoPath,
-            projectScoped: false,
-          },
-          launch: { kind: "projectRoot" },
-        };
-      }
-      return {
-        placement: {
-          repoPath,
-          projectScoped,
-          projectFolderId: defaultProjectFolderId(repoPath),
-        },
-        launch: { kind: "projectRoot" },
-      };
+      return projectRootScopeForSession(tab.session, projects);
     }
-    const repoPath = repoPathForCodeTabSession(tab, sessions);
+    if (tab.kind === "work-summary" && tab.sessionId) {
+      const session = sessionsById.get(tab.sessionId);
+      if (session) return projectRootScopeForSession(session, projects);
+    }
+    const repoPath =
+      tab.kind === "code"
+        ? repoPathForCodeTabSession(tab, sessions)
+        : tab.repoPath;
     const projectScoped = resolveProjectScopedForRepoPath(
       { sessions, projects },
       repoPath,
@@ -709,6 +698,31 @@ function normalizeWorkspacePath(path: string): string {
 
 function sameWorkspacePath(a: string, b: string): boolean {
   return normalizeWorkspacePath(a) === normalizeWorkspacePath(b);
+}
+
+function projectRootScopeForSession(
+  session: Session,
+  projects: readonly Project[],
+): SessionCreateScope {
+  const projectScoped = session.project_scoped !== false;
+  const repoPath = repoPathForSessionRootLaunch(session, projects);
+  if (!projectScoped) {
+    return {
+      placement: {
+        repoPath,
+        projectScoped: false,
+      },
+      launch: { kind: "projectRoot" },
+    };
+  }
+  return {
+    placement: {
+      repoPath,
+      projectScoped,
+      projectFolderId: defaultProjectFolderId(repoPath),
+    },
+    launch: { kind: "projectRoot" },
+  };
 }
 
 function repoPathForSessionRootLaunch(

--- a/src/components/RemoveSessionDialog.test.tsx
+++ b/src/components/RemoveSessionDialog.test.tsx
@@ -31,6 +31,7 @@ describe("RemoveSessionDialog", () => {
   let root: Root;
 
   beforeEach(() => {
+    useSettings.getState().reset();
     useSettings.getState().patchLanguage("en");
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -63,9 +64,59 @@ describe("RemoveSessionDialog", () => {
     expect(document.body.textContent).toContain(
       "This session is using a linked git worktree:",
     );
-    expect(document.body.textContent).toContain("Keep worktree");
-    expect(document.body.textContent).toContain("Delete worktree");
+    expect(document.body.textContent).toContain("Remove only");
+    expect(document.body.textContent).toContain("Remove + delete worktree");
+    expect(document.body.textContent).not.toContain(
+      "Delete standalone isolated worktrees without asking next time",
+    );
     expect(document.body.textContent).not.toContain("Don't ask again");
+  });
+
+  it("lets standalone isolated sessions update the future cleanup setting", () => {
+    const onClose = renderDialog(
+      session({
+        isolated: true,
+        in_worktree: true,
+        worktree_path: "/repo/.acorn/worktrees/session-1",
+      }),
+    );
+
+    expect(document.body.textContent).toContain(
+      "Delete standalone isolated worktrees without asking next time",
+    );
+
+    const checkbox = document.querySelector<HTMLInputElement>(
+      'input[type="checkbox"]',
+    );
+    expect(checkbox).toBeInstanceOf(HTMLInputElement);
+    expect(checkbox?.checked).toBe(false);
+
+    act(() => {
+      checkbox?.click();
+    });
+
+    expect(checkbox?.checked).toBe(true);
+    expect(
+      useSettings.getState().settings.sessions
+        .confirmDeleteIsolatedWorktrees,
+    ).toBe(true);
+
+    const deleteButton = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent === "Remove + delete worktree",
+    );
+    expect(deleteButton).toBeInstanceOf(HTMLButtonElement);
+
+    act(() => {
+      deleteButton?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    expect(
+      useSettings.getState().settings.sessions
+        .confirmDeleteIsolatedWorktrees,
+    ).toBe(false);
+    expect(onClose).toHaveBeenCalledWith("session_and_worktree");
   });
 
   it("keeps shared worktree workspace sessions on disk", () => {
@@ -74,9 +125,12 @@ describe("RemoveSessionDialog", () => {
     expect(document.body.textContent).toContain(
       "This worktree is shared by a workspace and will be kept on disk.",
     );
-    expect(document.body.textContent).not.toContain("Keep worktree");
-    expect(document.body.textContent).not.toContain("Delete worktree");
+    expect(document.body.textContent).not.toContain("Remove only");
+    expect(document.body.textContent).not.toContain("Remove + delete worktree");
     expect(document.body.textContent).toContain("Remove");
+    expect(document.body.textContent).not.toContain(
+      "Delete standalone isolated worktrees without asking next time",
+    );
   });
 
   it("keeps the plain session remove confirmation for non-worktree sessions", () => {
@@ -84,6 +138,6 @@ describe("RemoveSessionDialog", () => {
 
     expect(document.body.textContent).toContain("will not be touched");
     expect(document.body.textContent).toContain("Don't ask again");
-    expect(document.body.textContent).not.toContain("Delete worktree");
+    expect(document.body.textContent).not.toContain("Remove + delete worktree");
   });
 });

--- a/src/components/RemoveSessionDialog.tsx
+++ b/src/components/RemoveSessionDialog.tsx
@@ -30,13 +30,25 @@ export function RemoveSessionDialog({
   const isolated = session?.isolated ?? false;
   const recordedWorktree = session ? hasRecordedWorktree(session) : false;
   const showWorktreeDeleteChoice = recordedWorktree && canDeleteWorktree;
+  const showIsolatedCleanupSetting = isolated && canDeleteWorktree;
+  const confirmDeleteIsolatedWorktrees = useSettings(
+    (s) => s.settings.sessions.confirmDeleteIsolatedWorktrees,
+  );
   const patchSessions = useSettings((s) => s.patchSessions);
   const [dontAskAgain, setDontAskAgain] = useState(false);
+  const [
+    autoDeleteIsolatedWorktreesNextTime,
+    setAutoDeleteIsolatedWorktreesNextTime,
+  ] = useState(false);
 
-  // Reset checkbox each time dialog opens for a new session.
+  // Reset checkboxes each time dialog opens for a new session.
   useEffect(() => {
-    if (session) setDontAskAgain(false);
-  }, [session?.id]);
+    if (!session) return;
+    setDontAskAgain(false);
+    setAutoDeleteIsolatedWorktreesNextTime(
+      !confirmDeleteIsolatedWorktrees,
+    );
+  }, [confirmDeleteIsolatedWorktrees, session?.id]);
 
   // Keep Enter conservative for non-isolated linked worktrees, which may be
   // user-managed outside Acorn even though the session path is a real worktree.
@@ -45,8 +57,20 @@ export function RemoveSessionDialog({
     : "session_only";
 
   function commit(choice: RemoveChoice) {
-    if (choice !== "cancel" && dontAskAgain && !recordedWorktree) {
-      patchSessions({ confirmRemove: false });
+    if (choice !== "cancel") {
+      if (dontAskAgain && !recordedWorktree) {
+        patchSessions({ confirmRemove: false });
+      }
+      if (
+        showIsolatedCleanupSetting &&
+        autoDeleteIsolatedWorktreesNextTime !==
+          !confirmDeleteIsolatedWorktrees
+      ) {
+        patchSessions({
+          confirmDeleteIsolatedWorktrees:
+            !autoDeleteIsolatedWorktreesNextTime,
+        });
+      }
     }
     onClose(choice);
   }
@@ -99,7 +123,22 @@ export function RemoveSessionDialog({
                 {dt(t, "dialogs.removeSession.willNotBeTouched")}
               </p>
             )}
-            {!recordedWorktree ? (
+            {showIsolatedCleanupSetting ? (
+              <label className="flex cursor-pointer items-center gap-2 pt-1 text-xs text-fg-muted">
+                <input
+                  type="checkbox"
+                  checked={autoDeleteIsolatedWorktreesNextTime}
+                  onChange={(e) =>
+                    setAutoDeleteIsolatedWorktreesNextTime(e.target.checked)
+                  }
+                  className="accent-[var(--color-accent)]"
+                />
+                {dt(
+                  t,
+                  "dialogs.removeSession.autoDeleteIsolatedWorktreesNextTime",
+                )}
+              </label>
+            ) : !recordedWorktree ? (
               <label className="flex cursor-pointer items-center gap-2 pt-1 text-xs text-fg-muted">
                 <input
                   type="checkbox"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1304,13 +1304,14 @@
       "confirmPrefix": "Remove session",
       "isolatedWorktree": "This is an isolated worktree:",
       "linkedWorktree": "This session is using a linked git worktree:",
-      "deleteWorktreeQuestion": "Also delete the worktree from disk?",
+      "deleteWorktreeQuestion": "Remove the session only, or also delete the worktree from disk?",
       "filesIn": "Files in",
       "willNotBeTouched": "will not be touched.",
       "keepSharedWorktree": "This worktree is shared by a workspace and will be kept on disk.",
       "dontAskAgain": "Don't ask again (toggle in Settings → Sessions)",
-      "keepWorktree": "Keep worktree",
-      "deleteWorktree": "Delete worktree",
+      "autoDeleteIsolatedWorktreesNextTime": "Delete standalone isolated worktrees without asking next time",
+      "keepWorktree": "Remove only",
+      "deleteWorktree": "Remove + delete worktree",
       "remove": "Remove"
     },
     "runningSessionClose": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1304,13 +1304,14 @@
       "confirmPrefix": "세션 제거",
       "isolatedWorktree": "격리된 워크트리입니다:",
       "linkedWorktree": "이 세션은 연결된 Git 워크트리를 사용 중입니다:",
-      "deleteWorktreeQuestion": "디스크에서도 워크트리를 삭제할까요?",
+      "deleteWorktreeQuestion": "세션만 제거할까요, 아니면 디스크의 워크트리도 함께 삭제할까요?",
       "filesIn": "다음 위치의 파일은",
       "willNotBeTouched": "변경되지 않습니다.",
       "keepSharedWorktree": "이 워크트리는 작업공간에서 공유 중이므로 디스크에 유지됩니다.",
       "dontAskAgain": "다시 묻지 않기(설정 → 세션에서 변경)",
-      "keepWorktree": "워크트리 유지",
-      "deleteWorktree": "워크트리 삭제",
+      "autoDeleteIsolatedWorktreesNextTime": "다음부터 단독 격리 워크트리는 묻지 않고 삭제",
+      "keepWorktree": "세션만 제거",
+      "deleteWorktree": "세션 제거 + 워크트리 삭제",
       "remove": "제거"
     },
     "runningSessionClose": {

--- a/tests/e2e/session-lifecycle.spec.ts
+++ b/tests/e2e/session-lifecycle.spec.ts
@@ -363,6 +363,113 @@ test.describe("session lifecycle", () => {
     expect(calls[0]).toEqual({ id: "s-1", removeWorktree: true });
   });
 
+  test("standalone isolated worktree prompt can enable future auto-delete", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          sessions: {
+            confirmRemove: true,
+            confirmDeleteIsolatedWorktrees: true,
+            showRestartPromptOnExit: true,
+          },
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __sessionRemoved?: boolean };
+      return w.__sessionRemoved
+        ? []
+        : [
+            {
+              id: "s-1",
+              name: "alpha",
+              repo_path: "/tmp/demo",
+              worktree_path: "/tmp/demo/.acorn/worktrees/alpha",
+              branch: "main",
+              isolated: true,
+              in_worktree: true,
+              status: "idle",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:05Z",
+              last_message: null,
+            },
+          ];
+    });
+    await tauri.handle("remove_session", (args) => {
+      const w = window as unknown as {
+        __removeCalls?: unknown[];
+        __sessionRemoved?: boolean;
+      };
+      w.__removeCalls = w.__removeCalls ?? [];
+      w.__removeCalls.push(args);
+      w.__sessionRemoved = true;
+      return null;
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-panel-id="sidebar"]');
+    const row = sidebar
+      .getByRole("button", { name: /^alpha worktree main · Idle/ })
+      .first();
+    await expect(row).toBeVisible();
+
+    await row.hover();
+    await sidebar
+      .getByRole("button", { name: "Remove session", exact: true })
+      .click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(
+      dialog.getByRole("heading", { name: "Remove session" }),
+    ).toBeVisible();
+
+    const remember = dialog.getByRole("checkbox", {
+      name: "Delete standalone isolated worktrees without asking next time",
+    });
+    await expect(remember).not.toBeChecked();
+    await remember.check();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __removeCalls?: unknown[] }).__removeCalls
+              ?.length ?? 0,
+        ),
+      )
+      .toBe(0);
+
+    await dialog
+      .getByRole("button", { name: "Remove + delete worktree" })
+      .click();
+
+    await expect(
+      sidebar.getByRole("button", { name: /^alpha worktree main · Idle/ }),
+    ).toHaveCount(0);
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __removeCalls?: unknown[] }).__removeCalls,
+    )) as Array<{ id: string; removeWorktree: boolean }>;
+    expect(calls).toEqual([{ id: "s-1", removeWorktree: true }]);
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("acorn:settings:v1");
+          return raw
+            ? JSON.parse(raw).sessions?.confirmDeleteIsolatedWorktrees
+            : null;
+        }),
+      )
+      .toBe(false);
+  });
+
   test("shared worktree workspace session removal skips the confirmation", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Adds the isolated worktree cleanup preference directly to the session removal flow and includes the work-summary tab launch fix needed for green frontend checks.

1. **Inline cleanup preference** — show a checkbox in the Remove session dialog for standalone isolated worktrees so users can choose to delete future standalone isolated worktrees without another prompt.
2. **Safer commit timing** — keep the checkbox local while the dialog is open and persist `confirmDeleteIsolatedWorktrees` only when the user confirms removal, avoiding an immediate dialog re-evaluation.
3. **Clearer worktree actions** — clarify the keep/delete buttons as session removal actions in English and Korean copy.
4. **Summary-tab launch fix** — route tab-strip session creation from active work-summary tabs through the linked session scope when available, instead of treating every frontend tab as a code tab.
5. **Regression coverage** — cover the component behavior, the visible session-removal flow, and work-summary tab session creation.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Standalone isolated session removal | Users had to visit Settings to skip future isolated worktree cleanup prompts. | Users can opt into future auto-delete from the removal confirmation itself. |
| Linked/shared worktrees | No cleanup setting checkbox in this dialog. | Unchanged; the checkbox remains hidden because the setting only applies to standalone isolated worktrees. |
| Work-summary tabs | Tab-strip double-click session creation could hit the code-tab-only path and fail typecheck. | Work-summary tabs use their linked session scope when present and fall back to the tab repo path otherwise. |

## Design notes
- The dialog checkbox mirrors `confirmDeleteIsolatedWorktrees` with inverted wording: checked means future standalone isolated worktrees delete without asking.
- The setting is persisted only on a non-cancel removal choice. This avoids toggling Settings while the modal is open and triggering the existing auto-delete skip path against the current pending session.
- Linked worktree sessions and shared worktree workspace sessions keep their existing behavior and do not expose this standalone-isolated setting.
- The Pane fix extracts the existing session-root scope logic into `projectRootScopeForSession` so regular session tabs and linked work-summary tabs share the same placement rules.

## Test plan
- [x] `pnpm exec vitest run src/components/RemoveSessionDialog.test.tsx` — 1 file, 4 tests passed
- [x] `pnpm exec vitest run src/components/RemoveSessionDialog.test.tsx src/components/Pane.test.tsx` — 2 files, 26 tests passed
- [x] `pnpm run test:e2e -- tests/e2e/session-lifecycle.spec.ts` — 7 tests passed
- [x] `pnpm run typecheck` — passed
- [x] GitHub CI on PR #470 — Frontend and E2E passed
