### PR TITLE
fix(theme): clarify editable input surfaces

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,6 +21,9 @@
    */
   --color-fill: color-mix(in oklab, var(--color-fg) 6%, transparent);
   --color-fill-hover: color-mix(in oklab, var(--color-fg) 12%, transparent);
+  --color-input: var(--color-fill);
+  --color-input-hover: var(--color-fill-hover);
+  --color-input-border: color-mix(in oklab, var(--color-border) 72%, transparent);
 
   --font-sans: "Inter", "SF Pro Text", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", "SF Mono", "Menlo", monospace;

--- a/src/assets/themes/acorn-dark.css
+++ b/src/assets/themes/acorn-dark.css
@@ -2,6 +2,9 @@
   --color-bg: #1f2326;
   --color-bg-elevated: #272b2f;
   --color-bg-sidebar: #1a1d20;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #ededed;
   --color-fg-muted: oklch(64% 0.01 250);
   --color-border: #2f3338;

--- a/src/assets/themes/acorn-light-pink.css
+++ b/src/assets/themes/acorn-light-pink.css
@@ -3,6 +3,9 @@
   --color-bg: #ffffff;
   --color-bg-elevated: #f5f6f7;
   --color-bg-sidebar: #f0f1f3;
+  --color-input: color-mix(in oklab, var(--color-bg) 76%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg) 68%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #1a1d20;
   --color-fg-muted: oklch(45% 0.01 250);
   --color-border: #d8dade;

--- a/src/assets/themes/acorn-light.css
+++ b/src/assets/themes/acorn-light.css
@@ -3,6 +3,9 @@
   --color-bg: #ffffff;
   --color-bg-elevated: #f5f6f7;
   --color-bg-sidebar: #f0f1f3;
+  --color-input: color-mix(in oklab, var(--color-bg) 76%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg) 68%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #1a1d20;
   --color-fg-muted: oklch(45% 0.01 250);
   --color-border: #d8dade;

--- a/src/assets/themes/acorn-pink.css
+++ b/src/assets/themes/acorn-pink.css
@@ -2,6 +2,9 @@
   --color-bg: #1f2326;
   --color-bg-elevated: #272b2f;
   --color-bg-sidebar: #1a1d20;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #ededed;
   --color-fg-muted: oklch(64% 0.01 250);
   --color-border: #2f3338;

--- a/src/assets/themes/ayu-dark.css
+++ b/src/assets/themes/ayu-dark.css
@@ -2,6 +2,9 @@
   --color-bg: #0f1419;
   --color-bg-elevated: #1f2430;
   --color-bg-sidebar: #0b1016;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #e6e1cf;
   --color-fg-muted: #8a9199;
   --color-border: #2d3640;

--- a/src/assets/themes/catppuccin-latte.css
+++ b/src/assets/themes/catppuccin-latte.css
@@ -3,6 +3,9 @@
   --color-bg: #eff1f5;
   --color-bg-elevated: #e6e9ef;
   --color-bg-sidebar: #dce0e8;
+  --color-input: color-mix(in oklab, var(--color-bg) 76%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg) 68%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #4c4f69;
   --color-fg-muted: #6c6f85;
   --color-border: #ccd0da;

--- a/src/assets/themes/catppuccin-mocha.css
+++ b/src/assets/themes/catppuccin-mocha.css
@@ -2,6 +2,9 @@
   --color-bg: #1e1e2e;
   --color-bg-elevated: #313244;
   --color-bg-sidebar: #181825;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #cdd6f4;
   --color-fg-muted: #a6adc8;
   --color-border: #45475a;

--- a/src/assets/themes/dracula.css
+++ b/src/assets/themes/dracula.css
@@ -2,6 +2,9 @@
   --color-bg: #282a36;
   --color-bg-elevated: #343746;
   --color-bg-sidebar: #21222c;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #f8f8f2;
   --color-fg-muted: #b7bacf;
   --color-border: #44475a;

--- a/src/assets/themes/everforest-dark.css
+++ b/src/assets/themes/everforest-dark.css
@@ -2,6 +2,9 @@
   --color-bg: #2d353b;
   --color-bg-elevated: #343f44;
   --color-bg-sidebar: #232a2e;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #d3c6aa;
   --color-fg-muted: #859289;
   --color-border: #4f585e;

