### PR TITLE
fix(terminal): preserve fractional letter spacing

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -33,7 +33,6 @@ import {
 import { registerScrollbackFlusher } from "../lib/scrollback-coordinator";
 import {
   patchTerminalCellMeasurements,
-  unpatchTerminalCellMeasurements,
 } from "../lib/terminal-cjk-cell-width-addon";
 import {
   createTerminalRepaintScheduler,
@@ -901,9 +900,13 @@ export function Terminal({
     const fitWithCellMeasurements = () => {
       const cjkEnabled =
         useSettings.getState().settings.experiments.cjkCellWidthHeuristic;
-      if (cjkEnabled) patchTerminalCellMeasurements(term);
+      patchTerminalCellMeasurements(term, {
+        cjkCellWidthHeuristic: cjkEnabled,
+      });
       fitAddon.fit();
-      if (cjkEnabled) patchTerminalCellMeasurements(term);
+      patchTerminalCellMeasurements(term, {
+        cjkCellWidthHeuristic: cjkEnabled,
+      });
     };
     fitTerminalRef.current = fitWithCellMeasurements;
     try {
@@ -1074,11 +1077,9 @@ export function Terminal({
       const cjkNow = state.settings.experiments.cjkCellWidthHeuristic;
       const cjkPrev = prev.settings.experiments.cjkCellWidthHeuristic;
       if (cjkNow !== cjkPrev) {
-        if (cjkNow) {
-          patchTerminalCellMeasurements(term);
-        } else {
-          unpatchTerminalCellMeasurements(term);
-        }
+        patchTerminalCellMeasurements(term, {
+          cjkCellWidthHeuristic: cjkNow,
+        });
       }
       const nextBackground = state.settings.appearance.background;
       const previousBackground = prev.settings.appearance.background;

--- a/src/lib/terminal-cjk-cell-width-addon.test.ts
+++ b/src/lib/terminal-cjk-cell-width-addon.test.ts
@@ -5,6 +5,112 @@ import {
 } from "./terminal-cjk-cell-width-addon";
 
 describe("terminal CJK cell width patch", () => {
+  it("applies fractional letter spacing when CJK calibration is disabled", () => {
+    const rowContainer = document.createElement("div");
+    const rowFactory = {};
+    const rowElement = document.createElement("div");
+    const renderer = {
+      _rowContainer: rowContainer,
+      _rowFactory: rowFactory,
+      _rowElements: [rowElement],
+      _widthCache: {
+        clear: () => undefined,
+        get: (chars: string, _bold: boolean | number, _italic: boolean | number) => {
+          if (chars === "W") return 8;
+          if (chars === "가") return 16;
+          return 8;
+        },
+      },
+      dimensions: { css: { cell: { width: 8 }, canvas: { width: 48 } } },
+    };
+    const terminal = {
+      cols: 6,
+      options: { letterSpacing: -0.25 },
+      _core: {
+        _renderService: { _renderer: { value: renderer } },
+      },
+    };
+
+    patchTerminalCellMeasurements(terminal, {
+      cjkCellWidthHeuristic: false,
+    });
+
+    expect(renderer.dimensions.css.cell.width).toBe(7.75);
+    expect(renderer.dimensions.css.canvas.width).toBe(46.5);
+    expect(rowElement.style.width).toBe("46.5px");
+    expect(rowContainer.style.letterSpacing).toBe("-0.25px");
+    expect(rowFactory).toMatchObject({ defaultSpacing: -0.25 });
+  });
+
+  it("preserves xterm's default spacing correction when applying fractional letter spacing", () => {
+    const rowContainer = document.createElement("div");
+    const rowFactory = {};
+    const rowElement = document.createElement("div");
+    const renderer = {
+      _rowContainer: rowContainer,
+      _rowFactory: rowFactory,
+      _rowElements: [rowElement],
+      _widthCache: {
+        clear: () => undefined,
+        get: (chars: string, _bold: boolean | number, _italic: boolean | number) => {
+          if (chars === "W") return 8;
+          if (chars === "가") return 16;
+          return 8;
+        },
+      },
+      dimensions: { css: { cell: { width: 8.5 }, canvas: { width: 51 } } },
+    };
+    const terminal = {
+      cols: 6,
+      options: { letterSpacing: -0.25 },
+      _core: {
+        _renderService: { _renderer: { value: renderer } },
+      },
+    };
+
+    patchTerminalCellMeasurements(terminal, {
+      cjkCellWidthHeuristic: false,
+    });
+
+    expect(renderer.dimensions.css.cell.width).toBe(8.25);
+    expect(renderer.dimensions.css.canvas.width).toBe(49.5);
+    expect(rowElement.style.width).toBe("49.5px");
+    expect(rowContainer.style.letterSpacing).toBe("0.25px");
+    expect(rowFactory).toMatchObject({ defaultSpacing: 0.25 });
+  });
+
+  it("skips CJK half-width calibration when the heuristic is disabled", () => {
+    const rowContainer = document.createElement("div");
+    const rowFactory = {};
+    const renderer = {
+      _rowContainer: rowContainer,
+      _rowFactory: rowFactory,
+      _widthCache: {
+        clear: () => undefined,
+        get: (chars: string, _bold: boolean | number, _italic: boolean | number) =>
+          chars === "W" || chars === "가" ? 8 : 8,
+      },
+      dimensions: { css: { cell: { width: 8 }, canvas: { width: 48 } } },
+    };
+    const terminal = {
+      cols: 6,
+      options: { letterSpacing: 0 },
+      _core: {
+        _renderService: { _renderer: { value: renderer } },
+      },
+    };
+
+    patchTerminalCellMeasurements(terminal, {
+      cjkCellWidthHeuristic: false,
+    });
+
+    expect(renderer).not.toHaveProperty("__acornCjkCellPatch");
+    expect(renderer.dimensions.css.cell.width).toBe(8);
+    expect(renderer.dimensions.css.canvas.width).toBe(48);
+    expect(rowContainer.style.letterSpacing).toBe("");
+    expect(rowFactory).not.toHaveProperty("defaultSpacing");
+  });
+
   it("treats differing W and Hangul measurements as ASCII and leaves spacing untouched", () => {
     const rowContainer = document.createElement("div");
     const rowFactory = {};
@@ -392,10 +498,10 @@ describe("terminal CJK cell width patch", () => {
     wideGlyphWidth = 16;
     patchTerminalCellMeasurements(terminal);
 
-    expect(rowContainer.style.letterSpacing).toBe("0px");
-    expect(rowFactory).toMatchObject({ defaultSpacing: 0 });
-    expect(renderer.dimensions.css.cell.width).toBe(7);
-    expect(renderer.dimensions.css.canvas.width).toBe(42);
+    expect(rowContainer.style.letterSpacing).toBe("1px");
+    expect(rowFactory).toMatchObject({ defaultSpacing: 1 });
+    expect(renderer.dimensions.css.cell.width).toBe(8);
+    expect(renderer.dimensions.css.canvas.width).toBe(48);
   });
 
   it("recovers global cell width from the legacy CJK basis patch when auto patching", () => {

--- a/src/lib/terminal-cjk-cell-width-addon.ts
+++ b/src/lib/terminal-cjk-cell-width-addon.ts
@@ -13,6 +13,7 @@ interface DomRenderer {
   __acornCjkCellPatch?: {
     originalSetDefaultSpacing?: () => void;
     originalHandleResize?: (cols: number, rows: number) => void;
+    cjkCellWidthHeuristic?: boolean;
     // Legacy fields from the previous CJK-basis implementation. Keep reading
     // them so dev/HMR sessions can recover without recreating the terminal.
     originalCellWidth?: number;
@@ -50,8 +51,16 @@ interface TerminalInternals {
 }
 
 const CELL_WIDTH_EPSILON = 0.25;
+const PATCH_WIDTH_EPSILON = 0.001;
 
-export function patchTerminalCellMeasurements(term: TerminalInternals): void {
+interface CellMeasurementPatchOptions {
+  cjkCellWidthHeuristic?: boolean;
+}
+
+export function patchTerminalCellMeasurements(
+  term: TerminalInternals,
+  options: CellMeasurementPatchOptions = {},
+): void {
   const renderer = term._core?._renderService?._renderer?.value;
   const widthCache = renderer?._widthCache;
   if (!renderer || !widthCache || typeof widthCache.get !== "function") {
@@ -59,7 +68,17 @@ export function patchTerminalCellMeasurements(term: TerminalInternals): void {
   }
 
   restoreLegacyCellWidthPatch(renderer);
-  const targetCellWidth = measureTargetCellWidth(term, renderer, widthCache);
+  const patchOptions = normalizePatchOptions(options);
+  if (renderer.__acornCjkCellPatch) {
+    renderer.__acornCjkCellPatch.cjkCellWidthHeuristic =
+      patchOptions.cjkCellWidthHeuristic;
+  }
+  const targetCellWidth = measureTargetCellWidth(
+    term,
+    renderer,
+    widthCache,
+    patchOptions,
+  );
   if (targetCellWidth === null) {
     restoreTerminalCellMeasurements(renderer, widthCache);
     restoreDefaultSpacing(renderer);
@@ -70,7 +89,7 @@ export function patchTerminalCellMeasurements(term: TerminalInternals): void {
     renderer.__acornCjkCellPatch?.originalCellWidth ?? getCellWidth(renderer);
   if (
     renderer.__acornCjkCellPatch &&
-    !widthsDiffer(targetCellWidth, originalCellWidth)
+    !patchWidthsDiffer(targetCellWidth, originalCellWidth)
   ) {
     restoreTerminalCellMeasurements(renderer, widthCache);
     return;
@@ -78,7 +97,7 @@ export function patchTerminalCellMeasurements(term: TerminalInternals): void {
 
   if (
     !renderer.__acornCjkCellPatch &&
-    !widthsDiffer(targetCellWidth, getCellWidth(renderer))
+    !patchWidthsDiffer(targetCellWidth, getCellWidth(renderer))
   ) {
     restoreDefaultSpacing(renderer);
     return;
@@ -88,12 +107,19 @@ export function patchTerminalCellMeasurements(term: TerminalInternals): void {
     renderer.__acornCjkCellPatch = {
       originalSetDefaultSpacing: renderer._setDefaultSpacing?.bind(renderer),
       originalHandleResize: renderer.handleResize?.bind(renderer),
+      cjkCellWidthHeuristic: patchOptions.cjkCellWidthHeuristic,
       originalCellWidth: getCellWidth(renderer),
       originalCanvasWidth: renderer.dimensions?.css?.canvas?.width,
     };
     renderer._setDefaultSpacing = () => {
       restoreLegacyCellWidthPatch(renderer);
-      const targetCellWidth = measureTargetCellWidth(term, renderer, widthCache);
+      const patchOptions = currentPatchOptions(renderer);
+      const targetCellWidth = measureTargetCellWidth(
+        term,
+        renderer,
+        widthCache,
+        patchOptions,
+      );
       if (targetCellWidth === null) {
         restoreTerminalCellMeasurements(renderer, widthCache);
         restoreDefaultSpacing(renderer);
@@ -105,7 +131,7 @@ export function patchTerminalCellMeasurements(term: TerminalInternals): void {
       renderer.handleResize = (cols: number, rows: number) => {
         renderer.__acornCjkCellPatch?.originalHandleResize?.(cols, rows);
         rememberCurrentRendererMetrics(renderer);
-        patchTerminalCellMeasurements(term);
+        patchTerminalCellMeasurements(term, currentPatchOptions(renderer));
       };
     }
   }
@@ -209,6 +235,27 @@ function widthsDiffer(a: number, b: number): boolean {
   return Math.abs(a - b) > CELL_WIDTH_EPSILON;
 }
 
+function patchWidthsDiffer(a: number, b: number): boolean {
+  return Math.abs(a - b) > PATCH_WIDTH_EPSILON;
+}
+
+function normalizePatchOptions(
+  options: CellMeasurementPatchOptions,
+): Required<CellMeasurementPatchOptions> {
+  return {
+    cjkCellWidthHeuristic: options.cjkCellWidthHeuristic ?? true,
+  };
+}
+
+function currentPatchOptions(
+  renderer: DomRenderer,
+): Required<CellMeasurementPatchOptions> {
+  return {
+    cjkCellWidthHeuristic:
+      renderer.__acornCjkCellPatch?.cjkCellWidthHeuristic ?? true,
+  };
+}
+
 function configuredLetterSpacing(term: TerminalInternals): number {
   const letterSpacing = term.options?.letterSpacing;
   if (typeof letterSpacing !== "number" || !Number.isFinite(letterSpacing)) {
@@ -221,6 +268,7 @@ function measureTargetCellWidth(
   term: TerminalInternals,
   renderer: DomRenderer,
   widthCache: WidthCache,
+  options: CellMeasurementPatchOptions,
 ): number | null {
   if (renderer._rowContainer) {
     renderer._rowContainer.style.letterSpacing = "";
@@ -228,17 +276,25 @@ function measureTargetCellWidth(
   widthCache.clear?.();
 
   const asciiWidth = widthCache.get("W", false, false);
-  const hangulWidth = widthCache.get("가", false, false);
-  if (asciiWidth <= 0 || hangulWidth <= 0) return null;
+  if (asciiWidth <= 0) return null;
 
   const letterSpacing = configuredLetterSpacing(term);
-  return widthsDiffer(asciiWidth, hangulWidth)
-    ? asciiWidth + letterSpacing
-    : asciiWidth / 2 + letterSpacing;
+  if (options.cjkCellWidthHeuristic ?? true) {
+    const hangulWidth = widthCache.get("가", false, false);
+    if (hangulWidth <= 0) return null;
+    if (!widthsDiffer(asciiWidth, hangulWidth)) {
+      return asciiWidth / 2 + letterSpacing;
+    }
+  }
+  return getCellWidth(renderer) + fractionalLetterSpacingDelta(letterSpacing);
 }
 
 function restoreDefaultSpacing(renderer: DomRenderer): void {
   renderer._setDefaultSpacing?.();
+}
+
+function fractionalLetterSpacingDelta(letterSpacing: number): number {
+  return letterSpacing - Math.round(letterSpacing);
 }
 
 function recalibrateDefaultSpacing(

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -649,6 +649,45 @@ test.describe("terminal: spawn", () => {
       .toBe("subpixel-antialiased");
   });
 
+  test("applies fractional terminal letter spacing to the renderer", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({ terminal: { letterSpacing: -0.25 } }),
+      );
+    });
+    await seedWritableTerminal(tauri);
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const rowContainer =
+            document.querySelector<HTMLElement>(".xterm-rows");
+          const firstRow =
+            document.querySelector<HTMLElement>(".xterm-rows > div");
+          return {
+            letterSpacing: Number.parseFloat(
+              rowContainer?.style.letterSpacing ?? "",
+            ),
+            firstRowWidth: firstRow?.style.width ?? null,
+          };
+        }),
+      )
+      .toMatchObject({
+        letterSpacing: expect.closeTo(-0.25, 0.05),
+        firstRowWidth: expect.stringMatching(/\.\d+px$/),
+      });
+  });
+
   test("normalizes no-break spaces when pasting shell commands", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Terminal letter spacing now preserves fractional pixel values instead of inheriting xterm.js' integer rounding behavior.

1. **Fractional letter spacing** — apply Acorn's renderer metric patch even when the CJK cell-width heuristic is disabled, so values like `-0.25px` and `-0.5px` visibly affect terminal cell width.
2. **Default spacing preservation** — adjust xterm's already-computed cell width by only the fractional delta, preserving xterm's own font measurement correction instead of replacing it.
3. **CJK heuristic separation** — keep the existing CJK half-width calibration behind its experiment flag while sharing the metric patch path with fractional spacing.
4. **Coverage** — add unit coverage for fractional spacing, default xterm spacing correction, disabled CJK calibration, and browser coverage for rendered fractional terminal spacing.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal letter spacing | xterm rounded spacing to whole pixels, so `-0.25`/`-0.5` behaved like `0` and `-0.75` jumped to `-1` | Fractional settings shrink or expand terminal cells by the requested sub-pixel delta |
| CJK cell-width heuristic | Experiment-only half-width correction | Same behavior, still gated by the experiment flag |
| Font size | xterm already accepts fractional font sizes | Unchanged |

## Design notes
- xterm.js keeps `fontSize` fractional in CSS and measurement paths, so this PR does not patch font-size handling.
- xterm.js rounds `letterSpacing` internally when computing DOM renderer cell width. Acorn now reapplies the fractional remainder after xterm computes its rounded baseline.
- The patch preserves xterm's default `letter-spacing` correction (`cell.width - measured W width`) so font-specific measurement drift is not discarded.

## Test plan
- [x] `git diff --check` passes
- [x] `git diff --cached --check` passes after resolving the main-branch test conflict
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/lib/terminal-cjk-cell-width-addon.test.ts src/lib/settings.test.ts` — 2 files, 103 tests pass after merging `origin/main`
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts -g "applies fractional terminal letter spacing|applies terminal line height"` — 2 Chromium tests pass after merging `origin/main`