### PR TITLE
fix(transcript): infer codex roles from event types

### DIFF
--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -158,18 +158,8 @@ pub fn assistant_message_text(value: &Value) -> Option<String> {
 
 fn parse_codex_value(value: &Value) -> ParsedTranscriptLine {
     let event = codex_event_value(value);
-    let event_role = role_from_str(
-        event
-            .get("role")
-            .and_then(Value::as_str)
-            .or_else(|| value.get("role").and_then(Value::as_str)),
-    );
-    let role = role_from_str(
-        event
-            .get("role")
-            .and_then(Value::as_str)
-            .or_else(|| value.get("role").and_then(Value::as_str)),
-    );
+    let event_role = codex_role_from_event(value, event);
+    let role = event_role;
     let texts = codex_event_texts(value, event);
     let response_text = codex_response_text(value, event);
     let state_text = match event_role {
@@ -325,6 +315,24 @@ fn codex_event_value(value: &Value) -> &Value {
         .filter(|v| v.is_object())
         .or_else(|| value.get("msg").filter(|v| v.is_object()))
         .unwrap_or(value)
+}
+
+fn codex_role_from_event(value: &Value, event: &Value) -> TranscriptRole {
+    let explicit_role = role_from_str(
+        event
+            .get("role")
+            .and_then(Value::as_str)
+            .or_else(|| value.get("role").and_then(Value::as_str)),
+    );
+    if explicit_role != TranscriptRole::Other {
+        return explicit_role;
+    }
+
+    match event.get("type").and_then(Value::as_str) {
+        Some("user_message") => TranscriptRole::User,
+        Some("agent_message") => TranscriptRole::Assistant,
+        _ => TranscriptRole::Other,
+    }
 }
 
 fn antigravity_turn_state(value: &Value) -> Option<TurnState> {
@@ -771,6 +779,42 @@ mod tests {
         assert_eq!(parsed.preview_text.as_deref(), Some("hello codex"));
         assert_eq!(parsed.session_id.as_deref(), Some("inner-session"));
         assert_eq!(parsed.cwd.as_deref(), Some("/tmp/project"));
+    }
+
+    #[test]
+    fn codex_payload_user_message_infers_user_role_from_type() {
+        let value: Value = serde_json::from_str(
+            r#"{"timestamp":"t","type":"event_msg","payload":{"type":"user_message","message":"hello codex","cwd":"/tmp/project","id":"payload-session"}}"#,
+        )
+        .unwrap();
+        let parsed = parse_transcript_value(AgentKind::Codex, &value);
+
+        assert_eq!(parsed.turn_state, Some(TurnState::Working));
+        assert_eq!(parsed.role, TranscriptRole::User);
+        assert_eq!(parsed.text.as_deref(), Some("hello codex"));
+        assert_eq!(parsed.state_role, TranscriptRole::User);
+        assert_eq!(parsed.state_text.as_deref(), Some("hello codex"));
+        assert_eq!(parsed.preview_role, TranscriptRole::User);
+        assert_eq!(parsed.preview_text.as_deref(), Some("hello codex"));
+        assert_eq!(parsed.session_id.as_deref(), Some("payload-session"));
+        assert_eq!(parsed.cwd.as_deref(), Some("/tmp/project"));
+    }
+
+    #[test]
+    fn codex_payload_agent_message_infers_assistant_role_from_type() {
+        let value: Value = serde_json::from_str(
+            r#"{"timestamp":"t","type":"event_msg","payload":{"type":"agent_message","message":"all done","phase":"final_answer"}}"#,
+        )
+        .unwrap();
+        let parsed = parse_transcript_value(AgentKind::Codex, &value);
+
+        assert_eq!(parsed.turn_state, Some(TurnState::WaitingForInput));
+        assert_eq!(parsed.role, TranscriptRole::Assistant);
+        assert_eq!(parsed.text.as_deref(), Some("all done"));
+        assert_eq!(parsed.state_role, TranscriptRole::Assistant);
+        assert_eq!(parsed.state_text.as_deref(), Some("all done"));
+        assert_eq!(parsed.preview_role, TranscriptRole::Assistant);
+        assert_eq!(parsed.preview_text.as_deref(), Some("all done"));
     }
 
     #[test]

--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -1639,6 +1639,73 @@ mod tests {
     }
 
     #[test]
+    fn codex_history_infers_roles_from_event_types() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let id = "019e4818-7c15-7e60-9b3b-898a1c7803d6";
+        let transcript = dir
+            .path()
+            .join(format!("rollout-2026-06-09T00-00-00-{id}.jsonl"));
+        let mut file = fs::File::create(&transcript).unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "timestamp": "t",
+                "type": "event_msg",
+                "payload": {
+                    "type": "user_message",
+                    "id": id,
+                    "cwd": repo.display().to_string(),
+                    "message": "Review transcript parsing",
+                },
+            })
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "timestamp": "t",
+                "type": "event_msg",
+                "payload": {
+                    "type": "agent_message",
+                    "phase": "final_answer",
+                    "message": "Parsed provider events.",
+                },
+            })
+        )
+        .unwrap();
+        drop(file);
+
+        let scope_repo = normalize_path(&repo);
+        let item = parse_codex_file(&transcript, HistoryScope::Project(&scope_repo)).unwrap();
+        assert_eq!(item.id, id);
+        assert_eq!(item.title, "Review transcript parsing");
+        assert_eq!(item.preview.as_deref(), Some("Parsed provider events."));
+
+        let summary =
+            summarize_agent_transcript(AgentHistoryProvider::Codex, id.to_string(), &transcript)
+                .unwrap();
+        assert_eq!(summary.message_count, 2);
+        assert_eq!(summary.user_messages, 1);
+        assert_eq!(summary.assistant_messages, 1);
+        assert_eq!(summary.complete_turns, 1);
+        assert_eq!(
+            summary
+                .recent_messages
+                .iter()
+                .map(|message| (message.role.as_str(), message.text.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("user", "Review transcript parsing"),
+                ("assistant", "Parsed provider events."),
+            ]
+        );
+    }
+
+    #[test]
     fn codex_history_skips_marked_acorn_title_generation_prompt() {
         let dir = tempfile::tempdir().unwrap();
         let repo = dir.path().join("repo");


### PR DESCRIPTION
## Summary
Codex transcripts can omit explicit `role` fields on standard event payloads, which left Acorn's status detector correct but history/work-summary parsing incomplete.

1. **Codex role inference**: infer `user_message` as user and `agent_message` as assistant when a Codex event has no explicit role.
2. **Telemetry safety**: keep completion, token, reasoning, and tool/function events role-less so they do not become conversation summary entries.
3. **Coverage**: add parser and history-summary tests for role-less Codex payload events.

## Expected impact

| Area | Impact |
| --- | --- |
| Agent history | Codex sessions with role-less `user_message` payloads can produce the correct title. |
| Work summary | Recent transcript messages and turn counts include role-less Codex user/assistant events. |
| Status detection | No behavior change; existing turn-state mapping remains the source for Working/Waiting. |
| Performance | Neutral; role inference is a small in-memory branch during existing JSONL parsing. |

## Design notes

Explicit transcript roles still win. Event-type inference only applies to Codex `user_message` and `agent_message`, matching the status parser's existing classification without treating telemetry or turn-complete records as chat messages.

## Follow-up (not in this PR)

Keep extending the transcript fixture matrix when Codex, Claude, or Antigravity introduce new JSONL shapes.

## Test plan

- [x] `git diff --check`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-transcript` — 54 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-session -- status` — 33 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn --lib -- --test-threads=1` — 341 passed, 1 ignored

## Notes

Peer review was run against the diff with no findings. A parallel app-lib run briefly hit the existing local hook-server timing tests, and those tests passed both individually and in the final serial full-lib run.