### PR TITLE
feat(shortcuts): focus latest needs-input tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1665,6 +1665,10 @@ function App() {
         e.preventDefault();
         useAppStore.getState().cycleTab(-1);
       },
+      [shortcuts.focusLatestNeedsInput]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        useAppStore.getState().selectLatestNeedsInputSession();
+      },
       [shortcuts.nextProject]: (e: KeyboardEvent) => {
         e.preventDefault();
         useAppStore.getState().cycleProject(1);

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -1025,6 +1025,7 @@ describe("SettingsModal font controls", () => {
     expect(bodyText).toContain("Reset all shortcuts");
     expect(bodyText).toContain("Open command palette");
     expect(bodyText).toContain("New control session");
+    expect(bodyText).toContain("Latest needs-input tab");
     expect(bodyText).toContain("Right panel");
     expect(bodyText).toContain("Record");
     expect(bodyText).toMatch(/⌘P|Ctrl\+P/);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -217,6 +217,10 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
         labelKey: "settings.shortcuts.items.prevTab.label",
       },
       {
+        id: "focusLatestNeedsInput",
+        labelKey: "settings.shortcuts.items.focusLatestNeedsInput.label",
+      },
+      {
         id: "nextProject",
         labelKey: "settings.shortcuts.items.nextProject.label",
       },

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -75,6 +75,7 @@ export const DEFAULT_HOTKEYS = {
   // reserved by macOS for OS-level app switching.
   nextTab: "Control+Tab",
   prevTab: "Control+Shift+Tab",
+  focusLatestNeedsInput: "Control+Alt+BracketRight",
   nextProject: "Control+Alt+Tab",
   prevProject: "Control+Alt+Shift+Tab",
 } as const;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -508,6 +508,9 @@
         "prevTab": {
           "label": "Previous tab"
         },
+        "focusLatestNeedsInput": {
+          "label": "Latest needs-input tab"
+        },
         "nextProject": {
           "label": "Next project"
         },

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -508,6 +508,9 @@
         "prevTab": {
           "label": "이전 탭"
         },
+        "focusLatestNeedsInput": {
+          "label": "마지막 입력 필요 탭"
+        },
         "nextProject": {
           "label": "다음 프로젝트"
         },

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -269,6 +269,65 @@ describe("multi-input", () => {
   });
 });
 
