### PR TITLE
fix(kanban): refresh PR metadata after list updates

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -53,6 +53,7 @@ import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
 import { rightPanelCache } from "../lib/right-panel-cache";
 import { classifyRightPanelFsChange } from "../lib/right-panel-invalidation";
 import { useSettings } from "../lib/settings";
+import { primeCurrentPullRequestCacheFromListing } from "../lib/useCurrentPullRequest";
 import { useAppStore } from "../store";
 import {
   AgentProviderIcon,
@@ -2989,6 +2990,7 @@ function PullRequestsTab({
           repoPath,
           result.kind === "ok" ? result.account : null,
         );
+        primeCurrentPullRequestCacheFromListing(repoPath, result);
       } catch (e) {
         if (
           signal?.cancelled ||

--- a/src/lib/useCurrentPullRequest.test.tsx
+++ b/src/lib/useCurrentPullRequest.test.tsx
@@ -1,0 +1,123 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PullRequestInfo, PullRequestListing, Session } from "./types";
+
+vi.mock("./api", () => ({
+  api: {
+    listPullRequests: vi.fn<() => Promise<PullRequestListing>>(),
+  },
+}));
+
+import { api } from "./api";
+import {
+  primeCurrentPullRequestCacheFromListing,
+  useCurrentPullRequest,
+} from "./useCurrentPullRequest";
+
+const mockApi = vi.mocked(api);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "runner",
+    name: "runner",
+    repo_path: "/tmp/demo",
+    worktree_path: "/tmp/demo/.worktrees/runner",
+    branch: "feat/runner",
+    isolated: false,
+    status: "working",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: null,
+    title_source: "default",
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: false,
+    ...overrides,
+  };
+}
+
+function pullRequest(overrides: Partial<PullRequestInfo> = {}): PullRequestInfo {
+  return {
+    number: 77,
+    title: "Add kanban PR context",
+    state: "OPEN",
+    author: "ian",
+    head_branch: "feat/runner",
+    base_branch: "main",
+    url: "https://github.com/im-ian/acorn/pull/77",
+    updated_at: "2026-01-01T00:00:00Z",
+    is_draft: false,
+    checks: null,
+    labels: [],
+    ...overrides,
+  };
+}
+
+function Probe({ value }: { value: Session }) {
+  const currentPullRequest = useCurrentPullRequest(value);
+  return (
+    <div>{currentPullRequest ? `PR #${currentPullRequest.number}` : "none"}</div>
+  );
+}
+
+describe("useCurrentPullRequest", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockApi.listPullRequests.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("keeps a primed PR when an older direct lookup resolves empty", async () => {
+    const pending = deferred<PullRequestListing>();
+    mockApi.listPullRequests.mockReturnValueOnce(pending.promise);
+
+    await act(async () => {
+      root.render(<Probe value={session()} />);
+    });
+
+    expect(container.textContent).toBe("none");
+    expect(mockApi.listPullRequests).toHaveBeenCalledWith(
+      "/tmp/demo/.worktrees/runner",
+      "open",
+      10,
+      "head:feat/runner",
+    );
+
+    act(() => {
+      primeCurrentPullRequestCacheFromListing("/tmp/demo", {
+        kind: "ok",
+        account: "test",
+        items: [pullRequest()],
+      });
+    });
+    expect(container.textContent).toBe("PR #77");
+
+    await act(async () => {
+      pending.resolve({ kind: "ok", account: "test", items: [] });
+      await pending.promise;
+    });
+
+    expect(container.textContent).toBe("PR #77");
+  });
+});

--- a/src/lib/useCurrentPullRequest.ts
+++ b/src/lib/useCurrentPullRequest.ts
@@ -4,7 +4,11 @@ import {
   currentPullRequestSearchQuery,
   findCurrentPullRequestForBranch,
 } from "./sessionContext";
-import type { Session, SessionPullRequestSummary } from "./types";
+import type {
+  PullRequestListing,
+  Session,
+  SessionPullRequestSummary,
+} from "./types";
 
 const CURRENT_PR_CACHE_TTL_MS = 60_000;
 const CURRENT_PR_EMPTY_RETRY_MS = 15_000;
