### PR TITLE
fix(workspace): release kanban column resize drag on unmount

### DIFF
--- a/src/components/WorkspaceMain.test.tsx
+++ b/src/components/WorkspaceMain.test.tsx
@@ -51,6 +51,34 @@ function queryKanban(): HTMLElement | null {
   return document.querySelector<HTMLElement>("[data-testid='workspace-kanban']");
 }
 
+function queryColumnResizeHandle(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(
+    "[data-testid='workspace-kanban-column-resize-handle']",
+  );
+}
+
+function readColumnWidths(): number[] {
+  const board = document.querySelector<HTMLElement>(
+    "[data-kanban-column-widths]",
+  );
+  return (board?.dataset.kanbanColumnWidths ?? "").split(",").map(Number);
+}
+
+// jsdom has no PointerEvent constructor; React's pointer handlers and the
+// component's raw listeners only read MouseEvent fields plus `pointerId`,
+// which stays undefined on both sides and passes the same-pointer check.
+function firePointer(
+  target: EventTarget,
+  type: string,
+  init: MouseEventInit = {},
+): void {
+  act(() => {
+    target.dispatchEvent(
+      new MouseEvent(type, { bubbles: true, cancelable: true, ...init }),
+    );
+  });
+}
+
 describe("WorkspaceMain", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -100,5 +128,48 @@ describe("WorkspaceMain", () => {
 
     render("kanban");
     expect(queryLayout()?.parentElement?.className).toContain("hidden");
+  });
+
+  it("resizes the column during a drag and restores body styles on pointerup", () => {
+    render("kanban");
+    const handle = queryColumnResizeHandle();
+    expect(handle).not.toBeNull();
+    const initialWidth = readColumnWidths()[0];
+
+    firePointer(handle!, "pointerdown", { clientX: 100 });
+    expect(document.body.style.cursor).toBe("col-resize");
+    expect(document.body.style.userSelect).toBe("none");
+
+    firePointer(window, "pointermove", { clientX: 140 });
+    expect(readColumnWidths()[0]).toBe(initialWidth + 40);
+
+    firePointer(window, "pointerup", { clientX: 140 });
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+
+    // The drag listeners must be gone: further moves change nothing.
+    firePointer(window, "pointermove", { clientX: 200 });
+    expect(readColumnWidths()[0]).toBe(initialWidth + 40);
+  });
+
+  it("restores body styles and drops drag listeners when unmounted mid-drag", () => {
+    render("kanban");
+    const handle = queryColumnResizeHandle();
+    expect(handle).not.toBeNull();
+    const initialWidth = readColumnWidths()[0];
+
+    firePointer(handle!, "pointerdown", { clientX: 100 });
+    expect(document.body.style.cursor).toBe("col-resize");
+    expect(document.body.style.userSelect).toBe("none");
+
+    // Flipping the view mode away from kanban unmounts the board mid-drag.
+    render("panes");
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+
+    // The orphaned pointermove listener must not fire against a stale closure.
+    firePointer(window, "pointermove", { clientX: 300 });
+    render("kanban");
+    expect(readColumnWidths()[0]).toBe(initialWidth);
   });
 });

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -196,6 +196,7 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
   const [resizingColumnIndex, setResizingColumnIndex] = useState<number | null>(
     null,
   );
+  const columnResizeCleanupRef = useRef<(() => void) | null>(null);
 
   const sessions = useMemo(() => {
     const ordered: Session[] = [];
@@ -255,6 +256,16 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
     if (sessionsById.has(terminalPopover.sessionId)) return;
     closeTerminalPopover();
   }, [terminalPopover, sessionsById]);
