### PR TITLE
fix(status): keep Codex running during background tools

### DIFF
--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -106,7 +106,7 @@ if [ -n "${ACORN_AGENT_HOOK_URL-}" ] &&
   ) &
   ACORN_CODEX_WATCHER_PID=$!
 
-  "$REAL_BIN" --enable codex_hooks -c "notify=[\"bash\",\"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"]" "$@"
+  "$REAL_BIN" --enable hooks -c "notify=[\"bash\",\"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"]" "$@"
   ACORN_CODEX_STATUS=$?
 
   if [ -n "${ACORN_CODEX_WATCHER_PID-}" ]; then
@@ -489,7 +489,8 @@ mod tests {
         let dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
 
         let wrapper = fs::read_to_string(dir.join("codex")).unwrap();
-        assert!(wrapper.contains("--enable codex_hooks"));
+        assert!(wrapper.contains("--enable hooks"));
+        assert!(!wrapper.contains("--enable codex_hooks"));
         assert!(wrapper
             .contains("notify=[\\\"bash\\\",\\\"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\\\"]"));
         assert!(wrapper.contains("CODEX_TUI_RECORD_SESSION=1"));

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5046,13 +5046,12 @@ fn detect_session_statuses_blocking(
     // root). Without this, the StatusBar/Sidebar branch stays pinned to the
     // project root's branch regardless of `git checkout` performed inside
     // the PTY.
-    let mut sys =
-        System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()));
-    sys.refresh_processes_specifics(
-        ProcessesToUpdate::All,
-        true,
-        ProcessRefreshKind::new().with_cwd(UpdateKind::Always),
-    );
+    let refresh = ProcessRefreshKind::new()
+        .with_cwd(UpdateKind::Always)
+        .with_exe(UpdateKind::Always)
+        .with_cmd(UpdateKind::Always);
+    let mut sys = System::new_with_specifics(RefreshKind::new().with_processes(refresh));
+    sys.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh);
     let children = build_children_map(&sys);
     let daemon_session_pids = std::sync::OnceLock::<HashMap<Uuid, u32>>::new();
     let daemon_pid_for = |uuid: Uuid| {
@@ -5148,6 +5147,10 @@ fn detect_session_statuses_blocking(
             let live_agent_kind = root_pid_value.and_then(|pid| {
                 live_agent_kind_in_descendants(&sys, &children, Pid::from_u32(pid))
             });
+            let live_codex_tool_child = matches!(live_agent_kind, Some(StatusAgentKind::Codex))
+                && root_pid_value.is_some_and(|pid| {
+                    live_codex_has_tool_descendant(&sys, &children, Pid::from_u32(pid))
+                });
             // Resolve the live transcript via the persister's resume markers
             // first (covers claude/codex/antigravity run inside a shell session — JSONL
             // is named after the agent's own UUID, not Acorn's). When the PTY
@@ -5228,10 +5231,17 @@ fn detect_session_statuses_blocking(
             // I/O, and reusing the `previous` captured before that I/O would
             // clobber the newer hook status back to an old value.
             let status = if defer_to_hook {
-                parsed_id
+                let hook_status = parsed_id
                     .and_then(|uuid| state.sessions.get(&uuid).ok())
                     .map(|s| s.status)
-                    .unwrap_or(previous)
+                    .unwrap_or(previous);
+                // Codex can report turn-complete while a background terminal
+                // command is still alive. Keep the UI Running until it exits.
+                if hook_status == SessionStatus::NeedsInput && live_codex_tool_child {
+                    SessionStatus::Running
+                } else {
+                    hook_status
+                }
             } else {
                 detection.status
             };
@@ -5396,6 +5406,17 @@ fn live_agent_kind_in_descendants(
     })
 }
 
+fn live_codex_has_tool_descendant(
+    sys: &System,
+    children: &HashMap<Pid, Vec<Pid>>,
+    root: Pid,
+) -> bool {
+    has_descendant_below_nearest_matching(children, root, |pid| {
+        sys.process(pid)
+            .is_some_and(|proc| process_primary_basename_matches(proc, "codex"))
+    })
+}
+
 fn nearest_agent_kind_in_tree<F>(
     children: &HashMap<Pid, Vec<Pid>>,
     root: Pid,
@@ -5421,6 +5442,45 @@ where
         }
     }
     None
