### PR TITLE
fix(activity): coalesce repeated needs-input notices

### DIFF
--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -199,6 +199,45 @@ describe("notifications", () => {
     dispose();
   });
 
+  it("coalesces repeated needs-input activity for the same session", () => {
+    const dispose = startSessionActivityInboxWatcher();
+
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "needs_input",
+          updated_at: "2026-01-01T00:01:00Z",
+        }),
+      ],
+    });
+    const firstId = useAppStore.getState().sessionNotifications[0]?.id;
+    expect(firstId).toBeTruthy();
+
+    useAppStore.getState().markSessionNotificationRead(firstId!);
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "running",
+          updated_at: "2026-01-01T00:01:30Z",
+        }),
+      ],
+    });
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "needs_input",
+          updated_at: "2026-01-01T00:02:00Z",
+        }),
+      ],
+    });
+
+    const notifications = useAppStore.getState().sessionNotifications;
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.id).not.toBe(firstId);
+    expect(notifications[0]?.readAt).toBeUndefined();
+    dispose();
+  });
+
   it("marks in-app activity read when its session tab is focused and auto-delete is disabled", async () => {
     useSettings.getState().patchNotifications({ autoDeleteRead: false });
     const disposeActivity = startSessionActivityInboxWatcher();
@@ -226,24 +265,28 @@ describe("notifications", () => {
 
   it("trims in-app activity to the configured maximum", () => {
     useSettings.getState().patchNotifications({ maxHistory: 2 });
+    useAppStore.setState({
+      sessions: [
+        session({ id: "session-1", name: "Agent 1" }),
+        session({ id: "session-2", name: "Agent 2" }),
+        session({ id: "session-3", name: "Agent 3" }),
+      ],
+    });
     const dispose = startSessionActivityInboxWatcher();
 
     for (let i = 1; i <= 3; i += 1) {
+      const id = `session-${i}`;
       useAppStore.setState({
-        sessions: [
-          session({
-            status: "needs_input",
-            updated_at: `2026-01-01T00:0${i}:00Z`,
-          }),
-        ],
-      });
-      useAppStore.setState({
-        sessions: [
-          session({
-            status: "running",
-            updated_at: `2026-01-01T00:0${i}:30Z`,
-          }),
-        ],
+        sessions: useAppStore.getState().sessions.map((existing) =>
+          existing.id === id
+            ? session({
+                id,
+                name: existing.name,
+                status: "needs_input",
+                updated_at: `2026-01-01T00:0${i}:00Z`,
+              })
+            : existing,
+        ),
       });
     }
 

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -272,7 +272,9 @@ describe("multi-input", () => {
 describe("sessionNotifications", () => {
   it("adds newest notifications first and caps the in-memory list", () => {
     for (let i = 0; i < 105; i += 1) {
-      useAppStore.getState().addSessionNotification(notification(`n${i}`));
+      useAppStore.getState().addSessionNotification(
+        notification(`n${i}`, { sessionId: `s${i}` }),
+      );
     }
 
     const maxHistory = DEFAULT_SETTINGS.notifications.maxHistory;
@@ -282,10 +284,67 @@ describe("sessionNotifications", () => {
     expect(items[items.length - 1]?.id).toBe(`n${105 - maxHistory}`);
   });
 
+  it("coalesces needs-input activity per session", () => {
+    useAppStore.getState().addSessionNotification(
+      notification("old", {
+        sessionId: "s1",
+        createdAt: "2026-01-01T00:00:00Z",
+        readAt: "2026-01-01T00:01:00Z",
+      }),
+    );
+    useAppStore.getState().addSessionNotification(
+      notification("other", { sessionId: "s2" }),
+    );
+    useAppStore.getState().addSessionNotification(
+      notification("latest", {
+        sessionId: "s1",
+        createdAt: "2026-01-01T00:02:00Z",
+      }),
+    );
+
+    const items = useAppStore.getState().sessionNotifications;
+    expect(items.map((item) => item.id)).toEqual(["latest", "other"]);
+    expect(items[0]?.readAt).toBeUndefined();
+  });
+
+  it("normalizes duplicate persisted needs-input activity on rehydrate", async () => {
+    window.localStorage.clear();
+    resetStore();
+    window.localStorage.setItem(
+      "acorn-workspaces",
+      JSON.stringify({
+        state: {
+          sessionNotifications: [
+            notification("latest", {
+              sessionId: "s1",
+              createdAt: "2026-01-01T00:02:00Z",
+            }),
+            notification("old", {
+              sessionId: "s1",
+              createdAt: "2026-01-01T00:00:00Z",
+            }),
+            notification("other", { sessionId: "s2" }),
+          ],
+        },
+        version: 4,
+      }),
+    );
+
+    await useAppStore.persist.rehydrate();
+
+    expect(
+      useAppStore.getState().sessionNotifications.map((item) => item.id),
+    ).toEqual(["latest", "other"]);
+  });
+
   it("marks individual and all notifications read, then clears read items when auto-delete is disabled", () => {
     useSettings.getState().patchNotifications({ autoDeleteRead: false });
-    useAppStore.getState().addSessionNotification(notification("n1"));
-    useAppStore.getState().addSessionNotification(notification("n2"));
+    useAppStore
+      .getState()
+      .addSessionNotification(notification("n1", { sessionId: "s1" }));
+    useAppStore
+      .getState()
+      .addSessionNotification(notification("n2", { sessionId: "s2" }));
 
     useAppStore.getState().markSessionNotificationRead("n1");
     expect(
@@ -311,8 +370,12 @@ describe("sessionNotifications", () => {
   });
 
   it("dismisses one notification without touching others", () => {
-    useAppStore.getState().addSessionNotification(notification("n1"));
-    useAppStore.getState().addSessionNotification(notification("n2"));
+    useAppStore
+      .getState()
+      .addSessionNotification(notification("n1", { sessionId: "s1" }));
+    useAppStore
+      .getState()
+      .addSessionNotification(notification("n2", { sessionId: "s2" }));
 
     useAppStore.getState().dismissSessionNotification("n1");
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -104,6 +104,31 @@ interface SessionPlacementIntent {
 const sessionPlacementById = new Map<string, SessionPlacementIntent>();
 const activeSessionPlacementIntents = new Set<SessionPlacementIntent>();
 
+function coalescedSessionNotificationKey(
+  notification: SessionNotification,
+): string | null {
+  if (notification.kind !== "needs_input") return null;
+  return `${notification.sessionId}:${notification.kind}`;
+}
+
+function normalizeSessionNotifications(
+  notifications: SessionNotification[],
+  maxHistory: number,
+): SessionNotification[] {
+  const seen = new Set<string>();
+  const next: SessionNotification[] = [];
+  for (const notification of notifications) {
+    const key = coalescedSessionNotificationKey(notification);
+    if (key) {
+      if (seen.has(key)) continue;
+      seen.add(key);
+    }
+    next.push(notification);
+    if (next.length >= maxHistory) break;
+  }
+  return next;
+}
+
 async function loadWorkSummaryTokenBaseline(
   session: Session | null | undefined,
 ): Promise<WorkSummaryTokenBaseline | undefined> {
@@ -3134,12 +3159,17 @@ export const useAppStore = create<AppStateModel>()(
 
   addSessionNotification(notification) {
     const maxHistory = useSettings.getState().settings.notifications.maxHistory;
-    set((s) => ({
-      sessionNotifications: [
-        notification,
-        ...s.sessionNotifications.filter((n) => n.id !== notification.id),
-      ].slice(0, maxHistory),
-    }));
+    set((s) => {
+      const existing = s.sessionNotifications.filter(
+        (n) => n.id !== notification.id,
+      );
+      return {
+        sessionNotifications: normalizeSessionNotifications(
+          [notification, ...existing],
+          maxHistory,
+        ),
+      };
+    });
   },
 
   markSessionNotificationRead(id) {
@@ -3636,6 +3666,10 @@ export const useAppStore = create<AppStateModel>()(
         state.sessionFolderIds = normalizeStringRecord(state.sessionFolderIds);
         state.autoCloseSessionIds = normalizeTrueRecord(
           state.autoCloseSessionIds,
+        );
+        state.sessionNotifications = normalizeSessionNotifications(
+          state.sessionNotifications ?? [],
+          useSettings.getState().settings.notifications.maxHistory,
         );
         state.activeProjectFolderId =
           state.activeProjectFolderId ??


### PR DESCRIPTION
## Summary
Fixes duplicate `Needs input` rows in the Activity inbox by making repeated needs-input activity for a session update the existing row instead of stacking identical unread items.

1. **Needs-input coalescing** — add shared store normalization so incoming `needs_input` notifications are unique per session and keep the newest event.
2. **Persisted inbox cleanup** — normalize saved Activity entries during rehydrate so already duplicated local rows collapse on the next app load.
3. **Regression coverage** — add store and activity watcher tests for repeated transitions, rehydrated duplicates, max-history behavior, and read-state refresh.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Sidebar Activity | The same session could show multiple unread `Needs input` rows after status churn. | Each session keeps one latest `Needs input` row. |
| Status bar notifications | Duplicate needs-input rows could inflate the unread count. | Repeated needs-input events refresh the existing row and unread count. |
| Existing local data | Persisted duplicates remained until manually dismissed. | Persisted needs-input duplicates are folded during rehydrate. |

## Design notes
- Coalescing is intentionally scoped to `needs_input`; `failed`, `completed`, and `became_idle` activity history keeps the existing append behavior.
- The newest `needs_input` notification replaces the older one for the same session, so the displayed time moves to the latest event and a previously read row becomes unread again.
- The normalization path is shared by new inserts and persisted-state rehydrate to keep runtime and saved inbox behavior consistent.

## Test plan
- [x] `pnpm exec vitest run src/store.test.ts src/lib/notifications.test.ts` — 151 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec playwright test tests/e2e/session-notifications.spec.ts` — 1 Chromium test passed
