### PR TITLE
fix(kanban): open sidebar-selected terminal popovers

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -263,6 +263,7 @@ export function Sidebar() {
   const activeProjectFolderId = useAppStore((s) => s.activeProjectFolderId);
   const workspaceViewMode = useAppStore((s) => s.workspaceViewMode);
   const selectSession = useAppStore((s) => s.selectSession);
+  const openTerminalPopup = useAppStore((s) => s.openTerminalPopup);
   const focusLocalSessions = useAppStore((s) => s.focusLocalSessions);
   const setActiveProject = useAppStore((s) => s.setActiveProject);
   const setActiveProjectFolder = useAppStore((s) => s.setActiveProjectFolder);
@@ -403,6 +404,13 @@ export function Sidebar() {
     });
   }
 
+  function selectSidebarSession(sessionId: string) {
+    selectSession(sessionId);
+    if (useAppStore.getState().workspaceViewMode === "kanban") {
+      openTerminalPopup(sessionId);
+    }
+  }
+
   function applyClickPlan(
     plan: ProjectClickPlan,
     project: ProjectFolderProjectGroup,
@@ -415,7 +423,7 @@ export function Sidebar() {
     if (plan.shouldActivate) {
       setActiveProject(project.repoPath);
       const target = pickSessionToActivate(project.sessions, activeSessionId);
-      if (target) selectSession(target);
+      if (target) selectSidebarSession(target);
     }
   }
 
@@ -1176,12 +1184,12 @@ export function Sidebar() {
                             project.sessions,
                             activeSessionId,
                           );
-                          if (target) selectSession(target);
+                          if (target) selectSidebarSession(target);
                         }}
                         onSelectFolder={setActiveProjectFolder}
                         onSelectSession={(folderId, sessionId) => {
                           setActiveProjectFolder(folderId);
-                          selectSession(sessionId);
+                          selectSidebarSession(sessionId);
                         }}
                         onRemoveSession={(s) => requestRemoveSession(s.id)}
                         onAddSession={(
@@ -1249,7 +1257,7 @@ export function Sidebar() {
               onFocusArea={focusLocalSessions}
               onSelectFolder={setActiveProjectFolder}
               onToggleFolder={toggleProjectFolder}
-              onSelectSession={selectSession}
+              onSelectSession={selectSidebarSession}
               onRemoveSession={(s) => requestRemoveSession(s.id)}
               onRenameFolder={renameProjectFolder}
               onRemoveFolder={requestRemoveProjectFolder}

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -159,17 +159,10 @@ interface WorkspaceMainProps {
 export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
   const isKanban = viewMode === "kanban";
   const closeTerminalPopup = useAppStore((s) => s.closeTerminalPopup);
-  const activeWorkspaceId = useAppStore(
-    (s) => s.activeProjectFolderId ?? s.activeProject,
-  );
 
   useEffect(() => {
     if (!isKanban) closeTerminalPopup();
   }, [closeTerminalPopup, isKanban]);
-
-  useEffect(() => {
-    closeTerminalPopup();
-  }, [activeWorkspaceId, closeTerminalPopup]);
 
   return (
     <div className="h-full min-w-0 overflow-hidden" data-workspace-main>
@@ -302,6 +295,7 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
         (session) => session.id === terminalPopupSessionId,
       )
     ) {
+      closeTerminalPopup();
       return;
     }
     const anchor = document.querySelector<HTMLElement>(
@@ -315,7 +309,7 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
         ? current
         : { sessionId: terminalPopupSessionId, anchor },
     );
-  }, [terminalPopupSessionId, visibleSessions]);
+  }, [closeTerminalPopup, terminalPopupSessionId, visibleSessions]);
 
   useEffect(() => {
     if (!terminalPopover) return;

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -1034,6 +1034,143 @@ test.describe("workspace kanban mode", () => {
     });
   });
 
