### PR TITLE
fix(theme): themed, consistent text selection across shell and terminal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,15 @@
   --color-warning: oklch(78% 0.16 75);
 
   /*
+   * Text-selection highlight. Each theme overrides this with a brand-tinted,
+   * contrast-safe value; the terminal mirrors it through --color-term-selection
+   * so drag-selection looks identical across the shell and the embedded xterm.
+   * Default mirrors acorn-dark so the very first paint (before a theme attr is
+   * applied) still has a visible selection.
+   */
+  --color-selection: rgba(120, 232, 156, 0.45);
+
+  /*
    * Subtle contrast fills for borderless surfaces (neutral/ghost buttons,
    * inputs). Derived from the foreground token so they invert automatically
    * per theme — light alpha on dark themes, dark alpha on light themes — and
@@ -39,6 +48,21 @@
    */
   --acorn-canvas: color-mix(in oklab, var(--color-bg-sidebar) 82%, #000);
   --acorn-pane-radius: 0.5rem;
+}
+
+/*
+ * Themed text selection across the whole shell. Without this the React surfaces
+ * (chat, diff, sidebar, modals) fall back to the OS-default selection colour,
+ * which clashes with the xterm terminal's themed selection and can vanish
+ * against same-hue surfaces. Only the background is themed so selected text
+ * keeps its own colour and stays legible.
+ */
+::selection {
+  background-color: var(--color-selection);
+}
+
+::-moz-selection {
+  background-color: var(--color-selection);
 }
 
 .acorn-canvas {

--- a/src/assets/themes/acorn-dark.css
+++ b/src/assets/themes/acorn-dark.css
@@ -14,5 +14,6 @@
   --color-warning: oklch(78% 0.16 75);
   --color-terminal-bg: #1f2326;
   --color-terminal-fg: #ededed;
-  --color-term-selection: rgba(115, 210, 142, 0.32);
+  --color-selection: rgba(120, 232, 156, 0.45);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/acorn-light-pink.css
+++ b/src/assets/themes/acorn-light-pink.css
@@ -15,4 +15,6 @@
   --color-warning: oklch(65% 0.16 75);
   --color-terminal-bg: #ffffff;
   --color-terminal-fg: #1a1d20;
+  --color-selection: rgba(214, 110, 170, 0.30);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/acorn-light.css
+++ b/src/assets/themes/acorn-light.css
@@ -15,4 +15,6 @@
   --color-warning: oklch(65% 0.16 75);
   --color-terminal-bg: #ffffff;
   --color-terminal-fg: #1a1d20;
+  --color-selection: rgba(78, 170, 120, 0.32);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/acorn-pink.css
+++ b/src/assets/themes/acorn-pink.css
@@ -14,5 +14,6 @@
   --color-warning: oklch(78% 0.16 75);
   --color-terminal-bg: #1f2326;
   --color-terminal-fg: #ededed;
-  --color-term-selection: rgba(240, 112, 190, 0.32);
+  --color-selection: rgba(247, 150, 208, 0.45);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/ayu-dark.css
+++ b/src/assets/themes/ayu-dark.css
@@ -14,5 +14,6 @@
   --color-warning: #ffee99;
   --color-terminal-bg: #0f1419;
   --color-terminal-fg: #e6e1cf;
-  --color-term-selection: rgba(255, 180, 84, 0.28);
+  --color-selection: rgba(255, 180, 84, 0.40);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/catppuccin-latte.css
+++ b/src/assets/themes/catppuccin-latte.css
@@ -15,4 +15,6 @@
   --color-warning: #df8e1d;
   --color-terminal-bg: #eff1f5;
   --color-terminal-fg: #4c4f69;
+  --color-selection: rgba(30, 102, 245, 0.22);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/catppuccin-mocha.css
+++ b/src/assets/themes/catppuccin-mocha.css
@@ -14,5 +14,6 @@
   --color-warning: #f9e2af;
   --color-terminal-bg: #1e1e2e;
   --color-terminal-fg: #cdd6f4;
-  --color-term-selection: rgba(137, 180, 250, 0.3);
+  --color-selection: rgba(137, 180, 250, 0.40);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/dracula.css
+++ b/src/assets/themes/dracula.css
@@ -14,5 +14,6 @@
   --color-warning: #f1fa8c;
   --color-terminal-bg: #282a36;
   --color-terminal-fg: #f8f8f2;
-  --color-term-selection: rgba(189, 147, 249, 0.32);
+  --color-selection: rgba(189, 147, 249, 0.42);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/everforest-dark.css
+++ b/src/assets/themes/everforest-dark.css
@@ -14,7 +14,8 @@
   --color-warning: #dbbc7f;
   --color-terminal-bg: #2d353b;
   --color-terminal-fg: #d3c6aa;
-  --color-term-selection: #543a48;
+  --color-selection: rgba(133, 96, 116, 0.55);
+  --color-term-selection: var(--color-selection);
   --color-term-black: #232a2e;
   --color-term-red: #e67e80;
   --color-term-green: #a7c080;

--- a/src/assets/themes/flexoki-dark.css
+++ b/src/assets/themes/flexoki-dark.css
@@ -14,7 +14,8 @@
   --color-warning: #d0a215;
   --color-terminal-bg: #100f0f;
   --color-terminal-fg: #cecdc3;
-  --color-term-selection: rgba(30, 95, 91, 0.3);
+  --color-selection: rgba(58, 169, 159, 0.38);
+  --color-term-selection: var(--color-selection);
   --color-term-black: #100f0f;
   --color-term-red: #d14d41;
   --color-term-green: #879a39;

--- a/src/assets/themes/flexoki-light.css
+++ b/src/assets/themes/flexoki-light.css
@@ -15,7 +15,8 @@
   --color-warning: #ad8301;
   --color-terminal-bg: #fffcf0;
   --color-terminal-fg: #100f0f;
-  --color-term-selection: rgba(187, 220, 206, 0.3);
+  --color-selection: rgba(36, 131, 123, 0.26);
+  --color-term-selection: var(--color-selection);
   --color-term-black: #100f0f;
   --color-term-red: #af3029;
   --color-term-green: #66800b;

--- a/src/assets/themes/github-dark.css
+++ b/src/assets/themes/github-dark.css
@@ -14,7 +14,8 @@
   --color-warning: #d29922;
   --color-terminal-bg: #0d1117;
   --color-terminal-fg: #e6edf3;
-  --color-term-selection: rgba(56, 139, 253, 0.4);
+  --color-selection: rgba(56, 139, 253, 0.45);
+  --color-term-selection: var(--color-selection);
   --color-term-black: #0d1117;
   --color-term-red: #ff7b72;
   --color-term-green: #3fb950;

--- a/src/assets/themes/github-light.css
+++ b/src/assets/themes/github-light.css
@@ -15,4 +15,6 @@
   --color-warning: #9a6700;
   --color-terminal-bg: #ffffff;
   --color-terminal-fg: #1f2328;
+  --color-selection: rgba(9, 105, 218, 0.22);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/gruvbox-dark.css
+++ b/src/assets/themes/gruvbox-dark.css
@@ -14,5 +14,6 @@
   --color-warning: #fabd2f;
   --color-terminal-bg: #282828;
   --color-terminal-fg: #ebdbb2;
-  --color-term-selection: rgba(184, 187, 38, 0.3);
+  --color-selection: rgba(184, 187, 38, 0.34);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/gruvbox-light.css
+++ b/src/assets/themes/gruvbox-light.css
@@ -15,4 +15,6 @@
   --color-warning: #b57614;
   --color-terminal-bg: #fbf1c7;
   --color-terminal-fg: #3c3836;
+  --color-selection: rgba(181, 118, 20, 0.28);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/high-contrast-dark.css
+++ b/src/assets/themes/high-contrast-dark.css
@@ -14,7 +14,8 @@
   --color-warning: #f0b72f;
   --color-terminal-bg: #0a0c10;
   --color-terminal-fg: #f0f3f6;
-  --color-term-selection: rgba(64, 158, 255, 0.4);
+  --color-selection: rgba(64, 158, 255, 0.50);
+  --color-term-selection: var(--color-selection);
   --color-term-black: #0a0c10;
   --color-term-red: #ff9492;
   --color-term-green: #26cd4d;

--- a/src/assets/themes/high-contrast-light.css
+++ b/src/assets/themes/high-contrast-light.css
@@ -15,7 +15,8 @@
   --color-warning: #7a4d00;
   --color-terminal-bg: #ffffff;
   --color-terminal-fg: #05070a;
-  --color-term-selection: rgba(0, 78, 204, 0.26);
+  --color-selection: rgba(0, 78, 204, 0.30);
+  --color-term-selection: var(--color-selection);
   --color-term-scrollbar: rgba(0, 0, 0, 0.22);
   --color-term-scrollbar-hover: rgba(0, 0, 0, 0.34);
   --color-term-scrollbar-active: rgba(0, 0, 0, 0.46);

--- a/src/assets/themes/kanagawa-wave.css
+++ b/src/assets/themes/kanagawa-wave.css
@@ -14,7 +14,8 @@
   --color-warning: #ff9e3b;
   --color-terminal-bg: #1f1f28;
   --color-terminal-fg: #dcd7ba;
-  --color-term-selection: #223249;
+  --color-selection: rgba(52, 88, 140, 0.55);
+  --color-term-selection: var(--color-selection);
   --color-term-black: #16161d;
   --color-term-red: #c34043;
   --color-term-green: #76946a;

--- a/src/assets/themes/monokai-pro.css
+++ b/src/assets/themes/monokai-pro.css
@@ -14,7 +14,8 @@
   --color-warning: #ffd866;
   --color-terminal-bg: #2d2a2e;
   --color-terminal-fg: #fcfcfa;
-  --color-term-selection: #6e6c6f;
+  --color-selection: rgba(150, 147, 152, 0.45);
+  --color-term-selection: var(--color-selection);
   --color-term-black: #2d2a2e;
   --color-term-red: #ff6188;
   --color-term-green: #a9dc76;

--- a/src/assets/themes/nord.css
+++ b/src/assets/themes/nord.css
@@ -14,5 +14,6 @@
   --color-warning: #ebcb8b;
   --color-terminal-bg: #2e3440;
   --color-terminal-fg: #eceff4;
-  --color-term-selection: rgba(136, 192, 208, 0.3);
+  --color-selection: rgba(136, 192, 208, 0.40);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/one-dark-pro.css
+++ b/src/assets/themes/one-dark-pro.css
@@ -14,5 +14,6 @@
   --color-warning: #e5c07b;
   --color-terminal-bg: #282c34;
   --color-terminal-fg: #abb2bf;
-  --color-term-selection: rgba(97, 175, 239, 0.35);
+  --color-selection: rgba(97, 175, 239, 0.42);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/one-light.css
+++ b/src/assets/themes/one-light.css
@@ -15,4 +15,6 @@
   --color-warning: #c18401;
   --color-terminal-bg: #fafafa;
   --color-terminal-fg: #383a42;
+  --color-selection: rgba(64, 120, 242, 0.22);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/rose-pine.css
+++ b/src/assets/themes/rose-pine.css
@@ -14,5 +14,6 @@
   --color-warning: #f6c177;
   --color-terminal-bg: #191724;
   --color-terminal-fg: #e0def4;
-  --color-term-selection: rgba(196, 167, 231, 0.32);
+  --color-selection: rgba(196, 167, 231, 0.42);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/solarized-dark.css
+++ b/src/assets/themes/solarized-dark.css
@@ -14,7 +14,8 @@
   --color-warning: #b58900;
   --color-terminal-bg: #002b36;
   --color-terminal-fg: #839496;
-  --color-term-selection: #073642;
+  --color-selection: rgba(38, 139, 210, 0.38);
+  --color-term-selection: var(--color-selection);
   --color-term-black: #073642;
   --color-term-red: #dc322f;
   --color-term-green: #859900;

--- a/src/assets/themes/solarized-light.css
+++ b/src/assets/themes/solarized-light.css
@@ -15,4 +15,6 @@
   --color-warning: #b58900;
   --color-terminal-bg: #fdf6e3;
   --color-terminal-fg: #586e75;
+  --color-selection: rgba(38, 139, 210, 0.24);
+  --color-term-selection: var(--color-selection);
 }