@@ -15,10 +19,59 @@ type CurrentPullRequestCacheEntry = {
   promise?: Promise<SessionPullRequestSummary | null>;
 };
 
+type CurrentPullRequestSubscriber = {
+  projectRepoPath: string;
+  lookupRepoPath: string;
+  branch: string;
+  onPrime: (value: SessionPullRequestSummary) => void;
+};
+
 const currentPullRequestCache = new Map<string, CurrentPullRequestCacheEntry>();
+const currentPullRequestProjectCache = new Map<
+  string,
+  CurrentPullRequestCacheEntry
+>();
+const currentPullRequestSubscribers = new Set<CurrentPullRequestSubscriber>();
+
+function normalizeRepoPath(repoPath: string): string {
+  return repoPath.replace(/\\/g, "/").replace(/\/+$/, "");
+}
 
 function currentPullRequestCacheKey(repoPath: string, branch: string): string {
-  return `${repoPath}\u0000${branch}`;
+  return `${normalizeRepoPath(repoPath)}\u0000${branch}`;
+}
+
+function currentPullRequestProjectCacheKey(
+  repoPath: string,
+  branch: string,
+): string {
+  return `${normalizeRepoPath(repoPath)}\u0000${branch}`;
+}
+
+function setCurrentPullRequestCache(
+  repoPath: string,
+  branch: string,
+  value: SessionPullRequestSummary | null,
+  ttlMs: number,
+): void {
+  currentPullRequestCache.set(currentPullRequestCacheKey(repoPath, branch), {
+    value,
+    expiresAt: Date.now() + ttlMs,
+  });
+}
+
+function readPrimedCurrentPullRequest(
+  projectRepoPath: string,
+  branch: string,
+): SessionPullRequestSummary | null {
+  const key = currentPullRequestProjectCacheKey(projectRepoPath, branch);
+  const cached = currentPullRequestProjectCache.get(key);
+  if (!cached) return null;
+  if (cached.expiresAt <= Date.now()) {
+    currentPullRequestProjectCache.delete(key);
+    return null;
+  }
+  return cached.value;
 }
 
 function currentPullRequestRepoPath(session: Session): string {
@@ -27,6 +80,46 @@ function currentPullRequestRepoPath(session: Session): string {
     session.worktree_path ||
     session.repo_path
   );
+}
+
+export function primeCurrentPullRequestCacheFromListing(
+  projectRepoPath: string,
+  listing: PullRequestListing,
+): void {
+  if (listing.kind !== "ok") return;
+
+  const expiresAt = Date.now() + CURRENT_PR_CACHE_TTL_MS;
+  const summariesByBranch = new Map<string, SessionPullRequestSummary>();
+  for (const item of listing.items) {
+    const summary = findCurrentPullRequestForBranch(
+      { kind: "ok", account: listing.account, items: [item] },
+      item.head_branch,
+    );
+    if (!summary) continue;
+    summariesByBranch.set(summary.head_branch, summary);
+    currentPullRequestProjectCache.set(
+      currentPullRequestProjectCacheKey(projectRepoPath, summary.head_branch),
+      {
+        value: summary,
+        expiresAt,
+      },
+    );
+  }
+
+  if (summariesByBranch.size === 0) return;
+  const normalizedProjectRepoPath = normalizeRepoPath(projectRepoPath);
+  for (const subscriber of currentPullRequestSubscribers) {
+    if (subscriber.projectRepoPath !== normalizedProjectRepoPath) continue;
+    const summary = summariesByBranch.get(subscriber.branch);
+    if (!summary) continue;
+    setCurrentPullRequestCache(
+      subscriber.lookupRepoPath,
+      subscriber.branch,
+      summary,
+      CURRENT_PR_CACHE_TTL_MS,
+    );
+    subscriber.onPrime(summary);
+  }
 }
 
 function loadCurrentPullRequest(
@@ -55,6 +148,14 @@ function loadCurrentPullRequest(
   });
 
   return promise.then((value) => {
+    const latest = currentPullRequestCache.get(key);
+    if (
+      latest &&
+      latest.promise !== promise &&
+      latest.expiresAt > Date.now()
+    ) {
+      return latest.value;
+    }
     currentPullRequestCache.set(key, {
       value,
       expiresAt:
@@ -70,12 +171,35 @@ export function useCurrentPullRequest(
 ): SessionPullRequestSummary | null {
   const branch = session.branch.trim();
   const repoPath = currentPullRequestRepoPath(session);
+  const projectRepoPath = normalizeRepoPath(session.repo_path);
   const cacheKey = branch ? currentPullRequestCacheKey(repoPath, branch) : null;
   const [lookupAttempt, setLookupAttempt] = useState(0);
   const [currentPullRequest, setCurrentPullRequest] =
-    useState<SessionPullRequestSummary | null>(() =>
-      cacheKey ? (currentPullRequestCache.get(cacheKey)?.value ?? null) : null,
-    );
+    useState<SessionPullRequestSummary | null>(() => {
+      if (!cacheKey) return null;
+      return (
+        readPrimedCurrentPullRequest(projectRepoPath, branch) ??
+        currentPullRequestCache.get(cacheKey)?.value ??
+        null
+      );
+    });
+
+  useEffect(() => {
+    if (!branch) return;
+    const subscriber: CurrentPullRequestSubscriber = {
+      projectRepoPath,
+      lookupRepoPath: normalizeRepoPath(repoPath),
+      branch,
+      onPrime: (value) => {
+        setCurrentPullRequest(value);
+        setLookupAttempt((attempt) => attempt + 1);
+      },
+    };
+    currentPullRequestSubscribers.add(subscriber);
+    return () => {
+      currentPullRequestSubscribers.delete(subscriber);
+    };
+  }, [branch, projectRepoPath, repoPath]);
 
   useEffect(() => {
     const query = currentPullRequestSearchQuery(branch);
@@ -92,6 +216,20 @@ export function useCurrentPullRequest(
         if (!cancelled) setLookupAttempt((attempt) => attempt + 1);
       }, CURRENT_PR_EMPTY_RETRY_MS);
     };
+    const primed = readPrimedCurrentPullRequest(projectRepoPath, branch);
+    if (primed) {
+      setCurrentPullRequestCache(
+        repoPath,
+        branch,
+        primed,
+        CURRENT_PR_CACHE_TTL_MS,
+      );
+      setCurrentPullRequest(primed);
+      return () => {
+        cancelled = true;
+        if (retryTimer !== null) window.clearTimeout(retryTimer);
+      };
+    }
     const cached = currentPullRequestCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) {
       setCurrentPullRequest(cached.value);
@@ -117,7 +255,7 @@ export function useCurrentPullRequest(
       cancelled = true;
       if (retryTimer !== null) window.clearTimeout(retryTimer);
     };
-  }, [branch, cacheKey, lookupAttempt, repoPath]);
+  }, [branch, cacheKey, lookupAttempt, projectRepoPath, repoPath]);
 
   return currentPullRequest;
 }

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -42,6 +42,109 @@ function session(
 }
 
 test.describe("workspace kanban mode", () => {
+  test("updates card PR metadata when the PR list refresh discovers a new PR", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("runner", "runner", "working", {
+        agent_provider: "codex",
+      }),
+    ]);
+    await tauri.handle("detect_session_statuses", (args) => {
+      const ids = Array.isArray((args as { ids?: unknown }).ids)
+        ? ((args as { ids: string[] }).ids)
+        : [];
+      return ids.map((id) => ({
+        id,
+        status: "working",
+        branch: "feat/runner",
+        last_message: null,
+        last_user_message: null,
+        last_agent_message: null,
+      }));
+    });
+    await tauri.handle("list_pull_requests", (args) => {
+      const w = window as unknown as {
+        __kanbanPrCreated?: boolean;
+        __kanbanCurrentPrQueries?: number;
+        __kanbanOpenPrRefreshes?: number;
+      };
+      const pr = {
+        number: 77,
+        title: "Add kanban PR context",
+        state: "OPEN",
+        author: "ian",
+        head_branch: "feat/runner",
+        base_branch: "main",
+        url: "https://github.com/im-ian/acorn/pull/77",
+        updated_at: "2026-01-01T00:00:00Z",
+        is_draft: false,
+        checks: null,
+        labels: [],
+      };
+      const created = w.__kanbanPrCreated === true;
+      if (args?.query === "head:feat/runner") {
+        w.__kanbanCurrentPrQueries = (w.__kanbanCurrentPrQueries ?? 0) + 1;
+        return {
+          kind: "ok",
+          account: "test",
+          items: created ? [pr] : [],
+        };
+      }
+      if (args?.state === "open" && !args?.query) {
+        w.__kanbanOpenPrRefreshes = (w.__kanbanOpenPrRefreshes ?? 0) + 1;
+        return {
+          kind: "ok",
+          account: "test",
+          items: created ? [pr] : [],
+        };
+      }
+      return { kind: "ok", account: "test", items: [] };
+    });
+
+    await page.goto("/");
+
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    const board = page.getByTestId("workspace-kanban");
+    await expect(board).toBeVisible();
+    const runnerCard = board.locator('[data-kanban-session-id="runner"]');
+    await expect(runnerCard).toBeVisible();
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              (
+                window as unknown as {
+                  __kanbanCurrentPrQueries?: number;
+                }
+              ).__kanbanCurrentPrQueries ?? 0,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThan(0);
+    await expect(runnerCard).not.toContainText("PR #77");
+
+    await page.evaluate(() => {
+      (window as unknown as { __kanbanPrCreated?: boolean })
+        .__kanbanPrCreated = true;
+    });
+    await page.getByRole("button", { name: "GitHub" }).click();
+    const refresh = page.locator("aside").getByRole("button", {
+      name: "Refresh",
+    });
+    await expect(refresh).toBeEnabled();
+    await refresh.click();
+
+    await expect(
+      runnerCard.getByTestId("workspace-kanban-card-context"),
+    ).toContainText("PR #77");
+  });
+
   test("groups active workspace sessions by status and opens a card terminal popover", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Kanban cards now surface newly-created PRs as soon as the GitHub PR list refresh sees them.

1. **Shared current-PR cache priming** — let successful PR list refreshes prime the session current-PR cache by project repo + branch, then notify mounted kanban/sidebar subscribers immediately.
2. **Race protection** — prevent an older in-flight branch lookup from overwriting a freshly primed PR with an empty result.
3. **Regression coverage** — add focused hook coverage for the stale lookup race and an E2E for kanban cards updating without a status move.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Kanban PR metadata | Newly-created PR badges could wait for retry/status-change-driven rerender | PR badge updates when the PR list refresh discovers the PR |
| Sidebar PR metadata | Shared hook had the same delayed-cache path | Shared hook receives the same immediate cache prime |
| Existing PR lookups | Direct per-branch lookup still works | Direct lookup remains, with stale in-flight protection |

## Design notes
- `useCurrentPullRequest` keeps the direct branch lookup path for sessions whose PR has not appeared in the broader list cache yet.
- PR list refreshes run against the project root, while session lookups may use a live worktree path. The new project-level cache keeps those lookup keys separate and bridges them by branch.
- The cache prime only publishes open PR summaries from successful listings; existing retry behavior continues to handle empty or inaccessible results.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/lib/useCurrentPullRequest.test.tsx src/lib/sessionContext.test.ts src/lib/kanbanBoard.test.ts src/components/WorkspaceMain.test.tsx` — 4 files / 36 tests pass
- [x] `pnpm run test:e2e -- tests/e2e/kanban.spec.ts` — 14 tests pass
- [x] `pnpm run build` passes; Vite reports existing chunk-size/static-dynamic import warnings

## Notes
- No backend behavior changes.