+}
+
+fn nearest_descendant_matching<F>(
+    children: &HashMap<Pid, Vec<Pid>>,
+    root: Pid,
+    mut matches: F,
+) -> Option<Pid>
+where
+    F: FnMut(Pid) -> bool,
+{
+    let mut queue = VecDeque::new();
+    if let Some(direct) = children.get(&root) {
+        let mut direct = direct.clone();
+        direct.sort_by_key(|pid| pid.as_u32());
+        queue.extend(direct);
+    }
+    while let Some(pid) = queue.pop_front() {
+        if matches(pid) {
+            return Some(pid);
+        }
+        if let Some(kids) = children.get(&pid) {
+            let mut kids = kids.clone();
+            kids.sort_by_key(|pid| pid.as_u32());
+            queue.extend(kids);
+        }
+    }
+    None
+}
+
+fn has_descendant_below_nearest_matching<F>(
+    children: &HashMap<Pid, Vec<Pid>>,
+    root: Pid,
+    matches: F,
+) -> bool
+where
+    F: FnMut(Pid) -> bool,
+{
+    nearest_descendant_matching(children, root, matches)
+        .is_some_and(|pid| children.get(&pid).is_some_and(|direct| !direct.is_empty()))
 }
 
 /// `true` if any descendant of `root` exists in the children map. The root
@@ -5512,6 +5572,38 @@ mod status_hint_tests {
 
         assert!(has_live_descendant(&children, root));
         assert!(!has_live_descendant(&children, grandchild));
+    }
+
+    #[test]
+    fn matching_agent_with_child_reports_live_work_below_agent() {
+        let root = Pid::from_u32(1);
+        let wrapper = Pid::from_u32(2);
+        let codex = Pid::from_u32(3);
+        let tool = Pid::from_u32(4);
+        let mut children = HashMap::new();
+        children.insert(root, vec![wrapper]);
+        children.insert(wrapper, vec![codex]);
+        children.insert(codex, vec![tool]);
+
+        assert!(has_descendant_below_nearest_matching(
+            &children,
+            root,
+            |pid| pid == codex,
+        ));
+    }
+
+    #[test]
+    fn matching_agent_without_child_reports_no_live_work_below_agent() {
+        let root = Pid::from_u32(1);
+        let codex = Pid::from_u32(2);
+        let mut children = HashMap::new();
+        children.insert(root, vec![codex]);
+
+        assert!(!has_descendant_below_nearest_matching(
+            &children,
+            root,
+            |pid| pid == codex,
+        ));
     }
 }
 
