### PR TITLE
test(themes): guard --color-selection across all built-in themes

### DIFF
--- a/src/lib/themes.test.ts
+++ b/src/lib/themes.test.ts
@@ -90,6 +90,12 @@ describe("BUILT_IN_THEMES", () => {
     }
   });
 
+  it("gives every built-in theme an explicit UI selection color", () => {
+    for (const theme of BUILT_IN_THEMES) {
+      expect(theme.css, theme.id).toMatch(/--color-selection\s*:/);
+    }
+  });
+
   it("gives every built-in theme an explicit input surface", () => {
     for (const theme of BUILT_IN_THEMES) {
       expect(theme.css, theme.id).toMatch(/--color-input\s*:/);


### PR DESCRIPTION
## Summary

Adds a regression test asserting that every built-in theme (light and dark) explicitly defines `--color-selection` in its CSS. This closes a coverage gap left after 1e1f9b5, where only `--color-term-selection` was guarded and only for dark themes — a future theme omitting `--color-selection` would silently fall back to the acorn-dark default hardcoded in App.css `:root`.

Found in the v1.20.0..HEAD release review. Test-only change; all 26 current themes already pass.

## Test plan

- [x] `bunx vitest run src/lib/themes.test.ts` — 12 passed (11 existing + 1 new)
- [x] `bun run typecheck` clean
