### PR TITLE
fix(app): recover upgrade activity state crash

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,8 @@ use tracing_subscriber::EnvFilter;
 
 use crate::state::AppState;
 
+const MAIN_WINDOW_LABEL: &str = "main";
+
 #[derive(Clone, Copy)]
 struct NonPanickingStderr;
 
@@ -114,6 +116,49 @@ fn normalize_loaded_session(mut session: acorn_session::Session) -> (acorn_sessi
         session.repo_path = repo_path;
     }
     (session, changed)
+}
+
+fn reveal_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    #[cfg(target_os = "macos")]
+    if let Err(err) = app.show() {
+        tracing::warn!(error = %err, "failed to show application");
+    }
+
+    let window = match app.get_webview_window(MAIN_WINDOW_LABEL) {
+        Some(window) => window,
+        None => {
+            let Some(config) = app
+                .config()
+                .app
+                .windows
+                .iter()
+                .find(|config| config.label == MAIN_WINDOW_LABEL)
+                .or_else(|| app.config().app.windows.first())
+            else {
+                tracing::warn!("failed to recreate main window: no window config");
+                return;
+            };
+            match tauri::WebviewWindowBuilder::from_config(app, config)
+                .and_then(|builder| builder.build())
+            {
+                Ok(window) => window,
+                Err(err) => {
+                    tracing::warn!(error = %err, "failed to recreate main window");
+                    return;
+                }
+            }
+        }
+    };
+
+    if let Err(err) = window.unminimize() {
+        tracing::warn!(error = %err, "failed to unminimize main window");
+    }
+    if let Err(err) = window.show() {
+        tracing::warn!(error = %err, "failed to show main window");
+    }
+    if let Err(err) = window.set_focus() {
+        tracing::warn!(error = %err, "failed to focus main window");
+    }
 }
 
 #[cfg(test)]
@@ -191,14 +236,10 @@ pub fn run() {
     #[cfg(not(debug_assertions))]
     {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.unminimize();
-                let _ = window.show();
-                let _ = window.set_focus();
-            }
+            reveal_main_window(app);
         }));
     }
-    builder
+    builder = builder
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
@@ -304,7 +345,7 @@ pub fn run() {
                 }
                 #[cfg(debug_assertions)]
                 if event.id() == "reload" {
-                    if let Some(window) = handle.get_webview_window("main") {
+                    if let Some(window) = handle.get_webview_window(MAIN_WINDOW_LABEL) {
                         if let Err(err) = window.eval("window.location.reload()") {
                             tracing::warn!("failed to reload webview: {err}");
                         }
@@ -656,7 +697,15 @@ pub fn run() {
             fs_explorer::fs_git_diff_stats,
             fs_explorer::fs_git_diff_lines,
             fs_explorer::fs_watch_set_root,
-        ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        ]);
+
+    let app = builder
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+    app.run(|app, _event| {
+        #[cfg(target_os = "macos")]
+        if matches!(_event, tauri::RunEvent::Reopen { .. }) {
+            reveal_main_window(app);
+        }
+    });
 }

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -395,6 +395,68 @@ describe("sessionNotifications", () => {
     ).toEqual(["latest", "other"]);
   });
 
