### PR TITLE
fix(sidebar): prevent hidden action buttons from truncating titles

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1900,10 +1900,56 @@ function ProjectGroupView({
             {project.name}
           </span>
         </span>
-        {PROJECT_SESSION_PRIMARY_CREATE_ACTIONS.map((action) => (
+        <div className="ml-auto hidden shrink-0 items-center gap-1 group-hover:flex">
+          {PROJECT_SESSION_PRIMARY_CREATE_ACTIONS.map((action) => (
+            <Tooltip
+              key={action.id}
+              label={sidebarText(t, action.labelKey)}
+              side="bottom"
+            >
+              <button
+                type="button"
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setMenu(null);
+                  setCreateMenu(null);
+                  if (projectSessionCreationFolder) {
+                    onAddSession(
+                      projectSessionCreationFolder,
+                      action.isolated,
+                      action.kind,
+                      action.mode,
+                    );
+                  }
+                }}
+                className="flex size-5 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+                aria-label={sidebarText(t, action.ariaKey)}
+              >
+                {projectSessionCreateIcon(action.id)}
+              </button>
+            </Tooltip>
+          ))}
+          <button
+            type="button"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              const rect = e.currentTarget.getBoundingClientRect();
+              setMenu(null);
+              setCreateMenu((current) =>
+                current === null ? { x: rect.left, y: rect.bottom + 4 } : null,
+              );
+            }}
+            className="flex size-5 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+            aria-label={sidebarText(t, "sidebar.aria.newSessionMenuInProject")}
+            aria-haspopup="menu"
+            aria-expanded={createMenu !== null}
+          >
+            <MoreHorizontal size={13} />
+          </button>
           <Tooltip
-            key={action.id}
-            label={sidebarText(t, action.labelKey)}
+            label={sidebarText(t, "sidebar.actions.closeProject")}
             side="bottom"
           >
             <button
@@ -1911,59 +1957,15 @@ function ProjectGroupView({
               onPointerDown={(e) => e.stopPropagation()}
               onClick={(e) => {
                 e.stopPropagation();
-                setMenu(null);
-                setCreateMenu(null);
-                if (projectSessionCreationFolder) {
-                  onAddSession(
-                    projectSessionCreationFolder,
-                    action.isolated,
-                    action.kind,
-                    action.mode,
-                  );
-                }
+                onRemoveProject();
               }}
-              className="invisible flex size-5 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
-              aria-label={sidebarText(t, action.ariaKey)}
+              className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger"
+              aria-label={sidebarText(t, "sidebar.actions.closeProject")}
             >
-              {projectSessionCreateIcon(action.id)}
+              <X size={12} />
             </button>
           </Tooltip>
-        ))}
-        <button
-          type="button"
-          onPointerDown={(e) => e.stopPropagation()}
-          onClick={(e) => {
-            e.stopPropagation();
-            const rect = e.currentTarget.getBoundingClientRect();
-            setMenu(null);
-            setCreateMenu((current) =>
-              current === null ? { x: rect.left, y: rect.bottom + 4 } : null,
-            );
-          }}
-          className="invisible flex size-5 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover:visible"
-          aria-label={sidebarText(t, "sidebar.aria.newSessionMenuInProject")}
-          aria-haspopup="menu"
-          aria-expanded={createMenu !== null}
-        >
-          <MoreHorizontal size={13} />
-        </button>
-        <Tooltip
-          label={sidebarText(t, "sidebar.actions.closeProject")}
-          side="bottom"
-        >
-          <button
-            type="button"
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={(e) => {
-              e.stopPropagation();
-              onRemoveProject();
-            }}
-            className="invisible flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger group-hover:visible"
-            aria-label={sidebarText(t, "sidebar.actions.closeProject")}
-          >
-            <X size={12} />
-          </button>
-        </Tooltip>
+        </div>
       </div>
       <ContextMenu
         open={createMenu !== null}
