### PR TITLE
feat(ui): surface keyboard shortcuts in tooltips and context menus

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -1564,39 +1564,49 @@ function TabItem({
             </span>
           ) : null}
         </div>
-        <button
-          type="button"
-          aria-label={
+        <Tooltip
+          label={
             session
               ? paneT(t, "pane.aria.closeSession")
               : paneT(t, "pane.aria.closeTab")
           }
-          data-tab-close-button={tab.id}
-          draggable={false}
-          onPointerDown={(e) => {
-            e.stopPropagation();
-          }}
-          onMouseDown={(e) => {
-            e.stopPropagation();
-          }}
-          onDragStart={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          onClick={(e) => {
-            e.stopPropagation();
-            onClose();
-          }}
-          onKeyDown={(e) => e.stopPropagation()}
-          className={cn(
-            "ml-0.5 flex size-6 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg",
-            active
-              ? "opacity-70 hover:opacity-100"
-              : "opacity-0 group-hover:opacity-70 hover:opacity-100",
-          )}
+          shortcut={shortcutLabel(shortcuts, "closeTab")}
+          side="bottom"
         >
-          <X size={11} />
-        </button>
+          <button
+            type="button"
+            aria-label={
+              session
+                ? paneT(t, "pane.aria.closeSession")
+                : paneT(t, "pane.aria.closeTab")
+            }
+            data-tab-close-button={tab.id}
+            draggable={false}
+            onPointerDown={(e) => {
+              e.stopPropagation();
+            }}
+            onMouseDown={(e) => {
+              e.stopPropagation();
+            }}
+            onDragStart={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose();
+            }}
+            onKeyDown={(e) => e.stopPropagation()}
+            className={cn(
+              "ml-0.5 flex size-6 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg",
+              active
+                ? "opacity-70 hover:opacity-100"
+                : "opacity-0 group-hover:opacity-70 hover:opacity-100",
+            )}
+          >
+            <X size={11} />
+          </button>
+        </Tooltip>
         {isDraggingThisTab ? (
           <WorkspaceTabDragGhost
             drag={tabDrag}

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -48,6 +48,11 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { api, FS_CHANGED_EVENT, type FsChangePayload } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openFileInEditor } from "../lib/editor";
+import {
+  formatHotkey,
+  type HotkeyConfig,
+  type HotkeyId,
+} from "../lib/hotkeys";
 import { joinPath } from "../lib/paths";
 import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
 import {
@@ -232,6 +237,7 @@ async function prefetchProjectPanelData(repoPath: string): Promise<void> {
 
 export function RightPanel() {
   const t = useTranslation();
+  const shortcuts = useSettings((s) => s.settings.shortcuts);
   const sessions = useAppStore((s) => s.sessions);
   const projects = useAppStore((s) => s.projects);
   const activeSessionId = useAppStore((s) => s.activeSessionId);
@@ -495,6 +501,7 @@ export function RightPanel() {
               key={tab}
               icon={tabIcon(tab)}
               label={rt(t, tabLabelKey(tab))}
+              shortcut={rightTabShortcut(shortcuts, tab)}
               badge={tab === "todos" ? todosState.todos.length : undefined}
               active={tab === rightTab}
               onClick={() => setRightTab(tab)}
@@ -655,6 +662,7 @@ interface TabButtonProps {
   onClick: () => void;
   badge?: number;
   className?: string;
+  shortcut?: string;
 }
 
 function TabButton({ icon, label, active, onClick, badge, className }: TabButtonProps) {
@@ -690,8 +698,15 @@ function TabButton({ icon, label, active, onClick, badge, className }: TabButton
 
 // Sub-tabs sit under the group bar with denser padding and a lighter inactive
 // state, so the eye registers "group is primary, sub-tab is secondary".
-function SubTabButton({ icon, label, active, onClick, badge }: TabButtonProps) {
-  return (
+function SubTabButton({
+  icon,
+  label,
+  active,
+  onClick,
+  badge,
+  shortcut,
+}: TabButtonProps) {
+  const button = (
     <button
       type="button"
       onClick={onClick}
@@ -718,6 +733,29 @@ function SubTabButton({ icon, label, active, onClick, badge }: TabButtonProps) {
       ) : null}
     </button>
   );
+  return shortcut ? (
+    <Tooltip label={label} shortcut={shortcut} side="bottom">
+      {button}
+    </Tooltip>
+  ) : (
+    button
+  );
+}
+
+const RIGHT_TAB_HOTKEY: Partial<Record<RightTab, HotkeyId>> = {
+  todos: "toggleTodos",
+  commits: "toggleCommits",
+  staged: "toggleStaged",
+  prs: "togglePrs",
+  files: "toggleFiles",
+};
+
+function rightTabShortcut(
+  shortcuts: HotkeyConfig,
+  tab: RightTab,
+): string | undefined {
+  const id = RIGHT_TAB_HOTKEY[tab];
+  return id ? formatHotkey(shortcuts[id]) : undefined;
 }
 
 function groupIcon(group: RightGroup): ReactNode {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -73,6 +73,7 @@ import {
 import { api, type WorktreeRemoval } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
+import { formatHotkey } from "../lib/hotkeys";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import {
   useSettings,
@@ -269,6 +270,7 @@ function isLocalTerminalAreaFocused(): boolean {
 
 export function Sidebar() {
   const t = useTranslation();
+  const shortcuts = useSettings((s) => s.settings.shortcuts);
   const showToast = useToasts((s) => s.show);
   const sessions = useAppStore((s) => s.sessions);
   const projects = useAppStore((s) => s.projects);
@@ -1170,6 +1172,7 @@ export function Sidebar() {
           </Tooltip>
           <Tooltip
             label={sidebarText(t, "sidebar.projects.addExistingProject")}
+            shortcut={formatHotkey(shortcuts.addProject)}
             side="left"
           >
             <button
@@ -1875,6 +1878,7 @@ function ProjectGroupView({
   onToggleFolder,
 }: ProjectGroupViewProps) {
   const t = useTranslation();
+  const shortcuts = useSettings((s) => s.settings.shortcuts);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [createMenu, setCreateMenu] = useState<{
     x: number;
@@ -1919,6 +1923,9 @@ function ProjectGroupView({
         return {
           label: sidebarText(t, action.labelKey),
           icon: projectSessionCreateIcon(action.id),
+          shortcut: action.hotkeyId
+            ? formatHotkey(shortcuts[action.hotkeyId])
+            : undefined,
           onClick: () =>
             projectSessionCreationFolder
               ? onAddSession(
@@ -1930,7 +1937,7 @@ function ProjectGroupView({
               : undefined,
         };
       }),
-    [onAddSession, projectSessionCreationFolder, t],
+    [onAddSession, projectSessionCreationFolder, shortcuts, t],
   );
   const overflowCreateMenuItems = useMemo<ContextMenuItem[]>(
     () => {
@@ -1939,6 +1946,9 @@ function ProjectGroupView({
           return {
             label: sidebarText(t, action.labelKey),
             icon: projectSessionCreateIcon(action.id),
+            shortcut: action.hotkeyId
+              ? formatHotkey(shortcuts[action.hotkeyId])
+              : undefined,
             onClick: () =>
               projectSessionCreationFolder
                 ? onAddSession(
@@ -1974,6 +1984,7 @@ function ProjectGroupView({
       onAddSession,
       onAddWorktreeFolder,
       projectSessionCreationFolder,
+      shortcuts,
       t,
     ],
   );
@@ -2082,6 +2093,11 @@ function ProjectGroupView({
             <Tooltip
               key={action.id}
               label={sidebarText(t, action.labelKey)}
+              shortcut={
+                action.hotkeyId
+                  ? formatHotkey(shortcuts[action.hotkeyId])
+                  : undefined
+              }
               side="bottom"
             >
               <button
@@ -2345,6 +2361,7 @@ function ProjectFolderView({
   onMoveSessionToFolder,
 }: ProjectFolderViewProps) {
   const t = useTranslation();
+  const shortcuts = useSettings((s) => s.settings.shortcuts);
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [createMenu, setCreateMenu] = useState<{
@@ -2402,12 +2419,15 @@ function ProjectFolderView({
         return {
           label: sidebarText(t, action.labelKey),
           icon: projectSessionCreateIcon(action.id),
+          shortcut: action.hotkeyId
+            ? formatHotkey(shortcuts[action.hotkeyId])
+            : undefined,
           onClick: () =>
             onAddSession(action.isolated, action.kind, action.mode),
         };
       }),
     ],
-    [folderCreateMenu, onAddSession, t],
+    [folderCreateMenu, onAddSession, shortcuts, t],
   );
   const folderOverflowCreateMenuItems = useMemo<ContextMenuItem[]>(
     () => [
@@ -2418,12 +2438,15 @@ function ProjectFolderView({
         return {
           label: sidebarText(t, action.labelKey),
           icon: projectSessionCreateIcon(action.id),
+          shortcut: action.hotkeyId
+            ? formatHotkey(shortcuts[action.hotkeyId])
+            : undefined,
           onClick: () =>
             onAddSession(action.isolated, action.kind, action.mode),
         };
       }),
     ],
-    [folderOverflowCreateMenu, onAddSession, t],
+    [folderOverflowCreateMenu, onAddSession, shortcuts, t],
   );
 
   function submitRename(next: string) {
@@ -2539,6 +2562,7 @@ function ProjectFolderView({
           <div className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover/project-folder:flex group-focus-within/project-folder:flex">
             <Tooltip
               label={sidebarText(t, "sidebar.aria.newSessionInProjectFolder")}
+              shortcut={formatHotkey(shortcuts.newSession)}
               side="bottom"
             >
               <button
@@ -3461,6 +3485,9 @@ function LocalTerminalArea({
   onMoveSessionToFolder,
 }: LocalTerminalAreaProps) {
   const t = useTranslation();
+  const newSessionShortcut = useSettings((s) =>
+    formatHotkey(s.settings.shortcuts.newSession),
+  );
   const sessions = useMemo(
     () => groups.flatMap((group) => group.sessions),
     [groups],
@@ -3503,6 +3530,7 @@ function LocalTerminalArea({
         <div className="flex items-center gap-1">
           <Tooltip
             label={sidebarText(t, "sidebar.localTerminals.newSession")}
+            shortcut={newSessionShortcut}
             side="bottom"
           >
             <button
@@ -4025,6 +4053,9 @@ function LocalWorkspaceView({
   onMoveSessionToFolder,
 }: LocalWorkspaceViewProps) {
   const t = useTranslation();
+  const newSessionShortcut = useSettings((s) =>
+    formatHotkey(s.settings.shortcuts.newSession),
+  );
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const folder = folderGroup.folder;
@@ -4047,6 +4078,7 @@ function LocalWorkspaceView({
     {
       label: sidebarText(t, "sidebar.localTerminals.newSession"),
       icon: <Plus size={12} />,
+      shortcut: newSessionShortcut,
       onClick: onCreateSession,
     },
     contextMenuGroupTitle(t, "workspace"),
@@ -4173,6 +4205,7 @@ function LocalWorkspaceView({
           <div className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover/local-workspace:flex group-focus-within/local-workspace:flex">
             <Tooltip
               label={sidebarText(t, "sidebar.localTerminals.newSession")}
+              shortcut={newSessionShortcut}
               side="bottom"
             >
               <button

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -91,6 +91,21 @@ describe("Tooltip", () => {
     expect(tooltip()?.textContent).toBe("Tooltip details");
   });
 
+  it("renders a keyboard shortcut hint next to the label", () => {
+    act(() => {
+      root.render(
+        <Tooltip label="Close" shortcut="⌘W" delay={0}>
+          <button type="button">Trigger</button>
+        </Tooltip>,
+      );
+    });
+    hoverTrigger();
+    act(() => vi.advanceTimersByTime(0));
+
+    expect(tooltip()?.textContent).toBe("Close⌘W");
+    expect(tooltip()?.querySelector("kbd")?.textContent).toBe("⌘W");
+  });
+
   it("does not show when hover leaves before the delay completes", () => {
     renderTooltip(500);
     hoverTrigger();

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -17,6 +17,8 @@ interface TooltipProps {
    * wrappable layout.
    */
   label: ReactNode;
+  /** Platform-formatted keyboard shortcut shown after the label. */
+  shortcut?: string;
   /** Where the tooltip appears relative to the trigger. Default: "bottom". */
   side?: "top" | "bottom" | "left" | "right";
   /** Delay before showing on hover, in ms. Default: 1000. */
@@ -196,6 +198,7 @@ export function FloatingTooltip({
  */
 export function Tooltip({
   label,
+  shortcut,
   side = "bottom",
   delay = 1000,
   multiline = false,
@@ -256,7 +259,18 @@ export function Tooltip({
         {children}
       </span>
       <FloatingTooltip
-        label={label}
+        label={
+          shortcut ? (
+            <span className="inline-flex items-center gap-2">
+              <span>{label}</span>
+              <kbd className="font-sans text-[10px] text-fg-muted">
+                {shortcut}
+              </kbd>
+            </span>
+          ) : (
+            label
+          )
+        }
         anchorRect={anchorRect}
         side={side}
         multiline={multiline}

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -51,6 +51,7 @@ import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
 import { isInAcornFloatingLayer } from "../lib/floatingLayer";
+import { formatHotkey } from "../lib/hotkeys";
 import type { LayoutNode } from "../lib/layout";
 import { basename } from "../lib/pathUtils";
 import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
@@ -248,6 +249,9 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
 
 function KanbanFilePreviewOverlay() {
   const t = useTranslation();
+  const closeShortcut = useSettings((s) =>
+    formatHotkey(s.settings.shortcuts.closeTab),
+  );
   const activeTabId = useAppStore((s) => s.activeTabId);
   const workspaceTabs = useAppStore((s) => s.workspaceTabs);
   const closeWorkspaceTab = useAppStore((s) => s.closeWorkspaceTab);
@@ -281,12 +285,18 @@ function KanbanFilePreviewOverlay() {
           <div className="min-w-0 flex-1 truncate text-xs font-medium text-fg">
             {tab.title}
           </div>
-          <IconButton
-            aria-label={t("dialogs.common.close")}
-            onClick={() => closeWorkspaceTab(tab.id)}
+          <Tooltip
+            label={t("dialogs.common.close")}
+            shortcut={closeShortcut}
+            side="bottom"
           >
-            <X size={13} />
-          </IconButton>
+            <IconButton
+              aria-label={t("dialogs.common.close")}
+              onClick={() => closeWorkspaceTab(tab.id)}
+            >
+              <X size={13} />
+            </IconButton>
+          </Tooltip>
         </header>
         <div className="min-h-0 flex-1">
           <FileViewer
@@ -973,6 +983,7 @@ function KanbanToolbarButton({
 
 function KanbanCreateSessionDropdown({ t }: { t: Translator }) {
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const shortcuts = useSettings((s) => s.settings.shortcuts);
   const menuItems = useMemo<ContextMenuItem[]>(
     () => [
       workspaceContextMenuGroupTitle(t, "session"),
@@ -982,12 +993,15 @@ function KanbanCreateSessionDropdown({ t }: { t: Translator }) {
         return {
           label: sidebarText(t, action.labelKey),
           icon: kanbanSessionCreateIcon(action.id),
+          shortcut: action.hotkeyId
+            ? formatHotkey(shortcuts[action.hotkeyId])
+            : undefined,
           onClick: () =>
             dispatchKanbanAction(KANBAN_CREATE_ACTION_EVENTS[action.id]),
         };
       }),
     ],
-    [t],
+    [shortcuts, t],
   );
   const label = t("workspace.kanban.actions.createSession");
 
@@ -1747,6 +1761,9 @@ function KanbanTerminalPopover({
   const popoverDefaultSize = useSettings(
     (s) => s.settings.interface.kanbanTerminalPopoverDefaultSize,
   );
+  const closeShortcut = useSettings((s) =>
+    formatHotkey(s.settings.shortcuts.closeTab),
+  );
   const renameSession = useAppStore((s) => s.renameSession);
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
   const selectSession = useAppStore((s) => s.selectSession);
@@ -2391,14 +2408,20 @@ function KanbanTerminalPopover({
           >
             {isExpanded ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
           </IconButton>
-          <IconButton
-            aria-label={t("dialogs.common.close")}
-            onClick={onClose}
-            size="sm"
-            surface="panel"
+          <Tooltip
+            label={t("dialogs.common.close")}
+            shortcut={closeShortcut}
+            side="bottom"
           >
-            <X size={14} />
-          </IconButton>
+            <IconButton
+              aria-label={t("dialogs.common.close")}
+              onClick={onClose}
+              size="sm"
+              surface="panel"
+            >
+              <X size={14} />
+            </IconButton>
+          </Tooltip>
         </div>
       </header>
       <ContextMenu

--- a/src/lib/projectSessionCreateActions.test.ts
+++ b/src/lib/projectSessionCreateActions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { PROJECT_SESSION_CREATE_ACTIONS } from "./projectSessionCreateActions";
+
+describe("PROJECT_SESSION_CREATE_ACTIONS", () => {
+  it("maps session actions to their configurable hotkeys", () => {
+    expect(
+      Object.fromEntries(
+        PROJECT_SESSION_CREATE_ACTIONS.map((action) => [
+          action.id,
+          action.hotkeyId,
+        ]),
+      ),
+    ).toEqual({
+      terminal: "newSession",
+      isolated: "newIsolatedSession",
+      chat: undefined,
+      control: "newControlSession",
+    });
+  });
+});

--- a/src/lib/projectSessionCreateActions.ts
+++ b/src/lib/projectSessionCreateActions.ts
@@ -1,4 +1,5 @@
 import type { TranslationKey } from "./i18n";
+import type { HotkeyId } from "./hotkeys";
 import type { SessionKind, SessionMode } from "./types";
 
 type SidebarActionKey = Extract<TranslationKey, `sidebar.actions.${string}`>;
@@ -17,6 +18,7 @@ export interface ProjectSessionCreateAction {
   isolated: boolean;
   kind: SessionKind;
   mode: SessionMode;
+  hotkeyId?: HotkeyId;
 }
 
 const TERMINAL_ACTION = {
@@ -26,6 +28,7 @@ const TERMINAL_ACTION = {
   isolated: false,
   kind: "regular",
   mode: "terminal",
+  hotkeyId: "newSession",
 } as const satisfies ProjectSessionCreateAction;
 
 const ISOLATED_ACTION = {
@@ -35,6 +38,7 @@ const ISOLATED_ACTION = {
   isolated: true,
   kind: "regular",
   mode: "terminal",
+  hotkeyId: "newIsolatedSession",
 } as const satisfies ProjectSessionCreateAction;
 
 const CHAT_ACTION = {
@@ -44,6 +48,7 @@ const CHAT_ACTION = {
   isolated: false,
   kind: "regular",
   mode: "chat",
+  hotkeyId: undefined,
 } as const satisfies ProjectSessionCreateAction;
 
 const CONTROL_ACTION = {
@@ -53,6 +58,7 @@ const CONTROL_ACTION = {
   isolated: false,
   kind: "control",
   mode: "terminal",
+  hotkeyId: "newControlSession",
 } as const satisfies ProjectSessionCreateAction;
 
 export const PROJECT_SESSION_CREATE_ACTIONS = [

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -349,9 +349,11 @@ test.describe("workspace kanban mode", () => {
       board.getByRole("button", { name: "Equalize sizes" }),
     ).toBeVisible();
     await createSessionButton.click();
-    await expect(
-      page.getByRole("menuitem", { name: "New session" }),
-    ).toBeVisible();
+    const newSessionMenuItem = page.getByRole("menuitem", {
+      name: "New session",
+    });
+    await expect(newSessionMenuItem).toBeVisible();
+    await expect(newSessionMenuItem.locator("kbd")).not.toBeEmpty();
     await expect(
       page.getByRole("menuitem", { name: "New worktree session" }),
     ).toBeVisible();
@@ -361,6 +363,15 @@ test.describe("workspace kanban mode", () => {
     await expect(
       page.getByRole("menuitem", { name: "New control session" }),
     ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "New worktree session" }).locator("kbd"),
+    ).not.toBeEmpty();
+    await expect(
+      page.getByRole("menuitem", { name: "New chat session" }).locator("kbd"),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("menuitem", { name: "New control session" }).locator("kbd"),
+    ).not.toBeEmpty();
     await page.keyboard.press("Escape");
 
     await expect(
@@ -754,6 +765,14 @@ test.describe("workspace kanban mode", () => {
     await expect(
       shellPopover.getByRole("heading", { name: "shell" }),
     ).toBeVisible();
+    const closePopoverButton = shellPopover.getByRole("button", {
+      name: "Close",
+    });
+    await closePopoverButton.hover();
+    const closePopoverTooltip = page.getByRole("tooltip");
+    await expect(closePopoverTooltip).toContainText("Close");
+    await expect(closePopoverTooltip.locator("kbd")).not.toBeEmpty();
+    await page.mouse.move(0, 0);
     await expect(
       page.getByTestId("kanban-terminal-popover-reset-position"),
     ).toBeVisible();

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -353,7 +353,9 @@ test.describe("workspace kanban mode", () => {
       name: "New session",
     });
     await expect(newSessionMenuItem).toBeVisible();
-    await expect(newSessionMenuItem.locator("kbd")).not.toBeEmpty();
+    await expect(newSessionMenuItem.locator("kbd")).toHaveText(
+      /^(⌘T|Ctrl\+T)$/,
+    );
     await expect(
       page.getByRole("menuitem", { name: "New worktree session" }),
     ).toBeVisible();
@@ -771,7 +773,9 @@ test.describe("workspace kanban mode", () => {
     await closePopoverButton.hover();
     const closePopoverTooltip = page.getByRole("tooltip");
     await expect(closePopoverTooltip).toContainText("Close");
-    await expect(closePopoverTooltip.locator("kbd")).not.toBeEmpty();
+    await expect(closePopoverTooltip.locator("kbd")).toHaveText(
+      /^(⌘W|Ctrl\+W)$/,
+    );
     await page.mouse.move(0, 0);
     await expect(
       page.getByTestId("kanban-terminal-popover-reset-position"),

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -76,7 +76,12 @@ test.describe("right panel: tab switching", () => {
     // Default tab is Commits — placeholder is "Select a commit to see diff".
     await expect(page.getByText(/Select a commit to see diff/i)).toBeVisible();
 
-    await page.getByRole("button", { name: "Staged" }).click();
+    const stagedButton = page.getByRole("button", { name: "Staged" });
+    await stagedButton.hover();
+    await expect(page.getByRole("tooltip").locator("kbd")).toHaveText(
+      /^(⇧⌘S|Ctrl\+Shift\+S)$/,
+    );
+    await stagedButton.click();
     await expect(
       page.getByText(/No staged or modified files/i),
     ).toBeVisible();

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -2730,9 +2730,14 @@ test.describe("sidebar: project lifecycle", () => {
 
     const projectRow = page.getByRole("button", { name: "Project demo" });
     await projectRow.hover();
-    await expect(
-      page.getByRole("button", { name: "New session in this project" }),
-    ).toBeVisible();
+    const newSessionButton = page.getByRole("button", {
+      name: "New session in this project",
+    });
+    await expect(newSessionButton).toBeVisible();
+    await newSessionButton.hover();
+    await expect(page.getByRole("tooltip").locator("kbd")).toHaveText(
+      /^(⌘T|Ctrl\+T)$/,
+    );
     await expect(
       page.getByRole("button", {
         name: "New worktree session in this project",
@@ -2747,12 +2752,14 @@ test.describe("sidebar: project lifecycle", () => {
     const menuLabels = await page.getByRole("menuitem").evaluateAll((items) =>
       items.map((item) => item.textContent?.replace(/\s+/g, " ").trim()),
     );
-    expect(menuLabels.slice(0, 4)).toEqual([
+    expect(menuLabels.slice(0, 3)).toEqual([
       "New workspace",
       "New worktree workspace",
       "New chat session",
-      "New control session",
     ]);
+    expect(menuLabels[3]).toMatch(
+      /^New control session(?:⌥⇧⌘T|Ctrl\+Alt\+Shift\+T)$/,
+    );
     await expect(
       page.getByRole("menuitem", { name: "New session" }),
     ).toHaveCount(0);


### PR DESCRIPTION
## Summary

Mapped keyboard shortcuts are now discoverable directly from the controls and menus that invoke them.

1. **Button hints** — render platform-formatted shortcut keys in Tooltip surfaces for Kanban and pane close buttons, Sidebar creation actions, project add, and Right Panel tabs.
2. **Context menu hints** — connect shared session-creation actions to their configurable hotkey IDs so Kanban and Sidebar menus show the same current bindings.
3. **Coverage** — verify shortcut rendering, actions without bindings, pane interactions, menu ordering, and platform-specific labels with Vitest and Playwright.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Shortcut discoverability | Users must open Settings or know the binding | Hovered controls and matching context menus show the active binding |
| Custom shortcut consistency | Some pane menus showed bindings, other surfaces did not | All touched surfaces read from the current shortcut settings and platform formatter |
| Unmapped actions | No hint | Still no hint, avoiding misleading labels |

## Design notes

- Tooltip accepts an optional shortcut and renders it as a visually distinct `kbd` element without changing the trigger accessible name.
- Session creation metadata owns the hotkey ID for terminal, isolated, and control actions; Chat intentionally remains unmapped.
- Existing ContextMenu shortcut rendering remains the presentation path, so submenu behavior and menu semantics are unchanged.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm test` — 87 files, 966 tests pass
- [x] `pnpm exec playwright test tests/e2e/kanban.spec.ts tests/e2e/panes.spec.ts tests/e2e/sidebar.spec.ts tests/e2e/right-panel.spec.ts` — 100 tests pass
- [x] `pnpm run build` — production build passes