### PR TITLE
perf(ui): bound Acorn rain resources

### DIFF
--- a/src/components/AcornRain.test.tsx
+++ b/src/components/AcornRain.test.tsx
@@ -1,0 +1,68 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AcornRain } from "./AcornRain";
+
+describe("AcornRain resource lifecycle", () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({ matches: false })),
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) act(() => root?.unmount());
+    container.remove();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps only three active rain batches during repeated triggers", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    act(() => root?.render(<AcornRain />));
+
+    act(() => {
+      for (let i = 0; i < 5; i += 1) {
+        window.dispatchEvent(new Event("acorn:shake-tree"));
+      }
+    });
+
+    expect(vi.getTimerCount()).toBe(3);
+  });
+
+  it("uses unique React keys for batches triggered in the same millisecond", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    act(() => root?.render(<AcornRain />));
+
+    act(() => {
+      window.dispatchEvent(new Event("acorn:shake-tree"));
+      window.dispatchEvent(new Event("acorn:shake-tree"));
+    });
+
+    expect(consoleError.mock.calls.flat().join(" ")).not.toContain("same key");
+  });
+
+  it("clears batch cleanup timers when the host unmounts", () => {
+    act(() => root?.render(<AcornRain />));
+    act(() => window.dispatchEvent(new Event("acorn:shake-tree")));
+    expect(vi.getTimerCount()).toBe(1);
+
+    act(() => root?.unmount());
+    root = null;
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/components/AcornRain.tsx
+++ b/src/components/AcornRain.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import acornUrl from "../assets/acorn-trimmed.png";
 
 interface Acorn {
-  id: number;
+  id: string;
   leftPct: number;
   size: number;
   duration: number;
@@ -20,21 +20,21 @@ const MIN_DURATION = 4.5;
 const MAX_DURATION = 8.5;
 const MAX_DELAY = 3.5;
 const MAX_TOTAL = (MAX_DURATION + MAX_DELAY) * 1000 + 200;
+const MAX_ACTIVE_BATCHES = 3;
 
 function rand(min: number, max: number): number {
   return min + Math.random() * (max - min);
 }
 
-function buildBatch(): Acorn[] {
+function buildBatch(batchId: number): Acorn[] {
   const reduced =
     typeof window !== "undefined" &&
     window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   const count = reduced
     ? Math.floor(MIN_COUNT / 2)
     : Math.floor(rand(MIN_COUNT, MAX_COUNT));
-  const seed = Date.now();
   return Array.from({ length: count }, (_, i) => ({
-    id: seed + i,
+    id: `${batchId}:${i}`,
     leftPct: rand(-2, 102),
     size: Math.round(rand(MIN_SIZE, MAX_SIZE)),
     duration: rand(MIN_DURATION, MAX_DURATION),
@@ -47,26 +47,46 @@ function buildBatch(): Acorn[] {
 
 export function AcornRain() {
   const [batches, setBatches] = useState<Map<number, Acorn[]>>(new Map());
+  const cleanupTimersRef = useRef(new Map<number, number>());
+  const nextBatchIdRef = useRef(0);
 
   useEffect(() => {
     function handler() {
-      const batchId = Date.now() + Math.random();
-      const acorns = buildBatch();
-      setBatches((prev) => {
-        const next = new Map(prev);
-        next.set(batchId, acorns);
-        return next;
-      });
-      window.setTimeout(() => {
+      const batchId = ++nextBatchIdRef.current;
+      const acorns = buildBatch(batchId);
+      const cleanupTimer = window.setTimeout(() => {
+        cleanupTimersRef.current.delete(batchId);
         setBatches((prev) => {
           const next = new Map(prev);
           next.delete(batchId);
           return next;
         });
       }, MAX_TOTAL);
+      cleanupTimersRef.current.set(batchId, cleanupTimer);
+      setBatches((prev) => {
+        const next = new Map(prev);
+        next.set(batchId, acorns);
+        while (next.size > MAX_ACTIVE_BATCHES) {
+          const oldestBatchId = next.keys().next().value;
+          if (oldestBatchId === undefined) break;
+          next.delete(oldestBatchId);
+          const oldestTimer = cleanupTimersRef.current.get(oldestBatchId);
+          if (oldestTimer !== undefined) {
+            window.clearTimeout(oldestTimer);
+            cleanupTimersRef.current.delete(oldestBatchId);
+          }
+        }
+        return next;
+      });
     }
     window.addEventListener("acorn:shake-tree", handler);
-    return () => window.removeEventListener("acorn:shake-tree", handler);
+    return () => {
+      window.removeEventListener("acorn:shake-tree", handler);
+      for (const timer of cleanupTimersRef.current.values()) {
+        window.clearTimeout(timer);
+      }
+      cleanupTimersRef.current.clear();
+    };
   }, []);
 
   if (batches.size === 0) return null;


### PR DESCRIPTION
## Summary

Bounds Acorn rain animation resources without changing intended user-visible behavior.

1. **Regression coverage** — adds a focused test reproducing the unbounded or overlapping lifecycle.
2. **Bounded execution** — prevents repeated work from growing or overlapping indefinitely.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Acorn rain animation resources | Rapid triggers could accumulate batches and cleanup timers. | At most three active batches are retained and timers are cleared. |

## Design notes

- Use unique batch keys and deterministic timeout cleanup.
- This PR is stacked on `perf/pr-detail-refreshes` and should merge after that base PR.

## Test plan

- [x] Focused regression test passed during the RED/GREEN workflow.
- [x] `pnpm test` — 94 files, 1,004 tests passed on the complete stack.
- [x] `pnpm run typecheck` passes.
- [x] `pnpm run build` passes.
- [x] `cargo test --workspace` with control-session overrides removed — 564 passed, 1 ignored on the complete stack.
- [ ] GitHub Actions CI on this PR.

## Notes

- Stack position: 26/30.
- Existing Vite and Rust warnings are unchanged by this PR.