### PR TITLE
fix(sidebar): anchor resizable activity panel

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1106,7 +1106,7 @@ export function Sidebar() {
           </Tooltip>
         </div>
       </header>
-      <div className="acorn-no-scrollbar flex flex-1 flex-col overflow-y-auto px-1 pb-2">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <DndContext
           sensors={sensors}
           collisionDetection={scopedCollision}
@@ -1114,129 +1114,136 @@ export function Sidebar() {
           onDragEnd={onDragEnd}
           onDragCancel={() => setActiveDragId(null)}
         >
-          {projectGroups.length === 0 ? (
-            <EmptyState onOpenProject={onAddExistingProject} />
-          ) : (
-            <SortableContext
-              items={projectIds}
-              strategy={verticalListSortingStrategy}
-            >
-              <ul className="flex flex-col gap-1.5">
-                {projectGroups.map((project) => {
-                  return (
-                    <ProjectGroupView
-                      key={project.repoPath}
-                      project={project}
-                      collapsed={collapsed.has(project.repoPath)}
-                      activeSessionId={activeSessionId}
-                      isActiveProject={activeProject === project.repoPath}
-                      workspaceViewMode={
-                        activeProject === project.repoPath
-                          ? workspaceViewMode
-                          : "panes"
-                      }
-                      activeProjectFolderId={activeProjectFolderId}
-                      topLevelOrder={projectItemOrders[project.repoPath] ?? []}
-                      prioritizeNeedsInputTabs={prioritizeNeedsInputTabs}
-                      onTitleClick={() =>
-                        applyClickPlan(
-                          planTitleClick({
-                            wasActive: activeProject === project.repoPath,
-                            wasCollapsed: collapsed.has(project.repoPath),
-                          }),
-                          project,
-                        )
-                      }
-                      onChevronClick={() =>
-                        applyClickPlan(
-                          planChevronClick({
-                            wasActive: activeProject === project.repoPath,
-                            wasCollapsed: collapsed.has(project.repoPath),
-                          }),
-                          project,
-                        )
-                      }
-                      onActivate={() => {
-                        setActiveProject(project.repoPath);
-                        expandProject(project.repoPath);
-                        const target = pickSessionToActivate(
-                          project.sessions,
-                          activeSessionId,
-                        );
-                        if (target) selectSession(target);
-                      }}
-                      onSelectFolder={setActiveProjectFolder}
-                      onSelectSession={(folderId, sessionId) => {
-                        setActiveProjectFolder(folderId);
-                        selectSession(sessionId);
-                      }}
-                      onRemoveSession={(s) => requestRemoveSession(s.id)}
-                      onAddSession={(folder, isolated, kind, mode = "terminal") =>
-                        onNewSession(
+          <div className="acorn-no-scrollbar min-h-0 flex-1 overflow-y-auto px-1 pb-2">
+            {projectGroups.length === 0 ? (
+              <EmptyState onOpenProject={onAddExistingProject} />
+            ) : (
+              <SortableContext
+                items={projectIds}
+                strategy={verticalListSortingStrategy}
+              >
+                <ul className="flex flex-col gap-1.5">
+                  {projectGroups.map((project) => {
+                    return (
+                      <ProjectGroupView
+                        key={project.repoPath}
+                        project={project}
+                        collapsed={collapsed.has(project.repoPath)}
+                        activeSessionId={activeSessionId}
+                        isActiveProject={activeProject === project.repoPath}
+                        workspaceViewMode={
+                          activeProject === project.repoPath
+                            ? workspaceViewMode
+                            : "panes"
+                        }
+                        activeProjectFolderId={activeProjectFolderId}
+                        topLevelOrder={projectItemOrders[project.repoPath] ?? []}
+                        prioritizeNeedsInputTabs={prioritizeNeedsInputTabs}
+                        onTitleClick={() =>
+                          applyClickPlan(
+                            planTitleClick({
+                              wasActive: activeProject === project.repoPath,
+                              wasCollapsed: collapsed.has(project.repoPath),
+                            }),
+                            project,
+                          )
+                        }
+                        onChevronClick={() =>
+                          applyClickPlan(
+                            planChevronClick({
+                              wasActive: activeProject === project.repoPath,
+                              wasCollapsed: collapsed.has(project.repoPath),
+                            }),
+                            project,
+                          )
+                        }
+                        onActivate={() => {
+                          setActiveProject(project.repoPath);
+                          expandProject(project.repoPath);
+                          const target = pickSessionToActivate(
+                            project.sessions,
+                            activeSessionId,
+                          );
+                          if (target) selectSession(target);
+                        }}
+                        onSelectFolder={setActiveProjectFolder}
+                        onSelectSession={(folderId, sessionId) => {
+                          setActiveProjectFolder(folderId);
+                          selectSession(sessionId);
+                        }}
+                        onRemoveSession={(s) => requestRemoveSession(s.id)}
+                        onAddSession={(
+                          folder,
                           isolated,
                           kind,
-                          {
-                            placement: {
-                              repoPath: project.repoPath,
-                              projectScoped: true,
-                              projectFolderId: folder.id,
+                          mode = "terminal",
+                        ) =>
+                          onNewSession(
+                            isolated,
+                            kind,
+                            {
+                              placement: {
+                                repoPath: project.repoPath,
+                                projectScoped: true,
+                                projectFolderId: folder.id,
+                              },
+                              launch: {
+                                kind: "workspaceCwd",
+                                cwdPath: folder.cwdPath,
+                              },
                             },
-                            launch: {
-                              kind: "workspaceCwd",
-                              cwdPath: folder.cwdPath,
-                            },
-                          },
-                          mode,
-                        )
-                      }
-                      onAddFolder={() => onAddProjectFolder(project.repoPath)}
-                      onAddWorktreeFolder={() =>
-                        void onAddProjectFolderWorktree(project.repoPath)
-                      }
-                      onRenameFolder={renameProjectFolder}
-                      onRemoveFolder={requestRemoveProjectFolder}
-                      onMoveSessionToFolder={moveSessionToProjectFolder}
-                      onRemoveProject={() =>
-                        requestRemoveProject(project.repoPath)
-                      }
-                      onOpenSettings={() => setSettingsProject(project)}
-                      collapsedFolderIds={collapsedFolders}
-                      onToggleFolder={toggleProjectFolder}
-                    />
-                  );
-                })}
-              </ul>
-            </SortableContext>
-          )}
-          <LocalTerminalArea
-            groups={localWorkspaceGroups}
-            activeSessionId={activeSessionId}
-            activeProjectFolderId={activeProjectFolderId}
-            collapsedFolderIds={collapsedFolders}
-            onCreate={() => onNewLocalSession()}
-            onCreateInFolder={(folder) =>
-              onNewLocalSession({
-                placement: {
-                  repoPath: folder.repoPath,
-                  projectScoped: false,
-                  projectFolderId: folder.id,
-                },
-                launch: {
-                  kind: "workspaceCwd",
-                  cwdPath: folder.cwdPath,
-                },
-              })
-            }
-            onCreateWorkspace={onAddLocalWorkspace}
-            onFocusArea={focusLocalSessions}
-            onSelectFolder={setActiveProjectFolder}
-            onToggleFolder={toggleProjectFolder}
-            onSelectSession={selectSession}
-            onRemoveSession={(s) => requestRemoveSession(s.id)}
-            onRenameFolder={renameProjectFolder}
-            onRemoveFolder={requestRemoveProjectFolder}
-            onMoveSessionToFolder={moveSessionToProjectFolder}
-          />
+                            mode,
+                          )
+                        }
+                        onAddFolder={() => onAddProjectFolder(project.repoPath)}
+                        onAddWorktreeFolder={() =>
+                          void onAddProjectFolderWorktree(project.repoPath)
+                        }
+                        onRenameFolder={renameProjectFolder}
+                        onRemoveFolder={requestRemoveProjectFolder}
+                        onMoveSessionToFolder={moveSessionToProjectFolder}
+                        onRemoveProject={() =>
+                          requestRemoveProject(project.repoPath)
+                        }
+                        onOpenSettings={() => setSettingsProject(project)}
+                        collapsedFolderIds={collapsedFolders}
+                        onToggleFolder={toggleProjectFolder}
+                      />
+                    );
+                  })}
+                </ul>
+              </SortableContext>
+            )}
+            <LocalTerminalArea
+              groups={localWorkspaceGroups}
+              activeSessionId={activeSessionId}
+              activeProjectFolderId={activeProjectFolderId}
+              collapsedFolderIds={collapsedFolders}
+              onCreate={() => onNewLocalSession()}
+              onCreateInFolder={(folder) =>
+                onNewLocalSession({
+                  placement: {
+                    repoPath: folder.repoPath,
+                    projectScoped: false,
+                    projectFolderId: folder.id,
+                  },
+                  launch: {
+                    kind: "workspaceCwd",
+                    cwdPath: folder.cwdPath,
+                  },
+                })
+              }
+              onCreateWorkspace={onAddLocalWorkspace}
+              onFocusArea={focusLocalSessions}
+              onSelectFolder={setActiveProjectFolder}
+              onToggleFolder={toggleProjectFolder}
+              onSelectSession={selectSession}
+              onRemoveSession={(s) => requestRemoveSession(s.id)}
+              onRenameFolder={renameProjectFolder}
+              onRemoveFolder={requestRemoveProjectFolder}
+              onMoveSessionToFolder={moveSessionToProjectFolder}
+            />
+          </div>
           <DragOverlay dropAnimation={null}>
             {activeDragId
               ? renderDragOverlay(activeDragId, projectGroups, sessions, t)
@@ -3661,7 +3668,7 @@ function SessionActivityInbox() {
   return (
     <section
       aria-label={sidebarText(t, "sidebar.activity.ariaLabel")}
-      className="mt-3 flex shrink-0 flex-col pt-1"
+      className="mt-auto flex shrink-0 flex-col px-1 pb-2 pt-1"
     >
       <ResizeHandle
         mode="manual"

--- a/tests/e2e/session-notifications.spec.ts
+++ b/tests/e2e/session-notifications.spec.ts
@@ -80,13 +80,16 @@ test.describe("session notification center", () => {
 
     const activityBody = page.getByTestId("sidebar-activity-body");
     const resizeHandle = page.getByTestId("sidebar-activity-resize-handle");
-    const [bodyBoxBefore, resizeHandleBox] = await Promise.all([
-      activityBody.boundingBox(),
-      resizeHandle.boundingBox(),
-    ]);
+    const [bodyBoxBefore, resizeHandleBox, activityBoxBeforeResize] =
+      await Promise.all([
+        activityBody.boundingBox(),
+        resizeHandle.boundingBox(),
+        activity.boundingBox(),
+      ]);
     expect(bodyBoxBefore).not.toBeNull();
     expect(resizeHandleBox).not.toBeNull();
-    if (!bodyBoxBefore || !resizeHandleBox) {
+    expect(activityBoxBeforeResize).not.toBeNull();
+    if (!bodyBoxBefore || !resizeHandleBox || !activityBoxBeforeResize) {
       throw new Error("missing sidebar activity resize target");
     }
     expect(resizeHandleBox.height).toBeGreaterThanOrEqual(12);
@@ -107,6 +110,23 @@ test.describe("session notification center", () => {
         ),
       )
       .toBeGreaterThan(bodyBoxBefore.height + 48);
+    const [resizeHandleBoxAfter, activityBoxAfterResize] = await Promise.all([
+      resizeHandle.boundingBox(),
+      activity.boundingBox(),
+    ]);
+    expect(resizeHandleBoxAfter).not.toBeNull();
+    expect(activityBoxAfterResize).not.toBeNull();
+    if (!resizeHandleBoxAfter || !activityBoxAfterResize) {
+      throw new Error("missing sidebar activity resized layout");
+    }
+    expect(resizeHandleBoxAfter.y).toBeLessThan(resizeHandleBox.y - 48);
+    expect(
+      Math.abs(
+        activityBoxAfterResize.y +
+          activityBoxAfterResize.height -
+          (activityBoxBeforeResize.y + activityBoxBeforeResize.height),
+      ),
+    ).toBeLessThan(4);
 
     await page.getByRole("button", { name: "Session notifications" }).click();
 


### PR DESCRIPTION
## Summary
Keeps the sidebar Activity panel resizing from disturbing the instant-session area.

1. **Activity anchoring** — split the sidebar body so projects and Instant Sessions keep their own scroll region while Activity stays pinned to the lower edge.
2. **Activity-only resize behavior** — preserve the existing Activity resize handle and avoid adding resize controls above Instant Sessions.
3. **Regression coverage** — extend the session notification E2E to verify Activity grows upward while its bottom edge stays stable.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Sidebar Activity resize | Resizing could make the lower-left layout feel like the adjacent Activity/Instant Sessions areas were shifting awkwardly. | Activity resizes upward from the bottom while projects and Instant Sessions remain in the scrollable area above. |
| Instant Sessions | Shared the sidebar scroll flow with Activity. | Still not independently resizable; only Activity has a resize handle. |

## Design notes
- The project list and Instant Sessions remain inside a single scrollable sidebar region.
- Activity is a fixed lower sibling with `mt-auto`, so resizing changes the Activity body height without moving the lower boundary.
- The focused Playwright test checks both the Activity body growth and bottom-edge stability to catch layout regressions.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `git diff --check` passes
- [x] `PLAYWRIGHT_PORT=1430 pnpm exec playwright test tests/e2e/session-notifications.spec.ts` passes: 1 test

## Notes
- `pnpm exec prettier --write ...` was attempted locally, but this workspace does not expose a `prettier` binary through pnpm exec; formatting was validated by TypeScript and `git diff --check` instead.
