### PR TITLE
fix(ui): open async modals before data loads

### DIFF
--- a/src/components/ClosePullRequestDialog.tsx
+++ b/src/components/ClosePullRequestDialog.tsx
@@ -14,10 +14,29 @@ function dt(t: Translator, key: DialogTranslationKey): string {
   return t(key);
 }
 
+function CloseDialogSkeleton({ label }: { label: string }) {
+  return (
+    <div
+      aria-busy="true"
+      aria-label={label}
+      className="space-y-3 px-4 py-3 text-sm text-fg"
+    >
+      <div className="h-3 w-48 animate-pulse rounded bg-bg-sidebar" />
+      <div className="space-y-2 rounded-md border border-border bg-bg-sidebar/60 p-3">
+        <div className="h-3 w-3/4 animate-pulse rounded bg-bg-elevated" />
+        <div className="h-3 w-1/2 animate-pulse rounded bg-bg-elevated" />
+      </div>
+    </div>
+  );
+}
+
 interface ClosePullRequestDialogProps {
   open: boolean;
   repoPath: string;
+  number?: number;
   detail: PullRequestDetail | null;
+  loading?: boolean;
+  loadError?: string | null;
   onClose: () => void;
   onClosed: () => void;
 }
@@ -25,7 +44,10 @@ interface ClosePullRequestDialogProps {
 export function ClosePullRequestDialog({
   open,
   repoPath,
+  number,
   detail,
+  loading = false,
+  loadError = null,
   onClose,
   onClosed,
 }: ClosePullRequestDialogProps) {
@@ -64,12 +86,46 @@ export function ClosePullRequestDialog({
     }
   }
 
+  const dialogNumber = detail?.number ?? number;
+  const dialogTitle = `${dt(t, "dialogs.closePullRequest.titlePrefix")}${
+    dialogNumber ? ` #${dialogNumber}` : ""
+  }`;
+
   return (
     <Modal open={open} onClose={onClose} variant="dialog" size="md">
-      {detail ? (
+      {!detail ? (
         <>
           <ModalHeader
-            title={`${dt(t, "dialogs.closePullRequest.titlePrefix")} #${detail.number}`}
+            title={dialogTitle}
+            icon={<GitPullRequestClosed size={16} className="text-rose-400" />}
+            variant="dialog"
+            onClose={onClose}
+          />
+          {loadError && !loading ? (
+            <div className="space-y-3 px-4 py-3 text-xs text-fg">
+              <p className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-danger">
+                {loadError}
+              </p>
+            </div>
+          ) : (
+            <CloseDialogSkeleton
+              label={dt(t, "dialogs.closePullRequest.loadingDetails")}
+            />
+          )}
+          <footer className="flex items-center justify-end gap-2 border-t border-border bg-bg-sidebar/40 px-4 py-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
+            >
+              {dt(t, "dialogs.common.cancel")}
+            </button>
+          </footer>
+        </>
+      ) : (
+        <>
+          <ModalHeader
+            title={dialogTitle}
             icon={
               <GitPullRequestClosed size={16} className="text-rose-400" />
             }
@@ -117,7 +173,7 @@ export function ClosePullRequestDialog({
             </button>
           </footer>
         </>
-      ) : null}
+      )}
     </Modal>
   );
 }

