### PR TITLE
perf(terminal): coalesce eviction probes

### DIFF
--- a/src/components/TerminalHost.test.tsx
+++ b/src/components/TerminalHost.test.tsx
@@ -388,6 +388,40 @@ describe("TerminalHost", () => {
     ]);
   });
 
+  it("coalesces daemon eviction probes while a previous probe is pending", async () => {
+    const ids = ["s1", "s2", "s3", "s4"];
+    useSettings.setState({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        terminal: {
+          ...DEFAULT_SETTINGS.terminal,
+          maxMountedTerminals: 2,
+        },
+      },
+    });
+    let resolveProbe!: (
+      sessions: Array<{ id: string; alive: boolean }>,
+    ) => void;
+    mocks.daemonListSessions.mockReturnValue(
+      new Promise((resolve) => {
+        resolveProbe = resolve;
+      }),
+    );
+    installWorkspaceSessions(ids);
+    render();
+    await flushEffects();
+
+    await focusSession("s2");
+    await focusSession("s3");
+    expect(mocks.daemonListSessions).toHaveBeenCalledTimes(1);
+
+    await focusSession("s4");
+    expect(mocks.daemonListSessions).toHaveBeenCalledTimes(1);
+
+    resolveProbe(ids.map((id) => ({ id, alive: true })));
+    await flushEffects();
+  });
+
   it("keeps off-screen terminals mounted when resident terminal eviction is disabled", async () => {
     const ids = ["s1", "s2", "s3"];
     useSettings.setState({

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -70,6 +70,9 @@ export function TerminalHost() {
   // Mounted session ids ordered least-recently-visible → most-recent. Drives
   // which terminals the eviction policy sheds first when over the mount cap.
   const recencyRef = useRef<string[]>([]);
+  const daemonEvictionProbeRef = useRef<
+    ReturnType<typeof api.daemonListSessions> | null
+  >(null);
   useEffect(() => {
     const next = recencyRef.current.filter((id) => terminalSessionIds.has(id));
     for (const id of visibleSessionIds) {
@@ -95,7 +98,17 @@ export function TerminalHost() {
     void (async () => {
       let daemonAlive: Set<string>;
       try {
-        const summaries = await api.daemonListSessions();
+        let probe = daemonEvictionProbeRef.current;
+        if (!probe) {
+          const promise = api.daemonListSessions().finally(() => {
+            if (daemonEvictionProbeRef.current === promise) {
+              daemonEvictionProbeRef.current = null;
+            }
+          });
+          daemonEvictionProbeRef.current = promise;
+          probe = promise;
+        }
+        const summaries = await probe;
         daemonAlive = new Set(
           summaries.filter((s) => s.alive).map((s) => s.id),
         );


### PR DESCRIPTION
## Summary

Bounds terminal daemon eviction probes without changing intended user-visible behavior.

1. **Regression coverage** — adds a focused test reproducing the unbounded or overlapping lifecycle.
2. **Bounded execution** — prevents repeated work from growing or overlapping indefinitely.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| terminal daemon eviction probes | Slow eviction checks could overlap across refreshes. | All triggers share one in-flight probe. |

## Design notes

- Clear the shared promise by identity after completion.
- This PR is stacked on `perf/acorn-rain-resources` and should merge after that base PR.

## Test plan

- [x] Focused regression test passed during the RED/GREEN workflow.
- [x] `pnpm test` — 94 files, 1,004 tests passed on the complete stack.
- [x] `pnpm run typecheck` passes.
- [x] `pnpm run build` passes.
- [x] `cargo test --workspace` with control-session overrides removed — 564 passed, 1 ignored on the complete stack.
- [ ] GitHub Actions CI on this PR.

## Notes

- Stack position: 27/30.
- Existing Vite and Rust warnings are unchanged by this PR.