### PR TITLE
feat(status): show waiting reason details

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -149,6 +149,7 @@ import type {
   SessionNotificationKind,
   SessionPullRequestSummary,
   SessionStatus,
+  SessionStatusReason,
 } from "../lib/types";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { NewProjectDialog } from "./NewProjectDialog";
@@ -234,6 +235,26 @@ function contextMenuGroupTitle(
 
 function statusLabel(t: Translator, status: SessionStatus): string {
   return sidebarText(t, `sidebar.status.${status}`);
+}
+
+function statusReasonLabel(
+  t: Translator,
+  reason: SessionStatusReason | null | undefined,
+): string | null {
+  switch (reason) {
+    case "turn_complete":
+      return sidebarText(t, "sidebar.statusReason.turn_complete");
+    case "shell_prompt":
+      return sidebarText(t, "sidebar.statusReason.shell_prompt");
+    default:
+      return null;
+  }
+}
+
+function statusDetailLabel(t: Translator, session: Session): string {
+  const label = statusLabel(t, session.status);
+  const reason = statusReasonLabel(t, session.status_reason);
+  return reason ? `${label} · ${reason}` : label;
 }
 
 function isLocalTerminalAreaFocused(): boolean {
@@ -4545,7 +4566,7 @@ function buildSessionHoverDetails(
         icon={<Activity size={12} />}
         iconClassName={STATUS_ICON[session.status]}
         label={sidebarText(t, "sidebar.metadata.status")}
-        value={statusLabel(t, session.status)}
+        value={statusDetailLabel(t, session)}
         valueClassName={STATUS_ICON[session.status]}
       />
       {session.kind === "control" ? (

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -38,6 +38,7 @@ import type {
   SessionNotification,
   SessionNotificationKind,
   SessionStatus,
+  SessionStatusReason,
   AgentTokenProvider,
   AgentTokenUsageMetric,
   AgentTokenUsageSnapshot,
@@ -60,6 +61,30 @@ const SESSION_STATUS_KEYS: Record<SessionStatus, StatusBarTranslationKey> = {
   waiting_for_input: "statusBar.sessionStatus.waitingForInput",
   errored: "statusBar.sessionStatus.errored",
 };
+
+function sessionStatusReasonLabel(
+  t: Translator,
+  reason: SessionStatusReason | null | undefined,
+): string | null {
+  switch (reason) {
+    case "turn_complete":
+      return statusBarText(t, "statusBar.sessionStatusReason.turn_complete");
+    case "shell_prompt":
+      return statusBarText(t, "statusBar.sessionStatusReason.shell_prompt");
+    default:
+      return null;
+  }
+}
+
+function sessionStatusDetailLabel(
+  t: Translator,
+  status: SessionStatus,
+  reason: SessionStatusReason | null | undefined,
+): string {
+  const label = statusBarText(t, SESSION_STATUS_KEYS[status]);
+  const reasonLabel = sessionStatusReasonLabel(t, reason);
+  return reasonLabel ? `${label} · ${reasonLabel}` : label;
+}
 
 function statusBarText(t: Translator, key: StatusBarTranslationKey): string {
   return t(key);
@@ -314,7 +339,14 @@ export function StatusBar() {
             {showSessionCount ? (
               <span className="text-fg-muted/50">|</span>
             ) : null}
-            <span className="whitespace-nowrap">
+            <span
+              className="whitespace-nowrap"
+              title={sessionStatusDetailLabel(
+                t,
+                active.status,
+                active.status_reason,
+              )}
+            >
               {statusBarFormat(t, "statusBar.status", {
                 status: statusBarText(t, SESSION_STATUS_KEYS[active.status]),
               })}

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -60,6 +60,7 @@ import type {
   Session,
   SessionPullRequestSummary,
   SessionStatus,
+  SessionStatusReason,
 } from "../lib/types";
 import {
   summarizeAllSessionProcesses,
@@ -1903,8 +1904,9 @@ function KanbanTerminalPopover({
                     size="xs"
                   />
                 }
+                title={statusDetailLabel(t, session)}
               >
-                {statusLabel(t, session.status)}
+                {statusDetailLabel(t, session)}
               </WorkspaceSessionTerminalPopoverMetaItem>
               {currentPullRequest ? (
                 <KanbanTerminalPopoverPullRequestMetaItem
@@ -2430,6 +2432,26 @@ function statusLabel(t: Translator, status: SessionStatus): string {
     case "errored":
       return t("sidebar.status.errored");
   }
+}
+
+function statusReasonLabel(
+  t: Translator,
+  reason: SessionStatusReason | null | undefined,
+): string | null {
+  switch (reason) {
+    case "turn_complete":
+      return t("sidebar.statusReason.turn_complete");
+    case "shell_prompt":
+      return t("sidebar.statusReason.shell_prompt");
+    default:
+      return null;
+  }
+}
+
+function statusDetailLabel(t: Translator, session: Session): string {
+  const label = statusLabel(t, session.status);
+  const reason = statusReasonLabel(t, session.status_reason);
+  return reason ? `${label} · ${reason}` : label;
 }
 
 function sidebarText(t: Translator, key: SidebarTranslationKey): string {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -854,6 +854,10 @@
       "waitingForInput": "waiting for input",
       "errored": "error"
     },
+    "sessionStatusReason": {
+      "turn_complete": "agent turn complete",
+      "shell_prompt": "shell prompt detected"
+    },
     "notifications": {
       "ariaLabel": "Session notifications",
       "tooltipEmpty": "No unread session notifications",
@@ -1056,6 +1060,10 @@
       "working": "Working",
       "waiting_for_input": "Waiting for input",
       "errored": "Error"
+    },
+    "statusReason": {
+      "turn_complete": "Agent turn complete",
+      "shell_prompt": "Shell prompt detected"
     },
     "dialog": {
       "selectExistingProject": "Select an existing project",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -854,6 +854,10 @@
       "waitingForInput": "입력 대기",
       "errored": "오류"
     },
+    "sessionStatusReason": {
+      "turn_complete": "에이전트 응답 완료",
+      "shell_prompt": "셸 프롬프트 감지"
+    },
     "notifications": {
       "ariaLabel": "세션 알림",
       "tooltipEmpty": "읽지 않은 세션 알림 없음",
@@ -1056,6 +1060,10 @@
       "working": "작업 중",
       "waiting_for_input": "입력 대기",
       "errored": "오류"
+    },
+    "statusReason": {
+      "turn_complete": "에이전트 응답 완료",
+      "shell_prompt": "셸 프롬프트 감지"
     },
     "dialog": {
       "selectExistingProject": "기존 프로젝트 선택",

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -430,6 +430,7 @@ test.describe("sidebar: project lifecycle", () => {
         isolated: true,
         project_scoped: true,
         status: "waiting_for_input",
+        status_reason: "turn_complete",
         created_at: "2026-01-01T00:00:00Z",
         updated_at: "2026-01-01T00:00:00Z",
         last_message: null,
@@ -463,6 +464,7 @@ test.describe("sidebar: project lifecycle", () => {
     );
     await expect(tooltip).toContainText("Status");
     await expect(tooltip).toContainText("Waiting for input");
+    await expect(tooltip).toContainText("Agent turn complete");
     await expect(tooltip).toContainText("Kind");
     await expect(tooltip).toContainText("Control session");
     await expect(tooltip).toContainText("Isolated worktree");


### PR DESCRIPTION
## Summary

This PR makes Acorn explain why a session is marked Waiting for input.

1. **Sidebar details:** Session hover details now show the backend `status_reason` next to the lifecycle status.
2. **Kanban popover:** Terminal popover status metadata includes the same reason detail when present.
3. **Status bar hint:** The active-session status keeps the compact visible label but exposes the detailed reason in the hover title.
4. **Localization and coverage:** Adds English/Korean reason labels and extends the sidebar hover E2E fixture.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Waiting-for-input diagnosis | UI only showed the state name | Hover/details distinguish agent turn completion from shell prompt detection |
| Layout density | No reason text was shown | Sidebar/Kanban details show reason only where metadata already exists; StatusBar stays compact |
| State detection behavior | Backend status logic unchanged | Existing `status_reason` is surfaced to users |

## Design notes

This intentionally does not rename `waiting_for_input` or change the detector. Backend already distinguishes `turn_complete` and `shell_prompt`; the frontend now displays that distinction in low-risk metadata surfaces.

## Follow-up (not in this PR)

Consider adding per-provider reason text if future detectors expose more granular statuses, such as approval waiting or tool execution waiting.

## Test plan

- [x] `pnpm run typecheck` -> passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "session hover details render as icon rows"` -> 1 passed
- [x] `git diff --check` -> passed
