### PR TITLE
fix(settings): normalize terminal line height updates

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -73,6 +73,9 @@ import {
   TERMINAL_LETTER_SPACING_MAX,
   TERMINAL_LETTER_SPACING_MIN,
   TERMINAL_LETTER_SPACING_STEP,
+  TERMINAL_LINE_HEIGHT_MAX,
+  TERMINAL_LINE_HEIGHT_MIN,
+  TERMINAL_LINE_HEIGHT_STEP,
   TOAST_POSITION_OPTIONS,
   type KanbanTerminalPopoverDefaultSize,
   type KanbanTerminalPopoverPlacement,
@@ -649,9 +652,9 @@ function TerminalSettings() {
       >
         <Stepper
           value={settings.terminal.lineHeight}
-          min={1.0}
-          max={2.0}
-          step={0.05}
+          min={TERMINAL_LINE_HEIGHT_MIN}
+          max={TERMINAL_LINE_HEIGHT_MAX}
+          step={TERMINAL_LINE_HEIGHT_STEP}
           format={(n) => n.toFixed(2)}
           onChange={(n) => patchTerminal({ lineHeight: n })}
         />

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -14,6 +14,9 @@ import {
   TERMINAL_LETTER_SPACING_MAX,
   TERMINAL_LETTER_SPACING_MIN,
   TERMINAL_LETTER_SPACING_STEP,
+  TERMINAL_LINE_HEIGHT_MAX,
+  TERMINAL_LINE_HEIGHT_MIN,
+  TERMINAL_LINE_HEIGHT_STEP,
   resolveAiCommitRequest,
   resolveAiExecutionRequest,
   resolveSessionTitlePrompt,
@@ -609,6 +612,81 @@ describe("terminal.letterSpacing settings", () => {
 
   it("uses a fractional UI step for terminal letter spacing", () => {
     expect(TERMINAL_LETTER_SPACING_STEP).toBe(0.25);
+  });
+});
+
+describe("terminal.lineHeight settings", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("defaults to stock xterm line height", () => {
+    expect(DEFAULT_SETTINGS.terminal.lineHeight).toBe(1.0);
+  });
+
+  it("loads persisted line height and clamps it", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ terminal: { lineHeight: 1.35 } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.terminal.lineHeight).toBe(1.35);
+  });
+
+  it("clamps out-of-range persisted line height", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ terminal: { lineHeight: 99 } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.terminal.lineHeight).toBe(
+      TERMINAL_LINE_HEIGHT_MAX,
+    );
+  });
+
+  it("preserves patched decimal line height inside the supported range", async () => {
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    useSettings
+      .getState()
+      .patchTerminal({ lineHeight: TERMINAL_LINE_HEIGHT_MIN - 0.4 });
+    expect(useSettings.getState().settings.terminal.lineHeight).toBe(
+      TERMINAL_LINE_HEIGHT_MIN,
+    );
+
+    useSettings.getState().patchTerminal({ lineHeight: 1.375 });
+    expect(useSettings.getState().settings.terminal.lineHeight).toBe(1.38);
+  });
+
+  it("uses a fractional UI step for terminal line height", () => {
+    expect(TERMINAL_LINE_HEIGHT_STEP).toBe(0.05);
   });
 });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -125,6 +125,9 @@ export const TERMINAL_FONT_SIZE_STEP = 0.25;
 export const TERMINAL_LETTER_SPACING_MIN = -2;
 export const TERMINAL_LETTER_SPACING_MAX = 6;
 export const TERMINAL_LETTER_SPACING_STEP = 0.25;
+export const TERMINAL_LINE_HEIGHT_MIN = 1.0;
+export const TERMINAL_LINE_HEIGHT_MAX = 2.0;
+export const TERMINAL_LINE_HEIGHT_STEP = 0.05;
 
 export type ToastPosition = "top" | "bottom";
 export type DefaultWorkspaceViewMode = "panes" | "kanban";
