### PR TITLE
feat(sessions): silence per-session notifications and activity

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -276,6 +276,10 @@ export function Pane({ paneId }: PaneProps) {
   const isFocused = focusedPaneId === paneId;
   const lastEmptyPaneSpaceKeyDownAtRef = useRef<number | null>(null);
   const activeSession = active?.kind === "session" ? active.session : null;
+  const activeSessionSilenced = useAppStore((s) =>
+    activeSession ? Boolean(s.silencedSessionIds[activeSession.id]) : false,
+  );
+  const setSessionSilenced = useAppStore((s) => s.setSessionSilenced);
 
   useEffect(() => {
     const node = bodyRef.current;
@@ -646,6 +650,8 @@ export function Pane({ paneId }: PaneProps) {
           onClose: () => closePane(paneId),
           activeProjectFallback: useAppStore.getState().activeProject,
           shortcuts,
+          activeSessionSilenced,
+          setSessionSilenced,
           onOpenWorkSummary: activeSession
             ? () => void openWorkSummaryTab({ sessionId: activeSession.id })
             : undefined,
@@ -1757,6 +1763,8 @@ function buildPaneMenuItems({
   onClose,
   activeProjectFallback,
   shortcuts,
+  activeSessionSilenced,
+  setSessionSilenced,
   onOpenWorkSummary,
 }: {
   t: Translator;
@@ -1768,6 +1776,8 @@ function buildPaneMenuItems({
   onClose: () => void;
   activeProjectFallback: string | null;
   shortcuts: Record<HotkeyId, string>;
+  activeSessionSilenced: boolean;
+  setSessionSilenced: (sessionId: string, silenced: boolean) => void;
   onOpenWorkSummary?: () => void;
 }): ContextMenuItem[] {
   const editorReady = hasConfiguredEditor();
@@ -1783,6 +1793,21 @@ function buildPaneMenuItems({
               },
             ]
           : []),
+        {
+          label: paneT(
+            t,
+            activeSessionSilenced
+              ? "pane.menu.resumeNotifications"
+              : "pane.menu.silenceNotifications",
+          ),
+          icon: activeSessionSilenced ? (
+            <Bell size={12} />
+          ) : (
+            <BellOff size={12} />
+          ),
+          onClick: () =>
+            setSessionSilenced(activeSession.id, !activeSessionSilenced),
+        },
         {
           label: paneT(t, "pane.menu.openWorktreeInEditor"),
           icon: <PencilLine size={12} />,

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -1,6 +1,8 @@
 import {
   Bot,
   BarChart3,
+  Bell,
+  BellOff,
   CircleX,
   Columns2,
   Copy,
@@ -1018,6 +1020,10 @@ function TabItem({
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
   const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
   const session = tab.kind === "session" ? tab.session : null;
+  const sessionSilenced = useAppStore((s) =>
+    session ? Boolean(s.silencedSessionIds[session.id]) : false,
+  );
+  const setSessionSilenced = useAppStore((s) => s.setSessionSilenced);
   const isGeneratingTitle = useAppStore((s) =>
     session ? Boolean(s.generatingSessionTitleIds[session.id]) : false,
   );
@@ -1258,6 +1264,17 @@ function TabItem({
             label: paneT(t, "pane.menu.openWorkSummary"),
             icon: <BarChart3 size={12} />,
             onClick: () => void openWorkSummaryTab({ sessionId: session.id }),
+          },
+          {
+            label: paneT(
+              t,
+              sessionSilenced
+                ? "pane.menu.resumeNotifications"
+                : "pane.menu.silenceNotifications",
+            ),
+            icon: sessionSilenced ? <Bell size={12} /> : <BellOff size={12} />,
+            onClick: () =>
+              setSessionSilenced(session.id, !sessionSilenced),
           },
         ] satisfies ContextMenuItem[])
       : []),
@@ -1530,6 +1547,15 @@ function TabItem({
               className="pointer-events-none shrink-0 text-accent"
               aria-label={paneT(t, "pane.aria.controlSession")}
             />
+          ) : null}
+          {sessionSilenced ? (
+            <span
+              className="pointer-events-none inline-flex shrink-0 text-fg-muted"
+              aria-label={paneT(t, "pane.aria.notificationsSilenced")}
+              title={paneT(t, "pane.aria.notificationsSilenced")}
+            >
+              <BellOff size={10} aria-hidden />
+            </span>
           ) : null}
         </div>
         <button

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4276,6 +4276,10 @@ function LocalSessionRow({
   const showToast = useToasts((s) => s.show);
   const renameSession = useAppStore((s) => s.renameSession);
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
+  const sessionSilenced = useAppStore((s) =>
+    Boolean(s.silencedSessionIds[session.id]),
+  );
+  const setSessionSilenced = useAppStore((s) => s.setSessionSilenced);
   const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
   const currentPullRequest = useCurrentPullRequest(session);
   const titleText = resolveSessionTitle(session, sessionDisplay.title);
@@ -4360,6 +4364,16 @@ function LocalSessionRow({
       icon: <Sparkles size={12} />,
       onClick: () => void regenerateTitle(),
       disabled: !canRegenerateTitle,
+    },
+    {
+      label: sidebarText(
+        t,
+        sessionSilenced
+          ? "sidebar.actions.resumeNotifications"
+          : "sidebar.actions.silenceNotifications",
+      ),
+      icon: sessionSilenced ? <Bell size={12} /> : <BellOff size={12} />,
+      onClick: () => setSessionSilenced(session.id, !sessionSilenced),
     },
     ...(canCreateWorktreeWorkspace
       ? [

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,8 @@
 import {
   Activity,
   BarChart3,
+  Bell,
+  BellOff,
   Bot,
   CheckCheck,
   ChevronRight,
@@ -2724,6 +2726,10 @@ function SessionRow({
   const renameSession = useAppStore((s) => s.renameSession);
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
   const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
+  const sessionSilenced = useAppStore((s) =>
+    Boolean(s.silencedSessionIds[session.id]),
+  );
+  const setSessionSilenced = useAppStore((s) => s.setSessionSilenced);
   const createSession = useAppStore((s) => s.createSession);
   const selectSession = useAppStore((s) => s.selectSession);
   const setPendingTerminalInput = useAppStore(
@@ -2988,6 +2994,16 @@ function SessionRow({
         void openWorkSummaryTab({ sessionId: session.id });
       },
     },
+    {
+      label: sidebarText(
+        t,
+        sessionSilenced
+          ? "sidebar.actions.resumeNotifications"
+          : "sidebar.actions.silenceNotifications",
+      ),
+      icon: sessionSilenced ? <Bell size={12} /> : <BellOff size={12} />,
+      onClick: () => setSessionSilenced(session.id, !sessionSilenced),
+    },
     ...(forkItems.length > 0
       ? [contextMenuGroupTitle(t, "fork"), ...forkItems]
       : []),
@@ -3208,6 +3224,9 @@ function SessionRowLabel({
   // `in_worktree`) only apply as fallback when the session has no live PTY,
   // in which case `liveInWorktree[id]` is `undefined`.
   const liveInWorktree = useAppStore((s) => s.liveInWorktree[session.id]);
+  const notificationsSilenced = useAppStore((s) =>
+    Boolean(s.silencedSessionIds[session.id]),
+  );
   const inWorktree = liveInWorktree ?? hasRecordedWorktree(session);
   const processSummary = summarizeSessionProcesses(session.active_processes);
   const hasContextMetadata = Boolean(currentPullRequest || processSummary);
@@ -3241,6 +3260,15 @@ function SessionRowLabel({
             className="shrink-0 text-accent"
             aria-label={sidebarText(t, "sidebar.aria.controlSession")}
           />
+        ) : null}
+        {notificationsSilenced ? (
+          <span
+            className="inline-flex shrink-0 text-fg-muted"
+            aria-label={sidebarText(t, "sidebar.aria.notificationsSilenced")}
+            title={sidebarText(t, "sidebar.aria.notificationsSilenced")}
+          >
+            <BellOff size={10} aria-hidden />
+          </span>
         ) : null}
       </span>
       {metadataText ? (

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -18,6 +18,8 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   Activity,
   BarChart3,
+  Bell,
+  BellOff,
   Bot,
   CheckCircle2,
   ChevronDown,
@@ -1130,6 +1132,10 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
   const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
   const setWorkspaceViewMode = useAppStore((s) => s.setWorkspaceViewMode);
   const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
+  const sessionSilenced = useAppStore((s) =>
+    Boolean(s.silencedSessionIds[session.id]),
+  );
+  const setSessionSilenced = useAppStore((s) => s.setSessionSilenced);
   const editorCommand = useSettings((s) => s.settings.editor.command);
   const editorConfigured = editorCommand.trim().length > 0;
   const isGeneratingTitle = useAppStore((s) =>
@@ -1264,6 +1270,16 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
         },
       },
       {
+        label: sidebarText(
+          t,
+          sessionSilenced
+            ? "sidebar.actions.resumeNotifications"
+            : "sidebar.actions.silenceNotifications",
+        ),
+        icon: sessionSilenced ? <Bell size={12} /> : <BellOff size={12} />,
+        onClick: () => setSessionSilenced(session.id, !sessionSilenced),
+      },
+      {
         label: manualDone
           ? t("workspace.kanban.actions.restoreFromDone")
           : t("workspace.kanban.actions.markAsDone"),
@@ -1351,12 +1367,14 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
       renameSession,
       requestRemoveSession,
       selectSession,
+      sessionSilenced,
       session.branch,
       session.id,
       session.mode,
       session.name,
       session.worktree_path,
       showToast,
+      setSessionSilenced,
       setWorkspaceViewMode,
       t,
       transcriptPath,
@@ -1417,6 +1435,18 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
                 </span>
               )}
             </span>
+            {sessionSilenced ? (
+              <span
+                className="inline-flex shrink-0 text-fg-muted"
+                aria-label={sidebarText(
+                  t,
+                  "sidebar.aria.notificationsSilenced",
+                )}
+                title={sidebarText(t, "sidebar.aria.notificationsSilenced")}
+              >
+                <BellOff size={11} aria-hidden />
+              </span>
+            ) : null}
             {stalled ? (
               <span
                 className="shrink-0 rounded bg-danger/15 px-1 py-px text-[9px] font-semibold uppercase leading-4 tracking-wide text-danger"
@@ -1724,6 +1754,10 @@ function KanbanTerminalPopover({
   const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
   const setWorkspaceViewMode = useAppStore((s) => s.setWorkspaceViewMode);
   const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
+  const sessionSilenced = useAppStore((s) =>
+    Boolean(s.silencedSessionIds[session.id]),
+  );
+  const setSessionSilenced = useAppStore((s) => s.setSessionSilenced);
   const editorCommand = useSettings((s) => s.settings.editor.command);
   const editorConfigured = editorCommand.trim().length > 0;
   const isGeneratingTitle = useAppStore((s) =>
@@ -1880,6 +1914,16 @@ function KanbanTerminalPopover({
             });
         },
       },
+      {
+        label: sidebarText(
+          t,
+          sessionSilenced
+            ? "sidebar.actions.resumeNotifications"
+            : "sidebar.actions.silenceNotifications",
+        ),
+        icon: sessionSilenced ? <Bell size={12} /> : <BellOff size={12} />,
+        onClick: () => setSessionSilenced(session.id, !sessionSilenced),
+      },
       workspaceContextMenuGroupTitle(t, "open"),
       {
         label: sidebarText(t, "sidebar.actions.openWorktreeInEditor"),
@@ -1956,11 +2000,13 @@ function KanbanTerminalPopover({
       openWorkSummaryTab,
       requestRemoveSession,
       selectSession,
+      sessionSilenced,
       session.branch,
       session.id,
       session.name,
       session.worktree_path,
       showToast,
+      setSessionSilenced,
       setWorkspaceViewMode,
       t,
       transcriptPath,
@@ -2217,43 +2263,60 @@ function KanbanTerminalPopover({
             <WorkspaceSessionIcon session={session} scope="console" size="md" />
           </span>
           <div className="min-w-0 flex-1">
-            {editingTitle ? (
-              <KanbanTerminalPopoverTitleInput
-                initial={session.name}
-                onSubmit={(next) => void submitTitleRename(next)}
-                onCancel={() => setEditingTitle(false)}
-              />
-            ) : (
-              <h3
-                tabIndex={canRename ? 0 : undefined}
-                data-kanban-title-edit-trigger
-                onDoubleClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  if (canRename) setEditingTitle(true);
-                }}
-                onKeyDown={(event) => {
-                  if (!canRename) return;
-                  if (
-                    event.key !== "F2" &&
-                    event.key !== "Enter" &&
-                    event.key !== " "
-                  ) {
-                    return;
-                  }
-                  event.preventDefault();
-                  event.stopPropagation();
-                  setEditingTitle(true);
-                }}
-                className={cn(
-                  "truncate rounded-sm text-sm font-semibold text-fg",
-                  canRename &&
-                    "cursor-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
-                )}
-              >
-                {title}
-              </h3>
-            )}
+            <div className="flex min-w-0 items-center gap-1.5">
+              {editingTitle ? (
+                <KanbanTerminalPopoverTitleInput
+                  initial={session.name}
+                  onSubmit={(next) => void submitTitleRename(next)}
+                  onCancel={() => setEditingTitle(false)}
+                />
+              ) : (
+                <h3
+                  tabIndex={canRename ? 0 : undefined}
+                  data-kanban-title-edit-trigger
+                  onDoubleClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    if (canRename) setEditingTitle(true);
+                  }}
+                  onKeyDown={(event) => {
+                    if (!canRename) return;
+                    if (
+                      event.key !== "F2" &&
+                      event.key !== "Enter" &&
+                      event.key !== " "
+                    ) {
+                      return;
+                    }
+                    event.preventDefault();
+                    event.stopPropagation();
+                    setEditingTitle(true);
+                  }}
+                  className={cn(
+                    "min-w-0 flex-1 truncate rounded-sm text-sm font-semibold text-fg",
+                    canRename &&
+                      "cursor-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+                  )}
+                >
+                  {title}
+                </h3>
+              )}
+              {sessionSilenced ? (
+                <span
+                  className="inline-flex shrink-0 text-fg-muted"
+                  aria-label={sidebarText(
+                    t,
+                    "sidebar.aria.notificationsSilenced",
+                  )}
+                  title={sidebarText(
+                    t,
+                    "sidebar.aria.notificationsSilenced",
+                  )}
+                >
+                  <BellOff size={12} aria-hidden />
+                </span>
+              ) : null}
+            </div>
             <div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden text-[11px] font-medium leading-4 text-fg-muted">
               <WorkspaceSessionTerminalPopoverMetaItem
                 icon={

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -84,6 +84,7 @@ describe("notifications", () => {
       ],
       activeSessionId: null,
       sessionNotifications: [],
+      silencedSessionIds: {},
       sessionsLoadedCleanly: true,
     });
     useSettings.setState({
@@ -154,6 +155,56 @@ describe("notifications", () => {
     ]);
     expect(useAppStore.getState().sessionNotifications[0]?.readAt).toBeUndefined();
     dispose();
+  });
+
+  it("suppresses system notifications and activity while a session is silenced", async () => {
+    useAppStore.setState({
+      silencedSessionIds: { "session-1": true },
+    });
+    const disposeSystem = startSessionNotificationWatcher();
+    const disposeActivity = startSessionActivityInboxWatcher();
+
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "waiting_for_input",
+          updated_at: "2026-01-01T00:01:00Z",
+        }),
+      ],
+    });
+    await flushPromises();
+
+    expect(mocks.sendNotification).not.toHaveBeenCalled();
+    expect(useAppStore.getState().sessionNotifications).toEqual([]);
+
+    useAppStore.getState().setSessionSilenced("session-1", false);
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "working",
+          updated_at: "2026-01-01T00:02:00Z",
+        }),
+      ],
+    });
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "errored",
+          updated_at: "2026-01-01T00:03:00Z",
+        }),
+      ],
+    });
+    await flushPromises();
+
+    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().sessionNotifications).toMatchObject([
+      {
+        sessionId: "session-1",
+        kind: "errored",
+      },
+    ]);
+    disposeSystem();
+    disposeActivity();
   });
 
   it("does not record in-app activity for the focused session transition", () => {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -169,6 +169,7 @@ export function startSessionNotificationWatcher(): () => void {
       const prev = lastStatus.get(s.id);
       lastStatus.set(s.id, s.status);
       if (prev === undefined) continue;
+      if (state.silencedSessionIds[s.id]) continue;
       const { notify, key } = shouldNotifyTransition(prev, s.status);
       if (!notify || !key || !settings.events[key]) continue;
       if (isSessionFocused(s.id, state.activeSessionId)) {
@@ -205,6 +206,7 @@ export function startSessionActivityInboxWatcher(): () => void {
       const prev = lastStatus.get(s.id);
       lastStatus.set(s.id, s.status);
       if (prev === undefined) continue;
+      if (state.silencedSessionIds[s.id]) continue;
 
       const kind = notificationKindForTransition(prev, s.status);
       if (!kind) continue;
@@ -253,8 +255,9 @@ async function fire(
   session: Session,
   next: SessionStatus,
 ): Promise<void> {
+  if (useAppStore.getState().silencedSessionIds[session.id]) return;
   const ok = await ensurePermission();
-  if (!ok) return;
+  if (!ok || useAppStore.getState().silencedSessionIds[session.id]) return;
   try {
     sendNotification({
       title: `${projectNameFor(session)} — ${session.name}`,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1134,6 +1134,8 @@
       "rename": "Rename",
       "regenerateName": "Regenerate Name",
       "openWorkSummary": "Open Work Summary",
+      "silenceNotifications": "Silence Notifications",
+      "resumeNotifications": "Resume Notifications",
       "forkClaudeSession": "Fork Claude Session",
       "forkSession": "Fork Session",
       "forkClaudeInNewWorktree": "Fork Claude in New Worktree",
@@ -1179,7 +1181,8 @@
       "worktree": "worktree",
       "controlSession": "control session",
       "chatSession": "chat session",
-      "generatingSessionTitle": "Generating session title"
+      "generatingSessionTitle": "Generating session title",
+      "notificationsSilenced": "Notifications silenced"
     },
     "localTerminals": {
       "title": "Instant Sessions",
@@ -1239,6 +1242,7 @@
       "chatSession": "chat session",
       "workSummary": "work summary",
       "generatingSessionTitle": "Generating session title",
+      "notificationsSilenced": "Notifications silenced",
       "closeSession": "Close session",
       "closeTab": "Close tab"
     },
@@ -1254,6 +1258,8 @@
       "rename": "Rename",
       "regenerateName": "Regenerate Name",
       "openWorkSummary": "Open Work Summary",
+      "silenceNotifications": "Silence Notifications",
+      "resumeNotifications": "Resume Notifications",
       "forkClaudeSession": "Fork Claude Session",
       "forkSession": "Fork Session",
       "forkClaudeInNewWorktree": "Fork Claude in New Worktree",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1134,6 +1134,8 @@
       "rename": "이름 변경",
       "regenerateName": "이름 다시 생성",
       "openWorkSummary": "작업 요약 열기",
+      "silenceNotifications": "알림 끄기",
+      "resumeNotifications": "알림 다시 켜기",
       "forkClaudeSession": "Claude 세션 포크",
       "forkSession": "세션 포크",
       "forkClaudeInNewWorktree": "새 워크트리에 Claude 포크",
@@ -1179,7 +1181,8 @@
       "worktree": "워크트리",
       "controlSession": "컨트롤 세션",
       "chatSession": "채팅 세션",
-      "generatingSessionTitle": "세션 제목 생성 중"
+      "generatingSessionTitle": "세션 제목 생성 중",
+      "notificationsSilenced": "알림 꺼짐"
     },
     "localTerminals": {
       "title": "인스턴트 세션",
@@ -1239,6 +1242,7 @@
       "chatSession": "채팅 세션",
       "workSummary": "작업 요약",
       "generatingSessionTitle": "세션 제목 생성 중",
+      "notificationsSilenced": "알림 꺼짐",
       "closeSession": "세션 닫기",
       "closeTab": "탭 닫기"
     },
@@ -1254,6 +1258,8 @@
       "rename": "이름 변경",
       "regenerateName": "이름 다시 생성",
       "openWorkSummary": "작업 요약 열기",
+      "silenceNotifications": "알림 끄기",
+      "resumeNotifications": "알림 다시 켜기",
       "forkClaudeSession": "Claude 세션 포크",
       "forkSession": "세션 포크",
       "forkClaudeInNewWorktree": "새 워크트리에 Claude 포크",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -187,6 +187,7 @@ function resetStore(): void {
       prAccountByRepo: {},
       pendingTerminalInput: {},
       sessionNotifications: [],
+      silencedSessionIds: {},
       multiInputEnabled: false,
       loading: false,
       error: null,
@@ -328,6 +329,29 @@ describe("needs-input navigation", () => {
 });
 
 describe("sessionNotifications", () => {
+  it("ignores new activity for silenced sessions", () => {
+    useAppStore.getState().setSessionSilenced("s1", true);
+
+    useAppStore
+      .getState()
+      .addSessionNotification(notification("n1", { sessionId: "s1" }));
+    useAppStore
+      .getState()
+      .addSessionNotification(notification("n2", { sessionId: "s2" }));
+
+    expect(
+      useAppStore.getState().sessionNotifications.map((item) => item.id),
+    ).toEqual(["n2"]);
+    expect(useAppStore.getState().silencedSessionIds).toEqual({ s1: true });
+  });
+
+  it("removes a session from the silence set when notifications resume", () => {
+    useAppStore.getState().setSessionSilenced("s1", true);
+    useAppStore.getState().setSessionSilenced("s1", false);
+
+    expect(useAppStore.getState().silencedSessionIds).toEqual({});
+  });
+
   it("adds newest notifications first and caps the in-memory list", () => {
     for (let i = 0; i < 105; i += 1) {
       useAppStore.getState().addSessionNotification(

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1559,7 +1559,7 @@ describe("removeSession", () => {
     expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual(["a2"]);
   });
 
-  it("removes session activity locally before the backend delete finishes", async () => {
+  it("removes session activity and silence state locally before backend deletion finishes", async () => {
     const a1 = session("a1", REPO_A);
     const a2 = session("a2", REPO_A);
     await seed([project(REPO_A, 0)], [a1, a2]);
@@ -1569,6 +1569,8 @@ describe("removeSession", () => {
     useAppStore.getState().addSessionNotification(
       notification("n2", { sessionId: "a2" }),
     );
+    useAppStore.getState().setSessionSilenced("a1", true);
+    useAppStore.getState().setSessionSilenced("a2", true);
 
     const pending = deferred<null>();
     mockApi.removeSession.mockReturnValueOnce(pending.promise);
@@ -1580,6 +1582,7 @@ describe("removeSession", () => {
     expect(
       useAppStore.getState().sessionNotifications.map((item) => item.id),
     ).toEqual(["n2"]);
+    expect(useAppStore.getState().silencedSessionIds).toEqual({ a2: true });
 
     pending.resolve(null);
     await removal;
@@ -2198,7 +2201,7 @@ describe("reconcile via refreshSessions", () => {
     expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1"]);
   });
 
-  it("drops activity for sessions removed by backend refresh", async () => {
+  it("drops activity and silence state for sessions removed by backend refresh", async () => {
     await seed(
       [project(REPO_A, 0)],
       [session("a1", REPO_A), session("a2", REPO_A)],
@@ -2209,6 +2212,8 @@ describe("reconcile via refreshSessions", () => {
     useAppStore.getState().addSessionNotification(
       notification("n2", { sessionId: "a2" }),
     );
+    useAppStore.getState().setSessionSilenced("a1", true);
+    useAppStore.getState().setSessionSilenced("a2", true);
 
     mockApi.listSessions.mockResolvedValueOnce([session("a1", REPO_A)]);
     await useAppStore.getState().refreshSessions();
@@ -2216,6 +2221,7 @@ describe("reconcile via refreshSessions", () => {
     expect(
       useAppStore.getState().sessionNotifications.map((item) => item.id),
     ).toEqual(["n1"]);
+    expect(useAppStore.getState().silencedSessionIds).toEqual({ a1: true });
   });
 
   it("keeps activity when an unclean empty session load may be transient", async () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -361,6 +361,7 @@ interface AppStateModel {
    */
   pendingTerminalInput: Record<string, PendingTerminalInput>;
   sessionNotifications: SessionNotification[];
+  silencedSessionIds: Record<string, true>;
   multiInputEnabled: boolean;
   loading: boolean;
   error: string | null;
@@ -498,6 +499,7 @@ interface AppStateModel {
   markAllSessionNotificationsRead: () => void;
   dismissSessionNotification: (id: string) => void;
   clearReadSessionNotifications: () => void;
+  setSessionSilenced: (sessionId: string, silenced: boolean) => void;
   toggleMultiInput: () => boolean;
   /** Open a readonly code viewer tab for `path` in the focused pane. */
   openCodeViewerTab: (
@@ -1547,6 +1549,7 @@ export const useAppStore = create<AppStateModel>()(
   prAccountByRepo: {},
   pendingTerminalInput: {},
   sessionNotifications: [],
+  silencedSessionIds: {},
   multiInputEnabled: false,
   loading: false,
   error: null,
@@ -1615,6 +1618,9 @@ export const useAppStore = create<AppStateModel>()(
                 sessionIds.has(notification.sessionId),
               )
             : s.sessionNotifications,
+          silencedSessionIds: shouldPruneActivity
+            ? retainSessionIds(s.silencedSessionIds, sessionIds)
+            : s.silencedSessionIds,
           workspaces: reconciled.workspaces,
           projectFolders: reconciled.projectFolders,
           sessionFolderIds: reconciled.sessionFolderIds,
@@ -1754,6 +1760,9 @@ export const useAppStore = create<AppStateModel>()(
               sessionIds.has(notification.sessionId),
             )
           : s.sessionNotifications,
+        silencedSessionIds: shouldPruneActivity
+          ? retainSessionIds(s.silencedSessionIds, sessionIds)
+          : s.silencedSessionIds,
         workspaces: reconciled.workspaces,
         projectFolders: reconciled.projectFolders,
         sessionFolderIds: reconciled.sessionFolderIds,
@@ -2928,6 +2937,9 @@ export const useAppStore = create<AppStateModel>()(
         s.terminalPopupSessionId && removalIds.has(s.terminalPopupSessionId)
           ? null
           : s.terminalPopupSessionId;
+      const remainingSessionIds = new Set(
+        sessions.map((session) => session.id),
+      );
 
       return {
         sessions,
@@ -2938,6 +2950,10 @@ export const useAppStore = create<AppStateModel>()(
         terminalPopupSessionId,
         sessionNotifications: s.sessionNotifications.filter(
           (notification) => !removalIds.has(notification.sessionId),
+        ),
+        silencedSessionIds: retainSessionIds(
+          s.silencedSessionIds,
+          remainingSessionIds,
         ),
         workspaces: reconciled.workspaces,
         projectFolders: reconciled.projectFolders,
@@ -3237,6 +3253,9 @@ export const useAppStore = create<AppStateModel>()(
         )
           ? defaultProjectFolderId(repoPath)
           : s.activeProjectFolderId;
+        const remainingSessionIds = new Set(
+          sessions.map((session) => session.id),
+        );
         const reconciled = reconcileWorkspaces(
           sessions,
           s.projects,
@@ -3254,6 +3273,10 @@ export const useAppStore = create<AppStateModel>()(
           pendingTerminalInput,
           sessionNotifications: s.sessionNotifications.filter(
             (notification) => !removedSessionIds.has(notification.sessionId),
+          ),
+          silencedSessionIds: retainSessionIds(
+            s.silencedSessionIds,
+            remainingSessionIds,
           ),
           workspaces: reconciled.workspaces,
           projectFolders: reconciled.projectFolders,
@@ -3475,6 +3498,7 @@ export const useAppStore = create<AppStateModel>()(
   addSessionNotification(notification) {
     const maxHistory = useSettings.getState().settings.notifications.maxHistory;
     set((s) => {
+      if (s.silencedSessionIds[notification.sessionId]) return s;
       const existing = s.sessionNotifications.filter(
         (n) => n.id !== notification.id,
       );
@@ -3575,6 +3599,20 @@ export const useAppStore = create<AppStateModel>()(
         (notification) => !notification.readAt,
       ),
     }));
+  },
+
+  setSessionSilenced(sessionId, silenced) {
+    set((s) => {
+      const currentlySilenced = s.silencedSessionIds[sessionId] === true;
+      if (currentlySilenced === silenced) return s;
+      const silencedSessionIds = { ...s.silencedSessionIds };
+      if (silenced) {
+        silencedSessionIds[sessionId] = true;
+      } else {
+        delete silencedSessionIds[sessionId];
+      }
+      return { silencedSessionIds };
+    });
   },
 
   toggleMultiInput() {
@@ -3831,6 +3869,7 @@ export const useAppStore = create<AppStateModel>()(
         rightTab: state.rightTab,
         rightTabByGroup: state.rightTabByGroup,
         sessionNotifications: state.sessionNotifications,
+        silencedSessionIds: state.silencedSessionIds,
         workspaceTabs: Object.fromEntries(
           Object.entries(state.workspaceTabs).filter(([, tab]) =>
             isRestorableWorkspaceTab(tab),
@@ -3990,6 +4029,9 @@ export const useAppStore = create<AppStateModel>()(
           state.sessionNotifications ?? [],
           useSettings.getState().settings.notifications.maxHistory,
         );
+        state.silencedSessionIds = normalizeSilencedSessionIds(
+          state.silencedSessionIds,
+        );
         state.activeProjectFolderId =
           state.activeProjectFolderId ??
           (state.activeProject
@@ -4083,5 +4125,24 @@ function normalizeStringRecord(value: unknown): Record<string, string> {
     Object.entries(value as Record<string, unknown>).filter(
       (entry): entry is [string, string] => typeof entry[1] === "string",
     ),
+  );
+}
+
+function normalizeSilencedSessionIds(value: unknown): Record<string, true> {
+  if (!value || typeof value !== "object") return {};
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).filter(
+      (entry): entry is [string, true] =>
+        entry[0].trim().length > 0 && entry[1] === true,
+    ),
+  );
+}
+
+function retainSessionIds(
+  value: Record<string, true>,
+  sessionIds: ReadonlySet<string>,
+): Record<string, true> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([sessionId]) => sessionIds.has(sessionId)),
   );
 }

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -613,6 +613,9 @@ test.describe("workspace kanban mode", () => {
       page.getByRole("menuitem", { name: "Open Work Summary" }),
     ).toBeVisible();
     await expect(
+      page.getByRole("menuitem", { name: "Silence Notifications" }),
+    ).toBeVisible();
+    await expect(
       page.getByRole("menuitem", { name: "Reveal in Finder" }),
     ).toBeVisible();
     await expect(
@@ -673,6 +676,9 @@ test.describe("workspace kanban mode", () => {
     ).toBeVisible();
     await expect(
       page.getByRole("menuitem", { name: "Open Work Summary" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Silence Notifications" }),
     ).toBeVisible();
     await expect(
       page.getByRole("menuitem", { name: "Reveal in Finder" }),

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -350,6 +350,77 @@ test.describe("sidebar: project lifecycle", () => {
     expect(calls[0]).toMatchObject({ id: "session-1", force: true });
   });
 
+  test("session notification silence is shared by sidebar and tab menus", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "session-1",
+        name: "quiet-me",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "working",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+    ]);
+
+    await page.goto("/");
+
+    await page
+      .locator("aside")
+      .getByRole("button", { name: /quiet-me/ })
+      .click({ button: "right" });
+    await page
+      .getByRole("menuitem", { name: "Silence Notifications", exact: true })
+      .click();
+
+    await page
+      .locator('[data-tab-drag-handle="session-1"]')
+      .click({ button: "right" });
+    await expect(
+      page.getByRole("menuitem", {
+        name: "Resume Notifications",
+        exact: true,
+      }),
+    ).toBeVisible();
+    await page
+      .getByRole("menuitem", {
+        name: "Resume Notifications",
+        exact: true,
+      })
+      .click();
+
+    await page
+      .locator("aside")
+      .getByRole("button", { name: /quiet-me/ })
+      .click({ button: "right" });
+    await expect(
+      page.getByRole("menuitem", {
+        name: "Silence Notifications",
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
+
   test("ordinary terminal sessions cannot regenerate a session name", async ({
     page,
     tauri,

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -385,17 +385,24 @@ test.describe("sidebar: project lifecycle", () => {
 
     await page.goto("/");
 
-    await page
+    const sidebarSession = page
       .locator("aside")
-      .getByRole("button", { name: /quiet-me/ })
-      .click({ button: "right" });
+      .getByRole("button", { name: /quiet-me/ });
+    await sidebarSession.click({ button: "right" });
     await page
       .getByRole("menuitem", { name: "Silence Notifications", exact: true })
       .click();
+    await expect(
+      sidebarSession.getByLabel("Notifications silenced", { exact: true }),
+    ).toBeVisible();
 
-    await page
-      .locator('[data-tab-drag-handle="session-1"]')
-      .click({ button: "right" });
+    await page.reload();
+
+    const sessionTab = page.locator('[data-tab-drag-handle="session-1"]');
+    await expect(
+      sessionTab.getByLabel("Notifications silenced", { exact: true }),
+    ).toBeVisible();
+    await sessionTab.click({ button: "right" });
     await expect(
       page.getByRole("menuitem", {
         name: "Resume Notifications",
@@ -409,10 +416,15 @@ test.describe("sidebar: project lifecycle", () => {
       })
       .click();
 
-    await page
+    const resumedSidebarSession = page
       .locator("aside")
-      .getByRole("button", { name: /quiet-me/ })
-      .click({ button: "right" });
+      .getByRole("button", { name: /quiet-me/ });
+    await expect(
+      resumedSidebarSession.getByLabel("Notifications silenced", {
+        exact: true,
+      }),
+    ).toHaveCount(0);
+    await resumedSidebarSession.click({ button: "right" });
     await expect(
       page.getByRole("menuitem", {
         name: "Silence Notifications",

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -474,11 +474,11 @@ test.describe("sidebar: project lifecycle", () => {
       clientY: 300,
     });
     await page
-      .getByRole("menuitem", { name: "Silence Notifications", exact: true })
+      .getByRole("menuitem", { name: "Resume Notifications", exact: true })
       .click();
     await expect(
-      sessionTab.getByLabel("Notifications silenced", { exact: true }),
-    ).toBeVisible();
+      localSession.getByLabel("Notifications silenced", { exact: true }),
+    ).toHaveCount(0);
   });
 
   test("ordinary terminal sessions cannot regenerate a session name", async ({

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -350,7 +350,7 @@ test.describe("sidebar: project lifecycle", () => {
     expect(calls[0]).toMatchObject({ id: "session-1", force: true });
   });
 
-  test("session notification silence is shared by sidebar and tab menus", async ({
+  test("session notification silence is shared by every session menu", async ({
     page,
     tauri,
   }) => {
@@ -362,6 +362,7 @@ test.describe("sidebar: project lifecycle", () => {
         position: 0,
       },
     ]);
+    await tauri.handle("detect_session_statuses", () => []);
     await tauri.respond("list_sessions", [
       {
         id: "session-1",
@@ -379,6 +380,24 @@ test.describe("sidebar: project lifecycle", () => {
         kind: "regular",
         owner: { kind: "user" },
         position: 0,
+        in_worktree: false,
+      },
+      {
+        id: "local-1",
+        name: "local-quiet",
+        repo_path: "/Users/tester",
+        worktree_path: "/Users/tester",
+        branch: "HEAD",
+        isolated: false,
+        project_scoped: false,
+        status: "working",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 1,
         in_worktree: false,
       },
     ]);
@@ -430,6 +449,35 @@ test.describe("sidebar: project lifecycle", () => {
         name: "Silence Notifications",
         exact: true,
       }),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    const localSession = page
+      .getByRole("region", { name: "Local terminal sessions" })
+      .getByRole("button", { name: /local-quiet/ });
+    await localSession.click({ button: "right" });
+    const localSilenceAction = page.getByRole("menuitem", {
+      name: "Silence Notifications",
+      exact: true,
+    });
+    await expect(localSilenceAction).toBeVisible();
+    await localSilenceAction.click();
+    await expect(
+      localSession.getByLabel("Notifications silenced", { exact: true }),
+    ).toBeVisible();
+
+    await page.locator("[data-pane-body]").first().dispatchEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      button: 2,
+      clientX: 400,
+      clientY: 300,
+    });
+    await page
+      .getByRole("menuitem", { name: "Silence Notifications", exact: true })
+      .click();
+    await expect(
+      sessionTab.getByLabel("Notifications silenced", { exact: true }),
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary
Adds a persistent per-session silence control so noisy sessions can keep running without producing system notifications or Acorn Activity items.

1. **Persistent silence state** — store silenced session IDs in the persisted workspace state, normalize hydrated values, and prune IDs when sessions disappear.
2. **Notification filtering** — suppress both OS notifications and in-app Activity at the watcher and store boundaries, including an async permission-check race guard.
3. **Consistent session UI** — expose Silence/Resume actions across project rows, instant-session rows, tabs, active Pane menus, Kanban cards, and Kanban terminal popovers.
4. **Visible state** — show a localized `BellOff` indicator on silenced sidebar rows, tabs, Kanban cards, and popover headers.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Noisy background session | Every configured status transition can create OS and Activity alerts | New alerts are suppressed only for that session |
| Session menus | Notification control unavailable or inconsistent by surface | All six direct session menus share the same Silence/Resume state |
| App restart | No per-session notification preference | Silence state is restored from local persisted workspace state |
| Session removal | N/A | Persisted silence IDs are removed with deleted sessions |

## Design notes

- Silence is frontend UI state rather than a backend session schema field because both notification channels are frontend-owned and already persist alongside Activity history.
- Status snapshots continue advancing while a session is silenced, so resuming notifications does not replay transitions that happened during silence.
- Existing Activity history remains visible; only new items after silencing are suppressed.
- The OS notification path checks silence before and after the asynchronous permission lookup to avoid sending after a user silences the session mid-flight.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm test` — 86 files, 955 tests pass
- [x] `pnpm run build` — production build passes
- [x] `CI=1 pnpm exec playwright test tests/e2e/sidebar.spec.ts tests/e2e/kanban.spec.ts` — 60 tests pass on a fresh Vite server
