### PR TITLE
fix(kanban): preserve lifecycle columns after session deletion

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -592,6 +592,7 @@ describe("refreshAll", () => {
   it("preserves runtime session metadata while applying refreshed persisted fields", async () => {
     const runtimeSession = session("a1", REPO_A, {
       name: "before refresh",
+      branch: "feat/live-branch",
       status_reason: "turn_complete",
       status_started_at: "2026-01-02T00:00:00.000Z",
       last_message: "Finished the requested change",
@@ -615,6 +616,7 @@ describe("refreshAll", () => {
 
     expect(useAppStore.getState().sessions[0]).toMatchObject({
       name: "after refresh",
+      branch: "feat/live-branch",
       status_reason: "turn_complete",
       status_started_at: "2026-01-02T00:00:00.000Z",
       last_message: "Finished the requested change",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -588,6 +588,46 @@ describe("refreshAll", () => {
     expect(s.workspaces[folder.id].panes.root.tabIds).toEqual(["web"]);
     expect(s.workspaces[REPO_A].panes.root.tabIds).toEqual(["root"]);
   });
+
+  it("preserves runtime session metadata while applying refreshed persisted fields", async () => {
+    const runtimeSession = session("a1", REPO_A, {
+      name: "before refresh",
+      status_reason: "turn_complete",
+      status_started_at: "2026-01-02T00:00:00.000Z",
+      last_message: "Finished the requested change",
+      last_user_message: "Implement the requested change",
+      last_agent_message: "Finished the requested change",
+      agent_provider: "codex",
+      agent_transcript_provider: "codex",
+      agent_transcript_path: "/tmp/codex-session.jsonl",
+      agent_activity_at: "2026-01-02T00:00:05.000Z",
+      active_processes: [{ pid: 42, name: "codex", depth: 1 }],
+      git_context_path: `${REPO_A}/.worktrees/live`,
+    });
+    await seed([project(REPO_A, 0)], [runtimeSession]);
+
+    mockApi.listSessions.mockResolvedValueOnce([
+      session("a1", REPO_A, { name: "after refresh" }),
+    ]);
+    mockApi.listProjects.mockResolvedValueOnce([project(REPO_A, 0)]);
+
+    await useAppStore.getState().refreshAll();
+
+    expect(useAppStore.getState().sessions[0]).toMatchObject({
+      name: "after refresh",
+      status_reason: "turn_complete",
+      status_started_at: "2026-01-02T00:00:00.000Z",
+      last_message: "Finished the requested change",
+      last_user_message: "Implement the requested change",
+      last_agent_message: "Finished the requested change",
+      agent_provider: "codex",
+      agent_transcript_provider: "codex",
+      agent_transcript_path: "/tmp/codex-session.jsonl",
+      agent_activity_at: "2026-01-02T00:00:05.000Z",
+      active_processes: [{ pid: 42, name: "codex", depth: 1 }],
+      git_context_path: `${REPO_A}/.worktrees/live`,
+    });
+  });
 });
 
 describe("selectSession", () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -122,8 +122,10 @@ function mergeRefreshedSessionRuntimeState(
     if (!current) return refreshed;
 
     const merged = { ...refreshed };
+    const hasOwn = <K extends keyof Session>(session: Session, key: K) =>
+      Object.prototype.hasOwnProperty.call(session, key);
     const preserve = <K extends keyof Session>(key: K) => {
-      if (Object.prototype.hasOwnProperty.call(current, key)) {
+      if (!hasOwn(refreshed, key) && hasOwn(current, key)) {
         merged[key] = current[key];
       }
     };
@@ -143,7 +145,10 @@ function mergeRefreshedSessionRuntimeState(
     preserve("agent_activity_at");
     preserve("active_processes");
     preserve("git_context_path");
-    if (current.git_context_path?.trim()) {
+    if (
+      !hasOwn(refreshed, "git_context_path") &&
+      current.git_context_path?.trim()
+    ) {
       merged.branch = current.branch;
     }
     return merged;

--- a/src/store.ts
+++ b/src/store.ts
@@ -110,6 +110,46 @@ function sessionProcessSummariesEqual(
   );
 }
 
+function mergeRefreshedSessionRuntimeState(
+  refreshedSessions: Session[],
+  currentSessions: Session[],
+): Session[] {
+  const currentById = new Map(
+    currentSessions.map((session) => [session.id, session]),
+  );
+  return refreshedSessions.map((refreshed) => {
+    const current = currentById.get(refreshed.id);
+    if (!current) return refreshed;
+
+    const merged = { ...refreshed };
+    const preserve = <K extends keyof Session>(key: K) => {
+      if (Object.prototype.hasOwnProperty.call(current, key)) {
+        merged[key] = current[key];
+      }
+    };
+
+    if (current.status === refreshed.status) {
+      preserve("status_reason");
+      preserve("status_started_at");
+    }
+    if (refreshed.last_message === null && current.last_message !== null) {
+      merged.last_message = current.last_message;
+    }
+    preserve("last_user_message");
+    preserve("last_agent_message");
+    preserve("agent_provider");
+    preserve("agent_transcript_provider");
+    preserve("agent_transcript_path");
+    preserve("agent_activity_at");
+    preserve("active_processes");
+    preserve("git_context_path");
+    if (current.git_context_path?.trim()) {
+      merged.branch = current.branch;
+    }
+    return merged;
+  });
+}
+
 interface SessionPlacementIntent {
   projectFolderId: string;
   paneId: PaneId;
@@ -1582,9 +1622,13 @@ export const useAppStore = create<AppStateModel>()(
     const seq = ++refreshSessionsSeq;
     set({ loading: true, error: null });
     try {
-      const sessions = await api.listSessions();
+      const refreshedSessions = await api.listSessions();
       if (seq !== refreshSessionsSeq) return;
       set((s) => {
+        const sessions = mergeRefreshedSessionRuntimeState(
+          refreshedSessions,
+          s.sessions,
+        );
         const allowEmptyWipe = s.sessionsLoadedCleanly;
         const reconciled = reconcileWorkspaces(
           sessions,
@@ -1721,7 +1765,9 @@ export const useAppStore = create<AppStateModel>()(
             ? errorMessage(projectsResult.reason)
             : null;
       const sessions =
-        receivedSessions ? sessionsResult.value : s.sessions;
+        receivedSessions
+          ? mergeRefreshedSessionRuntimeState(sessionsResult.value, s.sessions)
+          : s.sessions;
       const projects =
         projectsResult.status === "fulfilled"
           ? projectsResult.value

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -104,6 +104,116 @@ test.describe("workspace kanban mode", () => {
     ).toContainText("+19-3");
   });
 
+  test("keeps surviving cards in their lifecycle columns while deleting a completed session", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          sessions: {
+            confirmRemove: true,
+            confirmDeleteIsolatedWorktrees: true,
+            showRestartPromptOnExit: true,
+          },
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __kanbanSessionRemoved?: boolean };
+      const survivor = {
+        id: "survivor",
+        name: "survivor",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.worktrees/survivor",
+        branch: "feat/survivor",
+        isolated: true,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: true,
+      };
+      if (w.__kanbanSessionRemoved) return [survivor];
+      return [
+        {
+          id: "completed",
+          name: "completed",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo/.worktrees/completed",
+          branch: "feat/completed",
+          isolated: true,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:05Z",
+          last_message: null,
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: true,
+        },
+        {
+          ...survivor,
+          last_user_message: "Implement the lifecycle refresh fix",
+          last_agent_message: "The lifecycle refresh fix is ready",
+          agent_activity_at: "2026-01-01T00:00:04Z",
+        },
+      ];
+    });
+    await tauri.handle("remove_session", () => {
+      const w = window as unknown as { __kanbanSessionRemoved?: boolean };
+      w.__kanbanSessionRemoved = true;
+      return {
+        token: "kanban-removal-token",
+        repoPath: "/tmp/demo",
+        worktreePath: "/tmp/demo/.worktrees/completed",
+        gitCommonDir: "/tmp/demo/.git",
+      };
+    });
+
+    await page.goto("/");
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    const board = page.getByTestId("workspace-kanban");
+    const completedCard = board.locator(
+      '[data-kanban-session-id="completed"]',
+    );
+    await completedCard.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Mark as done" }).click();
+    await expect(
+      board.locator(
+        'section[aria-label="Done"] [data-kanban-session-id="completed"]',
+      ),
+    ).toBeVisible();
+
+    await expect(page.getByRole("menu")).toHaveCount(0);
+    await page
+      .locator('[data-panel-id="sidebar"]')
+      .getByRole("button", { name: /^completed worktree/ })
+      .first()
+      .click({ button: "right" });
+    await page
+      .getByRole("menuitem", { name: "Remove Session", exact: true })
+      .click();
+    const dialog = page.getByRole("dialog");
+    await dialog
+      .getByRole("button", { name: "Remove + delete worktree" })
+      .click();
+
+    await expect(page.getByText(/Removing completed worktree in \d+s/)).toBeVisible();
+    await expect(
+      board.locator(
+        'section[aria-label="Review"] [data-kanban-session-id="survivor"]',
+      ),
+    ).toBeVisible();
+  });
+
   test("updates card PR metadata when the PR list refresh discovers a new PR", async ({
     page,
     tauri,

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -206,7 +206,9 @@ test.describe("workspace kanban mode", () => {
       .getByRole("button", { name: "Remove + delete worktree" })
       .click();
 
-    await expect(page.getByText(/Removing completed worktree in \d+s/)).toBeVisible();
+    await expect(
+      page.getByText(/Removing completed worktree in \d+s/),
+    ).toBeVisible();
     await expect(
       board.locator(
         'section[aria-label="Review"] [data-kanban-session-id="survivor"]',


### PR DESCRIPTION
## Summary

Session deletion now preserves the runtime metadata that keeps surviving Kanban cards in their correct lifecycle columns.

1. **Runtime-state merge** — merge persisted session refreshes with the latest status-poll metadata instead of replacing surviving session objects wholesale.
2. **Lifecycle stability** — preserve transcript previews, agent activity, process context, status timing, and paired live branch context until a fresher runtime value arrives.
3. **Regression coverage** — cover the store refresh contract and the visible completed-session deletion + worktree-removal-toast flow.

## Expected impact

| Behavior | Before | After |
| --- | --- | --- |
| Delete a completed Kanban session | Some surviving cards briefly fall back to Idle | Surviving cards remain in their lifecycle columns |
| Refresh persisted session fields | Runtime-only agent metadata is discarded | Persisted updates apply while runtime metadata remains stable |
| Fresh runtime values returned by refresh | Could be overwritten by older frontend state | Fresh response values take precedence |

## Design notes

- `refreshSessions()` and `refreshAll()` share one ID-based merge path so every backend session refresh follows the same contract.
- Persisted fields such as names still update from the backend. Runtime-only fields are copied from the current session only when the refresh response does not provide them.
- Live `git_context_path` and `branch` stay paired to avoid combining a live worktree path with a stale persisted branch.
- Status reason and start time are retained only while the persisted status is unchanged.

## Test plan

- [x] `pnpm run test` — 87 files, 971 tests passed
- [x] `pnpm run test:e2e` — 227 Playwright tests passed
- [x] `pnpm exec playwright test tests/e2e/kanban.spec.ts` — 19 Kanban tests passed
- [x] `pnpm run build` — TypeScript and Vite production build passed
- [x] `git diff --check origin/main...HEAD` — passed
