### PR TITLE
fix(terminal): release deleted scrollback snapshots

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ import {
 import { findFocusedSessionId } from "./lib/focus";
 import { isSessionTabId } from "./lib/workspaceTabs";
 import { flushAllScrollbacks } from "./lib/scrollback-coordinator";
+import { retainRememberedTerminalScrollbacks } from "./lib/terminalScrollbackHandoff";
 import { useToasts } from "./lib/toasts";
 import { useUpdater } from "./lib/updater-store";
 import {
@@ -526,6 +527,7 @@ function App() {
     );
     pruneSessionIdSet(primedResumeSessionsRef.current, liveSessionIds);
     pruneSessionIdSet(probedSessionsRef.current, liveSessionIds);
+    retainRememberedTerminalScrollbacks(liveSessionIds);
     titleGenerationLastAttemptAtRef.current = retainSessionMapEntries(
       titleGenerationLastAttemptAtRef.current,
       liveSessionIds,

--- a/src/lib/terminalScrollbackHandoff.test.ts
+++ b/src/lib/terminalScrollbackHandoff.test.ts
@@ -3,6 +3,7 @@ import {
   clearRememberedTerminalScrollback,
   rememberedTerminalScrollback,
   rememberTerminalScrollback,
+  retainRememberedTerminalScrollbacks,
 } from "./terminalScrollbackHandoff";
 
 describe("terminal scrollback handoff", () => {
@@ -29,5 +30,17 @@ describe("terminal scrollback handoff", () => {
     clearRememberedTerminalScrollback("s3");
 
     expect(rememberedTerminalScrollback("s3")).toBeNull();
+  });
+
+  it("releases snapshots for sessions that no longer exist", () => {
+    rememberTerminalScrollback("live", "keep this scrollback\n");
+    rememberTerminalScrollback("deleted", "release this scrollback\n");
+
+    retainRememberedTerminalScrollbacks(new Set(["live"]));
+
+    expect(rememberedTerminalScrollback("live")).toBe(
+      "keep this scrollback\n",
+    );
+    expect(rememberedTerminalScrollback("deleted")).toBeNull();
   });
 });

--- a/src/lib/terminalScrollbackHandoff.ts
+++ b/src/lib/terminalScrollbackHandoff.ts
@@ -22,3 +22,11 @@ export function rememberedTerminalScrollback(sessionId: string): string | null {
 export function clearRememberedTerminalScrollback(sessionId: string): void {
   snapshots.delete(sessionId);
 }
+
+export function retainRememberedTerminalScrollbacks(
+  liveSessionIds: ReadonlySet<string>,
+): void {
+  for (const sessionId of snapshots.keys()) {
+    if (!liveSessionIds.has(sessionId)) snapshots.delete(sessionId);
+  }
+}


### PR DESCRIPTION
## Summary

Bounds terminal scrollback handoff storage without changing intended user-visible behavior.

1. **Regression coverage** — adds a focused test reproducing the unbounded or overlapping lifecycle.
2. **Bounded execution** — prevents repeated work from growing or overlapping indefinitely.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| terminal scrollback handoff storage | Snapshots for deleted sessions could remain retained. | Snapshots are pruned whenever the live session set changes. |

## Design notes

- Keep scrollback handoff behavior intact for every still-existing session.
- This PR is stacked on `perf/codex-bind-registry` and should merge after that base PR.

## Test plan

- [x] Focused regression test passed during the RED/GREEN workflow.
- [x] `pnpm test` — 94 files, 1,004 tests passed on the complete stack.
- [x] `pnpm run typecheck` passes.
- [x] `pnpm run build` passes.
- [x] `cargo test --workspace` with control-session overrides removed — 564 passed, 1 ignored on the complete stack.
- [ ] GitHub Actions CI on this PR.

## Notes

- Stack position: 8/30.
- Existing Vite and Rust warnings are unchanged by this PR.