### PR TITLE
feat(settings): update default preference toggles

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -750,14 +750,14 @@ describe("SettingsModal font controls", () => {
     });
 
     expect(input).toBeInstanceOf(HTMLInputElement);
-    expect(input?.checked).toBe(false);
+    expect(input?.checked).toBe(true);
 
     act(() => {
       if (!input) throw new Error("Agent token usage checkbox not found");
       input.click();
     });
 
-    expect(patchStatusBar).toHaveBeenCalledWith({ showAgentTokenUsage: true });
+    expect(patchStatusBar).toHaveBeenCalledWith({ showAgentTokenUsage: false });
   });
 
   it("renders the Interface language selector in Korean and patches changes", async () => {
@@ -1078,14 +1078,14 @@ describe("SettingsModal font controls", () => {
       ),
     ).toBeInstanceOf(HTMLButtonElement);
     expect(toggle).toBeInstanceOf(HTMLInputElement);
-    expect(toggle?.checked).toBe(false);
+    expect(toggle?.checked).toBe(true);
 
     act(() => {
       toggle?.click();
     });
 
     expect(patchAgents).toHaveBeenCalledWith({
-      autoGenerateSessionTitles: true,
+      autoGenerateSessionTitles: false,
     });
   });
 

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -156,7 +156,8 @@ describe("notifications", () => {
     dispose();
   });
 
-  it("marks in-app activity read when its session tab is focused", async () => {
+  it("marks in-app activity read when its session tab is focused and auto-delete is disabled", async () => {
+    useSettings.getState().patchNotifications({ autoDeleteRead: false });
     const disposeActivity = startSessionActivityInboxWatcher();
     const disposeFocusedRead = startFocusedSessionNotificationReadWatcher();
 

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -597,16 +597,16 @@ describe("notification settings", () => {
     });
   });
 
-  it("defaults notification history to 50 records", () => {
-    expect(DEFAULT_SETTINGS.notifications.maxHistory).toBe(50);
-    expect(DEFAULT_SETTINGS.notifications.autoDeleteRead).toBe(false);
+  it("defaults notification history to 20 records and auto-deletes read items", () => {
+    expect(DEFAULT_SETTINGS.notifications.maxHistory).toBe(20);
+    expect(DEFAULT_SETTINGS.notifications.autoDeleteRead).toBe(true);
   });
 
   it("loads persisted notification history settings and clamps the limit", async () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        notifications: { maxHistory: 200, autoDeleteRead: true },
+        notifications: { maxHistory: 200, autoDeleteRead: false },
       }),
     );
 
@@ -617,7 +617,7 @@ describe("notification settings", () => {
       NOTIFICATION_HISTORY_LIMIT_MAX,
     );
     expect(useSettings.getState().settings.notifications.autoDeleteRead).toBe(
-      true,
+      false,
     );
   });
 });
@@ -651,8 +651,9 @@ describe("status bar settings", () => {
     expect(DEFAULT_SETTINGS.statusBar.showSessionActivity).toBe(true);
   });
 
