### PR TITLE
fix(kanban): restore session rename menu

### DIFF
--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -24,10 +24,12 @@ import {
   Maximize2,
   MessageSquareText,
   Minimize2,
+  Pencil,
   PencilLine,
   Plus,
   RotateCcw,
   Search,
+  Sparkles,
   Tag,
   Terminal as TerminalIcon,
   Trash2,
@@ -44,12 +46,21 @@ import {
   type ProjectSessionCreateAction,
 } from "../lib/projectSessionCreateActions";
 import { canConfigureSessionAutoClose } from "../lib/sessionAgentState";
+import {
+  canRegenerateSessionTitle,
+  canRenameSession,
+} from "../lib/sessionTitle";
 import type { Session, SessionStatus } from "../lib/types";
 import {
   AgentProviderIcon,
   resolveSessionAgentProvider,
 } from "../lib/agentProvider";
-import { useSettings } from "../lib/settings";
+import {
+  resolveAiExecutionRequest,
+  resolveSessionTitlePrompt,
+  useSettings,
+} from "../lib/settings";
+import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
 import {
   KANBAN_COLUMN_STATUSES,
@@ -756,11 +767,14 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
   onOpen: (sessionId: string, anchor: HTMLElement) => void;
 }) {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const worktreeName = basename(session.worktree_path);
   const branchName = session.branch?.trim();
   const lastMessage =
     session.last_agent_message?.trim() || session.last_message?.trim();
   const selectSession = useAppStore((s) => s.selectSession);
+  const renameSession = useAppStore((s) => s.renameSession);
+  const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
   const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
   const setWorkspaceViewMode = useAppStore((s) => s.setWorkspaceViewMode);
   const toggleSessionAutoClose = useAppStore(
@@ -772,12 +786,24 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
   );
   const editorCommand = useSettings((s) => s.settings.editor.command);
   const editorConfigured = editorCommand.trim().length > 0;
+  const isGeneratingTitle = useAppStore((s) =>
+    Boolean(s.generatingSessionTitleIds[session.id]),
+  );
+  const canRename = canRenameSession(session, { isGeneratingTitle });
+  const canRegenerateTitle =
+    canRegenerateSessionTitle(session) && !isGeneratingTitle;
   const canConfigureAutoClose = canConfigureSessionAutoClose(session);
+  const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const openLabel = t("workspace.kanban.openSession").replace(
     "{name}",
     session.name,
   );
+
+  useEffect(() => {
+    if (isGeneratingTitle && editing) setEditing(false);
+  }, [editing, isGeneratingTitle]);
+
   function openContextMenu(x: number, y: number) {
     setMenu({ x, y });
   }
@@ -789,18 +815,55 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
   }
 
   function handlePointerDown(event: ReactPointerEvent) {
+    if (editing) return;
     if (event.button !== 2) return;
     event.preventDefault();
     openContextMenu(event.clientX, event.clientY);
   }
 