+  test("opens a terminal popover when selecting a project session from the sidebar in kanban mode", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("alpha", "alpha", "ready"),
+      session("shell", "shell", "working", {
+        branch: "shell",
+      }),
+    ]);
+
+    await page.goto("/");
+
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    await expect(page.getByTestId("workspace-kanban")).toBeVisible();
+    await expect(page.getByTestId("kanban-terminal-popover")).toHaveCount(0);
+
+    await page
+      .locator("aside")
+      .getByRole("button", { name: /shell/ })
+      .click();
+
+    const shellPopover = page.getByTestId("kanban-terminal-popover");
+    await expect(shellPopover).toBeVisible();
+    await expect(
+      shellPopover.getByRole("heading", { name: "shell" }),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId("terminal-popover-body")
+        .locator('[data-acorn-terminal-slot="shell"] .acorn-terminal-shell'),
+    ).toBeVisible();
+  });
+
+  test("keeps the sidebar-opened terminal popover when switching kanban workspaces", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          interface: { defaultWorkspaceViewMode: "kanban" },
+        }),
+      );
+    });
+    const alpha = project("/tmp/alpha", "alpha", 0);
+    const beta = project("/tmp/beta", "beta", 1);
+    await tauri.respond("list_projects", [alpha, beta]);
+    await tauri.respond("list_sessions", [
+      session("alpha-session", "alpha-session", "ready", {
+        repo_path: "/tmp/alpha",
+        worktree_path: "/tmp/alpha/.worktrees/alpha-session",
+        branch: "feat/alpha",
+      }),
+      session("beta-session", "beta-session", "working", {
+        repo_path: "/tmp/beta",
+        worktree_path: "/tmp/beta/.worktrees/beta-session",
+        branch: "feat/beta",
+      }),
+    ]);
+
+    await page.goto("/");
+
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Kanban",
+    );
+    await page
+      .locator("aside")
+      .getByRole("button", { name: "Project beta" })
+      .click();
+
+    const betaPopover = page.getByTestId("kanban-terminal-popover");
+    await expect(betaPopover).toBeVisible();
+    await expect(
+      betaPopover.getByRole("heading", { name: "beta-session" }),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId("terminal-popover-body")
+        .locator(
+          '[data-acorn-terminal-slot="beta-session"] .acorn-terminal-shell',
+        ),
+    ).toBeVisible();
+  });
+
+  test("opens a terminal popover when selecting an instant session from the sidebar in kanban mode", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          interface: { defaultWorkspaceViewMode: "kanban" },
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("instant-shell", "instant-shell", "ready", {
+        repo_path: "/Users/me",
+        worktree_path: "/Users/me",
+        branch: "home",
+        project_scoped: false,
+      }),
+    ]);
+
+    await page.goto("/");
+
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Kanban",
+    );
+    await expect(page.getByTestId("kanban-terminal-popover")).toHaveCount(0);
+
+    await page
+      .locator('[data-local-terminal-area="true"]')
+      .getByRole("button", { name: /instant-shell/ })
+      .click();
+
+    const instantPopover = page.getByTestId("kanban-terminal-popover");
+    await expect(instantPopover).toBeVisible();
+    await expect(
+      instantPopover.getByRole("heading", { name: "instant-shell" }),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId("terminal-popover-body")
+        .locator(
+          '[data-acorn-terminal-slot="instant-shell"] .acorn-terminal-shell',
+        ),
+    ).toBeVisible();
+  });
+
   test("opens the new terminal popover from the kanban toolbar when enabled", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Kanban mode now opens the terminal popover from sidebar session selection paths, including project workspaces and Instant Sessions.

1. **Sidebar selection behavior** — route project-panel session clicks through a shared sidebar selector that opens the terminal popover when the active workspace is in Kanban mode.
2. **Workspace handoff** — stop closing the popover solely because the active workspace changes, while still closing stale popovers when the selected session is no longer visible on the Kanban board.
3. **Instant Session coverage** — apply the same sidebar selection behavior to local/Instant Session rows and cover the flow with E2E tests.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Project sidebar in Kanban | Selecting a session changed focus but did not show the terminal popover | Selecting a session opens its terminal popover |
| Workspace switch in Kanban | The workspace-change effect could immediately close a sidebar-opened popover | The popover remains when the selected session is visible in the new board |
| Instant Sessions in Kanban | Local session rows followed pane-style selection only | Local session rows open the Kanban terminal popover |

## Design notes
- `Sidebar` keeps the selection behavior centralized in `selectSidebarSession`, using the store's current `workspaceViewMode` after project/folder activation has run.
- `WorkspaceMain` still closes the popup when leaving Kanban mode, but delegates stale-session cleanup to `KanbanBoard` where visible sessions are known.
- The cleanup path closes `terminalPopupSessionId` when the requested session is filtered out or no longer part of the current board, preventing stale global popup state.

## Follow-up (not in this PR)
- None.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/components/WorkspaceMain.test.tsx src/lib/sidebar-actions.test.ts` passes — 2 files, 13 tests
- [x] `PLAYWRIGHT_PORT=1421 pnpm exec playwright test tests/e2e/kanban.spec.ts` passes — 12 tests
- [x] CI green on this PR — `Frontend` and `E2E` passed
