### PR TITLE
fix(status): scope agent hook ownership by provider

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -290,6 +290,11 @@ pub struct Session {
     /// new app instance (a resting agent may never emit one).
     #[serde(default)]
     pub hook_active: bool,
+    /// Provider whose lifecycle hooks own the session status. Kept with
+    /// `hook_active` so one provider's hook state does not mask a different
+    /// Claude/Codex/Antigravity run in the same terminal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hook_provider: Option<SessionAgentProvider>,
     /// Derived from status polling. This reflects the currently live
     /// Claude/Codex/Antigravity process under the session PTY and is not
     /// persisted in sessions.json.
@@ -333,6 +338,7 @@ impl Session {
             daemon_session_id: None,
             agent_resume_token: None,
             hook_active: false,
+            hook_provider: None,
             in_worktree: false,
             agent_provider: None,
             agent_transcript_id: None,
@@ -473,7 +479,7 @@ impl SessionStore {
     /// the session's persisted `hook_active` flag so hook ownership survives
     /// an app restart. The persisted flag is idempotent; the runtime revision
     /// advances for every event.
-    pub fn mark_hook_active(&self, id: &Uuid) {
+    pub fn mark_hook_active(&self, id: &Uuid, provider: SessionAgentProvider) {
         {
             let mut revision = self.hook_revisions.entry(*id).or_default();
             *revision = revision.saturating_add(1);
@@ -485,6 +491,8 @@ impl SessionStore {
                 // not reshuffle the sidebar's most-recent-first ordering.
                 entry.hook_active = true;
             }
+            entry.hook_provider = Some(provider);
+            entry.agent_provider = Some(provider);
         }
     }
 
@@ -516,6 +524,10 @@ impl SessionStore {
                 .get(id)
                 .map(|entry| entry.hook_active)
                 .unwrap_or(false)
+    }
+
+    pub fn hook_provider(&self, id: &Uuid) -> Option<SessionAgentProvider> {
+        self.inner.get(id).and_then(|entry| entry.hook_provider)
     }
 
     /// Whether `id` reported an agent lifecycle hook event *this run* — an
@@ -774,17 +786,26 @@ mod tests {
         assert!(!store.is_hook_active(&session.id));
         assert!(!store.is_hook_confirmed_this_run(&session.id));
 
-        store.mark_hook_active(&session.id);
+        store.mark_hook_active(&session.id, SessionAgentProvider::Codex);
         assert!(store.is_hook_active(&session.id));
         assert!(store.is_hook_confirmed_this_run(&session.id));
+        assert_eq!(
+            store.hook_provider(&session.id),
+            Some(SessionAgentProvider::Codex)
+        );
         assert_eq!(store.hook_revision(&session.id), 1);
-        store.mark_hook_active(&session.id);
+        store.mark_hook_active(&session.id, SessionAgentProvider::Claude);
         assert!(store.is_hook_active(&session.id));
+        assert_eq!(
+            store.hook_provider(&session.id),
+            Some(SessionAgentProvider::Claude)
+        );
         assert_eq!(store.hook_revision(&session.id), 2);
 
         store.remove(&session.id).expect("session exists");
         assert!(!store.is_hook_active(&session.id));
         assert!(!store.is_hook_confirmed_this_run(&session.id));
+        assert_eq!(store.hook_provider(&session.id), None);
         assert_eq!(store.hook_revision(&session.id), 0);
     }
 
@@ -826,7 +847,7 @@ mod tests {
         store
             .refresh_status(&session.id, SessionStatus::WaitingForInput)
             .expect("session exists");
-        store.mark_hook_active(&session.id);
+        store.mark_hook_active(&session.id, SessionAgentProvider::Codex);
 
         assert!(!store
             .refresh_status_if_hook_revision(
@@ -867,9 +888,10 @@ mod tests {
         let store = SessionStore::new();
         let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
 
-        store.mark_hook_active(&session.id);
+        store.mark_hook_active(&session.id, SessionAgentProvider::Claude);
         let marked = store.get(&session.id).expect("session exists");
         assert!(marked.hook_active);
+        assert_eq!(marked.hook_provider, Some(SessionAgentProvider::Claude));
 
         // Simulate an app restart: serialize, load into a fresh store.
         let json = serde_json::to_string(&marked).expect("session serializes");
@@ -881,6 +903,10 @@ mod tests {
         // confirmed against the new run's hook server yet.
         assert!(fresh.is_hook_active(&session.id));
         assert!(!fresh.is_hook_confirmed_this_run(&session.id));
+        assert_eq!(
+            fresh.hook_provider(&session.id),
+            Some(SessionAgentProvider::Claude)
+        );
     }
 
     #[test]
@@ -893,6 +919,7 @@ mod tests {
             .remove("hook_active");
         let reloaded: Session = serde_json::from_value(value).expect("legacy session deserializes");
         assert!(!reloaded.hook_active);
+        assert_eq!(reloaded.hook_provider, None);
     }
 
     #[test]

--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -54,12 +54,31 @@ pub fn apply_agent_hook_event(
     let session = sessions
         .get(&event.session_id)
         .map_err(|_| format!("session not found: {}", event.session_id))?;
+    // A terminal can carry stale live-provider metadata from a resting agent.
+    // Accept a provider switch only from a resting session; while the owner is
+    // Working, mismatched provider events are nested agent activity.
     if let Some(provider) = session.agent_provider {
         if provider != event.provider {
-            return Err(format!(
-                "provider mismatch for {}: expected {:?}, got {:?}",
-                event.session_id, provider, event.provider
-            ));
+            let provider_switch_from_resting_session = event.event == AgentHookEventKind::Start
+                && session.status != SessionStatus::Working;
+            if !provider_switch_from_resting_session {
+                return Err(format!(
+                    "provider mismatch for {}: expected {:?}, got {:?}",
+                    event.session_id, provider, event.provider
+                ));
+            }
+        }
+    }
+    if let Some(provider) = session.hook_provider {
+        if provider != event.provider {
+            let provider_switch_from_resting_session = event.event == AgentHookEventKind::Start
+                && session.status != SessionStatus::Working;
+            if !provider_switch_from_resting_session {
+                return Err(format!(
+                    "hook provider mismatch for {}: expected {:?}, got {:?}",
+                    event.session_id, provider, event.provider
+                ));
+            }
         }
     }
 
@@ -67,7 +86,7 @@ pub fn apply_agent_hook_event(
     // turn-boundary classification to these events instead of clobbering a
     // just-set resting status (Ready/WaitingForInput) back to Working on its
     // next tick. See `poll_defers_to_hook` in `commands`.
-    sessions.mark_hook_active(&event.session_id);
+    sessions.mark_hook_active(&event.session_id, event.provider);
 
     // The Codex JSONL watcher tags task and exec starts separately. This
     // runtime-only turn evidence lets the process poll distinguish a real
@@ -462,6 +481,88 @@ mod tests {
             sessions.get(&session_id).expect("session").status,
             SessionStatus::WaitingForInput
         );
+        assert_eq!(
+            sessions.hook_provider(&session_id),
+            Some(SessionAgentProvider::Codex)
+        );
+        assert_eq!(
+            sessions.get(&session_id).expect("session").agent_provider,
+            Some(SessionAgentProvider::Codex)
+        );
+    }
+
+    #[test]
+    fn apply_agent_hook_event_accepts_provider_switch_from_resting_session() {
+        let sessions = acorn_session::SessionStore::new();
+        let mut session = Session::new(
+            "Agent".to_string(),
+            "/tmp/repo".into(),
+            "/tmp/repo".into(),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        session.status = SessionStatus::Ready;
+        session.agent_provider = Some(SessionAgentProvider::Codex);
+        session.hook_provider = Some(SessionAgentProvider::Codex);
+        let session_id = session.id;
+        sessions.insert(session);
+
+        let status = apply_agent_hook_event(
+            &sessions,
+            AgentHookEvent {
+                session_id,
+                provider: SessionAgentProvider::Claude,
+                event: AgentHookEventKind::Start,
+                message: None,
+                source: Some("hook".to_string()),
+            },
+        )
+        .expect("resting provider switch applies");
+
+        let stored = sessions.get(&session_id).expect("session");
+        assert_eq!(status, SessionStatus::Working);
+        assert_eq!(stored.status, SessionStatus::Working);
+        assert_eq!(stored.agent_provider, Some(SessionAgentProvider::Claude));
+        assert_eq!(
+            sessions.hook_provider(&session_id),
+            Some(SessionAgentProvider::Claude)
+        );
+    }
+
+    #[test]
+    fn apply_agent_hook_event_rejects_nested_provider_while_owner_is_working() {
+        let sessions = acorn_session::SessionStore::new();
+        let mut session = Session::new(
+            "Agent".to_string(),
+            "/tmp/repo".into(),
+            "/tmp/repo".into(),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        session.status = SessionStatus::Working;
+        session.agent_provider = Some(SessionAgentProvider::Codex);
+        session.hook_provider = Some(SessionAgentProvider::Codex);
+        let session_id = session.id;
+        sessions.insert(session);
+
+        let err = apply_agent_hook_event(
+            &sessions,
+            AgentHookEvent {
+                session_id,
+                provider: SessionAgentProvider::Claude,
+                event: AgentHookEventKind::Start,
+                message: None,
+                source: Some("hook".to_string()),
+            },
+        )
+        .expect_err("nested provider event is rejected");
+
+        assert!(err.contains("provider mismatch"));
+        let stored = sessions.get(&session_id).expect("session");
+        assert_eq!(stored.status, SessionStatus::Working);
+        assert_eq!(stored.agent_provider, Some(SessionAgentProvider::Codex));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5215,12 +5215,23 @@ pub async fn detect_session_statuses(
 /// can mislabel a just-started turn as Ready. The poll therefore trusts the
 /// hook whenever an agent is live.
 ///
-/// Once no agent process is live (`live_agent` false — the agent exited, or an
-/// unrelated command now owns the PTY), the poll drives status again.
+/// Once no matching agent process is live (the agent exited, another provider
+/// now owns the PTY, or an unrelated command owns the PTY), the poll drives
+/// status again.
 /// Trade-off: a dropped terminating hook can leave status lagging at the last
 /// hook value until the next hook or the agent exits.
-fn poll_defers_to_hook(hook_active: bool, live_agent: bool) -> bool {
-    hook_active && live_agent
+fn poll_defers_to_hook(
+    hook_active: bool,
+    hook_provider: Option<AgentKind>,
+    live_agent_kind: Option<AgentKind>,
+) -> bool {
+    if !hook_active {
+        return false;
+    }
+    let Some(live_agent_kind) = live_agent_kind else {
+        return false;
+    };
+    hook_provider.map_or(true, |provider| provider == live_agent_kind)
 }
 
 /// Recover a turn boundary that was crossed while the app was closed.
@@ -5462,11 +5473,13 @@ fn detect_session_statuses_blocking(
                 }
             };
             let detection = session_status::detect_with_reason(transcript, previous, shell_hint);
+            let hook_provider = parsed_id.and_then(|uuid| state.sessions.hook_provider(&uuid));
             let defer_to_hook = poll_defers_to_hook(
                 parsed_id
                     .map(|uuid| state.sessions.is_hook_active(&uuid))
                     .unwrap_or(false),
-                live_agent_kind.is_some(),
+                hook_provider,
+                live_agent_kind,
             );
             // When a live hooked agent owns the status, keep the hook-set value
             // instead of the stale transcript reading. Re-read it fresh: a hook
@@ -6985,22 +6998,52 @@ mod tests {
         // While the agent process is alive the hook owns the turn boundary and
         // the transcript tail is ignored in both directions (stale Working just
         // after a turn ends, stale Ready just after the next prompt).
-        assert!(poll_defers_to_hook(true, true));
+        assert!(poll_defers_to_hook(
+            true,
+            Some(super::AgentKind::Codex),
+            Some(super::AgentKind::Codex)
+        ));
+    }
+
+    #[test]
+    fn poll_does_not_defer_to_a_different_provider_hook() {
+        assert!(!poll_defers_to_hook(
+            true,
+            Some(super::AgentKind::Codex),
+            Some(super::AgentKind::Claude)
+        ));
+    }
+
+    #[test]
+    fn poll_defers_when_hook_provider_is_unknown() {
+        assert!(poll_defers_to_hook(
+            true,
+            None,
+            Some(super::AgentKind::Antigravity)
+        ));
     }
 
     #[test]
     fn poll_owns_status_once_the_agent_is_gone() {
         // Agent exited, or an unrelated command now owns the PTY — the poll
         // drives liveness again from the current process tree.
-        assert!(!poll_defers_to_hook(true, false));
+        assert!(!poll_defers_to_hook(
+            true,
+            Some(super::AgentKind::Codex),
+            None
+        ));
     }
 
     #[test]
     fn poll_drives_status_without_a_hook_channel() {
         // No observed hook events (e.g. `claude` typed straight into a terminal
         // before hooks registered) — the transcript poll is the only signal.
-        assert!(!poll_defers_to_hook(false, true));
-        assert!(!poll_defers_to_hook(false, false));
+        assert!(!poll_defers_to_hook(
+            false,
+            None,
+            Some(super::AgentKind::Claude)
+        ));
+        assert!(!poll_defers_to_hook(false, None, None));
     }
 
     #[test]

--- a/src-tauri/src/daemon_commands.rs
+++ b/src-tauri/src/daemon_commands.rs
@@ -353,6 +353,7 @@ pub fn daemon_adopt_session(
         daemon_session_id: Some(id),
         agent_resume_token: Some(id.to_string()),
         hook_active: false,
+        hook_provider: None,
         in_worktree: false,
         agent_provider: None,
         agent_transcript_id: None,


### PR DESCRIPTION
## Summary
This fixes agent status ownership when a terminal moves between Claude, Codex, and Antigravity sessions.

1. **Provider-scoped hook ownership** — persist the provider that owns hook-driven status so one agent's hook state cannot mask a different live provider in the same terminal.
2. **Safe provider switching** — allow a new provider to take over from a resting session while still rejecting mismatched nested provider events during active work.
3. **Status poll alignment** — defer transcript-tail polling to hook status only when the live agent provider matches the hook owner, with backward compatibility for older hook-owned sessions.

## Expected impact
| Scenario | Before | After |
| --- | --- | --- |
| A terminal starts Claude/Codex/Antigravity after another provider rested | Old hook ownership could keep status matched to the wrong provider | The new provider can take status ownership |
| A nested peer agent runs while the owner is Working | Nested hook events could risk clobbering owner semantics if broadly accepted | Mismatched provider events remain rejected while the owner is Working |
| Existing hook-owned sessions without provider metadata | Could rely only on `hook_active` | Continue to defer conservatively until refreshed metadata is available |

## Design notes
- `hook_provider` travels with persisted `hook_active`, while `agent_provider` remains the live provider badge updated by hooks and status polling.
- The provider switch rule is intentionally limited to resting sessions. Active owner sessions keep the existing nested-agent guard.
- Daemon-adopted session literals initialize `hook_provider` to `None` for schema completeness.

## Test plan
- [x] `git diff --check` — passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-session -p acorn --lib` — 439 passed, 1 ignored