### PR TITLE
fix(viewer): preserve file viewer state across pane switches

### DIFF
--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -14,6 +14,7 @@ import { cn } from "../lib/cn";
 import { useSettings } from "../lib/settings";
 import { resolveThemeMode, useThemes } from "../lib/themes";
 import { useTranslation } from "../lib/useTranslation";
+import type { ScrollPosition } from "../lib/scrollPosition";
 import {
   estimateMaxLineWidthCh,
   lineIndexProps,
@@ -23,12 +24,22 @@ import {
 } from "./VirtualizedLines";
 import { Tooltip } from "./Tooltip";
 import { Button, FloatingToolbar, IconButton, Markdown } from "./ui";
-import type { CodeWorkspaceTabTarget } from "../lib/workspaceTabs";
+import type {
+  CodeWorkspaceTabTarget,
+  CodeWorkspaceTabViewState,
+} from "../lib/workspaceTabs";
+import {
+  scrollPositionFromEventTarget,
+  useDeferredScrollReporter,
+  useRestoredScrollRef,
+} from "./useScrollViewState";
 
 interface CodeViewerProps {
   path: string;
   isActive: boolean;
   target?: CodeWorkspaceTabTarget;
+  viewState?: CodeWorkspaceTabViewState;
+  onViewStateChange?: (patch: CodeWorkspaceTabViewState) => void;
 }
 
 interface ViewerState {
@@ -124,13 +135,21 @@ function pathsOverlap(a: string, b: string): boolean {
   return isSameOrInside(a, b) || isSameOrInside(b, a);
 }
 
-export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
+export function CodeViewer({
+  path,
+  isActive,
+  target,
+  viewState,
+  onViewStateChange,
+}: CodeViewerProps) {
   const t = useTranslation();
   const themeId = useSettings((s) => s.settings.appearance.themeId);
   const themes = useThemes((s) => s.themes);
   const [state, setState] = useState<ViewerState>(EMPTY_STATE);
   const [diffLines, setDiffLines] = useState<FsLineDiffEntry[]>([]);
-  const [previewMarkdown, setPreviewMarkdown] = useState(false);
+  const [previewMarkdown, setPreviewMarkdown] = useState(
+    () => viewState?.code?.previewMarkdown ?? false,
+  );
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [activeMatchIndex, setActiveMatchIndex] = useState(0);
@@ -142,6 +161,22 @@ export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
   const themeMode = useMemo(
     () => resolveThemeMode(themeId, themes),
     [themeId, themes],
+  );
+  const reportCodeScrollPosition = useDeferredScrollReporter(
+    useCallback(
+      (position: ScrollPosition) => onViewStateChange?.({ code: position }),
+      [onViewStateChange],
+    ),
+  );
+  const restorePreviewScrollRef = useRestoredScrollRef<HTMLDivElement>(
+    viewState?.code,
+  );
+  const setPreviewRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      previewRef.current = node;
+      restorePreviewScrollRef(node);
+    },
+    [restorePreviewScrollRef],
   );
 
   const refreshFile = useCallback(
@@ -180,7 +215,7 @@ export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
   }, [path]);
 
   useEffect(() => {
-    setPreviewMarkdown(false);
+    setPreviewMarkdown(viewState?.code?.previewMarkdown ?? false);
     setSearchOpen(false);
     setSearchQuery("");
     setActiveMatchIndex(0);
@@ -190,6 +225,12 @@ export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
       loadSeqRef.current += 1;
     };
   }, [path, refreshFile]);