+describe("needs-input navigation", () => {
+  it("selects the latest needs-input session from the activity inbox", async () => {
+    await seed(
+      [project(REPO_A, 0), project(REPO_B, 1)],
+      [
+        session("a1", REPO_A, { status: "needs_input" }),
+        session("b1", REPO_B, { status: "needs_input" }),
+      ],
+    );
+    useAppStore.getState().addSessionNotification(
+      notification("n-a", {
+        sessionId: "a1",
+        sessionName: "a1",
+        repoPath: REPO_A,
+        createdAt: "2026-01-01T00:00:01Z",
+      }),
+    );
+    useAppStore.getState().addSessionNotification(
+      notification("n-b", {
+        sessionId: "b1",
+        sessionName: "b1",
+        repoPath: REPO_B,
+        createdAt: "2026-01-01T00:00:02Z",
+      }),
+    );
+    useAppStore.getState().setActiveProject(REPO_B);
+    useAppStore.getState().setWorkspaceViewMode("kanban");
+    useAppStore.getState().setActiveProject(REPO_A);
+
+    expect(useAppStore.getState().selectLatestNeedsInputSession()).toBe(true);
+
+    expect(useAppStore.getState().activeProject).toBe(REPO_B);
+    expect(useAppStore.getState().activeSessionId).toBe("b1");
+    expect(useAppStore.getState().workspaceViewMode).toBe("panes");
+  });
+
+  it("falls back to the last current needs-input session", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, { status: "needs_input" }),
+        session("a2", REPO_A, { status: "idle" }),
+        session("a3", REPO_A, { status: "needs_input" }),
+      ],
+    );
+    useAppStore.getState().addSessionNotification(
+      notification("stale", {
+        sessionId: "a2",
+        sessionName: "a2",
+        repoPath: REPO_A,
+      }),
+    );
+
+    expect(useAppStore.getState().selectLatestNeedsInputSession()).toBe(true);
+
+    expect(useAppStore.getState().activeSessionId).toBe("a3");
+  });
+});
+
 describe("sessionNotifications", () => {
   it("adds newest notifications first and caps the in-memory list", () => {
     for (let i = 0; i < 105; i += 1) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -320,6 +320,7 @@ interface AppStateModel {
   requestRemoveSession: (id: string) => void;
   clearPendingRemove: () => void;
   cycleTab: (direction: 1 | -1) => void;
+  selectLatestNeedsInputSession: () => boolean;
   cycleProject: (direction: 1 | -1) => void;
   addProject: (title?: string) => Promise<void>;
   createNewProject: (
@@ -935,6 +936,24 @@ function findProjectFolder(
   for (const folders of Object.values(state.projectFolders ?? {})) {
     const folder = folders.find((candidate) => candidate.id === folderId);
     if (folder) return folder;
+  }
+  return null;
+}
+
+function latestNeedsInputSessionId(
+  state: Pick<AppStateModel, "sessions" | "sessionNotifications">,
+): string | null {
+  const sessionsById = new Map(
+    state.sessions.map((session) => [session.id, session]),
+  );
+  for (const notification of state.sessionNotifications) {
+    if (notification.kind !== "needs_input") continue;
+    const session = sessionsById.get(notification.sessionId);
+    if (session?.status === "needs_input") return session.id;
+  }
+  for (let index = state.sessions.length - 1; index >= 0; index -= 1) {
+    const session = state.sessions[index];
+    if (session.status === "needs_input") return session.id;
   }
   return null;
 }
@@ -2188,6 +2207,14 @@ export const useAppStore = create<AppStateModel>()(
       });
       return patch ?? s;
     });
+  },
+
+  selectLatestNeedsInputSession() {
+    const sessionId = latestNeedsInputSessionId(get());
+    if (!sessionId) return false;
+    get().selectSession(sessionId);
+    get().setWorkspaceViewMode("panes");
+    return get().activeSessionId === sessionId;
   },
 
   cycleProject(direction) {

--- a/tests/e2e/panes.spec.ts
+++ b/tests/e2e/panes.spec.ts
@@ -338,6 +338,46 @@ test.describe("pane / sidebar shortcuts", () => {
     );
   });
 
+  test("Control+Alt+] focuses the latest needs-input tab", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      {
+        ...SESSION,
+        id: "idle",
+        name: "idle",
+        status: "idle",
+      },
+      {
+        ...SESSION,
+        id: "need-earlier",
+        name: "earlier",
+        status: "needs_input",
+      },
+      {
+        ...SESSION,
+        id: "need-latest",
+        name: "latest",
+        status: "needs_input",
+      },
+    ]);
+
+    await page.goto("/");
+    await expect(page.locator('[data-tab-drag-handle="idle"]')).toBeVisible();
+    await expect(
+      page.locator('[data-tab-drag-handle="need-latest"]'),
+    ).toBeVisible();
+
+    await pressHotkey(page, { control: true, alt: true, key: "]" });
+
+    const latestTab = page
+      .locator('[data-tab-drag-handle="need-latest"]')
+      .locator("xpath=ancestor::div[@role='button'][1]");
+    await expect(latestTab).toHaveClass(/acorn-tab-active-bg/);
+  });
+
   test("tab close button has a reliable hit area outside the drag handle", async ({
     page,
     tauri,

--- a/tests/e2e/support.ts
+++ b/tests/e2e/support.ts
@@ -166,7 +166,13 @@ export const test = base.extend<{
  */
 export async function pressHotkey(
   page: Page,
-  combo: { mod?: boolean; shift?: boolean; alt?: boolean; key: string },
+  combo: {
+    mod?: boolean;
+    control?: boolean;
+    shift?: boolean;
+    alt?: boolean;
+    key: string;
+  },
 ): Promise<void> {
   await page.evaluate((c) => {
     const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
@@ -208,7 +214,7 @@ export async function pressHotkey(
       key: c.key,
       code: deriveCode(c.key),
       metaKey: !!c.mod && isMac,
-      ctrlKey: !!c.mod && !isMac,
+      ctrlKey: !!c.control || (!!c.mod && !isMac),
       shiftKey: !!c.shift,
       altKey: !!c.alt,
       bubbles: true,


### PR DESCRIPTION
## Summary
Adds a keyboard shortcut for jumping directly to the latest session waiting for user input.

1. **Shortcut action** — adds a configurable `focusLatestNeedsInput` hotkey that selects the latest current `needs_input` session and returns its workspace to pane view.
2. **Settings surface** — exposes the command in the Shortcuts settings navigation group with English and Korean labels.
3. **Test coverage** — covers store selection priority, settings rendering, and the Playwright hotkey path.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Needs-input navigation | User manually scanned tabs/sidebar for waiting sessions | `Control+Alt+]` jumps to the latest current needs-input tab |
| Shortcut settings | No configurable command for this jump | Command appears in Settings -> Shortcuts -> Navigation |

## Design notes
- The store first uses Acorn's in-app activity inbox, which records `needs_input` transitions newest-first, then falls back to the last currently `needs_input` session in the session list.
- Stale inbox entries are ignored unless the referenced session is still currently `needs_input`.
- The action reuses `selectSession` so project, workspace, pane focus, and tab activation follow existing behavior.
- The default binding is `Control+Alt+]` to stay near tab-navigation conventions without overloading creation or fullscreen-like keys.

## Test plan
- [x] `pnpm run test` — 79 files / 881 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec vitest run src/lib/hotkeys.test.ts src/store.test.ts src/components/SettingsModal.test.tsx` — 3 files / 192 tests passed
- [x] `pnpm exec playwright test tests/e2e/panes.spec.ts -g "Control\\+Alt\\+\\]"` — 1 test passed

## Notes
- No unrelated local changes were included.