### PR TITLE
perf(git): bound repository probe caches

### DIFF
--- a/src/lib/useIsGitHubRepo.test.ts
+++ b/src/lib/useIsGitHubRepo.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./api", () => ({
+  api: {
+    isGitRepository: vi.fn(),
+    githubOriginSlug: vi.fn(),
+  },
+}));
+
+import { api } from "./api";
+import {
+  __resetIsGitHubRepoCacheForTests,
+  prefetchGitHubRepoStatus,
+  prefetchGitRepositoryStatus,
+} from "./useIsGitHubRepo";
+
+const mockApi = vi.mocked(api);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("git repository probe cache", () => {
+  beforeEach(() => {
+    __resetIsGitHubRepoCacheForTests();
+    mockApi.isGitRepository.mockReset();
+    mockApi.githubOriginSlug.mockReset();
+  });
+
+  it("re-probes the oldest path after the cache reaches its path limit", async () => {
+    mockApi.isGitRepository.mockResolvedValue(true);
+    mockApi.githubOriginSlug.mockResolvedValue("acme/widgets");
+
+    for (let index = 0; index < 300; index += 1) {
+      await prefetchGitHubRepoStatus(`/tmp/repo-${index}`);
+    }
+
+    expect(mockApi.isGitRepository).toHaveBeenCalledTimes(300);
+    expect(mockApi.githubOriginSlug).toHaveBeenCalledTimes(300);
+
+    await prefetchGitHubRepoStatus("/tmp/repo-0");
+
+    expect(mockApi.isGitRepository).toHaveBeenCalledTimes(301);
+    expect(mockApi.githubOriginSlug).toHaveBeenCalledTimes(301);
+  });
+
+  it("does not let an evicted in-flight probe restore its cache entry", async () => {
+    const first = deferred<boolean>();
+    mockApi.isGitRepository.mockImplementation((repoPath) => {
+      if (repoPath === "/tmp/first" && firstCallCount === 0) {
+        firstCallCount += 1;
+        return first.promise;
+      }
+      return Promise.resolve(true);
+    });
+    let firstCallCount = 0;
+
+    const evictedProbe = prefetchGitRepositoryStatus("/tmp/first");
+    for (let index = 0; index < 256; index += 1) {
+      await prefetchGitRepositoryStatus(`/tmp/other-${index}`);
+    }
+    first.resolve(true);
+    await evictedProbe;
+
+    await prefetchGitRepositoryStatus("/tmp/first");
+
+    expect(
+      mockApi.isGitRepository.mock.calls.filter(
+        ([repoPath]) => repoPath === "/tmp/first",
+      ),
+    ).toHaveLength(2);
+  });
+});

--- a/src/lib/useIsGitHubRepo.ts
+++ b/src/lib/useIsGitHubRepo.ts
@@ -5,31 +5,55 @@ import { api } from "./api";
  * Per-repo caches for the git-repo + GitHub origin probes. The results rarely
  * change during a session (only when the user runs `git init` or edits git
  * metadata), so we resolve once per repoPath and reuse across mounts.
- * Concurrent callers for the same repoPath share one in-flight promise.
+ * Concurrent callers for the same repoPath share one in-flight promise. The
+ * shared path registry evicts every cache layer together so removed worktrees
+ * cannot accumulate indefinitely or be restored by a stale promise.
  */
+const REPO_PROBE_CACHE_MAX_PATHS = 256;
 const gitRepoCache = new Map<string, boolean>();
 const gitRepoInFlight = new Map<string, Promise<boolean>>();
 const githubRepoCache = new Map<string, boolean>();
 const githubRepoInFlight = new Map<string, Promise<boolean>>();
-const generations = new Map<string, number>();
+const repoTokens = new Map<string, symbol>();
 
