### PR TITLE
fix(worktree): start new worktree sessions from default branch

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8257,19 +8257,15 @@ mod tests {
         repo
     }
 
-    // Regression: libgit2's default `Repository::worktree(name, path, None)`
-    // auto-creates a branch named after the worktree. When that branch
-    // already exists (e.g. the user's primary branch happens to share the
-    // repo basename), the call returned ErrorCode::Exists and bubbled up to
-    // the user as "failed to write reference 'refs/heads/<name>'". The
-    // retry loop now bumps the suffix on Exists just like it does for
-    // path collisions.
+    // Regression: a generated worktree branch name can collide with an
+    // existing branch. The retry loop bumps the suffix on Exists just like it
+    // does for path collisions.
     #[test]
     fn create_unique_worktree_bumps_suffix_when_branch_name_taken() {
         let repo_dir = unique_repo_dir("branch-collision");
         let repo = init_repo_with_commit(&repo_dir);
-        // Create a branch named after the repo so the libgit2 auto-branch
-        // creation would collide on the first attempt.
+        // Create a branch named after the repo so generated branch creation
+        // collides on the first attempt.
         let head_commit = repo
             .head()
             .and_then(|h| h.peel_to_commit())

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -1,4 +1,4 @@
-use git2::{Repository, WorktreePruneOptions};
+use git2::{BranchType, Repository, WorktreeAddOptions, WorktreePruneOptions};
 use serde::Serialize;
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
@@ -114,8 +114,38 @@ pub fn create_worktree(repo_path: &Path, name: &str) -> AppResult<PathBuf> {
         )));
     }
 
-    repo.worktree(name, &target, None)?;
+    let base = worktree_base_commit(&repo)?;
+    repo.branch(name, &base, false)?;
+    let branch_ref_name = format!("refs/heads/{name}");
+    let branch_ref = repo.find_reference(&branch_ref_name)?;
+    let mut opts = WorktreeAddOptions::new();
+    opts.checkout_existing(true).reference(Some(&branch_ref));
+    if let Err(err) = repo.worktree(name, &target, Some(&opts)) {
+        if let Ok(mut branch) = repo.find_branch(name, BranchType::Local) {
+            let _ = branch.delete();
+        }
+        return Err(err.into());
+    }
     Ok(target)
+}
+
+fn worktree_base_commit(repo: &Repository) -> AppResult<git2::Commit<'_>> {
+    // Acorn-created worktrees start from the project's stable default branch,
+    // not whichever feature branch the project root is currently using.
+    for name in [
+        "refs/heads/main",
+        "refs/remotes/origin/main",
+        "refs/heads/master",
+        "refs/remotes/origin/master",
+    ] {
+        if let Ok(commit) = repo
+            .find_reference(name)
+            .and_then(|reference| reference.peel_to_commit())
+        {
+            return Ok(commit);
+        }
+    }
+    Ok(repo.head()?.peel_to_commit()?)
 }
 
 /// Returns absolute on-disk paths of linked worktrees. Used by the
@@ -431,6 +461,68 @@ mod tests {
             .expect("initial commit");
         drop(tree);
         repo
+    }
+
+    fn checkout_branch(repo: &Repository, name: &str) {
+        let refname = format!("refs/heads/{name}");
+        let object = repo
+            .revparse_single(&refname)
+            .unwrap_or_else(|_| panic!("find {refname}"));
+        let mut checkout = git2::build::CheckoutBuilder::new();
+        checkout.force();
+        repo.checkout_tree(&object, Some(&mut checkout))
+            .unwrap_or_else(|_| panic!("checkout {refname} tree"));
+        repo.set_head(&refname)
+            .unwrap_or_else(|_| panic!("set HEAD to {refname}"));
+    }
+
+    #[test]
+    fn create_worktree_starts_new_branch_from_main_when_head_is_elsewhere() {
+        let root = unique_temp_dir("base-main");
+        let repo = init_repo_with_tracked_file(&root);
+        let sig = git2::Signature::now("acorn-test", "test@acorn").expect("sig");
+        let initial = repo
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("initial commit");
+        let main_oid = initial.id();
+        repo.branch("main", &initial, false)
+            .expect("create main branch");
+        repo.branch("feature", &initial, false)
+            .expect("create feature branch");
+        drop(initial);
+
+        checkout_branch(&repo, "feature");
+        std::fs::write(root.join("tracked.txt"), "feature").expect("write feature contents");
+        let tree_id = {
+            let mut idx = repo.index().expect("index");
+            idx.add_path(Path::new("tracked.txt"))
+                .expect("add feature file");
+            idx.write_tree().expect("write feature tree")
+        };
+        let tree = repo.find_tree(tree_id).expect("feature tree");
+        let parent = repo
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("feature parent");
+        repo.commit(Some("HEAD"), &sig, &sig, "feature", &tree, &[&parent])
+            .expect("feature commit");
+        drop(parent);
+        drop(tree);
+        drop(repo);
+
+        let worktree_path = create_worktree(&root, "worker").expect("create worktree");
+        let worktree_repo = Repository::open(&worktree_path).expect("open worktree repo");
+        let head = worktree_repo.head().expect("worktree head");
+
+        assert_eq!(head.shorthand(), Some("worker"));
+        assert_eq!(head.target(), Some(main_oid));
+        assert_eq!(
+            std::fs::read_to_string(worktree_path.join("tracked.txt")).unwrap(),
+            "initial"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
New worktree sessions now start from the project's stable default branch instead of inheriting whichever branch the project root currently has checked out.

1. **Default-branch base selection** — create Acorn-managed worktree branches from `main`, `origin/main`, `master`, or `origin/master` before falling back to current `HEAD`.
2. **Explicit worktree checkout** — create the branch first and pass it to libgit2 worktree creation, avoiding libgit2's implicit current-HEAD branch behavior.
3. **Regression coverage** — add a Rust test proving a feature-branch project root still creates a new worktree branch at `main`, while preserving the existing branch-name collision retry test.

## Expected impact
| Scenario | Before | After |
| --- | --- | --- |
| New worktree session from a project root currently on a feature/worktree branch | New branch started from that feature/worktree branch | New branch starts from the repo's default branch when available |
| Repos without `main`/`master` refs | Used current `HEAD` | Still falls back to current `HEAD` |
| Generated worktree branch name already exists | Retry suffix path | Retry suffix path preserved |

## Design notes
- The change stays in `worktree::create_worktree`, so all Acorn-managed worktree creation paths share the same default-branch policy.
- Remote-tracking refs (`origin/main`, `origin/master`) are accepted as base commits so fresh local checkouts without local default branches still get the expected starting point.
- If worktree creation fails after creating the new branch, the just-created branch is deleted before returning the error.

## Test plan
- [x] `git diff --check HEAD~1..HEAD` — passed
- [x] `cargo test worktree::tests` — 16 passed
- [x] `cargo test create_unique_worktree_bumps_suffix_when_branch_name_taken` — passed

## Notes
- Playwright was not run locally; this is backend worktree creation behavior and is covered by focused Rust tests.
- PR #544 was opened from an older stacked branch and is superseded by this clean main-based PR.