### PR TITLE
feat(status): surface provider transcript metadata + polling perf

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4892,6 +4892,7 @@ pub struct SessionStatusEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_agent_message: Option<String>,
     pub agent_provider: Option<SessionAgentProvider>,
+    pub agent_transcript_provider: Option<SessionAgentProvider>,
     pub agent_transcript_id: Option<String>,
     pub agent_transcript_path: Option<String>,
     pub active_processes: Vec<SessionProcessSummary>,
@@ -5117,6 +5118,7 @@ fn detect_session_statuses_blocking(
                         .as_ref()
                         .and_then(|p| p.last_agent_message.clone()),
                     agent_provider: session.as_ref().and_then(|s| s.agent_provider),
+                    agent_transcript_provider: None,
                     agent_transcript_id: session
                         .as_ref()
                         .and_then(|s| s.agent_transcript_id.clone()),
@@ -5200,6 +5202,7 @@ fn detect_session_statuses_blocking(
             let agent_transcript_path = transcript
                 .as_ref()
                 .map(|(path, _)| path.to_string_lossy().into_owned());
+            let agent_transcript_provider = transcript.as_ref().map(|(_, kind)| *kind);
             let transcript_preview = conversation_preview
                 .as_ref()
                 .and_then(|p| p.last_agent_message.clone());
@@ -5317,6 +5320,7 @@ fn detect_session_statuses_blocking(
                     .as_ref()
                     .and_then(|p| p.last_agent_message.clone()),
                 agent_provider,
+                agent_transcript_provider,
                 agent_transcript_id,
                 agent_transcript_path,
                 active_processes,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4893,6 +4893,7 @@ pub struct SessionStatusEntry {
     pub last_agent_message: Option<String>,
     pub agent_provider: Option<SessionAgentProvider>,
     pub agent_transcript_id: Option<String>,
+    pub agent_transcript_path: Option<String>,
     pub active_processes: Vec<SessionProcessSummary>,
     /// Current branch read live from the session's worktree on each poll.
     /// `None` when the worktree has no readable HEAD (e.g. detached, or
@@ -5119,6 +5120,7 @@ fn detect_session_statuses_blocking(
                     agent_transcript_id: session
                         .as_ref()
                         .and_then(|s| s.agent_transcript_id.clone()),
+                    agent_transcript_path: None,
                     active_processes: Vec::new(),
                     branch,
                     git_context_path,
@@ -5195,6 +5197,9 @@ fn detect_session_statuses_blocking(
             let conversation_preview = transcript.as_ref().and_then(|(path, kind)| {
                 agent_resume::extract_conversation_preview(*kind, path).ok()
             });
+            let agent_transcript_path = transcript
+                .as_ref()
+                .map(|(path, _)| path.to_string_lossy().into_owned());
             let transcript_preview = conversation_preview
                 .as_ref()
                 .and_then(|p| p.last_agent_message.clone());
@@ -5313,6 +5318,7 @@ fn detect_session_statuses_blocking(
                     .and_then(|p| p.last_agent_message.clone()),
                 agent_provider,
                 agent_transcript_id,
+                agent_transcript_path,
                 active_processes,
                 branch,
                 git_context_path,

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -29,6 +29,7 @@ import {
   resolveSessionAgentProvider,
 } from "../lib/agentProvider";
 import { cn } from "../lib/cn";
+import { createInFlightCoalescer } from "../lib/inFlightCoalescer";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useSettings } from "../lib/settings";
 import { useToasts } from "../lib/toasts";
@@ -122,6 +123,10 @@ interface MemorySnapshot {
   processes: MemoryProcess[];
 }
 
+const getCoalescedMemoryUsage = createInFlightCoalescer(() =>
+  api.getMemoryUsage(),
+);
+
 function formatBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
   const units = ["B", "KB", "MB", "GB", "TB"];
@@ -147,7 +152,7 @@ function useMemoryUsage(
     let cancelled = false;
     const tick = async () => {
       try {
-        const usage = await api.getMemoryUsage();
+        const usage = await getCoalescedMemoryUsage();
         if (!cancelled) {
           setSnapshot({ bytes: usage.bytes, processes: usage.processes });
         }

--- a/src/components/WorkSummaryView.test.tsx
+++ b/src/components/WorkSummaryView.test.tsx
@@ -464,6 +464,65 @@ describe("WorkSummaryView", () => {
     expect(container.textContent).toContain("320 tokens");
   });
 
+  it("loads a terminal agent transcript by paired path on first render", async () => {
+    mocks.agentTranscriptSummaryAtPath.mockResolvedValue({
+      provider: "codex",
+      id: "transcript-1",
+      transcript_path: "/Users/me/.codex/sessions/transcript-1.jsonl",
+      updated_at: 1_766_000_000,
+      message_count: 4,
+      user_messages: 2,
+      assistant_messages: 2,
+      turn_count: 2,
+      complete_turns: 2,
+      running_turns: 0,
+      token_usage: {
+        input_tokens: 220,
+        output_tokens: 80,
+        cache_read_tokens: 20,
+        cache_creation_tokens: 0,
+        reasoning_tokens: 12,
+        total_tokens: 320,
+        messages_with_usage: 1,
+      },
+    });
+    const tab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: `${REPO}/.worktrees/s1`,
+      sessionId: "s1",
+      title: "Feature runner Summary",
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkSummaryView
+          tab={tab}
+          session={session({
+            mode: "terminal",
+            agent_provider: null,
+            agent_transcript_provider: "codex",
+            agent_transcript_id: "transcript-1",
+            agent_transcript_path: "/Users/me/.codex/sessions/transcript-1.jsonl",
+          })}
+          isActive
+        />,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mocks.agentTranscriptSummaryAtPath).toHaveBeenCalledWith(
+      REPO,
+      "codex",
+      "transcript-1",
+      "/Users/me/.codex/sessions/transcript-1.jsonl",
+    );
+    expect(mocks.agentTranscriptSummary).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("4 messages");
+    expect(container.textContent).toContain("320 tokens");
+  });
+
   it("polls a terminal agent transcript by cached path after the initial id lookup", async () => {
     vi.useFakeTimers();
     mocks.agentTranscriptSummary.mockResolvedValueOnce({

--- a/src/components/WorkSummaryView.tsx
+++ b/src/components/WorkSummaryView.tsx
@@ -151,10 +151,19 @@ export function WorkSummaryView({
 
     const transcriptId = session.agent_transcript_id;
     if (transcriptId) {
+      const pairedLocation =
+        session.agent_transcript_provider && session.agent_transcript_path
+          ? {
+              provider: session.agent_transcript_provider,
+              id: transcriptId,
+              transcriptPath: session.agent_transcript_path,
+            }
+          : null;
       const transcript = await fetchAgentTranscriptSummary(
         tab.repoPath,
         transcriptId,
         transcriptLocationRef,
+        pairedLocation,
       );
       return {
         chat: transcript ? chatMetricsFromTranscript(transcript) : null,
@@ -164,6 +173,8 @@ export function WorkSummaryView({
 
     return { chat: null, tokens: null };
   }, [
+    session?.agent_transcript_path,
+    session?.agent_transcript_provider,
     session?.agent_transcript_id,
     session?.id,
     session?.mode,
@@ -697,8 +708,10 @@ async function fetchAgentTranscriptSummary(
   repoPath: string,
   transcriptId: string,
   locationRef: { current: AgentTranscriptLocation | null },
+  initialLocation: AgentTranscriptLocation | null = null,
 ): Promise<AgentTranscriptSummary | null> {
-  const cached = locationRef.current;
+  const cached =
+    initialLocation?.id === transcriptId ? initialLocation : locationRef.current;
   let transcript: AgentTranscriptSummary | null = null;
 
   if (cached?.id === transcriptId) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -640,6 +640,7 @@ export const api = {
       id: string;
       status: SessionStatus;
       status_reason?: SessionStatusReason | null;
+      status_started_at?: string | null;
       last_message?: string | null;
       last_user_message?: string | null;
       last_agent_message?: string | null;
@@ -657,6 +658,7 @@ export const api = {
         id: string;
         status: SessionStatus;
         status_reason?: SessionStatusReason | null;
+        status_started_at?: string | null;
         last_message?: string | null;
         last_user_message?: string | null;
         last_agent_message?: string | null;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -645,6 +645,7 @@ export const api = {
       last_agent_message?: string | null;
       agent_provider?: SessionAgentProvider | null;
       agent_transcript_id?: string | null;
+      agent_transcript_path?: string | null;
       active_processes?: SessionProcessSummary[];
       git_context_path?: string | null;
       branch: string | null;
@@ -661,6 +662,7 @@ export const api = {
         last_agent_message?: string | null;
         agent_provider?: SessionAgentProvider | null;
         agent_transcript_id?: string | null;
+        agent_transcript_path?: string | null;
         active_processes?: SessionProcessSummary[];
         git_context_path?: string | null;
         branch: string | null;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -645,6 +645,7 @@ export const api = {
       last_user_message?: string | null;
       last_agent_message?: string | null;
       agent_provider?: SessionAgentProvider | null;
+      agent_transcript_provider?: SessionAgentProvider | null;
       agent_transcript_id?: string | null;
       agent_transcript_path?: string | null;
       active_processes?: SessionProcessSummary[];
@@ -663,6 +664,7 @@ export const api = {
         last_user_message?: string | null;
         last_agent_message?: string | null;
         agent_provider?: SessionAgentProvider | null;
+        agent_transcript_provider?: SessionAgentProvider | null;
         agent_transcript_id?: string | null;
         agent_transcript_path?: string | null;
         active_processes?: SessionProcessSummary[];

--- a/src/lib/inFlightCoalescer.test.ts
+++ b/src/lib/inFlightCoalescer.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { createInFlightCoalescer } from "./inFlightCoalescer";
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("createInFlightCoalescer", () => {
+  it("shares one loader call across overlapping requests", async () => {
+    const pending = deferred<number>();
+    const load = vi.fn(() => pending.promise);
+    const coalesced = createInFlightCoalescer(load);
+
+    const first = coalesced();
+    const second = coalesced();
+    pending.resolve(42);
+
+    await expect(first).resolves.toBe(42);
+    await expect(second).resolves.toBe(42);
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts a new loader call after the previous request settles", async () => {
+    const load = vi.fn(async () => load.mock.calls.length);
+    const coalesced = createInFlightCoalescer(load);
+
+    await expect(coalesced()).resolves.toBe(1);
+    await expect(coalesced()).resolves.toBe(2);
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/inFlightCoalescer.ts
+++ b/src/lib/inFlightCoalescer.ts
@@ -1,0 +1,13 @@
+export function createInFlightCoalescer<T>(
+  load: () => Promise<T>,
+): () => Promise<T> {
+  let inFlight: Promise<T> | null = null;
+
+  return () => {
+    if (inFlight) return inFlight;
+    inFlight = load().finally(() => {
+      inFlight = null;
+    });
+    return inFlight;
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -125,6 +125,8 @@ export interface Session {
   status: SessionStatus;
   /** Ephemeral status-poll detail. Not persisted in backend sessions. */
   status_reason?: SessionStatusReason | null;
+  /** Ephemeral time when the current status started. */
+  status_started_at?: string | null;
   created_at: string;
   updated_at: string;
   last_message: string | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -147,6 +147,8 @@ export interface Session {
   agent_provider?: SessionAgentProvider | null;
   /** Most recently paired agent transcript id, if Acorn has paired this tab to one. */
   agent_transcript_id?: string | null;
+  /** Ephemeral path to the transcript currently used for status/preview reads. */
+  agent_transcript_path?: string | null;
   /** Ephemeral live process names observed under the session PTY. */
   active_processes?: SessionProcessSummary[];
   /** Ephemeral git workdir that produced the current live branch. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -147,6 +147,8 @@ export interface Session {
   in_worktree: boolean;
   /** Current live agent provider, if a known agent process is under the PTY. */
   agent_provider?: SessionAgentProvider | null;
+  /** Provider for the paired transcript path/id, independent from live process state. */
+  agent_transcript_provider?: SessionAgentProvider | null;
   /** Most recently paired agent transcript id, if Acorn has paired this tab to one. */
   agent_transcript_id?: string | null;
   /** Ephemeral path to the transcript currently used for status/preview reads. */

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1223,7 +1223,8 @@ describe("workspace tabs", () => {
       name: "Feature runner",
       worktree_path: `${REPO_A}/.worktrees/a1`,
       mode: "terminal",
-      agent_provider: "codex",
+      agent_provider: null,
+      agent_transcript_provider: "codex",
       agent_transcript_id: "transcript-1",
       agent_transcript_path: "/Users/me/.codex/sessions/transcript-1.jsonl",
     });
@@ -2379,6 +2380,36 @@ describe("pollSessionStatuses", () => {
     );
   });
 
+  it("merges paired agent transcript providers from status polling", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          agent_provider: "codex",
+          agent_transcript_id: "codex-old",
+          agent_transcript_path: "/Users/me/.codex/sessions/old.jsonl",
+        }),
+      ],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "ready",
+        agent_provider: null,
+        agent_transcript_provider: "codex",
+        agent_transcript_id: "codex-old",
+        agent_transcript_path: "/Users/me/.codex/sessions/old.jsonl",
+        branch: null,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    const stored = useAppStore.getState().sessions[0];
+    expect(stored?.agent_provider).toBeNull();
+    expect(stored?.agent_transcript_provider).toBe("codex");
+  });
+
   it("merges active process summaries from status polling", async () => {
     await seed(
       [project(REPO_A, 0)],
@@ -2568,6 +2599,36 @@ describe("pollSessionStatuses", () => {
     expect(useAppStore.getState().sessions[0]?.status_started_at).toBe(
       "2026-01-01T00:00:00.000Z",
     );
+  });
+
+  it("records first observed active status time when polling starts mid-status", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T12:34:56.000Z"));
+      await seed(
+        [project(REPO_A, 0)],
+        [
+          session("a1", REPO_A, {
+            status: "working",
+          }),
+        ],
+      );
+      mockApi.detectSessionStatuses.mockResolvedValueOnce([
+        {
+          id: "a1",
+          status: "working",
+          branch: null,
+        },
+      ]);
+
+      await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+      expect(useAppStore.getState().sessions[0]?.status_started_at).toBe(
+        "2026-01-01T12:34:56.000Z",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("uses backend status start time when status polling provides one", async () => {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2522,6 +2522,72 @@ describe("pollSessionStatuses", () => {
     );
   });
 
+  it("records when a polled session status starts", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T12:34:56.000Z"));
+      await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+      mockApi.detectSessionStatuses.mockResolvedValueOnce([
+        {
+          id: "a1",
+          status: "waiting_for_input",
+          branch: null,
+        },
+      ]);
+
+      await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+      expect(useAppStore.getState().sessions[0]?.status_started_at).toBe(
+        "2026-01-01T12:34:56.000Z",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves status start time while the polled status is unchanged", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          status: "working",
+          status_started_at: "2026-01-01T00:00:00.000Z",
+        }),
+      ],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "working",
+        branch: null,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.status_started_at).toBe(
+      "2026-01-01T00:00:00.000Z",
+    );
+  });
+
+  it("uses backend status start time when status polling provides one", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "working",
+        status_started_at: "2026-01-01T01:02:03.000Z",
+        branch: null,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.status_started_at).toBe(
+      "2026-01-01T01:02:03.000Z",
+    );
+  });
+
   it("clears the live agent provider when status polling reports null", async () => {
     await seed(
       [project(REPO_A, 0)],

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2295,6 +2295,35 @@ describe("pollSessionStatuses", () => {
     );
   });
 
+  it("merges live agent transcript paths from status polling", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          agent_provider: "codex",
+          agent_transcript_id: "codex-old",
+          agent_transcript_path: "/Users/me/.codex/sessions/old.jsonl",
+        }),
+      ],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "working",
+        agent_provider: "codex",
+        agent_transcript_id: "codex-new",
+        agent_transcript_path: "/Users/me/.codex/sessions/new.jsonl",
+        branch: null,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.agent_transcript_path).toBe(
+      "/Users/me/.codex/sessions/new.jsonl",
+    );
+  });
+
   it("merges active process summaries from status polling", async () => {
     await seed(
       [project(REPO_A, 0)],

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1218,6 +1218,61 @@ describe("workspace tabs", () => {
     });
   });
 
+  it("loads terminal work summary token baseline from the paired transcript path", async () => {
+    const active = session("a1", REPO_A, {
+      name: "Feature runner",
+      worktree_path: `${REPO_A}/.worktrees/a1`,
+      mode: "terminal",
+      agent_provider: "codex",
+      agent_transcript_id: "transcript-1",
+      agent_transcript_path: "/Users/me/.codex/sessions/transcript-1.jsonl",
+    });
+    await seed([project(REPO_A, 0)], [active]);
+    mockApi.agentTranscriptSummaryAtPath.mockResolvedValueOnce({
+      provider: "codex",
+      id: "transcript-1",
+      transcript_path: "/Users/me/.codex/sessions/transcript-1.jsonl",
+      updated_at: 1_766_000_000,
+      message_count: 4,
+      user_messages: 2,
+      assistant_messages: 2,
+      turn_count: 2,
+      complete_turns: 2,
+      running_turns: 0,
+      token_usage: {
+        input_tokens: 320,
+        output_tokens: 90,
+        cache_read_tokens: 12,
+        cache_creation_tokens: 3,
+        reasoning_tokens: 21,
+        total_tokens: 426,
+        messages_with_usage: 2,
+      },
+    });
+
+    await useAppStore.getState().openWorkSummaryTab();
+    await flushPromises();
+
+    expect(mockApi.agentTranscriptSummaryAtPath).toHaveBeenCalledWith(
+      REPO_A,
+      "codex",
+      "transcript-1",
+      "/Users/me/.codex/sessions/transcript-1.jsonl",
+    );
+    expect(mockApi.agentTranscriptSummary).not.toHaveBeenCalled();
+    expect(useAppStore.getState().workspaceTabs[useAppStore.getState().activeTabId!])
+      .toMatchObject({
+        kind: "work-summary",
+        sessionId: "a1",
+        tokenBaseline: expect.objectContaining({
+          inputTokens: 320,
+          outputTokens: 90,
+          totalTokens: 426,
+          messagesWithUsage: 2,
+        }),
+      });
+  });
+
   it("opens a work summary tab before terminal token baseline loading finishes", async () => {
     const active = session("a1", REPO_A, {
       name: "Feature runner",

--- a/src/store.ts
+++ b/src/store.ts
@@ -1850,6 +1850,13 @@ export const useAppStore = create<AppStateModel>()(
                 )
                   ? (update.agent_transcript_id ?? null)
                   : (sess.agent_transcript_id ?? null);
+                const nextAgentTranscriptPath =
+                  Object.prototype.hasOwnProperty.call(
+                    update,
+                    "agent_transcript_path",
+                  )
+                    ? (update.agent_transcript_path ?? null)
+                    : (sess.agent_transcript_path ?? null);
                 const currentActiveProcesses = sess.active_processes ?? [];
                 const nextActiveProcesses = Object.prototype.hasOwnProperty.call(
                   update,
@@ -1878,6 +1885,8 @@ export const useAppStore = create<AppStateModel>()(
                   nextLastAgentMessage !== (sess.last_agent_message ?? null) ||
                   nextAgentProvider !== (sess.agent_provider ?? null) ||
                   nextAgentTranscriptId !== (sess.agent_transcript_id ?? null) ||
+                  nextAgentTranscriptPath !==
+                    (sess.agent_transcript_path ?? null) ||
                   !sessionProcessSummariesEqual(
                     nextActiveProcesses,
                     currentActiveProcesses,
@@ -1896,6 +1905,7 @@ export const useAppStore = create<AppStateModel>()(
                     last_agent_message: nextLastAgentMessage,
                     agent_provider: nextAgentProvider,
                     agent_transcript_id: nextAgentTranscriptId,
+                    agent_transcript_path: nextAgentTranscriptPath,
                     active_processes: nextActiveProcesses,
                     git_context_path: nextGitContextPath,
                     auto_title_enabled: nextAutoTitleEnabled,

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { api, type AiExecutionRequest, type WorktreeRemoval } from "./lib/api";
 import type {
+  AgentTranscriptSummary,
   Project,
   Session,
   SessionAgentProvider,
@@ -238,18 +239,23 @@ async function loadWorkSummaryTokenBaseline(
       };
     }
     if (!session.agent_transcript_id) return undefined;
-    const transcript =
-      session.agent_provider && session.agent_transcript_path
-        ? await api.agentTranscriptSummaryAtPath(
-            session.repo_path,
-            session.agent_provider,
-            session.agent_transcript_id,
-            session.agent_transcript_path,
-          )
-        : await api.agentTranscriptSummary(
-            session.repo_path,
-            session.agent_transcript_id,
-          );
+    let transcript: AgentTranscriptSummary | null = null;
+    if (session.agent_transcript_provider && session.agent_transcript_path) {
+      try {
+        transcript = await api.agentTranscriptSummaryAtPath(
+          session.repo_path,
+          session.agent_transcript_provider,
+          session.agent_transcript_id,
+          session.agent_transcript_path,
+        );
+      } catch {
+        transcript = null;
+      }
+    }
+    transcript ??= await api.agentTranscriptSummary(
+      session.repo_path,
+      session.agent_transcript_id,
+    );
     if (!transcript) return undefined;
     return {
       inputTokens: transcript.token_usage.input_tokens,
@@ -1817,6 +1823,7 @@ export const useAppStore = create<AppStateModel>()(
           try {
             const updates = await api.detectSessionStatuses(idsToPoll);
             const map = new Map(updates.map((u) => [u.id, u]));
+            const pollObservedAt = new Date().toISOString();
             set((s) => {
               let changed = false;
               const nextSessions = s.sessions.map((sess) => {
@@ -1835,8 +1842,10 @@ export const useAppStore = create<AppStateModel>()(
                 )
                   ? (update.status_started_at ?? null)
                   : nextStatus !== sess.status
-                    ? new Date().toISOString()
-                    : (sess.status_started_at ?? null);
+                    ? pollObservedAt
+                    : nextStatus !== "ready" && !sess.status_started_at
+                      ? pollObservedAt
+                      : (sess.status_started_at ?? null);
                 const nextBranch = update.branch ?? sess.branch;
                 const nextLastMessage = Object.prototype.hasOwnProperty.call(
                   update,
@@ -1860,6 +1869,13 @@ export const useAppStore = create<AppStateModel>()(
                   Object.prototype.hasOwnProperty.call(update, "agent_provider")
                     ? (update.agent_provider ?? null)
                     : (sess.agent_provider ?? null);
+                const nextAgentTranscriptProvider =
+                  Object.prototype.hasOwnProperty.call(
+                    update,
+                    "agent_transcript_provider",
+                  )
+                    ? (update.agent_transcript_provider ?? null)
+                    : (sess.agent_transcript_provider ?? null);
                 const nextAgentTranscriptId = Object.prototype.hasOwnProperty.call(
                   update,
                   "agent_transcript_id",
@@ -1901,6 +1917,8 @@ export const useAppStore = create<AppStateModel>()(
                   nextLastUserMessage !== (sess.last_user_message ?? null) ||
                   nextLastAgentMessage !== (sess.last_agent_message ?? null) ||
                   nextAgentProvider !== (sess.agent_provider ?? null) ||
+                  nextAgentTranscriptProvider !==
+                    (sess.agent_transcript_provider ?? null) ||
                   nextAgentTranscriptId !== (sess.agent_transcript_id ?? null) ||
                   nextAgentTranscriptPath !==
                     (sess.agent_transcript_path ?? null) ||
@@ -1922,6 +1940,7 @@ export const useAppStore = create<AppStateModel>()(
                     last_user_message: nextLastUserMessage,
                     last_agent_message: nextLastAgentMessage,
                     agent_provider: nextAgentProvider,
+                    agent_transcript_provider: nextAgentTranscriptProvider,
                     agent_transcript_id: nextAgentTranscriptId,
                     agent_transcript_path: nextAgentTranscriptPath,
                     active_processes: nextActiveProcesses,

--- a/src/store.ts
+++ b/src/store.ts
@@ -238,10 +238,18 @@ async function loadWorkSummaryTokenBaseline(
       };
     }
     if (!session.agent_transcript_id) return undefined;
-    const transcript = await api.agentTranscriptSummary(
-      session.repo_path,
-      session.agent_transcript_id,
-    );
+    const transcript =
+      session.agent_provider && session.agent_transcript_path
+        ? await api.agentTranscriptSummaryAtPath(
+            session.repo_path,
+            session.agent_provider,
+            session.agent_transcript_id,
+            session.agent_transcript_path,
+          )
+        : await api.agentTranscriptSummary(
+            session.repo_path,
+            session.agent_transcript_id,
+          );
     if (!transcript) return undefined;
     return {
       inputTokens: transcript.token_usage.input_tokens,

--- a/src/store.ts
+++ b/src/store.ts
@@ -1829,6 +1829,14 @@ export const useAppStore = create<AppStateModel>()(
                 )
                   ? (update.status_reason ?? null)
                   : (sess.status_reason ?? null);
+                const nextStatusStartedAt = Object.prototype.hasOwnProperty.call(
+                  update,
+                  "status_started_at",
+                )
+                  ? (update.status_started_at ?? null)
+                  : nextStatus !== sess.status
+                    ? new Date().toISOString()
+                    : (sess.status_started_at ?? null);
                 const nextBranch = update.branch ?? sess.branch;
                 const nextLastMessage = Object.prototype.hasOwnProperty.call(
                   update,
@@ -1887,6 +1895,7 @@ export const useAppStore = create<AppStateModel>()(
                 if (
                   nextStatus !== sess.status ||
                   nextStatusReason !== (sess.status_reason ?? null) ||
+                  nextStatusStartedAt !== (sess.status_started_at ?? null) ||
                   nextBranch !== sess.branch ||
                   nextLastMessage !== sess.last_message ||
                   nextLastUserMessage !== (sess.last_user_message ?? null) ||
@@ -1907,6 +1916,7 @@ export const useAppStore = create<AppStateModel>()(
                     ...sess,
                     status: nextStatus,
                     status_reason: nextStatusReason,
+                    status_started_at: nextStatusStartedAt,
                     branch: nextBranch,
                     last_message: nextLastMessage,
                     last_user_message: nextLastUserMessage,


### PR DESCRIPTION
## Summary
This PR applies the Orca benchmark findings as one Acorn-native status/metadata pass.

1. **Provider transcript metadata** — `detect_session_statuses` now returns the transcript provider and path actually used for status/preview extraction. The frontend stores that paired transcript metadata separately from the live `agent_provider` badge state.
2. **Path-first Work Summary reads** — terminal Work Summary token baselines and the visible Work Summary conversation view use provider + id + transcript path when paired, falling back to id lookup if the direct path read is unavailable.
3. **Status start timestamps** — status polling tracks when the current status was first observed, preserves the timestamp while status is unchanged, and accepts a backend timestamp when one is provided later.
4. **Memory polling coalescing** — status bar memory snapshots share an in-flight request so slow memory probes cannot stack overlapping backend calls.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Agent JSONL/provider handling | Frontend had transcript id only, and live `agent_provider` was easy to confuse with transcript ownership | Status polling carries `agent_transcript_provider` + path from the backend transcript used for detection |
| Work Summary token baseline | Terminal baseline used id-based transcript lookup unless a live provider was still present | Uses paired transcript provider/path even after the agent process exits, then falls back to id lookup |
| Work Summary conversation refresh | First render always did an id scan before cached path polling could start | First render can use the status-provided transcript path immediately |
| Status UX/model | Current status had no start timestamp, and active sessions observed after app boot could stay unset | Frontend records `status_started_at` on transitions and first observed active status |
| Memory status polling | Slow memory probes could overlap on the 2s interval | In-flight memory snapshot requests are coalesced |

## Design notes
- This keeps Acorn's current low-intrusion watcher/hook model rather than copying Orca's managed-provider-home model.
- `agent_provider` remains the live process/provider badge. `agent_transcript_provider` is the provider for the paired transcript path/id and can remain present after the agent exits.
- `agent_transcript_path` and `agent_transcript_provider` are intentionally ephemeral frontend/session state for now. They reflect the transcript currently used for detection/preview and do not change persisted backend session shape.
- `status_started_at` is frontend-derived when the backend omits it. The API type accepts a backend value so a later provider-native hook layer can become authoritative without changing consumers again.
- The memory polling helper is generic but intentionally small: it only coalesces overlapping calls and resets after settle.

## Follow-up (not in this PR)
- Promote live provider, transcript provider, transcript id, and transcript path into a single provider-session object if more consumers need the shape.
- Add provider-native hook payload fields for transcript path and state start time where providers expose them directly.
- Evaluate terminal output scheduling/hidden backlog caps separately; that is a broader terminal pipeline change than this metadata/status PR.

## Test plan
- [x] `pnpm vitest run src/store.test.ts src/components/WorkSummaryView.test.tsx src/lib/inFlightCoalescer.test.ts` — 160 passed
- [x] `pnpm run typecheck` passes
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` passes
- [x] `rustfmt --edition 2021 --check src-tauri/src/commands.rs` passes
- [x] `git diff --check main..HEAD` passes
- [x] `pnpm run test:e2e -- tests/e2e/statusbar.spec.ts` — 5 passed

## Notes
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` still reports pre-existing formatting differences in `src-tauri/src/git_ops.rs` and `src-tauri/src/pty_env.rs`; this PR's touched Rust file passes rustfmt directly.
- `pnpm run build:sidecar` was run in this worktree to stage the sidecars needed by Tauri's build script; generated sidecar binaries remain gitignored.