### PR TITLE
fix(terminal): normalize unicode spaces in user input

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -2489,6 +2489,20 @@ function ExperimentsSettings() {
         )}
       />
       <CheckboxRow
+        checked={experiments.normalizeTerminalUnicodeSpaces}
+        onChange={(checked) =>
+          patchExperiments({ normalizeTerminalUnicodeSpaces: checked })
+        }
+        label={st(
+          t,
+          "settings.experiments.normalizeTerminalUnicodeSpaces.label",
+        )}
+        description={st(
+          t,
+          "settings.experiments.normalizeTerminalUnicodeSpaces.description",
+        )}
+      />
+      <CheckboxRow
         checked={experiments.resumeModal}
         onChange={(checked) => patchExperiments({ resumeModal: checked })}
         label={st(t, "settings.experiments.resumeModal.label")}

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -67,6 +67,7 @@ import {
   terminalPasteAction,
   type ClipboardImageFile,
 } from "../lib/terminalPaste";
+import { normalizeShellCommandWhitespace } from "../lib/shellCommandWhitespace";
 import { saveClipboardImageAttachment } from "../lib/clipboardImageAttachment";
 import {
   createTerminalFileLinkProvider,
@@ -1139,6 +1140,8 @@ export function Terminal({
           return null;
         }
       };
+    const normalizeTerminalUnicodeSpaces = () =>
+      useSettings.getState().settings.experiments.normalizeTerminalUnicodeSpaces;
     const pasteNativeClipboard = async () => {
       const observedInputVersion = terminalInputVersion;
       const snapshot = await api.clipboardSnapshot();
@@ -1151,6 +1154,7 @@ export function Terminal({
       const action = terminalPasteAction({
         text: snapshot.text ?? "",
         hasImagePayload: Boolean(imageFile),
+        normalizeUnicodeSpaces: normalizeTerminalUnicodeSpaces(),
       });
       if (action.kind === "pasteText") {
         term.paste(action.text);
@@ -1384,6 +1388,35 @@ export function Terminal({
       hideComposing();
     };
 
+    const normalizedTextInsertion = (
+      value: string | null | undefined,
+    ): string | null => {
+      if (!normalizeTerminalUnicodeSpaces()) return null;
+      if (!value) return null;
+      const normalized = normalizeShellCommandWhitespace(value);
+      return normalized === value ? null : normalized;
+    };
+
+    const normalizedSpaceKey = (ev: KeyboardEvent): string | null => {
+      if (ev.ctrlKey || ev.metaKey) return null;
+      const key =
+        ev.key && ev.key.length === 1
+          ? ev.key
+          : ev.charCode
+            ? String.fromCharCode(ev.charCode)
+            : "";
+      const normalized = normalizedTextInsertion(key);
+      return normalized === " " ? normalized : null;
+    };
+
+    const sendCapturedUserInputToPty = (data: string) => {
+      terminalInputVersion += 1;
+      sendUserInputToPty(data);
+    };
+
+    let normalizedSpaceKeypressHandled = false;
+    let normalizedSpaceKeypressTimer: number | null = null;
+
     const onInput = (e: Event) => {
       const ev = e as InputEvent;
       const ta = container.querySelector<HTMLTextAreaElement>(
@@ -1418,6 +1451,29 @@ export function Terminal({
         }
 
         case "insertText": {
+          const normalizedText = normalizedTextInsertion(ev.data);
+          if (normalizedText) {
+            if (normalizedSpaceKeypressHandled) {
+              normalizedSpaceKeypressHandled = false;
+              if (normalizedSpaceKeypressTimer !== null) {
+                window.clearTimeout(normalizedSpaceKeypressTimer);
+                normalizedSpaceKeypressTimer = null;
+              }
+            } else {
+              if (lastKeyCode229 && composing) {
+                commitComposition();
+              }
+              sendCapturedUserInputToPty(normalizedText);
+            }
+            lastKeyCode229 = false;
+            hideComposing();
+            composing = false;
+            if (ta) ta.value = "";
+            sentPrefix = "";
+            ev.preventDefault();
+            ev.stopImmediatePropagation();
+            return;
+          }
           // Distinguish plain ASCII from an IME first-jamo: treat as
           // IME when a keyCode-229 keydown was just observed OR
           // `ev.data` is a CJK character. The data check covers the
@@ -1507,7 +1563,11 @@ export function Terminal({
         const TERMINATOR_KEYS = new Set([
           "Enter", "Tab", "Escape", "Backspace", " ", "Spacebar",
         ]);
-        const isTerminator = TERMINATOR_KEYS.has(ev.key);
+        const isSpaceLikeTerminator =
+          ev.key.length === 1 &&
+          normalizeShellCommandWhitespace(ev.key) === " ";
+        const isTerminator =
+          TERMINATOR_KEYS.has(ev.key) || isSpaceLikeTerminator;
         if (!isTerminator) {
           lastKeyCode229 = true;
           ev.stopImmediatePropagation();
@@ -1582,10 +1642,39 @@ export function Terminal({
       }
     };
 
+    const onKeypress = (e: Event) => {
+      const ev = e as KeyboardEvent;
+      const normalizedSpace = normalizedSpaceKey(ev);
+      if (!normalizedSpace) return;
+      if (lastKeyCode229 && composing) {
+        commitComposition();
+      }
+      sendCapturedUserInputToPty(normalizedSpace);
+      lastKeyCode229 = false;
+      hideComposing();
+      composing = false;
+      normalizedSpaceKeypressHandled = true;
+      if (normalizedSpaceKeypressTimer !== null) {
+        window.clearTimeout(normalizedSpaceKeypressTimer);
+      }
+      normalizedSpaceKeypressTimer = window.setTimeout(() => {
+        normalizedSpaceKeypressHandled = false;
+        normalizedSpaceKeypressTimer = null;
+      }, 0);
+      const ta = container.querySelector<HTMLTextAreaElement>(
+        ".xterm-helper-textarea",
+      );
+      if (ta) ta.value = "";
+      sentPrefix = "";
+      ev.preventDefault();
+      ev.stopImmediatePropagation();
+    };
+
     // Register on `container` (ancestor of helperTextarea) with capture=true
     // so we run before xterm's textarea-capture listeners.
     container.addEventListener("input", onInput, true);
     container.addEventListener("keydown", onKeydown, true);
+    container.addEventListener("keypress", onKeypress, true);
 
     // Own the paste path for text. xterm's built-in listener emits the
     // pasted text but only calls `stopPropagation()` — it never
@@ -1615,6 +1704,7 @@ export function Terminal({
       const action = terminalPasteAction({
         text,
         hasImagePayload: Boolean(imageFile) || hasClipboardImagePayload(cd),
+        normalizeUnicodeSpaces: normalizeTerminalUnicodeSpaces(),
       });
       if (action.kind === "deferImageAttachment") {
         scheduleClipboardImageFallback(imageFile, terminalInputVersion);
@@ -2375,10 +2465,15 @@ export function Terminal({
         window.clearTimeout(resizeTimer);
         resizeTimer = null;
       }
+      if (normalizedSpaceKeypressTimer !== null) {
+        window.clearTimeout(normalizedSpaceKeypressTimer);
+        normalizedSpaceKeypressTimer = null;
+      }
       resizeObserver.disconnect();
       commandSizeSyncScheduler.dispose();
       container.removeEventListener("input", onInput, true);
       container.removeEventListener("keydown", onKeydown, true);
+      container.removeEventListener("keypress", onKeypress, true);
       container.removeEventListener("paste", onPaste, true);
       window.removeEventListener(TERMINAL_PASTE_EVENT, onTerminalPaste);
       container.removeEventListener("dragover", onDragOver);

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -505,6 +505,73 @@ describe("power settings", () => {
   });
 });
 
+describe("experimental settings", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("normalizes terminal Unicode spaces by default", () => {
+    expect(DEFAULT_SETTINGS.experiments.normalizeTerminalUnicodeSpaces).toBe(
+      true,
+    );
+  });
+
+  it("loads a persisted terminal Unicode space normalization preference", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        experiments: { normalizeTerminalUnicodeSpaces: false },
+      }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(
+      useSettings.getState().settings.experiments
+        .normalizeTerminalUnicodeSpaces,
+    ).toBe(false);
+  });
+
+  it("patches and persists terminal Unicode space normalization", async () => {
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    useSettings
+      .getState()
+      .patchExperiments({ normalizeTerminalUnicodeSpaces: false });
+
+    expect(
+      useSettings.getState().settings.experiments
+        .normalizeTerminalUnicodeSpaces,
+    ).toBe(false);
+    expect(
+      JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}").experiments
+        .normalizeTerminalUnicodeSpaces,
+    ).toBe(false);
+  });
+});
+
 describe("notification settings", () => {
   const STORAGE_KEY = "acorn:settings:v1";
   let storage: Map<string, string>;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -441,6 +441,12 @@ export interface AcornSettings {
      * for future debugging).
      */
     resumeModal: boolean;
+    /**
+     * Convert Unicode space separators that reach interactive terminal input
+     * boundaries into ASCII space so shells keep parsing commands as separate
+     * words. Disable to preserve literal NBSP-like characters in TUIs or REPLs.
+     */
+    normalizeTerminalUnicodeSpaces: boolean;
   };
 }
 
@@ -542,6 +548,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     stickyPrompt: false,
     cjkCellWidthHeuristic: false,
     resumeModal: true,
+    normalizeTerminalUnicodeSpaces: true,
   },
 };
 
@@ -1063,6 +1070,10 @@ function loadSettings(): AcornSettings {
           typeof parsed.experiments?.resumeModal === "boolean"
             ? parsed.experiments.resumeModal
             : DEFAULT_SETTINGS.experiments.resumeModal,
+        normalizeTerminalUnicodeSpaces:
+          typeof parsed.experiments?.normalizeTerminalUnicodeSpaces === "boolean"
+            ? parsed.experiments.normalizeTerminalUnicodeSpaces
+            : DEFAULT_SETTINGS.experiments.normalizeTerminalUnicodeSpaces,
       },
     };
   } catch {

--- a/src/lib/shellCommandWhitespace.test.ts
+++ b/src/lib/shellCommandWhitespace.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { normalizeShellCommandWhitespace } from "./shellCommandWhitespace";
+
+describe("normalizeShellCommandWhitespace", () => {
+  it("converts no-break spaces that make shells treat commands as one word", () => {
+    expect(normalizeShellCommandWhitespace("pnpm\u00a0run\u202fdev")).toBe(
+      "pnpm run dev",
+    );
+  });
+
+  it("converts visible horizontal Unicode spaces without trimming or collapsing", () => {
+    expect(normalizeShellCommandWhitespace("git\u2003status\u3000--short")).toBe(
+      "git status --short",
+    );
+    expect(normalizeShellCommandWhitespace("cmd\u00a0\u00a0arg")).toBe(
+      "cmd  arg",
+    );
+  });
+
+  it("preserves tabs and line breaks", () => {
+    expect(normalizeShellCommandWhitespace("printf\tok\nnext\r\n")).toBe(
+      "printf\tok\nnext\r\n",
+    );
+  });
+});

--- a/src/lib/shellCommandWhitespace.ts
+++ b/src/lib/shellCommandWhitespace.ts
@@ -1,0 +1,5 @@
+const SHELL_COMMAND_SPACE_RE = /[\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000]/g;
+
+export function normalizeShellCommandWhitespace(input: string): string {
+  return input.replace(SHELL_COMMAND_SPACE_RE, " ");
+}

--- a/src/lib/terminalPaste.test.ts
+++ b/src/lib/terminalPaste.test.ts
@@ -38,6 +38,25 @@ describe("terminalPasteAction", () => {
       }),
     ).toEqual({ kind: "pasteText", text: "hello" });
   });
+
+  it("normalizes Unicode shell separators in pasted text", () => {
+    expect(
+      terminalPasteAction({
+        text: "pnpm\u00a0run\u202fdev",
+        hasImagePayload: false,
+      }),
+    ).toEqual({ kind: "pasteText", text: "pnpm run dev" });
+  });
+
+  it("preserves Unicode shell separators when normalization is disabled", () => {
+    expect(
+      terminalPasteAction({
+        text: "pnpm\u00a0run\u202fdev",
+        hasImagePayload: false,
+        normalizeUnicodeSpaces: false,
+      }),
+    ).toEqual({ kind: "pasteText", text: "pnpm\u00a0run\u202fdev" });
+  });
 });
 
 describe("clipboard image detection", () => {

--- a/src/lib/terminalPaste.ts
+++ b/src/lib/terminalPaste.ts
@@ -1,8 +1,11 @@
+import { normalizeShellCommandWhitespace } from "./shellCommandWhitespace";
+
 export const AGENT_IMAGE_PASTE_CONTROL = "\x16";
 
 type TerminalPasteInput = {
   text: string;
   hasImagePayload: boolean;
+  normalizeUnicodeSpaces?: boolean;
 };
 
 type ClipboardFilePayloadInput = {
@@ -122,9 +125,15 @@ export function hasClipboardImagePayload(
 export function terminalPasteAction({
   text,
   hasImagePayload,
+  normalizeUnicodeSpaces = true,
 }: TerminalPasteInput): TerminalPasteAction {
   if (text) {
-    return { kind: "pasteText", text };
+    return {
+      kind: "pasteText",
+      text: normalizeUnicodeSpaces
+        ? normalizeShellCommandWhitespace(text)
+        : text,
+    };
   }
   if (hasImagePayload) {
     return { kind: "deferImageAttachment" };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -611,6 +611,10 @@
       "resumeModal": {
         "label": "Show \"Resume previous conversation\" modal at cold boot",
         "description": "On Acorn launch, probes every persisted session for an unfinished claude or codex transcript and pops a one-shot modal when you focus the session so you can pick up where you left off. Disable to suppress the modal entirely."
+      },
+      "normalizeTerminalUnicodeSpaces": {
+        "label": "Normalize Unicode spaces in terminal input",
+        "description": "Converts NBSP-like Unicode separators in typed and pasted terminal text into regular spaces so shell commands keep parsing as separate words. Turn off to preserve literal Unicode spaces in TUIs, REPLs, or tests."
       }
     },
     "about": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -611,6 +611,10 @@
       "resumeModal": {
         "label": "콜드 부팅 시 \"이전 대화 재개\" 모달 표시",
         "description": "Acorn 실행 시 저장된 모든 세션에서 끝나지 않은 claude 또는 codex transcript를 확인하고, 해당 세션에 포커스하면 한 번만 표시되는 모달을 띄워 이전 작업을 이어갈 수 있게 합니다. 끄면 모달을 완전히 표시하지 않습니다."
+      },
+      "normalizeTerminalUnicodeSpaces": {
+        "label": "터미널 입력의 Unicode 공백 정규화",
+        "description": "입력하거나 붙여넣은 터미널 텍스트의 NBSP류 Unicode 구분자를 일반 공백으로 바꿔 셸 명령이 여러 단어로 파싱되도록 합니다. TUI, REPL, 테스트에서 실제 Unicode 공백을 보존해야 하면 끄세요."
       }
     },
     "about": {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2706,6 +2706,16 @@ describe("pendingTerminalInput", () => {
     });
   });
 
+  it("preserves Unicode spaces in queued commands", () => {
+    const { setPendingTerminalInput, consumePendingTerminalInput } =
+      useAppStore.getState();
+    setPendingTerminalInput("sess-1", "cd '/tmp/a\u00a0b'\n");
+    expect(consumePendingTerminalInput("sess-1")).toEqual({
+      command: "cd '/tmp/a\u00a0b'\n",
+      adoptWorktreeOnExit: false,
+    });
+  });
+
   it("does not cross-contaminate session ids", () => {
     const { setPendingTerminalInput, consumePendingTerminalInput } =
       useAppStore.getState();

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -178,6 +178,31 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     expect(writes.join("")).not.toContain("한한");
   });
 
+  test("Korean syllable + no-break-space terminator commits the syllable", async ({
+    page,
+    tauri,
+  }) => {
+    await seed(tauri);
+    await activateTerminal(page);
+
+    await runIme(page, [
+      { type: "keydown", key: "Process", keyCode: 229 },
+      { type: "input", inputType: "insertText", data: "한", taValue: "한" },
+      { type: "keydown", key: "\u00a0", keyCode: 229 },
+      {
+        type: "input",
+        inputType: "insertText",
+        data: "\u00a0",
+        taValue: "\u00a0",
+      },
+    ]);
+
+    const writes = await getWrites(page);
+    expect(writes.filter((w) => w === "한").length).toBe(1);
+    expect(writes.join("")).toBe("한 ");
+    expect(writes.join("")).not.toContain("한한");
+  });
+
   test("insertFromComposition arriving before any terminator still commits once", async ({
     page,
     tauri,

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -351,6 +351,19 @@ async function enableCjkCellWidthHeuristic(page: Page): Promise<void> {
   });
 }
 
+async function disableTerminalUnicodeSpaceNormalization(
+  page: Page,
+): Promise<void> {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "acorn:settings:v1",
+      JSON.stringify({
+        experiments: { normalizeTerminalUnicodeSpaces: false },
+      }),
+    );
+  });
+}
+
 async function terminalEmojiLetterSpacing(
   page: Page,
   marker: string,
@@ -540,6 +553,153 @@ test.describe("terminal: spawn", () => {
         ),
       )
       .toBe("subpixel-antialiased");
+  });
+
+  test("normalizes no-break spaces when pasting shell commands", async ({
+    page,
+    tauri,
+  }) => {
+    await seedWritableTerminal(tauri);
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await page.waitForTimeout(150);
+    await page.evaluate(() => {
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+    });
+
+    await page.evaluate(() => {
+      const ta = document.querySelector<HTMLTextAreaElement>(
+        ".xterm-helper-textarea",
+      );
+      if (!ta) throw new Error("xterm helper textarea missing");
+      const event = new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+      });
+      Object.defineProperty(event, "clipboardData", {
+        value: {
+          getData: (type: string) =>
+            type === "text/plain" ? "pnpm\u00a0run\u202fdev" : "",
+          files: { length: 0 },
+          items: { length: 0 },
+          types: ["text/plain"],
+        },
+      });
+      ta.dispatchEvent(event);
+    });
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as unknown as { __ptyWrites?: string[] }).__ptyWrites,
+        ),
+      )
+      .toEqual(["pnpm run dev"]);
+  });
+
+  test("normalizes no-break spaces from direct terminal input", async ({
+    page,
+    tauri,
+  }) => {
+    await seedWritableTerminal(tauri);
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await page.waitForTimeout(150);
+    await page.evaluate(() => {
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+    });
+
+    await page.locator(".xterm-helper-textarea").focus();
+    await page.keyboard.insertText("pnpm\u00a0run\u202fdev");
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (
+            (window as unknown as { __ptyWrites?: string[] }).__ptyWrites ?? []
+          ).join(""),
+        ),
+      )
+      .toBe("pnpm run dev");
+  });
+
+  test("preserves no-break spaces when terminal Unicode space normalization is disabled", async ({
+    page,
+    tauri,
+  }) => {
+    await disableTerminalUnicodeSpaceNormalization(page);
+    await seedWritableTerminal(tauri);
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await page.waitForTimeout(150);
+    await page.evaluate(() => {
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+    });
+
+    await page.locator(".xterm-helper-textarea").focus();
+    await page.keyboard.insertText("pnpm\u00a0run\u202fdev");
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (
+            (window as unknown as { __ptyWrites?: string[] }).__ptyWrites ?? []
+          ).join(""),
+        ),
+      )
+      .toBe("pnpm\u00a0run\u202fdev");
+  });
+
+  test("normalizes no-break space keypresses before xterm handles them", async ({
+    page,
+    tauri,
+  }) => {
+    await seedWritableTerminal(tauri);
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await page.waitForTimeout(150);
+    await page.evaluate(() => {
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+    });
+
+    await page.evaluate(() => {
+      const ta = document.querySelector<HTMLTextAreaElement>(
+        ".xterm-helper-textarea",
+      );
+      if (!ta) throw new Error("xterm helper textarea missing");
+      const event = new KeyboardEvent("keypress", {
+        key: "\u00a0",
+        bubbles: true,
+        cancelable: true,
+      });
+      Object.defineProperty(event, "charCode", { get: () => 0xa0 });
+      Object.defineProperty(event, "which", { get: () => 0xa0 });
+      ta.dispatchEvent(event);
+    });
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as unknown as { __ptyWrites?: string[] }).__ptyWrites,
+        ),
+      )
+      .toEqual([" "]);
   });
 
   test("drops desktop file paths into the focused terminal", async ({


### PR DESCRIPTION
## Summary
Fixes a terminal input edge case where non-breaking-space-like characters could make shell commands arrive as a single word.

1. **Direct terminal input** — normalize Unicode space separators from browser `insertText` and captured `keypress` events before xterm emits them to the PTY.
2. **Paste input** — normalize the same shell-separator characters on the terminal paste text path, while keeping image paste fallback precedence unchanged.
3. **IME safety** — treat NBSP-like terminators as composition terminators so Korean IME commits remain single-write and do not duplicate syllables.
4. **Experimental escape hatch** — add a default-on Settings → Experiments toggle so users can preserve literal Unicode spaces in TUIs, REPLs, or parser tests when needed.
5. **Raw queued commands** — keep queued terminal commands/store state raw so non-interactive command sources are not globally rewritten.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal command input | NBSP-like separators could reach zsh as part of a single command word, e.g. `pnpm run dev` | User-entered NBSP-like separators are converted to ASCII spaces at input boundaries by default |
| Literal Unicode-space input | No dedicated product control for this edge case | Users can disable the experimental toggle to preserve NBSP-like characters in direct terminal input and paste |
| IME composition | NBSP-like terminators were not covered by the space terminator path | IME composition commits once, then emits a normal ASCII space while the toggle is enabled |
| PTY transparency | A broad `onData` rewrite would risk mutating all terminal data | Normalization is limited to user text input and paste boundaries |

## Design notes
- The PTY write path remains byte-transparent; `term.onData` still forwards xterm data without whitespace rewriting.
- The direct input handling happens before xterm's textarea listeners for `input` / `keypress`, matching the existing IME capture pattern in `Terminal.tsx`.
- `terminalPasteAction` takes the experiment setting as an input, so text paste normalization can be disabled without changing image-paste fallback behavior.
- The experiment defaults on for existing users and newly loaded settings, preserving the command-input fix unless a user explicitly opts out.
- `pendingTerminalInput` coverage asserts queued commands preserve Unicode spaces, preventing store-level normalization from creeping in later.

## Test plan
- [x] `pnpm exec vitest run src/lib/settings.test.ts src/lib/terminalPaste.test.ts src/lib/shellCommandWhitespace.test.ts` — 3 files / 84 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed; emitted existing Vite dynamic/static import and large chunk warnings
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts -g "no-break"` — 4 tests passed
- [x] `pnpm exec playwright test tests/e2e/terminal-ime.spec.ts` — 11 tests passed
- [x] `git diff --check` / `git diff --cached --check` — passed

## Notes
- Build warnings about `api.ts` / `store.ts` dynamic imports and large chunks are pre-existing Vite warnings, not introduced by this PR.
