### PR TITLE
feat(transcript): copy paired transcript path

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2732,6 +2732,7 @@ function SessionRow({
       normalizeWorkspacePath(currentWorkspaceCwd);
   const currentPullRequest = useCurrentPullRequest(session);
   const titleText = resolveSessionTitle(session, sessionDisplay.title);
+  const transcriptPath = session.agent_transcript_path?.trim() || null;
   const metadataText = composeSessionMetadata(
     t,
     session,
@@ -3005,6 +3006,15 @@ function SessionRow({
           icon: <Copy size={12} />,
           onClick: () => void copyToClipboard(session.worktree_path),
         },
+        ...(transcriptPath
+          ? [
+              {
+                label: sidebarText(t, "sidebar.actions.transcriptPath"),
+                icon: <Copy size={12} />,
+                onClick: () => void copyToClipboard(transcriptPath),
+              } satisfies ContextMenuItem,
+            ]
+          : []),
         {
           label: sidebarText(t, "sidebar.actions.worktreeName"),
           icon: <Copy size={12} />,
@@ -4288,6 +4298,7 @@ function LocalSessionRow({
     onSelect();
   }
 
+  const transcriptPath = session.agent_transcript_path?.trim() || null;
   const menuItems: ContextMenuItem[] = [
     {
       label: sidebarText(t, "sidebar.actions.rename"),
@@ -4326,6 +4337,15 @@ function LocalSessionRow({
       icon: <Copy size={12} />,
       onClick: () => void copyToClipboard(session.worktree_path),
     },
+    ...(transcriptPath
+      ? [
+          {
+            label: sidebarText(t, "sidebar.actions.copyTranscriptPath"),
+            icon: <Copy size={12} />,
+            onClick: () => void copyToClipboard(transcriptPath),
+          } satisfies ContextMenuItem,
+        ]
+      : []),
     { type: "separator" },
     {
       label: sidebarText(t, "sidebar.actions.removeSessionMenu"),

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -933,6 +933,7 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
   const t = useTranslation();
   const showToast = useToasts((s) => s.show);
   const worktreeName = basename(session.worktree_path);
+  const transcriptPath = session.agent_transcript_path?.trim() || null;
   const branchName = session.branch?.trim();
   const lastMessage =
     session.last_agent_message?.trim() || session.last_message?.trim();
@@ -1108,6 +1109,15 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
             icon: <Copy size={12} />,
             onClick: () => void copyToClipboard(session.worktree_path),
           },
+          ...(transcriptPath
+            ? [
+                {
+                  label: sidebarText(t, "sidebar.actions.transcriptPath"),
+                  icon: <Copy size={12} />,
+                  onClick: () => void copyToClipboard(transcriptPath),
+                } satisfies ContextMenuItem,
+              ]
+            : []),
           {
             label: sidebarText(t, "sidebar.actions.worktreeName"),
             icon: <Copy size={12} />,
@@ -1153,6 +1163,7 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
       showToast,
       setWorkspaceViewMode,
       t,
+      transcriptPath,
       worktreeName,
     ],
   );
@@ -1394,6 +1405,7 @@ function KanbanTerminalPopover({
   const hasManualPositionRef = useRef(false);
 
   const worktreeName = basename(session.worktree_path);
+  const transcriptPath = session.agent_transcript_path?.trim() || null;
   const title = cleanWorkspaceSessionTerminalPopoverTitle(session.name);
   const statusTone = STATUS_TONE[session.status];
   const isChat = session.mode === "chat";
@@ -1558,6 +1570,15 @@ function KanbanTerminalPopover({
             icon: <Copy size={12} />,
             onClick: () => void copyToClipboard(session.worktree_path),
           },
+          ...(transcriptPath
+            ? [
+                {
+                  label: sidebarText(t, "sidebar.actions.transcriptPath"),
+                  icon: <Copy size={12} />,
+                  onClick: () => void copyToClipboard(transcriptPath),
+                } satisfies ContextMenuItem,
+              ]
+            : []),
           {
             label: sidebarText(t, "sidebar.actions.worktreeName"),
             icon: <Copy size={12} />,
@@ -1599,6 +1620,7 @@ function KanbanTerminalPopover({
       showToast,
       setWorkspaceViewMode,
       t,
+      transcriptPath,
       worktreeName,
     ],
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1105,10 +1105,12 @@
       "equalizePaneSizes": "Equalize Pane Sizes",
       "openWorktreeInEditor": "Open Worktree in Editor",
       "worktreePath": "Worktree Path",
+      "transcriptPath": "Transcript Path",
       "worktreeName": "Worktree Name",
       "branchName": "Branch Name",
       "sessionId": "Session ID",
       "copyWorktreePath": "Copy Worktree Path",
+      "copyTranscriptPath": "Copy Transcript Path",
       "remove": "Remove",
       "removeSession": "Remove session",
       "removeSessionMenu": "Remove Session"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1105,10 +1105,12 @@
       "equalizePaneSizes": "Pane 크기 균등화",
       "openWorktreeInEditor": "편집기에서 워크트리 열기",
       "worktreePath": "워크트리 경로",
+      "transcriptPath": "트랜스크립트 경로",
       "worktreeName": "워크트리 이름",
       "branchName": "브랜치 이름",
       "sessionId": "세션 ID",
       "copyWorktreePath": "워크트리 경로 복사",
+      "copyTranscriptPath": "트랜스크립트 경로 복사",
       "remove": "제거",
       "removeSession": "세션 제거",
       "removeSessionMenu": "세션 제거"

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -469,6 +469,73 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(tooltip.locator("svg")).toHaveCount(6);
   });
 
+  test("session context menu copies the paired transcript path", async ({
+    page,
+    tauri,
+  }) => {
+    const transcriptPath = "/Users/me/.codex/sessions/copyable.jsonl";
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: async (text: string) => {
+            (window as unknown as { __copiedText?: string }).__copiedText =
+              text;
+          },
+        },
+      });
+    });
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "session-1",
+        name: "copyable-session",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "waiting_for_input",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        mode: "terminal",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+        agent_provider: "codex",
+        agent_transcript_id: "codex-1",
+        agent_transcript_path: transcriptPath,
+      },
+    ]);
+
+    await page.goto("/");
+
+    await page
+      .locator("aside")
+      .getByRole("button", { name: /copyable-session/ })
+      .click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Copy" }).hover();
+    await page.getByRole("menuitem", { name: "Transcript Path" }).click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as unknown as { __copiedText?: string }).__copiedText,
+        ),
+      )
+      .toBe(transcriptPath);
+  });
+
   test("session rows surface open PR and active process context", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

This PR makes the provider JSONL path Acorn already paired to a session easier to inspect.

1. **Sidebar copy action:** Adds `Transcript Path` to the session Copy submenu when `agent_transcript_path` is available.
2. **Kanban copy action:** Adds the same copy action to Kanban cards and terminal popover menus.
3. **Local session menu:** Adds a compact `Copy Transcript Path` action for the simplified local-session row menu.
4. **Coverage:** Adds an E2E test that stubs the clipboard and verifies the paired transcript path is copied.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Transcript inspection | Users could see resume/status behavior but not easily grab the backing JSONL path | Users can copy the exact paired transcript path from session menus |
| xterm limitation workaround | Conversation state stayed implicit behind Acorn status/summary reads | The provider-native JSONL source is directly reachable for local inspection |
| Menu noise | Copy menu always had the same fixed items | Transcript action appears only when a paired path exists |

## Design notes

This keeps the feature local-only and read-only: no remote control behavior changes, no transcript mutation, and no new backend command. It reuses the `agent_transcript_path` already populated by status polling.

## Follow-up (not in this PR)

Consider an `Open transcript in editor` action once the preferred editor behavior for provider files is settled.

## Test plan

- [x] `pnpm run typecheck` -> passed
- [x] `pnpm vitest run src/components/WorkspaceMain.test.tsx` -> 5 passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts -g "session context menu copies the paired transcript path"` -> 1 passed
- [x] `git diff --check` -> passed
