### PR TITLE
feat(sidebar): session context + kanban activity handoff

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4923,17 +4923,30 @@ pub struct SessionStatusEntry {
     pub last_agent_message: Option<String>,
     pub agent_provider: Option<SessionAgentProvider>,
     pub agent_transcript_id: Option<String>,
+    pub active_processes: Vec<SessionProcessSummary>,
     /// Current branch read live from the session's worktree on each poll.
     /// `None` when the worktree has no readable HEAD (e.g. detached, or
     /// path was deleted out from under acorn). Lets the frontend reflect
     /// `git checkout` performed inside the session without requiring a
     /// manual refresh.
     pub branch: Option<String>,
+    /// Git workdir that produced `branch`. This may differ from the
+    /// recorded session worktree when a shell has `cd`'d into another
+    /// repo/worktree; consumers that query git/GitHub should keep the
+    /// branch and repo path paired.
+    pub git_context_path: Option<String>,
     /// Auto-title opt-in after this poll. Carries the promotion performed
     /// when an agent transcript is first detected (see
     /// `auto_title_promotion_needed`) so the frontend planner becomes
     /// eligible without waiting for the next full session refresh.
     pub auto_title_enabled: Option<bool>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct SessionProcessSummary {
+    pub pid: u32,
+    pub name: String,
+    pub depth: u32,
 }
 
 /// A session created as a plain terminal starts with
@@ -4985,6 +4998,16 @@ fn collapse_status_preview(s: &str) -> Option<String> {
         ""
     };
     Some(format!("{truncated}{suffix}"))
+}
+
+fn git_context_for_path(path: &std::path::Path) -> Option<(String, String)> {
+    let branch = worktree::current_branch(path).ok()?;
+    let repo = worktree::ensure_repo(path).ok()?;
+    let workdir = repo.workdir()?;
+    let root = workdir
+        .canonicalize()
+        .unwrap_or_else(|_| workdir.to_path_buf());
+    Some((branch, root.to_string_lossy().into_owned()))
 }
 
 #[tauri::command]
@@ -5116,9 +5139,13 @@ fn detect_session_statuses_blocking(
                 .map(|s| s.status)
                 .unwrap_or(SessionStatus::Idle);
             if matches!(session.as_ref().map(|s| s.mode), Some(SessionMode::Chat)) {
-                let branch = session
+                let git_context = session
                     .as_ref()
-                    .and_then(|s| worktree::current_branch(&s.worktree_path).ok());
+                    .and_then(|s| git_context_for_path(&s.worktree_path));
+                let branch = git_context
+                    .as_ref()
+                    .map(|(branch, _)| branch.clone());
+                let git_context_path = git_context.map(|(_, path)| path);
                 let conversation_preview = persistence::load_chat_session_state(&id)
                     .ok()
                     .map(|state| chat_conversation_preview(&state));
@@ -5139,7 +5166,9 @@ fn detect_session_statuses_blocking(
                     agent_transcript_id: session
                         .as_ref()
                         .and_then(|s| s.agent_transcript_id.clone()),
+                    active_processes: Vec::new(),
                     branch,
+                    git_context_path,
                     auto_title_enabled: session.as_ref().and_then(|s| s.auto_title_enabled),
                 };
             }
@@ -5174,6 +5203,9 @@ fn detect_session_statuses_blocking(
                 }
             });
             let root_pid_value = root_pid.map(|(pid, _)| pid);
+            let active_processes = root_pid_value
+                .map(|pid| session_process_summaries(&sys, &children, Pid::from_u32(pid)))
+                .unwrap_or_default();
             let live_agent_kind = root_pid_value.and_then(|pid| {
                 live_agent_kind_in_descendants(&sys, &children, Pid::from_u32(pid))
             });
@@ -5298,14 +5330,17 @@ fn detect_session_statuses_blocking(
             //     performed inside the terminal (and `claude -w` worktrees)
             //  2. recorded session worktree_path — fallback when no live PTY
             //     or descendant cwd lies outside any git repo
-            let live_cwd_branch = root_pid_value
+            let live_git_context = root_pid_value
                 .and_then(|pid| deepest_descendant_cwd(&sys, Pid::from_u32(pid)))
-                .and_then(|p| worktree::current_branch(std::path::Path::new(&p)).ok());
-            let branch = live_cwd_branch.or_else(|| {
-                session
-                    .as_ref()
-                    .and_then(|s| worktree::current_branch(&s.worktree_path).ok())
-            });
+                .and_then(|p| git_context_for_path(std::path::Path::new(&p)));
+            let fallback_git_context = session
+                .as_ref()
+                .and_then(|s| git_context_for_path(&s.worktree_path));
+            let git_context = live_git_context.or(fallback_git_context);
+            let branch = git_context
+                .as_ref()
+                .map(|(branch, _)| branch.clone());
+            let git_context_path = git_context.map(|(_, path)| path);
             // Mirror the detected status into the in-memory store so persisted
             // sessions reflect liveness on next save. Best-effort: ignore errors
             // (e.g. UUID parse failure for a stale id from the frontend).
@@ -5338,7 +5373,9 @@ fn detect_session_statuses_blocking(
                     .and_then(|p| p.last_agent_message.clone()),
                 agent_provider,
                 agent_transcript_id,
+                active_processes,
                 branch,
+                git_context_path,
                 auto_title_enabled,
             }
         })
@@ -5567,6 +5604,52 @@ fn has_live_descendant(children: &HashMap<Pid, Vec<Pid>>, root: Pid) -> bool {
     children.get(&root).is_some_and(|direct| !direct.is_empty())
 }
 
