### PR TITLE
feat(workspace): create workspaces from worktree sessions

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1469,6 +1469,33 @@ function canAssignSessionToWorkspace(
   return true;
 }
 
+function canCreateWorkspaceFromSessionWorktree(
+  session: Session,
+  projectFolders: readonly ProjectFolder[],
+  currentProjectFolderId: string | undefined,
+): boolean {
+  if (!hasRecordedWorktree(session)) return false;
+  if (
+    normalizeWorkspacePath(session.worktree_path) ===
+    normalizeWorkspacePath(session.repo_path)
+  ) {
+    return false;
+  }
+  const currentFolder = currentProjectFolderId
+    ? projectFolders.find((folder) => folder.id === currentProjectFolderId)
+    : null;
+  if (currentFolder && !isDefaultProjectFolder(currentFolder)) {
+    return false;
+  }
+  return !projectFolders.some(
+    (folder) =>
+      !isDefaultProjectFolder(folder) &&
+      isWorktreeWorkspace(folder) &&
+      normalizeWorkspacePath(folder.cwdPath) ===
+        normalizeWorkspacePath(session.worktree_path),
+  );
+}
+
 function isSessionDragCrossingLockedWorkspace(
   session: Session,
   activeFolder: ProjectFolder | null,
@@ -2565,6 +2592,7 @@ function SessionRow({
   const renameSession = useAppStore((s) => s.renameSession);
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
   const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
+  const createProjectFolder = useAppStore((s) => s.createProjectFolder);
   const toggleSessionAutoClose = useAppStore(
     (s) => s.toggleSessionAutoClose,
   );
@@ -2582,6 +2610,11 @@ function SessionRow({
   );
   const currentProjectFolder = projectFolders.find(
     (folder) => folder.id === currentProjectFolderId,
+  );
+  const canCreateWorktreeWorkspace = canCreateWorkspaceFromSessionWorktree(
+    session,
+    projectFolders,
+    currentProjectFolderId,
   );
   const currentWorkspaceCwd = currentProjectFolder?.cwdPath ?? null;
   const hideWorkspaceDuplicateContext =
@@ -2715,6 +2748,16 @@ function SessionRow({
     }
   }
 
+  function createWorkspaceFromWorktree() {
+    const folder = createProjectFolder(
+      session.repo_path,
+      basename(session.worktree_path),
+      session.worktree_path,
+    );
+    if (!folder) return;
+    selectSession(session.id);
+  }
+
   const agentProvider = showAgentProviderIcons
     ? resolveSessionAgentProvider(session)
     : null;
@@ -2831,6 +2874,21 @@ function SessionRow({
       });
     }
   }
+  const workspaceMenuItems: ContextMenuItem[] = [
+    ...(canCreateWorktreeWorkspace
+      ? [
+          {
+            label: sidebarText(t, "sidebar.actions.createWorkspaceFromWorktree"),
+            icon: <GitBranch size={12} />,
+            onClick: createWorkspaceFromWorktree,
+          } satisfies ContextMenuItem,
+        ]
+      : []),
+    ...(canCreateWorktreeWorkspace && folderMoveMenuItems.length > 0
+      ? [{ type: "separator" as const }]
+      : []),
+    ...folderMoveMenuItems,
+  ];
 
   const sessionMenuItems: ContextMenuItem[] = [
     contextMenuGroupTitle(t, "session"),
@@ -2867,8 +2925,8 @@ function SessionRow({
     ...(forkItems.length > 0
       ? [contextMenuGroupTitle(t, "fork"), ...forkItems]
       : []),
-    ...(folderMoveMenuItems.length > 0
-      ? [contextMenuGroupTitle(t, "workspace"), ...folderMoveMenuItems]
+    ...(workspaceMenuItems.length > 0
+      ? [contextMenuGroupTitle(t, "workspace"), ...workspaceMenuItems]
       : []),
     contextMenuGroupTitle(t, "open"),
     {
@@ -3724,6 +3782,8 @@ interface LocalSessionRowProps {
   active: boolean;
   onSelect: () => void;
   onRemove: () => void;
+  projectFolders?: readonly ProjectFolder[];
+  currentProjectFolderId?: string;
 }
 
 function LocalSessionRow({
@@ -3731,11 +3791,14 @@ function LocalSessionRow({
   active,
   onSelect,
   onRemove,
+  projectFolders = [],
+  currentProjectFolderId,
 }: LocalSessionRowProps) {
   const t = useTranslation();
   const showToast = useToasts((s) => s.show);
   const renameSession = useAppStore((s) => s.renameSession);
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
+  const createProjectFolder = useAppStore((s) => s.createProjectFolder);
   const toggleSessionAutoClose = useAppStore(
     (s) => s.toggleSessionAutoClose,
   );
@@ -3762,6 +3825,11 @@ function LocalSessionRow({
   const canRename = canRenameSession(session, { isGeneratingTitle });
   const canRegenerateTitle =
     canRegenerateSessionTitle(session) && !isGeneratingTitle;
+  const canCreateWorktreeWorkspace = canCreateWorkspaceFromSessionWorktree(
+    session,
+    projectFolders,
+    currentProjectFolderId,
+  );
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const {
@@ -3798,6 +3866,16 @@ function LocalSessionRow({
     }
   }
 
+  function createWorkspaceFromWorktree() {
+    const folder = createProjectFolder(
+      session.repo_path,
+      basename(session.worktree_path),
+      session.worktree_path,
+    );
+    if (!folder) return;
+    onSelect();
+  }
+
   const menuItems: ContextMenuItem[] = [
     {
       label: sidebarText(t, "sidebar.actions.rename"),
@@ -3818,6 +3896,16 @@ function LocalSessionRow({
             label: sidebarText(t, "sidebar.actions.autoCloseWhenFinished"),
             checked: autoCloseEnabled,
             onChange: () => toggleSessionAutoClose(session.id),
+          } satisfies ContextMenuItem,
+        ]
+      : []),
+    ...(canCreateWorktreeWorkspace
+      ? [
+          { type: "separator" as const },
+          {
+            label: sidebarText(t, "sidebar.actions.createWorkspaceFromWorktree"),
+            icon: <GitBranch size={12} />,
+            onClick: createWorkspaceFromWorktree,
           } satisfies ContextMenuItem,
         ]
       : []),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -991,6 +991,7 @@
       "newControlSession": "New control session",
       "newProjectFolder": "New workspace",
       "newProjectFolderWithWorktree": "New worktree workspace",
+      "createWorkspaceFromWorktree": "Create Workspace from Worktree",
       "renameProjectFolder": "Rename workspace",
       "removeProjectFolder": "Remove workspace",
       "moveToProjectFolder": "Move to",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -991,6 +991,7 @@
       "newControlSession": "새 컨트롤 세션",
       "newProjectFolder": "새 작업공간",
       "newProjectFolderWithWorktree": "새 워크트리 작업공간",
+      "createWorkspaceFromWorktree": "이 워크트리로 작업공간 만들기",
       "renameProjectFolder": "작업공간 이름 변경",
       "removeProjectFolder": "작업공간 제거",
       "moveToProjectFolder": "이동",

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -2098,6 +2098,78 @@ test.describe("sidebar: project lifecycle", () => {
     expect(calls ?? []).toEqual([]);
   });
 
+  test("project sessions can create a workspace from their worktree", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "worker-session",
+        name: "worker",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.acorn/worktrees/feature",
+        branch: "feature/branch",
+        isolated: true,
+        project_scoped: true,
+        status: "idle",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: true,
+      },
+    ]);
+
+    await page.goto("/");
+
+    const sidebar = page.locator("aside");
+    const worker = sidebar
+      .getByRole("button", { name: /^worker worktree feature\/branch · Idle/ })
+      .first();
+    await expect(worker).toBeVisible();
+
+    await worker.click({ button: "right" });
+    await page
+      .getByRole("menuitem", {
+        name: "Create Workspace from Worktree",
+        exact: true,
+      })
+      .click();
+
+    const workspace = sidebar
+      .locator("[data-sidebar-workspace-id]")
+      .filter({ hasText: "feature" })
+      .first();
+    await expect(workspace).toBeVisible();
+    await expectWorkspacePathOnly(workspace, "feature");
+    const nestedWorker = workspace
+      .locator("xpath=following-sibling::ul")
+      .getByRole("button", {
+        name: /^worker feature\/branch · Idle/,
+      })
+      .first();
+    await expect(nestedWorker).toBeVisible();
+
+    await nestedWorker.click({ button: "right" });
+    await expect(
+      page.getByRole("menuitem", {
+        name: "Create Workspace from Worktree",
+        exact: true,
+      }),
+    ).toHaveCount(0);
+  });
+
   test("project workspaces can collapse and expand their sessions", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Workspace-free worktree sessions can now become dedicated workspaces directly from the session context menu.

1. **Session context action** — adds a Workspace menu item for worktree-backed sessions that are still sitting in the project root/default workspace.
2. **Workspace materialization** — reuses the existing project-folder workspace model so the new workspace is rooted at the session's `worktree_path` and the session is immediately selected inside it.
3. **Localized labels and coverage** — adds English/Korean menu text and a sidebar E2E regression for creating the workspace and hiding the action once the session is inside it.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Worktree session organization | Users had to create a matching worktree workspace through another path or leave the session at project root. | Users can right-click the standalone worktree session and create the matching workspace in place. |
| Worktree workspace boundaries | Worktree workspace sessions stay locked to their matching workspace. | Boundary behavior is unchanged; the new action disappears once the session is in that workspace. |

## Design notes
- The action is shown only for sessions with a recorded linked/isolated worktree whose `worktree_path` differs from `repo_path`.
- Existing worktree workspace matching is reused via `createProjectFolder(repoPath, name, cwdPath)`, so backend session records remain unchanged and reconciliation moves the matching session naturally.
- The existing move-to-workspace and drag/drop guards still block moving sessions out of a worktree-backed workspace.

## Test plan
- [x] `git diff --check` — passes
- [x] `pnpm run typecheck` — passes
- [x] `PLAYWRIGHT_PORT=1424 pnpm exec playwright test tests/e2e/sidebar.spec.ts` — 39 passed

## Notes
- Created this PR from `origin/main` rather than the existing local worktree base so it does not include unrelated PR #513 changes.