### PR TITLE
fix(pr): preserve fresh in-flight cache entries

### DIFF
--- a/src/lib/right-panel-cache.test.ts
+++ b/src/lib/right-panel-cache.test.ts
@@ -222,6 +222,31 @@ describe("rightPanelCache", () => {
     expect(mockApi.commitDiff).toHaveBeenCalledTimes(21);
   });
 
+  it("keeps a fresh commit diff request when a pruned stale request settles", async () => {
+    const diff: DiffPayload = { files: [] };
+    const stale = deferred<DiffPayload>();
+    const fresh = deferred<DiffPayload>();
+    const unexpectedThird = deferred<DiffPayload>();
+    mockApi.commitDiff
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(fresh.promise)
+      .mockReturnValue(unexpectedThird.promise);
+
+    const staleRequest = rightPanelCache.fetchCommitDiff(REPO, "abc123");
+    rightPanelCache.retainRepos([OTHER_REPO]);
+    rightPanelCache.retainRepos([REPO]);
+    const freshRequest = rightPanelCache.fetchCommitDiff(REPO, "abc123");
+
+    stale.resolve(diff);
+    await staleRequest;
+
+    expect(rightPanelCache.fetchCommitDiff(REPO, "abc123")).toBe(freshRequest);
+    expect(mockApi.commitDiff).toHaveBeenCalledTimes(2);
+
+    fresh.resolve(diff);
+    await freshRequest;
+  });
+
   it("tracks project prefetch once until the repo is pruned", () => {
     expect(rightPanelCache.claimProjectPrefetch(REPO)).toBe(true);
     expect(rightPanelCache.claimProjectPrefetch(REPO)).toBe(false);

--- a/src/lib/right-panel-cache.ts
+++ b/src/lib/right-panel-cache.ts
@@ -121,7 +121,9 @@ class RightPanelCacheManager {
         return items;
       })
       .finally(() => {
-        this.agentHistoryInFlight.delete(repoPath);
+        if (this.agentHistoryInFlight.get(repoPath) === promise) {
+          this.agentHistoryInFlight.delete(repoPath);
+        }
       });
     this.agentHistoryInFlight.set(repoPath, promise);
     return promise;
@@ -150,7 +152,9 @@ class RightPanelCacheManager {
         return items;
       })
       .finally(() => {
-        this.unscopedAgentHistoryInFlight.delete(limit);
+        if (this.unscopedAgentHistoryInFlight.get(limit) === promise) {
+          this.unscopedAgentHistoryInFlight.delete(limit);
+        }
       });
     this.unscopedAgentHistoryInFlight.set(limit, promise);
     return promise;
@@ -185,7 +189,9 @@ class RightPanelCacheManager {
         return payload;
       })
       .finally(() => {
-        this.commitDiffInFlight.delete(key);
+        if (this.commitDiffInFlight.get(key) === promise) {
+          this.commitDiffInFlight.delete(key);
+        }
       });
     this.commitDiffInFlight.set(key, promise);
     return promise;
@@ -285,7 +291,9 @@ class RightPanelCacheManager {
         return result;
       })
       .finally(() => {
-        this.issueListInFlight.delete(key);
+        if (this.issueListInFlight.get(key) === promise) {
+          this.issueListInFlight.delete(key);
+        }
       });
     this.issueListInFlight.set(key, promise);
     return promise;
@@ -315,7 +323,9 @@ class RightPanelCacheManager {
         return result;
       })
       .finally(() => {
-        this.workflowRunsInFlight.delete(key);
+        if (this.workflowRunsInFlight.get(key) === promise) {
+          this.workflowRunsInFlight.delete(key);
+        }
       });
     this.workflowRunsInFlight.set(key, promise);
     return promise;


### PR DESCRIPTION
## Summary

Bounds RightPanel in-flight request cleanup without changing intended user-visible behavior.

1. **Regression coverage** — adds a focused test reproducing the unbounded or overlapping lifecycle.
2. **Bounded execution** — prevents repeated work from growing or overlapping indefinitely.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| RightPanel in-flight request cleanup | A stale request finalizer could delete a newer request for the same key. | Finalizers remove only the exact promise they registered. |

## Design notes

- Use promise identity checks at cleanup points without changing caller contracts.
- This PR is stacked on `perf/commit-diff-cache` and should merge after that base PR.

## Test plan

- [x] Focused regression test passed during the RED/GREEN workflow.
- [x] `pnpm test` — 94 files, 1,004 tests passed on the complete stack.
- [x] `pnpm run typecheck` passes.
- [x] `pnpm run build` passes.
- [x] `cargo test --workspace` with control-session overrides removed — 564 passed, 1 ignored on the complete stack.
- [ ] GitHub Actions CI on this PR.

## Notes

- Stack position: 11/30.
- Existing Vite and Rust warnings are unchanged by this PR.