### PR TITLE
fix(app): block modified wheel zoom gestures

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -620,26 +620,11 @@ function App() {
   }, [appearance.uiScalePercent]);
 
   useEffect(() => {
-    // Cmd/Ctrl + wheel zooms the UI scale, mirroring the keyboard zoom
-    // hotkeys. Registered on window in the capture phase with passive:false
-    // so it runs before the terminal's own wheel handler — otherwise the
-    // pointer sitting over a pane (xterm) would scroll the terminal instead
-    // of zooming. A macOS trackpad pinch arrives as a ctrlKey wheel event,
-    // so this path covers pinch-to-zoom as well.
-    const WHEEL_STEP_THRESHOLD = 80;
-    let accum = 0;
+    // Block modified wheel zoom gestures at the app boundary. Keyboard UI
+    // scale hotkeys and the Settings control still provide explicit resizing.
     const onWheel = (e: WheelEvent) => {
       if (!e.metaKey && !e.ctrlKey) return;
       e.preventDefault();
-      // Normalize line/page deltas to pixels so non-pixel wheels step sanely.
-      const unit = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? 400 : 1;
-      accum += e.deltaY * unit;
-      while (Math.abs(accum) >= WHEEL_STEP_THRESHOLD) {
-        // Scroll up (deltaY < 0) zooms in, matching native zoom convention.
-        const direction = accum > 0 ? -1 : 1;
-        updateUiScalePercent(direction * UI_SCALE_PERCENT_STEP);
-        accum -= Math.sign(accum) * WHEEL_STEP_THRESHOLD;
-      }
     };
     window.addEventListener("wheel", onWheel, {
       capture: true,

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -78,4 +78,37 @@ test.describe("smoke: app boots in mocked browser", () => {
       )
       .toBe("1");
   });
+
+  test("blocks modified wheel zoom without changing UI scale", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: "Projects" })).toBeVisible();
+
+    const result = await page.evaluate(() => {
+      const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+      const event = new WheelEvent("wheel", {
+        deltaY: -160,
+        metaKey: isMac,
+        ctrlKey: !isMac,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      return {
+        dispatched: window.dispatchEvent(event),
+        defaultPrevented: event.defaultPrevented,
+        scale: document.documentElement.style.getPropertyValue(
+          "--acorn-ui-scale",
+        ),
+      };
+    });
+
+    expect(result).toEqual({
+      dispatched: false,
+      defaultPrevented: true,
+      scale: "1",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Stops modifier-wheel gestures from changing Acorn's app-level UI scale while keeping explicit resize controls intact.

1. **Wheel gesture guard** — keep the capture-phase window listener so modified wheel gestures are consumed at the app boundary, but remove the UI-scale delta accumulation path.
2. **Regression coverage** — extend the mocked browser smoke suite to assert a modified wheel event is canceled and `--acorn-ui-scale` remains unchanged.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Cmd/Ctrl + wheel over the app | Changed Acorn UI scale | Event is blocked; UI scale stays unchanged |
| Keyboard UI scale shortcuts and Settings control | Explicit resize controls worked | Unchanged |

## Design notes
- The global wheel listener stays registered on `window` in capture phase with `passive: false` so the browser/webview default zoom gesture is still prevented before nested surfaces handle the wheel.
- Keyboard hotkeys and the Settings UI remain the explicit paths for changing app scale.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm run typecheck` passes
- [x] `PLAYWRIGHT_PORT=1421 pnpm exec playwright test tests/e2e/smoke.spec.ts --project=chromium` — 3 passed
- [x] `pnpm run build` passes

## Notes
- `pnpm run build` completed with Vite warning output and exit code 0.
