### PR TITLE
chore(release): v1.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.23.1",
+  "version": "1.24.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.23.1"
+version = "1.24.0"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.23.1"
+version = "1.24.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary
This release bumps Acorn from `1.23.1` to `1.24.0` after a green `main` and prepares the next stable release.

1. **Version metadata:** Updates `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` to `1.24.0`.
2. **Semver decision:** Uses a minor bump because the unreleased set includes user-visible feature work across the kanban board, command palette, status/history surfaces, transcript path actions, work summaries, and resume modal.
3. **Release notes source:** Includes merged PRs #532, #566, #567, #568, #569, #570, #571, #572, #573, #574, #575, #576, #577, #578, #579, #580, #581, #582, #583, #584, #585, #586, #587, #588, #589, and #591. PR #590 is labelled `skip-changelog` and is intentionally excluded from generated release notes.

## Expected impact

| Area | Expected impact |
| --- | --- |
| App version | Packaged builds and updater metadata report `1.24.0`. |
| Release notes | GitHub Release and `latest.json.notes` include the merged feature, fix, and performance PRs since `v1.23.1`. |
| Runtime behavior | No direct runtime code changes in this bump PR. |

## Design notes

The release bump PR intentionally changes only version metadata. The merged feature/fix/performance PRs supply the changelog entries, so this PR should stay labelled `skip-changelog`.

## Follow-up (not in this PR)

- Push tag `v1.24.0` after this PR merges to trigger the release workflow.
- Confirm the Release workflow publishes the GitHub Release and `latest.json` assets successfully.

## Test plan

- [x] `gh run list --branch main --limit 10 --json databaseId,workflowName,displayTitle,status,conclusion,headSha,createdAt,url` — latest `main` CI run `29002262133` passed at `origin/main` (`1e2345d7afd270f9a9851cc6301e1a00b7f4e193`).
- [x] `rg -n '1\\.23\\.1|1\\.24\\.0' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock` — only the four release metadata fields now show `1.24.0`.
- [x] `pnpm run typecheck` — passed.
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — passed and reports root package `1.24.0`.
- [x] `git show HEAD:scripts/release-notes.mjs | rg 'addReleaseSectionSummaries|formatReleaseSectionSummary'` — bilingual summary support present.
- [x] `REPO=im-ian/acorn TAG=v1.24.0 OUTPUT=/tmp/acorn-release-notes-v1.24.0.md node scripts/release-notes.mjs` — generated notes successfully.
- [x] `test -s /tmp/acorn-release-notes-v1.24.0.md` — generated notes file is non-empty.
- [x] `rg -n '^> .+<br>$' /tmp/acorn-release-notes-v1.24.0.md` — Korean summary blockquotes present.
- [x] `rg -n '^> (Feature updates|Fixes|Performance improvements|Security updates|Documentation updates|Internal cleanup|Build and CI updates|Other changes): ' /tmp/acorn-release-notes-v1.24.0.md` — English summary blockquotes present.
- [x] `git diff --check` — passed.

## Notes

`origin/main` was verified green at `1e2345d7afd270f9a9851cc6301e1a00b7f4e193` before this branch was created.
