### PR TITLE
chore(release): v1.26.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.26.1",
+  "version": "1.26.2",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.26.1"
+version = "1.26.2"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.26.1"
+version = "1.26.2"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

This patch release packages the two fixes merged since v1.26.1.

1. **Agent status detection** — includes #653 so current Codex TUI turn starts are detected reliably.
2. **Notification navigation** — includes #654 so notification-driven session navigation follows the destination workspace pane or kanban mode.
3. **Version metadata** — synchronizes the app, Tauri, and Rust package versions at 1.26.2.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Agent status | Current Codex TUI turn starts could be missed | Turn starts are detected from the current TUI state |
| Notification navigation | Cross-project session navigation could retain the source pane/kanban behavior | The selected session opens according to its destination workspace mode |
| Release metadata | App metadata reports 1.26.1 | All release version fields report 1.26.2 |

## Design notes

- This is a patch release because all unreleased user-visible changes are fixes.
- The release PR changes only the four canonical version metadata files; release notes are sourced from merged PRs #653 and #654.

## Test plan

- [x] `pnpm run typecheck`
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1`
- [x] Generated `/tmp/acorn-release-notes-v1.26.2.md` with `scripts/release-notes.mjs`
- [x] Verified Korean and English release-note summary blockquotes
- [x] `git diff --check`

## Notes

- `main` CI passed at https://github.com/im-ian/acorn/actions/runs/29313580074 before the release branch was created.
