### PR TITLE
fix(settings): allow decimal terminal font sizes

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -434,6 +434,38 @@ describe("SettingsModal font controls", () => {
     });
   });
 
+  it("patches decimal terminal font size from the Terminal tab", async () => {
+    const patchTerminal = vi.fn();
+    useSettings.setState({
+      settings: cloneSettings(),
+      patchTerminal,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openTerminalTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const label = Array.from(document.querySelectorAll("span")).find(
+      (element) => element.textContent === "Font size",
+    );
+    const field = label?.parentElement;
+    const valueInput = field?.querySelector<HTMLInputElement>(
+      'input[aria-label="Value"]',
+    );
+
+    expect(valueInput?.value).toBe("12");
+
+    setInputValue(valueInput as HTMLInputElement, "13.37");
+    blurInput(valueInput as HTMLInputElement);
+
+    expect(patchTerminal).toHaveBeenCalledWith({ fontSize: 13.37 });
+  });
+
   it("patches terminal letter spacing from the Terminal tab", async () => {
     const patchTerminal = vi.fn();
     useSettings.setState({

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -57,6 +57,9 @@ import {
   SESSION_TITLE_PROMPT_PREVIEW_MESSAGE,
   SESSION_TITLE_PROMPT_MAX_CHARS,
   SESSION_TITLE_OPTIONS,
+  TERMINAL_FONT_SIZE_MAX,
+  TERMINAL_FONT_SIZE_MIN,
+  TERMINAL_FONT_SIZE_STEP,
   TERMINAL_LETTER_SPACING_MAX,
   TERMINAL_LETTER_SPACING_MIN,
   TERMINAL_LETTER_SPACING_STEP,
@@ -511,7 +514,7 @@ export function SettingsModal() {
   );
 }
 
-function formatTerminalLetterSpacing(value: number): string {
+function formatTerminalDecimal(value: number): string {
   return Number.isInteger(value)
     ? String(value)
     : value.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
@@ -555,9 +558,13 @@ function TerminalSettings() {
       >
         <Stepper
           value={settings.terminal.fontSize}
-          min={8}
-          max={32}
+          min={TERMINAL_FONT_SIZE_MIN}
+          max={TERMINAL_FONT_SIZE_MAX}
+          step={TERMINAL_FONT_SIZE_STEP}
           unit="px"
+          inputPrecision={2}
+          snapInputToStep={false}
+          format={formatTerminalDecimal}
           onChange={(n) => patchTerminal({ fontSize: n })}
         />
       </Field>
@@ -571,7 +578,7 @@ function TerminalSettings() {
           max={TERMINAL_LETTER_SPACING_MAX}
           step={TERMINAL_LETTER_SPACING_STEP}
           unit="px"
-          format={formatTerminalLetterSpacing}
+          format={formatTerminalDecimal}
           onChange={(n) => patchTerminal({ letterSpacing: n })}
         />
       </Field>

--- a/src/components/ui/Stepper.tsx
+++ b/src/components/ui/Stepper.tsx
@@ -8,6 +8,8 @@ interface StepperProps {
   min: number;
   max: number;
   step?: number;
+  inputPrecision?: number;
+  snapInputToStep?: boolean;
   unit?: string;
   disabled?: boolean;
   /**
@@ -29,6 +31,8 @@ export function Stepper({
   min,
   max,
   step = 1,
+  inputPrecision,
+  snapInputToStep = true,
   unit,
   disabled = false,
   format,
@@ -36,12 +40,14 @@ export function Stepper({
 }: StepperProps) {
   const t = useTranslation();
   const precision = decimalPlaces(step);
+  const commitPrecision = inputPrecision ?? precision;
   const formatValue = (n: number) => (format ? format(n) : String(n));
   const clamp = (n: number) => Math.max(min, Math.min(max, n));
   // Round-to-step keeps fractional steps (e.g. 0.05) from accumulating
   // FP drift after many clicks.
   const snap = (n: number) =>
     Number((Math.round(n / step) * step).toFixed(precision));
+  const roundInput = (n: number) => Number(n.toFixed(commitPrecision));
   const dec = () => onChange(clamp(snap(value - step)));
   const inc = () => onChange(clamp(snap(value + step)));
   const display = formatValue(value);
@@ -64,7 +70,9 @@ export function Stepper({
       return;
     }
 
-    const next = clamp(snap(parsed));
+    const next = clamp(
+      snapInputToStep ? snap(parsed) : roundInput(parsed),
+    );
     setDraft(formatValue(next));
     if (next !== value) {
       onChange(next);

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -7,6 +7,9 @@ import {
   MOUNTED_TERMINAL_LIMIT_MAX,
   MOUNTED_TERMINAL_LIMIT_MIN,
   NOTIFICATION_HISTORY_LIMIT_MAX,
+  TERMINAL_FONT_SIZE_MAX,
+  TERMINAL_FONT_SIZE_MIN,
+  TERMINAL_FONT_SIZE_STEP,
   TERMINAL_FONT_SMOOTHING_VALUES,
   TERMINAL_LETTER_SPACING_MAX,
   TERMINAL_LETTER_SPACING_MIN,
@@ -244,6 +247,77 @@ describe("terminal.maxMountedTerminals settings", () => {
     expect(useSettings.getState().settings.terminal.detachOffscreenTerminals).toBe(
       true,
     );
+  });
+});
+
+describe("terminal.fontSize settings", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("loads persisted decimal font size and clamps it", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ terminal: { fontSize: 13.375 } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.terminal.fontSize).toBe(13.38);
+  });
+
+  it("clamps out-of-range persisted font size", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ terminal: { fontSize: 99 } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.terminal.fontSize).toBe(
+      TERMINAL_FONT_SIZE_MAX,
+    );
+  });
+
+  it("preserves patched decimal font size inside the supported range", async () => {
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    useSettings
+      .getState()
+      .patchTerminal({ fontSize: TERMINAL_FONT_SIZE_MIN - 0.4 });
+    expect(useSettings.getState().settings.terminal.fontSize).toBe(
+      TERMINAL_FONT_SIZE_MIN,
+    );
+
+    useSettings.getState().patchTerminal({ fontSize: 13.375 });
+    expect(useSettings.getState().settings.terminal.fontSize).toBe(13.38);
+  });
+
+  it("uses a fractional UI step for terminal font size", () => {
+    expect(TERMINAL_FONT_SIZE_STEP).toBe(0.25);
   });
 });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -123,6 +123,9 @@ export const NOTIFICATION_HISTORY_LIMIT_MAX = 100;
 export const MOUNTED_TERMINAL_LIMIT_MIN = 1;
 export const MOUNTED_TERMINAL_LIMIT_DEFAULT = 8;
 export const MOUNTED_TERMINAL_LIMIT_MAX = 64;
+export const TERMINAL_FONT_SIZE_MIN = 8;
+export const TERMINAL_FONT_SIZE_MAX = 32;
+export const TERMINAL_FONT_SIZE_STEP = 0.25;
 export const TERMINAL_LETTER_SPACING_MIN = -2;
 export const TERMINAL_LETTER_SPACING_MAX = 6;
 export const TERMINAL_LETTER_SPACING_STEP = 0.25;
@@ -659,6 +662,18 @@ function normalizeLineHeight(v: unknown, fallback: number): number {
   return Math.max(1.0, Math.min(2.0, v));
 }
 
+export function normalizeTerminalFontSize(
+  v: unknown,
+  fallback: number,
+): number {
+  if (typeof v !== "number" || !Number.isFinite(v)) return fallback;
+  const clamped = Math.max(
+    TERMINAL_FONT_SIZE_MIN,
+    Math.min(TERMINAL_FONT_SIZE_MAX, v),
+  );
+  return Math.round(clamped * 100) / 100;
+}
+
 export function normalizeTerminalLetterSpacing(
   v: unknown,
   fallback: number,
@@ -889,6 +904,10 @@ function loadSettings(): AcornSettings {
       terminal: {
         ...DEFAULT_SETTINGS.terminal,
         ...terminalRaw,
+        fontSize: normalizeTerminalFontSize(
+          (terminalRaw as { fontSize?: unknown }).fontSize,
+          DEFAULT_SETTINGS.terminal.fontSize,
+        ),
         fontWeight: normalizeWeight(
           terminalRaw.fontWeight,
           DEFAULT_SETTINGS.terminal.fontWeight,
@@ -1174,6 +1193,13 @@ export const useSettings = create<SettingsState>((set, get) => ({
               : normalizeMountedTerminalLimit(
                   patch.maxMountedTerminals,
                   s.settings.terminal.maxMountedTerminals,
+                ),
+          fontSize:
+            patch.fontSize === undefined
+              ? s.settings.terminal.fontSize
+              : normalizeTerminalFontSize(
+                  patch.fontSize,
+                  s.settings.terminal.fontSize,
                 ),
           letterSpacing:
             patch.letterSpacing === undefined


### PR DESCRIPTION
## Summary
Allow terminal font size settings to preserve decimal values.

1. **Decimal font-size input** — configure the font-size Stepper to accept two-decimal free-form values instead of snapping text input back to whole pixels.
2. **Settings normalization** — add shared font-size bounds and step constants, and normalize persisted or patched values to the supported 8-32 px range with two-decimal precision.
3. **Regression coverage** — cover Settings modal decimal input plus persisted and patched font-size normalization.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal font size setting | Text input snapped back to integer pixel values | Decimal values such as 13.37 px persist and apply |
| Invalid persisted values | `terminal.fontSize` could bypass the UI range | Values clamp to the same 8-32 px range as the UI |

## Design notes
- `Stepper` keeps its existing snap-to-step behavior by default; the new opt-out is used only by terminal font size so other settings retain their current stepping semantics.
- Terminal rendering already consumes `settings.terminal.fontSize` as a number, so no terminal integration change is needed beyond preserving the decimal setting value.

## Test plan
- [x] `pnpm exec vitest run src/lib/settings.test.ts src/components/SettingsModal.test.tsx` — 2 files passed, 98 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `git diff --check` — passed
