### PR TITLE
perf(build): native artifact reuse + incremental type checks + sharded CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,17 @@ jobs:
         run: pnpm run test
 
       - name: Build
-        run: pnpm run build
+        # Type checking already ran above. Build only the production bundle
+        # so this job does not check the same TypeScript graph twice.
+        run: pnpm run build:frontend
 
   e2e:
-    name: E2E
+    name: E2E (shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
       - uses: actions/checkout@v5
 
@@ -78,13 +84,13 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run E2E tests
-        run: pnpm run test:e2e
+        run: pnpm run test:e2e --shard=${{ matrix.shard }}/2
 
       - name: Upload report on failure
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.shard }}-of-2
           path: |
             playwright-report/
             test-results/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -102,7 +104,7 @@ jobs:
       # bumps). Wraps rustc to memoize per-crate compilation outputs.
       - name: Setup sccache
         continue-on-error: true
-        uses: mozilla-actions/sccache-action@v0.0.6
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       # Probe the GHA cache backend before trusting sccache. When the
       # Azure Edge layer behind `artifactcache.actions.githubusercontent.com`
@@ -167,7 +169,7 @@ jobs:
         # `frontend` job's artifact one step ago. The sidecar staging
         # script still runs per-target because it cross-compiles for each
         # apple triple.
-        run: pnpm run tauri build --target ${{ matrix.target }} --bundles app dmg --config '{"build":{"beforeBuildCommand":"TAURI_SIDECAR_PROFILE=release-ci pnpm run build:sidecar"}}' -- --profile release-ci
+        run: pnpm run tauri build --target ${{ matrix.target }} --bundles app dmg --config '{"build":{"beforeBuildCommand":"TAURI_SIDECAR_FORCE_TARGET=1 TAURI_SIDECAR_PROFILE=release-ci pnpm run build:sidecar"}}' -- --profile release-ci
 
       - name: Stage release artifacts
         id: stage
@@ -271,7 +273,7 @@ jobs:
         env:
           RUSTFLAGS: "-Z share-generics=y -Z threads=8"
           CARGO_INCREMENTAL: "0"
-        run: pnpm run tauri build --target aarch64-apple-darwin --bundles app --config '{"build":{"beforeBuildCommand":"TAURI_SIDECAR_PROFILE=release-ci pnpm run build:sidecar"}}' -- --profile release-ci
+        run: pnpm run tauri build --target aarch64-apple-darwin --bundles app --config '{"build":{"beforeBuildCommand":"TAURI_SIDECAR_FORCE_TARGET=1 TAURI_SIDECAR_PROFILE=release-ci pnpm run build:sidecar"}}' -- --profile release-ci
 
   release:
     name: Publish GitHub Release + latest.json

