### PR TITLE
fix(history): hide Codex control metadata from agent history

### DIFF
--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -162,7 +162,6 @@ pub fn assistant_message_text(value: &Value) -> Option<String> {
 fn parse_codex_value(value: &Value) -> ParsedTranscriptLine {
     let event = codex_event_value(value);
     let event_role = codex_role_from_event(value, event);
-    let role = event_role;
     let texts = codex_event_texts(value, event);
     let response_text = codex_response_text(value, event);
     let state_text = match event_role {
@@ -170,20 +169,25 @@ fn parse_codex_value(value: &Value) -> ParsedTranscriptLine {
         TranscriptRole::Assistant => first_text(&texts),
         TranscriptRole::Other => None,
     };
-    let text = match role {
+    let text = match event_role {
         TranscriptRole::User => joined_text(&texts),
         TranscriptRole::Assistant => first_text(&texts).or_else(|| response_text.clone()),
         TranscriptRole::Other => None,
+    };
+    let display_role = if event_role == TranscriptRole::User && text.is_none() {
+        TranscriptRole::Other
+    } else {
+        event_role
     };
     let (preview_role, preview_text) = codex_preview_role_and_text(value, event, event_role);
 
     ParsedTranscriptLine {
         timestamp: string_at(Some(value), "timestamp")
             .or_else(|| string_at(Some(event), "timestamp")),
-        role,
+        role: display_role,
         text,
         state_text,
-        state_role: event_role,
+        state_role: display_role,
         preview_role,
         preview_text,
         response_text,
@@ -642,6 +646,7 @@ fn looks_like_context_block(text: &str) -> bool {
         || lower.contains("<cwd>")
         || lower.contains("# agents.md")
         || lower.contains("<instructions>")
+        || looks_like_hidden_message_block(text)
         || looks_like_skill_context_block(text)
 }
 
@@ -649,15 +654,25 @@ fn looks_like_preview_context_block(text: &str) -> bool {
     let lower = text.trim_start().to_ascii_lowercase();
     lower.starts_with("<environment_context>")
         || lower.starts_with("<cwd>")
-        || lower.starts_with("<codex_internal_context")
-        || lower.starts_with("<turn_aborted>")
-        || lower.starts_with("<subagent_notification>")
-        || lower.starts_with("<recommended_plugins>")
-        || lower.starts_with("<user_shell_command>")
-        || lower.starts_with("<user_action>")
         || lower.starts_with("# agents.md instructions for ")
         || lower.starts_with("<instructions>")
+        || looks_like_hidden_message_block(text)
         || looks_like_skill_context_block(text)
+}
+
+fn looks_like_hidden_message_block(text: &str) -> bool {
+    let lower = text.trim_start().to_ascii_lowercase();
+    [
+        "<codex_internal_context",
+        "<turn_aborted>",
+        "<subagent_notification>",
+        "<recommended_plugins>",
+        "<user_shell_command>",
+        "<user_action>",
+        "<image name=",
+    ]
+    .iter()
+    .any(|tag| lower.starts_with(tag))
 }
 
 fn looks_like_skill_context_block(text: &str) -> bool {
@@ -864,6 +879,67 @@ mod tests {
         assert_eq!(parsed.timestamp.as_deref(), Some("t"));
         assert_eq!(parsed.session_id.as_deref(), Some("payload-session"));
         assert_eq!(parsed.cwd.as_deref(), Some("/tmp/project"));
+    }
+
+    #[test]
+    fn codex_hidden_message_blocks_are_not_user_content() {
+        let messages = [
+            "<codex_internal_context source=\"goal\">\nContinue the active goal.\n</codex_internal_context>",
+            "<turn_aborted>\nThe user interrupted the turn.\n</turn_aborted>",
+            "<subagent_notification>\nA task completed.\n</subagent_notification>",
+            "<recommended_plugins>\nInternal recommendations.\n</recommended_plugins>",
+            "<user_shell_command>\npnpm test\n</user_shell_command>",
+            "<user_action>\nInternal action metadata.\n</user_action>",
+            "<image name=[Image #1] path=\"/tmp/clipboard.png\">\n</image>\nShip the release",
+        ];
+
+        for message in messages {
+            let value = serde_json::json!({
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": message }],
+                },
+            });
+            let parsed = parse_transcript_value(AgentKind::Codex, &value);
+
+            assert_eq!(parsed.role, TranscriptRole::Other, "message: {message}");
+            assert_eq!(parsed.text, None, "message: {message}");
+            assert_eq!(
+                parsed.state_role,
+                TranscriptRole::Other,
+                "message: {message}"
+            );
+            assert_eq!(parsed.state_text, None, "message: {message}");
+            assert_eq!(
+                parsed.preview_role,
+                TranscriptRole::Other,
+                "message: {message}"
+            );
+            assert_eq!(parsed.preview_text, None, "message: {message}");
+        }
+    }
+
+    #[test]
+    fn codex_keeps_inline_hidden_tag_mentions_as_user_content() {
+        let message = "Why does <codex_internal_context> appear in History?";
+        let value = serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{ "type": "input_text", "text": message }],
+            },
+        });
+        let parsed = parse_transcript_value(AgentKind::Codex, &value);
+
+        assert_eq!(parsed.role, TranscriptRole::User);
+        assert_eq!(parsed.text.as_deref(), Some(message));
+        assert_eq!(parsed.state_role, TranscriptRole::User);
+        assert_eq!(parsed.state_text.as_deref(), Some(message));
+        assert_eq!(parsed.preview_role, TranscriptRole::User);
+        assert_eq!(parsed.preview_text.as_deref(), Some(message));
     }
 
     #[test]

--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -1935,6 +1935,92 @@ mod tests {
     }
 
     #[test]
+    fn codex_history_uses_real_request_after_hidden_message_blocks() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let id = "019e4818-7c15-7e60-9b3b-898a1c7803d6";
+        let transcript = dir
+            .path()
+            .join(format!("rollout-2026-07-15T00-00-00-{id}.jsonl"));
+        let mut file = fs::File::create(&transcript).unwrap();
+
+        for value in [
+            serde_json::json!({
+                "type": "session_meta",
+                "payload": {
+                    "id": id,
+                    "cwd": repo.display().to_string(),
+                },
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{
+                        "type": "input_text",
+                        "text": "<codex_internal_context source=\"goal\">\nContinue the active goal.\n</codex_internal_context>",
+                    }],
+                },
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{
+                        "type": "input_text",
+                        "text": "<image name=[Image #1] path=\"/tmp/clipboard.png\">\n</image>\nShip the release",
+                    }],
+                },
+            }),
+            serde_json::json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "user_message",
+                    "message": "Ship the release",
+                },
+            }),
+            serde_json::json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "agent_message",
+                    "phase": "final_answer",
+                    "message": "The release is published.",
+                },
+            }),
+        ] {
+            writeln!(file, "{value}").unwrap();
+        }
+        drop(file);
+
+        let scope_repo = normalize_path(&repo);
+        let item = parse_codex_file(&transcript, HistoryScope::Project(&scope_repo)).unwrap();
+        assert_eq!(item.title, "Ship the release");
+        assert_eq!(item.preview.as_deref(), Some("The release is published."));
+
+        let summary =
+            summarize_agent_transcript(AgentHistoryProvider::Codex, id.to_string(), &transcript)
+                .unwrap();
+        assert_eq!(summary.message_count, 2);
+        assert_eq!(summary.user_messages, 1);
+        assert_eq!(summary.assistant_messages, 1);
+        assert_eq!(summary.turn_count, 1);
+        assert_eq!(
+            summary
+                .recent_messages
+                .iter()
+                .map(|message| (message.role.as_str(), message.text.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("user", "Ship the release"),
+                ("assistant", "The release is published."),
+            ]
+        );
+    }
+
+    #[test]
     fn codex_history_skips_marked_acorn_title_generation_prompt() {
         let dir = tempfile::tempdir().unwrap();
         let repo = dir.path().join("repo");


### PR DESCRIPTION
## Summary

Codex transcript transport metadata no longer surfaces as user content across Agents → History and transcript summaries.

1. **Shared filtering** — reuse one anchored hidden-message classifier for goal context, control notifications, shell/action metadata, and image attachment envelopes across History, summaries, and previews.
2. **Consistent roles** — classify filtered Codex user events as non-conversation events so they do not become titles or inflate user-message and turn counts.
3. **Regression coverage** — verify that History selects the normalized real request after goal/image metadata while inline tag mentions remain visible.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| History title | Could start with `<codex_internal_context source="goal">` or a temporary image path | Uses the first normalized user request |
| Transcript summary | Internal control records could count as user messages | Hidden records are excluded from counts and recent messages |
| Conversation preview | Used a separate control filter | Shares the same hidden-message definitions as History |

## Design notes

- Filtering lives in the shared Rust transcript parser, so the RightPanel remains a presentation layer.
- Hidden-message matching is anchored at the start of a trimmed message. Real prompts that mention tags such as `<codex_internal_context>` inline remain visible.
- Image-bearing `response_item` envelopes are ignored in favor of the normalized `event_msg.user_message` that Codex records for the same turn.

## Test plan

- [x] `env -u ACORN_DATA_DIR -u ACORN_IPC_SOCKET -u ACORN_DAEMON_SOCKET -u ACORN_WORKSPACE_ID -u ACORN_WORKSPACE_PATH -u ACORN_WORKSPACE_NAME -u ACORN_AGENT_STATE_DIR -u ACORN_AGENT_WRAPPER_DIR -u ACORN_CLI_DIR -u ACORN_RESUME_TOKEN -u ACORN_STAGED_REV -u ACORN_USER_ZDOTDIR cargo test --workspace --quiet` — all workspace tests pass; main crate 385 passed, 1 ignored.
- [x] `rustfmt --edition 2021 --check crates/acorn-transcript/src/line.rs src/agent_history.rs`
- [x] `git diff --check origin/main...HEAD`

## Notes

- Existing dead-code warnings in unrelated cache helpers and an unused Acorn PTY test helper remain unchanged by this PR.