### PR TITLE
feat(command-palette): surface unread session activity

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from "react";
 import { Command, useCommandState } from "cmdk";
 import {
+  AlertCircle,
+  Bell,
   Bot,
+  CheckCircle2,
   Columns3,
   FolderOpen,
   FolderPlus,
@@ -32,6 +35,7 @@ import {
 import { suggestDefaultSessionName } from "../lib/sessionName";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
+import type { SessionNotificationKind } from "../lib/types";
 
 interface CommandPaletteProps {
   open: boolean;
@@ -53,8 +57,35 @@ function workspaceModeLabel(t: Translator, mode: WorkspaceViewMode): string {
     : t("workspace.mode.panes");
 }
 
+const ACTIVITY_KIND_KEYS: Record<
+  SessionNotificationKind,
+  CommandPaletteTranslationKey
+> = {
+  waiting_for_input: "commandPalette.activity.kind.waitingForInput",
+  errored: "commandPalette.activity.kind.errored",
+  became_ready: "commandPalette.activity.kind.becameReady",
+};
+
+function activityKindLabel(
+  t: Translator,
+  kind: SessionNotificationKind,
+): string {
+  return cpt(t, ACTIVITY_KIND_KEYS[kind]);
+}
+
+function ActivityKindIcon({ kind }: { kind: SessionNotificationKind }) {
+  if (kind === "errored") {
+    return <AlertCircle size={14} className="text-danger" />;
+  }
+  if (kind === "became_ready") {
+    return <CheckCircle2 size={14} className="text-fg-muted" />;
+  }
+  return <Bell size={14} className="text-warning" />;
+}
+
 export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const sessions = useAppStore((s) => s.sessions);
+  const notifications = useAppStore((s) => s.sessionNotifications);
   const workspaceViewMode = useAppStore((s) => s.workspaceViewMode);
   const t = useTranslation();
   const nextWorkspaceViewMode: WorkspaceViewMode =
@@ -65,6 +96,10 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   // Derived once per render — sessions array identity is stable from zustand
   // until the underlying list actually changes.
   const sessionItems = useMemo(() => sessions, [sessions]);
+  const unreadNotifications = useMemo(
+    () => notifications.filter((notification) => !notification.readAt),
+    [notifications],
+  );
 
   function close() {
     onOpenChange(false);
@@ -175,6 +210,16 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 
   function handleSelectSession(id: string) {
     useAppStore.getState().selectSession(id);
+    close();
+  }
+
+  function handleOpenActivity(notificationId: string, sessionId: string) {
+    const state = useAppStore.getState();
+    state.markSessionNotificationRead(notificationId);
+    state.selectSession(sessionId);
+    if (state.workspaceViewMode === "kanban") {
+      state.openTerminalPopup(sessionId);
+    }
     close();
   }
 
@@ -361,6 +406,39 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
                 </span>
                 <span className="ml-auto truncate text-xs text-fg-muted/80">
                   {session.branch}
+                </span>
+              </Command.Item>
+            ))}
+          </Command.Group>
+        ) : null}
+
+        {unreadNotifications.length > 0 ? (
+          <Command.Group heading={cpt(t, "commandPalette.groups.activity")}>
+            {unreadNotifications.map((notification) => (
+              <Command.Item
+                key={`activity-${notification.id}`}
+                value={`activity ${notification.projectName} ${notification.sessionName} ${notification.kind}`}
+                onSelect={() =>
+                  handleOpenActivity(notification.id, notification.sessionId)
+                }
+                keywords={[
+                  notification.projectName,
+                  notification.sessionName,
+                  notification.repoPath,
+                  notification.kind,
+                  activityKindLabel(t, notification.kind),
+                  "unread",
+                  "activity",
+                  "notification",
+                ]}
+              >
+                <ActivityKindIcon kind={notification.kind} />
+                <span className="truncate">
+                  {activityKindLabel(t, notification.kind)} ·{" "}
+                  {notification.sessionName}
+                </span>
+                <span className="ml-auto truncate text-xs text-fg-muted/80">
+                  {notification.projectName}
                 </span>
               </Command.Item>
             ))}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1950,6 +1950,7 @@
     "groups": {
       "sessions": "Sessions",
       "switchSession": "Switch session",
+      "activity": "Unread activity",
       "view": "View",
       "terminal": "Terminal",
       "ipc": "IPC",
@@ -1980,6 +1981,13 @@
       "shellEnvReloadFailed": "Failed to reload shell environment.",
       "ipcRestarted": "IPC server restarted.",
       "ipcRestartFailedPrefix": "Failed to restart IPC server:"
+    },
+    "activity": {
+      "kind": {
+        "waitingForInput": "Waiting for input",
+        "errored": "Error",
+        "becameReady": "Ready"
+      }
     }
   },
   "backgroundSessions": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1950,6 +1950,7 @@
     "groups": {
       "sessions": "세션",
       "switchSession": "세션 전환",
+      "activity": "새 활동",
       "view": "보기",
       "terminal": "터미널",
       "ipc": "IPC",
@@ -1980,6 +1981,13 @@
       "shellEnvReloadFailed": "셸 환경을 다시 불러오지 못했습니다.",
       "ipcRestarted": "IPC 서버를 다시 시작했습니다.",
       "ipcRestartFailedPrefix": "IPC 서버를 다시 시작하지 못했습니다:"
+    },
+    "activity": {
+      "kind": {
+        "waitingForInput": "입력 대기",
+        "errored": "오류",
+        "becameReady": "준비됨"
+      }
     }
   },
   "backgroundSessions": {

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -168,4 +168,79 @@ test.describe("command palette", () => {
       page.getByRole("option", { name: /Switch to feature-branch/i }),
     ).toBeVisible();
   });
