### PR TITLE
fix(terminal): repaint hidden terminals on reveal + keep pane layout mounted in kanban

### DIFF
--- a/src/components/LayoutRenderer.test.tsx
+++ b/src/components/LayoutRenderer.test.tsx
@@ -1,0 +1,120 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LayoutNode } from "../lib/layout";
+import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
+
+vi.mock("./Pane", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    Pane: ({ paneId }: { paneId: string }) =>
+      React.createElement("div", { "data-testid": "pane", "data-pane": paneId }),
+  };
+});
+
+// react-resizable-panels measures real DOM; in jsdom its imperative setLayout
+// throws "Invalid 0 panel layout" because no panels register. Stub it to a
+// passthrough with a no-op imperative handle so the test exercises only the
+// equalize event wiring and its effect on the persisted store layout.
+vi.mock("react-resizable-panels", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    PanelGroup: React.forwardRef(
+      (
+        { children }: { children?: React.ReactNode },
+        ref: React.Ref<{ setLayout: (sizes: number[]) => void }>,
+      ) => {
+        React.useImperativeHandle(ref, () => ({ setLayout: () => {} }));
+        return React.createElement("div", { "data-testid": "panel-group" }, children);
+      },
+    ),
+    Panel: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    PanelResizeHandle: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement("div", null, children),
+  };
+});
+
+import { LayoutRenderer } from "./LayoutRenderer";
+import { useAppStore } from "../store";
+
+const REPO = "/Users/me/repo";
+
+function splitLayout(sizes: [number, number]): LayoutNode {
+  return {
+    kind: "split",
+    id: "s1",
+    direction: "horizontal",
+    a: { kind: "pane", id: "root" },
+    b: { kind: "pane", id: "side" },
+    sizes,
+  };
+}
+
+function setup(viewMode: "panes" | "kanban", sizes: [number, number]): void {
+  const layout = splitLayout(sizes);
+  useAppStore.setState(
+    {
+      workspaces: {
+        [REPO]: { layout, panes: {}, focusedPaneId: "root" },
+      },
+      activeProject: REPO,
+      activeProjectFolderId: null,
+      layout,
+      workspaceViewMode: viewMode,
+    },
+    false,
+  );
+}
+
+function activeSizes(): readonly number[] | undefined {
+  const layout = useAppStore.getState().workspaces[REPO].layout;
+  return layout.kind === "split" ? layout.sizes : undefined;
+}
+
+describe("LayoutRenderer equalize-panes guard", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  function render(): void {
+    act(() => {
+      root.render(<LayoutRenderer node={useAppStore.getState().layout} />);
+    });
+  }
+
+  it("equalizes pane splits when the panes view is active", () => {
+    setup("panes", [70, 30]);
+    render();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
+    });
+
+    const sizes = activeSizes();
+    expect(sizes?.[0]).toBeCloseTo(50, 1);
+    expect(sizes?.[1]).toBeCloseTo(50, 1);
+  });
+
+  it("ignores the equalize event while the kanban view hides the panes", () => {
+    setup("kanban", [70, 30]);
+    render();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(EQUALIZE_PANES_EVENT));
+    });
+
+    expect(activeSizes()).toEqual([70, 30]);
+  });
+});