-  function handleOpen(event: ReactMouseEvent<HTMLButtonElement>) {
+  function handleOpen(event: ReactMouseEvent<HTMLElement>) {
     onOpen(session.id, event.currentTarget);
+  }
+
+  async function submitRename(next: string) {
+    setEditing(false);
+    if (canRename && next && next !== session.name) {
+      await renameSession(session.id, next);
+      const error = useAppStore.getState().consumeError();
+      if (error) showToast(`${t("toasts.session.renameFailed")} ${error}`);
+    }
+  }
+
+  async function regenerateTitle() {
+    const settings = useSettings.getState().settings;
+    const status = await generateSessionTitle(
+      session.id,
+      resolveAiExecutionRequest(settings),
+      resolveSessionTitlePrompt(settings),
+      true,
+    );
+    if (status === "not_ready") {
+      showToast(t("toasts.session.titleNotReady"));
+    } else if (status !== "generated") {
+      showToast(t("toasts.session.titleRegenerateSkipped"));
+    }
   }
 
   const sessionMenuItems = useMemo<ContextMenuItem[]>(
     () => [
       workspaceContextMenuGroupTitle(t, "session"),
+      {
+        label: sidebarText(t, "sidebar.actions.rename"),
+        icon: <Pencil size={12} />,
+        onClick: () => setEditing(true),
+        disabled: !canRename,
+      },
+      {
+        label: sidebarText(t, "sidebar.actions.regenerateName"),
+        icon: <Sparkles size={12} />,
+        onClick: () => void regenerateTitle(),
+        disabled: !canRegenerateTitle,
+      },
       {
         label: openLabel,
         icon:
@@ -899,16 +962,23 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
     [
       autoCloseEnabled,
       canConfigureAutoClose,
+      canRegenerateTitle,
+      canRename,
       editorConfigured,
+      generateSessionTitle,
+      isGeneratingTitle,
       onOpen,
       openLabel,
       openWorkSummaryTab,
+      renameSession,
       requestRemoveSession,
       selectSession,
       session.branch,
       session.id,
       session.mode,
+      session.name,
       session.worktree_path,
+      showToast,
       setWorkspaceViewMode,
       t,
       toggleSessionAutoClose,
@@ -934,22 +1004,41 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
         multiline
         className="flex w-full"
       >
-        <button
-          type="button"
+        <div
+          role="button"
+          tabIndex={0}
           data-testid="workspace-kanban-card"
           data-kanban-session-id={session.id}
-          onClick={handleOpen}
+          onClick={editing ? undefined : handleOpen}
           onPointerDown={handlePointerDown}
           onContextMenu={handleContextMenu}
+          onKeyDown={(event) => {
+            if (editing) return;
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              onOpen(session.id, event.currentTarget);
+            } else if (event.key === "F2") {
+              event.preventDefault();
+              if (canRename) setEditing(true);
+            }
+          }}
           className="group flex w-full flex-col gap-2 rounded-md border border-border bg-bg-elevated/45 p-2 text-left transition hover:border-accent/45 hover:bg-bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
           aria-label={openLabel}
         >
           <span className="flex min-w-0 items-start gap-1.5">
             <WorkspaceSessionIcon session={session} scope="kanban" />
             <span className="min-w-0 flex-1">
-              <span className="block truncate text-[12px] font-medium leading-5 text-fg">
-                {session.name}
-              </span>
+              {editing ? (
+                <KanbanCardRenameInput
+                  initial={session.name}
+                  onSubmit={submitRename}
+                  onCancel={() => setEditing(false)}
+                />
+              ) : (
+                <span className="block truncate text-[12px] font-medium leading-5 text-fg">
+                  {session.name}
+                </span>
+              )}
             </span>
           </span>
           {lastMessage ? (
@@ -992,7 +1081,7 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
               </>
             ) : null}
           </span>
-        </button>
+        </div>
       </Tooltip>
       <ContextMenu
         open={menu !== null}
@@ -1004,6 +1093,49 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
     </>
   );
 });
+
+function KanbanCardRenameInput({
+  initial,
+  onSubmit,
+  onCancel,
+}: {
+  initial: string;
+  onSubmit: (value: string) => void | Promise<void>;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(initial);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.select();
+  }, []);
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      data-kanban-card-rename-input
+      autoFocus
+      value={value}
+      onChange={(event) => setValue(event.currentTarget.value)}
+      onClick={(event) => event.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
+      onPointerDown={(event) => event.stopPropagation()}
+      onKeyDown={(event) => {
+        event.stopPropagation();
+        if (event.key === "Enter") {
+          event.preventDefault();
+          void onSubmit(value.trim());
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          onCancel();
+        }
+      }}
+      onBlur={() => void onSubmit(value.trim())}
+      className="h-5 w-full min-w-0 rounded border border-accent bg-input px-1 text-[12px] font-medium leading-4 text-fg outline-none"
+    />
+  );
+}
 
 function KanbanTerminalPopover({
   session,

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -352,6 +352,12 @@ test.describe("workspace kanban mode", () => {
       page.getByRole("menuitem", { name: "Open shell" }),
     ).toBeVisible();
     await expect(
+      page.getByRole("menuitem", { name: "Rename" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Regenerate Name" }),
+    ).toBeVisible();
+    await expect(
       page.getByRole("menuitem", { name: "Open Work Summary" }),
     ).toBeVisible();
     await expect(
@@ -501,6 +507,87 @@ test.describe("workspace kanban mode", () => {
       page
         .getByTestId("terminal-popover-body")
         .locator('[data-acorn-terminal-slot="broken"] .acorn-terminal-shell'),
+    ).toBeVisible();
+  });
+
+  test("card context menu can rename a session", async ({ page, tauri }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__sessions = w.__sessions ?? [
+        {
+          id: "rename-me",
+          name: "rename-me",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo/.worktrees/rename-me",
+          branch: "feat/rename-me",
+          isolated: false,
+          project_scoped: true,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          title_source: "manual",
+          kind: "regular",
+          mode: "terminal",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+        },
+      ];
+      return w.__sessions;
+    });
+    await tauri.handle("rename_session", (args) => {
+      const w = window as unknown as {
+        __renameCalls?: unknown[];
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__renameCalls = w.__renameCalls ?? [];
+      w.__renameCalls.push(args);
+      const a = args as { id: string; name: string };
+      const current = w.__sessions?.[0] ?? {};
+      const updated = { ...current, id: a.id, name: a.name };
+      w.__sessions = [updated];
+      return updated;
+    });
+
+    await page.goto("/");
+
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    const board = page.getByTestId("workspace-kanban");
+    const card = board.getByRole("button", { name: "Open rename-me" });
+    await card.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Rename", exact: true }).click();
+
+    const input = board.locator("[data-kanban-card-rename-input]");
+    await expect(input).toBeFocused();
+    await input.fill("renamed from kanban");
+    await input.press("Enter");
+
+    await expect
+      .poll(async () =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __renameCalls?: unknown[] })
+              .__renameCalls?.length ?? 0,
+        ),
+      )
+      .toBe(1);
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __renameCalls?: unknown[] }).__renameCalls,
+    )) as Array<{ id: string; name: string }>;
+    expect(calls[0]).toEqual({
+      id: "rename-me",
+      name: "renamed from kanban",
+    });
+    await expect(
+      board.getByRole("button", { name: "Open renamed from kanban" }),
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary
This fixes the kanban session card menu so session names can be edited without switching back to pane mode.

1. **Kanban session actions** — add Rename and Regenerate Name to the kanban card context menu using the same session-title eligibility checks as pane/sidebar menus.
2. **Inline card rename** — replace the card's native button wrapper with an accessible role button so the rename input can live inside the card, with Enter/Space open behavior and F2 rename preserved.
3. **Regression coverage** — add Playwright coverage for the kanban context menu rename path and assert the `rename_session` invoke contract.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Kanban card context menu | No Rename / Regenerate Name entries | Session title actions are available directly from the card |
| Kanban session rename | Required leaving kanban or using another surface | Rename can be completed inline from the card menu |
| Pane mode | Existing tab rename/menu behavior | Unchanged |

## Design notes
- The kanban card now uses `role="button"` instead of a native `<button>` because the inline rename field is an interactive child. Keyboard activation is handled explicitly for Enter, Space, and F2.
- The card keeps kanban-only actions scoped to kanban and does not copy pane-only Layout/Close items into the card menu.
- Regenerate Name follows the existing `canRegenerateSessionTitle` and generating-title guard so disabled behavior matches other session menus.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test -- src/components/WorkspaceMain.test.tsx` — passes (80 files, 889 tests)
- [x] `pnpm exec playwright test tests/e2e/kanban.spec.ts` — passes (7 tests)
- [x] `git diff --check` — passes
