### PR TITLE
fix(sessions): cascade control-owned session removal

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -376,6 +377,26 @@ impl SessionStore {
         v
     }
 
+    pub fn list_control_owned_descendants(&self, controller_id: Uuid) -> Vec<Session> {
+        let sessions = self.list();
+        let mut seen = HashSet::from([controller_id]);
+        let mut frontier = vec![controller_id];
+        let mut descendants = Vec::new();
+
+        while let Some(owner_id) = frontier.pop() {
+            for session in &sessions {
+                if seen.contains(&session.id) || !session.owner.is_control_owner(owner_id) {
+                    continue;
+                }
+                seen.insert(session.id);
+                frontier.push(session.id);
+                descendants.push(session.clone());
+            }
+        }
+
+        descendants
+    }
+
     pub fn update_status(&self, id: &Uuid, status: SessionStatus) -> SessionResult<Session> {
         let mut entry = self
             .inner
@@ -745,6 +766,63 @@ mod tests {
             store.get(&session.id).expect("session persisted").kind,
             SessionKind::Control
         );
+    }
+
+    #[test]
+    fn list_control_owned_descendants_follows_nested_ownership() {
+        let store = SessionStore::new();
+        let controller = store.insert({
+            let mut session = fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false);
+            session.kind = SessionKind::Control;
+            session
+        });
+        let worker = store.insert({
+            let mut session = fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false);
+            session.name = "worker".to_string();
+            session.owner = SessionOwner::control(controller.id);
+            session
+        });
+        let nested = store.insert({
+            let mut session = fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false);
+            session.name = "nested".to_string();
+            session.owner = SessionOwner::control(worker.id);
+            session
+        });
+        let user_owned = store.insert({
+            let mut session = fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false);
+            session.name = "user".to_string();
+            session
+        });
+
+        let descendants = store.list_control_owned_descendants(controller.id);
+        let ids: HashSet<_> = descendants.into_iter().map(|session| session.id).collect();
+
+        assert_eq!(ids, HashSet::from([worker.id, nested.id]));
+        assert!(!ids.contains(&controller.id));
+        assert!(!ids.contains(&user_owned.id));
+    }
+
+    #[test]
+    fn list_control_owned_descendants_handles_cycles() {
+        let store = SessionStore::new();
+        let controller = store.insert({
+            let mut session = fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false);
+            session.kind = SessionKind::Control;
+            session
+        });
+        let worker = store.insert({
+            let mut session = fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false);
+            session.owner = SessionOwner::control(controller.id);
+            session
+        });
+        let mut controller_cycle = controller.clone();
+        controller_cycle.owner = SessionOwner::control(worker.id);
+        store.insert(controller_cycle);
+
+        let descendants = store.list_control_owned_descendants(controller.id);
+
+        assert_eq!(descendants.len(), 1);
+        assert_eq!(descendants[0].id, worker.id);
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3169,13 +3169,29 @@ pub fn reorder_sessions(
 /// daemon-backed session is a no-op against `state.pty`, leaving its child
 /// process and stream pump thread running and leaking its `stream_registry`
 /// entry.
-fn terminate_session_pty(state: &AppState, id: &Uuid) {
-    if state.stream_registry.contains(id) {
+pub(crate) fn terminate_session_pty(state: &AppState, id: &Uuid) {
+    let stream_attached = state.stream_registry.contains(id);
+    if stream_attached || state.daemon_bridge.is_alive(*id) {
         state.daemon_bridge.kill(*id).ok();
-        state.stream_registry.drop_attachment(id);
+        if stream_attached {
+            state.stream_registry.drop_attachment(id);
+        }
     } else {
         state.pty.kill(id).ok();
     }
+}
+
+pub(crate) fn session_removal_cascade(state: &AppState, session: &Session) -> Vec<Session> {
+    let mut sessions = vec![session.clone()];
+    let mut seen = HashSet::from([session.id]);
+    if session.kind == SessionKind::Control {
+        for owned in state.sessions.list_control_owned_descendants(session.id) {
+            if seen.insert(owned.id) {
+                sessions.push(owned);
+            }
+        }
+    }
+    sessions
 }
 
 fn sessions_using_linked_worktree(
@@ -3208,9 +3224,18 @@ fn ensure_no_sessions_using_worktree_path_except(
     worktree_path: &Path,
     except_id: Option<&Uuid>,
 ) -> AppResult<()> {
+    let except_ids: HashSet<Uuid> = except_id.into_iter().copied().collect();
+    ensure_no_sessions_using_worktree_path_except_ids(state, worktree_path, &except_ids)
+}
+
+fn ensure_no_sessions_using_worktree_path_except_ids(
+    state: &AppState,
+    worktree_path: &Path,
+    except_ids: &HashSet<Uuid>,
+) -> AppResult<()> {
     let has_conflict = sessions_using_worktree_path(state, worktree_path)
         .into_iter()
-        .any(|session| except_id != Some(&session.id));
+        .any(|session| !except_ids.contains(&session.id));
     if has_conflict {
         return Err(AppError::Other(
             WORKTREE_IN_USE_BY_OTHER_SESSIONS.to_string(),
@@ -3308,16 +3333,25 @@ pub async fn remove_session(
     let app_state = state.inner().clone();
     let id = Uuid::parse_str(&id).map_err(|e| AppError::Other(e.to_string()))?;
     let session = app_state.sessions.get(&id)?;
+    let sessions_to_remove = session_removal_cascade(&app_state, &session);
+    let removal_ids: HashSet<_> = sessions_to_remove
+        .iter()
+        .map(|session| session.id)
+        .collect();
     if remove_worktree.unwrap_or(false) {
-        ensure_no_sessions_using_worktree_path_except(
+        ensure_no_sessions_using_worktree_path_except_ids(
             &app_state,
             &session.worktree_path,
-            Some(&id),
+            &removal_ids,
         )?;
     }
-    terminate_session_pty(&app_state, &id);
+    for session in &sessions_to_remove {
+        terminate_session_pty(&app_state, &session.id);
+    }
     if let Ok(dir) = persistence::data_dir() {
-        scrollback::delete(&dir, &id.to_string()).ok();
+        for session in &sessions_to_remove {
+            scrollback::delete(&dir, &session.id.to_string()).ok();
+        }
     }
     let removed_worktree = if remove_worktree.unwrap_or(false) {
         match stage_remove_linked_worktree_blocking(
@@ -3340,7 +3374,13 @@ pub async fn remove_session(
     } else {
         None
     };
-    app_state.sessions.remove(&id)?;
+    for session in &sessions_to_remove {
+        if session.id == id {
+            app_state.sessions.remove(&session.id)?;
+        } else {
+            app_state.sessions.remove(&session.id).ok();
+        }
+    }
     if should_remove_local_project_mirror(&session, &app_state.sessions.list()) {
         app_state.projects.remove(&session.repo_path);
     }

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -26,15 +26,15 @@ use std::io::{BufRead, BufReader, ErrorKind, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::RecvTimeoutError;
+use std::sync::Arc;
 use std::time::Duration;
 
 use acorn_ipc::primer;
 use acorn_ipc::proto::{
-    Envelope, ErrorCode, NewSessionOwner, PROTOCOL_VERSION, Request, Response, SessionSummary,
-    WorkspaceSummary,
+    Envelope, ErrorCode, NewSessionOwner, Request, Response, SessionSummary, WorkspaceSummary,
+    PROTOCOL_VERSION,
 };
 use acorn_ipc::socket_path;
 use base64::Engine;
@@ -42,8 +42,10 @@ use serde::Serialize;
 use tauri::{AppHandle, Emitter, Runtime};
 use uuid::Uuid;
 
-use crate::commands::{create_unique_worktree, sanitize_worktree_name};
-use crate::ipc::workspaces::{LIST_WORKSPACES_REQUEST_EVENT, ListWorkspacesRequestPayload};
+use crate::commands::{
+    create_unique_worktree, sanitize_worktree_name, session_removal_cascade, terminate_session_pty,
+};
+use crate::ipc::workspaces::{ListWorkspacesRequestPayload, LIST_WORKSPACES_REQUEST_EVENT};
 use crate::persistence;
 use crate::state::AppState;
 use crate::worktree;
@@ -832,31 +834,38 @@ fn handle_kill_session<R: Runtime>(
             message: "refusing to kill the source control session".to_string(),
         };
     }
-    let _ = state.pty.kill(&target.id);
-    if let Err(err) = state.sessions.remove(&target.id) {
-        return Response::Error {
-            code: ErrorCode::Internal,
-            message: format!("remove failed: {err}"),
-        };
+    let sessions_to_remove = session_removal_cascade(state, &target);
+    for session in &sessions_to_remove {
+        terminate_session_pty(state, &session.id);
+    }
+    for session in &sessions_to_remove {
+        if let Err(err) = state.sessions.remove(&session.id) {
+            return Response::Error {
+                code: ErrorCode::Internal,
+                message: format!("remove failed: {err}"),
+            };
+        }
     }
     if let Err(err) = persistence::save_sessions(&state.sessions.list()) {
         tracing::warn!(error = %err, "ipc: persist after kill-session failed");
     }
-    if let Err(err) = app.emit(
-        SESSIONS_CHANGED_EVENT,
-        SessionsChangedPayload {
-            action: "removed",
-            session_id: target.id.to_string(),
-            repo_path: target.repo_path.display().to_string(),
-            workspace_path: Some(target.worktree_path.display().to_string()),
-            workspace_id: None,
-        },
-    ) {
-        tracing::warn!(
-            error = %err,
-            event = SESSIONS_CHANGED_EVENT,
-            "ipc: sessions-changed emit failed",
-        );
+    for session in &sessions_to_remove {
+        if let Err(err) = app.emit(
+            SESSIONS_CHANGED_EVENT,
+            SessionsChangedPayload {
+                action: "removed",
+                session_id: session.id.to_string(),
+                repo_path: session.repo_path.display().to_string(),
+                workspace_path: Some(session.worktree_path.display().to_string()),
+                workspace_id: None,
+            },
+        ) {
+            tracing::warn!(
+                error = %err,
+                event = SESSIONS_CHANGED_EVENT,
+                "ipc: sessions-changed emit failed",
+            );
+        }
     }
     Response::Ack
 }
@@ -1077,6 +1086,37 @@ mod tests {
         let target = store.insert(make_session("/tmp/A", "user", SessionKind::Regular));
         let res = resolve_action_target(&ctl, &target.id.to_string(), &store, true);
         assert!(res.is_ok(), "allow_foreign should bypass owner guard");
+    }
+
+    #[test]
+    fn session_removal_cascade_includes_control_owned_descendants() {
+        let state = AppState::new();
+        let controller = state
+            .sessions
+            .insert(make_session("/tmp/A", "ctl", SessionKind::Control));
+        let worker = state.sessions.insert({
+            let mut session = make_session("/tmp/A", "worker", SessionKind::Regular);
+            session.owner = SessionOwner::control(controller.id);
+            session
+        });
+        let nested = state.sessions.insert({
+            let mut session = make_session("/tmp/A", "nested", SessionKind::Regular);
+            session.owner = SessionOwner::control(worker.id);
+            session
+        });
+        let user = state
+            .sessions
+            .insert(make_session("/tmp/A", "user", SessionKind::Regular));
+
+        let cascade = session_removal_cascade(&state, &controller);
+        let ids: std::collections::HashSet<_> =
+            cascade.into_iter().map(|session| session.id).collect();
+
+        assert_eq!(
+            ids,
+            std::collections::HashSet::from([controller.id, worker.id, nested.id])
+        );
+        assert!(!ids.contains(&user.id));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ import {
 } from "./lib/terminalConversation";
 import {
   canDeleteSessionWorktree,
+  controlOwnedSessionCount,
   hasRecordedWorktree,
   shouldAutoDeleteSessionWorktree,
 } from "./lib/sessionWorktree";
@@ -316,6 +317,11 @@ function App() {
   const pendingRemoveCanDeleteWorktree =
     pendingRemove !== null &&
     canDeleteSessionWorktree(pendingRemove, projectFolders, sessions);
+  const pendingRemoveOwnedSessionCount =
+    pendingRemove !== null
+      ? controlOwnedSessionCount(sessions, pendingRemove)
+      : 0;
+  const pendingRemoveHasOwnedSessions = pendingRemoveOwnedSessionCount > 0;
   const pendingRemoveKeepsSharedWorktree =
     pendingRemoveRecordedWorktree && !pendingRemoveCanDeleteWorktree;
   const pendingRemoveAutoDeletesWorktree =
@@ -331,6 +337,7 @@ function App() {
   const pendingRemoveSkipsDialog =
     pendingRemove !== null &&
     !pendingRemoveNeedsRunningWarning &&
+    !pendingRemoveHasOwnedSessions &&
     (pendingRemoveKeepsSharedWorktree ||
       (pendingRemoveAutoDeletesWorktree &&
         deleteIsolatedWorktreesWithoutPrompt) ||
@@ -1172,7 +1179,11 @@ function App() {
       projectFolders,
       sessions,
     );
-    if (autoDeleteWorktree && deleteIsolatedWorktreesWithoutPrompt) {
+    if (
+      autoDeleteWorktree &&
+      deleteIsolatedWorktreesWithoutPrompt &&
+      !pendingRemoveHasOwnedSessions
+    ) {
       clearPendingRemove();
       void removeSession(pendingRemove.id, true).then((removedWorktree) =>
         showStoreWorktreeRemovalToast(
@@ -1186,7 +1197,9 @@ function App() {
       );
       return;
     }
-    if (confirmRemoveSession || recordedWorktree) return;
+    if (confirmRemoveSession || recordedWorktree || pendingRemoveHasOwnedSessions) {
+      return;
+    }
     clearPendingRemove();
     void removeSession(pendingRemove.id, false).then(() =>
       showStoreOperationToast(
@@ -1196,6 +1209,7 @@ function App() {
     );
   }, [
     pendingRemove,
+    pendingRemoveHasOwnedSessions,
     pendingRemoveNeedsRunningWarning,
     deleteIsolatedWorktreesWithoutPrompt,
     clearPendingRemove,
@@ -1852,6 +1866,7 @@ function App() {
             : pendingRemove
         }
         canDeleteWorktree={pendingRemoveCanDeleteWorktree}
+        ownedSessionCount={pendingRemoveOwnedSessionCount}
         onClose={(choice) => {
           const target = pendingRemove;
           clearPendingRemove();

--- a/src/components/RemoveSessionDialog.test.tsx
+++ b/src/components/RemoveSessionDialog.test.tsx
@@ -44,19 +44,32 @@ describe("RemoveSessionDialog", () => {
     vi.clearAllMocks();
   });
 
-  function renderDialog(target: Session, canDeleteWorktree = true) {
+  function renderDialog(
+    target: Session,
+    canDeleteWorktree = true,
+    ownedSessionCount = 0,
+  ) {
     const onClose = vi.fn();
     act(() => {
       root.render(
         <RemoveSessionDialog
           session={target}
           canDeleteWorktree={canDeleteWorktree}
+          ownedSessionCount={ownedSessionCount}
           onClose={onClose}
         />,
       );
     });
     return onClose;
   }
+
+  it("warns when control-owned sessions will also be removed", () => {
+    renderDialog(session({ kind: "control" }), true, 2);
+
+    expect(document.body.textContent).toContain(
+      "This will also remove 2 control-owned session(s).",
+    );
+  });
 
   it("offers worktree deletion for a non-isolated linked worktree session", () => {
     renderDialog(session({ in_worktree: true }));

--- a/src/components/RemoveSessionDialog.tsx
+++ b/src/components/RemoveSessionDialog.tsx
@@ -18,12 +18,14 @@ function dt(t: Translator, key: DialogTranslationKey): string {
 interface RemoveSessionDialogProps {
   session: Session | null;
   canDeleteWorktree?: boolean;
+  ownedSessionCount?: number;
   onClose: (choice: RemoveChoice) => void;
 }
 
 export function RemoveSessionDialog({
   session,
   canDeleteWorktree = true,
+  ownedSessionCount = 0,
   onClose,
 }: RemoveSessionDialogProps) {
   const t = useTranslation();
@@ -101,6 +103,13 @@ export function RemoveSessionDialog({
               {dt(t, "dialogs.removeSession.confirmPrefix")}{" "}
               <span className="font-mono text-accent">{session.name}</span>?
             </p>
+            {ownedSessionCount > 0 ? (
+              <p className="text-xs text-warning">
+                {dt(t, "dialogs.removeSession.ownedSessionsWillBeRemovedPrefix")}{" "}
+                <span className="font-mono">{ownedSessionCount}</span>{" "}
+                {dt(t, "dialogs.removeSession.ownedSessionsWillBeRemovedSuffix")}
+              </p>
+            ) : null}
             {recordedWorktree ? (
               <div className="space-y-2 rounded-md border border-border bg-bg-sidebar/60 p-3">
                 <p className="text-xs text-fg-muted">

--- a/src/lib/sessionWorktree.test.ts
+++ b/src/lib/sessionWorktree.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import type { Session } from "./types";
 import {
   canDeleteSessionWorktree,
+  controlOwnedSessionCount,
   hasRecordedWorktree,
   isSessionInWorktreeWorkspace,
   otherSessionsUsingProjectWorktree,
   otherSessionsUsingWorktreePath,
+  sessionRemovalCascadeIds,
   sessionsUsingProjectWorktree,
   sessionsUsingWorktreePath,
   shouldAutoDeleteSessionWorktree,
@@ -98,6 +100,24 @@ describe("worktree deletion policy", () => {
     ).toBe(false);
   });
 
+  it("allows worktree deletion when only control-owned workers share it", () => {
+    const target = session({
+      id: "control",
+      kind: "control",
+      isolated: true,
+      worktree_path: "/repo/.acorn/worktrees/solo",
+    });
+    const worker = session({
+      id: "worker",
+      worktree_path: "/repo/.acorn/worktrees/solo/",
+      owner: { kind: "control", session_id: "control" },
+    });
+
+    expect(canDeleteSessionWorktree(target, foldersByRepo, [target, worker])).toBe(
+      true,
+    );
+  });
+
   it("preserves isolated sessions that are backing a worktree workspace", () => {
     const target = session({
       isolated: true,
@@ -119,6 +139,28 @@ describe("worktree deletion policy", () => {
 
     expect(canDeleteSessionWorktree(target, foldersByRepo)).toBe(true);
     expect(shouldAutoDeleteSessionWorktree(target, foldersByRepo)).toBe(false);
+  });
+});
+
+describe("sessionRemovalCascadeIds", () => {
+  it("includes nested control-owned descendants", () => {
+    const control = session({ id: "control", kind: "control" });
+    const worker = session({
+      id: "worker",
+      owner: { kind: "control", session_id: "control" },
+    });
+    const nested = session({
+      id: "nested",
+      owner: { kind: "control", session_id: "worker" },
+    });
+    const user = session({ id: "user" });
+
+    const ids = sessionRemovalCascadeIds([control, worker, nested, user], control);
+
+    expect([...ids].sort()).toEqual(["control", "nested", "worker"]);
+    expect(controlOwnedSessionCount([control, worker, nested, user], control)).toBe(
+      2,
+    );
   });
 });
 

--- a/src/lib/sessionWorktree.ts
+++ b/src/lib/sessionWorktree.ts
@@ -57,6 +57,40 @@ export function otherSessionsUsingWorktreePath(
   );
 }
 
+export function sessionRemovalCascadeIds(
+  sessions: readonly Session[],
+  target: Session,
+): Set<string> {
+  const ids = new Set<string>([target.id]);
+  if (target.kind !== "control") return ids;
+
+  const frontier = [target.id];
+  while (frontier.length > 0) {
+    const ownerId = frontier.pop();
+    if (!ownerId) continue;
+    for (const session of sessions) {
+      if (
+        ids.has(session.id) ||
+        session.owner.kind !== "control" ||
+        session.owner.session_id !== ownerId
+      ) {
+        continue;
+      }
+      ids.add(session.id);
+      frontier.push(session.id);
+    }
+  }
+
+  return ids;
+}
+
+export function controlOwnedSessionCount(
+  sessions: readonly Session[],
+  target: Session,
+): number {
+  return sessionRemovalCascadeIds(sessions, target).size - 1;
+}
+
 export function isSessionInWorktreeWorkspace(
   session: Session,
   foldersByRepo: ProjectFoldersByRepo,
@@ -73,6 +107,7 @@ export function canDeleteSessionWorktree(
   foldersByRepo: ProjectFoldersByRepo,
   sessions: readonly Session[] = [session],
 ): boolean {
+  const removalIds = sessionRemovalCascadeIds(sessions, session);
   return (
     hasRecordedWorktree(session) &&
     !isSessionInWorktreeWorkspace(session, foldersByRepo) &&
@@ -80,7 +115,7 @@ export function canDeleteSessionWorktree(
       sessions,
       session.worktree_path,
       session.id,
-    ).length === 0
+    ).every((candidate) => removalIds.has(candidate.id))
   );
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1315,6 +1315,8 @@
       "confirmPrefix": "Remove session",
       "isolatedWorktree": "This is an isolated worktree:",
       "linkedWorktree": "This session is using a linked git worktree:",
+      "ownedSessionsWillBeRemovedPrefix": "This will also remove",
+      "ownedSessionsWillBeRemovedSuffix": "control-owned session(s).",
       "deleteWorktreeQuestion": "Remove the session only, or also delete the worktree from disk?",
       "filesIn": "Files in",
       "willNotBeTouched": "will not be touched.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1315,6 +1315,8 @@
       "confirmPrefix": "세션 제거",
       "isolatedWorktree": "격리된 워크트리입니다:",
       "linkedWorktree": "이 세션은 연결된 Git 워크트리를 사용 중입니다:",
+      "ownedSessionsWillBeRemovedPrefix": "이 작업은 컨트롤 세션이 소유한 세션",
+      "ownedSessionsWillBeRemovedSuffix": "개도 함께 제거합니다.",
       "deleteWorktreeQuestion": "세션만 제거할까요, 아니면 디스크의 워크트리도 함께 삭제할까요?",
       "filesIn": "다음 위치의 파일은",
       "willNotBeTouched": "변경되지 않습니다.",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1288,6 +1288,30 @@ describe("removeSession", () => {
     );
   });
 
+  it("allows worktree deletion when only control-owned workers share it", async () => {
+    const worktreePath = `${REPO_A}/.worktrees/shared`;
+    const control = session("ctl", REPO_A, {
+      kind: "control",
+      isolated: true,
+      worktree_path: worktreePath,
+    });
+    const worker = session("worker", REPO_A, {
+      worktree_path: `${worktreePath}/`,
+      owner: { kind: "control", session_id: "ctl" },
+    });
+    await seed([project(REPO_A, 0)], [control, worker]);
+
+    mockApi.removeSession.mockResolvedValueOnce(null);
+    mockApi.listSessions.mockResolvedValue([]);
+    mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
+
+    const removed = await useAppStore.getState().removeSession("ctl", true);
+
+    expect(removed).toBeNull();
+    expect(mockApi.removeSession).toHaveBeenCalledWith("ctl", true);
+    expect(useAppStore.getState().error).toBeNull();
+  });
+
   it("collapses an empty split pane before the backend worktree delete finishes", async () => {
     const a1 = session("a1", REPO_A);
     const a2 = session("a2", REPO_A);

--- a/src/store.ts
+++ b/src/store.ts
@@ -49,6 +49,7 @@ import {
 } from "./lib/sessionCreation";
 import {
   otherSessionsUsingWorktreePath,
+  sessionRemovalCascadeIds,
   sessionsUsingProjectWorktree,
   sessionsUsingWorktreePath,
 } from "./lib/sessionWorktree";
@@ -2302,15 +2303,18 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   async removeSession(id, removeWorktree = false) {
+    const target = get().sessions.find((session) => session.id === id);
+    const removalIds = target
+      ? sessionRemovalCascadeIds(get().sessions, target)
+      : new Set<string>([id]);
     if (removeWorktree) {
       const state = get();
-      const target = state.sessions.find((session) => session.id === id);
       if (target) {
         const otherSessions = otherSessionsUsingWorktreePath(
           state.sessions,
           target.worktree_path,
           target.id,
-        );
+        ).filter((session) => !removalIds.has(session.id));
         if (otherSessions.length > 0) {
           set({ error: WORKTREE_IN_USE_BY_OTHER_SESSIONS });
           return null;
@@ -2318,11 +2322,15 @@ export const useAppStore = create<AppStateModel>()(
       }
     }
     const owning = findTabOwner(get(), id);
-    sessionPlacementById.delete(id);
+    for (const removalId of removalIds) {
+      sessionPlacementById.delete(removalId);
+    }
     set((s) => {
-      if (!s.sessions.some((session) => session.id === id)) return s;
+      if (!s.sessions.some((session) => removalIds.has(session.id))) return s;
 
-      const sessions = s.sessions.filter((session) => session.id !== id);
+      const sessions = s.sessions.filter(
+        (session) => !removalIds.has(session.id),
+      );
       const reconciled = reconcileWorkspaces(
         sessions,
         s.projects,
@@ -2334,9 +2342,13 @@ export const useAppStore = create<AppStateModel>()(
         true,
       );
       const liveInWorktree = { ...s.liveInWorktree };
-      delete liveInWorktree[id];
+      for (const removalId of removalIds) {
+        delete liveInWorktree[removalId];
+      }
       const pendingTerminalInput = { ...s.pendingTerminalInput };
-      delete pendingTerminalInput[id];
+      for (const removalId of removalIds) {
+        delete pendingTerminalInput[removalId];
+      }
 
       return {
         sessions,
@@ -2345,7 +2357,7 @@ export const useAppStore = create<AppStateModel>()(
         liveInWorktree,
         pendingTerminalInput,
         sessionNotifications: s.sessionNotifications.filter(
-          (notification) => notification.sessionId !== id,
+          (notification) => !removalIds.has(notification.sessionId),
         ),
         workspaces: reconciled.workspaces,
         projectFolders: reconciled.projectFolders,


### PR DESCRIPTION
## Summary
Control-owned session removal now treats the control session and its descendants as one removal cascade:

1. **Backend cascade removal** — removing a control session now removes transitively control-owned descendants, kills every target PTY through the daemon-aware termination path, clears scrollback, and persists/removes matching session rows from both app commands and IPC `kill-session`.
2. **Worktree safety alignment** — worktree deletion guards now ignore only sessions that are part of the same removal cascade, so unrelated sessions still block disk deletion while owned descendants do not.
3. **Frontend optimistic state + confirmation** — the store removes cascade targets optimistically, and the remove-session dialog warns when additional control-owned sessions will be removed.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Control session removal | Owned worker PTYs/session rows could survive depending on path | Control-owned descendants are removed with the controller |
| Daemon-backed PTYs | Detached daemon PTYs could remain visible as orphaned background sessions | Removal routes daemon-alive sessions through daemon kill |
| Worktree deletion | Owned sessions sharing the target worktree could block deletion | Only unrelated sessions block deletion |
| User confirmation | Auto-skip could hide multi-session removal impact | Dialog is shown when owned sessions are included |

## Design notes
- `SessionStore::list_control_owned_descendants` snapshots sessions and walks ownership transitively, with cycle protection.
- `commands::session_removal_cascade` centralizes the target-plus-descendants decision so Tauri commands and IPC share the same behavior.
- `terminate_session_pty` now checks daemon liveness in addition to stream attachments before falling back to the in-process PTY manager.
- Existing orphaned daemon sessions from older builds are not auto-cleaned; this PR prevents newly removed sessions from being left behind.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm exec vitest run src/lib/sessionWorktree.test.ts src/components/RemoveSessionDialog.test.tsx src/store.test.ts` — 3 files / 140 tests pass
- [x] `pnpm run test` — 73 files / 770 tests pass
- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` passes; Vite reports the existing dynamic/static import and large chunk warnings
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-session list_control_owned_descendants` — 2 tests pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn session_removal_cascade_includes_control_owned_descendants` — 1 test pass

## Notes
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` currently reports repo-wide formatting drift outside the scoped fix; CI does not run this check, so this PR avoids formatting-only churn.