+
+  const togglePreviewMarkdown = useCallback(() => {
+    const next = !previewMarkdown;
+    setPreviewMarkdown(next);
+    onViewStateChange?.({ code: { previewMarkdown: next } });
+  }, [onViewStateChange, previewMarkdown]);
 
   useEffect(() => {
     const data = state.data;
@@ -423,7 +464,12 @@ export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
       ) : null}
       {previewMarkdown && canPreviewMarkdown ? (
         <div
-          ref={previewRef}
+          ref={setPreviewRef}
+          onScroll={(event) =>
+            reportCodeScrollPosition(
+              scrollPositionFromEventTarget(event.currentTarget),
+            )
+          }
           className="acorn-selectable min-h-0 flex-1 overflow-auto px-8 py-6 pb-16"
         >
           <Markdown
@@ -440,6 +486,8 @@ export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
           estimateSize={estimateCodeLineHeight}
           getLineText={(index) => sourceLines[index] ?? ""}
           minWidthCh={minWidthCh}
+          restoreScrollPosition={viewState?.code}
+          onScrollPositionChange={reportCodeScrollPosition}
           renderLine={(index) => (
             <CodeLine
               key={index}
@@ -525,7 +573,7 @@ export function CodeViewer({ path, isActive, target }: CodeViewerProps) {
       {canPreviewMarkdown ? (
         <Button
           aria-pressed={previewMarkdown}
-          onClick={() => setPreviewMarkdown((v) => !v)}
+          onClick={togglePreviewMarkdown}
           variant="outline"
           size="xs"
           surface="dialog"

--- a/src/components/FileViewer.test.tsx
+++ b/src/components/FileViewer.test.tsx
@@ -42,6 +42,12 @@ async function flushPromises() {
   });
 }
 
+async function flushScrollReport() {
+  await act(async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 90));
+  });
+}
+
 describe("FileViewer", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -121,6 +127,54 @@ describe("FileViewer", () => {
     expect(image?.style.transform).toBe("scale(1)");
   });
 
+  it("restores and reports image media zoom and scroll state", async () => {
+    vi.mocked(api.fsPrepareAsset).mockResolvedValueOnce({ size: 1536 });
+    const onViewStateChange = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <FileViewer
+          path="/repo/assets/icon.svg"
+          isActive
+          viewState={{
+            media: { imageZoom: 1.5, scrollTop: 32, scrollLeft: 8 },
+          }}
+          onViewStateChange={onViewStateChange}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const image = container.querySelector<HTMLImageElement>('img[alt="icon.svg"]');
+    const scroller = container.querySelector<HTMLDivElement>(
+      '[data-acorn-media-scroll="image"]',
+    );
+    const zoomIn = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Zoom in"]',
+    );
+
+    expect(image?.style.transform).toBe("scale(1.5)");
+    expect(scroller?.scrollTop).toBe(32);
+    expect(scroller?.scrollLeft).toBe(8);
+
+    await act(async () => zoomIn!.click());
+
+    expect(onViewStateChange).toHaveBeenCalledWith({
+      media: { imageZoom: 1.75 },
+    });
+
+    await act(async () => {
+      scroller!.scrollTop = 64;
+      scroller!.scrollLeft = 12;
+      scroller!.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    await flushScrollReport();
+
+    expect(onViewStateChange).toHaveBeenLastCalledWith({
+      media: { scrollTop: 64, scrollLeft: 12 },
+    });
+  });
+
   it("opens pdf files in the media viewer", async () => {
     vi.mocked(api.fsPrepareAsset).mockResolvedValueOnce({ size: 2048 });
 
@@ -156,5 +210,44 @@ describe("FileViewer", () => {
 
     expect(container.textContent).toContain("hello from source");
     expect(api.fsPrepareAsset).not.toHaveBeenCalled();
+  });
+
+  it("restores and reports code viewer scroll state", async () => {
+    vi.mocked(api.fsReadFile).mockResolvedValueOnce({
+      content: Array.from({ length: 80 }, (_, i) => `line ${i + 1}`).join("\n"),
+      size: 640,
+      truncated: false,
+      binary: false,
+    });
+    vi.mocked(api.fsGitDiffLines).mockResolvedValueOnce([]);
+    const onViewStateChange = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <FileViewer
+          path="/repo/src/App.tsx"
+          isActive
+          viewState={{ code: { scrollTop: 48, scrollLeft: 6 } }}
+          onViewStateChange={onViewStateChange}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const codeScroller = container.querySelector<HTMLPreElement>("pre");
+    expect(codeScroller).not.toBeNull();
+    expect(codeScroller?.scrollTop).toBe(48);
+    expect(codeScroller?.scrollLeft).toBe(6);
+
+    await act(async () => {
+      codeScroller!.scrollTop = 96;
+      codeScroller!.scrollLeft = 14;
+      codeScroller!.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    await flushScrollReport();
+
+    expect(onViewStateChange).toHaveBeenLastCalledWith({
+      code: { scrollTop: 96, scrollLeft: 14 },
+    });
   });
 });

--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -1,4 +1,7 @@
-import type { CodeWorkspaceTabTarget } from "../lib/workspaceTabs";
+import type {
+  CodeWorkspaceTabTarget,
+  CodeWorkspaceTabViewState,
+} from "../lib/workspaceTabs";
 import { mediaKindFromPath } from "../lib/mediaFiles";
 import { CodeViewer } from "./CodeViewer";
 import { MediaViewer } from "./MediaViewer";
@@ -7,12 +10,36 @@ interface FileViewerProps {
   path: string;
   isActive: boolean;
   target?: CodeWorkspaceTabTarget;
+  viewState?: CodeWorkspaceTabViewState;
+  onViewStateChange?: (patch: CodeWorkspaceTabViewState) => void;
 }
 
-export function FileViewer({ path, isActive, target }: FileViewerProps) {
+export function FileViewer({
+  path,
+  isActive,
+  target,
+  viewState,
+  onViewStateChange,
+}: FileViewerProps) {
   const mediaKind = mediaKindFromPath(path);
   if (mediaKind) {
-    return <MediaViewer path={path} kind={mediaKind} isActive={isActive} />;
+    return (
+      <MediaViewer
+        path={path}
+        kind={mediaKind}
+        isActive={isActive}
+        viewState={viewState}
+        onViewStateChange={onViewStateChange}
+      />
+    );
   }
-  return <CodeViewer path={path} target={target} isActive={isActive} />;
+  return (
+    <CodeViewer
+      path={path}
+      target={target}
+      isActive={isActive}
+      viewState={viewState}
+      onViewStateChange={onViewStateChange}
+    />
+  );
 }

--- a/src/components/MediaViewer.tsx
+++ b/src/components/MediaViewer.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type UIEventHandler,
+} from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
@@ -10,14 +16,23 @@ import {
 } from "../lib/api";
 import { basenameFromPath, type MediaFileKind } from "../lib/mediaFiles";
 import { cn } from "../lib/cn";
+import type { ScrollPosition } from "../lib/scrollPosition";
 import { useTranslation } from "../lib/useTranslation";
 import { Tooltip } from "./Tooltip";
 import { FloatingToolbar, IconButton } from "./ui";
+import type { CodeWorkspaceTabViewState } from "../lib/workspaceTabs";
+import {
+  scrollPositionFromEventTarget,
+  useDeferredScrollReporter,
+  useRestoredScrollRef,
+} from "./useScrollViewState";
 
 interface MediaViewerProps {
   path: string;
   kind: MediaFileKind;
   isActive: boolean;
+  viewState?: CodeWorkspaceTabViewState;
+  onViewStateChange?: (patch: CodeWorkspaceTabViewState) => void;
 }
 
 interface MediaState {
@@ -38,12 +53,29 @@ const IMAGE_ZOOM_MIN = 0.25;
 const IMAGE_ZOOM_MAX = 5;
 const IMAGE_ZOOM_STEP = 0.25;
 
-export function MediaViewer({ path, kind, isActive }: MediaViewerProps) {
+export function MediaViewer({
+  path,
+  kind,
+  isActive,
+  viewState,
+  onViewStateChange,
+}: MediaViewerProps) {
   const t = useTranslation();
   const [state, setState] = useState<MediaState>(EMPTY_STATE);
-  const [imageZoom, setImageZoom] = useState(1);
+  const [imageZoom, setImageZoom] = useState(() =>
+    clampImageZoom(viewState?.media?.imageZoom ?? 1),
+  );
   const loadSeqRef = useRef(0);
   const title = basenameFromPath(path);
+  const reportMediaScrollPosition = useDeferredScrollReporter(
+    useCallback(
+      (position: ScrollPosition) => onViewStateChange?.({ media: position }),
+      [onViewStateChange],
+    ),
+  );
+  const restoreMediaScrollRef = useRestoredScrollRef<HTMLDivElement>(
+    viewState?.media,
+  );
 
   const refreshAsset = useCallback(
     async ({ reset = false }: { reset?: boolean } = {}) => {
@@ -81,8 +113,17 @@ export function MediaViewer({ path, kind, isActive }: MediaViewerProps) {
   }, [refreshAsset]);
 
   useEffect(() => {
-    setImageZoom(1);
+    setImageZoom(clampImageZoom(viewState?.media?.imageZoom ?? 1));
   }, [path, kind]);
+
+  const updateImageZoom = useCallback(
+    (updater: (value: number) => number) => {
+      const next = clampImageZoom(updater(imageZoom));
+      setImageZoom(next);
+      onViewStateChange?.({ media: { imageZoom: next } });
+    },
+    [imageZoom, onViewStateChange],
+  );
 
   useEffect(() => {
     let unlisten: UnlistenFn | null = null;
@@ -139,11 +180,23 @@ export function MediaViewer({ path, kind, isActive }: MediaViewerProps) {
         <>
           <ImageZoomControls
             zoom={imageZoom}
-            onZoomIn={() => setImageZoom((value) => nextImageZoom(value, 1))}
-            onZoomOut={() => setImageZoom((value) => nextImageZoom(value, -1))}
-            onReset={() => setImageZoom(1)}
+            onZoomIn={() => updateImageZoom((value) => nextImageZoom(value, 1))}
+            onZoomOut={() =>
+              updateImageZoom((value) => nextImageZoom(value, -1))
+            }
+            onReset={() => updateImageZoom(() => 1)}
           />
-          {renderMedia(kind, state.src, title, imageZoom)}
+          {renderMedia(
+            kind,
+            state.src,
+            title,
+            imageZoom,
+            restoreMediaScrollRef,
+            (event) =>
+              reportMediaScrollPosition(
+                scrollPositionFromEventTarget(event.currentTarget),
+              ),
+          )}
         </>
       ) : (
         renderMedia(kind, state.src, title)
@@ -157,10 +210,17 @@ function renderMedia(
   src: string,
   title: string,
   imageZoom = 1,
+  imageScrollRef?: (node: HTMLDivElement | null) => void,
+  onImageScroll?: UIEventHandler<HTMLDivElement>,
 ) {
   if (kind === "image") {
     return (
-      <div className="h-full w-full overflow-auto">
+      <div
+        ref={imageScrollRef}
+        onScroll={onImageScroll}
+        data-acorn-media-scroll="image"
+        className="h-full w-full overflow-auto"
+      >
         <div className="flex min-h-full min-w-full items-center justify-center p-6">
           <img
             src={src}

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -189,6 +189,9 @@ export function Pane({ paneId }: PaneProps) {
   const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
   const closeWorkspaceTab = useAppStore((s) => s.closeWorkspaceTab);
   const openCodeViewerTab = useAppStore((s) => s.openCodeViewerTab);
+  const updateCodeViewerTabViewState = useAppStore(
+    (s) => s.updateCodeViewerTabViewState,
+  );
   const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
   const moveTab = useAppStore((s) => s.moveTab);
   const splitFocusedPane = useAppStore((s) => s.splitFocusedPane);
@@ -242,6 +245,7 @@ export function Pane({ paneId }: PaneProps) {
           lifecycle: workspaceTab.lifecycle,
           path: workspaceTab.path,
           target: workspaceTab.target,
+          viewState: workspaceTab.viewState,
         });
       } else if (workspaceTab?.kind === "work-summary") {
         ordered.push({
@@ -585,8 +589,13 @@ export function Pane({ paneId }: PaneProps) {
         ) : null}
         {active?.kind === "code" ? (
           <FileViewer
+            key={active.id}
             path={active.path}
             target={active.target}
+            viewState={active.viewState}
+            onViewStateChange={(patch) =>
+              updateCodeViewerTabViewState(active.id, patch)
+            }
             isActive={isFocused}
           />
         ) : null}

--- a/src/components/VirtualizedLines.tsx
+++ b/src/components/VirtualizedLines.tsx
@@ -2,6 +2,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   forwardRef,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -9,7 +10,14 @@ import {
   type Key,
   type RefObject,
   type ReactNode,
+  type UIEvent,
 } from "react";
+import {
+  currentScrollPosition,
+  restoreScrollPosition,
+  type PartialScrollPosition,
+  type ScrollPosition,
+} from "../lib/scrollPosition";
 
 export const VIRTUALIZED_LINE_THRESHOLD = 500;
 
@@ -29,6 +37,8 @@ interface VirtualizedLineListProps {
   minWidthCh?: number;
   overscan?: number;
   threshold?: number;
+  restoreScrollPosition?: PartialScrollPosition;
+  onScrollPositionChange?: (position: ScrollPosition) => void;
 }
 
 export interface VirtualizedLineListHandle {
@@ -63,10 +73,15 @@ export const VirtualizedLineList = forwardRef<
     minWidthCh,
     overscan = DEFAULT_OVERSCAN,
     threshold = VIRTUALIZED_LINE_THRESHOLD,
+    restoreScrollPosition: restoredScrollPosition,
+    onScrollPositionChange,
   },
   ref,
 ) {
   const scrollRef = useRef<HTMLElement | null>(null);
+  const restoredScrollPositionRef = useRef(restoredScrollPosition);
+  const onScrollPositionChangeRef = useRef(onScrollPositionChange);
+  const didRestoreScrollRef = useRef(false);
   const virtualized = count > threshold;
   const averageInitialSize = useMemo(() => {
     if (count === 0) return 1;
@@ -105,8 +120,29 @@ export const VirtualizedLineList = forwardRef<
   const renderedItems: RenderedVirtualItem[] =
     virtualItems.length > 0 ? virtualItems : fallbackItems;
 
+  useEffect(() => {
+    restoredScrollPositionRef.current = restoredScrollPosition;
+  }, [restoredScrollPosition?.scrollLeft, restoredScrollPosition?.scrollTop]);
+
+  useEffect(() => {
+    onScrollPositionChangeRef.current = onScrollPositionChange;
+  }, [onScrollPositionChange]);
+
   const setScrollRef = useCallback((node: HTMLElement | null) => {
     scrollRef.current = node;
+    if (!node) {
+      didRestoreScrollRef.current = false;
+      return;
+    }
+    if (didRestoreScrollRef.current) return;
+    didRestoreScrollRef.current = true;
+    restoreScrollPosition(node, restoredScrollPositionRef.current);
+  }, []);
+
+  const handleScroll = useCallback((event: UIEvent<HTMLElement>) => {
+    onScrollPositionChangeRef.current?.(
+      currentScrollPosition(event.currentTarget),
+    );
   }, []);
 
   useImperativeHandle(
@@ -136,6 +172,7 @@ export const VirtualizedLineList = forwardRef<
   const props = {
     ref: setScrollRef,
     className,
+    onScroll: handleScroll,
     onCopy,
     "data-virtualized": virtualized ? "true" : "false",
   };

--- a/src/components/useScrollViewState.ts
+++ b/src/components/useScrollViewState.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useRef } from "react";
+import {
+  currentScrollPosition,
+  restoreScrollPosition,
+  type PartialScrollPosition,
+  type ScrollPosition,
+} from "../lib/scrollPosition";
+
+const SCROLL_REPORT_DELAY_MS = 80;
+
+export function useRestoredScrollRef<T extends HTMLElement>(
+  position: PartialScrollPosition | undefined,
+) {
+  const positionRef = useRef(position);
+  const restoredRef = useRef(false);
+
+  useEffect(() => {
+    positionRef.current = position;
+  }, [position?.scrollLeft, position?.scrollTop]);
+
+  return useCallback((node: T | null) => {
+    if (!node) {
+      restoredRef.current = false;
+      return;
+    }
+    if (restoredRef.current) return;
+    restoredRef.current = true;
+    restoreScrollPosition(node, positionRef.current);
+  }, []);
+}
+
+export function useDeferredScrollReporter(
+  onChange: ((position: ScrollPosition) => void) | undefined,
+) {
+  const onChangeRef = useRef(onChange);
+  const latestRef = useRef<ScrollPosition | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  const flush = useCallback(() => {
+    timeoutRef.current = null;
+    const latest = latestRef.current;
+    if (latest) onChangeRef.current?.(latest);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      const latest = latestRef.current;
+      if (latest) {
+        window.setTimeout(() => onChangeRef.current?.(latest), 0);
+      }
+    };
+  }, []);
+
+  return useCallback(
+    (position: ScrollPosition) => {
+      latestRef.current = position;
+      if (timeoutRef.current !== null) return;
+      timeoutRef.current = window.setTimeout(flush, SCROLL_REPORT_DELAY_MS);
+    },
+    [flush],
+  );
+}
+
+export function scrollPositionFromEventTarget(
+  target: EventTarget & HTMLElement,
+): ScrollPosition {
+  return currentScrollPosition(target);
+}

--- a/src/lib/scrollPosition.ts
+++ b/src/lib/scrollPosition.ts
@@ -1,0 +1,38 @@
+export interface ScrollPosition {
+  scrollTop: number;
+  scrollLeft: number;
+}
+
+export type PartialScrollPosition = Partial<ScrollPosition>;
+
+export function currentScrollPosition(element: HTMLElement): ScrollPosition {
+  return {
+    scrollTop: element.scrollTop,
+    scrollLeft: element.scrollLeft,
+  };
+}
+
+export function restoreScrollPosition(
+  element: HTMLElement,
+  position: PartialScrollPosition | undefined,
+): void {
+  if (!position) return;
+  const scrollTop = finiteScrollValue(position.scrollTop);
+  const scrollLeft = finiteScrollValue(position.scrollLeft);
+  element.scrollTop = scrollTop;
+  element.scrollLeft = scrollLeft;
+
+  // Some scroll surfaces get their real dimensions after a virtualizer or
+  // image has measured. A second frame keeps restoration deterministic without
+  // depending on the child implementation's mount order.
+  requestAnimationFrame(() => {
+    element.scrollTop = scrollTop;
+    element.scrollLeft = scrollLeft;
+  });
+}
+
+function finiteScrollValue(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, value)
+    : 0;
+}

--- a/src/lib/workspaceTabs.test.ts
+++ b/src/lib/workspaceTabs.test.ts
@@ -5,9 +5,11 @@ import {
   isRestorableWorkspaceTab,
   isSessionTabId,
   isWorkspaceTabId,
+  codeWorkspaceTabViewStateEqual,
   makeCodeWorkspaceTab,
   makeSessionWorkspaceTab,
   makeWorkSummaryWorkspaceTab,
+  mergeCodeWorkspaceTabViewState,
 } from "./workspaceTabs";
 
 afterEach(() => {
@@ -114,5 +116,40 @@ describe("workspace tab lifecycle", () => {
       title: "s1 summary",
     });
     expect(isRestorableWorkspaceTab(tab)).toBe(false);
+  });
+});
+
+describe("code workspace tab view state", () => {
+  it("merges code and media patches without dropping the other surface", () => {
+    const current = {
+      code: { scrollTop: 80, previewMarkdown: true },
+      media: { scrollLeft: 10, imageZoom: 1.5 },
+    };
+
+    expect(
+      mergeCodeWorkspaceTabViewState(current, {
+        code: { scrollLeft: 24 },
+      }),
+    ).toEqual({
+      code: { scrollTop: 80, scrollLeft: 24, previewMarkdown: true },
+      media: { scrollLeft: 10, imageZoom: 1.5 },
+    });
+  });
+
+  it("compares saved code/media view state by value", () => {
+    const state = {
+      code: { scrollTop: 12, scrollLeft: 3, previewMarkdown: false },
+      media: { scrollTop: 40, imageZoom: 2 },
+    };
+
+    expect(codeWorkspaceTabViewStateEqual(state, structuredClone(state))).toBe(
+      true,
+    );
+    expect(
+      codeWorkspaceTabViewStateEqual(state, {
+        ...state,
+        media: { scrollTop: 41, imageZoom: 2 },
+      }),
+    ).toBe(false);
   });
 });

--- a/src/lib/workspaceTabs.ts
+++ b/src/lib/workspaceTabs.ts
@@ -28,6 +28,7 @@ export interface CodeWorkspaceTab
   extends WorkspaceTabBase<"code", "ephemeral" | "restorable"> {
   path: string;
   target?: CodeWorkspaceTabTarget;
+  viewState?: CodeWorkspaceTabViewState;
 }
 
 export interface WorkSummaryWorkspaceTab
@@ -41,6 +42,24 @@ export interface CodeWorkspaceTabTarget {
   line: number;
   column?: number;
   token: string;
+}
+
+export interface FileScrollViewState {
+  scrollTop?: number;
+  scrollLeft?: number;
+}
+
+export interface CodeFileViewState extends FileScrollViewState {
+  previewMarkdown?: boolean;
+}
+
+export interface MediaFileViewState extends FileScrollViewState {
+  imageZoom?: number;
+}
+
+export interface CodeWorkspaceTabViewState {
+  code?: CodeFileViewState;
+  media?: MediaFileViewState;
 }
 
 export type WorkspaceTab =
@@ -148,4 +167,52 @@ export function isProcessBackedWorkspaceTab(
   tab: WorkspaceTab,
 ): tab is ProcessBackedWorkspaceTab {
   return tab.lifecycle === "process-backed";
+}
+
+export function mergeCodeWorkspaceTabViewState(
+  current: CodeWorkspaceTabViewState | undefined,
+  patch: CodeWorkspaceTabViewState,
+): CodeWorkspaceTabViewState {
+  const code = patch.code
+    ? { ...(current?.code ?? {}), ...patch.code }
+    : current?.code;
+  const media = patch.media
+    ? { ...(current?.media ?? {}), ...patch.media }
+    : current?.media;
+  return {
+    ...(code ? { code } : {}),
+    ...(media ? { media } : {}),
+  };
+}
+
+export function codeWorkspaceTabViewStateEqual(
+  a: CodeWorkspaceTabViewState | undefined,
+  b: CodeWorkspaceTabViewState | undefined,
+): boolean {
+  return (
+    codeFileViewStateEqual(a?.code, b?.code) &&
+    mediaFileViewStateEqual(a?.media, b?.media)
+  );
+}
+
+function codeFileViewStateEqual(
+  a: CodeFileViewState | undefined,
+  b: CodeFileViewState | undefined,
+): boolean {
+  return (
+    a?.scrollTop === b?.scrollTop &&
+    a?.scrollLeft === b?.scrollLeft &&
+    a?.previewMarkdown === b?.previewMarkdown
+  );
+}
+
+function mediaFileViewStateEqual(
+  a: MediaFileViewState | undefined,
+  b: MediaFileViewState | undefined,
+): boolean {
+  return (
+    a?.scrollTop === b?.scrollTop &&
+    a?.scrollLeft === b?.scrollLeft &&
+    a?.imageZoom === b?.imageZoom
+  );
 }

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1112,6 +1112,38 @@ describe("workspace tabs", () => {
     expect(updatedTab.target?.token).not.toBe(firstTarget?.token);
   });
 
+  it("merges code viewer scroll and zoom state into the existing tab", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+
+    useAppStore.getState().openCodeViewerTab(`${REPO_A}/src/App.tsx`, REPO_A);
+    const tabId = useAppStore.getState().activeTabId!;
+
+    useAppStore.getState().updateCodeViewerTabViewState(tabId, {
+      code: { scrollTop: 120, scrollLeft: 4 },
+    });
+    useAppStore.getState().updateCodeViewerTabViewState(tabId, {
+      media: { imageZoom: 1.5 },
+    });
+    useAppStore.getState().updateCodeViewerTabViewState(tabId, {
+      code: { previewMarkdown: true },
+    });
+
+    const tab = useAppStore.getState().workspaceTabs[tabId];
+    expect(tab).toMatchObject({
+      kind: "code",
+      viewState: {
+        code: {
+          scrollTop: 120,
+          scrollLeft: 4,
+          previewMarkdown: true,
+        },
+        media: {
+          imageZoom: 1.5,
+        },
+      },
+    });
+  });
+
   it("reselects a worktree-scoped code tab after switching projects", async () => {
     const a1 = session("a1", REPO_A, {
       worktree_path: `${REPO_A}/.worktrees/a1`,

--- a/src/store.ts
+++ b/src/store.ts
@@ -27,12 +27,15 @@ import {
 } from "./lib/layout";
 import {
   activeSessionIdFromTabId,
+  codeWorkspaceTabViewStateEqual,
   isRestorableWorkspaceTab,
   isWorkspaceTabId,
   makeCodeWorkspaceTab,
   makeCodeWorkspaceTabTarget,
   makeWorkSummaryWorkspaceTab,
+  mergeCodeWorkspaceTabViewState,
   type FrontendWorkspaceTab,
+  type CodeWorkspaceTabViewState,
 } from "./lib/workspaceTabs";
 import {
   defaultTabByGroup,
@@ -354,6 +357,11 @@ interface AppStateModel {
     path: string,
     repoPath?: string,
     target?: { line?: number; column?: number },
+  ) => void;
+  /** Persist transient scroll/zoom state for an open code/media viewer tab. */
+  updateCodeViewerTabViewState: (
+    id: string,
+    patch: CodeWorkspaceTabViewState,
   ) => void;
   /** Open a work summary tab for the current session or a provided worktree. */
   openWorkSummaryTab: (scope?: WorkSummaryTabScope) => Promise<void>;
@@ -3049,6 +3057,24 @@ export const useAppStore = create<AppStateModel>()(
           : { ...s.workspaceTabs, [tab.id]: tab },
         workspaces: newWorkspaces,
         ...mirrorActive(newWorkspaces, workspaceId),
+      };
+    });
+  },
+
+  updateCodeViewerTabViewState(id, patch) {
+    set((s) => {
+      const tab = s.workspaceTabs[id];
+      if (!tab || tab.kind !== "code") return s;
+      const viewState = mergeCodeWorkspaceTabViewState(tab.viewState, patch);
+      if (codeWorkspaceTabViewStateEqual(tab.viewState, viewState)) return s;
+      return {
+        workspaceTabs: {
+          ...s.workspaceTabs,
+          [id]: {
+            ...tab,
+            viewState,
+          },
+        },
       };
     });
   },


### PR DESCRIPTION
## Summary
File viewer tabs now retain their view position when the user leaves and returns to them.

1. **Per-tab viewer state** — add code/media view state to code workspace tabs and a store action that merges scroll, markdown preview, and image zoom updates without replacing the rest of the tab descriptor.
2. **Scroll restoration** — restore and report scroll positions for source view, markdown preview, and image media surfaces, including virtualized code lists.
3. **Image zoom retention** — persist image zoom changes per file tab so zoom no longer resets after switching panes or tabs.
4. **Focused coverage** — cover code scroll, image scroll/zoom, view-state merging, and equality helpers in Vitest.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Code file tabs | Scroll position could reset after leaving and returning | Scroll position is restored per file tab |
| Markdown preview | Preview mode reset on remount | Preview mode and scroll position are restored |
| Image tabs | Zoom reset to 100% on remount | Zoom and scroll position are restored per file tab |

## Design notes
- Viewer state is stored on the existing frontend-owned code workspace tab rather than in component-local state, because file viewers unmount when another tab or pane becomes active.
- Code and media state live under separate keys so text/PDF/image handling can share a tab descriptor without clobbering unrelated state.
- Scroll reporting is deferred briefly and flushed on unmount to avoid writing to Zustand/localStorage on every scroll event while still preserving the latest position during tab switches.
- `FileViewer` is keyed by tab id in `Pane` so switching between two code tabs remounts the viewer and applies the correct tab-specific restoration state.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/components/FileViewer.test.tsx src/store.test.ts src/lib/workspaceTabs.test.ts` — 3 files, 139 tests passed
- [x] `pnpm run test` — 73 files, 779 tests passed
- [x] `pnpm run build` passes

## Notes
- `pnpm run build` still emits the existing Vite dynamic/static import and large chunk warnings; the build exits successfully.