@@ -6005,6 +6097,39 @@ fn agent_is_running_in_session(state: &AppState, session_id: &Uuid, basename: &s
 /// makes the detection robust against the user's `claude` binary
 /// being a Bun-compiled symlink target rather than a script.
 fn process_basename_matches(proc: &sysinfo::Process, target: &str) -> bool {
+    if process_primary_basename_matches(proc, target) {
+        return true;
+    }
+    for arg in proc.cmd().iter().skip(1) {
+        let s = arg.to_string_lossy();
+        if process_basename_part_matches(&s, target) {
+            return true;
+        }
+    }
+    false
+}
+
+fn process_primary_basename_matches(proc: &sysinfo::Process, target: &str) -> bool {
+    if let Some(exe) = proc.exe().and_then(|p| p.to_str()) {
+        if process_basename_part_matches(exe, target) {
+            return true;
+        }
+    }
+    if let Some(name) = proc.name().to_str() {
+        if process_basename_part_matches(name, target) {
+            return true;
+        }
+    }
+    if let Some(arg0) = proc.cmd().first() {
+        let s = arg0.to_string_lossy();
+        if process_basename_part_matches(&s, target) {
+            return true;
+        }
+    }
+    false
+}
+
+fn process_basename_part_matches(s: &str, target: &str) -> bool {
     fn basename_matches(s: &str, target: &str) -> bool {
         let base = s.rsplit('/').next().unwrap_or(s);
         base == target
@@ -6013,23 +6138,7 @@ fn process_basename_matches(proc: &sysinfo::Process, target: &str) -> bool {
             || base.strip_suffix(".cjs") == Some(target)
     }
 
-    if let Some(exe) = proc.exe().and_then(|p| p.to_str()) {
-        if basename_matches(exe, target) {
-            return true;
-        }
-    }
-    if let Some(name) = proc.name().to_str() {
-        if basename_matches(name, target) {
-            return true;
-        }
-    }
-    for arg in proc.cmd() {
-        let s = arg.to_string_lossy();
-        if basename_matches(&s, target) {
-            return true;
-        }
-    }
-    false
+    basename_matches(s, target)
 }
 
 pub(crate) fn sanitize_worktree_name(name: &str) -> String {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1388,14 +1388,14 @@ function App() {
     };
   }, []);
 
-  // Agent hook callbacks update backend session status immediately. Refresh
-  // the session list from backend state so hook status can surface without
-  // waiting for the next transcript/process poll.
+  // Agent hook callbacks update backend session status immediately. Poll the
+  // affected session so hook status still goes through process-aware status
+  // arbitration before it reaches the UI.
   useEffect(() => {
     let unlisten: UnlistenFn | null = null;
     let cancelled = false;
-    listen<string>(AGENT_HOOK_STATUS_EVENT, () => {
-      useAppStore.getState().refreshSessions();
+    listen<string>(AGENT_HOOK_STATUS_EVENT, (event) => {
+      void useAppStore.getState().pollSessionStatuses([event.payload]);
     })
       .then((fn) => {
         if (cancelled) {


### PR DESCRIPTION
## Summary
Codex status handling now accounts for hook completion events that race with active background terminal commands.

1. **Hook feature flag** — update the generated Codex wrapper to use `--enable hooks` instead of the deprecated `--enable codex_hooks` flag, with test coverage to prevent regression.
2. **Process-aware hook arbitration** — keep hooked Codex sessions `running` when the hook reports `needs_input` but the live Codex process still has a child tool command.
3. **Immediate UI reconciliation** — route `acorn:agent-hook-status` frontend events through a targeted `pollSessionStatuses([id])` call so backend process arbitration applies before the UI updates.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Codex hook startup | Emitted a deprecation warning for `codex_hooks` | Uses the current `hooks` feature flag |
| Codex background tools | Could show `needs_input` while a background command was still running | Stays `running` until the tool child exits |
| Hook event refresh | Raw session refresh could surface hook status directly | Targeted status poll reconciles hook status with process state |

## Design notes
- Status polling now refreshes process cwd, executable, and command args in one process snapshot. The existing cwd refresh still supports branch detection, while executable/args allow live Codex tool detection.
- Provider detection still accepts wrapper-style command args via `process_basename_matches`, but the Codex live-tool override uses primary process identity to avoid treating the Acorn shell wrapper itself as the Codex process.
- The override is intentionally narrow: only Codex `needs_input` hook status is promoted back to `running`, and only while a live tool child remains below the live Codex process.

## Test plan
- [x] `TAURI_SIDECAR_PROFILE=debug pnpm run build:sidecar` — staged required sidecars for local Rust tests
- [x] `cargo test --manifest-path src-tauri/Cargo.toml status_hint_tests --lib` — 7 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml writes_codex_wrapper_and_notify_helper --lib` — 1 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 318 passed, 1 ignored
- [x] `pnpm install --frozen-lockfile` — lockfile already up to date; installed local deps for this worktree
- [x] `pnpm run test` — 79 files / 877 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed
