### PR TITLE
fix(sessions): reserve waiting status for explicit input requests

### DIFF
--- a/src-tauri/crates/acorn-pty/src/lib.rs
+++ b/src-tauri/crates/acorn-pty/src/lib.rs
@@ -35,10 +35,8 @@ const READ_BUFFER_SIZE: usize = 4096;
 /// user sees in the terminal. The frontend already persists its own
 /// scrollback to disk on a debounce; this ring lives purely in RAM.
 const TAIL_BUFFER_CAP: usize = 4 * 1024 * 1024;
-/// How long a "just-finished a command" cue lingers as `NeedsInput` on the
-/// Sidebar dot before we let it fall back to `Idle`. Long enough to actually
-/// catch the user's eye after a transient command (`ls`, `git status`),
-/// short enough that an abandoned shell does not look perpetually pending.
+/// How long a just-finished command remains distinguishable as a shell prompt
+/// before falling back to `Idle`.
 pub const NEEDS_INPUT_STICKY: Duration = Duration::from_secs(5);
 
 /// Errors surfaced by [`PtyManager`]. The host crate maps these into its
@@ -55,10 +53,9 @@ pub type PtyOutputSink = Arc<dyn Fn(&str, &Uuid, &[u8]) + Send + Sync + 'static>
 
 /// Coarse classification of a shell-mode session's liveness, derived purely
 /// from "does the PTY child have any descendant processes right now?".
-/// Mirrors the `SessionStatus` variants the Sidebar dot already knows how to
-/// render — we keep this enum private to the backend so the
-/// transcript-driven detector can map it without leaking shell-specific
-/// vocabulary into the public session status type.
+/// This stays private to the backend so the transcript-driven detector can map
+/// shell prompt cues without leaking shell-specific vocabulary into the public
+/// session status type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShellHint {
     Running,
