### PR TITLE
fix(workspace): allow empty instant view mode toggle

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -551,6 +551,28 @@ describe("focusLocalSessions", () => {
     expect(useAppStore.getState().activeProject).toBeNull();
     expect(useAppStore.getState().activeSessionId).toBeNull();
   });
+
+  it("can switch the empty local area out of kanban mode", async () => {
+    useSettings.setState({
+      settings: {
+        ...structuredClone(DEFAULT_SETTINGS),
+        interface: {
+          ...DEFAULT_SETTINGS.interface,
+          defaultWorkspaceViewMode: "kanban",
+        },
+      },
+    });
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+
+    useAppStore.getState().focusLocalSessions();
+    expect(useAppStore.getState().activeProject).toBeNull();
+    expect(useAppStore.getState().workspaceViewMode).toBe("kanban");
+
+    useAppStore.getState().setWorkspaceViewMode("panes");
+
+    expect(useAppStore.getState().workspaceViewMode).toBe("panes");
+    expect(useAppStore.getState().workspaces[REPO_A].viewMode).toBe("kanban");
+  });
 });
 
 describe("local workspaces", () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -2269,7 +2269,9 @@ export const useAppStore = create<AppStateModel>()(
   setWorkspaceViewMode(mode) {
     set((s) => {
       const workspaceId = activeWorkspaceId(s);
-      if (!s.activeProject || !workspaceId) return s;
+      if (!s.activeProject || !workspaceId) {
+        return s.workspaceViewMode === mode ? s : { workspaceViewMode: mode };
+      }
       const viewScope = workspaceViewScopeForActiveWorkspace(
         s.workspaces,
         workspaceId,

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -984,6 +984,55 @@ test.describe("workspace kanban mode", () => {
     await expect(page.getByTestId("workspace-kanban")).toHaveCount(0);
   });
 
+  test("switches mode after focusing the empty instant sessions area", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          interface: { defaultWorkspaceViewMode: "kanban" },
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("project-session", "project", "ready", {
+        project_scoped: true,
+        worktree_path: "/tmp/demo",
+      }),
+    ]);
+
+    await page.goto("/");
+
+    const modeSelect = page.getByTestId("workspace-view-status");
+    await expect(modeSelect).toContainText("Kanban");
+    await expect(page.getByTestId("workspace-kanban")).toBeVisible();
+
+    const instantArea = page.getByRole("region", {
+      name: "Local terminal sessions",
+    });
+    await instantArea
+      .getByText("Double-click to start an instant session.")
+      .click();
+    await modeSelect.click();
+    await page.getByRole("option", { name: "Panes" }).click();
+
+    await expect(modeSelect).toContainText("Panes");
+    await expect(page.getByTestId("workspace-kanban")).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = localStorage.getItem("acorn-workspaces");
+          return raw
+            ? JSON.parse(raw).state.workspaces["/tmp/demo"]?.viewMode
+            : null;
+        }),
+      )
+      .toBe("kanban");
+  });
+
   test("creates regular and worktree sessions from the kanban toolbar", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Fixes a workspace mode selector no-op when the empty Instant Sessions area is focused.

1. **Empty instant focus fallback** — allow `setWorkspaceViewMode` to update the current view-mode mirror when there is no active workspace to persist against.
2. **Regression coverage** — add store and Playwright coverage for switching Kanban → Panes after focusing the empty Instant Sessions area while preserving the project workspace mode.

## Expected impact
| Flow | Before | After |
| --- | --- | --- |
| Empty Instant Sessions area focused in Kanban mode | Selecting Panes appeared to do nothing | The main workspace switches to Panes immediately |
| Project and selected instant-session view modes | Project/local mode persistence already worked | Existing per-project and selected instant-session behavior is unchanged |

## Design notes
- The empty Instant Sessions area can clear `activeProject`/`activeProjectFolderId`, leaving no workspace record for `setWorkspaceViewMode` to update. In that state the selector should still control the visible workspace mode.
- Persisted project and local-session modes still flow through the existing scoped workspace-mode logic; the fallback only applies when there is no active workspace.

## Test plan
- [x] `git diff --check` passes
- [x] `pnpm exec vitest run src/store.test.ts` — 141 passed
- [x] `pnpm exec playwright test tests/e2e/kanban.spec.ts` — 14 passed
- [x] `pnpm run typecheck` passes