### PR TITLE
fix(worktrees): block removal while sessions share worktree

### DIFF
--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -574,6 +574,69 @@ describe("Pane empty state", () => {
     );
   });
 
+  it("creates root sessions from a work summary tab", async () => {
+    const summaryTab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: WORKTREE,
+      title: "Work Summary",
+    });
+    const created = session("new-session", {
+      name: "repo",
+      repo_path: REPO,
+      worktree_path: REPO,
+      branch: "main",
+      in_worktree: false,
+    });
+    mocks.createSession.mockResolvedValueOnce(created);
+    mocks.listSessions.mockResolvedValueOnce([created]);
+    mocks.listProjects.mockResolvedValueOnce([project(REPO)]);
+    const pane = {
+      id: "root",
+      tabIds: [summaryTab.id],
+      activeTabId: summaryTab.id,
+    };
+    useAppStore.setState((s) => ({
+      ...s,
+      sessions: [],
+      activeProject: REPO,
+      activeProjectFolderId: REPO,
+      activeSessionId: null,
+      activeTabId: summaryTab.id,
+      workspaceTabs: { [summaryTab.id]: summaryTab },
+      workspaces: {
+        ...s.workspaces,
+        [REPO]: {
+          layout: { kind: "pane", id: "root" },
+          panes: { root: pane },
+          focusedPaneId: "root",
+        },
+      },
+      panes: { root: pane },
+      focusedPaneId: "root",
+    }));
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+
+    const filler = container.querySelector('[data-pane-tab-filler="root"]');
+    expect(filler).not.toBeNull();
+
+    await act(async () => {
+      filler?.dispatchEvent(
+        new MouseEvent("dblclick", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(mocks.createSession).toHaveBeenCalledWith(
+      "repo",
+      REPO,
+      false,
+      "regular",
+      null,
+    );
+  });
+
   it("shows a session-title generation indicator on the tab", async () => {
     const active = session("agent-session", { agent_provider: "codex" });
     useAppStore.setState((s) => ({

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -293,7 +293,10 @@ export function Pane({ paneId }: PaneProps) {
         launch: { kind: "projectRoot" },
       };
     }
-    const repoPath = repoPathForCodeTabSession(tab, sessions);
+    const repoPath =
+      tab.kind === "code"
+        ? repoPathForCodeTabSession(tab, sessions)
+        : tab.repoPath;
     const projectScoped = resolveProjectScopedForRepoPath(
       { sessions, projects },
       repoPath,

--- a/src/components/ProjectSettingsModal.test.tsx
+++ b/src/components/ProjectSettingsModal.test.tsx
@@ -296,7 +296,7 @@ describe("ProjectSettingsModal", () => {
     expect(document.body.textContent).toContain("feature-beta");
   });
 
-  it("requires confirmation before deleting a worktree used by sessions", async () => {
+  it("requires confirmation before deleting a worktree used by the active session", async () => {
     mockApi.getProjectSettings.mockResolvedValue({
       key: "github:im-ian/acorn",
       settings: {
@@ -323,13 +323,8 @@ describe("ProjectSettingsModal", () => {
           worktree_path: "/repo/acorn/.acorn/worktrees/feature-alpha",
           in_worktree: true,
         }),
-        session({
-          id: "s-alpha-2",
-          name: "alpha chat",
-          worktree_path: "/repo/acorn/.acorn/worktrees/feature-alpha/",
-          in_worktree: true,
-        }),
       ],
+      activeSessionId: "s-alpha-1",
       projects: [
         {
           repo_path: "/repo/acorn",
@@ -359,7 +354,7 @@ describe("ProjectSettingsModal", () => {
     });
     await flushPromises();
 
-    expect(document.body.textContent).toContain("Used by 2 sessions");
+    expect(document.body.textContent).toContain("Used by 1 session");
 
     const remove = Array.from(
       document.body.querySelectorAll<HTMLButtonElement>("button"),
@@ -375,8 +370,7 @@ describe("ProjectSettingsModal", () => {
     });
 
     expect(document.body.textContent).toContain("alpha terminal");
-    expect(document.body.textContent).toContain("alpha chat");
-    expect(document.body.textContent).toContain("2 sessions will be removed");
+    expect(document.body.textContent).toContain("1 session will be removed");
 
     const confirm = Array.from(
       document.body.querySelectorAll<HTMLButtonElement>("button"),
@@ -397,5 +391,91 @@ describe("ProjectSettingsModal", () => {
     );
     expect(useAppStore.getState().sessions).toEqual([]);
     expect(document.body.textContent).not.toContain("feature-alpha");
+  });
+
+  it("blocks worktree deletion while another session uses it", async () => {
+    mockApi.getProjectSettings.mockResolvedValue({
+      key: "github:im-ian/acorn",
+      settings: {
+        remember_after_close: true,
+        pull_requests: {
+          generation_prompt: "Use concise release-note style.",
+        },
+      },
+    });
+    mockApi.listProjectWorktrees.mockResolvedValue([
+      {
+        name: "feature-alpha",
+        path: "/repo/acorn/.acorn/worktrees/feature-alpha",
+        modified_ms: null,
+      },
+    ]);
+    useAppStore.setState({
+      sessions: [
+        session({
+          id: "s-alpha-1",
+          name: "alpha terminal",
+          worktree_path: "/repo/acorn/.acorn/worktrees/feature-alpha",
+          in_worktree: true,
+        }),
+        session({
+          id: "s-alpha-2",
+          name: "alpha chat",
+          worktree_path: "/repo/acorn/.acorn/worktrees/feature-alpha/",
+          in_worktree: true,
+        }),
+      ],
+      activeSessionId: "s-alpha-1",
+      projects: [
+        {
+          repo_path: "/repo/acorn",
+          name: "acorn",
+          created_at: "2026-01-01T00:00:00Z",
+          position: 0,
+        },
+      ],
+    });
+
+    await act(async () => {
+      root.render(
+        <ProjectSettingsModal
+          project={{ name: "acorn", repoPath: "/repo/acorn" }}
+          onClose={() => {}}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const worktreesTab = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent === "Worktrees");
+    await act(async () => {
+      worktreesTab!.click();
+    });
+    await flushPromises();
+
+    expect(document.body.textContent).toContain("Used by 2 sessions");
+    expect(document.body.textContent).toContain(
+      "Close other sessions using this worktree before removing it.",
+    );
+
+    const remove = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find(
+      (button) =>
+        button.getAttribute("aria-label") ===
+        "Remove feature-alpha worktree",
+    );
+    expect(remove).toBeDefined();
+    expect(remove?.disabled).toBe(true);
+
+    await act(async () => {
+      remove!.click();
+    });
+
+    expect(document.body.textContent).not.toContain(
+      "Remove sessions and delete worktree",
+    );
+    expect(mockApi.removeWorktree).not.toHaveBeenCalled();
   });
 });

--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -11,6 +11,10 @@ import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { STANDARD_PR_GENERATION_PROMPT } from "../lib/project-settings";
+import {
+  otherSessionsUsingProjectWorktree,
+  sessionsUsingProjectWorktree,
+} from "../lib/sessionWorktree";
 import type { ProjectSettings, ProjectWorktree, Session } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
 import { useAppStore } from "../store";
@@ -77,27 +81,6 @@ function formatModifiedTime(value: number | null): string | null {
   }).format(date);
 }
 
-function normalizePath(path: string): string {
-  const normalized = path.replace(/\\/g, "/").replace(/\/+$/g, "");
-  return normalized.length > 0 ? normalized : "/";
-}
-
-function samePath(left: string, right: string): boolean {
-  return normalizePath(left) === normalizePath(right);
-}
-
-function sessionsUsingWorktree(
-  sessions: readonly Session[],
-  repoPath: string,
-  worktreePath: string,
-): Session[] {
-  return sessions.filter(
-    (session) =>
-      samePath(session.repo_path, repoPath) &&
-      samePath(session.worktree_path, worktreePath),
-  );
-}
-
 interface ProjectSettingsModalProps {
   project: { name: string; repoPath: string } | null;
   initialTab?: ProjectSettingsTab;
@@ -111,6 +94,7 @@ export function ProjectSettingsModal({
 }: ProjectSettingsModalProps) {
   const t = useTranslation();
   const sessions = useAppStore((s) => s.sessions);
+  const activeSessionId = useAppStore((s) => s.activeSessionId);
   const removeProjectWorktree = useAppStore((s) => s.removeProjectWorktree);
   const [tab, setTab] = useState<ProjectSettingsTab>(initialTab);
   const [settings, setSettings] = useState<ProjectSettings>(() =>
@@ -132,20 +116,39 @@ export function ProjectSettingsModal({
 
   const confirmRemoveSessions =
     project && confirmRemove
-      ? sessionsUsingWorktree(sessions, project.repoPath, confirmRemove.path)
+      ? sessionsUsingProjectWorktree(
+          sessions,
+          project.repoPath,
+          confirmRemove.path,
+        )
       : [];
+  const confirmRemoveOtherSessions =
+    project && confirmRemove
+      ? otherSessionsUsingProjectWorktree(
+          sessions,
+          project.repoPath,
+          confirmRemove.path,
+          activeSessionId,
+        )
+      : [];
+  const canShowConfirmRemove =
+    confirmRemove !== null && confirmRemoveOtherSessions.length === 0;
 
   useDialogShortcuts(project !== null && confirmRemove === null, {
     onCancel: onClose,
     onConfirm: () => {},
   });
 
-  useDialogShortcuts(confirmRemove !== null, {
+  useDialogShortcuts(canShowConfirmRemove, {
     onCancel: () => setConfirmRemove(null),
     onConfirm: () => {
       void removeConfirmedWorktree();
     },
   });
+
+  useEffect(() => {
+    if (confirmRemoveOtherSessions.length > 0) setConfirmRemove(null);
+  }, [confirmRemoveOtherSessions.length]);
 
   useEffect(() => {
     setTab(initialTab);
@@ -253,11 +256,18 @@ export function ProjectSettingsModal({
   async function removeConfirmedWorktree() {
     if (!project || !confirmRemove || removingPath !== null) return;
     const target = confirmRemove;
-    const targetSessions = sessionsUsingWorktree(
+    const targetSessions = sessionsUsingProjectWorktree(
       sessions,
       project.repoPath,
       target.path,
     );
+    const otherSessions = targetSessions.filter(
+      (session) => session.id !== activeSessionId,
+    );
+    if (otherSessions.length > 0) {
+      setConfirmRemove(null);
+      return;
+    }
     setRemovingPath(target.path);
     setWorktreeError(null);
     try {
@@ -273,6 +283,18 @@ export function ProjectSettingsModal({
     } finally {
       setRemovingPath(null);
     }
+  }
+
+  function requestRemoveWorktree(worktree: ProjectWorktree) {
+    if (!project) return;
+    const otherSessions = otherSessionsUsingProjectWorktree(
+      sessions,
+      project.repoPath,
+      worktree.path,
+      activeSessionId,
+    );
+    if (otherSessions.length > 0) return;
+    setConfirmRemove(worktree);
   }
 
   return (
@@ -390,10 +412,11 @@ export function ProjectSettingsModal({
                     repoPath={project.repoPath}
                     worktrees={worktrees}
                     sessions={sessions}
+                    activeSessionId={activeSessionId}
                     loading={worktreesLoading}
                     removingPath={removingPath}
                     error={worktreeError}
-                    onRequestRemove={setConfirmRemove}
+                    onRequestRemove={requestRemoveWorktree}
                     t={t}
                   />
                 </ProjectSettingsGroup>
@@ -427,7 +450,7 @@ export function ProjectSettingsModal({
             </button>
           </footer>
           <RemoveWorktreeConfirmDialog
-            worktree={confirmRemove}
+            worktree={canShowConfirmRemove ? confirmRemove : null}
             sessions={confirmRemoveSessions}
             removing={removingPath === confirmRemove?.path}
             onCancel={() => setConfirmRemove(null)}
@@ -468,6 +491,7 @@ function ProjectWorktreeList({
   repoPath,
   worktrees,
   sessions,
+  activeSessionId,
   loading,
   removingPath,
   error,
@@ -477,6 +501,7 @@ function ProjectWorktreeList({
   repoPath: string;
   worktrees: ProjectWorktree[];
   sessions: Session[];
+  activeSessionId: string | null;
   loading: boolean;
   removingPath: string | null;
   error: { kind: "load" | "remove"; message: string } | null;
@@ -503,12 +528,15 @@ function ProjectWorktreeList({
           {worktrees.map((worktree) => {
             const modified = formatModifiedTime(worktree.modified_ms);
             const isRemoving = removingPath === worktree.path;
-            const usedBySessions = sessionsUsingWorktree(
+            const usedBySessions = sessionsUsingProjectWorktree(
               sessions,
               repoPath,
               worktree.path,
             );
             const sessionCount = usedBySessions.length;
+            const removeBlockedByOtherSessions = usedBySessions.some(
+              (session) => session.id !== activeSessionId,
+            );
             return (
               <li key={worktree.path} className="px-3 py-2">
                 <div className="flex items-start justify-between gap-3">
@@ -541,6 +569,14 @@ function ProjectWorktreeList({
                         )}
                       </p>
                     ) : null}
+                    {removeBlockedByOtherSessions ? (
+                      <p className="text-[11px] text-fg-muted">
+                        {dt(
+                          t,
+                          "dialogs.projectSettings.removeWorktreeBlockedByOtherSessions",
+                        )}
+                      </p>
+                    ) : null}
                   </div>
                   <button
                     type="button"
@@ -549,8 +585,18 @@ function ProjectWorktreeList({
                       "dialogs.projectSettings.removeWorktreeAria",
                       { name: worktree.name },
                     )}
+                    title={
+                      removeBlockedByOtherSessions
+                        ? dt(
+                            t,
+                            "dialogs.projectSettings.removeWorktreeBlockedByOtherSessions",
+                          )
+                        : undefined
+                    }
                     onClick={() => onRequestRemove(worktree)}
-                    disabled={removingPath !== null}
+                    disabled={
+                      removingPath !== null || removeBlockedByOtherSessions
+                    }
                     className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md border border-border bg-bg px-2 text-[11px] text-fg-muted transition hover:text-danger disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     {isRemoving ? (

--- a/src/lib/sessionWorktree.test.ts
+++ b/src/lib/sessionWorktree.test.ts
@@ -4,6 +4,8 @@ import {
   canDeleteSessionWorktree,
   hasRecordedWorktree,
   isSessionInWorktreeWorkspace,
+  otherSessionsUsingProjectWorktree,
+  sessionsUsingProjectWorktree,
   shouldAutoDeleteSessionWorktree,
 } from "./sessionWorktree";
 
@@ -94,5 +96,67 @@ describe("worktree deletion policy", () => {
 
     expect(canDeleteSessionWorktree(target, foldersByRepo)).toBe(true);
     expect(shouldAutoDeleteSessionWorktree(target, foldersByRepo)).toBe(false);
+  });
+});
+
+describe("sessionsUsingProjectWorktree", () => {
+  it("matches sessions by repo and normalized worktree path", () => {
+    const sessions = [
+      session({
+        id: "active",
+        worktree_path: "/repo/.acorn/worktrees/feature",
+      }),
+      session({
+        id: "trailing",
+        worktree_path: "/repo/.acorn/worktrees/feature/",
+      }),
+      session({
+        id: "other-repo",
+        repo_path: "/other",
+        worktree_path: "/repo/.acorn/worktrees/feature",
+      }),
+      session({
+        id: "windows",
+        repo_path: "C:\\repo",
+        worktree_path: "C:\\repo\\.acorn\\worktrees\\feature",
+      }),
+    ];
+
+    expect(
+      sessionsUsingProjectWorktree(
+        sessions,
+        "/repo",
+        "/repo/.acorn/worktrees/feature/",
+      ).map((candidate) => candidate.id),
+    ).toEqual(["active", "trailing"]);
+    expect(
+      sessionsUsingProjectWorktree(
+        sessions,
+        "C:/repo",
+        "C:/repo/.acorn/worktrees/feature/",
+      ).map((candidate) => candidate.id),
+    ).toEqual(["windows"]);
+  });
+
+  it("reports only non-active sessions as other users", () => {
+    const sessions = [
+      session({
+        id: "active",
+        worktree_path: "/repo/.acorn/worktrees/feature",
+      }),
+      session({
+        id: "other",
+        worktree_path: "/repo/.acorn/worktrees/feature",
+      }),
+    ];
+
+    expect(
+      otherSessionsUsingProjectWorktree(
+        sessions,
+        "/repo",
+        "/repo/.acorn/worktrees/feature",
+        "active",
+      ).map((candidate) => candidate.id),
+    ).toEqual(["other"]);
   });
 });

--- a/src/lib/sessionWorktree.ts
+++ b/src/lib/sessionWorktree.ts
@@ -6,11 +6,36 @@ export function hasRecordedWorktree(session: Session): boolean {
 }
 
 function normalizeWorkspacePath(path: string): string {
-  return path.replace(/[\\/]+$/, "");
+  return path.replace(/\\/g, "/").replace(/\/+$/g, "");
 }
 
 function sameWorkspacePath(a: string, b: string): boolean {
   return normalizeWorkspacePath(a) === normalizeWorkspacePath(b);
+}
+
+export function sessionsUsingProjectWorktree(
+  sessions: readonly Session[],
+  repoPath: string,
+  worktreePath: string,
+): Session[] {
+  return sessions.filter(
+    (session) =>
+      sameWorkspacePath(session.repo_path, repoPath) &&
+      sameWorkspacePath(session.worktree_path, worktreePath),
+  );
+}
+
+export function otherSessionsUsingProjectWorktree(
+  sessions: readonly Session[],
+  repoPath: string,
+  worktreePath: string,
+  activeSessionId: string | null,
+): Session[] {
+  return sessionsUsingProjectWorktree(
+    sessions,
+    repoPath,
+    worktreePath,
+  ).filter((session) => session.id !== activeSessionId);
 }
 
 export function isSessionInWorktreeWorkspace(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1380,6 +1380,7 @@
       "usedBySessions": "Used by {count} sessions",
       "removeWorktree": "Remove",
       "removeWorktreeAria": "Remove {name} worktree",
+      "removeWorktreeBlockedByOtherSessions": "Close other sessions using this worktree before removing it.",
       "confirmRemoveDialog": "Delete worktree",
       "confirmRemoveTitle": "Delete {name}?",
       "confirmRemoveBody": "This removes the linked git worktree directory from disk. Sessions using it may need to be reopened from the main project.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1380,6 +1380,7 @@
       "usedBySessions": "{count}개 세션에서 사용 중",
       "removeWorktree": "제거",
       "removeWorktreeAria": "{name} 워크트리 제거",
+      "removeWorktreeBlockedByOtherSessions": "이 워크트리를 사용하는 다른 세션을 모두 닫은 뒤 제거할 수 있습니다.",
       "confirmRemoveDialog": "워크트리 삭제",
       "confirmRemoveTitle": "{name} 삭제",
       "confirmRemoveBody": "연결된 Git 워크트리 디렉터리를 디스크에서 제거합니다. 이 워크트리를 사용하는 세션은 메인 프로젝트에서 다시 열어야 할 수 있습니다.",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2217,6 +2217,39 @@ describe("removeProjectWorktree", () => {
     ).toBe(false);
     expect(state.workspaces[folder!.id]).toBeUndefined();
   });
+
+  it("refuses to delete a worktree while another session uses it", async () => {
+    const worktreePath = `${REPO_B}/.acorn/worktrees/feature-alpha`;
+    const repo = project(REPO_B, 0);
+    await seed(
+      [repo],
+      [
+        session("b1", REPO_B, {
+          worktree_path: worktreePath,
+          in_worktree: true,
+        }),
+        session("b2", REPO_B, {
+          worktree_path: `${worktreePath}/`,
+          in_worktree: true,
+        }),
+      ],
+    );
+    useAppStore.getState().selectSession("b1");
+
+    await expect(
+      useAppStore.getState().removeProjectWorktree(REPO_B, worktreePath, true),
+    ).rejects.toThrow("Close other sessions using this worktree");
+
+    const state = useAppStore.getState();
+    expect(mockApi.removeWorktree).not.toHaveBeenCalled();
+    expect(state.sessions.map((candidate) => candidate.id)).toEqual([
+      "b1",
+      "b2",
+    ]);
+    expect(state.error).toBe(
+      "Close other sessions using this worktree before removing it.",
+    );
+  });
 });
 
 describe("requestRemoveProject", () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -48,6 +48,10 @@ import {
   buildSessionCreateRequest,
 } from "./lib/sessionCreation";
 import {
+  otherSessionsUsingProjectWorktree,
+  sessionsUsingProjectWorktree,
+} from "./lib/sessionWorktree";
+import {
   DEFAULT_PROJECT_FOLDER_NAME,
   basenamePath,
   defaultProjectFolderId,
@@ -72,6 +76,8 @@ export type { RightGroup, RightTab };
 
 const ROOT_PANE_ID: PaneId = "root";
 const SESSION_TITLE_GENERATING_MIN_MS = 900;
+const WORKTREE_IN_USE_BY_OTHER_SESSIONS =
+  "Close other sessions using this worktree before removing it.";
 
 let statusPollRunning = false;
 let statusPollChain: Promise<void> | null = null;
@@ -2528,6 +2534,28 @@ export const useAppStore = create<AppStateModel>()(
 
   async removeProjectWorktree(repoPath, worktreePath, removeSessions = false) {
     try {
+      if (removeSessions) {
+        const state = get();
+        const otherSessions = otherSessionsUsingProjectWorktree(
+          state.sessions,
+          repoPath,
+          worktreePath,
+          state.activeSessionId,
+        );
+        const targetSessions = sessionsUsingProjectWorktree(
+          state.sessions,
+          repoPath,
+          worktreePath,
+        );
+        const canRemoveSessions =
+          targetSessions.length === 0 ||
+          (targetSessions.length === 1 &&
+            targetSessions[0]?.id === state.activeSessionId);
+        if (otherSessions.length > 0 || !canRemoveSessions) {
+          set({ error: WORKTREE_IN_USE_BY_OTHER_SESSIONS });
+          throw new Error(WORKTREE_IN_USE_BY_OTHER_SESSIONS);
+        }
+      }
       const removedWorktree = await api.removeWorktree(
         repoPath,
         worktreePath,

--- a/tests/e2e/project-settings.spec.ts
+++ b/tests/e2e/project-settings.spec.ts
@@ -96,7 +96,7 @@ test.describe("project settings", () => {
     ]);
   });
 
-  test("confirms before deleting a worktree used by sidebar sessions", async ({
+  test("confirms before deleting a worktree used by the active sidebar session", async ({
     page,
     tauri,
   }) => {
@@ -225,5 +225,103 @@ test.describe("project settings", () => {
         removeSessions: true,
       },
     ]);
+  });
+
+  test("does not open the delete confirmation while another session uses the worktree", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/acorn",
+        name: "acorn",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-alpha",
+        name: "alpha terminal",
+        repo_path: "/tmp/acorn",
+        worktree_path: "/tmp/acorn/.acorn/worktrees/feature-alpha",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        title_source: "default",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: true,
+      },
+      {
+        id: "s-alpha-other",
+        name: "alpha reviewer",
+        repo_path: "/tmp/acorn",
+        worktree_path: "/tmp/acorn/.acorn/worktrees/feature-alpha/",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        title_source: "default",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: true,
+      },
+    ]);
+    await tauri.handle("list_project_worktrees", () => [
+      {
+        name: "feature-alpha",
+        path: "/tmp/acorn/.acorn/worktrees/feature-alpha",
+        modified_ms: null,
+      },
+    ]);
+    await tauri.handle("remove_worktree", (args) => {
+      const w = window as unknown as { __removeWorktreeCalls?: unknown[] };
+      w.__removeWorktreeCalls = w.__removeWorktreeCalls ?? [];
+      w.__removeWorktreeCalls.push(args);
+      return undefined;
+    });
+
+    await page.goto("/");
+
+    await page
+      .getByRole("button", { name: "Project acorn" })
+      .click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Project Settings" }).click();
+
+    const modal = page.getByRole("dialog", { name: "Project Settings" });
+    await modal.getByRole("button", { name: "Worktrees" }).click();
+
+    const alphaRow = modal.getByRole("listitem").filter({
+      hasText: "feature-alpha",
+    });
+    await expect(alphaRow).toContainText("Used by 2 sessions");
+    await expect(alphaRow).toContainText(
+      "Close other sessions using this worktree before removing it.",
+    );
+    await expect(
+      alphaRow.getByRole("button", {
+        name: "Remove feature-alpha worktree",
+      }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("dialog", { name: "Delete worktree" }),
+    ).toHaveCount(0);
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __removeWorktreeCalls?: unknown[] })
+          .__removeWorktreeCalls ?? [],
+    )) as unknown[];
+    expect(calls).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
Prevent linked worktree deletion while another Acorn session is still using the same worktree folder.

1. **Shared-session guard** — project settings now disables worktree removal when any non-active session uses that worktree, so the delete confirmation modal is only reachable for unused worktrees or the active session's sole worktree.
2. **Store-level protection** — `removeProjectWorktree(..., true)` now rejects before calling the backend when matching worktree sessions include anything other than the active session.
3. **Shared path matching** — session/worktree matching moved into `sessionWorktree` helpers with slash normalization, and the UI shows localized guidance explaining why removal is blocked.
4. **CI type fix from latest main** — work-summary tabs now use their own `repoPath` when resolving tab-strip root session creation scope, avoiding the code-tab-only helper path that broke `tsc` on the current base.
5. **Regression coverage** — added Vitest and Playwright coverage for active-session deletion, other-session blocking, path normalization, store bypass protection, and work-summary tab root creation.

## Expected impact
| Scenario | Before | After |
| --- | --- | --- |
| Worktree used by another session | Delete modal could appear and remove sessions/worktree | Remove action is disabled until other sessions are closed |
| Worktree used only by active session | Delete confirmation appears | Delete confirmation still appears |
| Empty linked worktree | Delete confirmation appears | Delete confirmation still appears |
| Work-summary tab strip double-click | Latest base failed typecheck on mixed tab types | Work-summary tabs resolve project-root scope without using code-tab-only fields |

## Design notes
- The UI and store use the same `sessionsUsingProjectWorktree` / `otherSessionsUsingProjectWorktree` helpers so trailing slashes and platform path separators are handled consistently.
- The confirm dialog also closes itself if session state changes after it opens and the worktree becomes shared by another session.
- The backend command shape is unchanged; this PR constrains the frontend/store deletion policy without changing Rust worktree removal behavior.
- The Pane change is intentionally narrow: code tabs still use `repoPathForCodeTabSession`, while work-summary tabs use their existing `repoPath` because they do not expose a file `path`.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test -- src/lib/sessionWorktree.test.ts src/components/ProjectSettingsModal.test.tsx src/components/Pane.test.tsx src/store.test.ts` — 72 files / 736 tests passed
- [x] `pnpm run test:e2e -- tests/e2e/project-settings.spec.ts` — 3 tests passed
- [x] `git diff --check` — passes

## Notes
- PR #471 was opened from an older stacked branch and contained unrelated work-summary files. This PR replaces it with a clean branch based on current `origin/main`.