@@ -342,8 +339,8 @@ impl PtyManager {
 
     /// Per-poll state machine for shell-mode liveness. The caller has just
     /// computed `has_child_now` from a process-table snapshot; we fold it
-    /// against the previous observation and the sticky NeedsInput deadline
-    /// to produce the hint the Sidebar dot should show.
+    /// against the previous observation and the sticky prompt deadline to
+    /// produce the backend status hint.
     ///
     /// Returns `None` when the session has no live PTY (e.g. exited between
     /// the snapshot and this call) — the caller should treat that as Idle.

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -345,12 +345,12 @@ pub struct SessionStore {
     /// Sessions that reported at least one agent lifecycle hook event
     /// (Start/Stop/NeedsInput/Error) *this run*. Runtime-only. The status
     /// poll consults hook activity to decide whether hooks own the
-    /// Working/WaitingForInput classification: once a session proves its
-    /// hook channel is live, the transcript-tail poll stops second-guessing
+    /// Working/Ready/WaitingForInput classification: once a session proves
+    /// its hook channel is live, the transcript-tail poll stops second-guessing
     /// turn completion (a long or tool-heavy Claude turn often leaves no
     /// `end_turn` line inside the tail window, so the tail keeps reading
     /// Working long after the turn ended) and only keeps ownership of the
-    /// Ready (process-gone) edge, which no hook reports.
+    /// process-liveness edge after no agent remains.
     ///
     /// Hook activity itself also persists across restarts via the session's
     /// `hook_active` field; this set distinguishes "confirmed live this run"

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -360,6 +360,10 @@ pub struct SessionStore {
     /// lost its turn-end event forever and must be recovered from the
     /// transcript exactly once.
     hook_confirmed: DashSet<Uuid>,
+    /// Per-session lifecycle generation for this app run. Every hook event
+    /// advances the revision before touching the session row so conditional
+    /// status writes can reject observations made before a newer event.
+    hook_revisions: DashMap<Uuid, u64>,
 }
 
 impl SessionStore {
@@ -429,12 +433,46 @@ impl SessionStore {
         Ok(entry.clone())
     }
 
+    pub fn hook_revision(&self, id: &Uuid) -> u64 {
+        self.hook_revisions
+            .get(id)
+            .map(|revision| *revision)
+            .unwrap_or(0)
+    }
+
+    /// Refresh status only when both the stored state and hook generation
+    /// still match the caller's observation. Hook handlers advance the
+    /// generation before waiting on the session row, so a concurrent event
+    /// either rejects this write or overwrites it afterward.
+    pub fn refresh_status_if_hook_revision(
+        &self,
+        id: &Uuid,
+        expected_status: SessionStatus,
+        expected_hook_revision: u64,
+        status: SessionStatus,
+    ) -> SessionResult<bool> {
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        if entry.status != expected_status || self.hook_revision(id) != expected_hook_revision {
+            return Ok(false);
+        }
+        entry.status = status;
+        Ok(true)
+    }
+
     /// Record that `id` reported an agent lifecycle hook event, marking its
     /// hook channel live so the status poll defers turn-boundary
     /// classification to hooks (see the `hook_confirmed` field). Also stamps
     /// the session's persisted `hook_active` flag so hook ownership survives
-    /// an app restart. Idempotent.
+    /// an app restart. The persisted flag is idempotent; the runtime revision
+    /// advances for every event.
     pub fn mark_hook_active(&self, id: &Uuid) {
+        {
+            let mut revision = self.hook_revisions.entry(*id).or_default();
+            *revision = revision.saturating_add(1);
+        }
         self.hook_confirmed.insert(*id);
         if let Some(mut entry) = self.inner.get_mut(id) {
             if !entry.hook_active {
@@ -615,6 +653,7 @@ impl SessionStore {
 
     pub fn remove(&self, id: &Uuid) -> SessionResult<Session> {
         self.hook_confirmed.remove(id);
+        self.hook_revisions.remove(id);
         self.inner
             .remove(id)
             .map(|(_, v)| v)
@@ -714,13 +753,15 @@ mod tests {
         store.mark_hook_active(&session.id);
         assert!(store.is_hook_active(&session.id));
         assert!(store.is_hook_confirmed_this_run(&session.id));
-        // Idempotent.
+        assert_eq!(store.hook_revision(&session.id), 1);
         store.mark_hook_active(&session.id);
         assert!(store.is_hook_active(&session.id));
+        assert_eq!(store.hook_revision(&session.id), 2);
 
         store.remove(&session.id).expect("session exists");
         assert!(!store.is_hook_active(&session.id));
         assert!(!store.is_hook_confirmed_this_run(&session.id));
+        assert_eq!(store.hook_revision(&session.id), 0);
     }
 
     #[test]
@@ -732,6 +773,17 @@ mod tests {
             .expect("session exists");
 
         let waiting_revision = store.hook_revision(&session.id);
+        assert!(store
+            .refresh_status_if_hook_revision(
+                &session.id,
+                SessionStatus::WaitingForInput,
+                waiting_revision,
+                SessionStatus::Working,
+            )
+            .expect("session exists"));
+        store
+            .refresh_status(&session.id, SessionStatus::WaitingForInput)
+            .expect("session exists");
         store.mark_hook_active(&session.id);
 
         assert!(!store

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -284,8 +284,8 @@ pub struct Session {
     /// Whether this session has ever reported an agent lifecycle hook event.
     /// Persisted so hook ownership of the status survives an app restart: a
     /// daemon-managed PTY outlives the app, and its resting hook-set status
-    /// (`waiting_for_input`) must not be clobbered back to Working by the
-    /// transcript-tail poll before the agent emits its first event to the
+    /// (`ready` or `waiting_for_input`) must not be clobbered back to Working
+    /// by the transcript-tail poll before the agent emits its first event to the
     /// new app instance (a resting agent may never emit one).
     #[serde(default)]
     pub hook_active: bool,

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -724,6 +724,51 @@ mod tests {
     }
 
     #[test]
+    fn hook_revision_guards_conditional_status_refresh() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        store
+            .refresh_status(&session.id, SessionStatus::WaitingForInput)
+            .expect("session exists");
+
+        let waiting_revision = store.hook_revision(&session.id);
+        store.mark_hook_active(&session.id);
+
+        assert!(!store
+            .refresh_status_if_hook_revision(
+                &session.id,
+                SessionStatus::WaitingForInput,
+                waiting_revision,
+                SessionStatus::Working,
+            )
+            .expect("session exists"));
+        assert_eq!(
+            store.get(&session.id).expect("session exists").status,
+            SessionStatus::WaitingForInput
+        );
+    }
+
+    #[test]
+    fn conditional_status_refresh_requires_the_expected_status() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        let revision = store.hook_revision(&session.id);
+
+        assert!(!store
+            .refresh_status_if_hook_revision(
+                &session.id,
+                SessionStatus::WaitingForInput,
+                revision,
+                SessionStatus::Working,
+            )
+            .expect("session exists"));
+        assert_eq!(
+            store.get(&session.id).expect("session exists").status,
+            SessionStatus::Ready
+        );
+    }
+
+    #[test]
     fn hook_activity_persists_on_session_and_survives_reload() {
         let store = SessionStore::new();
         let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));

--- a/src-tauri/crates/acorn-session/src/status.rs
+++ b/src-tauri/crates/acorn-session/src/status.rs
@@ -2,10 +2,8 @@
 //! transcript the in-flight agent is writing. Status mapping:
 //!
 //! Claude transcripts:
-//! - last assistant turn with `stop_reason=end_turn` -> WaitingForInput
-//!   (claude has finished its turn and is awaiting the user's next prompt).
-//!   Surfaces the warning-tone status dot in the Sidebar and triggers the
-//!   `waitingForInput` system notification when the user has it enabled.
+//! - last assistant turn with `stop_reason=end_turn` -> Ready
+//!   (claude finished its turn and accepts an optional follow-up).
 //! - last assistant turn with `stop_reason=tool_use` -> Working (tool pending)
 //! - last user turn (new prompt or tool_result) -> Working (assistant pending)
 //! - no transcript yet -> Ready (session has not produced any conversation)
@@ -13,14 +11,14 @@
 //! Codex transcripts:
 //! - last `payload.type=task_complete` / `turn_complete` (also accepted
 //!   `msg`-wrapped or top-level; or `agent_message` with `phase=final_answer`)
-//!   -> WaitingForInput (codex finished a turn).
+//!   -> Ready (codex finished a turn).
 //! - last `payload.type=user_message` -> Working (the user just sent a
 //!   prompt and codex is composing the response).
 //! - everything else with content -> Working (function calls, intermediate
 //!   `agent_message phase=commentary`, reasoning, etc.).
 //!
 //! Antigravity transcripts:
-//! - last `type=PLANNER_RESPONSE` with `status=DONE` -> WaitingForInput.
+//! - last `type=PLANNER_RESPONSE` with `status=DONE` -> Ready.
 //! - last `type=USER_INPUT` or any non-DONE model/tool line -> Working.
 //!
 //! Meta-only lines (claude: `last-prompt` / `permission-mode` /
@@ -86,11 +84,12 @@ impl StatusDetection {
 ///
 /// `shell_hint` carries the descendant-process snapshot for the session's
 /// PTY. It also guards transcript markers from becoming sticky state:
-/// resume markers are durable, so an old transcript can still end in
-/// `waiting_for_input` long after the agent process exited. When the PTY is
-/// idle (or gone), the durable marker is stale for status purposes and the
-/// session should be Ready. When a live descendant exists, the transcript
-/// tail refines that live process into Working vs WaitingForInput.
+/// resume markers are durable, so an old transcript can still end in a
+/// completed turn long after the agent process exited. When the PTY is idle
+/// (or gone), the durable marker is stale for status purposes and the session
+/// should be Ready. When a live descendant exists, the transcript tail refines
+/// that live process into Working or Ready; explicit input requests arrive
+/// through agent lifecycle hooks.
 pub fn detect(
     transcript: Option<(PathBuf, AgentKind)>,
     previous: SessionStatus,
@@ -118,10 +117,9 @@ pub fn detect_with_reason(
         .and_then(|tail| latest_turn_state(kind, &tail.text, tail.read_full));
 
     match classified {
-        Some(TurnState::WaitingForInput) => StatusDetection::new(
-            SessionStatus::WaitingForInput,
-            Some(StatusReason::TurnComplete),
-        ),
+        Some(TurnState::Ready) => {
+            StatusDetection::new(SessionStatus::Ready, Some(StatusReason::TurnComplete))
+        }
         Some(TurnState::Working) => StatusDetection::new(SessionStatus::Working, None),
         // Transcript exists but the tail held no turn lines; keep
         // whatever the caller previously observed instead of regressing
@@ -139,10 +137,9 @@ fn map_shell_hint(hint: Option<ShellHint>) -> SessionStatus {
 fn detect_shell_hint(hint: Option<ShellHint>) -> StatusDetection {
     match hint {
         Some(ShellHint::Running) => StatusDetection::new(SessionStatus::Working, None),
-        Some(ShellHint::NeedsInput) => StatusDetection::new(
-            SessionStatus::WaitingForInput,
-            Some(StatusReason::ShellPrompt),
-        ),
+        Some(ShellHint::NeedsInput) => {
+            StatusDetection::new(SessionStatus::Ready, Some(StatusReason::ShellPrompt))
+        }
         Some(ShellHint::Idle) | None => StatusDetection::new(SessionStatus::Ready, None),
     }
 }
@@ -417,13 +414,13 @@ mod tests {
     }
 
     #[test]
-    fn detect_ignores_stale_waiting_for_input_transcript_when_shell_is_idle() {
+    fn detect_ignores_durable_completed_transcript_when_shell_is_idle() {
         let path = write_status_transcript(&assistant("end_turn"));
 
         assert_eq!(
             detect(
                 Some((path, AgentKind::Claude)),
-                SessionStatus::WaitingForInput,
+                SessionStatus::Ready,
                 Some(ShellHint::Idle),
             ),
             SessionStatus::Ready,
@@ -431,15 +428,11 @@ mod tests {
     }
 
     #[test]
-    fn detect_ignores_stale_waiting_for_input_transcript_without_live_pty() {
+    fn detect_ignores_durable_completed_transcript_without_live_pty() {
         let path = write_status_transcript(&assistant("end_turn"));
 
         assert_eq!(
-            detect(
-                Some((path, AgentKind::Claude)),
-                SessionStatus::WaitingForInput,
-                None,
-            ),
+            detect(Some((path, AgentKind::Claude)), SessionStatus::Ready, None,),
             SessionStatus::Ready,
         );
     }
@@ -470,10 +463,7 @@ mod tests {
                 SessionStatus::Working,
                 Some(ShellHint::Running),
             ),
-            StatusDetection::new(
-                SessionStatus::Ready,
-                Some(StatusReason::TurnComplete)
-            ),
+            StatusDetection::new(SessionStatus::Ready, Some(StatusReason::TurnComplete)),
         );
     }
 
@@ -481,10 +471,7 @@ mod tests {
     fn detect_reports_ready_with_shell_prompt_reason() {
         assert_eq!(
             detect_with_reason(None, SessionStatus::Working, Some(ShellHint::NeedsInput)),
-            StatusDetection::new(
-                SessionStatus::Ready,
-                Some(StatusReason::ShellPrompt)
-            ),
+            StatusDetection::new(SessionStatus::Ready, Some(StatusReason::ShellPrompt)),
         );
     }
 

--- a/src-tauri/crates/acorn-session/src/status.rs
+++ b/src-tauri/crates/acorn-session/src/status.rs
@@ -205,7 +205,7 @@ mod tests {
         }
         assert_eq!(
             classify_tail(AgentKind::Claude, &tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
@@ -257,10 +257,10 @@ mod tests {
     }
 
     #[test]
-    fn shell_hint_needs_input_maps_to_waiting_for_input() {
+    fn shell_prompt_maps_to_ready() {
         assert_eq!(
             map_shell_hint(Some(ShellHint::NeedsInput)),
-            SessionStatus::WaitingForInput,
+            SessionStatus::Ready,
         );
     }
 
@@ -284,47 +284,47 @@ mod tests {
     }
 
     #[test]
-    fn codex_task_complete_maps_to_waiting_for_input() {
+    fn codex_task_complete_maps_to_ready() {
         let tail = r#"{"timestamp":"t","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","last_agent_message":"done","completed_at":1,"duration_ms":1,"time_to_first_token_ms":1}}"#;
         assert_eq!(
             classify_tail(AgentKind::Codex, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
     #[test]
-    fn codex_turn_complete_maps_to_waiting_for_input() {
+    fn codex_turn_complete_maps_to_ready() {
         let tail = r#"{"timestamp":"t","type":"event_msg","payload":{"type":"turn_complete","turn_id":"t1","last_agent_message":"done","completed_at":1,"duration_ms":1,"time_to_first_token_ms":1}}"#;
         assert_eq!(
             classify_tail(AgentKind::Codex, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
     #[test]
-    fn codex_msg_wrapped_turn_complete_maps_to_waiting_for_input() {
+    fn codex_msg_wrapped_turn_complete_maps_to_ready() {
         let tail = r#"{"msg":{"type":"turn_complete","last_agent_message":"done"}}"#;
         assert_eq!(
             classify_tail(AgentKind::Codex, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
     #[test]
-    fn codex_top_level_turn_complete_maps_to_waiting_for_input() {
+    fn codex_top_level_turn_complete_maps_to_ready() {
         let tail = r#"{"type":"turn_complete","last_agent_message":"done"}"#;
         assert_eq!(
             classify_tail(AgentKind::Codex, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
     #[test]
-    fn codex_final_answer_agent_message_maps_to_waiting_for_input() {
+    fn codex_final_answer_agent_message_maps_to_ready() {
         let tail = r#"{"timestamp":"t","type":"event_msg","payload":{"type":"agent_message","message":"all done","phase":"final_answer","memory_citation":null}}"#;
         assert_eq!(
             classify_tail(AgentKind::Codex, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
@@ -364,7 +364,7 @@ mod tests {
         );
         assert_eq!(
             classify_tail(AgentKind::Codex, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
@@ -374,11 +374,11 @@ mod tests {
     }
 
     #[test]
-    fn antigravity_done_planner_maps_to_waiting_for_input() {
+    fn antigravity_done_planner_maps_to_ready() {
         let tail = r#"{"type":"PLANNER_RESPONSE","status":"DONE","content":"done"}"#;
         assert_eq!(
             classify_tail(AgentKind::Antigravity, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
@@ -445,7 +445,7 @@ mod tests {
     }
 
     #[test]
-    fn detect_uses_waiting_for_input_transcript_while_shell_has_live_child() {
+    fn detect_uses_ready_transcript_while_shell_has_live_child() {
         let path = write_status_transcript(&assistant("end_turn"));
 
         assert_eq!(
@@ -454,7 +454,7 @@ mod tests {
                 SessionStatus::Working,
                 Some(ShellHint::Running),
             ),
-            SessionStatus::WaitingForInput,
+            SessionStatus::Ready,
         );
     }
 
@@ -471,18 +471,18 @@ mod tests {
                 Some(ShellHint::Running),
             ),
             StatusDetection::new(
-                SessionStatus::WaitingForInput,
+                SessionStatus::Ready,
                 Some(StatusReason::TurnComplete)
             ),
         );
     }
 
     #[test]
-    fn detect_reports_shell_prompt_reason_for_shell_needs_input() {
+    fn detect_reports_ready_with_shell_prompt_reason() {
         assert_eq!(
             detect_with_reason(None, SessionStatus::Working, Some(ShellHint::NeedsInput)),
             StatusDetection::new(
-                SessionStatus::WaitingForInput,
+                SessionStatus::Ready,
                 Some(StatusReason::ShellPrompt)
             ),
         );

--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -734,7 +734,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_assistant_end_turn_wins_over_trailing_meta() {
+    fn claude_assistant_end_turn_maps_to_ready_over_trailing_meta() {
         let tail = format!(
             "{}\n{}\n{}\n",
             assistant("end_turn"),
@@ -743,7 +743,7 @@ mod tests {
         );
         assert_eq!(
             classify(AgentKind::Claude, &tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
@@ -756,7 +756,7 @@ mod tests {
         );
         assert_eq!(
             classify(AgentKind::Claude, &tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
         assert_eq!(
             classify(
@@ -786,29 +786,29 @@ mod tests {
     }
 
     #[test]
-    fn codex_task_complete_maps_to_waiting_for_input() {
+    fn codex_task_complete_maps_to_ready() {
         let tail = r#"{"timestamp":"t","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","last_agent_message":"done","completed_at":1,"duration_ms":1,"time_to_first_token_ms":1}}"#;
         assert_eq!(
             classify(AgentKind::Codex, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
     #[test]
-    fn codex_turn_complete_maps_to_waiting_for_input() {
+    fn codex_turn_complete_maps_to_ready() {
         let tail = r#"{"timestamp":"t","type":"event_msg","payload":{"type":"turn_complete","turn_id":"t1","last_agent_message":"done","completed_at":1,"duration_ms":1,"time_to_first_token_ms":1}}"#;
         assert_eq!(
             classify(AgentKind::Codex, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
     #[test]
-    fn codex_msg_wrapped_turn_complete_maps_to_waiting_for_input() {
+    fn codex_msg_wrapped_turn_complete_maps_to_ready() {
         let tail = r#"{"msg":{"type":"turn_complete","last_agent_message":"done"}}"#;
         assert_eq!(
             classify(AgentKind::Codex, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
@@ -858,7 +858,7 @@ mod tests {
         .unwrap();
         let parsed = parse_transcript_value(AgentKind::Codex, &value);
 
-        assert_eq!(parsed.turn_state, Some(TurnState::WaitingForInput));
+        assert_eq!(parsed.turn_state, Some(TurnState::Ready));
         assert_eq!(parsed.role, TranscriptRole::Assistant);
         assert_eq!(parsed.text.as_deref(), Some("all done"));
         assert_eq!(parsed.state_role, TranscriptRole::Assistant);
@@ -889,20 +889,20 @@ mod tests {
     }
 
     #[test]
-    fn codex_top_level_turn_complete_maps_to_waiting_for_input() {
+    fn codex_top_level_turn_complete_maps_to_ready() {
         let tail = r#"{"type":"turn_complete","last_agent_message":"done"}"#;
         assert_eq!(
             classify(AgentKind::Codex, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
     #[test]
-    fn codex_final_answer_agent_message_maps_to_waiting_for_input() {
+    fn codex_final_answer_agent_message_maps_to_ready() {
         let tail = r#"{"timestamp":"t","type":"event_msg","payload":{"type":"agent_message","message":"all done","phase":"final_answer","memory_citation":null}}"#;
         assert_eq!(
             classify(AgentKind::Codex, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
@@ -915,16 +915,16 @@ mod tests {
         );
         assert_eq!(
             classify(AgentKind::Codex, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 
     #[test]
-    fn antigravity_done_planner_maps_to_waiting_for_input() {
+    fn antigravity_done_planner_maps_to_ready() {
         let tail = r#"{"type":"PLANNER_RESPONSE","status":"DONE","content":"done"}"#;
         assert_eq!(
             classify(AgentKind::Antigravity, tail, true),
-            Some(TurnState::WaitingForInput),
+            Some(TurnState::Ready),
         );
     }
 

--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -24,7 +24,7 @@ impl TranscriptRole {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TurnState {
-    WaitingForInput,
+    Ready,
     Working,
 }
 
@@ -277,7 +277,7 @@ fn claude_turn_state(value: &Value) -> Option<TurnState> {
     }
     let stop_reason = msg.get("stop_reason").and_then(Value::as_str).unwrap_or("");
     Some(match stop_reason {
-        "end_turn" | "stop_sequence" => TurnState::WaitingForInput,
+        "end_turn" | "stop_sequence" => TurnState::Ready,
         "tool_use" => TurnState::Working,
         _ => TurnState::Working,
     })
@@ -287,13 +287,13 @@ fn codex_turn_state(value: &Value) -> Option<TurnState> {
     let event = codex_event_value(value);
     let payload_type = event.get("type").and_then(Value::as_str).unwrap_or("");
     match payload_type {
-        "task_complete" | "turn_complete" => Some(TurnState::WaitingForInput),
+        "task_complete" | "turn_complete" => Some(TurnState::Ready),
         "user_message" => Some(TurnState::Working),
         "function_call" | "function_call_output" | "reasoning" => Some(TurnState::Working),
         "agent_message" => {
             let phase = event.get("phase").and_then(Value::as_str).unwrap_or("");
             Some(if phase == "final_answer" {
-                TurnState::WaitingForInput
+                TurnState::Ready
             } else {
                 TurnState::Working
             })
@@ -341,7 +341,7 @@ fn antigravity_turn_state(value: &Value) -> Option<TurnState> {
     match line_type {
         "USER_INPUT" => Some(TurnState::Working),
         "PLANNER_RESPONSE" => Some(if status == "DONE" {
-            TurnState::WaitingForInput
+            TurnState::Ready
         } else {
             TurnState::Working
         }),

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -259,10 +259,10 @@ hook_event_name=$(printf '%s\n' "$input" | grep -oE '"hook_event_name"[[:space:]
 event=""
 # Claude fires Stop after every assistant turn, including ordinary completed
 # work that needs no response. Notification and PermissionRequest are the
-# attention-bearing events. SubagentStop fires mid-turn, so it re-asserts
-# Working.
+# attention-bearing events. Background subagent completion does not resolve a
+# main-agent permission or elicitation request, so it does not change status.
 case "$hook_event_name" in
-  SessionStart|UserPromptSubmit|SubagentStop) event="start" ;;
+  SessionStart|UserPromptSubmit) event="start" ;;
   Stop) event="stop" ;;
   Notification|PermissionRequest) event="needs_input" ;;
   Error) event="error" ;;
@@ -527,7 +527,6 @@ fn write_claude_settings(dir: &Path) -> io::Result<()> {
     "SessionStart": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "UserPromptSubmit": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "Stop": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
-    "SubagentStop": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "Notification": [{{"matcher":"permission_prompt|elicitation_dialog|agent_needs_input","hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "PermissionRequest": [{{"matcher":"*","hooks":[{{"type":"command","command":"{cmd}"}}]}}]
   }}

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -259,10 +259,10 @@ hook_event_name=$(printf '%s\n' "$input" | grep -oE '"hook_event_name"[[:space:]
 event=""
 # Claude fires Stop after every assistant turn, including ordinary completed
 # work that needs no response. Notification and PermissionRequest are the
-# attention-bearing events. Tool completion and SubagentStop both occur
-# mid-turn, so they re-assert Working.
+# attention-bearing events. SubagentStop fires mid-turn, so it re-asserts
+# Working.
 case "$hook_event_name" in
-  SessionStart|UserPromptSubmit|PostToolUse|PostToolUseFailure|SubagentStop) event="start" ;;
+  SessionStart|UserPromptSubmit|SubagentStop) event="start" ;;
   Stop) event="stop" ;;
   Notification|PermissionRequest) event="needs_input" ;;
   Error) event="error" ;;
@@ -526,8 +526,6 @@ fn write_claude_settings(dir: &Path) -> io::Result<()> {
   "hooks": {{
     "SessionStart": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "UserPromptSubmit": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
-    "PostToolUse": [{{"matcher":"*","hooks":[{{"type":"command","command":"{cmd}"}}]}}],
-    "PostToolUseFailure": [{{"matcher":"*","hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "Stop": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "SubagentStop": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "Notification": [{{"matcher":"permission_prompt|elicitation_dialog|agent_needs_input","hooks":[{{"type":"command","command":"{cmd}"}}]}}],

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -762,7 +762,9 @@ mod tests {
         assert!(notify.contains("\"provider\":\"claude\""));
         // SubagentStop re-asserts Running (grouped with start); a main-agent
         // Stop is ready, while notifications and permissions require input.
-        assert!(notify.contains("SessionStart|UserPromptSubmit|SubagentStop"));
+        assert!(notify.contains(
+            "SessionStart|UserPromptSubmit|PostToolUse|PostToolUseFailure|SubagentStop"
+        ));
         assert!(notify.contains("Stop) event=\"stop\""));
         assert!(notify.contains("Notification|PermissionRequest) event=\"needs_input\""));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
@@ -772,6 +774,8 @@ mod tests {
         let notify_path = dir.join("acorn-claude-notify").display().to_string();
         assert!(settings.contains("\"SessionStart\""));
         assert!(settings.contains("\"UserPromptSubmit\""));
+        assert!(settings.contains("\"PostToolUse\""));
+        assert!(settings.contains("\"PostToolUseFailure\""));
         assert!(settings.contains("\"Stop\""));
         assert!(settings.contains("\"SubagentStop\""));
         assert!(settings.contains("\"Notification\""));
@@ -944,6 +948,10 @@ mod tests {
         assert!(wrapper.contains("acorn-antigravity-notify"));
         assert!(wrapper.contains("PLANNER_RESPONSE"));
         assert!(wrapper.contains("USER_INPUT"));
+        assert!(wrapper.contains(
+            r#"*'\"type\":\"PLANNER_RESPONSE\"'*'\"status\":\"DONE\"'*)
+          \"$_acorn_notify\" stop"#
+        ));
 
         let notify = fs::read_to_string(dir.join("acorn-antigravity-notify")).unwrap();
         assert!(notify.contains("\"provider\":\"antigravity\""));

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -764,8 +764,7 @@ mod tests {
         assert!(notify.contains("\"provider\":\"claude\""));
         // SubagentStop re-asserts Running (grouped with start); a main-agent
         // Stop is ready, while notifications and permissions require input.
-        assert!(notify
-            .contains("SessionStart|UserPromptSubmit|PostToolUse|PostToolUseFailure|SubagentStop"));
+        assert!(notify.contains("SessionStart|UserPromptSubmit|SubagentStop"));
         assert!(notify.contains("Stop) event=\"stop\""));
         assert!(notify.contains("Notification|PermissionRequest) event=\"needs_input\""));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
@@ -775,8 +774,8 @@ mod tests {
         let notify_path = dir.join("acorn-claude-notify").display().to_string();
         assert!(settings.contains("\"SessionStart\""));
         assert!(settings.contains("\"UserPromptSubmit\""));
-        assert!(settings.contains("\"PostToolUse\""));
-        assert!(settings.contains("\"PostToolUseFailure\""));
+        assert!(!settings.contains("\"PostToolUse\""));
+        assert!(!settings.contains("\"PostToolUseFailure\""));
         assert!(settings.contains("\"Stop\""));
         assert!(settings.contains("\"SubagentStop\""));
         assert!(settings.contains("\"Notification\""));
@@ -852,9 +851,7 @@ mod tests {
         let base = ScratchDir::new("events");
         let dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
         let notify = fs::read_to_string(dir.join("acorn-claude-notify")).unwrap();
-        assert!(notify.contains(
-            "SessionStart|UserPromptSubmit|PostToolUse|PostToolUseFailure|SubagentStop) event=\"start\""
-        ));
+        assert!(notify.contains("SessionStart|UserPromptSubmit|SubagentStop) event=\"start\""));
         assert!(notify.contains("Stop) event=\"stop\""));
         assert!(notify.contains("Notification|PermissionRequest) event=\"needs_input\""));
         assert!(notify.contains("Error) event=\"error\""));

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -259,10 +259,10 @@ hook_event_name=$(printf '%s\n' "$input" | grep -oE '"hook_event_name"[[:space:]
 event=""
 # Claude fires Stop after every assistant turn, including ordinary completed
 # work that needs no response. Notification and PermissionRequest are the
-# attention-bearing events. SubagentStop fires mid-turn, so it re-asserts
-# Working.
+# attention-bearing events. Tool completion and SubagentStop both occur
+# mid-turn, so they re-assert Working.
 case "$hook_event_name" in
-  SessionStart|UserPromptSubmit|SubagentStop) event="start" ;;
+  SessionStart|UserPromptSubmit|PostToolUse|PostToolUseFailure|SubagentStop) event="start" ;;
   Stop) event="stop" ;;
   Notification|PermissionRequest) event="needs_input" ;;
   Error) event="error" ;;
@@ -383,7 +383,7 @@ if [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
           "$_acorn_notify" start >/dev/null 2>&1 || true
           ;;
         *'"type":"PLANNER_RESPONSE"'*'"status":"DONE"'*)
-          "$_acorn_notify" needs_input >/dev/null 2>&1 || true
+          "$_acorn_notify" stop >/dev/null 2>&1 || true
           ;;
         *'"status":"ERROR"'*)
           "$_acorn_notify" error >/dev/null 2>&1 || true
@@ -526,6 +526,8 @@ fn write_claude_settings(dir: &Path) -> io::Result<()> {
   "hooks": {{
     "SessionStart": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "UserPromptSubmit": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
+    "PostToolUse": [{{"matcher":"*","hooks":[{{"type":"command","command":"{cmd}"}}]}}],
+    "PostToolUseFailure": [{{"matcher":"*","hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "Stop": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "SubagentStop": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "Notification": [{{"matcher":"permission_prompt|elicitation_dialog|agent_needs_input","hooks":[{{"type":"command","command":"{cmd}"}}]}}],
@@ -762,9 +764,8 @@ mod tests {
         assert!(notify.contains("\"provider\":\"claude\""));
         // SubagentStop re-asserts Running (grouped with start); a main-agent
         // Stop is ready, while notifications and permissions require input.
-        assert!(notify.contains(
-            "SessionStart|UserPromptSubmit|PostToolUse|PostToolUseFailure|SubagentStop"
-        ));
+        assert!(notify
+            .contains("SessionStart|UserPromptSubmit|PostToolUse|PostToolUseFailure|SubagentStop"));
         assert!(notify.contains("Stop) event=\"stop\""));
         assert!(notify.contains("Notification|PermissionRequest) event=\"needs_input\""));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
@@ -851,7 +852,9 @@ mod tests {
         let base = ScratchDir::new("events");
         let dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
         let notify = fs::read_to_string(dir.join("acorn-claude-notify")).unwrap();
-        assert!(notify.contains("SessionStart|UserPromptSubmit|SubagentStop) event=\"start\""));
+        assert!(notify.contains(
+            "SessionStart|UserPromptSubmit|PostToolUse|PostToolUseFailure|SubagentStop) event=\"start\""
+        ));
         assert!(notify.contains("Stop) event=\"stop\""));
         assert!(notify.contains("Notification|PermissionRequest) event=\"needs_input\""));
         assert!(notify.contains("Error) event=\"error\""));
@@ -949,8 +952,8 @@ mod tests {
         assert!(wrapper.contains("PLANNER_RESPONSE"));
         assert!(wrapper.contains("USER_INPUT"));
         assert!(wrapper.contains(
-            r#"*'\"type\":\"PLANNER_RESPONSE\"'*'\"status\":\"DONE\"'*)
-          \"$_acorn_notify\" stop"#
+            r#"*'"type":"PLANNER_RESPONSE"'*'"status":"DONE"'*)
+          "$_acorn_notify" stop"#
         ));
 
         let notify = fs::read_to_string(dir.join("acorn-antigravity-notify")).unwrap();

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -144,14 +144,11 @@ case "$event" in
   *)
     event=""
     hook_event_name=$(printf '%s\n' "$input" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
-    # Codex's turn-completion events (Stop / agent-turn-complete /
-    # task_complete / turn_complete)
-    # mean the agent finished the turn and is awaiting the user, so they map to
-    # needs_input. Codex emits no "process exited" event here — that shows up as
-    # the status poll observing an idle shell.
+    # Turn completion means Codex is ready for optional follow-up. Approval and
+    # question events are the only signals that require user attention.
     case "$hook_event_name" in
       Start|UserPromptSubmit) event="start" ;;
-      Stop) event="needs_input" ;;
+      Stop) event="stop" ;;
       PermissionRequest) event="needs_input" ;;
       Error) event="error" ;;
     esac
@@ -159,7 +156,7 @@ case "$event" in
       codex_type=$(printf '%s\n' "$input" | grep -oE '"type"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
       case "$codex_type" in
         task_started) event="start" ;;
-        agent-turn-complete|task_complete|turn_complete) event="needs_input" ;;
+        agent-turn-complete|task_complete|turn_complete) event="stop" ;;
         exec_approval_request|apply_patch_approval_request|request_user_input) event="needs_input" ;;
       esac
     fi
@@ -260,15 +257,14 @@ input=$(cat 2>/dev/null || true)
 hook_event_name=$(printf '%s\n' "$input" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
 
 event=""
-# Claude fires Stop at the end of every assistant turn — it has finished
-# responding and is awaiting the user's next prompt — so Stop maps to
-# needs_input, matching the transcript classifier's end_turn semantics.
-# SubagentStop fires mid-turn (a Task subagent finished) so it re-asserts
-# Running. Claude has no "process exited" hook; that shows up as the status
-# poll observing an idle shell.
+# Claude fires Stop after every assistant turn, including ordinary completed
+# work that needs no response. Notification and PermissionRequest are the
+# attention-bearing events. SubagentStop fires mid-turn, so it re-asserts
+# Working.
 case "$hook_event_name" in
   SessionStart|UserPromptSubmit|SubagentStop) event="start" ;;
-  Stop|Notification|PermissionRequest) event="needs_input" ;;
+  Stop) event="stop" ;;
+  Notification|PermissionRequest) event="needs_input" ;;
   Error) event="error" ;;
 esac
 [ -n "$event" ] || exit 0
@@ -532,7 +528,7 @@ fn write_claude_settings(dir: &Path) -> io::Result<()> {
     "UserPromptSubmit": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "Stop": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "SubagentStop": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
-    "Notification": [{{"hooks":[{{"type":"command","command":"{cmd}"}}]}}],
+    "Notification": [{{"matcher":"permission_prompt|elicitation_dialog|agent_needs_input","hooks":[{{"type":"command","command":"{cmd}"}}]}}],
     "PermissionRequest": [{{"matcher":"*","hooks":[{{"type":"command","command":"{cmd}"}}]}}]
   }}
 }}
@@ -662,8 +658,7 @@ mod tests {
         assert!(notify.contains("\"provider\":\"codex\""));
         // A completed turn is ready for optional follow-up. Only explicit
         // approval or question events require user input.
-        assert!(notify
-            .contains("agent-turn-complete|task_complete|turn_complete) event=\"stop\""));
+        assert!(notify.contains("agent-turn-complete|task_complete|turn_complete) event=\"stop\""));
         assert!(notify.contains("Stop) event=\"stop\""));
         assert!(notify.contains(
             "exec_approval_request|apply_patch_approval_request|request_user_input) event=\"needs_input\""
@@ -780,6 +775,8 @@ mod tests {
         assert!(settings.contains("\"Stop\""));
         assert!(settings.contains("\"SubagentStop\""));
         assert!(settings.contains("\"Notification\""));
+        assert!(settings
+            .contains("\"matcher\":\"permission_prompt|elicitation_dialog|agent_needs_input\""));
         assert!(settings.contains("\"PermissionRequest\""));
         assert!(
             settings.contains(&format!(
@@ -850,24 +847,10 @@ mod tests {
         let base = ScratchDir::new("events");
         let dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
         let notify = fs::read_to_string(dir.join("acorn-claude-notify")).unwrap();
-        for (claude_event, acorn_event) in [
-            ("SessionStart", "start"),
-            ("UserPromptSubmit", "start"),
-            ("Stop", "needs_input"),
-            ("SubagentStop", "start"),
-            ("Notification", "needs_input"),
-            ("PermissionRequest", "needs_input"),
-            ("Error", "error"),
-        ] {
-            assert!(
-                notify.contains(claude_event),
-                "notify missing claude event {claude_event}"
-            );
-            assert!(
-                notify.contains(&format!("event=\"{acorn_event}\"")),
-                "notify missing acorn event mapping {acorn_event}"
-            );
-        }
+        assert!(notify.contains("SessionStart|UserPromptSubmit|SubagentStop) event=\"start\""));
+        assert!(notify.contains("Stop) event=\"stop\""));
+        assert!(notify.contains("Notification|PermissionRequest) event=\"needs_input\""));
+        assert!(notify.contains("Error) event=\"error\""));
     }
 
     #[test]

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -760,9 +760,8 @@ mod tests {
 
         let notify = fs::read_to_string(dir.join("acorn-claude-notify")).unwrap();
         assert!(notify.contains("\"provider\":\"claude\""));
-        // SubagentStop re-asserts Running (grouped with start); a main-agent
-        // Stop is ready, while notifications and permissions require input.
-        assert!(notify.contains("SessionStart|UserPromptSubmit|SubagentStop"));
+        assert!(notify.contains("SessionStart|UserPromptSubmit) event=\"start\""));
+        assert!(!notify.contains("SubagentStop"));
         assert!(notify.contains("Stop) event=\"stop\""));
         assert!(notify.contains("Notification|PermissionRequest) event=\"needs_input\""));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
@@ -775,7 +774,7 @@ mod tests {
         assert!(!settings.contains("\"PostToolUse\""));
         assert!(!settings.contains("\"PostToolUseFailure\""));
         assert!(settings.contains("\"Stop\""));
-        assert!(settings.contains("\"SubagentStop\""));
+        assert!(!settings.contains("\"SubagentStop\""));
         assert!(settings.contains("\"Notification\""));
         assert!(settings
             .contains("\"matcher\":\"permission_prompt|elicitation_dialog|agent_needs_input\""));
@@ -849,7 +848,8 @@ mod tests {
         let base = ScratchDir::new("events");
         let dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
         let notify = fs::read_to_string(dir.join("acorn-claude-notify")).unwrap();
-        assert!(notify.contains("SessionStart|UserPromptSubmit|SubagentStop) event=\"start\""));
+        assert!(notify.contains("SessionStart|UserPromptSubmit) event=\"start\""));
+        assert!(!notify.contains("SubagentStop"));
         assert!(notify.contains("Stop) event=\"stop\""));
         assert!(notify.contains("Notification|PermissionRequest) event=\"needs_input\""));
         assert!(notify.contains("Error) event=\"error\""));

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -660,12 +660,14 @@ mod tests {
 
         let notify = fs::read_to_string(dir.join("acorn-codex-notify")).unwrap();
         assert!(notify.contains("\"provider\":\"codex\""));
-        // Turn-completion events map to needs_input (awaiting the user), not a
-        // per-turn "completed"; Codex emits no process-exit hook here.
+        // A completed turn is ready for optional follow-up. Only explicit
+        // approval or question events require user input.
         assert!(notify
-            .contains("agent-turn-complete|task_complete|turn_complete) event=\"needs_input\""));
-        assert!(notify.contains("Stop) event=\"needs_input\""));
-        assert!(!notify.contains("event=\"stop\""));
+            .contains("agent-turn-complete|task_complete|turn_complete) event=\"stop\""));
+        assert!(notify.contains("Stop) event=\"stop\""));
+        assert!(notify.contains(
+            "exec_approval_request|apply_patch_approval_request|request_user_input) event=\"needs_input\""
+        ));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
         assert!(notify.contains("ACORN_AGENT_HOOK_SESSION_ID"));
     }
@@ -763,12 +765,11 @@ mod tests {
 
         let notify = fs::read_to_string(dir.join("acorn-claude-notify")).unwrap();
         assert!(notify.contains("\"provider\":\"claude\""));
-        // SubagentStop re-asserts Running (grouped with start); per-turn Stop
-        // maps to needs_input (awaiting the user), and Claude emits no "stop"
-        // (Completed) event at all — process exit is observed as idle.
+        // SubagentStop re-asserts Running (grouped with start); a main-agent
+        // Stop is ready, while notifications and permissions require input.
         assert!(notify.contains("SessionStart|UserPromptSubmit|SubagentStop"));
-        assert!(notify.contains("Stop|Notification|PermissionRequest) event=\"needs_input\""));
-        assert!(!notify.contains("event=\"stop\""));
+        assert!(notify.contains("Stop) event=\"stop\""));
+        assert!(notify.contains("Notification|PermissionRequest) event=\"needs_input\""));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
         assert!(notify.contains("ACORN_AGENT_HOOK_SESSION_ID"));
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5283,6 +5283,7 @@ fn detect_session_statuses_blocking(
     };
 
     let mut promoted_auto_title = false;
+    let mut reconciled_hook_status = false;
     let entries: Vec<SessionStatusEntry> = ids
         .into_iter()
         .map(|id| {
@@ -5475,6 +5476,7 @@ fn detect_session_statuses_blocking(
                         },
                     )
                 });
+                reconciled_hook_status |= reconciled.is_some();
                 let hook_status = parsed_id
                     .and_then(|uuid| state.sessions.get(&uuid).ok())
                     .map(|session| session.status)
@@ -5547,10 +5549,14 @@ fn detect_session_statuses_blocking(
         .collect();
     // Promotion must survive an app restart — without the save a session
     // would silently fall back to ineligible until the agent runs again.
-    if promoted_auto_title {
+    if status_poll_needs_persist(promoted_auto_title, reconciled_hook_status) {
         persist(&state);
     }
     Ok(entries)
+}
+
+fn status_poll_needs_persist(promoted_auto_title: bool, reconciled_hook_status: bool) -> bool {
+    promoted_auto_title || reconciled_hook_status
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4650,9 +4650,16 @@ pub fn pty_unsubscribe_output(
 }
 
 #[tauri::command]
-pub fn pty_write(state: State<'_, AppState>, session_id: String, data: String) -> AppResult<()> {
+pub fn pty_write<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, AppState>,
+    session_id: String,
+    data: String,
+) -> AppResult<()> {
     let id = parse_id(&session_id)?;
     let bytes = decode_b64(&data)?;
+    let submit_revision =
+        is_terminal_submit_frame(&bytes).then(|| state.sessions.hook_revision(&id));
     // Daemon-managed sessions route stdin through the control socket.
     // Keystrokes are small; one RPC round-trip per keystroke is well
     // under the typing-feedback threshold and avoids managing a second
@@ -4660,15 +4667,43 @@ pub fn pty_write(state: State<'_, AppState>, session_id: String, data: String) -
     // fast-path signal, but detached/re-attaching sessions can be alive in
     // the daemon without an app-side output pump for a short window.
     if daemon_session_alive_or_attached(&state, id) {
-        return state
+        state
             .daemon_bridge
             .send_input(id, &bytes)
-            .map_err(|e| AppError::Pty(e.to_string()));
+            .map_err(|e| AppError::Pty(e.to_string()))?;
+    } else {
+        state
+            .pty
+            .write(&id, &bytes)
+            .map_err(|e| AppError::Pty(e.to_string()))?;
     }
-    state
-        .pty
-        .write(&id, &bytes)
-        .map_err(|e| AppError::Pty(e.to_string()))
+
+    if let Some(revision) = submit_revision {
+        match state.sessions.refresh_status_if_hook_revision(
+            &id,
+            SessionStatus::WaitingForInput,
+            revision,
+            SessionStatus::Working,
+        ) {
+            Ok(true) => {
+                persist(&state);
+                if let Err(err) =
+                    app.emit(crate::agent_hooks::AGENT_HOOK_STATUS_EVENT, id.to_string())
+                {
+                    tracing::warn!(%id, error = %err, "terminal submit status emit failed");
+                }
+            }
+            Ok(false) => {}
+            Err(err) => {
+                tracing::warn!(%id, error = %err, "terminal submit status refresh failed");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_terminal_submit_frame(bytes: &[u8]) -> bool {
+    matches!(bytes, b"\r" | b"\n" | b"\r\n")
 }
 
 #[tauri::command]
@@ -5248,7 +5283,6 @@ fn detect_session_statuses_blocking(
     };
 
     let mut promoted_auto_title = false;
-    let mut reconciled_hook_status = false;
     let entries: Vec<SessionStatusEntry> = ids
         .into_iter()
         .map(|id| {
@@ -5332,11 +5366,10 @@ fn detect_session_statuses_blocking(
             let live_agent = root_pid_value
                 .and_then(|pid| live_agent_in_descendants(&sys, &children, Pid::from_u32(pid)));
             let live_agent_kind = live_agent.map(|(kind, _)| kind);
-            let live_agent_tool_child = live_agent.is_some_and(|agent| {
-                root_pid_value.is_some_and(|pid| {
-                    live_agent_has_tool_descendant(&sys, &children, Pid::from_u32(pid), agent)
-                })
-            });
+            let live_codex_tool_child = matches!(live_agent_kind, Some(AgentKind::Codex))
+                && root_pid_value.is_some_and(|pid| {
+                    live_codex_has_tool_descendant(&sys, &children, Pid::from_u32(pid))
+                });
             // Resolve the live transcript via the persister's resume markers
             // first (covers claude/codex/antigravity run inside a shell session — JSONL
             // is named after the agent's own UUID, not Acorn's). When the PTY
@@ -5422,26 +5455,37 @@ fn detect_session_statuses_blocking(
                 // here — after the poll's I/O — so an event landing during
                 // that window disables the recovery before it can clobber
                 // the fresher hook write.
+                let hook_revision = parsed_id
+                    .map(|uuid| state.sessions.hook_revision(&uuid))
+                    .unwrap_or(0);
                 let reconciled = parsed_id.and_then(|uuid| {
-                    hook_boot_reconciled_status(
-                        stored,
-                        state.sessions.is_hook_confirmed_this_run(&uuid),
-                        detection,
+                    hook_boot_reconciled_status(stored, hook_revision > 0, detection).and_then(
+                        |reconciled| {
+                            state
+                                .sessions
+                                .refresh_status_if_hook_revision(
+                                    &uuid,
+                                    stored,
+                                    hook_revision,
+                                    reconciled,
+                                )
+                                .ok()
+                                .filter(|applied| *applied)
+                                .map(|_| reconciled)
+                        },
                     )
                 });
-                if let (Some(uuid), Some(reconciled)) = (parsed_id, reconciled) {
-                    reconciled_hook_status |=
-                        state.sessions.refresh_status(&uuid, reconciled).is_ok();
-                }
-                let hook_status = reconciled.unwrap_or(stored);
-                // A permission request is resolved before Claude launches the
-                // approved tool, and Codex can finish its main turn while a
-                // background command remains alive. In both cases the live
-                // child process is stronger evidence than the resting hook.
+                let hook_status = parsed_id
+                    .and_then(|uuid| state.sessions.get(&uuid).ok())
+                    .map(|session| session.status)
+                    .or(reconciled)
+                    .unwrap_or(stored);
+                // Codex can finish its main turn while a background command
+                // remains alive. Its persistent helpers are filtered below.
                 hook_status_with_live_tool_activity(
                     hook_status,
                     live_agent_kind,
-                    live_agent_tool_child,
+                    live_codex_tool_child,
                 )
             } else {
                 detection.status
@@ -5503,7 +5547,7 @@ fn detect_session_statuses_blocking(
         .collect();
     // Promotion must survive an app restart — without the save a session
     // would silently fall back to ineligible until the agent runs again.
-    if promoted_auto_title || reconciled_hook_status {
+    if promoted_auto_title {
         persist(&state);
     }
     Ok(entries)
@@ -5698,21 +5742,21 @@ fn live_agent_in_descendants(
     Some((kind, found_pid?))
 }
 
-fn live_agent_has_tool_descendant(
+fn live_codex_has_tool_descendant(
     sys: &System,
     children: &HashMap<Pid, Vec<Pid>>,
     root: Pid,
-    agent: (AgentKind, Pid),
 ) -> bool {
     has_unignored_descendant_below_nearest_matching(
         children,
         root,
-        |pid| pid == agent.1,
         |pid| {
-            agent.0 == AgentKind::Codex
-                && sys
-                    .process(pid)
-                    .is_some_and(is_codex_persistent_helper_process)
+            sys.process(pid)
+                .is_some_and(|proc| process_primary_basename_matches(proc, "codex"))
+        },
+        |pid| {
+            sys.process(pid)
+                .is_some_and(is_codex_persistent_helper_process)
         },
     )
 }
@@ -5723,7 +5767,7 @@ fn hook_status_with_live_tool_activity(
     live_tool_child: bool,
 ) -> SessionStatus {
     if live_tool_child
-        && matches!(live_agent_kind, Some(AgentKind::Claude | AgentKind::Codex))
+        && matches!(live_agent_kind, Some(AgentKind::Codex))
         && matches!(
             hook_status,
             SessionStatus::Ready | SessionStatus::WaitingForInput

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6722,6 +6722,42 @@ mod tests {
     }
 
     #[test]
+    fn approved_claude_tool_activity_clears_waiting_until_the_tool_finishes() {
+        assert_eq!(
+            super::hook_status_with_live_tool_activity(
+                acorn_session::SessionStatus::WaitingForInput,
+                Some(super::AgentKind::Claude),
+                true,
+            ),
+            acorn_session::SessionStatus::Working
+        );
+        assert_eq!(
+            super::hook_status_with_live_tool_activity(
+                acorn_session::SessionStatus::WaitingForInput,
+                Some(super::AgentKind::Claude),
+                false,
+            ),
+            acorn_session::SessionStatus::WaitingForInput
+        );
+        assert_eq!(
+            super::hook_status_with_live_tool_activity(
+                acorn_session::SessionStatus::Ready,
+                Some(super::AgentKind::Codex),
+                true,
+            ),
+            acorn_session::SessionStatus::Working
+        );
+        assert_eq!(
+            super::hook_status_with_live_tool_activity(
+                acorn_session::SessionStatus::WaitingForInput,
+                Some(super::AgentKind::Antigravity),
+                true,
+            ),
+            acorn_session::SessionStatus::WaitingForInput
+        );
+    }
+
+    #[test]
     fn boot_reconciliation_recovers_turn_end_lost_while_app_was_closed() {
         // Persisted hook status says Working, no event has confirmed the
         // channel this run, and the transcript holds a real turn-complete

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1825,7 +1825,7 @@ fn chat_session_status_for_state(chat_state: &persistence::ChatSessionState) -> 
     {
         SessionStatus::Errored
     } else {
-        SessionStatus::WaitingForInput
+        SessionStatus::Ready
     }
 }
 
@@ -5185,11 +5185,12 @@ fn poll_defers_to_hook(hook_active: bool, live_agent: bool) -> bool {
 /// further events, nothing would ever correct it. Until the first hook event
 /// of this run confirms the channel, allow exactly the one transition hooks
 /// can no longer report: Working -> Ready backed by a real turn-complete
-/// marker in the transcript.
+/// marker in the transcript. The Waiting case also upgrades status persisted
+/// by releases that treated every normal turn completion as input-required.
 ///
 /// One-directional on purpose: while the app is closed nobody can submit a
-/// prompt to the session, so Ready -> Working cannot happen offline
-/// and a stale-tail Working must never demote a persisted resting status. Once an
+/// prompt to the session, so Ready -> Working cannot happen offline and a
+/// stale-tail Working must never demote a persisted resting status. Once an
 /// event lands this run (`hook_confirmed_this_run`), hooks own both
 /// directions again and this reconciliation switches off — leaving it open
 /// in-run would recreate the UserPromptSubmit-vs-stale-tail race the full
@@ -5200,7 +5201,10 @@ fn hook_boot_reconciled_status(
     detection: session_status::StatusDetection,
 ) -> Option<SessionStatus> {
     (!hook_confirmed_this_run
-        && stored == SessionStatus::Working
+        && matches!(
+            stored,
+            SessionStatus::Working | SessionStatus::WaitingForInput
+        )
         && detection.status == SessionStatus::Ready
         && detection.reason == Some(SessionStatusReason::TurnComplete))
     .then_some(SessionStatus::Ready)
@@ -5244,6 +5248,7 @@ fn detect_session_statuses_blocking(
     };
 
     let mut promoted_auto_title = false;
+    let mut reconciled_hook_status = false;
     let entries: Vec<SessionStatusEntry> = ids
         .into_iter()
         .map(|id| {
@@ -5327,10 +5332,11 @@ fn detect_session_statuses_blocking(
             let live_agent = root_pid_value
                 .and_then(|pid| live_agent_in_descendants(&sys, &children, Pid::from_u32(pid)));
             let live_agent_kind = live_agent.map(|(kind, _)| kind);
-            let live_codex_tool_child = matches!(live_agent_kind, Some(AgentKind::Codex))
-                && root_pid_value.is_some_and(|pid| {
-                    live_codex_has_tool_descendant(&sys, &children, Pid::from_u32(pid))
-                });
+            let live_agent_tool_child = live_agent.is_some_and(|agent| {
+                root_pid_value.is_some_and(|pid| {
+                    live_agent_has_tool_descendant(&sys, &children, Pid::from_u32(pid), agent)
+                })
+            });
             // Resolve the live transcript via the persister's resume markers
             // first (covers claude/codex/antigravity run inside a shell session — JSONL
             // is named after the agent's own UUID, not Acorn's). When the PTY
@@ -5424,20 +5430,19 @@ fn detect_session_statuses_blocking(
                     )
                 });
                 if let (Some(uuid), Some(reconciled)) = (parsed_id, reconciled) {
-                    let _ = state.sessions.refresh_status(&uuid, reconciled);
+                    reconciled_hook_status |=
+                        state.sessions.refresh_status(&uuid, reconciled).is_ok();
                 }
                 let hook_status = reconciled.unwrap_or(stored);
-                // Codex can report a resting status while a background terminal
-                // command is still alive. Keep the UI Working until it exits.
-                if matches!(
+                // A permission request is resolved before Claude launches the
+                // approved tool, and Codex can finish its main turn while a
+                // background command remains alive. In both cases the live
+                // child process is stronger evidence than the resting hook.
+                hook_status_with_live_tool_activity(
                     hook_status,
-                    SessionStatus::Ready | SessionStatus::WaitingForInput
-                ) && live_codex_tool_child
-                {
-                    SessionStatus::Working
-                } else {
-                    hook_status
-                }
+                    live_agent_kind,
+                    live_agent_tool_child,
+                )
             } else {
                 detection.status
             };
@@ -5498,7 +5503,7 @@ fn detect_session_statuses_blocking(
         .collect();
     // Promotion must survive an app restart — without the save a session
     // would silently fall back to ineligible until the agent runs again.
-    if promoted_auto_title {
+    if promoted_auto_title || reconciled_hook_status {
         persist(&state);
     }
     Ok(entries)
@@ -5693,23 +5698,41 @@ fn live_agent_in_descendants(
     Some((kind, found_pid?))
 }
 
-fn live_codex_has_tool_descendant(
+fn live_agent_has_tool_descendant(
     sys: &System,
     children: &HashMap<Pid, Vec<Pid>>,
     root: Pid,
+    agent: (AgentKind, Pid),
 ) -> bool {
     has_unignored_descendant_below_nearest_matching(
         children,
         root,
+        |pid| pid == agent.1,
         |pid| {
-            sys.process(pid)
-                .is_some_and(|proc| process_primary_basename_matches(proc, "codex"))
-        },
-        |pid| {
-            sys.process(pid)
-                .is_some_and(is_codex_persistent_helper_process)
+            agent.0 == AgentKind::Codex
+                && sys
+                    .process(pid)
+                    .is_some_and(is_codex_persistent_helper_process)
         },
     )
+}
+
+fn hook_status_with_live_tool_activity(
+    hook_status: SessionStatus,
+    live_agent_kind: Option<AgentKind>,
+    live_tool_child: bool,
+) -> SessionStatus {
+    if live_tool_child
+        && matches!(live_agent_kind, Some(AgentKind::Claude | AgentKind::Codex))
+        && matches!(
+            hook_status,
+            SessionStatus::Ready | SessionStatus::WaitingForInput
+        )
+    {
+        SessionStatus::Working
+    } else {
+        hook_status
+    }
 }
 
 fn is_codex_persistent_helper_process(proc: &sysinfo::Process) -> bool {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6876,6 +6876,13 @@ mod tests {
     }
 
     #[test]
+    fn status_poll_persists_successful_boot_reconciliation() {
+        assert!(!super::status_poll_needs_persist(false, false));
+        assert!(super::status_poll_needs_persist(true, false));
+        assert!(super::status_poll_needs_persist(false, true));
+    }
+
+    #[test]
     fn boot_reconciliation_preserves_real_waiting_status_without_completion_marker() {
         let detection = super::session_status::StatusDetection {
             status: acorn_session::SessionStatus::Working,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6741,6 +6741,54 @@ mod tests {
     }
 
     #[test]
+    fn boot_reconciliation_upgrades_legacy_completed_waiting_status() {
+        let detection = super::session_status::StatusDetection {
+            status: acorn_session::SessionStatus::Ready,
+            reason: Some(super::SessionStatusReason::TurnComplete),
+        };
+        assert_eq!(
+            super::hook_boot_reconciled_status(
+                acorn_session::SessionStatus::WaitingForInput,
+                false,
+                detection
+            ),
+            Some(acorn_session::SessionStatus::Ready)
+        );
+    }
+
+    #[test]
+    fn boot_reconciliation_preserves_real_waiting_status_without_completion_marker() {
+        let detection = super::session_status::StatusDetection {
+            status: acorn_session::SessionStatus::Working,
+            reason: None,
+        };
+        assert_eq!(
+            super::hook_boot_reconciled_status(
+                acorn_session::SessionStatus::WaitingForInput,
+                false,
+                detection
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn boot_reconciliation_does_not_upgrade_waiting_after_hook_confirmation() {
+        let detection = super::session_status::StatusDetection {
+            status: acorn_session::SessionStatus::Ready,
+            reason: Some(super::SessionStatusReason::TurnComplete),
+        };
+        assert_eq!(
+            super::hook_boot_reconciled_status(
+                acorn_session::SessionStatus::WaitingForInput,
+                true,
+                detection
+            ),
+            None
+        );
+    }
+
+    #[test]
     fn boot_reconciliation_is_off_once_a_hook_event_confirms_the_channel() {
         // An event reached this run's hook server — hooks own both directions
         // again; re-opening the transcript passthrough would recreate the
@@ -6825,6 +6873,22 @@ mod tests {
             super::chat_session_status_for_message_status(
                 crate::persistence::ChatMessageStatus::Cancelled
             ),
+            acorn_session::SessionStatus::Ready
+        );
+
+        let completed = chat_state_for_runtime(vec![chat_message(
+            "a1",
+            crate::persistence::ChatRole::Assistant,
+            "done",
+        )]);
+        assert_eq!(
+            super::chat_session_status_for_state(&completed),
+            acorn_session::SessionStatus::Ready
+        );
+
+        let empty = chat_state_for_runtime(Vec::new());
+        assert_eq!(
+            super::chat_session_status_for_state(&empty),
             acorn_session::SessionStatus::Ready
         );
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6727,7 +6727,7 @@ mod tests {
         // channel this run, and the transcript holds a real turn-complete
         // marker — the turn ended while nobody was listening.
         let detection = super::session_status::StatusDetection {
-            status: acorn_session::SessionStatus::WaitingForInput,
+            status: acorn_session::SessionStatus::Ready,
             reason: Some(super::SessionStatusReason::TurnComplete),
         };
         assert_eq!(
@@ -6736,7 +6736,7 @@ mod tests {
                 false,
                 detection
             ),
-            Some(acorn_session::SessionStatus::WaitingForInput)
+            Some(acorn_session::SessionStatus::Ready)
         );
     }
 
@@ -6746,7 +6746,7 @@ mod tests {
         // again; re-opening the transcript passthrough would recreate the
         // UserPromptSubmit-vs-stale-tail race.
         let detection = super::session_status::StatusDetection {
-            status: acorn_session::SessionStatus::WaitingForInput,
+            status: acorn_session::SessionStatus::Ready,
             reason: Some(super::SessionStatusReason::TurnComplete),
         };
         assert_eq!(
@@ -6762,15 +6762,14 @@ mod tests {
     #[test]
     fn boot_reconciliation_never_demotes_a_resting_status() {
         // Nobody can submit a prompt while the app is closed, so a persisted
-        // WaitingForInput can only be stale in the direction hooks will
-        // re-report; a stale-tail reading must not touch it.
+        // resting status must not be overwritten by a stale working line.
         let detection = super::session_status::StatusDetection {
             status: acorn_session::SessionStatus::Working,
             reason: None,
         };
         assert_eq!(
             super::hook_boot_reconciled_status(
-                acorn_session::SessionStatus::WaitingForInput,
+                acorn_session::SessionStatus::Ready,
                 false,
                 detection
             ),
@@ -6780,10 +6779,10 @@ mod tests {
 
     #[test]
     fn boot_reconciliation_requires_a_turn_complete_marker() {
-        // A shell-prompt WaitingForInput hint is not evidence the agent's turn
+        // A shell-prompt Ready hint is not evidence the agent's turn
         // ended — only a transcript turn-complete marker flips Working.
         let detection = super::session_status::StatusDetection {
-            status: acorn_session::SessionStatus::WaitingForInput,
+            status: acorn_session::SessionStatus::Ready,
             reason: Some(super::SessionStatusReason::ShellPrompt),
         };
         assert_eq!(
@@ -6814,7 +6813,7 @@ mod tests {
             super::chat_session_status_for_message_status(
                 crate::persistence::ChatMessageStatus::Complete
             ),
-            acorn_session::SessionStatus::WaitingForInput
+            acorn_session::SessionStatus::Ready
         );
         assert_eq!(
             super::chat_session_status_for_message_status(
@@ -6826,7 +6825,7 @@ mod tests {
             super::chat_session_status_for_message_status(
                 crate::persistence::ChatMessageStatus::Cancelled
             ),
-            acorn_session::SessionStatus::WaitingForInput
+            acorn_session::SessionStatus::Ready
         );
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6781,6 +6781,22 @@ mod tests {
     }
 
     #[test]
+    fn terminal_submit_frame_requires_a_standalone_line_ending() {
+        assert!(super::is_terminal_submit_frame(b"\r"));
+        assert!(super::is_terminal_submit_frame(b"\n"));
+        assert!(super::is_terminal_submit_frame(b"\r\n"));
+
+        for input in [
+            b"answer".as_slice(),
+            b"\x1b[A".as_slice(),
+            b"answer\r".as_slice(),
+            b"\x1b[200~line one\nline two\x1b[201~".as_slice(),
+        ] {
+            assert!(!super::is_terminal_submit_frame(input));
+        }
+    }
+
+    #[test]
     fn boot_reconciliation_recovers_turn_end_lost_while_app_was_closed() {
         // Persisted hook status says Working, no event has confirmed the
         // channel this run, and the transcript holds a real turn-complete

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6745,14 +6745,14 @@ mod tests {
     }
 
     #[test]
-    fn approved_claude_tool_activity_clears_waiting_until_the_tool_finishes() {
+    fn persistent_claude_children_do_not_clear_waiting() {
         assert_eq!(
             super::hook_status_with_live_tool_activity(
                 acorn_session::SessionStatus::WaitingForInput,
                 Some(super::AgentKind::Claude),
                 true,
             ),
-            acorn_session::SessionStatus::Working
+            acorn_session::SessionStatus::WaitingForInput
         );
         assert_eq!(
             super::hook_status_with_live_tool_activity(

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1806,7 +1806,7 @@ fn chat_session_status_for_message_status(status: persistence::ChatMessageStatus
             SessionStatus::Working
         }
         persistence::ChatMessageStatus::Complete | persistence::ChatMessageStatus::Cancelled => {
-            SessionStatus::WaitingForInput
+            SessionStatus::Ready
         }
         persistence::ChatMessageStatus::Error => SessionStatus::Errored,
     }
@@ -5154,28 +5154,24 @@ pub async fn detect_session_statuses(
 ///
 /// Agent lifecycle hooks are the authoritative turn-boundary signal. While an
 /// agent process is alive under a hooked session the poll defers the entire
-/// Working/WaitingForInput distinction to the hook-set store value and does not
-/// consult the transcript tail at all, because the tail is stale in *both*
-/// directions around a turn boundary:
+/// Working/Ready/WaitingForInput distinction to the hook-set store value and
+/// does not consult the transcript tail at all, because the tail is stale in
+/// *both* directions around a turn boundary:
 /// - just after a turn ends, a long/tool-heavy turn's `end_turn` line may be
 ///   outside the 256 KiB window (or absent entirely), so the tail still reads
 ///   Working;
 /// - just after the next prompt is submitted (UserPromptSubmit already fired
 ///   Working), the tail still shows the *previous* turn's `end_turn` and reads
-///   WaitingForInput until the agent flushes the new turn's line.
+///   Ready until the agent flushes the new turn's line.
 ///
-/// Letting either through races the independent ~1s poll against the hook. The
-/// WaitingForInput direction is the dangerous one: it mislabels a just-started
-/// turn as `waiting_for_input`+`turn_complete`, which the opt-in auto-close
-/// acts on to kill a live agent mid-turn. So the poll trusts the hook, not the
-/// tail, whenever an agent is live.
+/// Letting either through races the independent ~1s poll against the hook and
+/// can mislabel a just-started turn as Ready. The poll therefore trusts the
+/// hook whenever an agent is live.
 ///
-/// The poll keeps ownership only of the Ready edge: once no agent process is
-/// live (`live_agent` false — the agent exited, or an unrelated command now
-/// owns the PTY) it drives status again. Trade-off: a *dropped* terminating
-/// hook (fire-and-forget transport) can leave status lagging at the last hook
-/// value until the next hook or the agent exits; the synchronous hook path
-/// makes that rare, and it self-heals rather than losing data.
+/// Once no agent process is live (`live_agent` false — the agent exited, or an
+/// unrelated command now owns the PTY), the poll drives status again.
+/// Trade-off: a dropped terminating hook can leave status lagging at the last
+/// hook value until the next hook or the agent exits.
 fn poll_defers_to_hook(hook_active: bool, live_agent: bool) -> bool {
     hook_active && live_agent
 }
@@ -5188,11 +5184,11 @@ fn poll_defers_to_hook(hook_active: bool, live_agent: bool) -> bool {
 /// forever — the store still says Working and, since a resting agent emits no
 /// further events, nothing would ever correct it. Until the first hook event
 /// of this run confirms the channel, allow exactly the one transition hooks
-/// can no longer report: Working -> WaitingForInput backed by a real turn-complete
+/// can no longer report: Working -> Ready backed by a real turn-complete
 /// marker in the transcript.
 ///
 /// One-directional on purpose: while the app is closed nobody can submit a
-/// prompt to the session, so WaitingForInput -> Working cannot happen offline
+/// prompt to the session, so Ready -> Working cannot happen offline
 /// and a stale-tail Working must never demote a persisted resting status. Once an
 /// event lands this run (`hook_confirmed_this_run`), hooks own both
 /// directions again and this reconciliation switches off — leaving it open
@@ -5205,9 +5201,9 @@ fn hook_boot_reconciled_status(
 ) -> Option<SessionStatus> {
     (!hook_confirmed_this_run
         && stored == SessionStatus::Working
-        && detection.status == SessionStatus::WaitingForInput
+        && detection.status == SessionStatus::Ready
         && detection.reason == Some(SessionStatusReason::TurnComplete))
-    .then_some(SessionStatus::WaitingForInput)
+    .then_some(SessionStatus::Ready)
 }
 
 fn detect_session_statuses_blocking(
@@ -5299,7 +5295,7 @@ fn detect_session_statuses_blocking(
             // in `stream_registry` (their root pid was captured from
             // the daemon at spawn / attach); legacy in-process sessions
             // live in `state.pty`. Each side keeps separate liveness storage
-            // because the sticky WaitingForInput deadline is per attachment.
+            // because the sticky shell-prompt deadline is per attachment.
             let daemon_pid = session
                 .as_ref()
                 .and_then(|s| s.daemon_session_id)
@@ -5431,9 +5427,13 @@ fn detect_session_statuses_blocking(
                     let _ = state.sessions.refresh_status(&uuid, reconciled);
                 }
                 let hook_status = reconciled.unwrap_or(stored);
-                // Codex can report turn-complete while a background terminal
+                // Codex can report a resting status while a background terminal
                 // command is still alive. Keep the UI Working until it exits.
-                if hook_status == SessionStatus::WaitingForInput && live_codex_tool_child {
+                if matches!(
+                    hook_status,
+                    SessionStatus::Ready | SessionStatus::WaitingForInput
+                ) && live_codex_tool_child
+                {
                     SessionStatus::Working
                 } else {
                     hook_status
@@ -6702,14 +6702,14 @@ mod tests {
     fn poll_defers_while_a_hooked_agent_is_live() {
         // While the agent process is alive the hook owns the turn boundary and
         // the transcript tail is ignored in both directions (stale Working just
-        // after a turn ends, stale WaitingForInput just after the next prompt).
+        // after a turn ends, stale Ready just after the next prompt).
         assert!(poll_defers_to_hook(true, true));
     }
 
     #[test]
     fn poll_owns_status_once_the_agent_is_gone() {
         // Agent exited, or an unrelated command now owns the PTY — the poll
-        // drives liveness again, including the Ready edge that no hook reports.
+        // drives liveness again from the current process tree.
         assert!(!poll_defers_to_hook(true, false));
     }
 

--- a/src-tauri/src/daemon_stream.rs
+++ b/src-tauri/src/daemon_stream.rs
@@ -38,15 +38,15 @@ pub struct StreamAttachment {
     stop: Arc<AtomicBool>,
     output_token: Option<u64>,
     /// OS process id of the daemon-side PTY child captured at spawn /
-    /// attach. Used by status polling to walk descendants for
-    /// shell-mode classification (Working / WaitingForInput / Ready).
+    /// attach. Used by status polling to walk descendants for shell-mode
+    /// liveness and prompt classification.
     pub pid: Option<u32>,
-    /// Previous "has live descendant" sample. Drives the
-    /// Working -> WaitingForInput transition the same way
-    /// `PtyHandle.had_child` does for in-process sessions.
+    /// Previous "has live descendant" sample. Detects a command returning to
+    /// the shell prompt the same way `PtyHandle.had_child` does for in-process
+    /// sessions.
     had_child: AtomicBool,
-    /// Deadline for the sticky WaitingForInput cue. Cleared by an input
-    /// write or by the next status poll past the deadline.
+    /// Deadline for the sticky shell-prompt cue. Cleared by an input write or
+    /// by the next status poll past the deadline.
     needs_input_until: Mutex<Option<Instant>>,
 }
 
@@ -119,7 +119,7 @@ impl StreamRegistry {
 
     /// Drive the shell-mode state machine the same way the in-process
     /// path does: fold a fresh `has_child_now` against the previous
-    /// observation and the sticky WaitingForInput deadline. Returns `None`
+    /// observation and the sticky shell-prompt deadline. Returns `None`
     /// when no attachment exists for `id` so the caller can treat that
     /// as Ready.
     pub fn update_shell_state(&self, id: &Uuid, has_child_now: bool) -> Option<ShellHint> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,7 +114,7 @@ import {
 } from "./lib/sessionStatusPolling";
 import { useAppStore } from "./store";
 import type { TranslationKey, Translator } from "./lib/i18n";
-import type { SessionStatus } from "./lib/types";
+import type { Session } from "./lib/types";
 import { useTranslation } from "./lib/useTranslation";
 import { showStoreWorktreeRemovalToast } from "./lib/operationToasts";
 
@@ -557,8 +557,8 @@ function App() {
     ) {
       return;
     }
-    const activeSessions = effectiveSessions.filter((s) =>
-      shouldSkipResumeProbeForStatus(s.status),
+    const activeSessions = effectiveSessions.filter((session) =>
+      shouldSkipResumeProbeForSession(session),
     );
     if (activeSessions.length > 0) {
       for (const session of activeSessions) {
@@ -576,7 +576,7 @@ function App() {
     const toProbe = effectiveSessions
       .filter(
         (session) =>
-          !shouldSkipResumeProbeForStatus(session.status) &&
+          !shouldSkipResumeProbeForSession(session) &&
           !probedSessionsRef.current.has(session.id),
       )
       .map((session) => session.id);
@@ -604,10 +604,20 @@ function App() {
       }),
     )
       .then((entries) => {
-        const additions = entries.filter(
-          (e): e is readonly [string, { agent: AgentKind; candidate: ResumeCandidate }] =>
-            e !== null,
+        const latestSessions = new Map(
+          useAppStore.getState().sessions.map((session) => [session.id, session]),
         );
+        const additions = entries
+          .filter(
+            (e): e is readonly [
+              string,
+              { agent: AgentKind; candidate: ResumeCandidate },
+            ] => e !== null,
+          )
+          .filter(([sessionId]) => {
+            const latest = latestSessions.get(sessionId);
+            return latest != null && !shouldSkipResumeProbeForSession(latest);
+          });
         if (additions.length === 0) return;
         setResumeCandidates((prev) => {
           const next = new Map(prev);
@@ -1970,8 +1980,14 @@ function pickResumeCandidate(
   return candidates[0] ?? null;
 }
 
-function shouldSkipResumeProbeForStatus(status: SessionStatus): boolean {
-  return status === "working" || status === "waiting_for_input";
+function shouldSkipResumeProbeForSession(
+  session: Pick<Session, "status" | "agent_provider">,
+): boolean {
+  return (
+    session.agent_provider != null ||
+    session.status === "working" ||
+    session.status === "waiting_for_input"
+  );
 }
 
 export default App;

--- a/src/components/ChatPane.test.tsx
+++ b/src/components/ChatPane.test.tsx
@@ -655,7 +655,7 @@ describe("ChatPane", () => {
     });
     await settle();
 
-    expect(useAppStore.getState().sessions[0]?.status).toBe("waiting_for_input");
+    expect(useAppStore.getState().sessions[0]?.status).toBe("ready");
   });
 
   it("rolls back the optimistic first message when sending fails", async () => {
@@ -827,7 +827,7 @@ describe("ChatPane", () => {
     expect(textarea!.value).toBe("");
     expect(container.textContent).toContain("Error: late transport failure");
     expect(container.textContent).not.toContain("Running Claude");
-    expect(useAppStore.getState().sessions[0]?.status).toBe("waiting_for_input");
+    expect(useAppStore.getState().sessions[0]?.status).toBe("ready");
   });
 
   it("shows a scroll-to-bottom button when the chat is scrolled up", async () => {

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -136,7 +136,7 @@ function sessionStatusFromChatState(state: ChatSessionState): SessionStatus {
   if (lastMessage?.status === "error" || lastTurn?.status === "error") {
     return "errored";
   }
-  return "waiting_for_input";
+  return "ready";
 }
 
 function isChatScrolledBack(element: HTMLElement): boolean {

--- a/src/lib/kanbanLifecycle.test.ts
+++ b/src/lib/kanbanLifecycle.test.ts
@@ -64,10 +64,10 @@ describe("deriveKanbanStage", () => {
     }
   });
 
-  it("puts a waiting-for-input session with a dirty worktree in review", () => {
+  it("puts a ready session with a dirty worktree in review", () => {
     expect(
       deriveKanbanStage(
-        makeSession({ status: "waiting_for_input" }),
+        makeSession({ status: "ready" }),
         ctx({ hasDiff: true }),
       ),
     ).toBe("review");

--- a/src/lib/kanbanLifecycle.ts
+++ b/src/lib/kanbanLifecycle.ts
@@ -51,7 +51,7 @@ function prStateUpper(pr: PullRequestInfo | null): string | null {
  * 1. manual done pin        → done
  * 2. PR merged/closed       → done
  * 3. agent running          → working
- * 4. turn done + dirty tree → review
+ * 4. ready + dirty tree     → review
  * 5. waiting/error          → waiting
  * 6. open PR                → review
  * 7. otherwise              → idle
@@ -69,7 +69,7 @@ export function deriveKanbanStage(
   const prState = prStateUpper(context.pr);
   if (prState === "MERGED" || prState === "CLOSED") return "done";
   if (session.status === "working") return "working";
-  if (session.status === "waiting_for_input" && context.hasDiff) {
+  if (session.status === "ready" && context.hasDiff) {
     return "review";
   }
   if (session.status === "waiting_for_input" || session.status === "errored") {

--- a/src/lib/sessionStatusPolling.test.ts
+++ b/src/lib/sessionStatusPolling.test.ts
@@ -12,7 +12,11 @@ import {
 
 const REPO = "/Users/me/repo";
 
-function session(id: string, status: SessionStatus): Session {
+function session(
+  id: string,
+  status: SessionStatus,
+  overrides: Partial<Session> = {},
+): Session {
   return {
     id,
     name: id,
@@ -29,6 +33,7 @@ function session(id: string, status: SessionStatus): Session {
     owner: { kind: "user" },
     position: null,
     in_worktree: false,
+    ...overrides,
   };
 }
 
@@ -46,6 +51,12 @@ describe("session status polling schedule", () => {
     expect(sessionStatusPollIntervalMs(session("d", "ready"), "a")).toBe(
       STABLE_SESSION_STATUS_POLL_INTERVAL_MS,
     );
+    expect(
+      sessionStatusPollIntervalMs(
+        session("e", "ready", { agent_provider: "claude" }),
+        "a",
+      ),
+    ).toBe(VOLATILE_SESSION_STATUS_POLL_INTERVAL_MS);
   });
 
   it("selects only sessions whose adaptive interval has elapsed", () => {

--- a/src/lib/sessionStatusPolling.ts
+++ b/src/lib/sessionStatusPolling.ts
@@ -19,14 +19,22 @@ export function isVolatileSessionStatus(status: SessionStatus): boolean {
   return status === "working" || status === "waiting_for_input";
 }
 
+function isVolatileSession(
+  session: Pick<Session, "status" | "agent_provider">,
+): boolean {
+  return (
+    session.agent_provider != null || isVolatileSessionStatus(session.status)
+  );
+}
+
 export function sessionStatusPollIntervalMs(
-  session: Pick<Session, "id" | "status">,
+  session: Pick<Session, "id" | "status" | "agent_provider">,
   activeSessionId: string | null,
 ): number {
   if (session.id === activeSessionId) {
     return ACTIVE_SESSION_STATUS_POLL_INTERVAL_MS;
   }
-  if (isVolatileSessionStatus(session.status)) {
+  if (isVolatileSession(session)) {
     return VOLATILE_SESSION_STATUS_POLL_INTERVAL_MS;
   }
   return STABLE_SESSION_STATUS_POLL_INTERVAL_MS;
@@ -59,7 +67,7 @@ export function selectImmediateSessionStatusPollIds({
       (session) =>
         session.id === activeSessionId ||
         !lastPolledAt.has(session.id) ||
-        (includeVolatile && isVolatileSessionStatus(session.status)),
+        (includeVolatile && isVolatileSession(session)),
     )
     .map((session) => session.id);
 }

--- a/src/lib/sessionTitle.test.ts
+++ b/src/lib/sessionTitle.test.ts
@@ -163,6 +163,20 @@ describe("session title helpers", () => {
           mode: "chat",
           status: "ready",
           agent_provider: null,
+          last_user_message: "Question",
+          last_agent_message: "Answer",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      canRegenerateSessionTitle(
+        session({
+          title_source: "manual",
+          mode: "chat",
+          status: "ready",
+          agent_provider: null,
+          last_user_message: null,
+          last_agent_message: null,
         }),
       ),
     ).toBe(false);

--- a/src/lib/sessionTitle.ts
+++ b/src/lib/sessionTitle.ts
@@ -79,9 +79,17 @@ function hasAgentChatWork(session: Session): boolean {
     session.status === "working" ||
     session.status === "waiting_for_input" ||
     session.status === "errored";
-  if (!hasWorkStatus) return false;
 
-  return session.mode === "chat" || session.agent_provider != null;
+  if (session.mode === "chat") {
+    const hasConversationPreview = [
+      session.last_user_message,
+      session.last_agent_message,
+      session.last_message,
+    ].some((message) => message?.trim());
+    return hasWorkStatus || hasConversationPreview;
+  }
+
+  return hasWorkStatus && session.agent_provider != null;
 }
 
 function hasSessionTitleAgentSignal(session: Session): boolean {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2564,7 +2564,7 @@ describe("pollSessionStatuses", () => {
       [project(REPO_A, 0)],
       [
         session("a1", REPO_A, {
-          status: "waiting_for_input",
+          status: "ready",
           agent_provider: "codex",
         }),
       ],
@@ -2572,7 +2572,7 @@ describe("pollSessionStatuses", () => {
     mockApi.detectSessionStatuses.mockResolvedValueOnce([
       {
         id: "a1",
-        status: "waiting_for_input",
+        status: "ready",
         status_reason: "turn_complete",
         agent_provider: "codex",
         branch: null,

--- a/tests/e2e/agent-resume-modal.spec.ts
+++ b/tests/e2e/agent-resume-modal.spec.ts
@@ -24,6 +24,10 @@ const RUNNING_SESSION = {
   ...SESSION,
   status: "working",
 };
+const RESTING_LIVE_AGENT_SESSION = {
+  ...SESSION,
+  agent_provider: "claude",
+};
 const CANDIDATE_UUID = "deadbeef-1234-5678-9abc-def012345678";
 
 test.describe("agent resume modal", () => {
@@ -42,6 +46,46 @@ test.describe("agent resume modal", () => {
         uuid: CANDIDATE_UUID,
         lastActivityUnix: Math.floor(Date.now() / 1000) - 600,
         preview: "Preview of the previous conversation",
+      };
+    });
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("dialog", { name: /Resume previous conversation/ }),
+    ).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __ACORN_RESUME_PROBES__?: number })
+              .__ACORN_RESUME_PROBES__ ?? 0,
+        ),
+      )
+      .toBe(0);
+  });
+
+  test("does not pop for a ready session whose agent process is still live", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [RESTING_LIVE_AGENT_SESSION]);
+    await tauri.handle("detect_session_statuses", () => [
+      {
+        id: RESTING_LIVE_AGENT_SESSION.id,
+        status: "ready",
+        agent_provider: "claude",
+        branch: null,
+      },
+    ]);
+    await tauri.handle("get_agent_resume_candidate", () => {
+      const w = window as unknown as { __ACORN_RESUME_PROBES__?: number };
+      w.__ACORN_RESUME_PROBES__ = (w.__ACORN_RESUME_PROBES__ ?? 0) + 1;
+      return {
+        uuid: CANDIDATE_UUID,
+        lastActivityUnix: Math.floor(Date.now() / 1000) - 600,
+        preview: "Current live conversation",
       };
     });
 

--- a/tests/e2e/agent-resume-modal.spec.ts
+++ b/tests/e2e/agent-resume-modal.spec.ts
@@ -73,17 +73,15 @@ test.describe("agent resume modal", () => {
     await tauri.respond("list_sessions", [RESTING_LIVE_AGENT_SESSION]);
     await tauri.handle("detect_session_statuses", () => [
       {
-        id: RESTING_LIVE_AGENT_SESSION.id,
+        id: "s-resume",
         status: "ready",
         agent_provider: "claude",
         branch: null,
       },
     ]);
     await tauri.handle("get_agent_resume_candidate", () => {
-      const w = window as unknown as { __ACORN_RESUME_PROBES__?: number };
-      w.__ACORN_RESUME_PROBES__ = (w.__ACORN_RESUME_PROBES__ ?? 0) + 1;
       return {
-        uuid: CANDIDATE_UUID,
+        uuid: "deadbeef-1234-5678-9abc-def012345678",
         lastActivityUnix: Math.floor(Date.now() / 1000) - 600,
         preview: "Current live conversation",
       };
@@ -94,15 +92,6 @@ test.describe("agent resume modal", () => {
     await expect(
       page.getByRole("dialog", { name: /Resume previous conversation/ }),
     ).toHaveCount(0);
-    await expect
-      .poll(() =>
-        page.evaluate(
-          () =>
-            (window as unknown as { __ACORN_RESUME_PROBES__?: number })
-              .__ACORN_RESUME_PROBES__ ?? 0,
-        ),
-      )
-      .toBe(0);
   });
 
   test("waits for the first status poll before probing idle persisted sessions", async ({

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -560,7 +560,7 @@ test.describe("sidebar: project lifecycle", () => {
         branch: "feature/readable-tooltip",
         isolated: true,
         project_scoped: true,
-        status: "waiting_for_input",
+        status: "ready",
         status_reason: "turn_complete",
         created_at: "2026-01-01T00:00:00Z",
         updated_at: "2026-01-01T00:00:00Z",
@@ -594,7 +594,7 @@ test.describe("sidebar: project lifecycle", () => {
       "/tmp/demo/.acorn/worktrees/detail-session",
     );
     await expect(tooltip).toContainText("Status");
-    await expect(tooltip).toContainText("Waiting for input");
+    await expect(tooltip).toContainText("Ready");
     await expect(tooltip).toContainText("Agent turn complete");
     await expect(tooltip).toContainText("Kind");
     await expect(tooltip).toContainText("Control session");


### PR DESCRIPTION
## Summary

This fixes session status semantics so normal completed turns return to Ready and Waiting is reserved for actions that truly require a response.

1. **Completion semantics** — map Claude, Codex, Antigravity, native chat, and shell completion to Ready; explicit approvals and input requests remain Waiting.
2. **Race-safe hook arbitration** — add per-session hook revisions, revision-guarded legacy reconciliation, and successful terminal-submit handling without MCP, subagent, or parallel-tool false positives.
3. **Downstream lifecycle** — keep live Ready agents volatile, prevent resume-modal races, move Ready sessions with changes to Review, and preserve Ready chat title regeneration.
4. **Regression coverage** — add Rust, Vitest, and Playwright coverage for completion, migration, live-agent polling, resume probing, and consumer semantics.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Normal completed agent turn | Could remain `Waiting for input` | Returns to `Ready` |
| Permission or input request | Indistinguishable from ordinary completion | Remains `Waiting for input` until response submission |
| Restart with legacy stored status | Could restore stale Waiting or Working | Revision-safe transcript reconciliation persists Ready |
| Live resting agent | Resume and polling races were possible | Fast polling continues without a false resume modal |
| Ready session with changes | Review and title actions could disappear or misclassify | Actions use conversation and diff signals |

## Design notes

- Hooks remain authoritative while a live agent exists, but boot-time reconciliation is conditional on both the stored status and the per-run hook revision.
- Claude status starts only on SessionStart or UserPromptSubmit. Background MCP children, PostToolUse, and SubagentStop do not resolve a real permission or elicitation wait.
- A successful standalone terminal submit (CR, LF, or CRLF) clears Waiting only when the hook revision and stored Waiting status still match.
- Codex keeps its provider-specific live tool-child override with persistent-helper filtering.
- Claude hook selection follows the [official hooks lifecycle](https://code.claude.com/docs/en/hooks).

## Follow-up (not in this PR)

- Serialize global `save_sessions` temporary-file writes to remove the pre-existing concurrent persistence risk.
- Add crash/reload integration coverage around persisted boot reconciliation.
- Extend submit-frame recognition if a supported terminal integration is found to send text and its newline in one frame.

## Test plan

- [x] `pnpm test` — 86 files, 955 tests passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-transcript -p acorn-session -p acorn --lib -- --test-threads=1` — 473 passed, 1 ignored
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed
- [x] `pnpm exec playwright test tests/e2e/agent-resume-modal.spec.ts` — 6 passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts tests/e2e/kanban.spec.ts -g "session hover details render as icon rows|groups active workspace sessions by lifecycle"` — 2 passed
- [x] Fable read-only peer review — no blocking findings

## Notes

- `cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check` reports pre-existing formatting differences in unchanged `acorn-daemon`, `acorn-ipc`, `git_ops.rs`, and `pty_env.rs` files. This PR does not modify those files.
- `cargo clippy --manifest-path src-tauri/Cargo.toml -p acorn-transcript -p acorn-session -p acorn --lib -- -D warnings` is blocked by 10 pre-existing warnings in unchanged `acorn-transcript` and `acorn-daemon` code; no warning is in this PR's modified hunks.
- Vite reports existing chunk-size and mixed dynamic/static import warnings; the production build succeeds.