### PR TITLE
fix(status): ignore nested peer agent transcripts

### DIFF
--- a/src-tauri/src/agent_resume.rs
+++ b/src-tauri/src/agent_resume.rs
@@ -150,6 +150,17 @@ pub fn live_transcript(session_id: uuid::Uuid) -> Option<LiveTranscript> {
     live_transcript_at(&base, session_id)
 }
 
+/// Resolve only the marker for `kind`. Status polling uses this when the
+/// current PTY tree already tells us which live provider owns the tab, so a
+/// nested peer agent from another provider cannot steal the session status.
+pub fn live_transcript_for_kind(
+    session_id: uuid::Uuid,
+    kind: AgentKind,
+) -> Option<LiveTranscript> {
+    let base = acorn_daemon::paths::data_dir().ok()?;
+    live_transcript_for_kind_at(&base, session_id, kind)
+}
+
 fn live_transcript_at(base: &Path, session_id: uuid::Uuid) -> Option<LiveTranscript> {
     let dir = session_state_dir_if_exists_at(base, session_id)
         .ok()
@@ -168,20 +179,42 @@ fn live_transcript_at(base: &Path, session_id: uuid::Uuid) -> Option<LiveTranscr
     })
     .collect::<Vec<_>>();
     markers.sort_by(|a, b| b.1.cmp(&a.1));
-    let resolve = |kind: AgentKind| -> Option<LiveTranscript> {
-        let file = match kind {
-            AgentKind::Claude => CLAUDE_ID_FILE,
-            AgentKind::Codex => CODEX_ID_FILE,
-            AgentKind::Antigravity => ANTIGRAVITY_ID_FILE,
-        };
-        let id = fs::read_to_string(dir.join(file)).ok()?.trim().to_string();
-        if id.is_empty() {
-            return None;
-        }
-        let path = locate_transcript(kind, &id)?;
-        Some(LiveTranscript { id, path, kind })
+    markers
+        .into_iter()
+        .find_map(|(kind, _)| live_transcript_for_kind_in_dir(&dir, kind))
+}
+
+fn live_transcript_for_kind_at(
+    base: &Path,
+    session_id: uuid::Uuid,
+    kind: AgentKind,
+) -> Option<LiveTranscript> {
+    let dir = session_state_dir_if_exists_at(base, session_id)
+        .ok()
+        .flatten()?;
+    live_transcript_for_kind_in_dir(&dir, kind)
+}
+
+fn live_transcript_for_kind_in_dir(dir: &Path, kind: AgentKind) -> Option<LiveTranscript> {
+    live_transcript_for_kind_in_dir_with_locator(dir, kind, &locate_transcript)
+}
+
+fn live_transcript_for_kind_in_dir_with_locator(
+    dir: &Path,
+    kind: AgentKind,
+    locate: &dyn Fn(AgentKind, &str) -> Option<PathBuf>,
+) -> Option<LiveTranscript> {
+    let file = match kind {
+        AgentKind::Claude => CLAUDE_ID_FILE,
+        AgentKind::Codex => CODEX_ID_FILE,
+        AgentKind::Antigravity => ANTIGRAVITY_ID_FILE,
     };
-    markers.into_iter().find_map(|(kind, _)| resolve(kind))
+    let id = fs::read_to_string(dir.join(file)).ok()?.trim().to_string();
+    if id.is_empty() {
+        return None;
+    }
+    let path = locate(kind, &id)?;
+    Some(LiveTranscript { id, path, kind })
 }
 
 /// Mark the current `claude.id` value as seen so the modal stops popping
@@ -668,5 +701,26 @@ mod tests {
         );
         // No fixture JSONL exists for that UUID under ~/.claude/projects.
         assert!(live_transcript_at(base.path(), sid).is_none());
+    }
+
+    #[test]
+    fn live_transcript_for_kind_reads_only_requested_provider_marker() {
+        let base = ScratchDir::new("live-for-kind");
+        let sid = uuid::Uuid::new_v4();
+        let claude_id = "11111111-1111-1111-1111-111111111111";
+        let codex_id = "22222222-2222-2222-2222-222222222222";
+        write_id(base.path(), sid, CLAUDE_ID_FILE, claude_id);
+        write_id(base.path(), sid, CODEX_ID_FILE, codex_id);
+        let dir = base.path().join(AGENT_STATE_DIR_NAME).join(sid.to_string());
+
+        let found =
+            live_transcript_for_kind_in_dir_with_locator(&dir, AgentKind::Codex, &|kind, id| {
+                Some(base.path().join(format!("{kind:?}-{id}.jsonl")))
+            })
+            .expect("codex marker resolves");
+
+        assert_eq!(found.kind, AgentKind::Codex);
+        assert_eq!(found.id, codex_id);
+        assert!(found.path.ends_with(format!("Codex-{codex_id}.jsonl")));
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::io;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -4892,12 +4892,23 @@ fn detect_session_statuses_blocking(
                     }
                 }
             });
