### PR TITLE
feat(work-summary): show transcript path details

### DIFF
--- a/src/components/WorkSummaryView.test.tsx
+++ b/src/components/WorkSummaryView.test.tsx
@@ -193,6 +193,7 @@ function deferred<T>() {
 describe("WorkSummaryView", () => {
   let container: HTMLDivElement;
   let root: Root;
+  let restoreClipboard: (() => void) | null = null;
 
   beforeEach(() => {
     container = document.createElement("div");
@@ -228,6 +229,8 @@ describe("WorkSummaryView", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    restoreClipboard?.();
+    restoreClipboard = null;
     vi.useRealTimers();
     vi.clearAllMocks();
   });
@@ -465,6 +468,22 @@ describe("WorkSummaryView", () => {
   });
 
   it("loads a terminal agent transcript by paired path on first render", async () => {
+    const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
+    const originalClipboard = Object.getOwnPropertyDescriptor(
+      navigator,
+      "clipboard",
+    );
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: clipboardWriteText },
+    });
+    restoreClipboard = () => {
+      if (originalClipboard) {
+        Object.defineProperty(navigator, "clipboard", originalClipboard);
+      } else {
+        delete (navigator as unknown as { clipboard?: Clipboard }).clipboard;
+      }
+    };
     mocks.agentTranscriptSummaryAtPath.mockResolvedValue({
       provider: "codex",
       id: "transcript-1",
@@ -521,6 +540,45 @@ describe("WorkSummaryView", () => {
     expect(mocks.agentTranscriptSummary).not.toHaveBeenCalled();
     expect(container.textContent).toContain("4 messages");
     expect(container.textContent).toContain("320 tokens");
+    expect(
+      container.querySelector(
+        '[data-work-summary-metadata-key="transcriptProvider"]',
+      )?.textContent,
+    ).toContain("codex");
+    expect(
+      container.querySelector(
+        '[data-work-summary-metadata-key="transcriptPath"]',
+      )?.textContent,
+    ).toContain("/Users/me/.codex/sessions/transcript-1.jsonl");
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    clipboardWriteText.mockRejectedValueOnce(new Error("denied"));
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          'button[aria-label="Copy transcript path"]',
+        )!
+        .click();
+      await Promise.resolve();
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "[WorkSummaryView] clipboard write failed",
+      expect.any(Error),
+    );
+    expect(container.textContent).not.toContain("denied");
+    warn.mockRestore();
+
+    const copyButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy transcript path"]',
+    );
+    expect(copyButton).toBeTruthy();
+    await act(async () => {
+      copyButton!.click();
+      await Promise.resolve();
+    });
+    expect(clipboardWriteText).toHaveBeenCalledWith(
+      "/Users/me/.codex/sessions/transcript-1.jsonl",
+    );
   });
 
   it("polls a terminal agent transcript by cached path after the initial id lookup", async () => {

--- a/src/components/WorkSummaryView.tsx
+++ b/src/components/WorkSummaryView.tsx
@@ -1,6 +1,7 @@
 import {
   AlertTriangle,
   Clock,
+  Copy,
   FileText,
   Files,
   Hash,
@@ -52,6 +53,7 @@ import {
   MetricValueSkeleton,
   TokenUsageSkeleton,
 } from "./work-summary/WorkSummarySkeletons";
+import { Tooltip } from "./Tooltip";
 
 const GIT_STATUS_FILE_LIMIT = 500;
 const SUMMARY_REFRESH_DEBOUNCE_MS = 500;
@@ -107,6 +109,14 @@ interface AgentTranscriptLocation {
   provider: AgentTranscriptSummary["provider"];
   id: string;
   transcriptPath: string;
+}
+
+interface MetadataRow {
+  key: string;
+  label: string;
+  value: string | null | undefined;
+  copyValue?: string;
+  copyLabel?: string;
 }
 
 export function WorkSummaryView({
@@ -192,6 +202,14 @@ export function WorkSummaryView({
     },
     [],
   );
+
+  const copyText = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (err) {
+      console.warn("[WorkSummaryView] clipboard write failed", err);
+    }
+  }, []);
 
   const load = useCallback(async () => {
     setSummaryLoading(true);
@@ -347,23 +365,54 @@ export function WorkSummaryView({
   ]);
 
   const metadata = useMemo(() => {
-    const rows: Array<{ label: string; value: string | null | undefined }> = [
-      { label: wt(t, "workSummary.metadata.scope"), value: tab.cwdPath },
+    const rows: MetadataRow[] = [
+      {
+        key: "scope",
+        label: wt(t, "workSummary.metadata.scope"),
+        value: tab.cwdPath,
+      },
     ];
     if (session) {
       rows.push(
-        { label: wt(t, "workSummary.metadata.session"), value: session.name },
-        { label: wt(t, "workSummary.metadata.branch"), value: session.branch },
-        { label: wt(t, "workSummary.metadata.status"), value: session.status },
         {
+          key: "session",
+          label: wt(t, "workSummary.metadata.session"),
+          value: session.name,
+        },
+        {
+          key: "branch",
+          label: wt(t, "workSummary.metadata.branch"),
+          value: session.branch,
+        },
+        {
+          key: "status",
+          label: wt(t, "workSummary.metadata.status"),
+          value: session.status,
+        },
+        {
+          key: "mode",
           label: wt(t, "workSummary.metadata.mode"),
           value: session.mode ?? "terminal",
         },
         {
+          key: "transcript",
           label: wt(t, "workSummary.metadata.transcript"),
           value: session.agent_transcript_id,
         },
         {
+          key: "transcriptProvider",
+          label: wt(t, "workSummary.metadata.transcriptProvider"),
+          value: session.agent_transcript_provider,
+        },
+        {
+          key: "transcriptPath",
+          label: wt(t, "workSummary.metadata.transcriptPath"),
+          value: session.agent_transcript_path,
+          copyValue: session.agent_transcript_path ?? undefined,
+          copyLabel: wt(t, "workSummary.metadata.copyTranscriptPath"),
+        },
+        {
+          key: "updated",
           label: wt(t, "workSummary.metadata.updated"),
           value: formatDateTime(session.updated_at),
         },
@@ -543,12 +592,26 @@ export function WorkSummaryView({
             <SectionHeader title={wt(t, "workSummary.details.title")} />
             <dl className="space-y-2 px-4 py-3">
               {metadata.map((row) => (
-                <div key={row.label}>
+                <div key={row.key} data-work-summary-metadata-key={row.key}>
                   <dt className="text-[10px] uppercase text-fg-muted">
                     {row.label}
                   </dt>
-                  <dd className="mt-1 truncate font-mono text-[11px]">
-                    {row.value}
+                  <dd className="mt-1 flex min-w-0 items-center gap-1">
+                    <span className="min-w-0 truncate font-mono text-[11px]">
+                      {row.value}
+                    </span>
+                    {row.copyValue && row.copyLabel ? (
+                      <Tooltip label={row.copyLabel} side="left">
+                        <button
+                          type="button"
+                          aria-label={row.copyLabel}
+                          onClick={() => void copyText(row.copyValue!)}
+                          className="inline-flex size-5 shrink-0 items-center justify-center rounded border border-transparent text-fg-muted hover:border-border hover:bg-bg-elevated hover:text-fg"
+                        >
+                          <Copy size={11} />
+                        </button>
+                      </Tooltip>
+                    ) : null}
                   </dd>
                 </div>
               ))}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1266,6 +1266,9 @@
       "status": "Status",
       "mode": "Mode",
       "transcript": "Transcript",
+      "transcriptProvider": "Transcript provider",
+      "transcriptPath": "Transcript path",
+      "copyTranscriptPath": "Copy transcript path",
       "updated": "Updated"
     },
     "files": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1266,6 +1266,9 @@
       "status": "상태",
       "mode": "모드",
       "transcript": "Transcript",
+      "transcriptProvider": "Transcript 제공자",
+      "transcriptPath": "Transcript 경로",
+      "copyTranscriptPath": "Transcript 경로 복사",
       "updated": "업데이트"
     },
     "files": {


### PR DESCRIPTION
## Summary
This exposes paired terminal-agent transcript metadata in Work Summary so users can trace the local JSONL source behind conversation and token metrics.

1. **Details metadata:** Shows the transcript provider and transcript path when a terminal session has paired transcript metadata.
2. **Path copy affordance:** Adds a compact Copy action on the transcript path row without changing remote-control or status detection behavior.
3. **Coverage:** Extends WorkSummaryView tests to assert provider/path rendering, successful clipboard copy, and clipboard failure staying out of the load-error banner.

## Expected impact
| Area | Impact |
| --- | --- |
| Usability | Users can identify and copy the exact local provider transcript JSONL path from Work Summary. |
| Reliability | No transcript lookup logic changes; the UI only renders session metadata that is already present. |
| Performance | No meaningful impact; the copy action is local UI only. |

## Design notes
The copy failure path follows the existing app convention for clipboard helpers: warn in the console instead of reusing the Work Summary load-error banner. Metadata rows now use stable keys so tests can assert the specific provider/path rows without relying on broad text matches.

## Follow-up (not in this PR)
Consider a shared compact metadata-row component if more panels add copyable local-path details.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm vitest run src/components/WorkSummaryView.test.tsx`
- [x] `git diff --check`

## Notes
Read-only peer review flagged clipboard failure altitude and test isolation; both were addressed before opening this PR.