### PR TITLE
fix(app): recover from incompatible workspace state after updates

### DIFF
--- a/src/components/AppRecoveryBoundary.tsx
+++ b/src/components/AppRecoveryBoundary.tsx
@@ -10,7 +10,7 @@ const COPY = {
     description:
       "A saved workspace configuration may be incompatible with this version after the update.",
     resetHint:
-      "Your terminal sessions and projects will remain. Only window layout and folder organization will be reset.",
+      "Your terminal sessions and projects will remain. Only local workspace preferences will be reset.",
     reload: "Try again",
     reset: "Reset workspace view and reopen",
     details: "Error details",
@@ -23,7 +23,7 @@ const COPY = {
     description:
       "업데이트 후 저장된 작업공간 구성이 현재 버전과 호환되지 않을 수 있습니다.",
     resetHint:
-      "터미널 세션과 프로젝트 자체는 삭제되지 않고, 화면 배치와 폴더 구성만 초기화됩니다.",
+      "터미널 세션과 프로젝트 자체는 삭제되지 않고, 로컬 작업공간 설정만 초기화됩니다.",
     reload: "다시 열기",
     reset: "화면 설정 초기화 후 다시 열기",
     details: "오류 상세",
@@ -62,8 +62,11 @@ export class AppRecoveryBoundary extends Component<
     resetFailed: false,
   };
 
-  static getDerivedStateFromError(error: Error): AppRecoveryBoundaryState {
-    return { error, resetFailed: false };
+  static getDerivedStateFromError(error: unknown): AppRecoveryBoundaryState {
+    return {
+      error: error instanceof Error ? error : new Error(String(error)),
+      resetFailed: false,
+    };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {

--- a/src/components/AppRecoveryBoundary.tsx
+++ b/src/components/AppRecoveryBoundary.tsx
@@ -1,0 +1,133 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+const WORKSPACE_STORAGE_KEY = "acorn-workspaces";
+const SETTINGS_STORAGE_KEY = "acorn:settings:v1";
+
+const COPY = {
+  en: {
+    eyebrow: "Startup error",
+    title: "Acorn couldn't open",
+    description:
+      "A saved workspace configuration may be incompatible with this version after the update.",
+    resetHint:
+      "Your terminal sessions and projects will remain. Only window layout and folder organization will be reset.",
+    reload: "Try again",
+    reset: "Reset workspace view and reopen",
+    details: "Error details",
+    resetFailed:
+      "Acorn couldn't reset the workspace view. Quit the app and try again.",
+  },
+  ko: {
+    eyebrow: "시작 오류",
+    title: "Acorn을 열지 못했습니다",
+    description:
+      "업데이트 후 저장된 작업공간 구성이 현재 버전과 호환되지 않을 수 있습니다.",
+    resetHint:
+      "터미널 세션과 프로젝트 자체는 삭제되지 않고, 화면 배치와 폴더 구성만 초기화됩니다.",
+    reload: "다시 열기",
+    reset: "화면 설정 초기화 후 다시 열기",
+    details: "오류 상세",
+    resetFailed:
+      "화면 설정을 초기화하지 못했습니다. 앱을 완전히 종료한 뒤 다시 시도해 주세요.",
+  },
+} as const;
+
+type RecoveryLanguage = keyof typeof COPY;
+
+function recoveryLanguage(): RecoveryLanguage {
+  try {
+    const raw = window.localStorage.getItem(SETTINGS_STORAGE_KEY);
+    const parsed = raw ? (JSON.parse(raw) as { language?: unknown }) : null;
+    return parsed?.language === "ko" ? "ko" : "en";
+  } catch {
+    return "en";
+  }
+}
+
+interface AppRecoveryBoundaryProps {
+  children: ReactNode;
+}
+
+interface AppRecoveryBoundaryState {
+  error: Error | null;
+  resetFailed: boolean;
+}
+
+export class AppRecoveryBoundary extends Component<
+  AppRecoveryBoundaryProps,
+  AppRecoveryBoundaryState
+> {
+  state: AppRecoveryBoundaryState = {
+    error: null,
+    resetFailed: false,
+  };
+
+  static getDerivedStateFromError(error: Error): AppRecoveryBoundaryState {
+    return { error, resetFailed: false };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("[AppRecoveryBoundary] app render failed", error, info);
+  }
+
+  private resetWorkspaceView = (): void => {
+    try {
+      window.localStorage.removeItem(WORKSPACE_STORAGE_KEY);
+      window.location.reload();
+    } catch (error) {
+      console.error("[AppRecoveryBoundary] workspace reset failed", error);
+      this.setState({ resetFailed: true });
+    }
+  };
+
+  render(): ReactNode {
+    const { error, resetFailed } = this.state;
+    if (!error) return this.props.children;
+
+    const copy = COPY[recoveryLanguage()];
+    return (
+      <main className="flex h-screen w-screen items-center justify-center bg-bg p-6 text-fg">
+        <section
+          role="alert"
+          className="w-full max-w-lg rounded-xl border border-border bg-bg-elevated p-6 shadow-2xl"
+        >
+          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-danger">
+            {copy.eyebrow}
+          </p>
+          <h1 className="text-xl font-semibold">{copy.title}</h1>
+          <p className="mt-3 text-sm leading-6 text-fg-muted">
+            {copy.description}
+          </p>
+          <div className="mt-4 rounded-lg border border-border bg-bg p-3 text-sm leading-6 text-fg-muted">
+            {copy.resetHint}
+          </div>
+          {resetFailed ? (
+            <p className="mt-3 text-sm text-danger">{copy.resetFailed}</p>
+          ) : null}
+          <div className="mt-5 flex flex-wrap gap-2">
+            <button
+              type="button"
+              className="rounded-md border border-border bg-bg px-3 py-2 text-sm font-medium hover:bg-fill-hover"
+              onClick={() => window.location.reload()}
+            >
+              {copy.reload}
+            </button>
+            <button
+              type="button"
+              className="rounded-md bg-accent px-3 py-2 text-sm font-semibold text-on-accent hover:bg-accent-hover"
+              onClick={this.resetWorkspaceView}
+            >
+              {copy.reset}
+            </button>
+          </div>
+          <details className="mt-5 text-xs text-fg-muted">
+            <summary className="cursor-pointer select-none">{copy.details}</summary>
+            <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap rounded-md bg-bg p-3 font-mono">
+              {error.message || error.name}
+            </pre>
+          </details>
+        </section>
+      </main>
+    );
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { AppRecoveryBoundary } from "./components/AppRecoveryBoundary";
 
 // Block right-click context menu (Inspector access) globally.
 window.addEventListener("contextmenu", (e) => e.preventDefault());
@@ -22,6 +23,8 @@ window.addEventListener("keydown", (e) => {
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <AppRecoveryBoundary>
+      <App />
+    </AppRecoveryBoundary>
   </React.StrictMode>,
 );

--- a/tests/e2e/app-recovery.spec.ts
+++ b/tests/e2e/app-recovery.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "./support";
+
+test.describe("app recovery", () => {
+  test("recovers from incompatible persisted UI state instead of staying blank", async ({
+    page,
+    errorTracker,
+  }) => {
+    errorTracker.allow(/cannot read properties of undefined/i);
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn-workspaces",
+        JSON.stringify({
+          state: {
+            workspaces: {
+              "/tmp/legacy-project": {
+                panes: {},
+                focusedPaneId: "legacy-pane",
+              },
+            },
+            activeProject: "/tmp/legacy-project",
+            activeProjectFolderId: "/tmp/legacy-project",
+          },
+          version: 4,
+        }),
+      );
+    });
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", { name: "Acorn을 열지 못했습니다" }),
+    ).toBeVisible();
+    await expect(page.getByText("저장된 세션과 프로젝트는 삭제되지 않습니다"))
+      .toBeVisible();
+
+    await page
+      .getByRole("button", { name: "화면 설정 초기화 후 다시 열기" })
+      .click();
+
+    await expect(page.getByRole("heading", { name: "Projects" })).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(() => window.localStorage.getItem("acorn-workspaces")),
+      )
+      .toBeNull();
+  });
+});

--- a/tests/e2e/app-recovery.spec.ts
+++ b/tests/e2e/app-recovery.spec.ts
@@ -40,7 +40,7 @@ test.describe("app recovery", () => {
     ).toBeVisible();
     await expect(
       page.getByText(
-        "터미널 세션과 프로젝트 자체는 삭제되지 않고, 화면 배치와 폴더 구성만 초기화됩니다.",
+        "터미널 세션과 프로젝트 자체는 삭제되지 않고, 로컬 작업공간 설정만 초기화됩니다.",
       ),
     ).toBeVisible();
 

--- a/tests/e2e/app-recovery.spec.ts
+++ b/tests/e2e/app-recovery.spec.ts
@@ -7,6 +7,14 @@ test.describe("app recovery", () => {
   }) => {
     errorTracker.allow(/cannot read properties of undefined/i);
     await page.addInitScript(() => {
+      if (window.sessionStorage.getItem("acorn:test:legacy-state-seeded")) {
+        return;
+      }
+      window.sessionStorage.setItem("acorn:test:legacy-state-seeded", "1");
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({ language: "ko" }),
+      );
       window.localStorage.setItem(
         "acorn-workspaces",
         JSON.stringify({
@@ -30,18 +38,35 @@ test.describe("app recovery", () => {
     await expect(
       page.getByRole("heading", { name: "Acorn을 열지 못했습니다" }),
     ).toBeVisible();
-    await expect(page.getByText("저장된 세션과 프로젝트는 삭제되지 않습니다"))
-      .toBeVisible();
+    await expect(
+      page.getByText(
+        "터미널 세션과 프로젝트 자체는 삭제되지 않고, 화면 배치와 폴더 구성만 초기화됩니다.",
+      ),
+    ).toBeVisible();
 
     await page
       .getByRole("button", { name: "화면 설정 초기화 후 다시 열기" })
       .click();
 
-    await expect(page.getByRole("heading", { name: "Projects" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /^(Projects|프로젝트)$/ }),
+    ).toBeVisible();
     await expect
       .poll(() =>
-        page.evaluate(() => window.localStorage.getItem("acorn-workspaces")),
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("acorn-workspaces");
+          if (!raw) return null;
+          const parsed = JSON.parse(raw) as {
+            state?: { workspaces?: Record<string, unknown> };
+          };
+          return parsed.state?.workspaces ?? null;
+        }),
       )
-      .toBeNull();
+      .toEqual({});
+    await expect
+      .poll(() =>
+        page.evaluate(() => window.localStorage.getItem("acorn:settings:v1")),
+      )
+      .not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

This PR replaces the post-update blank screen with a safe, user-driven recovery path when persisted workspace state can no longer render.

1. **Top-level recovery boundary** — catch startup render failures before React clears the whole app shell and show a localized recovery surface with the original error details.
2. **Scoped workspace reset** — let users remove only `acorn-workspaces` and reopen Acorn while preserving backend terminal sessions, projects, and general app settings.
3. **Upgrade regression coverage** — seed schema-incompatible workspace state in Playwright, verify the recovery screen, exercise the reset, and confirm normal boot plus settings preservation.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Persisted workspace state cannot render after an update | Empty app window with no recovery action | Korean/English recovery screen with error details |
| User needs to recover | Manual localStorage cleanup or reinstall guidance | One-click workspace reset and reopen |
| Healthy startup | Normal app shell | Unchanged |

## Design notes

- The boundary sits directly above `App`, so failures anywhere in the application render tree converge on one recovery surface.
- The recovery copy reads the saved language without depending on the normal settings hooks, which may be part of the failed tree.
- Reset removes only the workspace Zustand key. Persistent terminal sessions and projects remain backend-owned, while `acorn:settings:v1` is intentionally preserved.
- The fallback also normalizes non-`Error` throw values so the details panel never renders an empty diagnostic.
- Existing updater download, signature, and connectivity errors remain handled by the updater banner/settings flow; this recovery path targets successful updates followed by startup rendering failures.

## Test plan

- [x] `pnpm exec playwright test tests/e2e/app-recovery.spec.ts --project=chromium` — 1 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test` — 87 files, 966 tests passed
- [x] `pnpm run test:e2e` — 226 tests passed
- [x] `pnpm run build` — production build passed

## Notes

- The recovery E2E intentionally provokes and allow-lists the expected React render error before asserting the fallback UI.
- Existing Vite mixed-import and large-chunk warnings remain unchanged and are not caused by this PR.
