### PR TITLE
fix(terminal): replay fresh daemon session scrollback

### DIFF
--- a/src/lib/terminalRestorePlan.test.ts
+++ b/src/lib/terminalRestorePlan.test.ts
@@ -58,7 +58,7 @@ describe("terminal restore plan", () => {
     });
   });
 
-  it("skips replay when there is no daemon session to replay", () => {
+  it("uses daemon replay when no local snapshot is restored", () => {
     expect(
       planTerminalRestore({
         daemonAlive: false,
@@ -68,7 +68,7 @@ describe("terminal restore plan", () => {
     ).toEqual({
       snapshot: null,
       source: null,
-      replayScrollback: false,
+      replayScrollback: true,
     });
   });
 });

--- a/src/lib/terminalRestorePlan.ts
+++ b/src/lib/terminalRestorePlan.ts
@@ -36,9 +36,11 @@ export function planTerminalRestore({
       replayScrollback: false,
     };
   }
+  // No local snapshot is restored, so let daemon attach replay bytes written
+  // between PTY spawn and stream attachment, including the first shell prompt.
   return {
     snapshot: null,
     source: null,
-    replayScrollback: false,
+    replayScrollback: true,
   };
 }


### PR DESCRIPTION
## Summary
Fixes a race where freshly created daemon-backed terminal tabs could appear blank because the first shell prompt was written before the frontend stream attachment completed.

1. **Fresh daemon session replay** — when no frontend handoff or disk scrollback snapshot is restored, the terminal now asks the daemon attach path to replay its ring buffer so spawn-time output reaches xterm.
2. **Restore-plan coverage** — updates the restore-plan unit test to lock the new no-local-snapshot behavior while preserving disk/handoff duplicate-output guards.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| New daemon-backed terminal tabs | Initial prompt could be missed if emitted before stream attach, leaving a blank terminal until later output | Initial daemon ring replay includes spawn-time prompt/output |
| Restored terminal tabs | Disk/handoff restore avoids daemon replay to prevent duplicate local snapshots | Unchanged |

## Design notes
- The change stays in `planTerminalRestore`, the pure policy function that decides whether the frontend restores a local snapshot or asks the daemon to replay its ring.
- Disk and in-memory handoff snapshots still set `replayScrollback: false`, so existing duplicate-output protection remains intact.

## Test plan
- [x] `pnpm exec vitest run src/lib/terminalRestorePlan.test.ts` — 5 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `git diff --check` — passed

## Notes
- No follow-up work is required for this targeted race fix. The separate daemon/session-store orphan cleanup observed locally is outside this PR.