### PR TITLE
feat(settings): terminal font presets for quick switching

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -62,11 +62,13 @@ import {
   NOTIFICATION_HISTORY_LIMIT_MAX,
   NOTIFICATION_HISTORY_LIMIT_MIN,
   PR_REFRESH_INTERVAL_OPTIONS,
+  matchingTerminalFontPresetId,
   resolveAiExecutionRequest,
   resolveSessionTitlePrompt,
   SESSION_TITLE_PROMPT_PREVIEW_MESSAGE,
   SESSION_TITLE_PROMPT_MAX_CHARS,
   SESSION_TITLE_OPTIONS,
+  TERMINAL_FONT_PRESETS,
   TERMINAL_FONT_SIZE_MAX,
   TERMINAL_FONT_SIZE_MIN,
   TERMINAL_FONT_SIZE_STEP,
@@ -89,6 +91,7 @@ import {
   type ToastPosition,
   TERMINAL_FONT_SMOOTHING_VALUES,
   TERMINAL_FONT_WEIGHTS,
+  terminalFontPresetById,
   useSettings,
 } from "../lib/settings";
 import {
@@ -564,10 +567,51 @@ function terminalFontSmoothingLabel(
 function TerminalSettings() {
   const settings = useSettings((s) => s.settings);
   const patchTerminal = useSettings((s) => s.patchTerminal);
+  const patchExperiments = useSettings((s) => s.patchExperiments);
   const t = useTranslation();
+  const activeFontPresetId = matchingTerminalFontPresetId(settings);
+  const fontPresetOptions: SelectItem[] = [
+    ...(activeFontPresetId === null
+      ? [
+          {
+            value: "custom",
+            label: st(t, "settings.terminal.fontPreset.custom"),
+            disabled: true,
+          },
+        ]
+      : []),
+    ...TERMINAL_FONT_PRESETS.map((preset) => ({
+      value: preset.id,
+      label: st(
+        t,
+        `settings.terminal.fontPreset.options.${preset.id}.label` as TranslationKey,
+      ),
+      description: st(
+        t,
+        `settings.terminal.fontPreset.options.${preset.id}.description` as TranslationKey,
+      ),
+    })),
+  ];
 
   return (
     <section className="space-y-4">
+      <Field
+        label={st(t, "settings.terminal.fontPreset.label")}
+        hint={st(t, "settings.terminal.fontPreset.hint")}
+      >
+        <Select
+          value={activeFontPresetId ?? "custom"}
+          onValueChange={(presetId) => {
+            const preset = terminalFontPresetById(presetId);
+            if (!preset) return;
+            patchTerminal(preset.settings);
+            patchExperiments(preset.experiments);
+          }}
+          options={fontPresetOptions}
+          className="min-w-[14rem]"
+          aria-label={st(t, "settings.terminal.fontPreset.label")}
+        />
+      </Field>
       <Field
         label={st(t, "settings.terminal.fontFamily.label")}
         hint={st(t, "settings.terminal.fontFamily.hint")}

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -7,6 +7,9 @@ import {
   MOUNTED_TERMINAL_LIMIT_MAX,
   MOUNTED_TERMINAL_LIMIT_MIN,
   NOTIFICATION_HISTORY_LIMIT_MAX,
+  TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS,
+  TERMINAL_FONT_PRESET_FIELDS,
+  TERMINAL_FONT_PRESETS,
   TERMINAL_FONT_SIZE_MAX,
   TERMINAL_FONT_SIZE_MIN,
   TERMINAL_FONT_SIZE_STEP,
@@ -17,10 +20,12 @@ import {
   TERMINAL_LINE_HEIGHT_MAX,
   TERMINAL_LINE_HEIGHT_MIN,
   TERMINAL_LINE_HEIGHT_STEP,
+  matchingTerminalFontPresetId,
   resolveAiCommitRequest,
   resolveAiExecutionRequest,
   resolveSessionTitlePrompt,
   SESSION_TITLE_PROMPT_MAX_CHARS,
+  terminalFontPresetById,
 } from "./settings";
 import { DEFAULT_HOTKEYS } from "./hotkeys";
 
@@ -398,6 +403,141 @@ describe("terminal.fontSmoothing settings", () => {
       fontSmoothing: invalidFontSmoothing,
     });
     expect(useSettings.getState().settings.terminal.fontSmoothing).toBe("none");
+  });
+});
+
+describe("terminal font presets", () => {
+  const STORAGE_KEY = "acorn:settings:v1";
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return storage.size;
+        },
+        clear: () => storage.clear(),
+        getItem: (key: string) => storage.get(key) ?? null,
+        key: (index: number) => Array.from(storage.keys())[index] ?? null,
+        removeItem: (key: string) => {
+          storage.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      } satisfies Storage,
+    });
+  });
+
+  it("matches the default terminal font settings to the default preset", () => {
+    expect(matchingTerminalFontPresetId(DEFAULT_SETTINGS)).toBe(
+      "default",
+    );
+    expect(terminalFontPresetById("missing")).toBeNull();
+  });
+
+  it("covers every font-related field in each preset", () => {
+    expect(TERMINAL_FONT_PRESET_FIELDS).toEqual([
+      "fontFamily",
+      "fontSize",
+      "letterSpacing",
+      "fontSmoothing",
+      "fontWeight",
+      "fontWeightBold",
+      "lineHeight",
+    ]);
+    expect(TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS).toEqual([
+      "cjkCellWidthHeuristic",
+    ]);
+
+    const expectedFields = [...TERMINAL_FONT_PRESET_FIELDS].sort();
+    const expectedExperimentFields = [
+      ...TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS,
+    ].sort();
+    for (const preset of TERMINAL_FONT_PRESETS) {
+      expect(Object.keys(preset.settings).sort()).toEqual(expectedFields);
+      expect(Object.keys(preset.experiments).sort()).toEqual(
+        expectedExperimentFields,
+      );
+    }
+  });
+
+  it("applies and persists all font-related fields from a preset", async () => {
+    vi.resetModules();
+    const {
+      TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS: experimentFields,
+      TERMINAL_FONT_PRESET_FIELDS: fields,
+      matchingTerminalFontPresetId: matchPreset,
+      terminalFontPresetById: presetById,
+      useSettings,
+    } = await import("./settings");
+
+    const preset = presetById("comfortable");
+    expect(preset).not.toBeNull();
+    if (!preset) return;
+
+    useSettings.getState().patchTerminal(preset.settings);
+    useSettings.getState().patchExperiments(preset.experiments);
+
+    const settings = useSettings.getState().settings;
+    const persisted = JSON.parse(
+      localStorage.getItem(STORAGE_KEY) ?? "{}",
+    );
+
+    expect(matchPreset(settings)).toBe("comfortable");
+    for (const field of fields) {
+      expect(settings.terminal[field]).toBe(preset.settings[field]);
+      expect(persisted.terminal[field]).toBe(preset.settings[field]);
+    }
+    for (const field of experimentFields) {
+      expect(settings.experiments[field]).toBe(preset.experiments[field]);
+      expect(persisted.experiments[field]).toBe(preset.experiments[field]);
+    }
+  });
+
+  it("treats manually changed font settings as custom", () => {
+    expect(
+      matchingTerminalFontPresetId({
+        terminal: {
+          ...DEFAULT_SETTINGS.terminal,
+          fontSize: DEFAULT_SETTINGS.terminal.fontSize + 0.25,
+        },
+        experiments: DEFAULT_SETTINGS.experiments,
+      }),
+    ).toBeNull();
+  });
+
+  it("includes the CJK cell-width correction in preset matching", () => {
+    const preset = terminalFontPresetById("cjk");
+    expect(preset).not.toBeNull();
+    if (!preset) return;
+
+    expect(
+      matchingTerminalFontPresetId({
+        terminal: {
+          ...DEFAULT_SETTINGS.terminal,
+          ...preset.settings,
+        },
+        experiments: {
+          ...DEFAULT_SETTINGS.experiments,
+          ...preset.experiments,
+        },
+      }),
+    ).toBe("cjk");
+    expect(
+      matchingTerminalFontPresetId({
+        terminal: {
+          ...DEFAULT_SETTINGS.terminal,
+          ...preset.settings,
+        },
+        experiments: {
+          ...DEFAULT_SETTINGS.experiments,
+          cjkCellWidthHeuristic: false,
+        },
+      }),
+    ).toBeNull();
   });
 });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -594,6 +594,148 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   },
 };
 
