### PR TITLE
fix(kanban): keep merged sessions linked across workspace views

### DIFF
--- a/docs/superpowers/specs/2026-07-03-kanban-lifecycle-board-design.md
+++ b/docs/superpowers/specs/2026-07-03-kanban-lifecycle-board-design.md
@@ -39,14 +39,14 @@ that a particular session performed the work.
 | Working | accent (pulse) | a known agent or chat run is working |
 | Waiting | warning (amber highlight) | `status === "needs_input"` or `status === "failed"` (failed cards keep a red accent) |
 | Review | success | an agent turn completed and still needs acknowledgement |
-| Done | neutral | a matching PR completed after the latest agent activity, or manually pinned done |
+| Done | neutral | a matching PR completed after the latest user request, or manually pinned done |
 
 Derivation precedence (first match wins):
 
 1. `needs_input` | `failed` → **Waiting**
 2. known agent/chat `running` → **Working**
 3. manual done pin → **Done**
-4. PR completion timestamp ≥ latest agent activity → **Done**
+4. PR completion timestamp ≥ latest user request → **Done**
 5. completed agent turn → **Review**
 6. otherwise → **Idle**
 
@@ -57,10 +57,13 @@ the single source of truth (mirrors the existing `kanbanBoard.ts` pattern).
 ## Data plumbing
 
 - **PRs:** reuse `rightPanelCache.fetchPullRequests(repoPath, "all", 50)`,
