### PR TITLE
feat(settings): user-managed terminal font presets

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -518,7 +518,9 @@ describe("SettingsModal font controls", () => {
       await Promise.resolve();
     });
 
-    const fontFamily = document.querySelector<HTMLInputElement>("input");
+    const fontFamily = Array.from(
+      document.querySelectorAll<HTMLInputElement>("input"),
+    ).find((input) => input.value === DEFAULT_SETTINGS.terminal.fontFamily);
     const patchTerminal = useSettings.getState().patchTerminal;
     const bodyText = document.body.textContent ?? "";
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -7,6 +7,7 @@ import {
   Keyboard,
   Loader2,
   RefreshCcw,
+  Save,
   Settings as SettingsIcon,
   Sparkles,
   Trash2,
@@ -68,7 +69,6 @@ import {
   SESSION_TITLE_PROMPT_PREVIEW_MESSAGE,
   SESSION_TITLE_PROMPT_MAX_CHARS,
   SESSION_TITLE_OPTIONS,
-  TERMINAL_FONT_PRESETS,
   TERMINAL_FONT_SIZE_MAX,
   TERMINAL_FONT_SIZE_MIN,
   TERMINAL_FONT_SIZE_STEP,
@@ -566,32 +566,67 @@ function terminalFontSmoothingLabel(
 
 function TerminalSettings() {
   const settings = useSettings((s) => s.settings);
+  const applyTerminalFontPreset = useSettings((s) => s.applyTerminalFontPreset);
+  const saveTerminalFontPreset = useSettings((s) => s.saveTerminalFontPreset);
+  const deleteTerminalFontPreset = useSettings(
+    (s) => s.deleteTerminalFontPreset,
+  );
   const patchTerminal = useSettings((s) => s.patchTerminal);
-  const patchExperiments = useSettings((s) => s.patchExperiments);
   const t = useTranslation();
-  const activeFontPresetId = matchingTerminalFontPresetId(settings);
+  const terminalFontPresets = settings.fontPresets.terminal;
+  const activeFontPresetId = matchingTerminalFontPresetId(
+    settings,
+    terminalFontPresets,
+  );
+  const activeFontPreset = activeFontPresetId
+    ? terminalFontPresetById(terminalFontPresets, activeFontPresetId)
+    : null;
+  const [presetNameDraft, setPresetNameDraft] = useState(
+    () => activeFontPreset?.name ?? "",
+  );
+  const activeFontPresetMarker = `${activeFontPresetId ?? ""}\u0000${
+    activeFontPreset?.name ?? ""
+  }`;
+  const previousActiveFontPresetMarkerRef = useRef<string>(
+    activeFontPresetMarker,
+  );
+
+  useEffect(() => {
+    if (previousActiveFontPresetMarkerRef.current === activeFontPresetMarker) {
+      return;
+    }
+    previousActiveFontPresetMarkerRef.current = activeFontPresetMarker;
+    setPresetNameDraft(activeFontPreset?.name ?? "");
+  }, [activeFontPreset?.name, activeFontPresetMarker]);
+
+  const hasFontPresets = terminalFontPresets.length > 0;
   const fontPresetOptions: SelectItem[] = [
-    ...(activeFontPresetId === null
+    ...(hasFontPresets && activeFontPresetId === null
       ? [
           {
             value: "custom",
             label: st(t, "settings.terminal.fontPreset.custom"),
+            description: st(t, "settings.terminal.fontPreset.customHint"),
             disabled: true,
           },
         ]
       : []),
-    ...TERMINAL_FONT_PRESETS.map((preset) => ({
-      value: preset.id,
-      label: st(
-        t,
-        `settings.terminal.fontPreset.options.${preset.id}.label` as TranslationKey,
-      ),
-      description: st(
-        t,
-        `settings.terminal.fontPreset.options.${preset.id}.description` as TranslationKey,
-      ),
-    })),
+    ...(hasFontPresets
+      ? terminalFontPresets.map((preset) => ({
+          value: preset.id,
+          label: preset.name,
+        }))
+      : [
+          {
+            value: "empty",
+            label: st(t, "settings.terminal.fontPreset.empty"),
+            disabled: true,
+          },
+        ]),
   ];
+  const savePreset = () => {
+    saveTerminalFontPreset(presetNameDraft);
+  };
 
   return (
     <section className="space-y-4">
@@ -599,18 +634,62 @@ function TerminalSettings() {
         label={st(t, "settings.terminal.fontPreset.label")}
         hint={st(t, "settings.terminal.fontPreset.hint")}
       >
-        <Select
-          value={activeFontPresetId ?? "custom"}
-          onValueChange={(presetId) => {
-            const preset = terminalFontPresetById(presetId);
-            if (!preset) return;
-            patchTerminal(preset.settings);
-            patchExperiments(preset.experiments);
-          }}
-          options={fontPresetOptions}
-          className="min-w-[14rem]"
-          aria-label={st(t, "settings.terminal.fontPreset.label")}
-        />
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <Select
+              value={
+                activeFontPresetId ??
+                (hasFontPresets ? "custom" : "empty")
+              }
+              onValueChange={(presetId) => {
+                if (presetId === "custom" || presetId === "empty") return;
+                applyTerminalFontPreset(presetId);
+              }}
+              options={fontPresetOptions}
+              className="min-w-[14rem] flex-1"
+              aria-label={st(t, "settings.terminal.fontPreset.selectLabel")}
+            />
+            <Button
+              variant="dangerGhost"
+              onClick={() => {
+                if (activeFontPresetId) {
+                  deleteTerminalFontPreset(activeFontPresetId);
+                }
+              }}
+              disabled={!activeFontPresetId}
+              aria-label={st(t, "settings.terminal.fontPreset.deleteLabel")}
+            >
+              <Trash2 size={12} />
+              {st(t, "settings.terminal.fontPreset.delete")}
+            </Button>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <TextInput
+              value={presetNameDraft}
+              onChange={(event) => setPresetNameDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  savePreset();
+                  event.currentTarget.blur();
+                }
+              }}
+              placeholder={st(
+                t,
+                "settings.terminal.fontPreset.namePlaceholder",
+              )}
+              aria-label={st(t, "settings.terminal.fontPreset.nameLabel")}
+              className="min-w-[14rem] flex-1"
+            />
+            <Button
+              variant="outline"
+              onClick={savePreset}
+              disabled={!presetNameDraft.trim()}
+            >
+              <Save size={12} />
+              {st(t, "settings.terminal.fontPreset.save")}
+            </Button>
+          </div>
+        </div>
       </Field>
       <Field
         label={st(t, "settings.terminal.fontFamily.label")}

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -9,7 +9,6 @@ import {
   NOTIFICATION_HISTORY_LIMIT_MAX,
   TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS,
   TERMINAL_FONT_PRESET_FIELDS,
-  TERMINAL_FONT_PRESETS,
   TERMINAL_FONT_SIZE_MAX,
   TERMINAL_FONT_SIZE_MIN,
   TERMINAL_FONT_SIZE_STEP,
@@ -431,14 +430,18 @@ describe("terminal font presets", () => {
     });
   });
 
-  it("matches the default terminal font settings to the default preset", () => {
-    expect(matchingTerminalFontPresetId(DEFAULT_SETTINGS)).toBe(
-      "default",
-    );
-    expect(terminalFontPresetById("missing")).toBeNull();
+  it("starts with no Acorn-provided terminal font presets", () => {
+    expect(DEFAULT_SETTINGS.fontPresets.terminal).toEqual([]);
+    expect(
+      matchingTerminalFontPresetId(
+        DEFAULT_SETTINGS,
+        DEFAULT_SETTINGS.fontPresets.terminal,
+      ),
+    ).toBeNull();
+    expect(terminalFontPresetById([], "missing")).toBeNull();
   });
 
-  it("covers every font-related field in each preset", () => {
+  it("defines the font fields saved in each user preset", () => {
     expect(TERMINAL_FONT_PRESET_FIELDS).toEqual([
       "fontFamily",
       "fontSize",
@@ -451,20 +454,71 @@ describe("terminal font presets", () => {
     expect(TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS).toEqual([
       "cjkCellWidthHeuristic",
     ]);
-
-    const expectedFields = [...TERMINAL_FONT_PRESET_FIELDS].sort();
-    const expectedExperimentFields = [
-      ...TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS,
-    ].sort();
-    for (const preset of TERMINAL_FONT_PRESETS) {
-      expect(Object.keys(preset.settings).sort()).toEqual(expectedFields);
-      expect(Object.keys(preset.experiments).sort()).toEqual(
-        expectedExperimentFields,
-      );
-    }
   });
 
-  it("applies and persists all font-related fields from a preset", async () => {
+  it("loads persisted user font presets and normalizes their values", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        fontPresets: {
+          terminal: [
+            {
+              id: "tiny",
+              name: "  Tiny  Mono  ",
+              settings: {
+                fontFamily: '"Berkeley Mono", Menlo, monospace',
+                fontSize: 4,
+                letterSpacing: 9,
+                fontSmoothing: "sharp",
+                fontWeight: 450,
+                fontWeightBold: 900,
+                lineHeight: 9,
+              },
+              experiments: {
+                cjkCellWidthHeuristic: true,
+              },
+            },
+            {
+              id: "duplicate",
+              name: "tiny mono",
+              settings: {
+                fontFamily: "Ignored",
+              },
+            },
+            {
+              id: "broken",
+              name: "",
+              settings: null,
+            },
+          ],
+        },
+      }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(useSettings.getState().settings.fontPresets.terminal).toEqual([
+      {
+        id: "tiny",
+        name: "Tiny Mono",
+        settings: {
+          fontFamily: '"Berkeley Mono", Menlo, monospace',
+          fontSize: TERMINAL_FONT_SIZE_MIN,
+          letterSpacing: TERMINAL_LETTER_SPACING_MAX,
+          fontSmoothing: DEFAULT_SETTINGS.terminal.fontSmoothing,
+          fontWeight: DEFAULT_SETTINGS.terminal.fontWeight,
+          fontWeightBold: 900,
+          lineHeight: TERMINAL_LINE_HEIGHT_MAX,
+        },
+        experiments: {
+          cjkCellWidthHeuristic: true,
+        },
+      },
+    ]);
+  });
+
+  it("registers the current terminal font settings as a user preset", async () => {
     vi.resetModules();
     const {
       TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS: experimentFields,
@@ -474,69 +528,142 @@ describe("terminal font presets", () => {
       useSettings,
     } = await import("./settings");
 
-    const preset = presetById("comfortable");
-    expect(preset).not.toBeNull();
-    if (!preset) return;
-
-    useSettings.getState().patchTerminal(preset.settings);
-    useSettings.getState().patchExperiments(preset.experiments);
+    useSettings.getState().patchTerminal({
+      fontFamily: '"Berkeley Mono", Menlo, monospace',
+      fontSize: 13.25,
+      letterSpacing: 0.25,
+      fontSmoothing: "subpixel",
+      fontWeight: 500,
+      fontWeightBold: 800,
+      lineHeight: 1.2,
+    });
+    useSettings.getState().patchExperiments({
+      cjkCellWidthHeuristic: true,
+    });
+    const presetId = useSettings
+      .getState()
+      .saveTerminalFontPreset("  Focus  Mono  ");
 
     const settings = useSettings.getState().settings;
     const persisted = JSON.parse(
       localStorage.getItem(STORAGE_KEY) ?? "{}",
     );
+    const preset = presetById(settings.fontPresets.terminal, presetId ?? "");
 
-    expect(matchPreset(settings)).toBe("comfortable");
+    expect(presetId).toBe("font-focus-mono");
+    expect(preset).not.toBeNull();
+    expect(preset?.name).toBe("Focus Mono");
+    expect(matchPreset(settings, settings.fontPresets.terminal)).toBe(
+      "font-focus-mono",
+    );
+    expect(persisted.fontPresets.terminal).toHaveLength(1);
+    expect(persisted.fontPresets.terminal[0].name).toBe("Focus Mono");
     for (const field of fields) {
-      expect(settings.terminal[field]).toBe(preset.settings[field]);
-      expect(persisted.terminal[field]).toBe(preset.settings[field]);
+      expect(preset?.settings[field]).toBe(settings.terminal[field]);
+      expect(persisted.fontPresets.terminal[0].settings[field]).toBe(
+        settings.terminal[field],
+      );
     }
     for (const field of experimentFields) {
-      expect(settings.experiments[field]).toBe(preset.experiments[field]);
-      expect(persisted.experiments[field]).toBe(preset.experiments[field]);
+      expect(preset?.experiments[field]).toBe(settings.experiments[field]);
+      expect(persisted.fontPresets.terminal[0].experiments[field]).toBe(
+        settings.experiments[field],
+      );
     }
+  });
+
+  it("updates an existing user preset when saving the same name", async () => {
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(
+      useSettings.getState().saveTerminalFontPreset("Focus Mono"),
+    ).toBe("font-focus-mono");
+
+    useSettings.getState().patchTerminal({ fontSize: 15 });
+    expect(
+      useSettings.getState().saveTerminalFontPreset("focus mono"),
+    ).toBe("font-focus-mono");
+
+    const presets = useSettings.getState().settings.fontPresets.terminal;
+    expect(presets).toHaveLength(1);
+    expect(presets[0].name).toBe("focus mono");
+    expect(presets[0].settings.fontSize).toBe(15);
+  });
+
+  it("applies and deletes user font presets without changing unrelated settings", async () => {
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    useSettings.getState().patchTerminal({
+      fontFamily: 'D2Coding, "Sarasa Mono K", "JetBrains Mono", monospace',
+      fontSize: 13,
+      letterSpacing: 0,
+      lineHeight: 1.15,
+    });
+    useSettings.getState().patchExperiments({
+      cjkCellWidthHeuristic: true,
+    });
+    const presetId = useSettings.getState().saveTerminalFontPreset("CJK Mono");
+
+    useSettings.getState().patchTerminal({ fontSize: 11, lineHeight: 1 });
+    useSettings.getState().patchExperiments({
+      cjkCellWidthHeuristic: false,
+      stickyPrompt: true,
+    });
+    useSettings.getState().applyTerminalFontPreset(presetId ?? "");
+
+    expect(useSettings.getState().settings.terminal.fontSize).toBe(13);
+    expect(useSettings.getState().settings.terminal.lineHeight).toBe(1.15);
+    expect(
+      useSettings.getState().settings.experiments.cjkCellWidthHeuristic,
+    ).toBe(true);
+    expect(useSettings.getState().settings.experiments.stickyPrompt).toBe(
+      true,
+    );
+
+    useSettings.getState().deleteTerminalFontPreset(presetId ?? "");
+
+    expect(useSettings.getState().settings.fontPresets.terminal).toEqual([]);
+    expect(useSettings.getState().settings.terminal.fontSize).toBe(13);
+    expect(
+      useSettings.getState().settings.experiments.cjkCellWidthHeuristic,
+    ).toBe(true);
   });
 
   it("treats manually changed font settings as custom", () => {
-    expect(
-      matchingTerminalFontPresetId({
-        terminal: {
-          ...DEFAULT_SETTINGS.terminal,
-          fontSize: DEFAULT_SETTINGS.terminal.fontSize + 0.25,
-        },
-        experiments: DEFAULT_SETTINGS.experiments,
-      }),
-    ).toBeNull();
-  });
+    const preset = {
+      id: "font-default-copy",
+      name: "Default copy",
+      settings: {
+        fontFamily: DEFAULT_SETTINGS.terminal.fontFamily,
+        fontSize: DEFAULT_SETTINGS.terminal.fontSize,
+        letterSpacing: DEFAULT_SETTINGS.terminal.letterSpacing,
+        fontSmoothing: DEFAULT_SETTINGS.terminal.fontSmoothing,
+        fontWeight: DEFAULT_SETTINGS.terminal.fontWeight,
+        fontWeightBold: DEFAULT_SETTINGS.terminal.fontWeightBold,
+        lineHeight: DEFAULT_SETTINGS.terminal.lineHeight,
+      },
+      experiments: {
+        cjkCellWidthHeuristic:
+          DEFAULT_SETTINGS.experiments.cjkCellWidthHeuristic,
+      },
+    };
 
-  it("includes the CJK cell-width correction in preset matching", () => {
-    const preset = terminalFontPresetById("cjk");
-    expect(preset).not.toBeNull();
-    if (!preset) return;
-
     expect(
-      matchingTerminalFontPresetId({
-        terminal: {
-          ...DEFAULT_SETTINGS.terminal,
-          ...preset.settings,
-        },
-        experiments: {
-          ...DEFAULT_SETTINGS.experiments,
-          ...preset.experiments,
-        },
-      }),
-    ).toBe("cjk");
+      matchingTerminalFontPresetId(DEFAULT_SETTINGS, [preset]),
+    ).toBe("font-default-copy");
     expect(
-      matchingTerminalFontPresetId({
-        terminal: {
-          ...DEFAULT_SETTINGS.terminal,
-          ...preset.settings,
+      matchingTerminalFontPresetId(
+        {
+          terminal: {
+            ...DEFAULT_SETTINGS.terminal,
+            fontSize: DEFAULT_SETTINGS.terminal.fontSize + 0.25,
+          },
+          experiments: DEFAULT_SETTINGS.experiments,
         },
-        experiments: {
-          ...DEFAULT_SETTINGS.experiments,
-          cjkCellWidthHeuristic: false,
-        },
-      }),
+        [preset],
+      ),
     ).toBeNull();
   });
 });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -168,6 +168,43 @@ export type TerminalFontSmoothing =
 export const TERMINAL_FONT_SMOOTHING_VALUES: ReadonlyArray<TerminalFontSmoothing> =
   ["grayscale", "subpixel", "system", "none"];
 
+export const TERMINAL_FONT_PRESET_FIELDS = [
+  "fontFamily",
+  "fontSize",
+  "letterSpacing",
+  "fontSmoothing",
+  "fontWeight",
+  "fontWeightBold",
+  "lineHeight",
+] as const;
+
+export const TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS = [
+  "cjkCellWidthHeuristic",
+] as const;
+
+type TerminalFontPresetField = (typeof TERMINAL_FONT_PRESET_FIELDS)[number];
+type TerminalFontPresetExperimentField =
+  (typeof TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS)[number];
+
+export type TerminalFontPresetSettings = Pick<
+  AcornSettings["terminal"],
+  TerminalFontPresetField
+>;
+export type TerminalFontPresetExperimentSettings = Pick<
+  AcornSettings["experiments"],
+  TerminalFontPresetExperimentField
+>;
+
+export interface TerminalFontPreset {
+  id: string;
+  name: string;
+  settings: TerminalFontPresetSettings;
+  experiments: TerminalFontPresetExperimentSettings;
+}
+
+export const TERMINAL_FONT_PRESET_LIMIT = 50;
+export const TERMINAL_FONT_PRESET_NAME_MAX_CHARS = 80;
+
 /**
  * Which field acorn shows as the primary line of a sidebar session row.
  * Mirrors Warp's "Pane title as" picker — `name` is the editable session
@@ -444,6 +481,9 @@ export interface AcornSettings {
     uiScalePercent: number;
     toastPosition: ToastPosition;
   };
+  fontPresets: {
+    terminal: TerminalFontPreset[];
+  };
   shortcuts: HotkeyConfig;
   /**
    * Opt-in toggles for unfinished features. Anything under here is
@@ -585,6 +625,9 @@ export const DEFAULT_SETTINGS: AcornSettings = {
     uiScalePercent: 100,
     toastPosition: "top",
   },
+  fontPresets: {
+    terminal: [],
+  },
   shortcuts: { ...DEFAULT_HOTKEYS },
   experiments: {
     stickyPrompt: false,
@@ -594,125 +637,36 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   },
 };
 
-export const TERMINAL_FONT_PRESET_FIELDS = [
-  "fontFamily",
-  "fontSize",
-  "letterSpacing",
-  "fontSmoothing",
-  "fontWeight",
-  "fontWeightBold",
-  "lineHeight",
-] as const;
-
-export const TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS = [
-  "cjkCellWidthHeuristic",
-] as const;
-
-type TerminalFontPresetField = (typeof TERMINAL_FONT_PRESET_FIELDS)[number];
-type TerminalFontPresetExperimentField =
-  (typeof TERMINAL_FONT_PRESET_EXPERIMENT_FIELDS)[number];
-
-export type TerminalFontPresetSettings = Pick<
-  AcornSettings["terminal"],
-  TerminalFontPresetField
->;
-export type TerminalFontPresetExperimentSettings = Pick<
-  AcornSettings["experiments"],
-  TerminalFontPresetExperimentField
->;
-
-export type TerminalFontPresetId =
-  | "default"
-  | "compact"
-  | "comfortable"
-  | "cjk";
-
-export interface TerminalFontPreset {
-  id: TerminalFontPresetId;
-  settings: TerminalFontPresetSettings;
-  experiments: TerminalFontPresetExperimentSettings;
-}
-
-export const TERMINAL_FONT_PRESETS = [
-  {
-    id: "default",
-    settings: {
-      fontFamily: DEFAULT_SETTINGS.terminal.fontFamily,
-      fontSize: DEFAULT_SETTINGS.terminal.fontSize,
-      letterSpacing: DEFAULT_SETTINGS.terminal.letterSpacing,
-      fontSmoothing: DEFAULT_SETTINGS.terminal.fontSmoothing,
-      fontWeight: DEFAULT_SETTINGS.terminal.fontWeight,
-      fontWeightBold: DEFAULT_SETTINGS.terminal.fontWeightBold,
-      lineHeight: DEFAULT_SETTINGS.terminal.lineHeight,
-    },
-    experiments: {
-      cjkCellWidthHeuristic:
-        DEFAULT_SETTINGS.experiments.cjkCellWidthHeuristic,
-    },
-  },
-  {
-    id: "compact",
-    settings: {
-      fontFamily: fontStackFromSlots(
-        ["JetBrains Mono", "Fira Code", "Menlo"],
-        "monospace",
-      ),
-      fontSize: 11,
-      letterSpacing: -0.25,
-      fontSmoothing: "grayscale",
-      fontWeight: 400,
-      fontWeightBold: 700,
-      lineHeight: 1.0,
-    },
-    experiments: {
-      cjkCellWidthHeuristic: false,
-    },
-  },
-  {
-    id: "comfortable",
-    settings: {
-      fontFamily: fontStackFromSlots(
-        ["JetBrains Mono", "Fira Code", "Menlo"],
-        "monospace",
-      ),
-      fontSize: 13.25,
-      letterSpacing: 0.25,
-      fontSmoothing: "grayscale",
-      fontWeight: 400,
-      fontWeightBold: 700,
-      lineHeight: 1.2,
-    },
-    experiments: {
-      cjkCellWidthHeuristic: false,
-    },
-  },
-  {
-    id: "cjk",
-    settings: {
-      fontFamily: fontStackFromSlots(
-        ["D2Coding", "Sarasa Mono K", "JetBrains Mono"],
-        "monospace",
-      ),
-      fontSize: 13,
-      letterSpacing: 0,
-      fontSmoothing: "grayscale",
-      fontWeight: 400,
-      fontWeightBold: 700,
-      lineHeight: 1.15,
-    },
-    experiments: {
-      cjkCellWidthHeuristic: true,
-    },
-  },
-] as const satisfies ReadonlyArray<TerminalFontPreset>;
-
 export function terminalFontPresetById(
+  presets: ReadonlyArray<TerminalFontPreset>,
   id: string,
 ): TerminalFontPreset | null {
-  return TERMINAL_FONT_PRESETS.find((preset) => preset.id === id) ?? null;
+  return presets.find((preset) => preset.id === id) ?? null;
 }
 
-function terminalFontPresetMatches(
+export function terminalFontPresetSettings(
+  settings: Pick<AcornSettings, "terminal">,
+): TerminalFontPresetSettings {
+  return {
+    fontFamily: settings.terminal.fontFamily,
+    fontSize: settings.terminal.fontSize,
+    letterSpacing: settings.terminal.letterSpacing,
+    fontSmoothing: settings.terminal.fontSmoothing,
+    fontWeight: settings.terminal.fontWeight,
+    fontWeightBold: settings.terminal.fontWeightBold,
+    lineHeight: settings.terminal.lineHeight,
+  };
+}
+
+export function terminalFontPresetExperiments(
+  settings: Pick<AcornSettings, "experiments">,
+): TerminalFontPresetExperimentSettings {
+  return {
+    cjkCellWidthHeuristic: settings.experiments.cjkCellWidthHeuristic,
+  };
+}
+
+export function terminalFontPresetMatches(
   settings: Pick<AcornSettings, "terminal" | "experiments">,
   preset: TerminalFontPreset,
 ): boolean {
@@ -728,9 +682,10 @@ function terminalFontPresetMatches(
 
 export function matchingTerminalFontPresetId(
   settings: Pick<AcornSettings, "terminal" | "experiments">,
-): TerminalFontPresetId | null {
+  presets: ReadonlyArray<TerminalFontPreset>,
+): string | null {
   return (
-    TERMINAL_FONT_PRESETS.find((preset) =>
+    presets.find((preset) =>
       terminalFontPresetMatches(settings, preset),
     )?.id ?? null
   );
@@ -929,6 +884,143 @@ function normalizeWeight(
   return fallback;
 }
 
+function normalizeTerminalFontPresetName(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  const name = v.trim().replace(/\s+/g, " ");
+  if (!name) return null;
+  return Array.from(name)
+    .slice(0, TERMINAL_FONT_PRESET_NAME_MAX_CHARS)
+    .join("");
+}
+
+function terminalFontPresetIdBase(name: string): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug ? `font-${slug}` : "font-preset";
+}
+
+function uniqueTerminalFontPresetId(
+  name: string,
+  presets: ReadonlyArray<TerminalFontPreset>,
+): string {
+  const existing = new Set(presets.map((preset) => preset.id));
+  const base = terminalFontPresetIdBase(name);
+  if (!existing.has(base)) return base;
+
+  for (let index = 2; index < 10_000; index += 1) {
+    const candidate = `${base}-${index}`;
+    if (!existing.has(candidate)) return candidate;
+  }
+
+  return `${base}-${Date.now()}`;
+}
+
+function normalizeTerminalFontPresetId(v: unknown, fallback: string): string {
+  if (typeof v !== "string") return fallback;
+  const id = v.trim();
+  return id ? id.slice(0, 120) : fallback;
+}
+
+function normalizeTerminalFontPresetSettings(
+  v: unknown,
+): TerminalFontPresetSettings | null {
+  if (!v || typeof v !== "object") return null;
+  const raw = v as Partial<TerminalFontPresetSettings>;
+  return {
+    fontFamily:
+      typeof raw.fontFamily === "string" && raw.fontFamily.trim()
+        ? raw.fontFamily
+        : DEFAULT_SETTINGS.terminal.fontFamily,
+    fontSize: normalizeTerminalFontSize(
+      raw.fontSize,
+      DEFAULT_SETTINGS.terminal.fontSize,
+    ),
+    letterSpacing: normalizeTerminalLetterSpacing(
+      raw.letterSpacing,
+      DEFAULT_SETTINGS.terminal.letterSpacing,
+    ),
+    fontSmoothing: normalizeTerminalFontSmoothing(
+      raw.fontSmoothing,
+      DEFAULT_SETTINGS.terminal.fontSmoothing,
+    ),
+    fontWeight: normalizeWeight(
+      raw.fontWeight,
+      DEFAULT_SETTINGS.terminal.fontWeight,
+    ),
+    fontWeightBold: normalizeWeight(
+      raw.fontWeightBold,
+      DEFAULT_SETTINGS.terminal.fontWeightBold,
+    ),
+    lineHeight: normalizeLineHeight(
+      raw.lineHeight,
+      DEFAULT_SETTINGS.terminal.lineHeight,
+    ),
+  };
+}
+
+function normalizeTerminalFontPresetExperiments(
+  v: unknown,
+): TerminalFontPresetExperimentSettings {
+  const raw =
+    v && typeof v === "object"
+      ? (v as Partial<TerminalFontPresetExperimentSettings>)
+      : {};
+  return {
+    cjkCellWidthHeuristic:
+      typeof raw.cjkCellWidthHeuristic === "boolean"
+        ? raw.cjkCellWidthHeuristic
+        : DEFAULT_SETTINGS.experiments.cjkCellWidthHeuristic,
+  };
+}
+
+function normalizeTerminalFontPresets(
+  v: unknown,
+): TerminalFontPreset[] {
+  if (!Array.isArray(v)) return DEFAULT_SETTINGS.fontPresets.terminal;
+
+  const presets: TerminalFontPreset[] = [];
+  const seenIds = new Set<string>();
+  const seenNames = new Set<string>();
+
+  for (const item of v) {
+    if (!item || typeof item !== "object") continue;
+    const raw = item as {
+      id?: unknown;
+      name?: unknown;
+      settings?: unknown;
+      experiments?: unknown;
+    };
+    const name = normalizeTerminalFontPresetName(raw.name);
+    const settings = normalizeTerminalFontPresetSettings(raw.settings);
+    if (!name || !settings) continue;
+
+    const nameKey = name.toLocaleLowerCase();
+    if (seenNames.has(nameKey)) continue;
+
+    const fallbackId = uniqueTerminalFontPresetId(name, presets);
+    const id = normalizeTerminalFontPresetId(raw.id, fallbackId);
+    const uniqueId = seenIds.has(id)
+      ? uniqueTerminalFontPresetId(name, presets)
+      : id;
+
+    presets.push({
+      id: uniqueId,
+      name,
+      settings,
+      experiments: normalizeTerminalFontPresetExperiments(raw.experiments),
+    });
+    seenIds.add(uniqueId);
+    seenNames.add(nameKey);
+
+    if (presets.length >= TERMINAL_FONT_PRESET_LIMIT) break;
+  }
+
+  return presets;
+}
+
 function normalizeSelectedAgent(
   v: unknown,
   fallback: SelectedAgent,
@@ -1047,6 +1139,9 @@ function loadSettings(): AcornSettings {
       AcornSettings["interface"]
     >;
     const terminalRaw: Partial<AcornSettings["terminal"]> = parsed.terminal ?? {};
+    const fontPresetsRaw = (parsed.fontPresets ?? {}) as {
+      terminal?: unknown;
+    };
     const sessionsRaw = (parsed.sessions ?? {}) as PersistedSessionSettings;
     const notificationEventsRaw = (parsed.notifications?.events ?? {}) as {
       waitingForInput?: unknown;
@@ -1350,6 +1445,9 @@ function loadSettings(): AcornSettings {
             : DEFAULT_SETTINGS.sessionDisplay.showDetailsOnHover,
       },
       appearance,
+      fontPresets: {
+        terminal: normalizeTerminalFontPresets(fontPresetsRaw.terminal),
+      },
       shortcuts: resolveHotkeys(
         (parsed.shortcuts ?? {}) as Partial<Record<HotkeyId, unknown>>,
       ),
@@ -1439,6 +1537,9 @@ interface SettingsState {
       fontSlots?: AcornSettings["appearance"]["fontSlots"];
     },
   ) => void;
+  applyTerminalFontPreset: (id: string) => void;
+  saveTerminalFontPreset: (name: string) => string | null;
+  deleteTerminalFontPreset: (id: string) => void;
   patchShortcut: (id: HotkeyId, binding: string) => void;
   resetShortcut: (id: HotkeyId) => void;
   resetShortcuts: () => void;
@@ -1698,6 +1799,86 @@ export const useSettings = create<SettingsState>((set, get) => ({
       const next: AcornSettings = {
         ...s.settings,
         appearance,
+      };
+      persist(next);
+      return { settings: next };
+    }),
+  applyTerminalFontPreset: (id) =>
+    set((s) => {
+      const preset = terminalFontPresetById(
+        s.settings.fontPresets.terminal,
+        id,
+      );
+      if (!preset) return s;
+      const next: AcornSettings = {
+        ...s.settings,
+        terminal: {
+          ...s.settings.terminal,
+          ...preset.settings,
+        },
+        experiments: {
+          ...s.settings.experiments,
+          ...preset.experiments,
+        },
+      };
+      persist(next);
+      return { settings: next };
+    }),
+  saveTerminalFontPreset: (name) => {
+    let savedId: string | null = null;
+    set((s) => {
+      const normalizedName = normalizeTerminalFontPresetName(name);
+      if (!normalizedName) return s;
+
+      const presets = s.settings.fontPresets.terminal;
+      const existingIndex = presets.findIndex(
+        (preset) =>
+          preset.name.toLocaleLowerCase() ===
+          normalizedName.toLocaleLowerCase(),
+      );
+      const preset: TerminalFontPreset = {
+        id:
+          existingIndex >= 0
+            ? presets[existingIndex].id
+            : uniqueTerminalFontPresetId(normalizedName, presets),
+        name: normalizedName,
+        settings: terminalFontPresetSettings(s.settings),
+        experiments: terminalFontPresetExperiments(s.settings),
+      };
+      savedId = preset.id;
+
+      const terminal =
+        existingIndex >= 0
+          ? presets.map((item, index) =>
+              index === existingIndex ? preset : item,
+            )
+          : [preset, ...presets].slice(0, TERMINAL_FONT_PRESET_LIMIT);
+      const next: AcornSettings = {
+        ...s.settings,
+        fontPresets: {
+          ...s.settings.fontPresets,
+          terminal,
+        },
+      };
+      persist(next);
+      return { settings: next };
+    });
+    return savedId;
+  },
+  deleteTerminalFontPreset: (id) =>
+    set((s) => {
+      const terminal = s.settings.fontPresets.terminal.filter(
+        (preset) => preset.id !== id,
+      );
+      if (terminal.length === s.settings.fontPresets.terminal.length) {
+        return s;
+      }
+      const next: AcornSettings = {
+        ...s.settings,
+        fontPresets: {
+          ...s.settings.fontPresets,
+          terminal,
+        },
       };
       persist(next);
       return { settings: next };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -117,27 +117,17 @@
     },
     "terminal": {
       "fontPreset": {
-        "label": "Font preset",
-        "hint": "Applies the family stack, size, spacing, anti-aliasing, weights, and line height together.",
+        "label": "Font presets",
+        "hint": "Save the current terminal font settings as your own preset, then apply it later.",
+        "selectLabel": "Saved font preset",
         "custom": "Custom",
-        "options": {
-          "default": {
-            "label": "Acorn default",
-            "description": "Balanced JetBrains Mono stack at 12px."
-          },
-          "compact": {
-            "label": "Compact",
-            "description": "Smaller type with tighter horizontal spacing."
-          },
-          "comfortable": {
-            "label": "Comfortable",
-            "description": "Larger type with more row and cell spacing."
-          },
-          "cjk": {
-            "label": "CJK mono",
-            "description": "D2Coding / Sarasa stack tuned for Korean and CJK glyphs."
-          }
-        }
+        "customHint": "Current settings are not saved as a preset.",
+        "empty": "No saved presets",
+        "nameLabel": "Preset name",
+        "namePlaceholder": "e.g. Compact D2Coding",
+        "save": "Save current",
+        "delete": "Delete",
+        "deleteLabel": "Delete selected font preset"
       },
       "fontFamily": {
         "label": "Font family",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -118,26 +118,16 @@
     "terminal": {
       "fontPreset": {
         "label": "글꼴 프리셋",
-        "hint": "서체 목록, 크기, 간격, 안티앨리어싱, 두께, 줄 높이를 함께 적용합니다.",
+        "hint": "현재 터미널 글꼴 설정을 내 프리셋으로 저장한 뒤 나중에 다시 적용합니다.",
+        "selectLabel": "저장된 글꼴 프리셋",
         "custom": "사용자 지정",
-        "options": {
-          "default": {
-            "label": "Acorn 기본값",
-            "description": "JetBrains Mono 스택을 12px로 맞춘 균형 잡힌 설정입니다."
-          },
-          "compact": {
-            "label": "조밀하게",
-            "description": "더 작은 글꼴과 촘촘한 가로 간격을 사용합니다."
-          },
-          "comfortable": {
-            "label": "넓게",
-            "description": "더 큰 글꼴과 여유 있는 행/셀 간격을 사용합니다."
-          },
-          "cjk": {
-            "label": "CJK 고정폭",
-            "description": "한국어와 CJK 글리프에 맞춘 D2Coding / Sarasa 스택입니다."
-          }
-        }
+        "customHint": "현재 설정은 저장된 프리셋과 일치하지 않습니다.",
+        "empty": "저장된 프리셋 없음",
+        "nameLabel": "프리셋 이름",
+        "namePlaceholder": "예: 조밀한 D2Coding",
+        "save": "현재 설정 저장",
+        "delete": "삭제",
+        "deleteLabel": "선택한 글꼴 프리셋 삭제"
       },
       "fontFamily": {
         "label": "글꼴 패밀리",

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -112,7 +112,7 @@ test.describe("settings modal", () => {
       .toBe("subpixel");
   });
 
-  test("applies terminal font presets and marks manual font changes as custom", async ({
+  test("registers terminal font presets and applies them later", async ({
     page,
   }) => {
     await page.goto("/");
@@ -122,36 +122,41 @@ test.describe("settings modal", () => {
     await modal.getByRole("button", { name: /^(Terminal|터미널)$/ }).click();
 
     const presetSelect = modal.getByRole("combobox", {
-      name: /^(Font preset|글꼴 프리셋)$/,
+      name: /^(Saved font preset|저장된 글꼴 프리셋)$/,
     });
-    await expect(presetSelect).toContainText("Acorn default");
+    await expect(presetSelect).toContainText("No saved presets");
 
-    await presetSelect.click();
-    await page.getByRole("option", { name: /CJK mono/ }).click();
+    await modal
+      .getByRole("textbox", {
+        name: /^(Preset name|프리셋 이름)$/,
+      })
+      .fill("Default copy");
+    await modal
+      .getByRole("button", {
+        name: /^(Save current|현재 설정 저장)$/,
+      })
+      .click();
 
-    await expect(presetSelect).toContainText("CJK mono");
+    await expect(presetSelect).toContainText("Default copy");
     await expect
       .poll(() =>
         page.evaluate(() => {
           const raw = window.localStorage.getItem("acorn:settings:v1");
           const settings = raw ? JSON.parse(raw) : null;
-          const terminal = settings?.terminal ?? null;
-          return {
-            fontFamily: terminal?.fontFamily ?? null,
-            fontSize: terminal?.fontSize ?? null,
-            letterSpacing: terminal?.letterSpacing ?? null,
-            lineHeight: terminal?.lineHeight ?? null,
-            cjkCellWidthHeuristic:
-              settings?.experiments?.cjkCellWidthHeuristic ?? null,
-          };
+          return settings?.fontPresets?.terminal?.[0] ?? null;
         }),
       )
-      .toEqual({
-        fontFamily: 'D2Coding, "Sarasa Mono K", "JetBrains Mono", monospace',
-        fontSize: 13,
-        letterSpacing: 0,
-        lineHeight: 1.15,
-        cjkCellWidthHeuristic: true,
+      .toMatchObject({
+        id: "font-default-copy",
+        name: "Default copy",
+        settings: {
+          fontSize: 12,
+          letterSpacing: 0,
+          lineHeight: 1,
+        },
+        experiments: {
+          cjkCellWidthHeuristic: false,
+        },
       });
 
     const fontSizeField = modal
@@ -164,6 +169,21 @@ test.describe("settings modal", () => {
     await fontSizeInput.press("Enter");
 
     await expect(presetSelect).toContainText("Custom");
+
+    await presetSelect.click();
+    await page.getByRole("option", { name: "Default copy" }).click();
+
+    await expect(presetSelect).toContainText("Default copy");
+    await expect(fontSizeInput).toHaveValue("12");
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("acorn:settings:v1");
+          const settings = raw ? JSON.parse(raw) : null;
+          return settings?.terminal?.fontSize ?? null;
+        }),
+      )
+      .toBe(12);
   });
 
   test("changes kanban terminal popover settings and persists them", async ({


### PR DESCRIPTION
## Summary
Terminal font presets now come from user-saved settings instead of Acorn's fixed built-in list.

1. **User preset storage** — add `fontPresets.terminal` to persisted settings, with normalization for preset names, ids, terminal font fields, and the CJK cell-width experiment flag.
2. **Settings UI workflow** — replace the built-in preset picker with saved-preset selection, current-settings save, and selected-preset delete controls in Settings → Terminal.
3. **Preset application behavior** — apply saved presets across font family, size, spacing, smoothing, weights, line height, and CJK cell-width correction while leaving unrelated terminal/session settings untouched.
4. **Coverage and copy** — update English/Korean settings copy plus Vitest and Playwright coverage for registration, custom detection, apply, delete, and malformed persisted values.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Font presets | Acorn-provided presets only | Users create and manage their own presets |
| Settings persistence | No user preset registry | Presets persist under `fontPresets.terminal` |
| Existing installs | Fixed presets disappear from the selector | Existing terminal font values remain unchanged and can be saved as a preset |

## Design notes
- Presets intentionally snapshot only the fields the old preset system controlled: terminal font family, size, letter spacing, smoothing, normal/bold weights, line height, and `experiments.cjkCellWidthHeuristic`.
- Invalid persisted presets are dropped or clamped during settings load so hand-edited localStorage cannot push terminal font controls outside the supported UI ranges.
- Matching a preset is now computed against the saved user preset list, so manual edits show as Custom until the user saves or reapplies a matching preset.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test -- src/lib/settings.test.ts src/components/SettingsModal.test.tsx` — 80 files / 885 tests passed
- [x] `pnpm run test:e2e -- tests/e2e/settings.spec.ts` — 11 tests passed
