### PR TITLE
chore(release): v1.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.20.0",
+  "version": "1.21.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.20.0"
+version = "1.21.0"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.20.0"
+version = "1.21.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

This release bump publishes the user-visible feature, fix, and performance work merged after `v1.20.0`.

1. **Version metadata:** Bumps Acorn from `1.20.0` to `1.21.0` in `package.json`, `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock`.
2. **Semver decision:** Uses a minor release because the unreleased set includes new user-visible features, including workspace kanban mode, terminal text selection/right-click paste, workspace creation from worktree sessions, configurable terminal popovers, agent session auto-close, macOS permission controls, and friendly tab/worktree names.
3. **Release scope:** Includes merged PRs #501, #502, #503, #505, #506, #507, #508, #510, #511, #512, #513, #514, #515, #516, #517, #518, #519, #520, #521, #522, #523, #524, #525, and #526.

## Expected impact

| Area | Impact |
| --- | --- |
| User-visible version | Acorn updater and app metadata move to `1.21.0`. |
| Release notes | Generated release notes include the merged feature, fix, performance, chore, and dependency PRs since `v1.20.0`; this bump PR is excluded via `skip-changelog`. |
| Runtime behavior | No code behavior changes in this PR beyond version metadata. |

## Design notes

- The release is a minor bump because the release train contains new user-visible capabilities.
- Only release metadata files are changed so the PR stays reviewable and easy to validate.

## Test plan

- [x] `rg -n '1\.20\.0|1\.21\.0' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock`
- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1`
- [x] `REPO=im-ian/acorn TAG=v1.21.0 OUTPUT=/tmp/acorn-release-notes-v1.21.0.md node scripts/release-notes.mjs`
- [x] `git diff --check`

## Notes

- Label this PR `skip-changelog`; the merged product PRs provide the release notes entries.
