### PR TITLE
feat(terminal): add right-click selection paste setting

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -535,6 +535,42 @@ describe("SettingsModal font controls", () => {
     expect(patchTerminal).toHaveBeenCalledWith({ fontSmoothing: "subpixel" });
   });
 
+  it("patches terminal right-click selection paste from the Terminal tab", async () => {
+    const patchTerminal = vi.fn();
+    useSettings.setState({
+      settings: cloneSettings(),
+      patchTerminal,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openTerminalTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const toggle = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    ).find((input) =>
+      input
+        .closest("label")
+        ?.textContent?.includes("Paste selected text on right-click"),
+    );
+
+    expect(toggle).toBeInstanceOf(HTMLInputElement);
+    expect(toggle?.checked).toBe(false);
+
+    act(() => {
+      toggle?.click();
+    });
+
+    expect(patchTerminal).toHaveBeenCalledWith({
+      rightClickPasteSelection: true,
+    });
+  });
+
   it("patches the resident terminal limit from the Sessions tab", async () => {
     const patchTerminal = vi.fn();
     useSettings.setState({

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -664,6 +664,15 @@ function TerminalSettings() {
           />
         </div>
       </Field>
+      <CheckboxRow
+        label={st(t, "settings.terminal.rightClickPasteSelection.label")}
+        description={st(
+          t,
+          "settings.terminal.rightClickPasteSelection.description",
+        )}
+        checked={settings.terminal.rightClickPasteSelection}
+        onChange={(v) => patchTerminal({ rightClickPasteSelection: v })}
+      />
     </section>
   );
 }

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -515,6 +515,28 @@ function usesExplicitRelativePath(path: string): boolean {
   return path.startsWith("./") || path.startsWith("../");
 }
 
+function selectedTextForTerminalContextPaste(
+  container: HTMLElement,
+  term: XTerm,
+): string {
+  const terminalSelection = term.getSelection();
+  if (terminalSelection.length > 0) return terminalSelection;
+
+  const selection = container.ownerDocument.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return "";
+  }
+  if (
+    !selection.anchorNode ||
+    !selection.focusNode ||
+    !container.contains(selection.anchorNode) ||
+    !container.contains(selection.focusNode)
+  ) {
+    return "";
+  }
+  return selection.toString();
+}
+
 export function Terminal({
   sessionId,
   repoPath,
@@ -1761,6 +1783,24 @@ export function Terminal({
     };
     container.addEventListener("paste", onPaste, true);
 
+    const onContextMenu = (e: MouseEvent) => {
+      if (!useSettings.getState().settings.terminal.rightClickPasteSelection) {
+        return;
+      }
+      const text = selectedTextForTerminalContextPaste(container, term);
+      if (text.length === 0) return;
+      const action = terminalPasteAction({
+        text,
+        hasImagePayload: false,
+        normalizeUnicodeSpaces: normalizeTerminalUnicodeSpaces(),
+      });
+      if (action.kind === "pasteText") term.paste(action.text);
+      term.focus();
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    };
+    container.addEventListener("contextmenu", onContextMenu, true);
+
     const onTerminalPaste = (e: Event) => {
       const detail = (e as CustomEvent<TerminalPasteEventDetail>).detail;
       if (detail?.sessionId !== sessionId) return;
@@ -2518,6 +2558,7 @@ export function Terminal({
       container.removeEventListener("keydown", onKeydown, true);
       container.removeEventListener("keypress", onKeypress, true);
       container.removeEventListener("paste", onPaste, true);
+      container.removeEventListener("contextmenu", onContextMenu, true);
       window.removeEventListener(TERMINAL_PASTE_EVENT, onTerminalPaste);
       container.removeEventListener("dragover", onDragOver);
       container.removeEventListener("drop", onDrop);

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -75,6 +75,65 @@ describe("terminal.linkActivation default", () => {
   });
 });
 
+describe("terminal.rightClickPasteSelection settings", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("defaults right-click selection paste off", () => {
+    expect(DEFAULT_SETTINGS.terminal.rightClickPasteSelection).toBe(false);
+  });
+
+  it("loads a persisted right-click selection paste toggle", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ terminal: { rightClickPasteSelection: true } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(
+      useSettings.getState().settings.terminal.rightClickPasteSelection,
+    ).toBe(true);
+  });
+
+  it("patches the right-click selection paste toggle", async () => {
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    useSettings.getState().patchTerminal({ rightClickPasteSelection: true });
+    expect(
+      useSettings.getState().settings.terminal.rightClickPasteSelection,
+    ).toBe(true);
+
+    useSettings.getState().patchTerminal({ rightClickPasteSelection: false });
+    expect(
+      useSettings.getState().settings.terminal.rightClickPasteSelection,
+    ).toBe(false);
+  });
+});
+
 describe("terminal.fontSmoothing settings", () => {
   const STORAGE_KEY = "acorn:settings:v1";
   let storage: Map<string, string>;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -242,6 +242,11 @@ export interface AcornSettings {
      */
     linkActivation: TerminalLinkActivation;
     /**
+     * When enabled, right-clicking selected terminal text writes that
+     * selection back to the PTY. Default off because it is an input gesture.
+     */
+    rightClickPasteSelection: boolean;
+    /**
      * Upper bound on simultaneously-mounted terminal sessions. Visible
      * terminals are always exempt, so this only evicts off-screen daemon
      * sessions that can be re-attached with scrollback replay.
@@ -467,6 +472,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     fontWeightBold: 700,
     lineHeight: 1.0,
     linkActivation: "click",
+    rightClickPasteSelection: false,
     maxMountedTerminals: MOUNTED_TERMINAL_LIMIT_DEFAULT,
     detachOffscreenTerminals: true,
   },
@@ -932,6 +938,12 @@ function loadSettings(): AcornSettings {
           (terminalRaw as { linkActivation?: unknown }).linkActivation,
           DEFAULT_SETTINGS.terminal.linkActivation,
         ),
+        rightClickPasteSelection:
+          typeof (terminalRaw as { rightClickPasteSelection?: unknown })
+            .rightClickPasteSelection === "boolean"
+            ? (terminalRaw as { rightClickPasteSelection: boolean })
+                .rightClickPasteSelection
+            : DEFAULT_SETTINGS.terminal.rightClickPasteSelection,
         maxMountedTerminals: normalizeMountedTerminalLimit(
           (terminalRaw as { maxMountedTerminals?: unknown })
             .maxMountedTerminals,
@@ -1215,6 +1227,12 @@ export const useSettings = create<SettingsState>((set, get) => ({
                   patch.fontSmoothing,
                   s.settings.terminal.fontSmoothing,
                 ),
+          rightClickPasteSelection:
+            patch.rightClickPasteSelection === undefined
+              ? s.settings.terminal.rightClickPasteSelection
+              : typeof patch.rightClickPasteSelection === "boolean"
+                ? patch.rightClickPasteSelection
+                : s.settings.terminal.rightClickPasteSelection,
           detachOffscreenTerminals:
             patch.detachOffscreenTerminals === undefined
               ? s.settings.terminal.detachOffscreenTerminals

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -121,6 +121,10 @@
         "modifierClick": {
           "description": "Hold {modifier} while clicking to open. Stops stray clicks on output containing URLs from yanking focus to the browser."
         }
+      },
+      "rightClickPasteSelection": {
+        "label": "Paste selected text on right-click",
+        "description": "When terminal text is selected, right-click writes that selection back to terminal input. Off by default."
       }
     },
     "sessions": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -121,6 +121,10 @@
         "modifierClick": {
           "description": "{modifier} 키를 누른 채 클릭하면 열립니다. URL이 포함된 출력에서 실수로 클릭해 브라우저로 포커스가 넘어가는 일을 막습니다."
         }
+      },
+      "rightClickPasteSelection": {
+        "label": "선택 텍스트 우클릭 입력",
+        "description": "터미널 텍스트를 선택한 상태에서 우클릭하면 선택 내용을 터미널 입력으로 다시 보냅니다. 기본값은 꺼짐입니다."
       }
     },
     "sessions": {

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -423,6 +423,35 @@ async function disableTerminalUnicodeSpaceNormalization(
   });
 }
 
+async function enableTerminalRightClickPasteSelection(
+  page: Page,
+): Promise<void> {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "acorn:settings:v1",
+      JSON.stringify({
+        terminal: { rightClickPasteSelection: true },
+      }),
+    );
+  });
+}
+
+async function rightClickSelectedTerminalText(
+  page: Page,
+  text: string,
+): Promise<void> {
+  const textRect = await terminalTextRect(page, text);
+  expect(textRect).not.toBeNull();
+  const y = (textRect!.top + textRect!.bottom) / 2;
+  await page.mouse.move(textRect!.left + 2, y);
+  await page.mouse.down();
+  await page.mouse.move(textRect!.left + textRect!.width - 2, y, {
+    steps: 8,
+  });
+  await page.mouse.up();
+  await page.mouse.click(textRect!.left + 10, y, { button: "right" });
+}
+
 async function terminalEmojiLetterSpacing(
   page: Page,
   marker: string,
@@ -658,6 +687,155 @@ test.describe("terminal: spawn", () => {
         ),
       )
       .toEqual(["pnpm run dev"]);
+  });
+
+  test("does not write selected terminal text on right-click by default", async ({
+    page,
+    tauri,
+  }) => {
+    await seedWritableTerminal(tauri);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __contextPasteChannelId?: number;
+      };
+      w.__contextPasteChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __contextPasteChannelId?: number })
+              .__contextPasteChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    await emitSubscribedPtyOutput(
+      page,
+      "__contextPasteChannelId",
+      "run-selected\r\n",
+    );
+    await expect(page.locator(".xterm")).toContainText("run-selected");
+    await page.evaluate(() => {
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+    });
+
+    await rightClickSelectedTerminalText(page, "run-selected");
+    await page.waitForTimeout(150);
+
+    expect(
+      await page.evaluate(
+        () => (window as unknown as { __ptyWrites?: string[] }).__ptyWrites,
+      ),
+    ).toEqual([]);
+  });
+
+  test("writes selected terminal text on right-click when enabled", async ({
+    page,
+    tauri,
+  }) => {
+    await enableTerminalRightClickPasteSelection(page);
+    await seedWritableTerminal(tauri);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __contextPasteChannelId?: number;
+      };
+      w.__contextPasteChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __contextPasteChannelId?: number })
+              .__contextPasteChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    await emitSubscribedPtyOutput(
+      page,
+      "__contextPasteChannelId",
+      "run-selected\r\n",
+    );
+    await expect(page.locator(".xterm")).toContainText("run-selected");
+    await page.evaluate(() => {
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+    });
+
+    await rightClickSelectedTerminalText(page, "run-selected");
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as unknown as { __ptyWrites?: string[] }).__ptyWrites,
+        ),
+      )
+      .toEqual(["run-selected"]);
+  });
+
+  test("does not write non-terminal selected text on terminal right-click", async ({
+    page,
+    tauri,
+  }) => {
+    await enableTerminalRightClickPasteSelection(page);
+    await seedWritableTerminal(tauri);
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Idle$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await page.waitForTimeout(150);
+    await page.evaluate(() => {
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+    });
+
+    await page.evaluate(() => {
+      const selected = document.createElement("div");
+      selected.textContent = "foreign-selection";
+      selected.style.userSelect = "text";
+      document.body.appendChild(selected);
+
+      const range = document.createRange();
+      range.selectNodeContents(selected);
+      const selection = window.getSelection();
+      if (!selection) throw new Error("missing document selection");
+      selection.removeAllRanges();
+      selection.addRange(range);
+
+      const terminal = document.querySelector<HTMLElement>(".acorn-terminal");
+      if (!terminal) throw new Error("missing terminal element");
+      terminal.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          button: 2,
+        }),
+      );
+    });
+    await page.waitForTimeout(150);
+
+    expect(
+      await page.evaluate(
+        () => (window as unknown as { __ptyWrites?: string[] }).__ptyWrites,
+      ),
+    ).toEqual([]);
   });
 
   test("normalizes no-break spaces from direct terminal input", async ({


### PR DESCRIPTION
## Summary
Adds an opt-in terminal setting for right-clicking selected terminal text back into input.

1. **Terminal input gesture** — right-clicking selected terminal text now routes through xterm paste only when the new setting is enabled.
2. **Settings control** — adds a default-off Terminal tab toggle below link-click behavior, with English and Korean copy.
3. **Regression coverage** — covers default-off, enabled, and external-selection guard paths in E2E plus settings store/modal tests.

## Expected impact
| Area | Impact |
| --- | --- |
| Default terminal behavior | Unchanged; the new gesture is off by default. |
| Opt-in workflow | Users can enable right-click selection paste from Settings -> Terminal. |
| Safety | Non-terminal selected text is ignored, so other panel selections are not written to the PTY. |

## Design notes
- The setting lives under Terminal near `Open links on` because both control mouse behavior on terminal output.
- The handler uses xterm selection first and only falls back to DOM selection when both anchor and focus are inside the terminal container.
- Selected text is routed through existing terminal paste normalization so Unicode space handling stays consistent.

## Test plan
- [x] `pnpm run typecheck` passed
- [x] `pnpm exec vitest run src/lib/settings.test.ts src/components/SettingsModal.test.tsx` passed: 2 files, 102 tests
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts -g "right-click|non-terminal selected text"` passed: 3 tests
- [x] `git diff --check` passed

## Notes
- A local dev app launched earlier for manual inspection was stopped before merge work.
