### PR TITLE
docs(readme): add isolated screenshot capture CLI

### DIFF
--- a/docs/README_SCREENSHOTS.md
+++ b/docs/README_SCREENSHOTS.md
@@ -1,0 +1,30 @@
+# README screenshots
+
+Generate README/GitHub screenshots from an isolated Playwright browser session:
+
+```sh
+pnpm run capture:readme
+```
+
+The capture run starts Vite, injects the existing Tauri mock, seeds deterministic
+project/session/GitHub data, and writes PNGs to `assets/screenshots` by default.
+It does not use OS-level screen capture, a real Tauri app profile, a live shell,
+or the user's browser profile.
+
+Useful variants:
+
+```sh
+pnpm run capture:readme -- --list
+pnpm run capture:readme -- workspace pr-modal
+pnpm run capture:readme -- --out /tmp/acorn-captures --headed
+pnpm run capture:readme -- --port 1425
+```
+
+Available scenes:
+
+- `workspace` -> `workspace.png`
+- `pr-modal` -> `pr-modal.png`
+- `command-palette` -> `command-palette.png`
+
+Use `--out` for review runs when you do not want to overwrite tracked README
+assets.

--- a/docs/README_SCREENSHOTS.md
+++ b/docs/README_SCREENSHOTS.md
@@ -15,7 +15,7 @@ Useful variants:
 
 ```sh
 pnpm run capture:readme -- --list
-pnpm run capture:readme -- workspace pr-modal chat-session
+pnpm run capture:readme -- workspace pr-modal chat-session staged-diff
 pnpm run capture:readme -- --out /tmp/acorn-captures --headed
 pnpm run capture:readme -- --port 1425
 ```
@@ -26,6 +26,9 @@ Available scenes:
 - `pr-modal` -> `pr-modal.png`
 - `chat-session` -> `chat-session.png`
 - `control-session` -> `control-session.png`
+- `staged-diff` -> `staged-diff.png`
+- `agent-history` -> `agent-history.png`
+- `work-summary` -> `work-summary.png`
 - `command-palette` -> `command-palette.png`
 
 Use `--out` for review runs when you do not want to overwrite tracked README

--- a/docs/README_SCREENSHOTS.md
+++ b/docs/README_SCREENSHOTS.md
@@ -15,7 +15,7 @@ Useful variants:
 
 ```sh
 pnpm run capture:readme -- --list
-pnpm run capture:readme -- workspace pr-modal
+pnpm run capture:readme -- workspace pr-modal chat-session
 pnpm run capture:readme -- --out /tmp/acorn-captures --headed
 pnpm run capture:readme -- --port 1425
 ```
@@ -24,6 +24,8 @@ Available scenes:
 
 - `workspace` -> `workspace.png`
 - `pr-modal` -> `pr-modal.png`
+- `chat-session` -> `chat-session.png`
+- `control-session` -> `control-session.png`
 - `command-palette` -> `command-palette.png`
 
 Use `--out` for review runs when you do not want to overwrite tracked README

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
+    "capture:readme": "node scripts/capture-readme.mjs",
     "storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build"
   },

--- a/playwright.capture.config.ts
+++ b/playwright.capture.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = Number(process.env.ACORN_CAPTURE_PORT ?? 1421);
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+  testDir: "./tests/captures",
+  testMatch: /.*\.spec\.ts$/,
+  fullyParallel: false,
+  forbidOnly: false,
+  retries: 0,
+  workers: 1,
+  reporter: "list",
+  use: {
+    baseURL: BASE_URL,
+    viewport: { width: 1600, height: 1000 },
+    deviceScaleFactor: 2,
+    trace: "off",
+    screenshot: "off",
+    video: "off",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1600, height: 1000 },
+        deviceScaleFactor: 2,
+      },
+    },
+  ],
+  webServer: {
+    command: `pnpm run dev --host 127.0.0.1 --port ${PORT}`,
+    url: BASE_URL,
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+});

--- a/scripts/capture-readme.mjs
+++ b/scripts/capture-readme.mjs
@@ -6,6 +6,9 @@ const SCENES = [
   "pr-modal",
   "chat-session",
   "control-session",
+  "staged-diff",
+  "agent-history",
+  "work-summary",
   "command-palette",
 ];
 
@@ -25,7 +28,7 @@ Options:
 
 Examples:
   pnpm run capture:readme
-  pnpm run capture:readme -- workspace pr-modal chat-session
+  pnpm run capture:readme -- workspace pr-modal chat-session staged-diff
   pnpm run capture:readme -- --out /tmp/acorn-captures --headed
   pnpm run capture:readme -- --port 1425
 `);

--- a/scripts/capture-readme.mjs
+++ b/scripts/capture-readme.mjs
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 
-const SCENES = ["workspace", "pr-modal", "command-palette"];
+const SCENES = [
+  "workspace",
+  "pr-modal",
+  "chat-session",
+  "control-session",
+  "command-palette",
+];
 
 function usage() {
   console.log(`Usage:
@@ -19,7 +25,7 @@ Options:
 
 Examples:
   pnpm run capture:readme
