### PR TITLE
fix(permissions): guide terminal recovery after folder-access denial

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,7 @@ import { flushAllScrollbacks } from "./lib/scrollback-coordinator";
 import { useToasts } from "./lib/toasts";
 import { useUpdater } from "./lib/updater-store";
 import {
+  FOLDER_PERMISSION_RECHECK_EVENT,
   hasDeniedFolderPermission,
   isMacPlatform,
   type FolderPermissionWarmupResult,
@@ -832,28 +833,44 @@ function App() {
     const platform = navigator.platform;
     if (!isMacPlatform(platform)) return;
 
-    const auditKey = platform;
-    let audit = permissionWarmupAuditRef.current;
-    if (!audit || audit.key !== auditKey) {
-      audit = {
-        key: auditKey,
-        promise: api.warmMacosFolderPermissions(),
-      };
-      permissionWarmupAuditRef.current = audit;
-    }
-
     let cancelled = false;
-    void audit.promise
-      .then((results) => {
-        if (cancelled || !hasDeniedFolderPermission(results)) return;
-        setPermissionWarmupInitialResults(results);
-        setPermissionWarmupOpen(true);
-      })
-      .catch((err) => {
-        console.warn("[App] folder permission audit failed", err);
-      });
+    const auditKey = platform;
+    const runAudit = () => {
+      let audit = permissionWarmupAuditRef.current;
+      if (!audit || audit.key !== auditKey) {
+        const promise = api.warmMacosFolderPermissions();
+        audit = { key: auditKey, promise };
+        permissionWarmupAuditRef.current = audit;
+        const clearAudit = () => {
+          if (permissionWarmupAuditRef.current?.promise === promise) {
+            permissionWarmupAuditRef.current = null;
+          }
+        };
+        void promise.then(clearAudit, clearAudit);
+      }
+
+      void audit.promise
+        .then((results) => {
+          if (cancelled || !hasDeniedFolderPermission(results)) return;
+          setPermissionWarmupInitialResults(results);
+          setPermissionWarmupOpen(true);
+        })
+        .catch((err) => {
+          console.warn("[App] folder permission audit failed", err);
+        });
+    };
+    const onPermissionRecheck = () => runAudit();
+    window.addEventListener(
+      FOLDER_PERMISSION_RECHECK_EVENT,
+      onPermissionRecheck,
+    );
+    runAudit();
     return () => {
       cancelled = true;
+      window.removeEventListener(
+        FOLDER_PERMISSION_RECHECK_EVENT,
+        onPermissionRecheck,
+      );
     };
   }, []);
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -88,6 +88,10 @@ import {
   useSettings,
   type TerminalLinkActivation,
 } from "../lib/settings";
+import {
+  createFolderPermissionOutputDetector,
+  FOLDER_PERMISSION_RECHECK_EVENT,
+} from "../lib/permissionWarmup";
 import { buildXtermTheme } from "../lib/terminalTheme";
 import { useThemes, type ThemeMode } from "../lib/themes";
 import type { SessionAgentDetection, SessionAgentProvider } from "../lib/types";
