### PR TITLE
feat(kanban): improve terminal popover header controls

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -261,6 +261,7 @@ function ContextMenuPanel({
         else if (outerPanelRef) outerPanelRef.current = node;
       }}
       role="menu"
+      data-acorn-context-menu
       style={{
         position: "fixed",
         left: position.left,

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -26,6 +26,7 @@ import {
   FolderOpen,
   GitBranch,
   GitPullRequest,
+  LocateFixed,
   Maximize2,
   MessageSquareText,
   Minimize2,
@@ -1356,11 +1357,23 @@ function KanbanTerminalPopover({
   onClose: () => void;
 }) {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const popoverPlacement = useSettings(
     (s) => s.settings.interface.kanbanTerminalPopoverPlacement,
   );
   const popoverDefaultSize = useSettings(
     (s) => s.settings.interface.kanbanTerminalPopoverDefaultSize,
+  );
+  const renameSession = useAppStore((s) => s.renameSession);
+  const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
+  const selectSession = useAppStore((s) => s.selectSession);
+  const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
+  const setWorkspaceViewMode = useAppStore((s) => s.setWorkspaceViewMode);
+  const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
+  const editorCommand = useSettings((s) => s.settings.editor.command);
+  const editorConfigured = editorCommand.trim().length > 0;
+  const isGeneratingTitle = useAppStore((s) =>
+    Boolean(s.generatingSessionTitleIds[session.id]),
   );
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const [position, setPosition] =
@@ -1371,6 +1384,11 @@ function KanbanTerminalPopover({
   const [isExpanded, setIsExpanded] = useState(
     () => popoverDefaultSize === "fullscreen",
   );
+  const [headerMenu, setHeaderMenu] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+  const [editingTitle, setEditingTitle] = useState(false);
   const positionRef = useRef<KanbanTerminalPopoverPosition | null>(null);
   const sizeRef = useRef(size);
   const hasManualPositionRef = useRef(false);
@@ -1379,6 +1397,10 @@ function KanbanTerminalPopover({
   const title = cleanWorkspaceSessionTerminalPopoverTitle(session.name);
   const statusTone = STATUS_TONE[session.status];
   const isChat = session.mode === "chat";
+  const canRename = canRenameSession(session, { isGeneratingTitle });
+  const canRegenerateTitle =
+    canRegenerateSessionTitle(session) && !isGeneratingTitle;
+  const currentPullRequest = useCurrentPullRequest(session);
 
   const updatePosition = useCallback(() => {
     const margin = KANBAN_TERMINAL_POPOVER_MARGIN_PX;
@@ -1444,6 +1466,143 @@ function KanbanTerminalPopover({
     sizeRef.current = size;
   }, [size]);
 
+  useEffect(() => {
+    setEditingTitle(false);
+    setHeaderMenu(null);
+  }, [session.id]);
+
+  useEffect(() => {
+    if (isGeneratingTitle && editingTitle) setEditingTitle(false);
+  }, [editingTitle, isGeneratingTitle]);
+
+  async function submitTitleRename(next: string) {
+    setEditingTitle(false);
+    if (!canRename || !next || next === session.name) return;
+    await renameSession(session.id, next);
+    const error = useAppStore.getState().consumeError();
+    if (error) showToast(`${t("toasts.session.renameFailed")} ${error}`);
+  }
+
+  async function regenerateTitle() {
+    const settings = useSettings.getState().settings;
+    const status = await generateSessionTitle(
+      session.id,
+      resolveAiExecutionRequest(settings),
+      resolveSessionTitlePrompt(settings),
+      true,
+    );
+    if (status === "not_ready") {
+      showToast(t("toasts.session.titleNotReady"));
+    } else if (status !== "generated") {
+      showToast(t("toasts.session.titleRegenerateSkipped"));
+    }
+  }
+
+  const headerMenuItems = useMemo<ContextMenuItem[]>(
+    () => [
+      workspaceContextMenuGroupTitle(t, "session"),
+      {
+        label: sidebarText(t, "sidebar.actions.rename"),
+        icon: <Pencil size={12} />,
+        onClick: () => setEditingTitle(true),
+        disabled: !canRename,
+      },
+      {
+        label: sidebarText(t, "sidebar.actions.regenerateName"),
+        icon: <Sparkles size={12} />,
+        onClick: () => void regenerateTitle(),
+        disabled: !canRegenerateTitle,
+      },
+      {
+        label: sidebarText(t, "sidebar.actions.openWorkSummary"),
+        icon: <BarChart3 size={12} />,
+        onClick: () => {
+          selectSession(session.id);
+          void openWorkSummaryTab({ sessionId: session.id })
+            .then(() => setWorkspaceViewMode("panes"))
+            .catch((err: unknown) => {
+              console.error("[WorkspaceMain] open work summary failed", err);
+            });
+        },
+      },
+      workspaceContextMenuGroupTitle(t, "open"),
+      {
+        label: sidebarText(t, "sidebar.actions.openWorktreeInEditor"),
+        icon: <PencilLine size={12} />,
+        disabled: !editorConfigured,
+        onClick: () => {
+          void openInConfiguredEditor(session.worktree_path).catch(
+            (err: unknown) => {
+              console.error("[WorkspaceMain] open in editor failed", err);
+            },
+          );
+        },
+      },
+      {
+        label: sidebarText(t, "sidebar.actions.revealInFinder"),
+        icon: <FolderOpen size={12} />,
+        onClick: () => {
+          void api.fsReveal(session.worktree_path).catch((err: unknown) => {
+            console.error("[WorkspaceMain] reveal failed", err);
+          });
+        },
+      },
+      workspaceContextMenuGroupTitle(t, "copy"),
+      {
+        type: "submenu",
+        label: sidebarText(t, "sidebar.actions.copy"),
+        icon: <Copy size={12} />,
+        children: [
+          {
+            label: sidebarText(t, "sidebar.actions.worktreePath"),
+            icon: <Copy size={12} />,
+            onClick: () => void copyToClipboard(session.worktree_path),
+          },
+          {
+            label: sidebarText(t, "sidebar.actions.worktreeName"),
+            icon: <Copy size={12} />,
+            onClick: () => void copyToClipboard(worktreeName),
+          },
+          {
+            label: sidebarText(t, "sidebar.actions.branchName"),
+            icon: <Copy size={12} />,
+            onClick: () => void copyToClipboard(session.branch),
+            disabled: !session.branch,
+          },
+          {
+            label: sidebarText(t, "sidebar.actions.sessionId"),
+            icon: <Copy size={12} />,
+            onClick: () => void copyToClipboard(session.id),
+          },
+        ],
+      },
+      workspaceContextMenuGroupTitle(t, "danger"),
+      {
+        label: sidebarText(t, "sidebar.actions.removeSessionMenu"),
+        icon: <Trash2 size={12} />,
+        onClick: () => requestRemoveSession(session.id),
+      },
+    ],
+    [
+      canRegenerateTitle,
+      canRename,
+      editorConfigured,
+      generateSessionTitle,
+      isGeneratingTitle,
+      openWorkSummaryTab,
+      requestRemoveSession,
+      selectSession,
+      session.branch,
+      session.id,
+      session.name,
+      session.worktree_path,
+      showToast,
+      setWorkspaceViewMode,
+      t,
+      worktreeName,
+    ],
+  );
+
   useLayoutEffect(() => {
     hasManualPositionRef.current = false;
   }, [anchor, session.id]);
@@ -1480,6 +1639,12 @@ function KanbanTerminalPopover({
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target;
       if (!(target instanceof Node)) return;
+      if (
+        target instanceof Element &&
+        target.closest("[data-acorn-context-menu]")
+      ) {
+        return;
+      }
       if (popoverRef.current?.contains(target)) return;
       if (anchor.contains(target)) return;
       if (isModalDialogOpen()) return;
@@ -1496,7 +1661,9 @@ function KanbanTerminalPopover({
     const target = event.target;
     if (
       target instanceof Element &&
-      target.closest("button,a,input,textarea,select")
+      target.closest(
+        "button,a,input,textarea,select,[data-kanban-title-edit-trigger]",
+      )
     ) {
       return;
     }
@@ -1601,6 +1768,46 @@ function KanbanTerminalPopover({
     window.addEventListener("pointercancel", stopResize);
   }
 
+  function openHeaderContextMenu(x: number, y: number) {
+    setHeaderMenu({ x, y });
+  }
+
+  function handleHeaderContextMenu(event: ReactMouseEvent<HTMLElement>) {
+    const target = event.target;
+    if (
+      target instanceof Element &&
+      target.closest("input,textarea,select")
+    ) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    openHeaderContextMenu(event.clientX, event.clientY);
+  }
+
+  function resetPopoverPosition() {
+    hasManualPositionRef.current = false;
+    if (isExpanded) {
+      setIsExpanded(false);
+      return;
+    }
+    updatePosition();
+  }
+
+  function resetPopoverSize() {
+    const nextSize = clampKanbanTerminalPopoverSize(
+      defaultKanbanTerminalPopoverSize(),
+    );
+    sizeRef.current = nextSize;
+    setSize(nextSize);
+    writeKanbanTerminalPopoverSize(nextSize);
+    if (isExpanded) {
+      setIsExpanded(false);
+      return;
+    }
+    updatePosition();
+  }
+
   function handlePopoverKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
     if (event.key !== "Escape") return;
     event.preventDefault();
@@ -1639,6 +1846,7 @@ function KanbanTerminalPopover({
       <header
         data-testid="kanban-terminal-popover-drag-handle"
         onPointerDown={startDrag}
+        onContextMenu={handleHeaderContextMenu}
         className={cn(
           "shrink-0 border-b border-border px-3 py-2.5",
           !isExpanded && "cursor-move select-none",
@@ -1649,7 +1857,43 @@ function KanbanTerminalPopover({
             <WorkspaceSessionIcon session={session} scope="console" size="md" />
           </span>
           <div className="min-w-0 flex-1">
-            <h3 className="truncate text-sm font-semibold text-fg">{title}</h3>
+            {editingTitle ? (
+              <KanbanTerminalPopoverTitleInput
+                initial={session.name}
+                onSubmit={(next) => void submitTitleRename(next)}
+                onCancel={() => setEditingTitle(false)}
+              />
+            ) : (
+              <h3
+                tabIndex={canRename ? 0 : undefined}
+                data-kanban-title-edit-trigger
+                onDoubleClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  if (canRename) setEditingTitle(true);
+                }}
+                onKeyDown={(event) => {
+                  if (!canRename) return;
+                  if (
+                    event.key !== "F2" &&
+                    event.key !== "Enter" &&
+                    event.key !== " "
+                  ) {
+                    return;
+                  }
+                  event.preventDefault();
+                  event.stopPropagation();
+                  setEditingTitle(true);
+                }}
+                className={cn(
+                  "truncate rounded-sm text-sm font-semibold text-fg",
+                  canRename &&
+                    "cursor-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+                )}
+              >
+                {title}
+              </h3>
+            )}
             <div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden text-[11px] font-medium leading-4 text-fg-muted">
               <WorkspaceSessionTerminalPopoverMetaItem
                 icon={
@@ -1662,8 +1906,16 @@ function KanbanTerminalPopover({
               >
                 {statusLabel(t, session.status)}
               </WorkspaceSessionTerminalPopoverMetaItem>
+              {currentPullRequest ? (
+                <KanbanTerminalPopoverPullRequestMetaItem
+                  pullRequest={currentPullRequest}
+                  t={t}
+                />
+              ) : null}
               {session.branch ? (
-                <WorkspaceSessionTerminalPopoverMetaItem icon={<GitBranch size={11} />}>
+                <WorkspaceSessionTerminalPopoverMetaItem
+                  icon={<GitBranch size={11} />}
+                >
                   {session.branch}
                 </WorkspaceSessionTerminalPopoverMetaItem>
               ) : null}
@@ -1675,6 +1927,34 @@ function KanbanTerminalPopover({
               </WorkspaceSessionTerminalPopoverMetaItem>
             </div>
           </div>
+          <Tooltip
+            label={t("workspace.kanban.terminalPopover.resetPosition")}
+            side="bottom"
+          >
+            <IconButton
+              aria-label={t("workspace.kanban.terminalPopover.resetPosition")}
+              data-testid="kanban-terminal-popover-reset-position"
+              onClick={resetPopoverPosition}
+              size="sm"
+              surface="panel"
+            >
+              <LocateFixed size={14} />
+            </IconButton>
+          </Tooltip>
+          <Tooltip
+            label={t("workspace.kanban.terminalPopover.resetSize")}
+            side="bottom"
+          >
+            <IconButton
+              aria-label={t("workspace.kanban.terminalPopover.resetSize")}
+              data-testid="kanban-terminal-popover-reset-size"
+              onClick={resetPopoverSize}
+              size="sm"
+              surface="panel"
+            >
+              <RotateCcw size={14} />
+            </IconButton>
+          </Tooltip>
           <IconButton
             aria-label={t(
               isExpanded
@@ -1698,6 +1978,13 @@ function KanbanTerminalPopover({
           </IconButton>
         </div>
       </header>
+      <ContextMenu
+        open={headerMenu !== null}
+        x={headerMenu?.x ?? 0}
+        y={headerMenu?.y ?? 0}
+        onClose={() => setHeaderMenu(null)}
+        items={headerMenuItems}
+      />
       <div className="min-h-0 flex-1 bg-bg p-2">
         {isChat ? (
           <div
@@ -1737,6 +2024,100 @@ function KanbanTerminalPopover({
   );
 
   return createPortal(popover, document.body);
+}
+
+function KanbanTerminalPopoverTitleInput({
+  initial,
+  onSubmit,
+  onCancel,
+}: {
+  initial: string;
+  onSubmit: (value: string) => void;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(initial);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.select();
+  }, []);
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      data-testid="kanban-terminal-popover-title-input"
+      autoFocus
+      draggable={false}
+      value={value}
+      onChange={(event) => setValue(event.currentTarget.value)}
+      onClick={(event) => event.stopPropagation()}
+      onPointerDown={(event) => event.stopPropagation()}
+      onDragStart={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onKeyDown={(event) => {
+        event.stopPropagation();
+        if (event.key === "Enter") {
+          event.preventDefault();
+          onSubmit(value.trim());
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          onCancel();
+        }
+      }}
+      onBlur={() => onSubmit(value.trim())}
+      className="h-6 w-full min-w-0 rounded border border-accent/50 bg-input px-1.5 text-sm font-semibold text-fg outline-none focus:border-accent focus:bg-input-hover"
+    />
+  );
+}
+
+function KanbanTerminalPopoverPullRequestMetaItem({
+  pullRequest,
+  t,
+}: {
+  pullRequest: SessionPullRequestSummary;
+  t: Translator;
+}) {
+  const draftLabel = t("rightPanel.prStates.draft");
+  const tooltip = `${pullRequest.is_draft ? `${draftLabel} ` : ""}#${pullRequest.number} ${pullRequest.title}\n${pullRequest.head_branch} -> ${pullRequest.base_branch}`;
+  return (
+    <Tooltip label={tooltip} side="bottom" delay={350} multiline>
+      <button
+        type="button"
+        aria-label={`${sidebarText(t, "sidebar.metadata.openPullRequest")} #${pullRequest.number}: ${pullRequest.title}`}
+        onMouseDown={(event) => event.stopPropagation()}
+        onPointerDown={(event) => event.stopPropagation()}
+        onKeyDown={(event) => event.stopPropagation()}
+        onKeyUp={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          event.stopPropagation();
+          void openUrl(pullRequest.url).catch((err: unknown) => {
+            console.error("[WorkspaceMain] open PR URL failed", err);
+          });
+        }}
+        className={cn(
+          "inline-flex min-w-0 max-w-[18rem] shrink items-center gap-1.5 rounded-sm underline-offset-2 transition hover:text-fg hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/60",
+          pullRequestNumberClassName(pullRequest),
+        )}
+        title={pullRequest.title}
+      >
+        <GitPullRequest size={11} aria-hidden className="shrink-0" />
+        <span className="shrink-0">{`PR #${pullRequest.number}`}</span>
+        <span aria-hidden className="shrink-0 text-fg-muted/55">
+          ·
+        </span>
+        <span className="min-w-0 truncate">{pullRequest.title}</span>
+        {pullRequest.is_draft ? (
+          <span className="shrink-0 rounded-[2px] border border-current/30 px-0.5 text-[9px] font-semibold leading-3 no-underline">
+            {draftLabel}
+          </span>
+        ) : null}
+        <ExternalLink size={10} aria-hidden className="shrink-0 opacity-80" />
+      </button>
+    </Tooltip>
+  );
 }
 
 function isModalDialogOpen(): boolean {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -955,6 +955,8 @@
         "ariaLabel": "Session terminal",
         "expand": "Expand terminal",
         "restore": "Restore terminal size",
+        "resetPosition": "Reset terminal position",
+        "resetSize": "Reset terminal size",
         "resize": "Resize terminal"
       },
       "popover": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -955,6 +955,8 @@
         "ariaLabel": "세션 터미널",
         "expand": "터미널 크게 보기",
         "restore": "터미널 원래 크기로",
+        "resetPosition": "터미널 원위치",
+        "resetSize": "터미널 크기 초기화",
         "resize": "터미널 크기 조절"
       },
       "popover": {

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -207,6 +207,27 @@ test.describe("workspace kanban mode", () => {
       });
     });
     await tauri.handle("list_pull_requests", (args) => {
+      if (args?.query === "head:shell") {
+        return {
+          kind: "ok",
+          account: "test",
+          items: [
+            {
+              number: 42,
+              title: "Add kanban overlay header affordances",
+              state: "OPEN",
+              author: "ian",
+              head_branch: "shell",
+              base_branch: "main",
+              url: "https://github.com/im-ian/acorn/pull/42",
+              updated_at: "2026-01-01T00:00:00Z",
+              is_draft: false,
+              checks: null,
+              labels: [],
+            },
+          ],
+        };
+      }
       if (args?.query !== "head:feat/runner") {
         return { kind: "ok", items: [], account: "test" };
       }
@@ -594,6 +615,10 @@ test.describe("workspace kanban mode", () => {
     await expect(
       shellPopover.getByRole("heading", { name: "shell" }),
     ).toBeVisible();
+    const shellPopoverPrButton = shellPopover.getByRole("button", {
+      name: /Open PR #42: Add kanban overlay header affordances/,
+    });
+    await expect(shellPopoverPrButton).toBeVisible();
     await expect(page.getByTestId("terminal-popover-body")).toBeVisible();
     await expect(
       page
@@ -605,6 +630,57 @@ test.describe("workspace kanban mode", () => {
         .getByTestId("terminal-popover-body")
         .locator(".xterm-helper-textarea"),
     ).toBeFocused();
+    await shellPopoverPrButton.click();
+    const openedUrlsAfterPopoverPr = await page.evaluate(
+      () =>
+        (
+          (window as unknown as {
+            __openUrlCalls?: Array<{ url?: string }>;
+          }).__openUrlCalls ?? []
+        ).map((call) => call.url),
+    );
+    expect(openedUrlsAfterPopoverPr).toEqual([
+      "https://github.com/im-ian/acorn/pull/77",
+      "https://github.com/im-ian/acorn/pull/42",
+    ]);
+    const headerHandle = page.getByTestId(
+      "kanban-terminal-popover-drag-handle",
+    );
+    const headerBox = await headerHandle.boundingBox();
+    expect(headerBox).not.toBeNull();
+    if (!headerBox) throw new Error("missing popover header");
+    await headerHandle.dispatchEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      button: 2,
+      clientX: headerBox.x + headerBox.width / 2,
+      clientY: headerBox.y + headerBox.height / 2,
+    });
+    await expect(page.getByRole("menuitem", { name: "Rename" })).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Regenerate Name" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Open Work Summary" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Reveal in Finder" }),
+    ).toBeVisible();
+    await page.getByRole("menuitem", { name: "Rename" }).click();
+    const titleInput = page.getByTestId(
+      "kanban-terminal-popover-title-input",
+    );
+    await expect(titleInput).toBeVisible();
+    await titleInput.press("Escape");
+    await expect(
+      shellPopover.getByRole("heading", { name: "shell" }),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("kanban-terminal-popover-reset-position"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("kanban-terminal-popover-reset-size"),
+    ).toBeVisible();
     const shellPopoverBoxBefore = await shellPopover.boundingBox();
     expect(shellPopoverBoxBefore).not.toBeNull();
     if (!shellPopoverBoxBefore) throw new Error("missing shell popover");
@@ -703,6 +779,24 @@ test.describe("workspace kanban mode", () => {
       Math.abs((popoverBoxAfterDrag?.y ?? 0) - popoverBoxBeforeDrag.y),
     ).toBeGreaterThan(16);
 
+    await page.getByTestId("kanban-terminal-popover-reset-position").click();
+    const popoverBoxAfterPositionReset = await shellPopover.boundingBox();
+    expect(
+      Math.abs((popoverBoxAfterPositionReset?.x ?? 0) - popoverBoxBeforeDrag.x),
+    ).toBeLessThan(4);
+    expect(
+      Math.abs((popoverBoxAfterPositionReset?.y ?? 0) - popoverBoxBeforeDrag.y),
+    ).toBeLessThan(4);
+
+    await page.getByTestId("kanban-terminal-popover-reset-size").click();
+    const popoverBoxAfterSizeReset = await shellPopover.boundingBox();
+    expect(
+      Math.abs((popoverBoxAfterSizeReset?.width ?? 0) - 560),
+    ).toBeLessThan(2);
+    expect(
+      Math.abs((popoverBoxAfterSizeReset?.height ?? 0) - 420),
+    ).toBeLessThan(2);
+
     await board.getByRole("button", { name: "Open broken" }).click();
 
     await expect(page.getByTestId("workspace-kanban")).toBeVisible();
@@ -792,7 +886,10 @@ test.describe("workspace kanban mode", () => {
     await expect(runner).toBeFocused();
   });
 
-  test("card context menu can rename a session", async ({ page, tauri }) => {
+  test("card context menu and terminal popover header can rename a session", async ({
+    page,
+    tauri,
+  }) => {
     await tauri.respond("list_projects", [PROJECT]);
     await tauri.handle("list_sessions", () => {
       const w = window as unknown as {
@@ -870,6 +967,34 @@ test.describe("workspace kanban mode", () => {
     });
     await expect(
       board.getByRole("button", { name: "Open renamed from kanban" }),
+    ).toBeVisible();
+
+    await board
+      .getByRole("button", { name: "Open renamed from kanban" })
+      .click();
+    const popover = page.getByTestId("kanban-terminal-popover");
+    const heading = popover.getByRole("heading", {
+      name: "renamed from kanban",
+    });
+    await heading.dblclick();
+    const popoverTitleInput = page.getByTestId(
+      "kanban-terminal-popover-title-input",
+    );
+    await expect(popoverTitleInput).toBeFocused();
+    await popoverTitleInput.fill("renamed from popover");
+    await popoverTitleInput.press("Enter");
+
+    await expect
+      .poll(async () =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __renameCalls?: unknown[] })
+              .__renameCalls?.length ?? 0,
+        ),
+      )
+      .toBe(2);
+    await expect(
+      popover.getByRole("heading", { name: "renamed from popover" }),
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

Kanban terminal popovers now expose the same session context and header affordances users expect from pane/card workflows.

1. **Header context menu:** right-clicking the popover header opens session actions for rename, regenerate name, work summary, worktree open/reveal, copy, and removal.
2. **Header editing and reset controls:** double-click/F2/Enter on the popover title starts inline rename, and dedicated buttons reset the popover position or size.
3. **PR context in overlay:** the popover header shows the current open PR with title, state coloring, draft marker, tooltip, and browser-open action.
4. **Interaction coverage:** kanban E2E now verifies header menus, title rename, PR chip visibility/opening, and position/size reset behavior.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Kanban overlay UX | Users can manage a session from the overlay header without switching back to panes or cards. |
| PR visibility | Open PR context remains visible after opening a kanban session popover. |
| Layout recovery | Users can quickly restore a moved or resized terminal popover. |
| Regression coverage | Header interactions and PR content are covered by the kanban E2E suite. |

## Design notes

- The popover reuses the existing `useCurrentPullRequest` lookup and `pullRequestNumberClassName` presentation so card/sidebar and overlay PR state stay consistent.
- `ContextMenu` now marks its portal panel with `data-acorn-context-menu`; the popover outside-click handler uses that marker so selecting menu items does not close the popover first.
- Title editing is isolated from header drag by excluding the title trigger from drag start, while the rest of the header remains draggable.
- Reset size writes the default popover dimensions back through the existing popover-size persistence path.

## Test plan

- [x] `git diff --cached --check`
- [x] `pnpm run typecheck`
- [x] `pnpm exec playwright test tests/e2e/kanban.spec.ts` — 16 passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts` — 41 passed