--- a/src/assets/themes/tokyo-night.css
+++ b/src/assets/themes/tokyo-night.css
@@ -14,5 +14,6 @@
   --color-warning: #e0af68;
   --color-terminal-bg: #1a1b26;
   --color-terminal-fg: #c0caf5;
-  --color-term-selection: rgba(122, 162, 247, 0.34);
+  --color-selection: rgba(122, 162, 247, 0.40);
+  --color-term-selection: var(--color-selection);
 }


### PR DESCRIPTION
## Summary

Text selection (drag-highlight) was inconsistent and could become invisible. The React shell never defined a `::selection` rule, so chat / diff / sidebar / modals fell back to the OS-default selection colour (blue on macOS), while the xterm terminal painted its own themed selection. The two never matched, and the terminal's accent-hued selection blended into same-hue surfaces — e.g. the green codex input box on `acorn-dark` — and effectively disappeared.

## Changes

- Add a canonical `--color-selection` token per theme (all 26 built-in themes), brand-tuned and contrast-safe.
- Drive a global `::selection` / `::-moz-selection` rule from it in `App.css`, with a sensible default in `@theme` for the first paint before a theme attribute is applied.
- Point `--color-term-selection` at the same token so the embedded xterm terminal and the rest of the shell share one highlight. Only the background is themed, so selected text keeps its own colour and stays legible.
- Fix previously broken selections discovered along the way:
  - `solarized-dark` used a colour identical to its own `--color-bg-elevated` (invisible by construction).
  - `kanagawa-wave`, `everforest-dark`, `monokai-pro` were fully opaque.
  - 7 light themes (`acorn-light`, `acorn-light-pink`, `catppuccin-latte`, `github-light`, `gruvbox-light`, `one-light`, `solarized-light`) had no selection colour at all.
- `acorn-dark` / `acorn-pink` keep their pure brand hue by design; green-on-green / pink-on-pink over same-hue filled content stays intentionally modest.

## Test plan

- [x] `vitest run` — 802 pass (includes `themes.test.ts` selection-colour assertions and `terminalTheme.test.ts`).
- [x] `vite build` — succeeds (CSS compiles; chunk-size warning is pre-existing).
- [x] Isolated xterm 6.0 + Playwright repro: native UI now shows the themed highlight instead of OS blue; terminal selection visible on plain content and as a distinct band over a simulated green codex box.
- [x] Per-theme colour self-review: rendered all 26 themes' selection over bg / elevated / accent surfaces. Every hue is the theme's own accent or authentic selection colour (harmonious + visible). Known-modest cases are selection over same-hue *filled* chrome only (e.g. acorn green-on-green), which is the intended brand-pure tradeoff.
- [ ] Optional follow-up: in-app `tauri dev` drag-select spot-check per theme (colours already verified via the swatch review above).
