### PR TITLE
chore(release): v1.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.17.4",
+  "version": "1.18.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.17.4"
+version = "1.18.0"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.17.4"
+version = "1.18.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.17.4",
+  "version": "1.18.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
This prepares the v1.18.0 minor release after the terminal, GitHub, chat, IPC, Work Summary, and worktree safety updates merged since v1.17.4.

1. **Version metadata** - bump Acorn from `1.17.4` to `1.18.0` in `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock`.
2. **Semver decision** - use a minor release because the unreleased set includes user-visible `feat` / `enhancement` changes for terminal settings, GitHub issues, native chat streaming, workspace-aware control sessions, Work Summary, and session cleanup UX.
3. **Included PRs** - release notes include #456, #457, #458, #459, #460, #461, #462, #463, #464, #465, #466, #467, #468, #469, #470, #472, #473, #474, #475, #476, and #477.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| App version | `1.17.4` | `1.18.0` |
| Release channel | Latest stable remains v1.17.4 | Tagging this merge will publish v1.18.0 |
| User-visible release notes | No post-v1.17.4 changes shipped | Features and fixes since v1.17.4 are included |

## Design notes
- This PR intentionally changes release version metadata only.
- Changelog entries come from the already-merged feature, enhancement, and fix PRs; this release PR is labelled `skip-changelog`.
- `origin/main` CI at `da27b37248da49437585cc9960e9bee681aac098` passed before creating this release PR.

## Follow-up (not in this PR)
- Tag `v1.18.0` after this PR merges and `origin/main` points at the release bump commit.

## Test plan
- [x] `rg -n '1\\.17\\.4|1\\.18\\.0' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock`
- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1`
- [x] `REPO=im-ian/acorn TAG=v1.18.0 OUTPUT=/tmp/acorn-release-notes-v1.18.0.md node scripts/release-notes.mjs`
- [x] `git diff --check`

## Notes
- Latest stable release before this PR is `v1.17.4`.
