### PR TITLE
fix(workspace): re-validate worktree workspace creation at click time

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -90,7 +90,9 @@ import {
   buildProjectFolderGroups,
   defaultProjectFolderId,
   findProjectFolderById,
+  findWorktreeWorkspaceForPath,
   isDefaultProjectFolder,
+  resolveProjectFolderIdForSession,
   type ProjectFolder,
   type ProjectFolderGroup,
   type ProjectFolderProjectGroup,
@@ -1487,12 +1489,59 @@ function canCreateWorkspaceFromSessionWorktree(
   if (currentFolder && !isDefaultProjectFolder(currentFolder)) {
     return false;
   }
-  return !projectFolders.some(
-    (folder) =>
-      !isDefaultProjectFolder(folder) &&
-      isWorktreeWorkspace(folder) &&
-      normalizeWorkspacePath(folder.cwdPath) ===
-        normalizeWorkspacePath(session.worktree_path),
+  return !findWorktreeWorkspaceForPath(projectFolders, session.worktree_path);
+}
+
+/**
+ * Click-time counterpart of `canCreateWorkspaceFromSessionWorktree`, which
+ * only gates the context-menu item's *visibility* with a snapshot taken when
+ * the menu opened. By the time the item is clicked, another click or session
+ * may already have created a workspace for the same worktree, so eligibility
+ * is re-resolved against fresh store state: an existing workspace pointing at
+ * the same path is activated instead of duplicated, a worktree missing from
+ * disk surfaces a toast, and any other stale snapshot silently no-ops.
+ */
+async function createWorkspaceFromSessionWorktree(
+  session: Session,
+  showToast: (message: string) => void,
+  t: Translator,
+): Promise<ProjectFolder | null> {
+  const worktreeOnDisk = await api
+    .isPathLinkedWorktree(session.worktree_path)
+    .catch((err: unknown) => {
+      console.error("[Sidebar] worktree existence check failed", err);
+      return false;
+    });
+  // Read state only after the IPC roundtrip above so validation and creation
+  // run synchronously against the same snapshot, with no await in between.
+  const state = useAppStore.getState();
+  const folders = state.projectFolders[session.repo_path] ?? [];
+  const existing = findWorktreeWorkspaceForPath(
+    folders,
+    session.worktree_path,
+  );
+  if (existing) {
+    state.setActiveProjectFolder(existing.id);
+    return existing;
+  }
+  const currentFolderId = resolveProjectFolderIdForSession(
+    folders,
+    session,
+    state.sessionFolderIds,
+  );
+  if (
+    !canCreateWorkspaceFromSessionWorktree(session, folders, currentFolderId)
+  ) {
+    return null;
+  }
+  if (!worktreeOnDisk) {
+    showToast(t("toasts.session.worktreeMissing"));
+    return null;
+  }
+  return state.createProjectFolder(
+    session.repo_path,
+    basename(session.worktree_path),
+    session.worktree_path,
   );
 }
 
@@ -2590,7 +2639,6 @@ function SessionRow({
   const renameSession = useAppStore((s) => s.renameSession);
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
   const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
-  const createProjectFolder = useAppStore((s) => s.createProjectFolder);
   const toggleSessionAutoClose = useAppStore(
     (s) => s.toggleSessionAutoClose,
   );
@@ -2747,11 +2795,11 @@ function SessionRow({
     }
   }
 
-  function createWorkspaceFromWorktree() {
-    const folder = createProjectFolder(
-      session.repo_path,
-      basename(session.worktree_path),
-      session.worktree_path,
+  async function createWorkspaceFromWorktree() {
+    const folder = await createWorkspaceFromSessionWorktree(
+      session,
+      showToast,
+      t,
     );
     if (!folder) return;
     selectSession(session.id);
@@ -3797,7 +3845,6 @@ function LocalSessionRow({
   const showToast = useToasts((s) => s.show);
   const renameSession = useAppStore((s) => s.renameSession);
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
-  const createProjectFolder = useAppStore((s) => s.createProjectFolder);
   const toggleSessionAutoClose = useAppStore(
     (s) => s.toggleSessionAutoClose,
   );
@@ -3865,11 +3912,11 @@ function LocalSessionRow({
     }
   }
 
-  function createWorkspaceFromWorktree() {
-    const folder = createProjectFolder(
-      session.repo_path,
-      basename(session.worktree_path),
-      session.worktree_path,
+  async function createWorkspaceFromWorktree() {
+    const folder = await createWorkspaceFromSessionWorktree(
+      session,
+      showToast,
+      t,
     );
     if (!folder) return;
     onSelect();

--- a/src/lib/projectFolders.ts
+++ b/src/lib/projectFolders.ts
@@ -57,6 +57,25 @@ export function findProjectFolderById(
   return null;
 }
 
+/**
+ * Find the non-default workspace folder that already points at the given
+ * worktree path, if any. Matching uses the same normalization as the
+ * sidebar's worktree grouping (`isMatchingWorktreeFolder`), so callers can
+ * use this as a duplicate guard before creating a workspace for a worktree.
+ */
+export function findWorktreeWorkspaceForPath(
+  folders: readonly ProjectFolder[],
+  worktreePath: string,
+): ProjectFolder | null {
+  return (
+    folders.find(
+      (folder) =>
+        isWorktreeFolder(folder) &&
+        normalizePath(folder.cwdPath) === normalizePath(worktreePath),
+    ) ?? null
+  );
+}
+
 export function makeProjectFolderId(repoPath: string): string {
   const suffix =
     typeof crypto !== "undefined" && "randomUUID" in crypto

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,7 +13,8 @@
       "titleNotReady": "No transcript is available for this session yet.",
       "titleRegenerateSkipped": "Session name was not regenerated.",
       "worktreeAdopted": "Worktree adopted: {name}",
-      "worktreeAdoptFailed": "Failed to adopt worktree:"
+      "worktreeAdoptFailed": "Failed to adopt worktree:",
+      "worktreeMissing": "Worktree folder no longer exists on disk."
     },
     "project": {
       "addFailed": "Failed to add project:",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -13,7 +13,8 @@
       "titleNotReady": "아직 이 세션에서 사용할 transcript가 없습니다.",
       "titleRegenerateSkipped": "세션 이름을 다시 생성하지 않았습니다.",
       "worktreeAdopted": "새 워크트리를 가져왔습니다: {name}",
-      "worktreeAdoptFailed": "워크트리를 가져오지 못했습니다:"
+      "worktreeAdoptFailed": "워크트리를 가져오지 못했습니다:",
+      "worktreeMissing": "워크트리 폴더가 디스크에 더 이상 존재하지 않습니다."
     },
     "project": {
       "addFailed": "프로젝트를 추가하지 못했습니다:",

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -2130,6 +2130,14 @@ test.describe("sidebar: project lifecycle", () => {
         in_worktree: true,
       },
     ]);
+    // The click-time guard verifies the worktree still exists on disk before
+    // creating a workspace for it; the mock default answers false.
+    await tauri.handle(
+      "is_path_linked_worktree",
+      (args) =>
+        (args as { path?: string }).path ===
+        "/tmp/demo/.acorn/worktrees/feature",
+    );
 
     await page.goto("/");
 


### PR DESCRIPTION
## Summary

`canCreateWorkspaceFromSessionWorktree` only gated the context-menu item's visibility, using a snapshot taken when the menu opened. The click handler then called `createProjectFolder` unconditionally, which never checks for an existing folder pointing at the same path — so a stale snapshot (another click or another session already created a workspace for the same worktree) produced a duplicate project folder. Nothing verified the worktree directory still existed on disk either.

The click handler now goes through a click-time counterpart that re-resolves eligibility against fresh store state: an existing workspace pointing at the same path is activated instead of duplicated, a worktree missing from disk surfaces a toast (new `toasts.session.worktreeMissing` string in en/ko), and any other stale snapshot silently no-ops. The duplicate lookup is extracted to `findWorktreeWorkspaceForPath` in `projectFolders.ts` and shared with the visibility guard. The existence check reuses the existing `is_path_linked_worktree` command.

Found in the v1.20.0..HEAD release review (follow-up to #514).

## Test plan

- [x] e2e `sidebar.spec.ts` — 39/39 pass locally (existing worktree-workspace test updated to answer the new existence check through the mock)
- [x] `bun run typecheck` clean
- [x] `bunx vitest run src/store.test.ts src/lib` — 664 passed
- [x] en/ko locale key parity verified — zero divergent keys
