### PR TITLE
fix(kanban): keep worked sessions out of idle on durable agent evidence

### DIFF
--- a/src/lib/kanbanLifecycle.test.ts
+++ b/src/lib/kanbanLifecycle.test.ts
@@ -151,6 +151,35 @@ describe("deriveKanbanStage", () => {
     ).toBe("review");
   });
 
+  it("keeps a worked session out of idle on a paired transcript when previews are empty", () => {
+    // Long, attachment-heavy claude sessions routinely lose every tail-derived
+    // preview: the real turn lines fall outside the 256 KiB status/preview
+    // window, so last_*_message and status_reason all come back empty. The
+    // paired transcript is the durable signal that this session's own agent has
+    // produced work, so the card must not regress to idle.
+    expect(
+      deriveKanbanStage(
+        makeSession({
+          status: "ready",
+          agent_transcript_id: "934c9bac-d8ea-4d46-aefa-659aca6f71db",
+        }),
+        ctx(),
+      ),
+    ).toBe("review");
+  });
+
+  it("uses transcript activity as completed-work evidence", () => {
+    expect(
+      deriveKanbanStage(
+        makeSession({
+          status: "ready",
+          agent_activity_at: "2026-01-02T00:00:00.000Z",
+        }),
+        ctx(),
+      ),
+    ).toBe("review");
+  });
+
   it("moves completed work to done only when the PR finished after agent activity", () => {
     for (const [state, timestamps] of [
       ["merged", { merged_at: "2026-01-03T00:00:00.000Z" }],

--- a/src/lib/kanbanLifecycle.ts
+++ b/src/lib/kanbanLifecycle.ts
@@ -43,6 +43,13 @@ function prStateUpper(pr: PullRequestInfo | null): string | null {
 
 function hasCompletedAgentWork(session: Session): boolean {
   if (session.status_reason === "turn_complete") return true;
+  // Durable own-agent evidence. The message previews and status_reason are
+  // derived from the last 256 KiB of the transcript; for long, attachment-heavy
+  // sessions the real turn lines fall outside that window and every tail signal
+  // comes back empty, which would otherwise regress a clearly-worked session to
+  // idle. A paired transcript (persisted) or observed transcript activity means
+  // this session's own agent has run, independent of the volatile tail preview.
+  if (session.agent_transcript_id || session.agent_activity_at) return true;
   return [
     session.last_user_message,
     session.last_agent_message,


### PR DESCRIPTION
## Problem

Claude sessions that have clearly done work sit in the **Idle** column of the lifecycle board — the card shows `status: Ready`, has an open PR, and hundreds of turns, yet lands in Idle.

## Root cause

`deriveKanbanStage` gates on `hasCompletedAgentWork` before any PR/review logic (`if (!hasCompletedAgentWork(session)) return "idle"`, added in #601). `hasCompletedAgentWork` checked only **ephemeral, tail-derived** signals: `status_reason === "turn_complete"` and the `last_*_message` previews. Those are derived from the last 256 KiB of the transcript (`extract_conversation_preview` and per-poll status detection). For long, attachment-heavy claude sessions the real turn lines fall outside that window, so every signal comes back empty and the card regresses to idle. `status_reason` has no `skip_serializing_if`, so it is also overwritten to `null` on every poll that finds no turn.

Measured on a real 13,333-line transcript, the 256 KiB tail was 26 attachment lines plus a handful of `tool_use`/`tool_result` and trailing meta — no usable assistant text line survived the window.

## Fix

`hasCompletedAgentWork` now also treats the session's own **durable** agent evidence as completed work: a paired `agent_transcript_id` (persisted in `sessions.json`) or observed `agent_activity_at` (transcript mtime). This keeps the intended rule that a stray branch-matching PR must not promote a never-worked session — an unstarted session has neither field — while making worked sessions robust to the volatile tail window.

Trade-off: a claude session that was opened but never prompted now shows **Review** instead of Idle, since it has a paired transcript.

## Test plan

- [x] Added two `deriveKanbanStage` cases: paired `agent_transcript_id` and `agent_activity_at` each keep a Ready session out of idle when previews are empty (RED before the fix: `expected 'idle' to be 'review'`).
- [x] `bunx vitest run src/lib/kanbanLifecycle.test.ts` — 31 passed.
- [x] `bunx vitest run src/lib/kanbanBoard.test.ts src/store.test.ts` — 179 passed.
- [x] `tsc --noEmit` clean for the change.
