### PR TITLE
fix(worktrees): block removal while sessions share worktree

### DIFF
--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -108,6 +108,29 @@ pub fn agent_transcript_summary(
     Ok(item.and_then(|item| summarize_agent_history_item(&item)))
 }
 
+pub fn agent_transcript_summary_at_path(
+    repo_path: PathBuf,
+    provider: AgentHistoryProvider,
+    id: String,
+    transcript_path: PathBuf,
+) -> AppResult<Option<AgentTranscriptSummary>> {
+    let repo = normalize_path(&repo_path);
+    if repo.as_os_str().is_empty() {
+        return Err(AppError::InvalidPath(repo_path.display().to_string()));
+    }
+    let path = canonical_agent_transcript_path(transcript_path)?;
+    validate_agent_transcript_identity(&provider, &id, &path)?;
+    let scope = HistoryScope::Project(&repo);
+    let item = match provider {
+        AgentHistoryProvider::Codex => parse_codex_file(&path, scope),
+        AgentHistoryProvider::Claude => parse_claude_file(&path, scope),
+        AgentHistoryProvider::Antigravity => parse_antigravity_file(&path, scope),
+    };
+    Ok(item
+        .filter(|item| item.id == id)
+        .and_then(|item| summarize_agent_history_item(&item)))
+}
+
 pub fn list_unscoped_agent_history(
     project_paths: Vec<PathBuf>,
     limit: Option<usize>,
@@ -136,6 +159,13 @@ pub fn trash_agent_history_transcript(
     id: String,
     transcript_path: PathBuf,
 ) -> AppResult<()> {
+    let path = canonical_agent_transcript_path(transcript_path)?;
+    validate_agent_transcript_identity(&provider, &id, &path)?;
+    move_to_trash(&path)?;
+    Ok(())
+}
+
+fn canonical_agent_transcript_path(transcript_path: PathBuf) -> AppResult<PathBuf> {
     let path = transcript_path.canonicalize().map_err(|_| {
         AppError::InvalidPath(format!("transcript missing: {}", transcript_path.display()))
     })?;
@@ -151,19 +181,26 @@ pub fn trash_agent_history_transcript(
             path.display()
         )));
     }
+    Ok(path)
+}
 
+fn validate_agent_transcript_identity(
+    provider: &AgentHistoryProvider,
+    id: &str,
+    path: &Path,
+) -> AppResult<()> {
     match provider {
         AgentHistoryProvider::Codex => {
             let root = codex_sessions_root()
                 .and_then(|p| p.canonicalize().ok())
                 .ok_or_else(|| AppError::InvalidPath("Codex sessions root missing".to_string()))?;
-            if !is_codex_transcript_path(&path, &root) {
+            if !is_codex_transcript_path(path, &root) {
                 return Err(AppError::InvalidPath(format!(
                     "transcript is outside Codex sessions: {}",
                     path.display()
                 )));
             }
-            if !codex_transcript_matches_id(&path, &id) {
+            if !codex_transcript_matches_id(path, id) {
                 return Err(AppError::InvalidPath(
                     "transcript id does not match selected Codex session".to_string(),
                 ));
@@ -173,14 +210,14 @@ pub fn trash_agent_history_transcript(
             let root = claude_projects_root()
                 .and_then(|p| p.canonicalize().ok())
                 .ok_or_else(|| AppError::InvalidPath("Claude projects root missing".to_string()))?;
-            if !is_claude_transcript_path(&path, &root) {
+            if !is_claude_transcript_path(path, &root) {
                 return Err(AppError::InvalidPath(format!(
                     "transcript is outside Claude projects: {}",
                     path.display()
                 )));
             }
             let stem = path.file_stem().and_then(|s| s.to_str());
-            if stem != Some(id.as_str()) {
+            if stem != Some(id) {
                 return Err(AppError::InvalidPath(
                     "transcript id does not match selected Claude session".to_string(),
                 ));
@@ -202,12 +239,12 @@ pub fn trash_agent_history_transcript(
                     path.display()
                 )));
             }
-            if !antigravity_transcript_matches_id(&path, &id) {
+            if !antigravity_transcript_matches_id(path, id) {
                 return Err(AppError::InvalidPath(
                     "transcript id does not match selected Antigravity session".to_string(),
                 ));
             }
-            if !is_antigravity_transcript_path(&path) {
+            if !is_antigravity_transcript_path(path) {
                 return Err(AppError::InvalidPath(format!(
                     "transcript is outside Antigravity sessions: {}",
                     path.display()
@@ -215,8 +252,6 @@ pub fn trash_agent_history_transcript(
             }
         }
     }
-
-    move_to_trash(&path)?;
     Ok(())
 }
 
@@ -475,7 +510,18 @@ pub fn transcript_title_context(
 }
 
 fn summarize_agent_history_item(item: &AgentHistoryItem) -> Option<AgentTranscriptSummary> {
-    let path = Path::new(&item.transcript_path);
+    summarize_agent_transcript(
+        item.provider.clone(),
+        item.id.clone(),
+        Path::new(&item.transcript_path),
+    )
+}
+
+fn summarize_agent_transcript(
+    provider: AgentHistoryProvider,
+    id: String,
+    path: &Path,
+) -> Option<AgentTranscriptSummary> {
     let file = fs::File::open(path).ok()?;
     let mut message_count = 0_u64;
     let mut user_messages = 0_u64;
@@ -491,7 +537,7 @@ fn summarize_agent_history_item(item: &AgentHistoryItem) -> Option<AgentTranscri
         let Ok(value) = serde_json::from_str::<Value>(line) else {
             continue;
         };
-        if let Some(entry) = title_context_entry(&item.provider, &value) {
+        if let Some(entry) = title_context_entry(&provider, &value) {
             match entry.role {
                 "User" => user_messages += 1,
                 "Assistant" => assistant_messages += 1,
@@ -499,8 +545,8 @@ fn summarize_agent_history_item(item: &AgentHistoryItem) -> Option<AgentTranscri
             }
             message_count += 1;
         }
-        if let Some(usage) = transcript_usage_from_value(&item.provider, &value) {
-            if is_cumulative_usage_event(&item.provider, &value) {
+        if let Some(usage) = transcript_usage_from_value(&provider, &value) {
+            if is_cumulative_usage_event(&provider, &value) {
                 cumulative_usage = max_token_usage(cumulative_usage, usage);
             } else {
                 add_token_usage(&mut summed_usage, usage);
@@ -516,10 +562,10 @@ fn summarize_agent_history_item(item: &AgentHistoryItem) -> Option<AgentTranscri
     let complete_turns = user_messages.min(assistant_messages);
     let running_turns = user_messages.saturating_sub(assistant_messages);
     Some(AgentTranscriptSummary {
-        provider: item.provider.clone(),
-        id: item.id.clone(),
-        transcript_path: item.transcript_path.clone(),
-        updated_at: item.updated_at,
+        provider,
+        id,
+        transcript_path: path.display().to_string(),
+        updated_at: file_updated_at(path),
         message_count,
         user_messages,
         assistant_messages,
@@ -1542,7 +1588,42 @@ fn home_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
     use std::io::Write;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &Path) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: This test module serializes environment mutation through
+            // ENV_LOCK and restores the previous value on drop.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: The guard is only created while ENV_LOCK is held, so the
+            // matching restore runs under the same serialized test section.
+            unsafe {
+                if let Some(previous) = &self.previous {
+                    std::env::set_var(self.key, previous);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
 
     #[test]
     fn codex_transcript_match_accepts_payload_id_when_filename_differs() {
@@ -2254,6 +2335,83 @@ mod tests {
         assert_eq!(summary.token_usage.reasoning_tokens, 4);
         assert_eq!(summary.token_usage.total_tokens, 59);
         assert_eq!(summary.token_usage.messages_with_usage, 1);
+    }
+
+    #[test]
+    fn transcript_summary_at_path_reads_validated_codex_file() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let codex_home = dir.path().join("codex-home");
+        let id = "019e4818-7c15-7e60-9b3b-898a1c7803d6";
+        let transcript = codex_home
+            .join("sessions/2026/05/21")
+            .join(format!("rollout-2026-05-21T10-13-44-{id}.jsonl"));
+        fs::create_dir_all(transcript.parent().unwrap()).unwrap();
+        let mut file = fs::File::create(&transcript).unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "payload": {
+                    "id": id,
+                    "cwd": repo.display().to_string(),
+                    "role": "user",
+                    "content": "Do it",
+                },
+            })
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "payload": {
+                    "role": "assistant",
+                    "content": "Done",
+                },
+            })
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "msg": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 20,
+                            "cached_input_tokens": 7,
+                            "output_tokens": 5,
+                            "total_tokens": 32,
+                        },
+                    },
+                },
+            })
+        )
+        .unwrap();
+        drop(file);
+        let _env = EnvVarGuard::set("CODEX_HOME", &codex_home);
+
+        let summary = agent_transcript_summary_at_path(
+            repo,
+            AgentHistoryProvider::Codex,
+            id.to_string(),
+            transcript.clone(),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(summary.provider, AgentHistoryProvider::Codex);
+        assert_eq!(summary.id, id);
+        assert_eq!(
+            summary.transcript_path,
+            transcript.canonicalize().unwrap().display().to_string()
+        );
+        assert_eq!(summary.message_count, 2);
+        assert_eq!(summary.token_usage.total_tokens, 32);
     }
 
     #[test]

--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -52,6 +52,32 @@ pub struct AgentHistoryWorktree {
     pub exists: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Default, PartialEq, Eq)]
+pub struct AgentTranscriptTokenUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub reasoning_tokens: u64,
+    pub total_tokens: u64,
+    pub messages_with_usage: u64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentTranscriptSummary {
+    pub provider: AgentHistoryProvider,
+    pub id: String,
+    pub transcript_path: String,
+    pub updated_at: u64,
+    pub message_count: u64,
+    pub user_messages: u64,
+    pub assistant_messages: u64,
+    pub turn_count: u64,
+    pub complete_turns: u64,
+    pub running_turns: u64,
+    pub token_usage: AgentTranscriptTokenUsage,
+}
+
 pub fn list_agent_history(
     repo_path: PathBuf,
     limit: Option<usize>,
@@ -70,6 +96,16 @@ pub fn list_agent_history(
     items.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
     items.truncate(limit);
     Ok(items)
+}
+
+pub fn agent_transcript_summary(
+    repo_path: PathBuf,
+    transcript_id: String,
+) -> AppResult<Option<AgentTranscriptSummary>> {
+    let item = list_agent_history(repo_path, Some(DEFAULT_LIMIT))?
+        .into_iter()
+        .find(|item| item.id == transcript_id);
+    Ok(item.and_then(|item| summarize_agent_history_item(&item)))
 }
 
 pub fn list_unscoped_agent_history(
@@ -436,6 +472,202 @@ pub fn transcript_title_context(
         builder.push(entry);
     }
     builder.finish()
+}
+
+fn summarize_agent_history_item(item: &AgentHistoryItem) -> Option<AgentTranscriptSummary> {
+    let path = Path::new(&item.transcript_path);
+    let file = fs::File::open(path).ok()?;
+    let mut message_count = 0_u64;
+    let mut user_messages = 0_u64;
+    let mut assistant_messages = 0_u64;
+    let mut summed_usage = AgentTranscriptTokenUsage::default();
+    let mut cumulative_usage = AgentTranscriptTokenUsage::default();
+
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let line = line.trim();
+        if !line.starts_with('{') {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if let Some(entry) = title_context_entry(&item.provider, &value) {
+            match entry.role {
+                "User" => user_messages += 1,
+                "Assistant" => assistant_messages += 1,
+                _ => {}
+            }
+            message_count += 1;
+        }
+        if let Some(usage) = transcript_usage_from_value(&item.provider, &value) {
+            if is_cumulative_usage_event(&item.provider, &value) {
+                cumulative_usage = max_token_usage(cumulative_usage, usage);
+            } else {
+                add_token_usage(&mut summed_usage, usage);
+            }
+        }
+    }
+
+    let token_usage = if cumulative_usage.total_tokens > summed_usage.total_tokens {
+        cumulative_usage
+    } else {
+        summed_usage
+    };
+    let complete_turns = user_messages.min(assistant_messages);
+    let running_turns = user_messages.saturating_sub(assistant_messages);
+    Some(AgentTranscriptSummary {
+        provider: item.provider.clone(),
+        id: item.id.clone(),
+        transcript_path: item.transcript_path.clone(),
+        updated_at: item.updated_at,
+        message_count,
+        user_messages,
+        assistant_messages,
+        turn_count: user_messages,
+        complete_turns,
+        running_turns,
+        token_usage,
+    })
+}
+
+fn transcript_usage_from_value(
+    provider: &AgentHistoryProvider,
+    value: &Value,
+) -> Option<AgentTranscriptTokenUsage> {
+    match provider {
+        AgentHistoryProvider::Claude => value
+            .get("usage")
+            .or_else(|| {
+                value
+                    .get("message")
+                    .and_then(|message| message.get("usage"))
+            })
+            .and_then(token_usage_from_object),
+        AgentHistoryProvider::Codex => codex_usage_from_value(value),
+        AgentHistoryProvider::Antigravity => generic_usage_from_value(value),
+    }
+}
+
+fn codex_usage_from_value(value: &Value) -> Option<AgentTranscriptTokenUsage> {
+    if let Some(event) = codex_token_count_event(value) {
+        return event
+            .get("info")
+            .and_then(|info| info.get("total_token_usage").or(Some(info)))
+            .and_then(token_usage_from_object);
+    }
+    generic_usage_from_value(value)
+}
+
+fn generic_usage_from_value(value: &Value) -> Option<AgentTranscriptTokenUsage> {
+    for key in [
+        "usage",
+        "token_usage",
+        "tokenUsage",
+        "total_token_usage",
+        "totalTokenUsage",
+        "info",
+    ] {
+        if let Some(usage) = value.get(key).and_then(token_usage_from_object) {
+            return Some(usage);
+        }
+    }
+    for key in ["message", "payload", "response"] {
+        if let Some(usage) = value.get(key).and_then(generic_usage_from_value) {
+            return Some(usage);
+        }
+    }
+    token_usage_from_object(value)
+}
+
+fn token_usage_from_object(value: &Value) -> Option<AgentTranscriptTokenUsage> {
+    let input_tokens = first_u64(value, &["input_tokens", "inputTokens", "prompt_tokens"]);
+    let output_tokens = first_u64(
+        value,
+        &["output_tokens", "outputTokens", "completion_tokens"],
+    );
+    let cache_read_tokens = first_u64(
+        value,
+        &[
+            "cache_read_input_tokens",
+            "cacheReadInputTokens",
+            "cached_input_tokens",
+            "cachedInputTokens",
+            "cached_tokens",
+        ],
+    );
+    let cache_creation_tokens = first_u64(
+        value,
+        &["cache_creation_input_tokens", "cacheCreationInputTokens"],
+    );
+    let reasoning_tokens = first_u64(
+        value,
+        &[
+            "reasoning_output_tokens",
+            "reasoningOutputTokens",
+            "reasoning_tokens",
+        ],
+    );
+    let explicit_total = first_u64(value, &["total_tokens", "totalTokens"]);
+    let total_tokens = explicit_total.unwrap_or_else(|| {
+        input_tokens.unwrap_or(0)
+            + output_tokens.unwrap_or(0)
+            + cache_read_tokens.unwrap_or(0)
+            + cache_creation_tokens.unwrap_or(0)
+    });
+    if total_tokens == 0 && reasoning_tokens.unwrap_or(0) == 0 {
+        return None;
+    }
+    Some(AgentTranscriptTokenUsage {
+        input_tokens: input_tokens.unwrap_or(0),
+        output_tokens: output_tokens.unwrap_or(0),
+        cache_read_tokens: cache_read_tokens.unwrap_or(0),
+        cache_creation_tokens: cache_creation_tokens.unwrap_or(0),
+        reasoning_tokens: reasoning_tokens.unwrap_or(0),
+        total_tokens,
+        messages_with_usage: 1,
+    })
+}
+
+fn first_u64(value: &Value, keys: &[&str]) -> Option<u64> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_u64))
+}
+
+fn is_cumulative_usage_event(provider: &AgentHistoryProvider, value: &Value) -> bool {
+    provider == &AgentHistoryProvider::Codex && codex_token_count_event(value).is_some()
+}
+
+fn codex_token_count_event(value: &Value) -> Option<&Value> {
+    if string_at(Some(value), "type").as_deref() == Some("token_count") {
+        return Some(value);
+    }
+    for key in ["msg", "payload"] {
+        if let Some(event) = value.get(key).and_then(codex_token_count_event) {
+            return Some(event);
+        }
+    }
+    None
+}
+
+fn add_token_usage(total: &mut AgentTranscriptTokenUsage, usage: AgentTranscriptTokenUsage) {
+    total.input_tokens += usage.input_tokens;
+    total.output_tokens += usage.output_tokens;
+    total.cache_read_tokens += usage.cache_read_tokens;
+    total.cache_creation_tokens += usage.cache_creation_tokens;
+    total.reasoning_tokens += usage.reasoning_tokens;
+    total.total_tokens += usage.total_tokens;
+    total.messages_with_usage += usage.messages_with_usage;
+}
+
+fn max_token_usage(
+    current: AgentTranscriptTokenUsage,
+    candidate: AgentTranscriptTokenUsage,
+) -> AgentTranscriptTokenUsage {
+    if candidate.total_tokens > current.total_tokens {
+        candidate
+    } else {
+        current
+    }
 }
 
 fn parse_codex_state(path: &Path) -> Option<ParsedAgentFile> {
@@ -1925,6 +2157,103 @@ mod tests {
         assert!(context.contains("Turn 0"));
         assert!(context.contains("[...]"));
         assert!(context.contains("Turn 19"));
+    }
+
+    #[test]
+    fn transcript_summary_counts_messages_and_uses_codex_cumulative_token_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = dir
+            .path()
+            .join("rollout-2026-05-21T10-13-44-019e4818-7c15-7e60-9b3b-898a1c7803d6.jsonl");
+        let mut file = fs::File::create(&transcript).unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "payload": {
+                    "id": "019e4818-7c15-7e60-9b3b-898a1c7803d6",
+                    "cwd": "/tmp/demo",
+                    "role": "user",
+                    "content": "Do it",
+                },
+            })
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "payload": {
+                    "role": "assistant",
+                    "content": "Done",
+                },
+            })
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "msg": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 20,
+                            "cached_input_tokens": 7,
+                            "output_tokens": 5,
+                            "reasoning_output_tokens": 2,
+                            "total_tokens": 32,
+                        },
+                    },
+                },
+            })
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "msg": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 40,
+                            "cached_input_tokens": 9,
+                            "output_tokens": 10,
+                            "reasoning_output_tokens": 4,
+                            "total_tokens": 59,
+                        },
+                    },
+                },
+            })
+        )
+        .unwrap();
+        drop(file);
+
+        let item = AgentHistoryItem {
+            provider: AgentHistoryProvider::Codex,
+            id: "019e4818-7c15-7e60-9b3b-898a1c7803d6".to_string(),
+            title: "Do it".to_string(),
+            preview: Some("Done".to_string()),
+            cwd: Some("/tmp/demo".to_string()),
+            worktree: None,
+            transcript_path: transcript.display().to_string(),
+            updated_at: 1_766_000_000,
+            resume_command: None,
+        };
+
+        let summary = summarize_agent_history_item(&item).unwrap();
+
+        assert_eq!(summary.message_count, 2);
+        assert_eq!(summary.user_messages, 1);
+        assert_eq!(summary.assistant_messages, 1);
+        assert_eq!(summary.complete_turns, 1);
+        assert_eq!(summary.token_usage.input_tokens, 40);
+        assert_eq!(summary.token_usage.cache_read_tokens, 9);
+        assert_eq!(summary.token_usage.output_tokens, 10);
+        assert_eq!(summary.token_usage.reasoning_tokens, 4);
+        assert_eq!(summary.token_usage.total_tokens, 59);
+        assert_eq!(summary.token_usage.messages_with_usage, 1);
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -476,6 +476,7 @@ struct ChatCliOutputParser {
     pending_line: String,
     emitted_text: String,
     final_text: Option<String>,
+    usage: Option<serde_json::Value>,
 }
 
 impl ChatCliOutputParser {
@@ -485,6 +486,7 @@ impl ChatCliOutputParser {
             pending_line: String::new(),
             emitted_text: String::new(),
             final_text: None,
+            usage: None,
         }
     }
 
@@ -526,6 +528,9 @@ impl ChatCliOutputParser {
         let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
             return;
         };
+        if let Some(usage) = extract_chat_stream_usage(self.mode, &value) {
+            self.usage = Some(usage);
+        }
         let Some(event) = extract_chat_stream_text(self.mode, &value) else {
             return;
         };
@@ -567,6 +572,12 @@ impl ChatCliOutputParser {
         self.emitted_text.push_str(delta);
         on_chunk(delta);
     }
+
+    fn provider_metadata(&self) -> Option<serde_json::Value> {
+        self.usage
+            .as_ref()
+            .map(|usage| serde_json::json!({ "usage": usage }))
+    }
 }
 
 struct ChatStreamTextEvent {
@@ -604,6 +615,45 @@ fn extract_chat_stream_text(
         ChatCliOutputMode::ClaudeStreamJson => extract_claude_stream_text(value),
         ChatCliOutputMode::CodexJson => extract_codex_stream_text(value),
     }
+}
+
+fn extract_chat_stream_usage(
+    mode: ChatCliOutputMode,
+    value: &serde_json::Value,
+) -> Option<serde_json::Value> {
+    match mode {
+        ChatCliOutputMode::Text => None,
+        ChatCliOutputMode::ClaudeStreamJson => extract_claude_stream_usage(value),
+        ChatCliOutputMode::CodexJson => extract_codex_stream_usage(value),
+    }
+}
+
+fn extract_claude_stream_usage(value: &serde_json::Value) -> Option<serde_json::Value> {
+    value
+        .get("usage")
+        .or_else(|| {
+            value
+                .get("message")
+                .and_then(|message| message.get("usage"))
+        })
+        .cloned()
+}
+
+fn extract_codex_stream_usage(value: &serde_json::Value) -> Option<serde_json::Value> {
+    extract_codex_event_usage(value)
+        .or_else(|| value.get("msg").and_then(extract_codex_event_usage))
+        .or_else(|| value.get("payload").and_then(extract_codex_event_usage))
+}
+
+fn extract_codex_event_usage(value: &serde_json::Value) -> Option<serde_json::Value> {
+    let event_type = value.get("type").and_then(serde_json::Value::as_str);
+    if event_type == Some("token_count") {
+        return value
+            .get("info")
+            .and_then(|info| info.get("total_token_usage").or(Some(info)))
+            .cloned();
+    }
+    value.get("usage").cloned()
 }
 
 fn extract_claude_stream_text(value: &serde_json::Value) -> Option<ChatStreamTextEvent> {
@@ -778,7 +828,7 @@ impl ChatProviderAdapter for CliChatProviderAdapter {
             native_thread_id,
             resume_token,
             last_response_id: None,
-            metadata: None,
+            metadata: output_parser.provider_metadata(),
         })
     }
 }
