### PR TITLE
chore(release): v1.23.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.23.0",
+  "version": "1.23.1",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.23.0"
+version = "1.23.1"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.23.0"
+version = "1.23.1"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
This release bumps Acorn from `1.23.0` to `1.23.1` after the upgrade crash fix landed on a green `main`.

1. **Version metadata:** Updates `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` to `1.23.1`.
2. **Semver decision:** Uses a patch bump because the unreleased set contains the bug fix in #564 and no new feature work.
3. **Release notes source:** Includes merged PR #564 under Fixes; the generated notes also retain the cumulative `1.23.x` stable-line sections.

## Expected impact

| Area | Expected impact |
| --- | --- |
| App version | Packaged builds and updater metadata report `1.23.1`. |
| Release notes | GitHub Release and `latest.json.notes` include the upgrade crash fix from #564. |
| Runtime behavior | No direct runtime code changes in this bump PR. |

## Design notes

The release bump PR intentionally changes only version metadata. The merged fix PR supplies the changelog entry, so this PR should stay labelled `skip-changelog`.

## Follow-up (not in this PR)

- Push tag `v1.23.1` after this PR merges to trigger the release workflow.
- Confirm the Release workflow publishes the GitHub Release and `latest.json` assets successfully.

## Test plan

- [x] `gh run watch 28882655980 --exit-status` — `main` CI passed after #564; Frontend passed in 1m37s and E2E passed in 6m9s.
- [x] `rg -n '1\.23\.0|1\.23\.1' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock` — only the four release metadata fields now show `1.23.1`.
- [x] `pnpm typecheck` — passed.
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — passed and reports root package `1.23.1`.
- [x] `REPO=im-ian/acorn TAG=v1.23.1 OUTPUT=/tmp/acorn-release-notes-v1.23.1.md node scripts/release-notes.mjs` — generated notes successfully.
- [x] `test -s /tmp/acorn-release-notes-v1.23.1.md` — generated notes file is non-empty.
- [x] `rg -n '^> .+<br>$' /tmp/acorn-release-notes-v1.23.1.md` — Korean summary blockquotes present.
- [x] `rg -n '^> (Feature updates|Fixes|Performance improvements|Security updates|Documentation updates|Internal cleanup|Build and CI updates|Other changes): ' /tmp/acorn-release-notes-v1.23.1.md` — English summary blockquotes present.
- [x] `git diff --check` — passed.

## Notes

This PR depends on #564 and should be merged only after its own PR checks are green.
