### PR TITLE
fix(files): dispose late filesystem listeners

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8569,7 +8569,7 @@ mod tests {
     /// re-arms the warning for the next streak.
     #[test]
     fn codex_bind_failure_warns_once_per_streak() {
-        let mut warned = std::collections::HashSet::new();
+        let mut warned = super::CodexBindFailureRegistry::with_capacity(2);
         let session_id = Uuid::from_u128(7);
 
         assert!(super::note_codex_bind_failure(&mut warned, session_id));
@@ -8577,6 +8577,23 @@ mod tests {
 
         super::note_codex_bind_recovered(&mut warned, session_id);
         assert!(super::note_codex_bind_failure(&mut warned, session_id));
+    }
+
+    #[test]
+    fn codex_bind_failure_registry_evicts_oldest_session_at_capacity() {
+        let mut warned = super::CodexBindFailureRegistry::with_capacity(2);
+        let first = Uuid::from_u128(1);
+        let second = Uuid::from_u128(2);
+        let third = Uuid::from_u128(3);
+
+        assert!(super::note_codex_bind_failure(&mut warned, first));
+        assert!(super::note_codex_bind_failure(&mut warned, second));
+        assert!(super::note_codex_bind_failure(&mut warned, third));
+
+        assert_eq!(warned.len(), 2);
+        assert!(!warned.contains(&first));
+        assert!(warned.contains(&second));
+        assert!(warned.contains(&third));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5710,23 +5710,80 @@ fn codex_live_transcript_fallback(
 /// Sessions whose codex marker fallback already warned about a write
 /// failure this streak. Guards the poll-frequency `warn!` from repeating
 /// every tick while the failure persists.
-fn codex_bind_failure_registry() -> std::sync::MutexGuard<'static, HashSet<Uuid>> {
-    static WARNED: std::sync::OnceLock<Mutex<HashSet<Uuid>>> = std::sync::OnceLock::new();
+const CODEX_BIND_FAILURE_REGISTRY_CAPACITY: usize = 256;
+
+struct CodexBindFailureRegistry {
+    warned: HashSet<Uuid>,
+    insertion_order: VecDeque<Uuid>,
+    capacity: usize,
+}
+
+impl CodexBindFailureRegistry {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            warned: HashSet::with_capacity(capacity),
+            insertion_order: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    fn note_failure(&mut self, session_id: Uuid) -> bool {
+        if self.warned.contains(&session_id) {
+            return false;
+        }
+        if self.capacity == 0 {
+            return true;
+        }
+        while self.warned.len() >= self.capacity {
+            let Some(oldest) = self.insertion_order.pop_front() else {
+                break;
+            };
+            self.warned.remove(&oldest);
+        }
+        self.insertion_order.push_back(session_id);
+        self.warned.insert(session_id);
+        true
+    }
+
+    fn note_recovered(&mut self, session_id: Uuid) {
+        if self.warned.remove(&session_id) {
+            self.insertion_order.retain(|id| *id != session_id);
+        }
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.warned.len()
+    }
+
+    #[cfg(test)]
+    fn contains(&self, session_id: &Uuid) -> bool {
+        self.warned.contains(session_id)
+    }
+}
+
+fn codex_bind_failure_registry() -> std::sync::MutexGuard<'static, CodexBindFailureRegistry> {
+    static WARNED: std::sync::OnceLock<Mutex<CodexBindFailureRegistry>> =
+        std::sync::OnceLock::new();
     WARNED
-        .get_or_init(Default::default)
+        .get_or_init(|| {
+            Mutex::new(CodexBindFailureRegistry::with_capacity(
+                CODEX_BIND_FAILURE_REGISTRY_CAPACITY,
+            ))
+        })
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 /// Record a fallback write failure; `true` when this is the first failure
 /// of the current streak (i.e. the caller should warn, not just debug).
-fn note_codex_bind_failure(warned: &mut HashSet<Uuid>, session_id: Uuid) -> bool {
-    warned.insert(session_id)
+fn note_codex_bind_failure(warned: &mut CodexBindFailureRegistry, session_id: Uuid) -> bool {
+    warned.note_failure(session_id)
 }
 
 /// A successful bind ends the failure streak so the next failure warns again.
-fn note_codex_bind_recovered(warned: &mut HashSet<Uuid>, session_id: Uuid) {
-    warned.remove(&session_id);
+fn note_codex_bind_recovered(warned: &mut CodexBindFailureRegistry, session_id: Uuid) {
+    warned.note_recovered(session_id);
 }
 
 /// Resolve the nearest live agent process under `root`, with its pid.

--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -552,6 +552,26 @@ mod tests {
     }
 
     #[test]
+    fn ssh_hostname_cache_bounds_successes_and_failures() {
+        let mut cache = SshHostnameCache::with_capacity(2);
+
+        cache.insert("first".to_string(), Some("github.com".to_string()));
+        cache.insert("second".to_string(), None);
+        cache.insert("third".to_string(), Some("example.com".to_string()));
+
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get("first"), None);
+        assert_eq!(cache.get("second"), Some(&None));
+        assert_eq!(cache.get("third"), Some(&Some("example.com".to_string())));
+    }
+
+    #[test]
+    fn ssh_hostname_validation_rejects_oversized_cache_keys() {
+        assert!(is_plain_hostname(&"a".repeat(255)));
+        assert!(!is_plain_hostname(&"a".repeat(256)));
+    }
+
+    #[test]
     fn diff_for_commit_includes_hunk_headers() {
         let root = unique_temp_dir("hunk-headers");
         let repo = git2::Repository::init(&root).expect("init repo");

--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -1,6 +1,8 @@
 use git2::{DiffOptions, Repository};
 use serde::Serialize;
+use std::collections::{HashMap, VecDeque};
 use std::path::Path;
+use std::sync::{Mutex, OnceLock};
 
 use crate::error::{AppError, AppResult};
 use crate::worktree::ensure_repo;
@@ -134,17 +136,67 @@ fn is_github_host(host: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn cached_ssh_hostname(alias: &str) -> Option<String> {
-    use std::collections::HashMap;
-    use std::sync::{Mutex, OnceLock};
+const SSH_HOSTNAME_CACHE_CAPACITY: usize = 64;
 
-    static CACHE: OnceLock<Mutex<HashMap<String, Option<String>>>> = OnceLock::new();
-    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+struct SshHostnameCache {
+    entries: HashMap<String, Option<String>>,
+    insertion_order: VecDeque<String>,
+    capacity: usize,
+}
+
+impl SshHostnameCache {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::with_capacity(capacity),
+            insertion_order: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    fn get(&self, alias: &str) -> Option<&Option<String>> {
+        self.entries.get(alias)
+    }
+
+    fn insert(&mut self, alias: String, hostname: Option<String>) {
+        if self.entries.contains_key(&alias) {
+            self.entries.insert(alias, hostname);
+            return;
+        }
+        if self.capacity == 0 {
+            return;
+        }
+        while self.entries.len() >= self.capacity {
+            let Some(oldest) = self.insertion_order.pop_front() else {
+                break;
+            };
+            self.entries.remove(&oldest);
+        }
+        self.insertion_order.push_back(alias.clone());
+        self.entries.insert(alias, hostname);
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+fn ssh_hostname_cache() -> &'static Mutex<SshHostnameCache> {
+    static CACHE: OnceLock<Mutex<SshHostnameCache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(SshHostnameCache::with_capacity(SSH_HOSTNAME_CACHE_CAPACITY)))
+}
+
+fn cached_ssh_hostname(alias: &str) -> Option<String> {
+    if !is_plain_hostname(alias) {
+        return None;
+    }
+    let cache = ssh_hostname_cache();
 
     // A poisoned lock would otherwise silently skip the cache and re-spawn
     // `ssh -G` on every call; the map itself stays valid, so recover it.
     {
-        let map = cache.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let map = cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         if let Some(hit) = map.get(alias) {
             return hit.clone();
         }

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -26,7 +26,7 @@
 //! The picked token is passed to `gh pr list` via `GH_TOKEN`, overriding
 //! whichever account `gh` would otherwise pick.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Mutex;
@@ -1772,10 +1772,54 @@ fn build_commit_login_query(count: usize) -> String {
     query
 }
 
-fn commit_login_cache() -> &'static Mutex<HashMap<(String, String), Option<String>>> {
+const COMMIT_LOGIN_CACHE_CAPACITY: usize = 4096;
+
+struct CommitLoginCache {
+    entries: HashMap<(String, String), Option<String>>,
+    insertion_order: VecDeque<(String, String)>,
+    capacity: usize,
+}
+
+impl CommitLoginCache {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::with_capacity(capacity),
+            insertion_order: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    fn get(&self, key: &(String, String)) -> Option<&Option<String>> {
+        self.entries.get(key)
+    }
+
+    fn insert(&mut self, key: (String, String), login: Option<String>) {
+        if self.entries.contains_key(&key) {
+            self.entries.insert(key, login);
+            return;
+        }
+        if self.capacity == 0 {
+            return;
+        }
+        while self.entries.len() >= self.capacity {
+            let Some(oldest) = self.insertion_order.pop_front() else {
+                break;
+            };
+            self.entries.remove(&oldest);
+        }
+        self.insertion_order.push_back(key.clone());
+        self.entries.insert(key, login);
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+fn commit_login_cache() -> &'static Mutex<CommitLoginCache> {
     use std::sync::OnceLock;
-    static CELL: OnceLock<Mutex<HashMap<(String, String), Option<String>>>> = OnceLock::new();
-    CELL.get_or_init(|| Mutex::new(HashMap::new()))
+    static CELL: OnceLock<Mutex<CommitLoginCache>> = OnceLock::new();
+    CELL.get_or_init(|| Mutex::new(CommitLoginCache::with_capacity(COMMIT_LOGIN_CACHE_CAPACITY)))
 }
 
 /// For every image file in `payload`, fetch the actual blob bytes from
@@ -3077,10 +3121,7 @@ mod tests {
         cache.insert(first.clone(), Some("alice-updated".to_string()));
 
         assert_eq!(cache.len(), 2);
-        assert_eq!(
-            cache.get(&first),
-            Some(&Some("alice-updated".to_string()))
-        );
+        assert_eq!(cache.get(&first), Some(&Some("alice-updated".to_string())));
         assert_eq!(cache.get(&second), Some(&Some("bob".to_string())));
     }
 

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -3126,6 +3126,45 @@ mod tests {
     }
 
     #[test]
+    fn resolution_cache_removes_expired_entries_on_read() {
+        let mut cache = ResolutionCache::with_capacity(2);
+        let repo = PathBuf::from("/tmp/expired-worktree");
+        let expired_at = Instant::now()
+            .checked_sub(RESOLUTION_TTL)
+            .expect("resolution TTL should fit before now");
+        cache.insert_at(repo.clone(), "alice".to_string(), expired_at);
+
+        assert!(cache.get(&repo).is_none());
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn resolution_cache_evicts_oldest_fresh_repo_at_capacity() {
+        let mut cache = ResolutionCache::with_capacity(2);
+        let now = Instant::now();
+        let first = PathBuf::from("/tmp/first-worktree");
+        let second = PathBuf::from("/tmp/second-worktree");
+        let third = PathBuf::from("/tmp/third-worktree");
+
+        cache.insert_at(
+            first.clone(),
+            "alice".to_string(),
+            now.checked_sub(Duration::from_secs(2)).unwrap(),
+        );
+        cache.insert_at(
+            second.clone(),
+            "bob".to_string(),
+            now.checked_sub(Duration::from_secs(1)).unwrap(),
+        );
+        cache.insert_at(third.clone(), "carol".to_string(), now);
+
+        assert_eq!(cache.len(), 2);
+        assert!(cache.get(&first).is_none());
+        assert_eq!(cache.get(&second).map(|entry| entry.login), Some("bob".into()));
+        assert_eq!(cache.get(&third).map(|entry| entry.login), Some("carol".into()));
+    }
+
+    #[test]
     fn commit_login_input_validation_rejects_graphql_fragments() {
         assert_eq!(
             validate_github_slug("acme/widgets").unwrap(),

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -3050,6 +3050,41 @@ mod tests {
     }
 
     #[test]
+    fn commit_login_cache_evicts_oldest_entry_at_capacity() {
+        let mut cache = CommitLoginCache::with_capacity(2);
+        let first = ("acme/widgets".to_string(), "1".repeat(40));
+        let second = ("acme/widgets".to_string(), "2".repeat(40));
+        let third = ("acme/widgets".to_string(), "3".repeat(40));
+
+        cache.insert(first.clone(), Some("alice".to_string()));
+        cache.insert(second.clone(), Some("bob".to_string()));
+        cache.insert(third.clone(), Some("carol".to_string()));
+
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(&first), None);
+        assert_eq!(cache.get(&second), Some(&Some("bob".to_string())));
+        assert_eq!(cache.get(&third), Some(&Some("carol".to_string())));
+    }
+
+    #[test]
+    fn commit_login_cache_update_does_not_consume_capacity() {
+        let mut cache = CommitLoginCache::with_capacity(2);
+        let first = ("acme/widgets".to_string(), "1".repeat(40));
+        let second = ("acme/widgets".to_string(), "2".repeat(40));
+
+        cache.insert(first.clone(), Some("alice".to_string()));
+        cache.insert(second.clone(), Some("bob".to_string()));
+        cache.insert(first.clone(), Some("alice-updated".to_string()));
+
+        assert_eq!(cache.len(), 2);
+        assert_eq!(
+            cache.get(&first),
+            Some(&Some("alice-updated".to_string()))
+        );
+        assert_eq!(cache.get(&second), Some(&Some("bob".to_string())));
+    }
+
+    #[test]
     fn commit_login_input_validation_rejects_graphql_fragments() {
         assert_eq!(
             validate_github_slug("acme/widgets").unwrap(),

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -313,6 +313,7 @@ const PR_PLAIN_TEXT_FALLBACK_MIN_CHARS: usize = 3;
 /// cheap, short enough that a `gh auth login` for a new account becomes
 /// usable without restarting the app.
 const RESOLUTION_TTL: Duration = Duration::from_secs(10 * 60);
+const RESOLUTION_CACHE_CAPACITY: usize = 128;
 
 #[derive(Clone)]
 struct CachedResolution {
@@ -326,37 +327,76 @@ impl CachedResolution {
     }
 }
 
+struct ResolutionCache {
+    entries: HashMap<PathBuf, CachedResolution>,
+    capacity: usize,
+}
+
+impl ResolutionCache {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    fn get(&mut self, repo_path: &Path) -> Option<CachedResolution> {
+        let entry = self.entries.get(repo_path)?.clone();
+        if entry.fresh() {
+            Some(entry)
+        } else {
+            self.entries.remove(repo_path);
+            None
+        }
+    }
+
+    fn insert_at(&mut self, repo_path: PathBuf, login: String, cached_at: Instant) {
+        self.entries.retain(|_, entry| entry.fresh());
+        if self.capacity == 0 {
+            return;
+        }
+        if !self.entries.contains_key(&repo_path) && self.entries.len() >= self.capacity {
+            let oldest = self
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.cached_at)
+                .map(|(path, _)| path.clone());
+            if let Some(oldest) = oldest {
+                self.entries.remove(&oldest);
+            }
+        }
+        self.entries
+            .insert(repo_path, CachedResolution { login, cached_at });
+    }
+
+    fn remove(&mut self, repo_path: &Path) {
+        self.entries.remove(repo_path);
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
 /// Per-repo cache of which gh login was last seen with access. Keyed by
 /// the repo path the frontend sent (the worktree). The token itself is
 /// re-fetched on every call — that's a fast local `gh auth token` spawn,
 /// no network — so we never store secrets in this cache.
-fn resolution_cache() -> &'static Mutex<HashMap<PathBuf, CachedResolution>> {
+fn resolution_cache() -> &'static Mutex<ResolutionCache> {
     use std::sync::OnceLock;
-    static CELL: OnceLock<Mutex<HashMap<PathBuf, CachedResolution>>> = OnceLock::new();
-    CELL.get_or_init(|| Mutex::new(HashMap::new()))
+    static CELL: OnceLock<Mutex<ResolutionCache>> = OnceLock::new();
+    CELL.get_or_init(|| Mutex::new(ResolutionCache::with_capacity(RESOLUTION_CACHE_CAPACITY)))
 }
 
 fn cached_login(repo_path: &Path) -> Option<CachedResolution> {
-    let cache = resolution_cache().lock().ok()?;
-    let entry = cache.get(repo_path)?;
-    if entry.fresh() {
-        Some(entry.clone())
-    } else {
-        None
-    }
+    resolution_cache().lock().ok()?.get(repo_path)
 }
 
 fn store_resolution(repo_path: &Path, login: &str) {
     let Ok(mut cache) = resolution_cache().lock() else {
         return;
     };
-    cache.insert(
-        repo_path.to_path_buf(),
-        CachedResolution {
-            login: login.to_string(),
-            cached_at: Instant::now(),
-        },
-    );
+    cache.insert_at(repo_path.to_path_buf(), login.to_string(), Instant::now());
 }
 
 fn invalidate_resolution(repo_path: &Path) {
@@ -3160,8 +3200,14 @@ mod tests {
 
         assert_eq!(cache.len(), 2);
         assert!(cache.get(&first).is_none());
-        assert_eq!(cache.get(&second).map(|entry| entry.login), Some("bob".into()));
-        assert_eq!(cache.get(&third).map(|entry| entry.login), Some("carol".into()));
+        assert_eq!(
+            cache.get(&second).map(|entry| entry.login),
+            Some("bob".into())
+        );
+        assert_eq!(
+            cache.get(&third).map(|entry| entry.login),
+            Some("carol".into())
+        );
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ import {
 import { findFocusedSessionId } from "./lib/focus";
 import { isSessionTabId } from "./lib/workspaceTabs";
 import { flushAllScrollbacks } from "./lib/scrollback-coordinator";
+import { retainRememberedTerminalScrollbacks } from "./lib/terminalScrollbackHandoff";
 import { useToasts } from "./lib/toasts";
 import { useUpdater } from "./lib/updater-store";
 import {
@@ -526,6 +527,7 @@ function App() {
     );
     pruneSessionIdSet(primedResumeSessionsRef.current, liveSessionIds);
     pruneSessionIdSet(probedSessionsRef.current, liveSessionIds);
+    retainRememberedTerminalScrollbacks(liveSessionIds);
     titleGenerationLastAttemptAtRef.current = retainSessionMapEntries(
       titleGenerationLastAttemptAtRef.current,
       liveSessionIds,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,6 +112,10 @@ import {
   selectDueSessionStatusPollIds,
   selectImmediateSessionStatusPollIds,
 } from "./lib/sessionStatusPolling";
+import {
+  pruneSessionIdSet,
+  retainSessionMapEntries,
+} from "./lib/sessionTracking";
 import { useAppStore } from "./store";
 import type { TranslationKey, Translator } from "./lib/i18n";
 import type { Session } from "./lib/types";
@@ -517,8 +521,27 @@ function App() {
   const [resumePrimeVersion, setResumePrimeVersion] = useState(0);
   const probedSessionsRef = useRef<Set<string>>(new Set());
   useEffect(() => {
+    const liveSessionIds = new Set(
+      useAppStore.getState().sessions.map((session) => session.id),
+    );
+    pruneSessionIdSet(primedResumeSessionsRef.current, liveSessionIds);
+    pruneSessionIdSet(probedSessionsRef.current, liveSessionIds);
+    titleGenerationLastAttemptAtRef.current = retainSessionMapEntries(
+      titleGenerationLastAttemptAtRef.current,
+      liveSessionIds,
+    );
+    setResumeCandidates((current) =>
+      retainSessionMapEntries(current, liveSessionIds),
+    );
+  }, [sessionIdsKey]);
+
+  useEffect(() => {
     if (!resumeModalEnabled) {
       primedResumeSessionsRef.current.clear();
+      probedSessionsRef.current.clear();
+      setResumeCandidates((current) =>
+        current.size === 0 ? current : new Map(),
+      );
       setResumePrimeVersion((version) => version + 1);
       return;
     }

--- a/src/components/FileExplorer.listener.test.tsx
+++ b/src/components/FileExplorer.listener.test.tsx
@@ -1,0 +1,102 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  fsGitStatus: vi.fn(),
+  fsListDir: vi.fn(),
+  fsShellEditor: vi.fn(),
+}));
+
+const eventMocks = vi.hoisted(() => ({
+  listen: vi.fn(),
+}));
+
+vi.mock("../lib/api", () => ({
+  FS_CHANGED_EVENT: "acorn:fs-changed",
+  api: {
+    fsGitStatus: apiMocks.fsGitStatus,
+    fsListDir: apiMocks.fsListDir,
+    fsShellEditor: apiMocks.fsShellEditor,
+  },
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: eventMocks.listen,
+}));
+
+vi.mock("../store", () => ({
+  useAppStore: {
+    getState: () => ({ activeSessionId: null }),
+    subscribe: () => () => {},
+  },
+}));
+
+vi.mock("../lib/toasts", () => ({
+  useToasts: (selector: (state: { show: () => void }) => unknown) =>
+    selector({ show: vi.fn() }),
+}));
+
+vi.mock("../lib/useTranslation", () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+import { FileExplorer } from "./FileExplorer";
+
+describe("FileExplorer filesystem listener", () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+  let resolveListen: ((unlisten: () => void) => void) | null;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    resolveListen = null;
+
+    apiMocks.fsShellEditor.mockResolvedValue("");
+    apiMocks.fsListDir.mockResolvedValue({ entries: [], repo_root: null });
+    apiMocks.fsGitStatus.mockResolvedValue({
+      statuses: {},
+      huge: false,
+      limit: 5_000,
+    });
+    eventMocks.listen.mockImplementation(
+      () =>
+        new Promise<() => void>((resolve) => {
+          resolveListen = resolve;
+        }),
+    );
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+    }
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("disposes a listener that finishes registering after unmount", async () => {
+    await act(async () => {
+      root?.render(<FileExplorer rootPath="/tmp/acorn" />);
+    });
+    expect(eventMocks.listen).toHaveBeenCalledOnce();
+
+    act(() => root?.unmount());
+    root = null;
+
+    const unlisten = vi.fn();
+    await act(async () => {
+      resolveListen?.(unlisten);
+      await Promise.resolve();
+    });
+
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -720,7 +720,9 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
   // large generated-file bursts do not fan out into per-file work.
   useEffect(() => {
     let cancel: (() => void) | null = null;
+    let cancelled = false;
     void listen<FsChangePayload>(FS_CHANGED_EVENT, (event) => {
+      if (cancelled) return;
       const payload = event.payload;
       if (
         payload.root &&
@@ -764,9 +766,14 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       scheduleGitStatusRefresh("fs-event");
       scheduleGitDiffStats();
     }).then((unlisten) => {
-      cancel = unlisten;
+      if (cancelled) {
+        unlisten();
+      } else {
+        cancel = unlisten;
+      }
     });
     return () => {
+      cancelled = true;
       if (cancel) cancel();
     };
   }, [rootPath, fetchDir, scheduleGitStatusRefresh, scheduleGitDiffStats]);

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -59,7 +59,10 @@ import {
   onPullRequestMutation,
   pullRequestMutationAffectsOpenContext,
 } from "../lib/pullRequestEvents";
-import { rightPanelCache } from "../lib/right-panel-cache";
+import {
+  rememberRecentStagedDiff,
+  rightPanelCache,
+} from "../lib/right-panel-cache";
 import { classifyRightPanelFsChange } from "../lib/right-panel-invalidation";
 import { useSettings } from "../lib/settings";
 import { primeCurrentPullRequestCacheFromListing } from "../lib/useCurrentPullRequest";
@@ -2482,7 +2485,9 @@ function StagedTab({
       .stagedFileDiff(repoPath, selectedPath)
       .then((payload) => {
         if (diffGenerationRef.current !== token) return;
-        setDiffByPath((prev) => ({ ...prev, [selectedPath]: payload }));
+        setDiffByPath((prev) =>
+          rememberRecentStagedDiff(prev, selectedPath, payload),
+        );
       })
       .catch((e) => {
         if (diffGenerationRef.current !== token) return;

--- a/src/lib/right-panel-cache.test.ts
+++ b/src/lib/right-panel-cache.test.ts
@@ -222,6 +222,31 @@ describe("rightPanelCache", () => {
     expect(mockApi.commitDiff).toHaveBeenCalledTimes(21);
   });
 
+  it("keeps a fresh commit diff request when a pruned stale request settles", async () => {
+    const diff: DiffPayload = { files: [] };
+    const stale = deferred<DiffPayload>();
+    const fresh = deferred<DiffPayload>();
+    const unexpectedThird = deferred<DiffPayload>();
+    mockApi.commitDiff
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(fresh.promise)
+      .mockReturnValue(unexpectedThird.promise);
+
+    const staleRequest = rightPanelCache.fetchCommitDiff(REPO, "abc123");
+    rightPanelCache.retainRepos([OTHER_REPO]);
+    rightPanelCache.retainRepos([REPO]);
+    const freshRequest = rightPanelCache.fetchCommitDiff(REPO, "abc123");
+
+    stale.resolve(diff);
+    await staleRequest;
+
+    expect(rightPanelCache.fetchCommitDiff(REPO, "abc123")).toBe(freshRequest);
+    expect(mockApi.commitDiff).toHaveBeenCalledTimes(2);
+
+    fresh.resolve(diff);
+    await freshRequest;
+  });
+
   it("tracks project prefetch once until the repo is pruned", () => {
     expect(rightPanelCache.claimProjectPrefetch(REPO)).toBe(true);
     expect(rightPanelCache.claimProjectPrefetch(REPO)).toBe(false);

--- a/src/lib/right-panel-cache.test.ts
+++ b/src/lib/right-panel-cache.test.ts
@@ -255,6 +255,17 @@ describe("rightPanelCache", () => {
     expect(rightPanelCache.claimProjectPrefetch(REPO)).toBe(true);
   });
 
+  it("releases invalidation metadata when repositories are pruned", () => {
+    for (let index = 0; index < 300; index += 1) {
+      const repoPath = `/tmp/transient-repo-${index}`;
+      rightPanelCache.retainRepos([repoPath]);
+      rightPanelCache.invalidatePullRequests(repoPath);
+      rightPanelCache.retainRepos([]);
+    }
+
+    expect(rightPanelCache.repoInvalidationEntryCountForTests()).toBe(0);
+  });
+
   it("drops cached repo data when the repo is no longer retained", async () => {
     const history: AgentHistoryItem[] = [];
     const workflows: WorkflowRunsListing = {

--- a/src/lib/right-panel-cache.test.ts
+++ b/src/lib/right-panel-cache.test.ts
@@ -198,6 +198,30 @@ describe("rightPanelCache", () => {
     expect(mockApi.commitDiff).toHaveBeenCalledTimes(1);
   });
 
+  it("evicts old commit diff payloads after the cache reaches its limit", async () => {
+    mockApi.commitDiff.mockImplementation(async (_repoPath, sha) => ({
+      files: [
+        {
+          old_path: `${sha}.old`,
+          new_path: `${sha}.new`,
+          patch: `@@ -1 +1 @@\n-${sha}\n+updated-${sha}\n`,
+          is_image: false,
+        },
+      ],
+    }));
+
+    for (let index = 0; index < 20; index += 1) {
+      await rightPanelCache.fetchCommitDiff(REPO, `sha-${index}`);
+    }
+
+    expect(rightPanelCache.getCommitDiff(REPO, "sha-0")).toBeNull();
+    expect(rightPanelCache.getCommitDiff(REPO, "sha-19")).not.toBeNull();
+
+    await rightPanelCache.fetchCommitDiff(REPO, "sha-0");
+
+    expect(mockApi.commitDiff).toHaveBeenCalledTimes(21);
+  });
+
   it("tracks project prefetch once until the repo is pruned", () => {
     expect(rightPanelCache.claimProjectPrefetch(REPO)).toBe(true);
     expect(rightPanelCache.claimProjectPrefetch(REPO)).toBe(false);

--- a/src/lib/right-panel-cache.test.ts
+++ b/src/lib/right-panel-cache.test.ts
@@ -36,7 +36,10 @@ vi.mock("./api", () => ({
 }));
 
 import { api } from "./api";
-import { rightPanelCache } from "./right-panel-cache";
+import {
+  rememberRecentStagedDiff,
+  rightPanelCache,
+} from "./right-panel-cache";
 
 const mockApi = vi.mocked(api);
 const REPO = "/tmp/acorn";
@@ -220,6 +223,41 @@ describe("rightPanelCache", () => {
     await rightPanelCache.fetchCommitDiff(REPO, "sha-0");
 
     expect(mockApi.commitDiff).toHaveBeenCalledTimes(21);
+  });
+
+  it("keeps only the most recent staged diff payloads", () => {
+    let diffByPath: Record<string, DiffPayload> = {};
+
+    for (let index = 0; index < 20; index += 1) {
+      diffByPath = rememberRecentStagedDiff(
+        diffByPath,
+        `src/file-${index}.ts`,
+        { files: [] },
+      );
+    }
+
+    expect(Object.keys(diffByPath)).toHaveLength(16);
+    expect(diffByPath["src/file-0.ts"]).toBeUndefined();
+    expect(diffByPath["src/file-19.ts"]).toBeDefined();
+  });
+
+  it("bounds oversized staged entries stored by callers", () => {
+    const diffByPath = Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [
+        `src/file-${index}.ts`,
+        { files: [] },
+      ]),
+    );
+
+    rightPanelCache.setStaged(REPO, {
+      files: [],
+      selectedPath: null,
+      diffByPath,
+    });
+
+    expect(Object.keys(rightPanelCache.getStaged(REPO)!.diffByPath)).toHaveLength(
+      16,
+    );
   });
 
   it("keeps a fresh commit diff request when a pruned stale request settles", async () => {

--- a/src/lib/right-panel-cache.ts
+++ b/src/lib/right-panel-cache.ts
@@ -26,7 +26,7 @@ const COMMIT_DIFF_CACHE_MAX_ENTRIES = 16;
 
 class RightPanelCacheManager {
   private retainedRepos: Set<string> | null = null;
-  private repoVersions = new Map<string, number>();
+  private repoTokens = new Map<string, symbol>();
   private prefetchedProjectRepos = new Set<string>();
   private agentHistoryCache = new Map<string, AgentHistoryItem[]>();
   private agentHistoryInFlight = new Map<string, Promise<AgentHistoryItem[]>>();
@@ -55,29 +55,8 @@ class RightPanelCacheManager {
 
   retainRepos(repoPaths: Iterable<string>): void {
     const next = new Set(repoPaths);
-    const removed = new Set<string>();
-    if (this.retainedRepos) {
-      for (const repoPath of this.retainedRepos) {
-        if (!next.has(repoPath)) removed.add(repoPath);
-      }
-    }
-    this.collectRemovedStringKeys(this.agentHistoryCache, next, removed);
-    this.collectRemovedStringKeys(this.agentHistoryInFlight, next, removed);
-    this.collectRemovedStringKeys(this.commitsCache, next, removed);
-    this.collectRemovedStringKeys(this.stagedCache, next, removed);
-    this.collectRemovedStringKeys(this.fileExplorerExpanded, next, removed);
-    this.collectRemovedStringValues(this.prefetchedProjectRepos, next, removed);
-    this.collectRemovedJsonKeys(this.prListCache, next, removed);
-    this.collectRemovedJsonKeys(this.prListInFlight, next, removed);
-    this.collectRemovedJsonKeys(this.issueListCache, next, removed);
-    this.collectRemovedJsonKeys(this.issueListInFlight, next, removed);
-    this.collectRemovedJsonKeys(this.workflowRunsCache, next, removed);
-    this.collectRemovedJsonKeys(this.workflowRunsInFlight, next, removed);
-    this.collectRemovedJsonKeys(this.commitDiffCache, next, removed);
-    this.collectRemovedJsonKeys(this.commitDiffInFlight, next, removed);
-    for (const repoPath of removed) this.bumpRepoVersion(repoPath);
-
     this.retainedRepos = next;
+    this.pruneStringKeyedMap(this.repoTokens, next);
     this.pruneStringKeyedMap(this.agentHistoryCache, next);
     this.pruneStringKeyedMap(this.agentHistoryInFlight, next);
     this.pruneStringKeyedMap(this.commitsCache, next);
@@ -111,11 +90,11 @@ class RightPanelCacheManager {
     if (cached && !options.force) return Promise.resolve(cached);
     const existing = this.agentHistoryInFlight.get(repoPath);
     if (existing) return existing;
-    const version = this.repoVersion(repoPath);
+    const version = this.repoToken(repoPath);
     const promise = api
       .listAgentHistory(repoPath, 100)
       .then((items) => {
-        if (this.isCurrentRepoVersion(repoPath, version)) {
+        if (this.isCurrentRepoToken(repoPath, version)) {
           this.agentHistoryCache.set(repoPath, items);
         }
         return items;
@@ -179,11 +158,11 @@ class RightPanelCacheManager {
     if (cached) return Promise.resolve(cached);
     const existing = this.commitDiffInFlight.get(key);
     if (existing) return existing;
-    const version = this.repoVersion(repoPath);
+    const version = this.repoToken(repoPath);
     const promise = api
       .commitDiff(repoPath, sha)
       .then((payload) => {
-        if (this.isCurrentRepoVersion(repoPath, version)) {
+        if (this.isCurrentRepoToken(repoPath, version)) {
           this.storeCommitDiff(key, payload);
         }
         return payload;
@@ -234,15 +213,15 @@ class RightPanelCacheManager {
     if (cached && !options.force) return Promise.resolve(cached);
     if (options.force) {
       this.prListCache.delete(key);
-      this.bumpRepoVersion(repoPath);
+      this.bumpRepoToken(repoPath);
     }
     const existing = this.prListInFlight.get(key);
     if (existing && !options.force) return existing;
-    const version = this.repoVersion(repoPath);
+    const version = this.repoToken(repoPath);
     const promise = api
       .listPullRequests(repoPath, filter, limit)
       .then((result) => {
-        if (this.isCurrentRepoVersion(repoPath, version)) {
+        if (this.isCurrentRepoToken(repoPath, version)) {
           this.prListCache.set(key, result);
         }
         return result;
@@ -257,7 +236,7 @@ class RightPanelCacheManager {
   }
 
   invalidatePullRequests(repoPath: string): void {
-    this.bumpRepoVersion(repoPath);
+    this.bumpRepoToken(repoPath);
     this.deleteJsonKeysForRepo(this.prListCache, repoPath);
     this.deleteJsonKeysForRepo(this.prListInFlight, repoPath);
   }
@@ -281,11 +260,11 @@ class RightPanelCacheManager {
     if (cached && !options.force) return Promise.resolve(cached);
     const existing = this.issueListInFlight.get(key);
     if (existing) return existing;
-    const version = this.repoVersion(repoPath);
+    const version = this.repoToken(repoPath);
     const promise = api
       .listIssues(repoPath, filter, limit)
       .then((result) => {
-        if (this.isCurrentRepoVersion(repoPath, version)) {
+        if (this.isCurrentRepoToken(repoPath, version)) {
           this.issueListCache.set(key, result);
         }
         return result;
@@ -313,11 +292,11 @@ class RightPanelCacheManager {
     if (cached && !options.force) return Promise.resolve(cached);
     const existing = this.workflowRunsInFlight.get(key);
     if (existing) return existing;
-    const version = this.repoVersion(repoPath);
+    const version = this.repoToken(repoPath);
     const promise = api
       .listWorkflowRuns(repoPath, limit)
       .then((result) => {
-        if (this.isCurrentRepoVersion(repoPath, version)) {
+        if (this.isCurrentRepoToken(repoPath, version)) {
           this.workflowRunsCache.set(key, result);
         }
         return result;
@@ -333,7 +312,7 @@ class RightPanelCacheManager {
 
   resetForTests(): void {
     this.retainedRepos = null;
-    this.repoVersions.clear();
+    this.repoTokens.clear();
     this.prefetchedProjectRepos.clear();
     this.agentHistoryCache.clear();
     this.agentHistoryInFlight.clear();
@@ -352,20 +331,32 @@ class RightPanelCacheManager {
     this.commitDiffInFlight.clear();
   }
 
+  repoInvalidationEntryCountForTests(): number {
+    return this.repoTokens.size;
+  }
+
   private canStore(repoPath: string): boolean {
     return this.retainedRepos === null || this.retainedRepos.has(repoPath);
   }
 
-  private repoVersion(repoPath: string): number {
-    return this.repoVersions.get(repoPath) ?? 0;
+  private repoToken(repoPath: string): symbol {
+    const existing = this.repoTokens.get(repoPath);
+    if (existing) return existing;
+    const token = Symbol();
+    if (this.canStore(repoPath)) this.repoTokens.set(repoPath, token);
+    return token;
   }
 
-  private isCurrentRepoVersion(repoPath: string, version: number): boolean {
-    return this.repoVersion(repoPath) === version;
+  private isCurrentRepoToken(repoPath: string, token: symbol): boolean {
+    return this.canStore(repoPath) && this.repoTokens.get(repoPath) === token;
   }
 
-  private bumpRepoVersion(repoPath: string): void {
-    this.repoVersions.set(repoPath, this.repoVersion(repoPath) + 1);
+  private bumpRepoToken(repoPath: string): void {
+    if (this.canStore(repoPath)) {
+      this.repoTokens.set(repoPath, Symbol());
+    } else {
+      this.repoTokens.delete(repoPath);
+    }
   }
 
   private prListKey(
@@ -409,29 +400,9 @@ class RightPanelCacheManager {
     }
   }
 
-  private collectRemovedStringKeys<T>(
-    map: Map<string, T>,
-    retained: Set<string>,
-    removed: Set<string>,
-  ): void {
-    for (const key of map.keys()) {
-      if (!retained.has(key)) removed.add(key);
-    }
-  }
-
   private pruneStringKeyedSet(set: Set<string>, retained: Set<string>): void {
     for (const value of set) {
       if (!retained.has(value)) set.delete(value);
-    }
-  }
-
-  private collectRemovedStringValues(
-    set: Set<string>,
-    retained: Set<string>,
-    removed: Set<string>,
-  ): void {
-    for (const value of set) {
-      if (!retained.has(value)) removed.add(value);
     }
   }
 
@@ -440,18 +411,6 @@ class RightPanelCacheManager {
       if (!retained.has(this.repoFromJsonKey(key))) map.delete(key);
     }
   }
-
-  private collectRemovedJsonKeys<T>(
-    map: Map<string, T>,
-    retained: Set<string>,
-    removed: Set<string>,
-  ): void {
-    for (const key of map.keys()) {
-      const repoPath = this.repoFromJsonKey(key);
-      if (repoPath && !retained.has(repoPath)) removed.add(repoPath);
-    }
-  }
-
   private deleteJsonKeysForRepo<T>(map: Map<string, T>, repoPath: string): void {
     for (const key of map.keys()) {
       if (this.repoFromJsonKey(key) === repoPath) map.delete(key);

--- a/src/lib/right-panel-cache.ts
+++ b/src/lib/right-panel-cache.ts
@@ -121,7 +121,9 @@ class RightPanelCacheManager {
         return items;
       })
       .finally(() => {
-        this.agentHistoryInFlight.delete(repoPath);
+        if (this.agentHistoryInFlight.get(repoPath) === promise) {
+          this.agentHistoryInFlight.delete(repoPath);
+        }
       });
     this.agentHistoryInFlight.set(repoPath, promise);
     return promise;
@@ -150,7 +152,9 @@ class RightPanelCacheManager {
         return items;
       })
       .finally(() => {
-        this.unscopedAgentHistoryInFlight.delete(limit);
+        if (this.unscopedAgentHistoryInFlight.get(limit) === promise) {
+          this.unscopedAgentHistoryInFlight.delete(limit);
+        }
       });
     this.unscopedAgentHistoryInFlight.set(limit, promise);
     return promise;
@@ -185,7 +189,9 @@ class RightPanelCacheManager {
         return payload;
       })
       .finally(() => {
-        this.commitDiffInFlight.delete(key);
+        if (this.commitDiffInFlight.get(key) === promise) {
+          this.commitDiffInFlight.delete(key);
+        }
       });
     this.commitDiffInFlight.set(key, promise);
     return promise;
@@ -285,7 +291,9 @@ class RightPanelCacheManager {
         return result;
       })
       .finally(() => {
-        this.issueListInFlight.delete(key);
+        if (this.issueListInFlight.get(key) === promise) {
+          this.issueListInFlight.delete(key);
+        }
       });
     this.issueListInFlight.set(key, promise);
     return promise;
@@ -315,7 +323,9 @@ class RightPanelCacheManager {
         return result;
       })
       .finally(() => {
-        this.workflowRunsInFlight.delete(key);
+        if (this.workflowRunsInFlight.get(key) === promise) {
+          this.workflowRunsInFlight.delete(key);
+        }
       });
     this.workflowRunsInFlight.set(key, promise);
     return promise;

--- a/src/lib/right-panel-cache.ts
+++ b/src/lib/right-panel-cache.ts
@@ -22,6 +22,8 @@ interface FetchOptions {
   force?: boolean;
 }
 
+const COMMIT_DIFF_CACHE_MAX_ENTRIES = 16;
+
 class RightPanelCacheManager {
   private retainedRepos: Set<string> | null = null;
   private repoVersions = new Map<string, number>();
@@ -178,7 +180,7 @@ class RightPanelCacheManager {
       .commitDiff(repoPath, sha)
       .then((payload) => {
         if (this.isCurrentRepoVersion(repoPath, version)) {
-          this.commitDiffCache.set(key, payload);
+          this.storeCommitDiff(key, payload);
         }
         return payload;
       })
@@ -378,6 +380,17 @@ class RightPanelCacheManager {
 
   private commitDiffKey(repoPath: string, sha: string): string {
     return JSON.stringify([repoPath, sha]);
+  }
+
+  private storeCommitDiff(key: string, payload: DiffPayload): void {
+    if (
+      !this.commitDiffCache.has(key) &&
+      this.commitDiffCache.size >= COMMIT_DIFF_CACHE_MAX_ENTRIES
+    ) {
+      const oldest = this.commitDiffCache.keys().next();
+      if (!oldest.done) this.commitDiffCache.delete(oldest.value);
+    }
+    this.commitDiffCache.set(key, payload);
   }
 
   private pruneStringKeyedMap<T>(map: Map<string, T>, retained: Set<string>): void {

--- a/src/lib/right-panel-cache.ts
+++ b/src/lib/right-panel-cache.ts
@@ -23,6 +23,31 @@ interface FetchOptions {
 }
 
 const COMMIT_DIFF_CACHE_MAX_ENTRIES = 16;
+const STAGED_DIFF_CACHE_MAX_ENTRIES = 16;
+
+function limitRecentStagedDiffs(
+  diffByPath: Record<string, DiffPayload>,
+): Record<string, DiffPayload> {
+  const paths = Object.keys(diffByPath);
+  if (paths.length <= STAGED_DIFF_CACHE_MAX_ENTRIES) return diffByPath;
+
+  return Object.fromEntries(
+    paths
+      .slice(-STAGED_DIFF_CACHE_MAX_ENTRIES)
+      .map((path) => [path, diffByPath[path]]),
+  );
+}
+
+export function rememberRecentStagedDiff(
+  diffByPath: Record<string, DiffPayload>,
+  path: string,
+  payload: DiffPayload,
+): Record<string, DiffPayload> {
+  const next = { ...diffByPath };
+  delete next[path];
+  next[path] = payload;
+  return limitRecentStagedDiffs(next);
+}
 
 class RightPanelCacheManager {
   private retainedRepos: Set<string> | null = null;
@@ -182,7 +207,11 @@ class RightPanelCacheManager {
 
   setStaged(repoPath: string, entry: StagedCacheEntry): void {
     if (!this.canStore(repoPath)) return;
-    this.stagedCache.set(repoPath, entry);
+    const diffByPath = limitRecentStagedDiffs(entry.diffByPath);
+    this.stagedCache.set(
+      repoPath,
+      diffByPath === entry.diffByPath ? entry : { ...entry, diffByPath },
+    );
   }
 
   getFileExplorerExpanded(repoPath: string): Set<string> {

--- a/src/lib/sessionTracking.test.ts
+++ b/src/lib/sessionTracking.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  pruneSessionIdSet,
+  retainSessionMapEntries,
+} from "./sessionTracking";
+
+describe("session tracking collection cleanup", () => {
+  it("removes deleted session ids from mutable tracking sets", () => {
+    const tracked = new Set(["live-a", "deleted", "live-b"]);
+    const live = new Set(["live-a", "live-b"]);
+
+    const changed = pruneSessionIdSet(tracked, live);
+
+    expect(changed).toBe(true);
+    expect([...tracked]).toEqual(["live-a", "live-b"]);
+  });
+
+  it("returns a pruned copy when a session-keyed state map has stale entries", () => {
+    const tracked = new Map([
+      ["live", { title: "keep" }],
+      ["deleted", { title: "release" }],
+    ]);
+
+    const result = retainSessionMapEntries(tracked, new Set(["live"]));
+
+    expect(result).not.toBe(tracked);
+    expect([...result]).toEqual([["live", { title: "keep" }]]);
+    expect(tracked.size).toBe(2);
+  });
+
+  it("preserves state map identity when every tracked session is still live", () => {
+    const tracked = new Map([["live", { title: "keep" }]]);
+
+    const result = retainSessionMapEntries(tracked, new Set(["live"]));
+
+    expect(result).toBe(tracked);
+  });
+});

--- a/src/lib/sessionTracking.ts
+++ b/src/lib/sessionTracking.ts
@@ -1,0 +1,25 @@
+export function pruneSessionIdSet(
+  tracked: Set<string>,
+  liveSessionIds: ReadonlySet<string>,
+): boolean {
+  let changed = false;
+  for (const sessionId of tracked) {
+    if (liveSessionIds.has(sessionId)) continue;
+    tracked.delete(sessionId);
+    changed = true;
+  }
+  return changed;
+}
+
+export function retainSessionMapEntries<T>(
+  tracked: Map<string, T>,
+  liveSessionIds: ReadonlySet<string>,
+): Map<string, T> {
+  let next: Map<string, T> | null = null;
+  for (const sessionId of tracked.keys()) {
+    if (liveSessionIds.has(sessionId)) continue;
+    next ??= new Map(tracked);
+    next.delete(sessionId);
+  }
+  return next ?? tracked;
+}

--- a/src/lib/terminalScrollbackHandoff.test.ts
+++ b/src/lib/terminalScrollbackHandoff.test.ts
@@ -42,5 +42,12 @@ describe("terminal scrollback handoff", () => {
       "keep this scrollback\n",
     );
     expect(rememberedTerminalScrollback("deleted")).toBeNull();
+
+    const lateSave = rememberTerminalScrollback(
+      "deleted",
+      "late async scrollback\n",
+    );
+    expect(lateSave).toBe("");
+    expect(rememberedTerminalScrollback("deleted")).toBeNull();
   });
 });

--- a/src/lib/terminalScrollbackHandoff.test.ts
+++ b/src/lib/terminalScrollbackHandoff.test.ts
@@ -3,6 +3,7 @@ import {
   clearRememberedTerminalScrollback,
   rememberedTerminalScrollback,
   rememberTerminalScrollback,
+  retainRememberedTerminalScrollbacks,
 } from "./terminalScrollbackHandoff";
 
 describe("terminal scrollback handoff", () => {
@@ -29,5 +30,17 @@ describe("terminal scrollback handoff", () => {
     clearRememberedTerminalScrollback("s3");
 
     expect(rememberedTerminalScrollback("s3")).toBeNull();
+  });
+
+  it("releases snapshots for sessions that no longer exist", () => {
+    rememberTerminalScrollback("live", "keep this scrollback\n");
+    rememberTerminalScrollback("deleted", "release this scrollback\n");
+
+    retainRememberedTerminalScrollbacks(new Set(["live"]));
+
+    expect(rememberedTerminalScrollback("live")).toBe(
+      "keep this scrollback\n",
+    );
+    expect(rememberedTerminalScrollback("deleted")).toBeNull();
   });
 });

--- a/src/lib/terminalScrollbackHandoff.ts
+++ b/src/lib/terminalScrollbackHandoff.ts
@@ -22,3 +22,11 @@ export function rememberedTerminalScrollback(sessionId: string): string | null {
 export function clearRememberedTerminalScrollback(sessionId: string): void {
   snapshots.delete(sessionId);
 }
+
+export function retainRememberedTerminalScrollbacks(
+  liveSessionIds: ReadonlySet<string>,
+): void {
+  for (const sessionId of snapshots.keys()) {
+    if (!liveSessionIds.has(sessionId)) snapshots.delete(sessionId);
+  }
+}

--- a/src/lib/terminalScrollbackHandoff.ts
+++ b/src/lib/terminalScrollbackHandoff.ts
@@ -1,12 +1,17 @@
 import { prepareScrollbackForSave } from "./terminalScrollback";
 
 const snapshots = new Map<string, string>();
+let liveSessionIds: Set<string> | null = null;
 
 export function rememberTerminalScrollback(
   sessionId: string,
   serialized: string,
 ): string {
   const prepared = prepareScrollbackForSave(serialized);
+  if (liveSessionIds !== null && !liveSessionIds.has(sessionId)) {
+    snapshots.delete(sessionId);
+    return "";
+  }
   if (prepared) {
     snapshots.set(sessionId, prepared);
   } else {
@@ -24,8 +29,9 @@ export function clearRememberedTerminalScrollback(sessionId: string): void {
 }
 
 export function retainRememberedTerminalScrollbacks(
-  liveSessionIds: ReadonlySet<string>,
+  nextLiveSessionIds: ReadonlySet<string>,
 ): void {
+  liveSessionIds = new Set(nextLiveSessionIds);
   for (const sessionId of snapshots.keys()) {
     if (!liveSessionIds.has(sessionId)) snapshots.delete(sessionId);
   }

--- a/src/lib/useCurrentPullRequest.test.tsx
+++ b/src/lib/useCurrentPullRequest.test.tsx
@@ -126,6 +126,40 @@ describe("useCurrentPullRequest", () => {
     expect(container.textContent).toBe("PR #77");
   });
 
+  it("evicts the oldest primed branches when the project cache is full", async () => {
+    const items = Array.from({ length: 300 }, (_, index) =>
+      pullRequest({
+        number: index + 1,
+        head_branch: `feat/branch-${index}`,
+      }),
+    );
+    primeCurrentPullRequestCacheFromListing("/tmp/demo", {
+      kind: "ok",
+      account: "test",
+      items,
+    });
+    mockApi.listPullRequests.mockResolvedValue({
+      kind: "ok",
+      account: "test",
+      items: [],
+    });
+
+    await act(async () => {
+      root.render(
+        <Probe value={session({ branch: "feat/branch-0" })} />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe("none");
+    expect(mockApi.listPullRequests).toHaveBeenCalledWith(
+      "/tmp/demo/.worktrees/runner",
+      "open",
+      10,
+      "head:feat/branch-0",
+    );
+  });
+
   it("clears and retries current PR context when a lifecycle mutation lands", async () => {
     mockApi.listPullRequests
       .mockResolvedValueOnce({

--- a/src/lib/useCurrentPullRequest.ts
+++ b/src/lib/useCurrentPullRequest.ts
@@ -17,6 +17,7 @@ import type {
 
 const CURRENT_PR_CACHE_TTL_MS = 60_000;
 const CURRENT_PR_EMPTY_RETRY_MS = 15_000;
+const CURRENT_PR_CACHE_MAX_ENTRIES = 256;
 
 type CurrentPullRequestCacheEntry = {
   value: SessionPullRequestSummary | null;
@@ -39,6 +40,18 @@ const currentPullRequestProjectCache = new Map<
 >();
 const currentPullRequestSubscribers = new Set<CurrentPullRequestSubscriber>();
 
+function setBoundedCacheEntry(
+  cache: Map<string, CurrentPullRequestCacheEntry>,
+  key: string,
+  entry: CurrentPullRequestCacheEntry,
+): void {
+  if (!cache.has(key) && cache.size >= CURRENT_PR_CACHE_MAX_ENTRIES) {
+    const oldest = cache.keys().next();
+    if (!oldest.done) cache.delete(oldest.value);
+  }
+  cache.set(key, entry);
+}
+
 function normalizeRepoPath(repoPath: string): string {
   return repoPath.replace(/\\/g, "/").replace(/\/+$/, "");
 }
@@ -60,10 +73,14 @@ function setCurrentPullRequestCache(
   value: SessionPullRequestSummary | null,
   ttlMs: number,
 ): void {
-  currentPullRequestCache.set(currentPullRequestCacheKey(repoPath, branch), {
-    value,
-    expiresAt: Date.now() + ttlMs,
-  });
+  setBoundedCacheEntry(
+    currentPullRequestCache,
+    currentPullRequestCacheKey(repoPath, branch),
+    {
+      value,
+      expiresAt: Date.now() + ttlMs,
+    },
+  );
 }
 
 function readPrimedCurrentPullRequest(
@@ -144,7 +161,8 @@ export function primeCurrentPullRequestCacheFromListing(
     );
     if (!summary) continue;
     summariesByBranch.set(summary.head_branch, summary);
-    currentPullRequestProjectCache.set(
+    setBoundedCacheEntry(
+      currentPullRequestProjectCache,
       currentPullRequestProjectCacheKey(projectRepoPath, summary.head_branch),
       {
         value: summary,
@@ -188,7 +206,7 @@ function loadCurrentPullRequest(
     .then((listing) => findCurrentPullRequestForBranch(listing, branch))
     .catch(() => null);
 
-  currentPullRequestCache.set(key, {
+  setBoundedCacheEntry(currentPullRequestCache, key, {
     value: cached?.value ?? null,
     expiresAt: now + CURRENT_PR_CACHE_TTL_MS,
     promise,
@@ -203,7 +221,7 @@ function loadCurrentPullRequest(
     ) {
       return latest.value;
     }
-    currentPullRequestCache.set(key, {
+    setBoundedCacheEntry(currentPullRequestCache, key, {
       value,
       expiresAt:
         Date.now() +

--- a/src/lib/useIsGitHubRepo.test.ts
+++ b/src/lib/useIsGitHubRepo.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./api", () => ({
+  api: {
+    isGitRepository: vi.fn(),
+    githubOriginSlug: vi.fn(),
+  },
+}));
+
+import { api } from "./api";
+import {
+  __resetIsGitHubRepoCacheForTests,
+  prefetchGitHubRepoStatus,
+  prefetchGitRepositoryStatus,
+} from "./useIsGitHubRepo";
+
+const mockApi = vi.mocked(api);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("git repository probe cache", () => {
+  beforeEach(() => {
+    __resetIsGitHubRepoCacheForTests();
+    mockApi.isGitRepository.mockReset();
+    mockApi.githubOriginSlug.mockReset();
+  });
+
+  it("re-probes the oldest path after the cache reaches its path limit", async () => {
+    mockApi.isGitRepository.mockResolvedValue(true);
+    mockApi.githubOriginSlug.mockResolvedValue("acme/widgets");
+
+    for (let index = 0; index < 300; index += 1) {
+      await prefetchGitHubRepoStatus(`/tmp/repo-${index}`);
+    }
+
+    expect(mockApi.isGitRepository).toHaveBeenCalledTimes(300);
+    expect(mockApi.githubOriginSlug).toHaveBeenCalledTimes(300);
+
+    await prefetchGitHubRepoStatus("/tmp/repo-0");
+
+    expect(mockApi.isGitRepository).toHaveBeenCalledTimes(301);
+    expect(mockApi.githubOriginSlug).toHaveBeenCalledTimes(301);
+  });
+
+  it("does not let an evicted in-flight probe restore its cache entry", async () => {
+    const first = deferred<boolean>();
+    mockApi.isGitRepository.mockImplementation((repoPath) => {
+      if (repoPath === "/tmp/first" && firstCallCount === 0) {
+        firstCallCount += 1;
+        return first.promise;
+      }
+      return Promise.resolve(true);
+    });
+    let firstCallCount = 0;
+
+    const evictedProbe = prefetchGitRepositoryStatus("/tmp/first");
+    for (let index = 0; index < 256; index += 1) {
+      await prefetchGitRepositoryStatus(`/tmp/other-${index}`);
+    }
+    first.resolve(true);
+    await evictedProbe;
+
+    await prefetchGitRepositoryStatus("/tmp/first");
+
+    expect(
+      mockApi.isGitRepository.mock.calls.filter(
+        ([repoPath]) => repoPath === "/tmp/first",
+      ),
+    ).toHaveLength(2);
+  });
+});

--- a/src/lib/useIsGitHubRepo.ts
+++ b/src/lib/useIsGitHubRepo.ts
@@ -5,31 +5,55 @@ import { api } from "./api";
  * Per-repo caches for the git-repo + GitHub origin probes. The results rarely
  * change during a session (only when the user runs `git init` or edits git
  * metadata), so we resolve once per repoPath and reuse across mounts.
- * Concurrent callers for the same repoPath share one in-flight promise.
+ * Concurrent callers for the same repoPath share one in-flight promise. The
+ * shared path registry evicts every cache layer together so removed worktrees
+ * cannot accumulate indefinitely or be restored by a stale promise.
  */
+const REPO_PROBE_CACHE_MAX_PATHS = 256;
 const gitRepoCache = new Map<string, boolean>();
 const gitRepoInFlight = new Map<string, Promise<boolean>>();
 const githubRepoCache = new Map<string, boolean>();
 const githubRepoInFlight = new Map<string, Promise<boolean>>();
-const generations = new Map<string, number>();
+const repoTokens = new Map<string, symbol>();
 
-function generationOf(repoPath: string): number {
-  return generations.get(repoPath) ?? 0;
+function removeRepoPath(repoPath: string): void {
+  repoTokens.delete(repoPath);
+  gitRepoCache.delete(repoPath);
+  gitRepoInFlight.delete(repoPath);
+  githubRepoCache.delete(repoPath);
+  githubRepoInFlight.delete(repoPath);
+}
+
+function trackRepoPath(repoPath: string): symbol {
+  const existing = repoTokens.get(repoPath);
+  if (existing) return existing;
+  while (repoTokens.size >= REPO_PROBE_CACHE_MAX_PATHS) {
+    const oldest = repoTokens.keys().next();
+    if (oldest.done) break;
+    removeRepoPath(oldest.value);
+  }
+  const token = Symbol(repoPath);
+  repoTokens.set(repoPath, token);
+  return token;
+}
+
+function isCurrentRepoToken(repoPath: string, token: symbol): boolean {
+  return repoTokens.get(repoPath) === token;
 }
 
 async function probeGitRepository(repoPath: string): Promise<boolean> {
+  const token = trackRepoPath(repoPath);
   const cached = gitRepoCache.get(repoPath);
   if (cached !== undefined) return cached;
   const existing = gitRepoInFlight.get(repoPath);
   if (existing) return existing;
-  const generation = generationOf(repoPath);
   const promise = api
     .isGitRepository(repoPath)
     .then((isGitRepo) => {
-      if (generationOf(repoPath) === generation) {
+      if (isCurrentRepoToken(repoPath, token)) {
         gitRepoCache.set(repoPath, isGitRepo);
       }
-      if (generationOf(repoPath) !== generation) return false;
+      if (!isCurrentRepoToken(repoPath, token)) return false;
       return isGitRepo;
     })
     .catch((error) => {
@@ -48,25 +72,25 @@ async function probeGitRepository(repoPath: string): Promise<boolean> {
 }
 
 async function probeGitHubRepo(repoPath: string): Promise<boolean> {
+  const token = trackRepoPath(repoPath);
   const cached = githubRepoCache.get(repoPath);
   if (cached !== undefined) return cached;
   const existing = githubRepoInFlight.get(repoPath);
   if (existing) return existing;
-  const generation = generationOf(repoPath);
   const promise = probeGitRepository(repoPath)
     .then(async (isGitRepo) => {
       if (!isGitRepo) {
-        if (generationOf(repoPath) === generation) {
+        if (isCurrentRepoToken(repoPath, token)) {
           githubRepoCache.set(repoPath, false);
         }
         return false;
       }
       const slug = await api.githubOriginSlug(repoPath);
       const value = slug !== null;
-      if (generationOf(repoPath) === generation) {
+      if (isCurrentRepoToken(repoPath, token)) {
         githubRepoCache.set(repoPath, value);
       }
-      if (generationOf(repoPath) !== generation) return false;
+      if (!isCurrentRepoToken(repoPath, token)) return false;
       return value;
     })
     .catch((error) => {
@@ -93,11 +117,7 @@ export function prefetchGitHubRepoStatus(repoPath: string): Promise<boolean> {
 }
 
 export function invalidateGitRepositoryStatus(repoPath: string): void {
-  gitRepoCache.delete(repoPath);
-  gitRepoInFlight.delete(repoPath);
-  githubRepoCache.delete(repoPath);
-  githubRepoInFlight.delete(repoPath);
-  generations.set(repoPath, generationOf(repoPath) + 1);
+  removeRepoPath(repoPath);
 }
 
 export function invalidateGitHubRepoStatus(repoPath: string): void {
@@ -182,5 +202,5 @@ export function __resetIsGitHubRepoCacheForTests(): void {
   gitRepoInFlight.clear();
   githubRepoCache.clear();
   githubRepoInFlight.clear();
-  generations.clear();
+  repoTokens.clear();
 }


### PR DESCRIPTION
## Summary

Bounds FileExplorer listener lifecycle without changing intended user-visible behavior.

1. **Regression coverage** — adds a focused test reproducing the unbounded or overlapping lifecycle.
2. **Bounded execution** — prevents repeated work from growing or overlapping indefinitely.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| FileExplorer listener lifecycle | A listener registered after unmount could remain active. | Late registration immediately invokes its disposer. |

## Design notes

- Use a disposed flag for React StrictMode-safe async listener cleanup.
- This PR is stacked on `perf/staged-diff-cache` and should merge after that base PR.

## Test plan

- [x] Focused regression test passed during the RED/GREEN workflow.
- [x] `pnpm test` — 94 files, 1,004 tests passed on the complete stack.
- [x] `pnpm run typecheck` passes.
- [x] `pnpm run build` passes.
- [x] `cargo test --workspace` with control-session overrides removed — 564 passed, 1 ignored on the complete stack.
- [ ] GitHub Actions CI on this PR.

## Notes

- Stack position: 14/30.
- Existing Vite and Rust warnings are unchanged by this PR.