### PR TITLE
chore(release): v1.26.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.26.0",
+  "version": "1.26.1",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.26.0"
+version = "1.26.1"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

This release bumps Acorn from `1.26.0` to `1.26.1` after a green `main` and prepares the next stable patch release.

1. **Version metadata:** Updates `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` to `1.26.1`.
2. **Semver decision:** Uses a patch bump because the unreleased set contains a user-visible fix to completed-turn waiting status with no breaking behavior or new feature surface.
3. **Release notes source:** Includes merged PR #651.

## Expected impact

| Area | Expected impact |
| --- | --- |
| App version | Packaged builds and updater metadata report `1.26.1`. |
| Release notes | GitHub Release and `latest.json.notes` add the completed-turn waiting-status fix from PR #651 while retaining cumulative `1.26.x` notes. |
| Runtime behavior | No direct runtime code changes in this bump PR. |

## Design notes

The release bump PR intentionally changes only version metadata. PR #651 supplies the fix changelog entry, so this PR is labelled `skip-changelog`.

## Follow-up (not in this PR)

- Push tag `v1.26.1` after this PR merges to trigger the Release workflow.
- Confirm the Release workflow publishes the GitHub Release, both architecture bundles, updater signatures, and `latest.json` successfully.

## Test plan

- [x] `gh run watch 29299145620 --exit-status` — `main` CI passed at `origin/main` (`b37de6de170a7e989f30a919a1d7512c0fc3c727`), including frontend checks and both E2E shards (116 tests passed).
- [x] `rg -n '1\\.26\\.0|1\\.26\\.1' package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml src-tauri/Cargo.lock` — only the four Acorn release metadata fields now show `1.26.1`.
- [x] `pnpm run typecheck` — passed.
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — passed and reports root package `1.26.1`.
- [x] `git show HEAD:scripts/release-notes.mjs | rg 'addReleaseSectionSummaries|formatReleaseSectionSummary'` — bilingual summary support present.
- [x] `REPO=im-ian/acorn TAG=v1.26.1 OUTPUT=/tmp/acorn-release-notes-v1.26.1.md node scripts/release-notes.mjs` — generated notes successfully.
- [x] `test -s /tmp/acorn-release-notes-v1.26.1.md` — generated notes file is non-empty.
- [x] `rg -n '^> .+<br>$' /tmp/acorn-release-notes-v1.26.1.md` — Korean summary blockquotes present.
- [x] `rg -n '^> (Feature updates|Fixes|Performance improvements|Security updates|Documentation updates|Internal cleanup|Build and CI updates|Other changes): ' /tmp/acorn-release-notes-v1.26.1.md` — English summary blockquotes present.
- [x] `git diff --check` — passed.

## Notes

`origin/main` was verified green at `b37de6de170a7e989f30a919a1d7512c0fc3c727` before this branch was created.
