### PR TITLE
feat(kanban): surface transcript turn previews

### DIFF
--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -121,6 +121,25 @@ const KANBAN_COLUMNS: ReadonlyArray<{
   tone: STATUS_TONE[status],
 }));
 
+interface KanbanConversationPreview {
+  userMessage?: string;
+  agentMessage?: string;
+  fallbackMessage?: string;
+}
+
+function trimPreviewMessage(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function kanbanConversationPreview(session: Session): KanbanConversationPreview {
+  return {
+    userMessage: trimPreviewMessage(session.last_user_message),
+    agentMessage: trimPreviewMessage(session.last_agent_message),
+    fallbackMessage: trimPreviewMessage(session.last_message),
+  };
+}
+
 const STATUS_ICON_CLASS: Record<SessionStatus, string> = {
   ready: "text-fg-muted",
   working: "text-accent",
@@ -934,8 +953,12 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
   const showToast = useToasts((s) => s.show);
   const worktreeName = basename(session.worktree_path);
   const branchName = session.branch?.trim();
+  const conversationPreview = kanbanConversationPreview(session);
   const lastMessage =
-    session.last_agent_message?.trim() || session.last_message?.trim();
+    conversationPreview.agentMessage ?? conversationPreview.fallbackMessage;
+  const hasStructuredPreview = Boolean(
+    conversationPreview.userMessage || conversationPreview.agentMessage,
+  );
   const selectSession = useAppStore((s) => s.selectSession);
   const renameSession = useAppStore((s) => s.renameSession);
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
@@ -1164,7 +1187,9 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
           <KanbanSessionCardTooltip
             t={t}
             title={session.name}
-            lastMessage={lastMessage}
+            userMessage={conversationPreview.userMessage}
+            agentMessage={conversationPreview.agentMessage}
+            fallbackMessage={conversationPreview.fallbackMessage}
             branch={branchName}
             worktreeName={worktreeName}
             worktreePath={session.worktree_path}
@@ -1205,7 +1230,39 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
               )}
             </span>
           </span>
