### PR TITLE
fix(files): stop late diff-stat reschedules

### DIFF
--- a/src/components/FileExplorer.listener.test.tsx
+++ b/src/components/FileExplorer.listener.test.tsx
@@ -192,4 +192,85 @@ describe("FileExplorer filesystem listener", () => {
     });
     expect(apiMocks.fsGitDiffStats).toHaveBeenCalledTimes(2);
   });
+
+  it("does not schedule a queued diff-stat refresh after unmount", async () => {
+    vi.useFakeTimers();
+    const path = "/tmp/acorn/first.ts";
+    let fsListener:
+      | ((event: {
+          payload: {
+            paths: string[];
+            root: string;
+            cap: number;
+            dotgit_changed: boolean;
+          };
+        }) => void)
+      | null = null;
+    eventMocks.listen.mockImplementation((_event, handler) => {
+      fsListener = handler;
+      return Promise.resolve(() => {});
+    });
+    apiMocks.fsListDir.mockResolvedValue({
+      entries: [
+        {
+          name: "first.ts",
+          path,
+          is_dir: false,
+          is_symlink: false,
+          size: 1,
+          modified_ms: 1,
+          gitignored: false,
+        },
+      ],
+      repo_root: "/tmp/acorn",
+    });
+    apiMocks.fsGitStatus.mockResolvedValue({
+      statuses: {
+        [path]: { kind: "modified", additions: 0, deletions: 0 },
+      },
+      huge: false,
+      limit: 5_000,
+    });
+    let resolveFirst!: (stats: Record<string, never>) => void;
+    apiMocks.fsGitDiffStats.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFirst = resolve;
+      }),
+    );
+
+    await act(async () => {
+      root?.render(<FileExplorer rootPath="/tmp/acorn" />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1_200);
+      await Promise.resolve();
+    });
+    act(() => {
+      fsListener?.({
+        payload: {
+          paths: [path],
+          root: "/tmp/acorn",
+          cap: 256,
+          dotgit_changed: false,
+        },
+      });
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1_200);
+      await Promise.resolve();
+    });
+    expect(apiMocks.fsGitDiffStats).toHaveBeenCalledTimes(1);
+
+    act(() => root?.unmount());
+    root = null;
+    resolveFirst({});
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -580,6 +580,11 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
 
   useEffect(() => {
     scheduleGitDiffStatsRef.current = scheduleGitDiffStats;
+    return () => {
+      if (scheduleGitDiffStatsRef.current === scheduleGitDiffStats) {
+        scheduleGitDiffStatsRef.current = null;
+      }
+    };
   }, [scheduleGitDiffStats]);
 
   const gitStatusKindFingerprint = useMemo(


### PR DESCRIPTION
## Summary

Bounds FileExplorer diff-stat cleanup without changing intended user-visible behavior.

1. **Regression coverage** — adds a focused test reproducing the unbounded or overlapping lifecycle.
2. **Bounded execution** — prevents repeated work from growing or overlapping indefinitely.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| FileExplorer diff-stat cleanup | A request settling after unmount could schedule another timer. | Unmount clears the scheduler ref before late finalizers run. |

## Design notes

- Use identity-safe effect cleanup so mounted replacements remain untouched.
- This PR is stacked on `perf/file-diff-stats` and should merge after that base PR.

## Test plan

- [x] Focused regression test passed during the RED/GREEN workflow.
- [x] `pnpm test` — 94 files, 1,004 tests passed on the complete stack.
- [x] `pnpm run typecheck` passes.
- [x] `pnpm run build` passes.
- [x] `cargo test --workspace` with control-session overrides removed — 564 passed, 1 ignored on the complete stack.
- [ ] GitHub Actions CI on this PR.

## Notes

- Stack position: 30/30.
- Existing Vite and Rust warnings are unchanged by this PR.