### PR TITLE
chore(release): v1.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.19.0",
+  "version": "1.19.1",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.19.0"
+version = "1.19.1"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
This prepares the v1.19.1 patch release after the fix PRs merged since v1.19.0.

1. **Version metadata** - bump Acorn from `1.19.0` to `1.19.1` in `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock`.
2. **Semver decision** - use a patch release because the unreleased set contains fix-only changes for control-session removal and terminal rendering behavior.
3. **Included PRs** - release notes include #493, #494, and #495.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| App version | `1.19.0` | `1.19.1` |
| Release channel | Latest stable remains v1.19.0 | Tagging this merge will publish v1.19.1 |
| User-visible release notes | Recent session and terminal fixes are not shipped in a stable release | Those fixes are included in the next stable release |

## Design notes
- This PR intentionally changes release version metadata only.
- Changelog entries come from the already-merged fix PRs; this release PR is labelled `skip-changelog`.
- `origin/main` CI at `b9a2882976231a4a6041e4ee4e32c81742f110eb` passed before creating this release PR.

## Follow-up (not in this PR)
- Tag `v1.19.1` after this PR merges and `origin/main` points at the release bump commit.

## Test plan
- [x] `rg -n '1\\.19\\.0|1\\.19\\.1' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock` - only release metadata reports `1.19.1`.
- [x] `pnpm run typecheck` - passed.
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` - passed and reports `acorn@1.19.1`.
- [x] `REPO=im-ian/acorn TAG=v1.19.1 OUTPUT=/tmp/acorn-release-notes-v1.19.1.md node scripts/release-notes.mjs` - passed and generated notes for #493, #494, and #495.
- [x] `git diff --check` - passed.
- [x] `git diff --cached --check` - passed.

## Notes
- Latest stable release before this PR is `v1.19.0`.
