### PR TITLE
fix(status): stop agent sessions getting stuck on Running

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -352,6 +352,16 @@ impl Session {
 #[derive(Default)]
 pub struct SessionStore {
     inner: DashMap<Uuid, Session>,
+    /// Sessions that reported at least one agent lifecycle hook event
+    /// (Start/Stop/NeedsInput/Error) this run. Runtime-only, never persisted.
+    /// The status poll consults this to decide whether hooks own the
+    /// Running/NeedsInput/Completed classification: once a session proves its
+    /// hook channel is live, the transcript-tail poll stops second-guessing
+    /// turn completion (a long or tool-heavy Claude turn often leaves no
+    /// `end_turn` line inside the tail window, so the tail keeps reading
+    /// Running long after the turn ended) and only keeps ownership of the
+    /// Idle (process-gone) edge, which no hook reports.
+    hook_active: DashSet<Uuid>,
 }
 
 impl SessionStore {
@@ -419,6 +429,18 @@ impl SessionStore {
             entry.status = status;
         }
         Ok(entry.clone())
+    }
+
+    /// Record that `id` reported an agent lifecycle hook event, marking its
+    /// hook channel live so the status poll defers turn-boundary
+    /// classification to hooks (see the `hook_active` field). Idempotent.
+    pub fn mark_hook_active(&self, id: &Uuid) {
+        self.hook_active.insert(*id);
+    }
+
+    /// Whether `id` has reported any agent lifecycle hook event this run.
+    pub fn is_hook_active(&self, id: &Uuid) -> bool {
+        self.hook_active.contains(id)
     }
 
     /// Refresh derived live-agent metadata without bumping `updated_at`.
@@ -569,6 +591,7 @@ impl SessionStore {
     }
 
     pub fn remove(&self, id: &Uuid) -> SessionResult<Session> {
+        self.hook_active.remove(id);
         self.inner
             .remove(id)
             .map(|(_, v)| v)
@@ -655,6 +678,23 @@ mod tests {
                 .auto_title_enabled,
             Some(true)
         );
+    }
+
+    #[test]
+    fn hook_activity_is_tracked_and_cleared_on_remove() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+
+        assert!(!store.is_hook_active(&session.id));
+
+        store.mark_hook_active(&session.id);
+        assert!(store.is_hook_active(&session.id));
+        // Idempotent.
+        store.mark_hook_active(&session.id);
+        assert!(store.is_hook_active(&session.id));
+
+        store.remove(&session.id).expect("session exists");
+        assert!(!store.is_hook_active(&session.id));
     }
 
     #[test]

--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -63,6 +63,12 @@ pub fn apply_agent_hook_event(
         }
     }
 
+    // Mark the hook channel live so the transcript-tail status poll defers
+    // turn-boundary classification to these events instead of clobbering a
+    // just-set resting status (Completed/NeedsInput) back to Running on its
+    // next tick. See `poll_defers_to_hook` in `commands`.
+    sessions.mark_hook_active(&event.session_id);
+
     let status = event.event.session_status();
     sessions
         .refresh_status(&event.session_id, status)

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -132,9 +132,13 @@ case "$event" in
   *)
     event=""
     hook_event_name=$(printf '%s\n' "$input" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+    # Codex's turn-completion events (Stop / agent-turn-complete / task_complete)
+    # mean the agent finished the turn and is awaiting the user, so they map to
+    # needs_input. Codex emits no "process exited" event here — that shows up as
+    # the status poll observing an idle shell.
     case "$hook_event_name" in
       Start|UserPromptSubmit) event="start" ;;
-      Stop) event="stop" ;;
+      Stop) event="needs_input" ;;
       PermissionRequest) event="needs_input" ;;
       Error) event="error" ;;
     esac
@@ -142,7 +146,7 @@ case "$event" in
       codex_type=$(printf '%s\n' "$input" | grep -oE '"type"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
       case "$codex_type" in
         task_started) event="start" ;;
-        agent-turn-complete|task_complete) event="stop" ;;
+        agent-turn-complete|task_complete) event="needs_input" ;;
         exec_approval_request|apply_patch_approval_request|request_user_input) event="needs_input" ;;
       esac
     fi
@@ -217,13 +221,15 @@ input=$(cat 2>/dev/null || true)
 hook_event_name=$(printf '%s\n' "$input" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
 
 event=""
-# SubagentStop fires when a Task subagent finishes while the main agent is
-# still mid-turn, so it re-asserts Running rather than marking the session
-# done — only the main-agent Stop ends the turn.
+# Claude fires Stop at the end of every assistant turn — it has finished
+# responding and is awaiting the user's next prompt — so Stop maps to
+# needs_input, matching the transcript classifier's end_turn semantics.
+# SubagentStop fires mid-turn (a Task subagent finished) so it re-asserts
+# Running. Claude has no "process exited" hook; that shows up as the status
+# poll observing an idle shell.
 case "$hook_event_name" in
   SessionStart|UserPromptSubmit|SubagentStop) event="start" ;;
