### PR TITLE
fix(kanban): keep chat provider selector inside popover

### DIFF
--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -261,6 +261,7 @@ function ContextMenuPanel({
         else if (outerPanelRef) outerPanelRef.current = node;
       }}
       role="menu"
+      data-acorn-floating-layer="context-menu"
       data-acorn-context-menu
       style={{
         position: "fixed",

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -49,6 +49,7 @@ import {
 import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
+import { isInAcornFloatingLayer } from "../lib/floatingLayer";
 import type { LayoutNode } from "../lib/layout";
 import { basename } from "../lib/pathUtils";
 import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
@@ -2089,12 +2090,7 @@ function KanbanTerminalPopover({
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target;
       if (!(target instanceof Node)) return;
-      if (
-        target instanceof Element &&
-        target.closest("[data-acorn-context-menu]")
-      ) {
-        return;
-      }
+      if (isInAcornFloatingLayer(target)) return;
       if (popoverRef.current?.contains(target)) return;
       if (anchor.contains(target)) return;
       if (isModalDialogOpen()) return;

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -481,6 +481,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
         ? createPortal(
             <div
               ref={listboxRef}
+              data-acorn-floating-layer="select"
               className="fixed z-[60] overflow-hidden rounded-[var(--acorn-pane-radius)] border border-border bg-bg-elevated font-mono text-xs text-fg shadow-xl"
               style={{
                 left: listboxRect.left,

--- a/src/lib/floatingLayer.ts
+++ b/src/lib/floatingLayer.ts
@@ -1,0 +1,13 @@
+export const ACORN_FLOATING_LAYER_SELECTOR = "[data-acorn-floating-layer]";
+
+export function isInAcornFloatingLayer(target: EventTarget | null): boolean {
+  if (target instanceof Element) {
+    return target.closest(ACORN_FLOATING_LAYER_SELECTOR) !== null;
+  }
+  if (target instanceof Node) {
+    return (
+      target.parentElement?.closest(ACORN_FLOATING_LAYER_SELECTOR) !== null
+    );
+  }
+  return false;
+}

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -1465,6 +1465,107 @@ test.describe("workspace kanban mode", () => {
     });
   });
 
+  test("keeps a chat popover open when choosing a provider", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__sessions = w.__sessions ?? [
+        {
+          id: "seed",
+          name: "seed",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          project_scoped: true,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          title_source: "manual",
+          kind: "regular",
+          mode: "terminal",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+        },
+      ];
+      return w.__sessions;
+    });
+    await tauri.handle("create_session", (args) => {
+      const input = args as Record<string, unknown>;
+      const w = window as unknown as {
+        __createSessionCalls?: Array<Record<string, unknown>>;
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(input);
+      const id = `created-${w.__createSessionCalls.length}`;
+      const repoPath =
+        typeof input.repoPath === "string" ? input.repoPath : "/tmp/demo";
+      const session = {
+        id,
+        name: typeof input.name === "string" ? input.name : id,
+        repo_path: repoPath,
+        worktree_path:
+          typeof input.cwdPath === "string" ? input.cwdPath : repoPath,
+        branch: "main",
+        isolated: input.isolated === true,
+        project_scoped: input.projectScoped !== false,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: typeof input.kind === "string" ? input.kind : "regular",
+        mode: typeof input.mode === "string" ? input.mode : "terminal",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      };
+      w.__sessions = [...(w.__sessions ?? []), session];
+      return session;
+    });
+
+    await page.goto("/");
+
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    const board = page.getByTestId("workspace-kanban");
+    await board.getByRole("button", { name: "Create session" }).click();
+    await page.getByRole("menuitem", { name: "New chat session" }).click();
+
+    const chatCard = board.locator('[data-kanban-session-id="created-1"]');
+    await expect(chatCard).toBeVisible();
+    await expect(page.getByTestId("kanban-terminal-popover")).toHaveCount(0);
+
+    await chatCard.click();
+
+    const popover = page.getByTestId("kanban-terminal-popover");
+    await expect(popover).toBeVisible();
+    await expect(page.getByTestId("chat-popover-body")).toBeVisible();
+
+    const providerSelect = popover.getByRole("combobox", {
+      name: "Chat provider",
+    });
+    await expect(providerSelect).toBeVisible();
+    await providerSelect.click();
+    await expect(
+      page.locator('[data-acorn-floating-layer="select"]'),
+    ).toBeVisible();
+
+    await page.getByRole("option", { name: "Codex" }).click();
+
+    await expect(popover).toBeVisible();
+    await expect(providerSelect).toContainText("Codex");
+  });
+
   test("opens a terminal popover when selecting a project session from the sidebar in kanban mode", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
This PR fixes a kanban chat popover closure bug caused by portal-rendered floating controls.

1. **Shared floating-layer marker** — add a small `isInAcornFloatingLayer` helper and mark common portal panels (`Select`, `ContextMenu`) with `data-acorn-floating-layer`.
2. **Kanban popover outside-click handling** — treat shared floating layers as in-popover interactions so selecting chat provider options does not close the kanban popover.
3. **Regression coverage** — add an E2E path for creating a kanban chat session, opening its popover, and changing the provider through the portalized select list.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Kanban chat popover | Choosing a provider option could close the popover | Provider selection keeps the popover open |
| Shared floating controls | Kanban had a context-menu-specific portal exception | Select and context menu use a common floating-layer contract |

## Design notes
- The fix avoids a one-off `Select` check in `WorkspaceMain`; kanban outside-click handling now depends on a reusable floating-layer marker for app-owned portal panels.
- Existing context menu behavior is preserved by marking `ContextMenu` with the same generic layer attribute while keeping its current `data-acorn-context-menu` hook intact.
- The E2E clicks the actual provider option in the body-level select portal, which is the event path that previously closed the kanban popover.

## Test plan
- [x] `pnpm exec playwright test tests/e2e/kanban.spec.ts -g "keeps a chat popover open"` — 1 passed
- [x] `pnpm exec vitest run src/components/ui/Select.test.tsx src/components/ContextMenu.test.tsx src/components/WorkspaceMain.test.tsx` — 3 files / 19 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed; existing Vite chunk-size/dynamic-import warnings only
- [x] `pnpm exec playwright test tests/e2e/kanban.spec.ts` — 17 passed
- [x] `pnpm run test` — 86 files / 943 tests passed

## Notes
- `pnpm install --frozen-lockfile` was run because this worktree did not have local `node_modules`; no lockfile or package manifest changes were produced.