### PR TITLE
refactor(workspace): persist kanban board prefs per project

### DIFF
--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -45,6 +45,20 @@ import { useDialogShortcuts } from "../lib/dialog";
 import { useSettings } from "../lib/settings";
 import { useTranslation } from "../lib/useTranslation";
 import {
+  KANBAN_COLUMN_STATUSES,
+  KANBAN_COLUMN_DEFAULT_WIDTH,
+  clampKanbanColumnWidth,
+  defaultKanbanColumnWidths,
+  equalizeKanbanColumnWidths,
+  readKanbanBoardPrefs,
+  sessionMatchesKanbanFilter,
+  sortKanbanSessions,
+  toKanbanSortMode,
+  writeKanbanBoardPrefs,
+  type KanbanBoardPrefs,
+  type KanbanSortMode,
+} from "../lib/kanbanBoard";
+import {
   selectSessionsById,
   useAppStore,
   type WorkspaceViewMode,
@@ -56,17 +70,6 @@ import { LayoutRenderer } from "./LayoutRenderer";
 import { ResizeHandle } from "./ResizeHandle";
 import { Tooltip } from "./Tooltip";
 
-const KANBAN_COLUMNS: ReadonlyArray<{
-  status: SessionStatus;
-  tone: StatusTone;
-}> = [
-  { status: "idle", tone: "neutral" },
-  { status: "needs_input", tone: "warning" },
-  { status: "running", tone: "accent" },
-  { status: "failed", tone: "danger" },
-  { status: "completed", tone: "success" },
-];
-
 const STATUS_TONE: Record<SessionStatus, StatusTone> = {
   idle: "neutral",
   running: "accent",
@@ -74,6 +77,16 @@ const STATUS_TONE: Record<SessionStatus, StatusTone> = {
   failed: "danger",
   completed: "success",
 };
+
+// Pair each column status (ordered by the board library) with its UI tone, so
+// the column order has a single source of truth in `kanbanBoard.ts`.
+const KANBAN_COLUMNS: ReadonlyArray<{
+  status: SessionStatus;
+  tone: StatusTone;
+}> = KANBAN_COLUMN_STATUSES.map((status) => ({
+  status,
+  tone: STATUS_TONE[status],
+}));
 
 const STATUS_ICON_CLASS: Record<SessionStatus, string> = {
   idle: "text-fg-muted",
@@ -83,13 +96,9 @@ const STATUS_ICON_CLASS: Record<SessionStatus, string> = {
   completed: "text-accent/70",
 };
 
-type KanbanSortMode = "updated-desc" | "created-desc" | "name-asc";
 type SidebarTranslationKey = Extract<TranslationKey, `sidebar.${string}`>;
 type WorkspaceKanbanContextGroup = "session" | "open" | "copy" | "danger";
 
-const KANBAN_COLUMN_WIDTHS_KEY = "acorn:workspace-kanban:column-widths:v2";
-const KANBAN_COLUMN_DEFAULT_WIDTH = 192;
-const KANBAN_COLUMN_MIN_WIDTH = 152;
 const KANBAN_COLUMN_GAP_PX = 6;
 const KANBAN_BOARD_PADDING_X_PX = 16;
 
@@ -112,18 +121,23 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
 }
 
 function WorkspaceKanbanBoard() {
+  // Remount per project so each board hydrates its own persisted prefs through
+  // the useState initializer rather than racing an effect to swap them in.
+  const projectId = useAppStore((s) => s.activeProject);
+  return (
+    <KanbanBoard key={projectId ?? "__no-project__"} projectId={projectId} />
+  );
+}
+
+function KanbanBoard({ projectId }: { projectId: string | null }) {
   const t = useTranslation();
   const panes = useAppStore((s) => s.panes);
   const sessionsById = useAppStore(selectSessionsById);
   const openTerminalPopup = useAppStore((s) => s.openTerminalPopup);
-  const [filterQuery, setFilterQuery] = useState("");
-  const [sortMode, setSortMode] = useState<KanbanSortMode>("updated-desc");
-  const [columnWidths, setColumnWidths] = useState<number[]>(
-    readKanbanColumnWidths,
+  const [prefs, setPrefs] = useState<KanbanBoardPrefs>(() =>
+    readKanbanBoardPrefs(projectId),
   );
-  const [lastEditedColumnWidth, setLastEditedColumnWidth] = useState(
-    KANBAN_COLUMN_DEFAULT_WIDTH,
-  );
+  const { filterQuery, sortMode, columnWidths } = prefs;
   const [resizingColumnIndex, setResizingColumnIndex] = useState<number | null>(
     null,
   );
@@ -171,9 +185,30 @@ function WorkspaceKanbanBoard() {
     [columnWidths],
   );
 
+  // Persist board prefs per project. projectId is fixed for this instance (the
+  // wrapper remounts via key on project switch), so a board can never write one
+  // project's prefs into another project's bucket.
   useEffect(() => {
-    writeKanbanColumnWidths(columnWidths);
-  }, [columnWidths]);
+    writeKanbanBoardPrefs(projectId, prefs);
+  }, [projectId, prefs]);
+
+  function setFilterQuery(filterQuery: string) {
+    setPrefs((current) => ({ ...current, filterQuery }));
+  }
+
+  function setSortMode(sortMode: KanbanSortMode) {
+    setPrefs((current) => ({ ...current, sortMode }));
+  }
+
+  function updateColumnWidths(
+    next: number[] | ((current: number[]) => number[]),
+  ) {
+    setPrefs((current) => ({
+      ...current,
+      columnWidths:
+        typeof next === "function" ? next(current.columnWidths) : next,
+    }));
+  }
 
   function openSession(id: string) {
     openTerminalPopup(id);
@@ -190,8 +225,7 @@ function WorkspaceKanbanBoard() {
 
   function resizeColumn(index: number, nextWidth: number) {
     const clampedWidth = clampKanbanColumnWidth(nextWidth);
-    setLastEditedColumnWidth(clampedWidth);
-    setColumnWidths((current) =>
+    updateColumnWidths((current) =>
       current.map((width, widthIndex) =>
         widthIndex === index ? clampedWidth : width,
       ),
@@ -203,13 +237,11 @@ function WorkspaceKanbanBoard() {
   }
 
   function resetColumnWidths() {
-    setLastEditedColumnWidth(KANBAN_COLUMN_DEFAULT_WIDTH);
-    setColumnWidths(defaultKanbanColumnWidths());
+    updateColumnWidths(defaultKanbanColumnWidths());
   }
 
   function equalizeColumnWidths() {
-    const equalWidth = clampKanbanColumnWidth(lastEditedColumnWidth);
-    setColumnWidths(KANBAN_COLUMNS.map(() => equalWidth));
+    updateColumnWidths((current) => equalizeKanbanColumnWidths(current));
   }
 
   function startColumnResize(
@@ -1036,113 +1068,6 @@ function workspaceContextMenuGroupTitle(
     type: "group-title",
     label: sidebarText(t, `sidebar.contextMenu.${group}`),
   };
-}
-
-function toKanbanSortMode(value: string): KanbanSortMode {
-  if (
-    value === "updated-desc" ||
-    value === "created-desc" ||
-    value === "name-asc"
-  ) {
-    return value;
-  }
-  return "updated-desc";
-}
-
-function defaultKanbanColumnWidths(): number[] {
-  return KANBAN_COLUMNS.map(() => KANBAN_COLUMN_DEFAULT_WIDTH);
-}
-
-function readKanbanColumnWidths(): number[] {
-  const fallback = defaultKanbanColumnWidths();
-  if (typeof window === "undefined") return fallback;
-
-  try {
-    const raw = window.localStorage.getItem(KANBAN_COLUMN_WIDTHS_KEY);
-    if (!raw) return fallback;
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") return fallback;
-    const byStatus = parsed as Partial<Record<SessionStatus, unknown>>;
-    return KANBAN_COLUMNS.map(({ status }, index) => {
-      const value = byStatus[status];
-      return typeof value === "number" && Number.isFinite(value)
-        ? clampKanbanColumnWidth(value)
-        : (fallback[index] ?? KANBAN_COLUMN_DEFAULT_WIDTH);
-    });
-  } catch {
-    return fallback;
-  }
-}
-
-function writeKanbanColumnWidths(widths: readonly number[]) {
-  if (typeof window === "undefined") return;
-  const byStatus: Partial<Record<SessionStatus, number>> = {};
-  KANBAN_COLUMNS.forEach(({ status }, index) => {
-    byStatus[status] = clampKanbanColumnWidth(
-      widths[index] ?? KANBAN_COLUMN_DEFAULT_WIDTH,
-    );
-  });
-  try {
-    window.localStorage.setItem(
-      KANBAN_COLUMN_WIDTHS_KEY,
-      JSON.stringify(byStatus),
-    );
-  } catch {
-    // Ignore private-mode or quota failures; resizing should still work.
-  }
-}
-
-function clampKanbanColumnWidth(width: number): number {
-  return Math.max(KANBAN_COLUMN_MIN_WIDTH, Math.round(width));
-}
-
-function sortKanbanSessions(
-  sessions: readonly Session[],
-  sortMode: KanbanSortMode,
-): Session[] {
-  return [...sessions].sort((a, b) => {
-    switch (sortMode) {
-      case "updated-desc":
-        return (
-          sessionTimestamp(b.updated_at) - sessionTimestamp(a.updated_at) ||
-          compareSessionName(a, b)
-        );
-      case "created-desc":
-        return (
-          sessionTimestamp(b.created_at) - sessionTimestamp(a.created_at) ||
-          compareSessionName(a, b)
-        );
-      case "name-asc":
-        return compareSessionName(a, b);
-    }
-  });
-}
-
-function sessionMatchesKanbanFilter(
-  session: Session,
-  filterQuery: string,
-): boolean {
-  const query = filterQuery.trim().toLowerCase();
-  if (!query) return true;
-  return [
-    session.name,
-    session.worktree_path,
-    basename(session.worktree_path),
-    session.branch,
-    session.id,
-  ].some((value) => value.toLowerCase().includes(query));
-}
-
-function sessionTimestamp(value: string): number {
-  const timestamp = Date.parse(value);
-  return Number.isFinite(timestamp) ? timestamp : 0;
-}
-
-function compareSessionName(a: Session, b: Session): number {
-  return a.name.localeCompare(b.name, undefined, {
-    sensitivity: "base",
-    numeric: true,
-  });
 }
 
 async function copyToClipboard(text: string): Promise<void> {

--- a/src/lib/kanbanBoard.test.ts
+++ b/src/lib/kanbanBoard.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_KANBAN_SORT_MODE,
+  KANBAN_COLUMN_DEFAULT_WIDTH,
+  KANBAN_COLUMN_MIN_WIDTH,
+  KANBAN_COLUMN_STATUSES,
+  clampKanbanColumnWidth,
+  defaultKanbanBoardPrefs,
+  defaultKanbanColumnWidths,
+  equalizeKanbanColumnWidths,
+  readKanbanBoardPrefs,
+  sessionMatchesKanbanFilter,
+  sortKanbanSessions,
+  toKanbanSortMode,
+  writeKanbanBoardPrefs,
+  type KanbanBoardPrefs,
+} from "./kanbanBoard";
+import type { Session } from "./types";
+
+function makeSession(overrides: Partial<Session>): Session {
+  return {
+    id: "s",
+    name: "session",
+    branch: "main",
+    worktree_path: "/repo/session",
+    status: "idle",
+    mode: "agent",
+    kind: "session",
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  } as unknown as Session;
+}
+
+const STORAGE_KEY = "acorn:workspace-kanban:board-prefs:v1";
+
+describe("clampKanbanColumnWidth", () => {
+  it("raises widths below the minimum to the minimum", () => {
+    expect(clampKanbanColumnWidth(10)).toBe(KANBAN_COLUMN_MIN_WIDTH);
+  });
+
+  it("rounds fractional widths", () => {
+    expect(clampKanbanColumnWidth(200.4)).toBe(200);
+    expect(clampKanbanColumnWidth(200.6)).toBe(201);
+  });
+
+  it("keeps widths at or above the minimum", () => {
+    expect(clampKanbanColumnWidth(300)).toBe(300);
+  });
+});
+
+describe("defaultKanbanColumnWidths", () => {
+  it("returns one default width per column", () => {
+    const widths = defaultKanbanColumnWidths();
+    expect(widths).toHaveLength(KANBAN_COLUMN_STATUSES.length);
+    expect(widths.every((w) => w === KANBAN_COLUMN_DEFAULT_WIDTH)).toBe(true);
+  });
+});
+
+describe("toKanbanSortMode", () => {
+  it("accepts the known sort modes", () => {
+    expect(toKanbanSortMode("updated-desc")).toBe("updated-desc");
+    expect(toKanbanSortMode("created-desc")).toBe("created-desc");
+    expect(toKanbanSortMode("name-asc")).toBe("name-asc");
+  });
+
+  it("falls back to the default for unknown values", () => {
+    expect(toKanbanSortMode("nonsense")).toBe(DEFAULT_KANBAN_SORT_MODE);
+    expect(toKanbanSortMode(undefined)).toBe(DEFAULT_KANBAN_SORT_MODE);
+    expect(toKanbanSortMode(42)).toBe(DEFAULT_KANBAN_SORT_MODE);
+  });
+});
+
+describe("equalizeKanbanColumnWidths", () => {
+  it("sets every column to the clamped mean of the current widths", () => {
+    // mean of [552, 192, 192, 192, 192] = 264
+    const result = equalizeKanbanColumnWidths([552, 192, 192, 192, 192]);
+    expect(result).toEqual([264, 264, 264, 264, 264]);
+  });
+
+  it("never produces a width below the minimum", () => {
+    const result = equalizeKanbanColumnWidths([10, 10, 10]);
+    expect(result).toEqual([
+      KANBAN_COLUMN_MIN_WIDTH,
+      KANBAN_COLUMN_MIN_WIDTH,
+      KANBAN_COLUMN_MIN_WIDTH,
+    ]);
+  });
+
+  it("differs from reset when widths are uneven", () => {
+    const equalized = equalizeKanbanColumnWidths([400, 200, 200, 200, 200]);
+    expect(equalized).not.toEqual(defaultKanbanColumnWidths());
+    expect(new Set(equalized).size).toBe(1);
+  });
+
+  it("returns an empty array for no columns", () => {
+    expect(equalizeKanbanColumnWidths([])).toEqual([]);
+  });
+});
+
+describe("sortKanbanSessions", () => {
+  const a = makeSession({
+    id: "a",
+    name: "Beta",
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-03T00:00:00.000Z",
+  });
+  const b = makeSession({
+    id: "b",
+    name: "Alpha",
+    created_at: "2026-01-02T00:00:00.000Z",
+    updated_at: "2026-01-02T00:00:00.000Z",
+  });
+  const c = makeSession({
+    id: "c",
+    name: "alpha",
+    created_at: "2026-01-03T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+  });
+
+  it("orders by most-recently-updated first", () => {
+    expect(sortKanbanSessions([c, b, a], "updated-desc").map((s) => s.id)).toEqual(
+      ["a", "b", "c"],
+    );
+  });
+
+  it("orders by most-recently-created first", () => {
+    expect(sortKanbanSessions([a, b, c], "created-desc").map((s) => s.id)).toEqual(
+      ["c", "b", "a"],
+    );
+  });
+
+  it("orders by name case-insensitively", () => {
+    expect(sortKanbanSessions([a, b, c], "name-asc").map((s) => s.name)).toEqual([
+      "Alpha",
+      "alpha",
+      "Beta",
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [c, b, a];
+    sortKanbanSessions(input, "name-asc");
+    expect(input.map((s) => s.id)).toEqual(["c", "b", "a"]);
+  });
+
+  it("treats unparseable timestamps as the epoch", () => {
+    const bad = makeSession({ id: "bad", updated_at: "not-a-date" });
+    const good = makeSession({
+      id: "good",
+      updated_at: "2026-01-05T00:00:00.000Z",
+    });
+    expect(
+      sortKanbanSessions([bad, good], "updated-desc").map((s) => s.id),
+    ).toEqual(["good", "bad"]);
+  });
+});
+
+describe("sessionMatchesKanbanFilter", () => {
+  const session = makeSession({
+    id: "abc123",
+    name: "Build Pipeline",
+    branch: "feat/kanban",
+    worktree_path: "/repos/acorn/worktrees/pipeline",
+  });
+
+  it("matches everything for an empty or whitespace query", () => {
+    expect(sessionMatchesKanbanFilter(session, "")).toBe(true);
+    expect(sessionMatchesKanbanFilter(session, "   ")).toBe(true);
+  });
+
+  it("matches the name case-insensitively", () => {
+    expect(sessionMatchesKanbanFilter(session, "pipeline")).toBe(true);
+    expect(sessionMatchesKanbanFilter(session, "BUILD")).toBe(true);
+  });
+
+  it("matches branch, id, and worktree basename", () => {
+    expect(sessionMatchesKanbanFilter(session, "feat/kanban")).toBe(true);
+    expect(sessionMatchesKanbanFilter(session, "abc123")).toBe(true);
+    expect(sessionMatchesKanbanFilter(session, "worktrees")).toBe(true);
+  });
+
+  it("returns false when nothing matches", () => {
+    expect(sessionMatchesKanbanFilter(session, "zzz")).toBe(false);
+  });
+});
+
+describe("board prefs persistence", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns defaults for an unknown or null project", () => {
+    expect(readKanbanBoardPrefs(null)).toEqual(defaultKanbanBoardPrefs());
+    expect(readKanbanBoardPrefs("ghost")).toEqual(defaultKanbanBoardPrefs());
+  });
+
+  it("round-trips prefs for a project", () => {
+    const prefs: KanbanBoardPrefs = {
+      columnWidths: [300, 250, 200, 180, 160],
+      sortMode: "name-asc",
+      filterQuery: "shell",
+    };
+    writeKanbanBoardPrefs("/repo/a", prefs);
+    expect(readKanbanBoardPrefs("/repo/a")).toEqual(prefs);
+  });
+
+  it("does not write when the project id is null", () => {
+    writeKanbanBoardPrefs(null, {
+      columnWidths: [300, 300, 300, 300, 300],
+      sortMode: "name-asc",
+      filterQuery: "x",
+    });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("isolates prefs between projects", () => {
+    writeKanbanBoardPrefs("/repo/a", {
+      columnWidths: [300, 300, 300, 300, 300],
+      sortMode: "name-asc",
+      filterQuery: "a-only",
+    });
+    writeKanbanBoardPrefs("/repo/b", {
+      columnWidths: defaultKanbanColumnWidths(),
+      sortMode: "created-desc",
+      filterQuery: "b-only",
+    });
+    expect(readKanbanBoardPrefs("/repo/a").filterQuery).toBe("a-only");
+    expect(readKanbanBoardPrefs("/repo/b").filterQuery).toBe("b-only");
+    expect(readKanbanBoardPrefs("/repo/a").sortMode).toBe("name-asc");
+  });
+
+  it("clamps and fills missing column widths on read", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        "/repo/a": { columnWidths: { idle: 10, running: 400 } },
+      }),
+    );
+    const prefs = readKanbanBoardPrefs("/repo/a");
+    // idle clamped up, running kept, the rest fall back to the default width.
+    expect(prefs.columnWidths[0]).toBe(KANBAN_COLUMN_MIN_WIDTH);
+    expect(prefs.columnWidths[2]).toBe(400);
+    expect(prefs.columnWidths[1]).toBe(KANBAN_COLUMN_DEFAULT_WIDTH);
+    expect(prefs.sortMode).toBe(DEFAULT_KANBAN_SORT_MODE);
+    expect(prefs.filterQuery).toBe("");
+  });
+
+  it("falls back to defaults for corrupt stored JSON", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(readKanbanBoardPrefs("/repo/a")).toEqual(defaultKanbanBoardPrefs());
+  });
+
+  it("normalizes an invalid stored sort mode", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ "/repo/a": { sortMode: "bogus" } }),
+    );
+    expect(readKanbanBoardPrefs("/repo/a").sortMode).toBe(
+      DEFAULT_KANBAN_SORT_MODE,
+    );
+  });
+});

--- a/src/lib/kanbanBoard.ts
+++ b/src/lib/kanbanBoard.ts
@@ -1,0 +1,204 @@
+import { basename } from "./pathUtils";
+import type { Session, SessionStatus } from "./types";
+
+export type KanbanSortMode = "updated-desc" | "created-desc" | "name-asc";
+
+/**
+ * Column order is the single source of truth for the kanban board. The board
+ * component pairs each status with a UI tone; the pure board logic here only
+ * needs the order and identity of each column.
+ */
+export const KANBAN_COLUMN_STATUSES: readonly SessionStatus[] = [
+  "idle",
+  "needs_input",
+  "running",
+  "failed",
+  "completed",
+];
+
+export const KANBAN_COLUMN_DEFAULT_WIDTH = 192;
+export const KANBAN_COLUMN_MIN_WIDTH = 152;
+export const DEFAULT_KANBAN_SORT_MODE: KanbanSortMode = "updated-desc";
+
+const BOARD_PREFS_STORAGE_KEY = "acorn:workspace-kanban:board-prefs:v1";
+
+/** Persisted, per-project board view state. */
+export interface KanbanBoardPrefs {
+  columnWidths: number[];
+  sortMode: KanbanSortMode;
+  filterQuery: string;
+}
+
+export function clampKanbanColumnWidth(width: number): number {
+  return Math.max(KANBAN_COLUMN_MIN_WIDTH, Math.round(width));
+}
+
+export function defaultKanbanColumnWidths(): number[] {
+  return KANBAN_COLUMN_STATUSES.map(() => KANBAN_COLUMN_DEFAULT_WIDTH);
+}
+
+export function defaultKanbanBoardPrefs(): KanbanBoardPrefs {
+  return {
+    columnWidths: defaultKanbanColumnWidths(),
+    sortMode: DEFAULT_KANBAN_SORT_MODE,
+    filterQuery: "",
+  };
+}
+
+export function toKanbanSortMode(value: unknown): KanbanSortMode {
+  if (
+    value === "updated-desc" ||
+    value === "created-desc" ||
+    value === "name-asc"
+  ) {
+    return value;
+  }
+  return DEFAULT_KANBAN_SORT_MODE;
+}
+
+/**
+ * Equalize sets every column to the mean of the current widths (clamped to the
+ * minimum). This is deliberately distinct from reset, which restores the fixed
+ * default width — so the two toolbar actions never collapse into the same
+ * result.
+ */
+export function equalizeKanbanColumnWidths(
+  widths: readonly number[],
+): number[] {
+  if (widths.length === 0) return [];
+  const total = widths.reduce((sum, width) => sum + width, 0);
+  const equalWidth = clampKanbanColumnWidth(total / widths.length);
+  return widths.map(() => equalWidth);
+}
+
+function sessionTimestamp(value: string): number {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function compareSessionName(a: Session, b: Session): number {
+  return a.name.localeCompare(b.name, undefined, {
+    sensitivity: "base",
+    numeric: true,
+  });
+}
+
+export function sortKanbanSessions(
+  sessions: readonly Session[],
+  sortMode: KanbanSortMode,
+): Session[] {
+  return [...sessions].sort((a, b) => {
+    switch (sortMode) {
+      case "updated-desc":
+        return (
+          sessionTimestamp(b.updated_at) - sessionTimestamp(a.updated_at) ||
+          compareSessionName(a, b)
+        );
+      case "created-desc":
+        return (
+          sessionTimestamp(b.created_at) - sessionTimestamp(a.created_at) ||
+          compareSessionName(a, b)
+        );
+      case "name-asc":
+        return compareSessionName(a, b);
+    }
+  });
+}
+
+export function sessionMatchesKanbanFilter(
+  session: Session,
+  filterQuery: string,
+): boolean {
+  const query = filterQuery.trim().toLowerCase();
+  if (!query) return true;
+  return [
+    session.name,
+    session.worktree_path,
+    basename(session.worktree_path),
+    session.branch,
+    session.id,
+  ].some((value) => value.toLowerCase().includes(query));
+}
+
+interface StoredBoardPrefs {
+  columnWidths?: Partial<Record<SessionStatus, number>>;
+  sortMode?: string;
+  filterQuery?: string;
+}
+
+type StoredBoardPrefsMap = Record<string, StoredBoardPrefs>;
+
+function readStoredMap(): StoredBoardPrefsMap {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(BOARD_PREFS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    return parsed as StoredBoardPrefsMap;
+  } catch {
+    return {};
+  }
+}
+
+function columnWidthsFromStored(
+  stored: StoredBoardPrefs["columnWidths"],
+): number[] {
+  const fallback = defaultKanbanColumnWidths();
+  if (!stored || typeof stored !== "object") return fallback;
+  const byStatus = stored as Partial<Record<SessionStatus, unknown>>;
+  return KANBAN_COLUMN_STATUSES.map((status, index) => {
+    const value = byStatus[status];
+    return typeof value === "number" && Number.isFinite(value)
+      ? clampKanbanColumnWidth(value)
+      : (fallback[index] ?? KANBAN_COLUMN_DEFAULT_WIDTH);
+  });
+}
+
+/**
+ * Read the stored board prefs for a project. Returns defaults for an unknown or
+ * absent project, or when persisted state is missing/corrupt. Column widths are
+ * stored keyed by status so reordering columns never shuffles saved widths.
+ */
+export function readKanbanBoardPrefs(
+  projectId: string | null,
+): KanbanBoardPrefs {
+  if (!projectId) return defaultKanbanBoardPrefs();
+  const stored = readStoredMap()[projectId];
+  if (!stored || typeof stored !== "object") return defaultKanbanBoardPrefs();
+  return {
+    columnWidths: columnWidthsFromStored(stored.columnWidths),
+    sortMode: toKanbanSortMode(stored.sortMode),
+    filterQuery:
+      typeof stored.filterQuery === "string" ? stored.filterQuery : "",
+  };
+}
+
+/**
+ * Persist board prefs for a single project without disturbing other projects'
+ * saved state. No-ops without a project id or a `window` (e.g. SSR/tests).
+ */
+export function writeKanbanBoardPrefs(
+  projectId: string | null,
+  prefs: KanbanBoardPrefs,
+): void {
+  if (!projectId || typeof window === "undefined") return;
+  const byStatus: Partial<Record<SessionStatus, number>> = {};
+  KANBAN_COLUMN_STATUSES.forEach((status, index) => {
+    byStatus[status] = clampKanbanColumnWidth(
+      prefs.columnWidths[index] ?? KANBAN_COLUMN_DEFAULT_WIDTH,
+    );
+  });
+  try {
+    const map = readStoredMap();
+    map[projectId] = {
+      columnWidths: byStatus,
+      sortMode: toKanbanSortMode(prefs.sortMode),
+      filterQuery: prefs.filterQuery,
+    };
+    window.localStorage.setItem(BOARD_PREFS_STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // Ignore private-mode or quota failures; board controls still work without
+    // persistence.
+  }
+}

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -256,15 +256,20 @@ test.describe("workspace kanban mode", () => {
     ).toBeLessThan(1);
     expect(scrollWidthAfter).toBeGreaterThan(scrollWidthBefore + 40);
 
+    // Equalize distributes the mean width across columns, so every column ends
+    // up the same width as the others (distinct from reset, which restores the
+    // fixed default) and lands between the resized and untouched widths.
     await board.getByRole("button", { name: "Equalize sizes" }).click();
     await expect
       .poll(async () => {
         const widths = await kanbanColumnWidths();
-        return Math.max(
-          ...widths.map((width) => Math.abs(width - idleWidthAfter)),
-        );
+        return Math.max(...widths) - Math.min(...widths);
       })
       .toBeLessThan(1);
+    const equalizedWidths = await kanbanColumnWidths();
+    const equalizedWidth = equalizedWidths[0] ?? 0;
+    expect(equalizedWidth).toBeLessThan(idleWidthAfter);
+    expect(equalizedWidth).toBeGreaterThan(needsInputWidthAfter);
 
     await board.getByRole("button", { name: "Reset sizes" }).click();
     await expect


### PR DESCRIPTION
## Summary
Follow-up to #507 that addresses four gaps from the kanban workspace review: board sort/filter state was lost on remount, column widths were a single global record, "Equalize sizes" duplicated "Reset sizes", and the board's pure logic had no direct unit coverage.

## What changed
1. **Per-project board prefs** — column widths, sort mode, and filter query are now persisted together as a single per-project record (`acorn:workspace-kanban:board-prefs:v1`). Sort and filter survive kanban/pane toggles, project switches, and reloads instead of resetting, and each project keeps its own column layout rather than sharing one global width record.
2. **Equalize redefined** — "Equalize sizes" now distributes the mean of the current column widths (clamped to the minimum) instead of copying the last-edited width, so it is meaningfully distinct from "Reset sizes", which restores the fixed default width.
3. **Extracted board logic** — the pure board helpers (width clamping, sort, filter, equalize, prefs read/write) moved into `src/lib/kanbanBoard.ts`, with the column order now sourced from a single `KANBAN_COLUMN_STATUSES` constant the component derives its tone mapping from.
4. **Unit coverage** — `src/lib/kanbanBoard.test.ts` covers the extracted helpers directly: clamping, sort modes, filter matching, mean-based equalize, and per-project persistence (round-trip, project isolation, corrupt/partial storage fallbacks).

## Design notes
- The board remounts per project via a React `key`, so each instance hydrates its prefs from the `useState` initializer instead of racing an effect to swap them in. A board therefore can never write one project's prefs into another project's bucket.
- Column widths are stored keyed by status, so reordering columns never shuffles saved widths.
- The filter query persists across restarts, but it is always visible (and clearable) in the board's search box, so it stays discoverable.
- Persistence write frequency during a drag is unchanged from #507, which already wrote on every width change.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` — 75 files / 843 tests passed (adds the new `kanbanBoard` suite)
- [x] `pnpm exec playwright test tests/e2e/kanban.spec.ts` — 4 Playwright tests passed (equalize assertion updated for mean-distribution semantics)
- [x] `pnpm run build` passes; Vite reports the pre-existing large-chunk warning only

Refs #507
