### PR TITLE
fix(terminal): align link hover overlay after CJK text

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type ReactElement } from "react";
 import {
   Terminal as XTerm,
+  type IBufferLine,
   type IDisposable,
   type ITheme,
   type IViewportRange,
@@ -237,10 +238,10 @@ function suppressCurrentXtermLinkUnderline(term: XTerm): void {
   }
 }
 
-function textRangeRectForColumns(
+function textRangeRectForStringOffsets(
   rowElement: HTMLElement,
-  startCol: number,
-  endCol: number,
+  startOffset: number,
+  endOffset: number,
 ): DOMRect | null {
   const doc = rowElement.ownerDocument;
   const walker = doc.createTreeWalker(rowElement, NodeFilter.SHOW_TEXT);
@@ -256,12 +257,12 @@ function textRangeRectForColumns(
   ) {
     const textLength = node.textContent?.length ?? 0;
     const nextOffset = offset + textLength;
-    if (!startSet && startCol <= nextOffset) {
-      range.setStart(node, Math.max(0, startCol - offset));
+    if (!startSet && startOffset <= nextOffset) {
+      range.setStart(node, Math.max(0, startOffset - offset));
       startSet = true;
     }
-    if (startSet && endCol <= nextOffset) {
-      range.setEnd(node, Math.max(0, endCol - offset));
+    if (startSet && endOffset <= nextOffset) {
+      range.setEnd(node, Math.max(0, endOffset - offset));
       endSet = true;
       break;
     }
@@ -277,6 +278,44 @@ function textRangeRectForColumns(
   range.detach();
   if (rect.width <= 0 || rect.height <= 0) return null;
   return rect;
+}
+
+function bufferStringOffsetForColumn(
+  bufferLine: IBufferLine,
+  targetColumn: number,
+): number {
+  let stringOffset = 0;
+
+  for (let column = 0; column < bufferLine.length; column += 1) {
+    const cell = bufferLine.getCell(column);
+    if (!cell) break;
+
+    const width = cell.getWidth();
+    if (width === 0) continue;
+    if (targetColumn <= column) return stringOffset;
+
+    const chars = cell.getChars();
+    const nextOffset = stringOffset + (chars.length || 1);
+    const nextColumn = column + Math.max(width, 1);
+    if (targetColumn < nextColumn) return stringOffset;
+    if (targetColumn === nextColumn) return nextOffset;
+
+    stringOffset = nextOffset;
+  }
+
+  return stringOffset;
+}
+
+function textRangeRectForBufferColumns(
+  rowElement: HTMLElement,
+  bufferLine: IBufferLine,
+  startCol: number,
+  endCol: number,
+): DOMRect | null {
+  const startOffset = bufferStringOffsetForColumn(bufferLine, startCol);
+  const endOffset = bufferStringOffsetForColumn(bufferLine, endCol);
+  if (endOffset <= startOffset) return null;
+  return textRangeRectForStringOffsets(rowElement, startOffset, endOffset);
 }
 
 function rectToTooltipAnchorRect(rect: DOMRect): TooltipAnchorRect {
@@ -378,9 +417,11 @@ function linkRangeAnchorRects(
       y === endViewportY
         ? Math.max(startCol + 1, Math.min(term.cols, range.end.x))
         : term.cols;
-    const textRect = rowElement
-      ? textRangeRectForColumns(rowElement, startCol, endCol)
-      : null;
+    const bufferLine = term.buffer.active.getLine(viewportY + y);
+    const textRect =
+      rowElement && bufferLine
+        ? textRangeRectForBufferColumns(rowElement, bufferLine, startCol, endCol)
+        : null;
     if (textRect) {
       rects.push(rectToTooltipAnchorRect(textRect));
       continue;

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -233,6 +233,65 @@ async function terminalTextAndUnderlineRects(
   }, text);
 }
 
+async function terminalTextRect(
+  page: Page,
+  text: string,
+): Promise<{ top: number; bottom: number; left: number; width: number } | null> {
+  return page.evaluate((target) => {
+    const toPlainRect = (rect: DOMRect) => ({
+      top: rect.top,
+      bottom: rect.bottom,
+      left: rect.left,
+      width: rect.width,
+    });
+
+    for (const row of Array.from(
+      document.querySelectorAll<HTMLElement>(".xterm-rows > div"),
+    )) {
+      const rowText = row.textContent ?? "";
+      const start = rowText.indexOf(target);
+      if (start < 0) continue;
+
+      const end = start + target.length;
+      const walker = document.createTreeWalker(row, NodeFilter.SHOW_TEXT);
+      const range = document.createRange();
+      let offset = 0;
+      let startSet = false;
+      let endSet = false;
+
+      for (
+        let node = walker.nextNode() as Text | null;
+        node;
+        node = walker.nextNode() as Text | null
+      ) {
+        const textLength = node.textContent?.length ?? 0;
+        const nextOffset = offset + textLength;
+        if (!startSet && start <= nextOffset) {
+          range.setStart(node, Math.max(0, start - offset));
+          startSet = true;
+        }
+        if (startSet && end <= nextOffset) {
+          range.setEnd(node, Math.max(0, end - offset));
+          endSet = true;
+          break;
+        }
+        offset = nextOffset;
+      }
+
+      if (!startSet || !endSet) {
+        range.detach();
+        return null;
+      }
+
+      const textRect = range.getBoundingClientRect();
+      range.detach();
+      return toPlainRect(textRect);
+    }
+
+    return null;
+  }, text);
+}
+
 async function terminalEmojiTrailingOffsets(page: Page): Promise<{
   cellWidth: number;
   offsets: Record<string, number>;
@@ -1907,6 +1966,95 @@ test.describe("terminal: spawn", () => {
       (window as unknown as { __tooltipObserver?: MutationObserver })
         .__tooltipObserver?.disconnect();
     });
+  });
+
+  test("positions link hover underline after Korean prefix text", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({ terminal: { linkActivation: "modifier-click" } }),
+      );
+    });
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __koreanPrefixLinkChannelId?: number;
+      };
+      w.__koreanPrefixLinkChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __koreanPrefixLinkChannelId?: number })
+              .__koreanPrefixLinkChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const url = "https://example.test/docs/api/terminal/interfaces";
+    await emitSubscribedPtyOutput(
+      page,
+      "__koreanPrefixLinkChannelId",
+      `문서 링크 ${url}\r\n`,
+    );
+    await expect(page.locator(".xterm")).toContainText(url);
+
+    const textRect = await terminalTextRect(page, url);
+    expect(textRect).not.toBeNull();
+    await page.mouse.move(
+      textRect!.left + Math.min(12, textRect!.width / 2),
+      (textRect!.top + textRect!.bottom) / 2,
+    );
+
+    await expect(
+      page.getByRole("tooltip", { name: /to open link/ }),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-acorn-terminal-link-underline="true"]'),
+    ).toHaveCount(1);
+
+    const rects = await terminalTextAndUnderlineRects(page, url);
+    expect(rects).not.toBeNull();
+    expect(Math.abs(rects!.underline.left - rects!.text.left)).toBeLessThan(2);
+    expect(Math.abs(rects!.underline.width - rects!.text.width)).toBeLessThan(
+      2,
+    );
+    expect(
+      Math.abs(rects!.underline.top - (rects!.text.bottom - 1)),
+    ).toBeLessThan(2);
   });
 
   test("shows stable hover underline for OSC URI terminal links", async ({


### PR DESCRIPTION
## Summary
Terminal link hover chrome now stays aligned when a link appears after CJK-width text.

1. **Overlay range mapping** — convert xterm buffer cell columns into DOM string offsets before measuring the floating link underline and tooltip anchor.
2. **Korean-prefix regression coverage** — add an E2E case that emits Korean text before a URL and verifies the floating underline matches the real URL bounds.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal link hover UI | Floating underline/tooltip could shift or shrink after Korean/CJK prefix text | Floating underline/tooltip follows the visible URL bounds |
| Link activation | Unchanged | Unchanged |

## Design notes
- The actual xterm link range remains the source of truth; this PR only fixes Acorn's overlay geometry.
- `linkRangeAnchorRects` now resolves the visible buffer line and maps terminal columns through `IBufferLine` cells, so wide cells and width-zero continuations no longer get treated as plain DOM string positions.
- The fallback `cell.width` math remains in place for cases where a DOM row or buffer line cannot be measured.

## Test plan
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts -g "link tooltip|link hover|OSC URI|app UI scale|Korean prefix"` — 4 passed
- [x] `pnpm run typecheck` — passed
