### PR TITLE
feat(settings): macOS permission reset controls

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1789,6 +1789,70 @@ pub struct FolderPermissionWarmupResult {
     pub error: Option<String>,
 }
 
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub struct MacosPermissionResetResult {
+    pub id: &'static str,
+    pub service: &'static str,
+    pub status: &'static str,
+    pub error: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+struct MacosTccService {
+    id: &'static str,
+    service: &'static str,
+}
+
+const MACOS_FOLDER_TCC_SERVICES: &[MacosTccService] = &[
+    MacosTccService {
+        id: "desktop",
+        service: "SystemPolicyDesktopFolder",
+    },
+    MacosTccService {
+        id: "documents",
+        service: "SystemPolicyDocumentsFolder",
+    },
+    MacosTccService {
+        id: "downloads",
+        service: "SystemPolicyDownloadsFolder",
+    },
+];
+
+const MACOS_DEVELOPER_TCC_SERVICES: &[MacosTccService] = &[
+    MacosTccService {
+        id: "desktop",
+        service: "SystemPolicyDesktopFolder",
+    },
+    MacosTccService {
+        id: "documents",
+        service: "SystemPolicyDocumentsFolder",
+    },
+    MacosTccService {
+        id: "downloads",
+        service: "SystemPolicyDownloadsFolder",
+    },
+    MacosTccService {
+        id: "screen_capture",
+        service: "ScreenCapture",
+    },
+    MacosTccService {
+        id: "accessibility",
+        service: "Accessibility",
+    },
+    MacosTccService {
+        id: "automation",
+        service: "AppleEvents",
+    },
+    MacosTccService {
+        id: "input_monitoring",
+        service: "ListenEvent",
+    },
+    MacosTccService {
+        id: "developer_tools",
+        service: "DeveloperTool",
+    },
+];
+
 #[tauri::command]
 pub async fn warm_macos_folder_permissions() -> AppResult<Vec<FolderPermissionWarmupResult>> {
     run_blocking("warm_macos_folder_permissions", move || {
@@ -1802,6 +1866,17 @@ pub async fn reset_macos_folder_permissions<R: Runtime>(app: AppHandle<R>) -> Ap
     let bundle_id = app.config().identifier.clone();
     run_blocking("reset_macos_folder_permissions", move || {
         reset_macos_folder_permissions_inner(&bundle_id)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn reset_macos_developer_permissions<R: Runtime>(
+    app: AppHandle<R>,
+) -> AppResult<Vec<MacosPermissionResetResult>> {
+    let bundle_id = app.config().identifier.clone();
+    run_blocking("reset_macos_developer_permissions", move || {
+        Ok(reset_macos_developer_permissions_inner(&bundle_id))
     })
     .await
 }
@@ -1822,18 +1897,14 @@ fn reset_macos_folder_permissions_inner(bundle_id: &str) -> AppResult<()> {
         return Ok(());
     }
 
-    let failures: Vec<String> = [
-        "SystemPolicyDesktopFolder",
-        "SystemPolicyDocumentsFolder",
-        "SystemPolicyDownloadsFolder",
-    ]
-    .into_iter()
-    .filter_map(|service| {
-        reset_macos_tcc_service(service, bundle_id)
-            .err()
-            .map(|err| format!("{service}: {err}"))
-    })
-    .collect();
+    let failures: Vec<String> = MACOS_FOLDER_TCC_SERVICES
+        .iter()
+        .filter_map(|service| {
+            reset_macos_tcc_service(service.service, bundle_id)
+                .err()
+                .map(|err| format!("{}: {err}", service.service))
+        })
+        .collect();
 
     if failures.is_empty() {
         Ok(())
@@ -1843,6 +1914,38 @@ fn reset_macos_folder_permissions_inner(bundle_id: &str) -> AppResult<()> {
             failures.join("; ")
         )))
     }
+}
+
+fn reset_macos_developer_permissions_inner(bundle_id: &str) -> Vec<MacosPermissionResetResult> {
+    if !cfg!(target_os = "macos") {
+        return MACOS_DEVELOPER_TCC_SERVICES
+            .iter()
+            .map(|service| MacosPermissionResetResult {
+                id: service.id,
+                service: service.service,
+                status: "skipped",
+                error: None,
+            })
+            .collect();
+    }
+
+    MACOS_DEVELOPER_TCC_SERVICES
+        .iter()
+        .map(|service| match reset_macos_tcc_service(service.service, bundle_id) {
+            Ok(()) => MacosPermissionResetResult {
+                id: service.id,
+                service: service.service,
+                status: "reset",
+                error: None,
+            },
+            Err(err) => MacosPermissionResetResult {
+                id: service.id,
+                service: service.service,
+                status: "error",
+                error: Some(err.to_string()),
+            },
+        })
+        .collect()
 }
 
 fn reset_macos_tcc_service(service: &'static str, bundle_id: &str) -> AppResult<()> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -596,6 +596,7 @@ pub fn run() {
             clipboard::clipboard_snapshot,
             commands::warm_macos_folder_permissions,
             commands::reset_macos_folder_permissions,
+            commands::reset_macos_developer_permissions,
             commands::ipc_restart,
             commands::ipc_list_workspaces_response,
             commands::list_system_fonts,

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -36,6 +36,14 @@ import {
 } from "../lib/i18n";
 import { sendTestNotification } from "../lib/notifications";
 import {
+  hasDeniedFolderPermission,
+  type FolderPermissionWarmupResult,
+  type FolderPermissionWarmupStatus,
+  type MacosPermissionResetId,
+  type MacosPermissionResetResult,
+  type MacosPermissionResetStatus,
+} from "../lib/permissionWarmup";
+import {
   fetchLatestReleaseNotes,
   fetchReleaseNotes,
   type ReleaseNotes,
@@ -112,6 +120,7 @@ type Tab =
   | "notifications"
   | "shortcuts"
   | "storage"
+  | "permissions"
   | "experiments"
   | "about";
 
@@ -126,6 +135,7 @@ const TABS: Array<{ id: Tab; labelKey: TranslationKey }> = [
   { id: "notifications", labelKey: "settings.tabs.notifications" },
   { id: "shortcuts", labelKey: "settings.tabs.shortcuts" },
   { id: "storage", labelKey: "settings.tabs.storage" },
+  { id: "permissions", labelKey: "settings.tabs.permissions" },
   { id: "experiments", labelKey: "settings.tabs.experiments" },
   { id: "about", labelKey: "settings.tabs.about" },
 ];
@@ -467,6 +477,8 @@ export function SettingsModal() {
             <ShortcutsSettings />
           ) : tab === "storage" ? (
             <StorageSettings />
+          ) : tab === "permissions" ? (
+            <PermissionSettings />
           ) : tab === "experiments" ? (
             <ExperimentsSettings />
           ) : (
@@ -2324,6 +2336,389 @@ function formatBytes(bytes: number): string {
   const mb = kb / 1024;
   if (mb < 1024) return `${mb.toFixed(1)} MB`;
   return `${(mb / 1024).toFixed(2)} GB`;
+}
+
+function permissionStatusLabel(
+  t: SettingsTranslator,
+  status: FolderPermissionWarmupStatus,
+): string {
+  switch (status) {
+    case "ok":
+      return st(t, "dialogs.folderPermissionWarmup.status.ok");
+    case "missing":
+      return st(t, "dialogs.folderPermissionWarmup.status.missing");
+    case "denied":
+      return st(t, "dialogs.folderPermissionWarmup.status.denied");
+    case "error":
+      return st(t, "dialogs.folderPermissionWarmup.status.error");
+  }
+}
+
+function permissionStatusClass(status: FolderPermissionWarmupStatus): string {
+  switch (status) {
+    case "ok":
+      return "text-accent";
+    case "missing":
+      return "text-fg-muted";
+    case "denied":
+    case "error":
+      return "text-danger";
+  }
+}
+
+function hasFolderPermissionIssue(
+  results: FolderPermissionWarmupResult[],
+): boolean {
+  return results.some(
+    (result) => result.status === "denied" || result.status === "error",
+  );
+}
+
+type PermissionListItemKind = "folder" | "developer" | "external";
+type PermissionGroupId = "folders" | "automation" | "browser";
+
+interface PermissionListItem {
+  id: MacosPermissionResetId;
+  kind: PermissionListItemKind;
+  group: PermissionGroupId;
+  labelKey: TranslationKey;
+  descriptionKey: TranslationKey;
+}
+
+const PERMISSION_LIST_ITEMS: PermissionListItem[] = [
+  {
+    id: "desktop",
+    kind: "folder",
+    group: "folders",
+    labelKey: "settings.permissions.items.desktop.label",
+    descriptionKey: "settings.permissions.items.desktop.description",
+  },
+  {
+    id: "documents",
+    kind: "folder",
+    group: "folders",
+    labelKey: "settings.permissions.items.documents.label",
+    descriptionKey: "settings.permissions.items.documents.description",
+  },
+  {
+    id: "downloads",
+    kind: "folder",
+    group: "folders",
+    labelKey: "settings.permissions.items.downloads.label",
+    descriptionKey: "settings.permissions.items.downloads.description",
+  },
+  {
+    id: "icloud",
+    kind: "folder",
+    group: "folders",
+    labelKey: "settings.permissions.items.icloud.label",
+    descriptionKey: "settings.permissions.items.icloud.description",
+  },
+  {
+    id: "screen_capture",
+    kind: "developer",
+    group: "automation",
+    labelKey: "settings.permissions.items.screenCapture.label",
+    descriptionKey: "settings.permissions.items.screenCapture.description",
+  },
+  {
+    id: "accessibility",
+    kind: "developer",
+    group: "automation",
+    labelKey: "settings.permissions.items.accessibility.label",
+    descriptionKey: "settings.permissions.items.accessibility.description",
+  },
+  {
+    id: "automation",
+    kind: "developer",
+    group: "automation",
+    labelKey: "settings.permissions.items.automation.label",
+    descriptionKey: "settings.permissions.items.automation.description",
+  },
+  {
+    id: "input_monitoring",
+    kind: "developer",
+    group: "automation",
+    labelKey: "settings.permissions.items.inputMonitoring.label",
+    descriptionKey: "settings.permissions.items.inputMonitoring.description",
+  },
+  {
+    id: "developer_tools",
+    kind: "developer",
+    group: "automation",
+    labelKey: "settings.permissions.items.developerTools.label",
+    descriptionKey: "settings.permissions.items.developerTools.description",
+  },
+  {
+    id: "camera",
+    kind: "external",
+    group: "browser",
+    labelKey: "settings.permissions.items.camera.label",
+    descriptionKey: "settings.permissions.items.camera.description",
+  },
+  {
+    id: "microphone",
+    kind: "external",
+    group: "browser",
+    labelKey: "settings.permissions.items.microphone.label",
+    descriptionKey: "settings.permissions.items.microphone.description",
+  },
+];
+
+const PERMISSION_GROUPS: Array<{
+  id: PermissionGroupId;
+  titleKey: TranslationKey;
+  descriptionKey: TranslationKey;
+}> = [
+  {
+    id: "folders",
+    titleKey: "settings.permissions.groups.folders.title",
+    descriptionKey: "settings.permissions.groups.folders.description",
+  },
+  {
+    id: "automation",
+    titleKey: "settings.permissions.groups.automation.title",
+    descriptionKey: "settings.permissions.groups.automation.description",
+  },
+  {
+    id: "browser",
+    titleKey: "settings.permissions.groups.browser.title",
+    descriptionKey: "settings.permissions.groups.browser.description",
+  },
+];
+
+function resetStatusLabel(
+  t: SettingsTranslator,
+  status: MacosPermissionResetStatus,
+): string {
+  switch (status) {
+    case "reset":
+      return st(t, "settings.permissions.status.reset");
+    case "skipped":
+      return st(t, "settings.permissions.status.skipped");
+    case "error":
+      return st(t, "settings.permissions.status.resetFailed");
+  }
+}
+
+function resetStatusClass(status: MacosPermissionResetStatus): string {
+  switch (status) {
+    case "reset":
+      return "text-accent";
+    case "skipped":
+      return "text-fg-muted";
+    case "error":
+      return "text-danger";
+  }
+}
+
+function PermissionSettings() {
+  const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
+  const [busy, setBusy] = useState(false);
+  const [results, setResults] = useState<FolderPermissionWarmupResult[] | null>(
+    null,
+  );
+  const [resetResults, setResetResults] = useState<
+    MacosPermissionResetResult[] | null
+  >(null);
+  const [status, setStatus] = useState<{
+    tone: "danger" | "success" | "warning" | "neutral";
+    text: string;
+  } | null>(null);
+  const resultById = new Map(results?.map((result) => [result.id, result]));
+  const resetResultById = new Map(
+    resetResults?.map((result) => [result.id, result]),
+  );
+
+  async function handleReset() {
+    setBusy(true);
+    setStatus(null);
+    setResults(null);
+    setResetResults(null);
+    try {
+      const resetNext = await api.resetMacosDeveloperPermissions();
+      const next = await api.warmMacosFolderPermissions();
+      setResetResults(resetNext);
+      setResults(next);
+      const hasIssue =
+        hasFolderPermissionIssue(next) ||
+        resetNext.some((result) => result.status === "error");
+      const skipped =
+        next.length === 0 &&
+        resetNext.length > 0 &&
+        resetNext.every((result) => result.status === "skipped");
+      const empty = next.length === 0 && resetNext.length === 0;
+
+      const text =
+        skipped || empty
+          ? st(t, "settings.permissions.status.empty")
+          : hasIssue
+            ? st(t, "settings.permissions.status.needsAttention")
+            : st(t, "settings.permissions.status.ready");
+      setStatus({
+        tone: skipped || empty ? "neutral" : hasIssue ? "warning" : "success",
+        text,
+      });
+      showToast(text);
+    } catch (err) {
+      console.error("[Settings] folder permission reset failed", err);
+      const text = `${st(t, "settings.permissions.status.failed")} ${messageFromUnknownError(err)}`;
+      setStatus({ tone: "danger", text });
+      showToast(text);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="space-y-4">
+      <header className="space-y-1">
+        <h3 className="text-sm font-medium text-fg">
+          {st(t, "settings.permissions.title")}
+        </h3>
+        <p className="text-[11px] text-fg-muted">
+          {st(t, "settings.permissions.description")}
+        </p>
+      </header>
+
+      <Notice tone="info" density="compact">
+        {st(t, "settings.permissions.notice")}
+      </Notice>
+
+      <div className="flex items-center justify-between gap-3 rounded-[var(--acorn-pane-radius)] border border-border px-3 py-2.5">
+        <div className="min-w-0 space-y-1">
+          <div className="text-xs font-medium text-fg">
+            {st(t, "settings.permissions.folderAccess.label")}
+          </div>
+          <p className="text-[11px] text-fg-muted">
+            {st(t, "settings.permissions.folderAccess.description")}
+          </p>
+        </div>
+        <Button
+          onClick={() => void handleReset()}
+          disabled={busy}
+          variant="outline"
+          size="sm"
+        >
+          {busy ? (
+            <Loader2 size={12} className="animate-spin" />
+          ) : (
+            <RefreshCcw size={12} />
+          )}
+          {busy
+            ? st(t, "settings.permissions.reset.running")
+            : st(t, "settings.permissions.reset.button")}
+        </Button>
+      </div>
+
+      <div className="space-y-2">
+        <div>
+          <div className="text-xs font-medium text-fg">
+            {st(t, "settings.permissions.list.title")}
+          </div>
+          <p className="text-[11px] text-fg-muted">
+            {st(t, "settings.permissions.list.description")}
+          </p>
+        </div>
+        <div className="rounded-[var(--acorn-pane-radius)] border border-border">
+          {PERMISSION_GROUPS.map((group) => {
+            const items = PERMISSION_LIST_ITEMS.filter(
+              (item) => item.group === group.id,
+            );
+            return (
+              <div key={group.id} className="border-b border-border last:border-b-0">
+                <div className="border-b border-border bg-bg-sidebar/40 px-3 py-2">
+                  <div className="text-xs font-medium text-fg">
+                    {st(t, group.titleKey)}
+                  </div>
+                  <p className="mt-1 text-[11px] text-fg-muted">
+                    {st(t, group.descriptionKey)}
+                  </p>
+                </div>
+                {items.map((item) => {
+                  const folderResult =
+                    item.kind === "folder"
+                      ? resultById.get(
+                          item.id as FolderPermissionWarmupResult["id"],
+                        )
+                      : null;
+                  const resetResult =
+                    item.kind === "developer"
+                      ? resetResultById.get(item.id)
+                      : null;
+                  const statusText = folderResult
+                    ? permissionStatusLabel(t, folderResult.status)
+                    : resetResult
+                      ? resetStatusLabel(t, resetResult.status)
+                      : item.kind === "folder"
+                        ? st(t, "settings.permissions.status.checkOnReset")
+                        : item.kind === "external"
+                          ? st(t, "settings.permissions.status.browserManaged")
+                          : st(t, "settings.permissions.status.promptedByTool");
+                  const statusClass = folderResult
+                    ? permissionStatusClass(folderResult.status)
+                    : resetResult
+                      ? resetStatusClass(resetResult.status)
+                      : "text-fg-muted";
+                  const detail = folderResult
+                    ? (folderResult.error ?? folderResult.path)
+                    : (resetResult?.error ?? resetResult?.service);
+
+                  return (
+                    <div
+                      key={item.id}
+                      className="flex items-center justify-between gap-3 border-b border-border px-3 py-2 last:border-b-0"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs font-medium text-fg">
+                            {st(t, item.labelKey)}
+                          </span>
+                          <span className="rounded border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-fg-muted">
+                            {item.kind === "folder"
+                              ? st(t, "settings.permissions.kind.folder")
+                              : item.kind === "external"
+                                ? st(t, "settings.permissions.kind.external")
+                                : st(t, "settings.permissions.kind.developer")}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-[11px] text-fg-muted">
+                          {st(t, item.descriptionKey)}
+                        </p>
+                        {detail ? (
+                          <div className="mt-1 truncate text-[10px] text-fg-muted">
+                            {detail}
+                          </div>
+                        ) : null}
+                      </div>
+                      <div
+                        className={`shrink-0 text-[11px] font-medium ${statusClass}`}
+                      >
+                        {statusText}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {status ? (
+        <Notice tone={status.tone} density="compact">
+          {status.text}
+        </Notice>
+      ) : null}
+
+      {results && hasDeniedFolderPermission(results) ? (
+        <Notice tone="neutral" density="compact">
+          {st(t, "dialogs.folderPermissionWarmup.deniedHint")}
+        </Notice>
+      ) : null}
+    </section>
+  );
 }
 
 function StorageSettings() {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -36,7 +36,10 @@ import type {
   WorkflowRunDetailListing,
   WorkflowRunsListing,
 } from "./types";
-import type { FolderPermissionWarmupResult } from "./permissionWarmup";
+import type {
+  FolderPermissionWarmupResult,
+  MacosPermissionResetResult,
+} from "./permissionWarmup";
 import type { IpcListWorkspacesResponsePayload } from "./ipcWorkspaces";
 
 export type {
@@ -559,6 +562,11 @@ export const api = {
   },
   resetMacosFolderPermissions(): Promise<void> {
     return invoke<void>("reset_macos_folder_permissions");
+  },
+  resetMacosDeveloperPermissions(): Promise<MacosPermissionResetResult[]> {
+    return invoke<MacosPermissionResetResult[]>(
+      "reset_macos_developer_permissions",
+    );
   },
   /**
    * Stop the in-process IPC listener and spawn a fresh one. Used when the

--- a/src/lib/permissionWarmup.ts
+++ b/src/lib/permissionWarmup.ts
@@ -11,6 +11,25 @@ export interface FolderPermissionWarmupResult {
   error: string | null;
 }
 
+export type MacosPermissionResetStatus = "reset" | "skipped" | "error";
+
+export type MacosPermissionResetId =
+  | FolderPermissionWarmupResult["id"]
+  | "screen_capture"
+  | "accessibility"
+  | "automation"
+  | "input_monitoring"
+  | "camera"
+  | "microphone"
+  | "developer_tools";
+
+export interface MacosPermissionResetResult {
+  id: MacosPermissionResetId;
+  service: string;
+  status: MacosPermissionResetStatus;
+  error: string | null;
+}
+
 export function hasDeniedFolderPermission(
   results: FolderPermissionWarmupResult[],
 ): boolean {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -60,6 +60,7 @@
       "notifications": "Notifications",
       "shortcuts": "Shortcuts",
       "storage": "Storage",
+      "permissions": "Permissions",
       "experiments": "Experiments",
       "about": "About"
     },
@@ -606,6 +607,100 @@
         "clearing": "Clearing..."
       },
       "total": "Total: {size}"
+    },
+    "permissions": {
+      "title": "Permissions",
+      "description": "Reset Acorn's macOS privacy decisions and immediately check protected folders so macOS can ask again.",
+      "notice": "Use this when folders, Playwright, browser automation, or capture tools keep failing because macOS saved a stale permission decision.",
+      "kind": {
+        "folder": "Folder",
+        "developer": "Acorn",
+        "external": "External"
+      },
+      "groups": {
+        "folders": {
+          "title": "Protected folders",
+          "description": "These can be checked by briefly reading the folder."
+        },
+        "automation": {
+          "title": "Automation and capture",
+          "description": "These reset Acorn's macOS privacy decision. macOS prompts again when Acorn uses the protected capability."
+        },
+        "browser": {
+          "title": "Browser and Playwright media",
+          "description": "These are usually owned by Chrome, Chromium, or the Playwright browser process rather than Acorn."
+        }
+      },
+      "list": {
+        "title": "Permission areas",
+        "description": "Acorn-owned permissions can be reset here. Browser and Playwright media permissions are shown separately because macOS grants them to the browser process."
+      },
+      "folderAccess": {
+        "label": "macOS privacy permissions",
+        "description": "Resets saved Acorn decisions for protected folders and common developer-tool permissions, then reads protected folders once to surface folder prompts."
+      },
+      "reset": {
+        "button": "Reset permissions",
+        "running": "Resetting..."
+      },
+      "status": {
+        "ready": "Folder access was reset and checked.",
+        "needsAttention": "Some folders still need attention.",
+        "empty": "No macOS protected folders were checked on this platform.",
+        "failed": "Failed to reset macOS permissions.",
+        "checkOnReset": "Check on reset",
+        "promptedByTool": "Prompts when used",
+        "browserManaged": "Browser-managed",
+        "reset": "Will ask again",
+        "skipped": "macOS only",
+        "resetFailed": "Reset failed"
+      },
+      "items": {
+        "desktop": {
+          "label": "Desktop",
+          "description": "Files and folders under Desktop."
+        },
+        "documents": {
+          "label": "Documents",
+          "description": "Files and folders under Documents."
+        },
+        "downloads": {
+          "label": "Downloads",
+          "description": "Files and folders under Downloads."
+        },
+        "icloud": {
+          "label": "iCloud Drive",
+          "description": "Files and folders under iCloud Drive, when present."
+        },
+        "screenCapture": {
+          "label": "Screen Recording",
+          "description": "Used by screenshot, screen capture, and visual automation tools."
+        },
+        "accessibility": {
+          "label": "Accessibility",
+          "description": "Used by tools that inspect or control other app windows."
+        },
+        "automation": {
+          "label": "Automation",
+          "description": "Used by Apple Events and scripts that control other apps."
+        },
+        "inputMonitoring": {
+          "label": "Input Monitoring",
+          "description": "Used by tools that listen for keyboard input."
+        },
+        "camera": {
+          "label": "Camera",
+          "description": "Used by browser tests or tools that open camera devices."
+        },
+        "microphone": {
+          "label": "Microphone",
+          "description": "Used by browser tests or tools that open audio input devices."
+        },
+        "developerTools": {
+          "label": "Developer Tools",
+          "description": "Used by debugging and automation tools that attach to other processes."
+        }
+      }
     },
     "experiments": {
       "warning": "Unfinished features. Behavior may change between releases; the toggles themselves are stable.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -60,6 +60,7 @@
       "notifications": "알림",
       "shortcuts": "단축키",
       "storage": "저장 공간",
+      "permissions": "권한",
       "experiments": "실험 기능",
       "about": "정보"
     },
@@ -606,6 +607,100 @@
         "clearing": "지우는 중..."
       },
       "total": "합계: {size}"
+    },
+    "permissions": {
+      "title": "권한",
+      "description": "Acorn의 macOS 개인정보 보호 결정을 초기화한 뒤 보호 폴더를 바로 확인해서 macOS가 다시 물어볼 수 있게 합니다.",
+      "notice": "폴더, Playwright, 브라우저 자동화, 캡처 도구가 macOS에 저장된 오래된 권한 결정 때문에 계속 실패할 때 사용하세요.",
+      "kind": {
+        "folder": "폴더",
+        "developer": "Acorn",
+        "external": "외부"
+      },
+      "groups": {
+        "folders": {
+          "title": "보호 폴더",
+          "description": "폴더를 잠깐 읽어서 여기에서 확인할 수 있습니다."
+        },
+        "automation": {
+          "title": "자동화 및 캡처",
+          "description": "Acorn의 macOS 개인정보 보호 결정을 초기화합니다. Acorn이 보호 기능을 사용할 때 macOS가 다시 요청합니다."
+        },
+        "browser": {
+          "title": "브라우저 및 Playwright 미디어",
+          "description": "대부분 Acorn이 아니라 Chrome, Chromium 또는 Playwright 브라우저 프로세스의 권한입니다."
+        }
+      },
+      "list": {
+        "title": "권한 영역",
+        "description": "Acorn 소유 권한은 여기에서 초기화할 수 있습니다. 브라우저와 Playwright 미디어 권한은 macOS가 브라우저 프로세스에 부여하므로 별도로 표시합니다."
+      },
+      "folderAccess": {
+        "label": "macOS 개인정보 보호 권한",
+        "description": "Acorn에 저장된 보호 폴더와 일반적인 개발 도구 권한 결정을 초기화하고, 보호 폴더를 한 번 읽어 폴더 권한 요청을 표시합니다."
+      },
+      "reset": {
+        "button": "권한 초기화",
+        "running": "초기화 중..."
+      },
+      "status": {
+        "ready": "폴더 접근 권한을 초기화하고 확인했습니다.",
+        "needsAttention": "일부 폴더에 아직 확인이 필요합니다.",
+        "empty": "이 플랫폼에서 확인할 macOS 보호 폴더가 없습니다.",
+        "failed": "macOS 권한을 초기화하지 못했습니다.",
+        "checkOnReset": "초기화 시 확인",
+        "promptedByTool": "사용 시 요청",
+        "browserManaged": "브라우저에서 관리",
+        "reset": "다시 요청됨",
+        "skipped": "macOS 전용",
+        "resetFailed": "초기화 실패"
+      },
+      "items": {
+        "desktop": {
+          "label": "데스크탑",
+          "description": "데스크탑 아래의 파일과 폴더입니다."
+        },
+        "documents": {
+          "label": "문서",
+          "description": "문서 폴더 아래의 파일과 폴더입니다."
+        },
+        "downloads": {
+          "label": "다운로드",
+          "description": "다운로드 폴더 아래의 파일과 폴더입니다."
+        },
+        "icloud": {
+          "label": "iCloud Drive",
+          "description": "iCloud Drive가 있을 때 그 아래의 파일과 폴더입니다."
+        },
+        "screenCapture": {
+          "label": "화면 기록",
+          "description": "스크린샷, 화면 캡처, 시각 자동화 도구가 사용합니다."
+        },
+        "accessibility": {
+          "label": "손쉬운 사용",
+          "description": "다른 앱 창을 읽거나 제어하는 도구가 사용합니다."
+        },
+        "automation": {
+          "label": "자동화",
+          "description": "다른 앱을 제어하는 Apple Events와 스크립트가 사용합니다."
+        },
+        "inputMonitoring": {
+          "label": "입력 모니터링",
+          "description": "키보드 입력을 감지하는 도구가 사용합니다."
+        },
+        "camera": {
+          "label": "카메라",
+          "description": "카메라 장치를 여는 브라우저 테스트나 도구가 사용합니다."
+        },
+        "microphone": {
+          "label": "마이크",
+          "description": "오디오 입력 장치를 여는 브라우저 테스트나 도구가 사용합니다."
+        },
+        "developerTools": {
+          "label": "개발자 도구",
+          "description": "다른 프로세스에 붙는 디버깅 및 자동화 도구가 사용합니다."
+        }
+      }
     },
     "experiments": {
       "warning": "완성되지 않은 기능입니다. 릴리스 사이에 동작이 바뀔 수 있지만 토글 자체는 안정적입니다.",

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -259,6 +259,7 @@ export const tauriMockSource = `
     }
     if (cmd === 'warm_macos_folder_permissions') return Promise.resolve([]);
     if (cmd === 'reset_macos_folder_permissions') return Promise.resolve([]);
+    if (cmd === 'reset_macos_developer_permissions') return Promise.resolve([]);
     if (cmd === 'ipc_restart') return Promise.resolve(undefined);
     if (cmd === 'reorder_projects') return Promise.resolve([]);
     if (cmd === 'reorder_sessions') return Promise.resolve([]);

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -220,4 +220,97 @@ test.describe("settings modal", () => {
       )
       .toBe(false);
   });
+
+  test("resets macOS privacy permissions from Settings", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("reset_macos_developer_permissions", () => {
+      const w = window as unknown as { __permissionResetCalls?: number };
+      w.__permissionResetCalls = (w.__permissionResetCalls ?? 0) + 1;
+      return [
+        {
+          id: "screen_capture",
+          service: "ScreenCapture",
+          status: "reset",
+          error: null,
+        },
+        {
+          id: "accessibility",
+          service: "Accessibility",
+          status: "reset",
+          error: null,
+        },
+      ];
+    });
+    await tauri.handle("warm_macos_folder_permissions", () => {
+      const w = window as unknown as { __permissionWarmupCalls?: number };
+      w.__permissionWarmupCalls = (w.__permissionWarmupCalls ?? 0) + 1;
+      return [
+        {
+          id: "desktop",
+          path: "/Users/tester/Desktop",
+          status: "ok",
+          error: null,
+        },
+      ];
+    });
+
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "," });
+
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
+    await modal.getByRole("button", { name: /^(Permissions|권한)$/ }).click();
+    await expect(
+      modal.getByRole("heading", { name: /^(Permissions|권한)$/ }),
+    ).toBeVisible();
+    await expect(
+      modal.getByText("Protected folders", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      modal.getByText("Automation and capture", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      modal.getByText("Browser and Playwright media", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      modal.getByText("Screen Recording", { exact: true }),
+    ).toBeVisible();
+    await expect(modal.getByText("Camera", { exact: true })).toBeVisible();
+    await expect(
+      modal.getByText("Prompts when used", { exact: true }).first(),
+    ).toBeVisible();
+    await expect(
+      modal.getByText("Browser-managed", { exact: true }).first(),
+    ).toBeVisible();
+
+    await modal.getByRole("button", { name: "Reset permissions" }).click();
+
+    await expect(
+      modal.getByText("Folder access was reset and checked."),
+    ).toBeVisible();
+    await expect(modal.getByText("Desktop", { exact: true })).toBeVisible();
+    await expect(modal.getByText("Ready", { exact: true })).toBeVisible();
+    await expect(
+      modal.getByText("Will ask again", { exact: true }).first(),
+    ).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __permissionResetCalls?: number })
+              .__permissionResetCalls ?? 0,
+        ),
+      )
+      .toBe(1);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __permissionWarmupCalls?: number })
+              .__permissionWarmupCalls ?? 0,
+        ),
+      )
+      .toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
Adds a Settings permission surface for resetting Acorn-owned macOS privacy decisions and showing related permission areas clearly.

1. **Permissions tab** — adds a Settings → Permissions tab with grouped permission areas for protected folders, automation/capture, and browser/Playwright media.
2. **macOS reset command** — adds `reset_macos_developer_permissions`, returning per-service reset results for protected folders plus common developer-tool TCC services.
3. **Clearer permission states** — replaces ambiguous unchecked copy with explicit `Check on reset`, `Prompts when used`, and `Browser-managed` states.
4. **E2E coverage** — covers the new Settings flow, grouped list, reset action, and Tauri invoke mocks.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Settings | No dedicated permission management tab | Permissions tab exposes reset and grouped permission areas |
| macOS privacy reset | Folder reset was only available through the startup permission flow | Settings button resets Acorn-owned folder and developer-tool privacy decisions |
| Browser / Playwright media | Camera and microphone ownership was not explained | Camera and microphone are shown as browser-managed so Acorn does not imply false control |

## Design notes
- The backend resets Acorn-owned TCC decisions with `tccutil reset <service> <bundle id>` and returns per-service statuses so one failure does not hide the rest of the list.
- The existing folder-only reset command remains intact for the startup folder-permission modal.
- Browser and Playwright media permissions are displayed separately because macOS usually grants camera/microphone access to Chrome, Chromium, or the Playwright browser process rather than Acorn's bundle id.
- The UI avoids a blanket "allowed" claim for permissions that require capability-specific or target-specific native checks.

## Follow-up (not in this PR)
- Add native preflight checks for Screen Recording, Accessibility, and Input Monitoring if the Settings surface needs live allowed/denied status before reset.
- Add target-app selection before showing Automation as a concrete allowed/denied status, since Apple Events permission is target-specific.

## Test plan
- [x] `pnpm run build` passes; Vite emits chunk/dynamic import warnings but exits successfully
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --bin acorn` passes
- [x] `pnpm exec vitest run src/lib/permissionWarmup.test.ts src/components/SettingsModal.test.tsx` — 2 files, 28 tests pass
- [x] `pnpm exec playwright test tests/e2e/settings.spec.ts tests/e2e/permission-warmup.spec.ts` — 11 tests pass
- [x] `git diff --check` passes

## Notes
- No unrelated files are staged or committed.
