### PR TITLE
perf(actions): pause hidden duration ticker

### DIFF
--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -219,6 +219,11 @@ describe("RightPanel background tab loading", () => {
   let root: Root;
 
   beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
     vi.useFakeTimers();
     rightPanelCache.resetForTests();
     __resetIsGitHubRepoCacheForTests();
@@ -883,6 +888,41 @@ describe("RightPanel background tab loading", () => {
 
     expect(container.textContent).toContain("6s");
     expect(mockApi.listWorkflowRuns).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not tick running Actions durations while the tab is hidden", async () => {
+    useAppStore.setState({ rightTab: "prs" });
+    mockApi.listWorkflowRuns.mockResolvedValue({
+      kind: "ok",
+      account: "tester",
+      items: [
+        {
+          id: 42,
+          display_title: "Run CI",
+          workflow_name: "CI",
+          status: "in_progress",
+          conclusion: null,
+          event: "pull_request",
+          head_branch: "feature",
+          head_sha: "abc1234",
+          url: "https://github.com/im-ian/acorn/actions/runs/42",
+          created_at: "2026-05-19T11:59:50Z",
+          updated_at: "2026-05-19T12:00:05Z",
+          started_at: "2026-05-19T12:00:00Z",
+          attempt: 1,
+        },
+      ],
+    });
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await flushPromises();
+
+    expect(
+      setIntervalSpy.mock.calls.filter(([, intervalMs]) => intervalMs === 1_000),
+    ).toHaveLength(0);
   });
 
   it("ignores GitHub zero completedAt sentinels for running Actions jobs", async () => {

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -589,6 +589,7 @@ export function RightPanel() {
               <ActionsTab
                 key={`actions:${projectRootRepoPath}`}
                 repoPath={projectRootRepoPath}
+                active={rightTab === "actions"}
               />
             </BackgroundLoadedTab>
           </>
@@ -3716,7 +3717,13 @@ function fetchWorkflowRunsCached(
   return rightPanelCache.fetchWorkflowRuns(repoPath, limit, options);
 }
 
-function ActionsTab({ repoPath }: { repoPath: string }) {
+function ActionsTab({
+  repoPath,
+  active,
+}: {
+  repoPath: string;
+  active: boolean;
+}) {
   const t = useTranslation();
   const refreshIntervalMs = useSettings(
     (s) => s.settings.github.refreshIntervalMs,
@@ -3781,9 +3788,10 @@ function ActionsTab({ repoPath }: { repoPath: string }) {
         : listing.items.filter((r) => r.workflow_name === workflowFilter)
       : [];
   const nowUnix = useLiveUnixSeconds(
-    visibleItems.some(
-      (run) => run.status.toLowerCase() !== "completed" && !!run.started_at,
-    ),
+    active &&
+      visibleItems.some(
+        (run) => run.status.toLowerCase() !== "completed" && !!run.started_at,
+      ),
   );
 
   return (


### PR DESCRIPTION
## Summary

Bounds Actions duration rendering without changing intended user-visible behavior.

1. **Regression coverage** — adds a focused test reproducing the unbounded or overlapping lifecycle.
2. **Bounded execution** — prevents repeated work from growing or overlapping indefinitely.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Actions duration rendering | The duration interval kept updating while the Actions tab was hidden. | The ticker runs only while Actions content is visible. |

## Design notes

- Gate interval installation on active tab visibility.
- This PR is stacked on `perf/kanban-pr-polls` and should merge after that base PR.

## Test plan

- [x] Focused regression test passed during the RED/GREEN workflow.
- [x] `pnpm test` — 94 files, 1,004 tests passed on the complete stack.
- [x] `pnpm run typecheck` passes.
- [x] `pnpm run build` passes.
- [x] `cargo test --workspace` with control-session overrides removed — 564 passed, 1 ignored on the complete stack.
- [ ] GitHub Actions CI on this PR.

## Notes

- Stack position: 18/30.
- Existing Vite and Rust warnings are unchanged by this PR.