### PR TITLE
feat(resume): show conversation excerpts in resume modal

### DIFF
--- a/src-tauri/src/agent_resume.rs
+++ b/src-tauri/src/agent_resume.rs
@@ -80,6 +80,8 @@ pub struct ResumeCandidate {
     pub uuid: String,
     pub last_activity_unix: u64,
     pub preview: Option<String>,
+    pub last_user_message: Option<String>,
+    pub last_agent_message: Option<String>,
 }
 
 /// Surface the modal candidate for `session_id` and `kind`, or `Ok(None)`
@@ -233,14 +235,23 @@ fn candidate_at(
         .and_then(|mt| mt.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    let preview = transcript
+    let conversation_preview = transcript
         .as_ref()
-        .and_then(|p| extract_preview(kind, p).ok().flatten());
+        .and_then(|p| extract_conversation_preview(kind, p).ok());
+    let last_user_message = conversation_preview
+        .as_ref()
+        .and_then(|preview| preview.last_user_message.clone());
+    let last_agent_message = conversation_preview
+        .as_ref()
+        .and_then(|preview| preview.last_agent_message.clone());
+    let preview = last_agent_message.clone();
 
     Ok(Some(ResumeCandidate {
         uuid,
         last_activity_unix,
         preview,
+        last_user_message,
+        last_agent_message,
     }))
 }
 
@@ -319,10 +330,6 @@ fn antigravity_brain_roots() -> Vec<PathBuf> {
 pub(crate) struct ConversationPreview {
     pub last_user_message: Option<String>,
     pub last_agent_message: Option<String>,
-}
-
-pub(crate) fn extract_preview(kind: AgentKind, path: &Path) -> io::Result<Option<String>> {
-    Ok(extract_conversation_preview(kind, path)?.last_agent_message)
 }
 
 pub(crate) fn extract_conversation_preview(
@@ -462,7 +469,9 @@ mod tests {
         )
         .unwrap();
 
-        let preview = extract_preview(AgentKind::Codex, &path).unwrap();
+        let preview = extract_conversation_preview(AgentKind::Codex, &path)
+            .unwrap()
+            .last_agent_message;
 
         assert_eq!(preview.as_deref(), Some("Here is the latest Codex answer."));
     }
@@ -547,7 +556,9 @@ mod tests {
         )
         .unwrap();
 
-        let preview = extract_preview(AgentKind::Antigravity, &path).unwrap();
+        let preview = extract_conversation_preview(AgentKind::Antigravity, &path)
+            .unwrap()
+            .last_agent_message;
 
         assert_eq!(
             preview.as_deref(),

--- a/src/components/AgentResumeModal.test.tsx
+++ b/src/components/AgentResumeModal.test.tsx
@@ -24,12 +24,14 @@ vi.mock("../lib/toasts", () => ({
 }));
 
 import { AgentResumeModal } from "./AgentResumeModal";
-import type { AgentKind } from "../lib/api";
+import type { AgentKind, ResumeCandidate } from "../lib/api";
 
-const CANDIDATE = {
+const CANDIDATE: ResumeCandidate = {
   uuid: "deadbeef-1234-5678-9abc-def012345678",
   lastActivityUnix: Math.floor(Date.now() / 1000) - 600,
   preview: "Preview of the previous conversation",
+  lastUserMessage: "Please inspect the transcript watcher.",
+  lastAgentMessage: "The watcher is paired to this session.",
 };
 const SESSION_ID = "11111111-2222-3333-4444-555555555555";
 
@@ -56,7 +58,7 @@ describe("AgentResumeModal", () => {
     vi.clearAllMocks();
   });
 
-  function render(agent: AgentKind, candidate: typeof CANDIDATE | null) {
+  function render(agent: AgentKind, candidate: ResumeCandidate | null) {
     const onDismiss = vi.fn();
     act(() => {
       root.render(
@@ -84,9 +86,19 @@ describe("AgentResumeModal", () => {
     expect(document.querySelector('[role="dialog"]')).toBeNull();
   });
 
-  it("renders the UUID and preview when candidate is set", () => {
+  it("renders the UUID and conversation preview when candidate is set", () => {
     render("claude", CANDIDATE);
     expect(document.body.textContent).toContain(CANDIDATE.uuid);
+    expect(document.body.textContent).toContain(CANDIDATE.lastUserMessage);
+    expect(document.body.textContent).toContain(CANDIDATE.lastAgentMessage);
+  });
+
+  it("falls back to the legacy assistant preview when conversation fields are absent", () => {
+    render("claude", {
+      ...CANDIDATE,
+      lastUserMessage: null,
+      lastAgentMessage: null,
+    });
     expect(document.body.textContent).toContain(CANDIDATE.preview);
   });
 

--- a/src/components/AgentResumeModal.tsx
+++ b/src/components/AgentResumeModal.tsx
@@ -76,6 +76,9 @@ export function AgentResumeModal({
     () => formatRelativeTime(candidate?.lastActivityUnix ?? 0, t),
     [candidate?.lastActivityUnix, t],
   );
+  const lastUserMessage = candidate?.lastUserMessage?.trim() || null;
+  const lastAgentMessage =
+    candidate?.lastAgentMessage?.trim() || candidate?.preview?.trim() || null;
 
   if (!candidate) return null;
 
@@ -149,10 +152,21 @@ export function AgentResumeModal({
       />
       <div className="space-y-3 px-4 py-4 text-xs">
         <p className="text-fg-muted">{dt(t, copy.bodyKey)}</p>
-        {candidate.preview ? (
-          <blockquote className="border-l-2 border-border-emphasis bg-bg-elevated/60 px-3 py-2 italic text-fg-muted">
-            “{candidate.preview}”
-          </blockquote>
+        {lastUserMessage || lastAgentMessage ? (
+          <div className="space-y-2 border-l-2 border-border-emphasis bg-bg-elevated/60 px-3 py-2 text-fg-muted">
+            {lastUserMessage ? (
+              <ConversationPreviewLine
+                label={dt(t, "dialogs.agentResume.lastUser")}
+                text={lastUserMessage}
+              />
+            ) : null}
+            {lastAgentMessage ? (
+              <ConversationPreviewLine
+                label={dt(t, "dialogs.agentResume.lastAgent")}
+                text={lastAgentMessage}
+              />
+            ) : null}
+          </div>
         ) : null}
         <CodeValue surface="elevated" tone="muted">
           {candidate.uuid}
@@ -181,6 +195,23 @@ export function AgentResumeModal({
         </Button>
       </ModalFooter>
     </Modal>
+  );
+}
+
+function ConversationPreviewLine({
+  label,
+  text,
+}: {
+  label: string;
+  text: string;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="text-[10px] font-medium uppercase text-fg-muted/70">
+        {label}
+      </div>
+      <div className="line-clamp-2 leading-4 text-fg-muted">{text}</div>
+    </div>
   );
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1115,6 +1115,10 @@ export interface ResumeCandidate {
   lastActivityUnix: number;
   /** Single-line preview of the last assistant text, truncated. */
   preview: string | null;
+  /** Single-line preview of the last user text, truncated. */
+  lastUserMessage: string | null;
+  /** Single-line preview of the last assistant text, truncated. */
+  lastAgentMessage: string | null;
 }
 
 export interface DaemonStatus {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1778,6 +1778,8 @@
       "copyFailed": "Failed to copy session ID.",
       "copyId": "Copy ID",
       "resume": "Resume",
+      "lastUser": "User",
+      "lastAgent": "Agent",
       "lastActivityUnknown": "Last activity unknown",
       "justNow": "Just now",
       "minutesAgo": "min ago",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1778,6 +1778,8 @@
       "copyFailed": "세션 ID를 복사하지 못했습니다.",
       "copyId": "ID 복사",
       "resume": "재개",
+      "lastUser": "사용자",
+      "lastAgent": "에이전트",
       "lastActivityUnknown": "마지막 활동 알 수 없음",
       "justNow": "방금 전",
       "minutesAgo": "분 전",


### PR DESCRIPTION
## Summary
The resume modal now shows the conversation context behind the transcript it is offering, so users can decide whether to resume without relying on xterm scrollback.

1. **Candidate context**: include last user and last agent transcript excerpts in `ResumeCandidate` while keeping the existing `preview` field as a fallback.
2. **Modal UI**: render a compact user/agent conversation preview above the transcript UUID.
3. **Localization**: add English and Korean labels for the preview roles.
4. **Coverage**: update modal tests for conversation preview rendering and legacy `preview` fallback.

## Expected impact

| Area | Impact |
| --- | --- |
| Resume UX | Users can see what they are resuming before sending the resume command. |
| xterm limitation | Reduces reliance on terminal scrollback for previous conversation context. |
| Compatibility | Existing `preview` remains available and is still used as a fallback. |
| Performance | Neutral; the backend already extracts both preview fields from the transcript tail. |

## Design notes

The modal action semantics are unchanged: Resume writes the provider resume command without acknowledging the candidate, while Copy, Cancel, and dismiss still acknowledge it. Backend serialization remains camelCase for the new nullable fields.

## Follow-up (not in this PR)

A future pass could add richer transcript opening/search affordances from the modal, but this keeps the current dialog focused on resume decision context.

## Test plan

- [x] `git diff --check`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn -- agent_resume` — 20 passed
- [x] `pnpm exec vitest run src/components/AgentResumeModal.test.tsx` — 8 passed
- [x] `pnpm exec tsc --noEmit`

## Notes

Peer review was run against the diff with no findings.