### PR TITLE
perf(pr): bound current pull request caches

### DIFF
--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -26,7 +26,7 @@
 //! The picked token is passed to `gh pr list` via `GH_TOKEN`, overriding
 //! whichever account `gh` would otherwise pick.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Mutex;
@@ -1772,10 +1772,54 @@ fn build_commit_login_query(count: usize) -> String {
     query
 }
 
-fn commit_login_cache() -> &'static Mutex<HashMap<(String, String), Option<String>>> {
+const COMMIT_LOGIN_CACHE_CAPACITY: usize = 4096;
+
+struct CommitLoginCache {
+    entries: HashMap<(String, String), Option<String>>,
+    insertion_order: VecDeque<(String, String)>,
+    capacity: usize,
+}
+
+impl CommitLoginCache {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::with_capacity(capacity),
+            insertion_order: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    fn get(&self, key: &(String, String)) -> Option<&Option<String>> {
+        self.entries.get(key)
+    }
+
+    fn insert(&mut self, key: (String, String), login: Option<String>) {
+        if self.entries.contains_key(&key) {
+            self.entries.insert(key, login);
+            return;
+        }
+        if self.capacity == 0 {
+            return;
+        }
+        while self.entries.len() >= self.capacity {
+            let Some(oldest) = self.insertion_order.pop_front() else {
+                break;
+            };
+            self.entries.remove(&oldest);
+        }
+        self.insertion_order.push_back(key.clone());
+        self.entries.insert(key, login);
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+fn commit_login_cache() -> &'static Mutex<CommitLoginCache> {
     use std::sync::OnceLock;
-    static CELL: OnceLock<Mutex<HashMap<(String, String), Option<String>>>> = OnceLock::new();
-    CELL.get_or_init(|| Mutex::new(HashMap::new()))
+    static CELL: OnceLock<Mutex<CommitLoginCache>> = OnceLock::new();
+    CELL.get_or_init(|| Mutex::new(CommitLoginCache::with_capacity(COMMIT_LOGIN_CACHE_CAPACITY)))
 }
 
 /// For every image file in `payload`, fetch the actual blob bytes from
@@ -3077,10 +3121,7 @@ mod tests {
         cache.insert(first.clone(), Some("alice-updated".to_string()));
 
         assert_eq!(cache.len(), 2);
-        assert_eq!(
-            cache.get(&first),
-            Some(&Some("alice-updated".to_string()))
-        );
+        assert_eq!(cache.get(&first), Some(&Some("alice-updated".to_string())));
         assert_eq!(cache.get(&second), Some(&Some("bob".to_string())));
     }
 

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -3050,6 +3050,41 @@ mod tests {
     }
 
     #[test]
+    fn commit_login_cache_evicts_oldest_entry_at_capacity() {
+        let mut cache = CommitLoginCache::with_capacity(2);
+        let first = ("acme/widgets".to_string(), "1".repeat(40));
+        let second = ("acme/widgets".to_string(), "2".repeat(40));
+        let third = ("acme/widgets".to_string(), "3".repeat(40));
+
+        cache.insert(first.clone(), Some("alice".to_string()));
+        cache.insert(second.clone(), Some("bob".to_string()));
+        cache.insert(third.clone(), Some("carol".to_string()));
+
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(&first), None);
+        assert_eq!(cache.get(&second), Some(&Some("bob".to_string())));
+        assert_eq!(cache.get(&third), Some(&Some("carol".to_string())));
+    }
+
+    #[test]
+    fn commit_login_cache_update_does_not_consume_capacity() {
+        let mut cache = CommitLoginCache::with_capacity(2);
+        let first = ("acme/widgets".to_string(), "1".repeat(40));
+        let second = ("acme/widgets".to_string(), "2".repeat(40));
+
+        cache.insert(first.clone(), Some("alice".to_string()));
+        cache.insert(second.clone(), Some("bob".to_string()));
+        cache.insert(first.clone(), Some("alice-updated".to_string()));
+
+        assert_eq!(cache.len(), 2);
+        assert_eq!(
+            cache.get(&first),
+            Some(&Some("alice-updated".to_string()))
+        );
+        assert_eq!(cache.get(&second), Some(&Some("bob".to_string())));
+    }
+
+    #[test]
     fn commit_login_input_validation_rejects_graphql_fragments() {
         assert_eq!(
             validate_github_slug("acme/widgets").unwrap(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,6 +112,10 @@ import {
   selectDueSessionStatusPollIds,
   selectImmediateSessionStatusPollIds,
 } from "./lib/sessionStatusPolling";
+import {
+  pruneSessionIdSet,
+  retainSessionMapEntries,
+} from "./lib/sessionTracking";
 import { useAppStore } from "./store";
 import type { TranslationKey, Translator } from "./lib/i18n";
 import type { Session } from "./lib/types";
@@ -517,8 +521,27 @@ function App() {
   const [resumePrimeVersion, setResumePrimeVersion] = useState(0);
   const probedSessionsRef = useRef<Set<string>>(new Set());
   useEffect(() => {
+    const liveSessionIds = new Set(
+      useAppStore.getState().sessions.map((session) => session.id),
+    );
+    pruneSessionIdSet(primedResumeSessionsRef.current, liveSessionIds);
+    pruneSessionIdSet(probedSessionsRef.current, liveSessionIds);
+    titleGenerationLastAttemptAtRef.current = retainSessionMapEntries(
+      titleGenerationLastAttemptAtRef.current,
+      liveSessionIds,
+    );
+    setResumeCandidates((current) =>
+      retainSessionMapEntries(current, liveSessionIds),
+    );
+  }, [sessionIdsKey]);
+
+  useEffect(() => {
     if (!resumeModalEnabled) {
       primedResumeSessionsRef.current.clear();
+      probedSessionsRef.current.clear();
+      setResumeCandidates((current) =>
+        current.size === 0 ? current : new Map(),
+      );
       setResumePrimeVersion((version) => version + 1);
       return;
     }

--- a/src/lib/sessionTracking.test.ts
+++ b/src/lib/sessionTracking.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  pruneSessionIdSet,
+  retainSessionMapEntries,
+} from "./sessionTracking";
+
+describe("session tracking collection cleanup", () => {
+  it("removes deleted session ids from mutable tracking sets", () => {
+    const tracked = new Set(["live-a", "deleted", "live-b"]);
+    const live = new Set(["live-a", "live-b"]);
+
+    const changed = pruneSessionIdSet(tracked, live);
+
+    expect(changed).toBe(true);
+    expect([...tracked]).toEqual(["live-a", "live-b"]);
+  });
+
+  it("returns a pruned copy when a session-keyed state map has stale entries", () => {
+    const tracked = new Map([
+      ["live", { title: "keep" }],
+      ["deleted", { title: "release" }],
+    ]);
+
+    const result = retainSessionMapEntries(tracked, new Set(["live"]));
+
+    expect(result).not.toBe(tracked);
+    expect([...result]).toEqual([["live", { title: "keep" }]]);
+    expect(tracked.size).toBe(2);
+  });
+
+  it("preserves state map identity when every tracked session is still live", () => {
+    const tracked = new Map([["live", { title: "keep" }]]);
+
+    const result = retainSessionMapEntries(tracked, new Set(["live"]));
+
+    expect(result).toBe(tracked);
+  });
+});

--- a/src/lib/sessionTracking.ts
+++ b/src/lib/sessionTracking.ts
@@ -1,0 +1,25 @@
+export function pruneSessionIdSet(
+  tracked: Set<string>,
+  liveSessionIds: ReadonlySet<string>,
+): boolean {
+  let changed = false;
+  for (const sessionId of tracked) {
+    if (liveSessionIds.has(sessionId)) continue;
+    tracked.delete(sessionId);
+    changed = true;
+  }
+  return changed;
+}
+
+export function retainSessionMapEntries<T>(
+  tracked: Map<string, T>,
+  liveSessionIds: ReadonlySet<string>,
+): Map<string, T> {
+  let next: Map<string, T> | null = null;
+  for (const sessionId of tracked.keys()) {
+    if (liveSessionIds.has(sessionId)) continue;
+    next ??= new Map(tracked);
+    next.delete(sessionId);
+  }
+  return next ?? tracked;
+}

--- a/src/lib/useCurrentPullRequest.test.tsx
+++ b/src/lib/useCurrentPullRequest.test.tsx
@@ -126,6 +126,40 @@ describe("useCurrentPullRequest", () => {
     expect(container.textContent).toBe("PR #77");
   });
 
+  it("evicts the oldest primed branches when the project cache is full", async () => {
+    const items = Array.from({ length: 300 }, (_, index) =>
+      pullRequest({
+        number: index + 1,
+        head_branch: `feat/branch-${index}`,
+      }),
+    );
+    primeCurrentPullRequestCacheFromListing("/tmp/demo", {
+      kind: "ok",
+      account: "test",
+      items,
+    });
+    mockApi.listPullRequests.mockResolvedValue({
+      kind: "ok",
+      account: "test",
+      items: [],
+    });
+
+    await act(async () => {
+      root.render(
+        <Probe value={session({ branch: "feat/branch-0" })} />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe("none");
+    expect(mockApi.listPullRequests).toHaveBeenCalledWith(
+      "/tmp/demo/.worktrees/runner",
+      "open",
+      10,
+      "head:feat/branch-0",
+    );
+  });
+
   it("clears and retries current PR context when a lifecycle mutation lands", async () => {
     mockApi.listPullRequests
       .mockResolvedValueOnce({

--- a/src/lib/useCurrentPullRequest.ts
+++ b/src/lib/useCurrentPullRequest.ts
@@ -17,6 +17,7 @@ import type {
 
 const CURRENT_PR_CACHE_TTL_MS = 60_000;
 const CURRENT_PR_EMPTY_RETRY_MS = 15_000;
+const CURRENT_PR_CACHE_MAX_ENTRIES = 256;
 
 type CurrentPullRequestCacheEntry = {
   value: SessionPullRequestSummary | null;
@@ -39,6 +40,18 @@ const currentPullRequestProjectCache = new Map<
 >();
 const currentPullRequestSubscribers = new Set<CurrentPullRequestSubscriber>();
 
+function setBoundedCacheEntry(
+  cache: Map<string, CurrentPullRequestCacheEntry>,
+  key: string,
+  entry: CurrentPullRequestCacheEntry,
+): void {
+  if (!cache.has(key) && cache.size >= CURRENT_PR_CACHE_MAX_ENTRIES) {
+    const oldest = cache.keys().next();
+    if (!oldest.done) cache.delete(oldest.value);
+  }
+  cache.set(key, entry);
+}
+
 function normalizeRepoPath(repoPath: string): string {
   return repoPath.replace(/\\/g, "/").replace(/\/+$/, "");
 }
@@ -60,10 +73,14 @@ function setCurrentPullRequestCache(
   value: SessionPullRequestSummary | null,
   ttlMs: number,
 ): void {
-  currentPullRequestCache.set(currentPullRequestCacheKey(repoPath, branch), {
-    value,
-    expiresAt: Date.now() + ttlMs,
-  });
+  setBoundedCacheEntry(
+    currentPullRequestCache,
+    currentPullRequestCacheKey(repoPath, branch),
+    {
+      value,
+      expiresAt: Date.now() + ttlMs,
+    },
+  );
 }
 
 function readPrimedCurrentPullRequest(
@@ -144,7 +161,8 @@ export function primeCurrentPullRequestCacheFromListing(
     );
     if (!summary) continue;
     summariesByBranch.set(summary.head_branch, summary);
-    currentPullRequestProjectCache.set(
+    setBoundedCacheEntry(
+      currentPullRequestProjectCache,
       currentPullRequestProjectCacheKey(projectRepoPath, summary.head_branch),
       {
         value: summary,
@@ -188,7 +206,7 @@ function loadCurrentPullRequest(
     .then((listing) => findCurrentPullRequestForBranch(listing, branch))
     .catch(() => null);
 
-  currentPullRequestCache.set(key, {
+  setBoundedCacheEntry(currentPullRequestCache, key, {
     value: cached?.value ?? null,
     expiresAt: now + CURRENT_PR_CACHE_TTL_MS,
     promise,
@@ -203,7 +221,7 @@ function loadCurrentPullRequest(
     ) {
       return latest.value;
     }
-    currentPullRequestCache.set(key, {
+    setBoundedCacheEntry(currentPullRequestCache, key, {
       value,
       expiresAt:
         Date.now() +


### PR DESCRIPTION
## Summary

Bounds current pull request lookup state without changing intended user-visible behavior.

1. **Regression coverage** — adds a focused test reproducing the unbounded or overlapping lifecycle.
2. **Bounded execution** — prevents repeated work from growing or overlapping indefinitely.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| current pull request lookup state | Repository keys accumulated without a capacity limit. | Resolved and in-flight state is capped at 256 repositories. |

## Design notes

- Preserve request sharing while evicting the oldest settled repository state.
- This PR is stacked on `fix/memory-session-tracking` and should merge after that base PR.

## Test plan

- [x] Focused regression test passed during the RED/GREEN workflow.
- [x] `pnpm test` — 94 files, 1,004 tests passed on the complete stack.
- [x] `pnpm run typecheck` passes.
- [x] `pnpm run build` passes.
- [x] `cargo test --workspace` with control-session overrides removed — 564 passed, 1 ignored on the complete stack.
- [ ] GitHub Actions CI on this PR.

## Notes

- Stack position: 3/30.
- Existing Vite and Rust warnings are unchanged by this PR.