-  it("keeps agent token usage hidden by default", () => {
-    expect(DEFAULT_SETTINGS.statusBar.showAgentTokenUsage).toBe(false);
+  it("shows agent token usage and hides the working directory by default", () => {
+    expect(DEFAULT_SETTINGS.statusBar.showAgentTokenUsage).toBe(true);
+    expect(DEFAULT_SETTINGS.statusBar.showWorkingDirectory).toBe(false);
   });
 
   it("loads a persisted session activity shortcut preference", async () => {
@@ -672,14 +673,14 @@ describe("status bar settings", () => {
   it("loads a persisted agent token usage preference", async () => {
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ statusBar: { showAgentTokenUsage: true } }),
+      JSON.stringify({ statusBar: { showAgentTokenUsage: false } }),
     );
 
     vi.resetModules();
     const { useSettings } = await import("./settings");
 
     expect(useSettings.getState().settings.statusBar.showAgentTokenUsage).toBe(
-      true,
+      false,
     );
   });
 });
@@ -743,14 +744,14 @@ describe("shortcut settings", () => {
 });
 
 describe("AI commit command resolution", () => {
-  it("keeps automatic session title generation off by default", () => {
-    expect(DEFAULT_SETTINGS.agents.autoGenerateSessionTitles).toBe(false);
+  it("enables automatic session title generation by default", () => {
+    expect(DEFAULT_SETTINGS.agents.autoGenerateSessionTitles).toBe(true);
   });
 
   it("loads a persisted automatic session title preference", async () => {
     localStorage.setItem(
       "acorn:settings:v1",
-      JSON.stringify({ agents: { autoGenerateSessionTitles: true } }),
+      JSON.stringify({ agents: { autoGenerateSessionTitles: false } }),
     );
 
     vi.resetModules();
@@ -758,7 +759,7 @@ describe("AI commit command resolution", () => {
 
     expect(
       useSettings.getState().settings.agents.autoGenerateSessionTitles,
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("keeps the default session title prompt in settings", () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -118,7 +118,7 @@ export const UI_SCALE_PERCENT_MIN = 75;
 export const UI_SCALE_PERCENT_MAX = 150;
 export const UI_SCALE_PERCENT_STEP = 5;
 export const NOTIFICATION_HISTORY_LIMIT_MIN = 1;
-export const NOTIFICATION_HISTORY_LIMIT_DEFAULT = 50;
+export const NOTIFICATION_HISTORY_LIMIT_DEFAULT = 20;
 export const NOTIFICATION_HISTORY_LIMIT_MAX = 100;
 export const MOUNTED_TERMINAL_LIMIT_MIN = 1;
 export const MOUNTED_TERMINAL_LIMIT_DEFAULT = 8;
@@ -469,7 +469,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   },
   agents: {
     selected: "claude",
-    autoGenerateSessionTitles: false,
+    autoGenerateSessionTitles: true,
     sessionTitlePrompt: DEFAULT_SESSION_TITLE_PROMPT,
     customCommand: "",
     ollama: { model: "" },
@@ -491,7 +491,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   notifications: {
     enabled: true,
     maxHistory: NOTIFICATION_HISTORY_LIMIT_DEFAULT,
-    autoDeleteRead: false,
+    autoDeleteRead: true,
     events: {
       needsInput: true,
       failed: true,
@@ -503,8 +503,8 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     showSessionCount: true,
     showSessionStatus: true,
     showGithubAccount: true,
-    showWorkingDirectory: true,
-    showAgentTokenUsage: false,
+    showWorkingDirectory: false,
+    showAgentTokenUsage: true,
     showMemory: true,
   },
   github: {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -272,13 +272,15 @@ describe("sessionNotifications", () => {
       useAppStore.getState().addSessionNotification(notification(`n${i}`));
     }
 
+    const maxHistory = DEFAULT_SETTINGS.notifications.maxHistory;
     const items = useAppStore.getState().sessionNotifications;
-    expect(items).toHaveLength(50);
+    expect(items).toHaveLength(maxHistory);
     expect(items[0]?.id).toBe("n104");
-    expect(items[items.length - 1]?.id).toBe("n55");
+    expect(items[items.length - 1]?.id).toBe(`n${105 - maxHistory}`);
   });
 
-  it("marks individual and all notifications read, then clears read items", () => {
+  it("marks individual and all notifications read, then clears read items when auto-delete is disabled", () => {
+    useSettings.getState().patchNotifications({ autoDeleteRead: false });
     useAppStore.getState().addSessionNotification(notification("n1"));
     useAppStore.getState().addSessionNotification(notification("n2"));
 

--- a/tests/e2e/statusbar.spec.ts
+++ b/tests/e2e/statusbar.spec.ts
@@ -68,7 +68,10 @@ async function enableAgentTokenUsage(
   await pressHotkey(page, { mod: true, key: "," });
   const modal = page.getByRole("dialog", { name: "Settings" });
   await modal.getByRole("button", { name: "Appearance", exact: true }).click();
-  await modal.getByRole("checkbox", { name: /Agent token usage/ }).click();
+  const checkbox = modal.getByRole("checkbox", { name: /Agent token usage/ });
+  if (!(await checkbox.isChecked())) {
+    await checkbox.click();
+  }
   await page.keyboard.press("Escape");
 }
 


### PR DESCRIPTION
## Summary
Adjust default settings so new profiles start with the requested notification, status bar, and session-title behavior.

1. **Notification history defaults** — reduce the in-app notification history limit from 50 to 20 and enable auto-delete for read notifications by default.
2. **Status bar defaults** — hide Working directory by default and show Agent token usage by default.
3. **Session title defaults** — enable automatic session title generation by default.
4. **Regression coverage** — update settings, settings modal, store, notification, and status bar E2E tests, including persisted false preferences so existing user opt-outs remain respected.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Notification history | Keeps 50 records; read auto-delete off | Keeps 20 records; read auto-delete on |
| Status bar | Working directory visible; agent token usage hidden | Working directory hidden; agent token usage visible |
| Session titles | Auto-generation off | Auto-generation on |
| Existing persisted settings | Explicit saved values win | Explicit saved values still win |

## Design notes
- This changes `DEFAULT_SETTINGS` only. The settings loader still merges persisted values over defaults, so existing users who explicitly chose the previous behavior keep their saved preferences.
- Tests now use persisted `false` values for newly enabled defaults to prove opt-outs continue to survive loading.
- Notification/store tests were updated to avoid relying on the old default history limit or old read-retention behavior.
- Status bar E2E setup now enables Agent token usage idempotently, so it works whether the default is on or off.

## Test plan
- [x] `pnpm exec vitest run src/lib/settings.test.ts src/components/SettingsModal.test.tsx` — 2 files passed, 93 tests passed
- [x] `pnpm exec vitest run src/store.test.ts src/lib/notifications.test.ts` — 2 files passed, 128 tests passed
- [x] `pnpm run test` — 73 files passed, 757 tests passed
- [x] `pnpm exec playwright test tests/e2e/statusbar.spec.ts` — 5 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `git diff --check` — passed

## Notes
- No storage migration is included because the requested behavior is a default preference change, not an override for already persisted user settings.