+export const TERMINAL_FONT_PRESET_FIELDS = [
+  "fontFamily",
+  "fontSize",
+  "letterSpacing",
+  "fontSmoothing",
+  "fontWeight",
+  "fontWeightBold",
+  "lineHeight",
+] as const;
+
+export const TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS = [
+  "cjkCellWidthHeuristic",
+] as const;
+
+type TerminalFontPresetField = (typeof TERMINAL_FONT_PRESET_FIELDS)[number];
+type TerminalFontPresetExperimentField =
+  (typeof TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS)[number];
+
+export type TerminalFontPresetSettings = Pick<
+  AcornSettings["terminal"],
+  TerminalFontPresetField
+>;
+export type TerminalFontPresetExperimentSettings = Pick<
+  AcornSettings["experiments"],
+  TerminalFontPresetExperimentField
+>;
+
+export type TerminalFontPresetId =
+  | "default"
+  | "compact"
+  | "comfortable"
+  | "cjk";
+
+export interface TerminalFontPreset {
+  id: TerminalFontPresetId;
+  settings: TerminalFontPresetSettings;
+  experiments: TerminalFontPresetExperimentSettings;
+}
+
+export const TERMINAL_FONT_PRESETS = [
+  {
+    id: "default",
+    settings: {
+      fontFamily: DEFAULT_SETTINGS.terminal.fontFamily,
+      fontSize: DEFAULT_SETTINGS.terminal.fontSize,
+      letterSpacing: DEFAULT_SETTINGS.terminal.letterSpacing,
+      fontSmoothing: DEFAULT_SETTINGS.terminal.fontSmoothing,
+      fontWeight: DEFAULT_SETTINGS.terminal.fontWeight,
+      fontWeightBold: DEFAULT_SETTINGS.terminal.fontWeightBold,
+      lineHeight: DEFAULT_SETTINGS.terminal.lineHeight,
+    },
+    experiments: {
+      cjkCellWidthHeuristic:
+        DEFAULT_SETTINGS.experiments.cjkCellWidthHeuristic,
+    },
+  },
+  {
+    id: "compact",
+    settings: {
+      fontFamily: fontStackFromSlots(
+        ["JetBrains Mono", "Fira Code", "Menlo"],
+        "monospace",
+      ),
+      fontSize: 11,
+      letterSpacing: -0.25,
+      fontSmoothing: "grayscale",
+      fontWeight: 400,
+      fontWeightBold: 700,
+      lineHeight: 1.0,
+    },
+    experiments: {
+      cjkCellWidthHeuristic: false,
+    },
+  },
+  {
+    id: "comfortable",
+    settings: {
+      fontFamily: fontStackFromSlots(
+        ["JetBrains Mono", "Fira Code", "Menlo"],
+        "monospace",
+      ),
+      fontSize: 13.25,
+      letterSpacing: 0.25,
+      fontSmoothing: "grayscale",
+      fontWeight: 400,
+      fontWeightBold: 700,
+      lineHeight: 1.2,
+    },
+    experiments: {
+      cjkCellWidthHeuristic: false,
+    },
+  },
+  {
+    id: "cjk",
+    settings: {
+      fontFamily: fontStackFromSlots(
+        ["D2Coding", "Sarasa Mono K", "JetBrains Mono"],
+        "monospace",
+      ),
+      fontSize: 13,
+      letterSpacing: 0,
+      fontSmoothing: "grayscale",
+      fontWeight: 400,
+      fontWeightBold: 700,
+      lineHeight: 1.15,
+    },
+    experiments: {
+      cjkCellWidthHeuristic: true,
+    },
+  },
+] as const satisfies ReadonlyArray<TerminalFontPreset>;
+
+export function terminalFontPresetById(
+  id: string,
+): TerminalFontPreset | null {
+  return TERMINAL_FONT_PRESETS.find((preset) => preset.id === id) ?? null;
+}
+
+function terminalFontPresetMatches(
+  settings: Pick<AcornSettings, "terminal" | "experiments">,
+  preset: TerminalFontPreset,
+): boolean {
+  return (
+    TERMINAL_FONT_PRESET_FIELDS.every((field) =>
+      Object.is(settings.terminal[field], preset.settings[field]),
+    ) &&
+    TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS.every((field) =>
+      Object.is(settings.experiments[field], preset.experiments[field]),
+    )
+  );
+}
+
+export function matchingTerminalFontPresetId(
+  settings: Pick<AcornSettings, "terminal" | "experiments">,
+): TerminalFontPresetId | null {
+  return (
+    TERMINAL_FONT_PRESETS.find((preset) =>
+      terminalFontPresetMatches(settings, preset),
+    )?.id ?? null
+  );
+}
+
 const VALID_WEIGHTS = new Set<TerminalFontWeight>([
   100, 200, 300, 400, 500, 600, 700, 800, 900,
 ]);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -116,6 +116,29 @@
       }
     },
     "terminal": {
+      "fontPreset": {
+        "label": "Font preset",
+        "hint": "Applies the family stack, size, spacing, anti-aliasing, weights, and line height together.",
+        "custom": "Custom",
+        "options": {
+          "default": {
+            "label": "Acorn default",
+            "description": "Balanced JetBrains Mono stack at 12px."
+          },
+          "compact": {
+            "label": "Compact",
+            "description": "Smaller type with tighter horizontal spacing."
+          },
+          "comfortable": {
+            "label": "Comfortable",
+            "description": "Larger type with more row and cell spacing."
+          },
+          "cjk": {
+            "label": "CJK mono",
+            "description": "D2Coding / Sarasa stack tuned for Korean and CJK glyphs."
+          }
+        }
+      },
       "fontFamily": {
         "label": "Font family",
         "hint": "Comma-separated stack. First family that resolves wins."

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -116,6 +116,29 @@
       }
     },
     "terminal": {
+      "fontPreset": {
+        "label": "글꼴 프리셋",
+        "hint": "서체 목록, 크기, 간격, 안티앨리어싱, 두께, 줄 높이를 함께 적용합니다.",
+        "custom": "사용자 지정",
+        "options": {
+          "default": {
+            "label": "Acorn 기본값",
+            "description": "JetBrains Mono 스택을 12px로 맞춘 균형 잡힌 설정입니다."
+          },
+          "compact": {
+            "label": "조밀하게",
+            "description": "더 작은 글꼴과 촘촘한 가로 간격을 사용합니다."
+          },
+          "comfortable": {
+            "label": "넓게",
+            "description": "더 큰 글꼴과 여유 있는 행/셀 간격을 사용합니다."
+          },
+          "cjk": {
+            "label": "CJK 고정폭",
+            "description": "한국어와 CJK 글리프에 맞춘 D2Coding / Sarasa 스택입니다."
+          }
+        }
+      },
       "fontFamily": {
         "label": "글꼴 패밀리",
         "hint": "쉼표로 구분한 글꼴 목록입니다. 먼저 해석되는 글꼴이 사용됩니다."

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -112,6 +112,60 @@ test.describe("settings modal", () => {
       .toBe("subpixel");
   });
 
+  test("applies terminal font presets and marks manual font changes as custom", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "," });
+
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
+    await modal.getByRole("button", { name: /^(Terminal|터미널)$/ }).click();
+
+    const presetSelect = modal.getByRole("combobox", {
+      name: /^(Font preset|글꼴 프리셋)$/,
+    });
+    await expect(presetSelect).toContainText("Acorn default");
+
+    await presetSelect.click();
+    await page.getByRole("option", { name: /CJK mono/ }).click();
+
+    await expect(presetSelect).toContainText("CJK mono");
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("acorn:settings:v1");
+          const settings = raw ? JSON.parse(raw) : null;
+          const terminal = settings?.terminal ?? null;
+          return {
+            fontFamily: terminal?.fontFamily ?? null,
+            fontSize: terminal?.fontSize ?? null,
+            letterSpacing: terminal?.letterSpacing ?? null,
+            lineHeight: terminal?.lineHeight ?? null,
+            cjkCellWidthHeuristic:
+              settings?.experiments?.cjkCellWidthHeuristic ?? null,
+          };
+        }),
+      )
+      .toEqual({
+        fontFamily: 'D2Coding, "Sarasa Mono K", "JetBrains Mono", monospace',
+        fontSize: 13,
+        letterSpacing: 0,
+        lineHeight: 1.15,
+        cjkCellWidthHeuristic: true,
+      });
+
+    const fontSizeField = modal
+      .getByText("Font size", { exact: true })
+      .locator("..");
+    const fontSizeInput = fontSizeField.getByRole("textbox", {
+      name: /^(Value|값)$/,
+    });
+    await fontSizeInput.fill("14");
+    await fontSizeInput.press("Enter");
+
+    await expect(presetSelect).toContainText("Custom");
+  });
+
   test("changes kanban terminal popover settings and persists them", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
Adds a terminal font preset switcher so users can swap complete font configurations without tuning each field by hand.

1. **Preset catalog** — defines Acorn default, Compact, Comfortable, and CJK mono presets covering terminal font family, size, letter spacing, anti-aliasing, normal/bold weights, line height, and CJK cell-width correction.
2. **Settings UI** — adds a Font preset selector at the top of Settings → Terminal, applies the selected preset immediately, and shows Custom when manual edits no longer match a preset.
3. **Localization and coverage** — adds English/Korean copy plus unit and E2E coverage for preset matching, persistence, CJK correction, and manual custom state.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Terminal font setup | Users adjusted each font field individually. | Users can switch a full font configuration from one selector. |
| CJK terminal tuning | CJK font stack and cell-width correction were separate decisions. | CJK mono preset applies both together. |
| Existing custom settings | Manual values persisted but had no preset indicator. | Non-matching values appear as Custom and remain editable. |

## Design notes
- Presets are not stored as a separate setting; the active preset is derived from the current terminal and CJK correction values. This keeps existing persisted settings as the source of truth.
- The CJK preset includes the existing experimental cell-width correction because it changes how CJK monospaced glyphs fit the terminal grid.
- Applying a preset uses existing settings patch paths, so xterm keeps receiving the same live-update flow already used by individual controls.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/lib/settings.test.ts` passes — 90 tests
- [x] `pnpm exec playwright test tests/e2e/settings.spec.ts tests/e2e/settings-tabs.spec.ts` passes — 13 tests
- [x] `git diff --check HEAD~1 HEAD` passes
