### PR TITLE
feat(settings): configure find + rename shortcuts

### DIFF
--- a/src/components/CodeDiffVirtualization.test.tsx
+++ b/src/components/CodeDiffVirtualization.test.tsx
@@ -253,7 +253,7 @@ describe("virtualized code and diff rendering", () => {
       window.dispatchEvent(
         new KeyboardEvent("keydown", {
           key: "f",
-          metaKey: true,
+          ctrlKey: true,
           bubbles: true,
           cancelable: true,
         }),

--- a/src/components/CodeDiffVirtualization.test.tsx
+++ b/src/components/CodeDiffVirtualization.test.tsx
@@ -395,6 +395,9 @@ describe("virtualized code and diff rendering", () => {
   });
 
   it("finds and highlights matches inside a code viewer", async () => {
+    const settings = structuredClone(DEFAULT_SETTINGS);
+    settings.shortcuts.findInView = "F4";
+    useSettings.setState({ settings });
     const content = "alpha\nbeta alpha\nALPHA";
     vi.mocked(api.fsReadFile).mockResolvedValueOnce({
       content,
@@ -414,6 +417,21 @@ describe("virtualized code and diff rendering", () => {
         new KeyboardEvent("keydown", {
           key: "f",
           metaKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    expect(
+      container.querySelector<HTMLInputElement>('input[aria-label="Find in file"]'),
+    ).toBeNull();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "F4",
+          code: "F4",
           bubbles: true,
           cancelable: true,
         }),

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -10,6 +10,7 @@ import {
   type FsReadFileResult,
 } from "../lib/api";
 import { highlightCode, langFromPath } from "../lib/highlight";
+import { matchesHotkeyEvent } from "../lib/hotkeys";
 import { cn } from "../lib/cn";
 import { useSettings } from "../lib/settings";
 import { resolveThemeMode, useThemes } from "../lib/themes";
@@ -144,6 +145,7 @@ export function CodeViewer({
 }: CodeViewerProps) {
   const t = useTranslation();
   const themeId = useSettings((s) => s.settings.appearance.themeId);
+  const findShortcut = useSettings((s) => s.settings.shortcuts.findInView);
   const themes = useThemes((s) => s.themes);
   const [state, setState] = useState<ViewerState>(EMPTY_STATE);
   const [diffLines, setDiffLines] = useState<FsLineDiffEntry[]>([]);
@@ -414,13 +416,13 @@ export function CodeViewer({
   useEffect(() => {
     if (!isActive) return;
     function onKeyDown(event: KeyboardEvent) {
-      if (!isFindShortcut(event)) return;
+      if (!matchesHotkeyEvent(findShortcut, event)) return;
       event.preventDefault();
       openSearch();
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [isActive, openSearch]);
+  }, [findShortcut, isActive, openSearch]);
 
   if (state.loading) {
     return (
@@ -772,16 +774,6 @@ function findTextRanges(text: string, query: string): { start: number; end: numb
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function isFindShortcut(event: KeyboardEvent): boolean {
-  const primary = event.metaKey || event.ctrlKey;
-  return (
-    primary &&
-    !event.altKey &&
-    !event.shiftKey &&
-    event.key.toLocaleLowerCase() === "f"
-  );
 }
 
 function Notice({ title, body }: { title: string; body: string }) {

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -36,6 +36,7 @@ import {
   hasDetectedAgent,
 } from "../lib/agentContextMenu";
 import { cn } from "../lib/cn";
+import { matchesHotkeyEvent } from "../lib/hotkeys";
 import { planGitRefresh } from "../lib/git-refresh-scheduler";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { rightPanelCache } from "../lib/right-panel-cache";
@@ -57,6 +58,7 @@ import {
   scopeWithProjectRootLaunch,
 } from "../lib/sessionCreation";
 import { findProjectFolderById } from "../lib/projectFolders";
+import { useSettings } from "../lib/settings";
 import type { SessionAgentDetection } from "../lib/types";
 
 const SHOW_HIDDEN_KEY = "acorn:fs-show-hidden";
@@ -306,6 +308,8 @@ function setLocalBool(key: string, value: boolean) {
 
 export function FileExplorer({ rootPath }: FileExplorerProps) {
   const t = useTranslation();
+  const findShortcut = useSettings((s) => s.settings.shortcuts.findInView);
+  const renameShortcut = useSettings((s) => s.settings.shortcuts.renameItem);
   const showToast = useToasts((s) => s.show);
   const [cache, setCache] = useState<Cache>({});
   const [expanded, setExpanded] = useState<Set<string>>(() =>
@@ -328,7 +332,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
   // Selection — Cmd-click toggle, Shift-click range. When non-empty
   // the context menu offers bulk actions across `selection`.
   const [selection, setSelection] = useState<Set<string>>(new Set());
-  // VSCode-style search panel. Toggled via Cmd+F when the Files tab is
+  // VSCode-style search panel. Toggled via the configured shortcut when the Files tab is
   // active. Three composable filters: free-form query, include globs,
   // exclude globs. Case-sensitivity + regex are per-query toggles.
   const [searchOpen, setSearchOpen] = useState<boolean>(false);
@@ -1073,12 +1077,12 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
 
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  // Cmd+F toggles the VSCode-style search panel. Window-level so it
+  // The configured find shortcut toggles the VSCode-style search panel. Window-level so it
   // works even when focus is inside the tree (which doesn't bubble to
   // the container otherwise). Esc closes the panel when it is open.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
+      if (matchesHotkeyEvent(findShortcut, e)) {
         e.preventDefault();
         setSearchOpen((open) => {
           const next = !open;
@@ -1095,15 +1099,15 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [searchOpen]);
+  }, [findShortcut, searchOpen]);
 
-  // F2 to rename the focused / single-selected entry. Scoped to the
+  // The rename shortcut targets the focused / single-selected entry. Scoped to the
   // FileExplorer container so it does not collide with terminal input.
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
     const handler = (e: KeyboardEvent) => {
-      if (e.key !== "F2") return;
+      if (!matchesHotkeyEvent(renameShortcut, e)) return;
       if (selection.size === 1) {
         const path = Array.from(selection)[0];
         const name = path.split("/").pop() ?? "";
@@ -1119,7 +1123,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     };
     el.addEventListener("keydown", handler);
     return () => el.removeEventListener("keydown", handler);
-  }, [selection, activePath]);
+  }, [selection, activePath, renameShortcut]);
 
   const openMenu = useCallback(
     (e: React.MouseEvent, entry: FsEntry | null) => {

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -55,7 +55,11 @@ import {
   hasConfiguredEditor,
   openInConfiguredEditor,
 } from "../lib/editor";
-import { formatHotkey, type HotkeyId } from "../lib/hotkeys";
+import {
+  formatHotkey,
+  matchesHotkeyEvent,
+  type HotkeyId,
+} from "../lib/hotkeys";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
 import { basename } from "../lib/pathUtils";
 import {
@@ -1444,12 +1448,12 @@ function TabItem({
         }}
         onKeyDown={(e) => {
           if (editing) return;
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            onSelect();
-          } else if (e.key === "F2") {
+          if (matchesHotkeyEvent(shortcuts.renameItem, e)) {
             e.preventDefault();
             if (canRename) setEditing(true);
+          } else if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onSelect();
           }
         }}
         className={cn(

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -1033,6 +1033,8 @@ describe("SettingsModal font controls", () => {
     expect(bodyText).toContain("Focus pane to the right");
     expect(bodyText).toContain("Focus pane above");
     expect(bodyText).toContain("Focus pane below");
+    expect(bodyText).toContain("Find in current view");
+    expect(bodyText).toContain("Rename selected item");
     expect(bodyText).toContain("Right panel");
     expect(bodyText).toContain("Record");
     expect(bodyText).toMatch(/⌘P|Ctrl\+P/);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -197,6 +197,14 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
         id: "addProject",
         labelKey: "settings.shortcuts.items.addProject.label",
       },
+      {
+        id: "findInView",
+        labelKey: "settings.shortcuts.items.findInView.label",
+      },
+      {
+        id: "renameItem",
+        labelKey: "settings.shortcuts.items.renameItem.label",
+      },
     ],
   },
   {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -73,7 +73,7 @@ import {
 import { api, type WorktreeRemoval } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
-import { formatHotkey } from "../lib/hotkeys";
+import { formatHotkey, matchesHotkeyEvent } from "../lib/hotkeys";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import {
   useSettings,
@@ -2481,12 +2481,17 @@ function ProjectFolderView({
           if (editing) return;
           listeners?.onKeyDown?.(e);
           if (e.defaultPrevented) return;
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            onActivate();
-          } else if (e.key === "F2") {
+          if (
+            matchesHotkeyEvent(
+              useSettings.getState().settings.shortcuts.renameItem,
+              e,
+            )
+          ) {
             e.preventDefault();
             setEditing(true);
+          } else if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onActivate();
           }
         }}
         onContextMenu={(e) => {
@@ -3122,12 +3127,17 @@ function SessionRow({
         if (editing) return;
         listeners?.onKeyDown?.(e);
         if (e.defaultPrevented) return;
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onSelect();
-        } else if (e.key === "F2") {
+        if (
+          matchesHotkeyEvent(
+            useSettings.getState().settings.shortcuts.renameItem,
+            e,
+          )
+        ) {
           e.preventDefault();
           if (canRename) setEditing(true);
+        } else if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
         }
       }}
       onContextMenu={(e) => {
@@ -4123,12 +4133,17 @@ function LocalWorkspaceView({
         }}
         onKeyDown={(e) => {
           if (editing) return;
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            onActivate();
-          } else if (e.key === "F2") {
+          if (
+            matchesHotkeyEvent(
+              useSettings.getState().settings.shortcuts.renameItem,
+              e,
+            )
+          ) {
             e.preventDefault();
             setEditing(true);
+          } else if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onActivate();
           }
         }}
         onContextMenu={(e) => {
@@ -4468,12 +4483,17 @@ function LocalSessionRow({
         if (editing) return;
         listeners?.onKeyDown?.(e);
         if (e.defaultPrevented) return;
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onSelect();
-        } else if (e.key === "F2") {
+        if (
+          matchesHotkeyEvent(
+            useSettings.getState().settings.shortcuts.renameItem,
+            e,
+          )
+        ) {
           e.preventDefault();
           if (canRename) setEditing(true);
+        } else if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
         }
       }}
       onContextMenu={(e) => {

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -51,7 +51,7 @@ import { api } from "../lib/api";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
 import { isInAcornFloatingLayer } from "../lib/floatingLayer";
-import { formatHotkey } from "../lib/hotkeys";
+import { formatHotkey, matchesHotkeyEvent } from "../lib/hotkeys";
 import type { LayoutNode } from "../lib/layout";
 import { basename } from "../lib/pathUtils";
 import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
@@ -1200,14 +1200,19 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
 
   function handleKeyDown(event: ReactKeyboardEvent<HTMLElement>) {
     if (editing) return;
+    if (
+      matchesHotkeyEvent(
+        useSettings.getState().settings.shortcuts.renameItem,
+        event,
+      )
+    ) {
+      event.preventDefault();
+      if (canRename) setEditing(true);
+      return;
+    }
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
       onOpen(session.id, event.currentTarget);
-      return;
-    }
-    if (event.key === "F2") {
-      event.preventDefault();
-      if (canRename) setEditing(true);
       return;
     }
     const direction = kanbanCardFocusDirection(event.key);
@@ -2298,7 +2303,10 @@ function KanbanTerminalPopover({
                   onKeyDown={(event) => {
                     if (!canRename) return;
                     if (
-                      event.key !== "F2" &&
+                      !matchesHotkeyEvent(
+                        useSettings.getState().settings.shortcuts.renameItem,
+                        event,
+                      ) &&
                       event.key !== "Enter" &&
                       event.key !== " "
                     ) {

--- a/src/lib/hotkeys.test.ts
+++ b/src/lib/hotkeys.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_HOTKEYS,
   formatHotkey,
+  matchesHotkeyEvent,
   recordHotkeyFromEvent,
   resolveHotkeys,
   shouldUseTinykeysToggleMultiInputFallback,
@@ -148,6 +149,26 @@ describe("recordHotkeyFromEvent", () => {
   });
 });
 
+describe("matchesHotkeyEvent", () => {
+  it("matches configurable unmodified function keys", () => {
+    expect(
+      matchesHotkeyEvent(
+        "F3",
+        new KeyboardEvent("keydown", { key: "F3", code: "F3" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects the previous binding after a shortcut changes", () => {
+    expect(
+      matchesHotkeyEvent(
+        "F3",
+        new KeyboardEvent("keydown", { key: "F2", code: "F2" }),
+      ),
+    ).toBe(false);
+  });
+});
+
 describe("resolveHotkeys", () => {
   it("keeps every default binding unique", () => {
     const bindingCounts = new Map<string, number>();
@@ -163,6 +184,11 @@ describe("resolveHotkeys", () => {
   it("uses vertical mod-option arrows for conversation navigation", () => {
     expect(DEFAULT_HOTKEYS.previousConversation).toBe("$mod+Alt+ArrowUp");
     expect(DEFAULT_HOTKEYS.nextConversation).toBe("$mod+Alt+ArrowDown");
+  });
+
+  it("defines defaults for contextual find and rename commands", () => {
+    expect(DEFAULT_HOTKEYS.findInView).toBe("$mod+f");
+    expect(DEFAULT_HOTKEYS.renameItem).toBe("F2");
   });
 
   it("migrates persisted legacy defaults to current defaults", () => {

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -40,6 +40,8 @@ export const DEFAULT_HOTKEYS = {
   // hotkey lives next to the other terminal-creation bindings for symmetry.
   newControlSession: "$mod+Alt+Shift+KeyT",
   addProject: "$mod+Shift+n",
+  findInView: "$mod+f",
+  renameItem: "F2",
   focusSidebar: "$mod+1",
   focusMain: "$mod+2",
   focusRight: "$mod+3",
@@ -341,7 +343,17 @@ export function hotkeyBindingsFor(
   return Array.from(new Set(bindings));
 }
 
-function keyTokenFromEvent(event: KeyboardEvent): string | null {
+interface HotkeyEvent {
+  altKey: boolean;
+  code: string;
+  ctrlKey: boolean;
+  isComposing?: boolean;
+  key: string;
+  metaKey: boolean;
+  shiftKey: boolean;
+}
+
+function keyTokenFromEvent(event: HotkeyEvent): string | null {
   if (
     event.isComposing ||
     MODIFIER_EVENT_KEYS.has(event.key) ||
@@ -366,7 +378,7 @@ function keyTokenFromEvent(event: KeyboardEvent): string | null {
   return normalizeKeyToken(event.key);
 }
 
-export function recordHotkeyFromEvent(event: KeyboardEvent): string | null {
+export function recordHotkeyFromEvent(event: HotkeyEvent): string | null {
   const key = keyTokenFromEvent(event);
   if (!key) return null;
 
@@ -378,6 +390,14 @@ export function recordHotkeyFromEvent(event: KeyboardEvent): string | null {
   if (event.shiftKey) modifiers.push("Shift");
 
   return canonicalizeHotkeyBinding([...modifiers, key].join("+"));
+}
+
+export function matchesHotkeyEvent(
+  binding: string,
+  event: HotkeyEvent,
+): boolean {
+  const recorded = recordHotkeyFromEvent(event);
+  return recorded !== null && recorded === canonicalizeHotkeyBinding(binding);
 }
 
 export function setShortcutRecordingActive(active: boolean): void {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -506,6 +506,12 @@
         "addProject": {
           "label": "Add project"
         },
+        "findInView": {
+          "label": "Find in current view"
+        },
+        "renameItem": {
+          "label": "Rename selected item"
+        },
         "focusSidebar": {
           "label": "Focus sidebar"
         },

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -506,6 +506,12 @@
         "addProject": {
           "label": "프로젝트 추가"
         },
+        "findInView": {
+          "label": "현재 보기에서 찾기"
+        },
+        "renameItem": {
+          "label": "선택한 항목 이름 변경"
+        },
         "focusSidebar": {
           "label": "사이드바로 포커스 이동"
         },

--- a/tests/e2e/session-lifecycle.spec.ts
+++ b/tests/e2e/session-lifecycle.spec.ts
@@ -21,10 +21,16 @@ const BASE_SESSION = {
 };
 
 test.describe("session lifecycle", () => {
-  test("F2 → type → Enter invokes rename_session with the new name", async ({
+  test("a customized rename shortcut starts renaming the selected session", async ({
     page,
     tauri,
   }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({ shortcuts: { renameItem: "F3" } }),
+      );
+    });
     await tauri.respond("list_projects", [PROJECT]);
     await tauri.respond("list_sessions", [BASE_SESSION]);
     // rename_session captures args and returns the renamed session shape so
@@ -49,9 +55,10 @@ test.describe("session lifecycle", () => {
       .getByRole("button", { name: /^alpha main · Ready/ })
       .first();
     await row.click();
-    // After activation the row's accessible name now includes the visible
-    // Remove button, so re-resolve via the rename input that opens on F2.
+    // The configured key replaces the built-in F2 binding.
     await page.keyboard.press("F2");
+    await expect(sidebar.locator("input[type='text']")).toHaveCount(0);
+    await page.keyboard.press("F3");
 
     const input = sidebar.locator("input[type='text']");
     await expect(input).toBeVisible();

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -273,6 +273,8 @@ test.describe("settings modal", () => {
     await expect(modal.getByText("Focus pane to the right")).toBeVisible();
     await expect(modal.getByText("Focus pane above")).toBeVisible();
     await expect(modal.getByText("Focus pane below")).toBeVisible();
+    await expect(modal.getByText("Find in current view")).toBeVisible();
+    await expect(modal.getByText("Rename selected item")).toBeVisible();
 
     await modal
       .getByRole("button", {


### PR DESCRIPTION
## Summary
This makes Acorn's contextual find and rename commands configurable alongside the existing global shortcuts.

1. **Shortcut settings** — add Find in current view and Rename selected item to the shared hotkey configuration, Settings UI, persistence/reset flow, and English/Korean copy.
2. **Runtime wiring** — apply the configured find shortcut in code viewers and the file explorer, and the configured rename shortcut across pane tabs, sidebar rows, Kanban cards, terminal popovers, and file entries.
3. **Replacement semantics** — stop handling the previous default after a custom binding is saved, while preserving Cmd/Ctrl+F and F2 as defaults.

## Expected impact

| Behavior | Before | After |
| --- | --- | --- |
| Find in current view | Fixed to Cmd/Ctrl+F | Configurable in Settings |
| Rename selected item | Fixed to F2 | Configurable in Settings |
| Custom binding | Default key still owned the local handler | Custom key replaces the default |

## Design notes

- Contextual commands stay scoped to their active surface instead of becoming global App handlers.
- `matchesHotkeyEvent` reuses the same canonical binding format as shortcut recording, including platform-primary modifier handling and function keys.
- The existing Settings coverage invariant still requires every `HotkeyId` to appear exactly once in the shortcut groups.

## Test plan

- [x] `pnpm run test` — 87 files, 970 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — production build passed
- [x] `pnpm run test:e2e` — 226 tests passed