+fn session_process_summaries(
+    sys: &System,
+    children: &HashMap<Pid, Vec<Pid>>,
+    root: Pid,
+) -> Vec<SessionProcessSummary> {
+    let mut queue = VecDeque::new();
+    if let Some(direct) = children.get(&root) {
+        let mut direct = direct.clone();
+        direct.sort_by_key(|pid| pid.as_u32());
+        queue.extend(direct.into_iter().map(|pid| (pid, 1)));
+    }
+
+    let mut summaries = Vec::new();
+    let mut fallback = Vec::new();
+    while let Some((pid, depth)) = queue.pop_front() {
+        if let Some(proc) = sys.process(pid) {
+            let summary = SessionProcessSummary {
+                pid: pid.as_u32(),
+                name: process_display_name(proc),
+                depth,
+            };
+            if is_session_process_noise(&summary.name) {
+                fallback.push(summary);
+            } else {
+                summaries.push(summary);
+            }
+        }
+        if let Some(kids) = children.get(&pid) {
+            let mut kids = kids.clone();
+            kids.sort_by_key(|child| child.as_u32());
+            queue.extend(kids.into_iter().map(|child| (child, depth + 1)));
+        }
+    }
+
+    if summaries.is_empty() {
+        fallback
+    } else {
+        summaries
+    }
+}
+
+fn is_session_process_noise(name: &str) -> bool {
+    let base = basename(name).trim_matches(&['(', ')'][..]);
+    matches!(base, "sh" | "bash" | "zsh" | "tail")
+}
+
 #[cfg(test)]
 mod status_hint_tests {
     use super::*;
@@ -5720,6 +5803,14 @@ mod status_hint_tests {
             |pid| pid == codex,
             |pid| pid == helper,
         ));