-  Stop) event="stop" ;;
-  Notification|PermissionRequest) event="needs_input" ;;
+  Stop|Notification|PermissionRequest) event="needs_input" ;;
   Error) event="error" ;;
 esac
 [ -n "$event" ] || exit 0
@@ -491,7 +497,11 @@ mod tests {
 
         let notify = fs::read_to_string(dir.join("acorn-codex-notify")).unwrap();
         assert!(notify.contains("\"provider\":\"codex\""));
-        assert!(notify.contains("agent-turn-complete|task_complete"));
+        // Turn-completion events map to needs_input (awaiting the user), not a
+        // per-turn "completed"; Codex emits no process-exit hook here.
+        assert!(notify.contains("agent-turn-complete|task_complete) event=\"needs_input\""));
+        assert!(notify.contains("Stop) event=\"needs_input\""));
+        assert!(!notify.contains("event=\"stop\""));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
         assert!(notify.contains("ACORN_AGENT_HOOK_SESSION_ID"));
     }
@@ -531,11 +541,12 @@ mod tests {
 
         let notify = fs::read_to_string(dir.join("acorn-claude-notify")).unwrap();
         assert!(notify.contains("\"provider\":\"claude\""));
-        // SubagentStop re-asserts Running (grouped with start), so the main
-        // agent's turn is not marked done when a Task subagent finishes.
+        // SubagentStop re-asserts Running (grouped with start); per-turn Stop
+        // maps to needs_input (awaiting the user), and Claude emits no "stop"
+        // (Completed) event at all — process exit is observed as idle.
         assert!(notify.contains("SessionStart|UserPromptSubmit|SubagentStop"));
-        assert!(notify.contains("Stop) event=\"stop\""));
-        assert!(notify.contains("Notification"));
+        assert!(notify.contains("Stop|Notification|PermissionRequest) event=\"needs_input\""));
+        assert!(!notify.contains("event=\"stop\""));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
         assert!(notify.contains("ACORN_AGENT_HOOK_SESSION_ID"));
 
@@ -619,7 +630,7 @@ mod tests {
         for (claude_event, acorn_event) in [
             ("SessionStart", "start"),
             ("UserPromptSubmit", "start"),
-            ("Stop", "stop"),
+            ("Stop", "needs_input"),
             ("SubagentStop", "start"),
             ("Notification", "needs_input"),
             ("PermissionRequest", "needs_input"),

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -217,9 +217,12 @@ input=$(cat 2>/dev/null || true)
 hook_event_name=$(printf '%s\n' "$input" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
 
 event=""
+# SubagentStop fires when a Task subagent finishes while the main agent is
+# still mid-turn, so it re-asserts Running rather than marking the session
+# done — only the main-agent Stop ends the turn.
 case "$hook_event_name" in
-  SessionStart|UserPromptSubmit) event="start" ;;
-  Stop|SubagentStop) event="stop" ;;
+  SessionStart|UserPromptSubmit|SubagentStop) event="start" ;;
+  Stop) event="stop" ;;
   Notification|PermissionRequest) event="needs_input" ;;
   Error) event="error" ;;
 esac
@@ -526,8 +529,10 @@ mod tests {
 
         let notify = fs::read_to_string(dir.join("acorn-claude-notify")).unwrap();
         assert!(notify.contains("\"provider\":\"claude\""));
-        assert!(notify.contains("SessionStart|UserPromptSubmit"));
-        assert!(notify.contains("Stop|SubagentStop"));
+        // SubagentStop re-asserts Running (grouped with start), so the main
+        // agent's turn is not marked done when a Task subagent finishes.
+        assert!(notify.contains("SessionStart|UserPromptSubmit|SubagentStop"));
+        assert!(notify.contains("Stop) event=\"stop\""));
         assert!(notify.contains("Notification"));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
         assert!(notify.contains("ACORN_AGENT_HOOK_SESSION_ID"));

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -354,9 +354,11 @@ case "$event" in
     event=""
     hook_event_name=$(printf '%s\n' "$input" | grep -oE '"hookEventName"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
     [ -n "$hook_event_name" ] || hook_event_name=$(printf '%s\n' "$input" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+    # SubagentStop fires when a Task subagent finishes mid-turn, so it
+    # re-asserts Running rather than ending the turn — only Stop is complete.
     case "$hook_event_name" in
-      SessionStart|UserPromptSubmit|PreToolUse) event="start" ;;
-      Stop|SubagentStop) event="stop" ;;
+      SessionStart|UserPromptSubmit|PreToolUse|SubagentStop) event="start" ;;
+      Stop) event="stop" ;;
       Notification|PermissionRequest) event="needs_input" ;;
       Error) event="error" ;;
     esac