-  pnpm run capture:readme -- workspace pr-modal
+  pnpm run capture:readme -- workspace pr-modal chat-session
   pnpm run capture:readme -- --out /tmp/acorn-captures --headed
   pnpm run capture:readme -- --port 1425
 `);

--- a/scripts/capture-readme.mjs
+++ b/scripts/capture-readme.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+
+const SCENES = ["workspace", "pr-modal", "command-palette"];
+
+function usage() {
+  console.log(`Usage:
+  pnpm run capture:readme [-- all|scene...] [options]
+
+Scenes:
+  ${SCENES.join(", ")}
+
+Options:
+  --list             Print available scenes.
+  --out <dir>        Output directory. Default: assets/screenshots
+  --headed           Show the browser while capturing.
+  --port <port>      Vite port. Default: 1421
+  --help             Print this help.
+
+Examples:
+  pnpm run capture:readme
+  pnpm run capture:readme -- workspace pr-modal
+  pnpm run capture:readme -- --out /tmp/acorn-captures --headed
+  pnpm run capture:readme -- --port 1425
+`);
+}
+
+const requestedScenes = [];
+let outDir = "assets/screenshots";
+let headed = false;
+let port = "";
+
+const args = process.argv.slice(2);
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  if (arg === "--") {
+    continue;
+  }
+  if (arg === "--help" || arg === "-h") {
+    usage();
+    process.exit(0);
+  }
+  if (arg === "--list") {
+    console.log(SCENES.join("\n"));
+    process.exit(0);
+  }
+  if (arg === "--out") {
+    const value = args[i + 1];
+    if (!value || value.startsWith("--")) {
+      console.error("--out requires a directory");
+      process.exit(2);
+    }
+    outDir = value;
+    i += 1;
+    continue;
+  }
+  if (arg === "--headed") {
+    headed = true;
+    continue;
+  }
+  if (arg === "--port") {
+    const value = args[i + 1];
+    if (!value || value.startsWith("--")) {
+      console.error("--port requires a numeric port");
+      process.exit(2);
+    }
+    port = value;
+    i += 1;
+    continue;
+  }
+  if (arg.startsWith("--")) {
+    console.error(`Unknown option: ${arg}`);
+    usage();
+    process.exit(2);
+  }
+  requestedScenes.push(arg);
+}
+
+if (!outDir) {
+  console.error("--out requires a directory");
+  process.exit(2);
+}
+if (port && !/^\d+$/.test(port)) {
+  console.error("--port requires a numeric port");
+  process.exit(2);
+}
+
+const scenes =
+  requestedScenes.length === 0 || requestedScenes.includes("all")
+    ? SCENES
+    : requestedScenes;
+const invalidScenes = scenes.filter((scene) => !SCENES.includes(scene));
+if (invalidScenes.length > 0) {
+  console.error(`Unknown scene(s): ${invalidScenes.join(", ")}`);
+  console.error(`Available scenes: ${SCENES.join(", ")}`);
+  process.exit(2);
+}
+
+const playwrightArgs = [
+  "exec",
+  "playwright",
+  "test",
+  "--config",
+  "playwright.capture.config.ts",
+];
+if (headed) playwrightArgs.push("--headed");
+
+const child = spawnSync("pnpm", playwrightArgs, {
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    ACORN_CAPTURE_SCENES: scenes.join(","),
+    ACORN_CAPTURE_DIR: outDir,
+    ...(port ? { ACORN_CAPTURE_PORT: port } : {}),
+  },
+});
+
+if (child.error) {
+  console.error(child.error.message);
+  process.exit(1);
+}
+process.exit(child.status ?? 1);

--- a/tests/captures/readme.spec.ts
+++ b/tests/captures/readme.spec.ts
@@ -1,0 +1,820 @@
+import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { test, expect, type Page } from "@playwright/test";
+import { tauriMockSource } from "../e2e/fixtures/tauriMock";
+
+const CAPTURE_DIR = process.env.ACORN_CAPTURE_DIR ?? "assets/screenshots";
+const SELECTED_SCENES = new Set(
+  (process.env.ACORN_CAPTURE_SCENES ?? "workspace,pr-modal,command-palette")
+    .split(",")
+    .map((scene) => scene.trim())
+    .filter(Boolean),
+);
+const NOW = "2026-06-01T12:00:00Z";
+const REPOS = {
+  app: "/workspace/acorn-app",
+  website: "/workspace/acorn-site",
+  docs: "/workspace/acorn-docs",
+  local: "/workspace/instant",
+} as const;
+
+type SceneName = "workspace" | "pr-modal" | "command-palette";
+
+interface CaptureScene {
+  name: SceneName;
+  file: string;
+  prepare?: (page: Page) => Promise<void>;
+}
+
+const scenes: CaptureScene[] = [
+  {
+    name: "workspace",
+    file: "workspace.png",
+    prepare: async (page) => {
+      const rightPanel = page.locator('[data-panel-id="right"]');
+      await rightPanel.getByRole("button", { name: "Code", exact: true }).click();
+      await rightPanel
+        .getByRole("button", { name: "Files", exact: true })
+        .click();
+      await expect(
+        rightPanel.getByRole("button", { name: "src", exact: true }),
+      ).toBeVisible();
+      await expect(
+        page.locator("aside").getByRole("button", { name: /workspace-polish/ }),
+      ).toBeVisible();
+    },
+  },
+  {
+    name: "pr-modal",
+    file: "pr-modal.png",
+    prepare: async (page) => {
+      await page.getByRole("button", { name: "GitHub" }).click();
+      await page.getByRole("button", { name: "PRs" }).click();
+      await page.getByText("Polish README capture workflow").dblclick();
+      await expect(
+        page.getByRole("heading", {
+          name: "Polish README capture workflow",
+        }),
+      ).toBeVisible();
+      await expect(
+        page.getByText("Add deterministic README screenshots"),
+      ).toBeVisible();
+    },
+  },
+  {
+    name: "command-palette",
+    file: "command-palette.png",
+    prepare: async (page) => {
+      await page.evaluate(() => {
+        const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+        window.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "p",
+            code: "KeyP",
+            metaKey: isMac,
+            ctrlKey: !isMac,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+      await expect(page.getByRole("dialog")).toBeVisible();
+      await expect(page.getByText("New control session")).toBeVisible();
+    },
+  },
+];
+
+test.describe.configure({ mode: "serial" });
+
+for (const scene of scenes) {
+  test(scene.name, async ({ page }) => {
+    test.skip(
+      !SELECTED_SCENES.has(scene.name),
+      `scene ${scene.name} was not requested`,
+    );
+
+    await bootCapturePage(page);
+    await scene.prepare?.(page);
+    await waitForStablePaint(page);
+
+    mkdirSync(CAPTURE_DIR, { recursive: true });
+    await page.screenshot({
+      path: resolve(CAPTURE_DIR, scene.file),
+      fullPage: false,
+    });
+  });
+}
+
+async function bootCapturePage(page: Page) {
+  await page.clock.setFixedTime(new Date(NOW));
+  await page.addInitScript({
+    content: `(() => {
+      window.localStorage.clear();
+      window.localStorage.setItem("acorn:settings:v1", JSON.stringify({
+        language: "en",
+        appearance: { themeId: "acorn-dark", uiScalePercent: 100 },
+        experiments: { resumeModal: false, stickyPrompt: false },
+        github: { refreshIntervalMs: 60000 },
+        sessionDisplay: {
+          title: "name",
+          metadata: { branch: true, workingDirectory: false, status: true },
+          icons: { statusDot: true, agentProvider: true, sessionKind: true },
+          showDetailsOnHover: true
+        }
+      }));
+      window.localStorage.setItem("acorn:control-guide-dismissed-v1", "1");
+      window.localStorage.setItem(
+        "acorn:sidebar:collapsed-projects",
+        JSON.stringify([${JSON.stringify(REPOS.docs)}])
+      );
+      window.localStorage.setItem(
+        "acorn:sidebar:collapsed-project-folders",
+        JSON.stringify(["${folderId(REPOS.website, "release")}"])
+      );
+      window.localStorage.setItem("acorn-workspaces", JSON.stringify(${JSON.stringify(
+        persistedWorkspace(),
+      )}));
+    })();`,
+  });
+  await page.addInitScript({ content: tauriMockSource });
+  await page.addInitScript({ content: captureMockHandlersSource() });
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Projects" })).toBeVisible();
+  await expect(
+    page.locator("aside").getByRole("button", { name: /workspace-polish/ }),
+  ).toBeVisible();
+}
+
+async function waitForStablePaint(page: Page) {
+  await page.evaluate(() => document.fonts?.ready);
+  await page.waitForTimeout(250);
+}
+
+function folderId(repoPath: string, name: string) {
+  return `project-folder:${repoPath}:${name}`;
+}
+
+function persistedWorkspace() {
+  return {
+    state: {
+      workspaces: {
+        [REPOS.app]: {
+          layout: {
+            kind: "split",
+            id: "capture-root-split",
+            direction: "horizontal",
+            sizes: [62, 38],
+            a: { kind: "pane", id: "left-main" },
+            b: {
+              kind: "split",
+              id: "capture-right-stack",
+              direction: "vertical",
+              sizes: [50, 50],
+              a: { kind: "pane", id: "right-top" },
+              b: { kind: "pane", id: "right-bottom" },
+            },
+          },
+          panes: {
+            "left-main": paneState(
+              "left-main",
+              ["workspace-polish"],
+              "workspace-polish",
+            ),
+            "right-top": paneState(
+              "right-top",
+              ["agent-resume"],
+              "agent-resume",
+            ),
+            "right-bottom": paneState(
+              "right-bottom",
+              ["api-contracts"],
+              "api-contracts",
+            ),
+          },
+          focusedPaneId: "left-main",
+          rightTab: "files",
+          rightTabByGroup: {
+            code: "files",
+            github: "prs",
+            agents: "history",
+          },
+        },
+        [folderId(REPOS.app, "frontend")]: emptyWorkspace("ui-snapshot"),
+        [folderId(REPOS.app, "release")]: emptyWorkspace("release-checks"),
+        [REPOS.website]: emptyWorkspace("landing-refresh"),
+        [folderId(REPOS.website, "marketing")]: emptyWorkspace("landing-copy"),
+        [folderId(REPOS.website, "release")]: emptyWorkspace("site-build"),
+        [REPOS.docs]: emptyWorkspace("docs-outline"),
+        [folderId(REPOS.docs, "guides")]: emptyWorkspace("guide-refresh"),
+        [folderId(REPOS.docs, "api")]: emptyWorkspace("api-reference"),
+      },
+      projectFolders: projectFolders(),
+      sessionFolderIds: {
+        "ui-snapshot": folderId(REPOS.app, "frontend"),
+        "release-checks": folderId(REPOS.app, "release"),
+        "landing-copy": folderId(REPOS.website, "marketing"),
+        "site-build": folderId(REPOS.website, "release"),
+        "guide-refresh": folderId(REPOS.docs, "guides"),
+        "api-reference": folderId(REPOS.docs, "api"),
+      },
+      activeProject: REPOS.app,
+      activeProjectFolderId: REPOS.app,
+      rightTab: "files",
+      rightTabByGroup: {
+        code: "files",
+        github: "prs",
+        agents: "history",
+      },
+      sessionNotifications: [
+        {
+          id: "n-1",
+          sessionId: "workspace-polish",
+          kind: "needs_input",
+          status: "needs_input",
+          previousStatus: "running",
+          sessionName: "workspace-polish",
+          projectName: "acorn-app",
+          repoPath: REPOS.app,
+          createdAt: "2026-06-01T11:55:00Z",
+        },
+      ],
+      workspaceTabs: {},
+    },
+    version: 4,
+  };
+}
+
+function paneState(id: string, tabIds: string[], activeTabId: string) {
+  return { id, tabIds, activeTabId, activationHistory: tabIds };
+}
+
+function emptyWorkspace(activeSessionId: string) {
+  return {
+    layout: { kind: "pane", id: "root" },
+    panes: {
+      root: paneState("root", [activeSessionId], activeSessionId),
+    },
+    focusedPaneId: "root",
+    rightTab: "files",
+    rightTabByGroup: {
+      code: "files",
+      github: "prs",
+      agents: "history",
+    },
+  };
+}
+
+function projectFolders() {
+  return {
+    [REPOS.app]: [
+      projectFolder(REPOS.app, REPOS.app, "Default", REPOS.app, 0),
+      projectFolder(
+        REPOS.app,
+        folderId(REPOS.app, "frontend"),
+        "Frontend workspace",
+        `${REPOS.app}/packages/desktop`,
+        1,
+      ),
+      projectFolder(
+        REPOS.app,
+        folderId(REPOS.app, "release"),
+        "Release worktree",
+        `${REPOS.app}/.acorn/worktrees/release-readme-captures`,
+        2,
+      ),
+    ],
+    [REPOS.website]: [
+      projectFolder(REPOS.website, REPOS.website, "Default", REPOS.website, 0),
+      projectFolder(
+        REPOS.website,
+        folderId(REPOS.website, "marketing"),
+        "Marketing workspace",
+        `${REPOS.website}/apps/www`,
+        1,
+      ),
+      projectFolder(
+        REPOS.website,
+        folderId(REPOS.website, "release"),
+        "Preview worktree",
+        `${REPOS.website}/.acorn/worktrees/preview`,
+        2,
+      ),
+    ],
+    [REPOS.docs]: [
+      projectFolder(REPOS.docs, REPOS.docs, "Default", REPOS.docs, 0),
+      projectFolder(
+        REPOS.docs,
+        folderId(REPOS.docs, "guides"),
+        "Guides workspace",
+        `${REPOS.docs}/guides`,
+        1,
+      ),
+      projectFolder(
+        REPOS.docs,
+        folderId(REPOS.docs, "api"),
+        "API worktree",
+        `${REPOS.docs}/.acorn/worktrees/api-reference`,
+        2,
+      ),
+    ],
+    [REPOS.local]: [
+      projectFolder(REPOS.local, REPOS.local, "Default", REPOS.local, 0),
+    ],
+  };
+}
+
+function projectFolder(
+  repoPath: string,
+  id: string,
+  name: string,
+  cwdPath: string,
+  position: number,
+) {
+  return { id, repoPath, name, cwdPath, position };
+}
+
+function captureMockHandlersSource() {
+  return `(() => {
+    const repos = ${JSON.stringify(REPOS)};
+    const now = ${JSON.stringify(NOW)};
+    const handlers = window.__ACORN_MOCK_HANDLERS__ =
+      window.__ACORN_MOCK_HANDLERS__ || {};
+    const projectFolders = ${JSON.stringify(projectFolders())};
+    const sessions = ${JSON.stringify(seedSessions())};
+
+    function b64(input) {
+      return btoa(unescape(encodeURIComponent(input)));
+    }
+
+    function emitPtyOutput(token, text) {
+      const callback = window["_" + token];
+      if (typeof callback === "function") {
+        window.setTimeout(() => callback({ index: 0, message: b64(text) }), 40);
+      }
+    }
+
+    handlers.list_projects = () => [
+      project(repos.app, "acorn-app", 0),
+      project(repos.website, "acorn-site", 1),
+      project(repos.docs, "acorn-docs", 2),
+    ];
+    handlers.list_sessions = () => sessions;
+    handlers.detect_session_statuses = () =>
+      sessions.map((s) => ({ id: s.id, status: s.status }));
+    handlers.github_origin_slug = () => "im-ian/acorn";
+    handlers.is_git_repository = () => true;
+    handlers.pty_in_worktree_all = () => ({});
+    handlers.pty_repo_root = (args) =>
+      sessions.find((s) => s.id === args?.sessionId)?.repo_path ?? repos.app;
+    handlers.pty_cwd = (args) =>
+      sessions.find((s) => s.id === args?.sessionId)?.worktree_path ?? repos.app;
+    handlers.git_worktrees = (args) => {
+      const repo = args?.repoPath || repos.app;
+      const folders = projectFolders[repo] || [];
+      return folders.map((folder) => folder.cwdPath);
+    };
+    handlers.pty_subscribe_output = (args) => {
+      const channel = args && args.channel;
+      return typeof channel === "object" && channel && "id" in channel
+        ? channel.id
+        : 0;
+    };
+    handlers.pty_unsubscribe_output = () => undefined;
+    handlers.pty_spawn = (args) => {
+      const session = sessions.find((s) => s.id === args?.sessionId);
+      const text = terminalText(session?.id || "workspace-polish");
+      emitPtyOutput(args && args.outputToken, text);
+      return undefined;
+    };
+    handlers.pty_resize = () => undefined;
+    handlers.pty_write = () => undefined;
+    handlers.pty_kill = () => undefined;
+    handlers.scrollback_load = () => null;
+    handlers.scrollback_save = () => undefined;
+
+    handlers.fs_list_dir = (args) => {
+      const path = args && args.path;
+      if (path === repos.app) {
+        return { repo_root: repos.app, entries: [
+          fsEntry("src", repos.app + "/src", true),
+          fsEntry("src-tauri", repos.app + "/src-tauri", true),
+          fsEntry("tests", repos.app + "/tests", true),
+          fsEntry("README.md", repos.app + "/README.md", false, 9208),
+          fsEntry("package.json", repos.app + "/package.json", false, 2447),
+          fsEntry("playwright.capture.config.ts", repos.app + "/playwright.capture.config.ts", false, 778),
+        ] };
+      }
+      if (path === repos.app + "/src") {
+        return { repo_root: repos.app, entries: [
+          fsEntry("App.tsx", repos.app + "/src/App.tsx", false, 44112),
+          fsEntry("components", repos.app + "/src/components", true),
+          fsEntry("lib", repos.app + "/src/lib", true),
+          fsEntry("store.ts", repos.app + "/src/store.ts", false, 112000),
+        ] };
+      }
+      return { repo_root: repos.app, entries: [] };
+    };
+    handlers.fs_git_status = () => ({
+      statuses: {
+        [repos.app + "/README.md"]: { kind: "modified", additions: 8, deletions: 2 },
+        [repos.app + "/tests"]: { kind: "added", additions: 360, deletions: 0 },
+        [repos.app + "/playwright.capture.config.ts"]: { kind: "added", additions: 35, deletions: 0 },
+      },
+      huge: false,
+      limit: 10000,
+    });
+    handlers.fs_git_diff_stats = () => ({
+      [repos.app + "/README.md"]: { additions: 8, deletions: 2 },
+      [repos.app + "/tests"]: { additions: 360, deletions: 0 },
+      [repos.app + "/playwright.capture.config.ts"]: { additions: 35, deletions: 0 },
+    });
+    handlers.fs_git_branch = () => "main";
+    handlers.fs_read_file = () => ({
+      content: "# Acorn\\n\\nDeterministic screenshots for README assets.\\n",
+      size: 56,
+      truncated: false,
+      binary: false,
+    });
+
+    handlers.list_commits = () => [
+      {
+        sha: "8f4f8b7f4c7e4d6c8a0a6b1c2d3e4f5061728394",
+        short_sha: "8f4f8b7",
+        author: "Ian",
+        author_email: "ian@example.com",
+        timestamp: 1780309860,
+        summary: "docs(readme): refresh workspace screenshots",
+        body: "Capture the primary workspace and PR detail flow with deterministic sample data.",
+        pushed: false,
+      },
+    ];
+    handlers.resolve_commit_logins = () => ({
+      "8f4f8b7f4c7e4d6c8a0a6b1c2d3e4f5061728394": "im-ian",
+    });
+    handlers.list_staged = () => [
+      { path: "README.md", status: "modified" },
+      { path: "tests/captures/readme.spec.ts", status: "added" },
+      { path: "playwright.capture.config.ts", status: "added" },
+    ];
+    handlers.staged_file_diff = () => diffPayload();
+    handlers.staged_diff = () => diffPayload();
+    handlers.commit_diff = () => diffPayload();
+
+    const prs = [
+      {
+        number: 278,
+        title: "Polish README capture workflow",
+        state: "OPEN",
+        author: "im-ian",
+        head_branch: "capture/readme-assets",
+        base_branch: "main",
+        url: "https://github.com/im-ian/acorn/pull/278",
+        updated_at: now,
+        is_draft: false,
+        checks: { passed: 10, failed: 0, pending: 1 },
+        labels: [
+          { name: "docs", color: "0075ca" },
+          { name: "automation", color: "a2eeef" },
+        ],
+      },
+    ];
+    handlers.list_pull_requests = () => ({
+      kind: "ok",
+      items: prs,
+      account: "im-ian",
+    });
+    handlers.get_pull_request_detail = () => ({
+      kind: "ok",
+      account: "im-ian",
+      detail: pullRequestDetail(),
+    });
+    handlers.get_pull_request_diff = () => ({
+      kind: "ok",
+      account: "im-ian",
+      diff: diffPayload(),
+    });
+    handlers.list_issues = () => ({
+      kind: "ok",
+      account: "im-ian",
+      items: [],
+    });
+    handlers.list_workflow_runs = () => ({
+      kind: "ok",
+      account: "im-ian",
+      items: [],
+    });
+    handlers.list_unscoped_agent_history = () => [];
+    handlers.list_agent_history = () => [];
+    handlers.read_session_todos = () => [
+      { content: "Seed screenshot fixture data", status: "completed", activeForm: null },
+      { content: "Capture Files panel", status: "in_progress", activeForm: "Capturing Files panel" },
+    ];
+    handlers.get_memory_usage = () => ({
+      rss_bytes: 184000000,
+      sessions: [],
+      scrollback_disk_bytes: 42000,
+    });
+    handlers.get_agent_token_usage = () => ({
+      metrics: [],
+      updated_at: 1780309860,
+    });
+
+    function project(repo_path, name, position) {
+      return {
+        repo_path,
+        name,
+        created_at: "2026-06-01T10:00:00Z",
+        position,
+      };
+    }
+
+    function fsEntry(name, path, isDir, size = 0) {
+      return {
+        name,
+        path,
+        is_dir: isDir,
+        is_symlink: false,
+        size,
+        modified_ms: 1780309860000,
+        gitignored: false,
+      };
+    }
+
+    function diffPayload() {
+      return {
+        files: [{
+          old_path: "README.md",
+          new_path: "README.md",
+          is_image: false,
+          patch: "@@ -18,6 +18,8 @@\\n ## Screenshots\\n+Automated with the capture CLI.\\n+Sample data is isolated from the host.\\n",
+        }],
+      };
+    }
+
+    function pullRequestDetail() {
+      return {
+        number: 278,
+        title: "Polish README capture workflow",
+        body: "Add deterministic README screenshots generated from a mocked browser environment.\\n\\n- [x] Seed realistic project/session state\\n- [x] Capture the main workspace\\n- [ ] Refresh the README asset table",
+        state: "OPEN",
+        is_draft: false,
+        author: "im-ian",
+        head_branch: "capture/readme-assets",
+        base_branch: "main",
+        url: "https://github.com/im-ian/acorn/pull/278",
+        created_at: "2026-06-01T09:30:00Z",
+        updated_at: now,
+        merged_at: null,
+        additions: 412,
+        deletions: 28,
+        changed_files: 4,
+        mergeable: "MERGEABLE",
+        labels: [
+          { name: "docs", color: "0075ca" },
+          { name: "automation", color: "a2eeef" },
+        ],
+        comments: [],
+        reviews: [],
+        checks: [
+          check("Typecheck", "COMPLETED", "SUCCESS"),
+          check("Vitest", "COMPLETED", "SUCCESS"),
+          check("Playwright captures", "IN_PROGRESS", null),
+        ],
+        commits: [
+          {
+            oid: "8f4f8b7f4c7e4d6c8a0a6b1c2d3e4f5061728394",
+            message_headline: "Add deterministic README screenshots",
+            message_body: "Drive Acorn through Playwright with Tauri mock data.",
+            committed_date: "2026-06-01T10:00:00Z",
+            authors: [{ name: "Ian", email: "ian@example.com", login: "im-ian" }],
+          },
+        ],
+      };
+    }
+
+    function check(name, status, conclusion) {
+      return {
+        name,
+        status,
+        conclusion,
+        started_at: "2026-06-01T11:50:00Z",
+        completed_at: conclusion ? "2026-06-01T11:54:00Z" : null,
+        url: "https://github.com/im-ian/acorn/actions",
+        workflow_name: "CI",
+      };
+    }
+
+    function terminalText(id) {
+      if (id === "api-contracts") {
+        return [
+          "$ cargo test session_contracts",
+          "test maps_workspace_folder ... ok",
+          "test returns_git_status_counts ... ok",
+          "",
+          "$ pnpm exec vitest run api-contracts",
+          "PASS api-contracts.test.ts (12 tests) 684ms",
+          "",
+          "$ rg list_sessions src-tauri",
+          "src-tauri/src/commands/sessions.rs",
+          "42: async fn list_sessions(state)",
+        ].join("\\r\\n") + "\\r\\n";
+      }
+      if (id === "release-checks") {
+        return [
+          "$ gh run watch 9832",
+          "CI / typecheck passed in 1m 18s",
+          "CI / playwright smoke passed in 2m 14s",
+          "",
+          "$ pnpm run build",
+          "vite v7.2.4 building for production...",
+          "DONE 1834 modules transformed",
+        ].join("\\r\\n") + "\\r\\n";
+      }
+      if (id === "agent-resume") {
+        return [
+          "$ claude --continue agent-resume",
+          "Claude Code is reading the resume flow",
+          "Plan:",
+          "1. inspect pane handoff state",
+          "2. patch stale status refresh",
+          "3. run focused typecheck",
+          "",
+          "$ rg resume src src-tauri",
+          "src/lib/sessionActions.ts",
+          "78: export async function resumeSession(id)",
+          "src-tauri/src/commands/pty.rs",
+          "214: async fn resume_session(id)",
+          "",
+          "$ pnpm run typecheck",
+          "PASS ResumeDialog.tsx",
+          "PASS workspaces.ts",
+        ].join("\\r\\n") + "\\r\\n";
+      }
+      return [
+        "$ codex",
+        "Task: refine workspace split behavior",
+        "Reading src/store/workspaces.ts",
+        "Editing WorkspaceGrid.tsx",
+        "",
+        "$ pnpm exec vitest run src/store/workspaces.test.ts",
+        "PASS workspaces.test.ts (18 tests) 412ms",
+        "",
+        "$ git diff --stat",
+        " src/components/workspace/WorkspaceGrid.tsx | 42 +++++++++---",
+        " src/store/workspaces.ts                  | 18 ++++--",
+        " 2 files changed, 46 insertions(+), 14 deletions(-)",
+        "",
+        "$ pnpm exec eslint src/components/workspace --fix",
+      ].join("\\r\\n") + "\\r\\n";
+    }
+  })();`;
+}
+
+function seedSessions() {
+  return [
+    session("workspace-polish", "workspace-polish", REPOS.app, "main", {
+      status: "needs_input",
+      agent: "codex",
+      position: 0,
+    }),
+    session("agent-resume", "agent-resume", REPOS.app, "main", {
+      status: "running",
+      agent: "claude",
+      position: 1,
+    }),
+    session("api-contracts", "api-contracts", REPOS.app, "main", {
+      status: "idle",
+      agent: "claude",
+      position: 2,
+    }),
+    session(
+      "ui-snapshot",
+      "ui-snapshot",
+      REPOS.app,
+      "feature/ui-capture",
+      {
+        status: "completed",
+        agent: "codex",
+        position: 3,
+        cwd: `${REPOS.app}/packages/desktop`,
+      },
+    ),
+    session(
+      "release-checks",
+      "release-checks",
+      REPOS.app,
+      "release/readme-captures",
+      {
+        status: "running",
+        agent: "claude",
+        position: 5,
+        isolated: true,
+        inWorktree: true,
+        cwd: `${REPOS.app}/.acorn/worktrees/release-readme-captures`,
+      },
+    ),
+
+    session("landing-refresh", "landing-refresh", REPOS.website, "main", {
+      status: "running",
+      agent: "codex",
+      position: 0,
+    }),
+    session("landing-copy", "landing-copy", REPOS.website, "main", {
+      status: "idle",
+      agent: "codex",
+      position: 2,
+      cwd: `${REPOS.website}/apps/www`,
+    }),
+    session("site-build", "site-build", REPOS.website, "preview/readme", {
+      status: "running",
+      agent: "claude",
+      position: 4,
+      isolated: true,
+      inWorktree: true,
+      cwd: `${REPOS.website}/.acorn/worktrees/preview`,
+    }),
+
+    session("docs-outline", "docs-outline", REPOS.docs, "main", {
+      status: "idle",
+      agent: "codex",
+      position: 0,
+    }),
+    session("install-flow", "install-flow", REPOS.docs, "main", {
+      status: "needs_input",
+      agent: "claude",
+      position: 1,
+    }),
+    session("guide-refresh", "guide-refresh", REPOS.docs, "main", {
+      status: "running",
+      agent: "codex",
+      position: 2,
+      cwd: `${REPOS.docs}/guides`,
+    }),
+    session("api-reference", "api-reference", REPOS.docs, "api/reference", {
+      status: "idle",
+      agent: "claude",
+      position: 3,
+      isolated: true,
+      inWorktree: true,
+      cwd: `${REPOS.docs}/.acorn/worktrees/api-reference`,
+    }),
+
+    ...[1, 2, 3, 4, 5].map((index) =>
+      session(
+        `instant-${index}`,
+        `instant-${index}`,
+        REPOS.local,
+        "HEAD",
+        {
+          status: index === 2 ? "running" : index === 4 ? "needs_input" : "idle",
+          agent: index % 2 === 0 ? "claude" : "codex",
+          position: index,
+          projectScoped: false,
+          cwd: REPOS.local,
+        },
+      ),
+    ),
+  ];
+}
+
+function session(
+  id: string,
+  name: string,
+  repoPath: string,
+  branch: string,
+  options: {
+    status: "idle" | "running" | "needs_input" | "failed" | "completed";
+    agent: "claude" | "codex" | "antigravity";
+    position: number;
+    cwd?: string;
+    isolated?: boolean;
+    inWorktree?: boolean;
+    projectScoped?: boolean;
+    kind?: "regular" | "control";
+  },
+) {
+  const cwd = options.cwd ?? repoPath;
+  return {
+    id,
+    name,
+    repo_path: repoPath,
+    worktree_path: cwd,
+    branch,
+    isolated: options.isolated ?? false,
+    project_scoped: options.projectScoped ?? true,
+    status: options.status,
+    created_at: `2026-06-01T10:${String(options.position).padStart(2, "0")}:00Z`,
+    updated_at: "2026-06-01T11:58:00Z",
+    last_message: null,
+    title_source: "generated",
+    auto_title_enabled: true,
+    generated_title_transcript_id: `${options.agent}-${id}`,
+    kind: options.kind ?? "regular",
+    mode: "terminal",
+    owner: { kind: "user" },
+    position: options.position,
+    in_worktree: options.inWorktree ?? false,
+    agent_provider: options.agent,
+    agent_transcript_id: `${options.agent}-${id}`,
+  };
+}

--- a/tests/captures/readme.spec.ts
+++ b/tests/captures/readme.spec.ts
@@ -4,8 +4,15 @@ import { test, expect, type Page } from "@playwright/test";
 import { tauriMockSource } from "../e2e/fixtures/tauriMock";
 
 const CAPTURE_DIR = process.env.ACORN_CAPTURE_DIR ?? "assets/screenshots";
+const DEFAULT_SCENES = [
+  "workspace",
+  "pr-modal",
+  "chat-session",
+  "control-session",
+  "command-palette",
+] as const;
 const SELECTED_SCENES = new Set(
-  (process.env.ACORN_CAPTURE_SCENES ?? "workspace,pr-modal,command-palette")
+  (process.env.ACORN_CAPTURE_SCENES ?? DEFAULT_SCENES.join(","))
     .split(",")
     .map((scene) => scene.trim())
     .filter(Boolean),
@@ -18,7 +25,7 @@ const REPOS = {
   local: "/workspace/instant",
 } as const;
 
-type SceneName = "workspace" | "pr-modal" | "command-palette";
+type SceneName = (typeof DEFAULT_SCENES)[number];
 
 interface CaptureScene {
   name: SceneName;
@@ -62,6 +69,47 @@ const scenes: CaptureScene[] = [
     },
   },
   {
+    name: "chat-session",
+    file: "chat-session.png",
+    prepare: async (page) => {
+      const chatPane = page.locator('[data-pane-body="chat-root"]');
+      await expect(
+        page.getByRole("button", { name: /Chat handoff review/ }).first(),
+      ).toBeVisible();
+      await expect(
+        chatPane.getByText("Can you review the workspace split"),
+      ).toBeVisible();
+      await expect(
+        chatPane.getByText("I checked the workspace layout"),
+      ).toBeVisible();
+    },
+  },
+  {
+    name: "control-session",
+    file: "control-session.png",
+    prepare: async (page) => {
+      const controlPane = page.locator('[data-pane-body="control-left"]');
+      const uiPane = page.locator('[data-pane-body="control-right-top"]');
+      const testPane = page.locator('[data-pane-body="control-right-middle"]');
+      const docsPane = page.locator('[data-pane-body="control-right-bottom"]');
+      await expect(
+        page.locator("aside").getByRole("button", {
+          name: /control-orchestrator/,
+        }),
+      ).toBeVisible();
+      await expect(
+        controlPane.getByText("$ acorn-ipc list-sessions"),
+      ).toBeVisible();
+      await expect(uiPane.getByText("$ codex --resume ui-worker")).toBeVisible();
+      await expect(
+        testPane.getByText("$ claude --continue test-runner"),
+      ).toBeVisible();
+      await expect(
+        docsPane.getByText("$ codex --resume docs-refresh"),
+      ).toBeVisible();
+    },
+  },
+  {
     name: "command-palette",
     file: "command-palette.png",
     prepare: async (page) => {
@@ -93,7 +141,7 @@ for (const scene of scenes) {
       `scene ${scene.name} was not requested`,
     );
 
-    await bootCapturePage(page);
+    await bootCapturePage(page, scene.name);
     await scene.prepare?.(page);
     await waitForStablePaint(page);
 
@@ -105,7 +153,7 @@ for (const scene of scenes) {
   });
 }
 
-async function bootCapturePage(page: Page) {
+async function bootCapturePage(page: Page, sceneName: SceneName) {
   await page.clock.setFixedTime(new Date(NOW));
   await page.addInitScript({
     content: `(() => {
@@ -132,16 +180,24 @@ async function bootCapturePage(page: Page) {
         JSON.stringify(["${folderId(REPOS.website, "release")}"])
       );
       window.localStorage.setItem("acorn-workspaces", JSON.stringify(${JSON.stringify(
-        persistedWorkspace(),
+        persistedWorkspace(sceneName),
       )}));
     })();`,
   });
   await page.addInitScript({ content: tauriMockSource });
-  await page.addInitScript({ content: captureMockHandlersSource() });
+  await page.addInitScript({ content: captureMockHandlersSource(sceneName) });
   await page.goto("/");
   await expect(page.getByRole("heading", { name: "Projects" })).toBeVisible();
+  const expectedSidebarSession =
+    sceneName === "chat-session"
+      ? /Chat handoff review/
+      : sceneName === "control-session"
+        ? /control-orchestrator/
+        : /workspace-polish/;
   await expect(
-    page.locator("aside").getByRole("button", { name: /workspace-polish/ }),
+    page.locator("aside").getByRole("button", {
+      name: expectedSidebarSession,
+    }),
   ).toBeVisible();
 }
 
@@ -154,51 +210,11 @@ function folderId(repoPath: string, name: string) {
   return `project-folder:${repoPath}:${name}`;
 }
 
-function persistedWorkspace() {
+function persistedWorkspace(sceneName: SceneName) {
   return {
     state: {
       workspaces: {
-        [REPOS.app]: {
-          layout: {
-            kind: "split",
-            id: "capture-root-split",
-            direction: "horizontal",
-            sizes: [62, 38],
-            a: { kind: "pane", id: "left-main" },
-            b: {
-              kind: "split",
-              id: "capture-right-stack",
-              direction: "vertical",
-              sizes: [50, 50],
-              a: { kind: "pane", id: "right-top" },
-              b: { kind: "pane", id: "right-bottom" },
-            },
-          },
-          panes: {
-            "left-main": paneState(
-              "left-main",
-              ["workspace-polish"],
-              "workspace-polish",
-            ),
-            "right-top": paneState(
-              "right-top",
-              ["agent-resume"],
-              "agent-resume",
-            ),
-            "right-bottom": paneState(
-              "right-bottom",
-              ["api-contracts"],
-              "api-contracts",
-            ),
-          },
-          focusedPaneId: "left-main",
-          rightTab: "files",
-          rightTabByGroup: {
-            code: "files",
-            github: "prs",
-            agents: "history",
-          },
-        },
+        [REPOS.app]: appWorkspace(sceneName),
         [folderId(REPOS.app, "frontend")]: emptyWorkspace("ui-snapshot"),
         [folderId(REPOS.app, "release")]: emptyWorkspace("release-checks"),
         [REPOS.website]: emptyWorkspace("landing-refresh"),
@@ -244,8 +260,116 @@ function persistedWorkspace() {
   };
 }
 
+function appWorkspace(sceneName: SceneName) {
+  if (sceneName === "chat-session") {
+    return {
+      layout: { kind: "pane", id: "chat-root" },
+      panes: {
+        "chat-root": paneState("chat-root", ["chat-handoff"], "chat-handoff"),
+      },
+      focusedPaneId: "chat-root",
+      ...rightPanelWorkspaceState(),
+    };
+  }
+
+  if (sceneName === "control-session") {
+    return {
+      layout: {
+        kind: "split",
+        id: "control-root-split",
+        direction: "horizontal",
+        sizes: [40, 60],
+        a: { kind: "pane", id: "control-left" },
+        b: {
+          kind: "split",
+          id: "control-right-stack-top",
+          direction: "vertical",
+          sizes: [34, 66],
+          a: { kind: "pane", id: "control-right-top" },
+          b: {
+            kind: "split",
+            id: "control-right-stack-bottom",
+            direction: "vertical",
+            sizes: [50, 50],
+            a: { kind: "pane", id: "control-right-middle" },
+            b: { kind: "pane", id: "control-right-bottom" },
+          },
+        },
+      },
+      panes: {
+        "control-left": paneState(
+          "control-left",
+          ["control-orchestrator"],
+          "control-orchestrator",
+        ),
+        "control-right-top": paneState(
+          "control-right-top",
+          ["ui-worker"],
+          "ui-worker",
+        ),
+        "control-right-middle": paneState(
+          "control-right-middle",
+          ["test-runner"],
+          "test-runner",
+        ),
+        "control-right-bottom": paneState(
+          "control-right-bottom",
+          ["docs-refresh"],
+          "docs-refresh",
+        ),
+      },
+      focusedPaneId: "control-left",
+      ...rightPanelWorkspaceState(),
+    };
+  }
+
+  return {
+    layout: {
+      kind: "split",
+      id: "capture-root-split",
+      direction: "horizontal",
+      sizes: [62, 38],
+      a: { kind: "pane", id: "left-main" },
+      b: {
+        kind: "split",
+        id: "capture-right-stack",
+        direction: "vertical",
+        sizes: [50, 50],
+        a: { kind: "pane", id: "right-top" },
+        b: { kind: "pane", id: "right-bottom" },
+      },
+    },
+    panes: {
+      "left-main": paneState(
+        "left-main",
+        ["workspace-polish"],
+        "workspace-polish",
+      ),
+      "right-top": paneState("right-top", ["agent-resume"], "agent-resume"),
+      "right-bottom": paneState(
+        "right-bottom",
+        ["api-contracts"],
+        "api-contracts",
+      ),
+    },
+    focusedPaneId: "left-main",
+    ...rightPanelWorkspaceState(),
+  };
+}
+
 function paneState(id: string, tabIds: string[], activeTabId: string) {
   return { id, tabIds, activeTabId, activationHistory: tabIds };
+}
+
+function rightPanelWorkspaceState() {
+  return {
+    rightTab: "files",
+    rightTabByGroup: {
+      code: "files",
+      github: "prs",
+      agents: "history",
+    },
+  };
 }
 
 function emptyWorkspace(activeSessionId: string) {
@@ -333,14 +457,146 @@ function projectFolder(
   return { id, repoPath, name, cwdPath, position };
 }
 
-function captureMockHandlersSource() {
+function chatStates() {
+  return {
+    "chat-handoff": {
+      schema_version: 1,
+      session_id: "chat-handoff",
+      session: {
+        id: "chat-handoff",
+        workspace_path: REPOS.app,
+        title: "Chat handoff review",
+        active_provider: "claude",
+        active_model: "sonnet",
+        created_at: "2026-06-01T11:12:00Z",
+        updated_at: "2026-06-01T11:59:00Z",
+      },
+      provider: "claude",
+      model: "sonnet",
+      messages: [
+        chatMessage(
+          "chat-user-1",
+          "user",
+          [
+            "Can you review the workspace split behavior before I open the PR?",
+            "",
+            "Focus on pane persistence, tab handoff, and right-panel state.",
+          ].join("\n"),
+          "complete",
+          "2026-06-01T11:20:00Z",
+        ),
+        chatMessage(
+          "chat-assistant-1",
+          "assistant",
+          [
+            "I checked the workspace layout state and the pane split helpers.",
+            "",
+            "- `focusedPaneId` is preserved across workspace switches",
+            "- right-panel tab state now follows the active project",
+            "- chat sessions skip terminal portal mounting",
+            "",
+            "Next I would add a focused capture scene for the single-pane chat flow.",
+          ].join("\n"),
+          "complete",
+          "2026-06-01T11:22:00Z",
+        ),
+        chatMessage(
+          "chat-user-2",
+          "user",
+          "Good. Also check whether this survives a reload with a collapsed docs project.",
+          "complete",
+          "2026-06-01T11:48:00Z",
+        ),
+        chatMessage(
+          "chat-assistant-2",
+          "assistant",
+          "Running a reload pass now. The persisted layout shape looks stable.",
+          "streaming",
+          "2026-06-01T11:59:00Z",
+        ),
+      ],
+      turns: [
+        {
+          id: "chat-turn-1",
+          session_id: "chat-handoff",
+          provider: "claude",
+          model: "sonnet",
+          status: "complete",
+          user_message_id: "chat-user-1",
+          assistant_message_id: "chat-assistant-1",
+          started_at: "2026-06-01T11:20:00Z",
+          completed_at: "2026-06-01T11:22:00Z",
+          error: null,
+        },
+        {
+          id: "chat-turn-2",
+          session_id: "chat-handoff",
+          provider: "claude",
+          model: "sonnet",
+          status: "running",
+          user_message_id: "chat-user-2",
+          assistant_message_id: "chat-assistant-2",
+          started_at: "2026-06-01T11:58:00Z",
+          completed_at: null,
+          error: null,
+        },
+      ],
+      provider_threads: [
+        {
+          session_id: "chat-handoff",
+          provider: "claude",
+          model: "sonnet",
+          native_thread_id: "thread-readme-chat",
+          resume_token: null,
+          last_response_id: "resp-readme-chat",
+          updated_at: "2026-06-01T11:59:00Z",
+        },
+      ],
+      context_snapshots: [],
+      memory: {
+        session_id: "chat-handoff",
+        summary: "Reviewed workspace split persistence and chat pane behavior.",
+        important_decisions: [
+          "Keep chat sessions in a single pane for the README capture.",
+        ],
+        facts: ["Right-panel state remains scoped to the active project."],
+        through_message_id: "chat-assistant-1",
+        updated_at: "2026-06-01T11:50:00Z",
+      },
+      created_at: "2026-06-01T11:12:00Z",
+      updated_at: "2026-06-01T11:59:00Z",
+    },
+  };
+}
+
+function chatMessage(
+  id: string,
+  role: "user" | "assistant",
+  content: string,
+  status: "complete" | "streaming",
+  createdAt: string,
+) {
+  return {
+    id,
+    session_id: "chat-handoff",
+    turn_id: role === "user" ? null : id.replace("assistant", "turn"),
+    role,
+    content,
+    created_at: createdAt,
+    status,
+    metadata: role === "assistant" ? { provider: "claude" } : null,
+  };
+}
+
+function captureMockHandlersSource(sceneName: SceneName) {
   return `(() => {
     const repos = ${JSON.stringify(REPOS)};
     const now = ${JSON.stringify(NOW)};
     const handlers = window.__ACORN_MOCK_HANDLERS__ =
       window.__ACORN_MOCK_HANDLERS__ || {};
     const projectFolders = ${JSON.stringify(projectFolders())};
-    const sessions = ${JSON.stringify(seedSessions())};
+    const sessions = ${JSON.stringify(seedSessions(sceneName))};
+    const chatStates = ${JSON.stringify(chatStates())};
 
     function b64(input) {
       return btoa(unescape(encodeURIComponent(input)));
@@ -351,6 +607,38 @@ function captureMockHandlersSource() {
       if (typeof callback === "function") {
         window.setTimeout(() => callback({ index: 0, message: b64(text) }), 40);
       }
+    }
+
+    function emptyChatState(sessionId) {
+      return {
+        schema_version: 1,
+        session_id: sessionId,
+        session: {
+          id: sessionId,
+          workspace_path: repos.app,
+          title: "Chat",
+          active_provider: "claude",
+          active_model: null,
+          created_at: now,
+          updated_at: now,
+        },
+        provider: "claude",
+        model: null,
+        messages: [],
+        turns: [],
+        provider_threads: [],
+        context_snapshots: [],
+        memory: {
+          session_id: sessionId,
+          summary: null,
+          important_decisions: [],
+          facts: [],
+          through_message_id: null,
+          updated_at: now,
+        },
+        created_at: now,
+        updated_at: now,
+      };
     }
 
     handlers.list_projects = () => [
@@ -391,6 +679,45 @@ function captureMockHandlersSource() {
     handlers.pty_kill = () => undefined;
     handlers.scrollback_load = () => null;
     handlers.scrollback_save = () => undefined;
+    handlers.load_chat_session_state = (args) =>
+      chatStates[args?.sessionId] || emptyChatState(args?.sessionId || "chat");
+    handlers.save_chat_session_state = (args) => args?.chatState;
+    handlers.append_chat_message = (args) => {
+      const state = chatStates[args?.sessionId] || emptyChatState(args?.sessionId || "chat");
+      return { ...state, messages: [...state.messages, args?.message].filter(Boolean) };
+    };
+    handlers.send_chat_message = (args) => {
+      const state = chatStates[args?.sessionId] || emptyChatState(args?.sessionId || "chat");
+      return { ...state, messages: state.messages.concat({
+        id: "capture-user-draft",
+        session_id: args?.sessionId || "chat",
+        turn_id: "capture-turn-draft",
+        role: "user",
+        content: args?.content || "",
+        created_at: now,
+        status: "complete",
+        metadata: null,
+      }) };
+    };
+    handlers.retry_chat_message = () => emptyChatState("chat");
+    handlers.update_chat_message = (args) => {
+      const state = chatStates[args?.sessionId] || emptyChatState(args?.sessionId || "chat");
+      return {
+        ...state,
+        messages: state.messages.map((message) =>
+          message.id === args?.messageId ? { ...message, ...args?.patch } : message,
+        ),
+      };
+    };
+    handlers.delete_chat_message = (args) => {
+      const state = chatStates[args?.sessionId] || emptyChatState(args?.sessionId || "chat");
+      return {
+        ...state,
+        messages: state.messages.filter((message) => message.id !== args?.messageId),
+      };
+    };
+    handlers.cancel_chat_message = (args) =>
+      chatStates[args?.sessionId] || emptyChatState(args?.sessionId || "chat");
 
     handlers.fs_list_dir = (args) => {
       const path = args && args.path;
@@ -605,6 +932,62 @@ function captureMockHandlersSource() {
     }
 
     function terminalText(id) {
+      if (id === "control-orchestrator") {
+        return [
+          "$ acorn-ipc promote --self",
+          "promoted control-orchestrator to control session",
+          "",
+          "$ acorn-ipc list-sessions",
+          "ui-worker       running   codex",
+          "test-runner     running   claude",
+          "docs-refresh    idle      codex",
+          "",
+          "$ acorn-ipc send-input ui-worker",
+          "task: tighten the pane drag target",
+          "",
+          "$ acorn-ipc send-input test-runner",
+          "task: run focused regression tests",
+          "",
+          "$ acorn-ipc read-buffer ui-worker",
+          "Applying WorkspaceGrid patch...",
+        ].join("\\r\\n") + "\\r\\n";
+      }
+      if (id === "ui-worker") {
+        return [
+          "$ codex --resume ui-worker",
+          "Task: tighten the pane drag target",
+          "Reading PaneDropOverlay.tsx",
+          "Editing WorkspaceGrid.tsx",
+          "",
+          "$ pnpm exec vitest run PaneDropOverlay",
+          "PASS PaneDropOverlay.test.tsx (9 tests) 538ms",
+        ].join("\\r\\n") + "\\r\\n";
+      }
+      if (id === "test-runner") {
+        return [
+          "$ claude --continue test-runner",
+          "Running focused regression checks",
+          "",
+          "$ pnpm exec vitest run workspaces",
+          "PASS workspaces.test.ts (18 tests) 412ms",
+          "",
+          "$ pnpm run typecheck",
+          "PASS src/store/workspaces.ts",
+        ].join("\\r\\n") + "\\r\\n";
+      }
+      if (id === "docs-refresh") {
+        return [
+          "$ codex --resume docs-refresh",
+          "Task: update README screenshot notes",
+          "",
+          "$ rg capture:readme docs package.json",
+          "docs/README_SCREENSHOTS.md",
+          "package.json",
+          "",
+          "$ git diff -- docs/README_SCREENSHOTS.md",
+          "README screenshot workflow documented",
+        ].join("\\r\\n") + "\\r\\n";
+      }
       if (id === "api-contracts") {
         return [
           "$ cargo test session_contracts",
@@ -670,8 +1053,8 @@ function captureMockHandlersSource() {
   })();`;
 }
 
-function seedSessions() {
-  return [
+function seedSessions(sceneName: SceneName) {
+  const baseSessions = [
     session("workspace-polish", "workspace-polish", REPOS.app, "main", {
       status: "needs_input",
       agent: "codex",
@@ -775,6 +1158,60 @@ function seedSessions() {
       ),
     ),
   ];
+
+  if (sceneName === "chat-session") {
+    return [
+      session("chat-handoff", "Chat handoff review", REPOS.app, "main", {
+        status: "running",
+        agent: "claude",
+        position: 0,
+        mode: "chat",
+      }),
+      ...baseSessions.filter((candidate) => candidate.repo_path !== REPOS.app),
+    ];
+  }
+
+  if (sceneName === "control-session") {
+    const controlOwner = {
+      kind: "control" as const,
+      session_id: "control-orchestrator",
+    };
+    return [
+      session(
+        "control-orchestrator",
+        "control-orchestrator",
+        REPOS.app,
+        "main",
+        {
+          status: "running",
+          agent: "codex",
+          position: 0,
+          kind: "control",
+        },
+      ),
+      session("ui-worker", "ui-worker", REPOS.app, "feature/pane-dnd", {
+        status: "running",
+        agent: "codex",
+        position: 1,
+        owner: controlOwner,
+      }),
+      session("test-runner", "test-runner", REPOS.app, "main", {
+        status: "running",
+        agent: "claude",
+        position: 2,
+        owner: controlOwner,
+      }),
+      session("docs-refresh", "docs-refresh", REPOS.app, "docs/screenshots", {
+        status: "idle",
+        agent: "codex",
+        position: 3,
+        owner: controlOwner,
+      }),
+      ...baseSessions.filter((candidate) => candidate.repo_path !== REPOS.app),
+    ];
+  }
+
+  return baseSessions;
 }
 
 function session(
@@ -791,6 +1228,8 @@ function session(
     inWorktree?: boolean;
     projectScoped?: boolean;
     kind?: "regular" | "control";
+    mode?: "terminal" | "chat";
+    owner?: { kind: "user" } | { kind: "control"; session_id: string };
   },
 ) {
   const cwd = options.cwd ?? repoPath;
@@ -810,8 +1249,8 @@ function session(
     auto_title_enabled: true,
     generated_title_transcript_id: `${options.agent}-${id}`,
     kind: options.kind ?? "regular",
-    mode: "terminal",
-    owner: { kind: "user" },
+    mode: options.mode ?? "terminal",
+    owner: options.owner ?? { kind: "user" },
     position: options.position,
     in_worktree: options.inWorktree ?? false,
     agent_provider: options.agent,

--- a/tests/captures/readme.spec.ts
+++ b/tests/captures/readme.spec.ts
@@ -9,6 +9,9 @@ const DEFAULT_SCENES = [
   "pr-modal",
   "chat-session",
   "control-session",
+  "staged-diff",
+  "agent-history",
+  "work-summary",
   "command-palette",
 ] as const;
 const SELECTED_SCENES = new Set(
@@ -24,6 +27,7 @@ const REPOS = {
   docs: "/workspace/acorn-docs",
   local: "/workspace/instant",
 } as const;
+const WORK_SUMMARY_TAB_ID = "work-summary:readme-workspace-polish";
 
 type SceneName = (typeof DEFAULT_SCENES)[number];
 
@@ -107,6 +111,57 @@ const scenes: CaptureScene[] = [
       await expect(
         docsPane.getByText("$ codex --resume docs-refresh"),
       ).toBeVisible();
+    },
+  },
+  {
+    name: "staged-diff",
+    file: "staged-diff.png",
+    prepare: async (page) => {
+      const rightPanel = page.locator('[data-panel-id="right"]');
+      await rightPanel.getByRole("button", { name: "Code", exact: true }).click();
+      await rightPanel
+        .getByRole("button", { name: "Staged", exact: true })
+        .click();
+      await expect(
+        rightPanel.locator("#staged-list").getByText("README.md"),
+      ).toBeVisible();
+      await expect(
+        rightPanel.getByText("Automated with the capture CLI"),
+      ).toBeVisible();
+    },
+  },
+  {
+    name: "agent-history",
+    file: "agent-history.png",
+    prepare: async (page) => {
+      const rightPanel = page.locator('[data-panel-id="right"]');
+      await rightPanel
+        .getByRole("button", { name: "Agents", exact: true })
+        .click();
+      await rightPanel
+        .getByRole("button", { name: "History", exact: true })
+        .click();
+      await expect(
+        rightPanel.getByText("Refine workspace split behavior"),
+      ).toBeVisible();
+      await expect(
+        rightPanel.getByText("Review resume flow edge cases"),
+      ).toBeVisible();
+    },
+  },
+  {
+    name: "work-summary",
+    file: "work-summary.png",
+    prepare: async (page) => {
+      const summaryPane = page.locator('[data-pane-body="summary-root"]');
+      await expect(
+        page.getByRole("button", { name: /Workspace work summary/ }),
+      ).toBeVisible();
+      await expect(
+        summaryPane.getByText("workspace-polish", { exact: true }),
+      ).toBeVisible();
+      await expect(summaryPane.getByText("README.md")).toBeVisible();
+      await expect(summaryPane.getByText("Tokens", { exact: true })).toBeVisible();
     },
   },
   {
@@ -254,7 +309,7 @@ function persistedWorkspace(sceneName: SceneName) {
           createdAt: "2026-06-01T11:55:00Z",
         },
       ],
-      workspaceTabs: {},
+      workspaceTabs: workspaceTabs(sceneName),
     },
     version: 4,
   };
@@ -323,6 +378,21 @@ function appWorkspace(sceneName: SceneName) {
     };
   }
 
+  if (sceneName === "work-summary") {
+    return {
+      layout: { kind: "pane", id: "summary-root" },
+      panes: {
+        "summary-root": paneState(
+          "summary-root",
+          [WORK_SUMMARY_TAB_ID],
+          WORK_SUMMARY_TAB_ID,
+        ),
+      },
+      focusedPaneId: "summary-root",
+      ...rightPanelWorkspaceState(),
+    };
+  }
+
   return {
     layout: {
       kind: "split",
@@ -354,6 +424,31 @@ function appWorkspace(sceneName: SceneName) {
     },
     focusedPaneId: "left-main",
     ...rightPanelWorkspaceState(),
+  };
+}
+
+function workspaceTabs(sceneName: SceneName) {
+  if (sceneName !== "work-summary") return {};
+  return {
+    [WORK_SUMMARY_TAB_ID]: {
+      id: WORK_SUMMARY_TAB_ID,
+      kind: "work-summary",
+      lifecycle: "restorable",
+      title: "Workspace work summary",
+      repoPath: REPOS.app,
+      cwdPath: REPOS.app,
+      sessionId: "workspace-polish",
+      tokenBaseline: {
+        capturedAt: "2026-06-01T11:20:00Z",
+        inputTokens: 3200,
+        outputTokens: 1180,
+        cacheReadTokens: 840,
+        cacheCreationTokens: 220,
+        reasoningTokens: 360,
+        totalTokens: 5800,
+        messagesWithUsage: 8,
+      },
+    },
   };
 }
 
@@ -588,6 +683,107 @@ function chatMessage(
   };
 }
 
+function agentHistoryItems() {
+  return [
+    {
+      provider: "codex",
+      id: "codex-workspace-polish",
+      title: "Refine workspace split behavior",
+      preview:
+        "Adjusted pane persistence, tab handoff, and README capture layout.",
+      cwd: REPOS.app,
+      worktree: {
+        name: "feature/pane-dnd",
+        path: `${REPOS.app}/.acorn/worktrees/pane-dnd`,
+        exists: true,
+      },
+      transcript_path: `${REPOS.app}/.acorn/transcripts/codex-workspace-polish.jsonl`,
+      updated_at: 1780314900,
+      resume_command: "codex --resume codex-workspace-polish",
+    },
+    {
+      provider: "claude",
+      id: "claude-agent-resume",
+      title: "Review resume flow edge cases",
+      preview:
+        "Checked stale status refresh, transcript lookup, and handoff behavior.",
+      cwd: REPOS.app,
+      worktree: null,
+      transcript_path: `${REPOS.app}/.acorn/transcripts/claude-agent-resume.jsonl`,
+      updated_at: 1780313700,
+      resume_command: "claude --continue claude-agent-resume",
+    },
+    {
+      provider: "codex",
+      id: "codex-docs-refresh",
+      title: "Refresh README screenshot notes",
+      preview:
+        "Documented isolated Playwright captures and review output paths.",
+      cwd: REPOS.app,
+      worktree: {
+        name: "docs/screenshots",
+        path: `${REPOS.app}/.acorn/worktrees/docs-screenshots`,
+        exists: true,
+      },
+      transcript_path: `${REPOS.app}/.acorn/transcripts/codex-docs-refresh.jsonl`,
+      updated_at: 1780312800,
+      resume_command: "codex --resume codex-docs-refresh",
+    },
+  ];
+}
+
+function agentTranscriptSummaries() {
+  return {
+    "codex-workspace-polish": agentTranscriptSummary(
+      "codex",
+      "codex-workspace-polish",
+      18,
+      10840,
+    ),
+    "claude-agent-resume": agentTranscriptSummary(
+      "claude",
+      "claude-agent-resume",
+      14,
+      8420,
+    ),
+    "codex-docs-refresh": agentTranscriptSummary(
+      "codex",
+      "codex-docs-refresh",
+      9,
+      4380,
+    ),
+  };
+}
+
+function agentTranscriptSummary(
+  provider: "claude" | "codex",
+  id: string,
+  messageCount: number,
+  totalTokens: number,
+) {
+  return {
+    provider,
+    id,
+    transcript_path: `${REPOS.app}/.acorn/transcripts/${id}.jsonl`,
+    updated_at: 1780314900,
+    message_count: messageCount,
+    user_messages: Math.ceil(messageCount / 2),
+    assistant_messages: Math.floor(messageCount / 2),
+    turn_count: Math.floor(messageCount / 2),
+    complete_turns: Math.max(1, Math.floor(messageCount / 2) - 1),
+    running_turns: 1,
+    token_usage: {
+      input_tokens: Math.round(totalTokens * 0.42),
+      output_tokens: Math.round(totalTokens * 0.21),
+      cache_read_tokens: Math.round(totalTokens * 0.2),
+      cache_creation_tokens: Math.round(totalTokens * 0.06),
+      reasoning_tokens: Math.round(totalTokens * 0.11),
+      total_tokens: totalTokens,
+      messages_with_usage: messageCount,
+    },
+  };
+}
+
 function captureMockHandlersSource(sceneName: SceneName) {
   return `(() => {
     const repos = ${JSON.stringify(REPOS)};
@@ -597,6 +793,8 @@ function captureMockHandlersSource(sceneName: SceneName) {
     const projectFolders = ${JSON.stringify(projectFolders())};
     const sessions = ${JSON.stringify(seedSessions(sceneName))};
     const chatStates = ${JSON.stringify(chatStates())};
+    const agentHistory = ${JSON.stringify(agentHistoryItems())};
+    const transcriptSummaries = ${JSON.stringify(agentTranscriptSummaries())};
 
     function b64(input) {
       return btoa(unescape(encodeURIComponent(input)));
@@ -830,8 +1028,12 @@ function captureMockHandlersSource(sceneName: SceneName) {
       account: "im-ian",
       items: [],
     });
-    handlers.list_unscoped_agent_history = () => [];
-    handlers.list_agent_history = () => [];
+    handlers.list_unscoped_agent_history = () => agentHistory;
+    handlers.list_agent_history = () => agentHistory;
+    handlers.agent_transcript_summary = (args) =>
+      transcriptSummaries[args?.transcriptId] || null;
+    handlers.agent_transcript_summary_at_path = (args) =>
+      transcriptSummaries[args?.id] || null;
     handlers.read_session_todos = () => [
       { content: "Seed screenshot fixture data", status: "completed", activeForm: null },
       { content: "Capture Files panel", status: "in_progress", activeForm: "Capturing Files panel" },
@@ -1208,6 +1410,16 @@ function seedSessions(sceneName: SceneName) {
         owner: controlOwner,
       }),
       ...baseSessions.filter((candidate) => candidate.repo_path !== REPOS.app),
+    ];
+  }
+
+  if (sceneName === "work-summary") {
+    return [
+      ...baseSessions.filter(
+        (candidate) =>
+          candidate.repo_path !== REPOS.app ||
+          candidate.id === "workspace-polish",
+      ),
     ];
   }
 


### PR DESCRIPTION
## Summary
Adds a deterministic README/GitHub screenshot workflow that captures Acorn screens without exposing the developer's real desktop, shell, browser profile, or local paths.

1. **Capture CLI:** Adds `pnpm run capture:readme` with scene selection, `--out`, `--headed`, and `--port` options.
2. **Isolated capture harness:** Adds a Playwright capture config that runs Vite against the existing Tauri mock and writes retina PNGs at a 1600x1000 CSS viewport with 2x pixel density.
3. **Seeded product scenes:** Adds workspace, GitHub PR detail modal, single-pane chat session, control-session orchestration, staged diff, agent history, work summary, and command palette scenes with deterministic fake projects, workspaces, worktrees, instant sessions, file status, GitHub data, transcript summaries, and realistic Codex/Claude activity.
4. **Usage docs:** Documents the capture command and review-friendly output options in `docs/README_SCREENSHOTS.md`.

## Design notes
- The capture spec injects mock Tauri handlers and fake `/workspace/...` paths, so README assets do not depend on the host machine's real repositories or shell state.
- Scene-specific workspace seeds keep the default workspace screenshot unchanged while allowing focused scenes for chat, control orchestration, staged diffs, agent history, and work summary views.
- Work Summary uses a seeded frontend-owned summary tab plus mocked git status, diff stats, and transcript token usage so it renders the same UI surface as the product.
- The default output remains `assets/screenshots`, while `--out` supports temporary review runs that do not overwrite tracked assets.
- This is internal documentation tooling, so the PR is excluded from the app-facing changelog.

## Follow-up (not in this PR)
- Refresh tracked README assets once the exact screenshot set is finalized.
- Address the existing command palette Radix dialog accessibility warning separately.

## Test plan
- [x] `git diff --check` - passed.
- [x] `node --check scripts/capture-readme.mjs` - passed.
- [x] `pnpm run capture:readme -- staged-diff agent-history work-summary --out /tmp/acorn-captures-more-scenes` - passed; generated the three new scene PNGs.
- [x] `pnpm run capture:readme -- --out /tmp/acorn-captures-all-scenes` - passed; generated `workspace.png`, `pr-modal.png`, `chat-session.png`, `control-session.png`, `staged-diff.png`, `agent-history.png`, `work-summary.png`, and `command-palette.png`.

## Notes
- `pnpm exec tsc --noEmit --project tests/e2e/tsconfig.json` currently fails on existing unrelated e2e type errors in `tests/e2e/chat-message-actions.spec.ts`, `tests/e2e/sidebar.spec.ts`, and `tests/e2e/terminal.spec.ts`.
- The capture run currently logs an existing Radix warning for the command palette dialog title/description, but the scene still captures successfully.