--- a/src/components/DiffViewerModal.tsx
+++ b/src/components/DiffViewerModal.tsx
@@ -8,6 +8,9 @@ import { Markdown, Modal, ModalHeader } from "./ui";
 
 interface DiffViewerModalProps {
   payload: DiffPayload | null;
+  open?: boolean;
+  loading?: boolean;
+  error?: string | null;
   title: string;
   subtitle?: ReactNode;
   /** Right-side header actions (e.g. Copy SHA, Open on GitHub). */
@@ -24,35 +27,62 @@ interface DiffViewerModalProps {
    * active session's `worktree_path`. When omitted, the action is hidden.
    */
   cwd?: string;
+  loadingLabel?: string;
   onClose: () => void;
 }
 
 export function DiffViewerModal({
   payload,
+  open,
+  loading = false,
+  error = null,
   title,
   subtitle,
   headerActions,
   body,
   cwd,
+  loadingLabel,
   onClose,
 }: DiffViewerModalProps) {
+  const isOpen = open ?? payload !== null;
   // Read-only viewer: Enter dismisses just like Esc since there is no other
   // primary action.
-  useDialogShortcuts(payload !== null, {
+  useDialogShortcuts(isOpen, {
     onCancel: onClose,
     onConfirm: onClose,
   });
 
   const hasBody = !!body && body.trim().length > 0;
+  let content: ReactNode = null;
+  if (payload && hasBody) {
+    content = (
+      <PanelGroup
+        direction="vertical"
+        autoSaveId="acorn:commit-viewer-body-diff"
+        className="h-full"
+      >
+        <Panel id="body" order={1} defaultSize={25} minSize={8} maxSize={70}>
+          <div className="acorn-selectable h-full overflow-y-auto bg-bg-sidebar/40 px-4 py-2">
+            <Markdown content={body!} />
+          </div>
+        </Panel>
+        <ResizeHandle direction="vertical" thin />
+        <Panel id="diff" order={2} defaultSize={75} minSize={20}>
+          <DiffSplitView payload={payload} cwd={cwd} />
+        </Panel>
+      </PanelGroup>
+    );
+  } else if (payload) {
+    content = <DiffSplitView payload={payload} cwd={cwd} />;
+  } else if (error) {
+    content = <div className="p-4 text-xs text-danger">{error}</div>;
+  } else if (loading) {
+    content = <DiffViewerSkeleton label={loadingLabel} />;
+  }
 
   return (
-    <Modal
-      open={payload !== null}
-      onClose={onClose}
-      variant="panel"
-      size="5xl"
-    >
-      {payload ? (
+    <Modal open={isOpen} onClose={onClose} variant="panel" size="5xl">
+      {isOpen ? (
         <>
           <ModalHeader
             title={title}
@@ -61,28 +91,50 @@ export function DiffViewerModal({
             onClose={onClose}
           />
           <div className="min-h-0 flex-1 overflow-hidden">
-            {hasBody ? (
-              <PanelGroup
-                direction="vertical"
-                autoSaveId="acorn:commit-viewer-body-diff"
-                className="h-full"
-              >
-                <Panel id="body" order={1} defaultSize={25} minSize={8} maxSize={70}>
-                  <div className="acorn-selectable h-full overflow-y-auto bg-bg-sidebar/40 px-4 py-2">
-                    <Markdown content={body!} />
-                  </div>
-                </Panel>
-                <ResizeHandle direction="vertical" thin />
-                <Panel id="diff" order={2} defaultSize={75} minSize={20}>
-                  <DiffSplitView payload={payload} cwd={cwd} />
-                </Panel>
-              </PanelGroup>
-            ) : (
-              <DiffSplitView payload={payload} cwd={cwd} />
-            )}
+            {content}
           </div>
         </>
       ) : null}
     </Modal>
+  );
+}
+
+function DiffViewerSkeleton({ label }: { label?: string }) {
+  return (
+    <div
+      className="flex h-full min-h-0 animate-pulse"
+      aria-busy="true"
+      aria-label={label}
+    >
+      <aside className="flex w-64 shrink-0 flex-col gap-3 border-r border-border bg-bg-sidebar p-3">
+        <div className="h-3 w-24 rounded bg-fg-muted/15" />
+        <div className="space-y-2">
+          {Array.from({ length: 9 }, (_, index) => (
+            <div key={index} className="space-y-1.5">
+              <div className="h-3 rounded bg-fg-muted/15" />
+              <div className="h-2 w-2/3 rounded bg-fg-muted/10" />
+            </div>
+          ))}
+        </div>
+      </aside>
+      <section className="min-w-0 flex-1 space-y-4 overflow-hidden p-4">
+        <div className="flex items-center justify-between">
+          <div className="h-3 w-52 rounded bg-fg-muted/15" />
+          <div className="h-3 w-20 rounded bg-fg-muted/10" />
+        </div>
+        <div className="space-y-2">
+          {Array.from({ length: 18 }, (_, index) => (
+            <div
+              key={index}
+              className="h-3 rounded bg-fg-muted/10"
+              style={{
+                width:
+                  index % 7 === 0 ? "72%" : index % 5 === 0 ? "88%" : "100%",
+              }}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
   );
 }

--- a/src/components/MergePullRequestDialog.tsx
+++ b/src/components/MergePullRequestDialog.tsx
@@ -101,10 +101,40 @@ function formatCount(template: string, count: number): string {
   return template.replace("{count}", String(count));
 }
 
+function MergeDialogSkeleton({ label }: { label: string }) {
+  return (
+    <div
+      aria-busy="true"
+      aria-label={label}
+      className="space-y-4 px-4 py-3 text-xs text-fg"
+    >
+      <div className="space-y-2">
+        <div className="h-3 w-24 animate-pulse rounded bg-bg-sidebar" />
+        <div className="grid grid-cols-3 gap-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-14 animate-pulse rounded-md border border-border bg-bg-sidebar/60"
+            />
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        <div className="h-3 w-28 animate-pulse rounded bg-bg-sidebar" />
+        <div className="h-8 animate-pulse rounded-md border border-border bg-bg-sidebar/60" />
+        <div className="h-28 animate-pulse rounded-md border border-border bg-bg-sidebar/60" />
+      </div>
+    </div>
+  );
+}
+
 interface MergePullRequestDialogProps {
   open: boolean;
   repoPath: string;
+  number?: number;
   detail: PullRequestDetail | null;
+  loading?: boolean;
+  loadError?: string | null;
   onClose: () => void;
   onMerged: () => void;
 }
@@ -112,7 +142,10 @@ interface MergePullRequestDialogProps {
 export function MergePullRequestDialog({
   open,
   repoPath,
+  number,
   detail,
+  loading = false,
+  loadError = null,
   onClose,
   onMerged,
 }: MergePullRequestDialogProps) {
@@ -251,6 +284,10 @@ export function MergePullRequestDialog({
   const providerLabel = aiCommitProviderLabel(settings);
   const busy = submitting || generating;
   const mergeBlocked = checksBlock.blocked && !adminMerge;
+  const dialogNumber = detail?.number ?? number;
+  const dialogTitle = `${dt(t, "dialogs.mergePullRequest.titlePrefix")}${
+    dialogNumber ? ` #${dialogNumber}` : ""
+  }`;
 
   function handleMethodSelect(nextMethod: MergeMethod) {
     setMethod(nextMethod);
@@ -271,10 +308,39 @@ export function MergePullRequestDialog({
   return (
     <>
       <Modal open={open} onClose={onClose} variant="dialog" size="lg">
-        {detail ? (
+        {!detail ? (
           <>
             <ModalHeader
-              title={`${dt(t, "dialogs.mergePullRequest.titlePrefix")} #${detail.number}`}
+              title={dialogTitle}
+              icon={<GitMerge size={16} className="text-emerald-400" />}
+              variant="dialog"
+              onClose={onClose}
+            />
+            {loadError && !loading ? (
+              <div className="space-y-3 px-4 py-3 text-xs text-fg">
+                <p className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-danger">
+                  {loadError}
+                </p>
+              </div>
+            ) : (
+              <MergeDialogSkeleton
+                label={dt(t, "dialogs.mergePullRequest.loadingDetails")}
+              />
+            )}
+            <footer className="flex items-center justify-end gap-2 border-t border-border bg-bg-sidebar/40 px-4 py-3">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md px-3 py-1.5 text-xs text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"
+              >
+                {dt(t, "dialogs.common.cancel")}
+              </button>
+            </footer>
+          </>
+        ) : (
+          <>
+            <ModalHeader
+              title={dialogTitle}
               icon={<GitMerge size={16} className="text-emerald-400" />}
               variant="dialog"
               onClose={() => {
@@ -463,7 +529,7 @@ export function MergePullRequestDialog({
             </button>
           </footer>
           </>
-        ) : null}
+        )}
       </Modal>
       <ProjectSettingsModal
         project={

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -5,7 +5,9 @@ import {
   useRef,
   useState,
   type DependencyList,
+  type Dispatch,
   type ReactNode,
+  type SetStateAction,
 } from "react";
 import {
   Activity,
@@ -123,7 +125,7 @@ import {
 } from "../lib/sessionCreation";
 
 interface ExpandedDiff {
-  payload: DiffPayload;
+  payload: DiffPayload | null;
   title: string;
   /** Rich React subtitle — avatar + author + sha line for commit expansion. */
   subtitle?: ReactNode;
@@ -134,7 +136,12 @@ interface ExpandedDiff {
    * commit; omitted for staged-diff expansion (no commit context).
    */
   body?: string;
+  loading?: boolean;
+  error?: string | null;
+  requestId?: number;
 }
+
+type SetExpandedDiff = Dispatch<SetStateAction<ExpandedDiff | null>>;
 
 const COMMITS_PAGE_SIZE = 50;
 const COMMIT_ROW_HEIGHT = 48;
@@ -573,11 +580,15 @@ export function RightPanel() {
       </div>
       <DiffViewerModal
         payload={expanded?.payload ?? null}
+        open={expanded !== null}
+        loading={expanded?.loading ?? false}
+        error={expanded?.error ?? null}
         title={expanded?.title ?? ""}
         subtitle={expanded?.subtitle}
         headerActions={expanded?.headerActions}
         body={expanded?.body}
         cwd={codePanelRepoPath ?? undefined}
+        loadingLabel={rt(t, "rightPanel.loading.diffLower")}
         onClose={() => setExpanded(null)}
       />
       <PullRequestSearchModal
@@ -1950,7 +1961,7 @@ function CommitsTab({
 }: {
   repoPath: string;
   invalidateKey: number;
-  onExpand: (e: ExpandedDiff) => void;
+  onExpand: SetExpandedDiff;
 }) {
   const t = useTranslation();
   const cachedCommits = rightPanelCache.getCommits(repoPath);
@@ -1976,6 +1987,8 @@ function CommitsTab({
   } | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const generationRef = useRef(0);
+  const diffGenerationRef = useRef(0);
+  const expandRequestRef = useRef(0);
   // Hydrated cache counts as a successful top-of-history load so a failed
   // background refresh doesn't replace good data with an error banner.
   const loadedTopRef = useRef(!!cachedCommits);
@@ -2016,6 +2029,8 @@ function CommitsTab({
     generationRef.current += 1;
     return () => {
       generationRef.current += 1;
+      diffGenerationRef.current += 1;
+      expandRequestRef.current += 1;
     };
   }, [repoPath]);
 
@@ -2101,13 +2116,23 @@ function CommitsTab({
     });
   }, [repoPath, commits.length]);
 
+  function loadCommitDiff(sha: string): Promise<DiffPayload> {
+    return rightPanelCache.fetchCommitDiff(repoPath, sha);
+  }
+
   function selectCommit(sha: string) {
+    const token = ++diffGenerationRef.current;
     setSelected(sha);
     setDiff(null);
-    api
-      .commitDiff(repoPath, sha)
-      .then(setDiff)
-      .catch((e) => setError(String(e)));
+    loadCommitDiff(sha)
+      .then((payload) => {
+        if (diffGenerationRef.current !== token) return;
+        setDiff(payload);
+      })
+      .catch((e) => {
+        if (diffGenerationRef.current !== token) return;
+        setError(String(e));
+      });
   }
 
   function buildSubtitle(c: CommitInfo): ReactNode {
@@ -2154,20 +2179,45 @@ function CommitsTab({
   }
 
   async function expandCommit(c: CommitInfo) {
+    const requestId = ++expandRequestRef.current;
+    const cachedPayload = rightPanelCache.getCommitDiff(repoPath, c.sha);
+    onExpand({
+      payload: cachedPayload,
+      title: c.summary,
+      subtitle: buildSubtitle(c),
+      headerActions: buildHeaderActions(c, null),
+      body: c.body,
+      loading: cachedPayload === null,
+      error: null,
+      requestId,
+    });
     try {
       const [payload, webUrl] = await Promise.all([
-        api.commitDiff(repoPath, c.sha),
+        loadCommitDiff(c.sha),
         api.commitWebUrl(repoPath, c.sha).catch(() => null),
       ]);
-      onExpand({
-        payload,
-        title: c.summary,
-        subtitle: buildSubtitle(c),
-        headerActions: buildHeaderActions(c, webUrl),
-        body: c.body,
+      if (expandRequestRef.current !== requestId) return;
+      onExpand((current) => {
+        if (current?.requestId !== requestId) return current;
+        return {
+          ...current,
+          payload,
+          headerActions: buildHeaderActions(c, webUrl),
+          loading: false,
+          error: null,
+        };
       });
     } catch (e) {
-      setError(String(e));
+      if (expandRequestRef.current !== requestId) return;
+      const message = String(e);
+      onExpand((current) => {
+        if (current?.requestId !== requestId) return current;
+        return {
+          ...current,
+          loading: false,
+          error: message,
+        };
+      });
     }
   }
 
@@ -2420,7 +2470,7 @@ function StagedTab({
 }: {
   repoPath: string;
   invalidateKey: number;
-  onExpand: (e: ExpandedDiff) => void;
+  onExpand: SetExpandedDiff;
 }) {
   const t = useTranslation();
   const openCodeViewerTab = useAppStore((s) => s.openCodeViewerTab);
@@ -2776,6 +2826,14 @@ function prListStateFromCache(
   };
 }
 
+type PrDialogTarget = {
+  number: number;
+  detail: PullRequestDetail | null;
+  loading: boolean;
+  error: string | null;
+  requestId: number;
+};
+
 /**
  * Shared PR row actions: context menu, copy/open helpers, and the
  * merge/close dialog overlays. Lets the PRs tab and the search modal
@@ -2797,11 +2855,17 @@ function usePrRowActions(
   } | null>(null);
   const [mergeFor, setMergeFor] = useState<{
     number: number;
-    detail: PullRequestDetail;
+    detail: PullRequestDetail | null;
+    loading: boolean;
+    error: string | null;
+    requestId: number;
   } | null>(null);
   const [closeFor, setCloseFor] = useState<{
     number: number;
-    detail: PullRequestDetail;
+    detail: PullRequestDetail | null;
+    loading: boolean;
+    error: string | null;
+    requestId: number;
   } | null>(null);
   const [error, setError] = useState<string | null>(null);
   // Bumped on every detail fetch / dialog dismiss so stale getPullRequestDetail
@@ -2824,40 +2888,121 @@ function usePrRowActions(
     }
   }
 
-  async function loadDetailFor(
-    pr: PullRequestInfo,
-  ): Promise<PullRequestDetail | null> {
-    const epoch = ++dialogEpochRef.current;
-    try {
-      const listing = await api.getPullRequestDetail(repoPath, pr.number);
-      if (epoch !== dialogEpochRef.current) return null;
-      if (listing.kind !== "ok") {
-        setError(
-          listing.kind === "not_github"
-            ? rt(t, "rightPanel.errors.originNotGitHub")
-            : rtf(t, "rightPanel.errors.noAccessToSlug", {
-                slug: listing.slug,
-              }),
-        );
-        return null;
-      }
-      return listing.detail;
-    } catch (e) {
-      if (epoch === dialogEpochRef.current) setError(String(e));
-      return null;
-    }
+  function detailLoadError(listing: PullRequestListing): string | null {
+    if (listing.kind === "ok") return null;
+    return listing.kind === "not_github"
+      ? rt(t, "rightPanel.errors.originNotGitHub")
+      : rtf(t, "rightPanel.errors.noAccessToSlug", {
+          slug: listing.slug,
+        });
   }
 
-  async function openMergeFor(pr: PullRequestInfo) {
-    const detail = await loadDetailFor(pr);
-    if (!detail) return;
-    setMergeFor({ number: pr.number, detail });
+  function updateMergeTarget(
+    requestId: number,
+    update: (current: PrDialogTarget) => PrDialogTarget,
+  ) {
+    setMergeFor((current) => {
+      if (!current || current.requestId !== requestId) return current;
+      return update(current);
+    });
   }
 
-  async function openCloseFor(pr: PullRequestInfo) {
-    const detail = await loadDetailFor(pr);
-    if (!detail) return;
-    setCloseFor({ number: pr.number, detail });
+  function updateCloseTarget(
+    requestId: number,
+    update: (current: PrDialogTarget) => PrDialogTarget,
+  ) {
+    setCloseFor((current) => {
+      if (!current || current.requestId !== requestId) return current;
+      return update(current);
+    });
+  }
+
+  function openMergeFor(pr: PullRequestInfo) {
+    const requestId = ++dialogEpochRef.current;
+    setError(null);
+    setMergeFor({
+      number: pr.number,
+      detail: null,
+      loading: true,
+      error: null,
+      requestId,
+    });
+    void api
+      .getPullRequestDetail(repoPath, pr.number)
+      .then((listing) => {
+        if (requestId !== dialogEpochRef.current) return;
+        if (listing.kind !== "ok") {
+          const loadError = detailLoadError(listing);
+          if (!loadError) return;
+          setError(loadError);
+          updateMergeTarget(requestId, (current) => ({
+            ...current,
+            loading: false,
+            error: loadError,
+          }));
+          return;
+        }
+        updateMergeTarget(requestId, (current) => ({
+          ...current,
+          detail: listing.detail,
+          loading: false,
+          error: null,
+        }));
+      })
+      .catch((e) => {
+        if (requestId !== dialogEpochRef.current) return;
+        const message = String(e);
+        setError(message);
+        updateMergeTarget(requestId, (current) => ({
+          ...current,
+          loading: false,
+          error: message,
+        }));
+      });
+  }
+
+  function openCloseFor(pr: PullRequestInfo) {
+    const requestId = ++dialogEpochRef.current;
+    setError(null);
+    setCloseFor({
+      number: pr.number,
+      detail: null,
+      loading: true,
+      error: null,
+      requestId,
+    });
+    void api
+      .getPullRequestDetail(repoPath, pr.number)
+      .then((listing) => {
+        if (requestId !== dialogEpochRef.current) return;
+        if (listing.kind !== "ok") {
+          const loadError = detailLoadError(listing);
+          if (!loadError) return;
+          setError(loadError);
+          updateCloseTarget(requestId, (current) => ({
+            ...current,
+            loading: false,
+            error: loadError,
+          }));
+          return;
+        }
+        updateCloseTarget(requestId, (current) => ({
+          ...current,
+          detail: listing.detail,
+          loading: false,
+          error: null,
+        }));
+      })
+      .catch((e) => {
+        if (requestId !== dialogEpochRef.current) return;
+        const message = String(e);
+        setError(message);
+        updateCloseTarget(requestId, (current) => ({
+          ...current,
+          loading: false,
+          error: message,
+        }));
+      });
   }
 
   function openContextMenu(
@@ -2926,7 +3071,10 @@ function usePrRowActions(
       <MergePullRequestDialog
         open={mergeFor !== null}
         repoPath={repoPath}
+        number={mergeFor?.number}
         detail={mergeFor?.detail ?? null}
+        loading={mergeFor?.loading ?? false}
+        loadError={mergeFor?.error ?? null}
         onClose={() => {
           dialogEpochRef.current += 1;
           setMergeFor(null);
@@ -2940,7 +3088,10 @@ function usePrRowActions(
       <ClosePullRequestDialog
         open={closeFor !== null}
         repoPath={repoPath}
+        number={closeFor?.number}
         detail={closeFor?.detail ?? null}
+        loading={closeFor?.loading ?? false}
+        loadError={closeFor?.error ?? null}
         onClose={() => {
           dialogEpochRef.current += 1;
           setCloseFor(null);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -2451,7 +2451,7 @@ type WhatsNewSource =
       kind: "current";
       version: string;
       body: string;
-      htmlUrl: string;
+      htmlUrl?: string;
       /**
        * True when the running version doesn't have its own public
        * release and we're showing the latest published one as a
@@ -2718,6 +2718,7 @@ function AboutSettings() {
   const [currentNotes, setCurrentNotes] = useState<ReleaseNotes | null>(null);
   const [notesLoading, setNotesLoading] = useState(false);
   const [notesError, setNotesError] = useState<string | null>(null);
+  const notesRequestRef = useRef(0);
   const showToast = useToasts((s) => s.show);
 
   useEffect(() => {
@@ -2728,9 +2729,11 @@ function AboutSettings() {
 
   const openCurrentNotes = useCallback(async () => {
     if (!currentVersion) return;
+    const requestId = ++notesRequestRef.current;
     setNotesError(null);
     // Cache: skip the fetch if we already have notes for this version.
     if (currentNotes && currentNotes.version === currentVersion) {
+      setNotesLoading(false);
       setWhatsNewSource({
         kind: "current",
         version: currentNotes.version,
@@ -2740,9 +2743,16 @@ function AboutSettings() {
       });
       return;
     }
+    setWhatsNewSource({
+      kind: "current",
+      version: currentVersion,
+      body: "",
+      isFallback: false,
+    });
     setNotesLoading(true);
     try {
       const notes = await fetchReleaseNotes(currentVersion);
+      if (notesRequestRef.current !== requestId) return;
       if (notes !== null) {
         setCurrentNotes(notes);
         setWhatsNewSource({
@@ -2759,6 +2769,7 @@ function AboutSettings() {
       // latest published release so the user still sees something meaningful
       // instead of an empty placeholder.
       const latest = await fetchLatestReleaseNotes();
+      if (notesRequestRef.current !== requestId) return;
       setWhatsNewSource({
         kind: "current",
         version: latest.version,
@@ -2769,12 +2780,24 @@ function AboutSettings() {
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Failed to fetch release notes";
-      setNotesError(message);
-      showToast(`${st(t, "settings.about.toasts.releaseNotesFailed")} ${message}`);
+      if (notesRequestRef.current === requestId) {
+        setNotesError(message);
+        showToast(
+          `${st(t, "settings.about.toasts.releaseNotesFailed")} ${message}`,
+        );
+      }
     } finally {
-      setNotesLoading(false);
+      if (notesRequestRef.current === requestId) {
+        setNotesLoading(false);
+      }
     }
   }, [currentVersion, currentNotes, showToast, t]);
+
+  const closeWhatsNew = useCallback(() => {
+    notesRequestRef.current += 1;
+    setNotesLoading(false);
+    setWhatsNewSource(null);
+  }, []);
 
   const handleCheck = useCallback(async () => {
     await check();
@@ -2844,13 +2867,16 @@ function AboutSettings() {
               {hasNotes && available ? (
                 <button
                   type="button"
-                  onClick={() =>
+                  onClick={() => {
+                    notesRequestRef.current += 1;
+                    setNotesLoading(false);
+                    setNotesError(null);
                     setWhatsNewSource({
                       kind: "update",
                       version: available.version,
                       body: available.body ?? "",
-                    })
-                  }
+                    });
+                  }}
                   className="rounded px-2 py-1 text-[11px] text-fg-muted underline-offset-2 transition hover:text-fg hover:underline"
                 >
                   {st(t, "settings.about.whatsNew")}
@@ -2915,13 +2941,20 @@ function AboutSettings() {
 
       <WhatsNewModal
         open={whatsNewSource !== null}
-        onClose={() => setWhatsNewSource(null)}
+        onClose={closeWhatsNew}
         version={whatsNewSource?.version ?? ""}
         body={whatsNewSource?.body ?? ""}
         currentVersion={currentVersion}
         showInstall={whatsNewSource?.kind === "update"}
         busy={busy}
-        error={whatsNewSource?.kind === "update" ? error : null}
+        loading={whatsNewSource?.kind === "current" ? notesLoading : false}
+        error={
+          whatsNewSource?.kind === "current"
+            ? notesError
+            : whatsNewSource?.kind === "update"
+              ? error
+              : null
+        }
         onInstall={
           whatsNewSource?.kind === "update"
             ? () => void handleInstall()

--- a/src/components/WhatsNewModal.tsx
+++ b/src/components/WhatsNewModal.tsx
@@ -29,6 +29,8 @@ interface WhatsNewModalProps {
   showInstall?: boolean;
   /** Disables the install button while a download/install is running. */
   busy?: boolean;
+  /** Shows a skeleton while release notes are being fetched. */
+  loading?: boolean;
   /** Error message shown above the footer. */
   error?: string | null;
   /** Invoked when the install button is clicked. Required if showInstall. */
@@ -42,6 +44,27 @@ interface WhatsNewModalProps {
    * the latest one.
    */
   isFallback?: boolean;
+}
+
+function ReleaseNotesSkeleton({ label }: { label: string }) {
+  return (
+    <div
+      aria-busy="true"
+      aria-label={label}
+      className="space-y-4"
+    >
+      <div className="space-y-2">
+        <div className="h-4 w-40 animate-pulse rounded bg-bg-sidebar" />
+        <div className="h-3 w-full animate-pulse rounded bg-bg-sidebar" />
+        <div className="h-3 w-5/6 animate-pulse rounded bg-bg-sidebar" />
+      </div>
+      <div className="space-y-2">
+        <div className="h-4 w-28 animate-pulse rounded bg-bg-sidebar" />
+        <div className="h-3 w-11/12 animate-pulse rounded bg-bg-sidebar" />
+        <div className="h-3 w-2/3 animate-pulse rounded bg-bg-sidebar" />
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -67,6 +90,7 @@ export function WhatsNewModal({
   currentVersion,
   showInstall = false,
   busy = false,
+  loading = false,
   error,
   onInstall,
   htmlUrl,
@@ -99,9 +123,13 @@ export function WhatsNewModal({
         onClose={onClose}
       />
       <div className="max-h-[28rem] overflow-y-auto px-4 py-4">
-        {trimmedBody.length > 0 ? (
+        {loading ? (
+          <ReleaseNotesSkeleton
+            label={dt(t, "dialogs.whatsNew.loadingReleaseNotes")}
+          />
+        ) : trimmedBody.length > 0 ? (
           <Markdown content={trimmedBody} className="text-xs" />
-        ) : (
+        ) : error ? null : (
           <p className="text-xs text-fg-muted">
             {dt(t, "dialogs.whatsNew.noReleaseNotes")}
           </p>

--- a/src/lib/right-panel-cache.test.ts
+++ b/src/lib/right-panel-cache.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentHistoryItem,
+  DiffPayload,
   IssueListing,
   PullRequestListing,
   WorkflowRunsListing,
@@ -30,6 +31,7 @@ vi.mock("./api", () => ({
       >(),
     listWorkflowRuns:
       vi.fn<(repoPath: string, limit: number) => Promise<WorkflowRunsListing>>(),
+    commitDiff: vi.fn<(repoPath: string, sha: string) => Promise<DiffPayload>>(),
   },
 }));
 
@@ -96,6 +98,34 @@ describe("rightPanelCache", () => {
       rightPanelCache.fetchIssues(REPO, "closed", 50),
     ).resolves.toBe(listing);
     expect(mockApi.listIssues).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes in-flight commit diff fetches and reuses cached results", async () => {
+    const diff: DiffPayload = {
+      files: [
+        {
+          old_path: "src/old.ts",
+          new_path: "src/new.ts",
+          patch: "@@ -1 +1 @@\n-old\n+new\n",
+          is_image: false,
+        },
+      ],
+    };
+    const pending = deferred<DiffPayload>();
+    mockApi.commitDiff.mockReturnValueOnce(pending.promise);
+
+    const first = rightPanelCache.fetchCommitDiff(REPO, "abc123");
+    const second = rightPanelCache.fetchCommitDiff(REPO, "abc123");
+    expect(first).toBe(second);
+    expect(mockApi.commitDiff).toHaveBeenCalledTimes(1);
+
+    pending.resolve(diff);
+    await expect(first).resolves.toBe(diff);
+    expect(rightPanelCache.getCommitDiff(REPO, "abc123")).toBe(diff);
+    await expect(rightPanelCache.fetchCommitDiff(REPO, "abc123")).resolves.toBe(
+      diff,
+    );
+    expect(mockApi.commitDiff).toHaveBeenCalledTimes(1);
   });
 
   it("tracks project prefetch once until the repo is pruned", () => {

--- a/src/lib/right-panel-cache.ts
+++ b/src/lib/right-panel-cache.ts
@@ -42,6 +42,8 @@ class RightPanelCacheManager {
   private issueListInFlight = new Map<string, Promise<IssueListing>>();
   private workflowRunsCache = new Map<string, WorkflowRunsListing>();
   private workflowRunsInFlight = new Map<string, Promise<WorkflowRunsListing>>();
+  private commitDiffCache = new Map<string, DiffPayload>();
+  private commitDiffInFlight = new Map<string, Promise<DiffPayload>>();
 
   claimProjectPrefetch(repoPath: string): boolean {
     if (this.prefetchedProjectRepos.has(repoPath)) return false;
@@ -69,6 +71,8 @@ class RightPanelCacheManager {
     this.collectRemovedJsonKeys(this.issueListInFlight, next, removed);
     this.collectRemovedJsonKeys(this.workflowRunsCache, next, removed);
     this.collectRemovedJsonKeys(this.workflowRunsInFlight, next, removed);
+    this.collectRemovedJsonKeys(this.commitDiffCache, next, removed);
+    this.collectRemovedJsonKeys(this.commitDiffInFlight, next, removed);
     for (const repoPath of removed) this.bumpRepoVersion(repoPath);
 
     this.retainedRepos = next;
@@ -84,6 +88,8 @@ class RightPanelCacheManager {
     this.pruneJsonKeyedMap(this.issueListInFlight, next);
     this.pruneJsonKeyedMap(this.workflowRunsCache, next);
     this.pruneJsonKeyedMap(this.workflowRunsInFlight, next);
+    this.pruneJsonKeyedMap(this.commitDiffCache, next);
+    this.pruneJsonKeyedMap(this.commitDiffInFlight, next);
   }
 
   getAgentHistory(repoPath: string): AgentHistoryItem[] | null {
@@ -155,6 +161,32 @@ class RightPanelCacheManager {
   setCommits(repoPath: string, entry: CommitsCacheEntry): void {
     if (!this.canStore(repoPath)) return;
     this.commitsCache.set(repoPath, entry);
+  }
+
+  getCommitDiff(repoPath: string, sha: string): DiffPayload | null {
+    return this.commitDiffCache.get(this.commitDiffKey(repoPath, sha)) ?? null;
+  }
+
+  fetchCommitDiff(repoPath: string, sha: string): Promise<DiffPayload> {
+    const key = this.commitDiffKey(repoPath, sha);
+    const cached = this.commitDiffCache.get(key);
+    if (cached) return Promise.resolve(cached);
+    const existing = this.commitDiffInFlight.get(key);
+    if (existing) return existing;
+    const version = this.repoVersion(repoPath);
+    const promise = api
+      .commitDiff(repoPath, sha)
+      .then((payload) => {
+        if (this.isCurrentRepoVersion(repoPath, version)) {
+          this.commitDiffCache.set(key, payload);
+        }
+        return payload;
+      })
+      .finally(() => {
+        this.commitDiffInFlight.delete(key);
+      });
+    this.commitDiffInFlight.set(key, promise);
+    return promise;
   }
 
   getStaged(repoPath: string): StagedCacheEntry | null {
@@ -292,6 +324,8 @@ class RightPanelCacheManager {
     this.issueListInFlight.clear();
     this.workflowRunsCache.clear();
     this.workflowRunsInFlight.clear();
+    this.commitDiffCache.clear();
+    this.commitDiffInFlight.clear();
   }
 
   private canStore(repoPath: string): boolean {
@@ -328,6 +362,10 @@ class RightPanelCacheManager {
 
   private workflowRunsKey(repoPath: string, limit: number): string {
     return JSON.stringify([repoPath, limit]);
+  }
+
+  private commitDiffKey(repoPath: string, sha: string): string {
+    return JSON.stringify([repoPath, sha]);
   }
 
   private pruneStringKeyedMap<T>(map: Map<string, T>, retained: Set<string>): void {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1494,6 +1494,7 @@
     },
     "closePullRequest": {
       "titlePrefix": "Close",
+      "loadingDetails": "Loading pull request details...",
       "confirmPrefix": "Close pull request",
       "confirmSuffix": "without merging?",
       "closing": "Closing...",
@@ -1501,6 +1502,7 @@
     },
     "mergePullRequest": {
       "titlePrefix": "Merge",
+      "loadingDetails": "Loading pull request details...",
       "mergeMethod": "Merge method",
       "methodSquash": "Squash",
       "methodSquashHint": "Combine into one commit on the base branch.",
@@ -1554,6 +1556,7 @@
       "yourVersion": "your version",
       "currentlyRunning": "currently running",
       "onThisVersion": "you're on this version",
+      "loadingReleaseNotes": "Loading release notes...",
       "noReleaseNotes": "No release notes were published with this version.",
       "viewOnGithub": "View on GitHub",
       "installing": "Installing...",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1494,6 +1494,7 @@
     },
     "closePullRequest": {
       "titlePrefix": "닫기",
+      "loadingDetails": "Pull request 상세를 불러오는 중...",
       "confirmPrefix": "Pull request",
       "confirmSuffix": "를 병합하지 않고 닫을까요?",
       "closing": "닫는 중...",
@@ -1501,6 +1502,7 @@
     },
     "mergePullRequest": {
       "titlePrefix": "병합",
+      "loadingDetails": "Pull request 상세를 불러오는 중...",
       "mergeMethod": "병합 방식",
       "methodSquash": "Squash",
       "methodSquashHint": "기본 브랜치에 하나의 커밋으로 합칩니다.",
@@ -1554,6 +1556,7 @@
       "yourVersion": "현재 버전",
       "currentlyRunning": "현재 실행 중",
       "onThisVersion": "이 버전을 사용 중입니다",
+      "loadingReleaseNotes": "릴리스 노트를 불러오는 중...",
       "noReleaseNotes": "이 버전에는 공개된 릴리스 노트가 없습니다.",
       "viewOnGithub": "GitHub에서 보기",
       "installing": "설치 중...",

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -86,6 +86,81 @@ test.describe("right panel: tab switching", () => {
     await expect(page.getByText(/Select a commit to see diff/i)).toBeVisible();
   });
 
+  test("double-clicking a commit opens the diff modal before the diff finishes loading", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    await tauri.respond("list_commits", [
+      {
+        sha: "abc1234567890abcdef1234567890abcdef1234",
+        short_sha: "abc1234",
+        author: "Test Author",
+        author_email: "test@example.com",
+        summary: "Large diff commit",
+        body: "",
+        timestamp: 1_700_000_000,
+        pushed: true,
+      },
+    ]);
+    await tauri.handle("commit_diff", (args) => {
+      const w = window as unknown as {
+        __commitDiffCalls?: unknown[];
+        __releaseCommitDiff?: boolean;
+      };
+      w.__commitDiffCalls = w.__commitDiffCalls ?? [];
+      w.__commitDiffCalls.push(args);
+      return new Promise((resolve) => {
+        const tick = () => {
+          if (w.__releaseCommitDiff) {
+            resolve({
+              files: [
+                {
+                  old_path: "src/old.ts",
+                  new_path: "src/new.ts",
+                  patch: "@@ -1 +1 @@\n-old\n+new\n",
+                  is_image: false,
+                },
+              ],
+            });
+            return;
+          }
+          setTimeout(tick, 20);
+        };
+        tick();
+      });
+    });
+
+    await page.goto("/");
+    await expect(page.getByText("Large diff commit")).toBeVisible();
+
+    await page.getByText("Large diff commit").dblclick();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __commitDiffCalls?: unknown[] })
+              .__commitDiffCalls?.length ?? 0,
+        ),
+      )
+      .toBe(1);
+    const dialog = page.locator('[role="dialog"]').filter({
+      has: page.getByRole("heading", { name: "Large diff commit" }),
+    });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByLabel("loading diff...")).toBeVisible();
+
+    await page.evaluate(() => {
+      (window as unknown as { __releaseCommitDiff?: boolean })
+        .__releaseCommitDiff = true;
+    });
+    await expect(
+      dialog.getByRole("button", { name: /new\.ts\s+\+1\s+-1\s+src/ }),
+    ).toBeVisible();
+    await expect(dialog.getByLabel("loading diff...")).toHaveCount(0);
+  });
+
   test("double-clicking an issue opens its in-app detail modal", async ({
     page,
     tauri,
@@ -144,6 +219,213 @@ test.describe("right panel: tab switching", () => {
 
     await expect(page.getByText("Loaded issue body from gh.")).toBeVisible();
     await expect(page.getByText("First in-app issue comment.")).toBeVisible();
+  });
+
+  test("opening PR merge from the context menu shows a skeleton before details load", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    await tauri.respond("list_pull_requests", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 17,
+          title: "Slow merge PR",
+          state: "OPEN",
+          author: "im-ian",
+          head_branch: "feature/slow-merge",
+          base_branch: "main",
+          url: "https://github.com/im-ian/acorn/pull/17",
+          updated_at: "2026-05-19T00:00:00Z",
+          is_draft: false,
+          checks: null,
+          labels: [],
+        },
+      ],
+    });
+    await tauri.handle("get_pull_request_detail", (args) => {
+      const w = window as unknown as {
+        __prDetailCalls?: unknown[];
+        __releasePrDetail?: boolean;
+      };
+      w.__prDetailCalls = w.__prDetailCalls ?? [];
+      w.__prDetailCalls.push(args);
+      return new Promise((resolve) => {
+        const tick = () => {
+          if (w.__releasePrDetail) {
+            resolve({
+              kind: "ok",
+              account: "test-account",
+              detail: {
+                number: 17,
+                title: "Slow merge PR",
+                body: "Merge body",
+                state: "OPEN",
+                is_draft: false,
+                author: "im-ian",
+                head_branch: "feature/slow-merge",
+                base_branch: "main",
+                url: "https://github.com/im-ian/acorn/pull/17",
+                created_at: "2026-05-18T00:00:00Z",
+                updated_at: "2026-05-19T00:00:00Z",
+                merged_at: null,
+                additions: 12,
+                deletions: 3,
+                changed_files: 2,
+                mergeable: "MERGEABLE",
+                labels: [],
+                comments: [],
+                reviews: [],
+                checks: [],
+                commits: [],
+              },
+            });
+            return;
+          }
+          setTimeout(tick, 20);
+        };
+        tick();
+      });
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await expect(page.getByText("Slow merge PR")).toBeVisible();
+    await page.getByText("Slow merge PR").click({ button: "right" });
+    await page.getByRole("menuitem", { name: /^Merge…$/ }).click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __prDetailCalls?: unknown[] })
+              .__prDetailCalls?.length ?? 0,
+        ),
+      )
+      .toBe(1);
+    const dialog = page.locator('[role="dialog"]').filter({
+      has: page.getByRole("heading", { name: "Merge #17" }),
+    });
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByLabel("Loading pull request details..."),
+    ).toBeVisible();
+
+    await page.evaluate(() => {
+      (window as unknown as { __releasePrDetail?: boolean }).__releasePrDetail =
+        true;
+    });
+    await expect(dialog.locator("input")).toHaveValue("Slow merge PR");
+    await expect(
+      dialog.getByLabel("Loading pull request details..."),
+    ).toHaveCount(0);
+  });
+
+  test("opening PR close from the context menu shows a skeleton before details load", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    await tauri.respond("list_pull_requests", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 18,
+          title: "Slow close PR",
+          state: "OPEN",
+          author: "im-ian",
+          head_branch: "feature/slow-close",
+          base_branch: "main",
+          url: "https://github.com/im-ian/acorn/pull/18",
+          updated_at: "2026-05-19T00:00:00Z",
+          is_draft: false,
+          checks: null,
+          labels: [],
+        },
+      ],
+    });
+    await tauri.handle("get_pull_request_detail", (args) => {
+      const w = window as unknown as {
+        __prDetailCalls?: unknown[];
+        __releasePrDetail?: boolean;
+      };
+      w.__prDetailCalls = w.__prDetailCalls ?? [];
+      w.__prDetailCalls.push(args);
+      return new Promise((resolve) => {
+        const tick = () => {
+          if (w.__releasePrDetail) {
+            resolve({
+              kind: "ok",
+              account: "test-account",
+              detail: {
+                number: 18,
+                title: "Slow close PR",
+                body: "Close body",
+                state: "OPEN",
+                is_draft: false,
+                author: "im-ian",
+                head_branch: "feature/slow-close",
+                base_branch: "main",
+                url: "https://github.com/im-ian/acorn/pull/18",
+                created_at: "2026-05-18T00:00:00Z",
+                updated_at: "2026-05-19T00:00:00Z",
+                merged_at: null,
+                additions: 8,
+                deletions: 1,
+                changed_files: 1,
+                mergeable: "MERGEABLE",
+                labels: [],
+                comments: [],
+                reviews: [],
+                checks: [],
+                commits: [],
+              },
+            });
+            return;
+          }
+          setTimeout(tick, 20);
+        };
+        tick();
+      });
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await expect(page.getByText("Slow close PR")).toBeVisible();
+    await page.getByText("Slow close PR").click({ button: "right" });
+    await page.getByRole("menuitem", { name: /^Close…$/ }).click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __prDetailCalls?: unknown[] })
+              .__prDetailCalls?.length ?? 0,
+        ),
+      )
+      .toBe(1);
+    const dialog = page.locator('[role="dialog"]').filter({
+      has: page.getByRole("heading", { name: "Close #18" }),
+    });
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByLabel("Loading pull request details..."),
+    ).toBeVisible();
+
+    await page.evaluate(() => {
+      (window as unknown as { __releasePrDetail?: boolean }).__releasePrDetail =
+        true;
+    });
+    await expect(dialog.getByText("Slow close PR")).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: "Close PR" }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByLabel("Loading pull request details..."),
+    ).toHaveCount(0);
   });
 
   test("hotkey $mod+Shift+S routes to Staged tab", async ({ page, tauri }) => {

--- a/tests/e2e/whats-new.spec.ts
+++ b/tests/e2e/whats-new.spec.ts
@@ -30,6 +30,48 @@ test.describe("about tab: what's new button", () => {
     ).toBeVisible();
   });
 
+  test("clicking the button opens the modal before release notes finish loading", async ({
+    page,
+  }) => {
+    let releaseFetch!: () => void;
+    const releaseFetchPromise = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    await page.route(
+      "https://api.github.com/repos/im-ian/acorn/releases/tags/v0.0.0-test",
+      async (route) => {
+        await releaseFetchPromise;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            tag_name: "v0.0.0-test",
+            body: "## Highlights\n\n- Delayed release body",
+            html_url: "https://github.com/im-ian/acorn/releases/tag/v0.0.0-test",
+            published_at: "2026-05-11T07:00:00Z",
+          }),
+        });
+      },
+    );
+
+    const modal = await openAboutTab(page);
+    await modal
+      .getByRole("button", {
+        name: new RegExp(`What's new in ${TEST_VERSION}`),
+      })
+      .click();
+
+    const dialog = page.getByRole("dialog", {
+      name: new RegExp(`What's new in Acorn ${TEST_VERSION}`),
+    });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByLabel("Loading release notes...")).toBeVisible();
+
+    releaseFetch();
+    await expect(dialog.getByText(/Delayed release body/)).toBeVisible();
+    await expect(dialog.getByLabel("Loading release notes...")).toHaveCount(0);
+  });
+
   test("clicking the button fetches release notes from GitHub and opens the modal", async ({
     page,
   }) => {
@@ -129,7 +171,7 @@ test.describe("about tab: what's new button", () => {
     ).toBeVisible();
   });
 
-  test("surfaces a network/rate-limit error inline without opening the modal", async ({
+  test("surfaces a network/rate-limit error inside the open modal", async ({
     page,
     errorTracker,
   }) => {
@@ -152,9 +194,13 @@ test.describe("about tab: what's new button", () => {
       .click();
 
     await expect(modal.getByText(/GitHub releases request failed: 403/)).toBeVisible();
-    // The dialog must not have opened on failure.
+    const dialog = page.getByRole("dialog", {
+      name: new RegExp(`What's new in Acorn ${TEST_VERSION}`),
+    });
+    await expect(dialog).toBeVisible();
     await expect(
-      page.getByRole("dialog", { name: /What's new in Acorn/ }),
-    ).toHaveCount(0);
+      dialog.getByText(/GitHub releases request failed: 403/),
+    ).toBeVisible();
+    await expect(dialog.getByLabel("Loading release notes...")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary
This PR makes slow-loading modal flows open immediately and render skeleton/error states while their data loads.

1. **Commit diff expansion** — `Code -> Commits` double-click now opens the diff modal before `commit_diff` completes, shows a skeleton, reuses cached/in-flight commit diffs, and ignores stale responses.
2. **PR row actions** — PR list/search Merge and Close actions now open their dialogs immediately, show detail-loading skeletons, and surface detail-load errors inside the dialog.
3. **Release notes** — Settings -> About current-version release notes now opens the What's New modal immediately, shows a release-notes skeleton, and keeps network errors inside the modal.
4. **Coverage** — added focused cache tests and E2E coverage for commit diff, PR Merge/Close, and release-note loading/error behavior.

## Expected impact
| Flow | Before | After |
| --- | --- | --- |
| Commit diff double-click with large changes | Modal appears only after diff data resolves | Modal opens immediately with a diff skeleton |
| PR Merge/Close from row menu | Dialog waits for PR detail fetch | Dialog opens immediately with a detail skeleton or inline error |
| Settings current release notes | Modal waits for GitHub release fetch; failures only show inline About error | Modal opens immediately with skeleton; failures show inside the modal |

## Design notes
- `rightPanelCache` now caches and dedupes commit diff requests so the list preview and expanded modal share the same in-flight fetch.
- Modal state carries request ids so late responses are dropped when the user closes a modal or opens a newer target.
- Existing detail-driven modal call sites remain compatible through optional `number`, `loading`, and `loadError` props.

## Follow-up (not in this PR)
- None.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/lib/right-panel-cache.test.ts src/lib/releases.test.ts src/components/SettingsModal.test.tsx` — 40 tests passed
- [x] `PLAYWRIGHT_PORT=1435 pnpm exec playwright test tests/e2e/right-panel.spec.ts` — 22 tests passed
- [x] `PLAYWRIGHT_PORT=1436 pnpm exec playwright test tests/e2e/whats-new.spec.ts` — 5 tests passed
- [x] `pnpm run build` passes
- [x] `git diff --check` passes

## Notes
- `pnpm run build` still emits Vite dynamic-import/chunk-size warnings, but exits successfully.
