### PR TITLE
fix(sessions): make codex transcript binding resilient to marker misses

### DIFF
--- a/src-tauri/crates/acorn-transcript/src/lib.rs
+++ b/src-tauri/crates/acorn-transcript/src/lib.rs
@@ -504,6 +504,19 @@ fn scan_live_mappings(
                 }
             }
             out.push((c.session_id, c.kind, uuid));
+        } else {
+            // A live agent process with no matching transcript is the
+            // failure this scan exists to prevent — downstream, resume
+            // and tab-title generation silently stall on it. Keep the
+            // miss visible.
+            tracing::debug!(
+                session_id = %c.session_id,
+                kind = ?c.kind,
+                pid = c.pid,
+                cwd = ?c.cwd,
+                role = ?c.role,
+                "transcript_watcher: live agent matched no transcript this cycle"
+            );
         }
     }
 

--- a/src-tauri/crates/acorn-transcript/src/lib.rs
+++ b/src-tauri/crates/acorn-transcript/src/lib.rs
@@ -199,9 +199,10 @@ fn collect_mappings_cached(
     mappings
 }
 
-/// Resolve the provider conversation id created by a completed one-shot
-/// agent run. Native chat uses this after non-interactive CLI calls that
-/// create provider-side transcripts but do not print their id on stdout.
+/// Resolve the provider conversation id created by an agent run in `cwd`.
+/// Native chat uses this after non-interactive one-shot CLI calls that
+/// create provider-side transcripts but do not print their id on stdout;
+/// the path-returning sibling below also serves live processes.
 ///
 /// The helper intentionally returns `None` for ambiguous matches instead
 /// of guessing. A wrong provider cursor would silently resume another chat,