@@ -2460,8 +2464,13 @@ export function Terminal({
     // collision then orphans one PTY, which exits and triggers the second
     // PTY to also exit (zsh prints "Saving session..." twice). Guard every
     // await resumption point so a disposed mount short-circuits cleanly.
+    const folderPermissionOutputDetector =
+      createFolderPermissionOutputDetector();
     const handlePtyOutput = (bytes: Uint8Array) => {
       outputWriter.enqueue(bytes);
+      if (folderPermissionOutputDetector.push(bytes)) {
+        window.dispatchEvent(new Event(FOLDER_PERMISSION_RECHECK_EVENT));
+      }
       // Output is queued for the buffer — schedule a debounced save so the new
       // content reaches disk ~1s after activity ends.
       scheduleScrollbackSave();

--- a/src/lib/permissionWarmup.test.ts
+++ b/src/lib/permissionWarmup.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  createFolderPermissionOutputDetector,
   hasDeniedFolderPermission,
   isMacPlatform,
 } from "./permissionWarmup";
+
+function bytes(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
 
 describe("permission warmup gate", () => {
   it("only targets macOS-like platforms", () => {
@@ -38,5 +43,39 @@ describe("permission warmup gate", () => {
         },
       ]),
     ).toBe(true);
+  });
+
+  it("detects Homebrew's unreadable current-directory failure", () => {
+    const detector = createFolderPermissionOutputDetector();
+
+    expect(
+      detector.push(
+        bytes(
+          "Error: The current working directory must be readable to jthefloor to run brew.\r\n",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("detects a Codex permission failure split across output chunks", () => {
+    const detector = createFolderPermissionOutputDetector();
+
+    expect(detector.push(bytes("\u001b[31mError: Operation not per"))).toBe(
+      false,
+    );
+    expect(
+      detector.push(bytes("mitted (os error 1)\u001b[0m\r\n")),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated permission errors", () => {
+    const detector = createFolderPermissionOutputDetector();
+
+    expect(
+      detector.push(bytes("rm: cache.db: Operation not permitted\r\n")),
+    ).toBe(false);
+    expect(
+      detector.push(bytes("Error: current directory is unavailable\r\n")),
+    ).toBe(false);
   });
 });

--- a/src/lib/permissionWarmup.test.ts
+++ b/src/lib/permissionWarmup.test.ts
@@ -78,4 +78,13 @@ describe("permission warmup gate", () => {
       detector.push(bytes("Error: current directory is unavailable\r\n")),
     ).toBe(false);
   });
+
+  it("reports a permission failure only once per terminal detector", () => {
+    const detector = createFolderPermissionOutputDetector();
+    const failure = bytes("Error: Operation not permitted (os error 1)\r\n");
+
+    expect(detector.push(new Uint8Array())).toBe(false);
+    expect(detector.push(failure)).toBe(true);
+    expect(detector.push(failure)).toBe(false);
+  });
 });

--- a/src/lib/permissionWarmup.test.ts
+++ b/src/lib/permissionWarmup.test.ts
@@ -79,12 +79,13 @@ describe("permission warmup gate", () => {
     ).toBe(false);
   });
 
-  it("reports a permission failure only once per terminal detector", () => {
+  it("rearms after a permission failure so later commands can trigger another audit", () => {
     const detector = createFolderPermissionOutputDetector();
     const failure = bytes("Error: Operation not permitted (os error 1)\r\n");
 
     expect(detector.push(new Uint8Array())).toBe(false);
     expect(detector.push(failure)).toBe(true);
-    expect(detector.push(failure)).toBe(false);
+    expect(detector.push(bytes("jthefloor@mac . % "))).toBe(false);
+    expect(detector.push(failure)).toBe(true);
   });
 });

--- a/src/lib/permissionWarmup.ts
+++ b/src/lib/permissionWarmup.ts
@@ -31,6 +31,39 @@ export interface MacosPermissionResetResult {
   error: string | null;
 }
 
+export const FOLDER_PERMISSION_RECHECK_EVENT =
+  "acorn:folder-permission-recheck";
+
+const ANSI_CSI_SEQUENCE = /\u001b\[[0-?]*[ -/]*[@-~]/g;
+const MAX_PERMISSION_OUTPUT_TAIL = 512;
+const BREW_UNREADABLE_CWD =
+  /the current working directory must be readable to [^\r\n]+ to run brew\./i;
+const CODEX_PERMISSION_FAILURE =
+  /error:\s*operation not permitted \(os error 1\)/i;
+
+export function createFolderPermissionOutputDetector(): {
+  push: (bytes: Uint8Array) => boolean;
+} {
+  const decoder = new TextDecoder();
+  let tail = "";
+  let detected = false;
+
+  return {
+    push(bytes) {
+      if (detected || bytes.byteLength === 0) return false;
+      const output = (tail + decoder.decode(bytes, { stream: true })).replace(
+        ANSI_CSI_SEQUENCE,
+        "",
+      );
+      tail = output.slice(-MAX_PERMISSION_OUTPUT_TAIL);
+      detected =
+        BREW_UNREADABLE_CWD.test(output) ||
+        CODEX_PERMISSION_FAILURE.test(output);
+      return detected;
+    },
+  };
+}
+
 export function hasDeniedFolderPermission(
   results: FolderPermissionWarmupResult[],
 ): boolean {

--- a/src/lib/permissionWarmup.ts
+++ b/src/lib/permissionWarmup.ts
@@ -46,19 +46,19 @@ export function createFolderPermissionOutputDetector(): {
 } {
   const decoder = new TextDecoder();
   let tail = "";
-  let detected = false;
 
   return {
     push(bytes) {
-      if (detected || bytes.byteLength === 0) return false;
+      if (bytes.byteLength === 0) return false;
       const output = (tail + decoder.decode(bytes, { stream: true })).replace(
         ANSI_CSI_SEQUENCE,
         "",
       );
       tail = output.slice(-MAX_PERMISSION_OUTPUT_TAIL);
-      detected =
+      const detected =
         BREW_UNREADABLE_CWD.test(output) ||
         CODEX_PERMISSION_FAILURE.test(output);
+      if (detected) tail = "";
       return detected;
     },
   };

--- a/tests/e2e/permission-warmup.spec.ts
+++ b/tests/e2e/permission-warmup.spec.ts
@@ -1,6 +1,32 @@
 import type { Page } from "@playwright/test";
 import { test, expect } from "./support";
 
+async function emitSubscribedPtyOutput(
+  page: Page,
+  channelIdKey: string,
+  text: string,
+  index = 0,
+): Promise<void> {
+  await page.evaluate(
+    ({ channelIdKey, text, index }) => {
+      const w = window as unknown as { [key: string]: unknown };
+      const id = w[channelIdKey];
+      if (typeof id !== "number") {
+        throw new Error(`missing terminal output channel: ${channelIdKey}`);
+      }
+      const callback = w[`_${id}`] as
+        | ((payload: { index: number; message: number[] }) => void)
+        | undefined;
+      if (!callback) throw new Error("missing terminal output callback");
+      callback({
+        index,
+        message: Array.from(new TextEncoder().encode(text)),
+      });
+    },
+    { channelIdKey, text, index },
+  );
+}
+
 async function enableMacWarmup(page: Page) {
   await page.addInitScript(() => {
     (window as unknown as { __ACORN_ENABLE_PERMISSION_WARMUP__?: boolean })
@@ -155,5 +181,102 @@ test.describe("folder permission warmup", () => {
     await expect(
       page.getByRole("heading", { name: "Check folder permissions now?" }),
     ).toBeVisible();
+  });
+
+  test("rechecks and shows reset guidance when terminal output reports an unreadable cwd", async ({
+    page,
+    tauri,
+  }) => {
+    await enableMacWarmup(page);
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/Users/tester/Documents/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-permission",
+        name: "shell",
+        repo_path: "/Users/tester/Documents/demo",
+        worktree_path: "/Users/tester/Documents/demo",
+        branch: "main",
+        isolated: false,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __permissionOutputChannelId?: number;
+      };
+      w.__permissionOutputChannelId = channel.id;
+      return 1;
+    });
+    await tauri.handle("warm_macos_folder_permissions", () => {
+      const w = window as unknown as { __runtimeWarmupCalls?: number };
+      w.__runtimeWarmupCalls = (w.__runtimeWarmupCalls ?? 0) + 1;
+      if (w.__runtimeWarmupCalls === 1) {
+        return [
+          {
+            id: "documents",
+            path: "/Users/tester/Documents",
+            status: "ok",
+            error: null,
+          },
+        ];
+      }
+      return [
+        {
+          id: "documents",
+          path: "/Users/tester/Documents",
+          status: "denied",
+          error: "Operation not permitted",
+        },
+      ];
+    });
+
+    await page.goto("/");
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __permissionOutputChannelId?: number })
+              .__permissionOutputChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    await emitSubscribedPtyOutput(
+      page,
+      "__permissionOutputChannelId",
+      "Error: The current working directory must be readable to tester to run brew.\r\n",
+    );
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText("Documents", { exact: true })).toBeVisible();
+    await expect(dialog.getByText("Denied", { exact: true })).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: "Reset permissions" }),
+    ).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __runtimeWarmupCalls?: number })
+              .__runtimeWarmupCalls ?? 0,
+        ),
+      )
+      .toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