+            let root_pid_value = root_pid.map(|(pid, _)| pid);
+            let live_agent_kind = root_pid_value.and_then(|pid| {
+                live_agent_kind_in_descendants(&sys, &children, Pid::from_u32(pid))
+            });
             // Resolve the live transcript via the persister's resume markers
             // first (covers claude/codex/antigravity run inside a shell session — JSONL
-            // is named after the agent's own UUID, not Acorn's). Fall back
-            // to the legacy Acorn-UUID-named JSONL so any direct claude
-            // session-id caller keeps working.
-            let live = parsed_id.and_then(agent_resume::live_transcript);
+            // is named after the agent's own UUID, not Acorn's). When the PTY
+            // tree already exposes a live provider, only trust that provider's
+            // marker. A nested peer agent from another provider can update its
+            // own marker while the parent agent is still the session owner.
+            let live = parsed_id.and_then(|uuid| match live_agent_kind {
+                Some(kind) => agent_resume::live_transcript_for_kind(
+                    uuid,
+                    status_agent_kind_to_resume_kind(kind),
+                ),
+                None => agent_resume::live_transcript(uuid),
+            });
             let agent_transcript_id = live.as_ref().map(|t| t.id.clone());
             let transcript = match live.as_ref() {
                 Some(t) => {
@@ -4910,15 +4921,14 @@ fn detect_session_statuses_blocking(
                     };
                     Some((t.path.clone(), kind))
                 }
-                None => todos::locate_transcript_for(&id)
-                    .ok()
-                    .flatten()
-                    .map(|p| (p, acorn_session::status::AgentKind::Claude)),
+                None if matches!(live_agent_kind, None | Some(StatusAgentKind::Claude)) => {
+                    todos::locate_transcript_for(&id)
+                        .ok()
+                        .flatten()
+                        .map(|p| (p, acorn_session::status::AgentKind::Claude))
+                }
+                None => None,
             };
-            let root_pid_value = root_pid.map(|(pid, _)| pid);
-            let live_agent_kind = root_pid_value.and_then(|pid| {
-                live_agent_kind_in_descendants(&sys, &children, Pid::from_u32(pid))
-            });
             let shell_hint = refine_shell_hint_for_unpaired_agent(
                 shell_hint,
                 transcript.is_some(),
@@ -5029,6 +5039,14 @@ fn status_agent_kind_to_provider(kind: StatusAgentKind) -> SessionAgentProvider 
     }
 }
 
+fn status_agent_kind_to_resume_kind(kind: StatusAgentKind) -> agent_resume::AgentKind {
+    match kind {
+        StatusAgentKind::Claude => agent_resume::AgentKind::Claude,
+        StatusAgentKind::Codex => agent_resume::AgentKind::Codex,
+        StatusAgentKind::Antigravity => agent_resume::AgentKind::Antigravity,
+    }
+}
+
 /// One pass over `sys.processes()` that yields parent→children adjacency.
 /// Built once per poll so the per-session BFS does not rescan the whole
 /// table for every PTY root.
