### PR TITLE
fix(workspace): preview files over kanban board

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -199,6 +199,7 @@ export function Pane({ paneId }: PaneProps) {
   const splitFocusedPane = useAppStore((s) => s.splitFocusedPane);
   const closePane = useAppStore((s) => s.closePane);
   const sessionsById = useAppStore(selectSessionsById);
+  const workspaceViewMode = useAppStore((s) => s.workspaceViewMode);
   const shortcuts = useSettings((s) => s.settings.shortcuts);
   const [paneMenu, setPaneMenu] = useState<{ x: number; y: number } | null>(
     null,
@@ -589,7 +590,7 @@ export function Pane({ paneId }: PaneProps) {
             session={activeSession}
           />
         ) : null}
-        {active?.kind === "code" ? (
+        {active?.kind === "code" && workspaceViewMode === "panes" ? (
           <FileViewer
             key={active.id}
             path={active.path}

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -97,6 +97,7 @@ import {
 import { IconButton, StatusDot, type StatusTone } from "./ui";
 import { ChatPane } from "./ChatPane";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
+import { FileViewer } from "./FileViewer";
 import { LayoutRenderer } from "./LayoutRenderer";
 import { ResizeHandle } from "./ResizeHandle";
 import { Tooltip } from "./Tooltip";
@@ -166,10 +167,11 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
   return (
     <div className="h-full min-w-0 overflow-hidden" data-workspace-main>
       {isKanban ? (
-        <div className="flex h-full min-w-0 flex-col overflow-hidden">
+        <div className="relative flex h-full min-w-0 flex-col overflow-hidden">
           <div className="min-h-0 min-w-0 flex-1">
             <WorkspaceKanbanBoard />
           </div>
+          <KanbanFilePreviewOverlay />
         </div>
       ) : null}
       {/*
@@ -182,6 +184,65 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
       <div className={cn("h-full min-w-0", isKanban && "hidden")}>
         <LayoutRenderer node={layout} />
       </div>
+    </div>
+  );
+}
+
+function KanbanFilePreviewOverlay() {
+  const t = useTranslation();
+  const activeTabId = useAppStore((s) => s.activeTabId);
+  const workspaceTabs = useAppStore((s) => s.workspaceTabs);
+  const closeWorkspaceTab = useAppStore((s) => s.closeWorkspaceTab);
+  const closeTerminalPopup = useAppStore((s) => s.closeTerminalPopup);
+  const updateCodeViewerTabViewState = useAppStore(
+    (s) => s.updateCodeViewerTabViewState,
+  );
+  const tab = activeTabId ? workspaceTabs[activeTabId] : undefined;
+
+  useEffect(() => {
+    if (tab?.kind === "code") closeTerminalPopup();
+  }, [closeTerminalPopup, tab?.id, tab?.kind]);
+
+  if (!tab || tab.kind !== "code") return null;
+
+  return (
+    <div
+      className="absolute inset-0 z-20 flex items-center justify-center bg-bg/45 p-4 backdrop-blur-[1px]"
+      data-testid="kanban-file-preview-overlay"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) closeWorkspaceTab(tab.id);
+      }}
+    >
+      <section
+        role="dialog"
+        aria-label={tab.title}
+        className="flex h-[min(760px,calc(100%-2rem))] w-[min(980px,calc(100%-2rem))] min-w-0 flex-col overflow-hidden rounded-[var(--acorn-pane-radius)] border border-border bg-bg shadow-2xl"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <header className="flex h-9 shrink-0 items-center gap-2 border-b border-border bg-bg-sidebar/70 px-3">
+          <div className="min-w-0 flex-1 truncate text-xs font-medium text-fg">
+            {tab.title}
+          </div>
+          <IconButton
+            aria-label={t("dialogs.common.close")}
+            onClick={() => closeWorkspaceTab(tab.id)}
+          >
+            <X size={13} />
+          </IconButton>
+        </header>
+        <div className="min-h-0 flex-1">
+          <FileViewer
+            key={tab.id}
+            path={tab.path}
+            target={tab.target}
+            viewState={tab.viewState}
+            onViewStateChange={(patch) =>
+              updateCodeViewerTabViewState(tab.id, patch)
+            }
+            isActive
+          />
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1055,6 +1055,22 @@ describe("workspace tabs", () => {
     });
   });
 
+  it("keeps kanban mode when opening a code viewer tab", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+    useAppStore.getState().setWorkspaceViewMode("kanban");
+
+    useAppStore.getState().openCodeViewerTab(`${REPO_A}/src/App.tsx`);
+
+    const s = useAppStore.getState();
+    expect(s.workspaceViewMode).toBe("kanban");
+    expect(s.workspaces[REPO_A].viewMode).toBe("kanban");
+    expect(s.activeTabId).toMatch(/^code-viewer:/);
+    expect(s.workspaceTabs[s.activeTabId!]).toMatchObject({
+      kind: "code",
+      path: `${REPO_A}/src/App.tsx`,
+    });
+  });
+
   it("opens a work summary tab for the active session worktree", async () => {
     const active = session("a1", REPO_A, {
       name: "Feature runner",

--- a/tests/e2e/file-explorer.spec.ts
+++ b/tests/e2e/file-explorer.spec.ts
@@ -319,6 +319,95 @@ test.describe("file explorer", () => {
     await expect(page.getByText("export const util = true;")).toBeVisible();
   });
 
+  test("opens a right-panel file in an overlay while staying in kanban", async ({
+    page,
+    tauri,
+  }) => {
+    const repo = "/tmp/demo";
+
+    await tauri.respond("list_projects", [
+      {
+        repo_path: repo,
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-1",
+        name: "alpha",
+        repo_path: repo,
+        worktree_path: repo,
+        branch: "main",
+        isolated: false,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      },
+    ]);
+    await tauri.handle("pty_repo_root", () => "/tmp/demo");
+    await tauri.handle("fs_list_dir", (args) => {
+      const { path } = args as { path: string };
+      if (path !== "/tmp/demo") {
+        return { repo_root: "/tmp/demo", entries: [] };
+      }
+      return {
+        repo_root: "/tmp/demo",
+        entries: [
+          {
+            name: "README.md",
+            path: "/tmp/demo/README.md",
+            is_dir: false,
+            is_symlink: false,
+            size: 32,
+            modified_ms: 0,
+            gitignored: false,
+          },
+        ],
+      };
+    });
+    await tauri.handle("fs_read_file", () => ({
+      content: "# Demo\n\nOpened from kanban.\n",
+      size: 28,
+      truncated: false,
+      binary: false,
+    }));
+
+    await page.goto("/");
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+    await expect(page.getByTestId("workspace-kanban")).toBeVisible();
+
+    await page.getByRole("button", { name: "Code" }).click();
+    await page.getByRole("button", { name: "Files", exact: true }).click();
+    await page.getByRole("button", { name: "README.md" }).dblclick();
+
+    await expect(page.getByTestId("workspace-kanban")).toBeVisible();
+    await expect(page.getByTestId("kanban-file-preview-overlay")).toBeVisible();
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Kanban",
+    );
+    await expect(
+      page.getByRole("dialog", { name: "README.md" }),
+    ).toBeVisible();
+    await expect(page.getByText("Opened from kanban.")).toBeVisible();
+
+    await page
+      .getByRole("dialog", { name: "README.md" })
+      .getByRole("button", { name: "Close" })
+      .click();
+    await expect(page.getByTestId("kanban-file-preview-overlay")).toHaveCount(
+      0,
+    );
+    await expect(page.getByTestId("workspace-kanban")).toBeVisible();
+  });
+
   test("keeps expanded worktree folders after opening and closing a file", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Keep file previews usable from the right panel while the workspace stays in kanban mode.

1. **Kanban file preview overlay** — render active code/media file tabs as an overlay on top of the kanban board instead of forcing a switch back to panes.
2. **Hidden pane guard** — suppress the hidden pane's duplicate inline `FileViewer` while kanban is active, so the overlay is the single active viewer.
3. **Regression coverage** — add store and Playwright coverage for opening, viewing, and closing a right-panel file while remaining in kanban mode.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Kanban + right-panel Files | Double-clicking a file could appear to do nothing because the code tab opened in the hidden pane layout. | The file opens in a centered overlay and the board stays visible behind it. |
| Kanban terminal popover | Switching to panes implicitly closed it. | Opening a file preview closes the terminal popover so it cannot cover the preview. |

## Design notes
- The existing `openCodeViewerTab` store action still owns file-tab creation and reuse, so terminal links, staged files, and the file explorer keep the same tab semantics.
- `WorkspaceMain` renders the kanban-only overlay from the active code workspace tab and reuses `FileViewer`, preserving code/media preview behavior and scroll/view-state persistence.
- `Pane` only renders inline file viewers when `workspaceViewMode === "panes"`; the pane layout remains mounted in kanban for terminal DOM preservation, but it no longer mounts a duplicate file viewer.

## Test plan
- [x] `pnpm exec vitest run src/store.test.ts src/components/Pane.test.tsx src/components/WorkspaceMain.test.tsx` — 171 tests passed
- [x] `pnpm exec playwright test tests/e2e/file-explorer.spec.ts` — 8 tests passed
- [x] `pnpm run typecheck` — passed