-function generationOf(repoPath: string): number {
-  return generations.get(repoPath) ?? 0;
+function removeRepoPath(repoPath: string): void {
+  repoTokens.delete(repoPath);
+  gitRepoCache.delete(repoPath);
+  gitRepoInFlight.delete(repoPath);
+  githubRepoCache.delete(repoPath);
+  githubRepoInFlight.delete(repoPath);
+}
+
+function trackRepoPath(repoPath: string): symbol {
+  const existing = repoTokens.get(repoPath);
+  if (existing) return existing;
+  while (repoTokens.size >= REPO_PROBE_CACHE_MAX_PATHS) {
+    const oldest = repoTokens.keys().next();
+    if (oldest.done) break;
+    removeRepoPath(oldest.value);
+  }
+  const token = Symbol(repoPath);
+  repoTokens.set(repoPath, token);
+  return token;
+}
+
+function isCurrentRepoToken(repoPath: string, token: symbol): boolean {
+  return repoTokens.get(repoPath) === token;
 }
 
 async function probeGitRepository(repoPath: string): Promise<boolean> {
+  const token = trackRepoPath(repoPath);
   const cached = gitRepoCache.get(repoPath);
   if (cached !== undefined) return cached;
   const existing = gitRepoInFlight.get(repoPath);
   if (existing) return existing;
-  const generation = generationOf(repoPath);
   const promise = api
     .isGitRepository(repoPath)
     .then((isGitRepo) => {
-      if (generationOf(repoPath) === generation) {
+      if (isCurrentRepoToken(repoPath, token)) {
         gitRepoCache.set(repoPath, isGitRepo);
       }
-      if (generationOf(repoPath) !== generation) return false;
+      if (!isCurrentRepoToken(repoPath, token)) return false;
       return isGitRepo;
     })
     .catch((error) => {
@@ -48,25 +72,25 @@ async function probeGitRepository(repoPath: string): Promise<boolean> {
 }
 
 async function probeGitHubRepo(repoPath: string): Promise<boolean> {
+  const token = trackRepoPath(repoPath);
   const cached = githubRepoCache.get(repoPath);
   if (cached !== undefined) return cached;
   const existing = githubRepoInFlight.get(repoPath);
   if (existing) return existing;
-  const generation = generationOf(repoPath);
   const promise = probeGitRepository(repoPath)
     .then(async (isGitRepo) => {
       if (!isGitRepo) {
-        if (generationOf(repoPath) === generation) {
+        if (isCurrentRepoToken(repoPath, token)) {
           githubRepoCache.set(repoPath, false);
         }
         return false;
       }
       const slug = await api.githubOriginSlug(repoPath);
       const value = slug !== null;
-      if (generationOf(repoPath) === generation) {
+      if (isCurrentRepoToken(repoPath, token)) {
         githubRepoCache.set(repoPath, value);
       }
-      if (generationOf(repoPath) !== generation) return false;
+      if (!isCurrentRepoToken(repoPath, token)) return false;
       return value;
     })
     .catch((error) => {
@@ -93,11 +117,7 @@ export function prefetchGitHubRepoStatus(repoPath: string): Promise<boolean> {
 }
 
 export function invalidateGitRepositoryStatus(repoPath: string): void {
-  gitRepoCache.delete(repoPath);
-  gitRepoInFlight.delete(repoPath);
-  githubRepoCache.delete(repoPath);
-  githubRepoInFlight.delete(repoPath);
-  generations.set(repoPath, generationOf(repoPath) + 1);
+  removeRepoPath(repoPath);
 }
 
 export function invalidateGitHubRepoStatus(repoPath: string): void {
@@ -182,5 +202,5 @@ export function __resetIsGitHubRepoCacheForTests(): void {
   gitRepoInFlight.clear();
   githubRepoCache.clear();
   githubRepoInFlight.clear();
-  generations.clear();
+  repoTokens.clear();
 }


### PR DESCRIPTION
## Summary

Bounds Git and GitHub repository probes without changing intended user-visible behavior.

1. **Regression coverage** — adds a focused test reproducing the unbounded or overlapping lifecycle.
2. **Bounded execution** — prevents repeated work from growing or overlapping indefinitely.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Git and GitHub repository probes | Probe results accumulated for every observed path. | Probe caches retain at most 256 recent keys. |

## Design notes

- Use generation tokens so evicted in-flight probes cannot delete newer entries.
- This PR is stacked on `perf/ssh-host-cache` and should merge after that base PR.

## Test plan

- [x] Focused regression test passed during the RED/GREEN workflow.
- [x] `pnpm test` — 94 files, 1,004 tests passed on the complete stack.
- [x] `pnpm run typecheck` passes.
- [x] `pnpm run build` passes.
- [x] `cargo test --workspace` with control-session overrides removed — 564 passed, 1 ignored on the complete stack.
- [ ] GitHub Actions CI on this PR.

## Notes

- Stack position: 6/30.
- Existing Vite and Rust warnings are unchanged by this PR.