### PR TITLE
fix(chat): recover blank Codex native responses

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -810,20 +810,53 @@ fn codex_provider_thread_cursor(state: &persistence::ChatSessionState) -> Option
 fn latest_codex_agent_message_from_transcript(path: &Path) -> io::Result<Option<String>> {
     let file = std::fs::File::open(path)?;
     let reader = io::BufReader::new(file);
-    let mut parser = ChatCliOutputParser::new(ChatCliOutputMode::CodexJson);
-    let mut ignore_chunk = ignore_chat_streaming_chunk;
+    let lines = reader.lines().collect::<io::Result<Vec<_>>>()?;
+    let mut latest_agent_message = None;
 
-    for line in reader.lines() {
-        parser.push_chunk(&line?, &mut ignore_chunk);
-        parser.push_chunk("\n", &mut ignore_chunk);
+    for line in lines.iter().rev() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if let Some(event) = extract_codex_stream_text(&value) {
+            let text = event.text.trim();
+            if event.is_final {
+                return Ok(if text.is_empty() {
+                    None
+                } else {
+                    Some(text.to_string())
+                });
+            }
+            if latest_agent_message.is_none()
+                && event.boundary != ChatStreamTextBoundary::Delta
+                && !text.is_empty()
+            {
+                latest_agent_message = Some(text.to_string());
+            }
+        }
+        if is_codex_user_message_event(&value) {
+            return Ok(latest_agent_message);
+        }
     }
 
-    let content = parser.finish("");
-    if content.trim().is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(content))
-    }
+    Ok(latest_agent_message)
+}
+
+fn is_codex_user_message_event(value: &serde_json::Value) -> bool {
+    codex_event_type(value) == Some("user_message")
+        || value
+            .get("msg")
+            .is_some_and(|event| codex_event_type(event) == Some("user_message"))
+        || value
+            .get("payload")
+            .is_some_and(|event| codex_event_type(event) == Some("user_message"))
+}
+
+fn codex_event_type(value: &serde_json::Value) -> Option<&str> {
+    value.get("type").and_then(serde_json::Value::as_str)
 }
 
 fn backfill_latest_empty_codex_assistant_message_from_path(
@@ -6991,6 +7024,35 @@ mod tests {
             state.messages.last().unwrap().content,
             "안녕하세요. 무엇을 도와드릴까요?"
         );
+    }
+
+    #[test]
+    fn backfill_empty_codex_assistant_message_stops_at_latest_user_boundary() {
+        let mut state = chat_state_for_runtime(vec![
+            chat_message("u1", crate::persistence::ChatRole::User, "다시 봐줘"),
+            chat_message("a1", crate::persistence::ChatRole::Assistant, ""),
+        ]);
+        let tmp = tempfile::tempdir().unwrap();
+        let transcript = tmp.path().join("rollout.jsonl");
+        std::fs::write(
+            &transcript,
+            concat!(
+                r#"{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"이전 답변"}}"#,
+                "\n",
+                r#"{"type":"event_msg","payload":{"type":"user_message","message":"다시 봐줘"}}"#,
+                "\n",
+                r#"{"type":"event_msg","payload":{"type":"token_count","info":{}}}"#,
+            ),
+        )
+        .unwrap();
+
+        assert!(
+            !super::backfill_latest_empty_codex_assistant_message_from_path(
+                &mut state,
+                &transcript
+            )
+        );
+        assert_eq!(state.messages.last().unwrap().content, "");
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -812,6 +812,7 @@ fn latest_codex_agent_message_from_transcript(path: &Path) -> io::Result<Option<
     let reader = io::BufReader::new(file);
     let lines = reader.lines().collect::<io::Result<Vec<_>>>()?;
     let mut latest_agent_message = None;
+    let mut saw_empty_final = false;
 
     for line in lines.iter().rev() {
         let line = line.trim();
@@ -824,11 +825,14 @@ fn latest_codex_agent_message_from_transcript(path: &Path) -> io::Result<Option<
         if let Some(event) = extract_codex_stream_text(&value) {
             let text = event.text.trim();
             if event.is_final {
-                return Ok(if text.is_empty() {
-                    None
-                } else {
-                    Some(text.to_string())
-                });
+                if text.is_empty() {
+                    saw_empty_final = true;
+                    continue;
+                }
+                if saw_empty_final {
+                    return Ok(latest_agent_message);
+                }
+                return Ok(Some(text.to_string()));
             }
             if latest_agent_message.is_none()
                 && event.boundary != ChatStreamTextBoundary::Delta
@@ -846,13 +850,31 @@ fn latest_codex_agent_message_from_transcript(path: &Path) -> io::Result<Option<
 }
 
 fn is_codex_user_message_event(value: &serde_json::Value) -> bool {
-    codex_event_type(value) == Some("user_message")
+    is_codex_user_message_event_value(value)
         || value
             .get("msg")
-            .is_some_and(|event| codex_event_type(event) == Some("user_message"))
+            .is_some_and(is_codex_user_message_event_value)
         || value
             .get("payload")
-            .is_some_and(|event| codex_event_type(event) == Some("user_message"))
+            .is_some_and(is_codex_user_message_event_value)
+}
+
+fn is_codex_user_message_event_value(value: &serde_json::Value) -> bool {
+    match codex_event_type(value) {
+        Some("user_message") => true,
+        Some("response_item") | Some("raw_response_item") => value
+            .get("payload")
+            .is_some_and(is_codex_user_response_payload),
+        _ => false,
+    }
+}
+
+fn is_codex_user_response_payload(value: &serde_json::Value) -> bool {
+    codex_event_type(value) == Some("message")
+        && value
+            .get("role")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|role| role == "user")
 }
 
 fn codex_event_type(value: &serde_json::Value) -> Option<&str> {
@@ -7042,6 +7064,88 @@ mod tests {
                 r#"{"type":"event_msg","payload":{"type":"user_message","message":"다시 봐줘"}}"#,
                 "\n",
                 r#"{"type":"event_msg","payload":{"type":"token_count","info":{}}}"#,
+            ),
+        )
+        .unwrap();
+
+        assert!(
+            !super::backfill_latest_empty_codex_assistant_message_from_path(
+                &mut state,
+                &transcript
+            )
+        );
+        assert_eq!(state.messages.last().unwrap().content, "");
+    }
+
+    #[test]
+    fn backfill_empty_codex_assistant_message_stops_at_response_item_user_boundary() {
+        let mut state = chat_state_for_runtime(vec![
+            chat_message("u1", crate::persistence::ChatRole::User, "다시 봐줘"),
+            chat_message("a1", crate::persistence::ChatRole::Assistant, ""),
+        ]);
+        let tmp = tempfile::tempdir().unwrap();
+        let transcript = tmp.path().join("rollout.jsonl");
+        std::fs::write(
+            &transcript,
+            concat!(
+                r#"{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"이전 답변"}}"#,
+                "\n",
+                r#"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"다시 봐줘"}]}}"#,
+                "\n",
+                r#"{"type":"event_msg","payload":{"type":"token_count","info":{}}}"#
+            ),
+        )
+        .unwrap();
+
+        assert!(
+            !super::backfill_latest_empty_codex_assistant_message_from_path(
+                &mut state,
+                &transcript
+            )
+        );
+        assert_eq!(state.messages.last().unwrap().content, "");
+    }
+
+    #[test]
+    fn backfill_empty_codex_assistant_message_uses_agent_message_after_empty_final() {
+        let mut state = chat_state_for_runtime(vec![
+            chat_message("u1", crate::persistence::ChatRole::User, "다시 봐줘"),
+            chat_message("a1", crate::persistence::ChatRole::Assistant, ""),
+        ]);
+        let tmp = tempfile::tempdir().unwrap();
+        let transcript = tmp.path().join("rollout.jsonl");
+        std::fs::write(
+            &transcript,
+            concat!(
+                r#"{"type":"event_msg","payload":{"type":"user_message","message":"다시 봐줘"}}"#,
+                "\n",
+                r#"{"type":"event_msg","payload":{"type":"agent_message","message":"새 답변"}}"#,
+                "\n",
+                r#"{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"   "}}"#
+            ),
+        )
+        .unwrap();
+
+        assert!(
+            super::backfill_latest_empty_codex_assistant_message_from_path(&mut state, &transcript)
+        );
+        assert_eq!(state.messages.last().unwrap().content, "새 답변");
+    }
+
+    #[test]
+    fn backfill_empty_codex_assistant_message_ignores_previous_final_after_empty_final() {
+        let mut state = chat_state_for_runtime(vec![
+            chat_message("u1", crate::persistence::ChatRole::User, "다시 봐줘"),
+            chat_message("a1", crate::persistence::ChatRole::Assistant, ""),
+        ]);
+        let tmp = tempfile::tempdir().unwrap();
+        let transcript = tmp.path().join("rollout.jsonl");
+        std::fs::write(
+            &transcript,
+            concat!(
+                r#"{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"이전 답변"}}"#,
+                "\n",
+                r#"{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":""}}"#
             ),
         )
         .unwrap();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
-use std::io;
+use std::io::{self, BufRead};
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
@@ -759,6 +759,97 @@ fn string_field(value: &serde_json::Value, path: &[&str]) -> Option<String> {
         cursor = cursor.get(*key)?;
     }
     cursor.as_str().map(str::to_string)
+}
+
+fn chat_message_metadata_provider(message: &persistence::ChatMessage) -> Option<&str> {
+    message
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("provider"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|provider| !provider.is_empty())
+}
+
+fn latest_empty_codex_assistant_message_index(
+    state: &persistence::ChatSessionState,
+) -> Option<usize> {
+    let index = state.messages.len().checked_sub(1)?;
+    let message = &state.messages[index];
+    if message.role != persistence::ChatRole::Assistant || !message.content.trim().is_empty() {
+        return None;
+    }
+    if message.status != Some(persistence::ChatMessageStatus::Complete) {
+        return None;
+    }
+    let provider = chat_message_metadata_provider(message).or(state.provider.as_deref());
+    if provider != Some("codex") {
+        return None;
+    }
+    Some(index)
+}
+
+fn codex_provider_thread_cursor(state: &persistence::ChatSessionState) -> Option<String> {
+    state
+        .provider_threads
+        .iter()
+        .rev()
+        .filter(|thread| thread.provider == "codex")
+        .find_map(|thread| {
+            thread
+                .resume_token
+                .as_deref()
+                .or(thread.native_thread_id.as_deref())
+                .or(thread.last_response_id.as_deref())
+                .map(str::trim)
+                .filter(|cursor| !cursor.is_empty())
+                .map(str::to_string)
+        })
+}
+
+fn latest_codex_agent_message_from_transcript(path: &Path) -> io::Result<Option<String>> {
+    let file = std::fs::File::open(path)?;
+    let reader = io::BufReader::new(file);
+    let mut parser = ChatCliOutputParser::new(ChatCliOutputMode::CodexJson);
+    let mut ignore_chunk = ignore_chat_streaming_chunk;
+
+    for line in reader.lines() {
+        parser.push_chunk(&line?, &mut ignore_chunk);
+        parser.push_chunk("\n", &mut ignore_chunk);
+    }
+
+    let content = parser.finish("");
+    if content.trim().is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(content))
+    }
+}
+
+fn backfill_latest_empty_codex_assistant_message_from_path(
+    state: &mut persistence::ChatSessionState,
+    path: &Path,
+) -> bool {
+    let Some(index) = latest_empty_codex_assistant_message_index(state) else {
+        return false;
+    };
+    let Ok(Some(content)) = latest_codex_agent_message_from_transcript(path) else {
+        return false;
+    };
+    state.messages[index].content = content;
+    true
+}
+
+fn backfill_latest_empty_codex_assistant_message(
+    state: &mut persistence::ChatSessionState,
+) -> bool {
+    let Some(cursor) = codex_provider_thread_cursor(state) else {
+        return false;
+    };
+    let Some(path) = acorn_transcript::locate_codex_transcript(&cursor) else {
+        return false;
+    };
+    backfill_latest_empty_codex_assistant_message_from_path(state, &path)
 }
 
 struct CliChatProviderAdapter {
@@ -2850,6 +2941,26 @@ pub async fn load_chat_session_state(
     })
     .await?;
     apply_acorn_session_metadata(&mut chat_state, &session);