--- a/src/assets/themes/flexoki-dark.css
+++ b/src/assets/themes/flexoki-dark.css
@@ -2,6 +2,9 @@
   --color-bg: #100f0f;
   --color-bg-elevated: #1c1b1a;
   --color-bg-sidebar: #100f0f;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #cecdc3;
   --color-fg-muted: #878580;
   --color-border: #282726;

--- a/src/assets/themes/flexoki-light.css
+++ b/src/assets/themes/flexoki-light.css
@@ -3,6 +3,9 @@
   --color-bg: #fffcf0;
   --color-bg-elevated: #f2f0e5;
   --color-bg-sidebar: #e6e4d9;
+  --color-input: color-mix(in oklab, var(--color-bg) 76%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg) 68%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #100f0f;
   --color-fg-muted: #6f6e69;
   --color-border: #cecdc3;

--- a/src/assets/themes/github-dark.css
+++ b/src/assets/themes/github-dark.css
@@ -2,6 +2,9 @@
   --color-bg: #0d1117;
   --color-bg-elevated: #161b22;
   --color-bg-sidebar: #010409;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #e6edf3;
   --color-fg-muted: #848d97;
   --color-border: #30363d;

--- a/src/assets/themes/github-light.css
+++ b/src/assets/themes/github-light.css
@@ -3,6 +3,9 @@
   --color-bg: #ffffff;
   --color-bg-elevated: #f6f8fa;
   --color-bg-sidebar: #f0f3f6;
+  --color-input: color-mix(in oklab, var(--color-bg) 76%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg) 68%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #1f2328;
   --color-fg-muted: #59636e;
   --color-border: #d1d9e0;

--- a/src/assets/themes/gruvbox-dark.css
+++ b/src/assets/themes/gruvbox-dark.css
@@ -2,6 +2,9 @@
   --color-bg: #282828;
   --color-bg-elevated: #3c3836;
   --color-bg-sidebar: #1d2021;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #ebdbb2;
   --color-fg-muted: #a89984;
   --color-border: #504945;

--- a/src/assets/themes/gruvbox-light.css
+++ b/src/assets/themes/gruvbox-light.css
@@ -3,6 +3,9 @@
   --color-bg: #fbf1c7;
   --color-bg-elevated: #ebdbb2;
   --color-bg-sidebar: #f2e5bc;
+  --color-input: color-mix(in oklab, var(--color-bg) 76%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg) 68%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #3c3836;
   --color-fg-muted: #7c6f64;
   --color-border: #d5c4a1;

--- a/src/assets/themes/high-contrast-dark.css
+++ b/src/assets/themes/high-contrast-dark.css
@@ -2,6 +2,9 @@
   --color-bg: #0a0c10;
   --color-bg-elevated: #272b33;
   --color-bg-sidebar: #010409;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #f0f3f6;
   --color-fg-muted: #bdc4cc;
   --color-border: #7a828e;

--- a/src/assets/themes/high-contrast-light.css
+++ b/src/assets/themes/high-contrast-light.css
@@ -3,6 +3,9 @@
   --color-bg: #ffffff;
   --color-bg-elevated: #f2f4f7;
   --color-bg-sidebar: #e8edf3;
+  --color-input: color-mix(in oklab, var(--color-bg) 76%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg) 68%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #05070a;
   --color-fg-muted: #394150;
   --color-border: #5c6675;

--- a/src/assets/themes/kanagawa-wave.css
+++ b/src/assets/themes/kanagawa-wave.css
@@ -2,6 +2,9 @@
   --color-bg: #1f1f28;
   --color-bg-elevated: #2a2a37;
   --color-bg-sidebar: #181820;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #dcd7ba;
   --color-fg-muted: #727169;
   --color-border: #363646;

--- a/src/assets/themes/monokai-pro.css
+++ b/src/assets/themes/monokai-pro.css
@@ -2,6 +2,9 @@
   --color-bg: #2d2a2e;
   --color-bg-elevated: #363437;
   --color-bg-sidebar: #221f22;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #fcfcfa;
   --color-fg-muted: #939293;
   --color-border: #403e41;

--- a/src/assets/themes/nord.css
+++ b/src/assets/themes/nord.css
@@ -2,6 +2,9 @@
   --color-bg: #2e3440;
   --color-bg-elevated: #3b4252;
   --color-bg-sidebar: #242933;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #eceff4;
   --color-fg-muted: #aeb8c8;
   --color-border: #4c566a;

