### PR TITLE
fix(files): dispose late filesystem listeners

### DIFF
--- a/src/components/FileExplorer.listener.test.tsx
+++ b/src/components/FileExplorer.listener.test.tsx
@@ -1,0 +1,102 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  fsGitStatus: vi.fn(),
+  fsListDir: vi.fn(),
+  fsShellEditor: vi.fn(),
+}));
+
+const eventMocks = vi.hoisted(() => ({
+  listen: vi.fn(),
+}));
+
+vi.mock("../lib/api", () => ({
+  FS_CHANGED_EVENT: "acorn:fs-changed",
+  api: {
+    fsGitStatus: apiMocks.fsGitStatus,
+    fsListDir: apiMocks.fsListDir,
+    fsShellEditor: apiMocks.fsShellEditor,
+  },
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: eventMocks.listen,
+}));
+
+vi.mock("../store", () => ({
+  useAppStore: {
+    getState: () => ({ activeSessionId: null }),
+    subscribe: () => () => {},
+  },
+}));
+
+vi.mock("../lib/toasts", () => ({
+  useToasts: (selector: (state: { show: () => void }) => unknown) =>
+    selector({ show: vi.fn() }),
+}));
+
+vi.mock("../lib/useTranslation", () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+import { FileExplorer } from "./FileExplorer";
+
+describe("FileExplorer filesystem listener", () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+  let resolveListen: ((unlisten: () => void) => void) | null;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    resolveListen = null;
+
+    apiMocks.fsShellEditor.mockResolvedValue("");
+    apiMocks.fsListDir.mockResolvedValue({ entries: [], repo_root: null });
+    apiMocks.fsGitStatus.mockResolvedValue({
+      statuses: {},
+      huge: false,
+      limit: 5_000,
+    });
+    eventMocks.listen.mockImplementation(
+      () =>
+        new Promise<() => void>((resolve) => {
+          resolveListen = resolve;
+        }),
+    );
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+    }
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("disposes a listener that finishes registering after unmount", async () => {
+    await act(async () => {
+      root?.render(<FileExplorer rootPath="/tmp/acorn" />);
+    });
+    expect(eventMocks.listen).toHaveBeenCalledOnce();
+
+    act(() => root?.unmount());
+    root = null;
+
+    const unlisten = vi.fn();
+    await act(async () => {
+      resolveListen?.(unlisten);
+      await Promise.resolve();
+    });
+
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -724,7 +724,9 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
   // large generated-file bursts do not fan out into per-file work.
   useEffect(() => {
     let cancel: (() => void) | null = null;
+    let cancelled = false;
     void listen<FsChangePayload>(FS_CHANGED_EVENT, (event) => {
+      if (cancelled) return;
       const payload = event.payload;
       if (
         payload.root &&
@@ -768,9 +770,14 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       scheduleGitStatusRefresh("fs-event");
       scheduleGitDiffStats();
     }).then((unlisten) => {
-      cancel = unlisten;
+      if (cancelled) {
+        unlisten();
+      } else {
+        cancel = unlisten;
+      }
     });
     return () => {
+      cancelled = true;
       if (cancel) cancel();
     };
   }, [rootPath, fetchDir, scheduleGitStatusRefresh, scheduleGitDiffStats]);


### PR DESCRIPTION
Supersedes #617 (its branch/base was pruned mid-stack-merge). Disposes a FileExplorer filesystem listener that finishes registering after unmount, so late registration immediately invokes its disposer (StrictMode-safe). Adds regression coverage.