### PR TITLE
feat(history): copy transcript path from agent history

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1661,6 +1661,11 @@ function AgentHistoryTab({
                   onClick: () => void copy(menu.item.resume_command ?? ""),
                 },
                 {
+                  label: rt(t, "rightPanel.history.copyTranscriptPath"),
+                  icon: <Copy size={12} />,
+                  onClick: () => void copy(menu.item.transcript_path),
+                },
+                {
                   label: rt(t, "rightPanel.history.copyWorktreePath"),
                   icon: <GitBranch size={12} />,
                   disabled: !menu.item.worktree,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1381,6 +1381,7 @@
       "runSession": "Run in new terminal",
       "runInWorktree": "Run in worktree",
       "copyResume": "Copy resume command",
+      "copyTranscriptPath": "Copy transcript path",
       "copyWorktreePath": "Copy worktree path",
       "moveTranscriptToTrash": "Move transcript to Trash...",
       "worktreeMissing": "missing",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1381,6 +1381,7 @@
       "runSession": "새 터미널에서 실행",
       "runInWorktree": "워크트리에서 실행",
       "copyResume": "resume 명령 복사",
+      "copyTranscriptPath": "transcript 경로 복사",
       "copyWorktreePath": "워크트리 경로 복사",
       "moveTranscriptToTrash": "transcript를 휴지통으로 이동...",
       "worktreeMissing": "없음",

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -1862,4 +1862,57 @@ test.describe("right panel: groups", () => {
     });
     await expect(page.getByText("Disposable transcript")).toHaveCount(0);
   });
+
+  test("History context menu copies the transcript path", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: (text: string) => {
+            const w = window as unknown as { __clipboardWrites?: string[] };
+            w.__clipboardWrites = w.__clipboardWrites ?? [];
+            w.__clipboardWrites.push(text);
+            return Promise.resolve();
+          },
+        },
+      });
+    });
+    await seedActiveSession(tauri);
+    await tauri.handle("list_agent_history", () => [
+      {
+        provider: "codex",
+        id: "codex-copy-path",
+        title: "Copy path transcript",
+        preview: null,
+        cwd: "/tmp/demo",
+        worktree: null,
+        transcript_path: "/tmp/codex-copy-path.jsonl",
+        updated_at: 1770000000,
+        resume_command: "codex resume codex-copy-path",
+      },
+    ]);
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Agents" }).click();
+    await page.getByRole("button", { name: "History" }).click();
+    await page.getByText("Copy path transcript").click({ button: "right" });
+    await page
+      .getByRole("menuitem", { name: "Copy transcript path" })
+      .click();
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __clipboardWrites?: string[] })
+                .__clipboardWrites?.at(-1) ?? null,
+          ),
+        { timeout: 3_000 },
+      )
+      .toBe("/tmp/codex-copy-path.jsonl");
+  });
 });


### PR DESCRIPTION
## Summary
This adds a direct transcript JSONL path copy action to Agent History so users can jump from a history row to the original provider transcript file.

1. **History context menu:** Adds `Copy transcript path` next to the existing resume command and worktree path copy actions.
2. **Localization:** Adds English and Korean labels for the new menu item.
3. **E2E coverage:** Verifies the history context menu writes the row's `transcript_path` to the clipboard.

## Expected impact
| Area | Impact |
| --- | --- |
| Usability | Users can copy the original transcript JSONL path directly from Agent History without opening the trash confirmation or inspecting backend data. |
| Reliability | No detection or history loading behavior changes; the action reuses the existing clipboard helper and the non-null `transcript_path` already used by history rows. |
| Performance | No meaningful runtime impact; this only adds one context menu item. |

## Design notes
`AgentHistoryItem.transcript_path` is required, so the new action is always enabled. This mirrors the existing trash action, which already relies on the same path being present.

## Follow-up (not in this PR)
Keep transcript-path affordances consistent as more transcript surfaces are added outside History and session cards.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts -g "History context menu copies the transcript path|History transcript trash action requires confirmation and removes the row"`
- [x] `git diff --check`

## Notes
Read-only peer review found no material defects or missing tests for this scoped change.