### PR TITLE
fix(chat): roll back failed optimistic sends

### DIFF
--- a/src/components/ChatPane.test.tsx
+++ b/src/components/ChatPane.test.tsx
@@ -188,6 +188,12 @@ function emitChatState(state: ChatSessionState) {
   }
 }
 
+function renderedMessageText(container: HTMLElement) {
+  return Array.from(container.querySelectorAll(".acorn-chat-message-enter"))
+    .map((element) => element.textContent ?? "")
+    .join(" ");
+}
+
 function session(overrides: Partial<Session> = {}): Session {
   return {
     id: "s1",
@@ -630,6 +636,178 @@ describe("ChatPane", () => {
     });
     await settle();
 
+    expect(useAppStore.getState().sessions[0]?.status).toBe("needs_input");
+  });
+
+  it("rolls back the optimistic first message when sending fails", async () => {
+    mocks.loadChatSessionState.mockResolvedValueOnce(chatState("s1"));
+    mocks.sendChatMessage.mockRejectedValueOnce(new Error("send failed"));
+    useAppStore.setState({ sessions: [session()] });
+
+    await act(async () => {
+      root.render(<ChatPane sessionId="s1" />);
+    });
+    await settle();
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Chat message"]',
+    );
+    const form = container.querySelector("form");
+    expect(textarea).toBeTruthy();
+    expect(form).toBeTruthy();
+
+    await act(async () => {
+      changeTextareaValue(textarea!, "first failed message");
+      form!.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true }),
+      );
+    });
+    await settle();
+
+    expect(mocks.sendChatMessage).toHaveBeenCalledWith(
+      "s1",
+      expect.objectContaining({ provider: "claude" }),
+      "first failed message",
+    );
+    expect(container.textContent).toContain("Error: send failed");
+    expect(renderedMessageText(container)).not.toContain(
+      "first failed message",
+    );
+    expect(textarea!.value).toBe("first failed message");
+    expect(container.textContent).not.toContain("Running Claude");
+    expect(
+      container.querySelector('button[aria-label="Stop response"]'),
+    ).toBeNull();
+    expect(useAppStore.getState().sessions[0]?.status).toBe("failed");
+  });
+
+  it("preserves existing messages when a follow-up send fails", async () => {
+    mocks.loadChatSessionState.mockResolvedValueOnce(
+      chatState("s1", [
+        {
+          id: "u1",
+          role: "user",
+          content: "previous question",
+          created_at: "2026-01-01T00:00:00Z",
+          status: "complete",
+          metadata: null,
+        },
+        {
+          id: "a1",
+          role: "assistant",
+          content: "previous answer",
+          created_at: "2026-01-01T00:00:01Z",
+          status: "complete",
+          metadata: null,
+        },
+      ]),
+    );
+    mocks.sendChatMessage.mockRejectedValueOnce(new Error("follow-up failed"));
+    useAppStore.setState({ sessions: [session()] });
+
+    await act(async () => {
+      root.render(<ChatPane sessionId="s1" />);
+    });
+    await settle();
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Chat message"]',
+    );
+    const form = container.querySelector("form");
+    expect(textarea).toBeTruthy();
+    expect(form).toBeTruthy();
+    expect(container.textContent).toContain("previous answer");
+
+    await act(async () => {
+      changeTextareaValue(textarea!, "new failed question");
+      form!.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true }),
+      );
+    });
+    await settle();
+
+    const messageText = renderedMessageText(container);
+    expect(messageText).toContain("previous answer");
+    expect(messageText).not.toContain("new failed question");
+    expect(textarea!.value).toBe("new failed question");
+    expect(container.textContent).toContain("Error: follow-up failed");
+    expect(container.textContent).not.toContain("Running Claude");
+    expect(
+      container.querySelector('button[aria-label="Stop response"]'),
+    ).toBeNull();
+    expect(useAppStore.getState().sessions[0]?.status).toBe("failed");
+  });
+
+  it("keeps newer backend chat state when a send rejects after an event", async () => {
+    let rejectSend!: (error: Error) => void;
+    mocks.loadChatSessionState.mockResolvedValueOnce(chatState("s1"));
+    mocks.sendChatMessage.mockReturnValueOnce(
+      new Promise<ChatSessionState>((_resolve, reject) => {
+        rejectSend = reject;
+      }),
+    );
+    useAppStore.setState({ sessions: [session()] });
+
+    await act(async () => {
+      root.render(<ChatPane sessionId="s1" />);
+    });
+    await settle();
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Chat message"]',
+    );
+    const form = container.querySelector("form");
+    expect(textarea).toBeTruthy();
+    expect(form).toBeTruthy();
+
+    await act(async () => {
+      changeTextareaValue(textarea!, "late reject question");
+      form!.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true }),
+      );
+    });
+    await settle();
+    expect(useAppStore.getState().sessions[0]?.status).toBe("running");
+
+    await act(async () => {
+      emitChatState(
+        chatState(
+          "s1",
+          [
+            {
+              id: "u1",
+              role: "user",
+              content: "late reject question",
+              created_at: "2026-01-01T00:00:00Z",
+              status: "complete",
+              metadata: null,
+            },
+            {
+              id: "a1",
+              role: "assistant",
+              content: "backend response wins",
+              created_at: "2026-01-01T00:00:01Z",
+              status: "complete",
+              metadata: null,
+            },
+          ],
+          "claude",
+        ),
+      );
+    });
+
+    await act(async () => {
+      rejectSend(new Error("late transport failure"));
+      await Promise.resolve();
+    });
+    await settle();
+
+    const messageText = renderedMessageText(container);
+    expect(messageText).toContain("backend response wins");
+    expect(messageText).toContain("late reject question");
+    expect(textarea!.value).toBe("");
+    expect(container.textContent).toContain("Error: late transport failure");
+    expect(container.textContent).not.toContain("Running Claude");
     expect(useAppStore.getState().sessions[0]?.status).toBe("needs_input");
   });
 

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -621,6 +621,7 @@ export function ChatPane({
   session,
 }: ChatPaneProps) {
   const [state, setState] = useState<ChatSessionState | null>(null);
+  const latestChatStateRef = useRef<ChatSessionState | null>(null);
   const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
   const [cancelling, setCancelling] = useState(false);
@@ -691,6 +692,7 @@ export function ChatPane({
       return false;
     }
     latestChatStateUpdatedAtRef.current = loadedAt ?? currentAt;
+    latestChatStateRef.current = loaded;
     setState(loaded);
     setProvider(
       providerFromString(loaded.provider) ??
@@ -837,6 +839,7 @@ export function ChatPane({
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (sending) return;
+    const submittedDraft = draft;
     const submittedAttachments = attachments;
     const content = composeChatMessageContent(
       draft,
@@ -845,8 +848,15 @@ export function ChatPane({
     );
     if (!content) return;
 
-    const baseState = state ?? emptyChatState(sessionId);
+    const previousState =
+      latestChatStateRef.current?.session_id === sessionId
+        ? latestChatStateRef.current
+        : state?.session_id === sessionId
+          ? state
+          : null;
+    const baseState = previousState ?? emptyChatState(sessionId);
     const now = new Date().toISOString();
+    let optimisticState: ChatSessionState | null = null;
     forceScrollToBottomRef.current = true;
     setDraft("");
     setAttachments([]);
@@ -855,7 +865,7 @@ export function ChatPane({
 
     try {
       await prepareStartupWorktreeIfNeeded();
-      setState({
+      optimisticState = {
         ...baseState,
         provider,
         messages: [
@@ -882,7 +892,9 @@ export function ChatPane({
           },
         ],
         updated_at: now,
-      });
+      };
+      latestChatStateRef.current = optimisticState;
+      setState(optimisticState);
       setLocalChatSessionStatus(sessionId, "running");
       const saved = await api.sendChatMessage(
         sessionId,
@@ -892,8 +904,24 @@ export function ChatPane({
       applyChatState(saved);
       setLocalChatSessionStatus(sessionId, sessionStatusFromChatState(saved));
     } catch (err) {
+      const latestState = latestChatStateRef.current;
+      const shouldRollback =
+        optimisticState === null
+          ? latestState === previousState
+          : latestState === optimisticState;
+      if (shouldRollback) {
+        latestChatStateRef.current = previousState;
+        setState(previousState);
+        setDraft(submittedDraft);
+        setAttachments(submittedAttachments);
+        setLocalChatSessionStatus(sessionId, "failed");
+      } else if (latestState?.session_id === sessionId) {
+        setLocalChatSessionStatus(
+          sessionId,
+          sessionStatusFromChatState(latestState),
+        );
+      }
       setError(String(err));
-      setLocalChatSessionStatus(sessionId, "failed");
     } finally {
       setSending(false);
     }
@@ -1111,10 +1139,13 @@ export function ChatPane({
           composerIsCentered ? "pointer-events-none opacity-0" : "opacity-100"
         }`}
       >
+        {!loading && error ? (
+          <div className="mx-auto mb-3 w-full max-w-4xl text-sm text-danger">
+            {error}
+          </div>
+        ) : null}
         {loading ? (
           <div className="text-sm text-fg-muted">Loading...</div>
-        ) : error ? (
-          <div className="text-sm text-danger">{error}</div>
         ) : hasMessages ? (
           <div className="mx-auto flex w-full max-w-4xl flex-col gap-3">
             {messages.map((message, index) => {
@@ -1446,9 +1477,9 @@ export function ChatPane({
               );
             })}
           </div>
-        ) : (
+        ) : !error ? (
           <div aria-hidden="true" className="h-full" />
-        )}
+        ) : null}
       </div>
       {hasMessages && isScrolledBack ? (
         <Tooltip label="Scroll chat to bottom" side="top" delay={150}>


### PR DESCRIPTION
## Summary
This fixes chat send failures leaving optimistic pending UI behind after the backend rejects the send request.

1. **Failed-send rollback:** Restore the pre-submit chat state when `sendChatMessage` rejects so local pending assistant messages do not keep the session visually running.
2. **Composer recovery:** Restore the submitted draft and attachments after a failed send so the user can retry without retyping.
3. **State-event guard:** Preserve newer backend chat state if a state-change event arrives before a late send rejection.
4. **Error rendering:** Show send errors without hiding existing conversation messages.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Chat UX | Failed sends no longer leave a stuck Running/Stop state. |
| Reliability | Late backend state events are not overwritten by a stale optimistic rollback. |
| Data entry | Draft text and attachments are restored after failed sends. |

## Design notes

- `ChatPane` now tracks the latest applied chat state in a ref so submit handling does not depend on a stale render closure.
- Rollback only applies when the optimistic state is still the latest local state. If a newer backend event wins, the UI keeps that state and derives the local session status from it.
- The error banner is rendered alongside existing messages instead of replacing the message list.

## Test plan

- [x] `pnpm exec vitest run src/components/ChatPane.test.tsx` — 32 tests passed.
- [x] `pnpm run typecheck` — passed.
- [x] `pnpm run test` — 72 files / 742 tests passed.

## Notes

- Used `$agent-cowork` for the challenge pass and diff review. The peer review called out the error-rendering precedence and late-event rejection race; both are covered in this PR.
- `pnpm exec prettier --write src/components/ChatPane.tsx src/components/ChatPane.test.tsx` was attempted, but this repo does not include a `prettier` binary.
