### PR TITLE
fix(terminal): suppress redundant Claude TUI resize pulses

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1810,9 +1810,11 @@ export function Terminal({
       const fit = fitTerminalRef.current;
       if (!fit) return;
       repaintTerminalViewport({ container, fit, term });
-      // Even when xterm's cols/rows are unchanged, force a backend resize so
-      // TUIs launched from an already-open shell observe the current pane size.
-      sendPtyResize(true);
+      // Before a TUI starts, force one backend resize so commands launched
+      // from an already-open shell see the current pane size. Once a TUI has
+      // entered the alternate screen, avoid same-size SIGWINCH pulses; Claude
+      // Code's fullscreen renderer is sensitive to redundant resize redraws.
+      sendPtyResize(term.buffer.active.type !== "alternate");
     };
     const commandSizeSyncScheduler = createTerminalRepaintScheduler(
       syncViewportAndPtySize,


### PR DESCRIPTION
## Summary
Reduce redundant resize signals while fullscreen terminal TUIs are already active.

1. **Claude fullscreen stability** — avoid sending same-size forced PTY resizes while xterm is in the alternate screen, which reduces unnecessary SIGWINCH redraws inside Claude Code's fullscreen renderer.
2. **Shell launch sizing preserved** — keep the existing forced resize before a TUI starts so commands launched from an already-open shell still observe the current pane size.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Claude fullscreen redraws | Enter/input-triggered size sync could send a same-size PTY resize while Claude was already in alternate screen | Same-size forced resize is skipped in alternate screen; real cols/rows changes still propagate |
| Normal shell and TUI launch sizing | Forced size sync before command launch | Unchanged |

## Design notes
- The real resize path remains `term.onResize -> sendPtyResize(false, { cols, rows })`, so window, pane, and font-driven dimension changes still reach the PTY.
- The command-size sync path now uses `term.buffer.active.type !== "alternate"` as the force flag, limiting the behavior change to already-active TUIs.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run src/lib/terminalRepaint.test.ts src/lib/terminalMouseScale.test.ts src/lib/terminalScrollback.test.ts`
- [x] `pnpm run build`
- [x] `git diff --check`

## Notes
- `pnpm run build` still emits the existing Vite dynamic/static import and large chunk warnings; the build succeeds and these warnings are unrelated to this change.
