### PR TITLE
test(status): pin Claude queue-operation as metadata

### DIFF
--- a/src-tauri/crates/acorn-session/src/status.rs
+++ b/src-tauri/crates/acorn-session/src/status.rs
@@ -24,11 +24,11 @@
 //! - last `type=USER_INPUT` or any non-DONE model/tool line -> Working.
 //!
 //! Meta-only lines (claude: `last-prompt` / `permission-mode` /
-//! `attachment` / `file-history-snapshot` / `system`; codex: `token_count`
-//! and other event_msg telemetry) are ignored when picking the last
-//! message. The transcript line itself is the source of truth; we
-//! deliberately do not gate on mtime, otherwise the moment after a turn
-//! ends (file still warm) gets misreported as Working.
+//! `attachment` / `file-history-snapshot` / `queue-operation` / `system`;
+//! codex: `token_count` and other event_msg telemetry) are ignored when
+//! picking the last message. The transcript line itself is the source of truth;
+//! we deliberately do not gate on mtime, otherwise the moment after a turn ends
+//! (file still warm) gets misreported as Working.
 //!
 //! Transcript resolution lives in the host `acorn` crate (it consults
 //! `agent_resume`'s persister markers + the legacy `~/.claude/projects/`
@@ -167,6 +167,7 @@ mod tests {
             r#"{"type":"permission-mode","mode":"acceptEdits"}"#,
             r#"{"type":"attachment"}"#,
             r#"{"type":"file-history-snapshot"}"#,
+            r#"{"type":"queue-operation","operation":"enqueue","content":"follow up"}"#,
             // System lines (turn_duration, away_summary) get appended after the
             // assistant's `end_turn`. The walker must skip past them and still
             // classify the trailing assistant turn, otherwise the sidebar dot

--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -719,6 +719,27 @@ mod tests {
     }
 
     #[test]
+    fn claude_queue_operation_is_status_meta() {
+        let tail = format!(
+            "{}\n{}\n",
+            assistant("end_turn"),
+            r#"{"type":"queue-operation","operation":"enqueue","content":"follow up"}"#
+        );
+        assert_eq!(
+            classify(AgentKind::Claude, &tail, true),
+            Some(TurnState::WaitingForInput),
+        );
+        assert_eq!(
+            classify(
+                AgentKind::Claude,
+                r#"{"type":"queue-operation","operation":"enqueue","content":"follow up"}"#,
+                true,
+            ),
+            None,
+        );
+    }
+
+    #[test]
     fn claude_unknown_stop_reason_treated_as_working() {
         assert_eq!(
             classify(AgentKind::Claude, &assistant("max_tokens"), true),


### PR DESCRIPTION
## Summary
This PR pins Claude `queue-operation` transcript events as status metadata.

1. **Transcript classifier coverage** — add a focused `acorn-transcript` test showing a trailing Claude `queue-operation` does not override the previous assistant `end_turn`, and queue-only tails produce no turn state.
2. **Status detector coverage** — include `queue-operation` in the session-status meta-line fixture so status polling continues to skip it when selecting the latest turn.
3. **Documentation alignment** — update the status detector module notes to name Claude `queue-operation` alongside other ignored bookkeeping events.

## Design notes
- This intentionally does not change classifier logic. Current behavior already ignores non-`user`/`assistant` Claude lines; the PR locks that behavior down because recoverable queued prompts are handled by history metadata, not live status.
- Keeping `queue-operation` out of status prevents queued Claude prompt bookkeeping from masking the actual previous turn state.

## Test plan
- [x] `CARGO_TARGET_DIR=/Users/jthefloor/Documents/Personal/acorn/.acorn/cargo-target cargo test --manifest-path src-tauri/Cargo.toml -p acorn-transcript -- claude_queue_operation_is_status_meta` — 1 passed
- [x] `CARGO_TARGET_DIR=/Users/jthefloor/Documents/Personal/acorn/.acorn/cargo-target cargo test --manifest-path src-tauri/Cargo.toml -p acorn-session -- assistant_end_turn_wins_over_trailing_meta meta_only_tail_returns_none` — 2 passed
- [x] `rustfmt --check src-tauri/crates/acorn-transcript/src/line.rs src-tauri/crates/acorn-session/src/status.rs && git diff --check` — passes
