### PR TITLE
feat(kanban): configurable terminal popover

### DIFF
--- a/src-tauri/src/agent_resume.rs
+++ b/src-tauri/src/agent_resume.rs
@@ -153,10 +153,7 @@ pub fn live_transcript(session_id: uuid::Uuid) -> Option<LiveTranscript> {
 /// Resolve only the marker for `kind`. Status polling uses this when the
 /// current PTY tree already tells us which live provider owns the tab, so a
 /// nested peer agent from another provider cannot steal the session status.
-pub fn live_transcript_for_kind(
-    session_id: uuid::Uuid,
-    kind: AgentKind,
-) -> Option<LiveTranscript> {
+pub fn live_transcript_for_kind(session_id: uuid::Uuid, kind: AgentKind) -> Option<LiveTranscript> {
     let base = acorn_daemon::paths::data_dir().ok()?;
     live_transcript_for_kind_at(&base, session_id, kind)
 }
@@ -357,11 +354,24 @@ fn antigravity_brain_roots() -> Vec<PathBuf> {
         .collect()
 }
 
-fn extract_preview(kind: AgentKind, path: &Path) -> io::Result<Option<String>> {
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ConversationPreview {
+    pub last_user_message: Option<String>,
+    pub last_agent_message: Option<String>,
+}
+
+pub(crate) fn extract_preview(kind: AgentKind, path: &Path) -> io::Result<Option<String>> {
+    Ok(extract_conversation_preview(kind, path)?.last_agent_message)
+}
+
+pub(crate) fn extract_conversation_preview(
+    kind: AgentKind,
+    path: &Path,
+) -> io::Result<ConversationPreview> {
     match kind {
-        AgentKind::Claude => extract_claude_preview(path),
-        AgentKind::Codex => extract_codex_preview(path),
-        AgentKind::Antigravity => extract_antigravity_preview(path),
+        AgentKind::Claude => extract_claude_conversation_preview(path),
+        AgentKind::Codex => extract_codex_conversation_preview(path),
+        AgentKind::Antigravity => extract_antigravity_conversation_preview(path),
     }
 }
 
@@ -372,8 +382,9 @@ const PREVIEW_CHARS: usize = 90;
 /// `assistant` line and return its first text segment, truncated and
 /// newline-collapsed for single-line display. Conservative parsing —
 /// any JSON parse error or unexpected shape silently yields `None`.
-fn extract_claude_preview(path: &Path) -> io::Result<Option<String>> {
+fn extract_claude_conversation_preview(path: &Path) -> io::Result<ConversationPreview> {
     let text = read_tail_lossy(path)?;
+    let mut preview = ConversationPreview::default();
     for line in text.lines().rev() {
         let trimmed = line.trim();
         if trimmed.is_empty() || !trimmed.starts_with('{') {
@@ -382,27 +393,20 @@ fn extract_claude_preview(path: &Path) -> io::Result<Option<String>> {
         let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) else {
             continue;
         };
-        if v.get("type").and_then(|t| t.as_str()) != Some("assistant") {
-            continue;
+        match v.get("type").and_then(|t| t.as_str()) {
+            Some("assistant") if preview.last_agent_message.is_none() => {
+                preview.last_agent_message = claude_message_preview(&v);
+            }
+            Some("user") if preview.last_user_message.is_none() => {
+                preview.last_user_message = claude_message_preview(&v);
+            }
+            _ => {}
         }
-        let items = v
-            .get("message")
-            .and_then(|m| m.get("content"))
-            .and_then(|c| c.as_array());
-        let Some(items) = items else { continue };
-        for item in items {
-            if item.get("type").and_then(|t| t.as_str()) != Some("text") {
-                continue;
-            }
-            let Some(text) = item.get("text").and_then(|t| t.as_str()) else {
-                continue;
-            };
-            if let Some(p) = collapse_preview(text) {
-                return Ok(Some(p));
-            }
+        if preview.last_user_message.is_some() && preview.last_agent_message.is_some() {
+            break;
         }
     }
-    Ok(None)
+    Ok(preview)
 }
 
 /// Codex rollout schema: each line is a JSON event. Conversation turns
@@ -411,8 +415,9 @@ fn extract_claude_preview(path: &Path) -> io::Result<Option<String>> {
 /// .content[].text` (newer ones). Try the cheap variants in reverse so
 /// the latest assistant turn wins; give up to `None` if nothing matches —
 /// the modal still renders the UUID + timestamp.
-fn extract_codex_preview(path: &Path) -> io::Result<Option<String>> {
+fn extract_codex_conversation_preview(path: &Path) -> io::Result<ConversationPreview> {
     let text = read_tail_lossy(path)?;
+    let mut preview = ConversationPreview::default();
     for line in text.lines().rev() {
         let trimmed = line.trim();
         if trimmed.is_empty() || !trimmed.starts_with('{') {
@@ -422,81 +427,156 @@ fn extract_codex_preview(path: &Path) -> io::Result<Option<String>> {
             continue;
         };
 
-        if v.pointer("/payload/role").and_then(|r| r.as_str()) == Some("assistant") {
-            if let Some(content) = v.pointer("/payload/content").and_then(|c| c.as_array()) {
-                for item in content.iter().rev() {
-                    let text = item
-                        .get("text")
-                        .or_else(|| item.get("output_text"))
-                        .and_then(|t| t.as_str());
-                    if let Some(text) = text {
-                        if let Some(p) = collapse_preview(text) {
-                            return Ok(Some(p));
-                        }
-                    }
-                }
+        let payload_role = v.pointer("/payload/role").and_then(|r| r.as_str());
+        match payload_role {
+            Some("assistant") if preview.last_agent_message.is_none() => {
+                preview.last_agent_message = codex_payload_message_preview(&v);
             }
+            Some("user") if preview.last_user_message.is_none() => {
+                preview.last_user_message = codex_payload_message_preview(&v);
+            }
+            _ => {}
         }
 
-        if let Some(msg) = v
-            .pointer("/payload/message")
-            .and_then(|m| m.as_str())
-            .filter(|s| !s.is_empty())
-        {
-            if let Some(p) = collapse_preview(msg) {
-                return Ok(Some(p));
-            }
+        if preview.last_agent_message.is_none() && payload_role != Some("user") {
+            preview.last_agent_message = codex_response_output_preview(&v)
+                .or_else(|| codex_payload_message_fallback_preview(&v));
         }
 
-        let arrays = [
-            v.pointer("/payload/response/output"),
-            v.pointer("/response_payload/output"),
-            v.pointer("/payload/output"),
-        ];
-        for arr in arrays.into_iter().flatten() {
-            let Some(items) = arr.as_array() else {
-                continue;
-            };
+        if preview.last_user_message.is_some() && preview.last_agent_message.is_some() {
+            break;
+        }
+    }
+    Ok(preview)
+}
+
+fn extract_antigravity_conversation_preview(path: &Path) -> io::Result<ConversationPreview> {
+    extract_antigravity_brain_conversation_preview(path)
+}
+
+fn extract_antigravity_brain_conversation_preview(path: &Path) -> io::Result<ConversationPreview> {
+    let text = read_tail_lossy(path)?;
+    let mut preview = ConversationPreview::default();
+    for line in text.lines().rev() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || !trimmed.starts_with('{') {
+            continue;
+        }
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        match v.get("type").and_then(|t| t.as_str()) {
+            Some("PLANNER_RESPONSE") if preview.last_agent_message.is_none() => {
+                preview.last_agent_message = v
+                    .get("content")
+                    .and_then(|t| t.as_str())
+                    .and_then(collapse_preview);
+            }
+            Some("USER_INPUT") if preview.last_user_message.is_none() => {
+                preview.last_user_message = v
+                    .get("content")
+                    .and_then(|t| t.as_str())
+                    .and_then(collapse_antigravity_user_preview);
+            }
+            _ => {}
+        }
+        if preview.last_user_message.is_some() && preview.last_agent_message.is_some() {
+            break;
+        }
+    }
+    Ok(preview)
+}
+
+fn claude_message_preview(v: &serde_json::Value) -> Option<String> {
+    let content = v.get("message").and_then(|m| m.get("content"))?;
+    preview_from_content_value(content)
+}
+
+fn preview_from_content_value(content: &serde_json::Value) -> Option<String> {
+    if let Some(text) = content.as_str() {
+        return collapse_preview(text);
+    }
+    let items = content.as_array()?;
+    for item in items {
+        if item.get("type").and_then(|t| t.as_str()) != Some("text") {
+            continue;
+        }
+        let Some(text) = item.get("text").and_then(|t| t.as_str()) else {
+            continue;
+        };
+        if let Some(p) = collapse_preview(text) {
+            return Some(p);
+        }
+    }
+    None
+}
+
+fn codex_payload_message_preview(v: &serde_json::Value) -> Option<String> {
+    if let Some(content) = v.pointer("/payload/content") {
+        if let Some(text) = content.as_str() {
+            return collapse_preview(text);
+        }
+        if let Some(items) = content.as_array() {
             for item in items.iter().rev() {
-                let content = item.get("content").and_then(|c| c.as_array());
-                let Some(content) = content else { continue };
-                for c in content.iter().rev() {
-                    if let Some(text) = c.get("text").and_then(|t| t.as_str()) {
-                        if let Some(p) = collapse_preview(text) {
-                            return Ok(Some(p));
-                        }
+                let text = item
+                    .get("text")
+                    .or_else(|| item.get("output_text"))
+                    .and_then(|t| t.as_str());
+                if let Some(text) = text {
+                    if let Some(p) = collapse_preview(text) {
+                        return Some(p);
                     }
                 }
             }
         }
     }
-    Ok(None)
+    codex_payload_message_fallback_preview(v)
 }
 
-fn extract_antigravity_preview(path: &Path) -> io::Result<Option<String>> {
-    extract_antigravity_brain_preview(path)
+fn codex_payload_message_fallback_preview(v: &serde_json::Value) -> Option<String> {
+    v.pointer("/payload/message")
+        .and_then(|m| m.as_str())
+        .filter(|s| !s.is_empty())
+        .and_then(collapse_preview)
 }
 
-fn extract_antigravity_brain_preview(path: &Path) -> io::Result<Option<String>> {
-    let text = read_tail_lossy(path)?;
-    for line in text.lines().rev() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || !trimmed.starts_with('{') {
-            continue;
-        }
-        let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+fn codex_response_output_preview(v: &serde_json::Value) -> Option<String> {
+    let arrays = [
+        v.pointer("/payload/response/output"),
+        v.pointer("/response_payload/output"),
+        v.pointer("/payload/output"),
+    ];
+    for arr in arrays.into_iter().flatten() {
+        let Some(items) = arr.as_array() else {
             continue;
         };
-        if v.get("type").and_then(|t| t.as_str()) != Some("PLANNER_RESPONSE") {
-            continue;
-        }
-        if let Some(text) = v.get("content").and_then(|t| t.as_str()) {
-            if let Some(p) = collapse_preview(text) {
-                return Ok(Some(p));
+        for item in items.iter().rev() {
+            let content = item.get("content").and_then(|c| c.as_array());
+            let Some(content) = content else { continue };
+            for c in content.iter().rev() {
+                if let Some(text) = c.get("text").and_then(|t| t.as_str()) {
+                    if let Some(p) = collapse_preview(text) {
+                        return Some(p);
+                    }
+                }
             }
         }
     }
-    Ok(None)
+    None
+}
+
+fn collapse_antigravity_user_preview(s: &str) -> Option<String> {
+    let content = extract_tagged_antigravity_user_request(s).unwrap_or(s);
+    collapse_preview(content)
+}
+
+fn extract_tagged_antigravity_user_request(s: &str) -> Option<&str> {
+    let start_tag = "<USER_REQUEST>";
+    let end_tag = "</USER_REQUEST>";
+    let start = s.find(start_tag)? + start_tag.len();
+    let rest = &s[start..];
+    let end = rest.find(end_tag).unwrap_or(rest.len());
+    Some(&rest[..end])
 }
 
 fn read_tail_lossy(path: &Path) -> io::Result<String> {
@@ -625,9 +705,77 @@ mod tests {
         )
         .unwrap();
 
-        let preview = extract_codex_preview(&path).unwrap();
+        let preview = extract_preview(AgentKind::Codex, &path).unwrap();
 
         assert_eq!(preview.as_deref(), Some("Here is the latest Codex answer."));
+    }
+
+    #[test]
+    fn claude_conversation_preview_reads_latest_user_and_assistant() {
+        let base = ScratchDir::new("claude-conversation-preview");
+        let path = base.path().join("transcript.jsonl");
+        fs::write(
+            &path,
+            r#"{"type":"user","message":{"content":[{"type":"text","text":"Please fix the failing tests."}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"I found the failing assertion."}]}}
+"#,
+        )
+        .unwrap();
+
+        let preview = extract_conversation_preview(AgentKind::Claude, &path).unwrap();
+
+        assert_eq!(
+            preview.last_user_message.as_deref(),
+            Some("Please fix the failing tests.")
+        );
+        assert_eq!(
+            preview.last_agent_message.as_deref(),
+            Some("I found the failing assertion.")
+        );
+    }
+
+    #[test]
+    fn codex_conversation_preview_reads_payload_roles() {
+        let base = ScratchDir::new("codex-conversation-preview");
+        let path = base.path().join("rollout.jsonl");
+        fs::write(
+            &path,
+            r#"{"type":"message","payload":{"role":"user","content":[{"type":"input_text","text":"Check the drawer regression."}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"The regression is in the popover target."}]}}
+"#,
+        )
+        .unwrap();
+
+        let preview = extract_conversation_preview(AgentKind::Codex, &path).unwrap();
+
+        assert_eq!(
+            preview.last_user_message.as_deref(),
+            Some("Check the drawer regression.")
+        );
+        assert_eq!(
+            preview.last_agent_message.as_deref(),
+            Some("The regression is in the popover target.")
+        );
+    }
+
+    #[test]
+    fn codex_conversation_preview_does_not_treat_user_message_as_agent() {
+        let base = ScratchDir::new("codex-user-message-preview");
+        let path = base.path().join("rollout.jsonl");
+        fs::write(
+            &path,
+            r#"{"type":"message","payload":{"role":"user","message":"Please inspect the popover."}}
+"#,
+        )
+        .unwrap();
+
+        let preview = extract_conversation_preview(AgentKind::Codex, &path).unwrap();
+
+        assert_eq!(
+            preview.last_user_message.as_deref(),
+            Some("Please inspect the popover.")
+        );
+        assert_eq!(preview.last_agent_message, None);
     }
 
     #[test]
@@ -642,11 +790,35 @@ mod tests {
         )
         .unwrap();
 
-        let preview = extract_antigravity_preview(&path).unwrap();
+        let preview = extract_preview(AgentKind::Antigravity, &path).unwrap();
 
         assert_eq!(
             preview.as_deref(),
             Some("Here is the latest Antigravity answer.")
+        );
+    }
+
+    #[test]
+    fn antigravity_conversation_preview_reads_user_request_tag() {
+        let base = ScratchDir::new("antigravity-conversation-preview");
+        let path = base.path().join("transcript.jsonl");
+        fs::write(
+            &path,
+            r#"{"type":"USER_INPUT","status":"DONE","content":"<USER_REQUEST>Make the board calmer.</USER_REQUEST>"}
+{"type":"PLANNER_RESPONSE","status":"DONE","content":"I will reduce the terminal surface."}
+"#,
+        )
+        .unwrap();
+
+        let preview = extract_conversation_preview(AgentKind::Antigravity, &path).unwrap();
+
+        assert_eq!(
+            preview.last_user_message.as_deref(),
+            Some("Make the board calmer.")
+        );
+        assert_eq!(
+            preview.last_agent_message.as_deref(),
+            Some("I will reduce the terminal surface.")
         );
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4901,6 +4901,12 @@ pub struct SessionStatusEntry {
     pub id: String,
     pub status: SessionStatus,
     pub status_reason: Option<SessionStatusReason>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_user_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_agent_message: Option<String>,
     pub agent_provider: Option<SessionAgentProvider>,
     pub agent_transcript_id: Option<String>,
     /// Current branch read live from the session's worktree on each poll.
@@ -4926,6 +4932,45 @@ pub struct SessionStatusEntry {
 /// transcript-less shells are left untouched.
 fn auto_title_promotion_needed(auto_title_enabled: Option<bool>, has_transcript: bool) -> bool {
     has_transcript && auto_title_enabled == Some(false)
+}
+
+fn chat_conversation_preview(
+    chat_state: &persistence::ChatSessionState,
+) -> agent_resume::ConversationPreview {
+    let mut preview = agent_resume::ConversationPreview::default();
+    for message in chat_state.messages.iter().rev() {
+        match message.role {
+            persistence::ChatRole::User if preview.last_user_message.is_none() => {
+                preview.last_user_message = collapse_status_preview(&message.content);
+            }
+            persistence::ChatRole::Assistant if preview.last_agent_message.is_none() => {
+                preview.last_agent_message = collapse_status_preview(&message.content);
+            }
+            _ => {}
+        }
+        if preview.last_user_message.is_some() && preview.last_agent_message.is_some() {
+            break;
+        }
+    }
+    preview
+}
+
+fn collapse_status_preview(s: &str) -> Option<String> {
+    const STATUS_PREVIEW_CHARS: usize = 90;
+    let collapsed = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() {
+        return None;
+    }
+    let truncated = collapsed
+        .chars()
+        .take(STATUS_PREVIEW_CHARS)
+        .collect::<String>();
+    let suffix = if collapsed.chars().count() > STATUS_PREVIEW_CHARS {
+        "…"
+    } else {
+        ""
+    };
+    Some(format!("{truncated}{suffix}"))
 }
 
 #[tauri::command]
@@ -5000,10 +5045,22 @@ fn detect_session_statuses_blocking(
                 let branch = session
                     .as_ref()
                     .and_then(|s| worktree::current_branch(&s.worktree_path).ok());
+                let conversation_preview = persistence::load_chat_session_state(&id)
+                    .ok()
+                    .map(|state| chat_conversation_preview(&state));
                 return SessionStatusEntry {
                     id,
                     status: previous,
                     status_reason: None,
+                    last_message: conversation_preview
+                        .as_ref()
+                        .and_then(|p| p.last_agent_message.clone()),
+                    last_user_message: conversation_preview
+                        .as_ref()
+                        .and_then(|p| p.last_user_message.clone()),
+                    last_agent_message: conversation_preview
+                        .as_ref()
+                        .and_then(|p| p.last_agent_message.clone()),
                     agent_provider: session.as_ref().and_then(|s| s.agent_provider),
                     agent_transcript_id: session
                         .as_ref()
@@ -5079,6 +5136,16 @@ fn detect_session_statuses_blocking(
                 }
                 None => None,
             };
+            let conversation_preview = transcript.as_ref().and_then(|(path, kind)| {
+                agent_resume::extract_conversation_preview(
+                    status_agent_kind_to_resume_kind(*kind),
+                    path,
+                )
+                .ok()
+            });
+            let transcript_preview = conversation_preview
+                .as_ref()
+                .and_then(|p| p.last_agent_message.clone());
             let shell_hint = refine_shell_hint_for_unpaired_agent(
                 shell_hint,
                 transcript.is_some(),
@@ -5133,6 +5200,13 @@ fn detect_session_statuses_blocking(
                 id,
                 status,
                 status_reason: detection.reason,
+                last_message: transcript_preview,
+                last_user_message: conversation_preview
+                    .as_ref()
+                    .and_then(|p| p.last_user_message.clone()),
+                last_agent_message: conversation_preview
+                    .as_ref()
+                    .and_then(|p| p.last_agent_message.clone()),
                 agent_provider,
                 agent_transcript_id,
                 branch,

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -412,6 +412,45 @@ describe("SettingsModal font controls", () => {
     });
   });
 
+  it("patches kanban terminal popover options from the Interface tab", async () => {
+    const patchInterface = vi.fn();
+    useSettings.setState({
+      open: true,
+      settings: cloneSettings(),
+      patchInterface,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openInterfaceTab();
+
+    const centerInput = document.querySelector<HTMLInputElement>(
+      'input[name="kanban-terminal-popover-placement"][value="center"]',
+    );
+    const fullscreenInput = document.querySelector<HTMLInputElement>(
+      'input[name="kanban-terminal-popover-default-size"][value="fullscreen"]',
+    );
+    if (!centerInput || !fullscreenInput) {
+      throw new Error("Kanban terminal popover settings not found");
+    }
+
+    act(() => {
+      centerInput.click();
+    });
+    act(() => {
+      fullscreenInput.click();
+    });
+
+    expect(patchInterface).toHaveBeenNthCalledWith(1, {
+      kanbanTerminalPopoverPlacement: "center",
+    });
+    expect(patchInterface).toHaveBeenNthCalledWith(2, {
+      kanbanTerminalPopoverDefaultSize: "fullscreen",
+    });
+  });
+
   afterEach(() => {
     if (root) {
       act(() => root?.unmount());

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -74,6 +74,8 @@ import {
   TERMINAL_LETTER_SPACING_MIN,
   TERMINAL_LETTER_SPACING_STEP,
   TOAST_POSITION_OPTIONS,
+  type KanbanTerminalPopoverDefaultSize,
+  type KanbanTerminalPopoverPlacement,
   type SelectedAgent,
   type SessionTitleSource,
   type AcornSettings,
@@ -1162,20 +1164,33 @@ function InterfaceSettings({ t }: { t: SettingsTranslator }) {
   const patchAppearance = useSettings((s) => s.patchAppearance);
 
   return (
-    <section className="space-y-4">
-      <LanguageSection
-        language={settings.language}
-        onChange={patchLanguage}
-        t={t}
-      />
-      <UiScaleSection
-        value={settings.appearance.uiScalePercent}
-        onChange={(uiScalePercent) => patchAppearance({ uiScalePercent })}
-      />
-      <DefaultWorkspaceViewModeSection
-        value={settings.interface.defaultWorkspaceViewMode}
-        onChange={(defaultWorkspaceViewMode) =>
-          patchInterface({ defaultWorkspaceViewMode })
+    <section className="space-y-6">
+      <div className="space-y-4">
+        <LanguageSection
+          language={settings.language}
+          onChange={patchLanguage}
+          t={t}
+        />
+        <UiScaleSection
+          value={settings.appearance.uiScalePercent}
+          onChange={(uiScalePercent) => patchAppearance({ uiScalePercent })}
+        />
+        <DefaultWorkspaceViewModeSection
+          value={settings.interface.defaultWorkspaceViewMode}
+          onChange={(defaultWorkspaceViewMode) =>
+            patchInterface({ defaultWorkspaceViewMode })
+          }
+          t={t}
+        />
+      </div>
+      <KanbanTerminalPopoverSettings
+        placement={settings.interface.kanbanTerminalPopoverPlacement}
+        defaultSize={settings.interface.kanbanTerminalPopoverDefaultSize}
+        onPlacementChange={(kanbanTerminalPopoverPlacement) =>
+          patchInterface({ kanbanTerminalPopoverPlacement })
+        }
+        onDefaultSizeChange={(kanbanTerminalPopoverDefaultSize) =>
+          patchInterface({ kanbanTerminalPopoverDefaultSize })
         }
         t={t}
       />
@@ -1227,6 +1242,115 @@ function DefaultWorkspaceViewModeSection({
         className="w-44"
       />
     </Field>
+  );
+}
+
+function KanbanTerminalPopoverSettings({
+  placement,
+  defaultSize,
+  onPlacementChange,
+  onDefaultSizeChange,
+  t,
+}: {
+  placement: KanbanTerminalPopoverPlacement;
+  defaultSize: KanbanTerminalPopoverDefaultSize;
+  onPlacementChange: (value: KanbanTerminalPopoverPlacement) => void;
+  onDefaultSizeChange: (value: KanbanTerminalPopoverDefaultSize) => void;
+  t: SettingsTranslator;
+}) {
+  return (
+    <SettingsGroup
+      title={st(t, "settings.interface.kanbanTerminalPopover.title")}
+      description={st(
+        t,
+        "settings.interface.kanbanTerminalPopover.description",
+      )}
+    >
+      <div className="space-y-4">
+        <Field
+          label={st(
+            t,
+            "settings.interface.kanbanTerminalPopover.placement.label",
+          )}
+          hint={st(
+            t,
+            "settings.interface.kanbanTerminalPopover.placement.hint",
+          )}
+        >
+          <div className="grid gap-1.5 sm:grid-cols-2">
+            <RadioCard<KanbanTerminalPopoverPlacement>
+              name="kanban-terminal-popover-placement"
+              value="card"
+              current={placement}
+              label={st(
+                t,
+                "settings.interface.kanbanTerminalPopover.placement.card.label",
+              )}
+              description={st(
+                t,
+                "settings.interface.kanbanTerminalPopover.placement.card.description",
+              )}
+              onSelect={onPlacementChange}
+            />
+            <RadioCard<KanbanTerminalPopoverPlacement>
+              name="kanban-terminal-popover-placement"
+              value="center"
+              current={placement}
+              label={st(
+                t,
+                "settings.interface.kanbanTerminalPopover.placement.center.label",
+              )}
+              description={st(
+                t,
+                "settings.interface.kanbanTerminalPopover.placement.center.description",
+              )}
+              onSelect={onPlacementChange}
+            />
+          </div>
+        </Field>
+        <Field
+          label={st(
+            t,
+            "settings.interface.kanbanTerminalPopover.defaultSize.label",
+          )}
+          hint={st(
+            t,
+            "settings.interface.kanbanTerminalPopover.defaultSize.hint",
+          )}
+        >
+          <div className="grid gap-1.5 sm:grid-cols-2">
+            <RadioCard<KanbanTerminalPopoverDefaultSize>
+              name="kanban-terminal-popover-default-size"
+              value="custom"
+              current={defaultSize}
+              label={st(
+                t,
+                "settings.interface.kanbanTerminalPopover.defaultSize.custom.label",
+              )}
+              description={st(
+                t,
+                "settings.interface.kanbanTerminalPopover.defaultSize.custom.description",
+              )}
+              onSelect={onDefaultSizeChange}
+            />
+            <RadioCard<KanbanTerminalPopoverDefaultSize>
+              name="kanban-terminal-popover-default-size"
+              value="fullscreen"
+              current={defaultSize}
+              label={st(
+                t,
+                "settings.interface.kanbanTerminalPopover.defaultSize.fullscreen.label",
+              )}
+              description={st(
+                t,
+                "settings.interface.kanbanTerminalPopover.defaultSize.fullscreen.description",
+              )}
+              onSelect={onDefaultSizeChange}
+            />
+          </div>
+        </Field>
+      </div>
+    </SettingsGroup>
   );
 }
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -115,6 +115,7 @@ interface TerminalProps {
    */
   isActive?: boolean;
   isFocusedPane?: boolean;
+  autoFocusOnActive?: boolean;
 }
 
 interface PtyOutputPayload {
@@ -558,6 +559,7 @@ export function Terminal({
   pasteAgentProvider = null,
   isActive = true,
   isFocusedPane = true,
+  autoFocusOnActive = false,
 }: TerminalProps): ReactElement {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<XTerm | null>(null);
@@ -2874,6 +2876,20 @@ export function Terminal({
     window.addEventListener("acorn:focus-session", handler);
     return () => window.removeEventListener("acorn:focus-session", handler);
   }, [sessionId]);
+
+  useEffect(() => {
+    if (!isActive || !autoFocusOnActive) return;
+    const focus = () => termRef.current?.focus();
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const frame = requestAnimationFrame(() => {
+      focus();
+      timeout = setTimeout(focus, 0);
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      if (timeout !== null) clearTimeout(timeout);
+    };
+  }, [autoFocusOnActive, isActive, sessionId]);
 
   // When this terminal is hidden behind another tab in the same pane and
   // then made visible again, the DOM renderer may not have repainted while

--- a/src/components/TerminalHost.test.tsx
+++ b/src/components/TerminalHost.test.tsx
@@ -26,14 +26,17 @@ vi.mock("./Terminal", async () => {
     Terminal: ({
       sessionId,
       isActive,
+      autoFocusOnActive,
     }: {
       sessionId: string;
       isActive?: boolean;
+      autoFocusOnActive?: boolean;
     }) =>
       React.createElement("div", {
         "data-testid": "terminal",
         "data-session-id": sessionId,
         "data-active": String(Boolean(isActive)),
+        "data-auto-focus-on-active": String(Boolean(autoFocusOnActive)),
       }),
   };
 });
@@ -317,11 +320,11 @@ describe("TerminalHost", () => {
     ]);
   });
 
-  it("moves a popup terminal into the popup body without changing pane selection", async () => {
+  it("moves a popover terminal into the popover body without changing pane selection", async () => {
     installWorkspaceSessions(["first", "second"]);
-    const popupBody = document.createElement("div");
-    popupBody.dataset.terminalPopupBody = "second";
-    document.body.appendChild(popupBody);
+    const popoverBody = document.createElement("div");
+    popoverBody.dataset.terminalPopoverBody = "second";
+    document.body.appendChild(popoverBody);
 
     render();
     await act(async () => {
@@ -335,13 +338,23 @@ describe("TerminalHost", () => {
       { id: "second", active: true },
     ]);
     expect(
-      popupBody.querySelector(
+      popoverBody.querySelector(
         '[data-acorn-terminal-slot="second"] [data-testid="terminal"]',
       ),
     ).not.toBeNull();
+    expect(
+      popoverBody.querySelector<HTMLElement>(
+        '[data-acorn-terminal-slot="second"] [data-testid="terminal"]',
+      )?.dataset.autoFocusOnActive,
+    ).toBe("true");
+    expect(
+      document.querySelector<HTMLElement>(
+        '[data-acorn-terminal-slot="first"] [data-testid="terminal"]',
+      )?.dataset.autoFocusOnActive,
+    ).toBe("false");
     expect(useAppStore.getState().activeSessionId).toBe("first");
 
-    popupBody.remove();
+    popoverBody.remove();
   });
 
   it("uses the configured resident terminal limit when evicting idle daemon terminals", async () => {

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -182,7 +182,7 @@ function visibleTerminalTargetKey(
   sessionId: string,
 ): string | null {
   if (state.terminalPopupSessionId === sessionId) {
-    return `popup:${sessionId}`;
+    return `popover:${sessionId}`;
   }
   const workspaceId = activeWorkspaceId(state);
   if (!workspaceId) return null;
@@ -198,10 +198,10 @@ function terminalDestinationForTargetKey(
   targetKey: string | null,
 ): HTMLElement | null {
   if (!targetKey) return null;
-  if (targetKey.startsWith("popup:")) {
-    const sessionId = targetKey.slice("popup:".length);
+  if (targetKey.startsWith("popover:")) {
+    const sessionId = targetKey.slice("popover:".length);
     return document.querySelector(
-      `[data-terminal-popup-body="${cssEscape(sessionId)}"]`,
+      `[data-terminal-popover-body="${cssEscape(sessionId)}"]`,
     ) as HTMLElement | null;
   }
   if (targetKey.startsWith("pane:")) {
@@ -213,8 +213,8 @@ function terminalDestinationForTargetKey(
   return null;
 }
 
-function terminalTargetIsPopup(targetKey: string | null): boolean {
-  return Boolean(targetKey?.startsWith("popup:"));
+function terminalTargetIsPopover(targetKey: string | null): boolean {
+  return Boolean(targetKey?.startsWith("popover:"));
 }
 
 function parseSessionIdKey(key: string): Set<string> {
@@ -248,7 +248,7 @@ function PortaledTerminal({ session }: { session: Session }) {
       : null,
   );
   const isFocusedPane = useAppStore((state) =>
-    terminalTargetIsPopup(visibleTargetKey)
+    terminalTargetIsPopover(visibleTargetKey)
       ? true
       : isSessionInFocusedPane(session.id, state.panes, state.focusedPaneId),
   );
@@ -271,8 +271,8 @@ function PortaledTerminal({ session }: { session: Session }) {
   }, []);
 
   // Whenever the visible target changes, move our target div into that pane,
-  // popup body, or back to limbo. Popup bodies are rendered through a Modal
-  // portal, so keep looking briefly if the target has not landed yet.
+  // popover body, or back to limbo. Keep looking briefly if the target has not
+  // landed in the DOM yet.
   useLayoutEffect(() => {
     const target = targetRef.current;
     if (!target) return;
@@ -284,7 +284,7 @@ function PortaledTerminal({ session }: { session: Session }) {
       if (target.parentElement !== nextParent) nextParent.appendChild(target);
       if (
         dest === null &&
-        terminalTargetIsPopup(visibleTargetKey) &&
+        terminalTargetIsPopover(visibleTargetKey) &&
         attempts < 30
       ) {
         attempts += 1;
@@ -309,6 +309,7 @@ function PortaledTerminal({ session }: { session: Session }) {
       pasteAgentProvider={session.agent_provider ?? null}
       isActive={visibleTargetKey !== null}
       isFocusedPane={isFocusedPane}
+      autoFocusOnActive={terminalTargetIsPopover(visibleTargetKey)}
     />,
     targetRef.current,
   );

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -55,6 +55,16 @@ describe("Tooltip", () => {
     });
   }
 
+  function contextMenuTrigger() {
+    const trigger = container.querySelector("button");
+    if (!trigger) throw new Error("trigger not found");
+    act(() => {
+      trigger.dispatchEvent(
+        new MouseEvent("contextmenu", { bubbles: true, cancelable: true }),
+      );
+    });
+  }
+
   function tooltip() {
     return document.body.querySelector('[role="tooltip"]');
   }
@@ -90,5 +100,31 @@ describe("Tooltip", () => {
     act(() => vi.advanceTimersByTime(1));
 
     expect(tooltip()).toBeNull();
+  });
+
+  it("cancels a pending hover tooltip when the context menu opens", () => {
+    renderTooltip(500);
+    hoverTrigger();
+
+    act(() => vi.advanceTimersByTime(250));
+    contextMenuTrigger();
+    act(() => vi.advanceTimersByTime(250));
+
+    expect(tooltip()).toBeNull();
+  });
+
+  it("uses a block-level multiline surface so long content can wrap", () => {
+    act(() => {
+      root.render(
+        <Tooltip label="very/long/path/that/should/wrap" delay={0} multiline>
+          <button type="button">Trigger</button>
+        </Tooltip>,
+      );
+    });
+    hoverTrigger();
+    act(() => vi.advanceTimersByTime(0));
+
+    expect(tooltip()?.className).toContain("inline-block");
+    expect(tooltip()?.className).toContain("max-w-[min(34rem,calc(100vw-1rem))]");
   });
 });

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -178,8 +178,8 @@ export function FloatingTooltip({
       }}
       className={`${
         multiline
-          ? "pointer-events-none max-w-xs whitespace-pre-line break-words rounded border border-border bg-bg-elevated px-2 py-1 text-[11px] font-normal leading-snug text-fg shadow-md"
-          : "pointer-events-none whitespace-nowrap rounded border border-border bg-bg-elevated px-2 py-0.5 text-[11px] font-normal text-fg shadow-md"
+          ? "pointer-events-none inline-block max-w-[min(34rem,calc(100vw-1rem))] whitespace-pre-line break-words rounded border border-border bg-bg-elevated px-2 py-1 text-[11px] font-normal leading-snug text-fg shadow-md"
+          : "pointer-events-none inline-block whitespace-nowrap rounded border border-border bg-bg-elevated px-2 py-0.5 text-[11px] font-normal text-fg shadow-md"
       } ${overlayClassName ?? ""}`}
     >
       {label}
@@ -242,7 +242,9 @@ export function Tooltip({
         onMouseLeave={hide}
         onFocus={show}
         onBlur={hide}
+        onPointerDown={hide}
         onClick={hide}
+        onContextMenu={hide}
         draggable={draggable || undefined}
         style={
           draggable

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -1,26 +1,33 @@
 import {
   Fragment,
+  useCallback,
   useEffect,
-  useId,
+  useLayoutEffect,
   useMemo,
+  useRef,
   useState,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import {
   BarChart3,
   Bot,
   ChevronDown,
-  CheckCircle2,
   Columns3,
   Copy,
   FolderOpen,
   GitBranch,
+  Maximize2,
   MessageSquareText,
+  Minimize2,
   PencilLine,
   Plus,
   RotateCcw,
   Search,
+  Tag,
   Terminal as TerminalIcon,
   Trash2,
   X,
@@ -41,7 +48,6 @@ import {
   AgentProviderIcon,
   resolveSessionAgentProvider,
 } from "../lib/agentProvider";
-import { useDialogShortcuts } from "../lib/dialog";
 import { useSettings } from "../lib/settings";
 import { useTranslation } from "../lib/useTranslation";
 import {
@@ -63,7 +69,7 @@ import {
   useAppStore,
   type WorkspaceViewMode,
 } from "../store";
-import { IconButton, Modal, StatusDot, type StatusTone } from "./ui";
+import { IconButton, StatusDot, type StatusTone } from "./ui";
 import { ChatPane } from "./ChatPane";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { LayoutRenderer } from "./LayoutRenderer";
@@ -101,6 +107,24 @@ type WorkspaceKanbanContextGroup = "session" | "open" | "copy" | "danger";
 
 const KANBAN_COLUMN_GAP_PX = 6;
 const KANBAN_BOARD_PADDING_X_PX = 16;
+const KANBAN_TERMINAL_POPOVER_DEFAULT_WIDTH_PX = 560;
+const KANBAN_TERMINAL_POPOVER_DEFAULT_HEIGHT_PX = 420;
+const KANBAN_TERMINAL_POPOVER_MIN_WIDTH_PX = 360;
+const KANBAN_TERMINAL_POPOVER_MIN_HEIGHT_PX = 260;
+const KANBAN_TERMINAL_POPOVER_SIZE_STORAGE_KEY =
+  "acorn:kanban-terminal-popover-size";
+const KANBAN_TERMINAL_POPOVER_GAP_PX = 8;
+const KANBAN_TERMINAL_POPOVER_MARGIN_PX = 8;
+
+interface KanbanTerminalPopoverSize {
+  width: number;
+  height: number;
+}
+
+interface KanbanTerminalPopoverPosition {
+  left: number;
+  top: number;
+}
 
 interface WorkspaceMainProps {
   layout: LayoutNode;
@@ -109,9 +133,28 @@ interface WorkspaceMainProps {
 
 export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
   const isKanban = viewMode === "kanban";
+  const closeTerminalPopup = useAppStore((s) => s.closeTerminalPopup);
+  const activeWorkspaceId = useAppStore(
+    (s) => s.activeProjectFolderId ?? s.activeProject,
+  );
+
+  useEffect(() => {
+    if (!isKanban) closeTerminalPopup();
+  }, [closeTerminalPopup, isKanban]);
+
+  useEffect(() => {
+    closeTerminalPopup();
+  }, [activeWorkspaceId, closeTerminalPopup]);
+
   return (
-    <div className="h-full min-w-0" data-workspace-main>
-      {isKanban ? <WorkspaceKanbanBoard /> : null}
+    <div className="h-full min-w-0 overflow-hidden" data-workspace-main>
+      {isKanban ? (
+        <div className="flex h-full min-w-0 flex-col overflow-hidden">
+          <div className="min-h-0 min-w-0 flex-1">
+            <WorkspaceKanbanBoard />
+          </div>
+        </div>
+      ) : null}
       {/*
         Keep the pane layout mounted (hidden) in kanban mode instead of
         unmounting it. TerminalHost appendChild's each live terminal's target
@@ -122,7 +165,6 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
       <div className={cn("h-full min-w-0", isKanban && "hidden")}>
         <LayoutRenderer node={layout} />
       </div>
-      <WorkspaceSessionPopup />
     </div>
   );
 }
@@ -140,10 +182,16 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
   const t = useTranslation();
   const panes = useAppStore((s) => s.panes);
   const sessionsById = useAppStore(selectSessionsById);
+  const selectSession = useAppStore((s) => s.selectSession);
   const openTerminalPopup = useAppStore((s) => s.openTerminalPopup);
+  const closeTerminalPopup = useAppStore((s) => s.closeTerminalPopup);
   const [prefs, setPrefs] = useState<KanbanBoardPrefs>(() =>
     readKanbanBoardPrefs(projectId),
   );
+  const [terminalPopover, setTerminalPopover] = useState<{
+    sessionId: string;
+    anchor: HTMLElement;
+  } | null>(null);
   const { filterQuery, sortMode, columnWidths } = prefs;
   const [resizingColumnIndex, setResizingColumnIndex] = useState<number | null>(
     null,
@@ -191,6 +239,9 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
       KANBAN_BOARD_PADDING_X_PX,
     [columnWidths],
   );
+  const terminalPopoverSession = terminalPopover
+    ? sessionsById.get(terminalPopover.sessionId) ?? null
+    : null;
 
   // Persist board prefs per project. projectId is fixed for this instance (the
   // wrapper remounts via key on project switch), so a board can never write one
@@ -198,6 +249,12 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
   useEffect(() => {
     writeKanbanBoardPrefs(projectId, prefs);
   }, [projectId, prefs]);
+
+  useEffect(() => {
+    if (!terminalPopover) return;
+    if (sessionsById.has(terminalPopover.sessionId)) return;
+    closeTerminalPopover();
+  }, [terminalPopover, sessionsById]);
 
   function setFilterQuery(filterQuery: string) {
     setPrefs((current) => ({ ...current, filterQuery }));
@@ -217,8 +274,10 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
     }));
   }
 
-  function openSession(id: string) {
+  function openSessionTerminal(id: string, anchor: HTMLElement) {
+    selectSession(id);
     openTerminalPopup(id);
+    setTerminalPopover({ sessionId: id, anchor });
     if (typeof window !== "undefined") {
       requestAnimationFrame(() => {
         window.dispatchEvent(
@@ -228,6 +287,11 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
         );
       });
     }
+  }
+
+  function closeTerminalPopover() {
+    closeTerminalPopup();
+    setTerminalPopover(null);
   }
 
   function resizeColumn(index: number, nextWidth: number) {
@@ -348,7 +412,9 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
                           <KanbanSessionCard
                             key={session.id}
                             session={session}
-                            onOpen={() => openSession(session.id)}
+                            onOpen={(anchor) =>
+                              openSessionTerminal(session.id, anchor)
+                            }
                           />
                         ))
                       ) : (
@@ -404,6 +470,13 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
           })}
         </div>
       </div>
+      {terminalPopoverSession && terminalPopover ? (
+        <KanbanTerminalPopover
+          session={terminalPopoverSession}
+          anchor={terminalPopover.anchor}
+          onClose={closeTerminalPopover}
+        />
+      ) : null}
     </div>
   );
 }
@@ -599,11 +672,13 @@ function KanbanSessionCard({
   onOpen,
 }: {
   session: Session;
-  onOpen: () => void;
+  onOpen: (anchor: HTMLElement) => void;
 }) {
   const t = useTranslation();
   const worktreeName = basename(session.worktree_path);
-  const statusTone = STATUS_TONE[session.status];
+  const branchName = session.branch?.trim();
+  const lastMessage =
+    session.last_agent_message?.trim() || session.last_message?.trim();
   const selectSession = useAppStore((s) => s.selectSession);
   const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
   const setWorkspaceViewMode = useAppStore((s) => s.setWorkspaceViewMode);
@@ -622,6 +697,26 @@ function KanbanSessionCard({
     "{name}",
     session.name,
   );
+  function openContextMenu(x: number, y: number) {
+    setMenu({ x, y });
+  }
+
+  function handleContextMenu(event: ReactMouseEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    openContextMenu(event.clientX, event.clientY);
+  }
+
+  function handlePointerDown(event: ReactPointerEvent) {
+    if (event.button !== 2) return;
+    event.preventDefault();
+    openContextMenu(event.clientX, event.clientY);
+  }
+
+  function handleOpen(event: ReactMouseEvent<HTMLButtonElement>) {
+    onOpen(event.currentTarget);
+  }
+
   const sessionMenuItems = useMemo<ContextMenuItem[]>(
     () => [
       workspaceContextMenuGroupTitle(t, "session"),
@@ -633,7 +728,12 @@ function KanbanSessionCard({
           ) : (
             <TerminalIcon size={12} />
           ),
-        onClick: onOpen,
+        onClick: () => {
+          const anchor = document.querySelector<HTMLElement>(
+            `[data-kanban-session-id="${cssAttributeEscape(session.id)}"]`,
+          );
+          if (anchor) onOpen(anchor);
+        },
       },
       {
         label: sidebarText(t, "sidebar.actions.openWorkSummary"),
@@ -738,8 +838,18 @@ function KanbanSessionCard({
   return (
     <>
       <Tooltip
-        label={session.worktree_path}
+        label={
+          <KanbanSessionCardTooltip
+            t={t}
+            title={session.name}
+            lastMessage={lastMessage}
+            branch={branchName}
+            worktreeName={worktreeName}
+            worktreePath={session.worktree_path}
+          />
+        }
         side="right"
+        delay={350}
         multiline
         className="flex w-full"
       >
@@ -747,12 +857,9 @@ function KanbanSessionCard({
           type="button"
           data-testid="workspace-kanban-card"
           data-kanban-session-id={session.id}
-          onClick={onOpen}
-          onContextMenu={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            setMenu({ x: event.clientX, y: event.clientY });
-          }}
+          onClick={handleOpen}
+          onPointerDown={handlePointerDown}
+          onContextMenu={handleContextMenu}
           className="group flex w-full flex-col gap-2 rounded-md border border-border bg-bg-elevated/45 p-2 text-left transition hover:border-accent/45 hover:bg-bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
           aria-label={openLabel}
         >
@@ -762,36 +869,46 @@ function KanbanSessionCard({
               <span className="block truncate text-[12px] font-medium leading-5 text-fg">
                 {session.name}
               </span>
-              <span className="block truncate text-[11px] leading-4 text-fg-muted">
-                {worktreeName}
-              </span>
             </span>
           </span>
-          <span className="flex min-w-0 items-center gap-1.5 text-[10px] leading-none text-fg-muted">
-            <StatusDot
-              tone={statusTone}
-              pulse={session.status === "running"}
-              size="xs"
-            />
-            <span className="truncate">{statusLabel(t, session.status)}</span>
-            {session.branch ? (
+          {lastMessage ? (
+            <span
+              className="line-clamp-2 text-[11px] leading-4 text-fg-muted"
+              data-testid="workspace-kanban-card-last-message"
+            >
+              {lastMessage}
+            </span>
+          ) : null}
+          <span
+            className="flex min-w-0 items-center gap-1.5 text-[10px] leading-none text-fg-muted"
+            data-testid="workspace-kanban-card-meta"
+          >
+            {branchName ? (
               <>
-                <span className="text-fg-muted/45">|</span>
                 <GitBranch size={10} className="shrink-0" />
-                <span className="min-w-0 truncate">{session.branch}</span>
+                <span
+                  className="min-w-0 truncate"
+                  data-testid="workspace-kanban-card-branch"
+                >
+                  {branchName}
+                </span>
               </>
             ) : null}
+            {branchName ? (
+              <span className="text-fg-muted/45">|</span>
+            ) : null}
+            <FolderOpen size={10} className="shrink-0" />
+            <span
+              className="min-w-0 truncate"
+              data-testid="workspace-kanban-card-worktree"
+            >
+              {worktreeName}
+            </span>
             {session.kind === "control" ? (
               <>
                 <span className="text-fg-muted/45">|</span>
                 <Bot size={10} className="shrink-0 text-accent" />
               </>
-            ) : null}
-            {session.status === "completed" ? (
-              <CheckCircle2
-                size={10}
-                className="ml-auto shrink-0 text-accent"
-              />
             ) : null}
           </span>
         </button>
@@ -807,6 +924,562 @@ function KanbanSessionCard({
   );
 }
 
+function KanbanTerminalPopover({
+  session,
+  anchor,
+  onClose,
+}: {
+  session: Session;
+  anchor: HTMLElement;
+  onClose: () => void;
+}) {
+  const t = useTranslation();
+  const popoverPlacement = useSettings(
+    (s) => s.settings.interface.kanbanTerminalPopoverPlacement,
+  );
+  const popoverDefaultSize = useSettings(
+    (s) => s.settings.interface.kanbanTerminalPopoverDefaultSize,
+  );
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] =
+    useState<KanbanTerminalPopoverPosition | null>(null);
+  const [size, setSize] = useState<KanbanTerminalPopoverSize>(() =>
+    readKanbanTerminalPopoverSize(),
+  );
+  const [isExpanded, setIsExpanded] = useState(
+    () => popoverDefaultSize === "fullscreen",
+  );
+  const positionRef = useRef<KanbanTerminalPopoverPosition | null>(null);
+  const sizeRef = useRef(size);
+  const hasManualPositionRef = useRef(false);
+
+  const worktreeName = basename(session.worktree_path);
+  const title = cleanWorkspaceSessionTerminalPopoverTitle(session.name);
+  const statusTone = STATUS_TONE[session.status];
+  const isChat = session.mode === "chat";
+
+  const updatePosition = useCallback(() => {
+    const margin = KANBAN_TERMINAL_POPOVER_MARGIN_PX;
+    if (isExpanded) {
+      return;
+    }
+
+    const rect = anchor.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const popoverSize = clampKanbanTerminalPopoverSize(sizeRef.current);
+    const { width, height } = popoverSize;
+    if (hasManualPositionRef.current) {
+      const currentPosition =
+        positionRef.current ??
+        (popoverRef.current
+          ? {
+              left: popoverRef.current.getBoundingClientRect().left,
+              top: popoverRef.current.getBoundingClientRect().top,
+            }
+          : { left: margin, top: margin });
+      const nextPosition = clampKanbanTerminalPopoverPosition(
+        currentPosition,
+        popoverSize,
+      );
+      positionRef.current = nextPosition;
+      setPosition(nextPosition);
+      return;
+    }
+
+    if (popoverPlacement === "center") {
+      const nextPosition = clampKanbanTerminalPopoverPosition(
+        {
+          left: (viewportWidth - width) / 2,
+          top: (viewportHeight - height) / 2,
+        },
+        popoverSize,
+      );
+      positionRef.current = nextPosition;
+      setPosition(nextPosition);
+      return;
+    }
+
+    const gap = KANBAN_TERMINAL_POPOVER_GAP_PX;
+    let left = rect.right + gap;
+    if (left + width > viewportWidth - margin) {
+      left = rect.left - width - gap;
+    }
+    if (left < margin) {
+      left = Math.min(Math.max(margin, rect.left), viewportWidth - width - margin);
+    }
+    let top = rect.top;
+    if (top + height > viewportHeight - margin) {
+      top = viewportHeight - height - margin;
+    }
+    top = Math.max(margin, top);
+    const nextPosition = { left, top };
+    positionRef.current = nextPosition;
+    setPosition(nextPosition);
+  }, [anchor, isExpanded, popoverPlacement]);
+
+  useEffect(() => {
+    sizeRef.current = size;
+  }, [size]);
+
+  useLayoutEffect(() => {
+    hasManualPositionRef.current = false;
+  }, [anchor, session.id]);
+
+  useLayoutEffect(() => {
+    const onUpdate = () => {
+      if (!isExpanded) {
+        const nextSize = clampKanbanTerminalPopoverSize(sizeRef.current);
+        if (
+          nextSize.width !== sizeRef.current.width ||
+          nextSize.height !== sizeRef.current.height
+        ) {
+          sizeRef.current = nextSize;
+          setSize(nextSize);
+        }
+      }
+      updatePosition();
+    };
+    onUpdate();
+    window.addEventListener("resize", onUpdate);
+    window.addEventListener("scroll", onUpdate, true);
+    return () => {
+      window.removeEventListener("resize", onUpdate);
+      window.removeEventListener("scroll", onUpdate, true);
+    };
+  }, [isExpanded, updatePosition]);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(updatePosition);
+    return () => cancelAnimationFrame(frame);
+  }, [isExpanded, session.id, updatePosition]);
+
+  useEffect(() => {
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (popoverRef.current?.contains(target)) return;
+      if (anchor.contains(target)) return;
+      onClose();
+    };
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+    };
+  }, [anchor, onClose]);
+
+  function startDrag(event: ReactPointerEvent<HTMLElement>) {
+    if (isExpanded || event.button !== 0) return;
+    const target = event.target;
+    if (
+      target instanceof Element &&
+      target.closest("button,a,input,textarea,select")
+    ) {
+      return;
+    }
+    const popoverRect = popoverRef.current?.getBoundingClientRect();
+    if (!popoverRect) return;
+    event.preventDefault();
+    event.stopPropagation();
+
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const startPosition = {
+      left: popoverRect.left,
+      top: popoverRect.top,
+    };
+    const dragSize = {
+      width: popoverRect.width,
+      height: popoverRect.height,
+    };
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    let didMove = false;
+
+    document.body.style.cursor = "move";
+    document.body.style.userSelect = "none";
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const deltaX = moveEvent.clientX - startX;
+      const deltaY = moveEvent.clientY - startY;
+      if (!didMove && Math.abs(deltaX) + Math.abs(deltaY) < 3) return;
+      didMove = true;
+      hasManualPositionRef.current = true;
+      const nextPosition = clampKanbanTerminalPopoverPosition(
+        {
+          left: startPosition.left + deltaX,
+          top: startPosition.top + deltaY,
+        },
+        dragSize,
+      );
+      positionRef.current = nextPosition;
+      setPosition(nextPosition);
+    };
+
+    const stopDrag = () => {
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", stopDrag);
+      window.removeEventListener("pointercancel", stopDrag);
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", stopDrag);
+    window.addEventListener("pointercancel", stopDrag);
+  }
+
+  function startResize(event: ReactPointerEvent<HTMLButtonElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const startSize = sizeRef.current;
+    const popoverRect = popoverRef.current?.getBoundingClientRect();
+    const origin = {
+      left:
+        popoverRect?.left ??
+        position?.left ??
+        KANBAN_TERMINAL_POPOVER_MARGIN_PX,
+      top:
+        popoverRect?.top ?? position?.top ?? KANBAN_TERMINAL_POPOVER_MARGIN_PX,
+    };
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    let latestSize = startSize;
+
+    document.body.style.cursor = "nwse-resize";
+    document.body.style.userSelect = "none";
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const nextSize = clampKanbanTerminalPopoverSize(
+        {
+          width: startSize.width + moveEvent.clientX - startX,
+          height: startSize.height + moveEvent.clientY - startY,
+        },
+        origin,
+      );
+      latestSize = nextSize;
+      sizeRef.current = nextSize;
+      setSize(nextSize);
+    };
+
+    const stopResize = () => {
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", stopResize);
+      window.removeEventListener("pointercancel", stopResize);
+      writeKanbanTerminalPopoverSize(latestSize);
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", stopResize);
+    window.addEventListener("pointercancel", stopResize);
+  }
+
+  const popoverStyle: CSSProperties = isExpanded
+    ? {
+        position: "fixed",
+        width: `calc(100vw - ${KANBAN_TERMINAL_POPOVER_MARGIN_PX * 2}px)`,
+        height: `calc(100vh - ${KANBAN_TERMINAL_POPOVER_MARGIN_PX * 2}px)`,
+        left: KANBAN_TERMINAL_POPOVER_MARGIN_PX,
+        top: KANBAN_TERMINAL_POPOVER_MARGIN_PX,
+        visibility: "visible",
+      }
+    : {
+        position: "fixed",
+        width: size.width,
+        height: size.height,
+        left: position?.left ?? -9999,
+        top: position?.top ?? -9999,
+        visibility: position ? "visible" : "hidden",
+      };
+
+  const popover = (
+    <div
+      ref={popoverRef}
+      role="dialog"
+      aria-label={t("workspace.kanban.terminalPopover.ariaLabel")}
+      data-testid="kanban-terminal-popover"
+      className="relative z-50 flex min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-bg-elevated shadow-2xl shadow-black/35"
+      style={popoverStyle}
+    >
+      <header
+        data-testid="kanban-terminal-popover-drag-handle"
+        onPointerDown={startDrag}
+        className={cn(
+          "shrink-0 border-b border-border px-3 py-2.5",
+          !isExpanded && "cursor-move select-none",
+        )}
+      >
+        <div className="flex min-w-0 items-start gap-2">
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border bg-bg shadow-sm">
+            <WorkspaceSessionIcon session={session} scope="console" size="md" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <h3 className="truncate text-sm font-semibold text-fg">{title}</h3>
+            <div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden text-[11px] font-medium leading-4 text-fg-muted">
+              <WorkspaceSessionTerminalPopoverMetaItem
+                icon={
+                  <StatusDot
+                    tone={statusTone}
+                    pulse={session.status === "running"}
+                    size="xs"
+                  />
+                }
+              >
+                {statusLabel(t, session.status)}
+              </WorkspaceSessionTerminalPopoverMetaItem>
+              {session.branch ? (
+                <WorkspaceSessionTerminalPopoverMetaItem icon={<GitBranch size={11} />}>
+                  {session.branch}
+                </WorkspaceSessionTerminalPopoverMetaItem>
+              ) : null}
+              <WorkspaceSessionTerminalPopoverMetaItem
+                icon={<FolderOpen size={11} />}
+                title={session.worktree_path}
+              >
+                {worktreeName}
+              </WorkspaceSessionTerminalPopoverMetaItem>
+            </div>
+          </div>
+          <IconButton
+            aria-label={t(
+              isExpanded
+                ? "workspace.kanban.terminalPopover.restore"
+                : "workspace.kanban.terminalPopover.expand",
+            )}
+            data-testid="kanban-terminal-popover-expand"
+            onClick={() => setIsExpanded((current) => !current)}
+            size="sm"
+            surface="panel"
+          >
+            {isExpanded ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+          </IconButton>
+          <IconButton
+            aria-label={t("dialogs.common.close")}
+            onClick={onClose}
+            size="sm"
+            surface="panel"
+          >
+            <X size={14} />
+          </IconButton>
+        </div>
+      </header>
+      <div className="min-h-0 flex-1 bg-bg p-2">
+        {isChat ? (
+          <div
+            className="relative h-full min-h-0 overflow-hidden rounded-md border border-border bg-bg shadow-inner"
+            data-testid="chat-popover-body"
+          >
+            <ChatPane
+              sessionId={session.id}
+              isActive
+              repoPath={session.worktree_path}
+              session={session}
+            />
+          </div>
+        ) : (
+          <div
+            className="relative h-full min-h-0 w-full overflow-hidden rounded-md border border-border bg-bg shadow-inner"
+            data-terminal-popover-body={session.id}
+            data-testid="terminal-popover-body"
+          />
+        )}
+      </div>
+      {isExpanded ? null : (
+        <button
+          type="button"
+          aria-label={t("workspace.kanban.terminalPopover.resize")}
+          data-testid="kanban-terminal-popover-resize"
+          onPointerDown={startResize}
+          className="absolute bottom-0 right-0 z-10 flex size-5 cursor-nwse-resize items-end justify-end rounded-tl-md text-fg-muted/70 transition hover:bg-bg-elevated hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/45"
+        >
+          <span
+            aria-hidden="true"
+            className="mb-1 mr-1 block size-2.5 border-b border-r border-current"
+          />
+        </button>
+      )}
+    </div>
+  );
+
+  return createPortal(popover, document.body);
+}
+
+function defaultKanbanTerminalPopoverSize(): KanbanTerminalPopoverSize {
+  return {
+    width: KANBAN_TERMINAL_POPOVER_DEFAULT_WIDTH_PX,
+    height: KANBAN_TERMINAL_POPOVER_DEFAULT_HEIGHT_PX,
+  };
+}
+
+function clampKanbanTerminalPopoverPosition(
+  position: KanbanTerminalPopoverPosition,
+  size: KanbanTerminalPopoverSize,
+): KanbanTerminalPopoverPosition {
+  if (typeof window === "undefined") return position;
+  const margin = KANBAN_TERMINAL_POPOVER_MARGIN_PX;
+  const maxLeft = Math.max(margin, window.innerWidth - size.width - margin);
+  const maxTop = Math.max(margin, window.innerHeight - size.height - margin);
+  return {
+    left: Math.round(Math.min(Math.max(position.left, margin), maxLeft)),
+    top: Math.round(Math.min(Math.max(position.top, margin), maxTop)),
+  };
+}
+
+function clampKanbanTerminalPopoverSize(
+  size: KanbanTerminalPopoverSize,
+  origin?: { left: number; top: number },
+): KanbanTerminalPopoverSize {
+  if (typeof window === "undefined") return size;
+  const margin = KANBAN_TERMINAL_POPOVER_MARGIN_PX;
+  const maxWidth = Math.max(
+    240,
+    window.innerWidth - (origin?.left ?? margin) - margin,
+  );
+  const maxHeight = Math.max(
+    180,
+    window.innerHeight - (origin?.top ?? margin) - margin,
+  );
+  const minWidth = Math.min(KANBAN_TERMINAL_POPOVER_MIN_WIDTH_PX, maxWidth);
+  const minHeight = Math.min(KANBAN_TERMINAL_POPOVER_MIN_HEIGHT_PX, maxHeight);
+  const width = Number.isFinite(size.width)
+    ? size.width
+    : KANBAN_TERMINAL_POPOVER_DEFAULT_WIDTH_PX;
+  const height = Number.isFinite(size.height)
+    ? size.height
+    : KANBAN_TERMINAL_POPOVER_DEFAULT_HEIGHT_PX;
+  return {
+    width: Math.round(Math.min(Math.max(width, minWidth), maxWidth)),
+    height: Math.round(Math.min(Math.max(height, minHeight), maxHeight)),
+  };
+}
+
+function readKanbanTerminalPopoverSize(): KanbanTerminalPopoverSize {
+  const fallback = defaultKanbanTerminalPopoverSize();
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = window.localStorage.getItem(
+      KANBAN_TERMINAL_POPOVER_SIZE_STORAGE_KEY,
+    );
+    if (!raw) return clampKanbanTerminalPopoverSize(fallback);
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") {
+      return clampKanbanTerminalPopoverSize(fallback);
+    }
+    const stored = parsed as Partial<KanbanTerminalPopoverSize>;
+    return clampKanbanTerminalPopoverSize({
+      width:
+        typeof stored.width === "number" && Number.isFinite(stored.width)
+          ? stored.width
+          : fallback.width,
+      height:
+        typeof stored.height === "number" && Number.isFinite(stored.height)
+          ? stored.height
+          : fallback.height,
+    });
+  } catch {
+    return clampKanbanTerminalPopoverSize(fallback);
+  }
+}
+
+function writeKanbanTerminalPopoverSize(
+  size: KanbanTerminalPopoverSize,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      KANBAN_TERMINAL_POPOVER_SIZE_STORAGE_KEY,
+      JSON.stringify(clampKanbanTerminalPopoverSize(size)),
+    );
+  } catch {
+    // Ignore storage failures; resizing should still work for the open popover.
+  }
+}
+
+function KanbanSessionCardTooltip({
+  t,
+  title,
+  lastMessage,
+  branch,
+  worktreeName,
+  worktreePath,
+}: {
+  t: Translator;
+  title: string;
+  lastMessage?: string;
+  branch?: string;
+  worktreeName: string;
+  worktreePath: string;
+}) {
+  const detached = t("workspace.kanban.tooltip.detached");
+  return (
+    <span className="flex w-80 max-w-[calc(100vw-2rem)] flex-col gap-1.5">
+      <KanbanSessionTooltipRow
+        icon={<Tag size={12} />}
+        label={t("workspace.kanban.tooltip.title")}
+        value={title}
+      />
+      <KanbanSessionTooltipRow
+        icon={<MessageSquareText size={12} />}
+        label={t("workspace.kanban.tooltip.lastMessage")}
+        value={lastMessage || t("workspace.kanban.tooltip.noLastMessage")}
+        valueClassName={lastMessage ? undefined : "text-fg-muted"}
+      />
+      <KanbanSessionTooltipRow
+        icon={<GitBranch size={12} />}
+        label={t("workspace.kanban.tooltip.branch")}
+        value={branch || detached}
+        valueClassName="font-mono"
+      />
+      <KanbanSessionTooltipRow
+        icon={<FolderOpen size={12} />}
+        label={t("workspace.kanban.tooltip.worktree")}
+        value={`${worktreeName}\n${worktreePath}`}
+        valueClassName="break-all font-mono"
+      />
+    </span>
+  );
+}
+
+function KanbanSessionTooltipRow({
+  icon,
+  label,
+  value,
+  valueClassName,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  valueClassName?: string;
+}) {
+  return (
+    <span className="flex min-w-0 items-start gap-2">
+      <span
+        aria-hidden="true"
+        className="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded border border-border/70 bg-bg/60 text-fg-muted"
+      >
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-[10px] leading-3 text-fg-muted">
+          {label}
+        </span>
+        <span
+          className={cn(
+            "block min-w-0 whitespace-pre-line break-words text-[11px] leading-snug text-fg",
+            valueClassName,
+          )}
+        >
+          {value}
+        </span>
+      </span>
+    </span>
+  );
+}
+
 function WorkspaceSessionIcon({
   session,
   scope,
@@ -814,7 +1487,7 @@ function WorkspaceSessionIcon({
   className,
 }: {
   session: Session;
-  scope: "kanban" | "popup";
+  scope: "kanban" | "console";
   size?: "sm" | "md";
   className?: string;
 }) {
@@ -853,13 +1526,15 @@ function WorkspaceSessionIcon({
         scope === "kanban" ? agentProvider ?? fallbackKind : undefined
       }
       data-kanban-icon-status={scope === "kanban" ? session.status : undefined}
-      data-popup-agent-icon={
-        scope === "popup" ? agentProvider ?? undefined : undefined
+      data-console-agent-icon={
+        scope === "console" ? agentProvider ?? undefined : undefined
       }
-      data-popup-session-icon={
-        scope === "popup" ? agentProvider ?? fallbackKind : undefined
+      data-console-session-icon={
+        scope === "console" ? agentProvider ?? fallbackKind : undefined
       }
-      data-popup-icon-status={scope === "popup" ? session.status : undefined}
+      data-console-icon-status={
+        scope === "console" ? session.status : undefined
+      }
     >
       <span className={primaryClassName}>
         {agentProvider ? (
@@ -879,92 +1554,12 @@ function WorkspaceSessionIcon({
   );
 }
 
-function WorkspaceSessionPopupHeader({
-  session,
-  titleId,
-  t,
-  onClose,
-}: {
-  session: Session;
-  titleId: string;
-  t: Translator;
-  onClose: () => void;
-}) {
-  const worktreeName = basename(session.worktree_path);
-  const statusTone = STATUS_TONE[session.status];
-  const title = cleanWorkspaceSessionPopupTitle(session.name);
-
-  return (
-    <header className="shrink-0 border-b border-border bg-bg-elevated/70 px-4 py-3">
-      <div className="flex min-w-0 items-start justify-between gap-3">
-        <div className="flex min-w-0 flex-1 items-start gap-3">
-          <span className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border bg-bg shadow-sm">
-            <WorkspaceSessionIcon session={session} scope="popup" size="md" />
-          </span>
-          <div className="min-w-0 flex-1">
-            <h3
-              id={titleId}
-              className="truncate text-sm font-semibold tracking-tight text-fg"
-            >
-              {title}
-            </h3>
-            <div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden text-[11px] font-medium leading-4 text-fg-muted">
-              <WorkspaceSessionPopupMetaItem
-                icon={
-                  <StatusDot
-                    tone={statusTone}
-                    pulse={session.status === "running"}
-                    size="xs"
-                  />
-                }
-              >
-                {statusLabel(t, session.status)}
-              </WorkspaceSessionPopupMetaItem>
-              <WorkspaceSessionPopupMetaItem
-                icon={<FolderOpen size={11} />}
-                title={session.worktree_path}
-              >
-                {worktreeName}
-              </WorkspaceSessionPopupMetaItem>
-              {session.branch ? (
-                <WorkspaceSessionPopupMetaItem icon={<GitBranch size={11} />}>
-                  {session.branch}
-                </WorkspaceSessionPopupMetaItem>
-              ) : null}
-              {session.mode === "chat" ? (
-                <WorkspaceSessionPopupMetaItem
-                  icon={<MessageSquareText size={11} />}
-                >
-                  {t("sidebar.aria.chatSession")}
-                </WorkspaceSessionPopupMetaItem>
-              ) : null}
-              {session.kind === "control" ? (
-                <WorkspaceSessionPopupMetaItem icon={<Bot size={11} />}>
-                  {t("sidebar.aria.controlSession")}
-                </WorkspaceSessionPopupMetaItem>
-              ) : null}
-            </div>
-          </div>
-        </div>
-        <IconButton
-          aria-label={t("dialogs.common.close")}
-          onClick={onClose}
-          size="sm"
-          surface="panel"
-        >
-          <X size={14} />
-        </IconButton>
-      </div>
-    </header>
-  );
-}
-
-function cleanWorkspaceSessionPopupTitle(title: string): string {
+function cleanWorkspaceSessionTerminalPopoverTitle(title: string): string {
   const cleaned = title.replace(/\s+-\s*$/u, "").trimEnd();
   return cleaned.length > 0 ? cleaned : title;
 }
 
-function WorkspaceSessionPopupMetaItem({
+function WorkspaceSessionTerminalPopoverMetaItem({
   icon,
   title,
   children,
@@ -986,65 +1581,6 @@ function WorkspaceSessionPopupMetaItem({
       </span>
       <span className="min-w-0 truncate">{children}</span>
     </span>
-  );
-}
-
-function WorkspaceSessionPopup() {
-  const titleId = useId();
-  const t = useTranslation();
-  const sessionsById = useAppStore(selectSessionsById);
-  const sessionId = useAppStore((s) => s.terminalPopupSessionId);
-  const closeTerminalPopup = useAppStore((s) => s.closeTerminalPopup);
-  const session = sessionId ? sessionsById.get(sessionId) ?? null : null;
-  const open = session !== null;
-
-  useDialogShortcuts(open, { onCancel: closeTerminalPopup });
-
-  useEffect(() => {
-    if (!sessionId || session) return;
-    closeTerminalPopup();
-  }, [closeTerminalPopup, session, sessionId]);
-
-  const isChat = session?.mode === "chat";
-
-  return (
-    <Modal
-      open={open}
-      onClose={closeTerminalPopup}
-      variant="panel"
-      size="5xl"
-      ariaLabelledBy={titleId}
-      className="h-[min(82vh,54rem)] max-w-[min(76rem,calc(100vw-2rem))] border-border/80 bg-bg-elevated/95"
-    >
-      {session ? (
-        <>
-          <WorkspaceSessionPopupHeader
-            session={session}
-            titleId={titleId}
-            t={t}
-            onClose={closeTerminalPopup}
-          />
-          <div className="min-h-0 flex-1 bg-bg p-2">
-            {isChat ? (
-              <div className="relative h-full min-h-0 overflow-hidden rounded-md border border-border bg-bg shadow-inner">
-                <ChatPane
-                  sessionId={session.id}
-                  isActive
-                  repoPath={session.worktree_path}
-                  session={session}
-                />
-              </div>
-            ) : (
-              <div
-                className="relative h-full min-h-0 w-full overflow-hidden rounded-md border border-border bg-bg shadow-inner"
-                data-terminal-popup-body={session.id}
-                data-testid="terminal-popup-body"
-              />
-            )}
-          </div>
-        </>
-      ) : null}
-    </Modal>
   );
 }
 
@@ -1075,6 +1611,13 @@ function workspaceContextMenuGroupTitle(
     type: "group-title",
     label: sidebarText(t, `sidebar.contextMenu.${group}`),
   };
+}
+
+function cssAttributeEscape(value: string): string {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(value);
+  }
+  return value.replace(/(["\\\]\[])/g, "\\$1");
 }
 
 async function copyToClipboard(text: string): Promise<void> {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -639,6 +639,9 @@ export const api = {
       id: string;
       status: SessionStatus;
       status_reason?: SessionStatusReason | null;
+      last_message?: string | null;
+      last_user_message?: string | null;
+      last_agent_message?: string | null;
       agent_provider?: SessionAgentProvider | null;
       agent_transcript_id?: string | null;
       branch: string | null;
@@ -650,6 +653,9 @@ export const api = {
         id: string;
         status: SessionStatus;
         status_reason?: SessionStatusReason | null;
+        last_message?: string | null;
+        last_user_message?: string | null;
+        last_agent_message?: string | null;
         agent_provider?: SessionAgentProvider | null;
         agent_transcript_id?: string | null;
         branch: string | null;

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -96,12 +96,24 @@ describe("interface settings", () => {
 
   it("defaults new workspaces to pane mode", () => {
     expect(DEFAULT_SETTINGS.interface.defaultWorkspaceViewMode).toBe("panes");
+    expect(
+      DEFAULT_SETTINGS.interface.kanbanTerminalPopoverPlacement,
+    ).toBe("card");
+    expect(
+      DEFAULT_SETTINGS.interface.kanbanTerminalPopoverDefaultSize,
+    ).toBe("custom");
   });
 
   it("loads a persisted default workspace mode", async () => {
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ interface: { defaultWorkspaceViewMode: "kanban" } }),
+      JSON.stringify({
+        interface: {
+          defaultWorkspaceViewMode: "kanban",
+          kanbanTerminalPopoverPlacement: "center",
+          kanbanTerminalPopoverDefaultSize: "fullscreen",
+        },
+      }),
     );
 
     vi.resetModules();
@@ -110,12 +122,26 @@ describe("interface settings", () => {
     expect(
       useSettings.getState().settings.interface.defaultWorkspaceViewMode,
     ).toBe("kanban");
+    expect(
+      useSettings.getState().settings.interface
+        .kanbanTerminalPopoverPlacement,
+    ).toBe("center");
+    expect(
+      useSettings.getState().settings.interface
+        .kanbanTerminalPopoverDefaultSize,
+    ).toBe("fullscreen");
   });
 
-  it("falls back to panes for an unsupported default workspace mode", async () => {
+  it("falls back for unsupported interface values", async () => {
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ interface: { defaultWorkspaceViewMode: "grid" } }),
+      JSON.stringify({
+        interface: {
+          defaultWorkspaceViewMode: "grid",
+          kanbanTerminalPopoverPlacement: "dock",
+          kanbanTerminalPopoverDefaultSize: "huge",
+        },
+      }),
     );
 
     vi.resetModules();
@@ -124,27 +150,63 @@ describe("interface settings", () => {
     expect(
       useSettings.getState().settings.interface.defaultWorkspaceViewMode,
     ).toBe("panes");
+    expect(
+      useSettings.getState().settings.interface
+        .kanbanTerminalPopoverPlacement,
+    ).toBe("card");
+    expect(
+      useSettings.getState().settings.interface
+        .kanbanTerminalPopoverDefaultSize,
+    ).toBe("custom");
   });
 
-  it("patches the default workspace mode and preserves the previous value for invalid patches", async () => {
+  it("patches interface settings and preserves the previous value for invalid patches", async () => {
     vi.resetModules();
     const { useSettings } = await import("./settings");
 
     useSettings
       .getState()
-      .patchInterface({ defaultWorkspaceViewMode: "kanban" });
+      .patchInterface({
+        defaultWorkspaceViewMode: "kanban",
+        kanbanTerminalPopoverPlacement: "center",
+        kanbanTerminalPopoverDefaultSize: "fullscreen",
+      });
     expect(
       useSettings.getState().settings.interface.defaultWorkspaceViewMode,
     ).toBe("kanban");
+    expect(
+      useSettings.getState().settings.interface
+        .kanbanTerminalPopoverPlacement,
+    ).toBe("center");
+    expect(
+      useSettings.getState().settings.interface
+        .kanbanTerminalPopoverDefaultSize,
+    ).toBe("fullscreen");
 
     const invalidMode =
       "grid" as unknown as typeof DEFAULT_SETTINGS.interface.defaultWorkspaceViewMode;
+    const invalidPlacement =
+      "dock" as unknown as typeof DEFAULT_SETTINGS.interface.kanbanTerminalPopoverPlacement;
+    const invalidDefaultSize =
+      "huge" as unknown as typeof DEFAULT_SETTINGS.interface.kanbanTerminalPopoverDefaultSize;
     useSettings
       .getState()
-      .patchInterface({ defaultWorkspaceViewMode: invalidMode });
+      .patchInterface({
+        defaultWorkspaceViewMode: invalidMode,
+        kanbanTerminalPopoverPlacement: invalidPlacement,
+        kanbanTerminalPopoverDefaultSize: invalidDefaultSize,
+      });
     expect(
       useSettings.getState().settings.interface.defaultWorkspaceViewMode,
     ).toBe("kanban");
+    expect(
+      useSettings.getState().settings.interface
+        .kanbanTerminalPopoverPlacement,
+    ).toBe("center");
+    expect(
+      useSettings.getState().settings.interface
+        .kanbanTerminalPopoverDefaultSize,
+    ).toBe("fullscreen");
   });
 });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -132,6 +132,8 @@ export const TERMINAL_LETTER_SPACING_STEP = 0.25;
 
 export type ToastPosition = "top" | "bottom";
 export type DefaultWorkspaceViewMode = "panes" | "kanban";
+export type KanbanTerminalPopoverPlacement = "card" | "center";
+export type KanbanTerminalPopoverDefaultSize = "custom" | "fullscreen";
 
 export const TOAST_POSITION_OPTIONS: ReadonlyArray<{
   value: ToastPosition;
@@ -219,6 +221,16 @@ export interface AcornSettings {
      * Existing project workspaces keep their own stored mode.
      */
     defaultWorkspaceViewMode: DefaultWorkspaceViewMode;
+    /**
+     * Initial placement for terminal popovers opened from kanban cards.
+     * Users can still drag the popover after it opens.
+     */
+    kanbanTerminalPopoverPlacement: KanbanTerminalPopoverPlacement;
+    /**
+     * Initial size mode for terminal popovers opened from kanban cards.
+     * `custom` uses the remembered user-resized popover size.
+     */
+    kanbanTerminalPopoverDefaultSize: KanbanTerminalPopoverDefaultSize;
   };
   terminal: {
     fontFamily: string;
@@ -470,6 +482,8 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   language: "en",
   interface: {
     defaultWorkspaceViewMode: "panes",
+    kanbanTerminalPopoverPlacement: "card",
+    kanbanTerminalPopoverDefaultSize: "custom",
   },
   terminal: {
     fontFamily: fontStackFromSlots(
@@ -592,6 +606,10 @@ const VALID_WORKSPACE_VIEW_MODES = new Set<DefaultWorkspaceViewMode>([
   "panes",
   "kanban",
 ]);
+const VALID_KANBAN_TERMINAL_POPOVER_PLACEMENTS =
+  new Set<KanbanTerminalPopoverPlacement>(["card", "center"]);
+const VALID_KANBAN_TERMINAL_POPOVER_DEFAULT_SIZES =
+  new Set<KanbanTerminalPopoverDefaultSize>(["custom", "fullscreen"]);
 
 function normalizeBgFit(v: unknown, fallback: BackgroundFit): BackgroundFit {
   if (typeof v === "string" && VALID_BG_FITS.has(v as BackgroundFit)) {
@@ -807,6 +825,36 @@ function normalizeDefaultWorkspaceViewMode(
   return fallback;
 }
 
+function normalizeKanbanTerminalPopoverPlacement(
+  v: unknown,
+  fallback: KanbanTerminalPopoverPlacement,
+): KanbanTerminalPopoverPlacement {
+  if (
+    typeof v === "string" &&
+    VALID_KANBAN_TERMINAL_POPOVER_PLACEMENTS.has(
+      v as KanbanTerminalPopoverPlacement,
+    )
+  ) {
+    return v as KanbanTerminalPopoverPlacement;
+  }
+  return fallback;
+}
+
+function normalizeKanbanTerminalPopoverDefaultSize(
+  v: unknown,
+  fallback: KanbanTerminalPopoverDefaultSize,
+): KanbanTerminalPopoverDefaultSize {
+  if (
+    typeof v === "string" &&
+    VALID_KANBAN_TERMINAL_POPOVER_DEFAULT_SIZES.has(
+      v as KanbanTerminalPopoverDefaultSize,
+    )
+  ) {
+    return v as KanbanTerminalPopoverDefaultSize;
+  }
+  return fallback;
+}
+
 /**
  * v1 commitMessage block from the multi-provider commit-message PR. The
  * loader below lifts every field up into the new `agents.*` block so a
@@ -943,6 +991,16 @@ function loadSettings(): AcornSettings {
           interfaceRaw.defaultWorkspaceViewMode,
           DEFAULT_SETTINGS.interface.defaultWorkspaceViewMode,
         ),
+        kanbanTerminalPopoverPlacement:
+          normalizeKanbanTerminalPopoverPlacement(
+            interfaceRaw.kanbanTerminalPopoverPlacement,
+            DEFAULT_SETTINGS.interface.kanbanTerminalPopoverPlacement,
+          ),
+        kanbanTerminalPopoverDefaultSize:
+          normalizeKanbanTerminalPopoverDefaultSize(
+            interfaceRaw.kanbanTerminalPopoverDefaultSize,
+            DEFAULT_SETTINGS.interface.kanbanTerminalPopoverDefaultSize,
+          ),
       },
       terminal: {
         ...DEFAULT_SETTINGS.terminal,
@@ -1242,6 +1300,20 @@ export const useSettings = create<SettingsState>((set, get) => ({
               : normalizeDefaultWorkspaceViewMode(
                   patch.defaultWorkspaceViewMode,
                   s.settings.interface.defaultWorkspaceViewMode,
+                ),
+          kanbanTerminalPopoverPlacement:
+            patch.kanbanTerminalPopoverPlacement === undefined
+              ? s.settings.interface.kanbanTerminalPopoverPlacement
+              : normalizeKanbanTerminalPopoverPlacement(
+                  patch.kanbanTerminalPopoverPlacement,
+                  s.settings.interface.kanbanTerminalPopoverPlacement,
+                ),
+          kanbanTerminalPopoverDefaultSize:
+            patch.kanbanTerminalPopoverDefaultSize === undefined
+              ? s.settings.interface.kanbanTerminalPopoverDefaultSize
+              : normalizeKanbanTerminalPopoverDefaultSize(
+                  patch.kanbanTerminalPopoverDefaultSize,
+                  s.settings.interface.kanbanTerminalPopoverDefaultSize,
                 ),
         },
       };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -121,6 +121,10 @@ export interface Session {
   created_at: string;
   updated_at: string;
   last_message: string | null;
+  /** Ephemeral transcript/chat preview for the latest user turn. */
+  last_user_message?: string | null;
+  /** Ephemeral transcript/chat preview for the latest agent turn. */
+  last_agent_message?: string | null;
   title_source: SessionTitleSource;
   auto_title_enabled?: boolean | null;
   generated_title_transcript_id?: string | null;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -72,6 +72,34 @@
       "defaultWorkspaceViewMode": {
         "label": "Default workspace mode",
         "hint": "Mode used when Acorn creates a new project workspace. Existing project-specific choices stay unchanged."
+      },
+      "kanbanTerminalPopover": {
+        "title": "Kanban terminal popover",
+        "description": "Controls where card terminals open and how large they start.",
+        "placement": {
+          "label": "Open position",
+          "hint": "Initial placement when you open a terminal from a kanban card.",
+          "card": {
+            "label": "Beside card",
+            "description": "Open next to the selected kanban item."
+          },
+          "center": {
+            "label": "Center of screen",
+            "description": "Open in the middle of the workspace."
+          }
+        },
+        "defaultSize": {
+          "label": "Default size",
+          "hint": "Initial size mode for newly opened terminal popovers.",
+          "custom": {
+            "label": "Small / custom",
+            "description": "Use the remembered popover size; resizing updates it."
+          },
+          "fullscreen": {
+            "label": "Full screen",
+            "description": "Open expanded inside the app window."
+          }
+        }
       }
     },
     "terminal": {
@@ -881,7 +909,40 @@
         "createdDesc": "Newest",
         "nameAsc": "Name"
       },
-      "openSession": "Open {name}"
+      "openSession": "Open {name}",
+      "tooltip": {
+        "title": "Title",
+        "lastMessage": "Last message",
+        "noLastMessage": "No last message",
+        "branch": "Branch",
+        "detached": "(detached)",
+        "worktree": "Worktree"
+      },
+      "console": {
+        "ariaLabel": "Session console",
+        "terminal": "Terminal",
+        "chat": "Chat"
+      },
+      "terminalPopover": {
+        "ariaLabel": "Session terminal",
+        "expand": "Expand terminal",
+        "restore": "Restore terminal size",
+        "resize": "Resize terminal"
+      },
+      "popover": {
+        "ariaLabel": "Session conversation",
+        "userPrompt": "My last prompt",
+        "agentMessage": "Agent last message",
+        "emptyUser": "No user prompt yet",
+        "emptyAgent": "No agent message yet",
+        "messagePlaceholder": "Reply to this session...",
+        "disabledPlaceholder": "Open terminal to type into this session",
+        "send": "Send",
+        "sending": "Sending",
+        "openTerminal": "Open terminal",
+        "sendUnavailable": "Open the terminal to send to this session.",
+        "sendError": "Could not send the message."
+      }
     }
   },
   "topBar": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -72,6 +72,34 @@
       "defaultWorkspaceViewMode": {
         "label": "기본 작업공간 모드",
         "hint": "새 프로젝트 작업공간을 만들 때 사용할 모드입니다. 이미 프로젝트별로 선택한 모드는 유지됩니다."
+      },
+      "kanbanTerminalPopover": {
+        "title": "칸반 터미널 팝오버",
+        "description": "칸반 카드에서 터미널을 열 때 위치와 시작 크기를 정합니다.",
+        "placement": {
+          "label": "표시 위치",
+          "hint": "칸반 카드에서 터미널을 열 때 처음 나타나는 위치입니다.",
+          "card": {
+            "label": "칸반 아이템 옆",
+            "description": "선택한 칸반 카드 옆에 엽니다."
+          },
+          "center": {
+            "label": "화면 가운데",
+            "description": "작업공간 중앙에 엽니다."
+          }
+        },
+        "defaultSize": {
+          "label": "기본 크기",
+          "hint": "새 터미널 팝오버가 열릴 때의 시작 크기입니다.",
+          "custom": {
+            "label": "작은 화면 / 사용자 지정",
+            "description": "저장된 팝오버 크기를 사용하고, 리사이즈하면 기억합니다."
+          },
+          "fullscreen": {
+            "label": "전체 화면",
+            "description": "앱 창 안에서 크게 펼쳐서 엽니다."
+          }
+        }
       }
     },
     "terminal": {
@@ -881,7 +909,40 @@
         "createdDesc": "최신 생성",
         "nameAsc": "이름"
       },
-      "openSession": "{name} 열기"
+      "openSession": "{name} 열기",
+      "tooltip": {
+        "title": "제목",
+        "lastMessage": "마지막 메시지",
+        "noLastMessage": "마지막 메시지 없음",
+        "branch": "브랜치",
+        "detached": "(detached)",
+        "worktree": "워크트리"
+      },
+      "console": {
+        "ariaLabel": "세션 콘솔",
+        "terminal": "터미널",
+        "chat": "채팅"
+      },
+      "terminalPopover": {
+        "ariaLabel": "세션 터미널",
+        "expand": "터미널 크게 보기",
+        "restore": "터미널 원래 크기로",
+        "resize": "터미널 크기 조절"
+      },
+      "popover": {
+        "ariaLabel": "세션 대화",
+        "userPrompt": "내 마지막 프롬프트",
+        "agentMessage": "Agent 마지막 메시지",
+        "emptyUser": "아직 사용자 프롬프트가 없습니다",
+        "emptyAgent": "아직 Agent 메시지가 없습니다",
+        "messagePlaceholder": "이 세션에 답장하기...",
+        "disabledPlaceholder": "이 세션에는 터미널에서 입력하세요",
+        "send": "전송",
+        "sending": "전송 중",
+        "openTerminal": "터미널 열기",
+        "sendUnavailable": "이 세션에는 터미널을 열어 입력하세요.",
+        "sendError": "메시지를 보내지 못했습니다."
+      }
     }
   },
   "topBar": {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1482,7 +1482,10 @@ describe("splitFocusedPane", () => {
     useSettings.setState({
       settings: {
         ...structuredClone(DEFAULT_SETTINGS),
-        interface: { defaultWorkspaceViewMode: "kanban" },
+        interface: {
+          ...DEFAULT_SETTINGS.interface,
+          defaultWorkspaceViewMode: "kanban",
+        },
       },
     });
 
@@ -2085,6 +2088,88 @@ describe("pollSessionStatuses", () => {
 
     expect(useAppStore.getState().sessions[0]?.agent_transcript_id).toBe(
       "claude-new",
+    );
+  });
+
+  it("merges last messages from status polling even when status is unchanged", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          status: "running",
+          last_message: "Older transcript preview",
+        }),
+      ],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "running",
+        last_message: "New transcript preview",
+        branch: null,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.last_message).toBe(
+      "New transcript preview",
+    );
+  });
+
+  it("merges split conversation previews from status polling", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          status: "running",
+          last_user_message: "Older user prompt",
+          last_agent_message: "Older agent response",
+        }),
+      ],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "running",
+        last_user_message: "New user prompt",
+        last_agent_message: "New agent response",
+        branch: null,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.last_user_message).toBe(
+      "New user prompt",
+    );
+    expect(useAppStore.getState().sessions[0]?.last_agent_message).toBe(
+      "New agent response",
+    );
+  });
+
+  it("preserves last messages when status polling omits the field", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          status: "running",
+          last_message: "Current transcript preview",
+        }),
+      ],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "running",
+        branch: null,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.last_message).toBe(
+      "Current transcript preview",
     );
   });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1608,6 +1608,24 @@ export const useAppStore = create<AppStateModel>()(
                   ? (update.status_reason ?? null)
                   : (sess.status_reason ?? null);
                 const nextBranch = update.branch ?? sess.branch;
+                const nextLastMessage = Object.prototype.hasOwnProperty.call(
+                  update,
+                  "last_message",
+                )
+                  ? (update.last_message ?? null)
+                  : sess.last_message;
+                const nextLastUserMessage = Object.prototype.hasOwnProperty.call(
+                  update,
+                  "last_user_message",
+                )
+                  ? (update.last_user_message ?? null)
+                  : (sess.last_user_message ?? null);
+                const nextLastAgentMessage = Object.prototype.hasOwnProperty.call(
+                  update,
+                  "last_agent_message",
+                )
+                  ? (update.last_agent_message ?? null)
+                  : (sess.last_agent_message ?? null);
                 const nextAgentProvider =
                   Object.prototype.hasOwnProperty.call(update, "agent_provider")
                     ? (update.agent_provider ?? null)
@@ -1628,6 +1646,9 @@ export const useAppStore = create<AppStateModel>()(
                   nextStatus !== sess.status ||
                   nextStatusReason !== (sess.status_reason ?? null) ||
                   nextBranch !== sess.branch ||
+                  nextLastMessage !== sess.last_message ||
+                  nextLastUserMessage !== (sess.last_user_message ?? null) ||
+                  nextLastAgentMessage !== (sess.last_agent_message ?? null) ||
                   nextAgentProvider !== (sess.agent_provider ?? null) ||
                   nextAgentTranscriptId !== (sess.agent_transcript_id ?? null) ||
                   nextAutoTitleEnabled !== (sess.auto_title_enabled ?? null)
@@ -1638,6 +1659,9 @@ export const useAppStore = create<AppStateModel>()(
                     status: nextStatus,
                     status_reason: nextStatusReason,
                     branch: nextBranch,
+                    last_message: nextLastMessage,
+                    last_user_message: nextLastUserMessage,
+                    last_agent_message: nextLastAgentMessage,
                     agent_provider: nextAgentProvider,
                     agent_transcript_id: nextAgentTranscriptId,
                     auto_title_enabled: nextAutoTitleEnabled,

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -42,7 +42,7 @@ function session(
 }
 
 test.describe("workspace kanban mode", () => {
-  test("groups active workspace sessions by status and opens a card in a popup", async ({
+  test("groups active workspace sessions by status and opens a card terminal popover", async ({
     page,
     tauri,
   }) => {
@@ -57,14 +57,45 @@ test.describe("workspace kanban mode", () => {
       session("alpha", "alpha", "idle", {
         updated_at: "2026-01-01T00:00:01Z",
       }),
-      session("shell", "shell", "idle"),
+      session("shell", "shell", "idle", {
+        branch: "shell",
+      }),
       session("done", "done", "completed", {
         agent_provider: "antigravity",
       }),
       session("broken", "broken", "failed", {
         agent_provider: "codex",
+        last_message: "Tests failed in popover state handling.",
+        worktree_path:
+          "/tmp/demo/.worktrees/broken-session-with-a-very-long-worktree-directory-name-that-should-wrap-inside-the-card-tooltip",
       }),
     ]);
+    await tauri.handle("detect_session_statuses", (args) => {
+      const ids = Array.isArray((args as { ids?: unknown }).ids)
+        ? ((args as { ids: string[] }).ids)
+        : [];
+      const statuses: Record<string, string> = {
+        "needs-review": "needs_input",
+        runner: "running",
+        alpha: "idle",
+        shell: "idle",
+        done: "completed",
+        broken: "failed",
+      };
+      return ids.map((id) => ({
+        id,
+        status: statuses[id] ?? "idle",
+        branch: id === "shell" ? "shell" : `feat/${id}`,
+        last_message:
+          id === "broken"
+            ? "Updated from status polling."
+            : null,
+        last_user_message:
+          id === "broken" ? "Please check the failed tests." : null,
+        last_agent_message:
+          id === "broken" ? "Updated from status polling." : null,
+      }));
+    });
 
     await page.goto("/");
 
@@ -161,6 +192,47 @@ test.describe("workspace kanban mode", () => {
         .locator('[data-kanban-session-id="broken"]')
         .locator('[data-kanban-agent-icon="codex"]'),
     ).toBeVisible();
+    const brokenCard = board.locator('[data-kanban-session-id="broken"]');
+    await expect(
+      brokenCard.getByTestId("workspace-kanban-card-meta"),
+    ).toContainText("feat/broken");
+    await expect(brokenCard).not.toContainText("Failed");
+    await expect(
+      brokenCard.getByTestId("workspace-kanban-card-last-message"),
+    ).toContainText("Updated from status polling.");
+    await brokenCard.hover();
+    const cardTooltip = page.getByRole("tooltip");
+    await expect(cardTooltip).toBeVisible();
+    await expect(cardTooltip).toContainText("Title");
+    await expect(cardTooltip).toContainText("broken");
+    await expect(cardTooltip).toContainText("Last message");
+    await expect(cardTooltip).toContainText("Updated from status polling.");
+    await expect(cardTooltip).toContainText("Branch");
+    await expect(cardTooltip).toContainText("feat/broken");
+    await expect(cardTooltip).toContainText("Worktree");
+    await expect(cardTooltip).toContainText(
+      "/tmp/demo/.worktrees/broken-session-with-a-very-long-worktree-directory-name-that-should-wrap-inside-the-card-tooltip",
+    );
+    const tooltipMetrics = await cardTooltip.evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      const node = el as HTMLElement;
+      return {
+        clientWidth: node.clientWidth,
+        left: rect.left,
+        right: rect.right,
+        scrollWidth: node.scrollWidth,
+        viewportWidth: window.innerWidth,
+      };
+    });
+    expect(tooltipMetrics.left).toBeGreaterThanOrEqual(0);
+    expect(tooltipMetrics.right).toBeLessThanOrEqual(
+      tooltipMetrics.viewportWidth,
+    );
+    expect(tooltipMetrics.scrollWidth).toBeLessThanOrEqual(
+      tooltipMetrics.clientWidth + 1,
+    );
+    await page.mouse.move(0, 0);
+    await expect(cardTooltip).toHaveCount(0);
     await expect(
       board
         .locator('[data-kanban-session-id="runner"]')
@@ -171,6 +243,13 @@ test.describe("workspace kanban mode", () => {
         .locator('[data-kanban-session-id="shell"]')
         .locator('[data-kanban-session-icon="terminal"]'),
     ).toBeVisible();
+    const shellCard = board.locator('[data-kanban-session-id="shell"]');
+    await expect(
+      shellCard.getByTestId("workspace-kanban-card-branch"),
+    ).toHaveText("shell");
+    await expect(
+      shellCard.getByTestId("workspace-kanban-card-worktree"),
+    ).toHaveText("shell");
     await expect(
       board
         .locator('[data-kanban-session-id="done"]')
@@ -279,9 +358,17 @@ test.describe("workspace kanban mode", () => {
       })
       .toBeLessThan(1);
 
-    await board
-      .getByRole("button", { name: "Open shell" })
-      .click({ button: "right" });
+    const shellMenuTarget = board.getByRole("button", { name: "Open shell" });
+    const shellMenuTargetBox = await shellMenuTarget.boundingBox();
+    expect(shellMenuTargetBox).not.toBeNull();
+    if (!shellMenuTargetBox) throw new Error("missing shell card");
+    await shellMenuTarget.dispatchEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      button: 2,
+      clientX: shellMenuTargetBox.x + shellMenuTargetBox.width / 2,
+      clientY: shellMenuTargetBox.y + shellMenuTargetBox.height / 2,
+    });
     await expect(
       page.getByRole("menuitem", { name: "Open shell" }),
     ).toBeVisible();
@@ -296,21 +383,144 @@ test.describe("workspace kanban mode", () => {
     ).toBeVisible();
     await page.keyboard.press("Escape");
 
+    await board.getByRole("button", { name: "Open shell" }).click();
+    const shellPopover = page.getByTestId("kanban-terminal-popover");
+    await expect(shellPopover).toBeVisible();
+    await expect(
+      shellPopover.getByRole("heading", { name: "shell" }),
+    ).toBeVisible();
+    await expect(page.getByTestId("terminal-popover-body")).toBeVisible();
+    await expect(
+      page
+        .getByTestId("terminal-popover-body")
+        .locator('[data-acorn-terminal-slot="shell"] .acorn-terminal-shell'),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId("terminal-popover-body")
+        .locator(".xterm-helper-textarea"),
+    ).toBeFocused();
+    const shellPopoverBoxBefore = await shellPopover.boundingBox();
+    expect(shellPopoverBoxBefore).not.toBeNull();
+    if (!shellPopoverBoxBefore) throw new Error("missing shell popover");
+    const resizeHandle = page.getByTestId("kanban-terminal-popover-resize");
+    await expect(resizeHandle).toBeVisible();
+    const resizeHandleBox = await resizeHandle.boundingBox();
+    expect(resizeHandleBox).not.toBeNull();
+    if (!resizeHandleBox) throw new Error("missing popover resize handle");
+    await page.mouse.move(
+      resizeHandleBox.x + resizeHandleBox.width / 2,
+      resizeHandleBox.y + resizeHandleBox.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      resizeHandleBox.x + resizeHandleBox.width / 2 + 72,
+      resizeHandleBox.y + resizeHandleBox.height / 2 + 44,
+    );
+    await page.mouse.up();
+    const shellPopoverBoxAfter = await shellPopover.boundingBox();
+    expect(shellPopoverBoxAfter?.width ?? 0).toBeGreaterThan(
+      shellPopoverBoxBefore.width + 40,
+    );
+    expect(shellPopoverBoxAfter?.height ?? 0).toBeGreaterThan(
+      shellPopoverBoxBefore.height + 24,
+    );
+    const expandButton = page.getByTestId("kanban-terminal-popover-expand");
+    await expect(expandButton).toHaveAttribute(
+      "aria-label",
+      "Expand terminal",
+    );
+    await expandButton.click();
+    await expect(expandButton).toHaveAttribute(
+      "aria-label",
+      "Restore terminal size",
+    );
+    await expect(resizeHandle).toHaveCount(0);
+    const expandedPopoverBox = await shellPopover.boundingBox();
+    const viewport = await page.evaluate(() => ({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    }));
+    expect(expandedPopoverBox?.width ?? 0).toBeGreaterThan(
+      viewport.width - 24,
+    );
+    expect(expandedPopoverBox?.height ?? 0).toBeGreaterThan(
+      viewport.height - 24,
+    );
+    await expandButton.click();
+    await expect(expandButton).toHaveAttribute(
+      "aria-label",
+      "Expand terminal",
+    );
+    await expect(resizeHandle).toBeVisible();
+    const restoredPopoverBox = await shellPopover.boundingBox();
+    expect(
+      Math.abs((restoredPopoverBox?.width ?? 0) - shellPopoverBoxAfter.width),
+    ).toBeLessThan(2);
+    expect(
+      Math.abs((restoredPopoverBox?.height ?? 0) - shellPopoverBoxAfter.height),
+    ).toBeLessThan(2);
+    const dragHandle = page.getByTestId("kanban-terminal-popover-drag-handle");
+    const popoverBoxBeforeDrag = await shellPopover.boundingBox();
+    const dragHandleBox = await dragHandle.boundingBox();
+    expect(popoverBoxBeforeDrag).not.toBeNull();
+    expect(dragHandleBox).not.toBeNull();
+    if (!popoverBoxBeforeDrag || !dragHandleBox) {
+      throw new Error("missing draggable terminal popover");
+    }
+    const dragViewport = await page.evaluate(() => ({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    }));
+    const dragDeltaX =
+      dragViewport.width -
+        (popoverBoxBeforeDrag.x + popoverBoxBeforeDrag.width) >
+      64
+        ? 48
+        : -48;
+    const dragDeltaY =
+      dragViewport.height -
+        (popoverBoxBeforeDrag.y + popoverBoxBeforeDrag.height) >
+      48
+        ? 32
+        : -32;
+    const dragStartX = dragHandleBox.x + Math.min(96, dragHandleBox.width / 2);
+    const dragStartY = dragHandleBox.y + dragHandleBox.height / 2;
+    await page.mouse.move(dragStartX, dragStartY);
+    await page.mouse.down();
+    await page.mouse.move(dragStartX + dragDeltaX, dragStartY + dragDeltaY);
+    await page.mouse.up();
+    const popoverBoxAfterDrag = await shellPopover.boundingBox();
+    expect(
+      Math.abs((popoverBoxAfterDrag?.x ?? 0) - popoverBoxBeforeDrag.x),
+    ).toBeGreaterThan(24);
+    expect(
+      Math.abs((popoverBoxAfterDrag?.y ?? 0) - popoverBoxBeforeDrag.y),
+    ).toBeGreaterThan(16);
+
     await board.getByRole("button", { name: "Open broken" }).click();
 
     await expect(page.getByTestId("workspace-kanban")).toBeVisible();
     await expect(page.getByTestId("workspace-view-status")).toContainText(
       "Kanban",
     );
-    const dialog = page.getByRole("dialog", { name: "broken" });
-    await expect(dialog).toBeVisible();
+    const popover = page.getByTestId("kanban-terminal-popover");
+    await expect(popover).toBeVisible();
     await expect(
-      dialog.locator('[data-popup-agent-icon="codex"]'),
+      popover.getByRole("heading", { name: "broken" }),
     ).toBeVisible();
-    await expect(page.getByTestId("terminal-popup-body")).toBeVisible();
+    await expect(
+      popover.locator('[data-console-agent-icon="codex"]'),
+    ).toBeVisible();
+    await expect(page.getByTestId("terminal-popover-body")).toBeVisible();
+    const popoverBox = await popover.boundingBox();
+    expect(popoverBox?.x).toBeGreaterThanOrEqual(0);
+    expect((popoverBox?.x ?? 0) + (popoverBox?.width ?? 0)).toBeLessThanOrEqual(
+      await page.evaluate(() => window.innerWidth),
+    );
     await expect(
       page
-        .getByTestId("terminal-popup-body")
+        .getByTestId("terminal-popover-body")
         .locator('[data-acorn-terminal-slot="broken"] .acorn-terminal-shell'),
     ).toBeVisible();
   });
@@ -338,6 +548,88 @@ test.describe("workspace kanban mode", () => {
       "Kanban",
     );
     await expect(page.getByTestId("workspace-kanban")).toBeVisible();
+  });
+
+  test("uses configured kanban terminal popover placement", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          interface: {
+            defaultWorkspaceViewMode: "kanban",
+            kanbanTerminalPopoverPlacement: "center",
+            kanbanTerminalPopoverDefaultSize: "custom",
+          },
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("centered", "centered", "idle"),
+    ]);
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Open centered" }).click();
+
+    const popover = page.getByTestId("kanban-terminal-popover");
+    await expect(popover).toBeVisible();
+    const box = await popover.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) throw new Error("missing centered popover");
+    const viewport = await page.evaluate(() => ({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    }));
+    expect(Math.abs(box.x + box.width / 2 - viewport.width / 2)).toBeLessThan(
+      8,
+    );
+    expect(Math.abs(box.y + box.height / 2 - viewport.height / 2)).toBeLessThan(
+      8,
+    );
+  });
+
+  test("uses configured fullscreen kanban terminal popover size", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          interface: {
+            defaultWorkspaceViewMode: "kanban",
+            kanbanTerminalPopoverPlacement: "card",
+            kanbanTerminalPopoverDefaultSize: "fullscreen",
+          },
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("fullscreen", "fullscreen", "idle"),
+    ]);
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Open fullscreen" }).click();
+
+    const popover = page.getByTestId("kanban-terminal-popover");
+    await expect(popover).toBeVisible();
+    await expect(
+      page.getByTestId("kanban-terminal-popover-expand"),
+    ).toHaveAttribute("aria-label", "Restore terminal size");
+    await expect(page.getByTestId("kanban-terminal-popover-resize")).toHaveCount(
+      0,
+    );
+    const box = await popover.boundingBox();
+    const viewport = await page.evaluate(() => ({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    }));
+    expect(box?.width ?? 0).toBeGreaterThan(viewport.width - 24);
+    expect(box?.height ?? 0).toBeGreaterThan(viewport.height - 24);
   });
 
   test("restores kanban or pane mode per project", async ({ page, tauri }) => {

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -87,6 +87,37 @@ test.describe("settings modal", () => {
       .toBe("subpixel");
   });
 
+  test("changes kanban terminal popover settings and persists them", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "," });
+
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
+    await expect(modal.getByText("Kanban terminal popover")).toBeVisible();
+
+    await modal.getByText("Center of screen", { exact: true }).click();
+    await modal.getByText("Full screen", { exact: true }).click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("acorn:settings:v1");
+          const settings = raw ? JSON.parse(raw) : null;
+          return {
+            placement:
+              settings?.interface?.kanbanTerminalPopoverPlacement ?? null,
+            defaultSize:
+              settings?.interface?.kanbanTerminalPopoverDefaultSize ?? null,
+          };
+        }),
+      )
+      .toEqual({
+        placement: "center",
+        defaultSize: "fullscreen",
+      });
+  });
+
   test("records a custom shortcut and reset all restores defaults", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
This makes Kanban terminal access a configurable, card-adjacent popover instead of a blocking modal.

1. **Terminal popover workflow** - open sessions from Kanban cards into a floating terminal popover with resize, maximize/restore, drag positioning, automatic terminal focus, outside-click close, and stable xterm retargeting.
2. **Kanban card previews** - surface the latest agent message on cards, keep branch/worktree metadata together, and add a hover tooltip with title, last message, branch, and full worktree path.
3. **Popover settings** - add Interface settings for popover placement (card vs center) and default size (custom vs fullscreen), with validation and persistence.
4. **Conversation previews** - extend status polling to carry last user/agent previews from chat state and live agent transcripts so Kanban cards update without status changes.

## Expected impact
| Area | Impact |
| --- | --- |
| Kanban terminal access | Terminals open in context without taking over the whole workspace. |
| User control | Users can resize, move, maximize, and configure where popovers start. |
| Kanban scanning | Cards show fresher last-message context plus branch/worktree details. |

## Design notes
- `TerminalHost` now treats the Kanban popup target as `popover:<sessionId>` and mounts xterm into `[data-terminal-popover-body]`; the old modal body target is removed.
- Terminal auto-focus is implemented inside `Terminal` via `autoFocusOnActive`, so focus happens after the popover target and xterm ref are both ready instead of relying only on a global event.
- Popover size is persisted separately in `localStorage` under `acorn:kanban-terminal-popover-size`; settings only choose the default size mode.
- Status polling preserves existing preview fields when the backend omits them, so older payloads do not wipe card text.

## Follow-up (not in this PR)
- Consider a separate setting for outside-click close behavior if the floating popover still feels too easy to dismiss.

## Test plan
- [x] `git diff --check` - passed
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` - passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml agent_resume` - 16 passed
- [x] `pnpm run typecheck` - passed
- [x] `pnpm exec vitest run src/lib/settings.test.ts src/components/SettingsModal.test.tsx src/components/TerminalHost.test.tsx src/components/Tooltip.test.tsx src/store.test.ts` - 258 passed
- [x] `pnpm exec playwright test tests/e2e/settings.spec.ts tests/e2e/kanban.spec.ts` - 15 passed
- [x] `pnpm run build` - passed; Vite reported existing dynamic/static import and chunk-size warnings
