### PR TITLE
perf(sidebar): read fork data at click time instead of subscribing per row

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2587,8 +2587,6 @@ function SessionRow({
 }: SessionRowProps) {
   const t = useTranslation();
   const showToast = useToasts((s) => s.show);
-  const sessions = useAppStore((s) => s.sessions);
-  const projects = useAppStore((s) => s.projects);
   const renameSession = useAppStore((s) => s.renameSession);
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
   const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
@@ -2719,6 +2717,7 @@ function SessionRow({
     isolated: boolean,
   ) {
     selectSession(session.id);
+    const { sessions, projects } = useAppStore.getState();
     const request = buildSessionCreateRequestFromScope(
       { sessions, projects },
       scopeForSession(session),


### PR DESCRIPTION
## Summary

`SessionRow` subscribed to the full `sessions` and `projects` store arrays (added for the session-fork feature), so every status-poll tick that replaced either array reference re-rendered every row in the sidebar — O(n) re-renders per tick with n sessions.

Both values are only consumed inside the fork click handler, so the subscriptions are replaced with a synchronous `useAppStore.getState()` read at click time, matching the pattern the handler already uses for `consumeError()` and `refreshAll()`. No behavior change; rows now re-render only when their own props or remaining per-session selectors change.

Found in the v1.20.0..HEAD release review.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx vitest run src/store.test.ts` — 137 passed
- [x] Verified nothing in the render path references the removed subscriptions
