### PR TITLE
fix(status): preserve Codex input waits across process arbitration

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -765,6 +765,24 @@ mod tests {
     }
 
     #[test]
+    fn hook_tool_activity_is_scoped_to_a_turn_and_cleared_on_remove() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        let started_at = std::time::SystemTime::UNIX_EPOCH
+            + std::time::Duration::from_secs(123_456);
+
+        store.mark_hook_tool_started_at(&session.id, started_at);
+        assert_eq!(store.hook_tool_started_at(&session.id), Some(started_at));
+
+        store.begin_hook_turn(&session.id);
+        assert_eq!(store.hook_tool_started_at(&session.id), None);
+
+        store.mark_hook_tool_started_at(&session.id, started_at);
+        store.remove(&session.id).expect("session exists");
+        assert_eq!(store.hook_tool_started_at(&session.id), None);
+    }
+
+    #[test]
     fn hook_revision_guards_conditional_status_refresh() {
         let store = SessionStore::new();
         let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::SystemTime;
 use uuid::Uuid;
 
 fn default_true() -> bool {
@@ -364,6 +365,10 @@ pub struct SessionStore {
     /// advances the revision before touching the session row so conditional
     /// status writes can reject observations made before a newer event.
     hook_revisions: DashMap<Uuid, u64>,
+    /// Start of the first Codex exec tool observed in the current turn.
+    /// Runtime-only: after an app restart, process-tree arbitration stays
+    /// conservative until a fresh tagged tool event arrives.
+    hook_tool_started_at: DashMap<Uuid, SystemTime>,
 }
 
 impl SessionStore {
@@ -481,6 +486,24 @@ impl SessionStore {
                 entry.hook_active = true;
             }
         }
+    }
+
+    /// Reset per-turn tool evidence when Codex reports a new task boundary.
+    pub fn begin_hook_turn(&self, id: &Uuid) {
+        self.hook_tool_started_at.remove(id);
+    }
+
+    /// Record the first exec tool observed in the current Codex turn. Keeping
+    /// the earliest timestamp ensures a background process launched by an
+    /// earlier tool still counts after later tools run in the same turn.
+    pub fn mark_hook_tool_started_at(&self, id: &Uuid, started_at: SystemTime) {
+        self.hook_tool_started_at.entry(*id).or_insert(started_at);
+    }
+
+    pub fn hook_tool_started_at(&self, id: &Uuid) -> Option<SystemTime> {
+        self.hook_tool_started_at
+            .get(id)
+            .map(|started_at| *started_at)
     }
 
     /// Whether `id` has ever reported an agent lifecycle hook event — either
@@ -654,6 +677,7 @@ impl SessionStore {
     pub fn remove(&self, id: &Uuid) -> SessionResult<Session> {
         self.hook_confirmed.remove(id);
         self.hook_revisions.remove(id);
+        self.hook_tool_started_at.remove(id);
         self.inner
             .remove(id)
             .map(|(_, v)| v)
@@ -768,8 +792,8 @@ mod tests {
     fn hook_tool_activity_is_scoped_to_a_turn_and_cleared_on_remove() {
         let store = SessionStore::new();
         let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
-        let started_at = std::time::SystemTime::UNIX_EPOCH
-            + std::time::Duration::from_secs(123_456);
+        let started_at =
+            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(123_456);
 
         store.mark_hook_tool_started_at(&session.id, started_at);
         assert_eq!(store.hook_tool_started_at(&session.id), Some(started_at));

--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -2,7 +2,7 @@ use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use acorn_session::{SessionAgentProvider, SessionStatus, SessionStore};
 use serde::Deserialize;
@@ -68,6 +68,21 @@ pub fn apply_agent_hook_event(
     // just-set resting status (Ready/WaitingForInput) back to Working on its
     // next tick. See `poll_defers_to_hook` in `commands`.
     sessions.mark_hook_active(&event.session_id);
+
+    // The Codex JSONL watcher tags task and exec starts separately. This
+    // runtime-only turn evidence lets the process poll distinguish a real
+    // background command from helpers that live for the whole Codex session.
+    // Generic native hook events intentionally do not reset this marker: they
+    // arrive through a separate channel and can race the ordered JSONL tail.
+    if event.provider == SessionAgentProvider::Codex && event.event == AgentHookEventKind::Start {
+        match event.source.as_deref() {
+            Some("turn") => sessions.begin_hook_turn(&event.session_id),
+            Some("tool") => {
+                sessions.mark_hook_tool_started_at(&event.session_id, SystemTime::now())
+            }
+            _ => {}
+        }
+    }
 
     let status = event.event.session_status();
     sessions

--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -449,6 +449,48 @@ mod tests {
         );
     }
 
+    #[test]
+    fn codex_hook_sources_scope_tool_activity_to_the_current_turn() {
+        let sessions = acorn_session::SessionStore::new();
+        let mut session = Session::new(
+            "Codex".to_string(),
+            "/tmp/repo".into(),
+            "/tmp/repo".into(),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        session.agent_provider = Some(SessionAgentProvider::Codex);
+        let session_id = session.id;
+        sessions.insert(session);
+
+        let apply = |source: &str, event| {
+            apply_agent_hook_event(
+                &sessions,
+                AgentHookEvent {
+                    session_id,
+                    provider: SessionAgentProvider::Codex,
+                    event,
+                    message: None,
+                    source: Some(source.to_string()),
+                },
+            )
+            .expect("event applies")
+        };
+
+        apply("turn", AgentHookEventKind::Start);
+        assert_eq!(sessions.hook_tool_started_at(&session_id), None);
+
+        apply("tool", AgentHookEventKind::Start);
+        assert!(sessions.hook_tool_started_at(&session_id).is_some());
+
+        apply("hook", AgentHookEventKind::Stop);
+        assert!(sessions.hook_tool_started_at(&session_id).is_some());
+
+        apply("turn", AgentHookEventKind::Start);
+        assert_eq!(sessions.hook_tool_started_at(&session_id), None);
+    }
+
     fn post(hooks: &AgentHookServer, token: &str, body: &str) -> String {
         let mut stream = TcpStream::connect(addr_from_url(hooks.hook_url())).expect("connect hook");
         write!(

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -652,9 +652,13 @@ mod tests {
             .contains("notify=[\\\"bash\\\",\\\"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\\\"]"));
         assert!(wrapper.contains("CODEX_TUI_RECORD_SESSION=1"));
         assert!(wrapper.contains("ACORN_AGENT_HOOK_URL"));
+        assert!(wrapper.contains("\"$_acorn_notify\" start turn"));
+        assert!(wrapper.contains("\"$_acorn_notify\" start tool"));
 
         let notify = fs::read_to_string(dir.join("acorn-codex-notify")).unwrap();
         assert!(notify.contains("\"provider\":\"codex\""));
+        assert!(notify.contains("source=\"${2-hook}\""));
+        assert!(notify.contains("\"source\":\"%s\""));
         // A completed turn is ready for optional follow-up. Only explicit
         // approval or question events require user input.
         assert!(notify.contains("agent-turn-complete|task_complete|turn_complete) event=\"stop\""));

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -86,7 +86,7 @@ if [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
           [ -n "$_acorn_turn_id" ] || _acorn_turn_id="task_started"
           if [ "$_acorn_turn_id" != "$_acorn_last_turn_id" ]; then
             _acorn_last_turn_id="$_acorn_turn_id"
-            "$_acorn_notify" start >/dev/null 2>&1 || true
+            "$_acorn_notify" start turn >/dev/null 2>&1 || true
           fi
           ;;
         *'"dir":"to_tui"'*'"kind":"codex_event"'*'"msg":{"type":"'*'_approval_request"'*)
@@ -107,10 +107,10 @@ if [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
           if [ -n "$_acorn_exec_call_id" ]; then
             if [ "$_acorn_exec_call_id" != "$_acorn_last_exec_call_id" ]; then
               _acorn_last_exec_call_id="$_acorn_exec_call_id"
-              "$_acorn_notify" start >/dev/null 2>&1 || true
+              "$_acorn_notify" start tool >/dev/null 2>&1 || true
             fi
           else
-            "$_acorn_notify" start >/dev/null 2>&1 || true
+            "$_acorn_notify" start tool >/dev/null 2>&1 || true
           fi
           ;;
       esac
@@ -133,6 +133,11 @@ exec "$REAL_BIN" "$@"
 
 const CODEX_NOTIFY_BODY: &str = r#"#!/bin/sh
 input="${1-}"
+source="${2-hook}"
+case "$source" in
+  hook|turn|tool) ;;
+  *) source="hook" ;;
+esac
 if [ -z "$input" ]; then
   input=$(cat 2>/dev/null || true)
 fi
@@ -183,7 +188,7 @@ fi
 [ -n "$hook_token" ] || exit 0
 [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] || exit 0
 
-payload=$(printf '{"session_id":"%s","provider":"codex","event":"%s","source":"hook"}' "$ACORN_AGENT_HOOK_SESSION_ID" "$event")
+payload=$(printf '{"session_id":"%s","provider":"codex","event":"%s","source":"%s"}' "$ACORN_AGENT_HOOK_SESSION_ID" "$event" "$source")
 curl -sf -X POST \
   -H 'Content-Type: application/json' \
   -H "X-Acorn-Agent-Hook-Token: $hook_token" \

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6905,6 +6905,14 @@ mod tests {
         assert_eq!(
             super::hook_status_with_live_tool_activity(
                 acorn_session::SessionStatus::WaitingForInput,
+                Some(super::AgentKind::Codex),
+                true,
+            ),
+            acorn_session::SessionStatus::WaitingForInput
+        );
+        assert_eq!(
+            super::hook_status_with_live_tool_activity(
+                acorn_session::SessionStatus::WaitingForInput,
                 Some(super::AgentKind::Antigravity),
                 true,
             ),

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -37,6 +37,7 @@ use tauri_plugin_dialog::DialogExt;
 const CHAT_SESSION_STATE_CHANGED_EVENT: &str = "acorn:chat-session-state-changed";
 const WORKTREE_IN_USE_BY_OTHER_SESSIONS: &str =
     "Close other sessions using this worktree before removing it.";
+const CODEX_TOOL_PROCESS_START_TOLERANCE: std::time::Duration = std::time::Duration::from_secs(1);
 
 async fn run_blocking<T, F>(label: &'static str, f: F) -> AppResult<T>
 where
@@ -5385,9 +5386,16 @@ fn detect_session_statuses_blocking(
             let live_agent = root_pid_value
                 .and_then(|pid| live_agent_in_descendants(&sys, &children, Pid::from_u32(pid)));
             let live_agent_kind = live_agent.map(|(kind, _)| kind);
+            let codex_tool_started_at =
+                parsed_id.and_then(|uuid| state.sessions.hook_tool_started_at(&uuid));
             let live_codex_tool_child = matches!(live_agent_kind, Some(AgentKind::Codex))
                 && root_pid_value.is_some_and(|pid| {
-                    live_codex_has_tool_descendant(&sys, &children, Pid::from_u32(pid))
+                    live_codex_has_tool_descendant(
+                        &sys,
+                        &children,
+                        Pid::from_u32(pid),
+                        codex_tool_started_at,
+                    )
                 });
             // Resolve the live transcript via the persister's resume markers
             // first (covers claude/codex/antigravity run inside a shell session — JSONL
@@ -5834,8 +5842,16 @@ fn live_codex_has_tool_descendant(
     sys: &System,
     children: &HashMap<Pid, Vec<Pid>>,
     root: Pid,
+    tool_started_at: Option<SystemTime>,
 ) -> bool {
-    has_unignored_descendant_below_nearest_matching(
+    let Some(tool_started_at) = tool_started_at else {
+        return false;
+    };
+    let activity_cutoff = tool_started_at
+        .checked_sub(CODEX_TOOL_PROCESS_START_TOLERANCE)
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+
+    has_current_activity_descendant_below_nearest_matching(
         children,
         root,
         |pid| {
@@ -5845,6 +5861,13 @@ fn live_codex_has_tool_descendant(
         |pid| {
             sys.process(pid)
                 .is_some_and(is_codex_persistent_helper_process)
+        },
+        |pid| {
+            sys.process(pid).is_some_and(|proc| {
+                let process_started_at =
+                    SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(proc.start_time());
+                process_started_at >= activity_cutoff
+            })
         },
     )
 }
@@ -5867,6 +5890,7 @@ fn hook_status_with_live_tool_activity(
 fn is_codex_persistent_helper_process(proc: &sysinfo::Process) -> bool {
     process_basename_matches(proc, "node_repl")
         || process_basename_matches(proc, "SkyComputerUseClient")
+        || process_basename_matches(proc, "codex-code-mode-host")
 }
 
 /// BFS from `root` that returns on the FIRST pid the callback classifies.
@@ -5927,15 +5951,17 @@ where
     None
 }
 
-fn has_unignored_descendant_below_nearest_matching<F, G>(
+fn has_current_activity_descendant_below_nearest_matching<F, G, H>(
     children: &HashMap<Pid, Vec<Pid>>,
     root: Pid,
     matches: F,
     mut ignore_subtree: G,
+    mut is_current_activity: H,
 ) -> bool
 where
     F: FnMut(Pid) -> bool,
     G: FnMut(Pid) -> bool,
+    H: FnMut(Pid) -> bool,
 {
     let Some(anchor) = nearest_descendant_matching(children, root, matches) else {
         return false;
@@ -5950,9 +5976,36 @@ where
         if ignore_subtree(pid) {
             continue;
         }
-        return true;
+        if is_current_activity(pid) {
+            return true;
+        }
+        if let Some(kids) = children.get(&pid) {
+            let mut kids = kids.clone();
+            kids.sort_by_key(|pid| pid.as_u32());
+            queue.extend(kids);
+        }
     }
     false
+}
+
+#[cfg(test)]
+fn has_unignored_descendant_below_nearest_matching<F, G>(
+    children: &HashMap<Pid, Vec<Pid>>,
+    root: Pid,
+    matches: F,
+    ignore_subtree: G,
+) -> bool
+where
+    F: FnMut(Pid) -> bool,
+    G: FnMut(Pid) -> bool,
+{
+    has_current_activity_descendant_below_nearest_matching(
+        children,
+        root,
+        matches,
+        ignore_subtree,
+        |_| true,
+    )
 }
 
 /// `true` if any descendant of `root` exists in the children map. The root

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6874,7 +6874,7 @@ mod tests {
     }
 
     #[test]
-    fn persistent_claude_children_do_not_clear_waiting() {
+    fn live_tool_activity_preserves_explicit_waiting() {
         assert_eq!(
             super::hook_status_with_live_tool_activity(
                 acorn_session::SessionStatus::WaitingForInput,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6164,6 +6164,83 @@ mod status_hint_tests {
     }
 
     #[test]
+    fn only_descendants_started_during_current_tool_activity_count_as_live_work() {
+        let root = Pid::from_u32(1);
+        let codex = Pid::from_u32(2);
+        let old_mcp = Pid::from_u32(3);
+        let current_tool = Pid::from_u32(4);
+        let mut children = HashMap::new();
+        children.insert(root, vec![codex]);
+        children.insert(codex, vec![old_mcp, current_tool]);
+
+        assert!(has_current_activity_descendant_below_nearest_matching(
+            &children,
+            root,
+            |pid| pid == codex,
+            |_| false,
+            |pid| pid == current_tool,
+        ));
+    }
+
+    #[test]
+    fn infrastructure_started_before_current_tool_activity_does_not_count() {
+        let root = Pid::from_u32(1);
+        let codex = Pid::from_u32(2);
+        let old_mcp = Pid::from_u32(3);
+        let mut children = HashMap::new();
+        children.insert(root, vec![codex]);
+        children.insert(codex, vec![old_mcp]);
+
+        assert!(!has_current_activity_descendant_below_nearest_matching(
+            &children,
+            root,
+            |pid| pid == codex,
+            |_| false,
+            |_| false,
+        ));
+    }
+
+    #[test]
+    fn current_tool_below_older_intermediary_still_counts_as_live_work() {
+        let root = Pid::from_u32(1);
+        let codex = Pid::from_u32(2);
+        let old_intermediary = Pid::from_u32(3);
+        let current_tool = Pid::from_u32(4);
+        let mut children = HashMap::new();
+        children.insert(root, vec![codex]);
+        children.insert(codex, vec![old_intermediary]);
+        children.insert(old_intermediary, vec![current_tool]);
+
+        assert!(has_current_activity_descendant_below_nearest_matching(
+            &children,
+            root,
+            |pid| pid == codex,
+            |_| false,
+            |pid| pid == current_tool,
+        ));
+    }
+
+    #[test]
+    fn persistent_helper_subtrees_never_count_as_live_work() {
+        let root = Pid::from_u32(1);
+        let codex = Pid::from_u32(2);
+        let helper = Pid::from_u32(3);
+        let helper_child = Pid::from_u32(4);
+        let mut children = HashMap::new();
+        children.insert(root, vec![codex]);
+        children.insert(codex, vec![helper]);
+        children.insert(helper, vec![helper_child]);
+
+        assert!(!has_current_activity_descendant_below_nearest_matching(
+            &children,
+            root,
+            |pid| pid == codex,
+            |pid| pid == helper,
+            |pid| pid == helper_child,
+        ));
+    }
+
+    #[test]
     fn session_process_noise_filters_shell_wrappers() {
         assert!(is_session_process_noise("(zsh)"));
         assert!(is_session_process_noise("tail"));

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5856,10 +5856,7 @@ fn hook_status_with_live_tool_activity(
 ) -> SessionStatus {
     if live_tool_child
         && matches!(live_agent_kind, Some(AgentKind::Codex))
-        && matches!(
-            hook_status,
-            SessionStatus::Ready | SessionStatus::WaitingForInput
-        )
+        && hook_status == SessionStatus::Ready
     {
         SessionStatus::Working
     } else {

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -42,6 +42,64 @@ function session(
 }
 
 test.describe("workspace kanban mode", () => {
+  test("keeps kanban placement and terminal status in sync after an input request", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("input-request", "input request", "working", {
+        agent_provider: "codex",
+      }),
+    ]);
+    await tauri.handle("detect_session_statuses", (args) => {
+      const ids = Array.isArray((args as { ids?: unknown }).ids)
+        ? ((args as { ids: string[] }).ids)
+        : [];
+      const waiting = (
+        window as unknown as { __kanbanInputRequested?: boolean }
+      ).__kanbanInputRequested;
+      return ids.map((id) => ({
+        id,
+        status: waiting ? "waiting_for_input" : "working",
+        agent_provider: "codex",
+        branch: `feat/${id}`,
+      }));
+    });
+
+    await page.goto("/");
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    const board = page.getByTestId("workspace-kanban");
+    const workingCard = board.locator(
+      'section[aria-label="Working"] [data-kanban-session-id="input-request"]',
+    );
+    await expect(workingCard).toBeVisible();
+    await workingCard.click();
+
+    const popover = page.getByTestId("kanban-terminal-popover");
+    await expect(popover).toContainText("Working");
+
+    await page.evaluate(() => {
+      (
+        window as unknown as { __kanbanInputRequested?: boolean }
+      ).__kanbanInputRequested = true;
+    });
+
+    const waitingCard = board.locator(
+      'section[aria-label="Waiting"] [data-kanban-session-id="input-request"]',
+    );
+    await expect(waitingCard).toBeVisible({ timeout: 3_000 });
+    await expect(popover).toContainText("Waiting for input");
+    await expect(page.getByTestId("workspace-kanban-count-working")).toHaveText(
+      "0",
+    );
+    await expect(page.getByTestId("workspace-kanban-count-waiting")).toHaveText(
+      "1",
+    );
+  });
+
   test("derives lifecycle from agent work instead of shared Git state", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

This fixes Codex hook status arbitration so explicit input requests and completed turns are not hidden by persistent helper processes.

1. **Preserve explicit input waits** — keep WaitingForInput authoritative even when a Codex child process remains alive, allowing Activity and Kanban to observe the input request.
2. **Scope background work detection** — tag Codex task and exec hook events separately, retain runtime-only evidence for the current turn, and count only process descendants created during actual tool activity.
3. **Keep Kanban synchronized** — cover the transition from Working to Waiting across card placement, counters, and the terminal popover status.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Codex requests approval or input while a helper is alive | Status can return to Working and hide the request | Waiting remains authoritative |
| Codex completes a turn with session-long helpers | Persistent helper can keep the session in Working | Session settles in Ready |
| Codex leaves a real background command running | Child process keeps the turn active | Current-turn process evidence preserves Working |
| Claude or Antigravity input waits | Not affected by the Codex-specific override | Behavior remains unchanged |
| Kanban after an input request | Card and terminal status can disagree | Card, counters, and popover agree on Waiting |

## Design notes

- The Codex JSONL watcher emits separate turn and tool sources for task_started and exec_command_begin events.
- SessionStore keeps the first tool start time for the current turn in runtime memory only. After an app restart, status arbitration is conservative until fresh tool evidence arrives.
- Process traversal ignores known session-long helper subtrees and walks through older intermediaries so a newer real tool descendant still counts.
- Only Ready can be promoted to Working by Codex background tool activity; WaitingForInput and Errored remain authoritative.
- Activity and OS notifications still intentionally suppress transitions for the currently focused session.

## Follow-up (not in this PR)

- Add provider-specific dummy JSONL fixture integration tests for Codex, Claude, and Antigravity so transcript-driven status transitions are exercised end to end.

## Test plan

- [x] env -u ACORN_DATA_DIR -u ACORN_IPC_SOCKET -u ACORN_PROFILE cargo test --workspace — all workspace tests pass; one existing ignored test
- [x] pnpm exec vitest run --reporter=dot — 95 files, 1,028 tests pass
- [x] pnpm exec playwright test tests/e2e/kanban.spec.ts --reporter=line — 22 tests pass
- [x] pnpm run build — TypeScript and Vite production build pass
- [x] env -u ACORN_DATA_DIR -u ACORN_IPC_SOCKET -u ACORN_PROFILE cargo clippy --workspace --all-targets — passes

## Notes

- Control sessions export production profile path overrides, so Rust path tests require those variables to be stripped as documented in docs/COMMON.md.
- Existing Clippy warnings and Vite chunk-size/dynamic-import warnings remain. They are not caused by this PR.
