### PR TITLE
fix(kanban): keep settings edits from closing terminal popover

### DIFF
--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -1344,6 +1344,7 @@ function KanbanTerminalPopover({
       if (!(target instanceof Node)) return;
       if (popoverRef.current?.contains(target)) return;
       if (anchor.contains(target)) return;
+      if (isModalDialogOpen()) return;
       onClose();
     };
     document.addEventListener("pointerdown", handlePointerDown, true);
@@ -1590,6 +1591,10 @@ function KanbanTerminalPopover({
   );
 
   return createPortal(popover, document.body);
+}
+
+function isModalDialogOpen(): boolean {
+  return document.querySelector('[role="dialog"][aria-modal="true"]') !== null;
 }
 
 function defaultKanbanTerminalPopoverSize(): KanbanTerminalPopoverSize {

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "./support";
+import { test, expect, pressHotkey } from "./support";
 
 const PROJECT = {
   repo_path: "/tmp/demo",
@@ -728,6 +728,61 @@ test.describe("workspace kanban mode", () => {
     expect(Math.abs(box.y + box.height / 2 - viewport.height / 2)).toBeLessThan(
       8,
     );
+  });
+
+  test("keeps a terminal popover open while editing settings", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("settings-popover", "settings-popover", "ready"),
+    ]);
+
+    await page.goto("/");
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+    await page
+      .getByTestId("workspace-kanban")
+      .getByRole("button", { name: "Open settings-popover" })
+      .click();
+
+    const popover = page.getByTestId("kanban-terminal-popover");
+    await expect(popover).toBeVisible();
+
+    await pressHotkey(page, { mod: true, key: "," });
+    const modal = page.getByRole("dialog", { name: /^(Settings|설정)$/ });
+    await expect(modal).toBeVisible();
+
+    await modal
+      .getByRole("combobox", { name: "Default workspace mode" })
+      .click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+    await expect(popover).toBeVisible();
+
+    await modal.getByText("Center of screen", { exact: true }).click();
+    await modal.getByText("Full screen", { exact: true }).click();
+    await expect(popover).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("acorn:settings:v1");
+          const settings = raw ? JSON.parse(raw) : null;
+          return {
+            defaultMode:
+              settings?.interface?.defaultWorkspaceViewMode ?? null,
+            placement:
+              settings?.interface?.kanbanTerminalPopoverPlacement ?? null,
+            defaultSize:
+              settings?.interface?.kanbanTerminalPopoverDefaultSize ?? null,
+          };
+        }),
+      )
+      .toEqual({
+        defaultMode: "kanban",
+        placement: "center",
+        defaultSize: "fullscreen",
+      });
   });
 
   test("uses configured fullscreen kanban terminal popover size", async ({


### PR DESCRIPTION
## Summary
Settings interactions no longer dismiss the kanban terminal popover behind the modal.

1. **Modal-aware popover dismissal** — keep the kanban terminal popover open while any top-level modal dialog is active, so Settings owns pointer interactions until it closes.
2. **Regression coverage** — add a kanban E2E flow that opens Settings over a terminal popover, changes a portaled Select option, changes radio-card settings, and verifies the popover remains visible.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Kanban terminal popover + Settings | Clicking Settings controls could close the terminal popover behind the modal. | Settings edits leave the background terminal popover open. |
| Normal kanban outside-click dismissal | Outside clicks closed the popover. | Unchanged when no modal dialog is open. |

## Design notes
- The popover outside-click listener already ignored clicks inside the popover and its kanban-card anchor. It now also ignores outside clicks while an `aria-modal` dialog is present.
- This covers both regular Settings content and Settings controls whose popups are portaled to `document.body`, such as the default workspace mode Select listbox.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test:e2e -- tests/e2e/kanban.spec.ts -g "keeps a terminal popover open while editing settings"` passes
- [x] `pnpm run test:e2e -- tests/e2e/settings.spec.ts` passes
