### PR TITLE
feat(ipc): visible worker sessions for control agents

### DIFF
--- a/docs/CONTROL_SESSIONS.md
+++ b/docs/CONTROL_SESSIONS.md
@@ -210,7 +210,7 @@ acorn-ipc promote-self
 acorn-ipc context
 acorn-ipc list-sessions
 acorn-ipc list-workspaces
-acorn-ipc new-session   <name> [--workspace current|PATH] [--workspace-id ID] [--isolated] [--owner me|user]
+acorn-ipc new-session   <name> [--run COMMAND] [--workspace current|PATH] [--workspace-id ID] [--isolated] [--owner me|user]
 acorn-ipc send-keys     -t <uuid> --data "ls" --enter [--allow-foreign]
 acorn-ipc read-buffer   -t <uuid> [--max-bytes N] [--allow-foreign]
 acorn-ipc select-session -t <uuid> [--allow-foreign]
@@ -241,6 +241,18 @@ the control session, or `--workspace /absolute/path` to target a registered
 project cwd or one of that project's linked worktrees. `--workspace-id` is
 the exact frontend workspace placement hint; it is filled automatically for
 `--workspace current` when Acorn injected `ACORN_WORKSPACE_ID`.
+
+Pass `--run <command>` to open the new session in the UI and run a command as
+soon as its PTY is mounted. This is the preferred way to spawn visible worker
+agents from a control session:
+
+```sh
+acorn-ipc new-session "claude-worker" --workspace current --run "claude"
+```
+
+The worker remains an ordinary Acorn terminal session owned by the source
+control session, so it appears in the sidebar and can be opened, interrupted
+with Ctrl-C, or removed from the parent session's worker menu.
 
 `list-workspaces` is subject to the same authorization gate as every command
 except `promote-self`: the source session must already be `Control`, and the
@@ -290,6 +302,12 @@ Spin up a fresh isolated worktree and focus it:
 acorn-ipc promote-self   # no-op if this terminal is already control
 new_id=$(acorn-ipc new-session "patch-bot" --isolated)
 acorn-ipc select-session -t "$new_id"