--- a/src/components/LayoutRenderer.tsx
+++ b/src/components/LayoutRenderer.tsx
@@ -109,6 +109,10 @@ function EqualizablePanelGroup({
 
   useEffect(() => {
     const onEqualize = () => {
+      // The layout stays mounted (hidden) while the kanban view is shown, so
+      // this listener is still live there. Equalizing then would silently reset
+      // the hidden pane splits, so only act while the panes view is visible.
+      if (useAppStore.getState().workspaceViewMode !== "panes") return;
       onLayout(equalizedLayout);
       ref.current?.setLayout(equalizedLayout);
     };

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -33,6 +33,7 @@ import {
 } from "../lib/terminal-cjk-cell-width-addon";
 import {
   createTerminalRepaintScheduler,
+  createTerminalVisibilityRepaintObserver,
   repaintTerminalViewport,
 } from "../lib/terminalRepaint";
 import {
@@ -2940,6 +2941,29 @@ export function Terminal({
       scheduler.dispose();
     };
   }, [isActive]);
+
+  // Switching between in-app tabs keeps the window focused and does not always
+  // toggle `isActive`, so neither repaint effect above fires when a hidden
+  // terminal (background tab, kanban view, split/merge remount) scrolls back on
+  // screen. Watch real on-screen visibility so the buffer is rebuilt the moment
+  // the element regains a layout box, instead of staying blank until the user
+  // scrolls or clicks.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const refresh = () => {
+      const term = termRef.current;
+      const fit = fitTerminalRef.current;
+      const el = containerRef.current;
+      if (!term || !fit || !el) return;
+      repaintTerminalViewport({ container: el, fit, term });
+    };
+    const observer = createTerminalVisibilityRepaintObserver(
+      container,
+      refresh,
+    );
+    return observer.dispose;
+  }, []);
 
   // FitAddon subtracts padding from xterm.element, not its parent — keep the
   // gutter on the outer wrapper so xterm's parent stays padding-free and rows

--- a/src/components/WorkspaceMain.test.tsx
+++ b/src/components/WorkspaceMain.test.tsx
@@ -1,0 +1,104 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LayoutNode } from "../lib/layout";
+
+vi.mock("./LayoutRenderer", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    LayoutRenderer: () =>
+      React.createElement("div", { "data-testid": "layout-renderer" }),
+  };
+});
+
+import { WorkspaceMain } from "./WorkspaceMain";
+import { useAppStore } from "../store";
+import { DEFAULT_SETTINGS, useSettings } from "../lib/settings";
+
+const REPO = "/Users/me/repo";
+const LAYOUT: LayoutNode = { kind: "pane", id: "root" };
+
+function resetStore(): void {
+  const pane = { id: "root", tabIds: [], activeTabId: null };
+  useAppStore.setState(
+    {
+      sessions: [],
+      workspaces: {
+        [REPO]: {
+          layout: LAYOUT,
+          panes: { root: pane },
+          focusedPaneId: "root",
+        },
+      },
+      activeProject: REPO,
+      layout: LAYOUT,
+      panes: { root: pane },
+      focusedPaneId: "root",
+      activeTabId: null,
+      activeSessionId: null,
+      workspaceViewMode: "panes",
+      terminalPopupSessionId: null,
+    },
+    false,
+  );
+}
+
+function queryLayout(): HTMLElement | null {
+  return document.querySelector<HTMLElement>("[data-testid='layout-renderer']");
+}
+
+function queryKanban(): HTMLElement | null {
+  return document.querySelector<HTMLElement>("[data-testid='workspace-kanban']");
+}
+
+describe("WorkspaceMain", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    localStorage.clear();
+    resetStore();
+    useSettings.setState({ settings: structuredClone(DEFAULT_SETTINGS) });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  function render(viewMode: "panes" | "kanban"): void {
+    act(() => {
+      root.render(<WorkspaceMain layout={LAYOUT} viewMode={viewMode} />);
+    });
+  }
+
+  it("keeps the pane layout mounted with a stable DOM node across a kanban toggle", () => {
+    render("panes");
+    const initial = queryLayout();
+    expect(initial).not.toBeNull();
+    expect(queryKanban()).toBeNull();
+
+    render("kanban");
+    const duringKanban = queryLayout();
+    // The layout must stay mounted (same DOM node) so the terminal target divs
+    // appendChild'd into pane bodies keep their identity and are not orphaned.
+    expect(duringKanban).toBe(initial);
+    expect(queryKanban()).not.toBeNull();
+
+    render("panes");
+    expect(queryLayout()).toBe(initial);
+    expect(queryKanban()).toBeNull();
+  });
+
+  it("hides the pane layout while the kanban board is shown", () => {
+    render("panes");
+    expect(queryLayout()?.parentElement?.className).not.toContain("hidden");
+
+    render("kanban");
+    expect(queryLayout()?.parentElement?.className).toContain("hidden");
+  });
+});

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -108,13 +108,20 @@ interface WorkspaceMainProps {
 }
 
 export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
+  const isKanban = viewMode === "kanban";
   return (
     <div className="h-full min-w-0" data-workspace-main>
-      {viewMode === "kanban" ? (
-        <WorkspaceKanbanBoard />
-      ) : (
+      {isKanban ? <WorkspaceKanbanBoard /> : null}
+      {/*
+        Keep the pane layout mounted (hidden) in kanban mode instead of
+        unmounting it. TerminalHost appendChild's each live terminal's target
+        div into a pane body; unmounting the layout orphans those divs, so
+        returning to panes shows blank terminals until an unrelated reattach.
+        Hiding preserves the pane-body DOM identity so the terminals stay put.
+      */}
+      <div className={cn("h-full min-w-0", isKanban && "hidden")}>
         <LayoutRenderer node={layout} />
-      )}
+      </div>
       <WorkspaceSessionPopup />
     </div>
   );

--- a/src/lib/terminalRepaint.test.ts
+++ b/src/lib/terminalRepaint.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createTerminalRepaintScheduler,
+  createTerminalVisibilityRepaintObserver,
   repaintTerminalViewport,
