### PR TITLE
fix(ui): complete tooltip coverage across overlay actions

### DIFF
--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { ExternalLink, X } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useTranslation } from "../lib/useTranslation";
+import { Tooltip } from "./Tooltip";
 
 interface ImageLightboxProps {
   image: { src: string; alt?: string } | null;
@@ -58,25 +59,32 @@ export function ImageLightbox({ image, onClose }: ImageLightboxProps) {
       onClick={onClose}
     >
       <div className="absolute right-3 top-3 flex items-center gap-1">
-        <button
-          type="button"
-          aria-label={t("imageLightbox.openInBrowser")}
-          onClick={(e) => {
-            e.stopPropagation();
-            void openUrl(image.src);
-          }}
-          className="rounded p-1.5 text-white/70 transition hover:bg-white/10 hover:text-white"
+        <Tooltip
+          label={t("imageLightbox.openInBrowser")}
+          side="bottom"
         >
-          <ExternalLink size={16} />
-        </button>
-        <button
-          type="button"
-          aria-label={t("imageLightbox.close")}
-          onClick={onClose}
-          className="rounded p-1.5 text-white/70 transition hover:bg-white/10 hover:text-white"
-        >
-          <X size={18} />
-        </button>
+          <button
+            type="button"
+            aria-label={t("imageLightbox.openInBrowser")}
+            onClick={(e) => {
+              e.stopPropagation();
+              void openUrl(image.src);
+            }}
+            className="rounded p-1.5 text-white/70 transition hover:bg-white/10 hover:text-white"
+          >
+            <ExternalLink size={16} />
+          </button>
+        </Tooltip>
+        <Tooltip label={t("imageLightbox.close")} side="bottom">
+          <button
+            type="button"
+            aria-label={t("imageLightbox.close")}
+            onClick={onClose}
+            className="rounded p-1.5 text-white/70 transition hover:bg-white/10 hover:text-white"
+          >
+            <X size={18} />
+          </button>
+        </Tooltip>
       </div>
       <img
         src={image.src}

--- a/src/components/IssueDetailModal.tsx
+++ b/src/components/IssueDetailModal.tsx
@@ -399,14 +399,19 @@ function IssueDetailBody({
               <ExternalLink size={14} />
             </button>
           </Tooltip>
-          <button
-            type="button"
-            aria-label={dt(t, "dialogs.common.close")}
-            onClick={onClose}
-            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          <Tooltip
+            label={dt(t, "dialogs.common.close")}
+            side="bottom"
           >
-            <X size={16} />
-          </button>
+            <button
+              type="button"
+              aria-label={dt(t, "dialogs.common.close")}
+              onClick={onClose}
+              className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+            >
+              <X size={16} />
+            </button>
+          </Tooltip>
         </div>
       </header>
       <div className="acorn-no-scrollbar min-h-0 flex-1 overflow-y-auto">

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -726,14 +726,19 @@ function DetailBody({
               <ExternalLink size={14} />
             </button>
           </Tooltip>
-          <button
-            type="button"
-            aria-label={dt(t, "dialogs.common.close")}
-            onClick={onClose}
-            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          <Tooltip
+            label={dt(t, "dialogs.common.close")}
+            side="bottom"
           >
-            <X size={16} />
-          </button>
+            <button
+              type="button"
+              aria-label={dt(t, "dialogs.common.close")}
+              onClick={onClose}
+              className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+            >
+              <X size={16} />
+            </button>
+          </Tooltip>
         </div>
       </header>
 
@@ -909,14 +914,19 @@ function DetailSkeleton({
           <span className="mx-1 h-4 w-px bg-border" aria-hidden />
           <RefreshButton onClick={onRefresh} loading={refreshing} size={14} />
           <SkeletonBlock className="h-6 w-6 rounded bg-fg-muted/10" />
-          <button
-            type="button"
-            aria-label={dt(t, "dialogs.common.close")}
-            onClick={onClose}
-            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          <Tooltip
+            label={dt(t, "dialogs.common.close")}
+            side="bottom"
           >
-            <X size={16} />
-          </button>
+            <button
+              type="button"
+              aria-label={dt(t, "dialogs.common.close")}
+              onClick={onClose}
+              className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+            >
+              <X size={16} />
+            </button>
+          </Tooltip>
         </div>
       </header>
 

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -4108,14 +4108,19 @@ function WorkflowRunDetailModal({
                   </button>
                 </Tooltip>
               ) : null}
-              <button
-                type="button"
-                aria-label={t("dialogs.common.close")}
-                onClick={onClose}
-                className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+              <Tooltip
+                label={t("dialogs.common.close")}
+                side="bottom"
               >
-                <X size={16} />
-              </button>
+                <button
+                  type="button"
+                  aria-label={t("dialogs.common.close")}
+                  onClick={onClose}
+                  className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+                >
+                  <X size={16} />
+                </button>
+              </Tooltip>
             </div>
           </header>
           <div className="acorn-no-scrollbar min-h-0 flex-1 overflow-y-auto text-xs">
@@ -4164,14 +4169,19 @@ function WorkflowRunDetailSkeleton({ onClose }: { onClose: () => void }) {
         </div>
         <div className="flex shrink-0 items-center gap-1">
           <SkeletonBlock className="h-6 w-6 rounded bg-fg-muted/10" />
-          <button
-            type="button"
-            aria-label={t("dialogs.common.close")}
-            onClick={onClose}
-            className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          <Tooltip
+            label={t("dialogs.common.close")}
+            side="bottom"
           >
-            <X size={16} />
-          </button>
+            <button
+              type="button"
+              aria-label={t("dialogs.common.close")}
+              onClick={onClose}
+              className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+            >
+              <X size={16} />
+            </button>
+          </Tooltip>
         </div>
       </header>
       <div className="acorn-no-scrollbar min-h-0 flex-1 overflow-y-auto text-xs">

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -2435,19 +2435,28 @@ function KanbanTerminalPopover({
               <RotateCcw size={14} />
             </IconButton>
           </Tooltip>
-          <IconButton
-            aria-label={t(
+          <Tooltip
+            label={t(
               isExpanded
                 ? "workspace.kanban.terminalPopover.restore"
                 : "workspace.kanban.terminalPopover.expand",
             )}
-            data-testid="kanban-terminal-popover-expand"
-            onClick={() => setIsExpanded((current) => !current)}
-            size="sm"
-            surface="panel"
+            side="bottom"
           >
-            {isExpanded ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
-          </IconButton>
+            <IconButton
+              aria-label={t(
+                isExpanded
+                  ? "workspace.kanban.terminalPopover.restore"
+                  : "workspace.kanban.terminalPopover.expand",
+              )}
+              data-testid="kanban-terminal-popover-expand"
+              onClick={() => setIsExpanded((current) => !current)}
+              size="sm"
+              surface="panel"
+            >
+              {isExpanded ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+            </IconButton>
+          </Tooltip>
           <Tooltip
             label={t("dialogs.common.close")}
             shortcut={closeShortcut}

--- a/src/components/ui/ModalHeader.tsx
+++ b/src/components/ui/ModalHeader.tsx
@@ -2,6 +2,7 @@ import { X } from "lucide-react";
 import { type ReactNode } from "react";
 import type { TranslationKey, Translator } from "../../lib/i18n";
 import { useTranslation } from "../../lib/useTranslation";
+import { Tooltip } from "../Tooltip";
 import { IconButton } from "./Button";
 import { type ModalVariant } from "./Modal";
 
@@ -39,14 +40,19 @@ export function ModalHeader({
   const closeButton = (
     <div className="flex shrink-0 items-center gap-1">
       {actions}
-      <IconButton
-        aria-label={dt(t, "dialogs.common.close")}
-        onClick={onClose}
-        size="sm"
-        surface={variant}
+      <Tooltip
+        label={dt(t, "dialogs.common.close")}
+        side="bottom"
       >
-        <X size={14} />
-      </IconButton>
+        <IconButton
+          aria-label={dt(t, "dialogs.common.close")}
+          onClick={onClose}
+          size="sm"
+          surface={variant}
+        >
+          <X size={14} />
+        </IconButton>
+      </Tooltip>
     </div>
   );
 

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -1121,11 +1121,19 @@ test.describe("workspace kanban mode", () => {
       "aria-label",
       "Expand terminal",
     );
+    await expandButton.hover();
+    await expect(
+      page.getByRole("tooltip", { name: "Expand terminal" }),
+    ).toBeVisible();
     await expandButton.click();
     await expect(expandButton).toHaveAttribute(
       "aria-label",
       "Restore terminal size",
     );
+    await expandButton.hover();
+    await expect(
+      page.getByRole("tooltip", { name: "Restore terminal size" }),
+    ).toBeVisible();
     await expect(resizeHandle).toHaveCount(0);
     const expandedPopoverBox = await shellPopover.boundingBox();
     const viewport = await page.evaluate(() => ({

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -165,6 +165,10 @@ test.describe("right panel: tab switching", () => {
     });
     await expect(dialog).toBeVisible();
     await expect(dialog.getByLabel("loading diff...")).toBeVisible();
+    await dialog.getByRole("button", { name: "Close" }).hover();
+    await expect(
+      page.getByRole("tooltip", { name: "Close" }),
+    ).toBeVisible();
 
     await page.evaluate(() => {
       (window as unknown as { __releaseCommitDiff?: boolean })
@@ -205,7 +209,8 @@ test.describe("right panel: tab switching", () => {
       detail: {
         number: 42,
         title: "Render issue detail in app",
-        body: "Loaded issue body from gh.",
+        body:
+          "Loaded issue body from gh.\n\n![Issue screenshot](https://example.com/issue.png)",
         state: "OPEN",
         author: "im-ian",
         url: "https://github.com/im-ian/acorn/issues/42",
@@ -251,6 +256,27 @@ test.describe("right panel: tab switching", () => {
     const comments = dialog.locator("section ul > li");
     await expect(comments.nth(0)).toContainText("Older in-app issue comment.");
     await expect(comments.nth(1)).toContainText("Newer in-app issue comment.");
+
+    await dialog.getByRole("img", { name: "Issue screenshot" }).click();
+    const imagePreview = page.getByRole("dialog", { name: "Image preview" });
+    await expect(imagePreview).toBeVisible();
+    await imagePreview
+      .getByRole("button", { name: "Open in browser" })
+      .hover();
+    await expect(
+      page.getByRole("tooltip", { name: "Open in browser" }),
+    ).toBeVisible();
+    await imagePreview.getByRole("button", { name: "Close" }).hover();
+    await expect(
+      page.getByRole("tooltip", { name: "Close" }),
+    ).toBeVisible();
+    await imagePreview.getByRole("button", { name: "Close" }).click();
+    await expect(imagePreview).toHaveCount(0);
+
+    await dialog.getByRole("button", { name: "Close" }).hover();
+    await expect(
+      page.getByRole("tooltip", { name: "Close" }),
+    ).toBeVisible();
 
     await dialog.getByRole("button", { name: "Oldest first" }).click();
     await expect(comments.nth(0)).toContainText("Newer in-app issue comment.");


### PR DESCRIPTION
## Summary
Completes tooltip coverage for icon-only actions across kanban and modal overlays.

1. **Kanban terminal overlay** — add localized tooltips for expand and restore actions while preserving the dynamic accessible label.
2. **Shared modal header** — add a close tooltip at the common header level so settings, dialogs, and diff viewers inherit consistent behavior.
3. **Custom overlays** — cover close actions in issue, pull request, workflow-run, and loading-state headers plus open and close actions in the image lightbox.
4. **Regression coverage** — verify tooltip text through the existing kanban and right-panel Playwright flows.

## Expected impact
| Interaction | Before | After |
| --- | --- | --- |
| Kanban terminal expand / restore | Icon and accessible label only | Localized hover and focus tooltip |
| Standard modal close | Icon and accessible label only | Consistent close tooltip from the shared header |
| Custom detail and image overlays | Mixed tooltip coverage | Every icon-only header action exposes a tooltip |

## Design notes
- Reuses the existing portal-based Tooltip component so overlays are not clipped by modal or panel overflow.
- Keeps every existing aria-label and click handler intact; this change only adds the visible hover and focus affordance.
- Custom headers remain explicit because their richer metadata layouts do not use ModalHeader.

## Test plan
- [x] pnpm run typecheck
- [x] pnpm run test — 95 files and 1,028 tests passed
- [x] pnpm exec playwright test tests/e2e/kanban.spec.ts tests/e2e/right-panel.spec.ts --grep "groups active workspace sessions|double-clicking a commit|double-clicking an issue" — 3 tests passed
- [x] pnpm run build