### PR TITLE
feat(release): bilingual release note summary callouts

### DIFF
--- a/docs/PR_LABELS.md
+++ b/docs/PR_LABELS.md
@@ -3,6 +3,7 @@
 Acorn's release pipeline reuses GitHub's auto-generated changelog as the body of `latest.json`'s `notes` field.
 Stable patch releases include every release note entry in the current `major.minor` line, so an update from `1.8.0` to `1.8.2` surfaces the `1.8.0`, `1.8.1`, and `1.8.2` sections in the app.
 The Tauri updater plugin then surfaces that text inside the app's About tab and the "What's new" banner.
+The release notes script also adds a short Korean/English blockquote summary under each changelog section by condensing the PR titles in that section, so keep titles user-readable.
 
 To keep both the GitHub release page and the in-app changelog tidy, attach **one** of the labels below to every PR you open. The categorisation rules live in [`.github/release.yml`](../.github/release.yml).
 

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -5,6 +5,51 @@ import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const STABLE_TAG_RE = /^v(\d+)\.(\d+)\.(\d+)$/;
+const RELEASE_SECTION_SUMMARIES = [
+  {
+    titleRe: /\bFeatures\b/i,
+    koSuffix: "기능 업데이트가 포함되었어요.",
+    enPrefix: "Feature updates:",
+  },
+  {
+    titleRe: /\bFixes\b/i,
+    koSuffix: "문제가 수정되었어요.",
+    enPrefix: "Fixes:",
+  },
+  {
+    titleRe: /\bPerformance\b/i,
+    koSuffix: "성능 개선이 포함되었어요.",
+    enPrefix: "Performance improvements:",
+  },
+  {
+    titleRe: /\bSecurity\b/i,
+    koSuffix: "보안 업데이트가 포함되었어요.",
+    enPrefix: "Security updates:",
+  },
+  {
+    titleRe: /\bDocs\b/i,
+    koSuffix: "문서 업데이트가 포함되었어요.",
+    enPrefix: "Documentation updates:",
+  },
+  {
+    titleRe: /\bRefactor\b|\bchore\b/i,
+    koSuffix: "내부 정리가 포함되었어요.",
+    enPrefix: "Internal cleanup:",
+  },
+  {
+    titleRe: /\bBuild\b|\bCI\b/i,
+    koSuffix: "빌드와 CI 업데이트가 포함되었어요.",
+    enPrefix: "Build and CI updates:",
+  },
+  {
+    titleRe: /\bOther changes\b/i,
+    koSuffix: "기타 변경사항이 포함되었어요.",
+    enPrefix: "Other changes:",
+  },
+];
+const HEADING_RE = /^(#{1,6})\s+(.+?)\s*$/;
+const ENTRY_RE = /^\s*[-*]\s+(.+?)\s*$/;
+const MAX_SUMMARY_ITEMS = 4;
 
 export function parseStableSemverTag(tag) {
   const match = STABLE_TAG_RE.exec(tag);
@@ -67,6 +112,95 @@ export function stripGithubGeneratedComments(body) {
     .trim();
 }
 
+function releaseSectionSummaryForHeading(line) {
+  const match = HEADING_RE.exec(line);
+  if (!match) return null;
+
+  const title = match[2];
+  return (
+    RELEASE_SECTION_SUMMARIES.find((summary) =>
+      summary.titleRe.test(title),
+    ) ?? null
+  );
+}
+
+function extractReleaseEntryTitle(line) {
+  const match = ENTRY_RE.exec(line);
+  if (!match) return null;
+
+  return match[1]
+    .replace(/\s+by\s+@\S+\s+in\s+(?:https?:\/\/\S+|#\d+)\s*$/i, "")
+    .replace(/\s+\(#\d+\)\s*$/, "")
+    .replace(/\s+#\d+\s*$/, "")
+    .replace(/^[a-z]+(?:\([^)]+\))?!?:\s*/i, "")
+    .trim();
+}
+
+function summarizeReleaseEntries(entries, locale = "ko") {
+  const visibleEntries = entries.slice(0, MAX_SUMMARY_ITEMS);
+  const hiddenCount = entries.length - visibleEntries.length;
+  const visibleSummary = visibleEntries.join(", ");
+  if (hiddenCount === 0) return visibleSummary;
+  return locale === "en"
+    ? `${visibleSummary}, and ${hiddenCount} more`
+    : `${visibleSummary} 외 ${hiddenCount}개`;
+}
+
+function formatReleaseSectionSummary(entries, summary) {
+  return [
+    `> ${summarizeReleaseEntries(entries)} ${summary.koSuffix}<br>`,
+    `> ${summary.enPrefix} ${summarizeReleaseEntries(entries, "en")}.`,
+  ];
+}
+
+export function addReleaseSectionSummaries(body) {
+  const lines = body.split(/\r?\n/);
+  const output = [];
+
+  for (let i = 0; i < lines.length;) {
+    const line = lines[i];
+    const summary = releaseSectionSummaryForHeading(line);
+    if (!summary) {
+      output.push(line);
+      i += 1;
+      continue;
+    }
+
+    let nextHeadingIndex = i + 1;
+    while (
+      nextHeadingIndex < lines.length &&
+      !HEADING_RE.test(lines[nextHeadingIndex])
+    ) {
+      nextHeadingIndex += 1;
+    }
+
+    const contentStart = (() => {
+      let index = i + 1;
+      while (index < nextHeadingIndex && lines[index].trim().length === 0) {
+        index += 1;
+      }
+      return index;
+    })();
+    const contentLines = lines.slice(contentStart, nextHeadingIndex);
+    const entries = contentLines
+      .map(extractReleaseEntryTitle)
+      .filter((entry) => entry !== null && entry.length > 0);
+
+    output.push(line);
+    if (entries.length > 0) {
+      output.push(
+        "",
+        ...formatReleaseSectionSummary(entries, summary),
+      );
+      if (contentLines.length > 0) output.push("");
+    }
+    output.push(...contentLines);
+    i = nextHeadingIndex;
+  }
+
+  return output.join("\n").trim();
+}
+
 function readGitTags() {
   const stdout = execFileSync("git", ["tag", "-l", "v*.*.*"], {
     encoding: "utf8",
@@ -101,7 +235,12 @@ function generateNotes(repo, tag, previousTag) {
 }
 
 export function composeReleaseNotes(parts) {
-  const usableParts = parts.filter((part) => part.body.trim().length > 0);
+  const usableParts = parts
+    .map((part) => ({
+      tag: part.tag,
+      body: addReleaseSectionSummaries(part.body.trim()),
+    }))
+    .filter((part) => part.body.trim().length > 0);
   if (usableParts.length === 0) return "";
   if (usableParts.length === 1) return usableParts[0].body.trim();
 

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  addReleaseSectionSummaries,
+  composeReleaseNotes,
+} from "./release-notes.mjs";
+
+describe("addReleaseSectionSummaries", () => {
+  it("adds a callout summary above each generated PR list", () => {
+    const body = [
+      "## What's Changed",
+      "### 🚀 Features",
+      "* feat(workspace): add kanban workspace mode by @im-ian in https://github.com/im-ian/acorn/pull/507",
+      "* feat(settings): macOS permission reset controls by @im-ian in https://github.com/im-ian/acorn/pull/503",
+      "### 🐛 Fixes",
+      "* fix(status): stop agent sessions getting stuck on Running by @im-ian in https://github.com/im-ian/acorn/pull/516",
+      "",
+      "**Full Changelog**: https://github.com/im-ian/acorn/compare/v1.20.0...v1.21.0",
+    ].join("\n");
+
+    expect(addReleaseSectionSummaries(body)).toBe(
+      [
+        "## What's Changed",
+        "### 🚀 Features",
+        "",
+        "> add kanban workspace mode, macOS permission reset controls 기능 업데이트가 포함되었어요.<br>",
+        "> Feature updates: add kanban workspace mode, macOS permission reset controls.",
+        "",
+        "* feat(workspace): add kanban workspace mode by @im-ian in https://github.com/im-ian/acorn/pull/507",
+        "* feat(settings): macOS permission reset controls by @im-ian in https://github.com/im-ian/acorn/pull/503",
+        "### 🐛 Fixes",
+        "",
+        "> stop agent sessions getting stuck on Running 문제가 수정되었어요.<br>",
+        "> Fixes: stop agent sessions getting stuck on Running.",
+        "",
+        "* fix(status): stop agent sessions getting stuck on Running by @im-ian in https://github.com/im-ian/acorn/pull/516",
+        "",
+        "**Full Changelog**: https://github.com/im-ian/acorn/compare/v1.20.0...v1.21.0",
+      ].join("\n"),
+    );
+  });
+
+  it("keeps long sections compact with an overflow count", () => {
+    const body = [
+      "### ⚡ Performance",
+      "* perf(one): first update by @im-ian in #1",
+      "* perf(two): second update by @im-ian in #2",
+      "* perf(three): third update by @im-ian in #3",
+      "* perf(four): fourth update by @im-ian in #4",
+      "* perf(five): fifth update by @im-ian in #5",
+    ].join("\n");
+
+    expect(addReleaseSectionSummaries(body)).toContain(
+      "> first update, second update, third update, fourth update 외 1개 성능 개선이 포함되었어요.<br>",
+    );
+    expect(addReleaseSectionSummaries(body)).toContain(
+      "> Performance improvements: first update, second update, third update, fourth update, and 1 more.",
+    );
+  });
+});
+
+describe("composeReleaseNotes", () => {
+  it("adds summaries inside each cumulative tag section", () => {
+    const notes = composeReleaseNotes([
+      {
+        tag: "v1.8.2",
+        body: "### 🐛 Fixes\n* fix(ui): repair modal spacing by @im-ian in #2",
+      },
+      {
+        tag: "v1.8.1",
+        body: "### 🚀 Features\n* feat(ui): add settings shortcut by @im-ian in #1",
+      },
+    ]);
+
+    expect(notes).toBe(
+      [
+        "## v1.8.2",
+        "",
+        "### 🐛 Fixes",
+        "",
+        "> repair modal spacing 문제가 수정되었어요.<br>",
+        "> Fixes: repair modal spacing.",
+        "",
+        "* fix(ui): repair modal spacing by @im-ian in #2",
+        "",
+        "## v1.8.1",
+        "",
+        "### 🚀 Features",
+        "",
+        "> add settings shortcut 기능 업데이트가 포함되었어요.<br>",
+        "> Feature updates: add settings shortcut.",
+        "",
+        "* feat(ui): add settings shortcut by @im-ian in #1",
+      ].join("\n"),
+    );
+  });
+});

--- a/src/components/WhatsNewModal.tsx
+++ b/src/components/WhatsNewModal.tsx
@@ -135,7 +135,7 @@ export function WhatsNewModal({
             label={dt(t, "dialogs.whatsNew.loadingReleaseNotes")}
           />
         ) : trimmedBody.length > 0 ? (
-          <Markdown content={trimmedBody} className="text-xs" />
+          <Markdown content={trimmedBody} className="text-xs" softBreaks />
         ) : error ? null : (
           <p className="text-xs text-fg-muted">
             {dt(t, "dialogs.whatsNew.noReleaseNotes")}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,7 +58,10 @@ export default defineConfig(async () => ({
   test: {
     environment: "jsdom",
     globals: false,
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    include: [
+      "src/**/*.{test,spec}.{ts,tsx}",
+      "scripts/**/*.{test,spec}.mjs",
+    ],
     setupFiles: ["./src/test/setup.ts"],
     css: true,
   },


### PR DESCRIPTION
## Summary
Release notes now surface bilingual summary callouts above each generated changelog section.

1. **Section summaries** — `scripts/release-notes.mjs` now condenses each GitHub-generated changelog section into a short Korean/English blockquote before the PR list.
2. **Rendered line breaks** — Korean summary lines end with `<br>` and the What’s New modal enables soft breaks so the Korean and English lines render separately in-app and on GitHub.
3. **Test coverage** — release-note generation tests now cover section summaries, cumulative patch notes, and long-section overflow wording.
4. **Process docs** — `docs/PR_LABELS.md` notes that PR titles feed these generated summaries.

## Expected impact
| Surface | Before | After |
| --- | --- | --- |
| GitHub release body | Category headings jumped straight into PR bullets | Each category starts with a Korean/English summary callout |
| In-app What’s New modal | Release notes showed the raw generated changelog | Release notes show the same summary callouts with preserved line breaks |
| Release workflow | `release_notes.md` reused GitHub generated notes as-is | `release_notes.md` is post-processed before publishing and embedding in `latest.json` |

## Design notes
- The summary generator is deterministic: it derives summary text from PR titles and known changelog section headings, without adding a network or LLM dependency to the release workflow.
- Long sections show the first four PR titles plus an overflow count to keep the callout compact.
- The Korean line uses `<br>` because Markdown renderers can merge consecutive blockquote lines into one paragraph.

## Test plan
- [x] `pnpm exec vitest run scripts/release-notes.test.mjs` — 3 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test` — 872 tests passed
- [x] `pnpm run test:e2e -- tests/e2e/whats-new.spec.ts` — 5 tests passed

## Notes
- The already-published `v1.21.0` GitHub release body and `latest.json` asset were backfilled with the same Korean/English callout format so current users see the updated notes immediately.