+    if backfill_latest_empty_codex_assistant_message(&mut chat_state) {
+        let repaired_state = chat_state.clone();
+        match run_blocking("save repaired chat session state", move || {
+            persistence::save_chat_session_state(repaired_state)
+        })
+        .await
+        {
+            Ok(saved) => {
+                chat_state = saved;
+                apply_acorn_session_metadata(&mut chat_state, &session);
+            }
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    session_id = %chat_state.session_id,
+                    "failed to persist repaired chat session state"
+                );
+            }
+        }
+    }
     Ok(chat_state)
 }
 
@@ -6828,6 +6939,58 @@ mod tests {
 
         assert_eq!(chunks.concat(), "hello");
         assert_eq!(parser.finish(""), "hello");
+    }
+
+    #[test]
+    fn chat_stream_parser_extracts_codex_task_complete_payload_message() {
+        let mut parser = super::ChatCliOutputParser::new(super::ChatCliOutputMode::CodexJson);
+        let mut chunks = Vec::new();
+
+        {
+            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            parser.push_chunk(
+                r#"{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"안녕하세요. 무엇을 도와드릴까요?"}}"#,
+                &mut on_chunk,
+            );
+            parser.push_chunk("\n", &mut on_chunk);
+        }
+
+        assert_eq!(chunks.concat(), "안녕하세요. 무엇을 도와드릴까요?");
+        assert_eq!(parser.finish(""), "안녕하세요. 무엇을 도와드릴까요?");
+    }
+
+    #[test]
+    fn backfill_empty_codex_assistant_message_reads_transcript_final_message() {
+        let mut state = chat_state_for_runtime(vec![
+            chat_message("u1", crate::persistence::ChatRole::User, "안녕"),
+            chat_message("a1", crate::persistence::ChatRole::Assistant, ""),
+        ]);
+        state
+            .provider_threads
+            .push(crate::persistence::ProviderThread {
+                session_id: state.session_id.clone(),
+                provider: "codex".to_string(),
+                model: None,
+                native_thread_id: Some("019f4595-6b86-7183-878f-6fb1f523abf9".to_string()),
+                resume_token: Some("019f4595-6b86-7183-878f-6fb1f523abf9".to_string()),
+                last_response_id: None,
+                updated_at: chrono::Utc::now(),
+            });
+        let tmp = tempfile::tempdir().unwrap();
+        let transcript = tmp.path().join("rollout.jsonl");
+        std::fs::write(
+            &transcript,
+            r#"{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"안녕하세요. 무엇을 도와드릴까요?"}}"#,
+        )
+        .unwrap();
+
+        assert!(
+            super::backfill_latest_empty_codex_assistant_message_from_path(&mut state, &transcript)
+        );
+        assert_eq!(
+            state.messages.last().unwrap().content,
+            "안녕하세요. 무엇을 도와드릴까요?"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fix Codex native chat turns that completed successfully but rendered with an empty assistant body.

1. **Codex response recovery** — when loading a chat session, detect the latest completed Codex assistant message with empty content and recover its final response from the paired Codex rollout transcript.
2. **Latest-turn guard** — scan the rollout transcript from the end and stop at the latest Codex user boundary, including `response_item` / `raw_response_item` user payloads, so an empty latest assistant message cannot be filled with an older turn's response.
3. **Empty-final fallback** — if the latest `task_complete` / `turn_complete` marker has an empty `last_agent_message`, fall back only to a same-turn non-delta agent message and do not cross back to an older final snapshot.
4. **Best-effort persistence repair** — after a successful recovery, save the repaired chat state so already-affected sessions do not keep reloading blank responses.
5. **Regression coverage** — add coverage for Codex 0.143-style `event_msg` / `task_complete.last_agent_message` payloads, load-time backfill, latest user boundaries, `response_item` user boundaries, and empty-final fallback behavior.

## Expected impact
| Scenario | Before | After |
| --- | --- | --- |
| Codex native chat emits `task_complete.last_agent_message` but Acorn saved an empty assistant message | Chat pane shows only the Codex header with no body | Chat pane restores the final Codex response from the rollout transcript on load |
| Latest Codex turn has no final response after the latest user message | Could risk recovering an older transcript response | Leaves the assistant message empty instead of attaching the wrong answer |
| Latest final marker is empty but same-turn `agent_message` exists | Blank assistant message could remain unrecovered | Recovers the same-turn agent message without crossing into older turns |
| Normal Codex/Claude/Antigravity chat messages with content | Unchanged | Unchanged |

## Design notes
- The repair is intentionally narrow: only the latest assistant message is eligible, it must be `complete`, empty, and associated with Codex.
- Recovery reuses the existing Codex JSON text-event extractor, but scans from the transcript tail toward the latest user boundary instead of replaying the whole transcript as one stream.
- Persisting the repaired state is best effort. If the transcript is missing or the repaired state cannot be saved, the chat state still loads normally without failing the pane.
- Claude and Antigravity do not share the same failure shape: Claude native chat uses `stream-json` parsing covered by existing parser tests, while Antigravity native chat uses `agy -p/--print` plain stdout rather than Codex-style JSON events.

## Follow-up (not in this PR)
- Historical non-latest blank assistant turns remain untouched because mapping old Acorn turns back to older Codex transcript turns is more ambiguous and should be handled separately if needed.

## Test plan
- [x] `pnpm run build:sidecar`
- [x] `cargo test -p acorn --lib chat`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn --lib chat` — 36 passed after latest-turn guard and review fixes
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn --lib backfill_empty_codex_assistant_message` — 5 passed
- [x] `cargo test -p acorn-transcript assistant_message_text_concatenates_text_parts`
- [x] `git diff --check`

## Notes
- Existing affected chat sessions recover only if the paired Codex rollout transcript is still available under the user's Codex sessions directory.
- Local prod chat-state scan found blank completed assistant messages only for Codex-backed chat sessions, not Claude or Antigravity.
- A direct `rustfmt --edition 2024 --check src-tauri/src/commands.rs` reports pre-existing style deltas elsewhere in the large file, so it was not used as a merge gate for this scoped change.