--- a/src/assets/themes/one-dark-pro.css
+++ b/src/assets/themes/one-dark-pro.css
@@ -2,6 +2,9 @@
   --color-bg: #282c34;
   --color-bg-elevated: #2c313a;
   --color-bg-sidebar: #21252b;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #abb2bf;
   --color-fg-muted: #6b7280;
   --color-border: #3e4451;

--- a/src/assets/themes/one-light.css
+++ b/src/assets/themes/one-light.css
@@ -3,6 +3,9 @@
   --color-bg: #fafafa;
   --color-bg-elevated: #f0f0f0;
   --color-bg-sidebar: #eaeaeb;
+  --color-input: color-mix(in oklab, var(--color-bg) 76%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg) 68%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #383a42;
   --color-fg-muted: #696c77;
   --color-border: #d7d7d9;

--- a/src/assets/themes/rose-pine.css
+++ b/src/assets/themes/rose-pine.css
@@ -2,6 +2,9 @@
   --color-bg: #191724;
   --color-bg-elevated: #26233a;
   --color-bg-sidebar: #15131e;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #e0def4;
   --color-fg-muted: #908caa;
   --color-border: #403d52;

--- a/src/assets/themes/solarized-dark.css
+++ b/src/assets/themes/solarized-dark.css
@@ -2,6 +2,9 @@
   --color-bg: #002b36;
   --color-bg-elevated: #073642;
   --color-bg-sidebar: #00212b;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #839496;
   --color-fg-muted: #586e75;
   --color-border: #073642;

--- a/src/assets/themes/solarized-light.css
+++ b/src/assets/themes/solarized-light.css
@@ -3,6 +3,9 @@
   --color-bg: #fdf6e3;
   --color-bg-elevated: #eee8d5;
   --color-bg-sidebar: #eee8d5;
+  --color-input: color-mix(in oklab, var(--color-bg) 76%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg) 68%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #586e75;
   --color-fg-muted: #93a1a1;
   --color-border: #d8d2bb;

--- a/src/assets/themes/tokyo-night.css
+++ b/src/assets/themes/tokyo-night.css
@@ -2,6 +2,9 @@
   --color-bg: #1a1b26;
   --color-bg-elevated: #1f2335;
   --color-bg-sidebar: #16161e;
