### PR TITLE
fix(prs): refresh PR state after local mutations

### DIFF
--- a/src/components/ClosePullRequestDialog.tsx
+++ b/src/components/ClosePullRequestDialog.tsx
@@ -3,6 +3,7 @@ import { GitPullRequestClosed } from "lucide-react";
 import { api } from "../lib/api";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
+import { emitPullRequestMutation } from "../lib/pullRequestEvents";
 import { useToasts } from "../lib/toasts";
 import type { PullRequestDetail } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
@@ -84,6 +85,15 @@ export function ClosePullRequestDialog({
     setError(null);
     try {
       await api.closePullRequest(repoPath, detail.number);
+      emitPullRequestMutation({
+        kind: "closed",
+        repoPath,
+        number: detail.number,
+        headBranch: detail.head_branch,
+        baseBranch: detail.base_branch,
+        title: detail.title,
+        isDraft: detail.is_draft,
+      });
       onClosed();
     } catch (e) {
       const message = String(e);

--- a/src/components/MergePullRequestDialog.tsx
+++ b/src/components/MergePullRequestDialog.tsx
@@ -12,6 +12,7 @@ import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { loadLastMergeMethod, saveLastMergeMethod } from "../lib/merge-prefs";
 import { STANDARD_PR_GENERATION_PROMPT } from "../lib/project-settings";
+import { emitPullRequestMutation } from "../lib/pullRequestEvents";
 import {
   aiCommitProviderLabel,
   resolveAiCommitRequest,
@@ -251,6 +252,15 @@ export function MergePullRequestDialog({
         acceptsMessage ? body : null,
         checksBlock.blocked && adminMerge,
       );
+      emitPullRequestMutation({
+        kind: "merged",
+        repoPath,
+        number: detail.number,
+        headBranch: detail.head_branch,
+        baseBranch: detail.base_branch,
+        title: detail.title,
+        isDraft: detail.is_draft,
+      });
       onMerged();
     } catch (e) {
       const message = String(e);

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -27,6 +27,7 @@ import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
+import { emitPullRequestMutation } from "../lib/pullRequestEvents";
 import { useSettings } from "../lib/settings";
 import { useToasts } from "../lib/toasts";
 import { ResizeHandle } from "./ResizeHandle";
@@ -259,6 +260,11 @@ export function PullRequestDetailModal({
     async (body: string) => {
       if (!open) return;
       await api.addPullRequestComment(open.repoPath, open.number, body);
+      emitPullRequestMutation({
+        kind: "commented",
+        repoPath: open.repoPath,
+        number: open.number,
+      });
       setCommentDraft("");
       handleMutated();
     },
@@ -274,6 +280,11 @@ export function PullRequestDetailModal({
         commentId,
         body,
       );
+      emitPullRequestMutation({
+        kind: "commented",
+        repoPath: open.repoPath,
+        number: open.number,
+      });
       handleMutated();
     },
     [open, listing, handleMutated],
@@ -283,6 +294,11 @@ export function PullRequestDetailModal({
     async (commentId: number) => {
       if (!open || listing?.kind !== "ok") return;
       await api.deleteGithubComment(open.repoPath, listing.account, commentId);
+      emitPullRequestMutation({
+        kind: "commented",
+        repoPath: open.repoPath,
+        number: open.number,
+      });
       handleMutated();
     },
     [open, listing, handleMutated],
@@ -323,6 +339,15 @@ export function PullRequestDetailModal({
         .updatePullRequestBody(open.repoPath, open.number, next)
         .then(() => {
           if (seq !== bodyWriteSeqRef.current) return;
+          emitPullRequestMutation({
+            kind: "edited",
+            repoPath: open.repoPath,
+            number: open.number,
+            headBranch: detail.head_branch,
+            baseBranch: detail.base_branch,
+            title: detail.title,
+            isDraft: detail.is_draft,
+          });
           setReloadKey((k) => k + 1);
         })
         .catch((e) => {

--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -72,6 +72,7 @@ vi.mock("./FileExplorer", () => ({
 
 import { api } from "../lib/api";
 import { listen } from "@tauri-apps/api/event";
+import { emitPullRequestMutation } from "../lib/pullRequestEvents";
 import { rightPanelCache } from "../lib/right-panel-cache";
 import { DEFAULT_SETTINGS, useSettings } from "../lib/settings";
 import { __resetIsGitHubRepoCacheForTests } from "../lib/useIsGitHubRepo";
@@ -719,6 +720,53 @@ describe("RightPanel background tab loading", () => {
 
     expect(container.textContent).toContain("Add PR row display options");
     expect(container.textContent).not.toContain("1/2");
+  });
+
+  it("refreshes PR rows when a lifecycle mutation event lands", async () => {
+    useAppStore.setState({ rightTab: "prs" });
+    let openFetches = 0;
+    mockApi.listPullRequests.mockImplementation(
+      async (repoPath, state = "open") => {
+        if (repoPath === REPO && state === "open") {
+          openFetches += 1;
+          return {
+            kind: "ok",
+            items: [
+              openFetches === 1
+                ? labeledPullRequest
+                : {
+                    ...labeledPullRequest,
+                    number: 249,
+                    title: "Fresh PR list after mutation",
+                  },
+            ],
+            account: "tester",
+          };
+        }
+        return { kind: "ok", items: [], account: "tester" };
+      },
+    );
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+
+    expect(container.textContent).toContain("Hide git tabs outside repositories");
+    expect(container.textContent).not.toContain("Fresh PR list after mutation");
+
+    await act(async () => {
+      emitPullRequestMutation({
+        kind: "merged",
+        repoPath: REPO,
+        number: labeledPullRequest.number,
+        headBranch: labeledPullRequest.head_branch,
+      });
+    });
+    await flushPromises();
+
+    expect(openFetches).toBeGreaterThanOrEqual(2);
+    expect(container.textContent).toContain("Fresh PR list after mutation");
   });
 
   it("opens issue detail in app from the Issues tab", async () => {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -50,6 +50,10 @@ import { cn } from "../lib/cn";
 import { openFileInEditor } from "../lib/editor";
 import { joinPath } from "../lib/paths";
 import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
+import {
+  onPullRequestMutation,
+  pullRequestMutationAffectsOpenContext,
+} from "../lib/pullRequestEvents";
 import { rightPanelCache } from "../lib/right-panel-cache";
 import { classifyRightPanelFsChange } from "../lib/right-panel-invalidation";
 import { useSettings } from "../lib/settings";
@@ -448,6 +452,16 @@ export function RightPanel() {
   useEffect(() => {
     rightPanelCache.retainRepos(retainedRepoPaths);
   }, [retainedRepoPaths]);
+
+  useEffect(() => {
+    return onPullRequestMutation((event) => {
+      if (!pullRequestMutationAffectsOpenContext(event.kind)) return;
+      const eventRepoPath = normalizeRepoPath(event.repoPath);
+      if (!eventRepoPath || eventRepoPath !== projectRootRepoPath) return;
+      rightPanelCache.invalidatePullRequests(eventRepoPath);
+      setPrListVersion((version) => version + 1);
+    });
+  }, [projectRootRepoPath]);
 
   return (
     <aside className="flex h-full w-full flex-col overflow-hidden rounded-[var(--acorn-pane-radius)] border border-border bg-bg-sidebar">

--- a/src/lib/pullRequestEvents.test.ts
+++ b/src/lib/pullRequestEvents.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  emitPullRequestMutation,
+  onPullRequestMutation,
+  pullRequestMutationAffectsOpenContext,
+  type PullRequestMutationEvent,
+} from "./pullRequestEvents";
+
+describe("pullRequestEvents", () => {
+  it("notifies subscribers and supports unsubscribe", () => {
+    const listener = vi.fn();
+    const unsubscribe = onPullRequestMutation(listener);
+    const event: PullRequestMutationEvent = {
+      kind: "merged",
+      repoPath: "/tmp/acorn",
+      number: 42,
+      headBranch: "feature",
+    };
+
+    emitPullRequestMutation(event);
+    unsubscribe();
+    emitPullRequestMutation({ ...event, number: 43 });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+
+  it("classifies lifecycle and metadata changes that can stale open PR context", () => {
+    expect(pullRequestMutationAffectsOpenContext("merged")).toBe(true);
+    expect(pullRequestMutationAffectsOpenContext("closed")).toBe(true);
+    expect(pullRequestMutationAffectsOpenContext("reopened")).toBe(true);
+    expect(pullRequestMutationAffectsOpenContext("draft_changed")).toBe(true);
+    expect(pullRequestMutationAffectsOpenContext("edited")).toBe(true);
+    expect(pullRequestMutationAffectsOpenContext("checks_changed")).toBe(true);
+    expect(pullRequestMutationAffectsOpenContext("commented")).toBe(false);
+  });
+});

--- a/src/lib/pullRequestEvents.ts
+++ b/src/lib/pullRequestEvents.ts
@@ -1,0 +1,57 @@
+export type PullRequestMutationKind =
+  | "merged"
+  | "closed"
+  | "reopened"
+  | "draft_changed"
+  | "edited"
+  | "checks_changed"
+  | "synchronized"
+  | "commented"
+  | "reviewed";
+
+export interface PullRequestMutationEvent {
+  kind: PullRequestMutationKind;
+  repoPath: string;
+  number: number;
+  headBranch?: string | null;
+  baseBranch?: string | null;
+  title?: string | null;
+  isDraft?: boolean | null;
+}
+
+type PullRequestMutationListener = (event: PullRequestMutationEvent) => void;
+
+const listeners = new Set<PullRequestMutationListener>();
+
+export function onPullRequestMutation(
+  listener: PullRequestMutationListener,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function emitPullRequestMutation(event: PullRequestMutationEvent): void {
+  for (const listener of Array.from(listeners)) {
+    listener(event);
+  }
+}
+
+export function pullRequestMutationAffectsOpenContext(
+  kind: PullRequestMutationKind,
+): boolean {
+  switch (kind) {
+    case "merged":
+    case "closed":
+    case "reopened":
+    case "draft_changed":
+    case "edited":
+    case "checks_changed":
+    case "synchronized":
+      return true;
+    case "commented":
+    case "reviewed":
+      return false;
+  }
+}

--- a/src/lib/right-panel-cache.test.ts
+++ b/src/lib/right-panel-cache.test.ts
@@ -234,6 +234,37 @@ describe("rightPanelCache", () => {
     expect(rightPanelCache.getPullRequests(REPO, "merged", 50)).toBeNull();
   });
 
+  it("keeps a fresh PR in-flight request when a stale invalidated request settles", async () => {
+    const listing: PullRequestListing = {
+      kind: "ok",
+      items: [],
+      account: "tester",
+    };
+    const stale = deferred<PullRequestListing>();
+    const fresh = deferred<PullRequestListing>();
+    mockApi.listPullRequests
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(fresh.promise);
+
+    const staleRequest = rightPanelCache.fetchPullRequests(REPO, "open", 50);
+    rightPanelCache.invalidatePullRequests(REPO);
+    const freshRequest = rightPanelCache.fetchPullRequests(REPO, "open", 50);
+
+    expect(freshRequest).not.toBe(staleRequest);
+    expect(mockApi.listPullRequests).toHaveBeenCalledTimes(2);
+
+    stale.resolve(listing);
+    await staleRequest;
+
+    expect(rightPanelCache.fetchPullRequests(REPO, "open", 50)).toBe(
+      freshRequest,
+    );
+    expect(mockApi.listPullRequests).toHaveBeenCalledTimes(2);
+
+    fresh.resolve(listing);
+    await freshRequest;
+  });
+
   it("does not repopulate pruned issue data from a stale in-flight request", async () => {
     const listing: IssueListing = {
       kind: "ok",

--- a/src/lib/right-panel-cache.test.ts
+++ b/src/lib/right-panel-cache.test.ts
@@ -211,6 +211,29 @@ describe("rightPanelCache", () => {
     expect(rightPanelCache.getPullRequests(REPO, "open", 50)).toBeNull();
   });
 
+  it("invalidates PR listings and ignores stale in-flight PR requests for one repo", async () => {
+    const cached: PullRequestListing = {
+      kind: "ok",
+      items: [],
+      account: "tester",
+    };
+    const pending = deferred<PullRequestListing>();
+    mockApi.listPullRequests
+      .mockResolvedValueOnce(cached)
+      .mockReturnValueOnce(pending.promise);
+
+    await rightPanelCache.fetchPullRequests(REPO, "open", 50);
+    expect(rightPanelCache.getPullRequests(REPO, "open", 50)).toBe(cached);
+    const staleRequest = rightPanelCache.fetchPullRequests(REPO, "merged", 50);
+
+    rightPanelCache.invalidatePullRequests(REPO);
+
+    expect(rightPanelCache.getPullRequests(REPO, "open", 50)).toBeNull();
+    pending.resolve(cached);
+    await expect(staleRequest).resolves.toBe(cached);
+    expect(rightPanelCache.getPullRequests(REPO, "merged", 50)).toBeNull();
+  });
+
   it("does not repopulate pruned issue data from a stale in-flight request", async () => {
     const listing: IssueListing = {
       kind: "ok",

--- a/src/lib/right-panel-cache.ts
+++ b/src/lib/right-panel-cache.ts
@@ -236,10 +236,18 @@ class RightPanelCacheManager {
         return result;
       })
       .finally(() => {
-        this.prListInFlight.delete(key);
+        if (this.prListInFlight.get(key) === promise) {
+          this.prListInFlight.delete(key);
+        }
       });
     this.prListInFlight.set(key, promise);
     return promise;
+  }
+
+  invalidatePullRequests(repoPath: string): void {
+    this.bumpRepoVersion(repoPath);
+    this.deleteJsonKeysForRepo(this.prListCache, repoPath);
+    this.deleteJsonKeysForRepo(this.prListInFlight, repoPath);
   }
 
   getIssues(
@@ -414,6 +422,12 @@ class RightPanelCacheManager {
     for (const key of map.keys()) {
       const repoPath = this.repoFromJsonKey(key);
       if (repoPath && !retained.has(repoPath)) removed.add(repoPath);
+    }
+  }
+
+  private deleteJsonKeysForRepo<T>(map: Map<string, T>, repoPath: string): void {
+    for (const key of map.keys()) {
+      if (this.repoFromJsonKey(key) === repoPath) map.delete(key);
     }
   }
 

--- a/src/lib/useCurrentPullRequest.test.tsx
+++ b/src/lib/useCurrentPullRequest.test.tsx
@@ -10,7 +10,9 @@ vi.mock("./api", () => ({
 }));
 
 import { api } from "./api";
+import { emitPullRequestMutation } from "./pullRequestEvents";
 import {
+  resetCurrentPullRequestCacheForTests,
   primeCurrentPullRequestCacheFromListing,
   useCurrentPullRequest,
 } from "./useCurrentPullRequest";
@@ -81,6 +83,7 @@ describe("useCurrentPullRequest", () => {
     document.body.appendChild(container);
     root = createRoot(container);
     mockApi.listPullRequests.mockReset();
+    resetCurrentPullRequestCacheForTests();
   });
 
   afterEach(() => {
@@ -119,5 +122,42 @@ describe("useCurrentPullRequest", () => {
     });
 
     expect(container.textContent).toBe("PR #77");
+  });
+
+  it("clears and retries current PR context when a lifecycle mutation lands", async () => {
+    mockApi.listPullRequests
+      .mockResolvedValueOnce({
+        kind: "ok",
+        account: "test",
+        items: [pullRequest()],
+      })
+      .mockResolvedValueOnce({ kind: "ok", account: "test", items: [] });
+
+    await act(async () => {
+      root.render(<Probe value={session()} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.textContent).toBe("PR #77");
+
+    await act(async () => {
+      emitPullRequestMutation({
+        kind: "merged",
+        repoPath: "/tmp/demo",
+        number: 77,
+        headBranch: "feat/runner",
+      });
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe("none");
+    expect(mockApi.listPullRequests).toHaveBeenCalledTimes(2);
+    expect(mockApi.listPullRequests).toHaveBeenLastCalledWith(
+      "/tmp/demo/.worktrees/runner",
+      "open",
+      10,
+      "head:feat/runner",
+    );
   });
 });

--- a/src/lib/useCurrentPullRequest.ts
+++ b/src/lib/useCurrentPullRequest.ts
@@ -4,6 +4,11 @@ import {
   currentPullRequestSearchQuery,
   findCurrentPullRequestForBranch,
 } from "./sessionContext";
+import {
+  onPullRequestMutation,
+  pullRequestMutationAffectsOpenContext,
+  type PullRequestMutationEvent,
+} from "./pullRequestEvents";
 import type {
   PullRequestListing,
   Session,
@@ -24,6 +29,7 @@ type CurrentPullRequestSubscriber = {
   lookupRepoPath: string;
   branch: string;
   onPrime: (value: SessionPullRequestSummary) => void;
+  onInvalidate: () => void;
 };
 
 const currentPullRequestCache = new Map<string, CurrentPullRequestCacheEntry>();
@@ -80,6 +86,47 @@ function currentPullRequestRepoPath(session: Session): string {
     session.worktree_path ||
     session.repo_path
   );
+}
+
+function mutationMatchesSubscriber(
+  event: PullRequestMutationEvent,
+  subscriber: CurrentPullRequestSubscriber,
+): boolean {
+  const repoPath = normalizeRepoPath(event.repoPath);
+  if (
+    repoPath !== subscriber.projectRepoPath &&
+    repoPath !== subscriber.lookupRepoPath
+  ) {
+    return false;
+  }
+  return !event.headBranch || event.headBranch === subscriber.branch;
+}
+
+function invalidateCurrentPullRequestCaches(
+  event: PullRequestMutationEvent,
+): void {
+  if (!pullRequestMutationAffectsOpenContext(event.kind)) return;
+  for (const subscriber of currentPullRequestSubscribers) {
+    if (!mutationMatchesSubscriber(event, subscriber)) continue;
+    currentPullRequestProjectCache.delete(
+      currentPullRequestProjectCacheKey(
+        subscriber.projectRepoPath,
+        subscriber.branch,
+      ),
+    );
+    currentPullRequestCache.delete(
+      currentPullRequestCacheKey(subscriber.lookupRepoPath, subscriber.branch),
+    );
+    subscriber.onInvalidate();
+  }
+}
+
+onPullRequestMutation(invalidateCurrentPullRequestCaches);
+
+export function resetCurrentPullRequestCacheForTests(): void {
+  currentPullRequestCache.clear();
+  currentPullRequestProjectCache.clear();
+  currentPullRequestSubscribers.clear();
 }
 
 export function primeCurrentPullRequestCacheFromListing(
@@ -192,6 +239,10 @@ export function useCurrentPullRequest(
       branch,
       onPrime: (value) => {
         setCurrentPullRequest(value);
+        setLookupAttempt((attempt) => attempt + 1);
+      },
+      onInvalidate: () => {
+        setCurrentPullRequest(null);
         setLookupAttempt((attempt) => attempt + 1);
       },
     };


### PR DESCRIPTION
## Summary
Keep Acorn's GitHub PR surfaces current after local PR mutations instead of waiting for the next polling tick.

1. **Mutation event bus** — add a small typed PR mutation event channel for merge, close, draft, edit, checks, sync, comment, and review changes.
2. **List/cache invalidation** — invalidate right-panel PR list cache and refresh PR rows when lifecycle or row-affecting PR changes land.
3. **Current PR context refresh** — clear and retry session PR context when a matching open-PR-affecting mutation lands.
4. **Local emitters** — publish mutation events after Acorn merges, closes, edits PR bodies, or changes PR comments.
5. **Regression coverage** — cover event delivery, cache invalidation races, current PR context invalidation, and RightPanel row refresh.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| PRs tab after Acorn merge/close/edit | Could show stale rows until polling/manual refresh | Refreshes immediately from the mutation event |
| Session current-PR context | Could keep a stale open PR summary after lifecycle changes | Invalidates matching branch context and retries lookup |
| PR list cache races | Invalidated in-flight PR requests could interfere with newer requests | Stale requests cannot overwrite or clear fresh in-flight work |

## Design notes
- The event module is dependency-free so emitters and consumers do not create circular imports.
- `commented` and `reviewed` events are intentionally classified as not affecting open PR context; detail views still refetch through their existing mutation path.
- `draft_changed`, `reopened`, `checks_changed`, and `synchronized` are modeled now so future direct API/UI actions can reuse the same refresh path.

## Follow-up (not in this PR)
- Add first-class Draft / Ready for review actions once the backend command and row/menu UI are designed.
- Add external GitHub mutation detection separately if Acorn needs to react to PR changes made outside the app before the normal polling interval.

## Test plan
- [x] `pnpm test -- src/lib/pullRequestEvents.test.ts src/lib/right-panel-cache.test.ts src/lib/useCurrentPullRequest.test.tsx` — 15 tests passed
- [x] `pnpm test -- src/components/PullRequestDetailModal.modal.test.tsx src/components/RightPanel.test.tsx` — 25 tests passed
- [x] `pnpm test -- src/components/RightPanel.test.tsx src/lib/pullRequestEvents.test.ts src/lib/right-panel-cache.test.ts src/lib/useCurrentPullRequest.test.tsx` — 33 tests passed
- [x] `pnpm test` — 83 files / 905 tests passed
- [x] `pnpm typecheck` — passed

## Notes
- No external webhook behavior is included. This PR covers local Acorn-triggered PR mutations and the internal event path future external detectors can emit into.
