### PR TITLE
fix(sessions): correct background session actions

### DIFF
--- a/src/components/BackgroundSessionsSettings.tsx
+++ b/src/components/BackgroundSessionsSettings.tsx
@@ -1,6 +1,7 @@
 import {
   Activity,
   AlertCircle,
+  ExternalLink,
   Power,
   RefreshCcw,
   Loader2,
@@ -360,6 +361,7 @@ function SessionsList({
   const [rowError, setRowError] = useState<string | null>(null);
   const showToast = useToasts((s) => s.show);
   const refreshAll = useAppStore((s) => s.refreshAll);
+  const pollSessionStatuses = useAppStore((s) => s.pollSessionStatuses);
   const selectSession = useAppStore((s) => s.selectSession);
   const appById = useMemo(() => {
     const m = new Map<string, Session>();
@@ -367,14 +369,28 @@ function SessionsList({
     return m;
   }, [appSessions]);
 
-  const runRowAction = useCallback(
-    async (id: string, fn: () => Promise<void>, successMessage: string) => {
+  const killSessionPty = useCallback(
+    async (daemonSession: DaemonSessionSummary) => {
+      const appSession = appById.get(daemonSession.id);
+      const id = daemonSession.id;
       setRowBusy(id);
       setRowError(null);
       try {
-        await fn();
+        await api.daemonKillSession(id);
+        const stopped = await waitForDaemonSessionToStop(id);
         await onRefresh();
-        showToast(successMessage);
+        const stoppedAfterRefresh =
+          stopped || !(await isDaemonSessionAlive(id));
+        if (appSession) {
+          await refreshAll();
+          await pollSessionStatuses([id]);
+        }
+        if (!stoppedAfterRefresh) {
+          throw new Error(
+            t("backgroundSessions.toasts.sessionKillStillRunning"),
+          );
+        }
+        showToast(t("backgroundSessions.toasts.sessionKilled"));
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         setRowError(message);
@@ -385,16 +401,17 @@ function SessionsList({
         setRowBusy(null);
       }
     },
-    [onRefresh, showToast, t],
+    [appById, onRefresh, pollSessionStatuses, refreshAll, showToast, t],
   );
 
-  const restoreSessionToTab = useCallback(
+  const openOrRestoreSession = useCallback(
     async (daemonSession: DaemonSessionSummary) => {
       const appSession = appById.get(daemonSession.id);
+      const restore = !appSession;
       setRowBusy(daemonSession.id);
       setRowError(null);
       try {
-        if (!appSession) {
+        if (restore) {
           await api.daemonAdoptSession(daemonSession.id);
         }
         await refreshAll();
@@ -409,7 +426,13 @@ function SessionsList({
           });
         }
         await onRefresh();
-        showToast(t("backgroundSessions.toasts.sessionRestored"));
+        showToast(
+          t(
+            restore
+              ? "backgroundSessions.toasts.sessionRestored"
+              : "backgroundSessions.toasts.sessionOpened",
+          ),
+        );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         setRowError(message);
@@ -518,10 +541,14 @@ function SessionsList({
                 >
                   <RowButton
                     busy={busy}
-                    onClick={() => void restoreSessionToTab(s)}
-                    aria-label={t("backgroundSessions.actions.restore")}
+                    onClick={() => void openOrRestoreSession(s)}
+                    aria-label={t(
+                      app
+                        ? "backgroundSessions.actions.open"
+                        : "backgroundSessions.actions.restore",
+                    )}
                   >
-                    <Undo2 size={12} />
+                    {app ? <ExternalLink size={12} /> : <Undo2 size={12} />}
                   </RowButton>
                 </Tooltip>
                 {s.alive ? (
@@ -531,13 +558,7 @@ function SessionsList({
                   >
                     <RowButton
                       busy={busy}
-                      onClick={() =>
-                        void runRowAction(
-                          s.id,
-                          () => api.daemonKillSession(s.id),
-                          t("backgroundSessions.toasts.sessionKilled"),
-                        )
-                      }
+                      onClick={() => void killSessionPty(s)}
                       tone="danger"
                       aria-label={t("backgroundSessions.actions.killPty")}
                     >
@@ -558,6 +579,24 @@ function SessionsList({
       ) : null}
     </div>
   );
+}
+
+async function waitForDaemonSessionToStop(id: string): Promise<boolean> {
+  const delays = [0, 100, 150, 250, 500, 750, 1_000];
+  for (const delay of delays) {
+    if (delay > 0) await sleep(delay);
+    if (!(await isDaemonSessionAlive(id))) return true;
+  }
+  return false;
+}
+
+async function isDaemonSessionAlive(id: string): Promise<boolean> {
+  const sessions = await api.daemonListSessions();
+  return sessions.some((session) => session.id === id && session.alive);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
 function formatRelativeTime(timestampMs: number, ago: string): string {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1708,6 +1708,7 @@
     },
     "actions": {
       "killPty": "Kill PTY",
+      "open": "Open session",
       "openTooltip": "Open this session in its project tab",
       "restoreTooltip": "Adopt this session back into Acorn's sidebar",
       "restore": "Restore session",
@@ -1736,6 +1737,8 @@
       "shutdown": "Daemon shut down.",
       "shutdownFailed": "Failed to quit daemon:",
       "sessionKilled": "PTY killed.",
+      "sessionKillStillRunning": "PTY is still running after the kill request.",
+      "sessionOpened": "Session opened.",
       "sessionRestored": "Session restored.",
       "sessionForgotten": "Session removed from daemon list.",
       "inactiveCleared": "Inactive daemon sessions cleared.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1708,6 +1708,7 @@
     },
     "actions": {
       "killPty": "PTY 종료",
+      "open": "세션 열기",
       "openTooltip": "이 세션을 원래 프로젝트 탭에서 열기",
       "restoreTooltip": "이 세션을 Acorn 사이드바로 다시 가져오기",
       "restore": "세션 복원",
@@ -1736,6 +1737,8 @@
       "shutdown": "데몬을 종료했습니다.",
       "shutdownFailed": "데몬을 종료하지 못했습니다:",
       "sessionKilled": "PTY를 종료했습니다.",
+      "sessionKillStillRunning": "PTY 종료 요청 후에도 세션이 계속 실행 중입니다.",
+      "sessionOpened": "세션을 열었습니다.",
       "sessionRestored": "세션을 복원했습니다.",
       "sessionForgotten": "세션을 데몬 목록에서 제거했습니다.",
       "inactiveCleared": "비활성 데몬 세션을 정리했습니다.",

--- a/tests/e2e/background-sessions.spec.ts
+++ b/tests/e2e/background-sessions.spec.ts
@@ -68,14 +68,29 @@ test.describe("background sessions settings", () => {
         agent_kind: null,
       },
     ]);
+    await tauri.handle("daemon_adopt_session", (args) => {
+      const w = window as unknown as { __adoptCalls?: unknown[] };
+      w.__adoptCalls = w.__adoptCalls ?? [];
+      w.__adoptCalls.push(args);
+      return undefined;
+    });
 
     const modal = await openSessionsSettings(page);
 
     await expect(modal.getByText("alpha", { exact: true })).toBeVisible();
     await expect(modal.getByText("s-1", { exact: true })).toHaveCount(0);
     await expect(
-      modal.getByRole("button", { name: "Restore session" }),
+      modal.getByRole("button", { name: "Open session" }),
     ).toBeVisible();
+    await expect(
+      modal.getByRole("button", { name: "Restore session" }),
+    ).toHaveCount(0);
+    await modal.getByRole("button", { name: "Open session" }).click();
+    const adoptCalls = (await page.evaluate(
+      () =>
+        (window as unknown as { __adoptCalls?: unknown[] }).__adoptCalls ?? [],
+    )) as unknown[];
+    expect(adoptCalls).toEqual([]);
 
     await modal.getByText("alpha", { exact: true }).hover();
     const tooltip = page.getByRole("tooltip");
@@ -90,6 +105,126 @@ test.describe("background sessions settings", () => {
     await expect(tooltip).toContainText("Worktree");
     await expect(tooltip).toContainText("/tmp/demo");
     await expect(tooltip.locator("svg")).toHaveCount(5);
+  });
+
+  test("kill pty uses the daemon kill path and polls app status", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __ptyKilled?: boolean;
+        __listSessionsAfterKill?: number;
+      };
+      if (w.__ptyKilled) {
+        w.__listSessionsAfterKill = (w.__listSessionsAfterKill ?? 0) + 1;
+      }
+      return [
+        {
+          id: "s-1",
+          name: "alpha",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          status: "running",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:05Z",
+          last_message: null,
+          title_source: "manual",
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+          agent_provider: null,
+        },
+      ];
+    });
+    await tauri.respond("daemon_status", DAEMON_RUNNING);
+    await tauri.handle("daemon_list_sessions", () => {
+      const row = {
+        id: "s-1",
+        name: "alpha",
+        kind: "regular",
+        alive: true,
+        cwd: "/tmp/demo",
+        repo_path: "/tmp/demo",
+        branch: "main",
+        agent_kind: null,
+      };
+      const w = window as unknown as {
+        __ptyKilled?: boolean;
+        __daemonPollsAfterKill?: number;
+      };
+      if (!w.__ptyKilled) return [row];
+      w.__daemonPollsAfterKill = (w.__daemonPollsAfterKill ?? 0) + 1;
+      return w.__daemonPollsAfterKill >= 2 ? [] : [row];
+    });
+    await tauri.handle("daemon_kill_session", (args) => {
+      const w = window as unknown as {
+        __daemonKillCalls?: unknown[];
+        __ptyKilled?: boolean;
+      };
+      w.__daemonKillCalls = w.__daemonKillCalls ?? [];
+      w.__daemonKillCalls.push(args);
+      w.__ptyKilled = true;
+      return undefined;
+    });
+    await tauri.handle("detect_session_statuses", (args) => {
+      const w = window as unknown as { __statusPollCalls?: unknown[] };
+      w.__statusPollCalls = w.__statusPollCalls ?? [];
+      w.__statusPollCalls.push(args);
+      return [
+        {
+          id: "s-1",
+          status: "idle",
+          branch: "main",
+          agent_provider: null,
+          agent_transcript_id: null,
+          auto_title_enabled: null,
+        },
+      ];
+    });
+
+    const modal = await openSessionsSettings(page);
+    await expect(modal.getByText("alpha", { exact: true })).toBeVisible();
+    await page.evaluate(() => {
+      (window as unknown as { __statusPollCalls?: unknown[] }).__statusPollCalls =
+        [];
+    });
+
+    await modal.getByRole("button", { name: "Kill PTY" }).click();
+
+    await expect(
+      modal.getByText("No live sessions tracked.", { exact: true }),
+    ).toBeVisible();
+    const daemonKillCalls = (await page.evaluate(
+      () =>
+        (window as unknown as { __daemonKillCalls?: unknown[] })
+          .__daemonKillCalls ?? [],
+    )) as Array<{ targetSessionId: string }>;
+    expect(daemonKillCalls).toEqual([{ targetSessionId: "s-1" }]);
+    const statusPollCalls = (await page.evaluate(
+      () =>
+        (window as unknown as { __statusPollCalls?: unknown[] })
+          .__statusPollCalls ?? [],
+    )) as Array<{ ids: string[] }>;
+    expect(statusPollCalls).toContainEqual({ ids: ["s-1"] });
+    await expect(
+      page
+        .locator('[data-panel-id="sidebar"]')
+        .getByRole("button", { name: /^alpha main · Idle/ }),
+    ).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __listSessionsAfterKill?: number })
+              .__listSessionsAfterKill ?? 0,
+        ),
+      )
+      .toBeGreaterThan(0);
   });
 
   test("restore adopts an orphaned daemon session and opens its project tab", async ({


### PR DESCRIPTION
## Summary
Settings > Sessions now distinguishes app-owned daemon sessions from orphaned daemon sessions and waits for daemon-backed PTY termination to settle before reporting success.

1. **Open vs restore affordance** — app-known daemon sessions now show an Open action/icon and skip daemon adoption; orphaned daemon sessions keep the Restore action.
2. **PTY kill refresh flow** — row-level PTY termination now waits for the daemon row to disappear, refreshes the daemon panel, and polls the app session status so Sidebar/StatusBar stop showing stale running state.
3. **Regression coverage** — E2E coverage now locks the open-vs-restore split and verifies kill routes through `daemon_kill_session`, removes the daemon row, and updates app-visible status.

## Expected impact
| Area | Impact |
| --- | --- |
| Settings > Sessions | Existing Acorn sessions no longer appear recoverable; only orphaned daemon sessions show Restore. |
| Background session termination | Success feedback lines up with daemon/app state instead of showing a toast while the row/status remains stale. |

## Design notes
- The Settings list remains on `daemon_kill_session` rather than `pty_kill` so attached terminal streams can still receive their daemon exit frame.
- The post-kill wait uses daemon session listing as the source of truth, with a final check after refresh to avoid reporting failure if the row disappears at the boundary.
- App-side session status is refreshed through the existing store status poll instead of introducing a new backend command.

## Test plan
- [x] `git diff --check origin/main...HEAD`
- [x] `pnpm run typecheck`
- [x] `PLAYWRIGHT_PORT=1439 pnpm exec playwright test tests/e2e/background-sessions.spec.ts`
- [x] `pnpm run build`

## Notes
- `PLAYWRIGHT_PORT=1439` was used because port 1420 was already serving another local Acorn worktree.
- `pnpm run build` still emits the existing Vite dynamic/static import and large chunk warnings, then completes successfully.