@@ -1960,6 +2010,17 @@ pub async fn list_agent_history(
 ) -> AppResult<Vec<AgentHistoryItem>> {
     run_blocking("list_agent_history", move || {
         agent_history::list_agent_history(PathBuf::from(repo_path), limit)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn agent_transcript_summary(
+    repo_path: String,
+    transcript_id: String,
+) -> AppResult<Option<agent_history::AgentTranscriptSummary>> {
+    run_blocking("agent_transcript_summary", move || {
+        agent_history::agent_transcript_summary(PathBuf::from(repo_path), transcript_id)
     })
     .await
 }
@@ -5718,6 +5779,32 @@ mod tests {
     }
 
     #[test]
+    fn chat_stream_parser_records_claude_usage_metadata() {
+        let mut parser =
+            super::ChatCliOutputParser::new(super::ChatCliOutputMode::ClaudeStreamJson);
+        let mut chunks = Vec::new();
+
+        {
+            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            parser.push_chunk(
+                r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}],"usage":{"input_tokens":11,"output_tokens":3}}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+        }
+
+        assert_eq!(
+            parser.provider_metadata(),
+            Some(serde_json::json!({
+                "usage": {
+                    "input_tokens": 11,
+                    "output_tokens": 3,
+                }
+            }))
+        );
+    }
+
+    #[test]
     fn chat_stream_parser_separates_non_prefix_claude_assistant_messages() {
         let mut parser =
             super::ChatCliOutputParser::new(super::ChatCliOutputMode::ClaudeStreamJson);
@@ -5773,6 +5860,34 @@ mod tests {
 
         assert_eq!(chunks.concat(), "hello");
         assert_eq!(parser.finish(""), "hello");
+    }
+
+    #[test]
+    fn chat_stream_parser_records_codex_token_count_metadata() {
+        let mut parser = super::ChatCliOutputParser::new(super::ChatCliOutputMode::CodexJson);
+        let mut chunks = Vec::new();
+
+        {
+            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            parser.push_chunk(
+                r#"{"msg":{"type":"token_count","info":{"total_token_usage":{"input_tokens":20,"cached_input_tokens":7,"output_tokens":5,"reasoning_output_tokens":2,"total_tokens":32}}}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+        }
+
+        assert_eq!(
+            parser.provider_metadata(),
+            Some(serde_json::json!({
+                "usage": {
+                    "input_tokens": 20,
+                    "cached_input_tokens": 7,
+                    "output_tokens": 5,
+                    "reasoning_output_tokens": 2,
+                    "total_tokens": 32,
+                }
+            }))
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2026,6 +2026,24 @@ pub async fn agent_transcript_summary(
 }
 
 #[tauri::command]
+pub async fn agent_transcript_summary_at_path(
+    repo_path: String,
+    provider: agent_history::AgentHistoryProvider,
+    id: String,
+    transcript_path: String,
+) -> AppResult<Option<agent_history::AgentTranscriptSummary>> {
+    run_blocking("agent_transcript_summary_at_path", move || {
+        agent_history::agent_transcript_summary_at_path(
+            PathBuf::from(repo_path),
+            provider,
+            id,
+            PathBuf::from(transcript_path),
+        )
+    })
+    .await
+}
+
+#[tauri::command]
 pub async fn list_unscoped_agent_history(
     state: State<'_, AppState>,
     limit: Option<usize>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -595,6 +595,7 @@ pub fn run() {
             commands::ipc_restart,
             commands::list_system_fonts,
             commands::list_agent_history,
+            commands::agent_transcript_summary,
             commands::list_unscoped_agent_history,
             commands::trash_agent_history_transcript,
             commands::get_claude_resume_candidate,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -596,6 +596,7 @@ pub fn run() {
             commands::list_system_fonts,
             commands::list_agent_history,
             commands::agent_transcript_summary,
+            commands::agent_transcript_summary_at_path,
             commands::list_unscoped_agent_history,
             commands::trash_agent_history_transcript,
             commands::get_claude_resume_candidate,

--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -1,7 +1,12 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Project, Session, SessionStatus } from "../lib/types";
+import type {
+  ChatSessionState,
+  Project,
+  Session,
+  SessionStatus,
+} from "../lib/types";
 
 const mocks = vi.hoisted(() => ({
   createSession: vi.fn(async () => ({}) as Session),
@@ -19,10 +24,15 @@ const mocks = vi.hoisted(() => ({
     binary: false,
   })),
   fsGitDiffLines: vi.fn(async () => []),
+  fsGitStatus: vi.fn(),
+  fsGitDiffStats: vi.fn(),
+  loadChatSessionState: vi.fn(),
+  agentTranscriptSummary: vi.fn(),
   ptyWrite: vi.fn(async () => undefined),
 }));
 
 vi.mock("../lib/api", () => ({
+  CHAT_SESSION_STATE_CHANGED_EVENT: "acorn:chat-session-state-changed",
   FS_CHANGED_EVENT: "acorn:fs-changed",
   api: {
     loadStatus: vi.fn(async () => ({
@@ -36,6 +46,10 @@ vi.mock("../lib/api", () => ({
     ptyInWorktreeAll: mocks.ptyInWorktreeAll,
     fsReadFile: mocks.fsReadFile,
     fsGitDiffLines: mocks.fsGitDiffLines,
+    fsGitStatus: mocks.fsGitStatus,
+    fsGitDiffStats: mocks.fsGitDiffStats,
+    loadChatSessionState: mocks.loadChatSessionState,
+    agentTranscriptSummary: mocks.agentTranscriptSummary,
     ptyWrite: mocks.ptyWrite,
   },
 }));
@@ -60,6 +74,7 @@ import {
   cancelWorkspaceTabDrag,
   getWorkspaceTabDragSession,
 } from "../lib/workspaceTabDrag";
+import { makeWorkSummaryWorkspaceTab } from "../lib/workspaceTabs";
 
 const REPO = "/Users/me/repo";
 const HOME = "/Users/me";
@@ -93,6 +108,27 @@ function session(id: string, overrides: Partial<Session> = {}): Session {
     in_worktree: false,
     ...overrides,
   };
+}
+
+function chatStateWithTokens(totalTokens: number): ChatSessionState {
+  return {
+    messages: [
+      {
+        id: "a1",
+        role: "assistant",
+        metadata: {
+          provider_response: {
+            usage: {
+              input_tokens: totalTokens - 40,
+              output_tokens: 40,
+              total_tokens: totalTokens,
+            },
+          },
+        },
+      },
+    ],
+    turns: [],
+  } as unknown as ChatSessionState;
 }
 
 function resetStore(): void {
@@ -290,6 +326,13 @@ describe("Pane empty state", () => {
     clearFileDropTargetsForTest();
     cancelWorkspaceTabDrag();
     vi.clearAllMocks();
+    mocks.fsGitStatus.mockResolvedValue({
+      statuses: {},
+      huge: false,
+      limit: 500,
+    });
+    mocks.fsGitDiffStats.mockResolvedValue({});
+    mocks.loadChatSessionState.mockResolvedValue(chatStateWithTokens(140));
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -467,6 +510,123 @@ describe("Pane empty state", () => {
       indicator!.compareDocumentPosition(title!) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
+  });
+
+  it("passes a work summary token baseline through pane tab rendering", async () => {
+    const active = session("chat-session", { mode: "chat" });
+    const summaryTab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: active.worktree_path,
+      sessionId: active.id,
+      title: "Chat Summary",
+      tokenBaseline: {
+        inputTokens: 40,
+        outputTokens: 10,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        reasoningTokens: 0,
+        totalTokens: 50,
+        messagesWithUsage: 1,
+        capturedAt: "2026-01-01T00:00:00Z",
+      },
+    });
+    const pane = {
+      id: "root",
+      tabIds: [summaryTab.id],
+      activeTabId: summaryTab.id,
+    };
+    useAppStore.setState((s) => ({
+      ...s,
+      sessions: [active],
+      activeProject: REPO,
+      activeProjectFolderId: REPO,
+      activeSessionId: active.id,
+      activeTabId: summaryTab.id,
+      workspaceTabs: { [summaryTab.id]: summaryTab },
+      workspaces: {
+        ...s.workspaces,
+        [REPO]: {
+          layout: { kind: "pane", id: "root" },
+          panes: { root: pane },
+          focusedPaneId: "root",
+        },
+      },
+      panes: { root: pane },
+      focusedPaneId: "root",
+    }));
+
+    await act(async () => {
+      root.render(<Pane paneId="root" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Session used");
+    expect(container.textContent).toContain("Summary start");
+    expect(container.textContent).toContain("50");
+    expect(container.textContent).toContain("+90");
+  });
+
+  it("loads a visible work summary in an unfocused pane", async () => {
+    const active = session("chat-session", { mode: "chat" });
+    const summaryTab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: active.worktree_path,
+      sessionId: active.id,
+      title: "Chat Summary",
+    });
+    const rootPane = {
+      id: "root",
+      tabIds: [active.id],
+      activeTabId: active.id,
+    };
+    const summaryPane = {
+      id: "pane-2",
+      tabIds: [summaryTab.id],
+      activeTabId: summaryTab.id,
+    };
+    const layout = {
+      kind: "split" as const,
+      id: "split-test",
+      direction: "horizontal" as const,
+      a: { kind: "pane" as const, id: "root" },
+      b: { kind: "pane" as const, id: "pane-2" },
+    };
+
+    useAppStore.setState((s) => ({
+      ...s,
+      sessions: [active],
+      activeProject: REPO,
+      activeProjectFolderId: REPO,
+      activeSessionId: active.id,
+      activeTabId: active.id,
+      workspaceTabs: { [summaryTab.id]: summaryTab },
+      workspaces: {
+        ...s.workspaces,
+        [REPO]: {
+          layout,
+          panes: { root: rootPane, "pane-2": summaryPane },
+          focusedPaneId: "root",
+        },
+      },
+      layout,
+      panes: { root: rootPane, "pane-2": summaryPane },
+      focusedPaneId: "root",
+    }));
+
+    await act(async () => {
+      root.render(<Pane paneId="pane-2" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("140 tokens");
   });
 
   it("does not enter tab rename while title generation is active", async () => {

--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   fsGitDiffStats: vi.fn(),
   loadChatSessionState: vi.fn(),
   agentTranscriptSummary: vi.fn(),
+  agentTranscriptSummaryAtPath: vi.fn(),
   ptyWrite: vi.fn(async () => undefined),
 }));
 
@@ -50,6 +51,7 @@ vi.mock("../lib/api", () => ({
     fsGitDiffStats: mocks.fsGitDiffStats,
     loadChatSessionState: mocks.loadChatSessionState,
     agentTranscriptSummary: mocks.agentTranscriptSummary,
+    agentTranscriptSummaryAtPath: mocks.agentTranscriptSummaryAtPath,
     ptyWrite: mocks.ptyWrite,
   },
 }));
@@ -570,7 +572,7 @@ describe("Pane empty state", () => {
     expect(container.textContent).toContain("+90");
   });
 
-  it("loads a visible work summary in an unfocused pane", async () => {
+  it("does not load work summary data in an unfocused pane", async () => {
     const active = session("chat-session", { mode: "chat" });
     const summaryTab = makeWorkSummaryWorkspaceTab({
       repoPath: REPO,
@@ -626,7 +628,10 @@ describe("Pane empty state", () => {
       await Promise.resolve();
     });
 
-    expect(container.textContent).toContain("140 tokens");
+    expect(container.textContent).toContain("Work Summary");
+    expect(container.textContent).not.toContain("140 tokens");
+    expect(mocks.fsGitStatus).not.toHaveBeenCalled();
+    expect(mocks.loadChatSessionState).not.toHaveBeenCalled();
   });
 
   it("does not enter tab rename while title generation is active", async () => {

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -47,6 +47,7 @@ import {
 } from "../lib/editor";
 import { formatHotkey, type HotkeyId } from "../lib/hotkeys";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
+import { basename } from "../lib/pathUtils";
 import {
   useSettings,
   resolveAiExecutionRequest,
@@ -564,7 +565,7 @@ export function Pane({ paneId }: PaneProps) {
             session={
               active.sessionId ? sessionsById.get(active.sessionId) ?? null : null
             }
-            isActive
+            isActive={isFocused}
             onOpenFile={(path) => openCodeViewerTab(path, active.repoPath)}
           />
         ) : null}
@@ -1725,11 +1726,6 @@ function buildPaneMenuItems({
       disabled: totalPanes <= 1,
     },
   ];
-}
-
-function basename(path: string): string {
-  const parts = path.split(/[\\/]/).filter(Boolean);
-  return parts[parts.length - 1] ?? path;
 }
 
 async function copyToClipboard(text: string): Promise<void> {

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -1,5 +1,6 @@
 import {
   Bot,
+  BarChart3,
   CircleX,
   Columns2,
   Copy,
@@ -30,6 +31,7 @@ import { createPortal } from "react-dom";
 import { selectSessionsById, useAppStore } from "../store";
 import { FileViewer } from "./FileViewer";
 import { ChatPane } from "./ChatPane";
+import { WorkSummaryView } from "./WorkSummaryView";
 import { api } from "../lib/api";
 import {
   AgentProviderIcon,
@@ -83,6 +85,7 @@ import {
   makeSessionWorkspaceTab,
   type CodeWorkspaceTab,
   type SessionWorkspaceTab,
+  type WorkSummaryWorkspaceTab,
 } from "../lib/workspaceTabs";
 import {
   beginWorkspaceTabDrag,
@@ -150,7 +153,8 @@ interface PaneProps {
 
 type PaneTab =
   | (SessionWorkspaceTab & { session: Session })
-  | CodeWorkspaceTab;
+  | CodeWorkspaceTab
+  | WorkSummaryWorkspaceTab;
 
 /**
  * A single workspace pane. Hosts a tab strip and a body with the active
@@ -173,6 +177,8 @@ export function Pane({ paneId }: PaneProps) {
   const createSession = useAppStore((s) => s.createSession);
   const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
   const closeWorkspaceTab = useAppStore((s) => s.closeWorkspaceTab);
+  const openCodeViewerTab = useAppStore((s) => s.openCodeViewerTab);
+  const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
   const moveTab = useAppStore((s) => s.moveTab);
   const splitFocusedPane = useAppStore((s) => s.splitFocusedPane);
   const closePane = useAppStore((s) => s.closePane);
@@ -225,6 +231,17 @@ export function Pane({ paneId }: PaneProps) {
           lifecycle: workspaceTab.lifecycle,
           path: workspaceTab.path,
           target: workspaceTab.target,
+        });
+      } else if (workspaceTab?.kind === "work-summary") {
+        ordered.push({
+          kind: "work-summary",
+          id: workspaceTab.id,
+          title: workspaceTab.title,
+          repoPath: workspaceTab.repoPath,
+          lifecycle: workspaceTab.lifecycle,
+          cwdPath: workspaceTab.cwdPath,
+          sessionId: workspaceTab.sessionId,
+          tokenBaseline: workspaceTab.tokenBaseline,
         });
       }
     }
@@ -541,6 +558,16 @@ export function Pane({ paneId }: PaneProps) {
             isActive={isFocused}
           />
         ) : null}
+        {active?.kind === "work-summary" ? (
+          <WorkSummaryView
+            tab={active}
+            session={
+              active.sessionId ? sessionsById.get(active.sessionId) ?? null : null
+            }
+            isActive
+            onOpenFile={(path) => openCodeViewerTab(path, active.repoPath)}
+          />
+        ) : null}
         {active ? null : (
           <EmptyPane
             hasProjects={hasProjects}
@@ -573,6 +600,9 @@ export function Pane({ paneId }: PaneProps) {
           onClose: () => closePane(paneId),
           activeProjectFallback: useAppStore.getState().activeProject,
           shortcuts,
+          onOpenWorkSummary: activeSession
+            ? () => void openWorkSummaryTab({ sessionId: activeSession.id })
+            : undefined,
         })}
       />
     </div>
@@ -848,6 +878,7 @@ function TabItem({
   const showToast = useToasts((s) => s.show);
   const renameSession = useAppStore((s) => s.renameSession);
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
+  const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
   const session = tab.kind === "session" ? tab.session : null;
   const isGeneratingTitle = useAppStore((s) =>
     session ? Boolean(s.generatingSessionTitleIds[session.id]) : false,
@@ -866,7 +897,12 @@ function TabItem({
     showAgentProviderIcons && session
       ? resolveSessionAgentProvider(session)
       : null;
-  const tabPath = tab.kind === "session" ? tab.session.worktree_path : tab.path;
+  const tabPath =
+    tab.kind === "session"
+      ? tab.session.worktree_path
+      : tab.kind === "code"
+        ? tab.path
+        : tab.cwdPath;
   const liveInWorktree = useAppStore((s) =>
     session ? s.liveInWorktree[session.id] : false,
   );
@@ -1131,6 +1167,11 @@ function TabItem({
             onClick: () => void regenerateTitle(),
             disabled: !canRegenerateTitle,
           },
+          {
+            label: paneT(t, "pane.menu.openWorkSummary"),
+            icon: <BarChart3 size={12} />,
+            onClick: () => void openWorkSummaryTab({ sessionId: session.id }),
+          },
         ]
       : []),
     ...(forkItems.length > 0
@@ -1163,7 +1204,9 @@ function TabItem({
     {
       label: session
         ? paneT(t, "pane.menu.openWorktreeInEditor")
-        : paneT(t, "pane.menu.openFileInEditor"),
+        : tab.kind === "code"
+          ? paneT(t, "pane.menu.openFileInEditor")
+          : paneT(t, "pane.menu.openWorktreeInEditor"),
       icon: <PencilLine size={12} />,
       disabled: !editorConfigured,
       onClick: () => {
@@ -1192,7 +1235,9 @@ function TabItem({
         {
           label: session
             ? paneT(t, "pane.menu.worktreePath")
-            : paneT(t, "pane.menu.filePath"),
+            : tab.kind === "code"
+              ? paneT(t, "pane.menu.filePath")
+              : paneT(t, "pane.menu.worktreePath"),
           icon: <Copy size={12} />,
           onClick: () => {
             void copyToClipboard(tabPath);
@@ -1201,7 +1246,9 @@ function TabItem({
         {
           label: session
             ? paneT(t, "pane.menu.worktreeName")
-            : paneT(t, "pane.menu.fileName"),
+            : tab.kind === "code"
+              ? paneT(t, "pane.menu.fileName")
+              : paneT(t, "pane.menu.worktreeName"),
           icon: <Copy size={12} />,
           onClick: () => {
             void copyToClipboard(basename(tabPath));
@@ -1311,6 +1358,13 @@ function TabItem({
             <SessionTitleGeneratingIndicator
               label={paneT(t, "pane.aria.generatingSessionTitle")}
             />
+          ) : tab.kind === "work-summary" ? (
+            <Tooltip label={paneT(t, "pane.aria.workSummary")} side="bottom">
+              <BarChart3
+                size={12}
+                className="pointer-events-none shrink-0 text-accent"
+              />
+            </Tooltip>
           ) : session?.mode === "chat" ? (
             <Tooltip label={paneT(t, "pane.aria.chatSession")} side="bottom">
               <MessageSquareText
@@ -1567,6 +1621,7 @@ function buildPaneMenuItems({
   onClose,
   activeProjectFallback,
   shortcuts,
+  onOpenWorkSummary,
 }: {
   t: Translator;
   activeSession: Session | null;
@@ -1577,11 +1632,21 @@ function buildPaneMenuItems({
   onClose: () => void;
   activeProjectFallback: string | null;
   shortcuts: Record<HotkeyId, string>;
+  onOpenWorkSummary?: () => void;
 }): ContextMenuItem[] {
   const editorReady = hasConfiguredEditor();
   const worktreeItems: ContextMenuItem[] = activeSession
     ? [
         { type: "separator" },
+        ...(onOpenWorkSummary
+          ? [
+              {
+                label: paneT(t, "pane.menu.openWorkSummary"),
+                icon: <BarChart3 size={12} />,
+                onClick: onOpenWorkSummary,
+              },
+            ]
+          : []),
         {
           label: paneT(t, "pane.menu.openWorktreeInEditor"),
           icon: <PencilLine size={12} />,

--- a/src/components/ProjectSettingsModal.test.tsx
+++ b/src/components/ProjectSettingsModal.test.tsx
@@ -296,7 +296,7 @@ describe("ProjectSettingsModal", () => {
     expect(document.body.textContent).toContain("feature-beta");
   });
 
-  it("requires confirmation before deleting a worktree used by sessions", async () => {
+  it("requires confirmation before deleting a worktree used by the active session", async () => {
     mockApi.getProjectSettings.mockResolvedValue({
       key: "github:im-ian/acorn",
       settings: {
@@ -323,13 +323,8 @@ describe("ProjectSettingsModal", () => {
           worktree_path: "/repo/acorn/.acorn/worktrees/feature-alpha",
           in_worktree: true,
         }),
-        session({
-          id: "s-alpha-2",
-          name: "alpha chat",
-          worktree_path: "/repo/acorn/.acorn/worktrees/feature-alpha/",
-          in_worktree: true,
-        }),
       ],
+      activeSessionId: "s-alpha-1",
       projects: [
         {
           repo_path: "/repo/acorn",
@@ -359,7 +354,7 @@ describe("ProjectSettingsModal", () => {
     });
     await flushPromises();
 
-    expect(document.body.textContent).toContain("Used by 2 sessions");
+    expect(document.body.textContent).toContain("Used by 1 session");
 
     const remove = Array.from(
       document.body.querySelectorAll<HTMLButtonElement>("button"),
@@ -375,8 +370,7 @@ describe("ProjectSettingsModal", () => {
     });
 
     expect(document.body.textContent).toContain("alpha terminal");
-    expect(document.body.textContent).toContain("alpha chat");
-    expect(document.body.textContent).toContain("2 sessions will be removed");
+    expect(document.body.textContent).toContain("1 session will be removed");
 
     const confirm = Array.from(
       document.body.querySelectorAll<HTMLButtonElement>("button"),
@@ -397,5 +391,91 @@ describe("ProjectSettingsModal", () => {
     );
     expect(useAppStore.getState().sessions).toEqual([]);
     expect(document.body.textContent).not.toContain("feature-alpha");
+  });
+
+  it("blocks worktree deletion while another session uses it", async () => {
+    mockApi.getProjectSettings.mockResolvedValue({
+      key: "github:im-ian/acorn",
+      settings: {
+        remember_after_close: true,
+        pull_requests: {
+          generation_prompt: "Use concise release-note style.",
+        },
+      },
+    });
+    mockApi.listProjectWorktrees.mockResolvedValue([
+      {
+        name: "feature-alpha",
+        path: "/repo/acorn/.acorn/worktrees/feature-alpha",
+        modified_ms: null,
+      },
+    ]);
+    useAppStore.setState({
+      sessions: [
+        session({
+          id: "s-alpha-1",
+          name: "alpha terminal",
+          worktree_path: "/repo/acorn/.acorn/worktrees/feature-alpha",
+          in_worktree: true,
+        }),
+        session({
+          id: "s-alpha-2",
+          name: "alpha chat",
+          worktree_path: "/repo/acorn/.acorn/worktrees/feature-alpha/",
+          in_worktree: true,
+        }),
+      ],
+      activeSessionId: "s-alpha-1",
+      projects: [
+        {
+          repo_path: "/repo/acorn",
+          name: "acorn",
+          created_at: "2026-01-01T00:00:00Z",
+          position: 0,
+        },
+      ],
+    });
+
+    await act(async () => {
+      root.render(
+        <ProjectSettingsModal
+          project={{ name: "acorn", repoPath: "/repo/acorn" }}
+          onClose={() => {}}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const worktreesTab = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent === "Worktrees");
+    await act(async () => {
+      worktreesTab!.click();
+    });
+    await flushPromises();
+
+    expect(document.body.textContent).toContain("Used by 2 sessions");
+    expect(document.body.textContent).toContain(
+      "Close other sessions using this worktree before removing it.",
+    );
+
+    const remove = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find(
+      (button) =>
+        button.getAttribute("aria-label") ===
+        "Remove feature-alpha worktree",
+    );
+    expect(remove).toBeDefined();
+    expect(remove?.disabled).toBe(true);
+
+    await act(async () => {
+      remove!.click();
+    });
+
+    expect(document.body.textContent).not.toContain(
+      "Remove sessions and delete worktree",
+    );
+    expect(mockApi.removeWorktree).not.toHaveBeenCalled();
   });
 });

--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -11,6 +11,10 @@ import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { STANDARD_PR_GENERATION_PROMPT } from "../lib/project-settings";
+import {
+  otherSessionsUsingProjectWorktree,
+  sessionsUsingProjectWorktree,
+} from "../lib/sessionWorktree";
 import type { ProjectSettings, ProjectWorktree, Session } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
 import { useAppStore } from "../store";
@@ -77,27 +81,6 @@ function formatModifiedTime(value: number | null): string | null {
   }).format(date);
 }
 
-function normalizePath(path: string): string {
-  const normalized = path.replace(/\\/g, "/").replace(/\/+$/g, "");
-  return normalized.length > 0 ? normalized : "/";
-}
-
-function samePath(left: string, right: string): boolean {
-  return normalizePath(left) === normalizePath(right);
-}
-
-function sessionsUsingWorktree(
-  sessions: readonly Session[],
-  repoPath: string,
-  worktreePath: string,
-): Session[] {
-  return sessions.filter(
-    (session) =>
-      samePath(session.repo_path, repoPath) &&
-      samePath(session.worktree_path, worktreePath),
-  );
-}
-
 interface ProjectSettingsModalProps {
   project: { name: string; repoPath: string } | null;
   initialTab?: ProjectSettingsTab;
@@ -111,6 +94,7 @@ export function ProjectSettingsModal({
 }: ProjectSettingsModalProps) {
   const t = useTranslation();
   const sessions = useAppStore((s) => s.sessions);
+  const activeSessionId = useAppStore((s) => s.activeSessionId);
   const removeProjectWorktree = useAppStore((s) => s.removeProjectWorktree);
   const [tab, setTab] = useState<ProjectSettingsTab>(initialTab);
   const [settings, setSettings] = useState<ProjectSettings>(() =>
@@ -132,20 +116,39 @@ export function ProjectSettingsModal({
 
   const confirmRemoveSessions =
     project && confirmRemove
-      ? sessionsUsingWorktree(sessions, project.repoPath, confirmRemove.path)
+      ? sessionsUsingProjectWorktree(
+          sessions,
+          project.repoPath,
+          confirmRemove.path,
+        )
       : [];
+  const confirmRemoveOtherSessions =
+    project && confirmRemove
+      ? otherSessionsUsingProjectWorktree(
+          sessions,
+          project.repoPath,
+          confirmRemove.path,
+          activeSessionId,
+        )
+      : [];
+  const canShowConfirmRemove =
+    confirmRemove !== null && confirmRemoveOtherSessions.length === 0;
 
   useDialogShortcuts(project !== null && confirmRemove === null, {
     onCancel: onClose,
     onConfirm: () => {},
   });
 
-  useDialogShortcuts(confirmRemove !== null, {
+  useDialogShortcuts(canShowConfirmRemove, {
     onCancel: () => setConfirmRemove(null),
     onConfirm: () => {
       void removeConfirmedWorktree();
     },
   });
+
+  useEffect(() => {
+    if (confirmRemoveOtherSessions.length > 0) setConfirmRemove(null);
+  }, [confirmRemoveOtherSessions.length]);
 
   useEffect(() => {
     setTab(initialTab);
@@ -253,11 +256,18 @@ export function ProjectSettingsModal({
   async function removeConfirmedWorktree() {
     if (!project || !confirmRemove || removingPath !== null) return;
     const target = confirmRemove;
-    const targetSessions = sessionsUsingWorktree(
+    const targetSessions = sessionsUsingProjectWorktree(
       sessions,
       project.repoPath,
       target.path,
     );
+    const otherSessions = targetSessions.filter(
+      (session) => session.id !== activeSessionId,
+    );
+    if (otherSessions.length > 0) {
+      setConfirmRemove(null);
+      return;
+    }
     setRemovingPath(target.path);
     setWorktreeError(null);
     try {
@@ -273,6 +283,18 @@ export function ProjectSettingsModal({
     } finally {
       setRemovingPath(null);
     }
+  }
+
+  function requestRemoveWorktree(worktree: ProjectWorktree) {
+    if (!project) return;
+    const otherSessions = otherSessionsUsingProjectWorktree(
+      sessions,
+      project.repoPath,
+      worktree.path,
+      activeSessionId,
+    );
+    if (otherSessions.length > 0) return;
+    setConfirmRemove(worktree);
   }
 
   return (
@@ -390,10 +412,11 @@ export function ProjectSettingsModal({
                     repoPath={project.repoPath}
                     worktrees={worktrees}
                     sessions={sessions}
+                    activeSessionId={activeSessionId}
                     loading={worktreesLoading}
                     removingPath={removingPath}
                     error={worktreeError}
-                    onRequestRemove={setConfirmRemove}
+                    onRequestRemove={requestRemoveWorktree}
                     t={t}
                   />
                 </ProjectSettingsGroup>
@@ -427,7 +450,7 @@ export function ProjectSettingsModal({
             </button>
           </footer>
           <RemoveWorktreeConfirmDialog
-            worktree={confirmRemove}
+            worktree={canShowConfirmRemove ? confirmRemove : null}
             sessions={confirmRemoveSessions}
             removing={removingPath === confirmRemove?.path}
             onCancel={() => setConfirmRemove(null)}
@@ -468,6 +491,7 @@ function ProjectWorktreeList({
   repoPath,
   worktrees,
   sessions,
+  activeSessionId,
   loading,
   removingPath,
   error,
@@ -477,6 +501,7 @@ function ProjectWorktreeList({
   repoPath: string;
   worktrees: ProjectWorktree[];
   sessions: Session[];
+  activeSessionId: string | null;
   loading: boolean;
   removingPath: string | null;
   error: { kind: "load" | "remove"; message: string } | null;
@@ -503,12 +528,15 @@ function ProjectWorktreeList({
           {worktrees.map((worktree) => {
             const modified = formatModifiedTime(worktree.modified_ms);
             const isRemoving = removingPath === worktree.path;
-            const usedBySessions = sessionsUsingWorktree(
+            const usedBySessions = sessionsUsingProjectWorktree(
               sessions,
               repoPath,
               worktree.path,
             );
             const sessionCount = usedBySessions.length;
+            const removeBlockedByOtherSessions = usedBySessions.some(
+              (session) => session.id !== activeSessionId,
+            );
             return (
               <li key={worktree.path} className="px-3 py-2">
                 <div className="flex items-start justify-between gap-3">
@@ -541,6 +569,14 @@ function ProjectWorktreeList({
                         )}
                       </p>
                     ) : null}
+                    {removeBlockedByOtherSessions ? (
+                      <p className="text-[11px] text-fg-muted">
+                        {dt(
+                          t,
+                          "dialogs.projectSettings.removeWorktreeBlockedByOtherSessions",
+                        )}
+                      </p>
+                    ) : null}
                   </div>
                   <button
                     type="button"
@@ -549,8 +585,18 @@ function ProjectWorktreeList({
                       "dialogs.projectSettings.removeWorktreeAria",
                       { name: worktree.name },
                     )}
+                    title={
+                      removeBlockedByOtherSessions
+                        ? dt(
+                            t,
+                            "dialogs.projectSettings.removeWorktreeBlockedByOtherSessions",
+                          )
+                        : undefined
+                    }
                     onClick={() => onRequestRemove(worktree)}
-                    disabled={removingPath !== null}
+                    disabled={
+                      removingPath !== null || removeBlockedByOtherSessions
+                    }
                     className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md border border-border bg-bg px-2 text-[11px] text-fg-muted transition hover:text-danger disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     {isRemoving ? (

--- a/src/components/WorkSummaryView.test.tsx
+++ b/src/components/WorkSummaryView.test.tsx
@@ -1,0 +1,499 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatSessionState, Session } from "../lib/types";
+import { makeWorkSummaryWorkspaceTab } from "../lib/workspaceTabs";
+
+const mocks = vi.hoisted(() => ({
+  fsGitStatus: vi.fn(),
+  fsGitDiffStats: vi.fn(),
+  loadChatSessionState: vi.fn(),
+  agentTranscriptSummary: vi.fn(),
+}));
+
+const eventMocks = vi.hoisted(() => ({
+  listeners: new Map<string, Set<(event: { payload: unknown }) => void>>(),
+  listen: vi.fn(
+    (
+      event: string,
+      handler: (event: { payload: unknown }) => void,
+    ): Promise<() => void> => {
+      const listeners = eventMocks.listeners.get(event) ?? new Set();
+      listeners.add(handler);
+      eventMocks.listeners.set(event, listeners);
+      return Promise.resolve(() => listeners.delete(handler));
+    },
+  ),
+}));
+
+vi.mock("../lib/api", () => ({
+  CHAT_SESSION_STATE_CHANGED_EVENT: "acorn:chat-session-state-changed",
+  FS_CHANGED_EVENT: "acorn:fs-changed",
+  api: {
+    fsGitStatus: mocks.fsGitStatus,
+    fsGitDiffStats: mocks.fsGitDiffStats,
+    loadChatSessionState: mocks.loadChatSessionState,
+    agentTranscriptSummary: mocks.agentTranscriptSummary,
+  },
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: eventMocks.listen,
+}));
+
+import { WorkSummaryView } from "./WorkSummaryView";
+
+const REPO = "/Users/me/repo";
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "s1",
+    name: "Feature runner",
+    repo_path: REPO,
+    worktree_path: `${REPO}/.worktrees/s1`,
+    branch: "feat/summary",
+    isolated: false,
+    status: "idle",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: "done",
+    title_source: "default",
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: true,
+    ...overrides,
+  };
+}
+
+function chatState(): ChatSessionState {
+  return {
+    schema_version: 1,
+    session_id: "s1",
+    session: {
+      id: "s1",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+    messages: [
+      {
+        id: "u1",
+        role: "user",
+        content: "Do it",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "Done",
+        created_at: "2026-01-01T00:00:01Z",
+        metadata: {
+          provider_response: {
+            usage: {
+              input_tokens: 100,
+              output_tokens: 40,
+              total_tokens: 140,
+            },
+          },
+        },
+      },
+    ],
+    turns: [
+      {
+        id: "t1",
+        session_id: "s1",
+        provider: "codex",
+        status: "complete",
+        user_message_id: "u1",
+        assistant_message_id: "a1",
+        started_at: "2026-01-01T00:00:00Z",
+        completed_at: "2026-01-01T00:00:01Z",
+      },
+    ],
+    provider_threads: [],
+    context_snapshots: [],
+    memory: {
+      session_id: "s1",
+      important_decisions: [],
+      facts: [],
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:01Z",
+  };
+}
+
+function chatStateWithTokenTotal(totalTokens: number): ChatSessionState {
+  const state = chatState();
+  return {
+    ...state,
+    messages: [
+      ...state.messages,
+      {
+        id: "u2",
+        role: "user",
+        content: "Again",
+        created_at: "2026-01-01T00:00:02Z",
+      },
+      {
+        id: "a2",
+        role: "assistant",
+        content: "Again done",
+        created_at: "2026-01-01T00:00:03Z",
+        metadata: {
+          provider_response: {
+            usage: {
+              input_tokens: totalTokens - 80,
+              output_tokens: 80,
+              total_tokens: totalTokens,
+            },
+          },
+        },
+      },
+    ],
+    turns: [
+      ...state.turns,
+      {
+        id: "t2",
+        session_id: "s1",
+        provider: "codex",
+        status: "complete",
+        user_message_id: "u2",
+        assistant_message_id: "a2",
+        started_at: "2026-01-01T00:00:02Z",
+        completed_at: "2026-01-01T00:00:03Z",
+      },
+    ],
+    updated_at: "2026-01-01T00:00:03Z",
+  };
+}
+
+function emitEvent(event: string, payload: unknown) {
+  const listeners = eventMocks.listeners.get(event);
+  if (!listeners || listeners.size === 0) {
+    throw new Error(`listener not registered: ${event}`);
+  }
+  for (const listener of listeners) {
+    listener({ payload });
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("WorkSummaryView", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    eventMocks.listeners.clear();
+    eventMocks.listen.mockClear();
+    mocks.fsGitStatus.mockResolvedValue({
+      statuses: {
+        [`${REPO}/src/App.tsx`]: {
+          kind: "modified",
+          additions: 0,
+          deletions: 0,
+        },
+        [`${REPO}/README.md`]: {
+          kind: "added",
+          additions: 0,
+          deletions: 0,
+        },
+      },
+      huge: false,
+      limit: 500,
+    });
+    mocks.fsGitDiffStats.mockResolvedValue({
+      [`${REPO}/src/App.tsx`]: { additions: 12, deletions: 3 },
+      [`${REPO}/README.md`]: { additions: 4, deletions: 0 },
+    });
+    mocks.loadChatSessionState.mockResolvedValue(chatState());
+    mocks.agentTranscriptSummary.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("shows completed details while the first git summary snapshot is loading", async () => {
+    const pendingStatus = deferred<Awaited<ReturnType<typeof mocks.fsGitStatus>>>();
+    mocks.fsGitStatus.mockReturnValueOnce(pendingStatus.promise);
+    const tab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: `${REPO}/.worktrees/s1`,
+      sessionId: "s1",
+      title: "Feature runner Summary",
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkSummaryView
+          tab={tab}
+          session={session({ mode: "chat" })}
+          isActive
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Feature runner");
+    expect(
+      container.querySelector('[data-work-summary-section-skeleton="files"]'),
+    ).toBeInstanceOf(HTMLElement);
+    expect(
+      container.querySelector('[data-work-summary-section-skeleton="charts"]'),
+    ).toBeInstanceOf(HTMLElement);
+    expect(
+      container.querySelector('[data-work-summary-skeleton="true"]'),
+    ).toBeNull();
+    expect(container.textContent).not.toContain("README.md");
+
+    await act(async () => {
+      pendingStatus.resolve({
+        statuses: {},
+        huge: false,
+        limit: 500,
+      });
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('[data-work-summary-section-skeleton="files"]'),
+    ).toBeNull();
+  });
+
+  it("renders completed git summary while conversation metrics are still loading", async () => {
+    const pendingChat = deferred<ChatSessionState>();
+    mocks.loadChatSessionState.mockReturnValueOnce(pendingChat.promise);
+    const tab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: `${REPO}/.worktrees/s1`,
+      sessionId: "s1",
+      title: "Feature runner Summary",
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkSummaryView
+          tab={tab}
+          session={session({ mode: "chat" })}
+          isActive
+        />,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("2 files");
+    expect(container.textContent).toContain("README.md");
+    expect(
+      container.querySelector(
+        '[data-work-summary-section-skeleton="conversation"]',
+      ),
+    ).toBeInstanceOf(HTMLElement);
+    expect(container.textContent).not.toContain("2 messages");
+
+    await act(async () => {
+      pendingChat.resolve(chatState());
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("2 messages");
+  });
+
+  it("renders git and chat summary metrics for a chat session", async () => {
+    const tab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: `${REPO}/.worktrees/s1`,
+      sessionId: "s1",
+      title: "Feature runner Summary",
+      tokenBaseline: {
+        inputTokens: 40,
+        outputTokens: 10,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        reasoningTokens: 0,
+        totalTokens: 50,
+        messagesWithUsage: 1,
+        capturedAt: "2026-01-01T00:00:00Z",
+      },
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkSummaryView
+          tab={tab}
+          session={session({ mode: "chat" })}
+          isActive
+        />,
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mocks.fsGitStatus).toHaveBeenCalledWith(`${REPO}/.worktrees/s1`, 500);
+    expect(mocks.fsGitDiffStats).toHaveBeenCalledWith(
+      `${REPO}/.worktrees/s1`,
+      expect.arrayContaining([
+        { path: `${REPO}/src/App.tsx`, kind: "modified" },
+        { path: `${REPO}/README.md`, kind: "added" },
+      ]),
+    );
+    expect(mocks.loadChatSessionState).toHaveBeenCalledWith("s1");
+    expect(container.textContent).toContain("2 files");
+    expect(container.textContent).toContain("+16");
+    expect(container.textContent).toContain("-3");
+    expect(container.textContent).toContain("2 messages");
+    expect(container.textContent).toContain("140 tokens");
+    expect(container.textContent).toContain("Summary start");
+    expect(container.textContent).toContain("50");
+    expect(container.textContent).toContain("Session used");
+    expect(container.textContent).toContain("+90");
+    expect(container.textContent).toContain("Input");
+    expect(container.textContent).toContain("Output");
+    expect(container.textContent).toContain("README.md");
+    expect(container.textContent).toContain("src/App.tsx");
+  });
+
+  it("updates conversation and token metrics when the chat session changes", async () => {
+    const tab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: `${REPO}/.worktrees/s1`,
+      sessionId: "s1",
+      title: "Feature runner Summary",
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkSummaryView
+          tab={tab}
+          session={session({ mode: "chat" })}
+          isActive
+        />,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("2 messages");
+    expect(container.textContent).toContain("140 tokens");
+
+    act(() => {
+      emitEvent("acorn:chat-session-state-changed", {
+        session_id: "s1",
+        state: chatStateWithTokenTotal(260),
+      });
+    });
+
+    expect(container.textContent).toContain("4 messages");
+    expect(container.textContent).toContain("400 tokens");
+  });
+
+  it("renders conversation and token metrics from a terminal agent transcript", async () => {
+    mocks.agentTranscriptSummary.mockResolvedValue({
+      provider: "codex",
+      id: "transcript-1",
+      transcript_path: "/Users/me/.codex/sessions/transcript-1.jsonl",
+      updated_at: 1_766_000_000,
+      message_count: 4,
+      user_messages: 2,
+      assistant_messages: 2,
+      turn_count: 2,
+      complete_turns: 2,
+      running_turns: 0,
+      token_usage: {
+        input_tokens: 220,
+        output_tokens: 80,
+        cache_read_tokens: 20,
+        cache_creation_tokens: 0,
+        reasoning_tokens: 12,
+        total_tokens: 320,
+        messages_with_usage: 1,
+      },
+    });
+    const tab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: `${REPO}/.worktrees/s1`,
+      sessionId: "s1",
+      title: "Feature runner Summary",
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkSummaryView
+          tab={tab}
+          session={session({
+            mode: "terminal",
+            agent_transcript_id: "transcript-1",
+          })}
+          isActive
+        />,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mocks.loadChatSessionState).not.toHaveBeenCalled();
+    expect(mocks.agentTranscriptSummary).toHaveBeenCalledWith(
+      REPO,
+      "transcript-1",
+    );
+    expect(container.textContent).toContain("4 messages");
+    expect(container.textContent).toContain("320 tokens");
+  });
+
+  it("opens a changed file when its row is double-clicked", async () => {
+    const onOpenFile = vi.fn();
+    const tab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: `${REPO}/.worktrees/s1`,
+      sessionId: "s1",
+      title: "Feature runner Summary",
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkSummaryView
+          tab={tab}
+          session={session({ mode: "chat" })}
+          isActive
+          onOpenFile={onOpenFile}
+        />,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const fileRow = container.querySelector(
+      `[data-work-summary-file-path="${REPO}/README.md"]`,
+    );
+    expect(fileRow).toBeInstanceOf(HTMLElement);
+
+    await act(async () => {
+      fileRow!.dispatchEvent(
+        new MouseEvent("dblclick", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(onOpenFile).toHaveBeenCalledWith(`${REPO}/README.md`);
+  });
+});

--- a/src/components/WorkSummaryView.test.tsx
+++ b/src/components/WorkSummaryView.test.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   fsGitDiffStats: vi.fn(),
   loadChatSessionState: vi.fn(),
   agentTranscriptSummary: vi.fn(),
+  agentTranscriptSummaryAtPath: vi.fn(),
 }));
 
 const eventMocks = vi.hoisted(() => ({
@@ -34,6 +35,7 @@ vi.mock("../lib/api", () => ({
     fsGitDiffStats: mocks.fsGitDiffStats,
     loadChatSessionState: mocks.loadChatSessionState,
     agentTranscriptSummary: mocks.agentTranscriptSummary,
+    agentTranscriptSummaryAtPath: mocks.agentTranscriptSummaryAtPath,
   },
 }));
 
@@ -220,11 +222,13 @@ describe("WorkSummaryView", () => {
     });
     mocks.loadChatSessionState.mockResolvedValue(chatState());
     mocks.agentTranscriptSummary.mockResolvedValue(null);
+    mocks.agentTranscriptSummaryAtPath.mockResolvedValue(null);
   });
 
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 
@@ -458,6 +462,93 @@ describe("WorkSummaryView", () => {
     );
     expect(container.textContent).toContain("4 messages");
     expect(container.textContent).toContain("320 tokens");
+  });
+
+  it("polls a terminal agent transcript by cached path after the initial id lookup", async () => {
+    vi.useFakeTimers();
+    mocks.agentTranscriptSummary.mockResolvedValueOnce({
+      provider: "codex",
+      id: "transcript-1",
+      transcript_path: "/Users/me/.codex/sessions/transcript-1.jsonl",
+      updated_at: 1_766_000_000,
+      message_count: 4,
+      user_messages: 2,
+      assistant_messages: 2,
+      turn_count: 2,
+      complete_turns: 2,
+      running_turns: 0,
+      token_usage: {
+        input_tokens: 220,
+        output_tokens: 80,
+        cache_read_tokens: 20,
+        cache_creation_tokens: 0,
+        reasoning_tokens: 12,
+        total_tokens: 320,
+        messages_with_usage: 1,
+      },
+    });
+    mocks.agentTranscriptSummaryAtPath.mockResolvedValueOnce({
+      provider: "codex",
+      id: "transcript-1",
+      transcript_path: "/Users/me/.codex/sessions/transcript-1.jsonl",
+      updated_at: 1_766_000_015,
+      message_count: 6,
+      user_messages: 3,
+      assistant_messages: 3,
+      turn_count: 3,
+      complete_turns: 3,
+      running_turns: 0,
+      token_usage: {
+        input_tokens: 300,
+        output_tokens: 120,
+        cache_read_tokens: 20,
+        cache_creation_tokens: 0,
+        reasoning_tokens: 12,
+        total_tokens: 452,
+        messages_with_usage: 2,
+      },
+    });
+    const tab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: `${REPO}/.worktrees/s1`,
+      sessionId: "s1",
+      title: "Feature runner Summary",
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkSummaryView
+          tab={tab}
+          session={session({
+            mode: "terminal",
+            agent_transcript_id: "transcript-1",
+          })}
+          isActive
+        />,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mocks.agentTranscriptSummary).toHaveBeenCalledTimes(1);
+    expect(mocks.agentTranscriptSummaryAtPath).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(15_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.agentTranscriptSummaryAtPath).toHaveBeenCalledWith(
+      REPO,
+      "codex",
+      "transcript-1",
+      "/Users/me/.codex/sessions/transcript-1.jsonl",
+    );
+    expect(mocks.agentTranscriptSummary).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("6 messages");
+    expect(container.textContent).toContain("452 tokens");
   });
 
   it("opens a changed file when its row is double-clicked", async () => {

--- a/src/components/WorkSummaryView.tsx
+++ b/src/components/WorkSummaryView.tsx
@@ -1,0 +1,969 @@
+import {
+  AlertTriangle,
+  Clock,
+  FileText,
+  Files,
+  Hash,
+  MessageSquareText,
+} from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import {
+  CHAT_SESSION_STATE_CHANGED_EVENT,
+  FS_CHANGED_EVENT,
+  api,
+  type ChatSessionStateChangedPayload,
+  type FsChangePayload,
+  type FsGitDiffStatsRequest,
+  type FsGitStatus,
+} from "../lib/api";
+import { cn } from "../lib/cn";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import type { Session } from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
+import {
+  buildWorkSummary,
+  summarizeChatSession,
+  summarizeTokenUsage,
+  tokenUsageDelta,
+  type WorkSummary,
+  type WorkSummaryChatMetrics,
+  type WorkSummaryKindCounts,
+  type WorkSummaryTokenUsage,
+} from "../lib/workSummary";
+import type { WorkSummaryWorkspaceTab } from "../lib/workspaceTabs";
+import type { AgentTranscriptSummary } from "../lib/types";
+import { RefreshButton } from "./ui/RefreshButton";
+
+const STATUS_CLASS: Record<FsGitStatus, string> = {
+  added: "bg-emerald-500/10 text-emerald-300",
+  clean: "bg-bg-elevated text-fg-muted",
+  conflicted: "bg-danger/10 text-danger",
+  deleted: "bg-rose-500/10 text-rose-300",
+  modified: "bg-amber-500/10 text-amber-300",
+  renamed: "bg-sky-500/10 text-sky-300",
+};
+
+type WorkSummaryTranslationKey = Extract<
+  TranslationKey,
+  `workSummary.${string}`
+>;
+
+function wt(t: Translator, key: WorkSummaryTranslationKey): string {
+  return t(key);
+}
+
+function wtf(
+  t: Translator,
+  key: WorkSummaryTranslationKey,
+  values: Record<string, string | number>,
+): string {
+  return wt(t, key).replace(/\{(\w+)\}/g, (match, name) =>
+    Object.prototype.hasOwnProperty.call(values, name)
+      ? String(values[name])
+      : match,
+  );
+}
+
+interface WorkSummaryViewProps {
+  tab: WorkSummaryWorkspaceTab;
+  session?: Session | null;
+  isActive: boolean;
+  onOpenFile?: (path: string) => void;
+}
+
+interface WorkSummarySnapshot {
+  summary: WorkSummary;
+}
+
+interface WorkSummaryConversationSnapshot {
+  chat: WorkSummaryChatMetrics | null;
+  tokens: WorkSummaryTokenUsage | null;
+}
+
+export function WorkSummaryView({
+  tab,
+  session,
+  isActive,
+  onOpenFile,
+}: WorkSummaryViewProps) {
+  const t = useTranslation();
+  const [summary, setSummary] = useState<WorkSummary | null>(null);
+  const [chat, setChat] = useState<WorkSummaryChatMetrics | null>(null);
+  const [tokens, setTokens] = useState<WorkSummaryTokenUsage | null>(null);
+  const [summaryLoading, setSummaryLoading] = useState(false);
+  const [conversationLoading, setConversationLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const loading = summaryLoading || conversationLoading;
+
+  const fetchSummary = useCallback(async (): Promise<WorkSummarySnapshot> => {
+    const status = await api.fsGitStatus(tab.cwdPath, 500);
+    const entries: FsGitDiffStatsRequest[] = Object.entries(status.statuses)
+      .filter(([, entry]) => entry.kind !== "clean")
+      .map(([path, entry]) => ({ path, kind: entry.kind }));
+    const diffStats =
+      entries.length > 0 ? await api.fsGitDiffStats(tab.cwdPath, entries) : {};
+    const summary = buildWorkSummary(tab.cwdPath, status, diffStats);
+    return { summary };
+  }, [tab.cwdPath]);
+
+  const fetchConversation = useCallback(async (): Promise<WorkSummaryConversationSnapshot> => {
+    if (!session) {
+      return { chat: null, tokens: null };
+    }
+
+    if (session.mode === "chat") {
+      const chatState = await api.loadChatSessionState(session.id);
+      return {
+        chat: summarizeChatSession(chatState),
+        tokens: summarizeTokenUsage(chatState),
+      };
+    }
+
+    if (session.agent_transcript_id) {
+      const transcript = await api.agentTranscriptSummary(
+        tab.repoPath,
+        session.agent_transcript_id,
+      );
+      return {
+        chat: transcript ? chatMetricsFromTranscript(transcript) : null,
+        tokens: transcript ? tokenUsageFromTranscript(transcript) : null,
+      };
+    }
+
+    return { chat: null, tokens: null };
+  }, [
+    session?.agent_transcript_id,
+    session?.id,
+    session?.mode,
+    tab.repoPath,
+  ]);
+
+  const applySnapshot = useCallback((snapshot: WorkSummarySnapshot) => {
+    setSummary(snapshot.summary);
+  }, []);
+
+  const applyConversationSnapshot = useCallback(
+    (snapshot: WorkSummaryConversationSnapshot) => {
+      setChat(snapshot.chat);
+      setTokens(snapshot.tokens);
+    },
+    [],
+  );
+
+  const load = useCallback(async () => {
+    setSummaryLoading(true);
+    setConversationLoading(true);
+    setError(null);
+    const summaryTask = fetchSummary()
+      .then(applySnapshot)
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => setSummaryLoading(false));
+    const conversationTask = fetchConversation()
+      .then(applyConversationSnapshot)
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => setConversationLoading(false));
+    await Promise.allSettled([summaryTask, conversationTask]);
+  }, [
+    applyConversationSnapshot,
+    applySnapshot,
+    fetchConversation,
+    fetchSummary,
+  ]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    let cancelled = false;
+    setSummaryLoading(true);
+    setConversationLoading(true);
+    setError(null);
+
+    async function runSummary() {
+      try {
+        const snapshot = await fetchSummary();
+        if (!cancelled) applySnapshot(snapshot);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        if (!cancelled) setSummaryLoading(false);
+      }
+    }
+
+    async function runConversation() {
+      try {
+        const snapshot = await fetchConversation();
+        if (!cancelled) applyConversationSnapshot(snapshot);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        if (!cancelled) setConversationLoading(false);
+      }
+    }
+
+    void runSummary();
+    void runConversation();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    applyConversationSnapshot,
+    applySnapshot,
+    fetchConversation,
+    fetchSummary,
+    isActive,
+  ]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    let cancelled = false;
+    let fsUnlisten: UnlistenFn | null = null;
+    let chatUnlisten: UnlistenFn | null = null;
+    let refreshTimer: number | null = null;
+    let transcriptPollTimer: number | null = null;
+
+    async function refreshSummarySilently() {
+      try {
+        const snapshot = await fetchSummary();
+        if (!cancelled) applySnapshot(snapshot);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    }
+
+    async function refreshConversationSilently() {
+      try {
+        const snapshot = await fetchConversation();
+        if (!cancelled) applyConversationSnapshot(snapshot);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    }
+
+    function scheduleRefresh() {
+      if (refreshTimer !== null) window.clearTimeout(refreshTimer);
+      refreshTimer = window.setTimeout(() => {
+        refreshTimer = null;
+        void refreshSummarySilently();
+      }, 500);
+    }
+
+    void listen<FsChangePayload>(FS_CHANGED_EVENT, (event) => {
+      if (cancelled || !fsChangeTouchesRoot(event.payload, tab.cwdPath)) return;
+      scheduleRefresh();
+    }).then((dispose) => {
+      if (cancelled) dispose();
+      else fsUnlisten = dispose;
+    });
+
+    if (session?.mode === "chat") {
+      void listen<ChatSessionStateChangedPayload>(
+        CHAT_SESSION_STATE_CHANGED_EVENT,
+        (event) => {
+          if (cancelled || event.payload.session_id !== session.id) return;
+          setError(null);
+          setChat(summarizeChatSession(event.payload.state));
+          setTokens(summarizeTokenUsage(event.payload.state));
+        },
+      ).then((dispose) => {
+        if (cancelled) dispose();
+        else chatUnlisten = dispose;
+      });
+    } else if (session?.agent_transcript_id) {
+      transcriptPollTimer = window.setInterval(() => {
+        void refreshConversationSilently();
+      }, 5_000);
+    }
+
+    return () => {
+      cancelled = true;
+      if (refreshTimer !== null) window.clearTimeout(refreshTimer);
+      if (transcriptPollTimer !== null) {
+        window.clearInterval(transcriptPollTimer);
+      }
+      fsUnlisten?.();
+      chatUnlisten?.();
+    };
+  }, [
+    applyConversationSnapshot,
+    applySnapshot,
+    fetchConversation,
+    fetchSummary,
+    isActive,
+    session?.id,
+    session?.agent_transcript_id,
+    session?.mode,
+    tab.repoPath,
+    tab.cwdPath,
+  ]);
+
+  const metadata = useMemo(() => {
+    const rows: Array<{ label: string; value: string | null | undefined }> = [
+      { label: wt(t, "workSummary.metadata.scope"), value: tab.cwdPath },
+    ];
+    if (session) {
+      rows.push(
+        { label: wt(t, "workSummary.metadata.session"), value: session.name },
+        { label: wt(t, "workSummary.metadata.branch"), value: session.branch },
+        { label: wt(t, "workSummary.metadata.status"), value: session.status },
+        {
+          label: wt(t, "workSummary.metadata.mode"),
+          value: session.mode ?? "terminal",
+        },
+        {
+          label: wt(t, "workSummary.metadata.transcript"),
+          value: session.agent_transcript_id,
+        },
+        {
+          label: wt(t, "workSummary.metadata.updated"),
+          value: formatDateTime(session.updated_at),
+        },
+      );
+    }
+    return rows.filter((row) => row.value);
+  }, [session, t, tab.cwdPath]);
+  const summaryPending = summaryLoading && !summary;
+  const conversationPending = conversationLoading && !chat && !tokens;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-bg text-fg">
+      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <FileText size={16} className="shrink-0 text-accent" />
+            <h2 className="truncate text-sm font-semibold">
+              {wt(t, "workSummary.title")}
+            </h2>
+          </div>
+          <p className="mt-1 truncate font-mono text-[11px] text-fg-muted">
+            {tab.cwdPath}
+          </p>
+        </div>
+        <RefreshButton
+          onClick={load}
+          loading={loading}
+          title={wt(t, "workSummary.refresh")}
+          ariaLabel={wt(t, "workSummary.refresh")}
+        />
+      </header>
+
+      <div
+        className="min-h-0 flex-1 overflow-auto"
+        aria-busy={loading ? true : undefined}
+      >
+        {error ? (
+          <div className="m-4 flex items-start gap-2 rounded border border-danger/30 bg-danger/10 p-3 text-xs text-danger">
+            <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        ) : null}
+
+        <section className="grid grid-cols-2 border-b border-border md:grid-cols-4">
+          <MetricCell
+            icon={<Files size={14} />}
+            label={wt(t, "workSummary.metrics.files")}
+            value={
+              summaryPending ? (
+                <MetricValueSkeleton />
+              ) : summary ? (
+                wtf(t, "workSummary.values.files", {
+                  count: summary.totalFiles,
+                })
+              ) : (
+                wt(t, "workSummary.notAvailable")
+              )
+            }
+          />
+          <MetricCell
+            icon={<Hash size={14} />}
+            label={wt(t, "workSummary.metrics.lines")}
+            value={
+              summaryPending ? (
+                <MetricValueSkeleton />
+              ) : summary ? (
+                `+${summary.totalAdditions} / -${summary.totalDeletions}`
+              ) : (
+                wt(t, "workSummary.notAvailable")
+              )
+            }
+          />
+          <MetricCell
+            icon={<MessageSquareText size={14} />}
+            label={wt(t, "workSummary.metrics.messages")}
+            value={
+              conversationPending ? (
+                <MetricValueSkeleton />
+              ) : chat ? (
+                wtf(t, "workSummary.values.messages", {
+                  count: chat.messageCount,
+                })
+              ) : (
+                wt(t, "workSummary.notAvailable")
+              )
+            }
+          />
+          <MetricCell
+            icon={<Clock size={14} />}
+            label={wt(t, "workSummary.metrics.tokens")}
+            value={
+              conversationPending ? (
+                <MetricValueSkeleton />
+              ) : tokens && tokens.totalTokens > 0 ? (
+                wtf(t, "workSummary.values.tokens", {
+                  count: formatNumber(tokens.totalTokens),
+                })
+              ) : (
+                wt(t, "workSummary.notAvailable")
+              )
+            }
+          />
+        </section>
+
+        <section className="grid gap-0 border-b border-border lg:grid-cols-[minmax(0,1fr)_18rem]">
+          <div className="min-w-0 border-b border-border lg:border-b-0 lg:border-r">
+            <SectionHeader
+              title={wt(t, "workSummary.files.title")}
+              detail={
+                summary?.huge
+                  ? wtf(t, "workSummary.files.huge", {
+                      limit: summary.limit,
+                    })
+                : undefined
+              }
+            />
+            {summaryPending ? (
+              <ChangedFilesSkeleton />
+            ) : !summary ? (
+              <EmptyLine>{wt(t, "workSummary.notAvailable")}</EmptyLine>
+            ) : summary.files.length === 0 ? (
+              <EmptyLine>{wt(t, "workSummary.files.empty")}</EmptyLine>
+            ) : (
+              <div className="divide-y divide-border">
+                {summary.files.map((file) => (
+                  <div
+                    key={file.path}
+                    className={cn(
+                      "grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-4 py-2 text-xs",
+                      onOpenFile
+                        ? "cursor-default hover:bg-bg-elevated focus:outline-none focus:ring-1 focus:ring-inset focus:ring-accent"
+                        : null,
+                    )}
+                    data-work-summary-file-path={file.path}
+                    role={onOpenFile ? "button" : undefined}
+                    tabIndex={onOpenFile ? 0 : undefined}
+                    aria-label={
+                      onOpenFile
+                        ? wtf(t, "workSummary.files.openFile", {
+                            path: file.relativePath,
+                          })
+                        : undefined
+                    }
+                    onDoubleClick={() => onOpenFile?.(file.path)}
+                    onKeyDown={(event) => {
+                      if (!onOpenFile || event.key !== "Enter") return;
+                      event.preventDefault();
+                      onOpenFile(file.path);
+                    }}
+                  >
+                    <div className="min-w-0">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <span
+                          className={cn(
+                            "rounded px-1.5 py-0.5 text-[10px] font-medium uppercase",
+                            STATUS_CLASS[file.kind],
+                          )}
+                        >
+                          {wt(t, `workSummary.status.${file.kind}`)}
+                        </span>
+                        <span className="truncate font-mono">
+                          {file.relativePath}
+                        </span>
+                      </div>
+                    </div>
+                    <span className="font-mono text-[11px] tabular-nums text-fg-muted">
+                      <span className="text-emerald-300">+{file.additions}</span>
+                      <span className="mx-1 text-fg-muted">/</span>
+                      <span className="text-rose-300">-{file.deletions}</span>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <aside className="min-w-0">
+            <SectionHeader title={wt(t, "workSummary.details.title")} />
+            <dl className="divide-y divide-border">
+              {metadata.map((row) => (
+                <div key={row.label} className="px-4 py-2">
+                  <dt className="text-[10px] uppercase text-fg-muted">
+                    {row.label}
+                  </dt>
+                  <dd className="mt-1 truncate font-mono text-[11px]">
+                    {row.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </aside>
+        </section>
+
+        <section>
+          <div className="grid gap-0 border-b border-border lg:grid-cols-2">
+            <div className="border-b border-border lg:border-b-0 lg:border-r">
+              <SectionHeader title={wt(t, "workSummary.conversation.title")} />
+              {conversationPending ? (
+                <ConversationSkeleton />
+              ) : chat ? (
+                <div className="grid grid-cols-2 gap-px bg-border">
+                  <ConversationStat
+                    label={wt(t, "workSummary.conversation.user")}
+                    value={chat.userMessages}
+                  />
+                  <ConversationStat
+                    label={wt(t, "workSummary.conversation.assistant")}
+                    value={chat.assistantMessages}
+                  />
+                  <ConversationStat
+                    label={wt(t, "workSummary.conversation.turns")}
+                    value={chat.turnCount}
+                  />
+                  <ConversationStat
+                    label={wt(t, "workSummary.conversation.runningTurns")}
+                    value={chat.runningTurns}
+                  />
+                </div>
+              ) : (
+                <EmptyLine>
+                  {wt(t, "workSummary.conversation.terminalHint")}
+                </EmptyLine>
+              )}
+            </div>
+            <div>
+              <SectionHeader title={wt(t, "workSummary.tokens.title")} />
+              {conversationPending ? (
+                <TokenUsageSkeleton />
+              ) : tokens && tokens.totalTokens > 0 ? (
+                <TokenUsageChart
+                  tokens={tokens}
+                  baseline={tab.tokenBaseline}
+                  t={t}
+                />
+              ) : (
+                <EmptyLine>{wt(t, "workSummary.tokens.empty")}</EmptyLine>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeader title={wt(t, "workSummary.charts.title")} />
+          {summaryPending ? (
+            <ChartSkeleton />
+          ) : summary && summary.totalFiles > 0 ? (
+            <FileStatusChart
+              counts={summary.byKind}
+              total={summary.totalFiles}
+              t={t}
+            />
+          ) : (
+            <EmptyLine>{wt(t, "workSummary.files.empty")}</EmptyLine>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function MetricValueSkeleton() {
+  return <SkeletonBlock className="h-5 w-24 bg-fg-muted/15" />;
+}
+
+function ChangedFilesSkeleton() {
+  return (
+    <div
+      className="divide-y divide-border"
+      data-work-summary-section-skeleton="files"
+    >
+      {[0, 1, 2, 3, 4].map((idx) => (
+        <div
+          key={idx}
+          className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-4 py-2"
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            <SkeletonBlock className="h-5 w-10 bg-fg-muted/15" />
+            <SkeletonBlock
+              className={cn(
+                "h-3 min-w-0 bg-fg-muted/10",
+                idx % 3 === 0 ? "w-52" : idx % 3 === 1 ? "w-72" : "w-40",
+              )}
+            />
+          </div>
+          <SkeletonBlock className="h-3 w-16 bg-fg-muted/10" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ConversationSkeleton() {
+  return (
+    <div
+      className="grid grid-cols-2 gap-px bg-border"
+      data-work-summary-section-skeleton="conversation"
+    >
+      {Array.from({ length: 4 }).map((_, idx) => (
+        <div key={idx} className="bg-bg px-4 py-3">
+          <SkeletonBlock className="h-2.5 w-20 bg-fg-muted/10" />
+          <SkeletonBlock className="mt-2 h-4 w-10 bg-fg-muted/15" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TokenUsageSkeleton() {
+  return (
+    <div
+      className="space-y-3 px-4 py-3"
+      data-work-summary-section-skeleton="tokens"
+    >
+      <SkeletonBlock className="h-5 w-24 bg-fg-muted/15" />
+      <div className="space-y-2">
+        {[0, 1, 2, 3].map((idx) => (
+          <SkeletonChartRow key={idx} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ChartSkeleton() {
+  return (
+    <div
+      className="space-y-2 px-4 py-3"
+      data-work-summary-section-skeleton="charts"
+    >
+      {[0, 1, 2].map((idx) => (
+        <SkeletonChartRow key={idx} />
+      ))}
+    </div>
+  );
+}
+
+function SkeletonChartRow() {
+  return (
+    <div className="grid grid-cols-[7rem_minmax(0,1fr)_4.5rem] items-center gap-2">
+      <SkeletonBlock className="h-2.5 w-16 bg-fg-muted/10" />
+      <SkeletonBlock className="h-2 w-full bg-fg-muted/10" />
+      <SkeletonBlock className="h-2.5 w-10 bg-fg-muted/10" />
+    </div>
+  );
+}
+
+function SkeletonBlock({ className }: { className: string }) {
+  return (
+    <span
+      className={cn("block animate-pulse rounded bg-fg-muted/10", className)}
+    />
+  );
+}
+
+function MetricCell({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: ReactNode;
+}) {
+  return (
+    <div className="min-w-0 border-r border-border px-4 py-3 last:border-r-0">
+      <div className="flex items-center gap-2 text-[11px] text-fg-muted">
+        {icon}
+        <span className="truncate">{label}</span>
+      </div>
+      <div className="mt-1 truncate font-mono text-lg tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function SectionHeader({
+  title,
+  detail,
+}: {
+  title: string;
+  detail?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2">
+      <h3 className="text-xs font-semibold">{title}</h3>
+      {detail ? (
+        <span className="truncate text-[11px] text-fg-muted">{detail}</span>
+      ) : null}
+    </div>
+  );
+}
+
+function EmptyLine({ children }: { children: ReactNode }) {
+  return <div className="px-4 py-6 text-xs text-fg-muted">{children}</div>;
+}
+
+function ConversationStat({
+  label,
+  value,
+}: {
+  label: string;
+  value: number;
+}) {
+  return (
+    <div className="bg-bg px-4 py-3">
+      <div className="text-[11px] text-fg-muted">{label}</div>
+      <div className="mt-1 font-mono text-base tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function formatDateTime(value: string): string {
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) return value;
+  return new Date(ms).toLocaleString();
+}
+
+function TokenUsageChart({
+  tokens,
+  baseline,
+  t,
+}: {
+  tokens: WorkSummaryTokenUsage;
+  baseline?: WorkSummaryTokenUsage & { capturedAt: string };
+  t: Translator;
+}) {
+  const delta = tokenUsageDelta(tokens, baseline);
+  const rows = [
+    {
+      label: wt(t, "workSummary.tokens.input"),
+      value: tokens.inputTokens,
+      className: "bg-sky-400",
+    },
+    {
+      label: wt(t, "workSummary.tokens.output"),
+      value: tokens.outputTokens,
+      className: "bg-emerald-400",
+    },
+    {
+      label: wt(t, "workSummary.tokens.cache"),
+      value: tokens.cacheReadTokens + tokens.cacheCreationTokens,
+      className: "bg-amber-400",
+    },
+    {
+      label: wt(t, "workSummary.tokens.reasoning"),
+      value: tokens.reasoningTokens,
+      className: "bg-violet-400",
+    },
+  ].filter((row) => row.value > 0);
+  const max = Math.max(...rows.map((row) => row.value), 1);
+
+  return (
+    <div className="space-y-3 px-4 py-3">
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <div className="font-mono text-lg tabular-nums">
+            {formatNumber(tokens.totalTokens)}
+          </div>
+          <div className="text-[11px] text-fg-muted">
+            {wtf(t, "workSummary.tokens.fromMessages", {
+              count: tokens.messagesWithUsage,
+            })}
+          </div>
+        </div>
+      </div>
+      {baseline ? (
+        <div className="grid grid-cols-3 gap-px overflow-hidden rounded border border-border bg-border">
+          <TokenBaselineCell
+            label={wt(t, "workSummary.tokens.sessionUsed")}
+            value={formatNumber(tokens.totalTokens)}
+          />
+          <TokenBaselineCell
+            label={wt(t, "workSummary.tokens.summaryStart")}
+            value={formatNumber(baseline.totalTokens)}
+          />
+          <TokenBaselineCell
+            label={wt(t, "workSummary.tokens.sinceSummary")}
+            value={`+${formatNumber(delta.totalTokens)}`}
+          />
+        </div>
+      ) : null}
+      <div className="space-y-2">
+        {rows.map((row) => (
+          <ChartRow
+            key={row.label}
+            label={row.label}
+            value={formatNumber(row.value)}
+            width={(row.value / max) * 100}
+            className={row.className}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TokenBaselineCell({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="min-w-0 bg-bg px-2 py-2">
+      <div className="truncate text-[10px] uppercase text-fg-muted">
+        {label}
+      </div>
+      <div className="mt-0.5 truncate font-mono text-xs tabular-nums">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function FileStatusChart({
+  counts,
+  total,
+  t,
+}: {
+  counts: WorkSummaryKindCounts;
+  total: number;
+  t: Translator;
+}) {
+  const rows = (Object.keys(counts) as Array<keyof WorkSummaryKindCounts>)
+    .filter((kind) => kind !== "clean" && counts[kind] > 0)
+    .map((kind) => ({
+      label: wt(t, `workSummary.status.${kind}`),
+      value: counts[kind],
+      className:
+        kind === "added"
+          ? "bg-emerald-400"
+          : kind === "deleted"
+            ? "bg-rose-400"
+            : kind === "conflicted"
+              ? "bg-danger"
+              : kind === "renamed"
+                ? "bg-sky-400"
+                : "bg-amber-400",
+    }));
+
+  return (
+    <div className="space-y-2 px-4 py-3">
+      {rows.map((row) => (
+        <ChartRow
+          key={row.label}
+          label={row.label}
+          value={String(row.value)}
+          width={(row.value / total) * 100}
+          className={row.className}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ChartRow({
+  label,
+  value,
+  width,
+  className,
+}: {
+  label: string;
+  value: string;
+  width: number;
+  className: string;
+}) {
+  return (
+    <div className="grid grid-cols-[7rem_minmax(0,1fr)_4.5rem] items-center gap-2 text-[11px]">
+      <span className="truncate text-fg-muted">{label}</span>
+      <div className="h-2 overflow-hidden rounded bg-bg-elevated">
+        <div
+          className={cn("h-full rounded", className)}
+          style={{ width: `${Math.max(4, Math.min(100, width))}%` }}
+        />
+      </div>
+      <span className="text-right font-mono tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat().format(value);
+}
+
+function fsChangeTouchesRoot(payload: FsChangePayload, rootPath: string): boolean {
+  if (payload.overflow && payload.refresh) {
+    return pathsIntersect(payload.refresh.path, rootPath);
+  }
+  if (payload.root && pathsIntersect(payload.root, rootPath)) {
+    return true;
+  }
+  return payload.paths.some((path) => pathsIntersect(path, rootPath));
+}
+
+function pathsIntersect(a: string, b: string): boolean {
+  const left = normalizePath(a);
+  const right = normalizePath(b);
+  return left === right || pathInside(left, right) || pathInside(right, left);
+}
+
+function pathInside(path: string, root: string): boolean {
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  return path.startsWith(prefix);
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function chatMetricsFromTranscript(
+  transcript: AgentTranscriptSummary,
+): WorkSummaryChatMetrics {
+  return {
+    messageCount: transcript.message_count,
+    userMessages: transcript.user_messages,
+    assistantMessages: transcript.assistant_messages,
+    turnCount: transcript.turn_count,
+    completeTurns: transcript.complete_turns,
+    runningTurns: transcript.running_turns,
+  };
+}
+
+function tokenUsageFromTranscript(
+  transcript: AgentTranscriptSummary,
+): WorkSummaryTokenUsage {
+  return {
+    inputTokens: transcript.token_usage.input_tokens,
+    outputTokens: transcript.token_usage.output_tokens,
+    cacheReadTokens: transcript.token_usage.cache_read_tokens,
+    cacheCreationTokens: transcript.token_usage.cache_creation_tokens,
+    reasoningTokens: transcript.token_usage.reasoning_tokens,
+    totalTokens: transcript.token_usage.total_tokens,
+    messagesWithUsage: transcript.token_usage.messages_with_usage,
+  };
+}

--- a/src/components/WorkSummaryView.tsx
+++ b/src/components/WorkSummaryView.tsx
@@ -10,6 +10,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -25,21 +26,35 @@ import {
 } from "../lib/api";
 import { cn } from "../lib/cn";
 import type { TranslationKey, Translator } from "../lib/i18n";
+import { fsChangeTouchesRoot } from "../lib/workSummaryInvalidation";
 import type { Session } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
 import {
   buildWorkSummary,
   summarizeChatSession,
   summarizeTokenUsage,
-  tokenUsageDelta,
   type WorkSummary,
   type WorkSummaryChatMetrics,
-  type WorkSummaryKindCounts,
   type WorkSummaryTokenUsage,
 } from "../lib/workSummary";
 import type { WorkSummaryWorkspaceTab } from "../lib/workspaceTabs";
 import type { AgentTranscriptSummary } from "../lib/types";
 import { RefreshButton } from "./ui/RefreshButton";
+import {
+  FileStatusChart,
+  TokenUsageChart,
+} from "./work-summary/WorkSummaryCharts";
+import {
+  ChangedFilesSkeleton,
+  ChartSkeleton,
+  ConversationSkeleton,
+  MetricValueSkeleton,
+  TokenUsageSkeleton,
+} from "./work-summary/WorkSummarySkeletons";
+
+const GIT_STATUS_FILE_LIMIT = 500;
+const SUMMARY_REFRESH_DEBOUNCE_MS = 500;
+const TRANSCRIPT_POLL_INTERVAL_MS = 15_000;
 
 const STATUS_CLASS: Record<FsGitStatus, string> = {
   added: "bg-emerald-500/10 text-emerald-300",
@@ -87,6 +102,12 @@ interface WorkSummaryConversationSnapshot {
   tokens: WorkSummaryTokenUsage | null;
 }
 
+interface AgentTranscriptLocation {
+  provider: AgentTranscriptSummary["provider"];
+  id: string;
+  transcriptPath: string;
+}
+
 export function WorkSummaryView({
   tab,
   session,
@@ -100,10 +121,11 @@ export function WorkSummaryView({
   const [summaryLoading, setSummaryLoading] = useState(false);
   const [conversationLoading, setConversationLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const transcriptLocationRef = useRef<AgentTranscriptLocation | null>(null);
   const loading = summaryLoading || conversationLoading;
 
   const fetchSummary = useCallback(async (): Promise<WorkSummarySnapshot> => {
-    const status = await api.fsGitStatus(tab.cwdPath, 500);
+    const status = await api.fsGitStatus(tab.cwdPath, GIT_STATUS_FILE_LIMIT);
     const entries: FsGitDiffStatsRequest[] = Object.entries(status.statuses)
       .filter(([, entry]) => entry.kind !== "clean")
       .map(([path, entry]) => ({ path, kind: entry.kind }));
@@ -126,10 +148,12 @@ export function WorkSummaryView({
       };
     }
 
-    if (session.agent_transcript_id) {
-      const transcript = await api.agentTranscriptSummary(
+    const transcriptId = session.agent_transcript_id;
+    if (transcriptId) {
+      const transcript = await fetchAgentTranscriptSummary(
         tab.repoPath,
-        session.agent_transcript_id,
+        transcriptId,
+        transcriptLocationRef,
       );
       return {
         chat: transcript ? chatMetricsFromTranscript(transcript) : null,
@@ -240,9 +264,7 @@ export function WorkSummaryView({
         const snapshot = await fetchSummary();
         if (!cancelled) applySnapshot(snapshot);
       } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err));
-        }
+        void err;
       }
     }
 
@@ -251,9 +273,7 @@ export function WorkSummaryView({
         const snapshot = await fetchConversation();
         if (!cancelled) applyConversationSnapshot(snapshot);
       } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err));
-        }
+        void err;
       }
     }
 
@@ -262,7 +282,7 @@ export function WorkSummaryView({
       refreshTimer = window.setTimeout(() => {
         refreshTimer = null;
         void refreshSummarySilently();
-      }, 500);
+      }, SUMMARY_REFRESH_DEBOUNCE_MS);
     }
 
     void listen<FsChangePayload>(FS_CHANGED_EVENT, (event) => {
@@ -289,7 +309,7 @@ export function WorkSummaryView({
     } else if (session?.agent_transcript_id) {
       transcriptPollTimer = window.setInterval(() => {
         void refreshConversationSilently();
-      }, 5_000);
+      }, TRANSCRIPT_POLL_INTERVAL_MS);
     }
 
     return () => {
@@ -462,7 +482,7 @@ export function WorkSummaryView({
                     className={cn(
                       "grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-4 py-2 text-xs",
                       onOpenFile
-                        ? "cursor-default hover:bg-bg-elevated focus:outline-none focus:ring-1 focus:ring-inset focus:ring-accent"
+                        ? "cursor-pointer hover:bg-bg-elevated focus:outline-none focus:ring-1 focus:ring-inset focus:ring-accent"
                         : null,
                     )}
                     data-work-summary-file-path={file.path}
@@ -592,100 +612,6 @@ export function WorkSummaryView({
   );
 }
 
-function MetricValueSkeleton() {
-  return <SkeletonBlock className="h-5 w-24 bg-fg-muted/15" />;
-}
-
-function ChangedFilesSkeleton() {
-  return (
-    <div
-      className="divide-y divide-border"
-      data-work-summary-section-skeleton="files"
-    >
-      {[0, 1, 2, 3, 4].map((idx) => (
-        <div
-          key={idx}
-          className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-4 py-2"
-        >
-          <div className="flex min-w-0 items-center gap-2">
-            <SkeletonBlock className="h-5 w-10 bg-fg-muted/15" />
-            <SkeletonBlock
-              className={cn(
-                "h-3 min-w-0 bg-fg-muted/10",
-                idx % 3 === 0 ? "w-52" : idx % 3 === 1 ? "w-72" : "w-40",
-              )}
-            />
-          </div>
-          <SkeletonBlock className="h-3 w-16 bg-fg-muted/10" />
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function ConversationSkeleton() {
-  return (
-    <div
-      className="grid grid-cols-2 gap-px bg-border"
-      data-work-summary-section-skeleton="conversation"
-    >
-      {Array.from({ length: 4 }).map((_, idx) => (
-        <div key={idx} className="bg-bg px-4 py-3">
-          <SkeletonBlock className="h-2.5 w-20 bg-fg-muted/10" />
-          <SkeletonBlock className="mt-2 h-4 w-10 bg-fg-muted/15" />
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function TokenUsageSkeleton() {
-  return (
-    <div
-      className="space-y-3 px-4 py-3"
-      data-work-summary-section-skeleton="tokens"
-    >
-      <SkeletonBlock className="h-5 w-24 bg-fg-muted/15" />
-      <div className="space-y-2">
-        {[0, 1, 2, 3].map((idx) => (
-          <SkeletonChartRow key={idx} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function ChartSkeleton() {
-  return (
-    <div
-      className="space-y-2 px-4 py-3"
-      data-work-summary-section-skeleton="charts"
-    >
-      {[0, 1, 2].map((idx) => (
-        <SkeletonChartRow key={idx} />
-      ))}
-    </div>
-  );
-}
-
-function SkeletonChartRow() {
-  return (
-    <div className="grid grid-cols-[7rem_minmax(0,1fr)_4.5rem] items-center gap-2">
-      <SkeletonBlock className="h-2.5 w-16 bg-fg-muted/10" />
-      <SkeletonBlock className="h-2 w-full bg-fg-muted/10" />
-      <SkeletonBlock className="h-2.5 w-10 bg-fg-muted/10" />
-    </div>
-  );
-}
-
-function SkeletonBlock({ className }: { className: string }) {
-  return (
-    <span
-      className={cn("block animate-pulse rounded bg-fg-muted/10", className)}
-    />
-  );
-}
-
 function MetricCell({
   icon,
   label,
@@ -748,197 +674,47 @@ function formatDateTime(value: string): string {
   return new Date(ms).toLocaleString();
 }
 
-function TokenUsageChart({
-  tokens,
-  baseline,
-  t,
-}: {
-  tokens: WorkSummaryTokenUsage;
-  baseline?: WorkSummaryTokenUsage & { capturedAt: string };
-  t: Translator;
-}) {
-  const delta = tokenUsageDelta(tokens, baseline);
-  const rows = [
-    {
-      label: wt(t, "workSummary.tokens.input"),
-      value: tokens.inputTokens,
-      className: "bg-sky-400",
-    },
-    {
-      label: wt(t, "workSummary.tokens.output"),
-      value: tokens.outputTokens,
-      className: "bg-emerald-400",
-    },
-    {
-      label: wt(t, "workSummary.tokens.cache"),
-      value: tokens.cacheReadTokens + tokens.cacheCreationTokens,
-      className: "bg-amber-400",
-    },
-    {
-      label: wt(t, "workSummary.tokens.reasoning"),
-      value: tokens.reasoningTokens,
-      className: "bg-violet-400",
-    },
-  ].filter((row) => row.value > 0);
-  const max = Math.max(...rows.map((row) => row.value), 1);
+async function fetchAgentTranscriptSummary(
+  repoPath: string,
+  transcriptId: string,
+  locationRef: { current: AgentTranscriptLocation | null },
+): Promise<AgentTranscriptSummary | null> {
+  const cached = locationRef.current;
+  let transcript: AgentTranscriptSummary | null = null;
 
-  return (
-    <div className="space-y-3 px-4 py-3">
-      <div className="flex items-end justify-between gap-3">
-        <div>
-          <div className="font-mono text-lg tabular-nums">
-            {formatNumber(tokens.totalTokens)}
-          </div>
-          <div className="text-[11px] text-fg-muted">
-            {wtf(t, "workSummary.tokens.fromMessages", {
-              count: tokens.messagesWithUsage,
-            })}
-          </div>
-        </div>
-      </div>
-      {baseline ? (
-        <div className="grid grid-cols-3 gap-px overflow-hidden rounded border border-border bg-border">
-          <TokenBaselineCell
-            label={wt(t, "workSummary.tokens.sessionUsed")}
-            value={formatNumber(tokens.totalTokens)}
-          />
-          <TokenBaselineCell
-            label={wt(t, "workSummary.tokens.summaryStart")}
-            value={formatNumber(baseline.totalTokens)}
-          />
-          <TokenBaselineCell
-            label={wt(t, "workSummary.tokens.sinceSummary")}
-            value={`+${formatNumber(delta.totalTokens)}`}
-          />
-        </div>
-      ) : null}
-      <div className="space-y-2">
-        {rows.map((row) => (
-          <ChartRow
-            key={row.label}
-            label={row.label}
-            value={formatNumber(row.value)}
-            width={(row.value / max) * 100}
-            className={row.className}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
+  if (cached?.id === transcriptId) {
+    try {
+      transcript = await api.agentTranscriptSummaryAtPath(
+        repoPath,
+        cached.provider,
+        cached.id,
+        cached.transcriptPath,
+      );
+    } catch {
+      transcript = null;
+    }
+    if (!transcript) {
+      locationRef.current = null;
+    }
+  } else if (cached) {
+    locationRef.current = null;
+  }
 
-function TokenBaselineCell({
-  label,
-  value,
-}: {
-  label: string;
-  value: string;
-}) {
-  return (
-    <div className="min-w-0 bg-bg px-2 py-2">
-      <div className="truncate text-[10px] uppercase text-fg-muted">
-        {label}
-      </div>
-      <div className="mt-0.5 truncate font-mono text-xs tabular-nums">
-        {value}
-      </div>
-    </div>
-  );
-}
-
-function FileStatusChart({
-  counts,
-  total,
-  t,
-}: {
-  counts: WorkSummaryKindCounts;
-  total: number;
-  t: Translator;
-}) {
-  const rows = (Object.keys(counts) as Array<keyof WorkSummaryKindCounts>)
-    .filter((kind) => kind !== "clean" && counts[kind] > 0)
-    .map((kind) => ({
-      label: wt(t, `workSummary.status.${kind}`),
-      value: counts[kind],
-      className:
-        kind === "added"
-          ? "bg-emerald-400"
-          : kind === "deleted"
-            ? "bg-rose-400"
-            : kind === "conflicted"
-              ? "bg-danger"
-              : kind === "renamed"
-                ? "bg-sky-400"
-                : "bg-amber-400",
-    }));
-
-  return (
-    <div className="space-y-2 px-4 py-3">
-      {rows.map((row) => (
-        <ChartRow
-          key={row.label}
-          label={row.label}
-          value={String(row.value)}
-          width={(row.value / total) * 100}
-          className={row.className}
-        />
-      ))}
-    </div>
-  );
-}
-
-function ChartRow({
-  label,
-  value,
-  width,
-  className,
-}: {
-  label: string;
-  value: string;
-  width: number;
-  className: string;
-}) {
-  return (
-    <div className="grid grid-cols-[7rem_minmax(0,1fr)_4.5rem] items-center gap-2 text-[11px]">
-      <span className="truncate text-fg-muted">{label}</span>
-      <div className="h-2 overflow-hidden rounded bg-bg-elevated">
-        <div
-          className={cn("h-full rounded", className)}
-          style={{ width: `${Math.max(4, Math.min(100, width))}%` }}
-        />
-      </div>
-      <span className="text-right font-mono tabular-nums">{value}</span>
-    </div>
-  );
+  if (!transcript) {
+    transcript = await api.agentTranscriptSummary(repoPath, transcriptId);
+  }
+  if (transcript) {
+    locationRef.current = {
+      provider: transcript.provider,
+      id: transcript.id,
+      transcriptPath: transcript.transcript_path,
+    };
+  }
+  return transcript;
 }
 
 function formatNumber(value: number): string {
   return new Intl.NumberFormat().format(value);
-}
-
-function fsChangeTouchesRoot(payload: FsChangePayload, rootPath: string): boolean {
-  if (payload.overflow && payload.refresh) {
-    return pathsIntersect(payload.refresh.path, rootPath);
-  }
-  if (payload.root && pathsIntersect(payload.root, rootPath)) {
-    return true;
-  }
-  return payload.paths.some((path) => pathsIntersect(path, rootPath));
-}
-
-function pathsIntersect(a: string, b: string): boolean {
-  const left = normalizePath(a);
-  const right = normalizePath(b);
-  return left === right || pathInside(left, right) || pathInside(right, left);
-}
-
-function pathInside(path: string, root: string): boolean {
-  const prefix = root.endsWith("/") ? root : `${root}/`;
-  return path.startsWith(prefix);
-}
-
-function normalizePath(path: string): string {
-  return path.replace(/\\/g, "/").replace(/\/+$/, "");
 }
 
 function chatMetricsFromTranscript(

--- a/src/components/work-summary/WorkSummaryCharts.tsx
+++ b/src/components/work-summary/WorkSummaryCharts.tsx
@@ -1,0 +1,196 @@
+import { cn } from "../../lib/cn";
+import type { TranslationKey, Translator } from "../../lib/i18n";
+import {
+  tokenUsageDelta,
+  type WorkSummaryKindCounts,
+  type WorkSummaryTokenUsage,
+} from "../../lib/workSummary";
+
+type WorkSummaryTranslationKey = Extract<
+  TranslationKey,
+  `workSummary.${string}`
+>;
+
+function wt(t: Translator, key: WorkSummaryTranslationKey): string {
+  return t(key);
+}
+
+function wtf(
+  t: Translator,
+  key: WorkSummaryTranslationKey,
+  values: Record<string, string | number>,
+): string {
+  return wt(t, key).replace(/\{(\w+)\}/g, (match, name) =>
+    Object.prototype.hasOwnProperty.call(values, name)
+      ? String(values[name])
+      : match,
+  );
+}
+
+export function TokenUsageChart({
+  tokens,
+  baseline,
+  t,
+}: {
+  tokens: WorkSummaryTokenUsage;
+  baseline?: WorkSummaryTokenUsage & { capturedAt: string };
+  t: Translator;
+}) {
+  const delta = tokenUsageDelta(tokens, baseline);
+  const rows = [
+    {
+      label: wt(t, "workSummary.tokens.input"),
+      value: tokens.inputTokens,
+      className: "bg-sky-400",
+    },
+    {
+      label: wt(t, "workSummary.tokens.output"),
+      value: tokens.outputTokens,
+      className: "bg-emerald-400",
+    },
+    {
+      label: wt(t, "workSummary.tokens.cache"),
+      value: tokens.cacheReadTokens + tokens.cacheCreationTokens,
+      className: "bg-amber-400",
+    },
+    {
+      label: wt(t, "workSummary.tokens.reasoning"),
+      value: tokens.reasoningTokens,
+      className: "bg-violet-400",
+    },
+  ].filter((row) => row.value > 0);
+  const max = Math.max(...rows.map((row) => row.value), 1);
+
+  return (
+    <div className="space-y-3 px-4 py-3">
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <div className="font-mono text-lg tabular-nums">
+            {formatNumber(tokens.totalTokens)}
+          </div>
+          <div className="text-[11px] text-fg-muted">
+            {wtf(t, "workSummary.tokens.fromMessages", {
+              count: tokens.messagesWithUsage,
+            })}
+          </div>
+        </div>
+      </div>
+      {baseline ? (
+        <div className="grid grid-cols-3 gap-px overflow-hidden rounded border border-border bg-border">
+          <TokenBaselineCell
+            label={wt(t, "workSummary.tokens.sessionUsed")}
+            value={formatNumber(tokens.totalTokens)}
+          />
+          <TokenBaselineCell
+            label={wt(t, "workSummary.tokens.summaryStart")}
+            value={formatNumber(baseline.totalTokens)}
+          />
+          <TokenBaselineCell
+            label={wt(t, "workSummary.tokens.sinceSummary")}
+            value={`+${formatNumber(delta.totalTokens)}`}
+          />
+        </div>
+      ) : null}
+      <div className="space-y-2">
+        {rows.map((row) => (
+          <ChartRow
+            key={row.label}
+            label={row.label}
+            value={formatNumber(row.value)}
+            width={(row.value / max) * 100}
+            className={row.className}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TokenBaselineCell({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="min-w-0 bg-bg px-2 py-2">
+      <div className="truncate text-[10px] uppercase text-fg-muted">
+        {label}
+      </div>
+      <div className="mt-0.5 truncate font-mono text-xs tabular-nums">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export function FileStatusChart({
+  counts,
+  total,
+  t,
+}: {
+  counts: WorkSummaryKindCounts;
+  total: number;
+  t: Translator;
+}) {
+  const rows = (Object.keys(counts) as Array<keyof WorkSummaryKindCounts>)
+    .filter((kind) => kind !== "clean" && counts[kind] > 0)
+    .map((kind) => ({
+      label: wt(t, `workSummary.status.${kind}`),
+      value: counts[kind],
+      className:
+        kind === "added"
+          ? "bg-emerald-400"
+          : kind === "deleted"
+            ? "bg-rose-400"
+            : kind === "conflicted"
+              ? "bg-danger"
+              : kind === "renamed"
+                ? "bg-sky-400"
+                : "bg-amber-400",
+    }));
+
+  return (
+    <div className="space-y-2 px-4 py-3">
+      {rows.map((row) => (
+        <ChartRow
+          key={row.label}
+          label={row.label}
+          value={String(row.value)}
+          width={(row.value / total) * 100}
+          className={row.className}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ChartRow({
+  label,
+  value,
+  width,
+  className,
+}: {
+  label: string;
+  value: string;
+  width: number;
+  className: string;
+}) {
+  return (
+    <div className="grid grid-cols-[7rem_minmax(0,1fr)_4.5rem] items-center gap-2 text-[11px]">
+      <span className="truncate text-fg-muted">{label}</span>
+      <div className="h-2 overflow-hidden rounded bg-bg-elevated">
+        <div
+          className={cn("h-full rounded", className)}
+          style={{ width: `${Math.max(4, Math.min(100, width))}%` }}
+        />
+      </div>
+      <span className="text-right font-mono tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat().format(value);
+}

--- a/src/components/work-summary/WorkSummarySkeletons.tsx
+++ b/src/components/work-summary/WorkSummarySkeletons.tsx
@@ -1,0 +1,95 @@
+import { cn } from "../../lib/cn";
+
+export function MetricValueSkeleton() {
+  return <SkeletonBlock className="h-5 w-24 bg-fg-muted/15" />;
+}
+
+export function ChangedFilesSkeleton() {
+  return (
+    <div
+      className="divide-y divide-border"
+      data-work-summary-section-skeleton="files"
+    >
+      {[0, 1, 2, 3, 4].map((idx) => (
+        <div
+          key={idx}
+          className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-4 py-2"
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            <SkeletonBlock className="h-5 w-10 bg-fg-muted/15" />
+            <SkeletonBlock
+              className={cn(
+                "h-3 min-w-0 bg-fg-muted/10",
+                idx % 3 === 0 ? "w-52" : idx % 3 === 1 ? "w-72" : "w-40",
+              )}
+            />
+          </div>
+          <SkeletonBlock className="h-3 w-16 bg-fg-muted/10" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ConversationSkeleton() {
+  return (
+    <div
+      className="grid grid-cols-2 gap-px bg-border"
+      data-work-summary-section-skeleton="conversation"
+    >
+      {Array.from({ length: 4 }).map((_, idx) => (
+        <div key={idx} className="bg-bg px-4 py-3">
+          <SkeletonBlock className="h-2.5 w-20 bg-fg-muted/10" />
+          <SkeletonBlock className="mt-2 h-4 w-10 bg-fg-muted/15" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TokenUsageSkeleton() {
+  return (
+    <div
+      className="space-y-3 px-4 py-3"
+      data-work-summary-section-skeleton="tokens"
+    >
+      <SkeletonBlock className="h-5 w-24 bg-fg-muted/15" />
+      <div className="space-y-2">
+        {[0, 1, 2, 3].map((idx) => (
+          <SkeletonChartRow key={idx} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ChartSkeleton() {
+  return (
+    <div
+      className="space-y-2 px-4 py-3"
+      data-work-summary-section-skeleton="charts"
+    >
+      {[0, 1, 2].map((idx) => (
+        <SkeletonChartRow key={idx} />
+      ))}
+    </div>
+  );
+}
+
+function SkeletonChartRow() {
+  return (
+    <div className="grid grid-cols-[7rem_minmax(0,1fr)_4.5rem] items-center gap-2">
+      <SkeletonBlock className="h-2.5 w-16 bg-fg-muted/10" />
+      <SkeletonBlock className="h-2 w-full bg-fg-muted/10" />
+      <SkeletonBlock className="h-2.5 w-10 bg-fg-muted/10" />
+    </div>
+  );
+}
+
+function SkeletonBlock({ className }: { className: string }) {
+  return (
+    <span
+      className={cn("block animate-pulse rounded bg-fg-muted/10", className)}
+    />
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,6 +3,7 @@ import type {
   AcornIpcStatus,
   AgentTokenUsageSnapshot,
   AgentHistoryItem,
+  AgentTranscriptSummary,
   CommitInfo,
   ChatMessage,
   ChatMessagePatch,
@@ -527,6 +528,15 @@ export const api = {
     return invoke<AgentHistoryItem[]>("list_agent_history", {
       repoPath,
       limit,
+    });
+  },
+  agentTranscriptSummary(
+    repoPath: string,
+    transcriptId: string,
+  ): Promise<AgentTranscriptSummary | null> {
+    return invoke<AgentTranscriptSummary | null>("agent_transcript_summary", {
+      repoPath,
+      transcriptId,
     });
   },
   listUnscopedAgentHistory(limit = 100): Promise<AgentHistoryItem[]> {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
   AcornIpcStatus,
+  AgentHistoryProvider,
   AgentTokenUsageSnapshot,
   AgentHistoryItem,
   AgentTranscriptSummary,
@@ -538,6 +539,22 @@ export const api = {
       repoPath,
       transcriptId,
     });
+  },
+  agentTranscriptSummaryAtPath(
+    repoPath: string,
+    provider: AgentHistoryProvider,
+    id: string,
+    transcriptPath: string,
+  ): Promise<AgentTranscriptSummary | null> {
+    return invoke<AgentTranscriptSummary | null>(
+      "agent_transcript_summary_at_path",
+      {
+        repoPath,
+        provider,
+        id,
+        transcriptPath,
+      },
+    );
   },
   listUnscopedAgentHistory(limit = 100): Promise<AgentHistoryItem[]> {
     return invoke<AgentHistoryItem[]>("list_unscoped_agent_history", {

--- a/src/lib/pathUtils.test.ts
+++ b/src/lib/pathUtils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  basename,
+  normalizePath,
+  pathsIntersect,
+  relativePath,
+} from "./pathUtils";
+
+describe("path utils", () => {
+  it("normalizes trailing separators and Windows separators", () => {
+    expect(normalizePath("C:\\Users\\me\\repo\\")).toBe("C:/Users/me/repo");
+    expect(normalizePath("/Users/me/repo///")).toBe("/Users/me/repo");
+  });
+
+  it("extracts a basename from POSIX and Windows paths", () => {
+    expect(basename("/Users/me/repo/src/App.tsx")).toBe("App.tsx");
+    expect(basename("C:\\Users\\me\\repo")).toBe("repo");
+  });
+
+  it("builds a relative path when the child is inside the root", () => {
+    expect(relativePath("/repo", "/repo/src/App.tsx")).toBe("src/App.tsx");
+    expect(relativePath("/repo", "/other/App.tsx")).toBe("/other/App.tsx");
+  });
+
+  it("detects intersecting roots without treating sibling prefixes as matches", () => {
+    expect(pathsIntersect("/repo/src/App.tsx", "/repo")).toBe(true);
+    expect(pathsIntersect("/repo", "/repo/src")).toBe(true);
+    expect(pathsIntersect("/repo-other/src/App.tsx", "/repo")).toBe(false);
+  });
+});

--- a/src/lib/pathUtils.ts
+++ b/src/lib/pathUtils.ts
@@ -1,0 +1,31 @@
+export function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+export function basename(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] ?? path;
+}
+
+export function relativePath(rootPath: string, path: string): string {
+  const root = normalizePath(rootPath);
+  const normalized = normalizePath(path);
+  if (normalized === root) return basename(path);
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  return normalized.startsWith(prefix) ? normalized.slice(prefix.length) : path;
+}
+
+export function pathsIntersect(a: string, b: string): boolean {
+  const left = normalizePath(a);
+  const right = normalizePath(b);
+  return (
+    left === right ||
+    normalizedPathInside(left, right) ||
+    normalizedPathInside(right, left)
+  );
+}
+
+function normalizedPathInside(path: string, root: string): boolean {
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  return path.startsWith(prefix);
+}

--- a/src/lib/sessionWorktree.test.ts
+++ b/src/lib/sessionWorktree.test.ts
@@ -4,6 +4,8 @@ import {
   canDeleteSessionWorktree,
   hasRecordedWorktree,
   isSessionInWorktreeWorkspace,
+  otherSessionsUsingProjectWorktree,
+  sessionsUsingProjectWorktree,
   shouldAutoDeleteSessionWorktree,
 } from "./sessionWorktree";
 
@@ -94,5 +96,67 @@ describe("worktree deletion policy", () => {
 
     expect(canDeleteSessionWorktree(target, foldersByRepo)).toBe(true);
     expect(shouldAutoDeleteSessionWorktree(target, foldersByRepo)).toBe(false);
+  });
+});
+
+describe("sessionsUsingProjectWorktree", () => {
+  it("matches sessions by repo and normalized worktree path", () => {
+    const sessions = [
+      session({
+        id: "active",
+        worktree_path: "/repo/.acorn/worktrees/feature",
+      }),
+      session({
+        id: "trailing",
+        worktree_path: "/repo/.acorn/worktrees/feature/",
+      }),
+      session({
+        id: "other-repo",
+        repo_path: "/other",
+        worktree_path: "/repo/.acorn/worktrees/feature",
+      }),
+      session({
+        id: "windows",
+        repo_path: "C:\\repo",
+        worktree_path: "C:\\repo\\.acorn\\worktrees\\feature",
+      }),
+    ];
+
+    expect(
+      sessionsUsingProjectWorktree(
+        sessions,
+        "/repo",
+        "/repo/.acorn/worktrees/feature/",
+      ).map((candidate) => candidate.id),
+    ).toEqual(["active", "trailing"]);
+    expect(
+      sessionsUsingProjectWorktree(
+        sessions,
+        "C:/repo",
+        "C:/repo/.acorn/worktrees/feature/",
+      ).map((candidate) => candidate.id),
+    ).toEqual(["windows"]);
+  });
+
+  it("reports only non-active sessions as other users", () => {
+    const sessions = [
+      session({
+        id: "active",
+        worktree_path: "/repo/.acorn/worktrees/feature",
+      }),
+      session({
+        id: "other",
+        worktree_path: "/repo/.acorn/worktrees/feature",
+      }),
+    ];
+
+    expect(
+      otherSessionsUsingProjectWorktree(
+        sessions,
+        "/repo",
+        "/repo/.acorn/worktrees/feature",
+        "active",
+      ).map((candidate) => candidate.id),
+    ).toEqual(["other"]);
   });
 });

--- a/src/lib/sessionWorktree.ts
+++ b/src/lib/sessionWorktree.ts
@@ -6,11 +6,36 @@ export function hasRecordedWorktree(session: Session): boolean {
 }
 
 function normalizeWorkspacePath(path: string): string {
-  return path.replace(/[\\/]+$/, "");
+  return path.replace(/\\/g, "/").replace(/\/+$/g, "");
 }
 
 function sameWorkspacePath(a: string, b: string): boolean {
   return normalizeWorkspacePath(a) === normalizeWorkspacePath(b);
+}
+
+export function sessionsUsingProjectWorktree(
+  sessions: readonly Session[],
+  repoPath: string,
+  worktreePath: string,
+): Session[] {
+  return sessions.filter(
+    (session) =>
+      sameWorkspacePath(session.repo_path, repoPath) &&
+      sameWorkspacePath(session.worktree_path, worktreePath),
+  );
+}
+
+export function otherSessionsUsingProjectWorktree(
+  sessions: readonly Session[],
+  repoPath: string,
+  worktreePath: string,
+  activeSessionId: string | null,
+): Session[] {
+  return sessionsUsingProjectWorktree(
+    sessions,
+    repoPath,
+    worktreePath,
+  ).filter((session) => session.id !== activeSessionId);
 }
 
 export function isSessionInWorktreeWorkspace(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -287,6 +287,30 @@ export interface AgentHistoryItem {
   resume_command: string | null;
 }
 
+export interface AgentTranscriptTokenUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  reasoning_tokens: number;
+  total_tokens: number;
+  messages_with_usage: number;
+}
+
+export interface AgentTranscriptSummary {
+  provider: AgentHistoryProvider;
+  id: string;
+  transcript_path: string;
+  updated_at: number;
+  message_count: number;
+  user_messages: number;
+  assistant_messages: number;
+  turn_count: number;
+  complete_turns: number;
+  running_turns: number;
+  token_usage: AgentTranscriptTokenUsage;
+}
+
 export interface CommitInfo {
   sha: string;
   short_sha: string;

--- a/src/lib/workSummary.test.ts
+++ b/src/lib/workSummary.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import type { ChatSessionState } from "./types";
+import {
+  buildWorkSummary,
+  summarizeTokenUsage,
+  summarizeChatSession,
+  tokenUsageDelta,
+  type WorkSummaryDiffStatsByPath,
+} from "./workSummary";
+
+describe("work summary git aggregation", () => {
+  it("builds changed file rows and aggregate counts from git status and diff stats", () => {
+    const diffStats: WorkSummaryDiffStatsByPath = {
+      "/repo/src/App.tsx": { additions: 12, deletions: 3 },
+      "/repo/README.md": { additions: 4, deletions: 0 },
+    };
+
+    const summary = buildWorkSummary("/repo", {
+      statuses: {
+        "/repo/src/App.tsx": {
+          kind: "modified",
+          additions: 0,
+          deletions: 0,
+        },
+        "/repo/README.md": {
+          kind: "added",
+          additions: 0,
+          deletions: 0,
+        },
+      },
+      huge: false,
+      limit: 500,
+    }, diffStats);
+
+    expect(summary.totalFiles).toBe(2);
+    expect(summary.totalAdditions).toBe(16);
+    expect(summary.totalDeletions).toBe(3);
+    expect(summary.byKind).toEqual({
+      added: 1,
+      clean: 0,
+      conflicted: 0,
+      deleted: 0,
+      modified: 1,
+      renamed: 0,
+    });
+    expect(summary.files.map((file) => file.relativePath)).toEqual([
+      "README.md",
+      "src/App.tsx",
+    ]);
+  });
+
+  it("uses status-provided counts when diff stats are not available", () => {
+    const summary = buildWorkSummary("/repo", {
+      statuses: {
+        "/repo/package.json": {
+          kind: "modified",
+          additions: 2,
+          deletions: 1,
+        },
+      },
+      huge: true,
+      limit: 1,
+    }, {});
+
+    expect(summary.totalFiles).toBe(1);
+    expect(summary.totalAdditions).toBe(2);
+    expect(summary.totalDeletions).toBe(1);
+    expect(summary.huge).toBe(true);
+  });
+});
+
+describe("work summary chat aggregation", () => {
+  it("counts chat messages and turns by role and status", () => {
+    const chat = {
+      messages: [
+        { id: "u1", role: "user" },
+        { id: "a1", role: "assistant" },
+        { id: "u2", role: "user" },
+      ],
+      turns: [
+        { id: "t1", status: "complete" },
+        { id: "t2", status: "running" },
+      ],
+    } as ChatSessionState;
+
+    expect(summarizeChatSession(chat)).toEqual({
+      assistantMessages: 1,
+      completeTurns: 1,
+      messageCount: 3,
+      runningTurns: 1,
+      turnCount: 2,
+      userMessages: 2,
+    });
+  });
+
+  it("extracts token usage from provider response metadata", () => {
+    const chat = {
+      messages: [
+        {
+          id: "a1",
+          role: "assistant",
+          metadata: {
+            provider_response: {
+              usage: {
+                input_tokens: 1200,
+                output_tokens: 300,
+                cache_read_input_tokens: 500,
+              },
+            },
+          },
+        },
+        {
+          id: "a2",
+          role: "assistant",
+          metadata: {
+            provider_response: {
+              info: {
+                total_token_usage: {
+                  input_tokens: 100,
+                  output_tokens: 50,
+                  reasoning_output_tokens: 25,
+                  total_tokens: 175,
+                },
+              },
+            },
+          },
+        },
+      ],
+      turns: [],
+    } as unknown as ChatSessionState;
+
+    expect(summarizeTokenUsage(chat)).toEqual({
+      cacheCreationTokens: 0,
+      cacheReadTokens: 500,
+      inputTokens: 1300,
+      messagesWithUsage: 2,
+      outputTokens: 350,
+      reasoningTokens: 25,
+      totalTokens: 2175,
+    });
+  });
+
+  it("computes token usage since a captured baseline", () => {
+    expect(
+      tokenUsageDelta(
+        {
+          inputTokens: 120,
+          outputTokens: 40,
+          cacheReadTokens: 10,
+          cacheCreationTokens: 0,
+          reasoningTokens: 5,
+          totalTokens: 170,
+          messagesWithUsage: 2,
+        },
+        {
+          inputTokens: 100,
+          outputTokens: 10,
+          cacheReadTokens: 15,
+          cacheCreationTokens: 0,
+          reasoningTokens: 1,
+          totalTokens: 130,
+          messagesWithUsage: 1,
+        },
+      ),
+    ).toEqual({
+      inputTokens: 20,
+      outputTokens: 30,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      reasoningTokens: 4,
+      totalTokens: 40,
+      messagesWithUsage: 1,
+    });
+  });
+
+});

--- a/src/lib/workSummary.ts
+++ b/src/lib/workSummary.ts
@@ -1,0 +1,339 @@
+import type {
+  FsGitDiffStatsEntry,
+  FsGitStatus,
+  FsGitStatusResult,
+} from "./api";
+import type { ChatSessionState } from "./types";
+
+export type WorkSummaryDiffStatsByPath = Record<string, FsGitDiffStatsEntry>;
+
+export interface WorkSummaryChangedFile {
+  path: string;
+  relativePath: string;
+  kind: FsGitStatus;
+  additions: number;
+  deletions: number;
+}
+
+export type WorkSummaryKindCounts = Record<FsGitStatus, number>;
+
+export interface WorkSummary {
+  files: WorkSummaryChangedFile[];
+  totalFiles: number;
+  totalAdditions: number;
+  totalDeletions: number;
+  byKind: WorkSummaryKindCounts;
+  huge: boolean;
+  limit: number;
+}
+
+export interface WorkSummaryChatMetrics {
+  messageCount: number;
+  userMessages: number;
+  assistantMessages: number;
+  turnCount: number;
+  completeTurns: number;
+  runningTurns: number;
+}
+
+export interface WorkSummaryTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  reasoningTokens: number;
+  totalTokens: number;
+  messagesWithUsage: number;
+}
+
+export interface WorkSummaryTokenBaseline extends WorkSummaryTokenUsage {
+  capturedAt: string;
+}
+
+export function emptyKindCounts(): WorkSummaryKindCounts {
+  return {
+    added: 0,
+    clean: 0,
+    conflicted: 0,
+    deleted: 0,
+    modified: 0,
+    renamed: 0,
+  };
+}
+
+export function buildWorkSummary(
+  rootPath: string,
+  status: FsGitStatusResult,
+  diffStats: WorkSummaryDiffStatsByPath,
+): WorkSummary {
+  const byKind = emptyKindCounts();
+  const files = Object.entries(status.statuses)
+    .map(([path, entry]): WorkSummaryChangedFile => {
+      const stats = diffStats[path] ?? entry;
+      return {
+        path,
+        relativePath: relativePath(rootPath, path),
+        kind: entry.kind,
+        additions: stats.additions,
+        deletions: stats.deletions,
+      };
+    })
+    .sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+
+  let totalAdditions = 0;
+  let totalDeletions = 0;
+  for (const file of files) {
+    byKind[file.kind] += 1;
+    totalAdditions += file.additions;
+    totalDeletions += file.deletions;
+  }
+
+  return {
+    files,
+    totalFiles: files.length,
+    totalAdditions,
+    totalDeletions,
+    byKind,
+    huge: status.huge,
+    limit: status.limit,
+  };
+}
+
+export function summarizeChatSession(
+  state: ChatSessionState,
+): WorkSummaryChatMetrics {
+  let userMessages = 0;
+  let assistantMessages = 0;
+  for (const message of state.messages) {
+    if (message.role === "user") userMessages += 1;
+    if (message.role === "assistant") assistantMessages += 1;
+  }
+
+  let completeTurns = 0;
+  let runningTurns = 0;
+  for (const turn of state.turns) {
+    if (turn.status === "complete") completeTurns += 1;
+    if (turn.status === "running" || turn.status === "pending") {
+      runningTurns += 1;
+    }
+  }
+
+  return {
+    messageCount: state.messages.length,
+    userMessages,
+    assistantMessages,
+    turnCount: state.turns.length,
+    completeTurns,
+    runningTurns,
+  };
+}
+
+export function summarizeTokenUsage(
+  state: ChatSessionState,
+): WorkSummaryTokenUsage {
+  const total = emptyTokenUsage();
+
+  for (const message of state.messages) {
+    if (message.role !== "assistant") continue;
+    const usage = extractTokenUsage(message.metadata);
+    if (!usage) continue;
+    total.inputTokens += usage.inputTokens;
+    total.outputTokens += usage.outputTokens;
+    total.cacheReadTokens += usage.cacheReadTokens;
+    total.cacheCreationTokens += usage.cacheCreationTokens;
+    total.reasoningTokens += usage.reasoningTokens;
+    total.totalTokens += usage.totalTokens;
+    total.messagesWithUsage += 1;
+  }
+
+  return total;
+}
+
+export function emptyTokenUsage(): WorkSummaryTokenUsage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    reasoningTokens: 0,
+    totalTokens: 0,
+    messagesWithUsage: 0,
+  };
+}
+
+export function tokenUsageDelta(
+  current: WorkSummaryTokenUsage,
+  baseline: WorkSummaryTokenUsage | null | undefined,
+): WorkSummaryTokenUsage {
+  if (!baseline) return current;
+  return {
+    inputTokens: positiveDelta(current.inputTokens, baseline.inputTokens),
+    outputTokens: positiveDelta(current.outputTokens, baseline.outputTokens),
+    cacheReadTokens: positiveDelta(
+      current.cacheReadTokens,
+      baseline.cacheReadTokens,
+    ),
+    cacheCreationTokens: positiveDelta(
+      current.cacheCreationTokens,
+      baseline.cacheCreationTokens,
+    ),
+    reasoningTokens: positiveDelta(
+      current.reasoningTokens,
+      baseline.reasoningTokens,
+    ),
+    totalTokens: positiveDelta(current.totalTokens, baseline.totalTokens),
+    messagesWithUsage: positiveDelta(
+      current.messagesWithUsage,
+      baseline.messagesWithUsage,
+    ),
+  };
+}
+
+export function extractTokenUsage(
+  metadata: unknown,
+): WorkSummaryTokenUsage | null {
+  const candidates = collectUsageCandidates(metadata);
+  for (const candidate of candidates) {
+    const inputTokens = firstNumber(candidate, [
+      "input_tokens",
+      "inputTokens",
+      "prompt_tokens",
+      "promptTokens",
+    ]);
+    const outputTokens = firstNumber(candidate, [
+      "output_tokens",
+      "outputTokens",
+      "completion_tokens",
+      "completionTokens",
+    ]);
+    const cacheReadTokens = firstNumber(candidate, [
+      "cache_read_input_tokens",
+      "cacheReadInputTokens",
+      "cached_input_tokens",
+      "cachedInputTokens",
+      "cached_tokens",
+      "cachedTokens",
+    ]);
+    const cacheCreationTokens = firstNumber(candidate, [
+      "cache_creation_input_tokens",
+      "cacheCreationInputTokens",
+    ]);
+    const reasoningTokens = firstNumber(candidate, [
+      "reasoning_output_tokens",
+      "reasoningOutputTokens",
+      "reasoning_tokens",
+      "reasoningTokens",
+    ]);
+    const explicitTotal = firstNumber(candidate, [
+      "total_tokens",
+      "totalTokens",
+      "total_token_count",
+      "totalTokenCount",
+    ]);
+    const totalTokens =
+      explicitTotal ||
+      inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens;
+    if (
+      inputTokens ||
+      outputTokens ||
+      cacheReadTokens ||
+      cacheCreationTokens ||
+      reasoningTokens ||
+      totalTokens
+    ) {
+      return {
+        inputTokens,
+        outputTokens,
+        cacheReadTokens,
+        cacheCreationTokens,
+        reasoningTokens,
+        totalTokens,
+        messagesWithUsage: 1,
+      };
+    }
+  }
+  return null;
+}
+
+function relativePath(rootPath: string, path: string): string {
+  const root = normalizePath(rootPath);
+  const normalized = normalizePath(path);
+  if (normalized === root) return basename(path);
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  return normalized.startsWith(prefix)
+    ? normalized.slice(prefix.length)
+    : path;
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] ?? path;
+}
+
+function collectUsageCandidates(value: unknown): Record<string, unknown>[] {
+  if (!isRecord(value)) return [];
+  const candidates: Record<string, unknown>[] = [];
+  const stack: unknown[] = [value];
+  const seen = new Set<unknown>();
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!isRecord(current) || seen.has(current)) continue;
+    seen.add(current);
+
+    if (looksLikeUsageObject(current)) candidates.push(current);
+    for (const key of [
+      "provider_response",
+      "providerResponse",
+      "usage",
+      "token_usage",
+      "tokenUsage",
+      "total_token_usage",
+      "totalTokenUsage",
+      "info",
+      "message",
+      "response",
+      "payload",
+      "metadata",
+    ]) {
+      if (key in current) stack.push(current[key]);
+    }
+  }
+
+  return candidates;
+}
+
+function looksLikeUsageObject(value: Record<string, unknown>): boolean {
+  return [
+    "input_tokens",
+    "output_tokens",
+    "prompt_tokens",
+    "completion_tokens",
+    "total_tokens",
+    "cached_input_tokens",
+    "reasoning_output_tokens",
+    "cache_creation_input_tokens",
+  ].some((key) => typeof value[key] === "number");
+}
+
+function firstNumber(value: Record<string, unknown>, keys: string[]): number {
+  for (const key of keys) {
+    const raw = value[key];
+    if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+      return Math.round(raw);
+    }
+  }
+  return 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function positiveDelta(current: number, baseline: number): number {
+  return Math.max(0, current - baseline);
+}

--- a/src/lib/workSummary.ts
+++ b/src/lib/workSummary.ts
@@ -3,6 +3,7 @@ import type {
   FsGitStatus,
   FsGitStatusResult,
 } from "./api";
+import { relativePath } from "./pathUtils";
 import type { ChatSessionState } from "./types";
 
 export type WorkSummaryDiffStatsByPath = Record<string, FsGitDiffStatsEntry>;
@@ -253,25 +254,6 @@ export function extractTokenUsage(
     }
   }
   return null;
-}
-
-function relativePath(rootPath: string, path: string): string {
-  const root = normalizePath(rootPath);
-  const normalized = normalizePath(path);
-  if (normalized === root) return basename(path);
-  const prefix = root.endsWith("/") ? root : `${root}/`;
-  return normalized.startsWith(prefix)
-    ? normalized.slice(prefix.length)
-    : path;
-}
-
-function normalizePath(path: string): string {
-  return path.replace(/\\/g, "/").replace(/\/+$/, "");
-}
-
-function basename(path: string): string {
-  const parts = path.split(/[\\/]/).filter(Boolean);
-  return parts[parts.length - 1] ?? path;
 }
 
 function collectUsageCandidates(value: unknown): Record<string, unknown>[] {

--- a/src/lib/workSummaryInvalidation.test.ts
+++ b/src/lib/workSummaryInvalidation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { fsChangeTouchesRoot } from "./workSummaryInvalidation";
+
+describe("work summary invalidation", () => {
+  it("matches direct paths under the watched root", () => {
+    expect(
+      fsChangeTouchesRoot(
+        {
+          paths: ["/repo/src/App.tsx"],
+          dotgit_changed: false,
+        },
+        "/repo",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches refresh hints and roots that intersect the watched root", () => {
+    expect(
+      fsChangeTouchesRoot(
+        {
+          paths: [],
+          overflow: true,
+          refresh: { kind: "subtree", path: "/repo/src" },
+          dotgit_changed: false,
+        },
+        "/repo",
+      ),
+    ).toBe(true);
+    expect(
+      fsChangeTouchesRoot(
+        {
+          paths: [],
+          root: "/repo",
+          dotgit_changed: false,
+        },
+        "/repo/src",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match sibling paths", () => {
+    expect(
+      fsChangeTouchesRoot(
+        {
+          paths: ["/repo-other/src/App.tsx"],
+          dotgit_changed: false,
+        },
+        "/repo",
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/lib/workSummaryInvalidation.ts
+++ b/src/lib/workSummaryInvalidation.ts
@@ -1,0 +1,15 @@
+import type { FsChangePayload } from "./api";
+import { pathsIntersect } from "./pathUtils";
+
+export function fsChangeTouchesRoot(
+  payload: FsChangePayload,
+  rootPath: string,
+): boolean {
+  if (payload.overflow && payload.refresh) {
+    return pathsIntersect(payload.refresh.path, rootPath);
+  }
+  if (payload.root && pathsIntersect(payload.root, rootPath)) {
+    return true;
+  }
+  return payload.paths.some((path) => pathsIntersect(path, rootPath));
+}

--- a/src/lib/workspaceTabs.test.ts
+++ b/src/lib/workspaceTabs.test.ts
@@ -7,6 +7,7 @@ import {
   isWorkspaceTabId,
   makeCodeWorkspaceTab,
   makeSessionWorkspaceTab,
+  makeWorkSummaryWorkspaceTab,
 } from "./workspaceTabs";
 
 afterEach(() => {
@@ -24,6 +25,12 @@ describe("workspace tab identity", () => {
     expect(isSessionTabId("code-viewer:abc")).toBe(false);
     expect(isWorkspaceTabId("code-viewer:abc")).toBe(true);
     expect(activeSessionIdFromTabId("code-viewer:abc")).toBeNull();
+  });
+
+  it("treats work-summary ids as frontend-owned workspace tab ids", () => {
+    expect(isSessionTabId("work-summary:abc")).toBe(false);
+    expect(isWorkspaceTabId("work-summary:abc")).toBe(true);
+    expect(activeSessionIdFromTabId("work-summary:abc")).toBeNull();
   });
 });
 
@@ -83,5 +90,29 @@ describe("workspace tab lifecycle", () => {
       column: 7,
       token: "00000000-0000-4000-8000-000000000002",
     });
+  });
+
+  it("creates work summary tabs scoped to a session worktree", () => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000003",
+    );
+
+    const tab = makeWorkSummaryWorkspaceTab({
+      repoPath: "/repo",
+      cwdPath: "/repo/.worktrees/feature",
+      sessionId: "s1",
+      title: "s1 summary",
+    });
+
+    expect(tab).toMatchObject({
+      id: "work-summary:00000000-0000-4000-8000-000000000003",
+      kind: "work-summary",
+      lifecycle: "ephemeral",
+      repoPath: "/repo",
+      cwdPath: "/repo/.worktrees/feature",
+      sessionId: "s1",
+      title: "s1 summary",
+    });
+    expect(isRestorableWorkspaceTab(tab)).toBe(false);
   });
 });

--- a/src/lib/workspaceTabs.ts
+++ b/src/lib/workspaceTabs.ts
@@ -1,4 +1,5 @@
 import type { WorkSummaryTokenBaseline } from "./workSummary";
+import { basename } from "./pathUtils";
 
 export type WorkspaceTabId = string;
 export type WorkspaceTabKind = "session" | "code" | "work-summary";
@@ -147,9 +148,4 @@ export function isProcessBackedWorkspaceTab(
   tab: WorkspaceTab,
 ): tab is ProcessBackedWorkspaceTab {
   return tab.lifecycle === "process-backed";
-}
-
-export function basename(path: string): string {
-  const parts = path.split(/[\\/]/).filter(Boolean);
-  return parts[parts.length - 1] ?? path;
 }

--- a/src/lib/workspaceTabs.ts
+++ b/src/lib/workspaceTabs.ts
@@ -1,5 +1,7 @@
+import type { WorkSummaryTokenBaseline } from "./workSummary";
+
 export type WorkspaceTabId = string;
-export type WorkspaceTabKind = "session" | "code";
+export type WorkspaceTabKind = "session" | "code" | "work-summary";
 export type WorkspaceTabLifecycle =
   | "ephemeral"
   | "restorable"
@@ -27,14 +29,24 @@ export interface CodeWorkspaceTab
   target?: CodeWorkspaceTabTarget;
 }
 
+export interface WorkSummaryWorkspaceTab
+  extends WorkspaceTabBase<"work-summary", "ephemeral"> {
+  cwdPath: string;
+  sessionId?: string;
+  tokenBaseline?: WorkSummaryTokenBaseline;
+}
+
 export interface CodeWorkspaceTabTarget {
   line: number;
   column?: number;
   token: string;
 }
 
-export type WorkspaceTab = SessionWorkspaceTab | CodeWorkspaceTab;
-export type FrontendWorkspaceTab = CodeWorkspaceTab;
+export type WorkspaceTab =
+  | SessionWorkspaceTab
+  | CodeWorkspaceTab
+  | WorkSummaryWorkspaceTab;
+export type FrontendWorkspaceTab = CodeWorkspaceTab | WorkSummaryWorkspaceTab;
 export type RestorableWorkspaceTab = Extract<
   WorkspaceTab,
   { lifecycle: "restorable" }
@@ -45,11 +57,13 @@ export type ProcessBackedWorkspaceTab = Extract<
 >;
 
 export const CODE_VIEWER_TAB_PREFIX = "code-viewer:";
+export const WORK_SUMMARY_TAB_PREFIX = "work-summary:";
 const LEGACY_VIEWER_TAB_PREFIX = "viewer:";
 
 export function isWorkspaceTabId(id: string): boolean {
   return (
     id.startsWith(CODE_VIEWER_TAB_PREFIX) ||
+    id.startsWith(WORK_SUMMARY_TAB_PREFIX) ||
     id.startsWith(LEGACY_VIEWER_TAB_PREFIX)
   );
 }
@@ -101,6 +115,25 @@ export function makeCodeWorkspaceTabTarget(
     line: target.line,
     ...(target.column === undefined ? {} : { column: target.column }),
     token: crypto.randomUUID(),
+  };
+}
+
+export function makeWorkSummaryWorkspaceTab(input: {
+  repoPath: string;
+  cwdPath: string;
+  sessionId?: string;
+  title?: string;
+  tokenBaseline?: WorkSummaryTokenBaseline;
+}): WorkSummaryWorkspaceTab {
+  return {
+    id: `${WORK_SUMMARY_TAB_PREFIX}${crypto.randomUUID()}`,
+    kind: "work-summary",
+    lifecycle: "ephemeral",
+    repoPath: input.repoPath,
+    cwdPath: input.cwdPath,
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+    ...(input.tokenBaseline ? { tokenBaseline: input.tokenBaseline } : {}),
+    title: input.title ?? "Work Summary",
   };
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -919,6 +919,7 @@
       "worktree": "worktree",
       "controlSession": "control session",
       "chatSession": "chat session",
+      "workSummary": "work summary",
       "generatingSessionTitle": "Generating session title",
       "closeSession": "Close session",
       "closeTab": "Close tab"
@@ -934,6 +935,7 @@
     "menu": {
       "rename": "Rename",
       "regenerateName": "Regenerate Name",
+      "openWorkSummary": "Open Work Summary",
       "forkClaudeSession": "Fork Claude Session",
       "forkSession": "Fork Session",
       "forkClaudeInNewWorktree": "Fork Claude in New Worktree",
@@ -962,6 +964,77 @@
       "closeAll": "Close All",
       "newSessionInThisPane": "New Session in This Pane",
       "closePane": "Close Pane"
+    }
+  },
+  "workSummary": {
+    "title": "Work Summary",
+    "refresh": "Refresh summary",
+    "loading": "Loading...",
+    "notAvailable": "N/A",
+    "metrics": {
+      "files": "Changed files",
+      "lines": "Line delta",
+      "messages": "Conversation",
+      "tokens": "Tokens"
+    },
+    "values": {
+      "files": "{count} files",
+      "messages": "{count} messages",
+      "turns": "{count} turns",
+      "tokens": "{count} tokens"
+    },
+    "metadata": {
+      "scope": "Scope",
+      "session": "Session",
+      "branch": "Branch",
+      "status": "Status",
+      "mode": "Mode",
+      "transcript": "Transcript",
+      "updated": "Updated"
+    },
+    "files": {
+      "title": "Changed Files",
+      "empty": "No working tree changes",
+      "huge": "Showing first {limit} files",
+      "openFile": "Open {path}"
+    },
+    "details": {
+      "title": "Details"
+    },
+    "conversation": {
+      "title": "Conversation",
+      "user": "User",
+      "assistant": "Assistant",
+      "turns": "Turns",
+      "completeTurns": "Complete turns",
+      "runningTurns": "Running",
+      "terminalHint": "Conversation counts are available for native chat sessions."
+    },
+    "tokens": {
+      "title": "Token Usage",
+      "empty": "No token usage metadata is available yet.",
+      "input": "Input",
+      "output": "Output",
+      "cache": "Cache",
+      "reasoning": "Reasoning",
+      "start": "Start",
+      "current": "Current",
+      "sinceStart": "Since start",
+      "sessionUsed": "Session used",
+      "summaryStart": "Summary start",
+      "sinceSummary": "Since summary",
+      "fromMessages": "from {count} assistant messages"
+    },
+    "charts": {
+      "title": "Change Breakdown"
+    },
+    "status": {
+      "added": "Added",
+      "clean": "Clean",
+      "conflicted": "Conflicted",
+      "deleted": "Deleted",
+      "modified": "Modified",
+      "renamed": "Renamed"
     }
   },
   "rightPanel": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1380,6 +1380,7 @@
       "usedBySessions": "Used by {count} sessions",
       "removeWorktree": "Remove",
       "removeWorktreeAria": "Remove {name} worktree",
+      "removeWorktreeBlockedByOtherSessions": "Close other sessions using this worktree before removing it.",
       "confirmRemoveDialog": "Delete worktree",
       "confirmRemoveTitle": "Delete {name}?",
       "confirmRemoveBody": "This removes the linked git worktree directory from disk. Sessions using it may need to be reopened from the main project.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1380,6 +1380,7 @@
       "usedBySessions": "{count}개 세션에서 사용 중",
       "removeWorktree": "제거",
       "removeWorktreeAria": "{name} 워크트리 제거",
+      "removeWorktreeBlockedByOtherSessions": "이 워크트리를 사용하는 다른 세션을 모두 닫은 뒤 제거할 수 있습니다.",
       "confirmRemoveDialog": "워크트리 삭제",
       "confirmRemoveTitle": "{name} 삭제",
       "confirmRemoveBody": "연결된 Git 워크트리 디렉터리를 디스크에서 제거합니다. 이 워크트리를 사용하는 세션은 메인 프로젝트에서 다시 열어야 할 수 있습니다.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -919,6 +919,7 @@
       "worktree": "워크트리",
       "controlSession": "컨트롤 세션",
       "chatSession": "채팅 세션",
+      "workSummary": "작업 요약",
       "generatingSessionTitle": "세션 제목 생성 중",
       "closeSession": "세션 닫기",
       "closeTab": "탭 닫기"
@@ -934,6 +935,7 @@
     "menu": {
       "rename": "이름 변경",
       "regenerateName": "이름 다시 생성",
+      "openWorkSummary": "작업 요약 열기",
       "forkClaudeSession": "Claude 세션 포크",
       "forkSession": "세션 포크",
       "forkClaudeInNewWorktree": "새 워크트리에 Claude 포크",
@@ -962,6 +964,77 @@
       "closeAll": "모두 닫기",
       "newSessionInThisPane": "이 패널에서 새 세션",
       "closePane": "패널 닫기"
+    }
+  },
+  "workSummary": {
+    "title": "작업 요약",
+    "refresh": "요약 새로고침",
+    "loading": "불러오는 중...",
+    "notAvailable": "없음",
+    "metrics": {
+      "files": "변경 파일",
+      "lines": "라인 변화",
+      "messages": "대화",
+      "tokens": "토큰"
+    },
+    "values": {
+      "files": "{count}개 파일",
+      "messages": "{count}개 메시지",
+      "turns": "{count}개 턴",
+      "tokens": "{count} 토큰"
+    },
+    "metadata": {
+      "scope": "범위",
+      "session": "세션",
+      "branch": "브랜치",
+      "status": "상태",
+      "mode": "모드",
+      "transcript": "Transcript",
+      "updated": "업데이트"
+    },
+    "files": {
+      "title": "변경된 파일",
+      "empty": "작업 트리 변경이 없습니다",
+      "huge": "처음 {limit}개 파일 표시 중",
+      "openFile": "{path} 열기"
+    },
+    "details": {
+      "title": "세부 정보"
+    },
+    "conversation": {
+      "title": "대화",
+      "user": "사용자",
+      "assistant": "Assistant",
+      "turns": "턴",
+      "completeTurns": "완료 턴",
+      "runningTurns": "진행 중",
+      "terminalHint": "대화 수는 native chat 세션에서 사용할 수 있습니다."
+    },
+    "tokens": {
+      "title": "토큰 사용량",
+      "empty": "아직 사용할 수 있는 토큰 사용량 metadata가 없습니다.",
+      "input": "입력",
+      "output": "출력",
+      "cache": "캐시",
+      "reasoning": "추론",
+      "start": "시작",
+      "current": "현재",
+      "sinceStart": "시작 이후",
+      "sessionUsed": "세션 사용",
+      "summaryStart": "요약 시작",
+      "sinceSummary": "요약 이후",
+      "fromMessages": "assistant 메시지 {count}개 기준"
+    },
+    "charts": {
+      "title": "변경 분포"
+    },
+    "status": {
+      "added": "추가",
+      "clean": "깨끗함",
+      "conflicted": "충돌",
+      "deleted": "삭제",
+      "modified": "수정",
+      "renamed": "이름 변경"
     }
   },
   "rightPanel": {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   GenerateSessionTitleResult,
+  ChatSessionState,
   Project,
   Session,
   SessionNotification,
@@ -34,6 +35,11 @@ vi.mock("./lib/api", () => {
             session: {} as Session,
           }) as GenerateSessionTitleResult,
       ),
+      loadChatSessionState: vi.fn(async () => ({
+        messages: [],
+        turns: [],
+      }) as unknown as ChatSessionState),
+      agentTranscriptSummary: vi.fn(async () => null),
       addProject: vi.fn(async () => ({}) as Project),
       createNewProject: vi.fn(async () => ({}) as Project),
       removeProject: vi.fn(async () => []),
@@ -114,6 +120,45 @@ function notification(
   };
 }
 
+function chatStateWithTokenTotal(totalTokens: number): ChatSessionState {
+  return {
+    schema_version: 1,
+    session_id: "a1",
+    session: {
+      id: "a1",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+    messages: [
+      {
+        id: "a1",
+        role: "assistant",
+        content: "done",
+        created_at: "2026-01-01T00:00:00Z",
+        metadata: {
+          provider_response: {
+            usage: {
+              input_tokens: totalTokens,
+              total_tokens: totalTokens,
+            },
+          },
+        },
+      },
+    ],
+    turns: [],
+    provider_threads: [],
+    context_snapshots: [],
+    memory: {
+      session_id: "a1",
+      important_decisions: [],
+      facts: [],
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
 /**
  * Reset the zustand store to a clean slate. We re-import the initial-shape
  * fields directly since zustand has no built-in reset.
@@ -175,6 +220,12 @@ function deferred<T>(): {
   return { promise, resolve, reject };
 }
 
+async function flushPromises(times = 3): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await Promise.resolve();
+  }
+}
+
 beforeEach(() => {
   // resetAllMocks clears both call history *and* the queued
   // mockResolvedValueOnce return values; clearAllMocks leaves the queue
@@ -191,6 +242,11 @@ beforeEach(() => {
   mockApi.removeSession.mockResolvedValue(null);
   mockApi.removeWorktree.mockResolvedValue(null);
   mockApi.removeProject.mockResolvedValue([]);
+  mockApi.loadChatSessionState.mockResolvedValue({
+    messages: [],
+    turns: [],
+  } as unknown as ChatSessionState);
+  mockApi.agentTranscriptSummary.mockResolvedValue(null);
   useSettings.setState({
     settings: structuredClone(DEFAULT_SETTINGS),
     open: false,
@@ -815,6 +871,167 @@ describe("workspace tabs", () => {
     });
   });
 
+  it("opens a work summary tab for the active session worktree", async () => {
+    const active = session("a1", REPO_A, {
+      name: "Feature runner",
+      worktree_path: `${REPO_A}/.worktrees/a1`,
+      mode: "chat",
+    });
+    await seed([project(REPO_A, 0)], [active]);
+    mockApi.loadChatSessionState.mockResolvedValueOnce(
+      chatStateWithTokenTotal(120),
+    );
+
+    await useAppStore.getState().openWorkSummaryTab();
+    await flushPromises();
+
+    const s = useAppStore.getState();
+    expect(s.activeSessionId).toBeNull();
+    expect(s.activeTabId).toMatch(/^work-summary:/);
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1", s.activeTabId]);
+    expect(s.workspaceTabs[s.activeTabId!]).toMatchObject({
+      kind: "work-summary",
+      lifecycle: "ephemeral",
+      repoPath: REPO_A,
+      cwdPath: `${REPO_A}/.worktrees/a1`,
+      sessionId: "a1",
+      title: "Feature runner Summary",
+      tokenBaseline: expect.objectContaining({
+        inputTokens: 120,
+        totalTokens: 120,
+        messagesWithUsage: 1,
+      }),
+    });
+  });
+
+  it("records a work summary token baseline from a terminal agent transcript", async () => {
+    const active = session("a1", REPO_A, {
+      name: "Feature runner",
+      worktree_path: `${REPO_A}/.worktrees/a1`,
+      mode: "terminal",
+      agent_transcript_id: "transcript-1",
+    });
+    await seed([project(REPO_A, 0)], [active]);
+    mockApi.agentTranscriptSummary.mockResolvedValueOnce({
+      provider: "codex",
+      id: "transcript-1",
+      transcript_path: "/Users/me/.codex/sessions/transcript-1.jsonl",
+      updated_at: 1_766_000_000,
+      message_count: 4,
+      user_messages: 2,
+      assistant_messages: 2,
+      turn_count: 2,
+      complete_turns: 2,
+      running_turns: 0,
+      token_usage: {
+        input_tokens: 220,
+        output_tokens: 80,
+        cache_read_tokens: 20,
+        cache_creation_tokens: 0,
+        reasoning_tokens: 12,
+        total_tokens: 320,
+        messages_with_usage: 1,
+      },
+    });
+
+    await useAppStore.getState().openWorkSummaryTab();
+    await flushPromises();
+
+    const s = useAppStore.getState();
+    expect(mockApi.agentTranscriptSummary).toHaveBeenCalledWith(
+      REPO_A,
+      "transcript-1",
+    );
+    expect(s.workspaceTabs[s.activeTabId!]).toMatchObject({
+      kind: "work-summary",
+      sessionId: "a1",
+      tokenBaseline: expect.objectContaining({
+        inputTokens: 220,
+        outputTokens: 80,
+        cacheReadTokens: 20,
+        reasoningTokens: 12,
+        totalTokens: 320,
+        messagesWithUsage: 1,
+      }),
+    });
+  });
+
+  it("opens a work summary tab before terminal token baseline loading finishes", async () => {
+    const active = session("a1", REPO_A, {
+      name: "Feature runner",
+      worktree_path: `${REPO_A}/.worktrees/a1`,
+      mode: "terminal",
+      agent_transcript_id: "transcript-1",
+    });
+    await seed([project(REPO_A, 0)], [active]);
+    const pendingSummary = deferred<Awaited<
+      ReturnType<typeof mockApi.agentTranscriptSummary>
+    >>();
+    mockApi.agentTranscriptSummary.mockReturnValueOnce(pendingSummary.promise);
+
+    const openPromise = useAppStore.getState().openWorkSummaryTab();
+    await Promise.resolve();
+
+    let state = useAppStore.getState();
+    expect(state.activeTabId).toMatch(/^work-summary:/);
+    const tabId = state.activeTabId!;
+    expect(state.workspaceTabs[tabId]).toMatchObject({
+      kind: "work-summary",
+      sessionId: "a1",
+    });
+    expect(state.workspaceTabs[tabId]).not.toHaveProperty("tokenBaseline");
+
+    pendingSummary.resolve({
+      provider: "codex",
+      id: "transcript-1",
+      transcript_path: "/Users/me/.codex/sessions/transcript-1.jsonl",
+      updated_at: 1_766_000_000,
+      message_count: 4,
+      user_messages: 2,
+      assistant_messages: 2,
+      turn_count: 2,
+      complete_turns: 2,
+      running_turns: 0,
+      token_usage: {
+        input_tokens: 220,
+        output_tokens: 80,
+        cache_read_tokens: 20,
+        cache_creation_tokens: 0,
+        reasoning_tokens: 12,
+        total_tokens: 320,
+        messages_with_usage: 1,
+      },
+    });
+    await openPromise;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    state = useAppStore.getState();
+    expect(state.workspaceTabs[tabId]).toMatchObject({
+      tokenBaseline: expect.objectContaining({
+        totalTokens: 320,
+      }),
+    });
+  });
+
+  it("reuses an existing work summary tab for the same session", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+
+    await useAppStore.getState().openWorkSummaryTab();
+    const tabId = useAppStore.getState().activeTabId!;
+    useAppStore.getState().selectSession("a1");
+    await useAppStore.getState().openWorkSummaryTab();
+
+    const s = useAppStore.getState();
+    expect(s.activeTabId).toBe(tabId);
+    expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1", tabId]);
+    expect(
+      Object.values(s.workspaceTabs).filter(
+        (tab) => tab.kind === "work-summary",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("scopes code viewer tabs to the active session worktree", async () => {
     const s1 = session("a1", REPO_A, {
       worktree_path: `${REPO_A}/.worktrees/a1`,
@@ -840,17 +1057,21 @@ describe("workspace tabs", () => {
       .getState()
       .openCodeViewerTab(`${REPO_A}/src/App.tsx`, REPO_A, { line: 78 });
     const tabId = useAppStore.getState().activeTabId!;
-    const firstTarget = useAppStore.getState().workspaceTabs[tabId].target;
+    const firstTab = useAppStore.getState().workspaceTabs[tabId];
+    if (firstTab?.kind !== "code") throw new Error("expected code tab");
+    const firstTarget = firstTab.target;
 
     useAppStore
       .getState()
       .openCodeViewerTab(`${REPO_A}/src/App.tsx`, REPO_A, { line: 12 });
 
     const s = useAppStore.getState();
+    const updatedTab = s.workspaceTabs[tabId];
+    if (updatedTab?.kind !== "code") throw new Error("expected code tab");
     expect(s.activeTabId).toBe(tabId);
     expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1", tabId]);
-    expect(s.workspaceTabs[tabId].target).toMatchObject({ line: 12 });
-    expect(s.workspaceTabs[tabId].target?.token).not.toBe(firstTarget?.token);
+    expect(updatedTab.target).toMatchObject({ line: 12 });
+    expect(updatedTab.target?.token).not.toBe(firstTarget?.token);
   });
 
   it("reselects a worktree-scoped code tab after switching projects", async () => {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2182,6 +2182,39 @@ describe("removeProjectWorktree", () => {
     ).toBe(false);
     expect(state.workspaces[folder!.id]).toBeUndefined();
   });
+
+  it("refuses to delete a worktree while another session uses it", async () => {
+    const worktreePath = `${REPO_B}/.acorn/worktrees/feature-alpha`;
+    const repo = project(REPO_B, 0);
+    await seed(
+      [repo],
+      [
+        session("b1", REPO_B, {
+          worktree_path: worktreePath,
+          in_worktree: true,
+        }),
+        session("b2", REPO_B, {
+          worktree_path: `${worktreePath}/`,
+          in_worktree: true,
+        }),
+      ],
+    );
+    useAppStore.getState().selectSession("b1");
+
+    await expect(
+      useAppStore.getState().removeProjectWorktree(REPO_B, worktreePath, true),
+    ).rejects.toThrow("Close other sessions using this worktree");
+
+    const state = useAppStore.getState();
+    expect(mockApi.removeWorktree).not.toHaveBeenCalled();
+    expect(state.sessions.map((candidate) => candidate.id)).toEqual([
+      "b1",
+      "b2",
+    ]);
+    expect(state.error).toBe(
+      "Close other sessions using this worktree before removing it.",
+    );
+  });
 });
 
 describe("requestRemoveProject", () => {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -40,6 +40,7 @@ vi.mock("./lib/api", () => {
         turns: [],
       }) as unknown as ChatSessionState),
       agentTranscriptSummary: vi.fn(async () => null),
+      agentTranscriptSummaryAtPath: vi.fn(async () => null),
       addProject: vi.fn(async () => ({}) as Project),
       createNewProject: vi.fn(async () => ({}) as Project),
       removeProject: vi.fn(async () => []),

--- a/src/store.ts
+++ b/src/store.ts
@@ -48,6 +48,10 @@ import {
   buildSessionCreateRequest,
 } from "./lib/sessionCreation";
 import {
+  otherSessionsUsingProjectWorktree,
+  sessionsUsingProjectWorktree,
+} from "./lib/sessionWorktree";
+import {
   DEFAULT_PROJECT_FOLDER_NAME,
   basenamePath,
   defaultProjectFolderId,
@@ -72,6 +76,8 @@ export type { RightGroup, RightTab };
 
 const ROOT_PANE_ID: PaneId = "root";
 const SESSION_TITLE_GENERATING_MIN_MS = 900;
+const WORKTREE_IN_USE_BY_OTHER_SESSIONS =
+  "Close other sessions using this worktree before removing it.";
 
 let statusPollRunning = false;
 let statusPollChain: Promise<void> | null = null;
@@ -2449,6 +2455,28 @@ export const useAppStore = create<AppStateModel>()(
 
   async removeProjectWorktree(repoPath, worktreePath, removeSessions = false) {
     try {
+      if (removeSessions) {
+        const state = get();
+        const otherSessions = otherSessionsUsingProjectWorktree(
+          state.sessions,
+          repoPath,
+          worktreePath,
+          state.activeSessionId,
+        );
+        const targetSessions = sessionsUsingProjectWorktree(
+          state.sessions,
+          repoPath,
+          worktreePath,
+        );
+        const canRemoveSessions =
+          targetSessions.length === 0 ||
+          (targetSessions.length === 1 &&
+            targetSessions[0]?.id === state.activeSessionId);
+        if (otherSessions.length > 0 || !canRemoveSessions) {
+          set({ error: WORKTREE_IN_USE_BY_OTHER_SESSIONS });
+          throw new Error(WORKTREE_IN_USE_BY_OTHER_SESSIONS);
+        }
+      }
       const removedWorktree = await api.removeWorktree(
         repoPath,
         worktreePath,

--- a/src/store.ts
+++ b/src/store.ts
@@ -31,6 +31,7 @@ import {
   isWorkspaceTabId,
   makeCodeWorkspaceTab,
   makeCodeWorkspaceTabTarget,
+  makeWorkSummaryWorkspaceTab,
   type FrontendWorkspaceTab,
 } from "./lib/workspaceTabs";
 import {
@@ -62,6 +63,10 @@ import {
   type SessionFolderAssignments,
 } from "./lib/projectFolders";
 import { canRegenerateSessionTitle } from "./lib/sessionTitle";
+import {
+  summarizeTokenUsage,
+  type WorkSummaryTokenBaseline,
+} from "./lib/workSummary";
 
 export type { RightGroup, RightTab };
 
@@ -86,6 +91,39 @@ interface SessionPlacementIntent {
 
 const sessionPlacementById = new Map<string, SessionPlacementIntent>();
 const activeSessionPlacementIntents = new Set<SessionPlacementIntent>();
+
+async function loadWorkSummaryTokenBaseline(
+  session: Session | null | undefined,
+): Promise<WorkSummaryTokenBaseline | undefined> {
+  if (!session) return undefined;
+  try {
+    if (session.mode === "chat") {
+      const chatState = await api.loadChatSessionState(session.id);
+      return {
+        ...summarizeTokenUsage(chatState),
+        capturedAt: new Date().toISOString(),
+      };
+    }
+    if (!session.agent_transcript_id) return undefined;
+    const transcript = await api.agentTranscriptSummary(
+      session.repo_path,
+      session.agent_transcript_id,
+    );
+    if (!transcript) return undefined;
+    return {
+      inputTokens: transcript.token_usage.input_tokens,
+      outputTokens: transcript.token_usage.output_tokens,
+      cacheReadTokens: transcript.token_usage.cache_read_tokens,
+      cacheCreationTokens: transcript.token_usage.cache_creation_tokens,
+      reasoningTokens: transcript.token_usage.reasoning_tokens,
+      totalTokens: transcript.token_usage.total_tokens,
+      messagesWithUsage: transcript.token_usage.messages_with_usage,
+      capturedAt: new Date().toISOString(),
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
@@ -114,6 +152,13 @@ export interface MoveTabArgs {
   toIndex?: number;
   splitDirection?: Direction;
   splitSide?: SplitSide;
+}
+
+export interface WorkSummaryTabScope {
+  sessionId?: string;
+  repoPath?: string;
+  cwdPath?: string;
+  title?: string;
 }
 
 interface AppStateModel {
@@ -298,6 +343,8 @@ interface AppStateModel {
     repoPath?: string,
     target?: { line?: number; column?: number },
   ) => void;
+  /** Open a work summary tab for the current session or a provided worktree. */
+  openWorkSummaryTab: (scope?: WorkSummaryTabScope) => Promise<void>;
   /** Close any frontend-owned tab and remove it from panes. */
   closeWorkspaceTab: (id: string) => void;
 }
@@ -2864,6 +2911,112 @@ export const useAppStore = create<AppStateModel>()(
         ...mirrorActive(newWorkspaces, workspaceId),
       };
     });
+  },
+
+  async openWorkSummaryTab(scope = {}) {
+    let baselineTabId: string | null = null;
+    let baselineSession: Session | null = null;
+    let shouldLoadBaseline = false;
+
+    set((s) => {
+      const workspaceId = activeWorkspaceId(s);
+      if (!workspaceId || !s.activeProject) return s;
+      const ws = s.workspaces[workspaceId];
+      if (!ws) return s;
+      const focused = ws.focusedPaneId;
+      const pane = ws.panes[focused];
+      if (!pane) return s;
+
+      const activeSession = scope.sessionId
+        ? s.sessions.find((session) => session.id === scope.sessionId) ?? null
+        : s.activeSessionId
+          ? s.sessions.find((session) => session.id === s.activeSessionId) ?? null
+          : null;
+      const activeWorkspaceTab = pane.activeTabId
+        ? s.workspaceTabs[pane.activeTabId]
+        : undefined;
+      const repoPath =
+        scope.repoPath ??
+        activeSession?.repo_path ??
+        activeWorkspaceTab?.repoPath ??
+        s.activeProject;
+      const cwdPath =
+        scope.cwdPath ??
+        activeSession?.worktree_path ??
+        (activeWorkspaceTab?.kind === "work-summary"
+          ? activeWorkspaceTab.cwdPath
+          : activeWorkspaceTab?.repoPath) ??
+        repoPath;
+      const sessionId = scope.sessionId ?? activeSession?.id;
+      const title =
+        scope.title ??
+        (activeSession ? `${activeSession.name} Summary` : "Work Summary");
+
+      const existing = Object.values(s.workspaceTabs).find(
+        (tab) =>
+          tab.kind === "work-summary" &&
+          tab.repoPath === repoPath &&
+          tab.cwdPath === cwdPath &&
+          (tab.sessionId ?? null) === (sessionId ?? null),
+      );
+      const tab =
+        existing ??
+        makeWorkSummaryWorkspaceTab({
+          repoPath,
+          cwdPath,
+          ...(sessionId ? { sessionId } : {}),
+          title,
+        });
+      baselineTabId = tab.id;
+      baselineSession = activeSession;
+      shouldLoadBaseline = Boolean(
+        activeSession && tab.kind === "work-summary" && !tab.tokenBaseline,
+      );
+      const alreadyInPane = pane.tabIds.includes(tab.id);
+      const newPane: PaneState = alreadyInPane
+        ? activatePaneTab(pane, tab.id)
+        : {
+            ...activatePaneTab(pane, tab.id),
+            tabIds: [...pane.tabIds, tab.id],
+          };
+      const newWs: ProjectWorkspace = {
+        ...ws,
+        panes: { ...ws.panes, [focused]: newPane },
+      };
+      const newWorkspaces = {
+        ...s.workspaces,
+        [workspaceId]: newWs,
+      };
+      return {
+        workspaceTabs: existing
+          ? s.workspaceTabs
+          : { ...s.workspaceTabs, [tab.id]: tab },
+        workspaces: newWorkspaces,
+        ...mirrorActive(newWorkspaces, workspaceId),
+      };
+    });
+
+    if (shouldLoadBaseline && baselineTabId && baselineSession) {
+      const tabId = baselineTabId;
+      void loadWorkSummaryTokenBaseline(baselineSession).then((tokenBaseline) => {
+        if (!tokenBaseline) return;
+        set((s) => {
+          const tab = s.workspaceTabs[tabId];
+          if (!tab || tab.kind !== "work-summary" || tab.tokenBaseline) {
+            return s;
+          }
+          return {
+            workspaceTabs: {
+              ...s.workspaceTabs,
+              [tabId]: {
+                ...tab,
+                tokenBaseline,
+              },
+            },
+          };
+        });
+      });
+    }
   },
 
   closeWorkspaceTab(id) {

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -133,6 +133,9 @@ export const tauriMockSource = `
     if (cmd === 'agent_transcript_summary') {
       return Promise.resolve(null);
     }
+    if (cmd === 'agent_transcript_summary_at_path') {
+      return Promise.resolve(null);
+    }
     if (cmd === 'save_chat_session_state') {
       return Promise.resolve(args?.chatState || null);
     }

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -130,6 +130,9 @@ export const tauriMockSource = `
     if (cmd === 'load_chat_session_state') {
       return Promise.resolve(chatState(args?.sessionId, null, []));
     }
+    if (cmd === 'agent_transcript_summary') {
+      return Promise.resolve(null);
+    }
     if (cmd === 'save_chat_session_state') {
       return Promise.resolve(args?.chatState || null);
     }
@@ -315,6 +318,7 @@ export const tauriMockSource = `
     if (cmd === 'fs_open_default') return Promise.resolve(undefined);
     if (cmd === 'fs_shell_editor') return Promise.resolve('');
     if (cmd === 'fs_git_status') return Promise.resolve({ statuses: {}, huge: false, limit: 10000 });
+    if (cmd === 'fs_git_diff_stats') return Promise.resolve({});
     if (cmd === 'fs_git_branch') return Promise.resolve('');
     if (cmd === 'fs_file_exists') return Promise.resolve(false);
     if (cmd === 'fs_grant_external_file') return Promise.resolve(undefined);

--- a/tests/e2e/project-settings.spec.ts
+++ b/tests/e2e/project-settings.spec.ts
@@ -96,7 +96,7 @@ test.describe("project settings", () => {
     ]);
   });
 
-  test("confirms before deleting a worktree used by sidebar sessions", async ({
+  test("confirms before deleting a worktree used by the active sidebar session", async ({
     page,
     tauri,
   }) => {
@@ -225,5 +225,103 @@ test.describe("project settings", () => {
         removeSessions: true,
       },
     ]);
+  });
+
+  test("does not open the delete confirmation while another session uses the worktree", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/acorn",
+        name: "acorn",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-alpha",
+        name: "alpha terminal",
+        repo_path: "/tmp/acorn",
+        worktree_path: "/tmp/acorn/.acorn/worktrees/feature-alpha",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        title_source: "default",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: true,
+      },
+      {
+        id: "s-alpha-other",
+        name: "alpha reviewer",
+        repo_path: "/tmp/acorn",
+        worktree_path: "/tmp/acorn/.acorn/worktrees/feature-alpha/",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        title_source: "default",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: true,
+      },
+    ]);
+    await tauri.handle("list_project_worktrees", () => [
+      {
+        name: "feature-alpha",
+        path: "/tmp/acorn/.acorn/worktrees/feature-alpha",
+        modified_ms: null,
+      },
+    ]);
+    await tauri.handle("remove_worktree", (args) => {
+      const w = window as unknown as { __removeWorktreeCalls?: unknown[] };
+      w.__removeWorktreeCalls = w.__removeWorktreeCalls ?? [];
+      w.__removeWorktreeCalls.push(args);
+      return undefined;
+    });
+
+    await page.goto("/");
+
+    await page
+      .getByRole("button", { name: "Project acorn" })
+      .click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Project Settings" }).click();
+
+    const modal = page.getByRole("dialog", { name: "Project Settings" });
+    await modal.getByRole("button", { name: "Worktrees" }).click();
+
+    const alphaRow = modal.getByRole("listitem").filter({
+      hasText: "feature-alpha",
+    });
+    await expect(alphaRow).toContainText("Used by 2 sessions");
+    await expect(alphaRow).toContainText(
+      "Close other sessions using this worktree before removing it.",
+    );
+    await expect(
+      alphaRow.getByRole("button", {
+        name: "Remove feature-alpha worktree",
+      }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("dialog", { name: "Delete worktree" }),
+    ).toHaveCount(0);
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __removeWorktreeCalls?: unknown[] })
+          .__removeWorktreeCalls ?? [],
+    )) as unknown[];
+    expect(calls).toEqual([]);
   });
 });

--- a/tests/e2e/work-summary.spec.ts
+++ b/tests/e2e/work-summary.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from "./support";
+
+const PROJECT = {
+  repo_path: "/tmp/demo",
+  name: "demo",
+  created_at: "2026-01-01T00:00:00Z",
+  position: 0,
+};
+
+const SESSION = {
+  id: "session-1",
+  name: "summary-session",
+  repo_path: "/tmp/demo",
+  worktree_path: "/tmp/demo",
+  branch: "main",
+  isolated: false,
+  project_scoped: true,
+  status: "idle",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  last_message: null,
+  title_source: "manual",
+  kind: "regular",
+  owner: { kind: "user" },
+  position: 0,
+  in_worktree: true,
+  mode: "chat",
+};
+
+const CHAT_STATE = {
+  schema_version: 1,
+  session_id: "session-1",
+  session: {
+    id: "session-1",
+    workspace_path: "/tmp/demo",
+    title: "summary-session",
+    active_provider: "codex",
+    active_model: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:01Z",
+  },
+  provider: "codex",
+  model: null,
+  messages: [
+    {
+      id: "u1",
+      session_id: "session-1",
+      turn_id: "t1",
+      role: "user",
+      content: "Summarize this",
+      created_at: "2026-01-01T00:00:00Z",
+      status: "complete",
+      metadata: null,
+    },
+    {
+      id: "a1",
+      session_id: "session-1",
+      turn_id: "t1",
+      role: "assistant",
+      content: "Done",
+      created_at: "2026-01-01T00:00:01Z",
+      status: "complete",
+      metadata: {
+        provider_response: {
+          usage: {
+            input_tokens: 100,
+            output_tokens: 40,
+            total_tokens: 140,
+          },
+        },
+      },
+    },
+  ],
+  turns: [
+    {
+      id: "t1",
+      session_id: "session-1",
+      provider: "codex",
+      status: "complete",
+      user_message_id: "u1",
+      assistant_message_id: "a1",
+      started_at: "2026-01-01T00:00:00Z",
+      completed_at: "2026-01-01T00:00:01Z",
+    },
+  ],
+  provider_threads: [],
+  context_snapshots: [],
+  memory: {
+    session_id: "session-1",
+    summary: null,
+    important_decisions: [],
+    facts: [],
+    through_message_id: null,
+    updated_at: "2026-01-01T00:00:01Z",
+  },
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:01Z",
+};
+
+test.describe("work summary", () => {
+  test("opens a changed file from the summary tab", async ({ page, tauri }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [SESSION]);
+    await tauri.respond("load_chat_session_state", CHAT_STATE);
+    await tauri.respond("fs_git_status", {
+      statuses: {
+        "/tmp/demo/src/App.tsx": {
+          kind: "modified",
+          additions: 0,
+          deletions: 0,
+        },
+      },
+      huge: false,
+      limit: 500,
+    });
+    await tauri.respond("fs_git_diff_stats", {
+      "/tmp/demo/src/App.tsx": { additions: 3, deletions: 1 },
+    });
+    await tauri.respond("fs_read_file", {
+      content: "export const app = 'summary';\n",
+      size: 30,
+      truncated: false,
+      binary: false,
+    });
+
+    await page.goto("/");
+
+    await page.locator('[data-tab-drag-handle="session-1"]').click({
+      button: "right",
+    });
+    await page.getByRole("menuitem", { name: "Open Work Summary" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Work Summary" }),
+    ).toBeVisible();
+    await expect(page.getByText("2 messages")).toBeVisible();
+    await expect(page.getByText("140 tokens").first()).toBeVisible();
+
+    await page.getByRole("button", { name: "Open src/App.tsx" }).dblclick();
+
+    await expect(
+      page.getByRole("button", { name: /App\.tsx Close tab/ }),
+    ).toBeVisible();
+    await expect(page.getByText("export const app = 'summary';")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
Prevent linked worktree deletion while another Acorn session is still using the same worktree folder.

1. **Shared-session guard** — project settings now disables worktree removal when any non-active session uses that worktree, so the delete confirmation modal is only reachable for unused worktrees or the active session's sole worktree.
2. **Store-level protection** — `removeProjectWorktree(..., true)` now rejects before calling the backend when matching worktree sessions include anything other than the active session.
3. **Shared path matching** — session/worktree matching moved into `sessionWorktree` helpers with slash normalization, and the UI shows localized guidance explaining why removal is blocked.
4. **Regression coverage** — added Vitest and Playwright coverage for active-session deletion, other-session blocking, path normalization, and store bypass protection.

## Expected impact
| Scenario | Before | After |
| --- | --- | --- |
| Worktree used by another session | Delete modal could appear and remove sessions/worktree | Remove action is disabled until other sessions are closed |
| Worktree used only by active session | Delete confirmation appears | Delete confirmation still appears |
| Empty linked worktree | Delete confirmation appears | Delete confirmation still appears |

## Design notes
- The UI and store use the same `sessionsUsingProjectWorktree` / `otherSessionsUsingProjectWorktree` helpers so trailing slashes and platform path separators are handled consistently.
- The confirm dialog also closes itself if session state changes after it opens and the worktree becomes shared by another session.
- The backend command shape is unchanged; this PR constrains the frontend/store deletion policy without changing Rust worktree removal behavior.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test -- src/lib/sessionWorktree.test.ts src/components/ProjectSettingsModal.test.tsx src/store.test.ts` — 71 files / 727 tests passed
- [x] `pnpm run test:e2e -- tests/e2e/project-settings.spec.ts` — 3 tests passed
- [x] `git diff --check` — passes

## Notes
- No follow-up work is required for this behavior change.