+  --color-input: color-mix(in oklab, var(--color-bg-elevated) 90%, #fff);
+  --color-input-hover: color-mix(in oklab, var(--color-bg-elevated) 86%, #fff);
+  --color-input-border: color-mix(in oklab, var(--color-border) 84%, #fff);
   --color-fg: #c0caf5;
   --color-fg-muted: #565f89;
   --color-border: #2a2e44;

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -1274,7 +1274,7 @@ export function ChatPane({
                         <div className="flex min-w-0 flex-col gap-2">
                           <textarea
                             aria-label="Edit user message content"
-                            className="min-h-24 w-full min-w-[18rem] resize-y rounded border border-border bg-bg px-2 py-1.5 text-sm leading-5 text-fg outline-none focus:border-accent/70 disabled:opacity-60"
+                            className="min-h-24 w-full min-w-[18rem] resize-y rounded border border-input-border bg-input px-2 py-1.5 text-sm leading-5 text-fg outline-none focus:border-accent/70 focus:bg-input-hover disabled:opacity-60"
                             disabled={isActionBusy}
                             value={editDraft}
                             onChange={(event) => setEditDraft(event.target.value)}
@@ -1514,7 +1514,7 @@ export function ChatPane({
           </p>
         </div>
         <div
-          className={`mx-auto flex flex-col gap-2 rounded-[var(--acorn-pane-radius)] border border-border bg-bg-elevated/65 shadow-sm transition-[width,max-width,padding,box-shadow,border-color] duration-300 ease-out ${
+          className={`mx-auto flex flex-col gap-2 rounded-[var(--acorn-pane-radius)] border border-input-border bg-input shadow-sm transition-[width,max-width,padding,box-shadow,border-color,background-color] duration-300 ease-out focus-within:border-accent/60 focus-within:bg-input-hover ${
             composerIsCentered
               ? "w-[90%] max-w-none px-3 py-3 shadow-xl ring-1 ring-border/60"
               : "max-w-4xl px-2 py-2"

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -2079,7 +2079,7 @@ function EditRow({
           else if (e.key === "Escape") onCancel();
         }}
         onBlur={onCommit}
-        className="w-full bg-transparent text-[12px] text-fg outline outline-1 outline-accent/40 focus:outline-accent"
+        className="w-full rounded border border-accent/50 bg-input px-1 text-[12px] text-fg outline-none focus:border-accent focus:bg-input-hover"
       />
     </div>
   );

--- a/src/components/GitHubCommentComposer.tsx
+++ b/src/components/GitHubCommentComposer.tsx
@@ -85,7 +85,7 @@ export function GitHubCommentComposer({
           placeholder={placeholder}
           rows={3}
           disabled={submitting}
-          className="w-full resize-none rounded-md border border-border bg-bg p-2 font-mono text-[11px] leading-relaxed text-fg outline-none transition placeholder:text-fg-muted/70 focus:border-accent/60 disabled:opacity-60"
+          className="w-full resize-none rounded-md border border-input-border bg-input p-2 font-mono text-[11px] leading-relaxed text-fg outline-none transition placeholder:text-fg-muted/70 focus:border-accent/60 focus:bg-input-hover disabled:opacity-60"
         />
       ) : (
         <div

--- a/src/components/GitHubCommentEditForm.tsx
+++ b/src/components/GitHubCommentEditForm.tsx
@@ -75,7 +75,7 @@ export function GitHubCommentEditForm({
           }}
           rows={4}
           disabled={saving}
-          className="w-full resize-none rounded-md border border-border bg-bg p-2 font-mono text-[11px] leading-relaxed text-fg outline-none transition placeholder:text-fg-muted/70 focus:border-accent/60 disabled:opacity-60"
+          className="w-full resize-none rounded-md border border-input-border bg-input p-2 font-mono text-[11px] leading-relaxed text-fg outline-none transition placeholder:text-fg-muted/70 focus:border-accent/60 focus:bg-input-hover disabled:opacity-60"
         />
       ) : (
         <div

--- a/src/components/MergePullRequestDialog.tsx
+++ b/src/components/MergePullRequestDialog.tsx
@@ -436,7 +436,7 @@ export function MergePullRequestDialog({
                   onChange={(e) => setTitle(e.target.value)}
                   placeholder={dt(t, "dialogs.mergePullRequest.subjectPlaceholder")}
                   disabled={busy}
-                  className="w-full rounded-md border border-border bg-bg-sidebar/60 px-2 py-1.5 text-[11px] text-fg outline-none transition focus:border-accent/60 disabled:opacity-60"
+                  className="w-full rounded-md border border-input-border bg-input px-2 py-1.5 text-[11px] text-fg outline-none transition focus:border-accent/60 focus:bg-input-hover disabled:opacity-60"
                 />
                 <textarea
                   value={body}
@@ -444,7 +444,7 @@ export function MergePullRequestDialog({
                   placeholder={dt(t, "dialogs.mergePullRequest.bodyPlaceholder")}
                   rows={6}
                   disabled={busy}
-                  className="w-full resize-none rounded-md border border-border bg-bg-sidebar/60 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-fg outline-none transition focus:border-accent/60 disabled:opacity-60"
+                  className="w-full resize-none rounded-md border border-input-border bg-input px-2 py-1.5 font-mono text-[11px] leading-relaxed text-fg outline-none transition focus:border-accent/60 focus:bg-input-hover disabled:opacity-60"
                 />
               </div>
             ) : (

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -1754,7 +1754,7 @@ function TabRenameInput({ initial, onSubmit, onCancel }: TabRenameInputProps) {
         }
       }}
       onBlur={() => onSubmit(value.trim())}
-      className="w-32 min-w-0 rounded bg-bg-sidebar px-1 text-xs text-fg outline-none ring-1 ring-accent"
+      className="w-32 min-w-0 rounded border border-accent bg-input px-1 text-xs text-fg outline-none"
     />
   );
 }

--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -417,7 +417,7 @@ export function ProjectSettingsModal({
                         t,
                         "dialogs.projectSettings.generationPromptPlaceholder",
                       )}
-                      className="w-full resize-none rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[11px] leading-relaxed text-fg outline-none transition focus:border-accent disabled:opacity-60"
+                      className="w-full resize-none rounded-md border border-input-border bg-input px-2 py-1.5 font-mono text-[11px] leading-relaxed text-fg outline-none transition focus:border-accent focus:bg-input-hover disabled:opacity-60"
                     />
                     <p className="text-right text-[10px] tabular-nums text-fg-muted">
                       {promptCount(

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -2186,7 +2186,7 @@ function SessionTitlePromptModal({
               onChange={(e) =>
                 patchAgents({ sessionTitlePrompt: e.target.value })
               }
-              className="min-h-40 w-full resize-y rounded-md border border-border bg-bg px-2 py-2 font-mono text-xs leading-relaxed text-fg outline-none focus:border-accent"
+              className="min-h-40 w-full resize-y rounded-md border border-input-border bg-input px-2 py-2 font-mono text-xs leading-relaxed text-fg outline-none focus:border-accent focus:bg-input-hover"
             />
             <div className="flex items-center justify-between gap-2">
               <span className="text-[11px] text-fg-muted">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3004,7 +3004,7 @@ function RenameInput({ initial, onSubmit, onCancel }: RenameInputProps) {
         }
       }}
       onBlur={() => onSubmit(value.trim())}
-      className="min-w-0 w-full flex-1 rounded border border-accent/50 bg-bg px-1 py-0.5 text-[13px] font-medium text-fg outline-none focus:border-accent"
+      className="min-w-0 w-full flex-1 rounded border border-accent/50 bg-input px-1 py-0.5 text-[13px] font-medium text-fg outline-none focus:border-accent focus:bg-input-hover"
     />
   );
 }

--- a/src/components/ui/IconInput.tsx
+++ b/src/components/ui/IconInput.tsx
@@ -25,7 +25,7 @@ export const IconInput = forwardRef<HTMLInputElement, IconInputProps>(
     return (
       <div
         className={cn(
-          "flex h-8 items-center gap-1 rounded-lg border border-transparent bg-fill px-2.5 focus-within:border-accent focus-within:bg-fill-hover",
+          "flex h-8 items-center gap-1 rounded-lg border border-input-border bg-input px-2.5 focus-within:border-accent focus-within:bg-input-hover",
           invalid ? "border-rose-500/60" : "",
           className,
         )}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -129,7 +129,7 @@ interface ChildSeparatorProps {
 }
 
 export const SELECT_CLASS =
-  "flex h-8 w-full items-center rounded-lg border border-transparent bg-fill font-mono text-xs text-fg outline-none transition focus-visible:border-accent";
+  "flex h-8 w-full items-center rounded-lg border border-input-border bg-input font-mono text-xs text-fg outline-none transition focus-visible:border-accent focus-visible:bg-input-hover";
 
 const SELECT_ROOT_CLASS = "relative inline-block min-w-0 text-xs";
 
@@ -477,7 +477,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
             >
               {searchable ? (
                 <div className="border-b border-border p-1.5">
-                  <div className="flex h-8 items-center rounded-lg border border-transparent bg-fill px-2 focus-within:border-accent">
+                  <div className="flex h-8 items-center rounded-lg border border-input-border bg-input px-2 focus-within:border-accent focus-within:bg-input-hover">
                     <Search
                       aria-hidden="true"
                       size={13}

--- a/src/components/ui/Stepper.tsx
+++ b/src/components/ui/Stepper.tsx
@@ -74,7 +74,7 @@ export function Stepper({
   return (
     <div
       className={cn(
-        "inline-flex h-8 w-fit items-stretch self-start overflow-hidden rounded-lg bg-fill",
+        "inline-flex h-8 w-fit items-stretch self-start overflow-hidden rounded-lg border border-input-border bg-input",
         disabled && "opacity-50",
       )}
     >
@@ -83,11 +83,11 @@ export function Stepper({
         onClick={dec}
         disabled={disabled || value <= min}
         aria-label={t("ui.stepper.decrease")}
-        className="flex w-8 items-center justify-center text-fg-muted transition hover:bg-fill-hover hover:text-fg disabled:cursor-not-allowed disabled:opacity-40"
+        className="flex w-8 items-center justify-center text-fg-muted transition hover:bg-input-hover hover:text-fg disabled:cursor-not-allowed disabled:opacity-40"
       >
         <Minus size={12} />
       </button>
-      <div className="flex min-w-[4.25rem] items-center justify-center border-x border-border px-1.5 font-mono text-xs tabular-nums text-fg focus-within:ring-1 focus-within:ring-inset focus-within:ring-accent">
+      <div className="flex min-w-[4.25rem] items-center justify-center border-x border-input-border px-1.5 font-mono text-xs tabular-nums text-fg focus-within:ring-1 focus-within:ring-inset focus-within:ring-accent">
         <input
           aria-label={t("ui.stepper.value")}
           className="h-full w-12 bg-transparent text-center font-mono text-xs tabular-nums text-fg outline-none disabled:cursor-not-allowed"
@@ -120,7 +120,7 @@ export function Stepper({
         onClick={inc}
         disabled={disabled || value >= max}
         aria-label={t("ui.stepper.increase")}
-        className="flex w-8 items-center justify-center text-fg-muted transition hover:bg-fill-hover hover:text-fg disabled:cursor-not-allowed disabled:opacity-40"
+        className="flex w-8 items-center justify-center text-fg-muted transition hover:bg-input-hover hover:text-fg disabled:cursor-not-allowed disabled:opacity-40"
       >
         <Plus size={12} />
       </button>

--- a/src/components/ui/TextInput.tsx
+++ b/src/components/ui/TextInput.tsx
@@ -4,7 +4,7 @@ import { cn } from "../../lib/cn";
 type TextInputProps = InputHTMLAttributes<HTMLInputElement>;
 
 export const TEXT_INPUT_CLASS =
-  "h-8 w-full rounded-lg border border-transparent bg-fill px-2.5 font-mono text-xs text-fg outline-none focus:border-accent focus:bg-fill-hover";
+  "h-8 w-full rounded-lg border border-input-border bg-input px-2.5 font-mono text-xs text-fg outline-none focus:border-accent focus:bg-input-hover disabled:opacity-60";
 
 export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
   function TextInput({ className, type = "text", spellCheck = false, ...rest }, ref) {

--- a/src/lib/themes.test.ts
+++ b/src/lib/themes.test.ts
@@ -89,6 +89,14 @@ describe("BUILT_IN_THEMES", () => {
       expect(theme.css, theme.id).toMatch(/--color-term-selection\s*:/);
     }
   });
+
+  it("gives every built-in theme an explicit input surface", () => {
+    for (const theme of BUILT_IN_THEMES) {
+      expect(theme.css, theme.id).toMatch(/--color-input\s*:/);
+      expect(theme.css, theme.id).toMatch(/--color-input-hover\s*:/);
+      expect(theme.css, theme.id).toMatch(/--color-input-border\s*:/);
+    }
+  });
 });
 
 describe("validateThemeCss", () => {


### PR DESCRIPTION
## Summary
This fixes editable fields that looked too close to disabled surfaces across light and dark themes.

1. **Input surface tokens** — add `--color-input`, `--color-input-hover`, and `--color-input-border` to every built-in theme so editable controls no longer inherit muted fill surfaces.
2. **Editable controls** — switch shared input controls and direct edit fields to the new input tokens, including chat composer/editing, GitHub comment forms, merge dialog fields, rename fields, settings prompts, select search, and steppers.
3. **Theme coverage** — keep light themes visibly editable with brighter input surfaces, while dark themes are only slightly lifted from elevated backgrounds after visual tuning.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Light theme editable fields | Many inputs used muted fill/background colors and could read as disabled | Inputs use explicit brighter surfaces with clearer borders |
| Dark theme editable fields | Inputs could blend too deeply into nearby surfaces | Inputs are subtly brighter without changing the overall dark theme weight |
| Theme maintenance | Input colors were implicit through generic fill/background tokens | Every built-in theme declares explicit input surface tokens |

## Design notes
- The new tokens live beside existing theme color tokens and fall back through `src/App.css` for any custom or incomplete theme.
- Shared UI primitives now carry the token mapping, while direct `input` and `textarea` call sites were updated where they previously used panel or sidebar surfaces.
- Disabled state remains opacity-based; this change targets active editable fields so disabled controls still stay visually separate.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/lib/themes.test.ts src/components/ui/Select.test.tsx src/components/SettingsModal.test.tsx src/components/ChatPane.test.tsx` passes — 74 tests
- [x] `pnpm run test` passes — 73 files, 761 tests
- [x] `pnpm run build` passes
- [x] `git diff --check` passes

## Notes
- `pnpm run build` still prints the existing Vite dynamic import and large chunk warnings. This PR does not introduce or change those warnings.