+  shouldRepaintForVisibility,
 } from "./terminalRepaint";
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
@@ -107,5 +110,121 @@ describe("createTerminalRepaintScheduler", () => {
     vi.advanceTimersByTime(50);
 
     expect(repaint).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("shouldRepaintForVisibility", () => {
+  it("repaints only on the hidden -> visible transition", () => {
+    expect(shouldRepaintForVisibility(false, true)).toBe(true);
+    expect(shouldRepaintForVisibility(true, true)).toBe(false);
+    expect(shouldRepaintForVisibility(true, false)).toBe(false);
+    expect(shouldRepaintForVisibility(false, false)).toBe(false);
+  });
+});
+
+interface FakeEntry {
+  isIntersecting: boolean;
+  intersectionRatio: number;
+}
+
+class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = [];
+  callback: (entries: FakeEntry[]) => void;
+  observed: Element[] = [];
+  disconnected = false;
+
+  constructor(callback: (entries: FakeEntry[]) => void) {
+    this.callback = callback;
+    FakeIntersectionObserver.instances.push(this);
+  }
+
+  observe(element: Element): void {
+    this.observed.push(element);
+  }
+
+  disconnect(): void {
+    this.disconnected = true;
+  }
+
+  emit(...entries: FakeEntry[]): void {
+    this.callback(entries);
+  }
+}
+
+describe("createTerminalVisibilityRepaintObserver", () => {
+  function stubObserver(): typeof FakeIntersectionObserver {
+    FakeIntersectionObserver.instances = [];
+    vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
+    return FakeIntersectionObserver;
+  }
+
+  it("returns a no-op when IntersectionObserver is unavailable", () => {
+    vi.stubGlobal("IntersectionObserver", undefined);
+    const repaint = vi.fn();
+    const element = document.createElement("div");
+
+    const observer = createTerminalVisibilityRepaintObserver(element, repaint);
+    observer.dispose();
+
+    expect(repaint).not.toHaveBeenCalled();
+  });
+
+  it("observes the element and repaints when it becomes visible", () => {
+    const Observer = stubObserver();
+    const repaint = vi.fn();
+    const element = document.createElement("div");
+
+    createTerminalVisibilityRepaintObserver(element, repaint);
+    const instance = Observer.instances[0];
+
+    expect(instance.observed).toContain(element);
+
+    instance.emit({ isIntersecting: true, intersectionRatio: 1 });
+    expect(repaint).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not repaint again while the terminal stays visible", () => {
+    const Observer = stubObserver();
+    const repaint = vi.fn();
+
+    createTerminalVisibilityRepaintObserver(
+      document.createElement("div"),
+      repaint,
+    );
+    const instance = Observer.instances[0];
+
+    instance.emit({ isIntersecting: true, intersectionRatio: 0.5 });
+    instance.emit({ isIntersecting: true, intersectionRatio: 1 });
+
+    expect(repaint).toHaveBeenCalledTimes(1);
+  });
+
+  it("repaints again after the terminal is hidden and shown once more", () => {
+    const Observer = stubObserver();
+    const repaint = vi.fn();
+
+    createTerminalVisibilityRepaintObserver(
+      document.createElement("div"),
+      repaint,
+    );
+    const instance = Observer.instances[0];
+
+    instance.emit({ isIntersecting: true, intersectionRatio: 1 });
+    instance.emit({ isIntersecting: false, intersectionRatio: 0 });
+    instance.emit({ isIntersecting: true, intersectionRatio: 1 });
+
+    expect(repaint).toHaveBeenCalledTimes(2);
+  });
+
+  it("disconnects the observer on dispose", () => {
+    const Observer = stubObserver();
+    const observer = createTerminalVisibilityRepaintObserver(
+      document.createElement("div"),
+      vi.fn(),
+    );
+
+    observer.dispose();
+
+    expect(Observer.instances[0].disconnected).toBe(true);
   });
 });

--- a/src/lib/terminalRepaint.ts
+++ b/src/lib/terminalRepaint.ts
@@ -71,3 +71,47 @@ export function createTerminalRepaintScheduler(
 
   return { schedule, dispose };
 }
+
+/**
+ * Whether a repaint is needed for a visibility transition. xterm's DOM renderer
+ * skips row paints while its element has no layout box (background tab, hidden
+ * kanban view, split/merge remount), so it must be forced to rebuild only when
+ * the terminal comes back on-screen — not while it stays visible or hidden.
+ */
+export function shouldRepaintForVisibility(
+  wasVisible: boolean,
+  isVisible: boolean,
+): boolean {
+  return !wasVisible && isVisible;
+}
+
+/**
+ * Repaint the terminal whenever it transitions from hidden to on-screen.
+ *
+ * The isActive and window-`focus` repaint effects miss the common case of
+ * switching between in-app tabs while the window stays focused: no focus event
+ * fires, and a long output burst accumulated while the tab was hidden leaves
+ * the DOM renderer blank until the user scrolls. An IntersectionObserver reacts
+ * to genuine on-screen visibility, so the forced repaint runs once the element
+ * actually has a box.
+ */
+export function createTerminalVisibilityRepaintObserver(
+  element: Element,
+  repaint: () => void,
+): { dispose: () => void } {
+  if (typeof IntersectionObserver === "undefined") {
+    return { dispose: () => {} };
+  }
+  let wasVisible = false;
+  const observer = new IntersectionObserver((entries) => {
+    const entry = entries[entries.length - 1];
+    if (!entry) return;
+    const isVisible = entry.isIntersecting && entry.intersectionRatio > 0;
+    if (shouldRepaintForVisibility(wasVisible, isVisible)) repaint();
+    wasVisible = isVisible;
+  });
+  observer.observe(element);
+  return {
+    dispose: () => observer.disconnect(),
+  };
+}


### PR DESCRIPTION
## Summary

Fixes "terminal renders blank while the shell is still alive" issues in the terminal display path. Root cause: xterm's DOM renderer skips row paints while its element has no layout box, and the existing repaint triggers (`isActive` toggle, window `focus`, `visibilitychange`) miss the case where a hidden terminal returns on screen without the window ever losing focus.

## Fix 1 — repaint a hidden terminal when it returns on-screen (`cc5f0df`)

Switching between in-app tabs keeps the window focused and does not reliably toggle `isActive`, so no repaint fired when a background-tab terminal (or a hidden kanban view, or a split/merge remount) scrolled back into view. A long output burst accumulated while the tab was hidden then stayed blank until the user scrolled or clicked, even though the buffer was intact.

Adds an `IntersectionObserver`-driven repaint that reacts to genuine on-screen visibility and rebuilds the visible rows the moment the element regains a layout box. One observer per mounted terminal (bounded by `maxMountedTerminals`, default 8), disconnected on unmount; it fires only on the hidden→visible transition, not on scroll.

## Fix 2 — keep the pane layout mounted while the kanban view is shown (`a93526e`)

Entering kanban mode unmounted `LayoutRenderer`, removing every pane-body DOM node. `TerminalHost` appendChild's each live terminal's target div into those pane bodies, so unmounting orphaned the divs. Returning to panes mounted a fresh empty layout, and the reattach effect (keyed on the visible target key and layout ref, neither of which changes on a view-mode toggle) never re-ran — leaving previously-visible terminals blank until an unrelated action moved the target.

Keeps `LayoutRenderer` mounted and hides it with `display:none` in kanban mode, so pane bodies and their terminal target divs retain DOM identity across the toggle.

## Fix 3 — ignore the equalize-panes event while kanban hides the layout (`7c50588`)

Follow-up found in self-review. Because Fix 2 keeps `LayoutRenderer` mounted while hidden, its `EQUALIZE_PANES_EVENT` listener stays live in kanban view. Triggering the equalize-panes hotkey or the command-palette reset-layout action from kanban would then silently reset the hidden pane splits to equal widths (a no-op before Fix 2, since the layout used to unmount). Gated the handler on the active workspace view so it only equalizes while the panes view is visible.

## Performance / memory

Both mount changes are bounded and safe. Fix 1 adds at most `maxMountedTerminals` lightweight native observers, each firing only on visibility transitions. Fix 2 retains the hidden panes in memory while kanban is shown (bounded, and consistent with how background tabs already stay mounted); the `display:none` transition cannot corrupt the PTY (`fit()` no-ops on a zero-size container and `sendPtyResize` is guarded against zero dimensions) and cannot corrupt persisted split sizes (`react-resizable-panels` v3 uses percentage layout with no `ResizeObserver`, and `normalizeSplitSizes` independently rejects any non-positive size).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — 853 unit tests pass (10 new: visibility-repaint helper, kanban mount invariant, equalize-panes guard)
- [x] Independent code review pass (risks A–E scrutinized; only the Fix 3 edge case was real, now fixed)
- [ ] Native smoke test: view another tab for a while during a long-running task, return to a Claude terminal tab, confirm the transcript is visible immediately (no click/scroll needed)
- [ ] Native smoke test: with a live terminal in panes mode, toggle panes → kanban → panes and confirm the terminal is not blank on return