+
+  // Release a column drag that is still active when the board unmounts
+  // (view-mode flip or project switch mid-drag) so the body cursor and text
+  // selection are restored and no orphaned listeners keep firing.
+  useEffect(() => {
+    return () => {
+      columnResizeCleanupRef.current?.();
+      columnResizeCleanupRef.current = null;
+    };
+  }, []);
 
   function setFilterQuery(filterQuery: string) {
     setPrefs((current) => ({ ...current, filterQuery }));
@@ -322,6 +333,11 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
     event.preventDefault();
     event.stopPropagation();
 
+    // End any drag that is somehow still tracked before starting a new one.
+    columnResizeCleanupRef.current?.();
+
+    const source = event.currentTarget;
+    const pointerId = event.pointerId;
     const startX = event.clientX;
     const startWidth = columnWidths[index] ?? KANBAN_COLUMN_DEFAULT_WIDTH;
     const previousCursor = document.body.style.cursor;
@@ -330,22 +346,45 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
     document.body.style.userSelect = "none";
     setResizingColumnIndex(index);
 
-    function cleanup() {
+    const cleanup = () => {
       document.body.style.cursor = previousCursor;
       document.body.style.userSelect = previousUserSelect;
       setResizingColumnIndex(null);
+      try {
+        source.releasePointerCapture?.(pointerId);
+      } catch {
+        // The pointer may already be released if the handle unmounted.
+      }
       window.removeEventListener("pointermove", onPointerMove);
-      window.removeEventListener("pointerup", cleanup);
-      window.removeEventListener("pointercancel", cleanup);
-    }
+      window.removeEventListener("pointerup", onPointerEnd);
+      window.removeEventListener("pointercancel", onPointerEnd);
+      source.removeEventListener("lostpointercapture", onPointerEnd);
+      if (columnResizeCleanupRef.current === cleanup) {
+        columnResizeCleanupRef.current = null;
+      }
+    };
 
     function onPointerMove(moveEvent: PointerEvent) {
+      if (moveEvent.pointerId !== pointerId) return;
       resizeColumn(index, startWidth + moveEvent.clientX - startX);
     }
 
+    function onPointerEnd(endEvent: PointerEvent) {
+      if (endEvent.pointerId !== pointerId) return;
+      cleanup();
+    }
+
+    columnResizeCleanupRef.current = cleanup;
+    try {
+      source.setPointerCapture?.(pointerId);
+    } catch {
+      // Synthetic events and some webviews can reject capture; window
+      // listeners still cover normal in-window dragging.
+    }
     window.addEventListener("pointermove", onPointerMove);
-    window.addEventListener("pointerup", cleanup);
-    window.addEventListener("pointercancel", cleanup);
+    window.addEventListener("pointerup", onPointerEnd);
+    window.addEventListener("pointercancel", onPointerEnd);
+    source.addEventListener("lostpointercapture", onPointerEnd);
   }
 
   return (


### PR DESCRIPTION
## Summary

The kanban column-resize drag registered raw window pointer listeners whose only cleanup path was the drag's own pointerup/pointercancel events. Unmounting the board mid-drag (view-mode flip to panes or a project switch via the `key={projectId}` remount) left `document.body` stuck with a `col-resize` cursor and `user-select: none`, while an orphaned pointermove listener kept firing against a stale closure — and a pointerup released outside the OS window might never arrive to clean it up.

This reworks the drag to follow the established tab-drag pattern in `Pane.tsx`: pointer capture on the handle with pointerId-filtered listeners plus `lostpointercapture` handling, and the cleanup tracked in a ref invoked on unmount, so an interrupted drag always restores body styles and detaches its listeners. The resize math itself is unchanged.

Found in the v1.20.0..HEAD release review (follow-up to the kanban workspace mode).

## Test plan

- [x] New test: normal drag lifecycle — column resizes, pointerup restores body styles and drops listeners
- [x] New test: unmount mid-drag (view-mode flip) restores `cursor`/`userSelect`, orphaned pointermove no longer mutates widths
- [x] `bunx vitest run src/components/WorkspaceMain.test.tsx` — 4/4 passed
- [x] `bun run typecheck` clean