-  polled every 60 s per distinct `repo_path`, matched to sessions via
-  `head_branch === session.branch`. `closedAt` / `mergedAt` must not predate
-  the session's latest transcript/chat activity before the PR can move the
-  card to Done. Non-GitHub repos degrade gracefully (listing kind
+  polled every 60 s per distinct `repo_path`. Direct matches use
+  `head_branch === session.branch`; once observed, the PR branch is retained
+  per session so checking out the base branch after merge does not sever the
+  card's PR identity. `closedAt` / `mergedAt` must not predate the latest real
+  user request. Provider cleanup and final output from the same turn may land
+  after merge without reopening the card, while a later user request returns
+  it to Review. Non-GitHub repos degrade gracefully (listing kind
   `not_github` → no PR context).
 - **Diff:** `api.fsGitStatus(worktree_path)` per board-visible session, polled
   every 20 s, paused while `document.hidden`. Produces `hasDiff` and summed

--- a/docs/superpowers/specs/2026-07-03-kanban-lifecycle-board-design.md
+++ b/docs/superpowers/specs/2026-07-03-kanban-lifecycle-board-design.md
@@ -60,11 +60,12 @@ the single source of truth (mirrors the existing `kanbanBoard.ts` pattern).
   polled every 60 s per distinct `repo_path`. Direct matches use
   `head_branch === session.branch`; once observed, the PR branch is retained
   per session so checking out the base branch after merge does not sever the
-  card's PR identity. `closedAt` / `mergedAt` must not predate the latest real
-  user request. Provider cleanup and final output from the same turn may land
-  after merge without reopening the card, while a later user request returns
-  it to Review. Non-GitHub repos degrade gracefully (listing kind
-  `not_github` → no PR context).
+  card's PR identity. PR observation stays mounted at the workspace level in
+  both Panes and Kanban modes; only diff polling is Kanban-only. `closedAt` /
+  `mergedAt` must not predate the latest real user request. Provider cleanup
+  and final output from the same turn may land after merge without reopening
+  the card, while a later user request returns it to Review. Non-GitHub repos
+  degrade gracefully (listing kind `not_github` → no PR context).
 - **Diff:** `api.fsGitStatus(worktree_path)` per board-visible session, polled
   every 20 s, paused while `document.hidden`. Produces `hasDiff` and summed
   `+additions/−deletions` for the card chip without moving the card between

--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -30,6 +30,8 @@ pub enum TurnState {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParsedTranscriptLine {
+    /// Source timestamp for this transcript event, when the provider emits one.
+    pub timestamp: Option<String>,
     /// Role used by title-context and message-count consumers.
     pub role: TranscriptRole,
     /// Text used by history list titles and title-context consumers.
@@ -54,6 +56,7 @@ pub struct ParsedTranscriptLine {
 impl Default for ParsedTranscriptLine {
     fn default() -> Self {
         Self {
+            timestamp: None,
             role: TranscriptRole::Other,
             text: None,
             state_text: None,
@@ -175,6 +178,8 @@ fn parse_codex_value(value: &Value) -> ParsedTranscriptLine {
     let (preview_role, preview_text) = codex_preview_role_and_text(value, event, event_role);
 
     ParsedTranscriptLine {
+        timestamp: string_at(Some(value), "timestamp")
+            .or_else(|| string_at(Some(event), "timestamp")),
         role,
         text,
         state_text,
@@ -211,6 +216,7 @@ fn parse_claude_value(value: &Value) -> ParsedTranscriptLine {
     };
 
     ParsedTranscriptLine {
+        timestamp: string_at(Some(value), "timestamp"),
         role,
         state_text: text.clone(),
         text,
@@ -252,6 +258,9 @@ fn parse_antigravity_value(value: &Value) -> ParsedTranscriptLine {
     };
 
     ParsedTranscriptLine {
+        timestamp: string_at(Some(value), "timestamp")
+            .or_else(|| string_at(Some(value), "created_at"))
+            .or_else(|| string_at(Some(value), "createdAt")),
         role,
         state_text: text.clone(),
         text,
@@ -852,6 +861,7 @@ mod tests {
         assert_eq!(parsed.state_text.as_deref(), Some("hello codex"));
         assert_eq!(parsed.preview_role, TranscriptRole::User);
         assert_eq!(parsed.preview_text.as_deref(), Some("hello codex"));
+        assert_eq!(parsed.timestamp.as_deref(), Some("t"));
         assert_eq!(parsed.session_id.as_deref(), Some("payload-session"));
         assert_eq!(parsed.cwd.as_deref(), Some("/tmp/project"));
     }

--- a/src-tauri/src/agent_resume.rs
+++ b/src-tauri/src/agent_resume.rs
@@ -329,6 +329,7 @@ fn antigravity_brain_roots() -> Vec<PathBuf> {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ConversationPreview {
     pub last_user_message: Option<String>,
+    pub last_user_message_at: Option<String>,
     pub last_agent_message: Option<String>,
 }
 
@@ -354,6 +355,9 @@ pub(crate) fn extract_conversation_preview(
                     .preview_text
                     .as_deref()
                     .and_then(|text| collapse_preview(text, PREVIEW_CHARS));
+                if preview.last_user_message.is_some() {
+                    preview.last_user_message_at = parsed.timestamp;
+                }
             }
             TranscriptRole::Other => {}
             _ => {}

--- a/src-tauri/src/agent_resume.rs
+++ b/src-tauri/src/agent_resume.rs
@@ -568,7 +568,7 @@ mod tests {
         let path = base.path().join("rollout.jsonl");
         fs::write(
             &path,
-            r#"{"type":"message","payload":{"role":"user","content":[{"type":"input_text","text":"Check the drawer regression."}]}}
+            r#"{"timestamp":"2026-01-02T03:00:00.000Z","type":"message","payload":{"role":"user","content":[{"type":"input_text","text":"Check the drawer regression."}]}}
 {"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"The regression is in the popover target."}]}}
 "#,
         )
@@ -583,6 +583,10 @@ mod tests {
         assert_eq!(
             preview.last_agent_message.as_deref(),
             Some("The regression is in the popover target.")
+        );
+        assert_eq!(
+            preview.last_user_message_at.as_deref(),
+            Some("2026-01-02T03:00:00.000Z")
         );
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5091,6 +5091,8 @@ pub struct SessionStatusEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_user_message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_user_message_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_agent_message: Option<String>,
     pub agent_provider: Option<SessionAgentProvider>,
     pub agent_transcript_provider: Option<SessionAgentProvider>,
@@ -5145,6 +5147,9 @@ fn chat_conversation_preview(
             persistence::ChatRole::User if preview.last_user_message.is_none() => {
                 preview.last_user_message =
                     collapse_preview(&message.content, STATUS_PREVIEW_CHARS);
+                if preview.last_user_message.is_some() {
+                    preview.last_user_message_at = Some(message.created_at.to_rfc3339());
+                }
             }
             persistence::ChatRole::Assistant if preview.last_agent_message.is_none() => {
                 preview.last_agent_message =
@@ -5325,6 +5330,9 @@ fn detect_session_statuses_blocking(
                     last_user_message: conversation_preview
                         .as_ref()
                         .and_then(|p| p.last_user_message.clone()),
+                    last_user_message_at: conversation_preview
+                        .as_ref()
+                        .and_then(|p| p.last_user_message_at.clone()),
                     last_agent_message: conversation_preview
                         .as_ref()
                         .and_then(|p| p.last_agent_message.clone()),
@@ -5546,6 +5554,9 @@ fn detect_session_statuses_blocking(
                 last_user_message: conversation_preview
                     .as_ref()
                     .and_then(|p| p.last_user_message.clone()),
+                last_user_message_at: conversation_preview
+                    .as_ref()
+                    .and_then(|p| p.last_user_message_at.clone()),
                 last_agent_message: conversation_preview
                     .as_ref()
                     .and_then(|p| p.last_agent_message.clone()),

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -217,7 +217,27 @@ interface WorkspaceMainProps {
 
 export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
   const isKanban = viewMode === "kanban";
+  const panes = useAppStore((s) => s.panes);
+  const sessionsById = useAppStore(selectSessionsById);
   const closeTerminalPopup = useAppStore((s) => s.closeTerminalPopup);
+  const sessions = useMemo(() => {
+    const ordered: Session[] = [];
+    const seen = new Set<string>();
+    for (const pane of Object.values(panes)) {
+      for (const id of pane.tabIds) {
+        if (seen.has(id)) continue;
+        const session = sessionsById.get(id);
+        if (!session) continue;
+        seen.add(id);
+        ordered.push(session);
+      }
+    }
+    return ordered;
+  }, [panes, sessionsById]);
+  const [prRefreshKey, setPrRefreshKey] = useState(0);
+  const boardData = useKanbanBoardData(sessions, prRefreshKey, {
+    pollDiffs: isKanban,
+  });
 
   useEffect(() => {
     if (!isKanban) closeTerminalPopup();
@@ -228,7 +248,13 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
       {isKanban ? (
         <div className="relative flex h-full min-w-0 flex-col overflow-hidden">
           <div className="min-h-0 min-w-0 flex-1">
-            <WorkspaceKanbanBoard />
+            <WorkspaceKanbanBoard
+              sessions={sessions}
+              boardData={boardData}
+              onPullRequestsMutated={() =>
+                setPrRefreshKey((key) => key + 1)
+              }
+            />
           </div>
           <KanbanFilePreviewOverlay />
         </div>
@@ -315,18 +341,41 @@ function KanbanFilePreviewOverlay() {
   );
 }
 
-function WorkspaceKanbanBoard() {
+function WorkspaceKanbanBoard({
+  sessions,
+  boardData,
+  onPullRequestsMutated,
+}: {
+  sessions: readonly Session[];
+  boardData: ReadonlyMap<string, KanbanSessionBoardData>;
+  onPullRequestsMutated: () => void;
+}) {
   // Remount per project so each board hydrates its own persisted prefs through
   // the useState initializer rather than racing an effect to swap them in.
   const projectId = useAppStore((s) => s.activeProject);
   return (
-    <KanbanBoard key={projectId ?? "__no-project__"} projectId={projectId} />
+    <KanbanBoard
+      key={projectId ?? "__no-project__"}
+      projectId={projectId}
+      sessions={sessions}
+      boardData={boardData}
+      onPullRequestsMutated={onPullRequestsMutated}
+    />
   );
 }
 
-function KanbanBoard({ projectId }: { projectId: string | null }) {
+function KanbanBoard({
+  projectId,
+  sessions,
+  boardData,
+  onPullRequestsMutated,
+}: {
+  projectId: string | null;
+  sessions: readonly Session[];
+  boardData: ReadonlyMap<string, KanbanSessionBoardData>;
+  onPullRequestsMutated: () => void;
+}) {
   const t = useTranslation();
-  const panes = useAppStore((s) => s.panes);
   const sessionsById = useAppStore(selectSessionsById);
   const selectSession = useAppStore((s) => s.selectSession);
   const openTerminalPopup = useAppStore((s) => s.openTerminalPopup);
@@ -344,21 +393,6 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
     null,
   );
   const columnResizeCleanupRef = useRef<(() => void) | null>(null);
-
-  const sessions = useMemo(() => {
-    const ordered: Session[] = [];
-    const seen = new Set<string>();
-    for (const pane of Object.values(panes)) {
-      for (const id of pane.tabIds) {
-        if (seen.has(id)) continue;
-        const session = sessionsById.get(id);
-        if (!session) continue;
-        seen.add(id);
-        ordered.push(session);
-      }
-    }
-    return ordered;
-  }, [panes, sessionsById]);
 
   const visibleSessions = useMemo(
     () =>
@@ -382,8 +416,6 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
     return () => window.clearInterval(handle);
   }, []);
 
-  const [prRefreshKey, setPrRefreshKey] = useState(0);
-  const boardData = useKanbanBoardData(sessions, prRefreshKey);
   const [prDetail, setPrDetail] = useState<{
     repoPath: string;
     number: number;
@@ -841,7 +873,7 @@ function KanbanBoard({ projectId }: { projectId: string | null }) {
         open={prDetail}
         cwd={prDetail?.repoPath}
         onClose={() => setPrDetail(null)}
-        onMutated={() => setPrRefreshKey((key) => key + 1)}
+        onMutated={onPullRequestsMutated}
       />
     </div>
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -643,6 +643,7 @@ export const api = {
       status_started_at?: string | null;
       last_message?: string | null;
       last_user_message?: string | null;
+      last_user_message_at?: string | null;
       last_agent_message?: string | null;
       agent_provider?: SessionAgentProvider | null;
       agent_transcript_provider?: SessionAgentProvider | null;
@@ -663,6 +664,7 @@ export const api = {
         status_started_at?: string | null;
         last_message?: string | null;
         last_user_message?: string | null;
+        last_user_message_at?: string | null;
         last_agent_message?: string | null;
         agent_provider?: SessionAgentProvider | null;
         agent_transcript_provider?: SessionAgentProvider | null;

--- a/src/lib/kanbanLifecycle.test.ts
+++ b/src/lib/kanbanLifecycle.test.ts
@@ -168,6 +168,24 @@ describe("deriveKanbanStage", () => {
     }
   });
 
+  it("ignores same-turn cleanup written after the PR merged", () => {
+    expect(
+      deriveKanbanStage(
+        makeSession({
+          last_user_message: "Merge the pull request",
+          last_agent_message: "Merged and cleaned up the branch",
+          last_user_message_at: "2026-01-02T00:00:00.000Z",
+          agent_activity_at: "2026-01-02T00:10:40.000Z",
+        } as Partial<Session>),
+        ctx({
+          pr: makePr("MERGED", {
+            merged_at: "2026-01-02T00:10:13.000Z",
+          }),
+        }),
+      ),
+    ).toBe("done");
+  });
+
   it("keeps newer agent work in review when the matching PR was already finished", () => {
     expect(
       deriveKanbanStage(

--- a/src/lib/kanbanLifecycle.test.ts
+++ b/src/lib/kanbanLifecycle.test.ts
@@ -202,6 +202,24 @@ describe("deriveKanbanStage", () => {
     ).toBe("review");
   });
 
+  it("keeps a post-merge user request in review", () => {
+    expect(
+      deriveKanbanStage(
+        makeSession({
+          last_user_message: "Make a follow-up change",
+          last_user_message_at: "2026-01-04T00:00:00.000Z",
+          last_agent_message: "Follow-up completed",
+          agent_activity_at: "2026-01-04T00:05:00.000Z",
+        } as Partial<Session>),
+        ctx({
+          pr: makePr("MERGED", {
+            merged_at: "2026-01-03T00:00:00.000Z",
+          }),
+        }),
+      ),
+    ).toBe("review");
+  });
+
   it("keeps completed work in review when PR timing cannot be verified", () => {
     const session = makeSession({
       last_agent_message: "Ready for review",

--- a/src/lib/kanbanLifecycle.ts
+++ b/src/lib/kanbanLifecycle.ts
@@ -26,7 +26,7 @@ export const KANBAN_LIFECYCLE_STAGES: readonly KanbanLifecycleStage[] = [
 export const KANBAN_STALL_THRESHOLD_MS = 5 * 60_000;
 
 export interface KanbanStageContext {
-  /** PR whose head branch matches the session branch, if any. */
+  /** PR matched to the session's current or previously observed PR branch. */
   pr: PullRequestInfo | null;
   /** User pinned the card to Done via the card menu. */
   manualDone: boolean;
@@ -65,11 +65,13 @@ function completedPullRequestAt(pr: PullRequestInfo | null): string | null {
   return null;
 }
 
-function pullRequestCompletedAfterAgentWork(
+function pullRequestCompletedAfterAgentRequest(
   session: Session,
   pr: PullRequestInfo | null,
 ): boolean {
-  const activityAt = Date.parse(session.agent_activity_at ?? "");
+  const requestAt = Date.parse(session.last_user_message_at ?? "");
+  const fallbackActivityAt = Date.parse(session.agent_activity_at ?? "");
+  const activityAt = Number.isFinite(requestAt) ? requestAt : fallbackActivityAt;
   const completedAt = Date.parse(completedPullRequestAt(pr) ?? "");
   return (
     Number.isFinite(activityAt) &&
@@ -85,7 +87,7 @@ function pullRequestCompletedAfterAgentWork(
  * 1. waiting/error                         → waiting
  * 2. live agent work                       → working
  * 3. manual done pin                       → done
- * 4. PR completed after latest agent work  → done
+ * 4. PR completed after latest user request → done
  * 5. completed agent work                  → review
  * 6. otherwise                             → idle
  *
@@ -103,7 +105,7 @@ export function deriveKanbanStage(
   if (isAgentWorking(session)) return "working";
   if (context.manualDone) return "done";
   if (!hasCompletedAgentWork(session)) return "idle";
-  if (pullRequestCompletedAfterAgentWork(session, context.pr)) return "done";
+  if (pullRequestCompletedAfterAgentRequest(session, context.pr)) return "done";
   return "review";
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -129,6 +129,8 @@ export interface Session {
   last_message: string | null;
   /** Ephemeral transcript/chat preview for the latest user turn. */
   last_user_message?: string | null;
+  /** Ephemeral source timestamp for the latest real user turn. */
+  last_user_message_at?: string | null;
   /** Ephemeral transcript/chat preview for the latest agent turn. */
   last_agent_message?: string | null;
   title_source: SessionTitleSource;

--- a/src/lib/useKanbanBoardData.test.ts
+++ b/src/lib/useKanbanBoardData.test.ts
@@ -3,6 +3,7 @@ import {
   diffStatsEntries,
   kanbanSessionBoardLookupPath,
   pickPullRequestForBranch,
+  pickPullRequestForBranches,
   summarizeDiffStats,
 } from "./useKanbanBoardData";
 import type { PullRequestInfo, Session } from "./types";
@@ -57,6 +58,21 @@ describe("pickPullRequestForBranch", () => {
     });
     expect(pickPullRequestForBranch([older, newer])?.number).toBe(2);
     expect(pickPullRequestForBranch([newer, older])?.number).toBe(2);
+  });
+});
+
+describe("pickPullRequestForBranches", () => {
+  it("keeps a PR linked after the worktree checks out the base branch", () => {
+    const pr = makePr({
+      number: 604,
+      state: "MERGED",
+      head_branch: "feat/x",
+      merged_at: "2026-01-02T00:10:13.000Z",
+    });
+
+    expect(pickPullRequestForBranches([pr], ["main", "feat/x"])?.number).toBe(
+      604,
+    );
   });
 });
 

--- a/src/lib/useKanbanBoardData.test.ts
+++ b/src/lib/useKanbanBoardData.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   diffStatsEntries,
   kanbanSessionBoardLookupPath,
+  kanbanSessionPullRequestLookupPath,
   pickPullRequestForBranch,
   pickPullRequestForBranches,
   readKanbanPrBranchLinks,
@@ -160,5 +161,37 @@ describe("kanbanSessionBoardLookupPath", () => {
         session({ git_context_path: "   ", worktree_path: "" }),
       ),
     ).toBe("/repo/project");
+  });
+});
+
+describe("kanbanSessionPullRequestLookupPath", () => {
+  function session(overrides: Partial<Session> = {}): Session {
+    return {
+      repo_path: "/repo/project",
+      worktree_path: "/repo/project/.worktrees/session",
+      git_context_path: null,
+      ...overrides,
+    } as Session;
+  }
+
+  it("shares the project repo lookup for its recorded worktree", () => {
+    expect(kanbanSessionPullRequestLookupPath(session())).toBe(
+      "/repo/project",
+    );
+    expect(
+      kanbanSessionPullRequestLookupPath(
+        session({
+          git_context_path: "/repo/project/.worktrees/session/",
+        }),
+      ),
+    ).toBe("/repo/project");
+  });
+
+  it("keeps a live git context that points outside the session worktree", () => {
+    expect(
+      kanbanSessionPullRequestLookupPath(
+        session({ git_context_path: " /repo/other-project " }),
+      ),
+    ).toBe("/repo/other-project");
   });
 });

--- a/src/lib/useKanbanBoardData.test.ts
+++ b/src/lib/useKanbanBoardData.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   diffStatsEntries,
   kanbanSessionBoardLookupPath,
   pickPullRequestForBranch,
   pickPullRequestForBranches,
+  readKanbanPrBranchLinks,
   summarizeDiffStats,
+  writeKanbanPrBranchLinks,
 } from "./useKanbanBoardData";
 import type { PullRequestInfo, Session } from "./types";
 
@@ -73,6 +75,25 @@ describe("pickPullRequestForBranches", () => {
     expect(pickPullRequestForBranches([pr], ["main", "feat/x"])?.number).toBe(
       604,
     );
+  });
+});
+
+describe("kanban PR branch links", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("persists the PR branch independently from the live checkout", () => {
+    writeKanbanPrBranchLinks({
+      session: { repoPath: "/repo", headBranch: "feat/x" },
+    });
+
+    expect(readKanbanPrBranchLinks()).toEqual({
+      session: { repoPath: "/repo", headBranch: "feat/x" },
+    });
+  });
+
+  it("ignores corrupt persisted links", () => {
+    localStorage.setItem("acorn:workspace-kanban:pr-branch-links:v1", "{");
+    expect(readKanbanPrBranchLinks()).toEqual({});
   });
 });
 

--- a/src/lib/useKanbanBoardData.ts
+++ b/src/lib/useKanbanBoardData.ts
@@ -23,6 +23,56 @@ const CLEAN_DIFF: DiffSummary = { hasDiff: false, additions: 0, deletions: 0 };
 const PR_POLL_INTERVAL_MS = 60_000;
 const DIFF_POLL_INTERVAL_MS = 20_000;
 const PR_LIST_LIMIT = 50;
+const PR_BRANCH_LINKS_STORAGE_KEY =
+  "acorn:workspace-kanban:pr-branch-links:v1";
+
+export interface KanbanPrBranchLink {
+  repoPath: string;
+  headBranch: string;
+}
+
+export type KanbanPrBranchLinks = Record<string, KanbanPrBranchLink>;
+
+function isKanbanPrBranchLink(value: unknown): value is KanbanPrBranchLink {
+  if (!value || typeof value !== "object") return false;
+  const link = value as Partial<KanbanPrBranchLink>;
+  return (
+    typeof link.repoPath === "string" &&
+    link.repoPath.trim().length > 0 &&
+    typeof link.headBranch === "string" &&
+    link.headBranch.trim().length > 0
+  );
+}
+
+export function readKanbanPrBranchLinks(): KanbanPrBranchLinks {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(PR_BRANCH_LINKS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, KanbanPrBranchLink] =>
+          isKanbanPrBranchLink(entry[1]),
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+export function writeKanbanPrBranchLinks(links: KanbanPrBranchLinks): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      PR_BRANCH_LINKS_STORAGE_KEY,
+      JSON.stringify(links),
+    );
+  } catch {
+    // Current-branch PR matching still works when storage is unavailable.
+  }
+}
 
 /**
  * Pick the PR that best represents a branch when several share a head branch:
@@ -46,6 +96,18 @@ export function pickPullRequestForBranch(
     if (Date.parse(pr.updated_at) > Date.parse(best.updated_at)) best = pr;
   }
   return best;
+}
+
+export function pickPullRequestForBranches(
+  prs: readonly PullRequestInfo[],
+  branches: readonly string[],
+): PullRequestInfo | null {
+  const branchSet = new Set(
+    branches.map((branch) => branch.trim()).filter(Boolean),
+  );
+  return pickPullRequestForBranch(
+    prs.filter((pr) => branchSet.has(pr.head_branch)),
+  );
 }
 
 function indexListingByBranch(
@@ -111,6 +173,9 @@ export function useKanbanBoardData(
   const [diffBySession, setDiffBySession] = useState<
     ReadonlyMap<string, DiffSummary>
   >(new Map());
+  const [prBranchLinks, setPrBranchLinks] = useState<KanbanPrBranchLinks>(
+    readKanbanPrBranchLinks,
+  );
   const prRequestSeqRef = useRef(new Map<string, number>());
   const diffRefreshSeqRef = useRef(0);
 
@@ -275,14 +340,53 @@ export function useKanbanBoardData(
     };
   }, [worktreeKey]);
 
+  useEffect(() => {
+    setPrBranchLinks((previous) => {
+      let changed = false;
+      const next = { ...previous };
+      for (const session of sessions) {
+        const branch = session.branch?.trim();
+        if (!branch) continue;
+        const repoPath = kanbanSessionBoardLookupPath(session);
+        const direct = pickPullRequestForBranch(
+          prIndexByRepo.get(repoPath)?.get(branch) ?? [],
+        );
+        if (!direct) continue;
+        const current = next[session.id];
+        if (
+          current?.repoPath === repoPath &&
+          current.headBranch === direct.head_branch
+        ) {
+          continue;
+        }
+        next[session.id] = {
+          repoPath,
+          headBranch: direct.head_branch,
+        };
+        changed = true;
+      }
+      if (!changed) return previous;
+      writeKanbanPrBranchLinks(next);
+      return next;
+    });
+  }, [prIndexByRepo, sessions]);
+
   return useMemo(() => {
     const data = new Map<string, KanbanSessionBoardData>();
     for (const session of sessions) {
       const branch = session.branch?.trim();
       const repoPath = kanbanSessionBoardLookupPath(session);
-      const candidates = branch
-        ? (prIndexByRepo.get(repoPath)?.get(branch) ?? [])
-        : [];
+      const linkedBranch =
+        prBranchLinks[session.id]?.repoPath === repoPath
+          ? prBranchLinks[session.id]?.headBranch
+          : undefined;
+      const branches = [branch, linkedBranch].filter(
+        (candidate): candidate is string => Boolean(candidate),
+      );
+      const candidates = [...branches].flatMap(
+        (candidateBranch) =>
+          prIndexByRepo.get(repoPath)?.get(candidateBranch) ?? [],
+      );
       const diff = diffBySession.get(session.id) ?? CLEAN_DIFF;
       data.set(session.id, {
         repoPath,
@@ -293,5 +397,5 @@ export function useKanbanBoardData(
       });
     }
     return data;
-  }, [diffBySession, prIndexByRepo, sessions]);
+  }, [diffBySession, prBranchLinks, prIndexByRepo, sessions]);
 }

--- a/src/lib/useKanbanBoardData.ts
+++ b/src/lib/useKanbanBoardData.ts
@@ -161,6 +161,33 @@ export function kanbanSessionBoardLookupPath(
   );
 }
 
+function comparableRepoPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized || "/";
+}
+
+/**
+ * Resolve the repository used for PR listings. A session's live git context
+ * normally resolves to its own worktree, but PRs belong to the shared project
+ * repository and should be fetched once from that root. Preserve a genuinely
+ * different live repository so terminal `cd` workflows still follow it.
+ */
+export function kanbanSessionPullRequestLookupPath(
+  session: Pick<Session, "git_context_path" | "worktree_path" | "repo_path">,
+): string {
+  const livePath = session.git_context_path?.trim();
+  const worktreePath = session.worktree_path.trim();
+  const projectPath = session.repo_path.trim();
+  if (
+    livePath &&
+    comparableRepoPath(livePath) !== comparableRepoPath(worktreePath) &&
+    comparableRepoPath(livePath) !== comparableRepoPath(projectPath)
+  ) {
+    return livePath;
+  }
+  return projectPath || worktreePath || livePath || session.repo_path;
+}
+
 /**
  * Poll PR listings (per distinct repo) for the workspace lifecycle and,
  * optionally, worktree diff summaries per session for the visible Kanban.
@@ -190,7 +217,7 @@ export function useKanbanBoardData(
   // repo and worktree paths may contain spaces, never newlines.
   const repoPaths = useMemo(
     () =>
-      [...new Set(sessions.map(kanbanSessionBoardLookupPath))].sort(),
+      [...new Set(sessions.map(kanbanSessionPullRequestLookupPath))].sort(),
     [sessions],
   );
   const repoKey = repoPaths.join("\n");
@@ -353,7 +380,7 @@ export function useKanbanBoardData(
       for (const session of sessions) {
         const branch = session.branch?.trim();
         if (!branch) continue;
-        const repoPath = kanbanSessionBoardLookupPath(session);
+        const repoPath = kanbanSessionPullRequestLookupPath(session);
         const direct = pickPullRequestForBranch(
           prIndexByRepo.get(repoPath)?.get(branch) ?? [],
         );
@@ -381,7 +408,7 @@ export function useKanbanBoardData(
     const data = new Map<string, KanbanSessionBoardData>();
     for (const session of sessions) {
       const branch = session.branch?.trim();
-      const repoPath = kanbanSessionBoardLookupPath(session);
+      const repoPath = kanbanSessionPullRequestLookupPath(session);
       const linkedBranch =
         prBranchLinks[session.id]?.repoPath === repoPath
           ? prBranchLinks[session.id]?.headBranch

--- a/src/lib/useKanbanBoardData.ts
+++ b/src/lib/useKanbanBoardData.ts
@@ -18,6 +18,10 @@ export interface DiffSummary {
   deletions: number;
 }
 
+export interface KanbanBoardDataOptions {
+  pollDiffs?: boolean;
+}
+
 const CLEAN_DIFF: DiffSummary = { hasDiff: false, additions: 0, deletions: 0 };
 
 const PR_POLL_INTERVAL_MS = 60_000;
@@ -158,14 +162,16 @@ export function kanbanSessionBoardLookupPath(
 }
 
 /**
- * Poll PR listings (per distinct repo) and worktree diff summaries (per
- * session) for the workspace kanban. Both polls pause while the document is
- * hidden and refresh immediately when it becomes visible again. `refreshKey`
- * forces an immediate PR re-fetch (bump it after a PR mutation).
+ * Poll PR listings (per distinct repo) for the workspace lifecycle and,
+ * optionally, worktree diff summaries per session for the visible Kanban.
+ * Both polls pause while the document is hidden and refresh immediately when
+ * it becomes visible again. `refreshKey` forces an immediate PR re-fetch
+ * (bump it after a PR mutation).
  */
 export function useKanbanBoardData(
   sessions: readonly Session[],
   refreshKey = 0,
+  { pollDiffs = true }: KanbanBoardDataOptions = {},
 ): Map<string, KanbanSessionBoardData> {
   const [prIndexByRepo, setPrIndexByRepo] = useState<
     ReadonlyMap<string, Map<string, PullRequestInfo[]>>
@@ -276,7 +282,7 @@ export function useKanbanBoardData(
 
   useEffect(() => {
     let cancelled = false;
-    if (!worktreeKey) {
+    if (!pollDiffs || !worktreeKey) {
       setDiffBySession(new Map());
       return;
     }
@@ -338,7 +344,7 @@ export function useKanbanBoardData(
       window.clearInterval(handle);
       document.removeEventListener("visibilitychange", onVisible);
     };
-  }, [worktreeKey]);
+  }, [pollDiffs, worktreeKey]);
 
   useEffect(() => {
     setPrBranchLinks((previous) => {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2524,6 +2524,7 @@ describe("pollSessionStatuses", () => {
         id: "a1",
         status: "working",
         last_user_message: "New user prompt",
+        last_user_message_at: "2026-01-02T03:00:00.000Z",
         last_agent_message: "New agent response",
         agent_activity_at: "2026-01-02T03:04:05.000Z",
         branch: null,
@@ -2537,6 +2538,9 @@ describe("pollSessionStatuses", () => {
     );
     expect(useAppStore.getState().sessions[0]?.last_agent_message).toBe(
       "New agent response",
+    );
+    expect(useAppStore.getState().sessions[0]?.last_user_message_at).toBe(
+      "2026-01-02T03:00:00.000Z",
     );
     expect(useAppStore.getState().sessions[0]?.agent_activity_at).toBe(
       "2026-01-02T03:04:05.000Z",

--- a/src/store.ts
+++ b/src/store.ts
@@ -1864,6 +1864,12 @@ export const useAppStore = create<AppStateModel>()(
                 )
                   ? (update.last_user_message ?? null)
                   : (sess.last_user_message ?? null);
+                const nextLastUserMessageAt = Object.prototype.hasOwnProperty.call(
+                  update,
+                  "last_user_message_at",
+                )
+                  ? (update.last_user_message_at ?? null)
+                  : (sess.last_user_message_at ?? null);
                 const nextLastAgentMessage = Object.prototype.hasOwnProperty.call(
                   update,
                   "last_agent_message",
@@ -1926,6 +1932,8 @@ export const useAppStore = create<AppStateModel>()(
                   nextBranch !== sess.branch ||
                   nextLastMessage !== sess.last_message ||
                   nextLastUserMessage !== (sess.last_user_message ?? null) ||
+                  nextLastUserMessageAt !==
+                    (sess.last_user_message_at ?? null) ||
                   nextLastAgentMessage !== (sess.last_agent_message ?? null) ||
                   nextAgentProvider !== (sess.agent_provider ?? null) ||
                   nextAgentTranscriptProvider !==
@@ -1950,6 +1958,7 @@ export const useAppStore = create<AppStateModel>()(
                     branch: nextBranch,
                     last_message: nextLastMessage,
                     last_user_message: nextLastUserMessage,
+                    last_user_message_at: nextLastUserMessageAt,
                     last_agent_message: nextLastAgentMessage,
                     agent_provider: nextAgentProvider,
                     agent_transcript_provider: nextAgentTranscriptProvider,

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -300,6 +300,109 @@ test.describe("workspace kanban mode", () => {
     );
   });
 
+  test("tracks a PR in Panes before Kanban is opened after merge", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("pane-merge-runner", "pane merge runner", "ready", {
+        branch: "feat/pane-merge-runner",
+        status_reason: "turn_complete",
+        last_user_message: "Merge from the pane view",
+        last_user_message_at: "2026-01-02T00:00:00Z",
+        last_agent_message: "Merged and returned to main",
+        agent_activity_at: "2026-01-02T00:10:40Z",
+      }),
+    ]);
+    await tauri.handle("detect_session_statuses", (args) => {
+      const ids = Array.isArray((args as { ids?: unknown }).ids)
+        ? ((args as { ids: string[] }).ids)
+        : [];
+      const merged = (
+        window as unknown as { __paneMergeCompleted?: boolean }
+      ).__paneMergeCompleted;
+      return ids.map((id) => ({
+        id,
+        status: "ready",
+        status_reason: "turn_complete",
+        branch: merged ? "main" : "feat/pane-merge-runner",
+        last_user_message: "Merge from the pane view",
+        last_user_message_at: "2026-01-02T00:00:00Z",
+        last_agent_message: "Merged and returned to main",
+        agent_activity_at: "2026-01-02T00:10:40Z",
+      }));
+    });
+    await tauri.handle("list_pull_requests", () => {
+      const w = window as unknown as {
+        __paneMergeCompleted?: boolean;
+        __panePrQueries?: number;
+      };
+      w.__panePrQueries = (w.__panePrQueries ?? 0) + 1;
+      const merged = w.__paneMergeCompleted === true;
+      return {
+        kind: "ok",
+        account: "test",
+        items: [
+          {
+            number: 605,
+            title: "Track PRs outside Kanban",
+            state: merged ? "MERGED" : "OPEN",
+            author: "ian",
+            head_branch: "feat/pane-merge-runner",
+            base_branch: "main",
+            url: "https://github.com/im-ian/acorn/pull/605",
+            updated_at: "2026-01-02T00:10:13Z",
+            closed_at: merged ? "2026-01-02T00:10:13Z" : null,
+            merged_at: merged ? "2026-01-02T00:10:13Z" : null,
+            is_draft: false,
+            checks: null,
+            labels: [],
+          },
+        ],
+      };
+    });
+
+    await page.goto("/");
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Panes",
+    );
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              (
+                window as unknown as { __panePrQueries?: number }
+              ).__panePrQueries ?? 0,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThan(0);
+
+    await page.evaluate(() => {
+      (
+        window as unknown as { __paneMergeCompleted?: boolean }
+      ).__paneMergeCompleted = true;
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await expect(
+      page.getByRole("button", { name: /pane merge runner main/ }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    const board = page.getByTestId("workspace-kanban");
+    const card = board.locator(
+      'section[aria-label="Done"] [data-kanban-session-id="pane-merge-runner"]',
+    );
+    await expect(card).toBeVisible();
+    await expect(card.getByTestId("workspace-kanban-card-pr")).toContainText(
+      "#605",
+    );
+  });
+
   test("groups active workspace sessions by lifecycle and opens a card terminal popover", async ({
     page,
     tauri,

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -207,6 +207,99 @@ test.describe("workspace kanban mode", () => {
     ).toContainText("PR #77");
   });
 
+  test("moves a merged PR session to Done after the worktree returns to main", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("merge-runner", "merge runner", "ready", {
+        branch: "feat/merge-runner",
+        status_reason: "turn_complete",
+        last_user_message: "Merge the pull request",
+        last_user_message_at: "2026-01-02T00:00:00Z",
+        last_agent_message: "Merged and cleaned up the branch",
+        agent_activity_at: "2026-01-02T00:10:40Z",
+      }),
+    ]);
+    await tauri.handle("detect_session_statuses", (args) => {
+      const ids = Array.isArray((args as { ids?: unknown }).ids)
+        ? ((args as { ids: string[] }).ids)
+        : [];
+      const merged = (
+        window as unknown as { __kanbanMergeCompleted?: boolean }
+      ).__kanbanMergeCompleted;
+      return ids.map((id) => ({
+        id,
+        status: "ready",
+        status_reason: "turn_complete",
+        branch: merged ? "main" : "feat/merge-runner",
+        last_user_message: "Merge the pull request",
+        last_user_message_at: "2026-01-02T00:00:00Z",
+        last_agent_message: "Merged and cleaned up the branch",
+        agent_activity_at: "2026-01-02T00:10:40Z",
+      }));
+    });
+    await tauri.handle("list_pull_requests", () => {
+      const merged = (
+        window as unknown as { __kanbanMergeCompleted?: boolean }
+      ).__kanbanMergeCompleted;
+      return {
+        kind: "ok",
+        account: "test",
+        items: [
+          {
+            number: 604,
+            title: "Keep merged sessions linked",
+            state: merged ? "MERGED" : "OPEN",
+            author: "ian",
+            head_branch: "feat/merge-runner",
+            base_branch: "main",
+            url: "https://github.com/im-ian/acorn/pull/604",
+            updated_at: "2026-01-02T00:10:13Z",
+            closed_at: merged ? "2026-01-02T00:10:13Z" : null,
+            merged_at: merged ? "2026-01-02T00:10:13Z" : null,
+            is_draft: false,
+            checks: null,
+            labels: [],
+          },
+        ],
+      };
+    });
+
+    await page.goto("/");
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    const board = page.getByTestId("workspace-kanban");
+    const card = board.locator('[data-kanban-session-id="merge-runner"]');
+    await expect(
+      board.locator(
+        'section[aria-label="Review"] [data-kanban-session-id="merge-runner"]',
+      ),
+    ).toBeVisible();
+    await expect(card.getByTestId("workspace-kanban-card-pr")).toContainText(
+      "#604",
+    );
+
+    await page.evaluate(() => {
+      (
+        window as unknown as { __kanbanMergeCompleted?: boolean }
+      ).__kanbanMergeCompleted = true;
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await expect(
+      board.locator(
+        'section[aria-label="Done"] [data-kanban-session-id="merge-runner"]',
+      ),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(card).toContainText("main");
+    await expect(card.getByTestId("workspace-kanban-card-pr")).toContainText(
+      "#604",
+    );
+  });
+
   test("groups active workspace sessions by lifecycle and opens a card terminal popover", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

Merged work sessions now reach Done reliably even when the merge workflow renames the branch, checks out `main`, or runs entirely from Panes.

1. **Stable PR identity** — persist each session's observed PR head branch so the card stays linked after the worktree returns to the base branch.
2. **Turn-aware completion timing** — compare PR completion against the latest real user request instead of transcript mtime, allowing same-turn merge cleanup and final reporting without reopening the card.
3. **View-independent tracking** — keep PR observation mounted in both Panes and Kanban while limiting git diff polling to visible Kanban boards.
4. **Regression coverage** — cover direct Kanban merges, Panes-only merge workflows, persisted links, timestamp fallbacks, and post-merge follow-up work.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Merge workflow | Checking out `main` severed the session-to-PR match | The observed PR remains attached to the originating session |
| Same-turn cleanup | Final agent output after merge could leave the card in Review | Merge cleanup and final reporting keep the completed card in Done |
| Panes workflow | PR links were captured only while Kanban was mounted | PR links are captured in Panes before Kanban is opened |
| Follow-up work | Timing guard could not distinguish cleanup from a new request | A user request after merge returns the session to Review |

## Design notes

- PR branch links are stored under the `acorn:` localStorage namespace and validated on read; current-branch matching remains the fallback when storage is unavailable.
- Provider transcript parsing surfaces the latest real user-message timestamp through the existing session-status poll. Chat sessions use their persisted message timestamp.
- Transcripts without a usable user timestamp retain the previous transcript-mtime guard for compatibility.
- Workspace-level PR polling runs across Panes and Kanban, deduplicated at the project repository root for ordinary worktrees; worktree diff polling remains Kanban-only to avoid background git work in Panes.

## Follow-up (not in this PR)

- Existing sessions whose PR merged before this link tracking was present are not reconstructed retroactively. They can still be moved with the existing manual Done action; reflog-based historical backfill can be considered separately if needed.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm test` — 87 files, 974 tests pass
- [x] `pnpm exec playwright test tests/e2e/kanban.spec.ts tests/e2e/right-panel.spec.ts` — 46 tests pass
- [x] `pnpm run build` — production build passes
- [x] `CARGO_TARGET_DIR=/Users/jthefloor/Documents/Personal/acorn/.acorn/cargo-target cargo test --manifest-path src-tauri/Cargo.toml --lib` — passes (1 ignored)
- [x] `CARGO_TARGET_DIR=/Users/jthefloor/Documents/Personal/acorn/.acorn/cargo-target cargo test --manifest-path src-tauri/Cargo.toml -p acorn-transcript` — 55 tests pass