@@ -2341,7 +2343,7 @@ function ProjectFolderView({
           )}
         </span>
         {!editing ? (
-          <div className="ml-auto flex shrink-0 items-center gap-0.5">
+          <div className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover/project-folder:flex group-focus-within/project-folder:flex">
             <Tooltip
               label={sidebarText(t, "sidebar.aria.newSessionInProjectFolder")}
               side="bottom"
@@ -2358,7 +2360,7 @@ function ProjectFolderView({
                   onAddSession(false, "regular", "terminal");
                 }}
                 onKeyDown={(e) => e.stopPropagation()}
-                className="invisible flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover/project-folder:visible group-focus-within/project-folder:visible"
+                className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
               >
                 <Plus size={12} />
               </button>
@@ -2390,7 +2392,7 @@ function ProjectFolderView({
                   );
                 }}
                 onKeyDown={(e) => e.stopPropagation()}
-                className="invisible flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover/project-folder:visible group-focus-within/project-folder:visible"
+                className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
               >
                 <MoreHorizontal size={13} />
               </button>
@@ -2412,7 +2414,7 @@ function ProjectFolderView({
                     onRemoveFolder(folder.id);
                   }}
                   onKeyDown={(e) => e.stopPropagation()}
-                  className="invisible flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger group-hover/project-folder:visible group-focus-within/project-folder:visible"
+                  className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger"
                 >
                   <Trash2 size={12} />
                 </button>
@@ -2811,7 +2813,7 @@ function SessionRow({
         }}
         onCancelRename={() => setEditing(false)}
       />
-      <div className="ml-auto flex shrink-0 items-center gap-0.5">
+      <div className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover:flex">
         <button
           type="button"
           aria-label={sidebarText(t, "sidebar.actions.removeSession")}
@@ -2821,7 +2823,7 @@ function SessionRow({
             onRemove();
           }}
           onKeyDown={(e) => e.stopPropagation()}
-          className="invisible flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger group-hover:visible"
+          className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger"
         >
           <Trash2 size={12} />
         </button>
@@ -3439,7 +3441,7 @@ function LocalWorkspaceView({
           )}
         </span>
         {!editing ? (
-          <div className="ml-auto flex shrink-0 items-center gap-0.5">
+          <div className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover/local-workspace:flex group-focus-within/local-workspace:flex">
             <Tooltip
               label={sidebarText(t, "sidebar.localTerminals.newSession")}
               side="bottom"
@@ -3453,7 +3455,7 @@ function LocalWorkspaceView({
                   onCreateSession();
                 }}
                 onKeyDown={(e) => e.stopPropagation()}
-                className="invisible flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg group-hover/local-workspace:visible group-focus-within/local-workspace:visible"
+                className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
               >
                 <Plus size={12} />
               </button>
@@ -3471,7 +3473,7 @@ function LocalWorkspaceView({
                   onRemoveFolder(folder.id);
                 }}
                 onKeyDown={(e) => e.stopPropagation()}
-                className="invisible flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger group-hover/local-workspace:visible group-focus-within/local-workspace:visible"
+                className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger"
               >
                 <Trash2 size={12} />
               </button>
@@ -3719,7 +3721,7 @@ function LocalSessionRow({
             onRemove();
           }
         }}
-        className="invisible rounded p-1 text-fg-muted transition hover:text-danger group-hover:visible"
+        className="ml-auto hidden shrink-0 rounded p-1 text-fg-muted transition hover:text-danger group-hover:inline-flex"
       >
         <Trash2 size={12} />
       </span>

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -2169,6 +2169,59 @@ test.describe("sidebar: project lifecycle", () => {
     ).toBeVisible();
   });
 
+  test("hidden project header actions do not reserve title width", async ({
+    page,
+    tauri,
+  }) => {
+    const projectName = "codex-app-server-main";
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "codex-app-server-main",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+
+    await page.goto("/");
+    await page.mouse.move(900, 500);
+
+    const projectRow = page.getByRole("button", {
+      name: `Project ${projectName}`,
+    });
+    await expect(projectRow).toBeVisible();
+
+    const title = projectRow.getByText(projectName, { exact: true });
+    const newSessionButton = page.locator(
+      'button[aria-label="New session in this project"]',
+    );
+    await expect(newSessionButton).toHaveCount(1);
+
+    const hiddenButtonWidth = await newSessionButton.evaluate(
+      (el) => (el as HTMLElement).offsetWidth,
+    );
+    expect(hiddenButtonWidth).toBe(0);
+
+    const titleMetrics = await title.evaluate((el) => {
+      const titleEl = el as HTMLElement;
+      return {
+        clientWidth: titleEl.clientWidth,
+        scrollWidth: titleEl.scrollWidth,
+      };
+    });
+    expect(titleMetrics.scrollWidth).toBeLessThanOrEqual(
+      titleMetrics.clientWidth + 1,
+    );
+
+    await projectRow.hover();
+    await expect(newSessionButton).toBeVisible();
+    await expect
+      .poll(() =>
+        newSessionButton.evaluate((el) => (el as HTMLElement).offsetWidth),
+      )
+      .toBeGreaterThan(0);
+  });
+
   test("project header exposes regular and worktree session buttons outside the menu", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Fix sidebar row titles being truncated by action buttons that are visually hidden but still occupy layout space.

1. **Project header actions** — wrap the hover-only project action buttons in a hidden action group so they do not reserve width before hover.
2. **Related sidebar rows** — apply the same display behavior to workspace and session row action groups that used `invisible` controls.
3. **Regression coverage** — add a Playwright assertion that hidden project header actions have zero layout width and the title is not prematurely clipped.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Sidebar project headers | Hidden action buttons could squeeze the project title and show ellipsis before icons appeared. | Project title gets the available row width until hover actions are shown. |
| Workspace/session rows | Hidden row actions could still reserve layout width. | Hover-only actions no longer reduce label width while hidden. |

## Design notes
- This keeps the existing hover-triggered action model, but changes hidden controls from `visibility: hidden` to `display: none` at the action-group level.
- The project header menu/action behavior is otherwise unchanged; controls become visible on row hover and keep their existing labels and handlers.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "hidden project header actions do not reserve title width|project header exposes regular"` — 2 passed
