### PR TITLE
chore(release): v1.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.25.0",
+  "version": "1.26.0",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.25.0"
+version = "1.26.0"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.25.0"
+version = "1.26.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

This release bumps Acorn from `1.25.0` to `1.26.0` after a green `main` and prepares the next stable release.

1. **Version metadata:** Updates `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` to `1.26.0`.
2. **Semver decision:** Uses a minor bump because the unreleased set includes user-visible theme catalog and managed library support, new theme palettes, configurable find/rename shortcuts, and expanded shortcut hints.
3. **Release notes source:** Includes merged PRs #603, #604, #605, #606, #607, #608, #610, #611, #612, #613, #614, #615, #616, #618, #619, #620, #621, #622, #623, #624, #625, #626, #627, #628, #629, #630, #631, #632, #633, #634, #635, #636, #637, #638, #639, #640, #641, #642, #643, #644, #645, #646, #647, #648, and #649.

## Expected impact

| Area | Expected impact |
| --- | --- |
| App version | Packaged builds and updater metadata report `1.26.0`. |
| Release notes | GitHub Release and `latest.json.notes` include the merged feature, fix, performance, and build PRs since `v1.25.0`. |
| Runtime behavior | No direct runtime code changes in this bump PR. |

## Design notes

The release bump PR intentionally changes only version metadata. The merged feature, fix, performance, and build PRs supply the changelog entries, so this PR is labelled `skip-changelog`.

## Follow-up (not in this PR)

- Push tag `v1.26.0` after this PR merges to trigger the Release workflow.
- Confirm the Release workflow publishes the GitHub Release, both architecture bundles, updater signatures, and `latest.json` successfully.

## Test plan

- [x] `gh run list --branch main --limit 15 --json databaseId,workflowName,displayTitle,status,conclusion,headSha,createdAt,url` — latest `main` CI run `29291859065` passed at `origin/main` (`004308844bc27482401dea8263e6c113ee21997b`).
- [x] `rg -n '1\\.25\\.0|1\\.26\\.0' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock` — only the four Acorn release metadata fields now show `1.26.0`.
- [x] `pnpm run typecheck` — passed.
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — passed and reports root package `1.26.0`.
- [x] `git show HEAD:scripts/release-notes.mjs | rg 'addReleaseSectionSummaries|formatReleaseSectionSummary'` — bilingual summary support present.
- [x] `REPO=im-ian/acorn TAG=v1.26.0 OUTPUT=/tmp/acorn-release-notes-v1.26.0.md node scripts/release-notes.mjs` — generated notes successfully.
- [x] `test -s /tmp/acorn-release-notes-v1.26.0.md` — generated notes file is non-empty.
- [x] `rg -n '^> .+<br>$' /tmp/acorn-release-notes-v1.26.0.md` — Korean summary blockquotes present.
- [x] `rg -n '^> (Feature updates|Fixes|Performance improvements|Security updates|Documentation updates|Internal cleanup|Build and CI updates|Other changes): ' /tmp/acorn-release-notes-v1.26.0.md` — English summary blockquotes present.
- [x] `git diff --check` — passed.

## Notes

`origin/main` was verified green at `004308844bc27482401dea8263e6c113ee21997b` before this branch was created.
