### PR TITLE
fix(worktrees): block shared worktree deletion

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -33,6 +33,8 @@ use serde::Serialize;
 use tauri_plugin_dialog::DialogExt;
 
 const CHAT_SESSION_STATE_CHANGED_EVENT: &str = "acorn:chat-session-state-changed";
+const WORKTREE_IN_USE_BY_OTHER_SESSIONS: &str =
+    "Close other sessions using this worktree before removing it.";
 
 async fn run_blocking<T, F>(label: &'static str, f: F) -> AppResult<T>
 where
@@ -3176,6 +3178,57 @@ fn terminate_session_pty(state: &AppState, id: &Uuid) {
     }
 }
 
+fn sessions_using_linked_worktree(
+    state: &AppState,
+    repo_path: &Path,
+    worktree_path: &Path,
+) -> Vec<Session> {
+    state
+        .sessions
+        .list()
+        .into_iter()
+        .filter(|session| {
+            worktree::same_path(&session.repo_path, repo_path)
+                && worktree::same_path(&session.worktree_path, worktree_path)
+        })
+        .collect()
+}
+
+fn sessions_using_worktree_path(state: &AppState, worktree_path: &Path) -> Vec<Session> {
+    state
+        .sessions
+        .list()
+        .into_iter()
+        .filter(|session| worktree::same_path(&session.worktree_path, worktree_path))
+        .collect()
+}
+
+fn ensure_no_sessions_using_worktree_path_except(
+    state: &AppState,
+    worktree_path: &Path,
+    except_id: Option<&Uuid>,
+) -> AppResult<()> {
+    let has_conflict = sessions_using_worktree_path(state, worktree_path)
+        .into_iter()
+        .any(|session| except_id != Some(&session.id));
+    if has_conflict {
+        return Err(AppError::Other(
+            WORKTREE_IN_USE_BY_OTHER_SESSIONS.to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn worktree_path_used_outside_project(
+    state: &AppState,
+    repo_path: &Path,
+    worktree_path: &Path,
+) -> bool {
+    sessions_using_worktree_path(state, worktree_path)
+        .into_iter()
+        .any(|session| !worktree::same_path(&session.repo_path, repo_path))
+}
+
 #[tauri::command]
 pub async fn remove_project(
     state: State<'_, AppState>,
@@ -3200,6 +3253,19 @@ pub async fn remove_project(
         for session in session_ids {
             terminate_session_pty(&app_state, &session.id);
             if drop_worktrees && staged_worktree_paths.insert(session.worktree_path.clone()) {
+                if worktree_path_used_outside_project(
+                    &app_state,
+                    &path,
+                    &session.worktree_path,
+                ) {
+                    tracing::warn!(
+                        repo_path = %session.repo_path.display(),
+                        worktree_path = %session.worktree_path.display(),
+                        "skipping linked worktree removal because another project still has a session there"
+                    );
+                    app_state.sessions.remove(&session.id).ok();
+                    continue;
+                }
                 match stage_remove_linked_worktree_blocking(
                     session.repo_path.clone(),
                     session.worktree_path.clone(),
@@ -3242,6 +3308,13 @@ pub async fn remove_session(
     let app_state = state.inner().clone();
     let id = Uuid::parse_str(&id).map_err(|e| AppError::Other(e.to_string()))?;
     let session = app_state.sessions.get(&id)?;
+    if remove_worktree.unwrap_or(false) {
+        ensure_no_sessions_using_worktree_path_except(
+            &app_state,
+            &session.worktree_path,
+            Some(&id),
+        )?;
+    }
     terminate_session_pty(&app_state, &id);
     if let Ok(dir) = persistence::data_dir() {
         scrollback::delete(&dir, &id.to_string()).ok();
@@ -3730,7 +3803,18 @@ pub async fn remove_worktree(
     let app_state = state.inner().clone();
     let repo_path = PathBuf::from(repo_path);
     let worktree_path = PathBuf::from(worktree_path);
-    if remove_sessions.unwrap_or(false) {
+    let remove_sessions = remove_sessions.unwrap_or(false);
+    if remove_sessions {
+        let matching_sessions = sessions_using_worktree_path(&app_state, &worktree_path);
+        if matching_sessions.len() > 1
+            || matching_sessions
+                .iter()
+                .any(|session| !worktree::same_path(&session.repo_path, &repo_path))
+        {
+            return Err(AppError::Other(
+                WORKTREE_IN_USE_BY_OTHER_SESSIONS.to_string(),
+            ));
+        }
         return stage_remove_linked_worktree_and_sessions_blocking(
             app_state,
             repo_path,
@@ -3738,6 +3822,7 @@ pub async fn remove_worktree(
         )
         .await;
     }
+    ensure_no_sessions_using_worktree_path_except(&app_state, &worktree_path, None)?;
     stage_remove_linked_worktree_blocking(repo_path, worktree_path).await
 }
 
@@ -5344,15 +5429,7 @@ fn stage_remove_linked_worktree_at_path_and_sessions(
     repo_path: &Path,
     worktree_path: &Path,
 ) -> AppResult<Option<worktree::RemovedWorktree>> {
-    let sessions: Vec<_> = state
-        .sessions
-        .list()
-        .into_iter()
-        .filter(|session| {
-            worktree::same_path(&session.repo_path, repo_path)
-                && worktree::same_path(&session.worktree_path, worktree_path)
-        })
-        .collect();
+    let sessions = sessions_using_linked_worktree(state, repo_path, worktree_path);
 
     let removed = stage_remove_linked_worktree_at_path(repo_path, worktree_path)?;
 
@@ -5609,6 +5686,19 @@ mod tests {
             SessionKind::Regular,
         );
         session.project_scoped = project_scoped;
+        session
+    }
+
+    fn worktree_session(id: &str, repo_path: &str, worktree_path: &str) -> Session {
+        let mut session = Session::new(
+            id.to_string(),
+            PathBuf::from(repo_path),
+            PathBuf::from(worktree_path),
+            "main".to_string(),
+            true,
+            SessionKind::Regular,
+        );
+        session.in_worktree = true;
         session
     }
 
@@ -7235,6 +7325,87 @@ mod tests {
             "linked project root should be removed when explicitly requested"
         );
         std::fs::remove_dir_all(&repo_dir).ok();
+    }
+
+    #[test]
+    fn worktree_delete_guard_rejects_peer_session_on_same_worktree_path() {
+        let state = crate::state::AppState::default();
+        let root = std::env::temp_dir().join(format!(
+            "acorn-worktree-guard-{}",
+            Uuid::new_v4().simple()
+        ));
+        let repo = root.join("repo");
+        let other_repo = root.join("other");
+        let worktree = repo.join(".acorn/worktrees/shared");
+        std::fs::create_dir_all(&worktree).expect("create worktree path");
+        let active = state.sessions.insert(worktree_session(
+            "active",
+            &repo.display().to_string(),
+            &worktree.display().to_string(),
+        ));
+        state.sessions.insert(worktree_session(
+            "peer",
+            &other_repo.display().to_string(),
+            &format!("{}/", worktree.display()),
+        ));
+
+        let err = super::ensure_no_sessions_using_worktree_path_except(
+            &state,
+            &worktree,
+            Some(&active.id),
+        )
+        .expect_err("peer session should block worktree deletion");
+
+        assert_eq!(err.to_string(), super::WORKTREE_IN_USE_BY_OTHER_SESSIONS);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn worktree_delete_guard_detects_sessions_outside_project() {
+        let state = crate::state::AppState::default();
+        let repo = Path::new("/tmp/acorn-worktree-guard-project");
+        let other_repo = Path::new("/tmp/acorn-worktree-guard-project-other");
+        let worktree = repo.join(".acorn/worktrees/shared");
+        state.sessions.insert(worktree_session(
+            "active",
+            &repo.display().to_string(),
+            &worktree.display().to_string(),
+        ));
+        state.sessions.insert(worktree_session(
+            "peer",
+            &other_repo.display().to_string(),
+            &worktree.display().to_string(),
+        ));
+
+        assert!(super::worktree_path_used_outside_project(
+            &state,
+            repo,
+            &worktree,
+        ));
+        assert!(!super::worktree_path_used_outside_project(
+            &state,
+            other_repo,
+            &other_repo.join(".acorn/worktrees/solo"),
+        ));
+    }
+
+    #[test]
+    fn worktree_delete_guard_allows_target_session_only() {
+        let state = crate::state::AppState::default();
+        let repo = Path::new("/tmp/acorn-worktree-guard-solo");
+        let worktree = repo.join(".acorn/worktrees/solo");
+        let active = state.sessions.insert(worktree_session(
+            "active",
+            &repo.display().to_string(),
+            &worktree.display().to_string(),
+        ));
+
+        super::ensure_no_sessions_using_worktree_path_except(
+            &state,
+            &worktree,
+            Some(&active.id),
+        )
+        .expect("target session should not block its own worktree deletion");
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1173,6 +1173,7 @@ function App() {
     confirmRemoveSession,
     projectFolders,
     removeSession,
+    sessions,
     showStoreOperationToast,
   ]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -315,12 +315,12 @@ function App() {
     pendingRemove !== null && hasRecordedWorktree(pendingRemove);
   const pendingRemoveCanDeleteWorktree =
     pendingRemove !== null &&
-    canDeleteSessionWorktree(pendingRemove, projectFolders);
+    canDeleteSessionWorktree(pendingRemove, projectFolders, sessions);
   const pendingRemoveKeepsSharedWorktree =
     pendingRemoveRecordedWorktree && !pendingRemoveCanDeleteWorktree;
   const pendingRemoveAutoDeletesWorktree =
     pendingRemove !== null &&
-    shouldAutoDeleteSessionWorktree(pendingRemove, projectFolders);
+    shouldAutoDeleteSessionWorktree(pendingRemove, projectFolders, sessions);
   const [runningCloseWarningConfirmedId, setRunningCloseWarningConfirmedId] =
     useState<string | null>(null);
   const pendingRemoveNeedsRunningWarning =
@@ -1126,6 +1126,7 @@ function App() {
     const canDeleteWorktree = canDeleteSessionWorktree(
       pendingRemove,
       projectFolders,
+      sessions,
     );
     if (recordedWorktree && !canDeleteWorktree) {
       clearPendingRemove();
@@ -1140,6 +1141,7 @@ function App() {
     const autoDeleteWorktree = shouldAutoDeleteSessionWorktree(
       pendingRemove,
       projectFolders,
+      sessions,
     );
     if (autoDeleteWorktree && deleteIsolatedWorktreesWithoutPrompt) {
       clearPendingRemove();

--- a/src/components/ProjectSettingsModal.test.tsx
+++ b/src/components/ProjectSettingsModal.test.tsx
@@ -478,4 +478,91 @@ describe("ProjectSettingsModal", () => {
     );
     expect(mockApi.removeWorktree).not.toHaveBeenCalled();
   });
+
+  it("blocks worktree deletion while another project session uses the same path", async () => {
+    mockApi.getProjectSettings.mockResolvedValue({
+      key: "github:im-ian/acorn",
+      settings: {
+        remember_after_close: true,
+        pull_requests: {
+          generation_prompt: "Use concise release-note style.",
+        },
+      },
+    });
+    mockApi.listProjectWorktrees.mockResolvedValue([
+      {
+        name: "feature-alpha",
+        path: "/repo/acorn/.acorn/worktrees/feature-alpha",
+        modified_ms: null,
+      },
+    ]);
+    useAppStore.setState({
+      sessions: [
+        session({
+          id: "s-alpha-1",
+          name: "alpha terminal",
+          worktree_path: "/repo/acorn/.acorn/worktrees/feature-alpha",
+          in_worktree: true,
+        }),
+        session({
+          id: "s-other-1",
+          name: "other project chat",
+          repo_path: "/repo/other",
+          worktree_path: "/repo/acorn/.acorn/worktrees/feature-alpha/",
+          in_worktree: true,
+        }),
+      ],
+      activeSessionId: "s-alpha-1",
+      projects: [
+        {
+          repo_path: "/repo/acorn",
+          name: "acorn",
+          created_at: "2026-01-01T00:00:00Z",
+          position: 0,
+        },
+      ],
+    });
+
+    await act(async () => {
+      root.render(
+        <ProjectSettingsModal
+          project={{ name: "acorn", repoPath: "/repo/acorn" }}
+          onClose={() => {}}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const worktreesTab = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent === "Worktrees");
+    await act(async () => {
+      worktreesTab!.click();
+    });
+    await flushPromises();
+
+    expect(document.body.textContent).toContain("Used by 2 sessions");
+    expect(document.body.textContent).toContain(
+      "Close other sessions using this worktree before removing it.",
+    );
+
+    const remove = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find(
+      (button) =>
+        button.getAttribute("aria-label") ===
+        "Remove feature-alpha worktree",
+    );
+    expect(remove).toBeDefined();
+    expect(remove?.disabled).toBe(true);
+
+    await act(async () => {
+      remove!.click();
+    });
+
+    expect(document.body.textContent).not.toContain(
+      "Remove sessions and delete worktree",
+    );
+    expect(mockApi.removeWorktree).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -12,8 +12,8 @@ import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { STANDARD_PR_GENERATION_PROMPT } from "../lib/project-settings";
 import {
-  otherSessionsUsingProjectWorktree,
   sessionsUsingProjectWorktree,
+  sessionsUsingWorktreePath,
 } from "../lib/sessionWorktree";
 import type { ProjectSettings, ProjectWorktree, Session } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
@@ -81,6 +81,23 @@ function formatModifiedTime(value: number | null): string | null {
   }).format(date);
 }
 
+function blockingSessionsForProjectWorktree(
+  sessions: readonly Session[],
+  repoPath: string,
+  worktreePath: string,
+  activeSessionId: string | null,
+): Session[] {
+  const targetSessions = sessionsUsingProjectWorktree(
+    sessions,
+    repoPath,
+    worktreePath,
+  );
+  const targetIds = new Set(targetSessions.map((session) => session.id));
+  return sessionsUsingWorktreePath(sessions, worktreePath).filter(
+    (session) => !targetIds.has(session.id) || session.id !== activeSessionId,
+  );
+}
+
 interface ProjectSettingsModalProps {
   project: { name: string; repoPath: string } | null;
   initialTab?: ProjectSettingsTab;
@@ -124,7 +141,7 @@ export function ProjectSettingsModal({
       : [];
   const confirmRemoveOtherSessions =
     project && confirmRemove
-      ? otherSessionsUsingProjectWorktree(
+      ? blockingSessionsForProjectWorktree(
           sessions,
           project.repoPath,
           confirmRemove.path,
@@ -261,10 +278,13 @@ export function ProjectSettingsModal({
       project.repoPath,
       target.path,
     );
-    const otherSessions = targetSessions.filter(
-      (session) => session.id !== activeSessionId,
+    const blockingSessions = blockingSessionsForProjectWorktree(
+      sessions,
+      project.repoPath,
+      target.path,
+      activeSessionId,
     );
-    if (otherSessions.length > 0) {
+    if (blockingSessions.length > 0) {
       setConfirmRemove(null);
       return;
     }
@@ -287,13 +307,13 @@ export function ProjectSettingsModal({
 
   function requestRemoveWorktree(worktree: ProjectWorktree) {
     if (!project) return;
-    const otherSessions = otherSessionsUsingProjectWorktree(
+    const blockingSessions = blockingSessionsForProjectWorktree(
       sessions,
       project.repoPath,
       worktree.path,
       activeSessionId,
     );
-    if (otherSessions.length > 0) return;
+    if (blockingSessions.length > 0) return;
     setConfirmRemove(worktree);
   }
 
@@ -528,15 +548,18 @@ function ProjectWorktreeList({
           {worktrees.map((worktree) => {
             const modified = formatModifiedTime(worktree.modified_ms);
             const isRemoving = removingPath === worktree.path;
-            const usedBySessions = sessionsUsingProjectWorktree(
+            const usedBySessions = sessionsUsingWorktreePath(
               sessions,
-              repoPath,
               worktree.path,
             );
             const sessionCount = usedBySessions.length;
-            const removeBlockedByOtherSessions = usedBySessions.some(
-              (session) => session.id !== activeSessionId,
-            );
+            const removeBlockedByOtherSessions =
+              blockingSessionsForProjectWorktree(
+                sessions,
+                repoPath,
+                worktree.path,
+                activeSessionId,
+              ).length > 0;
             return (
               <li key={worktree.path} className="px-3 py-2">
                 <div className="flex items-start justify-between gap-3">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -426,10 +426,15 @@ export function Sidebar() {
     try {
       const removedWorktrees: WorktreeRemoval[] = [];
       for (const session of folderGroup.sessions) {
+        const currentState = useAppStore.getState();
         const removedWorktree = await removeSession(
           session.id,
           deleteIsolatedWorktreesWithoutPrompt &&
-            shouldAutoDeleteSessionWorktree(session, projectFolders),
+            shouldAutoDeleteSessionWorktree(
+              session,
+              currentState.projectFolders,
+              currentState.sessions,
+            ),
         );
         if (removedWorktree) {
           removedWorktrees.push(removedWorktree);
@@ -1205,7 +1210,11 @@ export function Sidebar() {
         deleteWorktrees={Boolean(
           deleteIsolatedWorktreesWithoutPrompt &&
             pendingRemoveProjectFolderGroup?.sessions.some((session) =>
-              shouldAutoDeleteSessionWorktree(session, projectFolders),
+              shouldAutoDeleteSessionWorktree(
+                session,
+                projectFolders,
+                sessions,
+              ),
             ),
         )}
         onClose={(choice) => {

--- a/src/lib/sessionWorktree.test.ts
+++ b/src/lib/sessionWorktree.test.ts
@@ -5,7 +5,9 @@ import {
   hasRecordedWorktree,
   isSessionInWorktreeWorkspace,
   otherSessionsUsingProjectWorktree,
+  otherSessionsUsingWorktreePath,
   sessionsUsingProjectWorktree,
+  sessionsUsingWorktreePath,
   shouldAutoDeleteSessionWorktree,
 } from "./sessionWorktree";
 
@@ -73,6 +75,27 @@ describe("worktree deletion policy", () => {
     expect(isSessionInWorktreeWorkspace(target, foldersByRepo)).toBe(false);
     expect(canDeleteSessionWorktree(target, foldersByRepo)).toBe(true);
     expect(shouldAutoDeleteSessionWorktree(target, foldersByRepo)).toBe(true);
+  });
+
+  it("preserves worktrees that another session still uses", () => {
+    const target = session({
+      id: "target",
+      isolated: true,
+      worktree_path: "/repo/.acorn/worktrees/solo",
+    });
+    const peer = session({
+      id: "peer",
+      repo_path: "/other",
+      isolated: true,
+      worktree_path: "/repo/.acorn/worktrees/solo/",
+    });
+
+    expect(canDeleteSessionWorktree(target, foldersByRepo, [target, peer])).toBe(
+      false,
+    );
+    expect(
+      shouldAutoDeleteSessionWorktree(target, foldersByRepo, [target, peer]),
+    ).toBe(false);
   });
 
   it("preserves isolated sessions that are backing a worktree workspace", () => {
@@ -158,5 +181,36 @@ describe("sessionsUsingProjectWorktree", () => {
         "active",
       ).map((candidate) => candidate.id),
     ).toEqual(["other"]);
+  });
+});
+
+describe("sessionsUsingWorktreePath", () => {
+  it("matches sessions by worktree path even when repo paths differ", () => {
+    const sessions = [
+      session({
+        id: "active",
+        repo_path: "/repo",
+        worktree_path: "/repo/.acorn/worktrees/feature",
+      }),
+      session({
+        id: "peer",
+        repo_path: "/other",
+        worktree_path: "/repo/.acorn/worktrees/feature/",
+      }),
+    ];
+
+    expect(
+      sessionsUsingWorktreePath(
+        sessions,
+        "/repo/.acorn/worktrees/feature",
+      ).map((candidate) => candidate.id),
+    ).toEqual(["active", "peer"]);
+    expect(
+      otherSessionsUsingWorktreePath(
+        sessions,
+        "/repo/.acorn/worktrees/feature",
+        "active",
+      ).map((candidate) => candidate.id),
+    ).toEqual(["peer"]);
   });
 });

--- a/src/lib/sessionWorktree.ts
+++ b/src/lib/sessionWorktree.ts
@@ -25,6 +25,15 @@ export function sessionsUsingProjectWorktree(
   );
 }
 
+export function sessionsUsingWorktreePath(
+  sessions: readonly Session[],
+  worktreePath: string,
+): Session[] {
+  return sessions.filter((session) =>
+    sameWorkspacePath(session.worktree_path, worktreePath),
+  );
+}
+
 export function otherSessionsUsingProjectWorktree(
   sessions: readonly Session[],
   repoPath: string,
@@ -36,6 +45,16 @@ export function otherSessionsUsingProjectWorktree(
     repoPath,
     worktreePath,
   ).filter((session) => session.id !== activeSessionId);
+}
+
+export function otherSessionsUsingWorktreePath(
+  sessions: readonly Session[],
+  worktreePath: string,
+  activeSessionId: string | null,
+): Session[] {
+  return sessionsUsingWorktreePath(sessions, worktreePath).filter(
+    (session) => session.id !== activeSessionId,
+  );
 }
 
 export function isSessionInWorktreeWorkspace(
@@ -52,16 +71,25 @@ export function isSessionInWorktreeWorkspace(
 export function canDeleteSessionWorktree(
   session: Session,
   foldersByRepo: ProjectFoldersByRepo,
+  sessions: readonly Session[] = [session],
 ): boolean {
   return (
     hasRecordedWorktree(session) &&
-    !isSessionInWorktreeWorkspace(session, foldersByRepo)
+    !isSessionInWorktreeWorkspace(session, foldersByRepo) &&
+    otherSessionsUsingWorktreePath(
+      sessions,
+      session.worktree_path,
+      session.id,
+    ).length === 0
   );
 }
 
 export function shouldAutoDeleteSessionWorktree(
   session: Session,
   foldersByRepo: ProjectFoldersByRepo,
+  sessions: readonly Session[] = [session],
 ): boolean {
-  return session.isolated && canDeleteSessionWorktree(session, foldersByRepo);
+  return (
+    session.isolated && canDeleteSessionWorktree(session, foldersByRepo, sessions)
+  );
 }

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1260,6 +1260,32 @@ describe("removeSession", () => {
     expect(s.activeSessionId).toBe("a1");
   });
 
+  it("refuses to delete a worktree while another session still uses it", async () => {
+    const worktreePath = `${REPO_A}/.worktrees/shared`;
+    const a1 = session("a1", REPO_A, {
+      isolated: true,
+      worktree_path: worktreePath,
+    });
+    const a2 = session("a2", REPO_A, {
+      repo_path: REPO_B,
+      isolated: true,
+      worktree_path: `${worktreePath}/`,
+    });
+    await seed([project(REPO_A, 0), project(REPO_B, 1)], [a1, a2]);
+
+    const removed = await useAppStore.getState().removeSession("a1", true);
+
+    expect(removed).toBeNull();
+    expect(mockApi.removeSession).not.toHaveBeenCalled();
+    expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual([
+      "a1",
+      "a2",
+    ]);
+    expect(useAppStore.getState().error).toBe(
+      "Close other sessions using this worktree before removing it.",
+    );
+  });
+
   it("collapses an empty split pane before the backend worktree delete finishes", async () => {
     const a1 = session("a1", REPO_A);
     const a2 = session("a2", REPO_A);

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2276,6 +2276,64 @@ describe("removeProjectWorktree", () => {
       "Close other sessions using this worktree before removing it.",
     );
   });
+
+  it("refuses to delete a worktree while another project session uses the same path", async () => {
+    const worktreePath = `${REPO_B}/.acorn/worktrees/feature-alpha`;
+    const repo = project(REPO_B, 0);
+    await seed(
+      [repo, project(REPO_A, 1)],
+      [
+        session("b1", REPO_B, {
+          worktree_path: worktreePath,
+          in_worktree: true,
+        }),
+        session("a1", REPO_A, {
+          worktree_path: `${worktreePath}/`,
+          in_worktree: true,
+        }),
+      ],
+    );
+    useAppStore.getState().selectSession("b1");
+
+    await expect(
+      useAppStore.getState().removeProjectWorktree(REPO_B, worktreePath, true),
+    ).rejects.toThrow("Close other sessions using this worktree");
+
+    const state = useAppStore.getState();
+    expect(mockApi.removeWorktree).not.toHaveBeenCalled();
+    expect(state.sessions.map((candidate) => candidate.id)).toEqual([
+      "b1",
+      "a1",
+    ]);
+    expect(state.error).toBe(
+      "Close other sessions using this worktree before removing it.",
+    );
+  });
+
+  it("refuses to delete a worktree path used only by another project session", async () => {
+    const worktreePath = `${REPO_B}/.acorn/worktrees/feature-alpha`;
+    const repo = project(REPO_B, 0);
+    await seed(
+      [repo, project(REPO_A, 1)],
+      [
+        session("a1", REPO_A, {
+          worktree_path: worktreePath,
+          in_worktree: true,
+        }),
+      ],
+    );
+
+    await expect(
+      useAppStore.getState().removeProjectWorktree(REPO_B, worktreePath, false),
+    ).rejects.toThrow("Close other sessions using this worktree");
+
+    const state = useAppStore.getState();
+    expect(mockApi.removeWorktree).not.toHaveBeenCalled();
+    expect(state.sessions.map((candidate) => candidate.id)).toEqual(["a1"]);
+    expect(state.error).toBe(
+      "Close other sessions using this worktree before removing it.",
+    );
+  });
 });
 
 describe("requestRemoveProject", () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -48,6 +48,7 @@ import {
   buildSessionCreateRequest,
 } from "./lib/sessionCreation";
 import {
+  otherSessionsUsingWorktreePath,
   otherSessionsUsingProjectWorktree,
   sessionsUsingProjectWorktree,
 } from "./lib/sessionWorktree";
@@ -2301,6 +2302,21 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   async removeSession(id, removeWorktree = false) {
+    if (removeWorktree) {
+      const state = get();
+      const target = state.sessions.find((session) => session.id === id);
+      if (target) {
+        const otherSessions = otherSessionsUsingWorktreePath(
+          state.sessions,
+          target.worktree_path,
+          target.id,
+        );
+        if (otherSessions.length > 0) {
+          set({ error: WORKTREE_IN_USE_BY_OTHER_SESSIONS });
+          return null;
+        }
+      }
+    }
     const owning = findTabOwner(get(), id);
     sessionPlacementById.delete(id);
     set((s) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -49,8 +49,8 @@ import {
 } from "./lib/sessionCreation";
 import {
   otherSessionsUsingWorktreePath,
-  otherSessionsUsingProjectWorktree,
   sessionsUsingProjectWorktree,
+  sessionsUsingWorktreePath,
 } from "./lib/sessionWorktree";
 import {
   DEFAULT_PROJECT_FOLDER_NAME,
@@ -2550,27 +2550,32 @@ export const useAppStore = create<AppStateModel>()(
 
   async removeProjectWorktree(repoPath, worktreePath, removeSessions = false) {
     try {
-      if (removeSessions) {
-        const state = get();
-        const otherSessions = otherSessionsUsingProjectWorktree(
-          state.sessions,
-          repoPath,
-          worktreePath,
-          state.activeSessionId,
-        );
-        const targetSessions = sessionsUsingProjectWorktree(
-          state.sessions,
-          repoPath,
-          worktreePath,
-        );
-        const canRemoveSessions =
-          targetSessions.length === 0 ||
-          (targetSessions.length === 1 &&
-            targetSessions[0]?.id === state.activeSessionId);
-        if (otherSessions.length > 0 || !canRemoveSessions) {
-          set({ error: WORKTREE_IN_USE_BY_OTHER_SESSIONS });
-          throw new Error(WORKTREE_IN_USE_BY_OTHER_SESSIONS);
-        }
+      const state = get();
+      const targetSessions = sessionsUsingProjectWorktree(
+        state.sessions,
+        repoPath,
+        worktreePath,
+      );
+      const targetSessionIds = new Set(
+        targetSessions.map((session) => session.id),
+      );
+      const sessionsOutsideProject = sessionsUsingWorktreePath(
+        state.sessions,
+        worktreePath,
+      ).filter((session) => !targetSessionIds.has(session.id));
+      const canRemoveSessions =
+        targetSessions.length === 0 ||
+        (targetSessions.length === 1 &&
+          targetSessions[0]?.id === state.activeSessionId);
+      const removingRequiredSessions =
+        targetSessions.length === 0 || removeSessions;
+      if (
+        sessionsOutsideProject.length > 0 ||
+        !canRemoveSessions ||
+        !removingRequiredSessions
+      ) {
+        set({ error: WORKTREE_IN_USE_BY_OTHER_SESSIONS });
+        throw new Error(WORKTREE_IN_USE_BY_OTHER_SESSIONS);
       }
       const removedWorktree = await api.removeWorktree(
         repoPath,


### PR DESCRIPTION
## Summary
This fixes the release-blocking worktree deletion path so Acorn does not remove a linked worktree while another session still points at the same physical path.

1. **Session close guard:** Update session worktree cleanup policy to consider every session using the same `worktree_path`, including cross-repo/adopted sessions.
2. **Backend invariant:** Reject `remove_session(..., remove_worktree=true)` and unsafe `remove_worktree` calls when peer sessions still use the worktree path.
3. **Project removal safety:** Skip worktree deletion during project removal when another project still has a session at that path.
4. **Project worktree UX:** Block project worktree removal in Settings when any session in another project uses the same physical path, matching the backend invariant before the destructive API call.
5. **Coverage:** Add frontend store/policy/settings tests and Rust guard tests, including an on-disk trailing-slash normalization case.

## Expected impact
| Area | Impact |
| --- | --- |
| Reliability | Prevents closing one session from deleting a worktree still used by another session. |
| User-visible behavior | Shared worktree cleanup is now blocked or skipped instead of deleting the shared path. |
| Data safety | Avoids dangling live terminals and stale worktree registrations caused by premature deletion. |

## Design notes
The final backend guard uses the physical `worktree_path` as the safety boundary instead of requiring matching `repo_path`. This covers adopted/cross-repo session records that can still refer to the same linked worktree directory.

Project removal keeps removing the project sessions, but it skips the worktree filesystem removal if another project still has a session there. Project Settings and store-side project worktree removal now use the same physical-path policy so the UI blocks the unsafe action before relying on the backend rejection.

## Test plan
- [x] `pnpm exec vitest run src/lib/sessionWorktree.test.ts src/store.test.ts src/components/ProjectSettingsModal.test.tsx` — 137 tests passed.
- [x] `pnpm run test` — 72 files / 745 tests passed.
- [x] `pnpm run typecheck` — passed.
- [x] `cargo test worktree_delete_guard --lib` — passed before the frontend follow-up.
- [x] `cargo test` — 296 passed / 1 ignored before the frontend follow-up.

## Notes
Reviewed with the `agent-cowork` peer workflow. The initial peer review called out cross-repo shared worktrees and Rust path-normalization coverage; both are included here. A follow-up peer review flagged the App effect dependency and Project Settings cross-repo UX gap; this branch now covers both.
