### PR TITLE
fix(notifications): open kanban terminal overlay on OS notification click

### DIFF
--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -290,7 +290,13 @@ export async function startNotificationClickHandler(): Promise<() => void> {
     void win.show();
     void win.unminimize();
     void win.setFocus();
-    useAppStore.getState().selectSession(sessionId);
+    const store = useAppStore.getState();
+    store.selectSession(sessionId);
+    // Kanban has no persistent terminal pane, so mirror the in-app inbox and
+    // pop the session's terminal overlay open (StatusBar NotificationRow).
+    if (store.workspaceViewMode === "kanban") {
+      store.openTerminalPopup(sessionId);
+    }
     markSessionNotificationsRead(sessionId);
   });
   return () => {


### PR DESCRIPTION
## Summary

In kanban mode, clicking a notification now opens the session's terminal overlay.

The in-app notification inbox (`StatusBar` `NotificationRow`) already popped the terminal overlay when clicked in kanban view, but the **OS notification** click handler in `startNotificationClickHandler` only called `selectSession`. Since kanban has no persistent terminal pane, clicking an OS banner brought the window forward but showed no session surface. This mirrors the inbox behavior so both entry points land on the same overlay.

## Changes

- `src/lib/notifications.ts` — after `selectSession`, call `openTerminalPopup(sessionId)` when `workspaceViewMode === "kanban"`.

## Test plan

- [ ] Kanban mode, session goes `waiting_for_input`/`errored` while unfocused → OS notification fires.
- [ ] Click the OS notification → app comes forward, session selected, terminal overlay opens on the matching card.
- [ ] Non-kanban (pane) mode → OS notification click still just selects the session (no overlay), unchanged.
- [ ] In-app inbox click in kanban still opens the overlay (unchanged).