Make macOS protected-folder denial recoverable when it first surfaces inside an already-running Acorn terminal.

1. **Detect terminal permission failures** — recognize Homebrew's unreadable-current-directory error and Codex's `Operation not permitted (os error 1)` output across ANSI styling and split PTY chunks.
2. **Re-audit protected folders** — dispatch an Acorn-scoped recheck signal and rerun the existing macOS folder probe, deduplicating only concurrent audits.
3. **Guide recovery only on confirmed denial** — open the existing folder-permission modal with denied results and its permission-reset action; unrelated terminal permission errors remain silent when the macOS probe is healthy.
4. **Keep recovery repeatable** — clear the detector tail after a match so a later command in the same terminal can trigger a fresh audit without every subsequent output chunk retriggering it.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| User denies Acorn access to a protected project folder | Terminal tools fail with permission errors and no contextual recovery UI | Acorn confirms the denied folder and opens the permission-reset guidance modal |
| Unrelated command emits a generic permission error | No modal | No modal unless the protected-folder audit also reports `denied` |
| Error text is ANSI-styled or split across PTY chunks | Runtime denial is missed | Signature is reconstructed and detected |

## Design notes

- PTY output detection stays in the frontend because both daemon-channel and Tauri-event output already converge in `Terminal.handlePtyOutput`.
- The terminal emits only an `acorn:folder-permission-recheck` signal; `App` remains the owner of the audit request and modal state.
- The terminal signature is a hint, not authority. The modal opens only after `warm_macos_folder_permissions` returns at least one denied folder.
- Existing reset behavior and localized modal copy are reused; no new backend command or TCC behavior is introduced.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 86 files, 952 tests pass
- [x] `pnpm exec playwright test tests/e2e/permission-warmup.spec.ts` — 4 Chromium flows pass
- [x] `pnpm run build` — production frontend build passes
- [x] `git diff --check origin/main...HEAD` — no whitespace or conflict-marker errors
- [x] GitHub Actions — Frontend and E2E green; full E2E reports 222 passing tests

## Notes

- The first Frontend CI attempt hit a pre-existing `FileViewer.test.tsx` virtualizer timer race after all 952 tests passed, producing `ReferenceError: window is not defined` during teardown. The failed job rerun passed unit tests and build without a code change; this was not caused by the PR.
- Vite still reports the existing mixed static/dynamic import and large-chunk warnings during `pnpm run build`; the build succeeds and this PR does not change bundling.