+    }
+
+    #[test]
+    fn session_process_noise_filters_shell_wrappers() {
+        assert!(is_session_process_noise("(zsh)"));
+        assert!(is_session_process_noise("tail"));
+        assert!(!is_session_process_noise("codex"));
+        assert!(!is_session_process_noise("rg"));
     }
 }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3945,6 +3945,7 @@ function SidebarActivityRow({
 }) {
   const t = useTranslation();
   const selectSession = useAppStore((s) => s.selectSession);
+  const openTerminalPopup = useAppStore((s) => s.openTerminalPopup);
   const markRead = useAppStore((s) => s.markSessionNotificationRead);
   const dismiss = useAppStore((s) => s.dismissSessionNotification);
   const unread = !notification.readAt;
@@ -3952,6 +3953,9 @@ function SidebarActivityRow({
   const openSession = () => {
     markRead(notification.id);
     selectSession(notification.sessionId);
+    if (useAppStore.getState().workspaceViewMode === "kanban") {
+      openTerminalPopup(notification.sessionId);
+    }
   };
 
   return (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,11 +5,13 @@ import {
   CheckCheck,
   ChevronRight,
   Copy,
+  ExternalLink,
   Folder,
   FolderOpen,
   FolderPlus,
   GitBranch,
   GitFork,
+  GitPullRequest,
   Home,
   LayoutPanelLeft,
   MessageSquareText,
@@ -24,6 +26,7 @@ import {
   X,
 } from "lucide-react";
 import { homeDir } from "@tauri-apps/api/path";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   useCallback,
   useEffect,
@@ -77,6 +80,12 @@ import {
   canRegenerateSessionTitle,
   canRenameSession,
 } from "../lib/sessionTitle";
+import {
+  currentPullRequestSearchQuery,
+  findCurrentPullRequestForBranch,
+  summarizeAllSessionProcesses,
+  summarizeSessionProcesses,
+} from "../lib/sessionContext";
 import { suggestDefaultSessionName } from "../lib/sessionName";
 import { canConfigureSessionAutoClose } from "../lib/sessionAgentState";
 import {
@@ -135,6 +144,7 @@ import type {
   SessionMode,
   SessionNotification,
   SessionNotificationKind,
+  SessionPullRequestSummary,
   SessionStatus,
 } from "../lib/types";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
@@ -189,6 +199,16 @@ const SESSION_FOLDER_DROP_PREFIX = `${SESSION_DRAG_PREFIX}folder:`;
 const SESSION_PROJECT_DROP_PREFIX = `${SESSION_DRAG_PREFIX}project:`;
 const LOCAL_SESSION_ROOT_DROP_ID = "__local-session-root__";
 const LOCAL_TERMINAL_AREA_SELECTOR = "[data-local-terminal-area='true']";
+const CURRENT_PR_CACHE_TTL_MS = 60_000;
+const CURRENT_PR_EMPTY_RETRY_MS = 15_000;
+
+type CurrentPullRequestCacheEntry = {
+  value: SessionPullRequestSummary | null;
+  expiresAt: number;
+  promise?: Promise<SessionPullRequestSummary | null>;
+};
+
+const currentPullRequestCache = new Map<string, CurrentPullRequestCacheEntry>();
 
 type SidebarTranslationKey = Extract<TranslationKey, `sidebar.${string}`>;
 
@@ -229,6 +249,106 @@ function contextMenuGroupTitle(
 
 function statusLabel(t: Translator, status: SessionStatus): string {
   return sidebarText(t, `sidebar.status.${status}`);
+}
+
+function currentPullRequestCacheKey(repoPath: string, branch: string): string {
+  return `${repoPath}\u0000${branch}`;
+}
+
+function loadCurrentPullRequest(
+  repoPath: string,
+  branch: string,
+): Promise<SessionPullRequestSummary | null> {
+  const key = currentPullRequestCacheKey(repoPath, branch);
+  const now = Date.now();
+  const cached = currentPullRequestCache.get(key);
+  if (cached && cached.expiresAt > now) {
+    return cached.promise ?? Promise.resolve(cached.value);
+  }
+
+  const query = currentPullRequestSearchQuery(branch);
+  if (!query) return Promise.resolve(null);
+
+  const promise = api
+    .listPullRequests(repoPath, "open", 10, query)
+    .then((listing) => findCurrentPullRequestForBranch(listing, branch))
+    .catch(() => null);
+
+  currentPullRequestCache.set(key, {
+    value: cached?.value ?? null,
+    expiresAt: now + CURRENT_PR_CACHE_TTL_MS,
+    promise,
+  });
+
+  return promise.then((value) => {
+    currentPullRequestCache.set(key, {
+      value,
+      expiresAt:
+        Date.now() +
+        (value ? CURRENT_PR_CACHE_TTL_MS : CURRENT_PR_EMPTY_RETRY_MS),
+    });
+    return value;
+  });
+}
+
+function useCurrentPullRequest(
+  session: Session,
+): SessionPullRequestSummary | null {
+  const branch = session.branch.trim();
+  const repoPath =
+    session.git_context_path?.trim() ||
+    session.worktree_path ||
+    session.repo_path;
+  const cacheKey = branch ? currentPullRequestCacheKey(repoPath, branch) : null;
+  const [lookupAttempt, setLookupAttempt] = useState(0);
+  const [currentPullRequest, setCurrentPullRequest] =
+    useState<SessionPullRequestSummary | null>(() =>
+      cacheKey ? (currentPullRequestCache.get(cacheKey)?.value ?? null) : null,
+    );
+
+  useEffect(() => {
+    const query = currentPullRequestSearchQuery(branch);
+    if (!branch || !cacheKey || !query) {
+      setCurrentPullRequest(null);
+      return;
+    }
+
+    let cancelled = false;
+    let retryTimer: number | null = null;
+    const scheduleEmptyRetry = (value: SessionPullRequestSummary | null) => {
+      if (value || cancelled) return;
+      retryTimer = window.setTimeout(() => {
+        if (!cancelled) setLookupAttempt((attempt) => attempt + 1);
+      }, CURRENT_PR_EMPTY_RETRY_MS);
+    };
+    const cached = currentPullRequestCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      setCurrentPullRequest(cached.value);
+      if (!cached.promise) {
+        scheduleEmptyRetry(cached.value);
+        return () => {
+          cancelled = true;
+          if (retryTimer !== null) window.clearTimeout(retryTimer);
+        };
+      }
+    } else {
+      setCurrentPullRequest(cached?.value ?? null);
+    }
+
+    loadCurrentPullRequest(repoPath, branch).then((value) => {
+      if (!cancelled) {
+        setCurrentPullRequest(value);
+        scheduleEmptyRetry(value);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      if (retryTimer !== null) window.clearTimeout(retryTimer);
+    };
+  }, [branch, cacheKey, lookupAttempt, repoPath]);
+
+  return currentPullRequest;
 }
 
 function isLocalTerminalAreaFocused(): boolean {
@@ -1416,6 +1536,7 @@ function SessionRowPreview({
         session={session}
         titleText={titleText}
         metadataText={metadataText}
+        currentPullRequest={null}
         showKindIcons={sessionDisplay.icons.sessionKind}
         t={t}
         onSubmitRename={() => undefined}
@@ -2668,6 +2789,7 @@ function SessionRow({
     isWorktreeWorkspace(currentProjectFolder) &&
     normalizeWorkspacePath(session.worktree_path) ===
       normalizeWorkspacePath(currentWorkspaceCwd);
+  const currentPullRequest = useCurrentPullRequest(session);
   const titleText = resolveSessionTitle(session, sessionDisplay.title);
   const metadataText = composeSessionMetadata(
     t,
@@ -2682,7 +2804,7 @@ function SessionRow({
     },
   );
   const hoverDetails = sessionDisplay.showDetailsOnHover
-    ? buildSessionHoverDetails(t, session)
+    ? buildSessionHoverDetails(t, session, currentPullRequest)
     : null;
   const isGeneratingTitle = useAppStore((s) =>
     Boolean(s.generatingSessionTitleIds[session.id]),
@@ -3097,6 +3219,7 @@ function SessionRow({
         session={session}
         titleText={titleText}
         metadataText={metadataText}
+        currentPullRequest={currentPullRequest}
         showKindIcons={sessionDisplay.icons.sessionKind}
         hideWorktreeIcon={hideWorkspaceDuplicateContext}
         t={t}
@@ -3158,6 +3281,7 @@ interface SessionRowLabelProps {
   session: Session;
   titleText: string;
   metadataText: string;
+  currentPullRequest: SessionPullRequestSummary | null;
   showKindIcons: boolean;
   hideWorktreeIcon?: boolean;
   t: Translator;
@@ -3170,6 +3294,7 @@ function SessionRowLabel({
   session,
   titleText,
   metadataText,
+  currentPullRequest,
   showKindIcons,
   hideWorktreeIcon = false,
   t,
@@ -3182,6 +3307,8 @@ function SessionRowLabel({
   // in which case `liveInWorktree[id]` is `undefined`.
   const liveInWorktree = useAppStore((s) => s.liveInWorktree[session.id]);
   const inWorktree = liveInWorktree ?? hasRecordedWorktree(session);
+  const processSummary = summarizeSessionProcesses(session.active_processes);
+  const hasContextMetadata = Boolean(currentPullRequest || processSummary);
   const body = (
     <span className="min-w-0 flex-1">
       <span className="flex h-5 items-center gap-1">
@@ -3212,8 +3339,49 @@ function SessionRowLabel({
         ) : null}
       </span>
       {metadataText ? (
-        <span className="block truncate text-[11px] text-fg-muted">
+        <span
+          data-session-base-metadata="true"
+          className="block truncate text-[11px] text-fg-muted"
+        >
           {metadataText}
+        </span>
+      ) : null}
+      {hasContextMetadata ? (
+        <span
+          data-session-context-metadata="true"
+          className="flex min-w-0 items-center gap-1 text-[11px] leading-4 text-fg-muted"
+        >
+          {currentPullRequest ? (
+            <button
+              type="button"
+              aria-label={`${sidebarText(t, "sidebar.metadata.openPullRequest")} #${currentPullRequest.number}`}
+              title={currentPullRequest.title}
+              onMouseDown={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
+              onKeyUp={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                void openUrl(currentPullRequest.url).catch((err: unknown) => {
+                  console.error("[Sidebar] open PR URL failed", err);
+                });
+              }}
+              className="inline-flex shrink-0 items-center gap-0.5 rounded-sm text-accent underline-offset-2 transition hover:text-fg hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/60"
+            >
+              <span>{`PR #${currentPullRequest.number}`}</span>
+              <ExternalLink size={9} aria-hidden className="opacity-80" />
+            </button>
+          ) : null}
+          {currentPullRequest && processSummary ? (
+            <span aria-hidden className="shrink-0 text-fg-muted/70">
+              ·
+            </span>
+          ) : null}
+          {processSummary ? (
+            <span className="min-w-0 truncate font-mono">
+              {processSummary}
+            </span>
+          ) : null}
         </span>
       ) : null}
     </span>
@@ -4174,6 +4342,7 @@ function LocalSessionRow({
     (s) => s.toggleSessionAutoClose,
   );
   const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
+  const currentPullRequest = useCurrentPullRequest(session);
   const titleText = resolveSessionTitle(session, sessionDisplay.title);
   const metadataText = composeSessionMetadata(
     t,
@@ -4184,7 +4353,7 @@ function LocalSessionRow({
     ? resolveSessionAgentProvider(session)
     : null;
   const hoverDetails = sessionDisplay.showDetailsOnHover
-    ? buildSessionHoverDetails(t, session)
+    ? buildSessionHoverDetails(t, session, currentPullRequest)
     : null;
   const isGeneratingTitle = useAppStore((s) =>
     Boolean(s.generatingSessionTitleIds[session.id]),
@@ -4367,6 +4536,7 @@ function LocalSessionRow({
         session={session}
         titleText={titleText}
         metadataText={metadataText}
+        currentPullRequest={currentPullRequest}
         showKindIcons={sessionDisplay.icons.sessionKind}
         t={t}
         onSubmitRename={async (next) => {
@@ -4467,9 +4637,16 @@ function composeSessionMetadata(
   return parts.join(" · ");
 }
 
-function buildSessionHoverDetails(t: Translator, session: Session): ReactNode {
+function buildSessionHoverDetails(
+  t: Translator,
+  session: Session,
+  currentPullRequest: SessionPullRequestSummary | null = null,
+): ReactNode {
   const branch =
     session.branch || sidebarText(t, "sidebar.metadata.detached");
+  const processSummary = summarizeAllSessionProcesses(
+    session.active_processes,
+  );
 
   return (
     <span className="flex w-72 max-w-full flex-col gap-1.5">
@@ -4484,12 +4661,28 @@ function buildSessionHoverDetails(t: Translator, session: Session): ReactNode {
         value={branch}
         valueClassName="font-mono"
       />
+      {currentPullRequest ? (
+        <SessionHoverDetailRow
+          icon={<GitPullRequest size={12} />}
+          iconClassName="text-accent"
+          label={sidebarText(t, "sidebar.metadata.openPullRequest")}
+          value={`#${currentPullRequest.number} ${currentPullRequest.title}`}
+        />
+      ) : null}
       <SessionHoverDetailRow
         icon={<Folder size={12} />}
         label={sidebarText(t, "sidebar.metadata.workingDirectory")}
         value={session.worktree_path}
         valueClassName="break-all font-mono"
       />
+      {processSummary ? (
+        <SessionHoverDetailRow
+          icon={<Activity size={12} />}
+          label={sidebarText(t, "sidebar.metadata.processes")}
+          value={processSummary}
+          valueClassName="font-mono"
+        />
+      ) : null}
       <SessionHoverDetailRow
         icon={<Activity size={12} />}
         iconClassName={STATUS_ICON[session.status]}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -933,6 +933,7 @@ function NotificationRow({
 }) {
   const t = useTranslation();
   const selectSession = useAppStore((s) => s.selectSession);
+  const openTerminalPopup = useAppStore((s) => s.openTerminalPopup);
   const markRead = useAppStore((s) => s.markSessionNotificationRead);
   const dismiss = useAppStore((s) => s.dismissSessionNotification);
   const unread = !notification.readAt;
@@ -940,6 +941,9 @@ function NotificationRow({
   const openSession = () => {
     markRead(notification.id);
     selectSession(notification.sessionId);
+    if (useAppStore.getState().workspaceViewMode === "kanban") {
+      openTerminalPopup(notification.sessionId);
+    }
     onClose();
   };
 

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -187,6 +187,7 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
   const selectSession = useAppStore((s) => s.selectSession);
   const openTerminalPopup = useAppStore((s) => s.openTerminalPopup);
   const closeTerminalPopup = useAppStore((s) => s.closeTerminalPopup);
+  const terminalPopupSessionId = useAppStore((s) => s.terminalPopupSessionId);
   const [prefs, setPrefs] = useState<KanbanBoardPrefs>(() =>
     readKanbanBoardPrefs(projectId),
   );
@@ -267,6 +268,31 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
       pendingPrefsWriteRef.current?.();
     };
   }, []);
+
+  useLayoutEffect(() => {
+    if (!terminalPopupSessionId) {
+      setTerminalPopover((current) => (current ? null : current));
+      return;
+    }
+    if (
+      !visibleSessions.some(
+        (session) => session.id === terminalPopupSessionId,
+      )
+    ) {
+      return;
+    }
+    const anchor = document.querySelector<HTMLElement>(
+      `[data-kanban-session-id="${cssAttributeEscape(terminalPopupSessionId)}"]`,
+    );
+    if (!anchor) return;
+    anchor.scrollIntoView({ block: "nearest", inline: "nearest" });
+    setTerminalPopover((current) =>
+      current?.sessionId === terminalPopupSessionId &&
+      current.anchor === anchor
+        ? current
+        : { sessionId: terminalPopupSessionId, anchor },
+    );
+  }, [terminalPopupSessionId, visibleSessions]);
 
   useEffect(() => {
     if (!terminalPopover) return;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -29,6 +29,7 @@ import type {
   SessionAgentProvider,
   SessionKind,
   SessionMode,
+  SessionProcessSummary,
   SessionStatus,
   SessionStatusReason,
   SessionTitleReadinessResult,
@@ -644,6 +645,8 @@ export const api = {
       last_agent_message?: string | null;
       agent_provider?: SessionAgentProvider | null;
       agent_transcript_id?: string | null;
+      active_processes?: SessionProcessSummary[];
+      git_context_path?: string | null;
       branch: string | null;
       auto_title_enabled?: boolean | null;
     }[]
@@ -658,6 +661,8 @@ export const api = {
         last_agent_message?: string | null;
         agent_provider?: SessionAgentProvider | null;
         agent_transcript_id?: string | null;
+        active_processes?: SessionProcessSummary[];
+        git_context_path?: string | null;
         branch: string | null;
         auto_title_enabled?: boolean | null;
       }[]

--- a/src/lib/sessionContext.test.ts
+++ b/src/lib/sessionContext.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  currentPullRequestSearchQuery,
+  findCurrentPullRequestForBranch,
+  summarizeAllSessionProcesses,
+  summarizeSessionProcesses,
+} from "./sessionContext";
+import type { PullRequestInfo, PullRequestListing } from "./types";
+
+function pr(overrides: Partial<PullRequestInfo>): PullRequestInfo {
+  return {
+    number: 1,
+    title: "Default PR",
+    state: "OPEN",
+    author: "octo",
+    head_branch: "feature/default",
+    base_branch: "main",
+    url: "https://github.com/im-ian/acorn/pull/1",
+    updated_at: "2026-01-01T00:00:00Z",
+    is_draft: false,
+    checks: null,
+    labels: [],
+    ...overrides,
+  };
+}
+
+describe("session context helpers", () => {
+  it("builds a GitHub search query for the exact head branch", () => {
+    expect(currentPullRequestSearchQuery("feature/sidebar-prs")).toBe(
+      "head:feature/sidebar-prs",
+    );
+    expect(currentPullRequestSearchQuery("   ")).toBeNull();
+    expect(currentPullRequestSearchQuery("main")).toBeNull();
+    expect(currentPullRequestSearchQuery("master")).toBeNull();
+  });
+
+  it("finds the open PR whose head branch matches the session branch", () => {
+    const listing: PullRequestListing = {
+      kind: "ok",
+      account: "ian",
+      items: [
+        pr({ number: 41, head_branch: "feature/other" }),
+        pr({
+          number: 42,
+          title: "Show session context",
+          head_branch: "feature/sidebar-prs",
+          url: "https://github.com/im-ian/acorn/pull/42",
+        }),
+      ],
+    };
+
+    expect(
+      findCurrentPullRequestForBranch(listing, "feature/sidebar-prs"),
+    ).toEqual({
+      number: 42,
+      title: "Show session context",
+      url: "https://github.com/im-ian/acorn/pull/42",
+      head_branch: "feature/sidebar-prs",
+      base_branch: "main",
+      is_draft: false,
+    });
+  });
+
+  it("summarizes the visible session process names", () => {
+    expect(
+      summarizeSessionProcesses([
+        { pid: 10, name: "codex", depth: 2 },
+        { pid: 11, name: "rg", depth: 3 },
+        { pid: 12, name: "node", depth: 3 },
+      ]),
+    ).toBe("codex, rg +1");
+  });
+
+  it("summarizes every session process name for detailed views", () => {
+    expect(
+      summarizeAllSessionProcesses([
+        { pid: 10, name: "codex", depth: 2 },
+        { pid: 11, name: "rg", depth: 3 },
+        { pid: 12, name: "node", depth: 3 },
+        { pid: 13, name: "cargo", depth: 3 },
+      ]),
+    ).toBe("codex, rg, node, cargo");
+  });
+});

--- a/src/lib/sessionContext.ts
+++ b/src/lib/sessionContext.ts
@@ -1,0 +1,60 @@
+import type {
+  PullRequestListing,
+  SessionProcessSummary,
+  SessionPullRequestSummary,
+} from "./types";
+
+const PROCESS_SUMMARY_VISIBLE = 2;
+
+function sessionProcessNames(
+  processes: readonly SessionProcessSummary[] | null | undefined,
+): string[] {
+  if (!processes || processes.length === 0) return [];
+  return processes
+    .map((process) => process.name.trim())
+    .filter((name) => name.length > 0);
+}
+
+export function currentPullRequestSearchQuery(branch: string): string | null {
+  const trimmed = branch.trim();
+  if (!trimmed) return null;
+  if (trimmed === "main" || trimmed === "master") return null;
+  return `head:${trimmed}`;
+}
+
+export function findCurrentPullRequestForBranch(
+  listing: PullRequestListing,
+  branch: string,
+): SessionPullRequestSummary | null {
+  const trimmed = branch.trim();
+  if (!trimmed || listing.kind !== "ok") return null;
+  const pr = listing.items.find(
+    (item) => item.state === "OPEN" && item.head_branch === trimmed,
+  );
+  if (!pr) return null;
+  return {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    head_branch: pr.head_branch,
+    base_branch: pr.base_branch,
+    is_draft: pr.is_draft,
+  };
+}
+
+export function summarizeSessionProcesses(
+  processes: readonly SessionProcessSummary[] | null | undefined,
+): string | null {
+  const names = sessionProcessNames(processes);
+  if (names.length === 0) return null;
+  const visible = names.slice(0, PROCESS_SUMMARY_VISIBLE).join(", ");
+  const hidden = names.length - PROCESS_SUMMARY_VISIBLE;
+  return hidden > 0 ? `${visible} +${hidden}` : visible;
+}
+
+export function summarizeAllSessionProcesses(
+  processes: readonly SessionProcessSummary[] | null | undefined,
+): string | null {
+  const names = sessionProcessNames(processes);
+  return names.length > 0 ? names.join(", ") : null;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -140,6 +140,16 @@ export interface Session {
   agent_provider?: SessionAgentProvider | null;
   /** Most recently paired agent transcript id, if Acorn has paired this tab to one. */
   agent_transcript_id?: string | null;
+  /** Ephemeral live process names observed under the session PTY. */
+  active_processes?: SessionProcessSummary[];
+  /** Ephemeral git workdir that produced the current live branch. */
+  git_context_path?: string | null;
+}
+
+export interface SessionProcessSummary {
+  pid: number;
+  name: string;
+  depth: number;
 }
 
 export type ChatRole = "system" | "user" | "assistant" | "tool";
@@ -441,6 +451,15 @@ export type PullRequestListing =
   | { kind: "ok"; items: PullRequestInfo[]; account: string }
   | { kind: "not_github" }
   | { kind: "no_access"; slug: string; accounts: AccountSummary[] };
+
+export interface SessionPullRequestSummary {
+  number: number;
+  title: string;
+  url: string;
+  head_branch: string;
+  base_branch: string;
+  is_draft: boolean;
+}
 
 export interface IssueInfo {
   number: number;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1168,6 +1168,8 @@
       "branch": "Branch",
       "detached": "(detached)",
       "workingDirectory": "Working directory",
+      "openPullRequest": "Open PR",
+      "processes": "Processes",
       "status": "Status",
       "kind": "Kind",
       "controlSession": "Control session",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1168,6 +1168,8 @@
       "branch": "브랜치",
       "detached": "(detached)",
       "workingDirectory": "작업 디렉터리",
+      "openPullRequest": "열린 PR",
+      "processes": "프로세스",
       "status": "상태",
       "kind": "종류",
       "controlSession": "컨트롤 세션",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2213,6 +2213,40 @@ describe("pollSessionStatuses", () => {
     );
   });
 
+  it("merges active process summaries from status polling", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          status: "running",
+          active_processes: [{ pid: 10, name: "node", depth: 1 }],
+        }),
+      ],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "running",
+        branch: null,
+        git_context_path: "/repo/acorn-worktree",
+        active_processes: [
+          { pid: 11, name: "codex", depth: 2 },
+          { pid: 12, name: "rg", depth: 3 },
+        ],
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.active_processes).toEqual([
+      { pid: 11, name: "codex", depth: 2 },
+      { pid: 12, name: "rg", depth: 3 },
+    ]);
+    expect(useAppStore.getState().sessions[0]?.git_context_path).toBe(
+      "/repo/acorn-worktree",
+    );
+  });
+
   it("merges last messages from status polling even when status is unchanged", async () => {
     await seed(
       [project(REPO_A, 0)],

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,6 +9,7 @@ import type {
   SessionMode,
   SessionTitleGenerationStatus,
   SessionNotification,
+  SessionProcessSummary,
 } from "./lib/types";
 import { commandRequestsWorktreeAdoption } from "./lib/worktreeAdoption";
 import { CONTROL_GUIDE_DISMISSED_KEY } from "./components/ControlSessionGuideModal";
@@ -93,6 +94,19 @@ let activeStatusPollAll = false;
 let activeStatusPollIds = new Set<string>();
 let refreshSessionsSeq = 0;
 let sessionPlacementSeq = 0;
+
+function sessionProcessSummariesEqual(
+  a: readonly SessionProcessSummary[],
+  b: readonly SessionProcessSummary[],
+): boolean {
+  if (a.length !== b.length) return false;
+  return a.every(
+    (process, index) =>
+      process.pid === b[index]?.pid &&
+      process.name === b[index]?.name &&
+      process.depth === b[index]?.depth,
+  );
+}
 
 interface SessionPlacementIntent {
   projectFolderId: string;
@@ -1680,6 +1694,19 @@ export const useAppStore = create<AppStateModel>()(
                 )
                   ? (update.agent_transcript_id ?? null)
                   : (sess.agent_transcript_id ?? null);
+                const currentActiveProcesses = sess.active_processes ?? [];
+                const nextActiveProcesses = Object.prototype.hasOwnProperty.call(
+                  update,
+                  "active_processes",
+                )
+                  ? (update.active_processes ?? [])
+                  : currentActiveProcesses;
+                const nextGitContextPath = Object.prototype.hasOwnProperty.call(
+                  update,
+                  "git_context_path",
+                )
+                  ? (update.git_context_path ?? null)
+                  : (sess.git_context_path ?? null);
                 // Carries the backend's auto-title promotion (terminal
                 // session that started an agent) so the title planner sees
                 // eligibility on the next poll instead of waiting for a
@@ -1695,6 +1722,11 @@ export const useAppStore = create<AppStateModel>()(
                   nextLastAgentMessage !== (sess.last_agent_message ?? null) ||
                   nextAgentProvider !== (sess.agent_provider ?? null) ||
                   nextAgentTranscriptId !== (sess.agent_transcript_id ?? null) ||
+                  !sessionProcessSummariesEqual(
+                    nextActiveProcesses,
+                    currentActiveProcesses,
+                  ) ||
+                  nextGitContextPath !== (sess.git_context_path ?? null) ||
                   nextAutoTitleEnabled !== (sess.auto_title_enabled ?? null)
                 ) {
                   changed = true;
@@ -1708,6 +1740,8 @@ export const useAppStore = create<AppStateModel>()(
                     last_agent_message: nextLastAgentMessage,
                     agent_provider: nextAgentProvider,
                     agent_transcript_id: nextAgentTranscriptId,
+                    active_processes: nextActiveProcesses,
+                    git_context_path: nextGitContextPath,
                     auto_title_enabled: nextAutoTitleEnabled,
                   };
                 }

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -1203,9 +1203,11 @@ test.describe("right panel: tab switching", () => {
       return null;
     });
     await tauri.handle("list_pull_requests", (args) => {
-      const w = window as unknown as { __prRepoPaths?: string[] };
-      w.__prRepoPaths = w.__prRepoPaths ?? [];
-      w.__prRepoPaths.push((args as { repoPath: string }).repoPath);
+      const w = window as unknown as {
+        __prCalls?: Array<{ repoPath: string; query?: string | null }>;
+      };
+      w.__prCalls = w.__prCalls ?? [];
+      w.__prCalls.push(args as { repoPath: string; query?: string | null });
       return { kind: "ok", items: [], account: null };
     });
     await tauri.handle("list_issues", (args) => {
@@ -1250,12 +1252,14 @@ test.describe("right panel: tab switching", () => {
     await page.waitForTimeout(1_500);
     const initialCalls = await page.evaluate(() => {
       const w = window as unknown as {
-        __prRepoPaths?: string[];
+        __prCalls?: Array<{ repoPath: string; query?: string | null }>;
         __issueRepoPaths?: string[];
         __workflowRepoPaths?: string[];
       };
       return [
-        ...(w.__prRepoPaths ?? []),
+        ...(w.__prCalls ?? [])
+          .filter((call) => !call.query?.startsWith("head:"))
+          .map((call) => call.repoPath),
         ...(w.__issueRepoPaths ?? []),
         ...(w.__workflowRepoPaths ?? []),
       ];
@@ -1268,11 +1272,11 @@ test.describe("right panel: tab switching", () => {
 
     await page.evaluate(() => {
       const w = window as unknown as {
-        __prRepoPaths?: string[];
+        __prCalls?: Array<{ repoPath: string; query?: string | null }>;
         __issueRepoPaths?: string[];
         __workflowRepoPaths?: string[];
       };
-      w.__prRepoPaths = [];
+      w.__prCalls = [];
       w.__issueRepoPaths = [];
       w.__workflowRepoPaths = [];
     });
@@ -1285,12 +1289,14 @@ test.describe("right panel: tab switching", () => {
 
     const calls = await page.evaluate(() => {
       const w = window as unknown as {
-        __prRepoPaths?: string[];
+        __prCalls?: Array<{ repoPath: string; query?: string | null }>;
         __issueRepoPaths?: string[];
         __workflowRepoPaths?: string[];
       };
       return {
-        prs: w.__prRepoPaths ?? [],
+        prs: (w.__prCalls ?? [])
+          .filter((call) => !call.query?.startsWith("head:"))
+          .map((call) => call.repoPath),
         issues: w.__issueRepoPaths ?? [],
         workflows: w.__workflowRepoPaths ?? [],
       };

--- a/tests/e2e/session-notifications.spec.ts
+++ b/tests/e2e/session-notifications.spec.ts
@@ -143,4 +143,102 @@ test.describe("session notification center", () => {
       .not.toContainText("1");
     await expect(activity).toContainText("0 unread");
   });
+
+  test("opens the kanban terminal popover from sidebar activity rows", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          interface: { defaultWorkspaceViewMode: "kanban" },
+        }),
+      );
+    });
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "session-1",
+        name: "foreground",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "running",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        mode: "terminal",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+      {
+        id: "session-2",
+        name: "agent run",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "running",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        mode: "terminal",
+        owner: { kind: "user" },
+        position: 1,
+        in_worktree: false,
+      },
+    ]);
+    await tauri.handle("detect_session_statuses", () => [
+      {
+        id: "session-2",
+        status: "needs_input",
+        branch: "main",
+        agent_provider: null,
+        last_message: "Awaiting input.",
+        last_user_message: null,
+        last_agent_message: "Awaiting input.",
+      },
+    ]);
+
+    await page.goto("/");
+
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Kanban",
+    );
+    await expect(page.getByTestId("workspace-kanban")).toBeVisible();
+    const activity = page.getByRole("region", {
+      name: "Session activity",
+    });
+    await expect(activity).toContainText("1 unread");
+    await activity.getByRole("button", { name: /demo · agent run/ }).click();
+
+    const popover = page.getByTestId("kanban-terminal-popover");
+    await expect(popover).toBeVisible();
+    await expect(
+      popover.getByRole("heading", { name: "agent run" }),
+    ).toBeVisible();
+    await expect(page.getByTestId("terminal-popover-body")).toBeVisible();
+    await expect(
+      page
+        .getByTestId("terminal-popover-body")
+        .locator(
+          '[data-acorn-terminal-slot="session-2"] .acorn-terminal-shell',
+        ),
+    ).toBeVisible();
+    await expect(activity).toContainText("0 unread");
+  });
 });

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -459,6 +459,129 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(tooltip.locator("svg")).toHaveCount(6);
   });
 
+  test("session rows surface open PR and active process context", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "session-1",
+        name: "context-session",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "feature/session-context",
+        isolated: false,
+        project_scoped: true,
+        status: "running",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        mode: "terminal",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+        active_processes: [
+          { pid: 11, name: "codex", depth: 2 },
+          { pid: 12, name: "rg", depth: 3 },
+          { pid: 13, name: "node", depth: 3 },
+          { pid: 14, name: "cargo", depth: 3 },
+        ],
+      },
+    ]);
+    await tauri.handle("detect_session_statuses", () => [
+      {
+        id: "session-1",
+        status: "running",
+        branch: "feature/session-context",
+        git_context_path: "/tmp/demo-live-worktree",
+        active_processes: [
+          { pid: 11, name: "codex", depth: 2 },
+          { pid: 12, name: "rg", depth: 3 },
+          { pid: 13, name: "node", depth: 3 },
+          { pid: 14, name: "cargo", depth: 3 },
+        ],
+      },
+    ]);
+    await tauri.handle("list_pull_requests", (args) => {
+      if (
+        args?.repoPath !== "/tmp/demo-live-worktree" ||
+        args?.query !== "head:feature/session-context"
+      ) {
+        return { kind: "ok", items: [], account: "test" };
+      }
+      return {
+        kind: "ok",
+        account: "test",
+        items: [
+          {
+            number: 99,
+            title: "Show session context",
+            state: "OPEN",
+            author: "ian",
+            head_branch: "feature/session-context",
+            base_branch: "main",
+            url: "https://github.com/im-ian/acorn/pull/99",
+            updated_at: "2026-01-01T00:00:00Z",
+            is_draft: false,
+            checks: null,
+            labels: [],
+          },
+        ],
+      };
+    });
+    await tauri.handle("plugin:opener|open_url", (args) => {
+      const w = window as unknown as {
+        __openUrlCalls?: Array<{ url?: string }>;
+      };
+      w.__openUrlCalls = w.__openUrlCalls ?? [];
+      w.__openUrlCalls.push(args as { url?: string });
+      return null;
+    });
+
+    await page.goto("/");
+
+    const row = page
+      .locator("aside")
+      .getByRole("button", { name: /context-session/ });
+    const contextLine = row.locator(
+      '[data-session-context-metadata="true"]',
+    );
+    await expect(contextLine).toHaveText(/PR #99\s*·\s*codex, rg \+2/);
+    const prButton = contextLine.getByRole("button", {
+      name: "Open PR #99",
+    });
+    await expect(prButton).toBeVisible();
+    await prButton.click();
+    const openedUrls = await page.evaluate(
+      () =>
+        (
+          (window as unknown as {
+            __openUrlCalls?: Array<{ url?: string }>;
+          }).__openUrlCalls ?? []
+        ).map((call) => call.url),
+    );
+    expect(openedUrls).toEqual([
+      "https://github.com/im-ian/acorn/pull/99",
+    ]);
+
+    await row.hover();
+    const tooltip = page.getByRole("tooltip");
+    await expect(tooltip).toContainText("Open PR");
+    await expect(tooltip).toContainText("#99 Show session context");
+    await expect(tooltip).toContainText("Processes");
+    await expect(tooltip).toContainText("codex, rg, node, cargo");
+  });
+
   test("clears agent provider icon after the agent process exits", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

세션 목록이 열린 PR과 실행 중인 프로세스 맥락을 바로 드러내고, 칸반 모드의 activity handoff가 실제 세션 popover까지 이어지도록 확장합니다.

1. **Sidebar session context:** show a second metadata line with a clickable `PR #n` link and a compact active-process summary.
2. **Hover details:** include the open PR and the full active-process list in the session tooltip.
3. **Status polling contract:** return active process summaries plus the git workdir that produced the live branch, so PR lookup keeps branch and repo context paired for resumed/control sessions and shells that `cd` into another worktree.
4. **Lookup resilience:** cache positive PR lookups briefly, retry empty results sooner, and skip PR lookup for `main`/`master` branches.
5. **Kanban activity handoff:** make sidebar/status-bar activity clicks open the selected session in the kanban terminal popover instead of only changing hidden pane selection.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Sidebar UX | Sessions expose the PR number and current process context without opening another panel. |
| PR discovery | Resumed/control sessions and nested worktree cwd changes are less likely to query the wrong repo path. |
| Activity navigation | In kanban mode, clicking an activity item visibly opens the target session in the terminal popover. |
| Runtime behavior | PR lookups are cached; process summaries reuse status polling data and keep row text compact. |

## Design notes

- The backend returns `git_context_path` with `branch`; the frontend uses that path for current-PR lookup instead of assuming the recorded session repo/worktree still matches the live shell.
- Row text intentionally shows only the first two process names plus `+N`; the tooltip shows the full process list.
- Activity and notification rows still use `selectSession` as the source of truth for workspace switching, then request a terminal popover only when the selected target workspace is in kanban mode.
- The kanban board reconciles `terminalPopupSessionId` to the rendered card anchor, preserving existing direct-card popover behavior while making external session opens visible.
- Chat sessions still report branch/git context from their recorded worktree but do not synthesize active process summaries.

## Follow-up (not in this PR)

- Add a richer process detail surface if users need PIDs, nesting depth, or direct process actions from the sidebar.

## Test plan

- [x] `git diff --cached --check`
- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run src/lib/sessionContext.test.ts src/store.test.ts --testNamePattern "session context helpers|merges active process summaries"`
- [x] `PLAYWRIGHT_PORT=1421 pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "session rows surface open PR"`
- [x] `pnpm run test:e2e -- tests/e2e/session-notifications.spec.ts`
- [x] `pnpm run test:e2e -- tests/e2e/kanban.spec.ts`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml session_process_noise_filters_shell_wrappers`

## Notes

- The E2E coverage verifies that PR lookup uses the live `git_context_path`, not the original recorded repo path.
- The kanban activity regression is covered by a new sidebar activity test plus the existing kanban popover suite.
