### PR TITLE
fix(status): detect current Codex TUI turn starts

### DIFF
--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -646,6 +646,53 @@ mod tests {
         }
     }
 
+    fn codex_wrapper_notifications_for_tui_line(line: &str) -> String {
+        let base = ScratchDir::new("codex-tui-event");
+        let wrapper_dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
+        let real_dir = base.path().join("real-bin");
+        fs::create_dir_all(&real_dir).unwrap();
+
+        let capture_path = base.path().join("notifications.log");
+        let session_log_path = base.path().join("session.jsonl");
+        write_executable(
+            &wrapper_dir.join("acorn-codex-notify"),
+            "#!/bin/sh\nprintf '%s %s\\n' \"$1\" \"$2\" >> \"$ACORN_NOTIFY_CAPTURE\"\n",
+        )
+        .unwrap();
+        write_executable(
+            &real_dir.join("codex"),
+            r#"#!/bin/sh
+: > "$CODEX_TUI_SESSION_LOG_PATH"
+sleep 0.1
+printf '%s\n' "$ACORN_TEST_TUI_LINE" >> "$CODEX_TUI_SESSION_LOG_PATH"
+_acorn_i=0
+while [ ! -s "$ACORN_NOTIFY_CAPTURE" ] && [ "$_acorn_i" -lt 50 ]; do
+  _acorn_i=$((_acorn_i + 1))
+  sleep 0.02
+done
+"#,
+        )
+        .unwrap();
+
+        let path = format!("{}:/usr/bin:/bin", real_dir.display());
+        let status = Command::new(wrapper_dir.join("codex"))
+            .env("PATH", path)
+            .env("ACORN_AGENT_WRAPPER_DIR", &wrapper_dir)
+            .env("ACORN_AGENT_HOOK_SESSION_ID", "session-1")
+            .env("ACORN_AGENT_HOOK_URL", "http://127.0.0.1:1/agent-hook")
+            .env("ACORN_AGENT_HOOK_TOKEN", "token-1")
+            .env("ACORN_NOTIFY_CAPTURE", &capture_path)
+            .env("ACORN_TEST_TUI_LINE", line)
+            .env("CODEX_TUI_SESSION_LOG_PATH", &session_log_path)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        fs::read_to_string(capture_path).unwrap_or_default()
+    }
+
     #[test]
     fn writes_codex_wrapper_and_notify_helper() {
         let base = ScratchDir::new("codex");
@@ -677,6 +724,13 @@ mod tests {
         ));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
         assert!(notify.contains("ACORN_AGENT_HOOK_SESSION_ID"));
+    }
+
+    #[test]
+    fn codex_wrapper_maps_current_tui_user_turn_to_turn_start() {
+        let line = r#"{"ts":"2026-07-14T05:31:15.813Z","dir":"from_tui","kind":"op","payload":{"UserTurn":{"items":[{"type":"text","text":"Fix the bug."}]}}}"#;
+
+        assert_eq!(codex_wrapper_notifications_for_tui_line(line), "start turn\n");
     }
 
     #[test]

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -649,6 +649,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     fn codex_wrapper_notifications_for_tui_line(line: &str) -> String {
         let base = ScratchDir::new("codex-tui-event");
         let wrapper_dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
@@ -729,11 +730,15 @@ done
         assert!(notify.contains("ACORN_AGENT_HOOK_SESSION_ID"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn codex_wrapper_maps_current_tui_user_turn_to_turn_start() {
         let line = r#"{"ts":"2026-07-14T05:31:15.813Z","dir":"from_tui","kind":"op","payload":{"UserTurn":{"items":[{"type":"text","text":"Fix the bug."}]}}}"#;
 
-        assert_eq!(codex_wrapper_notifications_for_tui_line(line), "start turn\n");
+        assert_eq!(
+            codex_wrapper_notifications_for_tui_line(line),
+            "start turn\n"
+        );
     }
 
     #[test]

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -81,6 +81,9 @@ if [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
 
     tail -n 0 -F "$_acorn_log" 2>/dev/null | while IFS= read -r _acorn_line; do
       case "$_acorn_line" in
+        *'"dir":"from_tui"'*'"kind":"op"'*'"payload":{"UserTurn"'*)
+          "$_acorn_notify" start turn >/dev/null 2>&1 || true
+          ;;
         *'"dir":"to_tui"'*'"kind":"codex_event"'*'"msg":{"type":"task_started"'*)
           _acorn_turn_id=$(printf '%s\n' "$_acorn_line" | awk -F'"turn_id":"' 'NF > 1 { sub(/".*/, "", $2); print $2; exit }')
           [ -n "$_acorn_turn_id" ] || _acorn_turn_id="task_started"


### PR DESCRIPTION
## Summary

Restore accurate working-state transitions for current Codex TUI sessions.

1. **Current turn-start detection** — recognize `from_tui` `op` records whose payload is a `UserTurn`, then forward them through the existing Acorn `start turn` hook channel.
2. **Backward compatibility** — retain the existing `codex_event/task_started` mapping for Codex versions that still emit the older event shape.
3. **Runtime regression coverage** — execute the generated wrapper against a representative current-format TUI record and assert that it emits the expected turn-start notification.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Current Codex TUI begins a user turn | Session can remain `Idle` or `Waiting` while Codex is working | Session transitions to `Working` when the `UserTurn` record is written |
| Older Codex emits `task_started` | Turn start detected | Unchanged |
| Existing long-lived Codex process after app update | Keeps its already-running watcher | Requires a Codex process restart to load the refreshed wrapper |

## Design notes

- The change extends the existing generated-wrapper watcher instead of changing the hook server or session status contract.
- The match uses the current compact TUI recording shape observed in Codex session logs: `dir=from_tui`, `kind=op`, and `payload.UserTurn`.
- Completion handling remains unchanged: `agent-turn-complete` and `Stop` map to `needs_input`, which is rendered as `Waiting`.
- The test runs the generated shell wrapper rather than only asserting that its source contains a pattern, covering the event-to-notification behavior end to end.

## Follow-up (not in this PR)

- Evaluate first-class Codex lifecycle hooks for observing user-launched TUI sessions. Hook installation and trust UX should be designed separately.
- If Acorn later owns the Codex runtime, consider the Codex App Server `turn/started` and `turn/completed` notifications instead of parsing TUI recording output.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml agent_wrappers::tests --lib` — 14 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 384 passed, 1 ignored
- [x] `rustfmt --edition 2021 --check src-tauri/src/agent_wrappers.rs` — passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test` — 95 files and 1,028 tests passed
- [x] `pnpm run build` — production build passed

## Notes

- Repository-wide `cargo fmt --all -- --check` still reports pre-existing formatting differences in unrelated Rust files. The changed file passes `rustfmt --check` independently.
- The frontend production build continues to report the existing chunk-size and mixed dynamic/static import warnings; the build succeeds and this Rust-only change does not affect those bundles.