--- a/src-tauri/crates/acorn-transcript/src/lib.rs
+++ b/src-tauri/crates/acorn-transcript/src/lib.rs
@@ -959,7 +959,10 @@ fn find_recent_codex_jsonl(
         let Some(uuid) = extract_uuid_from_path(&path) else {
             continue;
         };
-        if read_codex_transcript_cwd(&path).as_deref() != Some(cwd) {
+        let Some(head) = read_codex_rollout_head(&path) else {
+            continue;
+        };
+        if head.cwd != cwd || !head.is_terminal_writer() {
             continue;
         }
         let birth = meta.created().unwrap_or(mtime);
@@ -992,10 +995,10 @@ fn find_completed_codex_jsonl(
         if mtime < recency_cutoff || mtime < process_start {
             continue;
         }
-        let Some(transcript_cwd) = read_codex_transcript_cwd(&path) else {
+        let Some(head) = read_codex_rollout_head(&path) else {
             continue;
         };
-        if transcript_cwd != cwd {
+        if head.cwd != cwd || !head.is_terminal_writer() {
             continue;
         }
         let Some(uuid) = extract_uuid_from_path(&path) else {
@@ -1120,7 +1123,31 @@ fn find_completed_antigravity_jsonl(
 
 /// Read codex rollout's first non-empty JSONL line and pull `payload.cwd`.
 /// The first event is a `SessionMeta` with cwd nested under `payload`.
-fn read_codex_transcript_cwd(path: &Path) -> Option<PathBuf> {
+struct CodexRolloutHead {
+    cwd: PathBuf,
+    originator: Option<String>,
+}
+
+/// Rollout writers that share `~/.codex/sessions` with the terminal CLI but
+/// can never belong to an Acorn PTY session. Codex Desktop records every GUI
+/// conversation here; pairing one with a terminal process steals the marker
+/// from the real tui rollout (or trips the unique-candidate policy). Missing
+/// or unknown originators stay eligible — rollouts from older CLIs
+/// (`codex_cli_rs`) and `codex exec` one-shots are legitimate matches.
+const CODEX_GUI_HOST_ORIGINATORS: &[&str] = &["Codex Desktop"];
+
+impl CodexRolloutHead {
+    fn is_terminal_writer(&self) -> bool {
+        self.originator
+            .as_deref()
+            .is_none_or(|originator| !CODEX_GUI_HOST_ORIGINATORS.contains(&originator))
+    }
+}
+
+/// Read `cwd` (and `originator` when present) from a codex rollout's leading
+/// `session_meta` line. Both live at the top level in old formats and under
+/// `payload` in current ones.
+fn read_codex_rollout_head(path: &Path) -> Option<CodexRolloutHead> {
     use std::io::{BufRead, BufReader};
     let f = std::fs::File::open(path).ok()?;
     let reader = BufReader::new(f);
@@ -1131,15 +1158,17 @@ fn read_codex_transcript_cwd(path: &Path) -> Option<PathBuf> {
         let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
             continue;
         };
-        if let Some(cwd) = v.get("cwd").and_then(|c| c.as_str()) {
-            return Some(PathBuf::from(cwd));
-        }
-        if let Some(cwd) = v
-            .get("payload")
-            .and_then(|p| p.get("cwd"))
-            .and_then(|c| c.as_str())
-        {
-            return Some(PathBuf::from(cwd));
+        for scope in [Some(&v), v.get("payload")] {
+            let Some(scope) = scope else { continue };
+            if let Some(cwd) = scope.get("cwd").and_then(|c| c.as_str()) {
+                return Some(CodexRolloutHead {
+                    cwd: PathBuf::from(cwd),
+                    originator: scope
+                        .get("originator")
+                        .and_then(|o| o.as_str())
+                        .map(str::to_string),
+                });
+            }
         }
     }
     None
@@ -2278,6 +2307,152 @@ mod tests {
             pinned.map(|(_, id)| id).as_deref(),
             Some("019e2001-3250-76b0-8410-2e073b38a2c1"),
             "rotation must stay off when not the sole codex in cwd"
+        );
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// Codex Desktop shares `~/.codex/sessions` with the terminal CLI. Its
+    /// rollouts carry `originator: "Codex Desktop"` and can never belong to
+    /// an Acorn PTY session, so live pairing must skip them even when the
+    /// cwd matches.
+    #[test]
+    fn find_recent_codex_jsonl_ignores_gui_host_rollouts() {
+        use std::fs::{self, File};
+        use std::io::Write;
+
+        let root =
+            std::env::temp_dir().join(format!("acorn-cxgui-{}", uuid::Uuid::new_v4().simple()));
+        let day = root.join("sessions").join("2026").join("06").join("10");
+        fs::create_dir_all(&day).unwrap();
+        let cwd = root.join("repo");
+
+        let write_rollout = |name: &str, originator: Option<&str>| {
+            let path = day.join(name);
+            let mut f = File::create(&path).unwrap();
+            match originator {
+                Some(originator) => writeln!(
+                    f,
+                    "{{\"payload\":{{\"cwd\":\"{}\",\"originator\":\"{originator}\"}}}}",
+                    cwd.display()
+                )
+                .unwrap(),
+                None => writeln!(f, "{{\"payload\":{{\"cwd\":\"{}\"}}}}", cwd.display()).unwrap(),
+            }
+            path
+        };
+
+        let desktop = write_rollout(
+            "rollout-2026-06-10T10-00-00-019e2001-3250-76b0-8410-2e073b38a2d1.jsonl",
+            Some("Codex Desktop"),
+        );
+        let now = fs::metadata(&desktop).unwrap().modified().unwrap();
+        let process_start = now - Duration::from_secs(5);
+
+        let picked = find_recent_codex_jsonl(
+            &cwd,
+            Some(&root.join("sessions")),
+            SystemTime::UNIX_EPOCH,
+            process_start,
+            now,
+            false,
+            &HashSet::new(),
+        );
+        assert!(
+            picked.is_none(),
+            "a GUI-host rollout must never pair with a terminal codex process"
+        );
+
+        let tui = write_rollout(
+            "rollout-2026-06-10T10-00-01-019e2001-3250-76b0-8410-2e073b38a2d2.jsonl",
+            Some("codex-tui"),
+        );
+        set_mtime(&tui, now);
+        let picked = find_recent_codex_jsonl(
+            &cwd,
+            Some(&root.join("sessions")),
+            SystemTime::UNIX_EPOCH,
+            process_start,
+            now,
+            false,
+            &HashSet::new(),
+        );
+        assert_eq!(
+            picked.map(|(_, id)| id).as_deref(),
+            Some("019e2001-3250-76b0-8410-2e073b38a2d2"),
+            "the tui rollout must win with the GUI-host sibling filtered out"
+        );
+
+        // Rollouts predating the originator field stay eligible.
+        let legacy = write_rollout(
+            "rollout-2026-06-10T10-00-02-019e2001-3250-76b0-8410-2e073b38a2d3.jsonl",
+            None,
+        );
+        set_mtime(&legacy, now);
+        let picked = find_recent_codex_jsonl(
+            &cwd,
+            Some(&root.join("sessions")),
+            SystemTime::UNIX_EPOCH,
+            process_start,
+            now,
+            false,
+            &HashSet::new(),
+        );
+        assert!(
+            picked.is_some(),
+            "legacy rollouts without originator must remain eligible"
+        );
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// The completed-run resolver refuses ambiguous matches, so a GUI-host
+    /// rollout in the same cwd would otherwise turn one legitimate
+    /// candidate into two and resolve nothing.
+    #[test]
+    fn find_completed_codex_jsonl_ignores_gui_host_rollouts() {
+        use std::fs::{self, File};
+        use std::io::Write;
+
+        let root =
+            std::env::temp_dir().join(format!("acorn-cxguic-{}", uuid::Uuid::new_v4().simple()));
+        let day = root.join("sessions").join("2026").join("06").join("10");
+        fs::create_dir_all(&day).unwrap();
+        let cwd = root.join("repo");
+
+        let write_rollout = |name: &str, originator: &str| {
+            let path = day.join(name);
+            let mut f = File::create(&path).unwrap();
+            writeln!(
+                f,
+                "{{\"payload\":{{\"cwd\":\"{}\",\"originator\":\"{originator}\"}}}}",
+                cwd.display()
+            )
+            .unwrap();
+            path
+        };
+
+        write_rollout(
+            "rollout-2026-06-10T10-00-00-019e2001-3250-76b0-8410-2e073b38a2e1.jsonl",
+            "Codex Desktop",
+        );
+        let exec = write_rollout(
+            "rollout-2026-06-10T10-00-01-019e2001-3250-76b0-8410-2e073b38a2e2.jsonl",
+            "codex_exec",
+        );
+        let now = fs::metadata(&exec).unwrap().modified().unwrap();
+        let process_start = now - Duration::from_secs(5);
+
+        let resolved = find_completed_codex_jsonl(
+            &cwd,
+            Some(&root.join("sessions")),
+            SystemTime::UNIX_EPOCH,
+            process_start,
+        );
+        assert_eq!(
+            resolved.map(|(_, id)| id).as_deref(),
+            Some("019e2001-3250-76b0-8410-2e073b38a2e2"),
+            "GUI-host rollouts must not break the unique-candidate policy"
         );
 
         fs::remove_dir_all(&root).unwrap();

--- a/src-tauri/crates/acorn-transcript/src/lib.rs
+++ b/src-tauri/crates/acorn-transcript/src/lib.rs
@@ -211,6 +211,18 @@ pub fn find_completed_agent_run(
     kind: AgentKind,
     process_start: SystemTime,
 ) -> Option<String> {
+    find_agent_run_transcript(cwd, kind, process_start).map(|(_, id)| id)
+}
+
+/// Path-returning form of [`find_completed_agent_run`]. The status poll's
+/// codex marker fallback needs the transcript path (to read status and
+/// previews) alongside the id it persists, under the same conservative
+/// matching policy.
+pub fn find_agent_run_transcript(
+    cwd: &Path,
+    kind: AgentKind,
+    process_start: SystemTime,
+) -> Option<(PathBuf, String)> {
     let now = SystemTime::now();
     let recency_cutoff = now
         .checked_sub(Duration::from_secs(RECENCY_WINDOW_SECS))
@@ -228,22 +240,19 @@ pub fn find_completed_agent_run(
             now,
             false,
             &HashSet::new(),
-        )
-        .map(|(_, id)| id),
+        ),
         AgentKind::Codex => find_completed_codex_jsonl(
             cwd,
             codex_sessions_root().as_deref(),
             recency_cutoff,
             process_start,
-        )
-        .map(|(_, id)| id),
+        ),
         AgentKind::Antigravity => find_completed_antigravity_jsonl(
             cwd,
             &antigravity_brain_roots(),
             recency_cutoff,
             process_start,
-        )
-        .map(|(_, id)| id),
+        ),
     }
 }
 
@@ -2401,6 +2410,47 @@ mod tests {
         assert!(
             picked.is_some(),
             "legacy rollouts without originator must remain eligible"
+        );
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// Backs `find_agent_run_transcript`, the path-returning form the
+    /// status poll's codex marker fallback consumes: the resolver must
+    /// hand back the rollout path alongside the id.
+    #[test]
+    fn find_completed_codex_jsonl_returns_path_and_id() {
+        use std::fs::{self, File};
+        use std::io::Write;
+
+        let root =
+            std::env::temp_dir().join(format!("acorn-cxlive-{}", uuid::Uuid::new_v4().simple()));
+        let day = root.join("sessions").join("2026").join("06").join("10");
+        fs::create_dir_all(&day).unwrap();
+        let cwd = root.join("repo");
+
+        let id = "019e2001-3250-76b0-8410-2e073b38a2f1";
+        let rollout = day.join(format!("rollout-2026-06-10T10-00-00-{id}.jsonl"));
+        let mut f = File::create(&rollout).unwrap();
+        writeln!(
+            f,
+            "{{\"payload\":{{\"cwd\":\"{}\",\"originator\":\"codex-tui\"}}}}",
+            cwd.display()
+        )
+        .unwrap();
+        let now = fs::metadata(&rollout).unwrap().modified().unwrap();
+        let process_start = now - Duration::from_secs(5);
+
+        let resolved = find_completed_codex_jsonl(
+            &cwd,
+            Some(&root.join("sessions")),
+            SystemTime::UNIX_EPOCH,
+            process_start,
+        );
+        assert_eq!(
+            resolved,
+            Some((rollout.clone(), id.to_string())),
+            "resolver must return both the rollout path and its id"
         );
 
         fs::remove_dir_all(&root).unwrap();

--- a/src-tauri/src/agent_resume_persister.rs
+++ b/src-tauri/src/agent_resume_persister.rs
@@ -28,6 +28,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock, PoisonError};
 use std::time::{Duration, SystemTime};
 
 use acorn_session::Session;
@@ -165,12 +166,29 @@ fn tick(state: &AppState) -> io::Result<()> {
 /// the same guards the background tick applies. Exposed so out-of-band
 /// binders (the status poll's codex fallback) share one write policy
 /// instead of growing a second, subtly different marker writer.
+///
+/// Writer hierarchy: the background tick stays authoritative — its
+/// PTY-tree scan disambiguates multi-process cwds the fallback abstains
+/// from — and a fallback write it disagrees with is corrected on the next
+/// tick (forward moves pass, the dormant-echo gate blocks bad rollbacks).
 pub fn bind_session_marker(session_id: uuid::Uuid, kind: AgentKind, uuid: &str) -> io::Result<()> {
     let state_dir = agent_resume::ensure_session_state_dir(session_id)?;
     bind_marker_in_state_dir(&state_dir, kind, uuid)
 }
 
+/// Serializes marker writes across the background tick and the status
+/// poll's fallback. The read-check-write below is not atomic on its own;
+/// two threads interleaving could skip the dormant-echo arbitration and
+/// flap the marker.
+fn marker_bind_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 fn bind_marker_in_state_dir(state_dir: &Path, kind: AgentKind, uuid: &str) -> io::Result<()> {
+    let _guard = marker_bind_lock()
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
     let id_file = state_dir.join(id_filename(kind));
     let previous = read_trimmed(&id_file);
     if previous.as_deref() == Some(uuid) {
@@ -347,6 +365,42 @@ mod tests {
             read_trimmed(&marker).as_deref(),
             Some("019e2001-bbbb-76b0-8410-2e073b38a2c2"),
             "a new uuid must replace the marker"
+        );
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// Two writers race the same marker (background tick vs status-poll
+    /// fallback). The bind lock must serialize them: every call succeeds
+    /// and the surviving value is one of the written uuids, never a torn
+    /// or empty file.
+    #[test]
+    fn concurrent_binds_serialize_cleanly() {
+        let dir =
+            std::env::temp_dir().join(format!("acorn-bindrace-{}", uuid::Uuid::new_v4().simple()));
+        fs::create_dir_all(&dir).unwrap();
+
+        let a = "019e2001-aaaa-76b0-8410-2e073b38a2c1";
+        let b = "019e2001-bbbb-76b0-8410-2e073b38a2c2";
+        let handles: Vec<_> = [a, b, a, b]
+            .into_iter()
+            .map(|uuid| {
+                let dir = dir.clone();
+                std::thread::spawn(move || {
+                    for _ in 0..50 {
+                        bind_marker_in_state_dir(&dir, AgentKind::Codex, uuid).unwrap();
+                    }
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let survivor = read_trimmed(&dir.join("codex.id"));
+        assert!(
+            survivor.as_deref() == Some(a) || survivor.as_deref() == Some(b),
+            "marker must hold one intact uuid, got {survivor:?}"
         );
 
         fs::remove_dir_all(&dir).unwrap();

--- a/src-tauri/src/agent_resume_persister.rs
+++ b/src-tauri/src/agent_resume_persister.rs
@@ -151,23 +151,7 @@ fn tick(state: &AppState) -> io::Result<()> {
                 }
             }
         }
-        let id_file = state_dir.join(id_filename(kind));
-        let previous = read_trimmed(&id_file);
-        if previous.as_deref() == Some(uuid.as_str()) {
-            continue;
-        }
-        // A backwards move (to an earlier-born transcript) is legitimate
-        // when the user `--resume`d an old conversation — that transcript
-        // is hot again. But right after an in-session `/new` rotation the
-        // scan can echo the abandoned original once the new transcript
-        // goes idle; writing that echo would oscillate the marker. Skip
-        // only the dormant-echo case so the marker never flaps.
-        if let Some(prev) = previous.as_deref() {
-            if marker_rollback_is_dormant_echo(kind, prev, &uuid) {
-                continue;
-            }
-        }
-        if let Err(err) = write_if_changed(&id_file, &format!("{uuid}\n")) {
+        if let Err(err) = bind_marker_in_state_dir(&state_dir, kind, &uuid) {
             tracing::warn!(
                 %session_id, ?kind, %uuid, error = %err,
                 "agent_resume_persister: write failed"
@@ -175,6 +159,35 @@ fn tick(state: &AppState) -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Bind `uuid` as `session_id`'s durable resume marker for `kind`, under
+/// the same guards the background tick applies. Exposed so out-of-band
+/// binders (the status poll's codex fallback) share one write policy
+/// instead of growing a second, subtly different marker writer.
+pub fn bind_session_marker(session_id: uuid::Uuid, kind: AgentKind, uuid: &str) -> io::Result<()> {
+    let state_dir = agent_resume::ensure_session_state_dir(session_id)?;
+    bind_marker_in_state_dir(&state_dir, kind, uuid)
+}
+
+fn bind_marker_in_state_dir(state_dir: &Path, kind: AgentKind, uuid: &str) -> io::Result<()> {
+    let id_file = state_dir.join(id_filename(kind));
+    let previous = read_trimmed(&id_file);
+    if previous.as_deref() == Some(uuid) {
+        return Ok(());
+    }
+    // A backwards move (to an earlier-born transcript) is legitimate
+    // when the user `--resume`d an old conversation — that transcript
+    // is hot again. But right after an in-session `/new` rotation the
+    // scan can echo the abandoned original once the new transcript
+    // goes idle; writing that echo would oscillate the marker. Skip
+    // only the dormant-echo case so the marker never flaps.
+    if let Some(prev) = previous.as_deref() {
+        if marker_rollback_is_dormant_echo(kind, prev, uuid) {
+            return Ok(());
+        }
+    }
+    write_if_changed(&id_file, &format!("{uuid}\n"))
 }
 
 fn id_filename(kind: AgentKind) -> &'static str {

--- a/src-tauri/src/agent_resume_persister.rs
+++ b/src-tauri/src/agent_resume_persister.rs
@@ -314,6 +314,44 @@ mod tests {
         assert_eq!(pids[0].root_pid, Some(10));
     }
 
+    /// `bind_marker_in_state_dir` backs both the background tick and the
+    /// status poll's codex fallback: it must create a fresh marker, stay
+    /// idempotent on the same uuid, and move forward to a new uuid.
+    #[test]
+    fn bind_marker_writes_and_stays_idempotent() {
+        let dir =
+            std::env::temp_dir().join(format!("acorn-bindmk-{}", uuid::Uuid::new_v4().simple()));
+        fs::create_dir_all(&dir).unwrap();
+        let marker = dir.join("codex.id");
+
+        bind_marker_in_state_dir(&dir, AgentKind::Codex, "019e2001-aaaa-76b0-8410-2e073b38a2c1")
+            .unwrap();
+        assert_eq!(
+            read_trimmed(&marker).as_deref(),
+            Some("019e2001-aaaa-76b0-8410-2e073b38a2c1"),
+            "first bind must create the marker"
+        );
+
+        let mtime_before = fs::metadata(&marker).unwrap().modified().unwrap();
+        bind_marker_in_state_dir(&dir, AgentKind::Codex, "019e2001-aaaa-76b0-8410-2e073b38a2c1")
+            .unwrap();
+        assert_eq!(
+            fs::metadata(&marker).unwrap().modified().unwrap(),
+            mtime_before,
+            "same-uuid rebind must not rewrite the marker"
+        );
+
+        bind_marker_in_state_dir(&dir, AgentKind::Codex, "019e2001-bbbb-76b0-8410-2e073b38a2c2")
+            .unwrap();
+        assert_eq!(
+            read_trimmed(&marker).as_deref(),
+            Some("019e2001-bbbb-76b0-8410-2e073b38a2c2"),
+            "a new uuid must replace the marker"
+        );
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
     /// Forward birth-order moves always pass; a backwards move passes
     /// only while the older transcript is being actively written (a real
     /// `--resume`), and is skipped once it has gone dormant (the

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3593,12 +3593,26 @@ fn session_title_readiness_inner(
         .as_ref()
         .map(|input| input.transcript_id.as_str());
     if !crate::session_titles::can_generate_title(&session, transcript_id) {
+        // The auto-title planner retries on this status forever; without a
+        // trace the gate that keeps a tab stuck on "new session-N" is
+        // invisible (auto-title opt-out, manual title, unchanged transcript).
+        tracing::debug!(
+            session_id = %id,
+            title_source = ?session.title_source,
+            auto_title_enabled = ?session.auto_title_enabled,
+            has_title_input = transcript_id.is_some(),
+            "session title readiness: skipped (not eligible)"
+        );
         return Ok(SessionTitleReadinessResult {
             status: SessionTitleReadinessStatus::Skipped,
             session: enrich_session(session),
         });
     }
     if title_input.is_none() {
+        tracing::debug!(
+            session_id = %id,
+            "session title readiness: not ready (no transcript context resolved)"
+        );
         return Ok(SessionTitleReadinessResult {
             status: SessionTitleReadinessStatus::NotReady,
             session: enrich_session(session),

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5206,9 +5206,9 @@ fn detect_session_statuses_blocking(
             let active_processes = root_pid_value
                 .map(|pid| session_process_summaries(&sys, &children, Pid::from_u32(pid)))
                 .unwrap_or_default();
-            let live_agent_kind = root_pid_value.and_then(|pid| {
-                live_agent_kind_in_descendants(&sys, &children, Pid::from_u32(pid))
-            });
+            let live_agent = root_pid_value
+                .and_then(|pid| live_agent_in_descendants(&sys, &children, Pid::from_u32(pid)));
+            let live_agent_kind = live_agent.map(|(kind, _)| kind);
             let live_codex_tool_child = matches!(live_agent_kind, Some(StatusAgentKind::Codex))
                 && root_pid_value.is_some_and(|pid| {
                     live_codex_has_tool_descendant(&sys, &children, Pid::from_u32(pid))
@@ -5226,6 +5226,12 @@ fn detect_session_statuses_blocking(
                 ),
                 None => agent_resume::live_transcript(uuid),
             });
+            // Claude gets a marker-less fallback below via the todos
+            // mapping; codex has no equivalent, so a persister miss (pid
+            // gap at spawn, ambiguous host scan) silently disables auto
+            // titles and resume for the whole session. Bind the live
+            // codex process straight to its rollout instead.
+            let live = live.or_else(|| codex_live_transcript_fallback(&sys, parsed_id, live_agent));
             let agent_transcript_id = live.as_ref().map(|t| t.id.clone());
             let transcript = match live.as_ref() {
                 Some(t) => {
@@ -5468,27 +5474,91 @@ fn refine_shell_hint_for_unpaired_agent(
     }
 }
 
-fn live_agent_kind_in_descendants(
+/// Bind a live codex process to its rollout when the durable `codex.id`
+/// marker is missing. The persister normally writes that marker within
+/// seconds, but it can miss a run entirely (no root pid captured at spawn,
+/// host-scan ambiguity) and nothing retries on its behalf — codex, unlike
+/// claude, has no marker-less transcript mapping. Resolve the rollout from
+/// the process's own cwd and start time under the conservative
+/// single-candidate policy, and persist the marker so title generation and
+/// resume converge on the same binding.
+fn codex_live_transcript_fallback(
+    sys: &System,
+    session_id: Option<Uuid>,
+    live_agent: Option<(StatusAgentKind, Pid)>,
+) -> Option<agent_resume::LiveTranscript> {
+    let session_id = session_id?;
+    let (kind, pid) = live_agent?;
+    if kind != StatusAgentKind::Codex {
+        return None;
+    }
+    let proc = sys.process(pid)?;
+    let cwd = proc.cwd()?;
+    let process_start = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(proc.start_time());
+    let Some((path, id)) = acorn_transcript::find_agent_run_transcript(
+        cwd,
+        acorn_transcript::AgentKind::Codex,
+        process_start,
+    ) else {
+        tracing::debug!(
+            %session_id,
+            pid = pid.as_u32(),
+            ?cwd,
+            "status poll: live codex has no unambiguous rollout; marker fallback skipped"
+        );
+        return None;
+    };
+    match crate::agent_resume_persister::bind_session_marker(
+        session_id,
+        acorn_transcript::AgentKind::Codex,
+        &id,
+    ) {
+        Ok(()) => {
+            tracing::info!(
+                %session_id,
+                %id,
+                ?path,
+                "status poll: bound live codex transcript via marker fallback"
+            );
+        }
+        Err(err) => {
+            tracing::warn!(
+                %session_id, %id, error = %err,
+                "status poll: codex marker fallback write failed"
+            );
+        }
+    }
+    Some(agent_resume::LiveTranscript {
+        id,
+        path,
+        kind: agent_resume::AgentKind::Codex,
+    })
+}
+
+fn live_agent_in_descendants(
     sys: &System,
     children: &HashMap<Pid, Vec<Pid>>,
     root: Pid,
-) -> Option<StatusAgentKind> {
-    nearest_agent_kind_in_tree(children, root, |pid| {
+) -> Option<(StatusAgentKind, Pid)> {
+    let mut found_pid = None;
+    let kind = nearest_agent_kind_in_tree(children, root, |pid| {
         let proc = sys.process(pid)?;
-        if process_basename_matches(proc, "codex") {
-            return Some(StatusAgentKind::Codex);
-        }
-        if process_basename_matches(proc, "claude") {
-            return Some(StatusAgentKind::Claude);
-        }
-        if process_basename_matches(proc, "agy")
+        let kind = if process_basename_matches(proc, "codex") {
+            StatusAgentKind::Codex
+        } else if process_basename_matches(proc, "claude") {
+            StatusAgentKind::Claude
+        } else if process_basename_matches(proc, "agy")
             || process_basename_matches(proc, "antigravity")
             || process_basename_matches(proc, "antigravity-cli")
         {
-            return Some(StatusAgentKind::Antigravity);
-        }
-        None
-    })
+            StatusAgentKind::Antigravity
+        } else {
+            return None;
+        };
+        found_pid = Some(pid);
+        Some(kind)
+    })?;
+    Some((kind, found_pid?))
 }
 
 fn live_codex_has_tool_descendant(

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5496,6 +5496,10 @@ fn refine_shell_hint_for_unpaired_agent(
 /// the process's own cwd and start time under the conservative
 /// single-candidate policy, and persist the marker so title generation and
 /// resume converge on the same binding.
+///
+/// Known limitation: the single-candidate policy has no `assigned`-set
+/// reservation, so two codex processes in the same cwd stay ambiguous and
+/// the fallback fails safe to `None` rather than guessing.
 fn codex_live_transcript_fallback(
     sys: &System,
     session_id: Option<Uuid>,
@@ -5549,6 +5553,13 @@ fn codex_live_transcript_fallback(
     })
 }
 
+/// Resolve the nearest live agent process under `root`, with its pid.
+///
+/// `found_pid` rides side-channel out of the closure; the pairing with the
+/// returned kind is only sound because `nearest_agent_kind_in_tree` stops at
+/// the FIRST `Some` the callback yields (see its doc). If that traversal ever
+/// keeps scanning past a match, refactor the callback to return
+/// `Option<(StatusAgentKind, Pid)>` instead of relying on this capture.
 fn live_agent_in_descendants(
     sys: &System,
     children: &HashMap<Pid, Vec<Pid>>,
@@ -5599,6 +5610,10 @@ fn is_codex_persistent_helper_process(proc: &sysinfo::Process) -> bool {
         || process_basename_matches(proc, "SkyComputerUseClient")
 }
 
+/// BFS from `root` that returns on the FIRST pid the callback classifies.
+/// `live_agent_in_descendants` depends on this early-return to pair its
+/// side-channel pid with the returned kind — keep the invariant if this
+/// traversal ever grows ranking or multi-match behavior.
 fn nearest_agent_kind_in_tree<F>(
     children: &HashMap<Pid, Vec<Pid>>,
     root: Pid,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5532,6 +5532,7 @@ fn codex_live_transcript_fallback(
         &id,
     ) {
         Ok(()) => {
+            note_codex_bind_recovered(&mut codex_bind_failure_registry(), session_id);
             tracing::info!(
                 %session_id,
                 %id,
@@ -5540,10 +5541,20 @@ fn codex_live_transcript_fallback(
             );
         }
         Err(err) => {
-            tracing::warn!(
-                %session_id, %id, error = %err,
-                "status poll: codex marker fallback write failed"
-            );
+            // A persistent write failure (permissions, deleted state dir)
+            // re-enters this fallback every poll tick; warn once per
+            // failure streak, then drop to debug until a bind succeeds.
+            if note_codex_bind_failure(&mut codex_bind_failure_registry(), session_id) {
+                tracing::warn!(
+                    %session_id, %id, error = %err,
+                    "status poll: codex marker fallback write failed"
+                );
+            } else {
+                tracing::debug!(
+                    %session_id, %id, error = %err,
+                    "status poll: codex marker fallback write still failing"
+                );
+            }
         }
     }
     Some(agent_resume::LiveTranscript {
@@ -5551,6 +5562,28 @@ fn codex_live_transcript_fallback(
         path,
         kind: agent_resume::AgentKind::Codex,
     })
+}
+
+/// Sessions whose codex marker fallback already warned about a write
+/// failure this streak. Guards the poll-frequency `warn!` from repeating
+/// every tick while the failure persists.
+fn codex_bind_failure_registry() -> std::sync::MutexGuard<'static, HashSet<Uuid>> {
+    static WARNED: std::sync::OnceLock<Mutex<HashSet<Uuid>>> = std::sync::OnceLock::new();
+    WARNED
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Record a fallback write failure; `true` when this is the first failure
+/// of the current streak (i.e. the caller should warn, not just debug).
+fn note_codex_bind_failure(warned: &mut HashSet<Uuid>, session_id: Uuid) -> bool {
+    warned.insert(session_id)
+}
+
+/// A successful bind ends the failure streak so the next failure warns again.
+fn note_codex_bind_recovered(warned: &mut HashSet<Uuid>, session_id: Uuid) {
+    warned.remove(&session_id);
 }
 
 /// Resolve the nearest live agent process under `root`, with its pid.
@@ -8129,6 +8162,21 @@ mod tests {
         assert!(!super::auto_title_promotion_needed(Some(true), true));
         // Legacy rows keep using compatibility heuristics.
         assert!(!super::auto_title_promotion_needed(None, true));
+    }
+
+    /// The fallback's write-failure warning must fire once per failure
+    /// streak: repeat failures drop to debug, and a successful bind
+    /// re-arms the warning for the next streak.
+    #[test]
+    fn codex_bind_failure_warns_once_per_streak() {
+        let mut warned = std::collections::HashSet::new();
+        let session_id = Uuid::from_u128(7);
+
+        assert!(super::note_codex_bind_failure(&mut warned, session_id));
+        assert!(!super::note_codex_bind_failure(&mut warned, session_id));
+
+        super::note_codex_bind_recovered(&mut warned, session_id);
+        assert!(super::note_codex_bind_failure(&mut warned, session_id));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Codex sessions intermittently kept their `new session-N` placeholder tab name because the transcript binding that feeds auto-title generation has a single point of failure: the background persister's `codex.id` marker. Claude has a marker-less fallback in the status poll; codex had none, so one missed pairing (no root pid captured at spawn, ambiguous host scan) silently disabled titles and resume for the whole session. Field diagnosis also showed Codex Desktop rollouts sharing `~/.codex/sessions` with the terminal CLI and polluting the candidate pool (412 of 730 rollouts on the affected machine were Desktop-originated).

## Changes

- **GUI-host rollout filtering** — live pairing and completed-run resolution now read `originator` from the rollout head and skip known GUI hosts (`Codex Desktop`). Missing or unknown originators stay eligible so older CLIs (`codex_cli_rs`) and `codex exec` one-shots keep matching.
- **Status-poll codex fallback** — when a live codex process is detected but no marker resolves, the poll binds the rollout directly from the process cwd and start time under the conservative single-candidate policy, then persists the marker through the shared guarded write (`bind_session_marker`) so titles, readiness, and resume converge on one binding.
- **Serialized marker writers** — the persister tick and the poll fallback now share one process-wide bind lock, so the read-check-write (including dormant-echo arbitration) cannot interleave across threads; the tick's PTY-aware scan stays authoritative and corrects fallback writes on its next pass.
- **Bounded warn spam** — a persistent fallback write failure warns once per streak and drops to debug until a successful bind re-arms it.
- **Diagnostics** — debug traces at the previously silent choke points: live agent with no transcript match, and the title-readiness gates (`skipped` / `not_ready`) with the fields that decide the outcome.

## Test plan

- [x] `cargo test -p acorn-transcript --lib` — 36 passed (new: GUI-host filtering for live and completed paths, legacy originator compatibility, path+id resolver)
- [x] `cargo test --lib` — 333 passed (re-run after rebase onto #543) (new: marker bind create/idempotent/forward-move, concurrent bind serialization, warn-once failure streak)
- [x] `cargo check` clean; clippy/fmt findings verified pre-existing via `git blame` (rust is not part of CI, which covers frontend typecheck/tests/build + E2E — untouched here)
- [x] Reviewed by rust-reviewer agent: approve, no CRITICAL/HIGH; both MEDIUM follow-ups (missing unit tests, uncoordinated dual writers) addressed in follow-up commits