--- a/docs/COMMON.md
+++ b/docs/COMMON.md
@@ -74,7 +74,7 @@ For local Rust work across multiple Acorn worktrees, set `CARGO_TARGET_DIR` to a
 export CARGO_TARGET_DIR=/path/to/acorn/.acorn/cargo-target
 ```
 
-`src-tauri/scripts/build-sidecar.sh` honours the same setting when staging Tauri sidecars. Keep this as a local environment setting rather than a committed default so CI and release builds keep their normal per-workspace target layout.
+`src-tauri/scripts/build-sidecar.sh` honours the same setting when staging Tauri sidecars. Native sidecar builds use Cargo's standard host output directory, so the following Tauri app build reuses those dependency artifacts instead of compiling them again in a target-triple subdirectory. Keep `CARGO_TARGET_DIR` as a local environment setting rather than a committed default so CI and release builds keep their normal per-workspace target layout.
 
 **Launching `tauri dev` from inside a control session.** Acorn injects `ACORN_DATA_DIR`, `ACORN_IPC_SOCKET`, `ACORN_DAEMON_SOCKET`, and related session metadata into every control-session PTY so bundled CLIs talk to the host profile. `acorn-paths::data_dir` honours `ACORN_DATA_DIR` ahead of the debug/release profile fallback, and `acorn-ipc` honours `ACORN_IPC_SOCKET` ahead of computed profile paths. A plain `pnpm run tauri dev` from that shell can silently run the debug app against `profiles/prod` — same daemon, same `sessions.json`, same staged shell-init dir as the installed app. Strip the overrides before launching:
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "dev:sidecar": "TAURI_SIDECAR_PROFILE=debug ./src-tauri/scripts/build-sidecar.sh",
     "build": "tsc && vite build",
+    "build:frontend": "vite build",
     "build:sidecar": "./src-tauri/scripts/build-sidecar.sh",
     "preview": "vite preview",
     "tauri": "tauri",

--- a/src-tauri/scripts/build-sidecar.sh
+++ b/src-tauri/scripts/build-sidecar.sh
@@ -2,17 +2,17 @@
 # Build the sidecar binaries (`acorn-ipc`, `acornd`) and stage them where
 # Tauri's externalBin expects: `src-tauri/binaries/<name>-<target-triple>`.
 #
-# Tauri 2's externalBin convention names the staged file after the *target*
-# triple — the one being built for, not the host the script is running on.
-# When `tauri build --target X` runs, every matching `<name>-X` file must
-# exist before the build script's existence check fires. For the release
-# matrix on Apple-Silicon `macos-latest` runners that means producing an
-# x86_64 binary alongside the aarch64 one, even though the host is aarch64.
+# Tauri 2's externalBin convention names the staged file after the target
+# triple. Native builds use Cargo's standard host output directory so the
+# following Tauri app build can reuse the same dependency artifacts. Cross
+# builds keep target-specific output directories. Callers that explicitly
+# pass the host triple to Tauri can set TAURI_SIDECAR_FORCE_TARGET=1 to make
+# the sidecar use the same target-specific directory as the app build.
 #
 # Tauri passes the active target through `TAURI_ENV_TARGET_TRIPLE` to
 # commands spawned via `beforeBuildCommand`. Standalone callers (local
-# `pnpm run build:sidecar`, manual runs) fall back to the host triple so
-# the script keeps working without extra setup.
+# `pnpm run build:sidecar`, manual runs) use Cargo's configured target or
+# fall back to the host triple so the script works without extra setup.
 #
 # Exits non-zero on any failure so the build surfaces the problem instead
 # of silently shipping a `.app` without one of the sidecars.
@@ -22,11 +22,12 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 profile="${TAURI_SIDECAR_PROFILE:-release}"
-target_triple="${TAURI_ENV_TARGET_TRIPLE:-$(rustc -vV | sed -n 's|host: ||p')}"
+host_triple="$(rustc -vV | sed -n 's|host: ||p')"
+target_triple="${TAURI_ENV_TARGET_TRIPLE:-${CARGO_BUILD_TARGET:-$host_triple}}"
 target_dir="${CARGO_TARGET_DIR:-target}"
 
-if [ -z "$target_triple" ]; then
-  echo "error: could not determine target triple (TAURI_ENV_TARGET_TRIPLE unset and \`rustc -vV\` produced no host line)" >&2
+if [ -z "$host_triple" ] || [ -z "$target_triple" ]; then
+  echo "error: could not determine host and target triples" >&2
   exit 1
 fi
 
@@ -37,11 +38,16 @@ fi
 # single-line change; `externalBin` in tauri.conf.json must match.
 sidecars=("acorn-ipc:acorn-ipc" "acornd:acorn")
 
-# Always cross-compile with `--target` so the output lands in
-# `target/<triple>/<profile>/` even when host == target. The uniform
-# layout removes a branching copy step below and matches how the rest of
-# the release workflow already invokes cargo for the main binary.
-cargo_flags=(--target "$target_triple")
+# Cargo separates explicit-target artifacts from native artifacts even when
+# both triples are identical. Keep native sidecars in target/<profile>/ so a
+# regular `tauri dev` or `tauri build` does not compile the dependency graph
+# again under target/<host-triple>/<profile>/.
+cargo_flags=()
+artifact_dir="$target_dir/$profile"
+if [ "$target_triple" != "$host_triple" ] || [ "${TAURI_SIDECAR_FORCE_TARGET:-0}" = "1" ] || [ -n "${CARGO_BUILD_TARGET:-}" ]; then
+  cargo_flags+=(--target "$target_triple")
+  artifact_dir="$target_dir/$target_triple/$profile"
+fi
 for entry in "${sidecars[@]}"; do
   bin="${entry%%:*}"
   pkg="${entry##*:}"
@@ -75,7 +81,7 @@ cargo build "${cargo_flags[@]}"
 
 for entry in "${sidecars[@]}"; do
   bin="${entry%%:*}"
-  src="$target_dir/$target_triple/$profile/$bin"
+  src="$artifact_dir/$bin"
   dest="$dest_dir/$bin-$target_triple"
   if [ ! -f "$src" ]; then
     echo "error: expected built binary at $src" >&2

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.tsbuildinfo",
     "noEmit": true,
     "jsx": "react-jsx",
 


### PR DESCRIPTION
## Summary

This PR shortens repeat local builds and GitHub Actions wall time without skipping validation or changing runtime behavior.

1. **Reuse native Cargo artifacts** — build host sidecars in Cargo's standard host output directory so the following Tauri app build reuses the same dependency graph; explicit and cross-target release builds retain target-specific output through `TAURI_SIDECAR_FORCE_TARGET=1`.
2. **Cache TypeScript graph state** — persist `.tsbuildinfo` inside ignored `node_modules` and add a Vite-only `build:frontend` command so repeat local checks and CI avoid redundant type analysis.
3. **Shard Playwright CI** — split the 232-test E2E suite into two balanced 116-test jobs with shard-specific failure artifacts.
4. **Tighten release setup** — cache the pnpm store in macOS bundle jobs and update the official sccache action to its Node 24 release.

## Expected impact

| Path | Before | After |
| --- | --- | --- |
| Repeat local typecheck | 4.32s | 0.92s (-79%) |
| Repeat local frontend build | 6.53s | 3.44s (-47%) |
| Native Tauri sidecar → app build | Separate `target/<host>/debug` and `target/debug` dependency graphs | One shared native Cargo graph; measured follow-up app build completed in 2.90s |
| Frontend Actions job | 1m50s | 1m32s (-16%) |
| E2E / total Actions wall time | 232 tests in one 6m43s workflow | Two 116-test shards; workflow completed in 3m51s (-43%) |
| Release JS dependency install | 5–10s download/install per macOS matrix job | pnpm store restored on warm runs |

## Design notes

- Native sidecars omit Cargo's explicit `--target` flag because Cargo isolates explicit host-target artifacts from normal host artifacts even when the triples match.
- Cross targets, `CARGO_BUILD_TARGET`, and release matrix jobs still use `target/<triple>/<profile>` so sidecars and the Tauri app share the correct architecture-specific cache.
- CI keeps the standalone `typecheck` gate and only switches the later build step to `build:frontend`; no type-safety check is removed.
- Playwright already uses `fullyParallel: true`, so two-way sharding balances the suite at test granularity. Failure artifacts use unique names to avoid matrix upload collisions.

## Follow-up (not in this PR)

- Move the `acornd` binary out of the main Tauri package and extract its remaining `pty_env` dependency. Recent cold release logs spent 6m02s on the sidecar build and another 3m21s on the app build; removing that package coupling could reduce the remaining Rust rebuild, but it is a broader crate-boundary change that deserves a separate PR.
- Consider a reduced Shiki language/theme bundle if Vite production-build time becomes the next priority; the current build transforms 2,705 modules and changing that surface needs syntax-highlighting regression coverage.

## Test plan

- [x] `pnpm run test` — 95 files, 1,028 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed; repeat wall time 3.44s
- [x] `CARGO_TARGET_DIR=/Users/jthefloor/Documents/Personal/acorn/.acorn/cargo-target TAURI_SIDECAR_PROFILE=debug pnpm run build:sidecar` — native output staged successfully without explicit target
- [x] `CARGO_TARGET_DIR=/Users/jthefloor/Documents/Personal/acorn/.acorn/cargo-target TAURI_SIDECAR_PROFILE=debug TAURI_SIDECAR_FORCE_TARGET=1 pnpm run build:sidecar` — target-specific output staged successfully
- [x] `PLAYWRIGHT_PORT=1420 pnpm run test:e2e --shard=1/2` — 116 passed
- [x] `PLAYWRIGHT_PORT=1422 pnpm run test:e2e --shard=2/2` — 116 passed
- [x] `bash -n src-tauri/scripts/build-sidecar.sh` and YAML parse for both workflow files — passed
- [x] GitHub Actions — Frontend and both E2E shards passed

## Notes

- Vite's existing mixed static/dynamic import and large-chunk warnings remain; they are not caused by this PR.
- The existing Rust dead-code warnings for test-only cache length helpers remain; they are not caused by this PR.
