### PR TITLE
fix(terminal): focus terminal when switching to an existing session tab

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -2082,6 +2082,20 @@ export const useAppStore = create<AppStateModel>()(
 
   selectSession(id) {
     get().selectTab(id);
+    // Move keyboard focus into the shown terminal. Without this, switching to
+    // an existing session tab leaves focus on the previous terminal, so a
+    // session parked on an input prompt (e.g. Claude's AskUserQuestion) takes
+    // no keyboard until the user clicks into it. rAF defers past TerminalHost's
+    // portal reattach, same as the session-create focus path above.
+    if (id !== null && typeof window !== "undefined") {
+      requestAnimationFrame(() => {
+        window.dispatchEvent(
+          new CustomEvent("acorn:focus-session", {
+            detail: { sessionId: id },
+          }),
+        );
+      });
+    }
   },
 
   focusLocalSessions() {
@@ -2839,6 +2853,8 @@ export const useAppStore = create<AppStateModel>()(
       // Focus the new session so Cmd+T (and any other entry point that goes
       // through the store) immediately surfaces it in its pane instead of
       // silently appending behind the existing active tab.
+      // Focuses the new session's xterm via the focus-session dispatch in
+      // `selectSession` (rAF-deferred past TerminalHost's portal reattach).
       get().selectSession(created.id);
       if (
         mode === "terminal" &&
@@ -2847,18 +2863,6 @@ export const useAppStore = create<AppStateModel>()(
           .openKanbanTerminalOnSessionCreate
       ) {
         get().openTerminalPopup(created.id);
-      }
-      // Grab keyboard focus for the new session's xterm. rAF defers past the
-      // portal reattach in `TerminalHost` so the slot is mounted in its pane
-      // body by the time `Terminal` calls `term.focus()`.
-      if (typeof window !== "undefined") {
-        requestAnimationFrame(() => {
-          window.dispatchEvent(
-            new CustomEvent("acorn:focus-session", {
-              detail: { sessionId: created.id },
-            }),
-          );
-        });
       }
       // First-run guidance for control sessions. Gated on a localStorage
       // flag so power users only see it once. App.tsx hosts the modal.


### PR DESCRIPTION
## Problem

Opening a session that is parked on an input prompt — most visibly Claude's `AskUserQuestion` — made the terminal look frozen: keystrokes (arrow keys, Enter) did nothing until the user physically clicked into the terminal, and the only obvious click target was the question option itself.

Root cause: switching to an existing session tab went through `selectSession → selectTab`, which only updated store state (active tab, `focusedPaneId`). It never moved keyboard focus into the shown terminal. Keyboard focus stayed on the previously active terminal.

For a normal session this is masked by streaming PTY output (constant repaints, and you click in to type anyway). A session idle-waiting on a prompt emits no output, so nothing self-heals and no keystroke lands — it reads as a frozen screen. Clicking the option is the first action that both lands DOM focus in xterm and, via the mouse-tracking click replay, answers the prompt, so clicking specifically the option looked like "the one thing that works". Mouse mode was never the cause.

## Fix

`selectSession` now dispatches `acorn:focus-session` for the activated session (rAF-deferred past `TerminalHost`'s portal reattach) — the same focus path session-create already used. The now-redundant create-path dispatch is dropped.

All `selectSession` call sites are explicit user navigations (tab click, sidebar, command palette, notification click, needs-input jump shortcut), so focusing the target terminal is the intended behavior in every case.

## Test plan

- [ ] Start Claude in a session, drive it to an `AskUserQuestion` prompt.
- [ ] Switch to another tab, then switch back to the question session.
- [ ] Arrow keys move the selection and Enter answers without clicking into the terminal first.
- [ ] `Cmd+T` / session-create still focuses the new terminal (no regression from the dropped duplicate dispatch).
- [ ] Split view / multi-input: switching sessions does not steal focus from a pane the user is actively typing in unexpectedly.
