### PR TITLE
feat(sidebar): add resizable session activity inbox

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -82,8 +82,6 @@ import type {
   PullRequestInfo,
   PullRequestLabel,
   PullRequestListing,
-  SessionNotification,
-  SessionNotificationKind,
   SessionAgentProvider,
   StagedFile,
   TodoItem,
@@ -124,12 +122,10 @@ import {
   SkeletonCircle,
   SkeletonList,
   SkeletonText,
-  StatusDot,
   TextInput,
   listBoxClassName,
   listRowClassName,
   type ListRowDensity,
-  type StatusTone,
 } from "./ui";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
@@ -236,11 +232,6 @@ export function RightPanel() {
   const rightTab = useAppStore((s) => s.rightTab);
   const setRightTab = useAppStore((s) => s.setRightTab);
   const setRightGroup = useAppStore((s) => s.setRightGroup);
-  const activityUnreadCount = useAppStore(
-    (s) =>
-      s.sessionNotifications.filter((notification) => !notification.readAt)
-        .length,
-  );
   const active = sessions.find((s) => s.id === activeSessionId);
   const activeWorkspaceTab = activeTabId ? workspaceTabs[activeTabId] : undefined;
   // The session's recorded worktree path is what we set at spawn time. The
@@ -485,13 +476,7 @@ export function RightPanel() {
               key={tab}
               icon={tabIcon(tab)}
               label={rt(t, tabLabelKey(tab))}
-              badge={
-                tab === "activity"
-                  ? activityUnreadCount
-                  : tab === "todos"
-                    ? todosState.todos.length
-                    : undefined
-              }
+              badge={tab === "todos" ? todosState.todos.length : undefined}
               active={tab === rightTab}
               onClick={() => setRightTab(tab)}
             />
@@ -499,9 +484,7 @@ export function RightPanel() {
         </nav>
       ) : null}
       <div className="flex-1 overflow-hidden">
-        {rightTab === "activity" ? (
-          <ActivityTab />
-        ) : rightTab === "todos" ? (
+        {rightTab === "todos" ? (
           active && showTodos ? (
             <TodosTab todos={todosState.todos} />
           ) : (
@@ -754,8 +737,6 @@ function tabIcon(tab: RightTab): ReactNode {
       return <CircleDot size={12} />;
     case "actions":
       return <Activity size={12} />;
-    case "activity":
-      return <CircleAlert size={12} />;
     case "todos":
       return <ListTodo size={12} />;
     case "history":
@@ -1282,165 +1263,6 @@ function countByStatus(todos: TodoItem[]) {
     else pending++;
   }
   return { pending, in_progress, completed };
-}
-
-const ACTIVITY_KIND_KEYS: Record<
-  SessionNotificationKind,
-  RightPanelTranslationKey
-> = {
-  needs_input: "rightPanel.activity.kind.needsInput",
-  failed: "rightPanel.activity.kind.failed",
-  completed: "rightPanel.activity.kind.completed",
-  became_idle: "rightPanel.activity.kind.becameIdle",
-};
-
-function ActivityTab() {
-  const t = useTranslation();
-  const notifications = useAppStore((s) => s.sessionNotifications);
-  const markAllRead = useAppStore((s) => s.markAllSessionNotificationsRead);
-  const clearRead = useAppStore((s) => s.clearReadSessionNotifications);
-  const unreadCount = notifications.filter((notification) => !notification.readAt)
-    .length;
-  const readCount = notifications.length - unreadCount;
-
-  return (
-    <div className="flex h-full flex-col">
-      <div className="flex shrink-0 items-center justify-between border-b border-border px-3 py-2">
-        <div className="min-w-0 text-[10px] uppercase tracking-wide text-fg-muted">
-          <span className="mr-3">
-            {rtf(t, "rightPanel.activity.unreadCount", {
-              count: unreadCount,
-            })}
-          </span>
-          {readCount > 0 ? (
-            <span>
-              {rtf(t, "rightPanel.activity.readCount", { count: readCount })}
-            </span>
-          ) : null}
-        </div>
-        <div className="flex items-center gap-1">
-          <Tooltip
-            label={rt(t, "rightPanel.activity.actions.markAllRead")}
-            side="top"
-          >
-            <button
-              type="button"
-              onClick={markAllRead}
-              disabled={unreadCount === 0}
-              className="rounded border border-border px-2 py-1 text-[10px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
-            >
-              {rt(t, "rightPanel.activity.actions.markAllRead")}
-            </button>
-          </Tooltip>
-          <Tooltip
-            label={rt(t, "rightPanel.activity.actions.clearRead")}
-            side="top"
-          >
-            <button
-              type="button"
-              onClick={clearRead}
-              disabled={readCount === 0}
-              className="rounded border border-border px-2 py-1 text-[10px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
-            >
-              {rt(t, "rightPanel.activity.actions.clearRead")}
-            </button>
-          </Tooltip>
-        </div>
-      </div>
-      {notifications.length === 0 ? (
-        <Empty msg={rt(t, "rightPanel.activity.empty")} />
-      ) : (
-        <ListBox className="acorn-no-scrollbar flex-1 overflow-y-auto">
-          {notifications.map((notification) => (
-            <ActivityRow key={notification.id} notification={notification} />
-          ))}
-        </ListBox>
-      )}
-    </div>
-  );
-}
-
-function ActivityRow({
-  notification,
-}: {
-  notification: SessionNotification;
-}) {
-  const t = useTranslation();
-  const selectSession = useAppStore((s) => s.selectSession);
-  const markRead = useAppStore((s) => s.markSessionNotificationRead);
-  const dismiss = useAppStore((s) => s.dismissSessionNotification);
-  const unread = !notification.readAt;
-
-  const openSession = () => {
-    markRead(notification.id);
-    selectSession(notification.sessionId);
-  };
-
-  return (
-    <ListRow
-      interactive
-      className="group flex items-start gap-2"
-      selected={unread}
-      selectedClassName="bg-warning/5"
-    >
-      <button
-        type="button"
-        onClick={openSession}
-        className="flex min-w-0 flex-1 items-start gap-2 text-left"
-      >
-        <StatusDot
-          tone={activityDotTone(notification.kind)}
-          size="sm"
-          className="mt-1"
-        />
-        <span className="min-w-0 flex-1">
-          <span className="flex min-w-0 items-center gap-2">
-            <span
-              className={cn(
-                "truncate font-mono text-[11px]",
-                unread ? "text-fg" : "text-fg-muted",
-              )}
-            >
-              {rt(t, ACTIVITY_KIND_KEYS[notification.kind])}
-            </span>
-            <span className="shrink-0 font-mono text-[10px] text-fg-muted/70">
-              {formatActivityTime(notification.createdAt)}
-            </span>
-          </span>
-          <span className="block truncate text-[11px] text-fg">
-            {rtf(t, "rightPanel.activity.itemTitle", {
-              project: notification.projectName,
-              session: notification.sessionName,
-            })}
-          </span>
-          <span className="block truncate text-[10px] text-fg-muted">
-            {notification.repoPath}
-          </span>
-        </span>
-      </button>
-      <Tooltip label={rt(t, "rightPanel.activity.actions.dismiss")} side="top">
-        <button
-          type="button"
-          onClick={() => dismiss(notification.id)}
-          className="rounded p-1 text-fg-muted opacity-0 transition hover:bg-bg-sidebar hover:text-fg group-hover:opacity-100"
-        >
-          <X size={12} />
-        </button>
-      </Tooltip>
-    </ListRow>
-  );
-}
-
-function activityDotTone(kind: SessionNotificationKind): StatusTone {
-  if (kind === "failed") return "danger";
-  if (kind === "completed") return "accent";
-  return "warning";
-}
-
-function formatActivityTime(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "";
-  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
 const ALL_AGENT_HISTORY_PROVIDERS = "__all__";

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import {
   Activity,
   BarChart3,
   Bot,
+  CheckCheck,
   ChevronRight,
   Copy,
   Folder,
@@ -29,7 +30,9 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
+  type PointerEvent as ReactPointerEvent,
 } from "react";
 import {
   DndContext,
@@ -130,12 +133,15 @@ import type {
   SessionAgentProvider,
   SessionKind,
   SessionMode,
+  SessionNotification,
+  SessionNotificationKind,
   SessionStatus,
 } from "../lib/types";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { NewProjectDialog } from "./NewProjectDialog";
 import { ProjectSettingsModal } from "./ProjectSettingsModal";
 import { RemoveProjectFolderDialog } from "./RemoveProjectFolderDialog";
+import { ResizeHandle } from "./ResizeHandle";
 import { SessionTitleGeneratingIndicator } from "./SessionTitleGeneratingIndicator";
 import { Tooltip } from "./Tooltip";
 import {
@@ -170,6 +176,11 @@ function autoCloseSessionRowClassName(active: boolean): string {
 const COLLAPSED_KEY = "acorn:sidebar:collapsed-projects";
 const FOLDER_COLLAPSED_KEY = "acorn:sidebar:collapsed-project-folders";
 const PROJECT_ITEM_ORDER_KEY = "acorn:sidebar:project-item-order";
+const ACTIVITY_HEIGHT_KEY = "acorn:sidebar:activity-height";
+const ACTIVITY_DEFAULT_HEIGHT = 192;
+const ACTIVITY_MIN_HEIGHT = 96;
+const ACTIVITY_MAX_HEIGHT = 420;
+const ACTIVITY_KEYBOARD_STEP = 16;
 
 const PROJECT_DRAG_PREFIX = "project:";
 const FOLDER_DRAG_PREFIX = "folder:";
@@ -183,6 +194,18 @@ type SidebarTranslationKey = Extract<TranslationKey, `sidebar.${string}`>;
 
 function sidebarText(t: Translator, key: SidebarTranslationKey): string {
   return t(key);
+}
+
+function sidebarFormat(
+  t: Translator,
+  key: SidebarTranslationKey,
+  values: Record<string, string | number>,
+): string {
+  return sidebarText(t, key).replace(/\{(\w+)\}/g, (match, name) =>
+    Object.prototype.hasOwnProperty.call(values, name)
+      ? String(values[name])
+      : match,
+  );
 }
 
 type SidebarContextMenuGroup =
@@ -1220,6 +1243,7 @@ export function Sidebar() {
               : null}
           </DragOverlay>
         </DndContext>
+        <SessionActivityInbox />
       </div>
       <NewProjectDialog
         open={newProjectOpen}
@@ -3528,6 +3552,332 @@ function LocalTerminalArea({
       </div>
     </section>
   );
+}
+
+const SIDEBAR_ACTIVITY_KIND_KEYS: Record<
+  SessionNotificationKind,
+  SidebarTranslationKey
+> = {
+  needs_input: "sidebar.activity.kind.needsInput",
+  failed: "sidebar.activity.kind.failed",
+  completed: "sidebar.activity.kind.completed",
+  became_idle: "sidebar.activity.kind.becameIdle",
+};
+
+function SessionActivityInbox() {
+  const t = useTranslation();
+  const notifications = useAppStore((s) => s.sessionNotifications);
+  const markAllRead = useAppStore((s) => s.markAllSessionNotificationsRead);
+  const clearRead = useAppStore((s) => s.clearReadSessionNotifications);
+  const [activityHeight, setActivityHeight] = useState(() =>
+    readSidebarActivityHeight(),
+  );
+  const [resizing, setResizing] = useState(false);
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
+  const unreadCount = notifications.filter((notification) => !notification.readAt)
+    .length;
+  const readCount = notifications.length - unreadCount;
+
+  useEffect(() => {
+    return () => {
+      resizeCleanupRef.current?.();
+      resizeCleanupRef.current = null;
+    };
+  }, []);
+
+  function commitHeight(nextHeight: number) {
+    const clamped = clampSidebarActivityHeight(nextHeight);
+    setActivityHeight(clamped);
+    writeSidebarActivityHeight(clamped);
+  }
+
+  function startResize(event: ReactPointerEvent<HTMLDivElement>) {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    resizeCleanupRef.current?.();
+
+    const source = event.currentTarget;
+    const pointerId = event.pointerId;
+    const startY = event.clientY;
+    const startHeight = activityHeight;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = "row-resize";
+    document.body.style.userSelect = "none";
+    setResizing(true);
+
+    const cleanup = () => {
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      setResizing(false);
+      try {
+        source.releasePointerCapture?.(pointerId);
+      } catch {
+        // The pointer may already be released if the handle unmounted.
+      }
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerEnd);
+      window.removeEventListener("pointercancel", onPointerEnd);
+      source.removeEventListener("lostpointercapture", onPointerEnd);
+      if (resizeCleanupRef.current === cleanup) {
+        resizeCleanupRef.current = null;
+      }
+    };
+
+    function onPointerMove(moveEvent: PointerEvent) {
+      if (moveEvent.pointerId !== pointerId) return;
+      commitHeight(startHeight + startY - moveEvent.clientY);
+    }
+
+    function onPointerEnd(endEvent: PointerEvent) {
+      if (endEvent.pointerId !== pointerId) return;
+      cleanup();
+    }
+
+    resizeCleanupRef.current = cleanup;
+    try {
+      source.setPointerCapture?.(pointerId);
+    } catch {
+      // Window listeners still cover normal in-window dragging.
+    }
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerEnd);
+    window.addEventListener("pointercancel", onPointerEnd);
+    source.addEventListener("lostpointercapture", onPointerEnd);
+  }
+
+  function onResizeKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+    event.preventDefault();
+    commitHeight(
+      activityHeight +
+        (event.key === "ArrowUp"
+          ? ACTIVITY_KEYBOARD_STEP
+          : -ACTIVITY_KEYBOARD_STEP),
+    );
+  }
+
+  return (
+    <section
+      aria-label={sidebarText(t, "sidebar.activity.ariaLabel")}
+      className="mt-3 flex shrink-0 flex-col pt-1"
+    >
+      <ResizeHandle
+        mode="manual"
+        direction="vertical"
+        gap
+        manualDragging={resizing}
+        onPointerDown={startResize}
+        onKeyDown={onResizeKeyDown}
+        aria-label={sidebarText(t, "sidebar.activity.actions.resize")}
+        aria-valuemin={ACTIVITY_MIN_HEIGHT}
+        aria-valuemax={ACTIVITY_MAX_HEIGHT}
+        aria-valuenow={activityHeight}
+        data-testid="sidebar-activity-resize-handle"
+        className="mx-1 h-3"
+      />
+      <header className="flex h-8 shrink-0 items-center justify-between gap-2 px-3">
+        <h2 className="flex min-w-0 items-center gap-1.5 text-xs font-medium text-fg-muted">
+          <Activity size={13} className="shrink-0" />
+          <span className="truncate">
+            {sidebarText(t, "sidebar.activity.title")}
+          </span>
+          {unreadCount > 0 ? (
+            <span className="min-w-3 shrink-0 rounded-full bg-warning px-1 text-center text-[9px] leading-3 text-bg-sidebar">
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </span>
+          ) : null}
+        </h2>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <Tooltip
+            label={sidebarText(t, "sidebar.activity.actions.markAllRead")}
+            side="top"
+          >
+            <button
+              type="button"
+              onClick={markAllRead}
+              disabled={unreadCount === 0}
+              aria-label={sidebarText(
+                t,
+                "sidebar.activity.actions.markAllRead",
+              )}
+              className="flex size-6 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+            >
+              <CheckCheck size={13} />
+            </button>
+          </Tooltip>
+          <Tooltip
+            label={sidebarText(t, "sidebar.activity.actions.clearRead")}
+            side="top"
+          >
+            <button
+              type="button"
+              onClick={clearRead}
+              disabled={readCount === 0}
+              aria-label={sidebarText(t, "sidebar.activity.actions.clearRead")}
+              className="flex size-6 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-fg-muted"
+            >
+              <Trash2 size={12} />
+            </button>
+          </Tooltip>
+        </div>
+      </header>
+      <div className="mx-1 overflow-hidden rounded-md border border-border/70 bg-bg/20">
+        <div className="flex items-center gap-2 border-b border-border/60 px-2 py-1 text-[10px] uppercase text-fg-muted">
+          <span>
+            {sidebarFormat(t, "sidebar.activity.unreadCount", {
+              count: unreadCount,
+            })}
+          </span>
+          {readCount > 0 ? (
+            <span>
+              {sidebarFormat(t, "sidebar.activity.readCount", {
+                count: readCount,
+              })}
+            </span>
+          ) : null}
+        </div>
+        <div
+          className="min-h-0"
+          style={{ height: activityHeight }}
+          data-testid="sidebar-activity-body"
+        >
+          {notifications.length === 0 ? (
+            <div className="flex h-full items-center justify-center px-3 text-center text-[11px] text-fg-muted">
+              {sidebarText(t, "sidebar.activity.empty")}
+            </div>
+          ) : (
+            <ul className="acorn-no-scrollbar h-full overflow-y-auto p-1">
+              {notifications.map((notification) => (
+                <SidebarActivityRow
+                  key={notification.id}
+                  notification={notification}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SidebarActivityRow({
+  notification,
+}: {
+  notification: SessionNotification;
+}) {
+  const t = useTranslation();
+  const selectSession = useAppStore((s) => s.selectSession);
+  const markRead = useAppStore((s) => s.markSessionNotificationRead);
+  const dismiss = useAppStore((s) => s.dismissSessionNotification);
+  const unread = !notification.readAt;
+
+  const openSession = () => {
+    markRead(notification.id);
+    selectSession(notification.sessionId);
+  };
+
+  return (
+    <li
+      className={listRowClassName({
+        density: "sidebar",
+        surface: "sidebar",
+        interactive: true,
+        selected: unread,
+        selectedClassName: "bg-warning/5",
+        className: "group flex items-start gap-2",
+      })}
+    >
+      <button
+        type="button"
+        onClick={openSession}
+        className="flex min-w-0 flex-1 items-start gap-2 text-left"
+      >
+        <StatusDot
+          tone={sidebarActivityDotTone(notification.kind)}
+          size="sm"
+          className="mt-1"
+        />
+        <span className="min-w-0 flex-1">
+          <span className="flex min-w-0 items-center gap-2">
+            <span
+              className={cn(
+                "truncate font-mono text-[11px]",
+                unread ? "text-fg" : "text-fg-muted",
+              )}
+            >
+              {sidebarText(t, SIDEBAR_ACTIVITY_KIND_KEYS[notification.kind])}
+            </span>
+            <span className="shrink-0 font-mono text-[10px] text-fg-muted/70">
+              {formatSidebarActivityTime(notification.createdAt)}
+            </span>
+          </span>
+          <span className="block truncate text-[11px] text-fg">
+            {sidebarFormat(t, "sidebar.activity.itemTitle", {
+              project: notification.projectName,
+              session: notification.sessionName,
+            })}
+          </span>
+          <span className="block truncate text-[10px] text-fg-muted">
+            {notification.repoPath}
+          </span>
+        </span>
+      </button>
+      <Tooltip label={sidebarText(t, "sidebar.activity.actions.dismiss")} side="top">
+        <button
+          type="button"
+          onClick={() => dismiss(notification.id)}
+          aria-label={sidebarText(t, "sidebar.activity.actions.dismiss")}
+          className="rounded p-1 text-fg-muted opacity-0 transition hover:bg-bg-sidebar hover:text-fg group-hover:opacity-100"
+        >
+          <X size={12} />
+        </button>
+      </Tooltip>
+    </li>
+  );
+}
+
+function sidebarActivityDotTone(kind: SessionNotificationKind): StatusTone {
+  if (kind === "failed") return "danger";
+  if (kind === "completed") return "accent";
+  return "warning";
+}
+
+function formatSidebarActivityTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function clampSidebarActivityHeight(height: number): number {
+  if (!Number.isFinite(height)) return ACTIVITY_DEFAULT_HEIGHT;
+  return Math.round(
+    Math.min(Math.max(height, ACTIVITY_MIN_HEIGHT), ACTIVITY_MAX_HEIGHT),
+  );
+}
+
+function readSidebarActivityHeight(): number {
+  try {
+    const raw = localStorage.getItem(ACTIVITY_HEIGHT_KEY);
+    if (!raw) return ACTIVITY_DEFAULT_HEIGHT;
+    const parsed = Number(raw);
+    return clampSidebarActivityHeight(parsed);
+  } catch {
+    return ACTIVITY_DEFAULT_HEIGHT;
+  }
+}
+
+function writeSidebarActivityHeight(height: number): void {
+  try {
+    localStorage.setItem(
+      ACTIVITY_HEIGHT_KEY,
+      String(clampSidebarActivityHeight(height)),
+    );
+  } catch {
+    // Ignore storage failures; the current drag should still resize the panel.
+  }
 }
 
 interface LocalWorkspaceViewProps {

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -156,6 +156,49 @@ describe("notifications", () => {
     dispose();
   });
 
+  it("does not record in-app activity for the focused session transition", () => {
+    useAppStore.setState({ activeSessionId: "session-1" });
+    const dispose = startSessionActivityInboxWatcher();
+
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "needs_input",
+          updated_at: "2026-01-01T00:01:00Z",
+        }),
+      ],
+    });
+
+    expect(useAppStore.getState().sessionNotifications).toEqual([]);
+    dispose();
+  });
+
+  it("records in-app activity for the active session when the app is not focused", () => {
+    Object.defineProperty(document, "hasFocus", {
+      configurable: true,
+      value: () => false,
+    });
+    useAppStore.setState({ activeSessionId: "session-1" });
+    const dispose = startSessionActivityInboxWatcher();
+
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "needs_input",
+          updated_at: "2026-01-01T00:01:00Z",
+        }),
+      ],
+    });
+
+    expect(useAppStore.getState().sessionNotifications).toMatchObject([
+      {
+        sessionId: "session-1",
+        status: "needs_input",
+      },
+    ]);
+    dispose();
+  });
+
   it("marks in-app activity read when its session tab is focused and auto-delete is disabled", async () => {
     useSettings.getState().patchNotifications({ autoDeleteRead: false });
     const disposeActivity = startSessionActivityInboxWatcher();

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -209,6 +209,10 @@ export function startSessionActivityInboxWatcher(): () => void {
 
       const kind = notificationKindForTransition(prev, s.status);
       if (!kind) continue;
+      if (isSessionFocused(s.id, state.activeSessionId)) {
+        markSessionNotificationsRead(s.id);
+        continue;
+      }
       store.addSessionNotification(buildInboxNotification(s, prev, kind));
     }
 

--- a/src/lib/rightPanelGroups.ts
+++ b/src/lib/rightPanelGroups.ts
@@ -7,7 +7,6 @@ export type RightTab =
   | "prs"
   | "issues"
   | "actions"
-  | "activity"
   | "todos"
   | "history";
 
@@ -16,7 +15,7 @@ export const RIGHT_GROUPS: ReadonlyArray<RightGroup> = ["code", "github", "agent
 const TABS_BY_GROUP: Record<RightGroup, ReadonlyArray<RightTab>> = {
   code: ["files", "staged", "commits"],
   github: ["prs", "issues", "actions"],
-  agents: ["activity", "history", "todos"],
+  agents: ["history", "todos"],
 };
 
 export function tabsForGroup(group: RightGroup): ReadonlyArray<RightTab> {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -375,7 +375,7 @@
         "hint": "Choose which optional badges show in the bottom status bar.",
         "sessionActivity": {
           "label": "Session activity",
-          "description": "Bell shortcut for unread session activity. The Activity tab remains available when hidden."
+          "description": "Bell shortcut for unread session activity. The sidebar activity list remains available when hidden."
         },
         "sessionCount": {
           "label": "Session count",
@@ -1130,6 +1130,26 @@
       "newSession": "New instant session",
       "newWorkspace": "New workspace",
       "empty": "Double-click to start an instant session."
+    },
+    "activity": {
+      "ariaLabel": "Session activity",
+      "title": "Activity",
+      "unreadCount": "{count} unread",
+      "readCount": "{count} read",
+      "empty": "No session activity yet",
+      "itemTitle": "{project} · {session}",
+      "kind": {
+        "needsInput": "Needs input",
+        "failed": "Failed",
+        "completed": "Completed",
+        "becameIdle": "Idle"
+      },
+      "actions": {
+        "markAllRead": "Mark all read",
+        "clearRead": "Clear read",
+        "resize": "Resize activity",
+        "dismiss": "Dismiss"
+      }
     },
     "emptyProject": {
       "createSession": "Double-click to start a session."

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -375,7 +375,7 @@
         "hint": "하단 상태 표시줄에 표시할 선택 배지를 고릅니다.",
         "sessionActivity": {
           "label": "세션 활동",
-          "description": "읽지 않은 세션 활동으로 바로 가는 벨 버튼입니다. 숨겨도 Activity 탭은 계속 사용할 수 있습니다."
+          "description": "읽지 않은 세션 활동으로 바로 가는 벨 버튼입니다. 숨겨도 사이드바 활동 목록은 계속 사용할 수 있습니다."
         },
         "sessionCount": {
           "label": "세션 수",
@@ -1130,6 +1130,26 @@
       "newSession": "새 인스턴트 세션",
       "newWorkspace": "새 작업공간",
       "empty": "더블클릭하면 인스턴트 세션을 시작할 수 있습니다."
+    },
+    "activity": {
+      "ariaLabel": "세션 활동",
+      "title": "활동",
+      "unreadCount": "읽지 않음 {count}개",
+      "readCount": "읽음 {count}개",
+      "empty": "아직 세션 활동이 없습니다",
+      "itemTitle": "{project} · {session}",
+      "kind": {
+        "needsInput": "입력 필요",
+        "failed": "실패",
+        "completed": "완료",
+        "becameIdle": "유휴"
+      },
+      "actions": {
+        "markAllRead": "모두 읽음",
+        "clearRead": "읽은 항목 지우기",
+        "resize": "활동 영역 크기 조절",
+        "dismiss": "닫기"
+      }
     },
     "emptyProject": {
       "createSession": "더블클릭하면 세션을 시작할 수 있습니다."

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -3194,7 +3194,7 @@ describe("right panel groups", () => {
     expect(s.rightTabByGroup.github).toBe("actions");
     // Other groups untouched.
     expect(s.rightTabByGroup.code).toBe("files");
-    expect(s.rightTabByGroup.agents).toBe("activity");
+    expect(s.rightTabByGroup.agents).toBe("history");
   });
 
   it("setRightGroup restores the group's last sub-tab", () => {

--- a/tests/e2e/session-notifications.spec.ts
+++ b/tests/e2e/session-notifications.spec.ts
@@ -16,7 +16,7 @@ test.describe("session notification center", () => {
     await tauri.handle("list_sessions", () => [
       {
         id: "session-1",
-        name: "agent run",
+        name: "foreground",
         repo_path: "/tmp/demo",
         worktree_path: "/tmp/demo",
         branch: "main",
@@ -31,10 +31,27 @@ test.describe("session notification center", () => {
         position: 0,
         in_worktree: false,
       },
+      {
+        id: "session-2",
+        name: "agent run",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "running",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 1,
+        in_worktree: false,
+      },
     ]);
     await tauri.handle("detect_session_statuses", () => [
       {
-        id: "session-1",
+        id: "session-2",
         status: "needs_input",
         branch: null,
         agent_provider: null,
@@ -46,21 +63,50 @@ test.describe("session notification center", () => {
     await expect(page.getByRole("button", { name: "Session notifications" }))
       .toContainText("1");
 
-    await page.getByRole("button", { name: "Agents" }).click();
-    const subTabs = page.getByRole("navigation", {
-      name: "Right panel sub-tab",
+    const instantSessions = page.getByRole("region", {
+      name: "Local terminal sessions",
     });
-    const activityTab = subTabs.getByRole("button", { name: /Activity/ });
-    const historyTab = subTabs.getByRole("button", { name: "History" });
-    await expect(activityTab).toBeVisible();
-    await expect(activityTab).toContainText("1");
-    await expect(historyTab).toBeVisible();
-    const [activityBox, historyBox] = await Promise.all([
-      activityTab.boundingBox(),
-      historyTab.boundingBox(),
+    const activity = page.getByRole("region", {
+      name: "Session activity",
+    });
+    await expect(activity).toBeVisible();
+    await expect(activity).toContainText("1 unread");
+    const [instantBox, activityBox] = await Promise.all([
+      instantSessions.boundingBox(),
+      activity.boundingBox(),
     ]);
-    expect(activityBox?.x ?? 0).toBeLessThan(historyBox?.x ?? 0);
-    await expect(page.getByText("demo · agent run")).toBeVisible();
+    expect(activityBox?.y ?? 0).toBeGreaterThan(instantBox?.y ?? 0);
+    await expect(activity.getByText("demo · agent run")).toBeVisible();
+
+    const activityBody = page.getByTestId("sidebar-activity-body");
+    const resizeHandle = page.getByTestId("sidebar-activity-resize-handle");
+    const [bodyBoxBefore, resizeHandleBox] = await Promise.all([
+      activityBody.boundingBox(),
+      resizeHandle.boundingBox(),
+    ]);
+    expect(bodyBoxBefore).not.toBeNull();
+    expect(resizeHandleBox).not.toBeNull();
+    if (!bodyBoxBefore || !resizeHandleBox) {
+      throw new Error("missing sidebar activity resize target");
+    }
+    expect(resizeHandleBox.height).toBeGreaterThanOrEqual(12);
+    await page.mouse.move(
+      resizeHandleBox.x + resizeHandleBox.width / 2,
+      resizeHandleBox.y + resizeHandleBox.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      resizeHandleBox.x + resizeHandleBox.width / 2,
+      resizeHandleBox.y + resizeHandleBox.height / 2 - 72,
+    );
+    await page.mouse.up();
+    await expect
+      .poll(async () =>
+        activityBody.evaluate((element) =>
+          element.getBoundingClientRect().height,
+        ),
+      )
+      .toBeGreaterThan(bodyBoxBefore.height + 48);
 
     await page.getByRole("button", { name: "Session notifications" }).click();
 
@@ -75,6 +121,6 @@ test.describe("session notification center", () => {
 
     await expect(page.getByRole("button", { name: "Session notifications" }))
       .not.toContainText("1");
-    await expect(activityTab).not.toContainText("1");
+    await expect(activity).toContainText("0 unread");
   });
 });


### PR DESCRIPTION
## Summary
Session activity now lives below Instant Sessions so background agent signals stay visible next to session navigation.

1. **Sidebar activity inbox** — moves session activity out of the Agents panel into a resizable sidebar list under Instant Sessions, with mark-read, clear-read, dismiss, empty, and localized states.
2. **Right panel cleanup** — removes the Agents > Activity sub-tab and defaults the Agents group to History/Todos.
3. **Focused-session filtering** — avoids creating in-app activity rows when the transitioned session is already focused, while preserving activity records when the app is not focused.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Session activity visibility | Activity lived under Agents > Activity in the right panel. | Activity is available directly below Instant Sessions in the left sidebar. |
| Sidebar layout | No dedicated activity area below Instant Sessions. | Activity list has a persisted, draggable height. |
| Focused session transitions | Already-visible sessions could still leave read activity rows behind. | Focused session transitions are consumed without adding a new Activity row. |

## Design notes
- Reuses the existing `ResizeHandle` manual pointer pattern for sidebar activity resizing, with height persisted under `acorn:sidebar:activity-height`.
- Keeps the status-bar notification dropdown backed by the same `sessionNotifications` store so the sidebar list and bell menu stay consistent.
- Focused-session filtering checks `document.hasFocus()` before suppressing activity so background app transitions still remain visible for later review.

## Test plan
- [x] `pnpm exec vitest run src/store.test.ts src/components/RightPanel.test.tsx src/lib/notifications.test.ts` — 3 files, 165 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test:e2e -- tests/e2e/session-notifications.spec.ts` — 1 Chromium test passed
- [x] `git diff --check` — passed

## Notes
- No known caveats.
