### PR TITLE
refactor(ui): floating-card primitive migration

### DIFF
--- a/src/components/BackgroundSessionsSettings.tsx
+++ b/src/components/BackgroundSessionsSettings.tsx
@@ -30,7 +30,7 @@ import { useAppStore } from "../store";
 import type { Session } from "../lib/types";
 import { useToasts } from "../lib/toasts";
 import { Tooltip } from "./Tooltip";
-import { CheckboxRow, Field } from "./ui";
+import { Button, CheckboxRow, CodeValue, Field, Notice } from "./ui";
 
 type BackgroundSessionsTranslator = Translator;
 
@@ -226,14 +226,20 @@ export function BackgroundSessionsSettings() {
           {status?.log_path ? (
             <div className="mt-2 text-fg-muted">
               {t("backgroundSessions.status.log")}:{" "}
-              <code className="font-mono">{status.log_path}</code>
+              <CodeValue display="inline" surface="muted" tone="muted">
+                {status.log_path}
+              </CodeValue>
             </div>
           ) : null}
           {statusError ? (
-            <div className="mt-2 flex items-start gap-1 text-danger">
-              <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+            <Notice
+              tone="danger"
+              density="compact"
+              className="mt-2"
+              icon={<AlertTriangle size={12} />}
+            >
               <span className="font-mono">{statusError}</span>
-            </div>
+            </Notice>
           ) : null}
         </div>
       </Field>
@@ -283,31 +289,35 @@ export function BackgroundSessionsSettings() {
             </button>
           </Tooltip>
           {confirmShutdown ? (
-            <div className="flex items-center gap-2 rounded-md border border-danger/40 bg-danger/10 px-2 py-1 text-xs text-danger">
+            <Notice
+              tone="danger"
+              density="compact"
+              className="flex items-center gap-2"
+            >
               <span>
                 {t("backgroundSessions.controls.confirmShutdownPrompt")}
               </span>
-              <button
-                type="button"
+              <Button
                 onClick={() => void handleShutdown()}
                 disabled={busy !== null}
-                className="rounded-md bg-danger px-2 py-0.5 font-medium text-bg disabled:opacity-50"
+                variant="danger"
+                size="xs"
               >
                 {busy === "shutdown" ? (
                   <Loader2 size={10} className="animate-spin" />
                 ) : (
                   t("backgroundSessions.controls.confirm")
                 )}
-              </button>
-              <button
-                type="button"
+              </Button>
+              <Button
                 onClick={() => setConfirmShutdown(false)}
                 disabled={busy !== null}
-                className="px-2 py-0.5 hover:text-fg"
+                variant="ghost"
+                size="xs"
               >
                 {t("backgroundSessions.controls.cancel")}
-              </button>
-            </div>
+              </Button>
+            </Notice>
           ) : (
             <button
               type="button"
@@ -723,10 +733,13 @@ function renderAppMetaTooltip(
         valueClassName="break-all font-mono text-fg-muted"
       />
       {!app ? (
-        <div className="flex items-center gap-1.5 rounded-md border border-warning/30 bg-warning/10 px-1.5 py-1 text-[10px] leading-none text-warning">
-          <AlertCircle size={11} aria-hidden="true" className="shrink-0" />
+        <Notice
+          tone="warning"
+          density="compact"
+          icon={<AlertCircle size={11} aria-hidden="true" />}
+        >
           {t("backgroundSessions.metadata.orphaned")}
-        </div>
+        </Notice>
       ) : null}
       {rows.map((r) => (
         <BackgroundSessionTooltipRow

--- a/src/components/DeleteCommentDialog.tsx
+++ b/src/components/DeleteCommentDialog.tsx
@@ -3,7 +3,7 @@ import { AlertTriangle, Trash2 } from "lucide-react";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useTranslation } from "../lib/useTranslation";
-import { Button, Modal, ModalFooter, ModalHeader } from "./ui";
+import { Button, Modal, ModalFooter, ModalHeader, Notice } from "./ui";
 
 type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
 
@@ -70,9 +70,9 @@ export function DeleteCommentDialog({
       <div className="space-y-2 px-4 py-3 text-xs leading-relaxed text-fg-muted">
         <p>{dt(t, "dialogs.githubComment.deleteMessage")}</p>
         {error ? (
-          <p className="rounded-md border border-danger/30 bg-danger/10 px-3 py-2 text-danger">
+          <Notice tone="danger" density="compact">
             {dt(t, "dialogs.githubComment.deleteFailed")} {error}
-          </p>
+          </Notice>
         ) : null}
       </div>
       <ModalFooter variant="sidebar">

--- a/src/components/GitHubCommentComposer.tsx
+++ b/src/components/GitHubCommentComposer.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Eye, PencilLine, SendHorizontal } from "lucide-react";
 import { cn } from "../lib/cn";
-import { Markdown } from "./ui";
+import { Button, Markdown, SegmentedControl } from "./ui";
 
 interface GitHubCommentComposerProps {
   body: string;
@@ -63,34 +63,16 @@ export function GitHubCommentComposer({
       )}
     >
       <div className="mb-1.5 inline-flex rounded-md border border-border bg-bg p-0.5">
-        <button
-          type="button"
-          aria-pressed={mode === "write"}
-          onClick={() => setMode("write")}
-          className={cn(
-            "inline-flex items-center gap-1 rounded px-2 py-1 text-[10.5px] font-medium transition",
-            mode === "write"
-              ? "bg-bg-elevated text-fg"
-              : "text-fg-muted hover:bg-bg-elevated/60 hover:text-fg",
-          )}
-        >
-          <PencilLine size={11} />
-          {writeLabel}
-        </button>
-        <button
-          type="button"
-          aria-pressed={mode === "preview"}
-          onClick={() => setMode("preview")}
-          className={cn(
-            "inline-flex items-center gap-1 rounded px-2 py-1 text-[10.5px] font-medium transition",
-            mode === "preview"
-              ? "bg-bg-elevated text-fg"
-              : "text-fg-muted hover:bg-bg-elevated/60 hover:text-fg",
-          )}
-        >
-          <Eye size={11} />
-          {previewLabel}
-        </button>
+        <SegmentedControl
+          size="xs"
+          surface="subtle"
+          activeId={mode}
+          onChange={setMode}
+          items={[
+            { id: "write", label: writeLabel, icon: <PencilLine size={11} /> },
+            { id: "preview", label: previewLabel, icon: <Eye size={11} /> },
+          ]}
+        />
       </div>
       {mode === "write" ? (
         <textarea
@@ -123,15 +105,15 @@ export function GitHubCommentComposer({
         <div className="min-w-0 text-[10.5px] text-danger">
           {error ? `${errorPrefix} ${error}` : null}
         </div>
-        <button
-          type="button"
+        <Button
           onClick={() => void handleSubmit()}
           disabled={!canSubmit}
-          className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-accent/20 px-2.5 py-1 text-[11px] font-medium text-accent transition hover:bg-accent/30 disabled:cursor-not-allowed disabled:bg-bg-elevated disabled:text-fg-muted disabled:opacity-70"
+          variant="accentSoft"
+          size="xs"
         >
           <SendHorizontal size={12} />
           {submitting ? submittingLabel : submitLabel}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/GitHubCommentEditForm.tsx
+++ b/src/components/GitHubCommentEditForm.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { Eye, PencilLine, Save, X } from "lucide-react";
-import { cn } from "../lib/cn";
-import { Button, Markdown } from "./ui";
+import { Button, Markdown, SegmentedControl } from "./ui";
 
 interface GitHubCommentEditFormProps {
   initialBody: string;
@@ -55,34 +54,16 @@ export function GitHubCommentEditForm({
   return (
     <div className="space-y-2">
       <div className="inline-flex rounded-md border border-border bg-bg p-0.5">
-        <button
-          type="button"
-          aria-pressed={mode === "write"}
-          onClick={() => setMode("write")}
-          className={cn(
-            "inline-flex items-center gap-1 rounded px-2 py-1 text-[10.5px] font-medium transition",
-            mode === "write"
-              ? "bg-bg-elevated text-fg"
-              : "text-fg-muted hover:bg-bg-elevated/60 hover:text-fg",
-          )}
-        >
-          <PencilLine size={11} />
-          {writeLabel}
-        </button>
-        <button
-          type="button"
-          aria-pressed={mode === "preview"}
-          onClick={() => setMode("preview")}
-          className={cn(
-            "inline-flex items-center gap-1 rounded px-2 py-1 text-[10.5px] font-medium transition",
-            mode === "preview"
-              ? "bg-bg-elevated text-fg"
-              : "text-fg-muted hover:bg-bg-elevated/60 hover:text-fg",
-          )}
-        >
-          <Eye size={11} />
-          {previewLabel}
-        </button>
+        <SegmentedControl
+          size="xs"
+          surface="subtle"
+          activeId={mode}
+          onChange={setMode}
+          items={[
+            { id: "write", label: writeLabel, icon: <PencilLine size={11} /> },
+            { id: "preview", label: previewLabel, icon: <Eye size={11} /> },
+          ]}
+        />
       </div>
       {mode === "write" ? (
         <textarea

--- a/src/components/IssueDetailModal.tsx
+++ b/src/components/IssueDetailModal.tsx
@@ -29,6 +29,7 @@ import { GitHubCommentComposer } from "./GitHubCommentComposer";
 import { GitHubLabelChip } from "./GitHubLabelChip";
 import { Tooltip } from "./Tooltip";
 import {
+  CodeValue,
   Markdown,
   Modal,
   ModalHeader,
@@ -221,7 +222,7 @@ export function IssueDetailModal({
             >
               <div className="p-4 text-xs text-fg-muted">
                 {dt(t, "dialogs.issueDetail.noAccessPrefix")}{" "}
-                <code className="font-mono">gh</code>{" "}
+                <CodeValue display="inline">gh</CodeValue>{" "}
                 {dt(t, "dialogs.issueDetail.noAccessSuffix")} {listing.slug}.
               </div>
             </IssueModalShell>

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -52,6 +52,7 @@ import { GitHubLabelChip } from "./GitHubLabelChip";
 import { MergePullRequestDialog } from "./MergePullRequestDialog";
 import { Tooltip } from "./Tooltip";
 import {
+  CodeValue,
   ListBox,
   ListEmptyState,
   ListRow,
@@ -360,7 +361,7 @@ export function PullRequestDetailModal({
           <ModalShell title={`#${open.number}`} onClose={requestClose}>
             <div className="p-4 text-xs text-fg-muted">
               {dt(t, "dialogs.pullRequestDetail.noAccessPrefix")}{" "}
-              <code className="font-mono">gh</code>{" "}
+              <CodeValue display="inline">gh</CodeValue>{" "}
               {dt(t, "dialogs.pullRequestDetail.noAccessSuffix")}{" "}
               {listing.slug}.
             </div>

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -108,12 +108,15 @@ import { PullRequestDetailModal } from "./PullRequestDetailModal";
 import { ResizeHandle } from "./ResizeHandle";
 import { Tooltip } from "./Tooltip";
 import {
+  Button,
+  CodeValue,
   CommandHint,
   ListActionRow,
   ListBox,
   ListEmptyState,
   ListRow,
   Modal,
+  ModalFooter,
   ModalHeader,
   RefreshButton,
   Select,
@@ -121,10 +124,12 @@ import {
   SkeletonCircle,
   SkeletonList,
   SkeletonText,
+  StatusDot,
   TextInput,
   listBoxClassName,
   listRowClassName,
   type ListRowDensity,
+  type StatusTone,
 } from "./ui";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
@@ -1383,11 +1388,10 @@ function ActivityRow({
         onClick={openSession}
         className="flex min-w-0 flex-1 items-start gap-2 text-left"
       >
-        <span
-          className={cn(
-            "mt-1 h-1.5 w-1.5 shrink-0 rounded-full",
-            activityDotClass(notification.kind),
-          )}
+        <StatusDot
+          tone={activityDotTone(notification.kind)}
+          size="sm"
+          className="mt-1"
         />
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-center gap-2">
@@ -1427,10 +1431,10 @@ function ActivityRow({
   );
 }
 
-function activityDotClass(kind: SessionNotificationKind): string {
-  if (kind === "failed") return "bg-danger";
-  if (kind === "completed") return "bg-accent";
-  return "bg-warning";
+function activityDotTone(kind: SessionNotificationKind): StatusTone {
+  if (kind === "failed") return "danger";
+  if (kind === "completed") return "accent";
+  return "warning";
 }
 
 function formatActivityTime(value: string): string {
@@ -1878,20 +1882,21 @@ function AgentHistoryTab({
             })}
           </p>
           {worktreeNotice ? (
-            <div className="rounded border border-border bg-bg-sidebar px-3 py-2 font-mono text-[11px] text-fg-muted">
+            <CodeValue surface="muted" tone="muted" overflow="wrap">
               {worktreeNotice.path}
-            </div>
+            </CodeValue>
           ) : null}
-          <div className="flex justify-end">
-            <button
-              type="button"
-              className="rounded border border-border bg-bg-elevated px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
-              onClick={() => setWorktreeNotice(null)}
-            >
-              {rt(t, "rightPanel.history.worktreeRunConfirm")}
-            </button>
-          </div>
         </div>
+        <ModalFooter variant="sidebar">
+          <Button
+            onClick={() => setWorktreeNotice(null)}
+            variant="neutral"
+            size="md"
+            surface="dialog"
+          >
+            {rt(t, "rightPanel.history.worktreeRunConfirm")}
+          </Button>
+        </ModalFooter>
       </Modal>
       <Modal
         open={trashCandidate !== null}
@@ -1911,31 +1916,32 @@ function AgentHistoryTab({
             {rt(t, "rightPanel.history.trashTranscriptBody")}
           </p>
           {trashCandidate ? (
-            <div className="rounded border border-border bg-bg-sidebar px-3 py-2 font-mono text-[11px] text-fg-muted">
+            <CodeValue surface="muted" tone="muted" overflow="wrap">
               {trashCandidate.transcript_path}
-            </div>
+            </CodeValue>
           ) : null}
-          <div className="flex justify-end gap-2">
-            <button
-              type="button"
-              className="rounded border border-border bg-bg-elevated px-3 py-1.5 text-xs text-fg transition hover:bg-bg-sidebar"
-              onClick={() => setTrashCandidate(null)}
-            >
-              {rt(t, "rightPanel.history.trashTranscriptCancel")}
-            </button>
-            <button
-              type="button"
-              className="rounded border border-danger/50 bg-danger/10 px-3 py-1.5 text-xs text-danger transition hover:bg-danger/15"
-              onClick={() =>
-                trashCandidate
-                  ? void moveTranscriptToTrash(trashCandidate)
-                  : undefined
-              }
-            >
-              {rt(t, "rightPanel.history.trashTranscriptConfirm")}
-            </button>
-          </div>
         </div>
+        <ModalFooter variant="sidebar">
+          <Button
+            onClick={() => setTrashCandidate(null)}
+            size="md"
+            surface="dialog"
+          >
+            {rt(t, "rightPanel.history.trashTranscriptCancel")}
+          </Button>
+          <Button
+            onClick={() =>
+              trashCandidate
+                ? void moveTranscriptToTrash(trashCandidate)
+                : undefined
+            }
+            variant="dangerSoft"
+            size="md"
+            surface="dialog"
+          >
+            {rt(t, "rightPanel.history.trashTranscriptConfirm")}
+          </Button>
+        </ModalFooter>
       </Modal>
     </div>
   );

--- a/src/components/RunningSessionCloseWarningDialog.tsx
+++ b/src/components/RunningSessionCloseWarningDialog.tsx
@@ -5,7 +5,7 @@ import type { TranslationKey, Translator } from "../lib/i18n";
 import { useSettings } from "../lib/settings";
 import type { Session } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
-import { Button, Modal, ModalFooter, ModalHeader } from "./ui";
+import { Button, Modal, ModalFooter, ModalHeader, Notice } from "./ui";
 
 type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
 
@@ -65,14 +65,14 @@ export function RunningSessionCloseWarningDialog({
           />
           <div className="space-y-3 px-4 py-3 text-sm text-fg">
             <p>{dt(t, "dialogs.runningSessionClose.message")}</p>
-            <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2">
+            <Notice tone="warning">
               <div className="text-[11px] uppercase tracking-wide text-fg-muted">
                 {dt(t, "dialogs.runningSessionClose.sessionLabel")}
               </div>
               <div className="mt-1 truncate font-mono text-xs text-accent">
                 {session.name}
               </div>
-            </div>
+            </Notice>
             <label className="flex cursor-pointer items-center gap-2 pt-1 text-xs text-fg-muted">
               <input
                 type="checkbox"

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -2411,33 +2411,33 @@ function StorageSettings() {
       </ul>
 
       {confirming ? (
-        <div className="space-y-2 rounded-[var(--acorn-pane-radius)] border border-warning/40 bg-warning/10 p-3">
+        <Notice tone="warning" className="space-y-2">
           <p className="text-[11px] text-fg">
             {stf(t, "settings.storage.confirm.message", {
               size: formatBytes(totalBytes),
             })}
           </p>
           <div className="flex justify-end gap-2">
-            <button
-              type="button"
+            <Button
               onClick={() => setConfirming(false)}
               disabled={busy}
-              className="rounded border border-border px-2 py-1 text-[11px] text-fg-muted transition hover:text-fg disabled:opacity-50"
+              variant="ghost"
+              size="xs"
             >
               {st(t, "settings.storage.confirm.cancel")}
-            </button>
-            <button
-              type="button"
+            </Button>
+            <Button
               onClick={() => void handleClear()}
               disabled={busy}
-              className="rounded bg-danger px-2 py-1 text-[11px] font-medium text-white transition hover:bg-danger/90 disabled:opacity-50"
+              variant="danger"
+              size="xs"
             >
               {busy
                 ? st(t, "settings.storage.clear.clearing")
                 : st(t, "settings.storage.clear.button")}
-            </button>
+            </Button>
           </div>
-        </div>
+        </Notice>
       ) : (
         <div className="flex items-center justify-between gap-3">
           <span className="text-[11px] text-fg-muted">

--- a/src/components/chat/ChatCodeBlock.tsx
+++ b/src/components/chat/ChatCodeBlock.tsx
@@ -6,6 +6,7 @@ import { highlightCode, langFromPath } from "../../lib/highlight";
 import { useSettings } from "../../lib/settings";
 import { resolveThemeMode, useThemes } from "../../lib/themes";
 import { Tooltip } from "../Tooltip";
+import { IconButton } from "../ui";
 
 interface ChatCodeBlockProps {
   code: string;
@@ -162,25 +163,23 @@ export function ChatCodeBlock({
               label={expanded ? "Collapse code block" : "Expand code block"}
               side="bottom"
             >
-              <button
-                type="button"
+              <IconButton
+                size="sm"
                 aria-label={expanded ? "Collapse code block" : "Expand code block"}
-                className="inline-flex h-6 w-6 items-center justify-center rounded text-fg-muted transition hover:bg-bg hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/60"
                 onClick={() => setExpanded((value) => !value)}
               >
                 {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
-              </button>
+              </IconButton>
             </Tooltip>
           ) : null}
           <Tooltip label="Copy code" side="bottom">
-            <button
-              type="button"
+            <IconButton
+              size="sm"
               aria-label="Copy code block"
-              className="inline-flex h-6 w-6 items-center justify-center rounded text-fg-muted transition hover:bg-bg hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/60"
               onClick={() => void copyCode()}
             >
               {copied ? <Check size={13} /> : <Copy size={13} />}
-            </button>
+            </IconButton>
           </Tooltip>
         </span>
       </div>


### PR DESCRIPTION
## Summary

Follow-up to #483 (the floating-card workspace system). That PR introduced the shared UI primitives — `Button`/`IconButton`, `SegmentedControl`, `Notice`, `StatusDot`/`StatusBadge`, `CodeValue`, `ModalFooter` — and migrated most surfaces. This sweep closes the surfaces that were still hand-rolling those patterns, so the floating-card / soft-minimal language is applied consistently. Net change is a slight reduction in code.

## What changed

- **SegmentedControl + Button** — the comment composer and edit form drop their hand-rolled Write/Preview toggle for `SegmentedControl` (subtle surface inside the existing recessed track); the composer submit button becomes a `Button`.
- **IconButton** — the chat code block's expand/collapse and copy buttons use `IconButton`, matching the app-wide icon-button radius, fill, and focus ring.
- **Notice** — leftover colored callouts move onto the token-driven `Notice` primitive: the delete-comment and running-session-close dialogs, the settings storage-clear confirm, and the background-sessions shutdown-confirm / orphaned-daemon / status-error boxes.
- **ModalFooter + CodeValue** — the worktree-run and trash-transcript history modals get `ModalFooter` + `Button` footers and `CodeValue` path blocks, matching the other dialog chrome.
- **StatusDot** — the activity-row status dot uses the `StatusDot` primitive via a tone map instead of an inline `rounded-full` + bg class.
- **CodeValue** — the background-sessions log path and the inline `gh` token in the issue/PR no-access states render as `CodeValue`.

## Deliberately skipped (with reasons)

These were considered and left as-is because adopting a primitive would regress the design or change semantics:

- **ImageLightbox icon buttons** — white-on-dark over a fixed `bg-black` overlay; a theme-token `IconButton` would become invisible on light themes.
- **ToastHost pill** — a bespoke `rounded-full` toast surface with an embedded progress bar, not a `Button`-primitive shape.
- **StatusBar unread count** — a solid notification bubble; `StatusBadge` is a soft tint, a different pattern.
- **TopBar logo dot / worktree path** — the dot is a brand mark (not a status) and the path is a quiet flat header label; a bordered `CodeValue` chip would clutter the header.
- **MemoryBreakdownModal footer** — a structural info footer with no actions, distinct from the seamless action `ModalFooter`.
- **Agent-history provider colors** — Codex / Antigravity / Claude brand colors, intentionally fixed like diff add/del semantics rather than theme-shifting.
- **PR/issue inline timestamps and SHAs** — intentionally left as plain mono by the original migration; chips would regress them.
- **Tab-pill and list-row buttons across Sidebar / RightPanel / Settings** — deliberately bespoke; a blanket sweep is out of scope here.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 73 files / 760 tests passing
- [ ] e2e (`playwright`) — not run locally (needs the Tauri app); button text labels are unchanged, so text selectors are unaffected
- [ ] Manual native pass across a couple of themes (light + dark) to confirm the migrated callouts, footers, and segmented toggles read correctly