+  it("migrates legacy persisted activity status names on rehydrate", async () => {
+    window.localStorage.clear();
+    resetStore();
+    window.localStorage.setItem(
+      "acorn-workspaces",
+      JSON.stringify({
+        state: {
+          sessionNotifications: [
+            {
+              id: "legacy-needs",
+              sessionId: "s1",
+              kind: "needs_input",
+              status: "needs_input",
+              previousStatus: "running",
+              sessionName: "s1",
+              projectName: "repo-a",
+              repoPath: REPO_A,
+              createdAt: "2026-01-01T00:02:00Z",
+            },
+            {
+              id: "legacy-idle",
+              sessionId: "s2",
+              kind: "became_idle",
+              status: "idle",
+              previousStatus: "needs_input",
+              sessionName: "s2",
+              projectName: "repo-b",
+              repoPath: REPO_B,
+              createdAt: "2026-01-01T00:01:00Z",
+            },
+            {
+              id: "unknown",
+              sessionId: "s3",
+              kind: "unknown",
+              status: "idle",
+              previousStatus: "running",
+              createdAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+        },
+        version: 4,
+      }),
+    );
+
+    await useAppStore.persist.rehydrate();
+
+    expect(useAppStore.getState().sessionNotifications).toMatchObject([
+      {
+        id: "legacy-needs",
+        kind: "waiting_for_input",
+        status: "waiting_for_input",
+        previousStatus: "working",
+      },
+      {
+        id: "legacy-idle",
+        kind: "became_ready",
+        status: "ready",
+        previousStatus: "waiting_for_input",
+      },
+    ]);
+  });
+
   it("marks individual and all notifications read, then clears read items when auto-delete is disabled", () => {
     useSettings.getState().patchNotifications({ autoDeleteRead: false });
     useAppStore

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,7 +9,9 @@ import type {
   SessionMode,
   SessionTitleGenerationStatus,
   SessionNotification,
+  SessionNotificationKind,
   SessionProcessSummary,
+  SessionStatus,
 } from "./lib/types";
 import { commandRequestsWorktreeAdoption } from "./lib/worktreeAdoption";
 import { CONTROL_GUIDE_DISMISSED_KEY } from "./components/ControlSessionGuideModal";
@@ -124,13 +126,94 @@ function coalescedSessionNotificationKey(
   return `${notification.sessionId}:${notification.kind}`;
 }
 
+function normalizeSessionStatus(value: unknown): SessionStatus | null {
+  if (
+    value === "ready" ||
+    value === "working" ||
+    value === "waiting_for_input" ||
+    value === "errored"
+  ) {
+    return value;
+  }
+  if (value === "idle") return "ready";
+  if (value === "running") return "working";
+  if (value === "needs_input") return "waiting_for_input";
+  if (value === "error") return "errored";
+  return null;
+}
+
+function normalizeSessionNotificationKind(
+  value: unknown,
+): SessionNotificationKind | null {
+  if (
+    value === "waiting_for_input" ||
+    value === "errored" ||
+    value === "became_ready"
+  ) {
+    return value;
+  }
+  if (value === "needs_input") return "waiting_for_input";
+  if (value === "became_idle") return "became_ready";
+  if (value === "error") return "errored";
+  return null;
+}
+
+function statusForNotificationKind(
+  kind: SessionNotificationKind,
+): SessionStatus {
+  if (kind === "waiting_for_input") return "waiting_for_input";
+  if (kind === "errored") return "errored";
+  return "ready";
+}
+
+function normalizeSessionNotification(
+  value: unknown,
+): SessionNotification | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const kind = normalizeSessionNotificationKind(raw.kind);
+  if (!kind || typeof raw.sessionId !== "string") return null;
+  const status =
+    normalizeSessionStatus(raw.status) ?? statusForNotificationKind(kind);
+  const previousStatus = normalizeSessionStatus(raw.previousStatus) ?? "ready";
+  const createdAt =
+    typeof raw.createdAt === "string"
+      ? raw.createdAt
+      : new Date(0).toISOString();
+  const repoPath = typeof raw.repoPath === "string" ? raw.repoPath : "";
+  const sessionName =
+    typeof raw.sessionName === "string" ? raw.sessionName : raw.sessionId;
+  const projectName =
+    typeof raw.projectName === "string"
+      ? raw.projectName
+      : repoPath.split("/").filter(Boolean).pop() ?? repoPath;
+  return {
+    id:
+      typeof raw.id === "string"
+        ? raw.id
+        : `${createdAt}:${raw.sessionId}:${kind}`,
+    sessionId: raw.sessionId,
+    kind,
+    status,
+    previousStatus,
+    sessionName,
+    projectName,
+    repoPath,
+    createdAt,
+    ...(typeof raw.readAt === "string" ? { readAt: raw.readAt } : {}),
+  };
+}
+
 function normalizeSessionNotifications(
-  notifications: SessionNotification[],
+  notifications: unknown,
   maxHistory: number,
 ): SessionNotification[] {
+  if (!Array.isArray(notifications)) return [];
   const seen = new Set<string>();
   const next: SessionNotification[] = [];
-  for (const notification of notifications) {
+  for (const rawNotification of notifications) {
+    const notification = normalizeSessionNotification(rawNotification);
+    if (!notification) continue;
     const key = coalescedSessionNotificationKey(notification);
     if (key) {
       if (seen.has(key)) continue;


### PR DESCRIPTION
## Summary
This fix keeps Acorn from blanking during startup when a user upgrades with legacy persisted session activity in localStorage.

1. **Legacy activity migration:** Normalizes old persisted activity kinds and statuses such as `needs_input`, `became_idle`, `running`, and `idle` into the current session notification contract during store rehydrate.
2. **Window reveal recovery:** Reuses the same main-window reveal path for release single-instance launches and macOS Dock reopen, recreating the main window if the process is alive but the window is gone.
3. **Regression coverage:** Adds a store rehydrate test for legacy activity data and malformed persisted notification entries.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Upgrade reliability | Users updating from older Acorn builds no longer hit a startup render crash from stale activity records. |
| macOS reopen behavior | Dock reopen and duplicate launch attempts bring back the main window more reliably when the app process is already running. |
| Release notes | This PR should appear under Fixes in the `v1.23.1` changelog. |

## Design notes

- `normalizeSessionNotifications` now treats persisted data as untrusted input at the store boundary, maps known legacy values, and drops malformed unknown notification entries before React renders sidebar activity rows.
- The window reveal helper keeps the existing release-only single-instance behavior but shares the same path with macOS `RunEvent::Reopen`, so reopening the app does useful work even if the main window was previously destroyed.
- Version metadata is intentionally left unchanged here; the `v1.23.1` release bump should stay in a separate `skip-changelog` PR after this fix lands.

## Follow-up (not in this PR)

- Open and merge a `chore(release): v1.23.1` PR once this fix PR is green on `main`.
- Push tag `v1.23.1` after the release bump lands to trigger the release workflow.

## Test plan

- [x] `pnpm vitest run src/store.test.ts src/lib/notifications.test.ts` — 2 files passed, 151 tests passed.
- [x] `pnpm run test` — 81 files passed, 888 tests passed.
- [x] `pnpm typecheck` — passed.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — passed.
- [x] `rustfmt --edition 2021 --check --config skip_children=true src-tauri/src/lib.rs` — passed.
- [x] `pnpm run build` — passed; Vite reported existing chunk-size/dynamic-import warnings only.
- [x] `git diff --check` — passed.

## Notes

`v1.23.0` is the current latest stable release. This PR is the runtime fix that should feed the next patch release notes.
