### PR TITLE
perf(status): coalesce token usage polling

### DIFF
--- a/src/components/StatusBar.polling.test.tsx
+++ b/src/components/StatusBar.polling.test.tsx
@@ -5,12 +5,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const apiMocks = vi.hoisted(() => ({
   daemonStatus: vi.fn(),
   getAcornIpcStatus: vi.fn(),
+  getAgentTokenUsage: vi.fn(),
 }));
 
 vi.mock("../lib/api", () => ({
   api: {
     daemonStatus: apiMocks.daemonStatus,
     getAcornIpcStatus: apiMocks.getAcornIpcStatus,
+    getAgentTokenUsage: apiMocks.getAgentTokenUsage,
   },
 }));
 
@@ -84,5 +86,55 @@ describe("StatusBar service polling", () => {
 
     expect(apiMocks.getAcornIpcStatus).toHaveBeenCalledOnce();
     expect(apiMocks.daemonStatus).toHaveBeenCalledOnce();
+  });
+
+  it("does not overlap a slow agent token usage poll", async () => {
+    const settings = structuredClone(DEFAULT_SETTINGS);
+    settings.statusBar.showAgentTokenUsage = true;
+    useSettings.setState({ settings });
+    useAppStore.setState({
+      sessions: [
+        {
+          id: "session-a",
+          name: "Codex",
+          repo_path: "/repo/a",
+          worktree_path: "/repo/a",
+          branch: "main",
+          isolated: false,
+          project_scoped: true,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          title_source: "default",
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+          agent_provider: "codex",
+        },
+      ],
+      activeSessionId: "session-a",
+    });
+    apiMocks.getAcornIpcStatus.mockResolvedValue({ server_running: true });
+    apiMocks.daemonStatus.mockResolvedValue({
+      running: true,
+      enabled: true,
+      session_count_alive: 1,
+    });
+    const pending = deferred<unknown>();
+    apiMocks.getAgentTokenUsage.mockReturnValue(pending.promise);
+
+    await act(async () => {
+      root.render(<StatusBar />);
+    });
+    expect(apiMocks.getAgentTokenUsage).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+
+    expect(apiMocks.getAgentTokenUsage).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -151,6 +151,9 @@ interface MemorySnapshot {
 const getCoalescedMemoryUsage = createInFlightCoalescer(() =>
   api.getMemoryUsage(),
 );
+const getCoalescedAgentTokenUsage = createInFlightCoalescer(() =>
+  api.getAgentTokenUsage(),
+);
 
 function formatBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
@@ -210,7 +213,7 @@ function useAgentTokenUsage(
     let cancelled = false;
     const tick = async () => {
       try {
-        const usage = await api.getAgentTokenUsage();
+        const usage = await getCoalescedAgentTokenUsage();
         if (!cancelled) setSnapshot(usage);
       } catch {
         if (!cancelled) setSnapshot(null);


### PR DESCRIPTION
## Summary

Bounds agent token usage polling without changing intended user-visible behavior.

1. **Regression coverage** — adds a focused test reproducing the unbounded or overlapping lifecycle.
2. **Bounded execution** — prevents repeated work from growing or overlapping indefinitely.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| agent token usage polling | Token usage requests could overlap across interval ticks. | Concurrent triggers share one request and queue one refresh. |

## Design notes

- Preserve the latest usage result while avoiding duplicate backend work.
- This PR is stacked on `perf/status-service-polls` and should merge after that base PR.

## Test plan

- [x] Focused regression test passed during the RED/GREEN workflow.
- [x] `pnpm test` — 94 files, 1,004 tests passed on the complete stack.
- [x] `pnpm run typecheck` passes.
- [x] `pnpm run build` passes.
- [x] `cargo test --workspace` with control-session overrides removed — 564 passed, 1 ignored on the complete stack.
- [ ] GitHub Actions CI on this PR.

## Notes

- Stack position: 21/30.
- Existing Vite and Rust warnings are unchanged by this PR.