-          {lastMessage ? (
+          {hasStructuredPreview ? (
+            <span
+              className="flex min-w-0 flex-col gap-1 text-[11px] leading-4 text-fg-muted"
+              data-testid="workspace-kanban-card-last-message"
+            >
+              {conversationPreview.userMessage ? (
+                <span
+                  className="flex min-w-0 items-baseline gap-1.5"
+                  data-testid="workspace-kanban-card-user-message"
+                >
+                  <span className="shrink-0 text-[9px] font-medium uppercase text-fg-muted/70">
+                    {t("workspace.kanban.preview.user")}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">
+                    {conversationPreview.userMessage}
+                  </span>
+                </span>
+              ) : null}
+              {conversationPreview.agentMessage ? (
+                <span
+                  className="flex min-w-0 items-baseline gap-1.5"
+                  data-testid="workspace-kanban-card-agent-message"
+                >
+                  <span className="shrink-0 text-[9px] font-medium uppercase text-fg-muted/70">
+                    {t("workspace.kanban.preview.agent")}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">
+                    {conversationPreview.agentMessage}
+                  </span>
+                </span>
+              ) : null}
+            </span>
+          ) : lastMessage ? (
             <span
               className="line-clamp-2 text-[11px] leading-4 text-fg-muted"
               data-testid="workspace-kanban-card-last-message"
@@ -2218,7 +2275,9 @@ function writeKanbanTerminalPopoverSize(
 function KanbanSessionCardTooltip({
   t,
   title,
-  lastMessage,
+  userMessage,
+  agentMessage,
+  fallbackMessage,
   branch,
   worktreeName,
   worktreePath,
@@ -2227,7 +2286,9 @@ function KanbanSessionCardTooltip({
 }: {
   t: Translator;
   title: string;
-  lastMessage?: string;
+  userMessage?: string;
+  agentMessage?: string;
+  fallbackMessage?: string;
   branch?: string;
   worktreeName: string;
   worktreePath: string;
@@ -2235,6 +2296,7 @@ function KanbanSessionCardTooltip({
   processSummary?: string | null;
 }) {
   const detached = t("workspace.kanban.tooltip.detached");
+  const hasStructuredPreview = Boolean(userMessage || agentMessage);
   return (
     <span className="flex w-80 max-w-[calc(100vw-2rem)] flex-col gap-1.5">
       <KanbanSessionTooltipRow
@@ -2242,12 +2304,33 @@ function KanbanSessionCardTooltip({
         label={t("workspace.kanban.tooltip.title")}
         value={title}
       />
-      <KanbanSessionTooltipRow
-        icon={<MessageSquareText size={12} />}
-        label={t("workspace.kanban.tooltip.lastMessage")}
-        value={lastMessage || t("workspace.kanban.tooltip.noLastMessage")}
-        valueClassName={lastMessage ? undefined : "text-fg-muted"}
-      />
+      {hasStructuredPreview ? (
+        <>
+          {userMessage ? (
+            <KanbanSessionTooltipRow
+              icon={<MessageSquareText size={12} />}
+              label={t("workspace.kanban.tooltip.lastUserMessage")}
+              value={userMessage}
+            />
+          ) : null}
+          {agentMessage ? (
+            <KanbanSessionTooltipRow
+              icon={<Bot size={12} />}
+              label={t("workspace.kanban.tooltip.lastAgentMessage")}
+              value={agentMessage}
+            />
+          ) : null}
+        </>
+      ) : (
+        <KanbanSessionTooltipRow
+          icon={<MessageSquareText size={12} />}
+          label={t("workspace.kanban.tooltip.lastMessage")}
+          value={
+            fallbackMessage || t("workspace.kanban.tooltip.noLastMessage")
+          }
+          valueClassName={fallbackMessage ? undefined : "text-fg-muted"}
+        />
+      )}
       <KanbanSessionTooltipRow
         icon={<GitBranch size={12} />}
         label={t("workspace.kanban.tooltip.branch")}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -938,8 +938,14 @@
         "nameAsc": "Name"
       },
       "openSession": "Open {name}",
+      "preview": {
+        "user": "User",
+        "agent": "Agent"
+      },
       "tooltip": {
         "title": "Title",
+        "lastUserMessage": "Last user message",
+        "lastAgentMessage": "Last agent message",
         "lastMessage": "Last message",
         "noLastMessage": "No last message",
         "branch": "Branch",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -938,8 +938,14 @@
         "nameAsc": "이름"
       },
       "openSession": "{name} 열기",
+      "preview": {
+        "user": "사용자",
+        "agent": "에이전트"
+      },
       "tooltip": {
         "title": "제목",
+        "lastUserMessage": "마지막 사용자 메시지",
+        "lastAgentMessage": "마지막 에이전트 메시지",
         "lastMessage": "마지막 메시지",
         "noLastMessage": "마지막 메시지 없음",
         "branch": "브랜치",

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -360,12 +360,20 @@ test.describe("workspace kanban mode", () => {
     await expect(
       brokenCard.getByTestId("workspace-kanban-card-last-message"),
     ).toContainText("Updated from status polling.");
+    await expect(
+      brokenCard.getByTestId("workspace-kanban-card-user-message"),
+    ).toContainText("Please check the failed tests.");
+    await expect(
+      brokenCard.getByTestId("workspace-kanban-card-agent-message"),
+    ).toContainText("Updated from status polling.");
     await brokenCard.hover();
     const cardTooltip = page.getByRole("tooltip");
     await expect(cardTooltip).toBeVisible();
     await expect(cardTooltip).toContainText("Title");
     await expect(cardTooltip).toContainText("broken");
-    await expect(cardTooltip).toContainText("Last message");
+    await expect(cardTooltip).toContainText("Last user message");
+    await expect(cardTooltip).toContainText("Please check the failed tests.");
+    await expect(cardTooltip).toContainText("Last agent message");
     await expect(cardTooltip).toContainText("Updated from status polling.");
     await expect(cardTooltip).toContainText("Branch");
     await expect(cardTooltip).toContainText("feat/broken");


### PR DESCRIPTION
## Summary
This PR makes the Kanban board use the transcript preview fields added by status polling instead of collapsing the conversation into one last-message line.

1. **Role-aware card preview** — Kanban cards now show the latest user prompt and latest agent reply separately when `last_user_message` / `last_agent_message` are available.
2. **Tooltip detail** — Card tooltips now label the preview as last user message and last agent message, while preserving the existing single-message fallback for sessions that only have `last_message`.
3. **Localized labels** — Adds Korean and English labels for the role-aware preview rows.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Local transcript recovery | Status polling could store user/agent preview fields, but Kanban only surfaced the agent/fallback line | Cards and tooltips preserve both sides of the latest transcript turn |
| xterm-limited sessions | Users had to open the terminal/popover to infer what prompt produced the latest state | Waiting/errored cards can show the latest request and response from provider JSONL metadata |
| Existing sessions | `last_message` rendered as a single fallback line | Fallback rendering is unchanged when role-aware preview fields are absent |

## Design notes
- This is local-only UI plumbing over existing status-poll metadata; it does not add remote control behavior or new backend calls.
- The board uses role-aware rows only when at least one structured preview field exists. Plain sessions keep the previous single `last_message` display.
- The visible card keeps compact one-line rows; the tooltip carries the clearer role labels for scanning longer text.

## Follow-up (not in this PR)
- Add a richer transcript conversation drawer when users need more than the latest turn.
- Consider surfacing transcript provider/path metadata in debug/tooltips only if it helps diagnose provider mapping issues.

## Test plan
- [x] `pnpm run test:e2e -- tests/e2e/kanban.spec.ts -g "groups active workspace sessions"` — 16 passed
- [x] `pnpm vitest run src/components/WorkspaceMain.test.tsx` — 5 passed
- [x] `pnpm run typecheck` passes
- [x] `git diff --check` passes