### PR TITLE
perf(files): serialize diff-stat refreshes

### DIFF
--- a/src/components/FileExplorer.listener.test.tsx
+++ b/src/components/FileExplorer.listener.test.tsx
@@ -184,6 +184,9 @@ describe("FileExplorer filesystem listener", () => {
     resolveFirst({});
     await act(async () => {
       await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
       vi.advanceTimersByTime(1_200);
       await Promise.resolve();
     });

--- a/src/components/FileExplorer.listener.test.tsx
+++ b/src/components/FileExplorer.listener.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const apiMocks = vi.hoisted(() => ({
   fsGitStatus: vi.fn(),
+  fsGitDiffStats: vi.fn(),
   fsListDir: vi.fn(),
   fsShellEditor: vi.fn(),
 }));
@@ -16,6 +17,7 @@ vi.mock("../lib/api", () => ({
   FS_CHANGED_EVENT: "acorn:fs-changed",
   api: {
     fsGitStatus: apiMocks.fsGitStatus,
+    fsGitDiffStats: apiMocks.fsGitDiffStats,
     fsListDir: apiMocks.fsListDir,
     fsShellEditor: apiMocks.fsShellEditor,
   },
@@ -66,6 +68,7 @@ describe("FileExplorer filesystem listener", () => {
       huge: false,
       limit: 5_000,
     });
+    apiMocks.fsGitDiffStats.mockResolvedValue({});
     eventMocks.listen.mockImplementation(
       () =>
         new Promise<() => void>((resolve) => {
@@ -80,6 +83,7 @@ describe("FileExplorer filesystem listener", () => {
     }
     container.remove();
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it("disposes a listener that finishes registering after unmount", async () => {
@@ -98,5 +102,91 @@ describe("FileExplorer filesystem listener", () => {
     });
 
     expect(unlisten).toHaveBeenCalledOnce();
+  });
+
+  it("queues one follow-up diff-stat refresh instead of overlapping a slow request", async () => {
+    vi.useFakeTimers();
+    const firstPath = "/tmp/acorn/first.ts";
+    const secondPath = "/tmp/acorn/second.ts";
+    let fsListener:
+      | ((event: {
+          payload: {
+            paths: string[];
+            root: string;
+            cap: number;
+            dotgit_changed: boolean;
+          };
+        }) => void)
+      | null = null;
+    eventMocks.listen.mockImplementation((_event, handler) => {
+      fsListener = handler;
+      return Promise.resolve(() => {});
+    });
+    apiMocks.fsListDir.mockResolvedValue({
+      entries: [
+        {
+          name: "first.ts",
+          path: firstPath,
+          is_dir: false,
+          is_symlink: false,
+          size: 1,
+          modified_ms: 1,
+          gitignored: false,
+        },
+      ],
+      repo_root: "/tmp/acorn",
+    });
+    apiMocks.fsGitStatus.mockResolvedValue({
+      statuses: {
+        [firstPath]: { kind: "modified", additions: 0, deletions: 0 },
+        [secondPath]: { kind: "modified", additions: 0, deletions: 0 },
+      },
+      huge: false,
+      limit: 5_000,
+    });
+    let resolveFirst!: (stats: Record<string, never>) => void;
+    apiMocks.fsGitDiffStats
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockResolvedValue({});
+
+    await act(async () => {
+      root?.render(<FileExplorer rootPath="/tmp/acorn" />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1_200);
+      await Promise.resolve();
+    });
+    expect(apiMocks.fsGitDiffStats).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      fsListener?.({
+        payload: {
+          paths: [secondPath],
+          root: "/tmp/acorn",
+          cap: 256,
+          dotgit_changed: false,
+        },
+      });
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1_200);
+      await Promise.resolve();
+    });
+
+    expect(apiMocks.fsGitDiffStats).toHaveBeenCalledTimes(1);
+
+    resolveFirst({});
+    await act(async () => {
+      await Promise.resolve();
+      vi.advanceTimersByTime(1_200);
+      await Promise.resolve();
+    });
+    expect(apiMocks.fsGitDiffStats).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -356,6 +356,9 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     createEmptySessionAgentDetection(),
   );
   const gitStatsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const gitStatsInFlightRef = useRef<Promise<void> | null>(null);
+  const gitStatsRefreshPendingRef = useRef(false);
+  const scheduleGitDiffStatsRef = useRef<(() => void) | null>(null);
   const gitStatusRef = useRef<Record<string, FsGitStatusEntry>>({});
   const gitHugeRef = useRef(false);
   const visiblePathsRef = useRef<Set<string>>(new Set());
@@ -525,6 +528,10 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     }
     gitStatsTimerRef.current = setTimeout(() => {
       gitStatsTimerRef.current = null;
+      if (gitStatsInFlightRef.current) {
+        gitStatsRefreshPendingRef.current = true;
+        return;
+      }
       const targetPaths = new Set([
         ...visiblePathsRef.current,
         ...changedPathsRef.current,
@@ -535,7 +542,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
         .map(([path, status]) => ({ path, kind: status.kind }));
       if (entries.length === 0) return;
 
-      void api
+      const promise = api
         .fsGitDiffStats(rootPath, entries)
         .then((stats) => {
           const requestedKinds = new Map(entries.map((e) => [e.path, e.kind]));
@@ -558,9 +565,22 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
             return changed ? next : prev;
           });
         })
-        .catch(() => {});
+        .catch(() => {})
+        .finally(() => {
+          if (gitStatsInFlightRef.current !== promise) return;
+          gitStatsInFlightRef.current = null;
+          if (gitStatsRefreshPendingRef.current) {
+            gitStatsRefreshPendingRef.current = false;
+            scheduleGitDiffStatsRef.current?.();
+          }
+        });
+      gitStatsInFlightRef.current = promise;
     }, 1200);
   }, [rootPath]);
+
+  useEffect(() => {
+    scheduleGitDiffStatsRef.current = scheduleGitDiffStats;
+  }, [scheduleGitDiffStats]);
 
   const gitStatusKindFingerprint = useMemo(
     () =>


### PR DESCRIPTION
## Summary

Bounds FileExplorer diff-stat refreshes without changing intended user-visible behavior.

1. **Regression coverage** — adds a focused test reproducing the unbounded or overlapping lifecycle.
2. **Bounded execution** — prevents repeated work from growing or overlapping indefinitely.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| FileExplorer diff-stat refreshes | Slow bulk requests could overlap after watcher events. | One request runs at a time with one debounced latest rerun. |

## Design notes

- Combine debounce with promise identity and a single pending flag.
- This PR is stacked on `perf/file-stat-paths` and should merge after that base PR.

## Test plan

- [x] Focused regression test passed during the RED/GREEN workflow.
- [x] `pnpm test` — 94 files, 1,004 tests passed on the complete stack.
- [x] `pnpm run typecheck` passes.
- [x] `pnpm run build` passes.
- [x] `cargo test --workspace` with control-session overrides removed — 564 passed, 1 ignored on the complete stack.
- [ ] GitHub Actions CI on this PR.

## Notes

- Stack position: 29/30.
- Existing Vite and Rust warnings are unchanged by this PR.