### PR TITLE
fix(right-panel): guard stale github list responses

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -2981,15 +2981,15 @@ function PullRequestsTab({
   const [listsByState, setListsByState] = useState(() =>
     initialPrListStates(repoPath),
   );
-  const [loadingKeys, setLoadingKeys] = useState<string[]>([]);
+  const [loadingKeys, setLoadingKeys] = useState<Record<string, number>>({});
+  const requestSeqByListRef = useRef<Record<string, number>>({});
   const setPrAccountForRepo = useAppStore((s) => s.setPrAccountForRepo);
   const activeList = listsByState[stateFilter] ?? emptyPrListState();
   const listing = activeList.listing;
   const error = activeList.error;
   const limit = activeList.limit;
-  const loading = loadingKeys.some((key) =>
-    key.startsWith(`${repoPath}:${stateFilter}:`),
-  );
+  const activeLoadingKey = `${repoPath}:${stateFilter}:${limit}`;
+  const loading = loadingKeys[activeLoadingKey] !== undefined;
 
   const fetchPrs = useCallback(
     async (
@@ -2998,7 +2998,10 @@ function PullRequestsTab({
       signal?: { cancelled: boolean },
     ) => {
       const key = `${repoPath}:${filter}:${requestedLimit}`;
-      setLoadingKeys((prev) => (prev.includes(key) ? prev : [...prev, key]));
+      const listKey = `${repoPath}:${filter}`;
+      const requestSeq = (requestSeqByListRef.current[listKey] ?? 0) + 1;
+      requestSeqByListRef.current[listKey] = requestSeq;
+      setLoadingKeys((prev) => ({ ...prev, [key]: requestSeq }));
       try {
         const result = await fetchPullRequestsCached(
           repoPath,
@@ -3006,7 +3009,12 @@ function PullRequestsTab({
           requestedLimit,
           { force: true },
         );
-        if (signal?.cancelled) return;
+        if (
+          signal?.cancelled ||
+          requestSeqByListRef.current[listKey] !== requestSeq
+        ) {
+          return;
+        }
         setListsByState((prev) => ({
           ...prev,
           [filter]: {
@@ -3020,7 +3028,12 @@ function PullRequestsTab({
           result.kind === "ok" ? result.account : null,
         );
       } catch (e) {
-        if (signal?.cancelled) return;
+        if (
+          signal?.cancelled ||
+          requestSeqByListRef.current[listKey] !== requestSeq
+        ) {
+          return;
+        }
         setListsByState((prev) => ({
           ...prev,
           [filter]: {
@@ -3030,7 +3043,12 @@ function PullRequestsTab({
           },
         }));
       } finally {
-        setLoadingKeys((prev) => prev.filter((candidate) => candidate !== key));
+        setLoadingKeys((prev) => {
+          if (prev[key] !== requestSeq) return prev;
+          const next = { ...prev };
+          delete next[key];
+          return next;
+        });
       }
     },
     [repoPath, setPrAccountForRepo],
@@ -3044,7 +3062,8 @@ function PullRequestsTab({
   // first page cached so switching Open → Merged can be instant once the
   // background prefetch lands.
   useEffect(() => {
-    setLoadingKeys([]);
+    requestSeqByListRef.current = {};
+    setLoadingKeys({});
     setListsByState(initialPrListStates(repoPath));
   }, [repoPath]);
 
@@ -3369,7 +3388,8 @@ function IssuesTab({ repoPath }: { repoPath: string }) {
   const [listsByState, setListsByState] = useState(() =>
     initialIssueListStates(repoPath),
   );
-  const [loadingKeys, setLoadingKeys] = useState<string[]>([]);
+  const [loadingKeys, setLoadingKeys] = useState<Record<string, number>>({});
+  const requestSeqByListRef = useRef<Record<string, number>>({});
   const [searchOpen, setSearchOpen] = useState(false);
   const [issueDetail, setIssueDetail] = useState<{
     repoPath: string;
@@ -3379,9 +3399,8 @@ function IssuesTab({ repoPath }: { repoPath: string }) {
   const listing = activeList.listing;
   const error = activeList.error;
   const limit = activeList.limit;
-  const loading = loadingKeys.some((key) =>
-    key.startsWith(`${repoPath}:${stateFilter}:`),
-  );
+  const activeLoadingKey = `${repoPath}:${stateFilter}:${limit}`;
+  const loading = loadingKeys[activeLoadingKey] !== undefined;
 
   const fetchIssues = useCallback(
     async (
@@ -3390,7 +3409,10 @@ function IssuesTab({ repoPath }: { repoPath: string }) {
       signal?: { cancelled: boolean },
     ) => {
       const key = `${repoPath}:${filter}:${requestedLimit}`;
-      setLoadingKeys((prev) => (prev.includes(key) ? prev : [...prev, key]));
+      const listKey = `${repoPath}:${filter}`;
+      const requestSeq = (requestSeqByListRef.current[listKey] ?? 0) + 1;
+      requestSeqByListRef.current[listKey] = requestSeq;
+      setLoadingKeys((prev) => ({ ...prev, [key]: requestSeq }));
       try {
         const result = await fetchIssuesCached(
           repoPath,
@@ -3398,7 +3420,12 @@ function IssuesTab({ repoPath }: { repoPath: string }) {
           requestedLimit,
           { force: true },
         );
-        if (signal?.cancelled) return;
+        if (
+          signal?.cancelled ||
+          requestSeqByListRef.current[listKey] !== requestSeq
+        ) {
+          return;
+        }
         setListsByState((prev) => ({
           ...prev,
           [filter]: {
@@ -3408,7 +3435,12 @@ function IssuesTab({ repoPath }: { repoPath: string }) {
           },
         }));
       } catch (e) {
-        if (signal?.cancelled) return;
+        if (
+          signal?.cancelled ||
+          requestSeqByListRef.current[listKey] !== requestSeq
+        ) {
+          return;
+        }
         setListsByState((prev) => ({
           ...prev,
           [filter]: {
@@ -3418,7 +3450,12 @@ function IssuesTab({ repoPath }: { repoPath: string }) {
           },
         }));
       } finally {
-        setLoadingKeys((prev) => prev.filter((candidate) => candidate !== key));
+        setLoadingKeys((prev) => {
+          if (prev[key] !== requestSeq) return prev;
+          const next = { ...prev };
+          delete next[key];
+          return next;
+        });
       }
     },
     [repoPath],
@@ -3430,7 +3467,8 @@ function IssuesTab({ repoPath }: { repoPath: string }) {
   );
 
   useEffect(() => {
-    setLoadingKeys([]);
+    requestSeqByListRef.current = {};
+    setLoadingKeys({});
     setListsByState(initialIssueListStates(repoPath));
   }, [repoPath]);
 


### PR DESCRIPTION
## Summary
This fixes stale GitHub list responses in the Right Panel from overwriting newer PR or Issue list state.

1. **Per-list sequencing:** Track request sequence by repo/filter so stale responses for the same list cannot commit over newer responses.
2. **Precise loading keys:** Treat loading as exact repo/filter/limit activity instead of prefix-matching every request for the active filter.
3. **Safe loading cleanup:** Store loading keys with request tokens so an older same-key request cannot clear a newer same-key loading state, while superseded different-limit keys still clean themselves up.

## Expected impact

| Area | Impact |
| --- | --- |
| Right Panel reliability | Older PR/Issue responses no longer overwrite newer list state. |
| Loading UI | Loading indicators now reflect the active repo/filter/limit instead of unrelated in-flight requests. |
| Background refresh | Background prefetches for other filters can complete without invalidating the active filter. |

## Design notes

The sequence guard is scoped by repo/filter, not globally per tab, because PR and Issue state are stored independently per filter. Success and error writes both require the current sequence and a non-cancelled signal.

The loading map is keyed by full repo/filter/limit and stores the request token. This preserves cleanup for superseded keys while avoiding the original same-key finally race.

## Test plan

- [x] `pnpm exec vitest run src/components/RightPanel.test.tsx` — 17 tests passed.
- [x] `pnpm run typecheck` — passed.
- [x] `pnpm run test` — 72 files / 739 tests passed.

## Notes

Used `$agent-cowork` for the challenge pass. The peer review specifically called out per-filter sequencing and loading cleanup semantics; both are reflected in this implementation.
