### PR TITLE
fix(terminal): ignore control-only scrollback snapshots

### DIFF
--- a/src/lib/terminalScrollback.test.ts
+++ b/src/lib/terminalScrollback.test.ts
@@ -11,6 +11,14 @@ describe("terminal scrollback restore hygiene", () => {
     expect(shouldRestoreScrollback("\r\n\n   \x1b[0m\r\n")).toBe(false);
   });
 
+  it("does not restore terminal control-only snapshots", () => {
+    expect(
+      shouldRestoreScrollback(
+        "\x1b]0;⠴ acorn • Working\x1b\\\x1b]9;4;3;Working\x1b\\\x1b[2 q\x1b[?25h\x1b7\x1b8",
+      ),
+    ).toBe(false);
+  });
+
   it("does not restore a shell prompt with no session content", () => {
     expect(
       shouldRestoreScrollback(
@@ -26,6 +34,16 @@ describe("terminal scrollback restore hygiene", () => {
 
     expect(saved).not.toContain(legacyRestoreMarkerText);
     expect(saved).toContain("build ok");
+  });
+
+  it("drops control-only snapshots before saving", () => {
+    expect(prepareScrollbackForSave("\x1b]0;title\x1b\\\x1b[?25h")).toBe("");
+  });
+
+  it("keeps styled real output when saving", () => {
+    const saved = prepareScrollbackForSave("\x1b[32mDone\x1b[0m\r\n");
+
+    expect(saved).toBe("\x1b[32mDone\x1b[0m\r\n");
   });
 
   it("keeps real command output restorable", () => {

--- a/src/lib/terminalScrollback.ts
+++ b/src/lib/terminalScrollback.ts
@@ -1,20 +1,28 @@
 const LEGACY_RESTORE_MARKER_TEXT = "— restored from previous session —";
 
-const ANSI_ESCAPE_RE =
-  // OSC, CSI, and common one-character escape sequences.
-  /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-_]/g;
+const OSC_SEQUENCE_RE = /(?:\x1b\]|\x9d)[\s\S]*?(?:\x07|\x1b\\|\x9c)/g;
+const STRING_SEQUENCE_RE =
+  /(?:\x1b[P_^X]|\x90|\x98|\x9e|\x9f)[\s\S]*?(?:\x1b\\|\x9c)/g;
+const CSI_SEQUENCE_RE = /(?:\x1b\[|\x9b)[0-?]*[ -/]*[@-~]/g;
+const ESCAPE_SEQUENCE_RE = /\x1b[ -/]*[0-~]/g;
+const CONTROL_RE = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g;
 
 const LINE_RE = /[^\r\n]*(?:\r\n|\n|\r|$)/g;
 
-function stripAnsi(input: string): string {
-  return input.replace(ANSI_ESCAPE_RE, "");
+function stripTerminalControls(input: string): string {
+  return input
+    .replace(OSC_SEQUENCE_RE, "")
+    .replace(STRING_SEQUENCE_RE, "")
+    .replace(CSI_SEQUENCE_RE, "")
+    .replace(ESCAPE_SEQUENCE_RE, "")
+    .replace(CONTROL_RE, "");
 }
 
 function visibleLines(input: string): string[] {
   return stripRestoreMarkers(input)
     .replace(/\r/g, "\n")
     .split("\n")
-    .map((line) => stripAnsi(line).trim())
+    .map((line) => stripTerminalControls(line).trim())
     .filter((line) => line.length > 0);
 }
 
@@ -30,7 +38,7 @@ export function stripRestoreMarkers(input: string): string {
   return chunks
     .filter((chunk) => {
       if (chunk.length === 0) return false;
-      return !stripAnsi(chunk).includes(LEGACY_RESTORE_MARKER_TEXT);
+      return !stripTerminalControls(chunk).includes(LEGACY_RESTORE_MARKER_TEXT);
     })
     .join("");
 }


### PR DESCRIPTION
## Summary
Tighten terminal scrollback restore hygiene so control-only terminal frames are not treated as meaningful session output.

1. **Control-frame filtering** — expand the scrollback visibility check to ignore OSC, ST-terminated string controls, CSI sequences with intermediate bytes, single ESC controls, and C1/control bytes.
2. **Preserve styled scrollback** — keep the serialized xterm payload unchanged when it contains real output, so ANSI-styled restored terminal content remains intact.
3. **Regression coverage** — cover Codex/agent-style title/progress frames, cursor save/restore controls, control-only saves, and styled real output.

## Expected impact
| Scenario | Before | After |
| --- | --- | --- |
| Terminal snapshot contains only OSC title/progress/cursor-control frames | Could be considered restorable content | Dropped as empty/noise |
| Terminal snapshot contains styled real output | Restored with original bytes | Unchanged |
| Prompt-only shell snapshot | Dropped | Unchanged |

## Design notes
- This mirrors the useful part of Orca's terminal snapshot sanitizer without converting Acorn scrollback to plain text.
- `prepareScrollbackForSave` still returns the original serialized bytes for real content; the expanded stripping is only used to decide whether any visible content exists.
- The change is frontend-only and stays inside the existing `terminalScrollback` utility used by disk persistence and in-memory handoff.

## Follow-up (not in this PR)
- A larger Orca-style terminal snapshot API would require backend/main-buffer ownership changes; this PR keeps the current xterm serialize flow intact.

## Test plan
- [x] `pnpm exec vitest run src/lib/terminalScrollback.test.ts src/lib/terminalScrollbackHandoff.test.ts` — 10 passed
- [x] `pnpm exec tsc --noEmit`
- [x] `git diff --check`

## Notes
- Peer review via subagent was attempted, but the agent did not return within the short review window and was closed; this diff is scoped to two frontend utility/test files and covered by targeted tests.