### PR TITLE
perf(pr): bound staged diff cache

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -59,7 +59,10 @@ import {
   onPullRequestMutation,
   pullRequestMutationAffectsOpenContext,
 } from "../lib/pullRequestEvents";
-import { rightPanelCache } from "../lib/right-panel-cache";
+import {
+  rememberRecentStagedDiff,
+  rightPanelCache,
+} from "../lib/right-panel-cache";
 import { classifyRightPanelFsChange } from "../lib/right-panel-invalidation";
 import { useSettings } from "../lib/settings";
 import { primeCurrentPullRequestCacheFromListing } from "../lib/useCurrentPullRequest";
@@ -2482,7 +2485,9 @@ function StagedTab({
       .stagedFileDiff(repoPath, selectedPath)
       .then((payload) => {
         if (diffGenerationRef.current !== token) return;
-        setDiffByPath((prev) => ({ ...prev, [selectedPath]: payload }));
+        setDiffByPath((prev) =>
+          rememberRecentStagedDiff(prev, selectedPath, payload),
+        );
       })
       .catch((e) => {
         if (diffGenerationRef.current !== token) return;

--- a/src/lib/right-panel-cache.test.ts
+++ b/src/lib/right-panel-cache.test.ts
@@ -36,7 +36,10 @@ vi.mock("./api", () => ({
 }));
 
 import { api } from "./api";
-import { rightPanelCache } from "./right-panel-cache";
+import {
+  rememberRecentStagedDiff,
+  rightPanelCache,
+} from "./right-panel-cache";
 
 const mockApi = vi.mocked(api);
 const REPO = "/tmp/acorn";
@@ -220,6 +223,41 @@ describe("rightPanelCache", () => {
     await rightPanelCache.fetchCommitDiff(REPO, "sha-0");
 
     expect(mockApi.commitDiff).toHaveBeenCalledTimes(21);
+  });
+
+  it("keeps only the most recent staged diff payloads", () => {
+    let diffByPath: Record<string, DiffPayload> = {};
+
+    for (let index = 0; index < 20; index += 1) {
+      diffByPath = rememberRecentStagedDiff(
+        diffByPath,
+        `src/file-${index}.ts`,
+        { files: [] },
+      );
+    }
+
+    expect(Object.keys(diffByPath)).toHaveLength(16);
+    expect(diffByPath["src/file-0.ts"]).toBeUndefined();
+    expect(diffByPath["src/file-19.ts"]).toBeDefined();
+  });
+
+  it("bounds oversized staged entries stored by callers", () => {
+    const diffByPath = Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [
+        `src/file-${index}.ts`,
+        { files: [] },
+      ]),
+    );
+
+    rightPanelCache.setStaged(REPO, {
+      files: [],
+      selectedPath: null,
+      diffByPath,
+    });
+
+    expect(Object.keys(rightPanelCache.getStaged(REPO)!.diffByPath)).toHaveLength(
+      16,
+    );
   });
 
   it("keeps a fresh commit diff request when a pruned stale request settles", async () => {

--- a/src/lib/right-panel-cache.ts
+++ b/src/lib/right-panel-cache.ts
@@ -23,6 +23,31 @@ interface FetchOptions {
 }
 
 const COMMIT_DIFF_CACHE_MAX_ENTRIES = 16;
+const STAGED_DIFF_CACHE_MAX_ENTRIES = 16;
+
+function limitRecentStagedDiffs(
+  diffByPath: Record<string, DiffPayload>,
+): Record<string, DiffPayload> {
+  const paths = Object.keys(diffByPath);
+  if (paths.length <= STAGED_DIFF_CACHE_MAX_ENTRIES) return diffByPath;
+
+  return Object.fromEntries(
+    paths
+      .slice(-STAGED_DIFF_CACHE_MAX_ENTRIES)
+      .map((path) => [path, diffByPath[path]]),
+  );
+}
+
+export function rememberRecentStagedDiff(
+  diffByPath: Record<string, DiffPayload>,
+  path: string,
+  payload: DiffPayload,
+): Record<string, DiffPayload> {
+  const next = { ...diffByPath };
+  delete next[path];
+  next[path] = payload;
+  return limitRecentStagedDiffs(next);
+}
 
 class RightPanelCacheManager {
   private retainedRepos: Set<string> | null = null;
@@ -182,7 +207,11 @@ class RightPanelCacheManager {
 
   setStaged(repoPath: string, entry: StagedCacheEntry): void {
     if (!this.canStore(repoPath)) return;
-    this.stagedCache.set(repoPath, entry);
+    const diffByPath = limitRecentStagedDiffs(entry.diffByPath);
+    this.stagedCache.set(
+      repoPath,
+      diffByPath === entry.diffByPath ? entry : { ...entry, diffByPath },
+    );
   }
 
   getFileExplorerExpanded(repoPath: string): Set<string> {


### PR DESCRIPTION
## Summary

Bounds staged diff payload retention without changing intended user-visible behavior.

1. **Regression coverage** — adds a focused test reproducing the unbounded or overlapping lifecycle.
2. **Bounded execution** — prevents repeated work from growing or overlapping indefinitely.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| staged diff payload retention | Staged file diffs accumulated for every opened path. | Only the 16 most recent staged diffs are retained. |

## Design notes

- Route staged diff reads through the bounded RightPanel cache contract.
- This PR is stacked on `perf/repo-invalidation-metadata` and should merge after that base PR.

## Test plan

- [x] Focused regression test passed during the RED/GREEN workflow.
- [x] `pnpm test` — 94 files, 1,004 tests passed on the complete stack.
- [x] `pnpm run typecheck` passes.
- [x] `pnpm run build` passes.
- [x] `cargo test --workspace` with control-session overrides removed — 564 passed, 1 ignored on the complete stack.
- [ ] GitHub Actions CI on this PR.

## Notes

- Stack position: 13/30.
- Existing Vite and Rust warnings are unchanged by this PR.