@@ -618,7 +620,7 @@ mod tests {
             ("SessionStart", "start"),
             ("UserPromptSubmit", "start"),
             ("Stop", "stop"),
-            ("SubagentStop", "stop"),
+            ("SubagentStop", "start"),
             ("Notification", "needs_input"),
             ("PermissionRequest", "needs_input"),
             ("Error", "error"),
@@ -654,5 +656,16 @@ mod tests {
         assert!(notify.contains("PermissionRequest"));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
         assert!(notify.contains("ACORN_AGENT_HOOK_SESSION_ID"));
+    }
+
+    #[test]
+    fn antigravity_notify_treats_subagent_stop_as_running() {
+        let base = ScratchDir::new("agy-events");
+        let dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
+        let notify = fs::read_to_string(dir.join("acorn-antigravity-notify")).unwrap();
+        // SubagentStop fires mid-turn, so it re-asserts Running; only the
+        // main-agent Stop ends the turn.
+        assert!(notify.contains("SubagentStop) event=\"start\""));
+        assert!(notify.contains("Stop) event=\"stop\""));
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -304,11 +304,21 @@ fn inject_agent_hook_env(
     session: &Session,
     hooks: Option<&crate::agent_hooks::AgentHookServer>,
 ) {
-    let Some(provider) = session.agent_provider else {
-        return;
-    };
-    if !provider.supports_hooks() {
-        return;
+    // A known provider that can't use hooks opts out entirely. An unknown
+    // provider still gets the channel: a plain terminal session only learns
+    // its provider once the status poll spots a live agent in the process
+    // tree — long after the PTY (and its fixed environment) has spawned. If
+    // the hook env were withheld until then, `claude`/`codex` launched inside
+    // a terminal would never register hooks, and status would fall back to
+    // transcript polling, which cannot see turn completion after the
+    // `end_turn` line scrolls out of the tail window. The per-provider
+    // wrapper shim only activates hooks when an actual agent binary runs, and
+    // the notify script reports its own provider, so injecting the channel
+    // ahead of classification is safe.
+    if let Some(provider) = session.agent_provider {
+        if !provider.supports_hooks() {
+            return;
+        }
     }
 
     let Some(hooks) = hooks else {
@@ -325,9 +335,13 @@ fn inject_agent_hook_env(
         .entry("ACORN_AGENT_HOOK_SESSION_ID".to_string())
         .or_insert_with(|| session.id.to_string());
 
-    effective_env
-        .entry("ACORN_AGENT_HOOK_PROVIDER".to_string())
-        .or_insert_with(|| provider.hook_provider_env_value().to_string());
+    // Provider-specific metadata only when the provider is already known; the
+    // notify scripts hardcode their own provider so this stays optional.
+    if let Some(provider) = session.agent_provider {
+        effective_env
+            .entry("ACORN_AGENT_HOOK_PROVIDER".to_string())
+            .or_insert_with(|| provider.hook_provider_env_value().to_string());
+    }
 }
 
 fn authorize_chat_session(state: &AppState, session_id: &str) -> AppResult<Session> {
@@ -7460,7 +7474,12 @@ mod tests {
     }
 
     #[test]
-    fn inject_agent_hook_env_skips_until_provider_is_known() {
+    fn inject_agent_hook_env_injects_channel_when_provider_unknown() {
+        // A terminal session not yet classified as an agent still gets the
+        // hook channel so a later `claude`/`codex` launch inside it can
+        // register hooks. Without this the agent never reports Stop/Notify
+        // events and its status falls back to transcript polling, which can't
+        // see turn completion once `end_turn` scrolls out of the tail window.
         let hooks = crate::agent_hooks::AgentHookServer::start().expect("hook server starts");
         let mut session = Session::new(
             "Shell".to_string(),
@@ -7476,9 +7495,20 @@ mod tests {
         let mut env = HashMap::new();
         inject_agent_hook_env(&mut env, &session, Some(&hooks));
 
-        assert!(!env.contains_key("ACORN_AGENT_HOOK_URL"));
-        assert!(!env.contains_key("ACORN_AGENT_HOOK_TOKEN"));
-        assert!(!env.contains_key("ACORN_AGENT_HOOK_SESSION_ID"));
+        assert_eq!(
+            env.get("ACORN_AGENT_HOOK_URL"),
+            Some(&hooks.hook_url().to_string())
+        );
+        assert_eq!(
+            env.get("ACORN_AGENT_HOOK_TOKEN"),
+            Some(&hooks.token().to_string())
+        );
+        assert_eq!(
+            env.get("ACORN_AGENT_HOOK_SESSION_ID"),
+            Some(&session.id.to_string())
+        );
+        // Provider is unknown at spawn; the per-provider notify script reports
+        // its own provider, so the provider-specific var stays unset here.
         assert!(!env.contains_key("ACORN_AGENT_HOOK_PROVIDER"));
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4944,6 +4944,23 @@ pub async fn detect_session_statuses(
     .await
 }
 
+/// Whether the transcript-tail status poll should yield to the hook-set
+/// status instead of applying its own classification.
+///
+/// `hook_active` is true once a session has reported any agent lifecycle hook
+/// event this run (see `SessionStore::is_hook_active`). `detected` is the
+/// status the transcript/shell poll derived. Agent lifecycle hooks
+/// (Start/Stop/NeedsInput) are the authoritative turn-boundary signal, so when
+/// the channel is live the poll defers the Running/NeedsInput/Completed
+/// distinction to hooks and keeps ownership only of the Idle edge (agent
+/// process gone), which no hook reports. Without this, a long or tool-heavy
+/// Claude turn whose `end_turn` line has scrolled past the 256 KiB tail window
+/// keeps the poll reading Running and clobbering the hook's resting status on
+/// every tick — the session never returns to NeedsInput/Completed.
+fn poll_defers_to_hook(hook_active: bool, detected: SessionStatus) -> bool {
+    hook_active && detected != SessionStatus::Idle
+}
+
 fn detect_session_statuses_blocking(
     state: AppState,
     ids: Vec<String>,
@@ -5104,7 +5121,20 @@ fn detect_session_statuses_blocking(
                 }
             };
             let detection = session_status::detect_with_reason(transcript, previous, shell_hint);
-            let status = detection.status;
+            let defer_to_hook = poll_defers_to_hook(
+                parsed_id
+                    .map(|uuid| state.sessions.is_hook_active(&uuid))
+                    .unwrap_or(false),
+                detection.status,
+            );
+            // When a live hook channel owns the status, keep the hook-set
+            // value (`previous`) rather than the transcript-derived one; the
+            // poll still surfaces the Idle edge when the agent process exits.
+            let status = if defer_to_hook {
+                previous
+            } else {
+                detection.status
+            };
             // Branch source priority:
             //  1. deepest PTY descendant cwd — reflects `cd` + `git checkout`
             //     performed inside the terminal (and `claude -w` worktrees)
@@ -5132,7 +5162,11 @@ fn detect_session_statuses_blocking(
             SessionStatusEntry {
                 id,
                 status,
-                status_reason: detection.reason,
+                status_reason: if defer_to_hook {
+                    None
+                } else {
+                    detection.reason
+                },
                 agent_provider,
                 agent_transcript_id,
                 branch,
@@ -5943,12 +5977,12 @@ mod tests {
         auto_title_enabled_for_new_session, collect_memory_usage_from_roots,
         create_unique_worktree, daemon_spawn_name_for_session, detach_requested_by_stale_renderer,
         font_name_from_path, infer_acornd_root_from_session_pids, inject_agent_hook_env,
-        memory_root_pids, remove_linked_worktree_at_path, should_remove_local_project_mirror,
-        validate_editor_command, validate_new_project_name, ChatProviderAdapter,
-        ProcessMemorySnapshot,
+        memory_root_pids, poll_defers_to_hook, remove_linked_worktree_at_path,
+        should_remove_local_project_mirror, validate_editor_command, validate_new_project_name,
+        ChatProviderAdapter, ProcessMemorySnapshot,
     };
     use crate::error::{AppError, AppResult};
-    use acorn_session::{Session, SessionAgentProvider, SessionKind, SessionMode};
+    use acorn_session::{Session, SessionAgentProvider, SessionKind, SessionMode, SessionStatus};
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
@@ -6065,6 +6099,33 @@ mod tests {
                     metadata: None,
                 }))
         }
+    }
+
+    #[test]
+    fn poll_defers_to_hook_keeps_hook_status_for_live_agent() {
+        // A live hook channel owns the Running/NeedsInput/Completed
+        // distinction, so the transcript poll must defer for every non-Idle
+        // classification (a stale `tool_use` tail would otherwise clobber a
+        // hook-set resting status back to Running).
+        assert!(poll_defers_to_hook(true, SessionStatus::Running));
+        assert!(poll_defers_to_hook(true, SessionStatus::NeedsInput));
+        assert!(poll_defers_to_hook(true, SessionStatus::Completed));
+        assert!(poll_defers_to_hook(true, SessionStatus::Failed));
+    }
+
+    #[test]
+    fn poll_owns_idle_edge_even_when_hook_active() {
+        // No hook reports process death, so the poll always surfaces Idle.
+        assert!(!poll_defers_to_hook(true, SessionStatus::Idle));
+    }
+
+    #[test]
+    fn poll_drives_status_without_a_hook_channel() {
+        // Sessions with no observed hook events (e.g. `claude` typed straight
+        // into a terminal) rely on the transcript poll for every status.
+        assert!(!poll_defers_to_hook(false, SessionStatus::Running));
+        assert!(!poll_defers_to_hook(false, SessionStatus::NeedsInput));
+        assert!(!poll_defers_to_hook(false, SessionStatus::Idle));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5006,22 +5006,32 @@ pub async fn detect_session_statuses(
 /// Whether the transcript-tail status poll should yield to the hook-set
 /// status instead of applying its own classification.
 ///
-/// Agent lifecycle hooks are the authoritative turn-boundary signal. The poll
-/// defers **only** when all three hold:
-/// - `hook_active`: the session has reported a hook event this run
-///   (`SessionStore::is_hook_active`) — otherwise there is no hook status to
-///   trust and the transcript poll is the only signal.
-/// - `live_agent`: an agent process is currently alive under the PTY. Once it
-///   exits (or an unrelated command runs in the same tab) the hook status is
-///   stale and the poll must resume driving liveness.
-/// - `detected == Running`: the poll only ever *demotes* to Running from a
-///   stale tail (an `end_turn` line scrolled past the 256 KiB window). A
-///   transcript-derived `NeedsInput`/`Idle` is trustworthy and passes through —
-///   `NeedsInput` also backstops a dropped turn-end hook on short turns.
+/// Agent lifecycle hooks are the authoritative turn-boundary signal. While an
+/// agent process is alive under a hooked session the poll defers the entire
+/// Running/NeedsInput distinction to the hook-set store value and does not
+/// consult the transcript tail at all, because the tail is stale in *both*
+/// directions around a turn boundary:
+/// - just after a turn ends, a long/tool-heavy turn's `end_turn` line may be
+///   outside the 256 KiB window (or absent entirely), so the tail still reads
+///   Running;
+/// - just after the next prompt is submitted (UserPromptSubmit already fired
+///   Running), the tail still shows the *previous* turn's `end_turn` and reads
+///   NeedsInput until the agent flushes the new turn's line.
 ///
-/// The caller keeps the hook-set status (re-read fresh) when this returns true.
-fn poll_defers_to_hook(hook_active: bool, live_agent: bool, detected: SessionStatus) -> bool {
-    hook_active && live_agent && detected == SessionStatus::Running
+/// Letting either through races the independent ~1s poll against the hook. The
+/// NeedsInput direction is the dangerous one: it mislabels a just-started turn
+/// as `NeedsInput`+`turn_complete`, which the opt-in auto-close acts on to kill
+/// a live agent mid-turn. So the poll trusts the hook, not the tail, whenever
+/// an agent is live.
+///
+/// The poll keeps ownership only of the Idle edge: once no agent process is
+/// live (`live_agent` false — the agent exited, or an unrelated command now
+/// owns the PTY) it drives status again. Trade-off: a *dropped* terminating
+/// hook (fire-and-forget transport) can leave status lagging at the last hook
+/// value until the next hook or the agent exits; the synchronous hook path
+/// makes that rare, and it self-heals rather than losing data.
+fn poll_defers_to_hook(hook_active: bool, live_agent: bool) -> bool {
+    hook_active && live_agent
 }
 
 fn detect_session_statuses_blocking(
@@ -5211,7 +5221,6 @@ fn detect_session_statuses_blocking(
                     .map(|uuid| state.sessions.is_hook_active(&uuid))
                     .unwrap_or(false),
                 live_agent_kind.is_some(),
-                detection.status,
             );
             // When a live hooked agent owns the status, keep the hook-set value
             // instead of the stale transcript reading. Re-read it fresh: a hook
@@ -6084,7 +6093,7 @@ mod tests {
         ChatProviderAdapter, ProcessMemorySnapshot,
     };
     use crate::error::{AppError, AppResult};
-    use acorn_session::{Session, SessionAgentProvider, SessionKind, SessionMode, SessionStatus};
+    use acorn_session::{Session, SessionAgentProvider, SessionKind, SessionMode};
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
@@ -6204,41 +6213,26 @@ mod tests {
     }
 
     #[test]
-    fn poll_defers_only_when_demoting_a_live_hooked_agent_to_running() {
-        // The one case the poll must not win: a hooked, live agent whose stale
-        // transcript tail reads Running (its `end_turn` scrolled out of the
-        // window) — deferring keeps the hook's resting status.
-        assert!(poll_defers_to_hook(true, true, SessionStatus::Running));
-    }
-
-    #[test]
-    fn poll_lets_transcript_needs_input_through_as_backstop() {
-        // A transcript-derived NeedsInput is trustworthy (it saw `end_turn`)
-        // and backstops a dropped turn-end hook, so it is never deferred.
-        assert!(!poll_defers_to_hook(true, true, SessionStatus::NeedsInput));
+    fn poll_defers_while_a_hooked_agent_is_live() {
+        // While the agent process is alive the hook owns the turn boundary and
+        // the transcript tail is ignored in both directions (stale Running just
+        // after a turn ends, stale NeedsInput just after the next prompt).
+        assert!(poll_defers_to_hook(true, true));
     }
 
     #[test]
     fn poll_owns_status_once_the_agent_is_gone() {
-        // No live agent: the hook status is stale (agent exited, or an
-        // unrelated command now runs in the tab), so the poll drives again —
-        // including surfacing Idle, which no hook reports.
-        assert!(!poll_defers_to_hook(true, false, SessionStatus::Running));
-        assert!(!poll_defers_to_hook(true, false, SessionStatus::Idle));
-    }
-
-    #[test]
-    fn poll_owns_idle_edge_even_with_a_live_hooked_agent() {
-        assert!(!poll_defers_to_hook(true, true, SessionStatus::Idle));
+        // Agent exited, or an unrelated command now owns the PTY — the poll
+        // drives liveness again, including the Idle edge that no hook reports.
+        assert!(!poll_defers_to_hook(true, false));
     }
 
     #[test]
     fn poll_drives_status_without_a_hook_channel() {
-        // Sessions with no observed hook events (e.g. `claude` typed straight
-        // into a terminal before hooks registered) rely on the transcript poll.
-        assert!(!poll_defers_to_hook(false, true, SessionStatus::Running));
-        assert!(!poll_defers_to_hook(false, true, SessionStatus::NeedsInput));
-        assert!(!poll_defers_to_hook(false, true, SessionStatus::Idle));
+        // No observed hook events (e.g. `claude` typed straight into a terminal
+        // before hooks registered) — the transcript poll is the only signal.
+        assert!(!poll_defers_to_hook(false, true));
+        assert!(!poll_defers_to_hook(false, false));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4961,18 +4961,22 @@ pub async fn detect_session_statuses(
 /// Whether the transcript-tail status poll should yield to the hook-set
 /// status instead of applying its own classification.
 ///
-/// `hook_active` is true once a session has reported any agent lifecycle hook
-/// event this run (see `SessionStore::is_hook_active`). `detected` is the
-/// status the transcript/shell poll derived. Agent lifecycle hooks
-/// (Start/Stop/NeedsInput) are the authoritative turn-boundary signal, so when
-/// the channel is live the poll defers the Running/NeedsInput/Completed
-/// distinction to hooks and keeps ownership only of the Idle edge (agent
-/// process gone), which no hook reports. Without this, a long or tool-heavy
-/// Claude turn whose `end_turn` line has scrolled past the 256 KiB tail window
-/// keeps the poll reading Running and clobbering the hook's resting status on
-/// every tick — the session never returns to NeedsInput/Completed.
-fn poll_defers_to_hook(hook_active: bool, detected: SessionStatus) -> bool {
-    hook_active && detected != SessionStatus::Idle
+/// Agent lifecycle hooks are the authoritative turn-boundary signal. The poll
+/// defers **only** when all three hold:
+/// - `hook_active`: the session has reported a hook event this run
+///   (`SessionStore::is_hook_active`) — otherwise there is no hook status to
+///   trust and the transcript poll is the only signal.
+/// - `live_agent`: an agent process is currently alive under the PTY. Once it
+///   exits (or an unrelated command runs in the same tab) the hook status is
+///   stale and the poll must resume driving liveness.
+/// - `detected == Running`: the poll only ever *demotes* to Running from a
+///   stale tail (an `end_turn` line scrolled past the 256 KiB window). A
+///   transcript-derived `NeedsInput`/`Idle` is trustworthy and passes through —
+///   `NeedsInput` also backstops a dropped turn-end hook on short turns.
+///
+/// The caller keeps the hook-set status (re-read fresh) when this returns true.
+fn poll_defers_to_hook(hook_active: bool, live_agent: bool, detected: SessionStatus) -> bool {
+    hook_active && live_agent && detected == SessionStatus::Running
 }
 
 fn detect_session_statuses_blocking(
@@ -5139,13 +5143,19 @@ fn detect_session_statuses_blocking(
                 parsed_id
                     .map(|uuid| state.sessions.is_hook_active(&uuid))
                     .unwrap_or(false),
+                live_agent_kind.is_some(),
                 detection.status,
             );
-            // When a live hook channel owns the status, keep the hook-set
-            // value (`previous`) rather than the transcript-derived one; the
-            // poll still surfaces the Idle edge when the agent process exits.
+            // When a live hooked agent owns the status, keep the hook-set value
+            // instead of the stale transcript reading. Re-read it fresh: a hook
+            // may have written during this poll's process-table / transcript
+            // I/O, and reusing the `previous` captured before that I/O would
+            // clobber the newer hook status back to an old value.
             let status = if defer_to_hook {
-                previous
+                parsed_id
+                    .and_then(|uuid| state.sessions.get(&uuid).ok())
+                    .map(|s| s.status)
+                    .unwrap_or(previous)
             } else {
                 detection.status
             };
@@ -5166,7 +5176,11 @@ fn detect_session_statuses_blocking(
             // sessions reflect liveness on next save. Best-effort: ignore errors
             // (e.g. UUID parse failure for a stale id from the frontend).
             if let Some(uuid) = parsed_id {
-                let _ = state.sessions.refresh_status(&uuid, status);
+                // Deferring means a hook owns the status; leave the store value
+                // untouched so a hook write racing this poll's I/O survives.
+                if !defer_to_hook {
+                    let _ = state.sessions.refresh_status(&uuid, status);
+                }
                 let _ = state.sessions.refresh_agent_state(
                     &uuid,
                     agent_provider,
@@ -6116,30 +6130,41 @@ mod tests {
     }
 
     #[test]
-    fn poll_defers_to_hook_keeps_hook_status_for_live_agent() {
-        // A live hook channel owns the Running/NeedsInput/Completed
-        // distinction, so the transcript poll must defer for every non-Idle
-        // classification (a stale `tool_use` tail would otherwise clobber a
-        // hook-set resting status back to Running).
-        assert!(poll_defers_to_hook(true, SessionStatus::Running));
-        assert!(poll_defers_to_hook(true, SessionStatus::NeedsInput));
-        assert!(poll_defers_to_hook(true, SessionStatus::Completed));
-        assert!(poll_defers_to_hook(true, SessionStatus::Failed));
+    fn poll_defers_only_when_demoting_a_live_hooked_agent_to_running() {
+        // The one case the poll must not win: a hooked, live agent whose stale
+        // transcript tail reads Running (its `end_turn` scrolled out of the
+        // window) — deferring keeps the hook's resting status.
+        assert!(poll_defers_to_hook(true, true, SessionStatus::Running));
     }
 
     #[test]
-    fn poll_owns_idle_edge_even_when_hook_active() {
-        // No hook reports process death, so the poll always surfaces Idle.
-        assert!(!poll_defers_to_hook(true, SessionStatus::Idle));
+    fn poll_lets_transcript_needs_input_through_as_backstop() {
+        // A transcript-derived NeedsInput is trustworthy (it saw `end_turn`)
+        // and backstops a dropped turn-end hook, so it is never deferred.
+        assert!(!poll_defers_to_hook(true, true, SessionStatus::NeedsInput));
+    }
+
+    #[test]
+    fn poll_owns_status_once_the_agent_is_gone() {
+        // No live agent: the hook status is stale (agent exited, or an
+        // unrelated command now runs in the tab), so the poll drives again —
+        // including surfacing Idle, which no hook reports.
+        assert!(!poll_defers_to_hook(true, false, SessionStatus::Running));
+        assert!(!poll_defers_to_hook(true, false, SessionStatus::Idle));
+    }
+
+    #[test]
+    fn poll_owns_idle_edge_even_with_a_live_hooked_agent() {
+        assert!(!poll_defers_to_hook(true, true, SessionStatus::Idle));
     }
 
     #[test]
     fn poll_drives_status_without_a_hook_channel() {
         // Sessions with no observed hook events (e.g. `claude` typed straight
-        // into a terminal) rely on the transcript poll for every status.
-        assert!(!poll_defers_to_hook(false, SessionStatus::Running));
-        assert!(!poll_defers_to_hook(false, SessionStatus::NeedsInput));
-        assert!(!poll_defers_to_hook(false, SessionStatus::Idle));
+        // into a terminal before hooks registered) rely on the transcript poll.
+        assert!(!poll_defers_to_hook(false, true, SessionStatus::Running));
+        assert!(!poll_defers_to_hook(false, true, SessionStatus::NeedsInput));
+        assert!(!poll_defers_to_hook(false, true, SessionStatus::Idle));
     }
 
     #[test]

--- a/src/lib/sessionAutoClose.test.ts
+++ b/src/lib/sessionAutoClose.test.ts
@@ -256,6 +256,39 @@ describe("session auto-close", () => {
     dispose();
   });
 
+  it("removes an agent-backed session when it exits to idle from needs_input", async () => {
+    // A hooked Claude/Codex session settles at needs_input between turns; when
+    // the agent process exits the poll reports idle. That exit should close the
+    // session, matching the running→idle path.
+    const removeSession = vi.fn(async () => null);
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "needs_input",
+          updated_at: "2026-01-01T00:01:00Z",
+        }),
+      ],
+      autoCloseSessionIds: { "session-1": true },
+      removeSession,
+    });
+    const dispose = startSessionAutoCloseWatcher();
+
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "idle",
+          agent_provider: null,
+          agent_transcript_id: null,
+          updated_at: "2026-01-01T00:02:00Z",
+        }),
+      ],
+    });
+    await flushPromises();
+
+    expect(removeSession).toHaveBeenCalledWith("session-1", false);
+    dispose();
+  });
+
   it("does not remove a historical agent session for a later shell transition", async () => {
     const removeSession = vi.fn(async () => null);
     useAppStore.setState({

--- a/src/lib/sessionAutoClose.ts
+++ b/src/lib/sessionAutoClose.ts
@@ -19,10 +19,14 @@ export function shouldAutoCloseFinishedSession(
   // trusts that explicit reason.
   const needsInputAfterTurnComplete =
     session.status === "needs_input" && statusReason === "turn_complete";
-  // Agent transcripts normally finish as needs_input, but a fast process exit
-  // can collapse the next observed state to idle after the run.
+  // A hooked agent settles at needs_input between turns, then collapses to idle
+  // when its process exits; a non-hooked or fast exit can go straight from
+  // running to idle. Treat an exit from either the working (running) or resting
+  // (needs_input) state as the run ending — but never the running→needs_input
+  // turn boundary itself, so an interactive session is not closed mid-work.
   const returnedIdleAfterRun =
-    previousStatus === "running" && session.status === "idle";
+    (previousStatus === "running" || previousStatus === "needs_input") &&
+    session.status === "idle";
 
   return (
     enabled &&


### PR DESCRIPTION
## Problem

Agent sessions (Claude/Codex) get pinned to **Running** in the sidebar and never return to a resting "awaiting input" state while they actually sit waiting for the user's next prompt.

## Root cause

Reproduced against a live stuck session (a 1.7 MB Claude transcript). The status a session shows comes from two sources that were quietly fighting:

1. A live agent process is always a running PTY descendant even while it waits for input, so the shell-liveness hint is always `Running` — only the transcript tail can distinguish "working" from "turn finished".
2. The transcript classifier only reports the resting state when it finds an assistant JSONL line with `stop_reason` `end_turn`/`stop_sequence` inside the last 256 KiB. Long or tool-heavy turns push that marker (and every turn line) out of the window behind large `attachment`/tool-output lines — the stuck session had **zero** `end_turn` assistant records and 561 `attachment` meta lines — so the tail keeps classifying `Running`.
3. There is a reliable push-based hook path (`agent_hooks.rs`), but the ~1s status poll unconditionally overwrote the hook-set status via `refresh_status`, clobbering it back to `Running` every tick.
4. And hooks were not firing at all for terminal-launched agents: `inject_agent_hook_env` only stamped the hook channel when `session.agent_provider` was already known at PTY spawn, but a plain terminal session only learns its provider later (live process-tree detection), long after the PTY spawned with a fixed environment. So `claude` typed into a terminal never received `ACORN_AGENT_HOOK_*` and no hooks were registered.

## Fix

Make agent lifecycle hooks the authoritative turn-boundary signal, make them actually fire, and give them the correct resting semantics.

- **Wire hooks for terminal-launched agents** — inject the hook channel (`URL`/`TOKEN`/`SESSION_ID`) whenever the hook server is available, regardless of whether the provider is known yet. The per-provider wrapper shim only activates hooks when a real agent binary runs and each notify script hardcodes its own provider, so `ACORN_AGENT_HOOK_PROVIDER` stays optional.
- **Correct resting semantics** — Claude's `Stop` and Codex's `task_complete`/`agent-turn-complete` fire at the end of *every* assistant turn (awaiting the user), so they now map to `needs_input`, matching the transcript classifier — not `completed`. Antigravity's `stop` fires only after its process exits, so it keeps mapping to `completed`. `SubagentStop` re-asserts `Running` (a Task subagent finishing mid-turn is not turn completion).
- **Hooks own turn status over the poll while an agent is live** — once a session reports a hook event, and while an agent process is actually live under the PTY, the poll keeps the hook-set status and ignores the transcript tail (which is stale in *both* directions around a turn boundary — a just-ended long turn still reads Running, and a just-started turn still reads the prior `end_turn` as NeedsInput). It regains control only at the Idle edge (the agent exited, or an unrelated command now owns the tab). When deferring it re-reads the current status and skips its write, so a hook landing during the poll's I/O is never clobbered. Trade-off: a *dropped* terminating hook can briefly leave status lagging at the last hook value until the next hook or the agent exits — rare (synchronous transport) and self-healing, not a stuck state that loses work.
- **Auto-close fires on agent exit, not per turn** — because Claude/Codex now rest at `needs_input` (never `completed`) and the poll defers to hooks while the agent is live, the opt-in per-session auto-close would otherwise never fire for them. It now treats an exit to `idle` from the resting `needs_input` state as the run ending (alongside the existing `running`→`idle` path), while never firing on the `running`→`needs_input` turn boundary — so an interactive session is not closed after its first turn.

## Behavior changes

- Claude/Codex sessions settle to **needs_input** ("awaiting your next input") after each turn instead of drifting to a stale `Running`. They no longer produce a `completed` status; their true end is the process exiting, observed as idle. The opt-in per-session auto-close fires on that exit (from `needs_input` or `running` → `idle`) rather than on any single turn boundary.

## Security note

The hook token now reaches every agent-capable terminal session's environment, so a process inside that terminal could POST status events for its own session id. Localhost-only, and the only capability is flipping this session's status enum — no code execution or data access.

## Test plan

- [x] `cargo test -p acorn-session` and `cargo test --lib` in `src-tauri` (all pass with `--test-threads=1`; a couple of hook-server / scrollback tests bind ports or temp paths and flake only under parallelism)
- [x] Unit coverage added: `poll_defers_to_hook` contract (defer only while a hooked agent is live; poll owns the Idle edge and the no-hook-channel case), `hook_active` tracking + cleanup, `inject_agent_hook_env` channel injection when provider unknown, Claude/Codex/Antigravity notify event mappings
- [x] clippy + rustfmt clean on changed code
- [x] Independent adversarial review across multiple rounds; a CRITICAL turn-start auto-close race and several HIGH findings were caught and fixed (see commit history)
- [ ] Runtime (needs rebuild + a **new** session — the hook env is fixed at PTY spawn, so already-running sessions do not self-heal): launch a terminal session, run `claude`, confirm its process now has `ACORN_AGENT_HOOK_URL` set, finish a turn, and verify the status settles to needs_input instead of staying Running.