+
+  test("opens unread session activity from the palette", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "session-1",
+        name: "foreground",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "working",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+      {
+        id: "session-2",
+        name: "agent run",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "working",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 1,
+        in_worktree: false,
+      },
+    ]);
+    await tauri.handle("detect_session_statuses", () => [
+      {
+        id: "session-2",
+        status: "waiting_for_input",
+        branch: null,
+        agent_provider: null,
+      },
+    ]);
+
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: "Session notifications" }))
+      .toContainText("1");
+
+    await pressHotkey(page, { mod: true, key: "p" });
+    const palette = page.getByRole("dialog", { name: /Command palette/i });
+    await expect(palette.getByText("Unread activity")).toBeVisible();
+
+    await palette
+      .getByRole("option", { name: /Waiting for input.*agent run.*demo/ })
+      .click();
+
+    await expect(palette).toHaveCount(0);
+    await expect(page.getByText("agent run").first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Session notifications" }))
+      .not.toContainText("1");
+  });
 });


### PR DESCRIPTION
## Summary
This adds a small command-palette entry point for unread session activity.

1. **Unread activity group** — show unread session notifications in Command Palette under `Unread activity` / `새 활동`.
2. **Direct session jump** — selecting an activity item marks it read, selects the related session, and opens the terminal popover in kanban mode.
3. **Localized activity labels** — add English and Korean labels for waiting, error, and ready activity kinds.
4. **E2E coverage** — cover the unread activity command-palette flow.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Finding unread agent/session activity | Status bar notification menu only | Command Palette also surfaces unread activity |
| Notification state | Manual open/read from existing surfaces | Palette selection also marks the item read |
| Remote/control behavior | Unchanged | Unchanged |

## Design notes
- Reuses the existing `sessionNotifications` store and read behavior instead of adding new activity state.
- Keeps individual status labels separate from the group label: `Unread activity` is the group, while `Waiting for input`, `Error`, and `Ready` remain activity kinds.
- Keeps this PR scoped to the usability patch from the Orca benchmark; status detection, terminal recovery, and performance follow-ups are intentionally separate.

## Follow-up (not in this PR)
- Evaluate provider-session metadata (`providerSession`, `transcriptPath`, `stateStartedAt`) for more precise status/resume behavior.
- Prototype renderer-side terminal output scheduling and hidden backlog caps separately from this UX change.

## Test plan
- [x] `git diff --check HEAD~1..HEAD` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test:e2e -- tests/e2e/command-palette.spec.ts` passes — 5 passed

## Notes
- The Command Palette E2E still prints existing Radix dialog title/description warnings during the test run. The tests pass and this PR does not introduce those warnings.