### PR TITLE
feat(kanban): open new session terminal from board

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1200,11 +1200,15 @@ function InterfaceSettings({ t }: { t: SettingsTranslator }) {
       <KanbanTerminalPopoverSettings
         placement={settings.interface.kanbanTerminalPopoverPlacement}
         defaultSize={settings.interface.kanbanTerminalPopoverDefaultSize}
+        openOnCreate={settings.interface.openKanbanTerminalOnSessionCreate}
         onPlacementChange={(kanbanTerminalPopoverPlacement) =>
           patchInterface({ kanbanTerminalPopoverPlacement })
         }
         onDefaultSizeChange={(kanbanTerminalPopoverDefaultSize) =>
           patchInterface({ kanbanTerminalPopoverDefaultSize })
+        }
+        onOpenOnCreateChange={(openKanbanTerminalOnSessionCreate) =>
+          patchInterface({ openKanbanTerminalOnSessionCreate })
         }
         t={t}
       />
@@ -1289,14 +1293,18 @@ function DefaultWorkspaceViewModeSection({
 function KanbanTerminalPopoverSettings({
   placement,
   defaultSize,
+  openOnCreate,
   onPlacementChange,
   onDefaultSizeChange,
+  onOpenOnCreateChange,
   t,
 }: {
   placement: KanbanTerminalPopoverPlacement;
   defaultSize: KanbanTerminalPopoverDefaultSize;
+  openOnCreate: boolean;
   onPlacementChange: (value: KanbanTerminalPopoverPlacement) => void;
   onDefaultSizeChange: (value: KanbanTerminalPopoverDefaultSize) => void;
+  onOpenOnCreateChange: (value: boolean) => void;
   t: SettingsTranslator;
 }) {
   return (
@@ -1308,6 +1316,18 @@ function KanbanTerminalPopoverSettings({
       )}
     >
       <div className="space-y-4">
+        <CheckboxRow
+          label={st(
+            t,
+            "settings.interface.kanbanTerminalPopover.openOnCreate.label",
+          )}
+          description={st(
+            t,
+            "settings.interface.kanbanTerminalPopover.openOnCreate.description",
+          )}
+          checked={openOnCreate}
+          onChange={onOpenOnCreateChange}
+        />
         <Field
           label={st(
             t,

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -106,6 +106,9 @@ describe("interface settings", () => {
     expect(
       DEFAULT_SETTINGS.interface.kanbanTerminalPopoverDefaultSize,
     ).toBe("custom");
+    expect(
+      DEFAULT_SETTINGS.interface.openKanbanTerminalOnSessionCreate,
+    ).toBe(false);
   });
 
   it("loads a persisted default workspace mode", async () => {
@@ -117,6 +120,7 @@ describe("interface settings", () => {
           prioritizeNeedsInputTabs: true,
           kanbanTerminalPopoverPlacement: "center",
           kanbanTerminalPopoverDefaultSize: "fullscreen",
+          openKanbanTerminalOnSessionCreate: true,
         },
       }),
     );
@@ -138,6 +142,10 @@ describe("interface settings", () => {
       useSettings.getState().settings.interface
         .kanbanTerminalPopoverDefaultSize,
     ).toBe("fullscreen");
+    expect(
+      useSettings.getState().settings.interface
+        .openKanbanTerminalOnSessionCreate,
+    ).toBe(true);
   });
 
   it("falls back for unsupported interface values", async () => {
@@ -149,6 +157,7 @@ describe("interface settings", () => {
           prioritizeNeedsInputTabs: "yes",
           kanbanTerminalPopoverPlacement: "dock",
           kanbanTerminalPopoverDefaultSize: "huge",
+          openKanbanTerminalOnSessionCreate: "yes",
         },
       }),
     );
@@ -170,6 +179,10 @@ describe("interface settings", () => {
       useSettings.getState().settings.interface
         .kanbanTerminalPopoverDefaultSize,
     ).toBe("custom");
+    expect(
+      useSettings.getState().settings.interface
+        .openKanbanTerminalOnSessionCreate,
+    ).toBe(false);
   });
 
   it("patches interface settings and preserves the previous value for invalid patches", async () => {
@@ -183,6 +196,7 @@ describe("interface settings", () => {
         prioritizeNeedsInputTabs: true,
         kanbanTerminalPopoverPlacement: "center",
         kanbanTerminalPopoverDefaultSize: "fullscreen",
+        openKanbanTerminalOnSessionCreate: true,
       });
     expect(
       useSettings.getState().settings.interface.defaultWorkspaceViewMode,
@@ -198,6 +212,10 @@ describe("interface settings", () => {
       useSettings.getState().settings.interface
         .kanbanTerminalPopoverDefaultSize,
     ).toBe("fullscreen");
+    expect(
+      useSettings.getState().settings.interface
+        .openKanbanTerminalOnSessionCreate,
+    ).toBe(true);
 
     const invalidMode =
       "grid" as unknown as typeof DEFAULT_SETTINGS.interface.defaultWorkspaceViewMode;
@@ -205,12 +223,15 @@ describe("interface settings", () => {
       "dock" as unknown as typeof DEFAULT_SETTINGS.interface.kanbanTerminalPopoverPlacement;
     const invalidDefaultSize =
       "huge" as unknown as typeof DEFAULT_SETTINGS.interface.kanbanTerminalPopoverDefaultSize;
+    const invalidOpenOnCreate =
+      "yes" as unknown as typeof DEFAULT_SETTINGS.interface.openKanbanTerminalOnSessionCreate;
     useSettings
       .getState()
       .patchInterface({
         defaultWorkspaceViewMode: invalidMode,
         kanbanTerminalPopoverPlacement: invalidPlacement,
         kanbanTerminalPopoverDefaultSize: invalidDefaultSize,
+        openKanbanTerminalOnSessionCreate: invalidOpenOnCreate,
       });
     expect(
       useSettings.getState().settings.interface.defaultWorkspaceViewMode,
@@ -226,6 +247,10 @@ describe("interface settings", () => {
       useSettings.getState().settings.interface
         .kanbanTerminalPopoverDefaultSize,
     ).toBe("fullscreen");
+    expect(
+      useSettings.getState().settings.interface
+        .openKanbanTerminalOnSessionCreate,
+    ).toBe(true);
   });
 });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -235,6 +235,11 @@ export interface AcornSettings {
      * `custom` uses the remembered user-resized popover size.
      */
     kanbanTerminalPopoverDefaultSize: KanbanTerminalPopoverDefaultSize;
+    /**
+     * Open the terminal popover as soon as a terminal session is created while
+     * the active workspace is in kanban mode.
+     */
+    openKanbanTerminalOnSessionCreate: boolean;
   };
   terminal: {
     fontFamily: string;
@@ -487,6 +492,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     prioritizeNeedsInputTabs: false,
     kanbanTerminalPopoverPlacement: "card",
     kanbanTerminalPopoverDefaultSize: "custom",
+    openKanbanTerminalOnSessionCreate: false,
   },
   terminal: {
     fontFamily: fontStackFromSlots(
@@ -1011,6 +1017,10 @@ function loadSettings(): AcornSettings {
             interfaceRaw.kanbanTerminalPopoverDefaultSize,
             DEFAULT_SETTINGS.interface.kanbanTerminalPopoverDefaultSize,
           ),
+        openKanbanTerminalOnSessionCreate:
+          typeof interfaceRaw.openKanbanTerminalOnSessionCreate === "boolean"
+            ? interfaceRaw.openKanbanTerminalOnSessionCreate
+            : DEFAULT_SETTINGS.interface.openKanbanTerminalOnSessionCreate,
       },
       terminal: {
         ...DEFAULT_SETTINGS.terminal,
@@ -1339,6 +1349,12 @@ export const useSettings = create<SettingsState>((set, get) => ({
                   patch.kanbanTerminalPopoverDefaultSize,
                   s.settings.interface.kanbanTerminalPopoverDefaultSize,
                 ),
+          openKanbanTerminalOnSessionCreate:
+            patch.openKanbanTerminalOnSessionCreate === undefined
+              ? s.settings.interface.openKanbanTerminalOnSessionCreate
+              : typeof patch.openKanbanTerminalOnSessionCreate === "boolean"
+                ? patch.openKanbanTerminalOnSessionCreate
+                : s.settings.interface.openKanbanTerminalOnSessionCreate,
         },
       };
       persist(next);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -85,6 +85,10 @@
       "kanbanTerminalPopover": {
         "title": "Kanban terminal popover",
         "description": "Controls where card terminals open and how large they start.",
+        "openOnCreate": {
+          "label": "Open new session terminals immediately",
+          "description": "When you create a terminal session in kanban mode, open its terminal popover right away."
+        },
         "placement": {
           "label": "Open position",
           "hint": "Initial placement when you open a terminal from a kanban card.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -85,6 +85,10 @@
       "kanbanTerminalPopover": {
         "title": "칸반 터미널 팝오버",
         "description": "칸반 카드에서 터미널을 열 때 위치와 시작 크기를 정합니다.",
+        "openOnCreate": {
+          "label": "새 세션 터미널을 즉시 열기",
+          "description": "칸반 모드에서 터미널 세션을 만들면 해당 터미널 팝오버를 바로 엽니다."
+        },
         "placement": {
           "label": "표시 위치",
           "hint": "칸반 카드에서 터미널을 열 때 처음 나타나는 위치입니다.",

--- a/src/store.ts
+++ b/src/store.ts
@@ -2572,6 +2572,14 @@ export const useAppStore = create<AppStateModel>()(
       // through the store) immediately surfaces it in its pane instead of
       // silently appending behind the existing active tab.
       get().selectSession(created.id);
+      if (
+        mode === "terminal" &&
+        get().workspaceViewMode === "kanban" &&
+        useSettings.getState().settings.interface
+          .openKanbanTerminalOnSessionCreate
+      ) {
+        get().openTerminalPopup(created.id);
+      }
       // Grab keyboard focus for the new session's xterm. rAF defers past the
       // portal reattach in `TerminalHost` so the slot is mounted in its pane
       // body by the time `Terminal` calls `term.focus()`.

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -985,6 +985,19 @@ test.describe("workspace kanban mode", () => {
     });
     await createSessionButton.click();
     await page.getByRole("menuitem", { name: "New session" }).click();
+    await expect
+      .poll(async () =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __createSessionCalls?: Array<Record<string, unknown>>;
+              }
+            ).__createSessionCalls?.length ?? 0,
+        ),
+      )
+      .toBe(1);
+    await expect(page.getByTestId("kanban-terminal-popover")).toHaveCount(0);
     await createSessionButton.click();
     await page.getByRole("menuitem", { name: "New worktree session" }).click();
 
@@ -1019,5 +1032,107 @@ test.describe("workspace kanban mode", () => {
       isolated: true,
       kind: "regular",
     });
+  });
+
+  test("opens the new terminal popover from the kanban toolbar when enabled", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          interface: { openKanbanTerminalOnSessionCreate: true },
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__sessions = w.__sessions ?? [
+        {
+          id: "seed",
+          name: "seed",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          project_scoped: true,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          title_source: "manual",
+          kind: "regular",
+          mode: "terminal",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+        },
+      ];
+      return w.__sessions;
+    });
+    await tauri.handle("create_session", (args) => {
+      const input = args as Record<string, unknown>;
+      const w = window as unknown as {
+        __createSessionCalls?: Array<Record<string, unknown>>;
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(input);
+      const id = `created-${w.__createSessionCalls.length}`;
+      const repoPath =
+        typeof input.repoPath === "string" ? input.repoPath : "/tmp/demo";
+      const session = {
+        id,
+        name: typeof input.name === "string" ? input.name : id,
+        repo_path: repoPath,
+        worktree_path: repoPath,
+        branch: "main",
+        isolated: false,
+        project_scoped: input.projectScoped !== false,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: typeof input.kind === "string" ? input.kind : "regular",
+        mode: "terminal",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      };
+      w.__sessions = [...(w.__sessions ?? []), session];
+      return session;
+    });
+
+    await page.goto("/");
+
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    const board = page.getByTestId("workspace-kanban");
+    await board.getByRole("button", { name: "Create session" }).click();
+    await page.getByRole("menuitem", { name: "New session" }).click();
+
+    await expect
+      .poll(async () =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __createSessionCalls?: Array<Record<string, unknown>>;
+              }
+            ).__createSessionCalls?.length ?? 0,
+        ),
+      )
+      .toBe(1);
+    await expect(
+      board.locator('[data-kanban-session-id="created-1"]'),
+    ).toBeVisible();
+    await expect(page.getByTestId("kanban-terminal-popover")).toBeVisible();
+    await expect(page.getByTestId("terminal-popover-body")).toBeVisible();
   });
 });

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -121,6 +121,9 @@ test.describe("settings modal", () => {
     const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
     await expect(modal.getByText("Kanban terminal popover")).toBeVisible();
 
+    await modal
+      .getByText("Open new session terminals immediately", { exact: true })
+      .click();
     await modal.getByText("Center of screen", { exact: true }).click();
     await modal.getByText("Full screen", { exact: true }).click();
 
@@ -134,12 +137,15 @@ test.describe("settings modal", () => {
               settings?.interface?.kanbanTerminalPopoverPlacement ?? null,
             defaultSize:
               settings?.interface?.kanbanTerminalPopoverDefaultSize ?? null,
+            openOnCreate:
+              settings?.interface?.openKanbanTerminalOnSessionCreate ?? null,
           };
         }),
       )
       .toEqual({
         placement: "center",
         defaultSize: "fullscreen",
+        openOnCreate: true,
       });
   });
 


### PR DESCRIPTION
## Summary

Adds an opt-in kanban setting that opens a newly-created terminal session's popover immediately.

1. **Setting model:** add `interface.openKanbanTerminalOnSessionCreate`, persisted under existing settings with default `false`.
2. **Settings UI:** add a checkbox in the Kanban terminal popover settings group with English and Korean copy.
3. **Kanban create handoff:** when enabled, terminal session creation in kanban mode reuses the existing terminal popover signal so the new card opens immediately.
4. **Coverage:** extend settings unit tests, Settings UI persistence coverage, and the kanban toolbar create flow.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Kanban UX | Users can opt into opening the new terminal immediately after creating it from the board. |
| Defaults | Existing behavior is unchanged because the setting defaults to off. |
| Runtime behavior | Reuses the existing kanban terminal popover path; no backend or PTY contract changes. |

## Design notes

- The create-session path gates the behavior on `mode === "terminal"`, current `workspaceViewMode === "kanban"`, and the new setting, so chat sessions and pane mode keep their existing behavior.
- The implementation calls the existing `openTerminalPopup` store action after `selectSession`, letting `WorkspaceMain` resolve the rendered kanban card anchor and apply the current popover placement/size settings.

## Test plan

- [x] `git diff --check`
- [x] `pnpm exec vitest run src/lib/settings.test.ts`
- [x] `pnpm exec vitest run src/store.test.ts`
- [x] `pnpm exec vitest run src/components/SettingsModal.test.tsx`
- [x] `pnpm run typecheck`
- [x] `pnpm exec playwright test tests/e2e/settings.spec.ts tests/e2e/kanban.spec.ts`