@@ -5063,24 +5081,46 @@ fn live_agent_kind_in_descendants(
     children: &HashMap<Pid, Vec<Pid>>,
     root: Pid,
 ) -> Option<StatusAgentKind> {
-    let mut stack = children.get(&root).cloned().unwrap_or_default();
-    while let Some(pid) = stack.pop() {
-        if let Some(proc) = sys.process(pid) {
-            if process_basename_matches(proc, "codex") {
-                return Some(StatusAgentKind::Codex);
-            }
-            if process_basename_matches(proc, "claude") {
-                return Some(StatusAgentKind::Claude);
-            }
-            if process_basename_matches(proc, "agy")
-                || process_basename_matches(proc, "antigravity")
-                || process_basename_matches(proc, "antigravity-cli")
-            {
-                return Some(StatusAgentKind::Antigravity);
-            }
+    nearest_agent_kind_in_tree(children, root, |pid| {
+        let proc = sys.process(pid)?;
+        if process_basename_matches(proc, "codex") {
+            return Some(StatusAgentKind::Codex);
+        }
+        if process_basename_matches(proc, "claude") {
+            return Some(StatusAgentKind::Claude);
+        }
+        if process_basename_matches(proc, "agy")
+            || process_basename_matches(proc, "antigravity")
+            || process_basename_matches(proc, "antigravity-cli")
+        {
+            return Some(StatusAgentKind::Antigravity);
+        }
+        None
+    })
+}
+
+fn nearest_agent_kind_in_tree<F>(
+    children: &HashMap<Pid, Vec<Pid>>,
+    root: Pid,
+    mut kind_for_pid: F,
+) -> Option<StatusAgentKind>
+where
+    F: FnMut(Pid) -> Option<StatusAgentKind>,
+{
+    let mut queue = VecDeque::new();
+    if let Some(direct) = children.get(&root) {
+        let mut direct = direct.clone();
+        direct.sort_by_key(|pid| pid.as_u32());
+        queue.extend(direct);
+    }
+    while let Some(pid) = queue.pop_front() {
+        if let Some(kind) = kind_for_pid(pid) {
+            return Some(kind);
         }
         if let Some(kids) = children.get(&pid) {
-            stack.extend(kids.iter().copied());
+            let mut kids = kids.clone();
+            kids.sort_by_key(|pid| pid.as_u32());
+            queue.extend(kids);
         }
     }
     None
@@ -5139,6 +5179,42 @@ mod status_hint_tests {
             ),
             Some(acorn_pty::ShellHint::Running),
         );
+    }
+
+    #[test]
+    fn nearest_agent_kind_prefers_shallow_provider_over_nested_peer() {
+        let root = Pid::from_u32(1);
+        let codex = Pid::from_u32(2);
+        let wrapper = Pid::from_u32(3);
+        let nested_claude = Pid::from_u32(4);
+        let mut children = HashMap::new();
+        children.insert(root, vec![wrapper, codex]);
+        children.insert(wrapper, vec![nested_claude]);
+
+        let kind = nearest_agent_kind_in_tree(&children, root, |pid| {
+            if pid == codex {
+                Some(StatusAgentKind::Codex)
+            } else if pid == nested_claude {
+                Some(StatusAgentKind::Claude)
+            } else {
+                None
+            }
+        });
+
+        assert_eq!(kind, Some(StatusAgentKind::Codex));
+    }
+
+    #[test]
+    fn has_live_descendant_tracks_root_subtree_liveness() {
+        let root = Pid::from_u32(1);
+        let child = Pid::from_u32(2);
+        let grandchild = Pid::from_u32(3);
+        let mut children = HashMap::new();
+        children.insert(root, vec![child]);
+        children.insert(child, vec![grandchild]);
+
+        assert!(has_live_descendant(&children, root));
+        assert!(!has_live_descendant(&children, grandchild));
     }
 }
 


### PR DESCRIPTION
## Summary
Tighten terminal status detection so nested peer agents do not overwrite the parent session's live status.

1. **Provider-scoped transcript resolution** — when status polling sees a live Claude/Codex/Antigravity process under the PTY, it now resolves only that provider's transcript marker instead of whichever provider marker was most recently written.
2. **Stable live-provider selection** — provider detection now walks the PTY process tree breadth-first and chooses the nearest agent process deterministically, so a nested peer process is less likely to win over the parent agent.
3. **Focused regression coverage** — added Rust unit coverage for provider-specific marker lookup, nearest-provider selection, and the shell subtree liveness contract.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal status with nested peer agents | A peer agent transcript could drive the parent tab's Running / Needs input state | Status follows the live provider closest to the PTY root |
| Provider badge selection | Multiple descendants could be order-dependent | Nearest live agent is selected deterministically |
| Ordinary single-agent terminals | Existing transcript + shell hint flow | Unchanged |

## Design notes
- This keeps status scoped to one Acorn session. It does not add per-peer status aggregation for several nested agents inside one terminal.
- The legacy Claude UUID fallback remains available only when no live provider is known or when the live provider is Claude, so stale Claude fallbacks do not classify live Codex/Antigravity sessions.
- The existing shell liveness test documents that a root with any live child chain counts as active; this avoids churn around recursing a boolean that is already true when the subtree is non-empty.

## Follow-up (not in this PR)
- Representing each coworked AI as its own Acorn session, or adding an explicit aggregate multi-agent status, would be a larger product/architecture change.

## Test plan
- [x] `pnpm run build:sidecar` — sidecars staged for this worktree
- [x] `cargo test --manifest-path src-tauri/Cargo.toml status_hint_tests` — 5 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml agent_resume::tests` — 11 passed
- [x] `git diff --check` — passed

## Notes
- No unrelated local files were included.
