### PR TITLE
fix(status): ship v1.21.1 pinned-session hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.21.1",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.21.0"
+version = "1.21.1"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.21.0"
+version = "1.21.1"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -300,6 +300,14 @@ pub struct Session {
     /// worktrees when added.
     #[serde(default, skip_deserializing)]
     pub in_worktree: bool,
+    /// Whether this session has ever reported an agent lifecycle hook event.
+    /// Persisted so hook ownership of the status survives an app restart: a
+    /// daemon-managed PTY outlives the app, and its resting hook-set status
+    /// (`needs_input`) must not be clobbered back to Running by the
+    /// transcript-tail poll before the agent emits its first event to the
+    /// new app instance (a resting agent may never emit one).
+    #[serde(default)]
+    pub hook_active: bool,
     /// Derived from status polling. This reflects the currently live
     /// Claude/Codex/Antigravity process under the session PTY and is not
     /// persisted in sessions.json.
@@ -342,6 +350,7 @@ impl Session {
             position: None,
             daemon_session_id: None,
             agent_resume_token: None,
+            hook_active: false,
             in_worktree: false,
             agent_provider: None,
             agent_transcript_id: None,
@@ -353,15 +362,23 @@ impl Session {
 pub struct SessionStore {
     inner: DashMap<Uuid, Session>,
     /// Sessions that reported at least one agent lifecycle hook event
-    /// (Start/Stop/NeedsInput/Error) this run. Runtime-only, never persisted.
-    /// The status poll consults this to decide whether hooks own the
+    /// (Start/Stop/NeedsInput/Error) *this run*. Runtime-only. The status
+    /// poll consults hook activity to decide whether hooks own the
     /// Running/NeedsInput/Completed classification: once a session proves its
     /// hook channel is live, the transcript-tail poll stops second-guessing
     /// turn completion (a long or tool-heavy Claude turn often leaves no
     /// `end_turn` line inside the tail window, so the tail keeps reading
     /// Running long after the turn ended) and only keeps ownership of the
     /// Idle (process-gone) edge, which no hook reports.
-    hook_active: DashSet<Uuid>,
+    ///
+    /// Hook activity itself also persists across restarts via the session's
+    /// `hook_active` field; this set distinguishes "confirmed live this run"
+    /// (an event actually arrived at this app instance's hook server) from
+    /// "was hook-owned before the restart", which the poll's boot
+    /// reconciliation needs — a turn that ended while the app was closed
+    /// lost its turn-end event forever and must be recovered from the
+    /// transcript exactly once.
+    hook_confirmed: DashSet<Uuid>,
 }
 
 impl SessionStore {
@@ -433,14 +450,39 @@ impl SessionStore {
 
     /// Record that `id` reported an agent lifecycle hook event, marking its
     /// hook channel live so the status poll defers turn-boundary
-    /// classification to hooks (see the `hook_active` field). Idempotent.
+    /// classification to hooks (see the `hook_confirmed` field). Also stamps
+    /// the session's persisted `hook_active` flag so hook ownership survives
+    /// an app restart. Idempotent.
     pub fn mark_hook_active(&self, id: &Uuid) {
-        self.hook_active.insert(*id);
+        self.hook_confirmed.insert(*id);
+        if let Some(mut entry) = self.inner.get_mut(id) {
+            if !entry.hook_active {
+                // Deliberately no `updated_at` bump — hook telemetry must
+                // not reshuffle the sidebar's most-recent-first ordering.
+                entry.hook_active = true;
+            }
+        }
     }
 
-    /// Whether `id` has reported any agent lifecycle hook event this run.
+    /// Whether `id` has ever reported an agent lifecycle hook event — either
+    /// this run or (via the persisted `hook_active` session flag) in a
+    /// previous one.
     pub fn is_hook_active(&self, id: &Uuid) -> bool {
-        self.hook_active.contains(id)
+        self.hook_confirmed.contains(id)
+            || self
+                .inner
+                .get(id)
+                .map(|entry| entry.hook_active)
+                .unwrap_or(false)
+    }
+
+    /// Whether `id` reported an agent lifecycle hook event *this run* — an
+    /// event actually reached this app instance's hook server. False right
+    /// after a restart even for sessions whose persisted `hook_active` flag
+    /// is set; the status poll uses that gap to reconcile a turn boundary
+    /// that was crossed while the app was closed.
+    pub fn is_hook_confirmed_this_run(&self, id: &Uuid) -> bool {
+        self.hook_confirmed.contains(id)
     }
 
     /// Refresh derived live-agent metadata without bumping `updated_at`.
@@ -591,7 +633,7 @@ impl SessionStore {
     }
 
     pub fn remove(&self, id: &Uuid) -> SessionResult<Session> {
-        self.hook_active.remove(id);
+        self.hook_confirmed.remove(id);
         self.inner
             .remove(id)
             .map(|(_, v)| v)
@@ -686,15 +728,52 @@ mod tests {
         let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
 
         assert!(!store.is_hook_active(&session.id));
+        assert!(!store.is_hook_confirmed_this_run(&session.id));
 
         store.mark_hook_active(&session.id);
         assert!(store.is_hook_active(&session.id));
+        assert!(store.is_hook_confirmed_this_run(&session.id));
         // Idempotent.
         store.mark_hook_active(&session.id);
         assert!(store.is_hook_active(&session.id));
 
         store.remove(&session.id).expect("session exists");
         assert!(!store.is_hook_active(&session.id));
+        assert!(!store.is_hook_confirmed_this_run(&session.id));
+    }
+
+    #[test]
+    fn hook_activity_persists_on_session_and_survives_reload() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+
+        store.mark_hook_active(&session.id);
+        let marked = store.get(&session.id).expect("session exists");
+        assert!(marked.hook_active);
+
+        // Simulate an app restart: serialize, load into a fresh store.
+        let json = serde_json::to_string(&marked).expect("session serializes");
+        let reloaded: Session = serde_json::from_str(&json).expect("session deserializes");
+        let fresh = SessionStore::new();
+        fresh.insert(reloaded);
+
+        // Hook ownership survives the restart, but no event has been
+        // confirmed against the new run's hook server yet.
+        assert!(fresh.is_hook_active(&session.id));
+        assert!(!fresh.is_hook_confirmed_this_run(&session.id));
+    }
+
+    #[test]
+    fn sessions_persisted_before_hook_active_field_load_as_inactive() {
+        let session = fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false);
+        let mut value = serde_json::to_value(&session).expect("session serializes");
+        value
+            .as_object_mut()
+            .expect("session is an object")
+            .remove("hook_active");
+        let reloaded: Session =
+            serde_json::from_value(value).expect("legacy session deserializes");
+        assert!(!reloaded.hook_active);
     }
 
     #[test]

--- a/src-tauri/shell-init/zshrc
+++ b/src-tauri/shell-init/zshrc
@@ -42,17 +42,22 @@ ZDOTDIR=$_acorn_zd_save
 unset -f _acorn_realpath
 unset _acorn_zd_save _acorn_user_zd _acorn_zd_real _acorn_user_zd_real
 
-# Re-prepend Acorn-managed PATH entries if the user's rc replaced
-# PATH wholesale. Idempotent — duplicate entries are skipped.
-_acorn_prepend_path() {
-    case ":$PATH:" in
-        *":$1:"*) ;;
-        *) PATH=$1${PATH:+:$PATH} ;;
-    esac
+# Force Acorn-managed PATH entries to the FRONT after the user's rc
+# runs. Mere presence is not enough for the agent-wrapper shims: a user
+# rc that prepends its own entries (`~/.local/bin`, nvm, homebrew — the
+# usual `export PATH="…:$PATH"` patterns) leaves the shim dir in PATH
+# but buried behind a dir that also ships `claude`/`codex`/`agy`, so the
+# real binary wins the lookup and hook injection silently never happens.
+# Front placement is what makes the shim intercept. Idempotent — an
+# already-first entry is left alone, buried duplicates are collapsed.
+# (`$path` is zsh's array view of `$PATH`; `${path:#$1}` drops every
+# element equal to `$1`.)
+_acorn_force_path_front() {
+    path=("$1" ${path:#$1})
 }
-[ -n "${ACORN_CLI_DIR-}" ] && _acorn_prepend_path "$ACORN_CLI_DIR"
-[ -n "${ACORN_AGENT_WRAPPER_DIR-}" ] && _acorn_prepend_path "$ACORN_AGENT_WRAPPER_DIR"
-unset -f _acorn_prepend_path
+[ -n "${ACORN_CLI_DIR-}" ] && _acorn_force_path_front "$ACORN_CLI_DIR"
+[ -n "${ACORN_AGENT_WRAPPER_DIR-}" ] && _acorn_force_path_front "$ACORN_AGENT_WRAPPER_DIR"
+unset -f _acorn_force_path_front
 export PATH
 
 if [ -n "${ACORN_SESSION_ID-}" ] && [ -z "${ACORN_CONTROL_BANNER_SHOWN-}" ]; then

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -13,6 +13,7 @@ const CLAUDE_NOTIFY_NAME: &str = "acorn-claude-notify";
 const CLAUDE_SETTINGS_NAME: &str = "acorn-claude-settings.json";
 const ANTIGRAVITY_WRAPPER_NAME: &str = "agy";
 const ANTIGRAVITY_NOTIFY_NAME: &str = "acorn-antigravity-notify";
+const HOOK_ENDPOINT_NAME: &str = "agent-hook-endpoint";
 
 const CODEX_WRAPPER_BODY: &str = r#"#!/bin/sh
 _acorn_find_real_binary() {
@@ -41,10 +42,14 @@ if [ -z "$REAL_BIN" ]; then
   exit 127
 fi
 
-if [ -n "${ACORN_AGENT_HOOK_URL-}" ] &&
-   [ -n "${ACORN_AGENT_HOOK_TOKEN-}" ] &&
-   [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
+# Hook channel is available when the endpoint file exists (rewritten by each
+# app launch with the current server URL + token) or the spawn-time env pair
+# is present. The session id has no file fallback — without it, events cannot
+# be attributed to a session.
+if [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
    [ -n "${ACORN_AGENT_WRAPPER_DIR-}" ] &&
+   { [ -r "$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint" ] ||
+     { [ -n "${ACORN_AGENT_HOOK_URL-}" ] && [ -n "${ACORN_AGENT_HOOK_TOKEN-}" ]; }; } &&
    [ -x "$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify" ]; then
   export CODEX_TUI_RECORD_SESSION=1
   if [ -z "${CODEX_TUI_SESSION_LOG_PATH-}" ]; then
@@ -154,16 +159,31 @@ case "$event" in
     ;;
 esac
 
-[ -n "${ACORN_AGENT_HOOK_URL-}" ] || exit 0
-[ -n "${ACORN_AGENT_HOOK_TOKEN-}" ] || exit 0
+# Resolve the hook endpoint at send time. Each app launch rewrites the
+# endpoint file with that run's server URL + token (the hook server binds a
+# fresh port and token per run), so an agent session that outlives an app
+# restart keeps reaching the *current* server. The spawn-time env vars are
+# only a fallback for when the file is missing.
+hook_url=""
+hook_token=""
+if [ -n "${ACORN_AGENT_WRAPPER_DIR-}" ] && [ -r "$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint" ]; then
+  hook_url=$(sed -n '1p' "$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint" 2>/dev/null || true)
+  hook_token=$(sed -n '2p' "$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint" 2>/dev/null || true)
+fi
+if [ -z "$hook_url" ] || [ -z "$hook_token" ]; then
+  hook_url="${ACORN_AGENT_HOOK_URL-}"
+  hook_token="${ACORN_AGENT_HOOK_TOKEN-}"
+fi
+[ -n "$hook_url" ] || exit 0
+[ -n "$hook_token" ] || exit 0
 [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] || exit 0
 
 payload=$(printf '{"session_id":"%s","provider":"codex","event":"%s","source":"hook"}' "$ACORN_AGENT_HOOK_SESSION_ID" "$event")
 curl -sf -X POST \
   -H 'Content-Type: application/json' \
-  -H "X-Acorn-Agent-Hook-Token: $ACORN_AGENT_HOOK_TOKEN" \
+  -H "X-Acorn-Agent-Hook-Token: $hook_token" \
   -d "$payload" \
-  "$ACORN_AGENT_HOOK_URL" >/dev/null 2>&1 || true
+  "$hook_url" >/dev/null 2>&1 || true
 "#;
 
 // Claude Code wrapper.
@@ -203,10 +223,14 @@ if [ -z "$REAL_BIN" ]; then
   exit 127
 fi
 
-if [ -n "${ACORN_AGENT_HOOK_URL-}" ] &&
-   [ -n "${ACORN_AGENT_HOOK_TOKEN-}" ] &&
-   [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
+# Hook channel is available when the endpoint file exists (rewritten by each
+# app launch with the current server URL + token) or the spawn-time env pair
+# is present. The session id has no file fallback — without it, events cannot
+# be attributed to a session.
+if [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
    [ -n "${ACORN_AGENT_WRAPPER_DIR-}" ] &&
+   { [ -r "$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint" ] ||
+     { [ -n "${ACORN_AGENT_HOOK_URL-}" ] && [ -n "${ACORN_AGENT_HOOK_TOKEN-}" ]; }; } &&
    [ -f "$ACORN_AGENT_WRAPPER_DIR/acorn-claude-settings.json" ] &&
    [ -x "$ACORN_AGENT_WRAPPER_DIR/acorn-claude-notify" ]; then
   exec "$REAL_BIN" --settings "$ACORN_AGENT_WRAPPER_DIR/acorn-claude-settings.json" "$@"
@@ -234,16 +258,31 @@ case "$hook_event_name" in
 esac
 [ -n "$event" ] || exit 0
 
-[ -n "${ACORN_AGENT_HOOK_URL-}" ] || exit 0
-[ -n "${ACORN_AGENT_HOOK_TOKEN-}" ] || exit 0
+# Resolve the hook endpoint at send time. Each app launch rewrites the
+# endpoint file with that run's server URL + token (the hook server binds a
+# fresh port and token per run), so an agent session that outlives an app
+# restart keeps reaching the *current* server. The spawn-time env vars are
+# only a fallback for when the file is missing.
+hook_url=""
+hook_token=""
+if [ -n "${ACORN_AGENT_WRAPPER_DIR-}" ] && [ -r "$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint" ]; then
+  hook_url=$(sed -n '1p' "$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint" 2>/dev/null || true)
+  hook_token=$(sed -n '2p' "$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint" 2>/dev/null || true)
+fi
+if [ -z "$hook_url" ] || [ -z "$hook_token" ]; then
+  hook_url="${ACORN_AGENT_HOOK_URL-}"
+  hook_token="${ACORN_AGENT_HOOK_TOKEN-}"
+fi
+[ -n "$hook_url" ] || exit 0
+[ -n "$hook_token" ] || exit 0
 [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] || exit 0
 
 payload=$(printf '{"session_id":"%s","provider":"claude","event":"%s","source":"hook"}' "$ACORN_AGENT_HOOK_SESSION_ID" "$event")
 curl -sf -X POST \
   -H 'Content-Type: application/json' \
-  -H "X-Acorn-Agent-Hook-Token: $ACORN_AGENT_HOOK_TOKEN" \
+  -H "X-Acorn-Agent-Hook-Token: $hook_token" \
   -d "$payload" \
-  "$ACORN_AGENT_HOOK_URL" >/dev/null 2>&1 || true
+  "$hook_url" >/dev/null 2>&1 || true
 "#;
 
 const ANTIGRAVITY_WRAPPER_BODY: &str = r#"#!/bin/sh
@@ -299,10 +338,14 @@ if [ -z "$REAL_BIN" ]; then
   exit 127
 fi
 
-if [ -n "${ACORN_AGENT_HOOK_URL-}" ] &&
-   [ -n "${ACORN_AGENT_HOOK_TOKEN-}" ] &&
-   [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
+# Hook channel is available when the endpoint file exists (rewritten by each
+# app launch with the current server URL + token) or the spawn-time env pair
+# is present. The session id has no file fallback — without it, events cannot
+# be attributed to a session.
+if [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
    [ -n "${ACORN_AGENT_WRAPPER_DIR-}" ] &&
+   { [ -r "$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint" ] ||
+     { [ -n "${ACORN_AGENT_HOOK_URL-}" ] && [ -n "${ACORN_AGENT_HOOK_TOKEN-}" ]; }; } &&
    [ -x "$ACORN_AGENT_WRAPPER_DIR/acorn-antigravity-notify" ]; then
   _acorn_start_ts=$(date +%s 2>/dev/null || echo 0)
   (
@@ -372,20 +415,72 @@ case "$event" in
     ;;
 esac
 
-[ -n "${ACORN_AGENT_HOOK_URL-}" ] || exit 0
-[ -n "${ACORN_AGENT_HOOK_TOKEN-}" ] || exit 0
+# Resolve the hook endpoint at send time. Each app launch rewrites the
+# endpoint file with that run's server URL + token (the hook server binds a
+# fresh port and token per run), so an agent session that outlives an app
+# restart keeps reaching the *current* server. The spawn-time env vars are
+# only a fallback for when the file is missing.
+hook_url=""
+hook_token=""
+if [ -n "${ACORN_AGENT_WRAPPER_DIR-}" ] && [ -r "$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint" ]; then
+  hook_url=$(sed -n '1p' "$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint" 2>/dev/null || true)
+  hook_token=$(sed -n '2p' "$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint" 2>/dev/null || true)
+fi
+if [ -z "$hook_url" ] || [ -z "$hook_token" ]; then
+  hook_url="${ACORN_AGENT_HOOK_URL-}"
+  hook_token="${ACORN_AGENT_HOOK_TOKEN-}"
+fi
+[ -n "$hook_url" ] || exit 0
+[ -n "$hook_token" ] || exit 0
 [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] || exit 0
 
 payload=$(printf '{"session_id":"%s","provider":"antigravity","event":"%s","source":"hook"}' "$ACORN_AGENT_HOOK_SESSION_ID" "$event")
 curl -sf -X POST \
   -H 'Content-Type: application/json' \
-  -H "X-Acorn-Agent-Hook-Token: $ACORN_AGENT_HOOK_TOKEN" \
+  -H "X-Acorn-Agent-Hook-Token: $hook_token" \
   -d "$payload" \
-  "$ACORN_AGENT_HOOK_URL" >/dev/null 2>&1 || true
+  "$hook_url" >/dev/null 2>&1 || true
 "#;
 
 pub fn ensure_agent_wrapper_dir() -> io::Result<PathBuf> {
     ensure_agent_wrapper_dir_at(&acorn_daemon::paths::data_dir()?)
+}
+
+/// Publish the hook server's current URL + token where the notify scripts
+/// resolve them at send time. The hook server binds a fresh ephemeral port
+/// and token on every app launch, but agent PTYs (daemon-managed ones
+/// especially) outlive the app — their spawn-time `ACORN_AGENT_HOOK_URL`/
+/// `ACORN_AGENT_HOOK_TOKEN` env goes stale on the first restart and every
+/// event they emit afterwards would hit a dead port. Routing each POST
+/// through this file keeps surviving sessions attached to the current
+/// server. Two lines: URL, then token, trailing newline.
+pub fn write_agent_hook_endpoint(url: &str, token: &str) -> io::Result<PathBuf> {
+    let dir = ensure_agent_wrapper_dir()?;
+    write_agent_hook_endpoint_at(&dir, url, token)
+}
+
+fn write_agent_hook_endpoint_at(dir: &Path, url: &str, token: &str) -> io::Result<PathBuf> {
+    let path = dir.join(HOOK_ENDPOINT_NAME);
+    let tmp = dir.join(format!("{HOOK_ENDPOINT_NAME}.tmp"));
+    fs::write(&tmp, format!("{url}\n{token}\n"))?;
+    // The token authorizes status-event POSTs for any session id; keep it
+    // owner-readable only, like an SSH key. Set perms before the rename so
+    // the file is never observable in a looser mode.
+    #[cfg(unix)]
+    fs::set_permissions(&tmp, fs::Permissions::from_mode(0o600))?;
+    // Atomic rename — a notify script reading mid-publish sees either the
+    // previous endpoint or the new one, never a torn file.
+    fs::rename(&tmp, &path)?;
+    Ok(path)
+}
+
+/// Best-effort removal of a stale endpoint file. Called when this run has no
+/// hook server: a leftover file from a previous run would otherwise win over
+/// the env fallback in the notify scripts and swallow events silently.
+pub fn remove_agent_hook_endpoint() {
+    if let Ok(base) = acorn_daemon::paths::data_dir() {
+        let _ = fs::remove_file(base.join(WRAPPER_DIR_NAME).join(HOOK_ENDPOINT_NAME));
+    }
 }
 
 fn ensure_agent_wrapper_dir_at(base: &Path) -> io::Result<PathBuf> {
@@ -644,6 +739,83 @@ mod tests {
                 notify.contains(&format!("event=\"{acorn_event}\"")),
                 "notify missing acorn event mapping {acorn_event}"
             );
+        }
+    }
+
+    #[test]
+    fn writes_hook_endpoint_file_atomically_with_owner_only_perms() {
+        let base = ScratchDir::new("endpoint");
+        let dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
+
+        let path =
+            write_agent_hook_endpoint_at(&dir, "http://127.0.0.1:12345/agent-hook", "tok-1")
+                .unwrap();
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "http://127.0.0.1:12345/agent-hook\ntok-1\n"
+        );
+        #[cfg(unix)]
+        {
+            let mode = fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "endpoint file must be 0600");
+        }
+
+        // A relaunch overwrites with the new run's endpoint.
+        write_agent_hook_endpoint_at(&dir, "http://127.0.0.1:54321/agent-hook", "tok-2").unwrap();
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "http://127.0.0.1:54321/agent-hook\ntok-2\n"
+        );
+        assert!(
+            !dir.join(format!("{HOOK_ENDPOINT_NAME}.tmp")).exists(),
+            "publish must not leave the temp file behind"
+        );
+    }
+
+    #[test]
+    fn notify_scripts_resolve_endpoint_file_before_env() {
+        let base = ScratchDir::new("endpoint-notify");
+        let dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
+
+        for name in [
+            "acorn-claude-notify",
+            "acorn-codex-notify",
+            "acorn-antigravity-notify",
+        ] {
+            let notify = fs::read_to_string(dir.join(name)).unwrap();
+            assert!(
+                notify.contains("$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint"),
+                "{name} must read the endpoint file"
+            );
+            // The POST goes to the resolved values, not the spawn-time env —
+            // stale env from before an app restart must not win over the file.
+            assert!(
+                notify.contains("\"$hook_url\""),
+                "{name} must POST to the resolved url"
+            );
+            assert!(
+                notify.contains("X-Acorn-Agent-Hook-Token: $hook_token"),
+                "{name} must send the resolved token"
+            );
+            // Env fallback stays for the no-file case.
+            assert!(notify.contains("hook_url=\"${ACORN_AGENT_HOOK_URL-}\""));
+            assert!(notify.contains("hook_token=\"${ACORN_AGENT_HOOK_TOKEN-}\""));
+        }
+    }
+
+    #[test]
+    fn wrappers_activate_hooks_on_endpoint_file_without_env_pair() {
+        let base = ScratchDir::new("endpoint-gate");
+        let dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
+
+        for name in ["claude", "codex", "agy"] {
+            let wrapper = fs::read_to_string(dir.join(name)).unwrap();
+            assert!(
+                wrapper.contains("[ -r \"$ACORN_AGENT_WRAPPER_DIR/agent-hook-endpoint\" ] ||"),
+                "{name} wrapper must accept the endpoint file as a hook channel"
+            );
+            // Session id has no file fallback — it stays a hard requirement.
+            assert!(wrapper.contains("[ -n \"${ACORN_AGENT_HOOK_SESSION_ID-}\" ] &&"));
         }
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5034,6 +5034,36 @@ fn poll_defers_to_hook(hook_active: bool, live_agent: bool) -> bool {
     hook_active && live_agent
 }
 
+/// Recover a turn boundary that was crossed while the app was closed.
+///
+/// `hook_active` persists across restarts, so right after boot the poll
+/// already defers to the persisted hook-set status. But a hooked agent whose
+/// turn *ended* while no app instance was listening lost that turn-end event
+/// forever — the store still says Running and, since a resting agent emits no
+/// further events, nothing would ever correct it. Until the first hook event
+/// of this run confirms the channel, allow exactly the one transition hooks
+/// can no longer report: Running → NeedsInput backed by a real turn-complete
+/// marker in the transcript.
+///
+/// One-directional on purpose: while the app is closed nobody can submit a
+/// prompt to the session, so NeedsInput → Running cannot happen offline and a
+/// stale-tail Running must never demote a persisted resting status. Once an
+/// event lands this run (`hook_confirmed_this_run`), hooks own both
+/// directions again and this reconciliation switches off — leaving it open
+/// in-run would recreate the UserPromptSubmit-vs-stale-tail race the full
+/// hook deference exists to close.
+fn hook_boot_reconciled_status(
+    stored: SessionStatus,
+    hook_confirmed_this_run: bool,
+    detection: session_status::StatusDetection,
+) -> Option<SessionStatus> {
+    (!hook_confirmed_this_run
+        && stored == SessionStatus::Running
+        && detection.status == SessionStatus::NeedsInput
+        && detection.reason == Some(SessionStatusReason::TurnComplete))
+    .then_some(SessionStatus::NeedsInput)
+}
+
 fn detect_session_statuses_blocking(
     state: AppState,
     ids: Vec<String>,
@@ -5228,10 +5258,28 @@ fn detect_session_statuses_blocking(
             // I/O, and reusing the `previous` captured before that I/O would
             // clobber the newer hook status back to an old value.
             let status = if defer_to_hook {
-                parsed_id
+                let stored = parsed_id
                     .and_then(|uuid| state.sessions.get(&uuid).ok())
                     .map(|s| s.status)
-                    .unwrap_or(previous)
+                    .unwrap_or(previous);
+                // A turn that ended while the app was closed lost its
+                // turn-end hook event; recover it from the transcript until
+                // the first event of this run re-confirms the channel (see
+                // `hook_boot_reconciled_status`). The this-run flag is read
+                // here — after the poll's I/O — so an event landing during
+                // that window disables the recovery before it can clobber
+                // the fresher hook write.
+                let reconciled = parsed_id.and_then(|uuid| {
+                    hook_boot_reconciled_status(
+                        stored,
+                        state.sessions.is_hook_confirmed_this_run(&uuid),
+                        detection,
+                    )
+                });
+                if let (Some(uuid), Some(reconciled)) = (parsed_id, reconciled) {
+                    let _ = state.sessions.refresh_status(&uuid, reconciled);
+                }
+                reconciled.unwrap_or(stored)
             } else {
                 detection.status
             };
@@ -6233,6 +6281,81 @@ mod tests {
         // before hooks registered) — the transcript poll is the only signal.
         assert!(!poll_defers_to_hook(false, true));
         assert!(!poll_defers_to_hook(false, false));
+    }
+
+    #[test]
+    fn boot_reconciliation_recovers_turn_end_lost_while_app_was_closed() {
+        // Persisted hook status says Running, no event has confirmed the
+        // channel this run, and the transcript holds a real turn-complete
+        // marker — the turn ended while nobody was listening.
+        let detection = super::session_status::StatusDetection {
+            status: acorn_session::SessionStatus::NeedsInput,
+            reason: Some(super::SessionStatusReason::TurnComplete),
+        };
+        assert_eq!(
+            super::hook_boot_reconciled_status(
+                acorn_session::SessionStatus::Running,
+                false,
+                detection
+            ),
+            Some(acorn_session::SessionStatus::NeedsInput)
+        );
+    }
+
+    #[test]
+    fn boot_reconciliation_is_off_once_a_hook_event_confirms_the_channel() {
+        // An event reached this run's hook server — hooks own both directions
+        // again; re-opening the transcript passthrough would recreate the
+        // UserPromptSubmit-vs-stale-tail race.
+        let detection = super::session_status::StatusDetection {
+            status: acorn_session::SessionStatus::NeedsInput,
+            reason: Some(super::SessionStatusReason::TurnComplete),
+        };
+        assert_eq!(
+            super::hook_boot_reconciled_status(
+                acorn_session::SessionStatus::Running,
+                true,
+                detection
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn boot_reconciliation_never_demotes_a_resting_status() {
+        // Nobody can submit a prompt while the app is closed, so a persisted
+        // NeedsInput can only be stale in the direction hooks will re-report;
+        // a stale-tail reading must not touch it.
+        let detection = super::session_status::StatusDetection {
+            status: acorn_session::SessionStatus::Running,
+            reason: None,
+        };
+        assert_eq!(
+            super::hook_boot_reconciled_status(
+                acorn_session::SessionStatus::NeedsInput,
+                false,
+                detection
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn boot_reconciliation_requires_a_turn_complete_marker() {
+        // A shell-prompt NeedsInput hint is not evidence the agent's turn
+        // ended — only a transcript turn-complete marker flips Running.
+        let detection = super::session_status::StatusDetection {
+            status: acorn_session::SessionStatus::NeedsInput,
+            reason: Some(super::SessionStatusReason::ShellPrompt),
+        };
+        assert_eq!(
+            super::hook_boot_reconciled_status(
+                acorn_session::SessionStatus::Running,
+                false,
+                detection
+            ),
+            None
+        );
     }
 
     #[test]

--- a/src-tauri/src/daemon_commands.rs
+++ b/src-tauri/src/daemon_commands.rs
@@ -352,6 +352,7 @@ pub fn daemon_adopt_session(
         position: None,
         daemon_session_id: Some(id),
         agent_resume_token: Some(id.to_string()),
+        hook_active: false,
         in_worktree: false,
         agent_provider: None,
         agent_transcript_id: None,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -339,9 +339,27 @@ pub fn run() {
                 }
             }) {
                 Ok(server) => {
+                    // Publish this run's URL + token to the stable endpoint
+                    // file the notify scripts read at send time. Without it,
+                    // agent sessions that survived an app restart (daemon
+                    // PTYs) would keep POSTing hook events to the previous
+                    // run's dead port and pin their status forever.
+                    if let Err(err) = agent_wrappers::write_agent_hook_endpoint(
+                        server.hook_url(),
+                        server.token(),
+                    ) {
+                        tracing::warn!(
+                            error = %err,
+                            "agent hook endpoint publish failed; sessions surviving a restart will lose hook status updates",
+                        );
+                    }
                     *state.agent_hooks.lock() = Some(std::sync::Arc::new(server));
                 }
                 Err(err) => {
+                    // Drop any stale endpoint file from a previous run — it
+                    // would win over the notify scripts' env fallback and
+                    // swallow events silently.
+                    agent_wrappers::remove_agent_hook_endpoint();
                     tracing::warn!(error = %err, "agent hook server disabled");
                 }
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

This hotfix release publishes only the #530 status/session fix on top of `v1.21.0`; #528 and #529 stay out of this release train.

1. **Bug fix:** Cherry-picks #530 so agent sessions pinned to `Running` across app restarts and shadowed shell shims can be corrected in the patch release.
2. **Version metadata:** Bumps Acorn from `1.21.0` to `1.21.1` in `package.json`, `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock`.
3. **Release scope:** Starts from the `v1.21.0` tag and includes only the #530 fix plus this patch-release metadata bump.

## Expected impact

| Area | Impact |
| --- | --- |
| User-visible version | Acorn updater and app metadata move to `1.21.1`. |
| Runtime behavior | Fixes stale `Running` status recovery for affected agent sessions without shipping #528 or #529. |
| Release notes | This PR is labelled `fix` so the patch release has a single bug-fix entry. |

## Design notes

- This targets `release/v1.21.x` instead of `main` because `main` already contains #528 and #529.
- The hotfix branch was created from `v1.21.0`, then #530 was cherry-picked with provenance and the patch version metadata was bumped.
- A later mainline release can still publish #528 and #529 separately.

## Follow-up (not in this PR)

- When the mainline release train resumes, check the generated release notes for duplicate #530 wording because this hotfix uses a cherry-picked commit outside `main` history.

## Test plan

- [x] `rg -n '1\\.21\\.0|1\\.21\\.1' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock`
- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets`
- [x] `git diff --check`

## Notes

- `cargo check --workspace --all-targets` passed with one non-blocking unused-function warning in `crates/acorn-pty`, which is outside this hotfix diff.
