### PR TITLE
fix(notifications): follow destination pane and kanban mode

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -211,10 +211,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   function handleOpenActivity(notificationId: string, sessionId: string) {
     const state = useAppStore.getState();
     state.markSessionNotificationRead(notificationId);
-    state.selectSession(sessionId);
-    if (state.workspaceViewMode === "kanban") {
-      state.openTerminalPopup(sessionId);
-    }
+    state.openSessionSurface(sessionId);
     close();
   }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -281,7 +281,6 @@ export function Sidebar() {
   const activeProjectFolderId = useAppStore((s) => s.activeProjectFolderId);
   const workspaceViewMode = useAppStore((s) => s.workspaceViewMode);
   const selectSession = useAppStore((s) => s.selectSession);
-  const openTerminalPopup = useAppStore((s) => s.openTerminalPopup);
   const focusLocalSessions = useAppStore((s) => s.focusLocalSessions);
   const setActiveProject = useAppStore((s) => s.setActiveProject);
   const setActiveProjectFolder = useAppStore((s) => s.setActiveProjectFolder);
@@ -418,10 +417,7 @@ export function Sidebar() {
   }
 
   function selectSidebarSession(sessionId: string) {
-    selectSession(sessionId);
-    if (useAppStore.getState().workspaceViewMode === "kanban") {
-      openTerminalPopup(sessionId);
-    }
+    useAppStore.getState().openSessionSurface(sessionId);
   }
 
   function applyClickPlan(
@@ -3915,18 +3911,14 @@ function SidebarActivityRow({
   notification: SessionNotification;
 }) {
   const t = useTranslation();
-  const selectSession = useAppStore((s) => s.selectSession);
-  const openTerminalPopup = useAppStore((s) => s.openTerminalPopup);
+  const openSessionSurface = useAppStore((s) => s.openSessionSurface);
   const markRead = useAppStore((s) => s.markSessionNotificationRead);
   const dismiss = useAppStore((s) => s.dismissSessionNotification);
   const unread = !notification.readAt;
 
   const openSession = () => {
     markRead(notification.id);
-    selectSession(notification.sessionId);
-    if (useAppStore.getState().workspaceViewMode === "kanban") {
-      openTerminalPopup(notification.sessionId);
-    }
+    openSessionSurface(notification.sessionId);
   };
 
   return (

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -970,18 +970,14 @@ function NotificationRow({
   onClose: () => void;
 }) {
   const t = useTranslation();
-  const selectSession = useAppStore((s) => s.selectSession);
-  const openTerminalPopup = useAppStore((s) => s.openTerminalPopup);
+  const openSessionSurface = useAppStore((s) => s.openSessionSurface);
   const markRead = useAppStore((s) => s.markSessionNotificationRead);
   const dismiss = useAppStore((s) => s.dismissSessionNotification);
   const unread = !notification.readAt;
 
   const openSession = () => {
     markRead(notification.id);
-    selectSession(notification.sessionId);
-    if (useAppStore.getState().workspaceViewMode === "kanban") {
-      openTerminalPopup(notification.sessionId);
-    }
+    openSessionSurface(notification.sessionId);
     onClose();
   };
 

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -29,11 +29,14 @@ vi.mock("@tauri-apps/api/window", () => ({
 import {
   resetNotificationsForTests,
   startFocusedSessionNotificationReadWatcher,
+  startNotificationClickHandler,
   startSessionActivityInboxWatcher,
   startSessionNotificationWatcher,
 } from "./notifications";
 import { DEFAULT_SETTINGS, useSettings } from "./settings";
 import { useAppStore } from "../store";
+
+const originalOpenSessionSurface = useAppStore.getState().openSessionSurface;
 
 const BASE_SESSION: Session = {
   id: "session-1",
@@ -83,6 +86,7 @@ describe("notifications", () => {
         },
       ],
       activeSessionId: null,
+      openSessionSurface: originalOpenSessionSurface,
       sessionNotifications: [],
       silencedSessionIds: {},
       sessionsLoadedCleanly: true,
@@ -115,6 +119,30 @@ describe("notifications", () => {
       }),
     );
     dispose();
+  });
+
+  it("opens the destination session surface when a system notification is clicked", async () => {
+    const unregister = vi.fn();
+    mocks.onAction.mockResolvedValue({ unregister });
+    const openSessionSurface = vi.fn(() => true);
+    useAppStore.setState({ openSessionSurface });
+
+    const dispose = await startNotificationClickHandler();
+    const handleAction = mocks.onAction.mock.calls[0]?.[0] as
+      | ((notification: { extra?: Record<string, unknown> }) => void)
+      | undefined;
+    expect(handleAction).toBeDefined();
+    if (!handleAction) throw new Error("notification action handler missing");
+
+    handleAction({ extra: { sessionId: "session-1" } });
+
+    expect(openSessionSurface).toHaveBeenCalledWith("session-1");
+    expect(mocks.show).toHaveBeenCalled();
+    expect(mocks.unminimize).toHaveBeenCalled();
+    expect(mocks.setFocus).toHaveBeenCalled();
+
+    dispose();
+    expect(unregister).toHaveBeenCalled();
   });
 
   it("marks a focused session transition read instead of sending a system notification", async () => {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -292,13 +292,7 @@ export async function startNotificationClickHandler(): Promise<() => void> {
     void win.show();
     void win.unminimize();
     void win.setFocus();
-    const store = useAppStore.getState();
-    store.selectSession(sessionId);
-    // Kanban has no persistent terminal pane, so mirror the in-app inbox and
-    // pop the session's terminal overlay open (StatusBar NotificationRow).
-    if (store.workspaceViewMode === "kanban") {
-      store.openTerminalPopup(sessionId);
-    }
+    useAppStore.getState().openSessionSurface(sessionId);
     markSessionNotificationsRead(sessionId);
   });
   return () => {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -665,6 +665,44 @@ describe("selectSession", () => {
   });
 });
 
+describe("openSessionSurface", () => {
+  it("uses the destination workspace mode when moving between projects", async () => {
+    await seed(
+      [project(REPO_A, 0), project(REPO_B, 1)],
+      [session("a1", REPO_A), session("b1", REPO_B)],
+    );
+
+    useAppStore.getState().setActiveProject(REPO_B);
+    useAppStore.getState().setWorkspaceViewMode("kanban");
+    useAppStore.getState().setActiveProject(REPO_A);
+
+    expect(useAppStore.getState().workspaceViewMode).toBe("panes");
+    expect(useAppStore.getState().openSessionSurface("b1")).toBe(true);
+
+    let state = useAppStore.getState();
+    expect(state.activeProject).toBe(REPO_B);
+    expect(state.activeSessionId).toBe("b1");
+    expect(state.workspaceViewMode).toBe("kanban");
+    expect(state.terminalPopupSessionId).toBe("b1");
+
+    expect(useAppStore.getState().openSessionSurface("a1")).toBe(true);
+
+    state = useAppStore.getState();
+    expect(state.activeProject).toBe(REPO_A);
+    expect(state.activeSessionId).toBe("a1");
+    expect(state.workspaceViewMode).toBe("panes");
+    expect(state.terminalPopupSessionId).toBeNull();
+  });
+
+  it("does not open a surface for an unknown session", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+
+    expect(useAppStore.getState().openSessionSurface("missing")).toBe(false);
+    expect(useAppStore.getState().activeSessionId).toBe("a1");
+    expect(useAppStore.getState().terminalPopupSessionId).toBeNull();
+  });
+});
+
 describe("focusLocalSessions", () => {
   it("activates a local session so project focus is cleared in the UI", async () => {
     const local = session("local", "/Users/me", { project_scoped: false });

--- a/src/store.ts
+++ b/src/store.ts
@@ -442,6 +442,7 @@ interface AppStateModel {
   pollSessionStatuses: (ids?: string[]) => Promise<void>;
   selectTab: (id: string | null) => void;
   selectSession: (id: string | null) => void;
+  openSessionSurface: (id: string) => boolean;
   focusLocalSessions: () => void;
   setActiveProject: (repoPath: string) => void;
   setActiveProjectFolder: (folderId: string) => void;
@@ -2165,6 +2166,21 @@ export const useAppStore = create<AppStateModel>()(
         );
       });
     }
+  },
+
+  openSessionSurface(id) {
+    if (!get().sessions.some((session) => session.id === id)) return false;
+
+    get().selectSession(id);
+    const state = get();
+    if (state.activeSessionId !== id) return false;
+
+    if (state.workspaceViewMode === "kanban") {
+      state.openTerminalPopup(id);
+    } else {
+      state.closeTerminalPopup();
+    }
+    return true;
   },
 
   focusLocalSessions() {

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -169,24 +169,30 @@ test.describe("command palette", () => {
     ).toBeVisible();
   });
 
-  test("opens unread session activity from the palette", async ({
+  test("opens unread session activity in the destination workspace mode", async ({
     page,
     tauri,
   }) => {
     await tauri.handle("list_projects", () => [
       {
-        repo_path: "/tmp/demo",
-        name: "demo",
+        repo_path: "/tmp/beta",
+        name: "beta",
         created_at: "2026-01-01T00:00:00Z",
         position: 0,
+      },
+      {
+        repo_path: "/tmp/alpha",
+        name: "alpha",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 1,
       },
     ]);
     await tauri.handle("list_sessions", () => [
       {
         id: "session-1",
         name: "foreground",
-        repo_path: "/tmp/demo",
-        worktree_path: "/tmp/demo",
+        repo_path: "/tmp/beta",
+        worktree_path: "/tmp/beta",
         branch: "main",
         isolated: false,
         project_scoped: true,
@@ -202,8 +208,8 @@ test.describe("command palette", () => {
       {
         id: "session-2",
         name: "agent run",
-        repo_path: "/tmp/demo",
-        worktree_path: "/tmp/demo",
+        repo_path: "/tmp/alpha",
+        worktree_path: "/tmp/alpha",
         branch: "main",
         isolated: false,
         project_scoped: true,
@@ -217,16 +223,36 @@ test.describe("command palette", () => {
         in_worktree: false,
       },
     ]);
-    await tauri.handle("detect_session_statuses", () => [
-      {
-        id: "session-2",
-        status: "waiting_for_input",
-        branch: null,
-        agent_provider: null,
-      },
-    ]);
+    await tauri.handle("detect_session_statuses", () => {
+      const state = window as unknown as { __emitAlphaActivity?: boolean };
+      return state.__emitAlphaActivity
+        ? [
+            {
+              id: "session-2",
+              status: "waiting_for_input",
+              branch: null,
+              agent_provider: null,
+            },
+          ]
+        : [];
+    });
 
     await page.goto("/");
+
+    const modeSelect = page.getByTestId("workspace-view-status");
+    await expect(modeSelect).toContainText("Panes");
+    await page.getByRole("button", { name: "Project alpha" }).click();
+    await modeSelect.click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+    await expect(modeSelect).toContainText("Kanban");
+    await page.getByRole("button", { name: "Project beta" }).click();
+    await expect(modeSelect).toContainText("Panes");
+
+    await page.evaluate(() => {
+      (window as unknown as { __emitAlphaActivity?: boolean })
+        .__emitAlphaActivity = true;
+      window.dispatchEvent(new Event("focus"));
+    });
     await expect(page.getByRole("button", { name: "Session notifications" }))
       .toContainText("1");
 
@@ -235,11 +261,17 @@ test.describe("command palette", () => {
     await expect(palette.getByText("Unread activity")).toBeVisible();
 
     await palette
-      .getByRole("option", { name: /Waiting for input.*agent run.*demo/ })
+      .getByRole("option", { name: /Waiting for input.*agent run.*alpha/ })
       .click();
 
     await expect(palette).toHaveCount(0);
-    await expect(page.getByText("agent run").first()).toBeVisible();
+    await expect(modeSelect).toContainText("Kanban");
+    await expect(page.getByTestId("workspace-kanban")).toBeVisible();
+    const popover = page.getByTestId("kanban-terminal-popover");
+    await expect(popover).toBeVisible();
+    await expect(
+      popover.getByRole("heading", { name: "agent run" }),
+    ).toBeVisible();
     await expect(page.getByRole("button", { name: "Session notifications" }))
       .not.toContainText("1");
   });


### PR DESCRIPTION
## Summary

Notification clicks now reveal the target session correctly even when the source and destination workspaces use different view modes.

1. **Destination-aware routing** — add one store action that selects the session first, then evaluates the destination workspace mode to open a Kanban terminal popover or clear stale popup state for Panes.
2. **Consistent entry points** — route OS notifications, status-bar notifications, sidebar activity, Command Palette activity, and sidebar session selection through the same visible-session behavior.
3. **Regression coverage** — cover Panes ↔ Kanban transitions, unknown session IDs, OS notification delegation, and the cross-project Command Palette flow.

## Expected impact

| Flow | Before | After |
| --- | --- | --- |
| Panes → Kanban notification | Destination board opened without a visible terminal | Target session popover opens on the destination card |
| Kanban → Panes notification | Popup state could be carried across the transition | Target pane/tab is selected and popup state is cleared |
| Same-mode navigation | Separate callers duplicated the routing rules | All callers use one destination-aware action |

## Design notes

- `selectSession` remains the low-level tab/project selection primitive.
- `openSessionSurface` adds the user-visible layer: it validates the session, selects it synchronously, then reads the resulting workspace mode before deciding whether a Kanban popover is required.
- Unknown or unavailable session IDs remain a no-op and do not create orphaned popup state.

## Test plan

- [x] `pnpm test` — all Vitest suites pass
- [x] `pnpm run typecheck` — TypeScript passes
- [x] `pnpm exec playwright test tests/e2e/session-notifications.spec.ts tests/e2e/command-palette.spec.ts` — 8 tests pass
- [x] `pnpm run build` — production frontend build passes
- [x] `git diff --check` — no whitespace errors
