### PR TITLE
feat(kanban): keyboard navigation for board cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -244,10 +244,7 @@ function updateUiScalePercent(delta: number) {
 }
 
 function focusPaneTerminal(paneId: string) {
-  const escaped =
-    typeof CSS !== "undefined" && typeof CSS.escape === "function"
-      ? CSS.escape(paneId)
-      : paneId.replace(/(["\\\]\[])/g, "\\$1");
+  const escaped = cssAttributeEscape(paneId);
   const pane = document.querySelector(
     `[data-pane-body="${escaped}"]`,
   ) as HTMLElement | null;
@@ -255,6 +252,28 @@ function focusPaneTerminal(paneId: string) {
     (pane?.querySelector(".xterm-helper-textarea") as HTMLElement | null) ??
     (pane?.querySelector(FOCUSABLE_SELECTOR) as HTMLElement | null);
   target?.focus();
+}
+
+function focusKanbanSessionCard(sessionId: string) {
+  const card = document.querySelector(
+    `[data-kanban-session-id="${cssAttributeEscape(sessionId)}"]`,
+  ) as HTMLElement | null;
+  card?.focus();
+}
+
+function closeTerminalPopoverFromHotkey(): boolean {
+  const state = useAppStore.getState();
+  const sessionId = state.terminalPopupSessionId;
+  if (!sessionId) return false;
+  state.closeTerminalPopup();
+  requestAnimationFrame(() => focusKanbanSessionCard(sessionId));
+  return true;
+}
+
+function cssAttributeEscape(value: string): string {
+  return typeof CSS !== "undefined" && typeof CSS.escape === "function"
+    ? CSS.escape(value)
+    : value.replace(/(["\\\]\[])/g, "\\$1");
 }
 
 function dispatchFocusedTerminalConversationNav(
@@ -1651,6 +1670,7 @@ function App() {
       },
       [shortcuts.closeTab]: (e: KeyboardEvent) => {
         e.preventDefault();
+        if (closeTerminalPopoverFromHotkey()) return;
         useAppStore.getState().closeFocusedTab();
       },
       [shortcuts.nextTab]: (e: KeyboardEvent) => {

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
@@ -362,9 +363,34 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
     [selectSession, openTerminalPopup],
   );
 
+  const focusKanbanSessionCard = useCallback(
+    (sessionId: string) => {
+      const card = document.querySelector<HTMLElement>(
+        `[data-kanban-session-id="${cssAttributeEscape(sessionId)}"]`,
+      );
+      card?.focus();
+      card?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    },
+    [],
+  );
+
+  const focusAdjacentSessionCard = useCallback(
+    (sessionId: string, direction: KanbanCardFocusDirection) => {
+      const nextSessionId = nextKanbanSessionId(
+        sessionsByStatus,
+        sessionId,
+        direction,
+      );
+      if (nextSessionId) focusKanbanSessionCard(nextSessionId);
+    },
+    [focusKanbanSessionCard, sessionsByStatus],
+  );
+
   function closeTerminalPopover() {
+    const anchor = terminalPopover?.anchor;
     closeTerminalPopup();
     setTerminalPopover(null);
+    if (anchor) requestAnimationFrame(() => anchor.focus());
   }
 
   function resizeColumn(index: number, nextWidth: number) {
@@ -514,6 +540,7 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
                             key={session.id}
                             session={session}
                             onOpen={openSessionTerminal}
+                            onFocusAdjacent={focusAdjacentSessionCard}
                           />
                         ))
                       ) : (
@@ -766,12 +793,80 @@ function KanbanCreateSessionDropdown({ t }: { t: Translator }) {
   );
 }
 
+type KanbanCardFocusDirection = "up" | "down" | "left" | "right";
+
+function nextKanbanSessionId(
+  sessionsByStatus: ReadonlyMap<SessionStatus, readonly Session[]>,
+  sessionId: string,
+  direction: KanbanCardFocusDirection,
+): string | null {
+  const columns = KANBAN_COLUMNS.map(
+    ({ status }) => sessionsByStatus.get(status) ?? [],
+  );
+  let currentColumnIndex = -1;
+  let currentSessionIndex = -1;
+
+  for (let columnIndex = 0; columnIndex < columns.length; columnIndex += 1) {
+    const sessionIndex = columns[columnIndex].findIndex(
+      (session) => session.id === sessionId,
+    );
+    if (sessionIndex === -1) continue;
+    currentColumnIndex = columnIndex;
+    currentSessionIndex = sessionIndex;
+    break;
+  }
+
+  if (currentColumnIndex === -1 || currentSessionIndex === -1) return null;
+
+  if (direction === "up" || direction === "down") {
+    const column = columns[currentColumnIndex];
+    const nextIndex = currentSessionIndex + (direction === "down" ? 1 : -1);
+    return column[nextIndex]?.id ?? null;
+  }
+
+  const step = direction === "right" ? 1 : -1;
+  for (
+    let columnIndex = currentColumnIndex + step;
+    columnIndex >= 0 && columnIndex < columns.length;
+    columnIndex += step
+  ) {
+    const column = columns[columnIndex];
+    if (column.length === 0) continue;
+    const nextIndex = Math.min(currentSessionIndex, column.length - 1);
+    return column[nextIndex]?.id ?? null;
+  }
+
+  return null;
+}
+
+function kanbanCardFocusDirection(
+  key: string,
+): KanbanCardFocusDirection | null {
+  switch (key) {
+    case "ArrowUp":
+      return "up";
+    case "ArrowDown":
+      return "down";
+    case "ArrowLeft":
+      return "left";
+    case "ArrowRight":
+      return "right";
+    default:
+      return null;
+  }
+}
+
 const KanbanSessionCard = memo(function KanbanSessionCard({
   session,
   onOpen,
+  onFocusAdjacent,
 }: {
   session: Session;
   onOpen: (sessionId: string, anchor: HTMLElement) => void;
+  onFocusAdjacent: (
+    sessionId: string,
+    direction: KanbanCardFocusDirection,
+  ) => void;
 }) {
   const t = useTranslation();
   const showToast = useToasts((s) => s.show);
@@ -832,6 +927,24 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
 
   function handleOpen(event: ReactMouseEvent<HTMLElement>) {
     onOpen(session.id, event.currentTarget);
+  }
+
+  function handleKeyDown(event: ReactKeyboardEvent<HTMLElement>) {
+    if (editing) return;
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onOpen(session.id, event.currentTarget);
+      return;
+    }
+    if (event.key === "F2") {
+      event.preventDefault();
+      if (canRename) setEditing(true);
+      return;
+    }
+    const direction = kanbanCardFocusDirection(event.key);
+    if (!direction) return;
+    event.preventDefault();
+    onFocusAdjacent(session.id, direction);
   }
 
   async function submitRename(next: string) {
@@ -1010,16 +1123,7 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
           onClick={editing ? undefined : handleOpen}
           onPointerDown={handlePointerDown}
           onContextMenu={handleContextMenu}
-          onKeyDown={(event) => {
-            if (editing) return;
-            if (event.key === "Enter" || event.key === " ") {
-              event.preventDefault();
-              onOpen(session.id, event.currentTarget);
-            } else if (event.key === "F2") {
-              event.preventDefault();
-              if (canRename) setEditing(true);
-            }
-          }}
+          onKeyDown={handleKeyDown}
           className="group flex w-full flex-col gap-2 rounded-md border border-border bg-bg-elevated/45 p-2 text-left transition hover:border-accent/45 hover:bg-bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
           aria-label={openLabel}
         >
@@ -1436,6 +1540,13 @@ function KanbanTerminalPopover({
     window.addEventListener("pointercancel", stopResize);
   }
 
+  function handlePopoverKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "Escape") return;
+    event.preventDefault();
+    event.stopPropagation();
+    onClose();
+  }
+
   const popoverStyle: CSSProperties = isExpanded
     ? {
         position: "fixed",
@@ -1460,6 +1571,7 @@ function KanbanTerminalPopover({
       role="dialog"
       aria-label={t("workspace.kanban.terminalPopover.ariaLabel")}
       data-testid="kanban-terminal-popover"
+      onKeyDown={handlePopoverKeyDown}
       className="relative z-50 flex min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-bg-elevated shadow-2xl shadow-black/35"
       style={popoverStyle}
     >

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -730,6 +730,68 @@ test.describe("workspace kanban mode", () => {
     ).toBeVisible();
   });
 
+  test("moves between cards with arrow keys and closes the popover from the keyboard", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("alpha", "alpha", "ready", {
+        updated_at: "2026-01-01T00:00:01Z",
+      }),
+      session("shell", "shell", "ready"),
+      session("needs-review", "needs-review", "waiting_for_input"),
+      session("runner", "runner", "working"),
+      session("broken", "broken", "errored"),
+    ]);
+
+    await page.goto("/");
+
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    const board = page.getByTestId("workspace-kanban");
+    await expect(board).toBeVisible();
+    await board.getByLabel("Sort sessions").selectOption("name-asc");
+
+    const alpha = board.getByRole("button", { name: "Open alpha" });
+    const shell = board.getByRole("button", { name: "Open shell" });
+    const needsReview = board.getByRole("button", {
+      name: "Open needs-review",
+    });
+    const runner = board.getByRole("button", { name: "Open runner" });
+    const broken = board.getByRole("button", { name: "Open broken" });
+
+    await alpha.focus();
+    await expect(alpha).toBeFocused();
+
+    await alpha.press("ArrowDown");
+    await expect(shell).toBeFocused();
+
+    await shell.press("ArrowRight");
+    await expect(needsReview).toBeFocused();
+
+    await needsReview.press("ArrowRight");
+    await expect(runner).toBeFocused();
+
+    await runner.press("ArrowRight");
+    await expect(broken).toBeFocused();
+
+    await broken.press("ArrowLeft");
+    await expect(runner).toBeFocused();
+
+    await runner.press("Enter");
+    const popover = page.getByTestId("kanban-terminal-popover");
+    await expect(popover).toBeVisible();
+    await expect(
+      popover.getByRole("heading", { name: "runner" }),
+    ).toBeVisible();
+
+    await pressHotkey(page, { mod: true, key: "w" });
+    await expect(popover).toHaveCount(0);
+    await expect(runner).toBeFocused();
+  });
+
   test("card context menu can rename a session", async ({ page, tauri }) => {
     await tauri.respond("list_projects", [PROJECT]);
     await tauri.handle("list_sessions", () => {


### PR DESCRIPTION
## Summary
Keyboard-only users can now move through kanban cards, open a session terminal, and close the terminal popover without reaching for the mouse.

1. **Card focus movement** — add Arrow Up/Down movement within a column and Arrow Left/Right movement across the next non-empty kanban column, preserving the current filter and sort order.
2. **Keyboard open/close flow** — keep Enter/Space opening the selected card, restore focus to the source card after the popover closes, and let `$mod+W` close an open kanban terminal popover before closing a workspace tab.
3. **Regression coverage** — add Playwright coverage for arrow-key card movement, keyboard popover open, keyboard popover close, and focus restoration.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Kanban card navigation | Tab could eventually reach cards, but moving between board positions required repeated tabbing or mouse use. | Focused cards can move by row/column with arrow keys. |
| Kanban terminal popover | Cards opened with keyboard, but closing the terminal popover from the keyboard path was not covered. | `$mod+W` closes the open popover first and returns focus to the card. |
| Terminal input | Avoids stealing bare Escape from terminal programs. | Terminal Escape remains available; popover close uses the existing close-tab shortcut priority. |

## Design notes
- The focus target is computed from `sessionsByStatus`, so keyboard movement follows the same visible sessions, filters, status grouping, and sort order as the rendered board.
- Horizontal movement skips empty columns and lands on the closest row index in the target column when column lengths differ.
- The global close-tab shortcut now treats an open terminal popover as the topmost close target, matching overlay behavior while preserving normal tab closing when no popover is open.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm exec vitest run src/components/WorkspaceMain.test.tsx` — 5 passed
- [x] `pnpm exec playwright test tests/e2e/kanban.spec.ts` — 16 passed
- [x] `pnpm run build` passes

## Notes
- `pnpm run build` still emits the existing Vite chunk/dynamic-import warnings; build exits successfully.
