### PR TITLE
fix(activity): stop recording ready status transitions

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -4,7 +4,6 @@ import {
   AlertCircle,
   Bell,
   Bot,
-  CheckCircle2,
   Columns3,
   FolderOpen,
   FolderPlus,
@@ -63,7 +62,6 @@ const ACTIVITY_KIND_KEYS: Record<
 > = {
   waiting_for_input: "commandPalette.activity.kind.waitingForInput",
   errored: "commandPalette.activity.kind.errored",
-  became_ready: "commandPalette.activity.kind.becameReady",
 };
 
 function activityKindLabel(
@@ -76,9 +74,6 @@ function activityKindLabel(
 function ActivityKindIcon({ kind }: { kind: SessionNotificationKind }) {
   if (kind === "errored") {
     return <AlertCircle size={14} className="text-danger" />;
-  }
-  if (kind === "became_ready") {
-    return <CheckCircle2 size={14} className="text-fg-muted" />;
   }
   return <Bell size={14} className="text-warning" />;
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3698,7 +3698,6 @@ const SIDEBAR_ACTIVITY_KIND_KEYS: Record<
 > = {
   waiting_for_input: "sidebar.activity.kind.waitingForInput",
   errored: "sidebar.activity.kind.errored",
-  became_ready: "sidebar.activity.kind.becameReady",
 };
 
 function SessionActivityInbox() {
@@ -3982,7 +3981,6 @@ function SidebarActivityRow({
 
 function sidebarActivityDotTone(kind: SessionNotificationKind): StatusTone {
   if (kind === "errored") return "danger";
-  if (kind === "became_ready") return "neutral";
   return "warning";
 }
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -775,7 +775,6 @@ const NOTIFICATION_KIND_KEYS: Record<
 > = {
   waiting_for_input: "statusBar.notifications.kind.waitingForInput",
   errored: "statusBar.notifications.kind.errored",
-  became_ready: "statusBar.notifications.kind.becameReady",
 };
 
 function SessionNotificationsButton() {
@@ -1053,7 +1052,6 @@ function NotificationRow({
 
 function notificationDotClass(kind: SessionNotificationKind): string {
   if (kind === "errored") return "bg-danger";
-  if (kind === "became_ready") return "bg-fg-muted";
   return "bg-warning";
 }
 

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -157,6 +157,22 @@ describe("notifications", () => {
     dispose();
   });
 
+  it("does not record ready transitions as activity", () => {
+    const dispose = startSessionActivityInboxWatcher();
+
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "ready",
+          updated_at: "2026-01-01T00:01:00Z",
+        }),
+      ],
+    });
+
+    expect(useAppStore.getState().sessionNotifications).toEqual([]);
+    dispose();
+  });
+
   it("suppresses system notifications and activity while a session is silenced", async () => {
     useAppStore.setState({
       silencedSessionIds: { "session-1": true },

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -79,7 +79,6 @@ function notificationKindForTransition(
   if (prev === next) return null;
   if (next === "waiting_for_input") return "waiting_for_input";
   if (next === "errored") return "errored";
-  if (next === "ready") return "became_ready";
   return null;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,10 +6,7 @@ export type SessionStatus =
 
 export type SessionStatusReason = "turn_complete" | "shell_prompt";
 
-export type SessionNotificationKind =
-  | "waiting_for_input"
-  | "errored"
-  | "became_ready";
+export type SessionNotificationKind = "waiting_for_input" | "errored";
 
 export interface SessionNotification {
   id: string;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -880,8 +880,7 @@
       "itemTitle": "{project} · {session}",
       "kind": {
         "waitingForInput": "Waiting for input",
-        "errored": "Error",
-        "becameReady": "Ready"
+        "errored": "Error"
       },
       "actions": {
         "markAllRead": "Mark all read",
@@ -1199,8 +1198,7 @@
       "itemTitle": "{project} · {session}",
       "kind": {
         "waitingForInput": "Waiting for input",
-        "errored": "Error",
-        "becameReady": "Ready"
+        "errored": "Error"
       },
       "actions": {
         "markAllRead": "Mark all read",
@@ -1397,8 +1395,7 @@
       "itemTitle": "{project} · {session}",
       "kind": {
         "waitingForInput": "Waiting for input",
-        "errored": "Error",
-        "becameReady": "Ready"
+        "errored": "Error"
       },
       "actions": {
         "markAllRead": "Mark all read",
@@ -2043,8 +2040,7 @@
     "activity": {
       "kind": {
         "waitingForInput": "Waiting for input",
-        "errored": "Error",
-        "becameReady": "Ready"
+        "errored": "Error"
       }
     }
   },

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -880,8 +880,7 @@
       "itemTitle": "{project} · {session}",
       "kind": {
         "waitingForInput": "입력 대기",
-        "errored": "오류",
-        "becameReady": "준비됨"
+        "errored": "오류"
       },
       "actions": {
         "markAllRead": "모두 읽음",
@@ -1199,8 +1198,7 @@
       "itemTitle": "{project} · {session}",
       "kind": {
         "waitingForInput": "입력 대기",
-        "errored": "오류",
-        "becameReady": "준비됨"
+        "errored": "오류"
       },
       "actions": {
         "markAllRead": "모두 읽음",
@@ -1397,8 +1395,7 @@
       "itemTitle": "{project} · {session}",
       "kind": {
         "waitingForInput": "입력 대기",
-        "errored": "오류",
-        "becameReady": "준비됨"
+        "errored": "오류"
       },
       "actions": {
         "markAllRead": "모두 읽음",
@@ -2043,8 +2040,7 @@
     "activity": {
       "kind": {
         "waitingForInput": "입력 대기",
-        "errored": "오류",
-        "becameReady": "준비됨"
+        "errored": "오류"
       }
     }
   },

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -419,7 +419,7 @@ describe("sessionNotifications", () => {
     ).toEqual(["latest", "other"]);
   });
 
-  it("migrates legacy persisted activity status names on rehydrate", async () => {
+  it("migrates supported legacy activity and drops obsolete ready activity on rehydrate", async () => {
     window.localStorage.clear();
     resetStore();
     window.localStorage.setItem(
@@ -450,8 +450,19 @@ describe("sessionNotifications", () => {
               createdAt: "2026-01-01T00:01:00Z",
             },
             {
-              id: "unknown",
+              id: "obsolete-ready",
               sessionId: "s3",
+              kind: "became_ready",
+              status: "ready",
+              previousStatus: "working",
+              sessionName: "s3",
+              projectName: "repo-c",
+              repoPath: "/repo-c",
+              createdAt: "2026-01-01T00:00:30Z",
+            },
+            {
+              id: "unknown",
+              sessionId: "s4",
               kind: "unknown",
               status: "idle",
               previousStatus: "running",
@@ -471,12 +482,6 @@ describe("sessionNotifications", () => {
         kind: "waiting_for_input",
         status: "waiting_for_input",
         previousStatus: "working",
-      },
-      {
-        id: "legacy-idle",
-        kind: "became_ready",
-        status: "ready",
-        previousStatus: "waiting_for_input",
       },
     ]);
   });

--- a/src/store.ts
+++ b/src/store.ts
@@ -148,13 +148,11 @@ function normalizeSessionNotificationKind(
 ): SessionNotificationKind | null {
   if (
     value === "waiting_for_input" ||
-    value === "errored" ||
-    value === "became_ready"
+    value === "errored"
   ) {
     return value;
   }
   if (value === "needs_input") return "waiting_for_input";
-  if (value === "became_idle") return "became_ready";
   if (value === "error") return "errored";
   return null;
 }
@@ -162,9 +160,7 @@ function normalizeSessionNotificationKind(
 function statusForNotificationKind(
   kind: SessionNotificationKind,
 ): SessionStatus {
-  if (kind === "waiting_for_input") return "waiting_for_input";
-  if (kind === "errored") return "errored";
-  return "ready";
+  return kind;
 }
 
 function normalizeSessionNotification(

--- a/tests/e2e/session-notifications.spec.ts
+++ b/tests/e2e/session-notifications.spec.ts
@@ -144,6 +144,55 @@ test.describe("session notification center", () => {
     await expect(activity).toContainText("0 unread");
   });
 
+  test("does not collect ready status transitions", async ({ page, tauri }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "session-1",
+        name: "agent run",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "working",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+    ]);
+    await tauri.handle("detect_session_statuses", () => [
+      {
+        id: "session-1",
+        status: "ready",
+        branch: "main",
+        agent_provider: null,
+      },
+    ]);
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("button", { name: /^agent run main · Ready$/ }),
+    ).toBeVisible();
+    const activity = page.getByRole("region", {
+      name: "Session activity",
+    });
+    await expect(activity).toContainText("0 unread");
+    await expect(activity.getByText("Ready", { exact: true })).toHaveCount(0);
+  });
+
   test("opens the kanban terminal popover from sidebar activity rows", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

Keep the Activity inbox focused on session changes that require user attention instead of presenting historical `Ready` transitions as current state.

1. **Actionable activity only** — stop creating Activity entries when sessions transition to `ready`; waiting-for-input and error entries remain unchanged.
2. **Persisted cleanup** — drop obsolete `became_ready` and legacy `became_idle` entries while rehydrating saved Activity history.
3. **UI and regression coverage** — remove the retired notification kind from sidebar, status bar, command palette, and translations, with unit and Playwright coverage for the corrected behavior.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Background session transitions to `ready` | Unread `Ready` Activity entry appears and can outlive the current status | No Activity entry is created |
| Existing saved `Ready` Activity entries | Reappear after app restart | Removed during store rehydration |
| Session waits for input or errors | Activity entry appears | Unchanged |

## Design notes

- Session lifecycle status is unchanged; `ready` remains a valid live session status and is only removed from the Activity notification contract.
- The Activity inbox now matches the existing system-notification trigger set, which already limits delivery to waiting-for-input and error transitions.
- Persisted notification normalization provides the data cleanup without a separate storage-version migration.

## Test plan

- [x] `pnpm exec vitest run src/lib/notifications.test.ts src/store.test.ts` — 163 tests passed
- [x] `pnpm run test` — 967 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec playwright test tests/e2e/session-notifications.spec.ts` — 3 tests passed
- [x] `pnpm run test:e2e` — 226 tests passed
- [x] `pnpm run build` — production build passed
