### PR TITLE
feat(work-summary): show recent transcript messages

### DIFF
--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -2201,6 +2201,64 @@ mod tests {
     }
 
     #[test]
+    fn transcript_summary_keeps_only_most_recent_messages() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = dir
+            .path()
+            .join("rollout-2026-05-21T10-13-44-019e4818-7c15-7e60-9b3b-898a1c7803d6.jsonl");
+        let mut file = fs::File::create(&transcript).unwrap();
+        for index in 0..8 {
+            let role = if index % 2 == 0 { "user" } else { "assistant" };
+            writeln!(
+                file,
+                "{}",
+                serde_json::json!({
+                    "payload": {
+                        "role": role,
+                        "content": format!("message {index}"),
+                    },
+                })
+            )
+            .unwrap();
+        }
+        drop(file);
+
+        let item = AgentHistoryItem {
+            provider: AgentHistoryProvider::Codex,
+            id: "019e4818-7c15-7e60-9b3b-898a1c7803d6".to_string(),
+            title: "message 0".to_string(),
+            preview: Some("message 7".to_string()),
+            cwd: Some("/tmp/demo".to_string()),
+            worktree: None,
+            transcript_path: transcript.display().to_string(),
+            updated_at: 1_766_000_000,
+            resume_command: None,
+        };
+
+        let summary = summarize_agent_history_item(&item).unwrap();
+
+        assert_eq!(summary.message_count, 8);
+        assert_eq!(summary.recent_messages.len(), RECENT_SUMMARY_MESSAGES);
+        assert_eq!(
+            summary
+                .recent_messages
+                .iter()
+                .map(|message| message.text.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "message 2",
+                "message 3",
+                "message 4",
+                "message 5",
+                "message 6",
+                "message 7",
+            ]
+        );
+        assert_eq!(summary.recent_messages[0].role, "user");
+        assert_eq!(summary.recent_messages[5].role, "assistant");
+    }
+
+    #[test]
     fn transcript_summary_at_path_reads_validated_codex_file() {
         let _guard = ENV_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();

--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -28,6 +28,8 @@ const READ_HEAD_MAX_BYTES: u64 = 2 * 1024 * 1024;
 const READ_TAIL_BYTES: u64 = 256 * 1024;
 const PREVIEW_CHARS: usize = 160;
 const TITLE_CONTEXT_ENTRY_CHARS: usize = 700;
+const RECENT_SUMMARY_MESSAGES: usize = 6;
+const SUMMARY_MESSAGE_PREVIEW_CHARS: usize = 600;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -100,7 +102,14 @@ pub struct AgentTranscriptSummary {
     pub turn_count: u64,
     pub complete_turns: u64,
     pub running_turns: u64,
+    pub recent_messages: Vec<AgentTranscriptMessagePreview>,
     pub token_usage: AgentTranscriptTokenUsage,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentTranscriptMessagePreview {
+    pub role: String,
+    pub text: String,
 }
 
 pub fn list_agent_history(
@@ -671,6 +680,7 @@ fn summarize_agent_transcript(
     let mut assistant_messages = 0_u64;
     let mut summed_usage = AgentTranscriptTokenUsage::default();
     let mut cumulative_usage = AgentTranscriptTokenUsage::default();
+    let mut recent_messages = VecDeque::new();
     let kind = provider.kind();
 
     for line in BufReader::new(file).lines().map_while(Result::ok) {
@@ -683,10 +693,28 @@ fn summarize_agent_transcript(
         };
         let parsed = parse_transcript_value(kind, &value);
         if let Some(entry) = title_context_entry(&parsed) {
-            match entry.role {
-                "User" => user_messages += 1,
-                "Assistant" => assistant_messages += 1,
-                _ => {}
+            let role = match entry.role {
+                "User" => {
+                    user_messages += 1;
+                    Some("user")
+                }
+                "Assistant" => {
+                    assistant_messages += 1;
+                    Some("assistant")
+                }
+                _ => None,
+            };
+            if let Some((role, text)) = role.and_then(|role| {
+                collapse_preview(&entry.text, SUMMARY_MESSAGE_PREVIEW_CHARS)
+                    .map(|text| (role, text))
+            }) {
+                if recent_messages.len() == RECENT_SUMMARY_MESSAGES {
+                    recent_messages.pop_front();
+                }
+                recent_messages.push_back(AgentTranscriptMessagePreview {
+                    role: role.to_string(),
+                    text,
+                });
             }
             message_count += 1;
         }
@@ -717,6 +745,7 @@ fn summarize_agent_transcript(
         turn_count: user_messages,
         complete_turns,
         running_turns,
+        recent_messages: recent_messages.into_iter().collect(),
         token_usage,
     })
 }
@@ -2164,6 +2193,11 @@ mod tests {
         assert_eq!(summary.token_usage.reasoning_tokens, 4);
         assert_eq!(summary.token_usage.total_tokens, 59);
         assert_eq!(summary.token_usage.messages_with_usage, 1);
+        assert_eq!(summary.recent_messages.len(), 2);
+        assert_eq!(summary.recent_messages[0].role, "user");
+        assert_eq!(summary.recent_messages[0].text, "Do it");
+        assert_eq!(summary.recent_messages[1].role, "assistant");
+        assert_eq!(summary.recent_messages[1].text, "Done");
     }
 
     #[test]

--- a/src/components/WorkSummaryView.test.tsx
+++ b/src/components/WorkSummaryView.test.tsx
@@ -471,6 +471,116 @@ describe("WorkSummaryView", () => {
     expect(container.textContent).toContain("320 tokens");
   });
 
+  it("clears recent transcript messages while switching sessions", async () => {
+    const pendingNextTranscript = deferred<
+      Awaited<ReturnType<typeof mocks.agentTranscriptSummary>>
+    >();
+    mocks.agentTranscriptSummary
+      .mockResolvedValueOnce({
+        provider: "codex",
+        id: "transcript-1",
+        transcript_path: "/Users/me/.codex/sessions/transcript-1.jsonl",
+        updated_at: 1_766_000_000,
+        message_count: 2,
+        user_messages: 1,
+        assistant_messages: 1,
+        turn_count: 1,
+        complete_turns: 1,
+        running_turns: 0,
+        recent_messages: [{ role: "assistant", text: "Old session answer" }],
+        token_usage: {
+          input_tokens: 100,
+          output_tokens: 40,
+          cache_read_tokens: 0,
+          cache_creation_tokens: 0,
+          reasoning_tokens: 0,
+          total_tokens: 140,
+          messages_with_usage: 1,
+        },
+      })
+      .mockReturnValueOnce(pendingNextTranscript.promise);
+    const firstTab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: `${REPO}/.worktrees/s1`,
+      sessionId: "s1",
+      title: "Feature runner Summary",
+    });
+    const secondTab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: `${REPO}/.worktrees/s2`,
+      sessionId: "s2",
+      title: "Second runner Summary",
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkSummaryView
+          tab={firstTab}
+          session={session({
+            mode: "terminal",
+            agent_transcript_id: "transcript-1",
+          })}
+          isActive
+        />,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("Old session answer");
+
+    await act(async () => {
+      root.render(
+        <WorkSummaryView
+          tab={secondTab}
+          session={session({
+            id: "s2",
+            name: "Second runner",
+            worktree_path: `${REPO}/.worktrees/s2`,
+            branch: "feat/second",
+            mode: "terminal",
+            agent_transcript_id: "transcript-2",
+          })}
+          isActive
+        />,
+      );
+    });
+
+    expect(mocks.agentTranscriptSummary).toHaveBeenLastCalledWith(
+      REPO,
+      "transcript-2",
+    );
+    expect(container.textContent).not.toContain("Old session answer");
+
+    await act(async () => {
+      pendingNextTranscript.resolve({
+        provider: "codex",
+        id: "transcript-2",
+        transcript_path: "/Users/me/.codex/sessions/transcript-2.jsonl",
+        updated_at: 1_766_000_001,
+        message_count: 2,
+        user_messages: 1,
+        assistant_messages: 1,
+        turn_count: 1,
+        complete_turns: 1,
+        running_turns: 0,
+        recent_messages: [{ role: "assistant", text: "New session answer" }],
+        token_usage: {
+          input_tokens: 120,
+          output_tokens: 60,
+          cache_read_tokens: 0,
+          cache_creation_tokens: 0,
+          reasoning_tokens: 0,
+          total_tokens: 180,
+          messages_with_usage: 1,
+        },
+      });
+      await pendingNextTranscript.promise;
+    });
+
+    expect(container.textContent).toContain("New session answer");
+  });
+
   it("loads a terminal agent transcript by paired path on first render", async () => {
     mocks.agentTranscriptSummaryAtPath.mockResolvedValue({
       provider: "codex",

--- a/src/components/WorkSummaryView.test.tsx
+++ b/src/components/WorkSummaryView.test.tsx
@@ -422,6 +422,10 @@ describe("WorkSummaryView", () => {
       turn_count: 2,
       complete_turns: 2,
       running_turns: 0,
+      recent_messages: [
+        { role: "user", text: "Please review the failing tests." },
+        { role: "assistant", text: "The status poll fallback is fixed." },
+      ],
       token_usage: {
         input_tokens: 220,
         output_tokens: 80,
@@ -461,6 +465,9 @@ describe("WorkSummaryView", () => {
       "transcript-1",
     );
     expect(container.textContent).toContain("4 messages");
+    expect(container.textContent).toContain("Recent messages");
+    expect(container.textContent).toContain("Please review the failing tests.");
+    expect(container.textContent).toContain("The status poll fallback is fixed.");
     expect(container.textContent).toContain("320 tokens");
   });
 
@@ -476,6 +483,7 @@ describe("WorkSummaryView", () => {
       turn_count: 2,
       complete_turns: 2,
       running_turns: 0,
+      recent_messages: [],
       token_usage: {
         input_tokens: 220,
         output_tokens: 80,
@@ -536,6 +544,7 @@ describe("WorkSummaryView", () => {
       turn_count: 2,
       complete_turns: 2,
       running_turns: 0,
+      recent_messages: [],
       token_usage: {
         input_tokens: 220,
         output_tokens: 80,
@@ -557,6 +566,7 @@ describe("WorkSummaryView", () => {
       turn_count: 3,
       complete_turns: 3,
       running_turns: 0,
+      recent_messages: [],
       token_usage: {
         input_tokens: 300,
         output_tokens: 120,

--- a/src/components/WorkSummaryView.tsx
+++ b/src/components/WorkSummaryView.tsx
@@ -101,6 +101,7 @@ interface WorkSummarySnapshot {
 interface WorkSummaryConversationSnapshot {
   chat: WorkSummaryChatMetrics | null;
   tokens: WorkSummaryTokenUsage | null;
+  messages: AgentTranscriptSummary["recent_messages"];
 }
 
 interface AgentTranscriptLocation {
@@ -119,6 +120,9 @@ export function WorkSummaryView({
   const [summary, setSummary] = useState<WorkSummary | null>(null);
   const [chat, setChat] = useState<WorkSummaryChatMetrics | null>(null);
   const [tokens, setTokens] = useState<WorkSummaryTokenUsage | null>(null);
+  const [messages, setMessages] = useState<AgentTranscriptSummary["recent_messages"]>(
+    [],
+  );
   const [summaryLoading, setSummaryLoading] = useState(false);
   const [conversationLoading, setConversationLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -138,7 +142,7 @@ export function WorkSummaryView({
 
   const fetchConversation = useCallback(async (): Promise<WorkSummaryConversationSnapshot> => {
     if (!session) {
-      return { chat: null, tokens: null };
+      return { chat: null, tokens: null, messages: [] };
     }
 
     if (session.mode === "chat") {
@@ -146,6 +150,7 @@ export function WorkSummaryView({
       return {
         chat: summarizeChatSession(chatState),
         tokens: summarizeTokenUsage(chatState),
+        messages: [],
       };
     }
 
@@ -168,10 +173,11 @@ export function WorkSummaryView({
       return {
         chat: transcript ? chatMetricsFromTranscript(transcript) : null,
         tokens: transcript ? tokenUsageFromTranscript(transcript) : null,
+        messages: transcript?.recent_messages ?? [],
       };
     }
 
-    return { chat: null, tokens: null };
+    return { chat: null, tokens: null, messages: [] };
   }, [
     session?.agent_transcript_path,
     session?.agent_transcript_provider,
@@ -189,6 +195,7 @@ export function WorkSummaryView({
     (snapshot: WorkSummaryConversationSnapshot) => {
       setChat(snapshot.chat);
       setTokens(snapshot.tokens);
+      setMessages(snapshot.messages);
     },
     [],
   );
@@ -562,24 +569,45 @@ export function WorkSummaryView({
             {conversationPending ? (
               <ConversationSkeleton />
             ) : chat ? (
-              <div className="grid grid-cols-2 gap-2 p-3">
-                <ConversationStat
-                  label={wt(t, "workSummary.conversation.user")}
-                  value={chat.userMessages}
-                />
-                <ConversationStat
-                  label={wt(t, "workSummary.conversation.assistant")}
-                  value={chat.assistantMessages}
-                />
-                <ConversationStat
-                  label={wt(t, "workSummary.conversation.turns")}
-                  value={chat.turnCount}
-                />
-                <ConversationStat
-                  label={wt(t, "workSummary.conversation.runningTurns")}
-                  value={chat.runningTurns}
-                />
-              </div>
+              <>
+                <div className="grid grid-cols-2 gap-2 p-3">
+                  <ConversationStat
+                    label={wt(t, "workSummary.conversation.user")}
+                    value={chat.userMessages}
+                  />
+                  <ConversationStat
+                    label={wt(t, "workSummary.conversation.assistant")}
+                    value={chat.assistantMessages}
+                  />
+                  <ConversationStat
+                    label={wt(t, "workSummary.conversation.turns")}
+                    value={chat.turnCount}
+                  />
+                  <ConversationStat
+                    label={wt(t, "workSummary.conversation.runningTurns")}
+                    value={chat.runningTurns}
+                  />
+                </div>
+                {messages.length > 0 ? (
+                  <div
+                    className="border-t border-border px-3 pb-3 pt-2"
+                    data-testid="work-summary-recent-messages"
+                  >
+                    <div className="mb-2 text-[10px] font-medium uppercase text-fg-muted">
+                      {wt(t, "workSummary.conversation.recentMessages")}
+                    </div>
+                    <div className="space-y-2">
+                      {messages.map((message, index) => (
+                        <TranscriptMessagePreview
+                          key={`${message.role}:${index}:${message.text}`}
+                          message={message}
+                          t={t}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+              </>
             ) : (
               <EmptyLine>
                 {wt(t, "workSummary.conversation.terminalHint")}
@@ -694,6 +722,32 @@ function ConversationStat({
     <div className="rounded-md bg-bg-sidebar/40 px-3 py-2">
       <div className="text-[11px] text-fg-muted">{label}</div>
       <div className="mt-1 font-mono text-base tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function TranscriptMessagePreview({
+  message,
+  t,
+}: {
+  message: AgentTranscriptSummary["recent_messages"][number];
+  t: Translator;
+}) {
+  const label =
+    message.role === "user"
+      ? wt(t, "workSummary.conversation.user")
+      : wt(t, "workSummary.conversation.assistant");
+  return (
+    <div
+      className="grid grid-cols-[4.5rem_minmax(0,1fr)] gap-2 rounded-md bg-bg-sidebar/40 px-3 py-2 text-xs"
+      data-testid={`work-summary-recent-message-${message.role}`}
+    >
+      <div className="text-[10px] font-medium uppercase text-fg-muted">
+        {label}
+      </div>
+      <div className="line-clamp-3 min-w-0 whitespace-pre-wrap break-words text-fg">
+        {message.text}
+      </div>
     </div>
   );
 }

--- a/src/components/WorkSummaryView.tsx
+++ b/src/components/WorkSummaryView.tsx
@@ -128,6 +128,14 @@ export function WorkSummaryView({
   const [error, setError] = useState<string | null>(null);
   const transcriptLocationRef = useRef<AgentTranscriptLocation | null>(null);
   const loading = summaryLoading || conversationLoading;
+  const conversationIdentity = [
+    tab.repoPath,
+    session?.id ?? "",
+    session?.mode ?? "",
+    session?.agent_transcript_provider ?? "",
+    session?.agent_transcript_id ?? "",
+    session?.agent_transcript_path ?? "",
+  ].join("\u0000");
 
   const fetchSummary = useCallback(async (): Promise<WorkSummarySnapshot> => {
     const status = await api.fsGitStatus(tab.cwdPath, GIT_STATUS_FILE_LIMIT);
@@ -199,6 +207,13 @@ export function WorkSummaryView({
     },
     [],
   );
+
+  useEffect(() => {
+    transcriptLocationRef.current = null;
+    setChat(null);
+    setTokens(null);
+    setMessages([]);
+  }, [conversationIdentity]);
 
   const load = useCallback(async () => {
     setSummaryLoading(true);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -336,7 +336,13 @@ export interface AgentTranscriptSummary {
   turn_count: number;
   complete_turns: number;
   running_turns: number;
+  recent_messages: AgentTranscriptMessagePreview[];
   token_usage: AgentTranscriptTokenUsage;
+}
+
+export interface AgentTranscriptMessagePreview {
+  role: "user" | "assistant";
+  text: string;
 }
 
 export interface CommitInfo {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1281,6 +1281,7 @@
       "title": "Conversation",
       "user": "User",
       "assistant": "Assistant",
+      "recentMessages": "Recent messages",
       "turns": "Turns",
       "completeTurns": "Complete turns",
       "runningTurns": "Running",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1281,6 +1281,7 @@
       "title": "대화",
       "user": "사용자",
       "assistant": "Assistant",
+      "recentMessages": "최근 메시지",
       "turns": "턴",
       "completeTurns": "완료 턴",
       "runningTurns": "진행 중",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1185,6 +1185,7 @@ describe("workspace tabs", () => {
       turn_count: 2,
       complete_turns: 2,
       running_turns: 0,
+      recent_messages: [],
       token_usage: {
         input_tokens: 220,
         output_tokens: 80,
@@ -1240,6 +1241,7 @@ describe("workspace tabs", () => {
       turn_count: 2,
       complete_turns: 2,
       running_turns: 0,
+      recent_messages: [],
       token_usage: {
         input_tokens: 320,
         output_tokens: 90,
@@ -1310,6 +1312,7 @@ describe("workspace tabs", () => {
       turn_count: 2,
       complete_turns: 2,
       running_turns: 0,
+      recent_messages: [],
       token_usage: {
         input_tokens: 220,
         output_tokens: 80,


### PR DESCRIPTION
## Summary
This PR continues the local transcript recovery work by letting Work Summary show recent provider transcript messages, not only aggregate counts.

1. **Transcript summary payload** — `AgentTranscriptSummary` now includes a bounded `recent_messages` list with the latest user/assistant preview rows from the same parse pass that already computes message counts and token usage.
2. **Work Summary conversation detail** — terminal Work Summary tabs render recent transcript messages under the conversation metrics when provider JSONL metadata is available.
3. **Frontend contract coverage** — TypeScript types, component tests, and store mocks now cover the new summary field.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| xterm-limited conversation recovery | Work Summary showed message/token counts but not the actual latest transcript content | Work Summary can display recent local provider transcript messages without reading xterm history |
| Backend cost | Summary parsing counted messages and tokens only | The same pass keeps the latest 6 collapsed message previews, capped at 600 chars each |
| Existing chat/session behavior | Chat sessions and transcripts without messages showed the existing metrics/fallback UI | Existing fallback remains; recent message rows render only when summary metadata includes them |

## Design notes
- This is local-only: it reads already-discovered provider transcript files through existing summary commands and adds no remote-control behavior.
- The recent message list is deliberately bounded so large JSONL files do not inflate Tauri responses.
- The UI keeps messages inside the existing Conversation card rather than adding another top-level panel.

## Follow-up (not in this PR)
- Add a dedicated transcript drawer if users need longer history, search, or copy actions.
- Consider adding native chat recent-message previews to the same Work Summary section for parity.

## Test plan
- [x] `pnpm vitest run src/components/WorkSummaryView.test.tsx src/store.test.ts` — 158 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml transcript_summary_counts_messages_and_uses_codex_cumulative_token_count` passes
- [x] `pnpm run typecheck` passes
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` passes
- [x] `rustfmt --edition 2021 --check src-tauri/src/agent_history.rs` passes
- [x] `git diff --check` passes
- [x] `pnpm run test:e2e -- tests/e2e/work-summary.spec.ts` — 1 passed

## Notes
- This PR builds on the transcript path/provider metadata merged in PR #570, but it does not require PR #571.