### PR TITLE
fix(sessions): re-validate session state before auto-close removal

### DIFF
--- a/src/lib/sessionAutoClose.test.ts
+++ b/src/lib/sessionAutoClose.test.ts
@@ -286,6 +286,87 @@ describe("session auto-close", () => {
     dispose();
   });
 
+  it("does not remove a session whose status reverts to running before the queued close runs", async () => {
+    const removeSession = vi.fn(async () => null);
+    useAppStore.setState({
+      autoCloseSessionIds: { "session-1": true },
+      removeSession,
+    });
+    const dispose = startSessionAutoCloseWatcher();
+
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "needs_input",
+          status_reason: "turn_complete",
+          agent_provider: "codex",
+          updated_at: "2026-01-01T00:01:00Z",
+        }),
+      ],
+    });
+    // A new turn starts synchronously in the same tick, before the queued
+    // microtask drains.
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "running",
+          agent_provider: "codex",
+          updated_at: "2026-01-01T00:01:01Z",
+        }),
+      ],
+    });
+    await flushPromises();
+
+    expect(removeSession).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("still closes after an aborted close once the next turn finishes", async () => {
+    const removeSession = vi.fn(async () => null);
+    useAppStore.setState({
+      autoCloseSessionIds: { "session-1": true },
+      removeSession,
+    });
+    const dispose = startSessionAutoCloseWatcher();
+
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "needs_input",
+          status_reason: "turn_complete",
+          agent_provider: "codex",
+          updated_at: "2026-01-01T00:01:00Z",
+        }),
+      ],
+    });
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "running",
+          agent_provider: "codex",
+          updated_at: "2026-01-01T00:01:01Z",
+        }),
+      ],
+    });
+    await flushPromises();
+    expect(removeSession).not.toHaveBeenCalled();
+
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "needs_input",
+          status_reason: "turn_complete",
+          agent_provider: "codex",
+          updated_at: "2026-01-01T00:02:00Z",
+        }),
+      ],
+    });
+    await flushPromises();
+
+    expect(removeSession).toHaveBeenCalledWith("session-1", false);
+    dispose();
+  });
+
   it("does not remove stale finished sessions on watcher startup", async () => {
     const removeSession = vi.fn(async () => null);
     useAppStore.setState({

--- a/src/lib/sessionAutoClose.ts
+++ b/src/lib/sessionAutoClose.ts
@@ -33,6 +33,18 @@ export function shouldAutoCloseFinishedSession(
   );
 }
 
+// Auto-close must only ever remove sessions that are still finished at the
+// moment of removal; anything else (notably `running`) means a new turn
+// started after the close was queued.
+function isStillFinished(session: Session): boolean {
+  return (
+    session.status === "completed" ||
+    (session.status === "needs_input" &&
+      (session.status_reason ?? null) === "turn_complete") ||
+    session.status === "idle"
+  );
+}
+
 export function startSessionAutoCloseWatcher(): () => void {
   const lastStatus = new Map<string, SessionStatus>();
   const lastStatusReason = new Map<string, SessionStatusReason | null>();
@@ -74,11 +86,13 @@ export function startSessionAutoCloseWatcher(): () => void {
       closingIds.add(session.id);
       queueMicrotask(() => {
         const latest = useAppStore.getState();
-        const stillPresent = latest.sessions.some(
+        const latestSession = latest.sessions.find(
           (candidate) => candidate.id === session.id,
         );
         const stillEnabled = Boolean(latest.autoCloseSessionIds[session.id]);
-        if (!stillEnabled || !stillPresent) {
+        // Re-validate against the freshest state: the status can flip back to
+        // `running` in the same tick (a new turn), and removal kills the pty.
+        if (!stillEnabled || !latestSession || !isStillFinished(latestSession)) {
           closingIds.delete(session.id);
           return;
         }


### PR DESCRIPTION
## Summary

The session auto-close watcher queued `removeSession` in a microtask but only re-checked that the session was still present and auto-close was still enabled. A session whose status flipped back to `running` in the same tick (a new turn starting synchronously right after `turn_complete`) was still removed — unmounting its Terminal and killing the pty mid-turn.

The queued close now re-validates the latest store state and aborts unless the session is still in a finished state (`completed`, `needs_input` with `turn_complete`, or `idle`). A session whose latest status is `running` can no longer be auto-closed.

Found in the v1.20.0..HEAD release review (follow-up to #506).

## Test plan

- [x] New test: status reverts to `running` before the microtask drains → `removeSession` not called
- [x] New test: after an aborted close, the next finished turn still closes (verifies `closingIds` cleanup)
- [x] `bunx vitest run src/lib/sessionAutoClose.test.ts` — 13 passed
- [x] `bunx vitest run src/store.test.ts` — 137 passed
- [x] `bun run typecheck` clean
