### PR TITLE
chore(release): v1.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.22.0",
+  "version": "1.23.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.22.0"
+version = "1.23.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
This release bumps Acorn from `1.22.0` to `1.23.0` after a green `main` and prepares the next stable release.

1. **Version metadata:** Updates `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` to `1.23.0`.
2. **Semver decision:** Uses a minor bump because the unreleased set includes user-visible feature work in #540, #541, #543, #549, #554, #555, and #561.
3. **Release notes source:** Includes merged PRs #538, #539, #540, #541, #542, #543, #545, #546, #547, #548, #549, #550, #551, #552, #553, #554, #555, #556, #557, #558, #559, #560, #561, and #562.

## Expected impact

| Area | Expected impact |
| --- | --- |
| App version | Packaged builds and updater metadata report `1.23.0`. |
| Release notes | GitHub Release and `latest.json.notes` will be generated from the merged feature, fix, and refactor PR labels. |
| Runtime behavior | No direct runtime code changes in this bump PR. |

## Design notes

The release bump PR intentionally changes only version metadata. The merged feature/fix/refactor PRs supply the changelog entries, so this PR should stay labelled `skip-changelog`.

## Test plan

- [x] `gh run watch 28850661673 --exit-status` — `main` CI passed; frontend passed and E2E reported 214 passed.
- [x] `rg -n '1\.22\.0|1\.23\.0' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock` — only the four release metadata fields now show `1.23.0`.
- [x] `pnpm run typecheck` — passed.
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — passed and reports root package `1.23.0`.
- [x] `git show HEAD:scripts/release-notes.mjs | rg 'addReleaseSectionSummaries|formatReleaseSectionSummary'` — bilingual summary support present.
- [x] `REPO=im-ian/acorn TAG=v1.23.0 OUTPUT=/tmp/acorn-release-notes-v1.23.0.md node scripts/release-notes.mjs` — generated notes successfully.
- [x] `test -s /tmp/acorn-release-notes-v1.23.0.md` — generated notes file is non-empty.
- [x] `rg -n '^> .+<br>$' /tmp/acorn-release-notes-v1.23.0.md` — Korean summary blockquotes present.
- [x] `rg -n '^> (Feature updates|Fixes|Performance improvements|Security updates|Documentation updates|Internal cleanup|Build and CI updates|Other changes): ' /tmp/acorn-release-notes-v1.23.0.md` — English summary blockquotes present.
- [x] `git diff --check` — passed.

## Notes

`origin/main` was verified green at `e5ac85163b9e745e5f961296aba22780ff137c08` before this branch was created.
