### PR TITLE
fix(settings): expose pane focus shortcuts

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -132,8 +132,9 @@ import {
   SESSION_TITLE_PROMPT_PREVIEW_MESSAGE,
   useSettings,
 } from "../lib/settings";
+import { HOTKEY_IDS } from "../lib/hotkeys";
 import { useAppStore } from "../store";
-import { SettingsModal } from "./SettingsModal";
+import { SettingsModal, SHORTCUT_GROUPS } from "./SettingsModal";
 
 const mockApi = vi.mocked(api);
 
@@ -1028,9 +1029,22 @@ describe("SettingsModal font controls", () => {
     expect(bodyText).toContain("Open command palette");
     expect(bodyText).toContain("New control session");
     expect(bodyText).toContain("Latest needs-input tab");
+    expect(bodyText).toContain("Focus pane to the left");
+    expect(bodyText).toContain("Focus pane to the right");
+    expect(bodyText).toContain("Focus pane above");
+    expect(bodyText).toContain("Focus pane below");
     expect(bodyText).toContain("Right panel");
     expect(bodyText).toContain("Record");
     expect(bodyText).toMatch(/⌘P|Ctrl\+P/);
+  });
+
+  it("keeps every configurable hotkey visible in shortcut settings", () => {
+    const listedIds = SHORTCUT_GROUPS.flatMap((group) =>
+      group.items.map((item) => item.id),
+    );
+
+    expect(new Set(listedIds)).toEqual(new Set(HOTKEY_IDS));
+    expect(listedIds).toHaveLength(new Set(listedIds).size);
   });
 
   it("records and resets a shortcut binding", async () => {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -169,7 +169,7 @@ type ShortcutGroup = {
   items: ShortcutItem[];
 };
 
-const SHORTCUT_GROUPS: ShortcutGroup[] = [
+export const SHORTCUT_GROUPS: ShortcutGroup[] = [
   {
     titleKey: "settings.shortcuts.groups.general",
     items: [
@@ -246,6 +246,22 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
       {
         id: "toggleRightPanel",
         labelKey: "settings.shortcuts.items.toggleRightPanel.label",
+      },
+      {
+        id: "focusPaneLeft",
+        labelKey: "settings.shortcuts.items.focusPaneLeft.label",
+      },
+      {
+        id: "focusPaneRight",
+        labelKey: "settings.shortcuts.items.focusPaneRight.label",
+      },
+      {
+        id: "focusPaneUp",
+        labelKey: "settings.shortcuts.items.focusPaneUp.label",
+      },
+      {
+        id: "focusPaneDown",
+        labelKey: "settings.shortcuts.items.focusPaneDown.label",
       },
       {
         id: "splitVertical",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -536,6 +536,18 @@
         "toggleRightPanel": {
           "label": "Toggle right panel"
         },
+        "focusPaneLeft": {
+          "label": "Focus pane to the left"
+        },
+        "focusPaneRight": {
+          "label": "Focus pane to the right"
+        },
+        "focusPaneUp": {
+          "label": "Focus pane above"
+        },
+        "focusPaneDown": {
+          "label": "Focus pane below"
+        },
         "splitVertical": {
           "label": "Split pane vertically"
         },

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -536,6 +536,18 @@
         "toggleRightPanel": {
           "label": "오른쪽 패널 열기/닫기"
         },
+        "focusPaneLeft": {
+          "label": "왼쪽 Pane으로 포커스 이동"
+        },
+        "focusPaneRight": {
+          "label": "오른쪽 Pane으로 포커스 이동"
+        },
+        "focusPaneUp": {
+          "label": "위쪽 Pane으로 포커스 이동"
+        },
+        "focusPaneDown": {
+          "label": "아래쪽 Pane으로 포커스 이동"
+        },
         "splitVertical": {
           "label": "Pane 세로 분할"
         },

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -262,6 +262,29 @@ test.describe("settings modal", () => {
     await expect(modal.getByText(/⌘=|Ctrl\+=/).first()).toBeVisible();
   });
 
+  test("records a custom pane focus shortcut", async ({ page }) => {
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "," });
+
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
+    await modal.getByRole("button", { name: /^(Shortcuts|단축키)$/ }).click();
+
+    await expect(modal.getByText("Focus pane to the left")).toBeVisible();
+    await expect(modal.getByText("Focus pane to the right")).toBeVisible();
+    await expect(modal.getByText("Focus pane above")).toBeVisible();
+    await expect(modal.getByText("Focus pane below")).toBeVisible();
+
+    await modal
+      .getByRole("button", {
+        name: "Record shortcut for Focus pane to the left",
+      })
+      .click();
+    await expect(modal.getByText("Press keys")).toBeVisible();
+
+    await pressHotkey(page, { mod: true, alt: true, key: "u" });
+    await expect(modal.getByText(/⌥⌘U|Ctrl\+Alt\+U/)).toBeVisible();
+  });
+
   test("syncs the keep-awake toggle with the backend and local settings", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
This fixes a Settings -> Shortcuts coverage gap for existing pane-focus hotkeys.

1. **Shortcut list coverage** — add the four pane-focus hotkeys to the Settings -> Shortcuts layout group so users can see, record, and reset them.
2. **Localized labels** — add English and Korean labels for focusing the pane left, right, above, and below.
3. **Regression coverage** — assert every `DEFAULT_HOTKEYS` id is present in the settings shortcut groups, and add an E2E check that a pane-focus shortcut can be recorded from Settings.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Settings -> Shortcuts | Pane-focus shortcuts worked but could not be configured from Settings | Pane-focus shortcuts are visible and recordable |
| Future shortcut additions | Missing Settings rows could slip through | Component coverage fails if a configurable hotkey is omitted |

## Design notes
- The change keeps the existing manually grouped Settings layout and adds the missing pane-focus actions next to the other layout shortcuts.
- `SHORTCUT_GROUPS` is exported only so the component test can compare the rendered configuration against `HOTKEY_IDS` directly.

## Test plan
- [x] `pnpm exec vitest run src/components/SettingsModal.test.tsx` — 31 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test:e2e -- tests/e2e/settings.spec.ts -g "records a custom pane focus shortcut"` — settings spec ran, 12 passed
- [x] `pnpm run build` — passed

## Notes
- `pnpm run build` still emits existing Vite warnings about mixed static/dynamic imports and large chunks; this PR does not introduce those warnings.
