### PR TITLE
feat(workspace): show PR context on kanban cards

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -49,6 +49,7 @@ import { api, FS_CHANGED_EVENT, type FsChangePayload } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openFileInEditor } from "../lib/editor";
 import { joinPath } from "../lib/paths";
+import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
 import { rightPanelCache } from "../lib/right-panel-cache";
 import { classifyRightPanelFsChange } from "../lib/right-panel-invalidation";
 import { useSettings } from "../lib/settings";
@@ -4684,15 +4685,7 @@ function PrRow({
   /** Render CI/check status in the metadata row. */
   showChecks?: boolean;
 }) {
-  const upper = pr.state.toUpperCase();
-  const isDraft = pr.is_draft && upper === "OPEN";
-  const numberColor = isDraft
-    ? "text-fg-muted"
-    : upper === "OPEN"
-      ? "text-emerald-400"
-      : upper === "MERGED"
-        ? "text-purple-400"
-        : "text-rose-400";
+  const numberColor = pullRequestNumberClassName(pr);
   const meta =
     showBranches || showChecks ? (
       <span className="flex min-w-0 items-center gap-1">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -81,8 +81,6 @@ import {
   canRenameSession,
 } from "../lib/sessionTitle";
 import {
-  currentPullRequestSearchQuery,
-  findCurrentPullRequestForBranch,
   summarizeAllSessionProcesses,
   summarizeSessionProcesses,
 } from "../lib/sessionContext";
@@ -94,6 +92,7 @@ import {
 } from "../lib/sessionWorktree";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
+import { useCurrentPullRequest } from "../lib/useCurrentPullRequest";
 import { showWorktreeRemovalToast } from "../lib/operationToasts";
 import {
   buildLocalSessions,
@@ -137,6 +136,7 @@ import {
   planTitleClick,
   type ProjectClickPlan,
 } from "../lib/sidebar-actions";
+import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
 import type {
   Session,
   SessionAgentProvider,
@@ -197,16 +197,6 @@ const SESSION_FOLDER_DROP_PREFIX = `${SESSION_DRAG_PREFIX}folder:`;
 const SESSION_PROJECT_DROP_PREFIX = `${SESSION_DRAG_PREFIX}project:`;
 const LOCAL_SESSION_ROOT_DROP_ID = "__local-session-root__";
 const LOCAL_TERMINAL_AREA_SELECTOR = "[data-local-terminal-area='true']";
-const CURRENT_PR_CACHE_TTL_MS = 60_000;
-const CURRENT_PR_EMPTY_RETRY_MS = 15_000;
-
-type CurrentPullRequestCacheEntry = {
-  value: SessionPullRequestSummary | null;
-  expiresAt: number;
-  promise?: Promise<SessionPullRequestSummary | null>;
-};
-
-const currentPullRequestCache = new Map<string, CurrentPullRequestCacheEntry>();
 
 type SidebarTranslationKey = Extract<TranslationKey, `sidebar.${string}`>;
 
@@ -247,106 +237,6 @@ function contextMenuGroupTitle(
 
 function statusLabel(t: Translator, status: SessionStatus): string {
   return sidebarText(t, `sidebar.status.${status}`);
-}
-
-function currentPullRequestCacheKey(repoPath: string, branch: string): string {
-  return `${repoPath}\u0000${branch}`;
-}
-
-function loadCurrentPullRequest(
-  repoPath: string,
-  branch: string,
-): Promise<SessionPullRequestSummary | null> {
-  const key = currentPullRequestCacheKey(repoPath, branch);
-  const now = Date.now();
-  const cached = currentPullRequestCache.get(key);
-  if (cached && cached.expiresAt > now) {
-    return cached.promise ?? Promise.resolve(cached.value);
-  }
-
-  const query = currentPullRequestSearchQuery(branch);
-  if (!query) return Promise.resolve(null);
-
-  const promise = api
-    .listPullRequests(repoPath, "open", 10, query)
-    .then((listing) => findCurrentPullRequestForBranch(listing, branch))
-    .catch(() => null);
-
-  currentPullRequestCache.set(key, {
-    value: cached?.value ?? null,
-    expiresAt: now + CURRENT_PR_CACHE_TTL_MS,
-    promise,
-  });
-
-  return promise.then((value) => {
-    currentPullRequestCache.set(key, {
-      value,
-      expiresAt:
-        Date.now() +
-        (value ? CURRENT_PR_CACHE_TTL_MS : CURRENT_PR_EMPTY_RETRY_MS),
-    });
-    return value;
-  });
-}
-
-function useCurrentPullRequest(
-  session: Session,
-): SessionPullRequestSummary | null {
-  const branch = session.branch.trim();
-  const repoPath =
-    session.git_context_path?.trim() ||
-    session.worktree_path ||
-    session.repo_path;
-  const cacheKey = branch ? currentPullRequestCacheKey(repoPath, branch) : null;
-  const [lookupAttempt, setLookupAttempt] = useState(0);
-  const [currentPullRequest, setCurrentPullRequest] =
-    useState<SessionPullRequestSummary | null>(() =>
-      cacheKey ? (currentPullRequestCache.get(cacheKey)?.value ?? null) : null,
-    );
-
-  useEffect(() => {
-    const query = currentPullRequestSearchQuery(branch);
-    if (!branch || !cacheKey || !query) {
-      setCurrentPullRequest(null);
-      return;
-    }
-
-    let cancelled = false;
-    let retryTimer: number | null = null;
-    const scheduleEmptyRetry = (value: SessionPullRequestSummary | null) => {
-      if (value || cancelled) return;
-      retryTimer = window.setTimeout(() => {
-        if (!cancelled) setLookupAttempt((attempt) => attempt + 1);
-      }, CURRENT_PR_EMPTY_RETRY_MS);
-    };
-    const cached = currentPullRequestCache.get(cacheKey);
-    if (cached && cached.expiresAt > Date.now()) {
-      setCurrentPullRequest(cached.value);
-      if (!cached.promise) {
-        scheduleEmptyRetry(cached.value);
-        return () => {
-          cancelled = true;
-          if (retryTimer !== null) window.clearTimeout(retryTimer);
-        };
-      }
-    } else {
-      setCurrentPullRequest(cached?.value ?? null);
-    }
-
-    loadCurrentPullRequest(repoPath, branch).then((value) => {
-      if (!cancelled) {
-        setCurrentPullRequest(value);
-        scheduleEmptyRetry(value);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-      if (retryTimer !== null) window.clearTimeout(retryTimer);
-    };
-  }, [branch, cacheKey, lookupAttempt, repoPath]);
-
-  return currentPullRequest;
 }
 
 function isLocalTerminalAreaFocused(): boolean {
@@ -3307,6 +3197,9 @@ function SessionRowLabel({
   const inWorktree = liveInWorktree ?? hasRecordedWorktree(session);
   const processSummary = summarizeSessionProcesses(session.active_processes);
   const hasContextMetadata = Boolean(currentPullRequest || processSummary);
+  const pullRequestColor = currentPullRequest
+    ? pullRequestNumberClassName(currentPullRequest)
+    : null;
   const body = (
     <span className="min-w-0 flex-1">
       <span className="flex h-5 items-center gap-1">
@@ -3364,7 +3257,10 @@ function SessionRowLabel({
                   console.error("[Sidebar] open PR URL failed", err);
                 });
               }}
-              className="inline-flex shrink-0 items-center gap-0.5 rounded-sm text-accent underline-offset-2 transition hover:text-fg hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/60"
+              className={cn(
+                "inline-flex shrink-0 items-center gap-0.5 rounded-sm underline-offset-2 transition hover:text-fg hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/60",
+                pullRequestColor,
+              )}
             >
               <span>{`PR #${currentPullRequest.number}`}</span>
               <ExternalLink size={9} aria-hidden className="opacity-80" />
@@ -4664,9 +4560,10 @@ function buildSessionHoverDetails(
       {currentPullRequest ? (
         <SessionHoverDetailRow
           icon={<GitPullRequest size={12} />}
-          iconClassName="text-accent"
+          iconClassName={pullRequestNumberClassName(currentPullRequest)}
           label={sidebarText(t, "sidebar.metadata.openPullRequest")}
           value={`#${currentPullRequest.number} ${currentPullRequest.title}`}
+          valueClassName={pullRequestNumberClassName(currentPullRequest)}
         />
       ) : null}
       <SessionHoverDetailRow

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -13,14 +13,18 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import {
+  Activity,
   BarChart3,
   Bot,
   ChevronDown,
   Columns3,
   Copy,
+  ExternalLink,
   FolderOpen,
   GitBranch,
+  GitPullRequest,
   Maximize2,
   MessageSquareText,
   Minimize2,
@@ -40,6 +44,7 @@ import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
 import type { LayoutNode } from "../lib/layout";
 import { basename } from "../lib/pathUtils";
+import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import {
   PROJECT_SESSION_CREATE_MENU,
@@ -50,7 +55,16 @@ import {
   canRegenerateSessionTitle,
   canRenameSession,
 } from "../lib/sessionTitle";
-import type { Session, SessionStatus } from "../lib/types";
+import type {
+  Session,
+  SessionPullRequestSummary,
+  SessionStatus,
+} from "../lib/types";
+import {
+  summarizeAllSessionProcesses,
+  summarizeSessionProcesses,
+} from "../lib/sessionContext";
+import { useCurrentPullRequest } from "../lib/useCurrentPullRequest";
 import {
   AgentProviderIcon,
   resolveSessionAgentProvider,
@@ -793,6 +807,15 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
   const canRegenerateTitle =
     canRegenerateSessionTitle(session) && !isGeneratingTitle;
   const canConfigureAutoClose = canConfigureSessionAutoClose(session);
+  const currentPullRequest = useCurrentPullRequest(session);
+  const processSummary = summarizeSessionProcesses(session.active_processes);
+  const processTooltipSummary = summarizeAllSessionProcesses(
+    session.active_processes,
+  );
+  const hasContextMetadata = Boolean(currentPullRequest || processSummary);
+  const pullRequestColor = currentPullRequest
+    ? pullRequestNumberClassName(currentPullRequest)
+    : null;
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const openLabel = t("workspace.kanban.openSession").replace(
@@ -997,6 +1020,8 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
             branch={branchName}
             worktreeName={worktreeName}
             worktreePath={session.worktree_path}
+            currentPullRequest={currentPullRequest}
+            processSummary={processTooltipSummary}
           />
         }
         side="right"
@@ -1047,6 +1072,52 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
               data-testid="workspace-kanban-card-last-message"
             >
               {lastMessage}
+            </span>
+          ) : null}
+          {hasContextMetadata ? (
+            <span
+              className="flex min-w-0 items-center gap-1 text-[10px] leading-none text-fg-muted"
+              data-testid="workspace-kanban-card-context"
+            >
+              {currentPullRequest ? (
+                <button
+                  type="button"
+                  aria-label={`${sidebarText(t, "sidebar.metadata.openPullRequest")} #${currentPullRequest.number}`}
+                  title={currentPullRequest.title}
+                  onMouseDown={(event) => event.stopPropagation()}
+                  onPointerDown={(event) => event.stopPropagation()}
+                  onKeyDown={(event) => event.stopPropagation()}
+                  onKeyUp={(event) => event.stopPropagation()}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void openUrl(currentPullRequest.url).catch(
+                      (err: unknown) => {
+                        console.error(
+                          "[WorkspaceMain] open PR URL failed",
+                          err,
+                        );
+                      },
+                    );
+                  }}
+                  className={cn(
+                    "inline-flex min-w-0 shrink-0 items-center gap-0.5 rounded-sm underline-offset-2 transition hover:text-fg hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/60",
+                    pullRequestColor,
+                  )}
+                >
+                  <span>{`PR #${currentPullRequest.number}`}</span>
+                  <ExternalLink size={9} aria-hidden className="opacity-80" />
+                </button>
+              ) : null}
+              {currentPullRequest && processSummary ? (
+                <span aria-hidden className="shrink-0 text-fg-muted/70">
+                  ·
+                </span>
+              ) : null}
+              {processSummary ? (
+                <span className="min-w-0 truncate font-mono">
+                  {processSummary}
+                </span>
+              ) : null}
             </span>
           ) : null}
           <span
@@ -1619,6 +1690,8 @@ function KanbanSessionCardTooltip({
   branch,
   worktreeName,
   worktreePath,
+  currentPullRequest,
+  processSummary,
 }: {
   t: Translator;
   title: string;
@@ -1626,6 +1699,8 @@ function KanbanSessionCardTooltip({
   branch?: string;
   worktreeName: string;
   worktreePath: string;
+  currentPullRequest?: SessionPullRequestSummary | null;
+  processSummary?: string | null;
 }) {
   const detached = t("workspace.kanban.tooltip.detached");
   return (
@@ -1647,12 +1722,28 @@ function KanbanSessionCardTooltip({
         value={branch || detached}
         valueClassName="font-mono"
       />
+      {currentPullRequest ? (
+        <KanbanSessionTooltipRow
+          icon={<GitPullRequest size={12} />}
+          label={sidebarText(t, "sidebar.metadata.openPullRequest")}
+          value={`#${currentPullRequest.number} ${currentPullRequest.title}`}
+          valueClassName={pullRequestNumberClassName(currentPullRequest)}
+        />
+      ) : null}
       <KanbanSessionTooltipRow
         icon={<FolderOpen size={12} />}
         label={t("workspace.kanban.tooltip.worktree")}
         value={`${worktreeName}\n${worktreePath}`}
         valueClassName="break-all font-mono"
       />
+      {processSummary ? (
+        <KanbanSessionTooltipRow
+          icon={<Activity size={12} />}
+          label={sidebarText(t, "sidebar.metadata.processes")}
+          value={processSummary}
+          valueClassName="font-mono"
+        />
+      ) : null}
     </span>
   );
 }

--- a/src/lib/pullRequestPresentation.test.ts
+++ b/src/lib/pullRequestPresentation.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { pullRequestNumberClassName } from "./pullRequestPresentation";
+
+describe("pull request presentation", () => {
+  it("uses the right-panel number colors for PR states", () => {
+    expect(
+      pullRequestNumberClassName({ state: "OPEN", is_draft: false }),
+    ).toBe("text-emerald-400");
+    expect(
+      pullRequestNumberClassName({ state: "OPEN", is_draft: true }),
+    ).toBe("text-fg-muted");
+    expect(
+      pullRequestNumberClassName({ state: "MERGED", is_draft: false }),
+    ).toBe("text-purple-400");
+    expect(
+      pullRequestNumberClassName({ state: "CLOSED", is_draft: false }),
+    ).toBe("text-rose-400");
+  });
+});

--- a/src/lib/pullRequestPresentation.ts
+++ b/src/lib/pullRequestPresentation.ts
@@ -1,0 +1,14 @@
+export interface PullRequestStateLike {
+  state: string;
+  is_draft: boolean;
+}
+
+export function pullRequestNumberClassName(
+  pr: PullRequestStateLike,
+): string {
+  const upper = pr.state.toUpperCase();
+  if (pr.is_draft && upper === "OPEN") return "text-fg-muted";
+  if (upper === "OPEN") return "text-emerald-400";
+  if (upper === "MERGED") return "text-purple-400";
+  return "text-rose-400";
+}

--- a/src/lib/sessionContext.test.ts
+++ b/src/lib/sessionContext.test.ts
@@ -57,6 +57,7 @@ describe("session context helpers", () => {
       url: "https://github.com/im-ian/acorn/pull/42",
       head_branch: "feature/sidebar-prs",
       base_branch: "main",
+      state: "OPEN",
       is_draft: false,
     });
   });

--- a/src/lib/sessionContext.ts
+++ b/src/lib/sessionContext.ts
@@ -38,6 +38,7 @@ export function findCurrentPullRequestForBranch(
     url: pr.url,
     head_branch: pr.head_branch,
     base_branch: pr.base_branch,
+    state: pr.state,
     is_draft: pr.is_draft,
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -456,6 +456,7 @@ export interface SessionPullRequestSummary {
   url: string;
   head_branch: string;
   base_branch: string;
+  state: string;
   is_draft: boolean;
 }
 

--- a/src/lib/useCurrentPullRequest.ts
+++ b/src/lib/useCurrentPullRequest.ts
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+import { api } from "./api";
+import {
+  currentPullRequestSearchQuery,
+  findCurrentPullRequestForBranch,
+} from "./sessionContext";
+import type { Session, SessionPullRequestSummary } from "./types";
+
+const CURRENT_PR_CACHE_TTL_MS = 60_000;
+const CURRENT_PR_EMPTY_RETRY_MS = 15_000;
+
+type CurrentPullRequestCacheEntry = {
+  value: SessionPullRequestSummary | null;
+  expiresAt: number;
+  promise?: Promise<SessionPullRequestSummary | null>;
+};
+
+const currentPullRequestCache = new Map<string, CurrentPullRequestCacheEntry>();
+
+function currentPullRequestCacheKey(repoPath: string, branch: string): string {
+  return `${repoPath}\u0000${branch}`;
+}
+
+function currentPullRequestRepoPath(session: Session): string {
+  return (
+    session.git_context_path?.trim() ||
+    session.worktree_path ||
+    session.repo_path
+  );
+}
+
+function loadCurrentPullRequest(
+  repoPath: string,
+  branch: string,
+): Promise<SessionPullRequestSummary | null> {
+  const key = currentPullRequestCacheKey(repoPath, branch);
+  const now = Date.now();
+  const cached = currentPullRequestCache.get(key);
+  if (cached && cached.expiresAt > now) {
+    return cached.promise ?? Promise.resolve(cached.value);
+  }
+
+  const query = currentPullRequestSearchQuery(branch);
+  if (!query) return Promise.resolve(null);
+
+  const promise = api
+    .listPullRequests(repoPath, "open", 10, query)
+    .then((listing) => findCurrentPullRequestForBranch(listing, branch))
+    .catch(() => null);
+
+  currentPullRequestCache.set(key, {
+    value: cached?.value ?? null,
+    expiresAt: now + CURRENT_PR_CACHE_TTL_MS,
+    promise,
+  });
+
+  return promise.then((value) => {
+    currentPullRequestCache.set(key, {
+      value,
+      expiresAt:
+        Date.now() +
+        (value ? CURRENT_PR_CACHE_TTL_MS : CURRENT_PR_EMPTY_RETRY_MS),
+    });
+    return value;
+  });
+}
+
+export function useCurrentPullRequest(
+  session: Session,
+): SessionPullRequestSummary | null {
+  const branch = session.branch.trim();
+  const repoPath = currentPullRequestRepoPath(session);
+  const cacheKey = branch ? currentPullRequestCacheKey(repoPath, branch) : null;
+  const [lookupAttempt, setLookupAttempt] = useState(0);
+  const [currentPullRequest, setCurrentPullRequest] =
+    useState<SessionPullRequestSummary | null>(() =>
+      cacheKey ? (currentPullRequestCache.get(cacheKey)?.value ?? null) : null,
+    );
+
+  useEffect(() => {
+    const query = currentPullRequestSearchQuery(branch);
+    if (!branch || !cacheKey || !query) {
+      setCurrentPullRequest(null);
+      return;
+    }
+
+    let cancelled = false;
+    let retryTimer: number | null = null;
+    const scheduleEmptyRetry = (value: SessionPullRequestSummary | null) => {
+      if (value || cancelled) return;
+      retryTimer = window.setTimeout(() => {
+        if (!cancelled) setLookupAttempt((attempt) => attempt + 1);
+      }, CURRENT_PR_EMPTY_RETRY_MS);
+    };
+    const cached = currentPullRequestCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      setCurrentPullRequest(cached.value);
+      if (!cached.promise) {
+        scheduleEmptyRetry(cached.value);
+        return () => {
+          cancelled = true;
+          if (retryTimer !== null) window.clearTimeout(retryTimer);
+        };
+      }
+    } else {
+      setCurrentPullRequest(cached?.value ?? null);
+    }
+
+    loadCurrentPullRequest(repoPath, branch).then((value) => {
+      if (!cancelled) {
+        setCurrentPullRequest(value);
+        scheduleEmptyRetry(value);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      if (retryTimer !== null) window.clearTimeout(retryTimer);
+    };
+  }, [branch, cacheKey, lookupAttempt, repoPath]);
+
+  return currentPullRequest;
+}

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -78,19 +78,62 @@ test.describe("workspace kanban mode", () => {
         shell: "ready",
         broken: "errored",
       };
-      return ids.map((id) => ({
-        id,
-        status: statuses[id] ?? "ready",
-        branch: id === "shell" ? "shell" : `feat/${id}`,
-        last_message:
-          id === "broken"
-            ? "Updated from status polling."
-            : null,
-        last_user_message:
-          id === "broken" ? "Please check the failed tests." : null,
-        last_agent_message:
-          id === "broken" ? "Updated from status polling." : null,
-      }));
+      return ids.map((id) => {
+        const update: Record<string, unknown> = {
+          id,
+          status: statuses[id] ?? "ready",
+          branch: id === "shell" ? "shell" : `feat/${id}`,
+          last_message:
+            id === "broken"
+              ? "Updated from status polling."
+              : null,
+          last_user_message:
+            id === "broken" ? "Please check the failed tests." : null,
+          last_agent_message:
+            id === "broken" ? "Updated from status polling." : null,
+        };
+        if (id === "runner") {
+          update.git_context_path = "/tmp/demo-live-worktree";
+          update.active_processes = [
+            { pid: 11, name: "codex", depth: 2 },
+            { pid: 12, name: "rg", depth: 3 },
+            { pid: 13, name: "node", depth: 3 },
+          ];
+        }
+        return update;
+      });
+    });
+    await tauri.handle("list_pull_requests", (args) => {
+      if (args?.query !== "head:feat/runner") {
+        return { kind: "ok", items: [], account: "test" };
+      }
+      return {
+        kind: "ok",
+        account: "test",
+        items: [
+          {
+            number: 77,
+            title: "Add kanban PR context",
+            state: "OPEN",
+            author: "ian",
+            head_branch: "feat/runner",
+            base_branch: "main",
+            url: "https://github.com/im-ian/acorn/pull/77",
+            updated_at: "2026-01-01T00:00:00Z",
+            is_draft: false,
+            checks: null,
+            labels: [],
+          },
+        ],
+      };
+    });
+    await tauri.handle("plugin:opener|open_url", (args) => {
+      const w = window as unknown as {
+        __openUrlCalls?: Array<{ url?: string }>;
+      };
+      w.__openUrlCalls = w.__openUrlCalls ?? [];
+      w.__openUrlCalls.push(args as { url?: string });
+      return null;
     });
 
     await page.goto("/");
@@ -231,6 +274,36 @@ test.describe("workspace kanban mode", () => {
         .locator('[data-kanban-session-id="runner"]')
         .locator('[data-kanban-agent-icon="codex"]'),
     ).toBeVisible();
+    const runnerCard = board.locator('[data-kanban-session-id="runner"]');
+    const runnerContext = runnerCard.getByTestId(
+      "workspace-kanban-card-context",
+    );
+    await expect(runnerContext).toHaveText(/PR #77\s*·\s*codex, rg \+1/);
+    const runnerPrButton = runnerContext.getByRole("button", {
+      name: "Open PR #77",
+    });
+    await expect(runnerPrButton).toBeVisible();
+    await expect(runnerPrButton).toHaveClass(/text-emerald-400/);
+    await runnerPrButton.click();
+    const openedUrls = await page.evaluate(
+      () =>
+        (
+          (window as unknown as {
+            __openUrlCalls?: Array<{ url?: string }>;
+          }).__openUrlCalls ?? []
+        ).map((call) => call.url),
+    );
+    expect(openedUrls).toEqual([
+      "https://github.com/im-ian/acorn/pull/77",
+    ]);
+    await runnerCard.hover();
+    const runnerTooltip = page.getByRole("tooltip");
+    await expect(runnerTooltip).toContainText("Open PR");
+    await expect(runnerTooltip).toContainText("#77 Add kanban PR context");
+    await expect(runnerTooltip).toContainText("Processes");
+    await expect(runnerTooltip).toContainText("codex, rg, node");
+    await page.mouse.move(0, 0);
+    await expect(runnerTooltip).toHaveCount(0);
     await expect(
       board
         .locator('[data-kanban-session-id="shell"]')

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -561,6 +561,7 @@ test.describe("sidebar: project lifecycle", () => {
       name: "Open PR #99",
     });
     await expect(prButton).toBeVisible();
+    await expect(prButton).toHaveClass(/text-emerald-400/);
     await prButton.click();
     const openedUrls = await page.evaluate(
       () =>


### PR DESCRIPTION
## Summary
Adds sidebar-style pull request context to workspace kanban cards so active work keeps its GitHub state visible outside the sidebar.

1. **Kanban PR context** — render `PR #N` plus live process summary on kanban session cards, matching the sidebar context row and opening the PR URL when clicked.
2. **Shared PR lookup** — move current-branch PR lookup and cache logic into a shared hook used by both the sidebar and kanban cards.
3. **Status-colored PR numbers** — reuse the GitHub PRs row color rules for sidebar and kanban PR indicators: draft muted, open emerald, merged purple, closed rose.
4. **Hover details** — add PR title and full process list to kanban card hover tooltips.

## Expected impact
| Surface | Before | After |
| --- | --- | --- |
| Workspace kanban cards | Branch/worktree only | Shows open PR number and active process summary |
| Kanban card tooltip | Title, message, branch, worktree | Also shows PR title and full process list |
| PR indicators | Sidebar fixed accent color | Sidebar and kanban use GitHub PR state colors |

## Design notes
- `useCurrentPullRequest` preserves the existing sidebar query/cache behavior while making it reusable from kanban cards.
- `pullRequestNumberClassName` centralizes the color mapping previously embedded in the right-panel PR row, so right panel, sidebar, and kanban stay aligned.
- `SessionPullRequestSummary` now carries `state` so non-row surfaces can apply the same presentation rule without depending on the full PR listing shape.

## Test plan
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec vitest run src/lib/pullRequestPresentation.test.ts src/lib/sessionContext.test.ts` — 2 files, 5 tests passed
- [x] `pnpm exec vitest run src/components/RightPanel.test.tsx` — 1 file, 17 tests passed
- [x] `pnpm exec playwright test tests/e2e/kanban.spec.ts -g "groups active workspace sessions by status and opens a card terminal popover"` — 1 test passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "session rows surface open PR and active process context"` — 1 test passed
- [x] `git diff --check` — passed

## Notes
- Playwright emitted existing `NO_COLOR` / `FORCE_COLOR` warnings from the web server process; tests still passed.