@@ -691,7 +694,11 @@ function normalizeLineHeight(v: unknown, fallback: number): number {
   if (typeof v !== "number" || !Number.isFinite(v)) return fallback;
   // Clamp to the same range the Stepper enforces in the UI so a hand-
   // edited localStorage value can't make the terminal unusable.
-  return Math.max(1.0, Math.min(2.0, v));
+  const clamped = Math.max(
+    TERMINAL_LINE_HEIGHT_MIN,
+    Math.min(TERMINAL_LINE_HEIGHT_MAX, v),
+  );
+  return Math.round(clamped * 100) / 100;
 }
 
 export function normalizeTerminalFontSize(
@@ -1371,6 +1378,13 @@ export const useSettings = create<SettingsState>((set, get) => ({
               : normalizeTerminalFontSmoothing(
                   patch.fontSmoothing,
                   s.settings.terminal.fontSmoothing,
+                ),
+          lineHeight:
+            patch.lineHeight === undefined
+              ? s.settings.terminal.lineHeight
+              : normalizeLineHeight(
+                  patch.lineHeight,
+                  s.settings.terminal.lineHeight,
                 ),
           rightClickPasteSelection:
             patch.rightClickPasteSelection === undefined

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -61,6 +61,31 @@ test.describe("settings modal", () => {
       .toBe(0.75);
   });
 
+  test("adjusts terminal line height and persists it", async ({ page }) => {
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "," });
+
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
+    await modal.getByRole("button", { name: /^(Terminal|터미널)$/ }).click();
+
+    const field = modal.getByText("Line height", { exact: true }).locator("..");
+    const valueInput = field.getByRole("textbox", { name: /^(Value|값)$/ });
+    await expect(valueInput).toHaveValue("1.00");
+
+    await valueInput.fill("1.35");
+    await valueInput.press("Enter");
+
+    await expect(valueInput).toHaveValue("1.35");
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("acorn:settings:v1");
+          return raw ? JSON.parse(raw).terminal?.lineHeight : null;
+        }),
+      )
+      .toBe(1.35);
+  });
+
   test("changes terminal anti-aliasing and persists it", async ({ page }) => {
     await page.goto("/");
     await pressHotkey(page, { mod: true, key: "," });

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -649,6 +649,34 @@ test.describe("terminal: spawn", () => {
       .toBe("subpixel-antialiased");
   });
 
+  test("applies terminal line height setting to xterm rows", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({ terminal: { fontSize: 20, lineHeight: 2 } }),
+      );
+    });
+    await seedWritableTerminal(tauri);
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+
+    const firstRow = page
+      .locator("[data-pane-body] .xterm-rows > div")
+      .first();
+    await firstRow.waitFor({ state: "attached" });
+    await expect
+      .poll(() =>
+        firstRow.evaluate((element) => element.getBoundingClientRect().height),
+      )
+      .toBeGreaterThan(30);
+  });
+
   test("normalizes no-break spaces when pasting shell commands", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Tighten the terminal line-height setting so every settings entry point enforces the same safe range.

1. **Shared bounds** — expose terminal line-height min/max/step constants from the settings model and reuse them in the Settings modal.
2. **Patch normalization** — run `patchTerminal({ lineHeight })` through the same clamp/round path used when loading persisted settings.
3. **Regression coverage** — add store, Settings modal, and xterm row-height checks for persisted and rendered line-height behavior.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal line-height setting | UI constrained values, but direct settings patches could persist unsupported values | UI, persisted settings, and patch updates share the same 1.00-2.00 range |
| Regression coverage | Font size / letter spacing had focused coverage; line height did not | Unit and E2E coverage checks persistence, UI updates, and xterm row rendering |

## Design notes
- The default remains `1.0`, matching xterm's stock row packing.
- The Settings UI keeps the existing `0.05` step and now imports the same constants used by the settings normalizer.
- The xterm integration already applied `terminal.lineHeight`; this PR closes the validation/test gap around that path.

## Test plan
- [x] `pnpm exec vitest run src/lib/settings.test.ts` — 85 tests passed
- [x] `pnpm exec tsc --noEmit` — passed
- [x] `pnpm exec playwright test tests/e2e/settings.spec.ts tests/e2e/terminal.spec.ts -g "line height"` — 2 tests passed
- [x] `pnpm run build` — passed

## Notes
- `pnpm run build` still emits the existing Vite dynamic-import/chunk-size warnings; the build completed successfully.