### PR TITLE
perf(files): bound git-stat path retention

### DIFF
--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -36,6 +36,7 @@ import {
   hasDetectedAgent,
 } from "../lib/agentContextMenu";
 import { cn } from "../lib/cn";
+import { retainRecentGitStatPaths } from "../lib/fileExplorerGitStats";
 import { matchesHotkeyEvent } from "../lib/hotkeys";
 import { planGitRefresh } from "../lib/git-refresh-scheduler";
 import type { TranslationKey, Translator } from "../lib/i18n";
@@ -741,9 +742,11 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       const toFetch = new Set<string>();
       const changedPaths = payload.paths.filter((p) => pathInsideRoot(p, rootPath));
 
-      for (const p of changedPaths) {
-        changedPathsRef.current.add(p);
-      }
+      retainRecentGitStatPaths(
+        changedPathsRef.current,
+        changedPaths,
+        payload.cap,
+      );
 
       if (payload.overflow && payload.refresh) {
         const refreshPath =
@@ -1000,7 +1003,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       }
     }
     setSelection(new Set());
-    for (const p of paths) changedPathsRef.current.add(p);
+    retainRecentGitStatPaths(changedPathsRef.current, paths);
     pendingWorkingTreeRef.current = true;
     scheduleGitStatusRefresh("user");
     scheduleGitDiffStats();

--- a/src/lib/fileExplorerGitStats.test.ts
+++ b/src/lib/fileExplorerGitStats.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { retainRecentGitStatPaths } from "./fileExplorerGitStats";
+
+describe("retainRecentGitStatPaths", () => {
+  it("bounds accumulated watcher paths to the latest backend batch capacity", () => {
+    const retained = new Set<string>();
+
+    retainRecentGitStatPaths(
+      retained,
+      Array.from({ length: 256 }, (_, index) => `/repo/first-${index}`),
+      256,
+    );
+    retainRecentGitStatPaths(
+      retained,
+      Array.from({ length: 256 }, (_, index) => `/repo/second-${index}`),
+      256,
+    );
+
+    expect(retained.size).toBe(256);
+    expect(retained.has("/repo/first-0")).toBe(false);
+    expect(retained.has("/repo/second-255")).toBe(true);
+  });
+
+  it("refreshes an existing path without consuming extra capacity", () => {
+    const retained = new Set(["/repo/a", "/repo/b"]);
+
+    retainRecentGitStatPaths(retained, ["/repo/a", "/repo/c"], 2);
+
+    expect([...retained]).toEqual(["/repo/a", "/repo/c"]);
+  });
+});

--- a/src/lib/fileExplorerGitStats.ts
+++ b/src/lib/fileExplorerGitStats.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_GIT_STAT_PATH_CAP = 256;
+
+export function retainRecentGitStatPaths(
+  retained: Set<string>,
+  paths: Iterable<string>,
+  capacity = DEFAULT_GIT_STAT_PATH_CAP,
+): void {
+  const limit = Number.isFinite(capacity)
+    ? Math.max(1, Math.floor(capacity))
+    : DEFAULT_GIT_STAT_PATH_CAP;
+
+  for (const path of paths) {
+    retained.delete(path);
+    retained.add(path);
+    while (retained.size > limit) {
+      const oldest = retained.values().next().value;
+      if (oldest === undefined) break;
+      retained.delete(oldest);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Bounds FileExplorer changed-path tracking without changing intended user-visible behavior.

1. **Regression coverage** — adds a focused test reproducing the unbounded or overlapping lifecycle.
2. **Bounded execution** — prevents repeated work from growing or overlapping indefinitely.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| FileExplorer changed-path tracking | Filesystem events could retain an unbounded set of paths. | Only the 256 most recent paths are retained. |

## Design notes

- Preserve recency and evict oldest keys.
- This PR is stacked on `perf/terminal-eviction-probes` and should merge after that base PR.

## Test plan

- [x] Focused regression test passed during the RED/GREEN workflow.
- [x] `pnpm test` — 94 files, 1,004 tests passed on the complete stack.
- [x] `pnpm run typecheck` passes.
- [x] `pnpm run build` passes.
- [x] `cargo test --workspace` with control-session overrides removed — 564 passed, 1 ignored on the complete stack.
- [ ] GitHub Actions CI on this PR.

## Notes

- Stack position: 28/30.
- Existing Vite and Rust warnings are unchanged by this PR.