+```
+
+Spawn a visible Claude worker in the current Acorn workspace:
+
+```sh
+acorn-ipc new-session "claude-worker" --workspace current --run "claude"
 ```
 
 ## Security model

--- a/src-tauri/crates/acorn-ipc/src/bin/acorn-ipc.rs
+++ b/src-tauri/crates/acorn-ipc/src/bin/acorn-ipc.rs
@@ -19,8 +19,8 @@ use base64::Engine;
 use clap::{Parser, Subcommand};
 
 use acorn_ipc::proto::{
-    Envelope, ErrorCode, NewSessionOwner, PROTOCOL_VERSION, Request, Response, SessionSummary,
-    WorkspaceSummary,
+    Envelope, ErrorCode, NewSessionOwner, Request, Response, SessionSummary, WorkspaceSummary,
+    PROTOCOL_VERSION,
 };
 use acorn_ipc::socket_path;
 
@@ -118,6 +118,10 @@ enum Command {
     NewSession {
         /// Display name for the new session.
         name: String,
+        /// Run this shell command once the new Acorn terminal is visible.
+        /// Useful for launching worker agents, e.g. `--run "claude"`.
+        #[arg(long = "run", value_name = "COMMAND")]
+        run: Option<String>,
         /// Create the session inside a fresh git worktree.
         #[arg(long)]
         isolated: bool,
@@ -273,6 +277,7 @@ fn build_request_with_workspace_env(
         },
         Command::NewSession {
             name,
+            run,
             isolated,
             workspace,
             workspace_id,
@@ -280,16 +285,28 @@ fn build_request_with_workspace_env(
         } => {
             let (workspace_path, workspace_id) =
                 resolve_new_session_workspace(workspace, workspace_id, workspace_env)?;
-            Request::NewSession {
-                name: name.clone(),
-                isolated: *isolated,
-                workspace_path,
-                workspace_id,
-                owner: match owner.as_deref() {
-                    Some("user") => Some(NewSessionOwner::User),
-                    Some("me") | None => None,
-                    Some(other) => return Err(format!("unsupported --owner value: {other}")),
-                },
+            let owner = match owner.as_deref() {
+                Some("user") => Some(NewSessionOwner::User),
+                Some("me") | None => None,
+                Some(other) => return Err(format!("unsupported --owner value: {other}")),
+            };
+            if let Some(command) = run.clone().and_then(non_empty_string) {
+                Request::LaunchSession {
+                    name: name.clone(),
+                    command,
+                    isolated: *isolated,
+                    workspace_path,
+                    workspace_id,
+                    owner,
+                }
+            } else {
+                Request::NewSession {
+                    name: name.clone(),
+                    isolated: *isolated,
+                    workspace_path,
+                    workspace_id,
+                    owner,
+                }
             }
         }
         Command::SelectSession {
@@ -799,6 +816,7 @@ mod tests {
     fn new_session_owner_user_is_forwarded() {
         let req = build_request(&Command::NewSession {
             name: "worker".to_string(),
+            run: None,
             isolated: false,
             workspace: None,
             workspace_id: None,
@@ -818,6 +836,7 @@ mod tests {
         let req = build_request_with_workspace_env(
             &Command::NewSession {
                 name: "worker".to_string(),
+                run: None,
                 isolated: false,
                 workspace: Some("current".to_string()),
                 workspace_id: None,
@@ -848,6 +867,7 @@ mod tests {
         let result = build_request_with_workspace_env(
             &Command::NewSession {
                 name: "worker".to_string(),
+                run: None,
                 isolated: false,
                 workspace: Some("current".to_string()),
                 workspace_id: None,
@@ -872,6 +892,41 @@ mod tests {
         match req {
             Request::SendKeys { allow_foreign, .. } => assert!(allow_foreign),
             other => panic!("expected send-keys, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn new_session_run_builds_launch_session_request() {
+        let req = build_request_with_workspace_env(
+            &Command::NewSession {
+                name: "claude-worker".to_string(),
+                run: Some("claude".to_string()),
+                isolated: false,
+                workspace: Some("current".to_string()),
+                workspace_id: None,
+                owner: None,
+            },
+            WorkspaceEnv {
+                id: Some("project-folder:/repo:abc".to_string()),
+                path: Some("/repo".to_string()),
+                name: Some("repo".to_string()),
+            },
+        )
+        .expect("build");
+        match req {
+            Request::LaunchSession {
+                name,
+                command,
+                workspace_path,
+                workspace_id,
+                ..
+            } => {
+                assert_eq!(name, "claude-worker");
+                assert_eq!(command, "claude");
+                assert_eq!(workspace_path.as_deref(), Some("/repo"));
+                assert_eq!(workspace_id.as_deref(), Some("project-folder:/repo:abc"));
+            }
+            other => panic!("expected launch-session, got {other:?}"),
         }
     }
 }

--- a/src-tauri/crates/acorn-ipc/src/primer.rs
+++ b/src-tauri/crates/acorn-ipc/src/primer.rs
@@ -86,6 +86,9 @@ pub fn primer_for(
          - To create a session in this exact Acorn workspace, pass \
          `--workspace current`. To target a path explicitly, pass \
          `--workspace <absolute path>`.\n\
+         - To launch a visible worker agent, create the sibling session with \
+         `acorn-ipc new-session <name> --workspace current --run 'claude'`. \
+         Acorn opens the new terminal and runs the command there.\n\
          - To discover named workspaces first, run `acorn-ipc list-workspaces --json` \
          and pass both the returned `workspace_path` and `id` to \
          `new-session --workspace <path> --workspace-id <id>`.\n\
@@ -99,7 +102,7 @@ pub fn primer_for(
            acorn-ipc context                             # print this context\n\
            acorn-ipc list-sessions                       # see siblings + self\n\
            acorn-ipc list-workspaces                     # see frontend workspaces\n\
-           acorn-ipc new-session   <name> [--workspace current|PATH] [--workspace-id ID] [--isolated] [--owner me|user]\n\
+           acorn-ipc new-session   <name> [--run COMMAND] [--workspace current|PATH] [--workspace-id ID] [--isolated] [--owner me|user]\n\
            acorn-ipc send-keys     -t <uuid> --data '…' --enter [--allow-foreign]\n\
            acorn-ipc read-buffer   -t <uuid> [--max-bytes N] [--allow-foreign]\n\
            acorn-ipc select-session -t <uuid> [--allow-foreign]\n\

--- a/src-tauri/crates/acorn-ipc/src/proto.rs
+++ b/src-tauri/crates/acorn-ipc/src/proto.rs
@@ -78,6 +78,21 @@ pub enum Request {
         #[serde(default)]
         workspace_id: Option<String>,
     },
+    /// Create a new regular session and queue a shell command to run as soon
+    /// as the frontend mounts its PTY. This is intentionally a separate wire
+    /// variant from `NewSession` so older servers reject the request instead
+    /// of silently ignoring the command field.
+    LaunchSession {
+        name: String,
+        command: String,
+        isolated: bool,
+        #[serde(default)]
+        owner: Option<NewSessionOwner>,
+        #[serde(default)]
+        workspace_path: Option<String>,
+        #[serde(default)]
+        workspace_id: Option<String>,
+    },
     /// Ask the app to focus the given session in its pane. Emits a Tauri
     /// event the frontend reacts to.
     SelectSession {

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -72,6 +72,8 @@ struct SessionsChangedPayload {
     workspace_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     workspace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    initial_command: Option<String>,
 }
 
 /// Shutdown signal for an active IPC listener. The listener thread polls
@@ -313,6 +315,25 @@ fn dispatch<R: Runtime>(envelope: Envelope, app: &AppHandle<R>, state: &AppState
         } => handle_new_session(
             &source,
             name,
+            None,
+            isolated,
+            owner,
+            workspace_path,
+            workspace_id,
+            app,
+            state,
+        ),
+        Request::LaunchSession {
+            name,
+            command,
+            isolated,
+            owner,
+            workspace_path,
+            workspace_id,
+        } => handle_new_session(
+            &source,
+            name,
+            Some(command),
             isolated,
             owner,
             workspace_path,
@@ -340,6 +361,7 @@ fn request_label(req: &Request) -> &'static str {
         Request::SendKeys { .. } => "send-keys",
         Request::ReadBuffer { .. } => "read-buffer",
         Request::NewSession { .. } => "new-session",
+        Request::LaunchSession { .. } => "launch-session",
         Request::SelectSession { .. } => "select-session",
         Request::KillSession { .. } => "kill-session",
     }
@@ -408,6 +430,7 @@ fn handle_promote_self<R: Runtime>(
                 repo_path: session.repo_path.display().to_string(),
                 workspace_path: Some(session.worktree_path.display().to_string()),
                 workspace_id: None,
+                initial_command: None,
             },
         ) {
             tracing::warn!(
@@ -708,6 +731,7 @@ fn authorize_new_session_workspace(
 fn handle_new_session<R: Runtime>(
     source: &Session,
     name: String,
+    initial_command: Option<String>,
     isolated: bool,
     owner: Option<NewSessionOwner>,
     workspace_path: Option<String>,
@@ -721,6 +745,19 @@ fn handle_new_session<R: Runtime>(
             message: "name must not be empty".to_string(),
         };
     }
+    let raw_initial_command = initial_command;
+    let initial_command = match normalize_optional_string(raw_initial_command.clone()) {
+        Some(command) => Some(command),
+        None => {
+            if raw_initial_command.is_some() {
+                return Response::Error {
+                    code: ErrorCode::Invalid,
+                    message: "command must not be empty".to_string(),
+                };
+            }
+            None
+        }
+    };
     let workspace_id = normalize_optional_string(workspace_id);
     if isolated
         && (normalize_optional_string(workspace_path.clone()).is_some() || workspace_id.is_some())
@@ -784,6 +821,7 @@ fn handle_new_session<R: Runtime>(
             repo_path: inserted.repo_path.display().to_string(),
             workspace_path: Some(inserted.worktree_path.display().to_string()),
             workspace_id,
+            initial_command,
         },
     ) {
         tracing::warn!(
@@ -858,6 +896,7 @@ fn handle_kill_session<R: Runtime>(
                 repo_path: session.repo_path.display().to_string(),
                 workspace_path: Some(session.worktree_path.display().to_string()),
                 workspace_id: None,
+                initial_command: None,
             },
         ) {
             tracing::warn!(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,6 +136,7 @@ interface IpcSessionsChangedPayload {
   session_id?: string;
   workspace_id?: string | null;
   workspace_path?: string | null;
+  initial_command?: string | null;
 }
 
 function ipcSessionsChangedPayload(value: unknown): IpcSessionsChangedPayload | null {
@@ -149,6 +150,8 @@ function ipcSessionsChangedPayload(value: unknown): IpcSessionsChangedPayload | 
       typeof raw.workspace_id === "string" ? raw.workspace_id : null,
     workspace_path:
       typeof raw.workspace_path === "string" ? raw.workspace_path : null,
+    initial_command:
+      typeof raw.initial_command === "string" ? raw.initial_command : null,
   };
 }
 
@@ -1324,9 +1327,22 @@ function App() {
         .refreshSessions()
         .then(() => {
           if (payload?.action !== "created" || !payload.session_id) return;
-          useAppStore.getState().placeSessionInWorkspace(payload.session_id, {
+          const store = useAppStore.getState();
+          store.placeSessionInWorkspace(payload.session_id, {
             workspaceId: payload.workspace_id,
             workspacePath: payload.workspace_path,
+          });
+          const command = payload.initial_command?.trim();
+          if (!command) return;
+          const nextStore = useAppStore.getState();
+          nextStore.setPendingTerminalInput(payload.session_id, command);
+          nextStore.selectSession(payload.session_id);
+          requestAnimationFrame(() => {
+            window.dispatchEvent(
+              new CustomEvent("acorn:focus-session", {
+                detail: { sessionId: payload.session_id },
+              }),
+            );
           });
         });
     })

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -178,6 +178,7 @@ function sidebarText(t: Translator, key: SidebarTranslationKey): string {
 type SidebarContextMenuGroup =
   | "session"
   | "fork"
+  | "workers"
   | "workspace"
   | "project"
   | "open"
@@ -2552,6 +2553,7 @@ function SessionRow({
   const toggleSessionAutoClose = useAppStore(
     (s) => s.toggleSessionAutoClose,
   );
+  const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
   const createSession = useAppStore((s) => s.createSession);
   const selectSession = useAppStore((s) => s.selectSession);
   const setPendingTerminalInput = useAppStore(
@@ -2602,11 +2604,30 @@ function SessionRow({
     canRegenerateSessionTitle(session) && !isGeneratingTitle;
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const [workerMenu, setWorkerMenu] = useState<{ x: number; y: number } | null>(
+    null,
+  );
   const [agent, setAgent] = useState<{
     claude: string | null;
     codex: string | null;
     antigravity: string | null;
   } | null>(null);
+  const workers = sessions.filter(
+    (candidate) =>
+      candidate.owner?.kind === "control" &&
+      candidate.owner?.session_id === session.id,
+  );
+
+  function openWorkerSession(workerId: string) {
+    selectSession(workerId);
+    requestAnimationFrame(() => {
+      window.dispatchEvent(
+        new CustomEvent("acorn:focus-session", {
+          detail: { sessionId: workerId },
+        }),
+      );
+    });
+  }
   const {
     attributes,
     listeners,
@@ -2702,6 +2723,39 @@ function SessionRow({
   const agentProvider = showAgentProviderIcons
     ? resolveSessionAgentProvider(session)
     : null;
+  const workerMenuItems: ContextMenuItem[] = [
+    contextMenuGroupTitle(t, "workers"),
+    ...workers.map((worker) => {
+      const label = `${resolveSessionTitle(worker, sessionDisplay.title)} · ${statusLabel(t, worker.status)}`;
+      return {
+        type: "submenu" as const,
+        label,
+        icon: <Bot size={12} />,
+        children: [
+          {
+            label: sidebarText(t, "sidebar.actions.openWorker"),
+            icon: <LayoutPanelLeft size={12} />,
+            onClick: () => openWorkerSession(worker.id),
+          },
+          {
+            label: sidebarText(t, "sidebar.actions.interruptWorker"),
+            icon: <X size={12} />,
+            onClick: () => {
+              void api.ptyWrite(worker.id, "\x03").catch((err: unknown) => {
+                console.error("[Sidebar] worker interrupt failed", err);
+                showToast(String(err));
+              });
+            },
+          },
+          {
+            label: sidebarText(t, "sidebar.actions.terminateWorker"),
+            icon: <Trash2 size={12} />,
+            onClick: () => requestRemoveSession(worker.id),
+          },
+        ],
+      };
+    }),
+  ];
   const forkItems: ContextMenuItem[] = (() => {
     if (!agent) return [];
     const items: ContextMenuItem[] = [];
@@ -2990,7 +3044,38 @@ function SessionRow({
         }}
         onCancelRename={() => setEditing(false)}
       />
-      <div className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover:flex">
+      {workers.length > 0 && !editing ? (
+        <Tooltip
+          label={sidebarText(t, "sidebar.actions.workerSessions")}
+          side="right"
+        >
+          <button
+            type="button"
+            aria-label={sidebarText(t, "sidebar.actions.workerSessions")}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              const rect = e.currentTarget.getBoundingClientRect();
+              setWorkerMenu({
+                x: rect.right + 4,
+                y: rect.top,
+              });
+            }}
+            onKeyDown={(e) => e.stopPropagation()}
+            className="ml-auto flex h-5 shrink-0 items-center gap-1 rounded px-1 text-[10px] leading-none text-accent transition hover:bg-bg-elevated"
+          >
+            <Bot size={11} />
+            <span>{workers.length}</span>
+          </button>
+        </Tooltip>
+      ) : null}
+      <div
+        className={cn(
+          "hidden shrink-0 items-center gap-0.5 group-hover:flex",
+          workers.length === 0 && "ml-auto",
+        )}
+      >
         <button
           type="button"
           aria-label={sidebarText(t, "sidebar.actions.removeSession")}
@@ -3028,6 +3113,13 @@ function SessionRow({
         y={menu?.y ?? 0}
         onClose={() => setMenu(null)}
         items={sessionMenuItems}
+      />
+      <ContextMenu
+        open={workerMenu !== null && workers.length > 0}
+        x={workerMenu?.x ?? 0}
+        y={workerMenu?.y ?? 0}
+        onClose={() => setWorkerMenu(null)}
+        items={workerMenuItems}
       />
     </li>
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -964,6 +964,10 @@
       "regenerateName": "Regenerate Name",
       "openWorkSummary": "Open Work Summary",
       "autoCloseWhenFinished": "Close When Agent Finishes",
+      "workerSessions": "Worker sessions",
+      "openWorker": "Open",
+      "interruptWorker": "Send Ctrl-C",
+      "terminateWorker": "Terminate...",
       "forkClaudeSession": "Fork Claude Session",
       "forkSession": "Fork Session",
       "forkClaudeInNewWorktree": "Fork Claude in New Worktree",
@@ -986,6 +990,7 @@
     "contextMenu": {
       "session": "Session",
       "fork": "Fork",
+      "workers": "Workers",
       "workspace": "Workspace",
       "project": "Project",
       "open": "Open",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -964,6 +964,10 @@
       "regenerateName": "이름 다시 생성",
       "openWorkSummary": "작업 요약 열기",
       "autoCloseWhenFinished": "에이전트 완료 시 닫기",
+      "workerSessions": "워커 세션",
+      "openWorker": "열기",
+      "interruptWorker": "Ctrl-C 보내기",
+      "terminateWorker": "종료...",
       "forkClaudeSession": "Claude 세션 포크",
       "forkSession": "세션 포크",
       "forkClaudeInNewWorktree": "새 워크트리에 Claude 포크",
@@ -986,6 +990,7 @@
     "contextMenu": {
       "session": "세션",
       "fork": "포크",
+      "workers": "워커",
       "workspace": "작업공간",
       "project": "프로젝트",
       "open": "열기",

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -340,6 +340,106 @@ test.describe("sidebar: project lifecycle", () => {
     expect(calls[0]).toMatchObject({ id: "session-1", force: true });
   });
 
+  test("control session worker menu opens and interrupts owned workers", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "control-1",
+        name: "controller",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "control",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+      {
+        id: "worker-1",
+        name: "claude-worker",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "running",
+        created_at: "2026-01-01T00:00:01Z",
+        updated_at: "2026-01-01T00:00:01Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "control", session_id: "control-1" },
+        position: 1,
+        in_worktree: false,
+      },
+    ]);
+    await tauri.handle("pty_write", (args) => {
+      const w = window as unknown as { __ptyWrites?: unknown[] };
+      w.__ptyWrites = w.__ptyWrites ?? [];
+      w.__ptyWrites.push(args);
+      return null;
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator("aside");
+    const controller = sidebar.getByRole("button", {
+      name: /^controller control session main · Idle/,
+    });
+    await expect(controller).toBeVisible();
+    await expect(
+      controller.getByRole("button", { name: "Worker sessions" }),
+    ).toHaveText("1");
+
+    await controller.getByRole("button", { name: "Worker sessions" }).click();
+    await page
+      .getByRole("menuitem", { name: /claude-worker · Running/ })
+      .hover();
+    await page.getByRole("menuitem", { name: "Open", exact: true }).click();
+    await expect(
+      sidebar.getByRole("button", { name: /^claude-worker main · Running/ }),
+    ).toBeVisible();
+
+    await controller.getByRole("button", { name: "Worker sessions" }).click();
+    await page
+      .getByRole("menuitem", { name: /claude-worker · Running/ })
+      .hover();
+    await page
+      .getByRole("menuitem", { name: "Send Ctrl-C", exact: true })
+      .click();
+
+    const writes = (await page.evaluate(
+      () => (window as unknown as { __ptyWrites?: unknown[] }).__ptyWrites,
+    )) as Array<{ sessionId: string; data: string }>;
+    expect(writes).toEqual([{ sessionId: "worker-1", data: "Aw==" }]);
+
+    await controller.getByRole("button", { name: "Worker sessions" }).click();
+    await page
+      .getByRole("menuitem", { name: /claude-worker · Running/ })
+      .hover();
+    await page.getByRole("menuitem", { name: "Terminate..." }).click();
+    const dialog = page.getByRole("dialog", { name: "Close running session?" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("claude-worker");
+  });
+
   test("ordinary terminal sessions cannot regenerate a session name", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
This PR makes control-session-spawned worker PTYs visible and controllable from Acorn, with an explicit launch path for worker agents.

1. **IPC launch request** — adds `acorn-ipc new-session --run <command>` backed by a new `LaunchSession` wire variant, so worker sessions can be created, focused, and launched once their frontend PTY is mounted.
2. **Worker session surface** — adds a parent-session worker count/menu in the sidebar for control-owned sessions, with actions to open the worker, send Ctrl-C, or route termination through the existing session-close confirmations.
3. **Docs and coverage** — updates the control-session primer/docs and adds E2E coverage for the worker menu path.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Control-agent worker launch | Agents could create sibling sessions, but command launch/focus had to be handled separately. | `acorn-ipc new-session --run "claude" --workspace current` opens the worker terminal and runs the command after mount. |
| Worker visibility | Control-owned workers were not surfaced from the parent session row. | Parent control sessions show a worker count/menu with Open, Send Ctrl-C, and Terminate actions. |
| Session removal safety | Direct worker controls were absent. | Terminate reuses existing running-session/remove-session confirmation flows; no force-kill path is added. |

## Design notes
- `LaunchSession` is intentionally separate from `NewSession` so older IPC servers reject the request instead of silently ignoring a new command field.
- The backend only emits `initial_command`; the frontend queues it through the existing pending-terminal-input path so the command is written after the PTY is alive.
- Worker termination deliberately calls the existing session removal request path, preserving current running-session warnings and cascade behavior.
- The sidebar worker lookup tolerates legacy/mock session payloads without an `owner` field so partial runtime data cannot crash `SessionRow`.

## Follow-up (not in this PR)
- Consider a stronger force-stop affordance only after defining process-tree semantics for daemon-managed and in-process PTYs.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/components/ContextMenu.test.tsx src/store.test.ts src/lib/sessionWorktree.test.ts src/lib/sessionTitle.test.ts` — 4 files / 162 tests passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "control session worker menu"` — 1 passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts` — 39 passed
- [x] `env -u ACORN_DATA_DIR -u ACORN_IPC_SOCKET -u ACORN_DAEMON_SOCKET -u ACORN_WORKSPACE_ID -u ACORN_WORKSPACE_PATH -u ACORN_WORKSPACE_NAME -u ACORN_AGENT_STATE_DIR -u ACORN_AGENT_WRAPPER_DIR -u ACORN_CLI_DIR -u ACORN_RESUME_TOKEN -u ACORN_STAGED_REV -u ACORN_USER_ZDOTDIR cargo test -p acorn-ipc` — 21 lib tests + 14 bin tests passed
- [x] `env -u ACORN_DATA_DIR -u ACORN_IPC_SOCKET -u ACORN_DAEMON_SOCKET -u ACORN_WORKSPACE_ID -u ACORN_WORKSPACE_PATH -u ACORN_WORKSPACE_NAME -u ACORN_AGENT_STATE_DIR -u ACORN_AGENT_WRAPPER_DIR -u ACORN_CLI_DIR -u ACORN_RESUME_TOKEN -u ACORN_STAGED_REV -u ACORN_USER_ZDOTDIR cargo test --lib ipc::server` — 14 passed
- [x] `rustfmt --check crates/acorn-ipc/src/bin/acorn-ipc.rs crates/acorn-ipc/src/proto.rs crates/acorn-ipc/src/primer.rs src/ipc/server.rs` passes for touched Rust files
- [x] `git diff --check` and `git diff --cached --check` pass
- [x] `pnpm run build` passes
- [x] `pnpm run build:sidecar` stages `acorn-ipc` and `acornd`

## Notes
- `pnpm run build` still prints the existing Vite chunk/dynamic-import warnings.
- `cargo fmt --all -- --check` reports formatting drift in unrelated Rust files outside this PR; touched Rust files pass the targeted `rustfmt --check` command above.