### PR TITLE
fix(kanban): hide agent control context from conversation previews

### DIFF
--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -357,8 +357,8 @@ fn codex_preview_role_and_text(
 ) -> (TranscriptRole, Option<String>) {
     match event_role {
         TranscriptRole::User => {
-            let text =
-                codex_message_preview_text(event).filter(|text| !looks_like_context_block(text));
+            let text = codex_message_preview_text(event)
+                .filter(|text| !looks_like_preview_context_block(text));
             if text.is_some() {
                 (TranscriptRole::User, text)
             } else {
@@ -408,8 +408,9 @@ fn preview_from_content_value(content: &Value) -> Option<String> {
 }
 
 fn claude_preview_text(text: &str) -> Option<String> {
-    collapsible_text(text)
-        .filter(|text| !looks_like_context_block(text) && !looks_like_claude_control_text(text))
+    collapsible_text(text).filter(|text| {
+        !looks_like_preview_context_block(text) && !looks_like_claude_control_text(text)
+    })
 }
 
 fn codex_event_texts(value: &Value, event: &Value) -> Vec<String> {
@@ -632,9 +633,21 @@ fn looks_like_context_block(text: &str) -> bool {
         || lower.contains("<cwd>")
         || lower.contains("# agents.md")
         || lower.contains("<instructions>")
-        || (lower.trim_start().starts_with("<skill>")
-            && lower.contains("<name>")
-            && lower.contains("<path>"))
+        || looks_like_skill_context_block(text)
+}
+
+fn looks_like_preview_context_block(text: &str) -> bool {
+    let lower = text.trim_start().to_ascii_lowercase();
+    lower.starts_with("<environment_context>")
+        || lower.starts_with("<cwd>")
+        || lower.starts_with("# agents.md instructions for ")
+        || lower.starts_with("<instructions>")
+        || looks_like_skill_context_block(text)
+}
+
+fn looks_like_skill_context_block(text: &str) -> bool {
+    let lower = text.trim_start().to_ascii_lowercase();
+    lower.starts_with("<skill>") && lower.contains("<name>") && lower.contains("<path>")
 }
 
 fn extract_cwd_from_text(texts: &[String]) -> Option<String> {

--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -205,7 +205,7 @@ fn parse_claude_value(value: &Value) -> ParsedTranscriptLine {
         TranscriptRole::Assistant => first_claude_display_text(&texts),
         TranscriptRole::Other => None,
     };
-    let preview_text = match raw_role {
+    let preview_text = match role {
         TranscriptRole::User | TranscriptRole::Assistant => claude_message_preview_text(value),
         TranscriptRole::Other => None,
     };
@@ -215,7 +215,7 @@ fn parse_claude_value(value: &Value) -> ParsedTranscriptLine {
         state_text: text.clone(),
         text,
         state_role: role,
-        preview_role: raw_role,
+        preview_role: role,
         preview_text,
         turn_state: claude_turn_state(value),
         session_id: string_at(Some(value), "sessionId"),
@@ -390,7 +390,7 @@ fn claude_message_preview_text(value: &Value) -> Option<String> {
 
 fn preview_from_content_value(content: &Value) -> Option<String> {
     if let Some(text) = content.as_str() {
-        return collapsible_text(text);
+        return claude_preview_text(text);
     }
     let items = content.as_array()?;
     for item in items {
@@ -400,11 +400,16 @@ fn preview_from_content_value(content: &Value) -> Option<String> {
         let Some(text) = item.get("text").and_then(Value::as_str) else {
             continue;
         };
-        if let Some(text) = collapsible_text(text) {
+        if let Some(text) = claude_preview_text(text) {
             return Some(text);
         }
     }
     None
+}
+
+fn claude_preview_text(text: &str) -> Option<String> {
+    collapsible_text(text)
+        .filter(|text| !looks_like_context_block(text) && !looks_like_claude_control_text(text))
 }
 
 fn codex_event_texts(value: &Value, event: &Value) -> Vec<String> {

--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -356,7 +356,15 @@ fn codex_preview_role_and_text(
     event_role: TranscriptRole,
 ) -> (TranscriptRole, Option<String>) {
     match event_role {
-        TranscriptRole::User => (TranscriptRole::User, codex_message_preview_text(event)),
+        TranscriptRole::User => {
+            let text =
+                codex_message_preview_text(event).filter(|text| !looks_like_context_block(text));
+            if text.is_some() {
+                (TranscriptRole::User, text)
+            } else {
+                (TranscriptRole::Other, None)
+            }
+        }
         TranscriptRole::Assistant => (
             TranscriptRole::Assistant,
             codex_message_preview_text(event)
@@ -619,6 +627,9 @@ fn looks_like_context_block(text: &str) -> bool {
         || lower.contains("<cwd>")
         || lower.contains("# agents.md")
         || lower.contains("<instructions>")
+        || (lower.trim_start().starts_with("<skill>")
+            && lower.contains("<name>")
+            && lower.contains("<path>"))
 }
 
 fn extract_cwd_from_text(texts: &[String]) -> Option<String> {

--- a/src-tauri/src/agent_resume.rs
+++ b/src-tauri/src/agent_resume.rs
@@ -636,7 +636,7 @@ mod tests {
         let path = base.path().join("transcript.jsonl");
         fs::write(
             &path,
-            r#"{"type":"USER_INPUT","status":"DONE","content":"<USER_REQUEST>Make the board calmer.</USER_REQUEST>"}
+            r#"{"type":"USER_INPUT","status":"DONE","content":"<USER_REQUEST>Make the board calmer.</USER_REQUEST><ADDITIONAL_METADATA>Internal model settings.</ADDITIONAL_METADATA>"}
 {"type":"PLANNER_RESPONSE","status":"DONE","content":"I will reduce the terminal surface."}
 "#,
         )

--- a/src-tauri/src/agent_resume.rs
+++ b/src-tauri/src/agent_resume.rs
@@ -501,6 +501,48 @@ mod tests {
     }
 
     #[test]
+    fn claude_conversation_preview_skips_meta_messages() {
+        let base = ScratchDir::new("claude-meta-preview");
+        let path = base.path().join("transcript.jsonl");
+        fs::write(
+            &path,
+            r#"{"type":"user","message":{"content":"Please review the pull request."}}
+{"type":"assistant","message":{"content":"The pull request is ready."}}
+{"type":"user","isMeta":true,"message":{"content":"Synthetic session metadata."}}
+"#,
+        )
+        .unwrap();
+
+        let preview = extract_conversation_preview(AgentKind::Claude, &path).unwrap();
+
+        assert_eq!(
+            preview.last_user_message.as_deref(),
+            Some("Please review the pull request.")
+        );
+    }
+
+    #[test]
+    fn claude_conversation_preview_skips_control_messages() {
+        let base = ScratchDir::new("claude-control-preview");
+        let path = base.path().join("transcript.jsonl");
+        fs::write(
+            &path,
+            r#"{"type":"user","message":{"content":"Please review the pull request."}}
+{"type":"assistant","message":{"content":"The pull request is ready."}}
+{"type":"user","message":{"content":"<command-name>/exit</command-name>\n<command-message>exit</command-message>"}}
+"#,
+        )
+        .unwrap();
+
+        let preview = extract_conversation_preview(AgentKind::Claude, &path).unwrap();
+
+        assert_eq!(
+            preview.last_user_message.as_deref(),
+            Some("Please review the pull request.")
+        );
+    }
+
+    #[test]
     fn codex_conversation_preview_reads_payload_roles() {
         let base = ScratchDir::new("codex-conversation-preview");
         let path = base.path().join("rollout.jsonl");

--- a/src-tauri/src/agent_resume.rs
+++ b/src-tauri/src/agent_resume.rs
@@ -525,6 +525,25 @@ mod tests {
     }
 
     #[test]
+    fn codex_conversation_preview_skips_injected_skill_content() {
+        let base = ScratchDir::new("codex-skill-preview");
+        let path = base.path().join("rollout.jsonl");
+        fs::write(
+            &path,
+            r#"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"$merge-pr"}]}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<skill>\n<name>merge-pr</name>\n<path>/tmp/merge-pr/SKILL.md</path>\nInternal skill instructions\n</skill>"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Preflight passed."}]}}
+"#,
+        )
+        .unwrap();
+
+        let preview = extract_conversation_preview(AgentKind::Codex, &path).unwrap();
+
+        assert_eq!(preview.last_user_message.as_deref(), Some("$merge-pr"));
+        assert_eq!(preview.last_agent_message.as_deref(), Some("Preflight passed."));
+    }
+
+    #[test]
     fn codex_conversation_preview_does_not_treat_user_message_as_agent() {
         let base = ScratchDir::new("codex-user-message-preview");
         let path = base.path().join("rollout.jsonl");

--- a/src-tauri/src/agent_resume.rs
+++ b/src-tauri/src/agent_resume.rs
@@ -543,6 +543,26 @@ mod tests {
     }
 
     #[test]
+    fn claude_conversation_preview_keeps_inline_context_tag_mentions() {
+        let base = ScratchDir::new("claude-inline-context-preview");
+        let path = base.path().join("transcript.jsonl");
+        fs::write(
+            &path,
+            r#"{"type":"user","message":{"content":"Why does <cwd> appear in the preview?"}}
+{"type":"assistant","message":{"content":"I will inspect the preview parser."}}
+"#,
+        )
+        .unwrap();
+
+        let preview = extract_conversation_preview(AgentKind::Claude, &path).unwrap();
+
+        assert_eq!(
+            preview.last_user_message.as_deref(),
+            Some("Why does <cwd> appear in the preview?")
+        );
+    }
+
+    #[test]
     fn codex_conversation_preview_reads_payload_roles() {
         let base = ScratchDir::new("codex-conversation-preview");
         let path = base.path().join("rollout.jsonl");
@@ -585,6 +605,26 @@ mod tests {
         assert_eq!(
             preview.last_agent_message.as_deref(),
             Some("Preflight passed.")
+        );
+    }
+
+    #[test]
+    fn codex_conversation_preview_keeps_inline_context_tag_mentions() {
+        let base = ScratchDir::new("codex-inline-context-preview");
+        let path = base.path().join("rollout.jsonl");
+        fs::write(
+            &path,
+            r#"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Why does <cwd> appear in the preview?"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I will inspect the preview parser."}]}}
+"#,
+        )
+        .unwrap();
+
+        let preview = extract_conversation_preview(AgentKind::Codex, &path).unwrap();
+
+        assert_eq!(
+            preview.last_user_message.as_deref(),
+            Some("Why does <cwd> appear in the preview?")
         );
     }
 

--- a/src-tauri/src/agent_resume.rs
+++ b/src-tauri/src/agent_resume.rs
@@ -540,7 +540,10 @@ mod tests {
         let preview = extract_conversation_preview(AgentKind::Codex, &path).unwrap();
 
         assert_eq!(preview.last_user_message.as_deref(), Some("$merge-pr"));
-        assert_eq!(preview.last_agent_message.as_deref(), Some("Preflight passed."));
+        assert_eq!(
+            preview.last_agent_message.as_deref(),
+            Some("Preflight passed.")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Kanban conversation previews now show the latest real user/agent exchange instead of provider-injected control context.

1. **Codex preview filtering** — skip injected `<skill>` and other standalone context blocks while scanning transcript user messages.
2. **Claude preview filtering** — exclude `isMeta` records and local-command/system-control text from user-message previews.
3. **Provider-safe boundaries** — preserve normal user prompts that mention tags such as `<cwd>` inline, and lock Antigravity's existing `<USER_REQUEST>` extraction against trailing metadata.

## Expected impact
| Scenario | Before | After |
| --- | --- | --- |
| Codex skill invocation | Card could show `<skill><name>…` | Card shows the actual invocation, such as `$merge-pr` |
| Claude local/meta event | Card could show command or synthetic metadata | Card falls back to the latest real user message |
| User discusses a context tag | Prompt could be filtered out | Inline tag mention remains visible |
| Antigravity metadata | Request extraction already ignored metadata | Behavior preserved with explicit regression coverage |

## Design notes
- Filtering lives in the shared transcript parser, so cards and other status-preview consumers receive the same clean conversation fields without UI-specific string surgery.
- History/title context keeps its broader context-block heuristic, while status previews require injected blocks to start with a known marker. This avoids hiding legitimate questions that merely mention a marker inline.
- Antigravity parsing remains unchanged because `USER_INPUT` already isolates `<USER_REQUEST>` from `<ADDITIONAL_METADATA>`.

## Test plan
- [x] `cargo test -p acorn-transcript` — 55 passed
- [x] `cargo test -p acorn --lib` — 357 passed, 1 ignored
- [x] `rustfmt --edition 2021 --check src/agent_resume.rs crates/acorn-transcript/src/line.rs`
- [x] `git diff --check origin/main...HEAD`

## Notes
- The ignored `shell_env::tests::shell_capture_round_trips_against_real_shell` test is intentionally excluded by the existing suite and is not caused by this PR.
