### PR TITLE
chore(release): v1.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.22.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "acorn-daemon",
  "acorn-ipc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.21.0"
+version = "1.22.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

This release bump publishes the mainline user-visible feature and fix work after `v1.21.1` while bringing app metadata to `1.22.0`.

1. **Version metadata:** Bumps Acorn from `1.21.0` to `1.22.0` in `package.json`, `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock`.
2. **Semver decision:** Uses a minor release because the mainline unreleased set includes user-visible sidebar enhancements, especially the resizable session activity inbox.
3. **Release scope:** Includes merged PRs #528, #529, #530, #533, #534, #535, and #536.

## Expected impact

| Area | Impact |
| --- | --- |
| User-visible version | Acorn updater and app metadata move to `1.22.0`. |
| Release notes | Generated release notes include the mainline feature and fix PRs; this bump PR is excluded via `skip-changelog`. |
| Runtime behavior | No code behavior changes in this PR beyond version metadata. |

## Design notes

- The release is a minor bump because #533 adds a new user-visible sidebar activity inbox, alongside #528 and #529 sidebar/release-note improvements.
- Only release metadata files are changed so the PR stays reviewable and easy to validate.
- `v1.21.1` was a hotfix from `release/v1.21.x`, not an ancestor of `main`; generated `v1.22.0` notes still include mainline PR #530 even though the hotfix shipped the same user-facing fix through #531.

## Follow-up (not in this PR)

- Consider adding explicit release-note handling for future hotfix cherry-picks if duplicate mainline entries become noisy.

## Test plan

- [x] `rg -n '1\\.21\\.0|1\\.22\\.0' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock`
- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1`
- [x] `git show HEAD:scripts/release-notes.mjs | rg 'addReleaseSectionSummaries|formatReleaseSectionSummary'`
- [x] `REPO=im-ian/acorn TAG=v1.22.0 OUTPUT=/tmp/acorn-release-notes-v1.22.0.md node scripts/release-notes.mjs`
- [x] `test -s /tmp/acorn-release-notes-v1.22.0.md`
- [x] `rg -n '^> .+<br>$' /tmp/acorn-release-notes-v1.22.0.md`
- [x] `rg -n '^> (Feature updates|Fixes|Performance improvements|Security updates|Documentation updates|Internal cleanup|Build and CI updates|Other changes): ' /tmp/acorn-release-notes-v1.22.0.md`
- [x] `git diff --check`

## Notes

- `v1.22.0` release notes dry-run passed the bilingual summary checks.
- The generated notes include #530 because the mainline merge is not reachable from the `v1.21.1` hotfix tag; the same user-facing fix was already shipped in `v1.21.1` via #531.
