### PR TITLE
feat(workspace): add kanban workspace mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { StatusBar } from "./components/StatusBar";
 import { RemoveSessionDialog } from "./components/RemoveSessionDialog";
 import { RunningSessionCloseWarningDialog } from "./components/RunningSessionCloseWarningDialog";
 import { RemoveProjectDialog } from "./components/RemoveProjectDialog";
-import { LayoutRenderer } from "./components/LayoutRenderer";
+import { WorkspaceMain } from "./components/WorkspaceMain";
 import { RightPanel } from "./components/RightPanel";
 import { ResizeHandle } from "./components/ResizeHandle";
 import { AcornRain } from "./components/AcornRain";
@@ -289,6 +289,7 @@ function App() {
   const projects = useAppStore((s) => s.projects);
   const projectFolders = useAppStore((s) => s.projectFolders);
   const layout = useAppStore((s) => s.layout);
+  const workspaceViewMode = useAppStore((s) => s.workspaceViewMode);
   const pendingRemoveId = useAppStore((s) => s.pendingRemoveId);
   const pendingRemoveProject = useAppStore((s) => s.pendingRemoveProject);
   const clearPendingRemove = useAppStore((s) => s.clearPendingRemove);
@@ -1750,7 +1751,7 @@ function App() {
           </Panel>
           <ResizeHandle gap />
           <Panel id="main" order={2} defaultSize={56} minSize={30}>
-            <LayoutRenderer node={layout} />
+            <WorkspaceMain layout={layout} viewMode={workspaceViewMode} />
           </Panel>
           <ResizeHandle gap />
           <Panel

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -2,11 +2,13 @@ import { useMemo } from "react";
 import { Command, useCommandState } from "cmdk";
 import {
   Bot,
+  Columns3,
   FolderOpen,
   FolderPlus,
   GitBranch,
   GitCommit,
   GitPullRequest,
+  Kanban,
   LayoutTemplate,
   ListChecks,
   ListPlus,
@@ -19,7 +21,7 @@ import {
   Trees,
 } from "lucide-react";
 import { RESET_PANEL_SIZES_EVENT } from "../lib/layoutEvents";
-import { useAppStore } from "../store";
+import { useAppStore, type WorkspaceViewMode } from "../store";
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import type { TranslationKey, Translator } from "../lib/i18n";
@@ -44,9 +46,20 @@ function cpt(t: Translator, key: CommandPaletteTranslationKey): string {
   return t(key);
 }
 
+function workspaceModeLabel(t: Translator, mode: WorkspaceViewMode): string {
+  return mode === "kanban"
+    ? t("workspace.mode.kanban")
+    : t("workspace.mode.panes");
+}
+
 export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const sessions = useAppStore((s) => s.sessions);
+  const workspaceViewMode = useAppStore((s) => s.workspaceViewMode);
   const t = useTranslation();
+  const nextWorkspaceViewMode: WorkspaceViewMode =
+    workspaceViewMode === "kanban" ? "panes" : "kanban";
+  const NextWorkspaceViewIcon =
+    nextWorkspaceViewMode === "kanban" ? Kanban : Columns3;
 
   // Derived once per render — sessions array identity is stable from zustand
   // until the underlying list actually changes.
@@ -177,6 +190,11 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 
   function handleSetTab(tab: "todos" | "commits" | "staged" | "prs") {
     useAppStore.getState().setRightTab(tab);
+    close();
+  }
+
+  function handleToggleWorkspaceView() {
+    useAppStore.getState().setWorkspaceViewMode(nextWorkspaceViewMode);
     close();
   }
 
@@ -349,6 +367,17 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         ) : null}
 
         <Command.Group heading={cpt(t, "commandPalette.groups.view")}>
+          <Command.Item
+            value="toggle-workspace-view"
+            onSelect={handleToggleWorkspaceView}
+            keywords={["workspace", "view", "panes", "pane", "kanban", "board"]}
+          >
+            <NextWorkspaceViewIcon size={14} className="text-fg-muted" />
+            <span>{cpt(t, "commandPalette.commands.toggleWorkspaceView")}</span>
+            <span className="ml-auto truncate text-xs text-fg-muted/80">
+              {workspaceModeLabel(t, nextWorkspaceViewMode)}
+            </span>
+          </Command.Item>
           <Command.Item
             value="view-todos"
             onSelect={() => handleSetTab("todos")}

--- a/src/components/ResizeHandle.tsx
+++ b/src/components/ResizeHandle.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useId, useRef, useState } from "react";
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type HTMLAttributes,
+} from "react";
 import { createPortal } from "react-dom";
 import { PanelResizeHandle } from "react-resizable-panels";
 import { cn } from "../lib/cn";
@@ -7,7 +13,9 @@ import {
   type ExpandPanelDetail,
 } from "../lib/layoutEvents";
 
-interface ResizeHandleProps {
+interface ResizeHandleProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+  mode?: "panel" | "manual";
   direction?: "horizontal" | "vertical";
   showDivider?: boolean;
   thin?: boolean;
@@ -18,6 +26,7 @@ interface ResizeHandleProps {
    * into `gap` so those other surfaces stay unaffected.
    */
   gap?: boolean;
+  manualDragging?: boolean;
 }
 
 /**
@@ -41,18 +50,31 @@ const TOOLTIP_DELAY_MS = 250;
 const TOOLTIP_TEXT = "Double-click to expand";
 
 export function ResizeHandle({
+  mode = "panel",
   direction = "horizontal",
   showDivider = false,
   thin = false,
   gap = false,
+  manualDragging = false,
+  className,
+  onMouseEnter,
+  onMouseLeave,
+  onFocus,
+  onBlur,
+  role,
+  tabIndex,
+  ...rest
 }: ResizeHandleProps) {
   const isHorizontal = direction === "horizontal";
   const handleId = useId();
   const [dragging, setDragging] = useState(false);
   const [hovered, setHovered] = useState(false);
+  const [manualHovered, setManualHovered] = useState(false);
   const [tooltipAnchor, setTooltipAnchor] = useState<DOMRect | null>(null);
   const tooltipTimerRef = useRef<number | null>(null);
   const [collapsedPanelId, setCollapsedPanelId] = useState<string | null>(null);
+  const effectiveDragging = mode === "manual" ? manualDragging : dragging;
+  const effectiveHovered = mode === "manual" ? manualHovered : hovered;
 
   // Mirror the lib's `data-resize-handle-state` into React state. CSS
   // arbitrary variants (`data-[resize-handle-state=hover]:...`) compiled
@@ -142,6 +164,112 @@ export function ResizeHandle({
   // resize affordance. (A collapsed neighbour uses `showHandleVisual` for
   // the louder re-expand grip instead.)
   const showGapHint = gap && !showHandleVisual;
+  const handleClassName = cn(
+    "relative flex shrink-0 items-center justify-center bg-transparent transition-colors duration-150",
+    isHorizontal
+      ? gap
+        ? "w-1.5 cursor-col-resize"
+        : thin
+          ? "w-px cursor-col-resize"
+          : "w-3 cursor-col-resize"
+      : gap
+        ? "h-1.5 cursor-row-resize"
+        : thin
+          ? "h-px cursor-row-resize"
+          : "h-3 cursor-row-resize",
+    className,
+  );
+  const handleContent = (
+    <>
+      {(showHandleVisual || showGapHint) &&
+      (effectiveHovered || effectiveDragging) ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 transition-opacity duration-150"
+          style={{
+            // Gradient sits behind the grip in the gutter: keep the state
+            // color (white on hover, accent on drag) but fade the top and
+            // bottom ends to transparent.
+            backgroundImage: `linear-gradient(${
+              isHorizontal ? "to bottom" : "to right"
+            }, transparent, ${
+              effectiveDragging
+                ? "color-mix(in oklab, var(--color-accent) 65%, transparent)"
+                : "color-mix(in oklab, #ffffff 15%, transparent)"
+            }, transparent)`,
+          }}
+        />
+      ) : null}
+      {showDivider || (effectiveDragging && !showHandleVisual && !gap) ? (
+        <span
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute transition-colors duration-150",
+            effectiveDragging && !showHandleVisual
+              ? "bg-accent"
+              : "bg-border/80",
+            isHorizontal ? "h-full w-px" : "h-px w-full",
+          )}
+        />
+      ) : null}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none rounded-full transition duration-150",
+          // Fixed mid-size grip; only opacity/color changes between
+          // hover/drag so the user gets a steady rounded visual. For a gap
+          // gutter the grip turns accent on drag, replacing the square line.
+          isHorizontal ? "h-10 w-[2px]" : "h-[2px] w-10",
+          showGapHint && effectiveDragging ? "bg-accent" : "bg-white",
+          showHandleVisual
+            ? effectiveDragging
+              ? "opacity-100"
+              : effectiveHovered
+                ? "opacity-70"
+                : "opacity-0"
+            : showGapHint
+              ? effectiveDragging
+                ? "opacity-100"
+                : effectiveHovered
+                  ? "opacity-60"
+                  : "opacity-0"
+              : "opacity-0",
+        )}
+      />
+    </>
+  );
+
+  if (mode === "manual") {
+    return (
+      <div
+        {...rest}
+        role={role ?? "separator"}
+        tabIndex={tabIndex ?? 0}
+        aria-orientation={
+          rest["aria-orientation"] ?? (isHorizontal ? "vertical" : "horizontal")
+        }
+        onMouseEnter={(event) => {
+          setManualHovered(true);
+          onMouseEnter?.(event);
+        }}
+        onMouseLeave={(event) => {
+          setManualHovered(false);
+          onMouseLeave?.(event);
+        }}
+        onFocus={(event) => {
+          setManualHovered(true);
+          onFocus?.(event);
+        }}
+        onBlur={(event) => {
+          setManualHovered(false);
+          onBlur?.(event);
+        }}
+        className={handleClassName}
+      >
+        {handleContent}
+      </div>
+    );
+  }
 
   return (
     <>
@@ -152,73 +280,9 @@ export function ResizeHandle({
         }
         onDragging={setDragging}
         onDoubleClick={handleDoubleClick}
-        className={cn(
-          "relative flex shrink-0 items-center justify-center bg-transparent transition-colors duration-150",
-          isHorizontal
-            ? gap
-              ? "w-1.5 cursor-col-resize"
-              : thin
-                ? "w-px cursor-col-resize"
-                : "w-3 cursor-col-resize"
-            : gap
-              ? "h-1.5 cursor-row-resize"
-              : thin
-                ? "h-px cursor-row-resize"
-                : "h-3 cursor-row-resize",
-        )}
+        className={handleClassName}
       >
-        {(showHandleVisual || showGapHint) && (hovered || dragging) ? (
-          <span
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-0 transition-opacity duration-150"
-            style={{
-              // Gradient sits behind the grip in the gutter: keep the state
-              // color (white on hover, accent on drag) but fade the top and
-              // bottom ends to transparent.
-              backgroundImage: `linear-gradient(${
-                isHorizontal ? "to bottom" : "to right"
-              }, transparent, ${
-                dragging
-                  ? "color-mix(in oklab, var(--color-accent) 65%, transparent)"
-                  : "color-mix(in oklab, #ffffff 15%, transparent)"
-              }, transparent)`,
-            }}
-          />
-        ) : null}
-        {showDivider || (dragging && !showHandleVisual && !gap) ? (
-          <span
-            aria-hidden="true"
-            className={cn(
-              "pointer-events-none absolute transition-colors duration-150",
-              dragging && !showHandleVisual ? "bg-accent" : "bg-border/80",
-              isHorizontal ? "h-full w-px" : "h-px w-full",
-            )}
-          />
-        ) : null}
-        <span
-          aria-hidden="true"
-          className={cn(
-            "pointer-events-none rounded-full transition duration-150",
-            // Fixed mid-size grip; only opacity/color changes between
-            // hover/drag so the user gets a steady rounded visual. For a gap
-            // gutter the grip turns accent on drag, replacing the square line.
-            isHorizontal ? "h-10 w-[2px]" : "h-[2px] w-10",
-            showGapHint && dragging ? "bg-accent" : "bg-white",
-            showHandleVisual
-              ? dragging
-                ? "opacity-100"
-                : hovered
-                  ? "opacity-70"
-                  : "opacity-0"
-              : showGapHint
-                ? dragging
-                  ? "opacity-100"
-                  : hovered
-                    ? "opacity-60"
-                    : "opacity-0"
-                : "opacity-0",
-          )}
-        />
+        {handleContent}
       </PanelResizeHandle>
       {tooltipAnchor && !dragging
         ? createPortal(

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -352,6 +352,7 @@ describe("SettingsModal font controls", () => {
     useSettings.setState({
       open: true,
       settings: cloneSettings(),
+      patchInterface: vi.fn(),
       patchAppearance: vi.fn(),
       patchTerminal: vi.fn(),
     });
@@ -387,6 +388,28 @@ describe("SettingsModal font controls", () => {
     expect(document.body.textContent).toContain("Custom Command");
     expect(document.body.textContent).not.toContain("Ollama");
     expect(document.body.textContent).not.toContain("llm CLI");
+  });
+
+  it("patches the default workspace mode from the Interface tab", async () => {
+    const patchInterface = vi.fn();
+    useSettings.setState({
+      open: true,
+      settings: cloneSettings(),
+      patchInterface,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openInterfaceTab();
+
+    clickElement(getComboboxByLabel("Default workspace mode"));
+    clickOption("Kanban");
+
+    expect(patchInterface).toHaveBeenCalledWith({
+      defaultWorkspaceViewMode: "kanban",
+    });
   });
 
   afterEach(() => {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,7 +1,9 @@
 import {
+  Columns3,
   Download,
   FolderOpen,
   ImagePlus,
+  Kanban,
   Keyboard,
   Loader2,
   RefreshCcw,
@@ -75,6 +77,7 @@ import {
   type SelectedAgent,
   type SessionTitleSource,
   type AcornSettings,
+  type DefaultWorkspaceViewMode,
   type TerminalFontSmoothing,
   type TerminalFontWeight,
   type TerminalLinkActivation,
@@ -106,6 +109,7 @@ import {
   Stepper,
   TextInput,
   type SelectItem,
+  type SelectOption,
   type SelectOptionGroup,
 } from "./ui";
 
@@ -1153,6 +1157,7 @@ function GithubSettings() {
 
 function InterfaceSettings({ t }: { t: SettingsTranslator }) {
   const settings = useSettings((s) => s.settings);
+  const patchInterface = useSettings((s) => s.patchInterface);
   const patchLanguage = useSettings((s) => s.patchLanguage);
   const patchAppearance = useSettings((s) => s.patchAppearance);
 
@@ -1167,7 +1172,61 @@ function InterfaceSettings({ t }: { t: SettingsTranslator }) {
         value={settings.appearance.uiScalePercent}
         onChange={(uiScalePercent) => patchAppearance({ uiScalePercent })}
       />
+      <DefaultWorkspaceViewModeSection
+        value={settings.interface.defaultWorkspaceViewMode}
+        onChange={(defaultWorkspaceViewMode) =>
+          patchInterface({ defaultWorkspaceViewMode })
+        }
+        t={t}
+      />
     </section>
+  );
+}
+
+function isDefaultWorkspaceViewMode(
+  value: string,
+): value is DefaultWorkspaceViewMode {
+  return value === "panes" || value === "kanban";
+}
+
+function DefaultWorkspaceViewModeSection({
+  value,
+  onChange,
+  t,
+}: {
+  value: DefaultWorkspaceViewMode;
+  onChange: (value: DefaultWorkspaceViewMode) => void;
+  t: SettingsTranslator;
+}) {
+  const label = st(t, "settings.interface.defaultWorkspaceViewMode.label");
+  const options: SelectOption[] = [
+    {
+      value: "panes",
+      label: t("workspace.mode.panes"),
+      icon: <Columns3 size={13} />,
+    },
+    {
+      value: "kanban",
+      label: t("workspace.mode.kanban"),
+      icon: <Kanban size={13} />,
+    },
+  ];
+
+  return (
+    <Field
+      label={label}
+      hint={st(t, "settings.interface.defaultWorkspaceViewMode.hint")}
+    >
+      <Select
+        aria-label={label}
+        value={value}
+        options={options}
+        onValueChange={(nextValue) => {
+          if (isDefaultWorkspaceViewMode(nextValue)) onChange(nextValue);
+        }}
+        className="w-44"
+      />
+    </Field>
   );
 }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -52,7 +52,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { useAppStore } from "../store";
+import { useAppStore, type WorkspaceViewMode } from "../store";
 import {
   AgentProviderIcon,
   buildAgentForkCommand,
@@ -216,6 +216,7 @@ export function Sidebar() {
   const activeSessionId = useAppStore((s) => s.activeSessionId);
   const activeProject = useAppStore((s) => s.activeProject);
   const activeProjectFolderId = useAppStore((s) => s.activeProjectFolderId);
+  const workspaceViewMode = useAppStore((s) => s.workspaceViewMode);
   const selectSession = useAppStore((s) => s.selectSession);
   const focusLocalSessions = useAppStore((s) => s.focusLocalSessions);
   const setActiveProject = useAppStore((s) => s.setActiveProject);
@@ -1089,6 +1090,11 @@ export function Sidebar() {
                       collapsed={collapsed.has(project.repoPath)}
                       activeSessionId={activeSessionId}
                       isActiveProject={activeProject === project.repoPath}
+                      workspaceViewMode={
+                        activeProject === project.repoPath
+                          ? workspaceViewMode
+                          : "panes"
+                      }
                       activeProjectFolderId={activeProjectFolderId}
                       topLevelOrder={projectItemOrders[project.repoPath] ?? []}
                       onTitleClick={() =>
@@ -1664,6 +1670,7 @@ interface ProjectGroupViewProps {
   collapsed: boolean;
   activeSessionId: string | null;
   isActiveProject: boolean;
+  workspaceViewMode: WorkspaceViewMode;
   activeProjectFolderId: string | null;
   topLevelOrder: readonly string[];
   /** Title click: activate (preserve collapse if inactive); ensure expanded if already active. */
@@ -1697,6 +1704,7 @@ function ProjectGroupView({
   collapsed,
   activeSessionId,
   isActiveProject,
+  workspaceViewMode,
   activeProjectFolderId,
   topLevelOrder,
   onTitleClick,
@@ -2076,7 +2084,10 @@ function ProjectGroupView({
                   <SessionRow
                     key={item.id}
                     session={item.session}
-                    active={item.session.id === activeSessionId}
+                    active={
+                      workspaceViewMode === "panes" &&
+                      item.session.id === activeSessionId
+                    }
                     onSelect={() =>
                       onSelectSession(item.folderId, item.session.id)
                     }
@@ -2090,8 +2101,13 @@ function ProjectGroupView({
                     key={item.id}
                     folderGroup={item.folderGroup}
                     projectFolders={projectFoldersForRows}
-                    activeSessionId={activeSessionId}
-                    active={activeProjectFolderId === item.folderGroup.folder.id}
+                    activeSessionId={
+                      workspaceViewMode === "panes" ? activeSessionId : null
+                    }
+                    active={
+                      workspaceViewMode === "panes" &&
+                      activeProjectFolderId === item.folderGroup.folder.id
+                    }
                     collapsed={collapsedFolderIds.has(
                       item.folderGroup.folder.id,
                     )}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -14,7 +14,9 @@ import {
   Bell,
   CheckCheck,
   Clock,
+  Columns3,
   Gauge,
+  Kanban,
   Loader2,
   Settings,
   Trash2,
@@ -40,10 +42,10 @@ import type {
   AgentTokenWindow,
 } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
-import { useAppStore } from "../store";
+import { useAppStore, type WorkspaceViewMode } from "../store";
 import { MemoryBreakdownModal } from "./MemoryBreakdownModal";
 import { Tooltip } from "./Tooltip";
-import { StatusDot, type StatusTone } from "./ui";
+import { Select, StatusDot, type SelectOption, type StatusTone } from "./ui";
 
 const MEMORY_POLL_MS = 2000;
 const TOKEN_USAGE_POLL_MS = 60_000;
@@ -72,6 +74,16 @@ function statusBarFormat(
       ? String(values[name])
       : match,
   );
+}
+
+function workspaceViewLabel(t: Translator, mode: WorkspaceViewMode): string {
+  return mode === "kanban"
+    ? t("workspace.mode.kanban")
+    : t("workspace.mode.panes");
+}
+
+function isWorkspaceViewMode(value: string): value is WorkspaceViewMode {
+  return value === "panes" || value === "kanban";
 }
 
 function useHomeDir(): string | null {
@@ -203,8 +215,15 @@ function GitHubMark() {
 
 export function StatusBar() {
   const t = useTranslation();
-  const { sessions, activeSessionId, activeProject, error, loading } =
-    useAppStore();
+  const {
+    sessions,
+    activeSessionId,
+    activeProject,
+    error,
+    loading,
+    workspaceViewMode,
+  } = useAppStore();
+  const setWorkspaceViewMode = useAppStore((s) => s.setWorkspaceViewMode);
   const multiInputEnabled = useAppStore((s) => s.multiInputEnabled);
   const prAccountByRepo = useAppStore((s) => s.prAccountByRepo);
   const showSessionCount = useSettings(
@@ -248,6 +267,19 @@ export function StatusBar() {
   // then fall back to the active project root.
   const prAccountKey = active?.worktree_path ?? activeProject ?? null;
   const prAccount = prAccountKey ? prAccountByRepo[prAccountKey] ?? null : null;
+  const workspaceModeText = workspaceViewLabel(t, workspaceViewMode);
+  const workspaceViewOptions: SelectOption[] = [
+    {
+      value: "panes",
+      label: workspaceViewLabel(t, "panes"),
+      icon: <Columns3 size={12} />,
+    },
+    {
+      value: "kanban",
+      label: workspaceViewLabel(t, "kanban"),
+      icon: <Kanban size={12} />,
+    },
+  ];
 
   return (
     <>
@@ -301,6 +333,26 @@ export function StatusBar() {
             children (branch, path) shrink instead of forcing the row
             wider than the footer. */}
         <span className="ml-auto flex min-w-0 items-center gap-3">
+          <Select
+            data-testid="workspace-view-status"
+            value={workspaceViewMode}
+            options={workspaceViewOptions}
+            placement="top"
+            aria-label={statusBarFormat(t, "statusBar.workspaceView", {
+              mode: workspaceModeText,
+            })}
+            onValueChange={(value) => {
+              if (isWorkspaceViewMode(value)) setWorkspaceViewMode(value);
+            }}
+            className={cn(
+              "w-[5.75rem] shrink-0",
+              "[&>button]:h-5 [&>button]:rounded [&>button]:border-transparent [&>button]:bg-transparent",
+              "[&>button]:font-mono [&>button]:text-xs [&>button]:text-fg-muted",
+              "[&>button]:hover:bg-bg-elevated [&>button]:hover:text-fg",
+              "[&>button]:focus-visible:ring-1 [&>button]:focus-visible:ring-accent/40",
+              "[&_[data-select-trigger-icon]]:ml-1 [&_[data-select-trigger-label]]:px-1 [&>button>svg]:mr-1 [&>button>svg]:size-3",
+            )}
+          />
           {loading ? (
             <span className="whitespace-nowrap">
               {statusBarText(t, "statusBar.working")}

--- a/src/components/TerminalHost.test.tsx
+++ b/src/components/TerminalHost.test.tsx
@@ -95,6 +95,8 @@ function resetStore(): void {
       focusedPaneId: "root",
       activeTabId: null,
       activeSessionId: null,
+      workspaceViewMode: "panes",
+      terminalPopupSessionId: null,
       rightTab: "commits",
       rightTabByGroup: defaultTabByGroup(),
       workspaceTabs: {},
@@ -313,6 +315,33 @@ describe("TerminalHost", () => {
       { id: "first", active: false },
       { id: "second", active: true },
     ]);
+  });
+
+  it("moves a popup terminal into the popup body without changing pane selection", async () => {
+    installWorkspaceSessions(["first", "second"]);
+    const popupBody = document.createElement("div");
+    popupBody.dataset.terminalPopupBody = "second";
+    document.body.appendChild(popupBody);
+
+    render();
+    await act(async () => {
+      useAppStore.getState().openTerminalPopup("second");
+      await Promise.resolve();
+    });
+    await flushEffects();
+
+    expect(terminalRows()).toEqual([
+      { id: "first", active: true },
+      { id: "second", active: true },
+    ]);
+    expect(
+      popupBody.querySelector(
+        '[data-acorn-terminal-slot="second"] [data-testid="terminal"]',
+      ),
+    ).not.toBeNull();
+    expect(useAppStore.getState().activeSessionId).toBe("first");
+
+    popupBody.remove();
   });
 
   it("uses the configured resident terminal limit when evicting idle daemon terminals", async () => {

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -162,14 +162,59 @@ interface TerminalWorkspaceContext {
 
 function visibleTerminalSessionIdKey(state: AppStateSnapshot): string {
   const workspaceId = activeWorkspaceId(state);
-  if (!workspaceId) return "";
+  const ids: string[] = [];
+  if (workspaceId) {
+    const ws = state.workspaces[workspaceId];
+    if (ws) {
+      ids.push(
+        ...Object.values(ws.panes)
+          .map((pane) => pane.activeTabId)
+          .filter((id): id is string => Boolean(id)),
+      );
+    }
+  }
+  if (state.terminalPopupSessionId) ids.push(state.terminalPopupSessionId);
+  return [...new Set(ids)].sort().join(SESSION_ID_KEY_SEPARATOR);
+}
+
+function visibleTerminalTargetKey(
+  state: AppStateSnapshot,
+  sessionId: string,
+): string | null {
+  if (state.terminalPopupSessionId === sessionId) {
+    return `popup:${sessionId}`;
+  }
+  const workspaceId = activeWorkspaceId(state);
+  if (!workspaceId) return null;
   const ws = state.workspaces[workspaceId];
-  if (!ws) return "";
-  return Object.values(ws.panes)
-    .map((pane) => pane.activeTabId)
-    .filter((id): id is string => Boolean(id))
-    .sort()
-    .join(SESSION_ID_KEY_SEPARATOR);
+  if (!ws) return null;
+  for (const pane of Object.values(ws.panes)) {
+    if (pane.activeTabId === sessionId) return `pane:${pane.id}`;
+  }
+  return null;
+}
+
+function terminalDestinationForTargetKey(
+  targetKey: string | null,
+): HTMLElement | null {
+  if (!targetKey) return null;
+  if (targetKey.startsWith("popup:")) {
+    const sessionId = targetKey.slice("popup:".length);
+    return document.querySelector(
+      `[data-terminal-popup-body="${cssEscape(sessionId)}"]`,
+    ) as HTMLElement | null;
+  }
+  if (targetKey.startsWith("pane:")) {
+    const paneId = targetKey.slice("pane:".length);
+    return document.querySelector(
+      `[data-pane-body="${cssEscape(paneId)}"]`,
+    ) as HTMLElement | null;
+  }
+  return null;
+}
+
+function terminalTargetIsPopup(targetKey: string | null): boolean {
+  return Boolean(targetKey?.startsWith("popup:"));
 }
 
 function parseSessionIdKey(key: string): Set<string> {
@@ -189,30 +234,23 @@ function PortaledTerminal({ session }: { session: Session }) {
     targetRef.current = el;
   }
 
-  // Which pane (in the active workspace) is currently displaying this
-  // session as its active tab? null when this session is not visible.
-  const visiblePaneId = useAppStore((state) => {
-    const workspaceId = activeWorkspaceId(state);
-    if (!workspaceId) return null;
-    const ws = state.workspaces[workspaceId];
-    if (!ws) return null;
-    for (const pane of Object.values(ws.panes)) {
-      if (pane.activeTabId === session.id) return pane.id;
-    }
-    return null;
-  });
+  const visibleTargetKey = useAppStore((state) =>
+    visibleTerminalTargetKey(state, session.id),
+  );
 
   // The workspace layout reference. Splits/merges replace the layout node, so
   // a new reference signals that pane DOM bodies were remounted — even when
-  // `visiblePaneId` is unchanged. Without this dep the reattach effect skips
-  // re-running and the terminal target stays detached from the new pane body.
+  // the visible target is unchanged. Without this dep the reattach effect
+  // skips re-running and the terminal target stays detached from the new body.
   const layoutRef = useAppStore((state) =>
     activeWorkspaceId(state)
       ? state.workspaces[activeWorkspaceId(state)!]?.layout ?? null
       : null,
   );
   const isFocusedPane = useAppStore((state) =>
-    isSessionInFocusedPane(session.id, state.panes, state.focusedPaneId),
+    terminalTargetIsPopup(visibleTargetKey)
+      ? true
+      : isSessionInFocusedPane(session.id, state.panes, state.focusedPaneId),
   );
   const workspaceKey = useAppStore((state) =>
     workspaceContextKeyForSession(state, session.id),
@@ -232,24 +270,32 @@ function PortaledTerminal({ session }: { session: Session }) {
     };
   }, []);
 
-  // Whenever the visible pane changes, move our target div into that pane's
-  // body (or back to limbo). This must run as a layout effect: Terminal's
-  // passive mount effect opens xterm and spawns the PTY with the current
-  // measured cols/rows, so the target needs to be in its real pane before
-  // that effect runs. Waiting for rAF leaves the first spawn fitted against
-  // the off-screen limbo size, which narrow panes and agent TUIs expose as
-  // stale wrapping/paint until the next resize or tab refit.
+  // Whenever the visible target changes, move our target div into that pane,
+  // popup body, or back to limbo. Popup bodies are rendered through a Modal
+  // portal, so keep looking briefly if the target has not landed yet.
   useLayoutEffect(() => {
     const target = targetRef.current;
     if (!target) return;
-    const dest = visiblePaneId
-      ? (document.querySelector(
-          `[data-pane-body="${cssEscape(visiblePaneId)}"]`,
-        ) as HTMLElement | null)
-      : null;
-    const nextParent = dest ?? getTerminalLimbo();
-    if (target.parentElement !== nextParent) nextParent.appendChild(target);
-  }, [visiblePaneId, layoutRef]);
+    let frame: number | null = null;
+    let attempts = 0;
+    const move = () => {
+      const dest = terminalDestinationForTargetKey(visibleTargetKey);
+      const nextParent = dest ?? getTerminalLimbo();
+      if (target.parentElement !== nextParent) nextParent.appendChild(target);
+      if (
+        dest === null &&
+        terminalTargetIsPopup(visibleTargetKey) &&
+        attempts < 30
+      ) {
+        attempts += 1;
+        frame = requestAnimationFrame(move);
+      }
+    };
+    move();
+    return () => {
+      if (frame !== null) cancelAnimationFrame(frame);
+    };
+  }, [visibleTargetKey, layoutRef]);
 
   return createPortal(
     <Terminal
@@ -261,7 +307,7 @@ function PortaledTerminal({ session }: { session: Session }) {
       workspacePath={workspace?.path ?? null}
       agentProvider={resolveSessionAgentProvider(session)}
       pasteAgentProvider={session.agent_provider ?? null}
-      isActive={visiblePaneId !== null}
+      isActive={visibleTargetKey !== null}
       isFocusedPane={isFocusedPane}
     />,
     targetRef.current,

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
+import { cn } from "../lib/cn";
 
 interface TooltipProps {
   /**
@@ -248,7 +249,7 @@ export function Tooltip({
             ? ({ WebkitUserDrag: "element" } as CSSProperties)
             : undefined
         }
-        className={`inline-flex ${className ?? ""}`}
+        className={cn("inline-flex", className)}
       >
         {children}
       </span>

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -1,0 +1,1154 @@
+import {
+  Fragment,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
+import {
+  BarChart3,
+  Bot,
+  ChevronDown,
+  CheckCircle2,
+  Columns3,
+  Copy,
+  FolderOpen,
+  GitBranch,
+  MessageSquareText,
+  PencilLine,
+  Plus,
+  RotateCcw,
+  Search,
+  Terminal as TerminalIcon,
+  Trash2,
+  X,
+} from "lucide-react";
+import { api } from "../lib/api";
+import { cn } from "../lib/cn";
+import { openInConfiguredEditor } from "../lib/editor";
+import type { LayoutNode } from "../lib/layout";
+import { basename } from "../lib/pathUtils";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import {
+  PROJECT_SESSION_CREATE_MENU,
+  type ProjectSessionCreateAction,
+} from "../lib/projectSessionCreateActions";
+import { canConfigureSessionAutoClose } from "../lib/sessionAgentState";
+import type { Session, SessionStatus } from "../lib/types";
+import {
+  AgentProviderIcon,
+  resolveSessionAgentProvider,
+} from "../lib/agentProvider";
+import { useDialogShortcuts } from "../lib/dialog";
+import { useSettings } from "../lib/settings";
+import { useTranslation } from "../lib/useTranslation";
+import {
+  selectSessionsById,
+  useAppStore,
+  type WorkspaceViewMode,
+} from "../store";
+import { IconButton, Modal, StatusDot, type StatusTone } from "./ui";
+import { ChatPane } from "./ChatPane";
+import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
+import { LayoutRenderer } from "./LayoutRenderer";
+import { ResizeHandle } from "./ResizeHandle";
+import { Tooltip } from "./Tooltip";
+
+const KANBAN_COLUMNS: ReadonlyArray<{
+  status: SessionStatus;
+  tone: StatusTone;
+}> = [
+  { status: "idle", tone: "neutral" },
+  { status: "needs_input", tone: "warning" },
+  { status: "running", tone: "accent" },
+  { status: "failed", tone: "danger" },
+  { status: "completed", tone: "success" },
+];
+
+const STATUS_TONE: Record<SessionStatus, StatusTone> = {
+  idle: "neutral",
+  running: "accent",
+  needs_input: "warning",
+  failed: "danger",
+  completed: "success",
+};
+
+const STATUS_ICON_CLASS: Record<SessionStatus, string> = {
+  idle: "text-fg-muted",
+  running: "text-accent",
+  needs_input: "text-warning",
+  failed: "text-danger",
+  completed: "text-accent/70",
+};
+
+type KanbanSortMode = "updated-desc" | "created-desc" | "name-asc";
+type SidebarTranslationKey = Extract<TranslationKey, `sidebar.${string}`>;
+type WorkspaceKanbanContextGroup = "session" | "open" | "copy" | "danger";
+
+const KANBAN_COLUMN_WIDTHS_KEY = "acorn:workspace-kanban:column-widths:v2";
+const KANBAN_COLUMN_DEFAULT_WIDTH = 192;
+const KANBAN_COLUMN_MIN_WIDTH = 152;
+const KANBAN_COLUMN_GAP_PX = 6;
+const KANBAN_BOARD_PADDING_X_PX = 16;
+
+interface WorkspaceMainProps {
+  layout: LayoutNode;
+  viewMode: WorkspaceViewMode;
+}
+
+export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
+  return (
+    <div className="h-full min-w-0" data-workspace-main>
+      {viewMode === "kanban" ? (
+        <WorkspaceKanbanBoard />
+      ) : (
+        <LayoutRenderer node={layout} />
+      )}
+      <WorkspaceSessionPopup />
+    </div>
+  );
+}
+
+function WorkspaceKanbanBoard() {
+  const t = useTranslation();
+  const panes = useAppStore((s) => s.panes);
+  const sessionsById = useAppStore(selectSessionsById);
+  const openTerminalPopup = useAppStore((s) => s.openTerminalPopup);
+  const [filterQuery, setFilterQuery] = useState("");
+  const [sortMode, setSortMode] = useState<KanbanSortMode>("updated-desc");
+  const [columnWidths, setColumnWidths] = useState<number[]>(
+    readKanbanColumnWidths,
+  );
+  const [lastEditedColumnWidth, setLastEditedColumnWidth] = useState(
+    KANBAN_COLUMN_DEFAULT_WIDTH,
+  );
+  const [resizingColumnIndex, setResizingColumnIndex] = useState<number | null>(
+    null,
+  );
+
+  const sessions = useMemo(() => {
+    const ordered: Session[] = [];
+    const seen = new Set<string>();
+    for (const pane of Object.values(panes)) {
+      for (const id of pane.tabIds) {
+        if (seen.has(id)) continue;
+        const session = sessionsById.get(id);
+        if (!session) continue;
+        seen.add(id);
+        ordered.push(session);
+      }
+    }
+    return ordered;
+  }, [panes, sessionsById]);
+
+  const visibleSessions = useMemo(
+    () =>
+      sortKanbanSessions(
+        sessions.filter((session) =>
+          sessionMatchesKanbanFilter(session, filterQuery),
+        ),
+        sortMode,
+      ),
+    [filterQuery, sessions, sortMode],
+  );
+
+  const sessionsByStatus = useMemo(() => {
+    const grouped = new Map<SessionStatus, Session[]>();
+    for (const { status } of KANBAN_COLUMNS) grouped.set(status, []);
+    for (const session of visibleSessions) {
+      grouped.get(session.status)?.push(session);
+    }
+    return grouped;
+  }, [visibleSessions]);
+
+  const boardWidth = useMemo(
+    () =>
+      columnWidths.reduce((total, width) => total + width, 0) +
+      KANBAN_COLUMN_GAP_PX * (KANBAN_COLUMNS.length - 1) +
+      KANBAN_BOARD_PADDING_X_PX,
+    [columnWidths],
+  );
+
+  useEffect(() => {
+    writeKanbanColumnWidths(columnWidths);
+  }, [columnWidths]);
+
+  function openSession(id: string) {
+    openTerminalPopup(id);
+    if (typeof window !== "undefined") {
+      requestAnimationFrame(() => {
+        window.dispatchEvent(
+          new CustomEvent("acorn:focus-session", {
+            detail: { sessionId: id },
+          }),
+        );
+      });
+    }
+  }
+
+  function resizeColumn(index: number, nextWidth: number) {
+    const clampedWidth = clampKanbanColumnWidth(nextWidth);
+    setLastEditedColumnWidth(clampedWidth);
+    setColumnWidths((current) =>
+      current.map((width, widthIndex) =>
+        widthIndex === index ? clampedWidth : width,
+      ),
+    );
+  }
+
+  function resetColumn(index: number) {
+    resizeColumn(index, KANBAN_COLUMN_DEFAULT_WIDTH);
+  }
+
+  function resetColumnWidths() {
+    setLastEditedColumnWidth(KANBAN_COLUMN_DEFAULT_WIDTH);
+    setColumnWidths(defaultKanbanColumnWidths());
+  }
+
+  function equalizeColumnWidths() {
+    const equalWidth = clampKanbanColumnWidth(lastEditedColumnWidth);
+    setColumnWidths(KANBAN_COLUMNS.map(() => equalWidth));
+  }
+
+  function startColumnResize(
+    index: number,
+    event: ReactPointerEvent<HTMLDivElement>,
+  ) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const startX = event.clientX;
+    const startWidth = columnWidths[index] ?? KANBAN_COLUMN_DEFAULT_WIDTH;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    setResizingColumnIndex(index);
+
+    function cleanup() {
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      setResizingColumnIndex(null);
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", cleanup);
+      window.removeEventListener("pointercancel", cleanup);
+    }
+
+    function onPointerMove(moveEvent: PointerEvent) {
+      resizeColumn(index, startWidth + moveEvent.clientX - startX);
+    }
+
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", cleanup);
+    window.addEventListener("pointercancel", cleanup);
+  }
+
+  return (
+    <div
+      className="flex h-full min-w-0 flex-col overflow-hidden"
+      role="region"
+      aria-label={t("workspace.kanban.title")}
+      data-testid="workspace-kanban"
+    >
+      <KanbanToolbar
+        t={t}
+        filterQuery={filterQuery}
+        onFilterQueryChange={setFilterQuery}
+        sortMode={sortMode}
+        onSortModeChange={setSortMode}
+        onResetColumnWidths={resetColumnWidths}
+        onEqualizeColumnWidths={equalizeColumnWidths}
+      />
+      <div
+        className="min-h-0 flex-1 overflow-x-auto"
+        data-testid="workspace-kanban-scroll"
+      >
+        <div
+          className="flex h-full items-stretch p-2"
+          data-kanban-column-widths={columnWidths.join(",")}
+          style={{
+            width: `${boardWidth}px`,
+            minWidth: "100%",
+          }}
+        >
+          {KANBAN_COLUMNS.map((column, columnIndex) => {
+            const columnSessions = sessionsByStatus.get(column.status) ?? [];
+            const label = statusLabel(t, column.status);
+            return (
+              <Fragment key={column.status}>
+                <div
+                  className="h-full min-h-0 shrink-0"
+                  style={{
+                    width: `${
+                      columnWidths[columnIndex] ?? KANBAN_COLUMN_DEFAULT_WIDTH
+                    }px`,
+                  }}
+                >
+                  <section
+                    className="flex h-full min-h-0 flex-col overflow-hidden rounded-[var(--acorn-pane-radius)] border border-border bg-bg"
+                    aria-label={label}
+                    data-kanban-column-status={column.status}
+                  >
+                    <header className="flex h-9 shrink-0 items-center gap-2 border-b border-border px-2.5">
+                      <StatusDot
+                        tone={column.tone}
+                        pulse={column.status === "running"}
+                      />
+                      <h2 className="min-w-0 flex-1 truncate text-[12px] font-medium text-fg">
+                        {label}
+                      </h2>
+                      <span className="rounded bg-fg-muted/10 px-1.5 py-px text-[10px] tabular-nums text-fg-muted">
+                        {columnSessions.length}
+                      </span>
+                    </header>
+                    <div className="acorn-no-scrollbar min-h-0 flex-1 space-y-1.5 overflow-y-auto p-2">
+                      {columnSessions.length > 0 ? (
+                        columnSessions.map((session) => (
+                          <KanbanSessionCard
+                            key={session.id}
+                            session={session}
+                            onOpen={() => openSession(session.id)}
+                          />
+                        ))
+                      ) : (
+                        <p className="px-1 py-3 text-center text-[11px] text-fg-muted">
+                          {t("workspace.kanban.emptyColumn")}
+                        </p>
+                      )}
+                    </div>
+                  </section>
+                </div>
+                {columnIndex < KANBAN_COLUMNS.length - 1 ? (
+                  <ResizeHandle
+                    mode="manual"
+                    direction="horizontal"
+                    gap
+                    manualDragging={resizingColumnIndex === columnIndex}
+                    aria-label={t("workspace.kanban.resizeColumn").replace(
+                      "{name}",
+                      label,
+                    )}
+                    data-testid="workspace-kanban-column-resize-handle"
+                    data-kanban-resize-status={column.status}
+                    onPointerDown={(event) =>
+                      startColumnResize(columnIndex, event)
+                    }
+                    onDoubleClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      resetColumn(columnIndex);
+                    }}
+                    onKeyDown={(event) => {
+                      if (
+                        event.key !== "ArrowLeft" &&
+                        event.key !== "ArrowRight"
+                      ) {
+                        return;
+                      }
+                      event.preventDefault();
+                      const delta = event.shiftKey ? 24 : 8;
+                      const currentWidth =
+                        columnWidths[columnIndex] ??
+                        KANBAN_COLUMN_DEFAULT_WIDTH;
+                      resizeColumn(
+                        columnIndex,
+                        currentWidth +
+                          (event.key === "ArrowRight" ? delta : -delta),
+                      );
+                    }}
+                  />
+                ) : null}
+              </Fragment>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type KanbanActionEvent =
+  | "acorn:new-session"
+  | "acorn:new-isolated-session"
+  | "acorn:new-chat-session"
+  | "acorn:new-control-session";
+
+const KANBAN_CREATE_ACTION_EVENTS: Record<
+  ProjectSessionCreateAction["id"],
+  KanbanActionEvent
+> = {
+  terminal: "acorn:new-session",
+  isolated: "acorn:new-isolated-session",
+  chat: "acorn:new-chat-session",
+  control: "acorn:new-control-session",
+};
+
+function dispatchKanbanAction(eventName: KanbanActionEvent) {
+  window.dispatchEvent(new CustomEvent(eventName));
+}
+
+function kanbanSessionCreateIcon(id: ProjectSessionCreateAction["id"]) {
+  switch (id) {
+    case "terminal":
+      return <Plus size={12} />;
+    case "isolated":
+      return <GitBranch size={12} />;
+    case "chat":
+      return <MessageSquareText size={12} />;
+    case "control":
+      return <Bot size={12} />;
+  }
+}
+
+function KanbanToolbar({
+  t,
+  filterQuery,
+  onFilterQueryChange,
+  sortMode,
+  onSortModeChange,
+  onResetColumnWidths,
+  onEqualizeColumnWidths,
+}: {
+  t: Translator;
+  filterQuery: string;
+  onFilterQueryChange: (query: string) => void;
+  sortMode: KanbanSortMode;
+  onSortModeChange: (mode: KanbanSortMode) => void;
+  onResetColumnWidths: () => void;
+  onEqualizeColumnWidths: () => void;
+}) {
+  return (
+    <div className="shrink-0 px-2 pt-2">
+      <div
+        className="w-full max-w-full overflow-x-auto rounded-[var(--acorn-pane-radius)] border border-border bg-bg px-2 py-2"
+        data-testid="workspace-kanban-toolbar"
+      >
+        <div className="flex min-w-[54rem] items-center justify-between gap-2">
+          <div className="flex items-center gap-1.5">
+            <KanbanCreateSessionDropdown t={t} />
+            <KanbanToolbarButton
+              icon={<RotateCcw size={12} />}
+              label={t("workspace.kanban.actions.resetColumnSizes")}
+              onClick={onResetColumnWidths}
+            />
+            <KanbanToolbarButton
+              icon={<Columns3 size={12} />}
+              label={t("workspace.kanban.actions.equalizeColumnSizes")}
+              onClick={onEqualizeColumnWidths}
+            />
+          </div>
+          <div className="flex shrink-0 items-center gap-1.5">
+            <label className="flex h-7 w-44 items-center gap-1.5 rounded-md border border-border bg-bg-elevated/55 px-2 text-fg-muted transition focus-within:border-accent/40 focus-within:bg-bg-elevated focus-within:ring-2 focus-within:ring-accent/40 hover:border-accent/40 hover:bg-bg-elevated">
+              <Search size={12} className="shrink-0" aria-hidden="true" />
+              <input
+                value={filterQuery}
+                onChange={(event) =>
+                  onFilterQueryChange(event.currentTarget.value)
+                }
+                aria-label={t("workspace.kanban.filterLabel")}
+                placeholder={t("workspace.kanban.filterPlaceholder")}
+                className="min-w-0 flex-1 bg-transparent text-[11px] font-medium text-fg outline-none placeholder:text-fg-muted/60"
+              />
+            </label>
+            <select
+              value={sortMode}
+              onChange={(event) =>
+                onSortModeChange(toKanbanSortMode(event.currentTarget.value))
+              }
+              aria-label={t("workspace.kanban.sort.label")}
+              className="h-7 rounded-md border border-border bg-bg-elevated/55 px-2 text-[11px] font-medium text-fg-muted outline-none transition hover:border-accent/40 hover:bg-bg-elevated hover:text-fg focus-visible:border-accent/40 focus-visible:ring-2 focus-visible:ring-accent/40"
+            >
+              <option value="updated-desc">
+                {t("workspace.kanban.sort.updatedDesc")}
+              </option>
+              <option value="created-desc">
+                {t("workspace.kanban.sort.createdDesc")}
+              </option>
+              <option value="name-asc">
+                {t("workspace.kanban.sort.nameAsc")}
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function KanbanToolbarButton({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <Tooltip label={label} side="bottom">
+      <button
+        type="button"
+        aria-label={label}
+        onClick={onClick}
+        className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border bg-bg-elevated/55 px-2 text-[11px] font-medium text-fg-muted transition hover:border-accent/40 hover:bg-bg-elevated hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      >
+        <span className="inline-flex size-3.5 shrink-0 items-center justify-center">
+          {icon}
+        </span>
+        <span>{label}</span>
+      </button>
+    </Tooltip>
+  );
+}
+
+function KanbanCreateSessionDropdown({ t }: { t: Translator }) {
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const menuItems = useMemo<ContextMenuItem[]>(
+    () => [
+      workspaceContextMenuGroupTitle(t, "session"),
+      ...PROJECT_SESSION_CREATE_MENU.map((item) => {
+        if (item.type === "separator") return { type: "separator" as const };
+        const action = item.action;
+        return {
+          label: sidebarText(t, action.labelKey),
+          icon: kanbanSessionCreateIcon(action.id),
+          onClick: () =>
+            dispatchKanbanAction(KANBAN_CREATE_ACTION_EVENTS[action.id]),
+        };
+      }),
+    ],
+    [t],
+  );
+  const label = t("workspace.kanban.actions.createSession");
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={label}
+        aria-haspopup="menu"
+        aria-expanded={menu !== null}
+        onClick={(event) => {
+          const rect = event.currentTarget.getBoundingClientRect();
+          setMenu((current) =>
+            current === null ? { x: rect.left, y: rect.bottom + 4 } : null,
+          );
+        }}
+        className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border bg-bg-elevated/55 px-2 text-[11px] font-medium text-fg-muted transition hover:border-accent/40 hover:bg-bg-elevated hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      >
+        <span className="inline-flex size-3.5 shrink-0 items-center justify-center">
+          <Plus size={12} />
+        </span>
+        <span>{label}</span>
+        <ChevronDown size={12} className="shrink-0" aria-hidden="true" />
+      </button>
+      <ContextMenu
+        open={menu !== null}
+        x={menu?.x ?? 0}
+        y={menu?.y ?? 0}
+        onClose={() => setMenu(null)}
+        items={menuItems}
+      />
+    </>
+  );
+}
+
+function KanbanSessionCard({
+  session,
+  onOpen,
+}: {
+  session: Session;
+  onOpen: () => void;
+}) {
+  const t = useTranslation();
+  const worktreeName = basename(session.worktree_path);
+  const statusTone = STATUS_TONE[session.status];
+  const selectSession = useAppStore((s) => s.selectSession);
+  const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
+  const setWorkspaceViewMode = useAppStore((s) => s.setWorkspaceViewMode);
+  const toggleSessionAutoClose = useAppStore(
+    (s) => s.toggleSessionAutoClose,
+  );
+  const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
+  const autoCloseEnabled = useAppStore((s) =>
+    Boolean(s.autoCloseSessionIds[session.id]),
+  );
+  const editorCommand = useSettings((s) => s.settings.editor.command);
+  const editorConfigured = editorCommand.trim().length > 0;
+  const canConfigureAutoClose = canConfigureSessionAutoClose(session);
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const openLabel = t("workspace.kanban.openSession").replace(
+    "{name}",
+    session.name,
+  );
+  const sessionMenuItems = useMemo<ContextMenuItem[]>(
+    () => [
+      workspaceContextMenuGroupTitle(t, "session"),
+      {
+        label: openLabel,
+        icon:
+          session.mode === "chat" ? (
+            <MessageSquareText size={12} />
+          ) : (
+            <TerminalIcon size={12} />
+          ),
+        onClick: onOpen,
+      },
+      {
+        label: sidebarText(t, "sidebar.actions.openWorkSummary"),
+        icon: <BarChart3 size={12} />,
+        onClick: () => {
+          selectSession(session.id);
+          void openWorkSummaryTab({ sessionId: session.id })
+            .then(() => setWorkspaceViewMode("panes"))
+            .catch((err: unknown) => {
+              console.error("[WorkspaceMain] open work summary failed", err);
+            });
+        },
+      },
+      ...(canConfigureAutoClose
+        ? [
+            {
+              type: "checkbox",
+              label: sidebarText(t, "sidebar.actions.autoCloseWhenFinished"),
+              checked: autoCloseEnabled,
+              onChange: () => toggleSessionAutoClose(session.id),
+            } satisfies ContextMenuItem,
+          ]
+        : []),
+      workspaceContextMenuGroupTitle(t, "open"),
+      {
+        label: sidebarText(t, "sidebar.actions.openWorktreeInEditor"),
+        icon: <PencilLine size={12} />,
+        disabled: !editorConfigured,
+        onClick: () => {
+          void openInConfiguredEditor(session.worktree_path).catch(
+            (err: unknown) => {
+              console.error("[WorkspaceMain] open in editor failed", err);
+            },
+          );
+        },
+      },
+      {
+        label: sidebarText(t, "sidebar.actions.revealInFinder"),
+        icon: <FolderOpen size={12} />,
+        onClick: () => {
+          void api.fsReveal(session.worktree_path).catch((err: unknown) => {
+            console.error("[WorkspaceMain] reveal failed", err);
+          });
+        },
+      },
+      workspaceContextMenuGroupTitle(t, "copy"),
+      {
+        type: "submenu",
+        label: sidebarText(t, "sidebar.actions.copy"),
+        icon: <Copy size={12} />,
+        children: [
+          {
+            label: sidebarText(t, "sidebar.actions.worktreePath"),
+            icon: <Copy size={12} />,
+            onClick: () => void copyToClipboard(session.worktree_path),
+          },
+          {
+            label: sidebarText(t, "sidebar.actions.worktreeName"),
+            icon: <Copy size={12} />,
+            onClick: () => void copyToClipboard(worktreeName),
+          },
+          {
+            label: sidebarText(t, "sidebar.actions.branchName"),
+            icon: <Copy size={12} />,
+            onClick: () => void copyToClipboard(session.branch),
+            disabled: !session.branch,
+          },
+          {
+            label: sidebarText(t, "sidebar.actions.sessionId"),
+            icon: <Copy size={12} />,
+            onClick: () => void copyToClipboard(session.id),
+          },
+        ],
+      },
+      workspaceContextMenuGroupTitle(t, "danger"),
+      {
+        label: sidebarText(t, "sidebar.actions.removeSessionMenu"),
+        icon: <Trash2 size={12} />,
+        onClick: () => requestRemoveSession(session.id),
+      },
+    ],
+    [
+      autoCloseEnabled,
+      canConfigureAutoClose,
+      editorConfigured,
+      onOpen,
+      openLabel,
+      openWorkSummaryTab,
+      requestRemoveSession,
+      selectSession,
+      session.branch,
+      session.id,
+      session.mode,
+      session.worktree_path,
+      setWorkspaceViewMode,
+      t,
+      toggleSessionAutoClose,
+      worktreeName,
+    ],
+  );
+
+  return (
+    <>
+      <Tooltip
+        label={session.worktree_path}
+        side="right"
+        multiline
+        className="flex w-full"
+      >
+        <button
+          type="button"
+          data-testid="workspace-kanban-card"
+          data-kanban-session-id={session.id}
+          onClick={onOpen}
+          onContextMenu={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            setMenu({ x: event.clientX, y: event.clientY });
+          }}
+          className="group flex w-full flex-col gap-2 rounded-md border border-border bg-bg-elevated/45 p-2 text-left transition hover:border-accent/45 hover:bg-bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          aria-label={openLabel}
+        >
+          <span className="flex min-w-0 items-start gap-1.5">
+            <WorkspaceSessionIcon session={session} scope="kanban" />
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-[12px] font-medium leading-5 text-fg">
+                {session.name}
+              </span>
+              <span className="block truncate text-[11px] leading-4 text-fg-muted">
+                {worktreeName}
+              </span>
+            </span>
+          </span>
+          <span className="flex min-w-0 items-center gap-1.5 text-[10px] leading-none text-fg-muted">
+            <StatusDot
+              tone={statusTone}
+              pulse={session.status === "running"}
+              size="xs"
+            />
+            <span className="truncate">{statusLabel(t, session.status)}</span>
+            {session.branch ? (
+              <>
+                <span className="text-fg-muted/45">|</span>
+                <GitBranch size={10} className="shrink-0" />
+                <span className="min-w-0 truncate">{session.branch}</span>
+              </>
+            ) : null}
+            {session.kind === "control" ? (
+              <>
+                <span className="text-fg-muted/45">|</span>
+                <Bot size={10} className="shrink-0 text-accent" />
+              </>
+            ) : null}
+            {session.status === "completed" ? (
+              <CheckCircle2
+                size={10}
+                className="ml-auto shrink-0 text-accent"
+              />
+            ) : null}
+          </span>
+        </button>
+      </Tooltip>
+      <ContextMenu
+        open={menu !== null}
+        x={menu?.x ?? 0}
+        y={menu?.y ?? 0}
+        onClose={() => setMenu(null)}
+        items={sessionMenuItems}
+      />
+    </>
+  );
+}
+
+function WorkspaceSessionIcon({
+  session,
+  scope,
+  size = "sm",
+  className,
+}: {
+  session: Session;
+  scope: "kanban" | "popup";
+  size?: "sm" | "md";
+  className?: string;
+}) {
+  const showAgentProviderIcons = useSettings(
+    (s) => s.settings.sessionDisplay.icons.agentProvider,
+  );
+  const agentProvider = showAgentProviderIcons
+    ? resolveSessionAgentProvider(session)
+    : null;
+  const fallbackKind =
+    session.kind === "control"
+      ? "control"
+      : session.mode === "chat"
+        ? "chat"
+        : "terminal";
+  const isMedium = size === "md";
+  const primaryClassName = cn(
+    isMedium ? "size-6 rounded-md" : "size-5 rounded",
+    "shrink-0 border border-border bg-bg-elevated",
+    "flex items-center justify-center transition-colors",
+    session.status === "needs_input" && "border-warning/35",
+    session.status === "failed" && "border-danger/35",
+    session.status === "running" && "border-accent/35",
+    session.status === "completed" && "border-accent/25",
+    STATUS_ICON_CLASS[session.status],
+  );
+
+  return (
+    <span
+      className={cn("shrink-0", scope === "kanban" && "mt-px", className)}
+      aria-hidden="true"
+      data-kanban-agent-icon={
+        scope === "kanban" ? agentProvider ?? undefined : undefined
+      }
+      data-kanban-session-icon={
+        scope === "kanban" ? agentProvider ?? fallbackKind : undefined
+      }
+      data-kanban-icon-status={scope === "kanban" ? session.status : undefined}
+      data-popup-agent-icon={
+        scope === "popup" ? agentProvider ?? undefined : undefined
+      }
+      data-popup-session-icon={
+        scope === "popup" ? agentProvider ?? fallbackKind : undefined
+      }
+      data-popup-icon-status={scope === "popup" ? session.status : undefined}
+    >
+      <span className={primaryClassName}>
+        {agentProvider ? (
+          <AgentProviderIcon
+            provider={agentProvider}
+            className={isMedium ? "size-3.5" : "size-3"}
+          />
+        ) : fallbackKind === "control" ? (
+          <Bot size={isMedium ? 14 : 12} />
+        ) : fallbackKind === "chat" ? (
+          <MessageSquareText size={isMedium ? 14 : 12} />
+        ) : (
+          <TerminalIcon size={isMedium ? 14 : 12} />
+        )}
+      </span>
+    </span>
+  );
+}
+
+function WorkspaceSessionPopupHeader({
+  session,
+  titleId,
+  t,
+  onClose,
+}: {
+  session: Session;
+  titleId: string;
+  t: Translator;
+  onClose: () => void;
+}) {
+  const worktreeName = basename(session.worktree_path);
+  const statusTone = STATUS_TONE[session.status];
+  const title = cleanWorkspaceSessionPopupTitle(session.name);
+
+  return (
+    <header className="shrink-0 border-b border-border bg-bg-elevated/70 px-4 py-3">
+      <div className="flex min-w-0 items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border bg-bg shadow-sm">
+            <WorkspaceSessionIcon session={session} scope="popup" size="md" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <h3
+              id={titleId}
+              className="truncate text-sm font-semibold tracking-tight text-fg"
+            >
+              {title}
+            </h3>
+            <div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden text-[11px] font-medium leading-4 text-fg-muted">
+              <WorkspaceSessionPopupMetaItem
+                icon={
+                  <StatusDot
+                    tone={statusTone}
+                    pulse={session.status === "running"}
+                    size="xs"
+                  />
+                }
+              >
+                {statusLabel(t, session.status)}
+              </WorkspaceSessionPopupMetaItem>
+              <WorkspaceSessionPopupMetaItem
+                icon={<FolderOpen size={11} />}
+                title={session.worktree_path}
+              >
+                {worktreeName}
+              </WorkspaceSessionPopupMetaItem>
+              {session.branch ? (
+                <WorkspaceSessionPopupMetaItem icon={<GitBranch size={11} />}>
+                  {session.branch}
+                </WorkspaceSessionPopupMetaItem>
+              ) : null}
+              {session.mode === "chat" ? (
+                <WorkspaceSessionPopupMetaItem
+                  icon={<MessageSquareText size={11} />}
+                >
+                  {t("sidebar.aria.chatSession")}
+                </WorkspaceSessionPopupMetaItem>
+              ) : null}
+              {session.kind === "control" ? (
+                <WorkspaceSessionPopupMetaItem icon={<Bot size={11} />}>
+                  {t("sidebar.aria.controlSession")}
+                </WorkspaceSessionPopupMetaItem>
+              ) : null}
+            </div>
+          </div>
+        </div>
+        <IconButton
+          aria-label={t("dialogs.common.close")}
+          onClick={onClose}
+          size="sm"
+          surface="panel"
+        >
+          <X size={14} />
+        </IconButton>
+      </div>
+    </header>
+  );
+}
+
+function cleanWorkspaceSessionPopupTitle(title: string): string {
+  const cleaned = title.replace(/\s+-\s*$/u, "").trimEnd();
+  return cleaned.length > 0 ? cleaned : title;
+}
+
+function WorkspaceSessionPopupMetaItem({
+  icon,
+  title,
+  children,
+}: {
+  icon: ReactNode;
+  title?: string;
+  children: ReactNode;
+}) {
+  return (
+    <span
+      className="inline-flex min-w-0 shrink items-center gap-1.5"
+      title={title}
+    >
+      <span
+        className="inline-flex h-4 shrink-0 items-center justify-center text-fg-muted/75"
+        aria-hidden="true"
+      >
+        {icon}
+      </span>
+      <span className="min-w-0 truncate">{children}</span>
+    </span>
+  );
+}
+
+function WorkspaceSessionPopup() {
+  const titleId = useId();
+  const t = useTranslation();
+  const sessionsById = useAppStore(selectSessionsById);
+  const sessionId = useAppStore((s) => s.terminalPopupSessionId);
+  const closeTerminalPopup = useAppStore((s) => s.closeTerminalPopup);
+  const session = sessionId ? sessionsById.get(sessionId) ?? null : null;
+  const open = session !== null;
+
+  useDialogShortcuts(open, { onCancel: closeTerminalPopup });
+
+  useEffect(() => {
+    if (!sessionId || session) return;
+    closeTerminalPopup();
+  }, [closeTerminalPopup, session, sessionId]);
+
+  const isChat = session?.mode === "chat";
+
+  return (
+    <Modal
+      open={open}
+      onClose={closeTerminalPopup}
+      variant="panel"
+      size="5xl"
+      ariaLabelledBy={titleId}
+      className="h-[min(82vh,54rem)] max-w-[min(76rem,calc(100vw-2rem))] border-border/80 bg-bg-elevated/95"
+    >
+      {session ? (
+        <>
+          <WorkspaceSessionPopupHeader
+            session={session}
+            titleId={titleId}
+            t={t}
+            onClose={closeTerminalPopup}
+          />
+          <div className="min-h-0 flex-1 bg-bg p-2">
+            {isChat ? (
+              <div className="relative h-full min-h-0 overflow-hidden rounded-md border border-border bg-bg shadow-inner">
+                <ChatPane
+                  sessionId={session.id}
+                  isActive
+                  repoPath={session.worktree_path}
+                  session={session}
+                />
+              </div>
+            ) : (
+              <div
+                className="relative h-full min-h-0 w-full overflow-hidden rounded-md border border-border bg-bg shadow-inner"
+                data-terminal-popup-body={session.id}
+                data-testid="terminal-popup-body"
+              />
+            )}
+          </div>
+        </>
+      ) : null}
+    </Modal>
+  );
+}
+
+function statusLabel(t: Translator, status: SessionStatus): string {
+  switch (status) {
+    case "idle":
+      return t("sidebar.status.idle");
+    case "running":
+      return t("sidebar.status.running");
+    case "needs_input":
+      return t("sidebar.status.needs_input");
+    case "failed":
+      return t("sidebar.status.failed");
+    case "completed":
+      return t("sidebar.status.completed");
+  }
+}
+
+function sidebarText(t: Translator, key: SidebarTranslationKey): string {
+  return t(key);
+}
+
+function workspaceContextMenuGroupTitle(
+  t: Translator,
+  group: WorkspaceKanbanContextGroup,
+): ContextMenuItem {
+  return {
+    type: "group-title",
+    label: sidebarText(t, `sidebar.contextMenu.${group}`),
+  };
+}
+
+function toKanbanSortMode(value: string): KanbanSortMode {
+  if (
+    value === "updated-desc" ||
+    value === "created-desc" ||
+    value === "name-asc"
+  ) {
+    return value;
+  }
+  return "updated-desc";
+}
+
+function defaultKanbanColumnWidths(): number[] {
+  return KANBAN_COLUMNS.map(() => KANBAN_COLUMN_DEFAULT_WIDTH);
+}
+
+function readKanbanColumnWidths(): number[] {
+  const fallback = defaultKanbanColumnWidths();
+  if (typeof window === "undefined") return fallback;
+
+  try {
+    const raw = window.localStorage.getItem(KANBAN_COLUMN_WIDTHS_KEY);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return fallback;
+    const byStatus = parsed as Partial<Record<SessionStatus, unknown>>;
+    return KANBAN_COLUMNS.map(({ status }, index) => {
+      const value = byStatus[status];
+      return typeof value === "number" && Number.isFinite(value)
+        ? clampKanbanColumnWidth(value)
+        : (fallback[index] ?? KANBAN_COLUMN_DEFAULT_WIDTH);
+    });
+  } catch {
+    return fallback;
+  }
+}
+
+function writeKanbanColumnWidths(widths: readonly number[]) {
+  if (typeof window === "undefined") return;
+  const byStatus: Partial<Record<SessionStatus, number>> = {};
+  KANBAN_COLUMNS.forEach(({ status }, index) => {
+    byStatus[status] = clampKanbanColumnWidth(
+      widths[index] ?? KANBAN_COLUMN_DEFAULT_WIDTH,
+    );
+  });
+  try {
+    window.localStorage.setItem(
+      KANBAN_COLUMN_WIDTHS_KEY,
+      JSON.stringify(byStatus),
+    );
+  } catch {
+    // Ignore private-mode or quota failures; resizing should still work.
+  }
+}
+
+function clampKanbanColumnWidth(width: number): number {
+  return Math.max(KANBAN_COLUMN_MIN_WIDTH, Math.round(width));
+}
+
+function sortKanbanSessions(
+  sessions: readonly Session[],
+  sortMode: KanbanSortMode,
+): Session[] {
+  return [...sessions].sort((a, b) => {
+    switch (sortMode) {
+      case "updated-desc":
+        return (
+          sessionTimestamp(b.updated_at) - sessionTimestamp(a.updated_at) ||
+          compareSessionName(a, b)
+        );
+      case "created-desc":
+        return (
+          sessionTimestamp(b.created_at) - sessionTimestamp(a.created_at) ||
+          compareSessionName(a, b)
+        );
+      case "name-asc":
+        return compareSessionName(a, b);
+    }
+  });
+}
+
+function sessionMatchesKanbanFilter(
+  session: Session,
+  filterQuery: string,
+): boolean {
+  const query = filterQuery.trim().toLowerCase();
+  if (!query) return true;
+  return [
+    session.name,
+    session.worktree_path,
+    basename(session.worktree_path),
+    session.branch,
+    session.id,
+  ].some((value) => value.toLowerCase().includes(query));
+}
+
+function sessionTimestamp(value: string): number {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function compareSessionName(a: Session, b: Session): number {
+  return a.name.localeCompare(b.name, undefined, {
+    sensitivity: "base",
+    numeric: true,
+  });
+}
+
+async function copyToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (err) {
+    console.warn("[WorkspaceMain] clipboard write failed", err);
+  }
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "../../lib/cn";
+import { useAppHotkeyBlocker } from "../../lib/hotkeys";
 
 export type ModalVariant = "dialog" | "panel";
 export type ModalSize = "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "5xl";
@@ -65,6 +66,7 @@ export function Modal({
 }: ModalProps) {
   const mounted = useHasMounted();
   const backdropPointerDownRef = useRef(false);
+  useAppHotkeyBlocker(open && mounted);
   if (!open || !mounted) return null;
   const isDialog = variant === "dialog";
   // Portal to <body> so every Modal renders as a top-level sibling. This

--- a/src/components/ui/Select.test.tsx
+++ b/src/components/ui/Select.test.tsx
@@ -246,6 +246,33 @@ describe("Select", () => {
     expect(optionLabels()).toEqual(["Enterprise Plan"]);
   });
 
+  it("renders option icons in the trigger and option list", () => {
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <Select
+          value="panes"
+          options={[
+            { value: "panes", label: "Panes", icon: <span>P</span> },
+            { value: "kanban", label: "Kanban", icon: <span>K</span> },
+          ]}
+        />,
+      );
+    });
+
+    expect(
+      document.querySelector("[data-select-trigger-icon]")?.textContent,
+    ).toBe("P");
+
+    clickElement(getCombobox());
+
+    expect(
+      Array.from(document.querySelectorAll("[data-select-option-icon]")).map(
+        (icon) => icon.textContent,
+      ),
+    ).toEqual(["P", "K"]);
+  });
+
   it("renders separators without making them selectable", () => {
     const onValueChange = vi.fn();
     const options: SelectItem[] = [
@@ -349,5 +376,23 @@ describe("Select", () => {
     pressKey(trigger, "Enter");
 
     expect(onValueChange).toHaveBeenCalledWith("acorn-pink");
+  });
+
+  it("can place the options above the trigger", () => {
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <Select
+          placement="top"
+          value="acorn-dark"
+          options={THEME_OPTIONS}
+        />,
+      );
+    });
+
+    clickElement(getCombobox());
+
+    const listbox = document.querySelector<HTMLElement>('[role="listbox"]');
+    expect(listbox?.parentElement?.style.transform).toBe("translateY(-100%)");
   });
 });

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -24,6 +24,7 @@ export interface SelectOption {
   label: string;
   description?: string;
   disabled?: boolean;
+  icon?: ReactNode;
   searchText?: string;
 }
 
@@ -61,6 +62,7 @@ type BaseSelectProps = Omit<
   disabled?: boolean;
   emptyMessage?: string;
   name?: string;
+  placement?: "bottom" | "top";
   placeholder?: string;
   searchable?: boolean;
   searchPlaceholder?: string;
@@ -92,6 +94,7 @@ interface NormalizedOption {
   label: string;
   description?: string;
   disabled: boolean;
+  icon?: ReactNode;
   group?: string;
   searchText: string;
 }
@@ -142,6 +145,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
       emptyMessage = "No options",
       name,
       options,
+      placement = "bottom",
       placeholder = "",
       searchable = false,
       searchPlaceholder = "Search options",
@@ -191,10 +195,19 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
       () => new Set(selectedValues),
       [selectedValues],
     );
-    const selectedLabels = useMemo(() => {
+    const selectedOptions = useMemo(() => {
       const byValue = new Map(allOptions.map((option) => [option.value, option]));
-      return selectedValues.map((value) => byValue.get(value)?.label ?? value);
+      return selectedValues.map((value) => byValue.get(value) ?? null);
     }, [allOptions, selectedValues]);
+    const selectedLabels = useMemo(
+      () =>
+        selectedValues.map(
+          (value, index) => selectedOptions[index]?.label ?? value,
+        ),
+      [selectedOptions, selectedValues],
+    );
+    const selectedIcon =
+      selectedOptions.length === 1 ? selectedOptions[0]?.icon : undefined;
     const [isOpen, setIsOpen] = useState(false);
     const [listboxRect, setListboxRect] = useState<{
       left: number;
@@ -280,7 +293,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
         if (!rect) return;
         setListboxRect({
           left: rect.left,
-          top: rect.bottom + 4,
+          top: placement === "top" ? rect.top - 4 : rect.bottom + 4,
           width: rect.width,
         });
       };
@@ -292,7 +305,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
         window.removeEventListener("resize", updateListboxRect);
         window.removeEventListener("scroll", updateListboxRect, true);
       };
-    }, [isOpen]);
+    }, [isOpen, placement]);
 
     useLayoutEffect(() => {
       if (!isOpen || !searchable || !listboxRect) return;
@@ -473,6 +486,8 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
                 left: listboxRect.left,
                 minWidth: listboxRect.width,
                 top: listboxRect.top,
+                transform:
+                  placement === "top" ? "translateY(-100%)" : undefined,
               }}
             >
               {searchable ? (
@@ -549,6 +564,14 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
                             }}
                             onClick={() => selectOption(option)}
                           >
+                            {option.icon ? (
+                              <span
+                                data-select-option-icon
+                                className="shrink-0 text-fg-muted"
+                              >
+                                {option.icon}
+                              </span>
+                            ) : null}
                             <span className="min-w-0 flex-1">
                               <span
                                 data-select-option-label
@@ -615,9 +638,19 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
           onClick={handleTriggerClick}
           onKeyDown={handleTriggerKeyDown}
         >
+          {selectedIcon ? (
+            <span
+              data-select-trigger-icon
+              className="ml-2 shrink-0 text-fg-muted"
+            >
+              {selectedIcon}
+            </span>
+          ) : null}
           <span
+            data-select-trigger-label
             className={cn(
-              "min-w-0 flex-1 truncate px-2",
+              "min-w-0 flex-1 truncate pr-2",
+              selectedIcon ? "pl-1" : "pl-2",
               !hasDisplayValue && "text-fg-muted",
             )}
           >
@@ -801,6 +834,7 @@ function normalizeOption(
     label,
     description,
     disabled: option.disabled === true,
+    icon: option.icon,
     group,
     searchText: [label, description, value, group, option.searchText]
       .filter(Boolean)

--- a/src/lib/hotkeys.react.test.tsx
+++ b/src/lib/hotkeys.react.test.tsx
@@ -1,9 +1,20 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useHotkeys, type HotkeyBindings } from "./hotkeys";
+import {
+  useAppHotkeyBlocker,
+  useHotkeys,
+  type HotkeyBindings,
+} from "./hotkeys";
 
-function HotkeyHarness({ bindings }: { bindings: HotkeyBindings }) {
+function HotkeyHarness({
+  bindings,
+  blockAppHotkeys = false,
+}: {
+  bindings: HotkeyBindings;
+  blockAppHotkeys?: boolean;
+}) {
+  useAppHotkeyBlocker(blockAppHotkeys);
   useHotkeys(bindings);
   return <input aria-label="hotkey target" />;
 }
@@ -23,9 +34,17 @@ describe("useHotkeys", () => {
     container.remove();
   });
 
-  function render(bindings: HotkeyBindings): HTMLInputElement {
+  function render(
+    bindings: HotkeyBindings,
+    blockAppHotkeys = false,
+  ): HTMLInputElement {
     act(() => {
-      root.render(<HotkeyHarness bindings={bindings} />);
+      root.render(
+        <HotkeyHarness
+          bindings={bindings}
+          blockAppHotkeys={blockAppHotkeys}
+        />,
+      );
     });
     const input = container.querySelector("input");
     if (!input) throw new Error("missing hotkey target");
@@ -70,5 +89,26 @@ describe("useHotkeys", () => {
 
     expect(descendantHandler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks app-level modifier shortcuts while a modal is open", () => {
+    const handler = vi.fn((event: KeyboardEvent) => event.preventDefault());
+    const input = render({ "Control+Shift+e": handler }, true);
+    const descendantHandler = vi.fn();
+    input.addEventListener("keydown", descendantHandler, { capture: true });
+
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "e",
+        code: "KeyE",
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(descendantHandler).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -192,6 +192,7 @@ const MODIFIER_EVENT_KEYS = new Set([
 ]);
 
 let shortcutRecordingActive = false;
+let appHotkeyBlockDepth = 0;
 
 type TauriRuntimeWindow = Window & { __TAURI_INTERNALS__?: unknown };
 
@@ -386,6 +387,20 @@ export function isShortcutRecordingActive(): boolean {
   return shortcutRecordingActive;
 }
 
+export function areAppHotkeysBlocked(): boolean {
+  return appHotkeyBlockDepth > 0;
+}
+
+export function useAppHotkeyBlocker(active: boolean): void {
+  useEffect(() => {
+    if (!active) return;
+    appHotkeyBlockDepth += 1;
+    return () => {
+      appHotkeyBlockDepth = Math.max(0, appHotkeyBlockDepth - 1);
+    };
+  }, [active]);
+}
+
 const MAC_KEY_SYMBOL: Record<string, string> = {
   $mod: "⌘",
   Meta: "⌘",
@@ -498,6 +513,11 @@ function stopPropagationAfterHandling(
       binding,
       (event: KeyboardEvent) => {
         if (isShortcutRecordingActive()) return;
+        if (areAppHotkeysBlocked()) {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          return;
+        }
         handler(event);
         // App-level shortcuts that handled the key must own it before focused
         // surfaces like xterm also interpret the same chord.
@@ -515,6 +535,7 @@ function skipWhileRecording(bindings: HotkeyBindings): HotkeyBindings {
       binding,
       (event: KeyboardEvent) => {
         if (isShortcutRecordingActive()) return;
+        if (areAppHotkeysBlocked()) return;
         handler(event);
       },
     ]),

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -69,6 +69,85 @@ describe("language settings", () => {
   });
 });
 
+describe("interface settings", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("defaults new workspaces to pane mode", () => {
+    expect(DEFAULT_SETTINGS.interface.defaultWorkspaceViewMode).toBe("panes");
+  });
+
+  it("loads a persisted default workspace mode", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ interface: { defaultWorkspaceViewMode: "kanban" } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(
+      useSettings.getState().settings.interface.defaultWorkspaceViewMode,
+    ).toBe("kanban");
+  });
+
+  it("falls back to panes for an unsupported default workspace mode", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ interface: { defaultWorkspaceViewMode: "grid" } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(
+      useSettings.getState().settings.interface.defaultWorkspaceViewMode,
+    ).toBe("panes");
+  });
+
+  it("patches the default workspace mode and preserves the previous value for invalid patches", async () => {
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    useSettings
+      .getState()
+      .patchInterface({ defaultWorkspaceViewMode: "kanban" });
+    expect(
+      useSettings.getState().settings.interface.defaultWorkspaceViewMode,
+    ).toBe("kanban");
+
+    const invalidMode =
+      "grid" as unknown as typeof DEFAULT_SETTINGS.interface.defaultWorkspaceViewMode;
+    useSettings
+      .getState()
+      .patchInterface({ defaultWorkspaceViewMode: invalidMode });
+    expect(
+      useSettings.getState().settings.interface.defaultWorkspaceViewMode,
+    ).toBe("kanban");
+  });
+});
+
 describe("terminal.linkActivation default", () => {
   it("defaults to plain click so xterm's stock behaviour is preserved", () => {
     expect(DEFAULT_SETTINGS.terminal.linkActivation).toBe("click");

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -131,6 +131,7 @@ export const TERMINAL_LETTER_SPACING_MAX = 6;
 export const TERMINAL_LETTER_SPACING_STEP = 0.25;
 
 export type ToastPosition = "top" | "bottom";
+export type DefaultWorkspaceViewMode = "panes" | "kanban";
 
 export const TOAST_POSITION_OPTIONS: ReadonlyArray<{
   value: ToastPosition;
@@ -212,6 +213,13 @@ export const TERMINAL_FONT_WEIGHTS: ReadonlyArray<{
 
 export interface AcornSettings {
   language: Language;
+  interface: {
+    /**
+     * Initial workspace view mode for newly-created project workspaces.
+     * Existing project workspaces keep their own stored mode.
+     */
+    defaultWorkspaceViewMode: DefaultWorkspaceViewMode;
+  };
   terminal: {
     fontFamily: string;
     fontSize: number;
@@ -460,6 +468,9 @@ export interface AcornSettings {
 
 export const DEFAULT_SETTINGS: AcornSettings = {
   language: "en",
+  interface: {
+    defaultWorkspaceViewMode: "panes",
+  },
   terminal: {
     fontFamily: fontStackFromSlots(
       ["JetBrains Mono", "Fira Code", "Menlo"],
@@ -577,6 +588,10 @@ const VALID_PR_INTERVALS = new Set<number>(
 
 const VALID_BG_FITS = new Set<BackgroundFit>(["cover", "contain", "tile"]);
 const VALID_TOAST_POSITIONS = new Set<ToastPosition>(["top", "bottom"]);
+const VALID_WORKSPACE_VIEW_MODES = new Set<DefaultWorkspaceViewMode>([
+  "panes",
+  "kanban",
+]);
 
 function normalizeBgFit(v: unknown, fallback: BackgroundFit): BackgroundFit {
   if (typeof v === "string" && VALID_BG_FITS.has(v as BackgroundFit)) {
@@ -779,6 +794,19 @@ function normalizeLanguage(v: unknown, fallback: Language): Language {
   return isLanguage(v) ? v : fallback;
 }
 
+function normalizeDefaultWorkspaceViewMode(
+  v: unknown,
+  fallback: DefaultWorkspaceViewMode,
+): DefaultWorkspaceViewMode {
+  if (
+    typeof v === "string" &&
+    VALID_WORKSPACE_VIEW_MODES.has(v as DefaultWorkspaceViewMode)
+  ) {
+    return v as DefaultWorkspaceViewMode;
+  }
+  return fallback;
+}
+
 /**
  * v1 commitMessage block from the multi-provider commit-message PR. The
  * loader below lifts every field up into the new `agents.*` block so a
@@ -819,6 +847,9 @@ function loadSettings(): AcornSettings {
         })
       | null;
     if (!parsed || typeof parsed !== "object") return DEFAULT_SETTINGS;
+    const interfaceRaw = (parsed.interface ?? {}) as Partial<
+      AcornSettings["interface"]
+    >;
     const terminalRaw: Partial<AcornSettings["terminal"]> = parsed.terminal ?? {};
     const sessionsRaw = (parsed.sessions ?? {}) as PersistedSessionSettings;
 
@@ -907,6 +938,12 @@ function loadSettings(): AcornSettings {
     };
     return {
       language: normalizeLanguage(parsed.language, DEFAULT_SETTINGS.language),
+      interface: {
+        defaultWorkspaceViewMode: normalizeDefaultWorkspaceViewMode(
+          interfaceRaw.defaultWorkspaceViewMode,
+          DEFAULT_SETTINGS.interface.defaultWorkspaceViewMode,
+        ),
+      },
       terminal: {
         ...DEFAULT_SETTINGS.terminal,
         ...terminalRaw,
@@ -1134,6 +1171,7 @@ interface SettingsState {
   /// default tab.
   openTab: (tab: string) => void;
   consumePendingTab: () => string | null;
+  patchInterface: (patch: Partial<AcornSettings["interface"]>) => void;
   patchTerminal: (patch: Partial<AcornSettings["terminal"]>) => void;
   patchAgents: (
     patch: Partial<{
@@ -1192,6 +1230,24 @@ export const useSettings = create<SettingsState>((set, get) => ({
     }
     return t;
   },
+  patchInterface: (patch) =>
+    set((s) => {
+      const next: AcornSettings = {
+        ...s.settings,
+        interface: {
+          ...s.settings.interface,
+          defaultWorkspaceViewMode:
+            patch.defaultWorkspaceViewMode === undefined
+              ? s.settings.interface.defaultWorkspaceViewMode
+              : normalizeDefaultWorkspaceViewMode(
+                  patch.defaultWorkspaceViewMode,
+                  s.settings.interface.defaultWorkspaceViewMode,
+                ),
+        },
+      };
+      persist(next);
+      return { settings: next };
+    }),
   patchTerminal: (patch) =>
     set((s) => {
       const next: AcornSettings = {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -68,6 +68,12 @@
       "label": "Language",
       "hint": "Language used for the Acorn interface. New translations are added gradually."
     },
+    "interface": {
+      "defaultWorkspaceViewMode": {
+        "label": "Default workspace mode",
+        "hint": "Mode used when Acorn creates a new project workspace. Existing project-specific choices stay unchanged."
+      }
+    },
     "terminal": {
       "fontFamily": {
         "label": "Font family",
@@ -770,6 +776,8 @@
     "working": "working...",
     "error": "error: {error}",
     "githubAccountTooltip": "PRs listed via gh account {account}",
+    "workspaceView": "view: {mode}",
+    "workspaceViewTooltip": "Workspace view",
     "branch": "branch: {branch}",
     "memoryTooltip": "Click to view per-process breakdown",
     "memory": "memory: {memory}",
@@ -842,6 +850,38 @@
         "restarting": "Restarting...",
         "settings": "Settings"
       }
+    }
+  },
+  "workspace": {
+    "mode": {
+      "ariaLabel": "Workspace view mode",
+      "panes": "Panes",
+      "kanban": "Kanban"
+    },
+    "kanban": {
+      "title": "Workspace kanban",
+      "empty": "No sessions in this workspace.",
+      "emptyColumn": "No sessions",
+      "filterLabel": "Filter sessions",
+      "filterPlaceholder": "Filter sessions",
+      "newSession": "New session",
+      "resizeColumn": "Resize {name} column",
+      "actions": {
+        "createSession": "Create session",
+        "resetColumnSizes": "Reset sizes",
+        "equalizeColumnSizes": "Equalize sizes",
+        "newSession": "New session",
+        "newWorktreeSession": "New worktree",
+        "newChatSession": "New chat",
+        "newControlSession": "Control"
+      },
+      "sort": {
+        "label": "Sort sessions",
+        "updatedDesc": "Recently updated",
+        "createdDesc": "Newest",
+        "nameAsc": "Name"
+      },
+      "openSession": "Open {name}"
     }
   },
   "topBar": {
@@ -1819,6 +1859,7 @@
       "viewCommits": "View Commits",
       "viewStaged": "View Staged",
       "viewPullRequests": "View Pull Requests",
+      "toggleWorkspaceView": "Toggle workspace view",
       "resetPanelSizes": "Reset panel sizes",
       "reloadShellEnvironment": "Reload shell environment",
       "restartIpcServer": "Restart IPC server",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -68,6 +68,12 @@
       "label": "언어",
       "hint": "Acorn 인터페이스에 사용할 언어입니다. 새 번역은 점진적으로 추가됩니다."
     },
+    "interface": {
+      "defaultWorkspaceViewMode": {
+        "label": "기본 작업공간 모드",
+        "hint": "새 프로젝트 작업공간을 만들 때 사용할 모드입니다. 이미 프로젝트별로 선택한 모드는 유지됩니다."
+      }
+    },
     "terminal": {
       "fontFamily": {
         "label": "글꼴 패밀리",
@@ -770,6 +776,8 @@
     "working": "작업 중...",
     "error": "오류: {error}",
     "githubAccountTooltip": "{account} gh 계정으로 PR을 표시합니다",
+    "workspaceView": "보기: {mode}",
+    "workspaceViewTooltip": "작업공간 보기",
     "branch": "브랜치: {branch}",
     "memoryTooltip": "프로세스별 세부 정보를 보려면 클릭",
     "memory": "메모리: {memory}",
@@ -842,6 +850,38 @@
         "restarting": "재시작 중...",
         "settings": "설정"
       }
+    }
+  },
+  "workspace": {
+    "mode": {
+      "ariaLabel": "작업공간 보기 모드",
+      "panes": "패널",
+      "kanban": "칸반"
+    },
+    "kanban": {
+      "title": "작업공간 칸반",
+      "empty": "이 작업공간에 세션이 없습니다.",
+      "emptyColumn": "세션 없음",
+      "filterLabel": "세션 필터",
+      "filterPlaceholder": "세션 필터",
+      "newSession": "새 세션",
+      "resizeColumn": "{name} 컬럼 크기 조절",
+      "actions": {
+        "createSession": "세션 생성",
+        "resetColumnSizes": "크기 초기화",
+        "equalizeColumnSizes": "크기 균등화",
+        "newSession": "새 세션",
+        "newWorktreeSession": "새 워크트리",
+        "newChatSession": "새 채팅",
+        "newControlSession": "컨트롤"
+      },
+      "sort": {
+        "label": "세션 정렬",
+        "updatedDesc": "최근 업데이트",
+        "createdDesc": "최신 생성",
+        "nameAsc": "이름"
+      },
+      "openSession": "{name} 열기"
     }
   },
   "topBar": {
@@ -1819,6 +1859,7 @@
       "viewCommits": "커밋 보기",
       "viewStaged": "스테이징 보기",
       "viewPullRequests": "Pull requests 보기",
+      "toggleWorkspaceView": "작업공간 보기 전환",
       "resetPanelSizes": "패널 크기 재설정",
       "reloadShellEnvironment": "셸 환경 다시 로드",
       "restartIpcServer": "IPC 서버 다시 시작",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -179,6 +179,8 @@ function resetStore(): void {
       focusedPaneId: "root",
       activeTabId: null,
       activeSessionId: null,
+      workspaceViewMode: "panes",
+      terminalPopupSessionId: null,
       rightTab: "commits",
       rightTabByGroup: defaultTabByGroup(),
       workspaceTabs: {},
@@ -1476,6 +1478,131 @@ describe("removeSession", () => {
 });
 
 describe("splitFocusedPane", () => {
+  it("uses the configured default workspace mode for new project workspaces", async () => {
+    useSettings.setState({
+      settings: {
+        ...structuredClone(DEFAULT_SETTINGS),
+        interface: { defaultWorkspaceViewMode: "kanban" },
+      },
+    });
+
+    await seed([project(REPO_A, 0)], []);
+
+    const state = useAppStore.getState();
+    expect(state.workspaceViewMode).toBe("kanban");
+    expect(state.workspaces[REPO_A].viewMode).toBe("kanban");
+  });
+
+  it("preserves an explicit project mode when hydrating old workspaces with a missing default view mode", async () => {
+    window.localStorage.clear();
+    await seed(
+      [project(REPO_A, 0)],
+      [session("root", REPO_A), session("web", REPO_A)],
+    );
+    const folder = useAppStore
+      .getState()
+      .createProjectFolder(REPO_A, "Frontend", `${REPO_A}/web`);
+    expect(folder).not.toBeNull();
+    useAppStore.getState().setWorkspaceViewMode("kanban");
+
+    const raw = window.localStorage.getItem("acorn-workspaces");
+    expect(raw).not.toBeNull();
+    const persisted = JSON.parse(raw!);
+    delete persisted.state.workspaces[REPO_A].viewMode;
+    persisted.state.activeProject = REPO_A;
+    persisted.state.activeProjectFolderId = REPO_A;
+
+    resetStore();
+    window.localStorage.setItem("acorn-workspaces", JSON.stringify(persisted));
+    await useAppStore.persist.rehydrate();
+
+    const state = useAppStore.getState();
+    expect(state.workspaceViewMode).toBe("kanban");
+    expect(state.workspaces[REPO_A].viewMode).toBe("kanban");
+    expect(state.workspaces[folder!.id].viewMode).toBe("kanban");
+  });
+
+  it("materializes a missing workspace view mode even when selecting the apparent fallback mode", async () => {
+    await seed([project(REPO_A, 0)], []);
+    useAppStore.setState((state) => {
+      const { viewMode: _viewMode, ...workspaceWithoutMode } =
+        state.workspaces[REPO_A];
+      return {
+        workspaces: {
+          ...state.workspaces,
+          [REPO_A]: workspaceWithoutMode,
+        },
+      };
+    });
+
+    useAppStore.getState().setWorkspaceViewMode("panes");
+
+    expect(useAppStore.getState().workspaces[REPO_A].viewMode).toBe("panes");
+  });
+
+  it("stores the workspace view mode per project", async () => {
+    await seed(
+      [project(REPO_A, 0), project(REPO_B, 1)],
+      [session("a1", REPO_A), session("b1", REPO_B)],
+    );
+
+    useAppStore.getState().setActiveProject(REPO_A);
+    useAppStore.getState().setWorkspaceViewMode("kanban");
+    expect(useAppStore.getState().workspaceViewMode).toBe("kanban");
+
+    const folder = useAppStore
+      .getState()
+      .createProjectFolder(REPO_A, "Feature", `${REPO_A}/feature`);
+    expect(folder).not.toBeNull();
+    expect(useAppStore.getState().workspaceViewMode).toBe("kanban");
+    expect(useAppStore.getState().workspaces[folder!.id].viewMode).toBe(
+      "kanban",
+    );
+
+    useAppStore.getState().setWorkspaceViewMode("panes");
+    expect(useAppStore.getState().workspaceViewMode).toBe("panes");
+    expect(useAppStore.getState().workspaces[REPO_A].viewMode).toBe("panes");
+    expect(useAppStore.getState().workspaces[folder!.id].viewMode).toBe(
+      "panes",
+    );
+
+    useAppStore.getState().setWorkspaceViewMode("kanban");
+    useAppStore.getState().setActiveProject(REPO_B);
+    expect(useAppStore.getState().workspaceViewMode).toBe("panes");
+
+    useAppStore.getState().setActiveProject(REPO_A);
+    expect(useAppStore.getState().workspaceViewMode).toBe("kanban");
+  });
+
+  it("tracks the terminal popup session independently from pane selection", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A), session("a2", REPO_A)]);
+
+    expect(useAppStore.getState().activeSessionId).toBe("a1");
+
+    useAppStore.getState().openTerminalPopup("a2");
+    expect(useAppStore.getState().terminalPopupSessionId).toBe("a2");
+    expect(useAppStore.getState().activeSessionId).toBe("a1");
+
+    useAppStore.getState().closeTerminalPopup();
+    expect(useAppStore.getState().terminalPopupSessionId).toBeNull();
+    expect(useAppStore.getState().activeSessionId).toBe("a1");
+  });
+
+  it("clears the terminal popup when the popup session is removed", async () => {
+    const a1 = session("a1", REPO_A);
+    const a2 = session("a2", REPO_A);
+    await seed([project(REPO_A, 0)], [a1, a2]);
+
+    useAppStore.getState().openTerminalPopup("a2");
+    mockApi.listProjects.mockResolvedValueOnce([project(REPO_A, 0)]);
+    mockApi.listSessions.mockResolvedValueOnce([a1]);
+
+    await useAppStore.getState().removeSession("a2", true);
+
+    expect(useAppStore.getState().terminalPopupSessionId).toBeNull();
+    expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual(["a1"]);
+  });
+
   it("creates a new pane and focuses it; layout becomes a split", async () => {
     await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
     expect(useAppStore.getState().layout.kind).toBe("pane");

--- a/src/store.ts
+++ b/src/store.ts
@@ -153,9 +153,12 @@ export interface ProjectWorkspace {
   layout: LayoutNode;
   panes: Record<PaneId, PaneState>;
   focusedPaneId: PaneId;
+  viewMode?: WorkspaceViewMode;
   rightTab?: RightTab;
   rightTabByGroup?: Record<RightGroup, RightTab>;
 }
+
+export type WorkspaceViewMode = "panes" | "kanban";
 
 export interface MoveTabArgs {
   tabId: string;
@@ -191,6 +194,8 @@ interface AppStateModel {
   focusedPaneId: PaneId;
   activeTabId: string | null;
   activeSessionId: string | null;
+  workspaceViewMode: WorkspaceViewMode;
+  terminalPopupSessionId: string | null;
   consumeError: () => string | null;
 
   rightTab: RightTab;
@@ -275,6 +280,9 @@ interface AppStateModel {
     folderId: string | null,
   ) => void;
   setFocusedPane: (paneId: PaneId) => void;
+  setWorkspaceViewMode: (mode: WorkspaceViewMode) => void;
+  openTerminalPopup: (sessionId: string) => void;
+  closeTerminalPopup: () => void;
   focusAdjacentPane: (direction: PaneFocusDirection) => void;
   setPaneSplitSizes: (splitId: string, sizes: readonly number[]) => void;
   splitFocusedPane: (direction: Direction) => void;
@@ -483,11 +491,14 @@ function normalizePaneState(
   };
 }
 
-function emptyWorkspace(): ProjectWorkspace {
+function emptyWorkspace(
+  viewMode: WorkspaceViewMode = defaultWorkspaceViewMode(),
+): ProjectWorkspace {
   return {
     layout: makePaneNode(ROOT_PANE_ID),
     panes: { [ROOT_PANE_ID]: emptyPane(ROOT_PANE_ID) },
     focusedPaneId: ROOT_PANE_ID,
+    viewMode,
     rightTab: "commits",
     rightTabByGroup: defaultTabByGroup(),
   };
@@ -516,6 +527,21 @@ function normalizeRightPanelState(
   };
 }
 
+function defaultWorkspaceViewMode(): WorkspaceViewMode {
+  return useSettings.getState().settings.interface.defaultWorkspaceViewMode;
+}
+
+function readWorkspaceViewMode(value: unknown): WorkspaceViewMode | null {
+  return value === "kanban" || value === "panes" ? value : null;
+}
+
+function normalizeWorkspaceViewMode(
+  value: unknown,
+  fallback: WorkspaceViewMode = defaultWorkspaceViewMode(),
+): WorkspaceViewMode {
+  return readWorkspaceViewMode(value) ?? fallback;
+}
+
 let indexedSessions: Session[] | null = null;
 let indexedSessionsById: ReadonlyMap<string, Session> = new Map();
 
@@ -542,6 +568,7 @@ function fallbackEmptyMirror() {
     focusedPaneId: ROOT_PANE_ID as PaneId,
     activeTabId,
     activeSessionId: activeSessionIdFromTabId(activeTabId),
+    workspaceViewMode: defaultWorkspaceViewMode(),
   };
 }
 
@@ -560,6 +587,7 @@ function mirrorActive(
     focusedPaneId: ws.focusedPaneId,
     activeTabId,
     activeSessionId: activeSessionIdFromTabId(activeTabId),
+    workspaceViewMode: normalizeWorkspaceViewMode(ws.viewMode),
     ...rightPanel,
   };
 }
@@ -764,9 +792,15 @@ function reconcileWorkspaces(
   if (newActiveFolderId && !newWorkspaces[newActiveFolderId]) {
     newActiveFolderId = newActive ? defaultProjectFolderId(newActive) : null;
   }
+  const syncedWorkspaces = syncProjectWorkspaceViewModes(
+    newWorkspaces,
+    nextProjectFolders,
+    newActive,
+    newActiveFolderId,
+  );
 
   return {
-    workspaces: newWorkspaces,
+    workspaces: syncedWorkspaces,
     projectFolders: nextProjectFolders,
     sessionFolderIds: nextSessionFolderIds,
     activeProject: newActive,
@@ -805,6 +839,82 @@ function activeWorkspaceId(
   s: Pick<AppStateModel, "activeProject" | "activeProjectFolderId">,
 ): string | null {
   return s.activeProjectFolderId ?? s.activeProject;
+}
+
+function projectWorkspaceIds(
+  projectFolders: ProjectFoldersByRepo,
+  repoPath: string,
+): string[] {
+  const ids = new Set<string>([defaultProjectFolderId(repoPath)]);
+  for (const folder of projectFolders[repoPath] ?? []) {
+    ids.add(folder.id);
+  }
+  return [...ids];
+}
+
+function workspaceViewModeForProject(
+  workspaces: Record<string, ProjectWorkspace>,
+  projectFolders: ProjectFoldersByRepo,
+  repoPath: string,
+  preferredWorkspaceId: string | null = null,
+): WorkspaceViewMode {
+  const ids = projectWorkspaceIds(projectFolders, repoPath);
+  const candidates = [
+    preferredWorkspaceId && ids.includes(preferredWorkspaceId)
+      ? preferredWorkspaceId
+      : null,
+    defaultProjectFolderId(repoPath),
+    ...ids,
+  ];
+  const seen = new Set<string>();
+  for (const id of candidates) {
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    const ws = workspaces[id];
+    const mode = readWorkspaceViewMode(ws?.viewMode);
+    if (mode) return mode;
+  }
+  return defaultWorkspaceViewMode();
+}
+
+function syncProjectWorkspaceViewModes(
+  workspaces: Record<string, ProjectWorkspace>,
+  projectFolders: ProjectFoldersByRepo,
+  preferredRepoPath: string | null = null,
+  preferredWorkspaceId: string | null = null,
+): Record<string, ProjectWorkspace> {
+  let next = workspaces;
+  for (const repoPath of Object.keys(projectFolders)) {
+    const mode = workspaceViewModeForProject(
+      workspaces,
+      projectFolders,
+      repoPath,
+      preferredRepoPath === repoPath ? preferredWorkspaceId : null,
+    );
+    for (const workspaceId of projectWorkspaceIds(projectFolders, repoPath)) {
+      const ws = next[workspaceId];
+      if (!ws || readWorkspaceViewMode(ws.viewMode) === mode) continue;
+      if (next === workspaces) next = { ...workspaces };
+      next[workspaceId] = { ...ws, viewMode: mode };
+    }
+  }
+  return next;
+}
+
+function setProjectWorkspaceViewMode(
+  workspaces: Record<string, ProjectWorkspace>,
+  projectFolders: ProjectFoldersByRepo,
+  repoPath: string,
+  mode: WorkspaceViewMode,
+): Record<string, ProjectWorkspace> {
+  let next = workspaces;
+  for (const workspaceId of projectWorkspaceIds(projectFolders, repoPath)) {
+    const ws = next[workspaceId];
+    if (!ws || readWorkspaceViewMode(ws.viewMode) === mode) continue;
+    if (next === workspaces) next = { ...workspaces };
+    next[workspaceId] = { ...ws, viewMode: mode };
+  }
+  return next;
 }
 
 function repoPathForProjectFolderId(
@@ -1211,6 +1321,8 @@ export const useAppStore = create<AppStateModel>()(
   focusedPaneId: ROOT_PANE_ID,
   activeTabId: null,
   activeSessionId: null,
+  workspaceViewMode: defaultWorkspaceViewMode(),
+  terminalPopupSessionId: null,
 
   rightTab: "commits",
   rightTabByGroup: defaultTabByGroup(),
@@ -1708,7 +1820,16 @@ export const useAppStore = create<AppStateModel>()(
           };
       const workspaces = hasWorkspace
         ? s.workspaces
-        : { ...s.workspaces, [folderId]: emptyWorkspace() };
+        : {
+            ...s.workspaces,
+            [folderId]: emptyWorkspace(
+              workspaceViewModeForProject(
+                s.workspaces,
+                projectFolders,
+                repoPath,
+              ),
+            ),
+          };
       return {
         workspaces,
         projectFolders,
@@ -1725,7 +1846,19 @@ export const useAppStore = create<AppStateModel>()(
       if (!folder) return s;
       const workspaces = s.workspaces[folder.id]
         ? s.workspaces
-        : { ...s.workspaces, [folder.id]: emptyWorkspace() };
+        : {
+            ...s.workspaces,
+            [folder.id]: emptyWorkspace(
+              workspaceViewModeForProject(
+                s.workspaces,
+                s.projectFolders,
+                folder.repoPath,
+                s.activeProject === folder.repoPath
+                  ? activeWorkspaceId(s)
+                  : null,
+              ),
+            ),
+          };
       return {
         workspaces,
         activeProject: folder.repoPath,
@@ -1775,7 +1908,14 @@ export const useAppStore = create<AppStateModel>()(
       };
       const workspaces = {
         ...s.workspaces,
-        [created.id]: emptyWorkspace(),
+        [created.id]: emptyWorkspace(
+          workspaceViewModeForProject(
+            s.workspaces,
+            projectFolders,
+            repoPath,
+            s.activeProject === repoPath ? activeWorkspaceId(s) : null,
+          ),
+        ),
       };
       const reconciled = reconcileWorkspaces(
         s.sessions,
@@ -1918,6 +2058,32 @@ export const useAppStore = create<AppStateModel>()(
       });
       return patch ?? s;
     });
+  },
+
+  setWorkspaceViewMode(mode) {
+    set((s) => {
+      const workspaceId = activeWorkspaceId(s);
+      if (!s.activeProject || !workspaceId) return s;
+      const workspaces = setProjectWorkspaceViewMode(
+        s.workspaces,
+        s.projectFolders,
+        s.activeProject,
+        mode,
+      );
+      if (workspaces === s.workspaces) return s;
+      return {
+        workspaces,
+        ...mirrorActive(workspaces, workspaceId),
+      };
+    });
+  },
+
+  openTerminalPopup(sessionId) {
+    set({ terminalPopupSessionId: sessionId });
+  },
+
+  closeTerminalPopup() {
+    set({ terminalPopupSessionId: null });
   },
 
   focusAdjacentPane(direction) {
@@ -2389,6 +2555,10 @@ export const useAppStore = create<AppStateModel>()(
       for (const removalId of removalIds) {
         delete autoCloseSessionIds[removalId];
       }
+      const terminalPopupSessionId =
+        s.terminalPopupSessionId && removalIds.has(s.terminalPopupSessionId)
+          ? null
+          : s.terminalPopupSessionId;
 
       return {
         sessions,
@@ -2397,6 +2567,7 @@ export const useAppStore = create<AppStateModel>()(
         liveInWorktree,
         pendingTerminalInput,
         autoCloseSessionIds,
+        terminalPopupSessionId,
         sessionNotifications: s.sessionNotifications.filter(
           (notification) => !removalIds.has(notification.sessionId),
         ),
@@ -3386,6 +3557,9 @@ export const useAppStore = create<AppStateModel>()(
         );
         const sanitized: Record<string, ProjectWorkspace> = {};
         for (const [key, ws] of Object.entries(state.workspaces ?? {})) {
+          const explicitViewMode = readWorkspaceViewMode(
+            (ws as PersistedWorkspaceState).viewMode,
+          );
           const newPanes: Record<PaneId, PaneState> = {};
           for (const [pid, pane] of Object.entries(ws.panes ?? {})) {
             const normalized = normalizePaneState(
@@ -3408,7 +3582,7 @@ export const useAppStore = create<AppStateModel>()(
               activationHistory: activationHistoryFor(normalized, ids, active),
             };
           }
-          sanitized[key] = {
+          const normalizedWorkspace: ProjectWorkspace = {
             ...ws,
             panes: newPanes,
             ...normalizeRightPanelState(
@@ -3417,11 +3591,23 @@ export const useAppStore = create<AppStateModel>()(
                 state.rightTabByGroup,
             ),
           };
+          if (explicitViewMode) {
+            normalizedWorkspace.viewMode = explicitViewMode;
+          } else {
+            delete normalizedWorkspace.viewMode;
+          }
+          sanitized[key] = normalizedWorkspace;
         }
-        state.workspaces = sanitized;
-        state.projectFolders = normalizePersistedProjectFolders(
+        const projectFolders = normalizePersistedProjectFolders(
           state.projectFolders,
           sanitized,
+        );
+        state.projectFolders = projectFolders;
+        state.workspaces = syncProjectWorkspaceViewModes(
+          sanitized,
+          projectFolders,
+          state.activeProject,
+          state.activeProjectFolderId,
         );
         state.sessionFolderIds = normalizeStringRecord(state.sessionFolderIds);
         state.autoCloseSessionIds = normalizeTrueRecord(

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -1,0 +1,488 @@
+import { test, expect } from "./support";
+
+const PROJECT = {
+  repo_path: "/tmp/demo",
+  name: "demo",
+  created_at: "2026-01-01T00:00:00Z",
+  position: 0,
+};
+
+function project(repoPath: string, name: string, position: number) {
+  return {
+    repo_path: repoPath,
+    name,
+    created_at: "2026-01-01T00:00:00Z",
+    position,
+  };
+}
+
+function session(
+  id: string,
+  name: string,
+  status: "idle" | "running" | "needs_input" | "failed" | "completed",
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id,
+    name,
+    repo_path: "/tmp/demo",
+    worktree_path: `/tmp/demo/.worktrees/${id}`,
+    branch: `feat/${id}`,
+    isolated: false,
+    status,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:05Z",
+    last_message: null,
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: false,
+    ...overrides,
+  };
+}
+
+test.describe("workspace kanban mode", () => {
+  test("groups active workspace sessions by status and opens a card in a popup", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("needs-review", "needs-review", "needs_input", {
+        agent_provider: "claude",
+      }),
+      session("runner", "runner", "running", {
+        agent_provider: "codex",
+      }),
+      session("alpha", "alpha", "idle", {
+        updated_at: "2026-01-01T00:00:01Z",
+      }),
+      session("shell", "shell", "idle"),
+      session("done", "done", "completed", {
+        agent_provider: "antigravity",
+      }),
+      session("broken", "broken", "failed", {
+        agent_provider: "codex",
+      }),
+    ]);
+
+    await page.goto("/");
+
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Panes",
+    );
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    const board = page.getByTestId("workspace-kanban");
+    await expect(board).toBeVisible();
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Kanban",
+    );
+    await expect(page.getByTestId("sidebar-kanban-workspace-row")).toHaveCount(
+      0,
+    );
+    const createSessionButton = board.getByRole("button", {
+      name: "Create session",
+    });
+    await expect(createSessionButton).toBeVisible();
+    await expect(
+      board.getByRole("button", { name: "Reset sizes" }),
+    ).toBeVisible();
+    await expect(
+      board.getByRole("button", { name: "Equalize sizes" }),
+    ).toBeVisible();
+    await createSessionButton.click();
+    await expect(
+      page.getByRole("menuitem", { name: "New session" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "New worktree session" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "New chat session" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "New control session" }),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    await expect(
+      board.getByRole("heading", { name: "Needs input" }),
+    ).toBeVisible();
+    await expect(board.getByRole("heading", { name: "Failed" })).toBeVisible();
+    await expect(board.getByRole("heading", { name: "Running" })).toBeVisible();
+    await expect(board.getByRole("heading", { name: "Idle" })).toBeVisible();
+    await expect(
+      board.getByRole("heading", { name: "Completed" }),
+    ).toBeVisible();
+    await expect(
+      board.locator("section > header h2"),
+    ).toHaveText(["Idle", "Needs input", "Running", "Failed", "Completed"]);
+
+    const filterInput = board.getByLabel("Filter sessions");
+    await expect(filterInput).toBeVisible();
+    await filterInput.fill("shell");
+    await expect(
+      board.getByRole("button", { name: "Open shell" }),
+    ).toBeVisible();
+    await expect(
+      board.getByRole("button", { name: "Open runner" }),
+    ).toBeHidden();
+    await filterInput.fill("");
+
+    await board.getByLabel("Sort sessions").selectOption("name-asc");
+    const idleCards = board.locator(
+      'section[aria-label="Idle"] [data-testid="workspace-kanban-card"]',
+    );
+    await expect(idleCards).toHaveCount(2);
+    await expect(idleCards.nth(0)).toHaveAttribute(
+      "data-kanban-session-id",
+      "alpha",
+    );
+    await expect(idleCards.nth(1)).toHaveAttribute(
+      "data-kanban-session-id",
+      "shell",
+    );
+
+    await expect(
+      board.getByRole("button", { name: "Open needs-review" }),
+    ).toBeVisible();
+    await expect(
+      board.getByRole("button", { name: "Open runner" }),
+    ).toBeVisible();
+    await expect(
+      board
+        .locator('[data-kanban-session-id="needs-review"]')
+        .locator('[data-kanban-agent-icon="claude"]'),
+    ).toBeVisible();
+    await expect(
+      board
+        .locator('[data-kanban-session-id="broken"]')
+        .locator('[data-kanban-agent-icon="codex"]'),
+    ).toBeVisible();
+    await expect(
+      board
+        .locator('[data-kanban-session-id="runner"]')
+        .locator('[data-kanban-agent-icon="codex"]'),
+    ).toBeVisible();
+    await expect(
+      board
+        .locator('[data-kanban-session-id="shell"]')
+        .locator('[data-kanban-session-icon="terminal"]'),
+    ).toBeVisible();
+    await expect(
+      board
+        .locator('[data-kanban-session-id="done"]')
+        .locator('[data-kanban-agent-icon="antigravity"]'),
+    ).toBeVisible();
+
+    const shellCardWidths = await board
+      .locator('[data-kanban-session-id="shell"]')
+      .evaluate((button) => {
+        const wrapper = button.parentElement;
+        const list = wrapper?.parentElement;
+        if (!wrapper || !list) {
+          throw new Error("missing kanban card wrapper");
+        }
+        const listStyle = window.getComputedStyle(list);
+        const listContentWidth =
+          list.getBoundingClientRect().width -
+          parseFloat(listStyle.paddingLeft) -
+          parseFloat(listStyle.paddingRight);
+        return {
+          card: button.getBoundingClientRect().width,
+          wrapper: wrapper.getBoundingClientRect().width,
+          listContent: listContentWidth,
+        };
+      });
+    expect(
+      Math.abs(shellCardWidths.card - shellCardWidths.wrapper),
+    ).toBeLessThan(1);
+    expect(
+      Math.abs(shellCardWidths.wrapper - shellCardWidths.listContent),
+    ).toBeLessThan(1);
+
+    const kanbanScroll = page.getByTestId("workspace-kanban-scroll");
+    const kanbanColumnWidths = () =>
+      board
+        .locator("[data-kanban-column-status]")
+        .evaluateAll((columns) =>
+          columns.map((column) => column.getBoundingClientRect().width),
+        );
+    const idleColumn = board.locator('[data-kanban-column-status="idle"]');
+    const needsInputColumn = board.locator(
+      '[data-kanban-column-status="needs_input"]',
+    );
+    const idleResizeHandle = board
+      .locator('[data-kanban-resize-status="idle"]');
+    await expect(idleResizeHandle).toBeVisible();
+    const [idleWidthBefore, needsInputWidthBefore, scrollWidthBefore] =
+      await Promise.all([
+        idleColumn.evaluate((column) => column.getBoundingClientRect().width),
+        needsInputColumn.evaluate((column) =>
+          column.getBoundingClientRect().width,
+        ),
+        kanbanScroll.evaluate((scroll) => scroll.scrollWidth),
+      ]);
+    const handleBox = await idleResizeHandle.boundingBox();
+    expect(handleBox).not.toBeNull();
+    if (!handleBox) throw new Error("missing kanban resize handle");
+    await page.mouse.move(
+      handleBox.x + handleBox.width / 2,
+      handleBox.y + handleBox.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      handleBox.x + handleBox.width / 2 + 360,
+      handleBox.y + handleBox.height / 2,
+    );
+    await page.mouse.up();
+    await expect
+      .poll(async () =>
+        idleColumn.evaluate((column) => column.getBoundingClientRect().width),
+      )
+      .toBeGreaterThan(idleWidthBefore + 300);
+    const [idleWidthAfter, needsInputWidthAfter, scrollWidthAfter] =
+      await Promise.all([
+        idleColumn.evaluate((column) => column.getBoundingClientRect().width),
+        needsInputColumn.evaluate((column) =>
+          column.getBoundingClientRect().width,
+        ),
+        kanbanScroll.evaluate((scroll) => scroll.scrollWidth),
+      ]);
+    expect(
+      Math.abs(needsInputWidthAfter - needsInputWidthBefore),
+    ).toBeLessThan(1);
+    expect(scrollWidthAfter).toBeGreaterThan(scrollWidthBefore + 40);
+
+    await board.getByRole("button", { name: "Equalize sizes" }).click();
+    await expect
+      .poll(async () => {
+        const widths = await kanbanColumnWidths();
+        return Math.max(
+          ...widths.map((width) => Math.abs(width - idleWidthAfter)),
+        );
+      })
+      .toBeLessThan(1);
+
+    await board.getByRole("button", { name: "Reset sizes" }).click();
+    await expect
+      .poll(async () => {
+        const widths = await kanbanColumnWidths();
+        return Math.max(...widths.map((width) => Math.abs(width - 192)));
+      })
+      .toBeLessThan(1);
+
+    await board
+      .getByRole("button", { name: "Open shell" })
+      .click({ button: "right" });
+    await expect(
+      page.getByRole("menuitem", { name: "Open shell" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Open Work Summary" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Reveal in Finder" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Remove Session" }),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    await board.getByRole("button", { name: "Open broken" }).click();
+
+    await expect(page.getByTestId("workspace-kanban")).toBeVisible();
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Kanban",
+    );
+    const dialog = page.getByRole("dialog", { name: "broken" });
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.locator('[data-popup-agent-icon="codex"]'),
+    ).toBeVisible();
+    await expect(page.getByTestId("terminal-popup-body")).toBeVisible();
+    await expect(
+      page
+        .getByTestId("terminal-popup-body")
+        .locator('[data-acorn-terminal-slot="broken"] .acorn-terminal-shell'),
+    ).toBeVisible();
+  });
+
+  test("uses the configured default workspace mode on first project load", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          interface: { defaultWorkspaceViewMode: "kanban" },
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("default-kanban", "default-kanban", "idle"),
+    ]);
+
+    await page.goto("/");
+
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Kanban",
+    );
+    await expect(page.getByTestId("workspace-kanban")).toBeVisible();
+  });
+
+  test("restores kanban or pane mode per project", async ({ page, tauri }) => {
+    const alpha = project("/tmp/alpha", "alpha", 0);
+    const beta = project("/tmp/beta", "beta", 1);
+    await tauri.respond("list_projects", [alpha, beta]);
+    await tauri.respond("list_sessions", [
+      session("alpha-session", "alpha-session", "idle", {
+        repo_path: "/tmp/alpha",
+        worktree_path: "/tmp/alpha/.worktrees/alpha-session",
+      }),
+      session("beta-session", "beta-session", "idle", {
+        repo_path: "/tmp/beta",
+        worktree_path: "/tmp/beta/.worktrees/beta-session",
+      }),
+    ]);
+
+    await page.goto("/");
+
+    const modeSelect = page.getByTestId("workspace-view-status");
+    await expect(modeSelect).toContainText("Panes");
+    await modeSelect.click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+    await expect(modeSelect).toContainText("Kanban");
+    await expect(page.getByTestId("workspace-kanban")).toBeVisible();
+
+    await page.getByRole("button", { name: "Project beta" }).click();
+    await expect(modeSelect).toContainText("Panes");
+    await expect(page.getByTestId("workspace-kanban")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Project alpha" }).click();
+    await expect(modeSelect).toContainText("Kanban");
+    await expect(page.getByTestId("workspace-kanban")).toBeVisible();
+  });
+
+  test("creates regular and worktree sessions from the kanban toolbar", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__sessions = w.__sessions ?? [
+        {
+          id: "seed",
+          name: "seed",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          project_scoped: true,
+          status: "idle",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          title_source: "manual",
+          kind: "regular",
+          mode: "terminal",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+        },
+      ];
+      return w.__sessions;
+    });
+    await tauri.handle("create_session", (args) => {
+      const input = args as Record<string, unknown>;
+      const w = window as unknown as {
+        __createSessionCalls?: Array<Record<string, unknown>>;
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(input);
+      const id = `created-${w.__createSessionCalls.length}`;
+      const repoPath =
+        typeof input.repoPath === "string" ? input.repoPath : "/tmp/demo";
+      const cwdPath =
+        typeof input.cwdPath === "string" ? input.cwdPath : repoPath;
+      const isolated = input.isolated === true;
+      const session = {
+        id,
+        name: typeof input.name === "string" ? input.name : id,
+        repo_path: repoPath,
+        worktree_path: isolated
+          ? `${repoPath}/.worktrees/${id}`
+          : cwdPath,
+        branch: isolated ? `acorn/${id}` : "main",
+        isolated,
+        project_scoped: input.projectScoped !== false,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: typeof input.kind === "string" ? input.kind : "regular",
+        mode: typeof input.mode === "string" ? input.mode : "terminal",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: isolated,
+      };
+      w.__sessions = [...(w.__sessions ?? []), session];
+      return session;
+    });
+
+    await page.goto("/");
+
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    const board = page.getByTestId("workspace-kanban");
+    const createSessionButton = board.getByRole("button", {
+      name: "Create session",
+    });
+    await createSessionButton.click();
+    await page.getByRole("menuitem", { name: "New session" }).click();
+    await createSessionButton.click();
+    await page.getByRole("menuitem", { name: "New worktree session" }).click();
+
+    await expect
+      .poll(async () =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __createSessionCalls?: Array<Record<string, unknown>>;
+              }
+            ).__createSessionCalls?.length ?? 0,
+        ),
+      )
+      .toBe(2);
+
+    const calls = await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __createSessionCalls?: Array<Record<string, unknown>>;
+          }
+        ).__createSessionCalls ?? [],
+    );
+    expect(calls[0]).toMatchObject({
+      repoPath: "/tmp/demo",
+      isolated: false,
+      kind: "regular",
+    });
+    expect(calls[1]).toMatchObject({
+      repoPath: "/tmp/demo",
+      isolated: true,
+      kind: "regular",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds a project-scoped kanban workspace mode alongside the existing pane layout, with session popups and controls that fit the current Acorn workspace model.

1. **Workspace view mode** — add pane/kanban switching from the status bar and command palette, persist mode per project workspace, and add a Settings default for newly-created workspaces.
2. **Kanban board** — group active workspace sessions by status in the requested order, show compact agent/session icons, support filtering/sorting, context menus, and top toolbar session creation.
3. **Session popup** — open kanban sessions in a modal without changing pane selection, portal live terminals into the popup body, and render chat sessions with `ChatPane`.
4. **Column sizing** — add manual kanban column resize handles with reset and equalize actions, persisting column widths across reloads.
5. **Modal safety** — block app-level hotkeys while a modal is open so underlying panes do not react to shortcuts.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Workspace layout | Pane-only main workspace | Per-project pane or kanban mode |
| Session inspection from kanban | Selecting a card could disturb pane context | Card opens in a modal/popup while kanban remains visible |
| Project defaults | New workspaces always used pane mode | Settings can choose pane or kanban for new workspaces; default remains pane |
| Kanban density | Fixed column/card sizing | Resizable columns, reset, and equalize controls |

## Design notes
- Workspace `viewMode` is stored on each `ProjectWorkspace`; project folders share their project mode so switching between named workspaces stays consistent.
- Hydration preserves explicit persisted project modes and materializes missing values only after project-folder normalization, avoiding old persisted state from overriding a deliberate mode choice.
- `TerminalHost` now treats a popup body as another visible terminal target, so the PTY stays live and moves between pane/popup/limbo without spawning a duplicate terminal.
- The common `Modal` component increments a hotkey block depth while mounted. Dialog-scoped Escape/Enter handlers still run through `useDialogShortcuts`, but app-level shortcuts are suppressed.

## Follow-up (not in this PR)
- Dragging cards between columns is intentionally not included because session status is currently backend-owned, not a user-editable kanban field.
- Column sizing is global for kanban mode. Per-project kanban sizing can be added later if users need different board layouts by project.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` — 74 files / 817 tests passed
- [x] `pnpm run test:e2e` — 192 Playwright tests passed
- [x] `pnpm run build` passes; Vite reports the existing large chunk warning

## Notes
- `pnpm run test:e2e` emitted existing browser-console accessibility warnings from Radix dialog usage in unrelated tests; the suite still passed.
