### PR TITLE
feat(settings): always show inline session icons

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -1044,13 +1044,7 @@ function TabItem({
     session != null &&
     canRegenerateSessionTitle(session) &&
     !isGeneratingTitle;
-  const showAgentProviderIcons = useSettings(
-    (s) => s.settings.sessionDisplay.icons.agentProvider,
-  );
-  const agentProvider =
-    showAgentProviderIcons && session
-      ? resolveSessionAgentProvider(session)
-      : null;
+  const agentProvider = session ? resolveSessionAgentProvider(session) : null;
   const tabPath =
     tab.kind === "session"
       ? tab.session.worktree_path

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -871,13 +871,7 @@ function PrSkeletonList({ count = 6 }: { count?: number }) {
  * timestamp stacked on the right — so the panel doesn't reflow when items
  * arrive. Some rows skip the worktree bar to look like a real mixed list.
  */
-function HistorySkeletonRow({
-  index,
-  showAgentProviderIcons,
-}: {
-  index: number;
-  showAgentProviderIcons: boolean;
-}) {
+function HistorySkeletonRow({ index }: { index: number }) {
   const titleWidths = ["68%", "82%", "54%", "74%", "60%", "88%"];
   const previewWidths = ["92%", "76%", "60%", "84%"];
   const titleW = titleWidths[index % titleWidths.length];
@@ -890,10 +884,7 @@ function HistorySkeletonRow({
       style={{ animationDelay: `${index * 60}ms` }}
     >
       <SkeletonBlock
-        className={cn(
-          "mt-0.5 shrink-0 bg-fg-muted/15",
-          showAgentProviderIcons ? "size-5" : "h-4 w-12",
-        )}
+        className="mt-0.5 size-5 shrink-0 bg-fg-muted/15"
       />
       <div className="min-w-0 flex-1 space-y-1.5">
         <SkeletonBlock
@@ -1374,9 +1365,6 @@ function AgentHistoryTab({
   const createSession = useAppStore((s) => s.createSession);
   const adoptSessionWorktree = useAppStore((s) => s.adoptSessionWorktree);
   const setPendingTerminalInput = useAppStore((s) => s.setPendingTerminalInput);
-  const showAgentProviderIcons = useSettings(
-    (s) => s.settings.sessionDisplay.icons.agentProvider,
-  );
   const historyLimit = 100;
   // Hydrate from the module-level cache so re-opening a project or the
   // unscoped Chats history shows its list instantly.
@@ -1594,11 +1582,7 @@ function AgentHistoryTab({
             aria-label={rt(t, "rightPanel.history.loading")}
           >
             {Array.from({ length: 8 }).map((_, i) => (
-              <HistorySkeletonRow
-                key={i}
-                index={i}
-                showAgentProviderIcons={showAgentProviderIcons}
-              />
+              <HistorySkeletonRow key={i} index={i} />
             ))}
           </div>
         ) : historyItems.length === 0 ? (
@@ -1629,30 +1613,19 @@ function AgentHistoryTab({
                   }}
                 >
                   <div className="flex items-start gap-2">
-                    {showAgentProviderIcons ? (
-                      <span
-                        className={cn(
-                          "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded",
-                          providerTone,
-                        )}
-                      >
-                        <Tooltip label={item.provider} side="right">
-                          <AgentProviderIcon
-                            provider={item.provider}
-                            className="size-3"
-                          />
-                        </Tooltip>
-                      </span>
-                    ) : (
-                      <span
-                        className={cn(
-                          "mt-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide",
-                          providerTone,
-                        )}
-                      >
-                        {item.provider}
-                      </span>
-                    )}
+                    <span
+                      className={cn(
+                        "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded",
+                        providerTone,
+                      )}
+                    >
+                      <Tooltip label={item.provider} side="right">
+                        <AgentProviderIcon
+                          provider={item.provider}
+                          className="size-3"
+                        />
+                      </Tooltip>
+                    </span>
                     <div className="min-w-0 flex-1">
                       <div className="truncate text-xs font-medium text-fg">
                         {item.title}

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -875,6 +875,22 @@ describe("SettingsModal font controls", () => {
     expect(document.querySelector('[role="listbox"]')).toBeNull();
   });
 
+  it("does not render inline icon preferences", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openAppearanceTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(document.body.textContent).not.toContain("Inline icons");
+    expect(document.body.textContent).not.toContain("Status dot");
+    expect(document.body.textContent).not.toContain("Agent provider icons");
+    expect(document.body.textContent).not.toContain("Session kind icons");
+  });
+
   it("renders searchable grouped theme options with separators including user themes", async () => {
     await act(async () => {
       root = createRoot(container);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -2208,11 +2208,8 @@ function SessionDisplaySection({
 }: {
   sessionDisplay: AcornSettings["sessionDisplay"];
   patch: (
-    patch: Partial<
-      Omit<AcornSettings["sessionDisplay"], "metadata" | "icons">
-    > & {
+    patch: Partial<Omit<AcornSettings["sessionDisplay"], "metadata">> & {
       metadata?: Partial<AcornSettings["sessionDisplay"]["metadata"]>;
-      icons?: Partial<AcornSettings["sessionDisplay"]["icons"]>;
     },
   ) => void;
 }) {
@@ -2284,49 +2281,6 @@ function SessionDisplaySection({
             )}
             checked={sessionDisplay.metadata.status}
             onChange={(v) => patch({ metadata: { status: v } })}
-          />
-        </div>
-      </Field>
-      <Field
-        label={st(t, "settings.appearance.sessionDisplay.icons.label")}
-        hint={st(t, "settings.appearance.sessionDisplay.icons.hint")}
-      >
-        <div className="flex flex-col gap-1">
-          <CheckboxRow
-            label={st(
-              t,
-              "settings.appearance.sessionDisplay.icons.statusDot.label",
-            )}
-            description={st(
-              t,
-              "settings.appearance.sessionDisplay.icons.statusDot.description",
-            )}
-            checked={sessionDisplay.icons.statusDot}
-            onChange={(v) => patch({ icons: { statusDot: v } })}
-          />
-          <CheckboxRow
-            label={st(
-              t,
-              "settings.appearance.sessionDisplay.icons.agentProvider.label",
-            )}
-            description={st(
-              t,
-              "settings.appearance.sessionDisplay.icons.agentProvider.description",
-            )}
-            checked={sessionDisplay.icons.agentProvider}
-            onChange={(v) => patch({ icons: { agentProvider: v } })}
-          />
-          <CheckboxRow
-            label={st(
-              t,
-              "settings.appearance.sessionDisplay.icons.sessionKind.label",
-            )}
-            description={st(
-              t,
-              "settings.appearance.sessionDisplay.icons.sessionKind.description",
-            )}
-            checked={sessionDisplay.icons.sessionKind}
-            onChange={(v) => patch({ icons: { sessionKind: v } })}
           />
         </div>
       </Field>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1479,28 +1479,23 @@ function SessionRowPreview({
     session,
     sessionDisplay.metadata,
   );
-  const agentProvider = sessionDisplay.icons.agentProvider
-    ? resolveSessionAgentProvider(session)
-    : null;
+  const agentProvider = resolveSessionAgentProvider(session);
 
   return (
     <div className="flex w-full items-start gap-1.5 rounded-md bg-bg-elevated/95 px-2 py-1 shadow-lg ring-1 ring-border/60">
-      {sessionDisplay.icons.statusDot ? (
-        <SessionStatusMarker
-          session={session}
-          agentProvider={agentProvider}
-          isGeneratingTitle={false}
-          generatingLabel={sidebarText(t, "sidebar.aria.generatingSessionTitle")}
-          chatLabel={sidebarText(t, "sidebar.aria.chatSession")}
-        />
-      ) : null}
+      <SessionStatusMarker
+        session={session}
+        agentProvider={agentProvider}
+        isGeneratingTitle={false}
+        generatingLabel={sidebarText(t, "sidebar.aria.generatingSessionTitle")}
+        chatLabel={sidebarText(t, "sidebar.aria.chatSession")}
+      />
       <SessionRowLabel
         editing={false}
         session={session}
         titleText={titleText}
         metadataText={metadataText}
         currentPullRequest={null}
-        showKindIcons={sessionDisplay.icons.sessionKind}
         t={t}
         onSubmitRename={() => undefined}
         onCancelRename={() => undefined}
@@ -2767,7 +2762,6 @@ function SessionRow({
   const editorCommand = useSettings((s) => s.settings.editor.command);
   const editorConfigured = editorCommand.trim().length > 0;
   const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
-  const showAgentProviderIcons = sessionDisplay.icons.agentProvider;
   const namedProjectFolders = projectFolders.filter(
     (folder) => !isDefaultProjectFolder(folder),
   );
@@ -2916,9 +2910,7 @@ function SessionRow({
     selectSession(session.id);
   }
 
-  const agentProvider = showAgentProviderIcons
-    ? resolveSessionAgentProvider(session)
-    : null;
+  const agentProvider = resolveSessionAgentProvider(session);
   const forkItems: ContextMenuItem[] = (() => {
     if (!agent) return [];
     return buildAgentContextMenuItems({
@@ -3157,22 +3149,19 @@ function SessionRow({
         ),
       })}
     >
-      {sessionDisplay.icons.statusDot || isGeneratingTitle ? (
-        <SessionStatusMarker
-          session={session}
-          agentProvider={agentProvider}
-          isGeneratingTitle={isGeneratingTitle}
-          generatingLabel={sidebarText(t, "sidebar.aria.generatingSessionTitle")}
-          chatLabel={sidebarText(t, "sidebar.aria.chatSession")}
-        />
-      ) : null}
+      <SessionStatusMarker
+        session={session}
+        agentProvider={agentProvider}
+        isGeneratingTitle={isGeneratingTitle}
+        generatingLabel={sidebarText(t, "sidebar.aria.generatingSessionTitle")}
+        chatLabel={sidebarText(t, "sidebar.aria.chatSession")}
+      />
       <SessionRowLabel
         editing={editing}
         session={session}
         titleText={titleText}
         metadataText={metadataText}
         currentPullRequest={currentPullRequest}
-        showKindIcons={sessionDisplay.icons.sessionKind}
         hideWorktreeIcon={hideWorkspaceDuplicateContext}
         t={t}
         onSubmitRename={async (next) => {
@@ -3234,7 +3223,6 @@ interface SessionRowLabelProps {
   titleText: string;
   metadataText: string;
   currentPullRequest: SessionPullRequestSummary | null;
-  showKindIcons: boolean;
   hideWorktreeIcon?: boolean;
   t: Translator;
   onSubmitRename: (value: string) => void | Promise<void>;
@@ -3247,7 +3235,6 @@ function SessionRowLabel({
   titleText,
   metadataText,
   currentPullRequest,
-  showKindIcons,
   hideWorktreeIcon = false,
   t,
   onSubmitRename,
@@ -3281,14 +3268,14 @@ function SessionRowLabel({
             {titleText}
           </span>
         )}
-        {showKindIcons && inWorktree && !hideWorktreeIcon ? (
+        {inWorktree && !hideWorktreeIcon ? (
           <GitBranch
             size={10}
             className="shrink-0 text-fg-muted"
             aria-label={sidebarText(t, "sidebar.aria.worktree")}
           />
         ) : null}
-        {showKindIcons && session.kind === "control" ? (
+        {session.kind === "control" ? (
           <Bot
             size={10}
             className="shrink-0 text-accent"
@@ -4334,9 +4321,7 @@ function LocalSessionRow({
     session,
     sessionDisplay.metadata,
   );
-  const agentProvider = sessionDisplay.icons.agentProvider
-    ? resolveSessionAgentProvider(session)
-    : null;
+  const agentProvider = resolveSessionAgentProvider(session);
   const hoverDetails = sessionDisplay.showDetailsOnHover
     ? buildSessionHoverDetails(t, session, currentPullRequest)
     : null;
@@ -4513,22 +4498,19 @@ function LocalSessionRow({
         ),
       })}
     >
-      {sessionDisplay.icons.statusDot || isGeneratingTitle ? (
-        <SessionStatusMarker
-          session={session}
-          agentProvider={agentProvider}
-          isGeneratingTitle={isGeneratingTitle}
-          generatingLabel={sidebarText(t, "sidebar.aria.generatingSessionTitle")}
-          chatLabel={sidebarText(t, "sidebar.aria.chatSession")}
-        />
-      ) : null}
+      <SessionStatusMarker
+        session={session}
+        agentProvider={agentProvider}
+        isGeneratingTitle={isGeneratingTitle}
+        generatingLabel={sidebarText(t, "sidebar.aria.generatingSessionTitle")}
+        chatLabel={sidebarText(t, "sidebar.aria.chatSession")}
+      />
       <SessionRowLabel
         editing={editing}
         session={session}
         titleText={titleText}
         metadataText={metadataText}
         currentPullRequest={currentPullRequest}
-        showKindIcons={sessionDisplay.icons.sessionKind}
         t={t}
         onSubmitRename={async (next) => {
           setEditing(false);

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -277,9 +277,6 @@ export function StatusBar() {
   const showAgentTokenUsage = useSettings(
     (s) => s.settings.statusBar.showAgentTokenUsage,
   );
-  const showAgentProviderIcons = useSettings(
-    (s) => s.settings.sessionDisplay.icons.agentProvider,
-  );
   const showMemory = useSettings((s) => s.settings.statusBar.showMemory);
   const active = sessions.find((s) => s.id === activeSessionId);
   const activeTokenProvider: AgentTokenProvider | null = active
@@ -443,7 +440,6 @@ export function StatusBar() {
               <span className="text-fg-muted/50">|</span>
               <AgentTokenUsageBadge
                 provider={activeTokenProvider}
-                showProviderIcon={showAgentProviderIcons}
                 snapshot={tokenUsage}
               />
             </>
@@ -485,11 +481,9 @@ const TOKEN_WINDOWS: AgentTokenWindow[] = ["five_hour", "weekly"];
 
 function AgentTokenUsageBadge({
   provider,
-  showProviderIcon,
   snapshot,
 }: {
   provider: AgentTokenProvider;
-  showProviderIcon: boolean;
   snapshot: AgentTokenUsageSnapshot | null;
 }) {
   const t = useTranslation();
@@ -502,11 +496,7 @@ function AgentTokenUsageBadge({
         data-testid="agent-token-usage"
         className="inline-flex h-5 shrink-0 items-center gap-1 whitespace-nowrap rounded px-1 text-fg-muted"
       >
-        {showProviderIcon ? (
-          <AgentProviderIcon provider={provider} />
-        ) : (
-          <Gauge size={12} />
-        )}
+        <AgentProviderIcon provider={provider} />
         {summary}
       </span>
     </Tooltip>

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -2848,12 +2848,7 @@ function WorkspaceSessionIcon({
   size?: "sm" | "md";
   className?: string;
 }) {
-  const showAgentProviderIcons = useSettings(
-    (s) => s.settings.sessionDisplay.icons.agentProvider,
-  );
-  const agentProvider = showAgentProviderIcons
-    ? resolveSessionAgentProvider(session)
-    : null;
+  const agentProvider = resolveSessionAgentProvider(session);
   const fallbackKind =
     session.kind === "control"
       ? "control"

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -457,17 +457,6 @@ export interface AcornSettings {
       status: boolean;
     };
     /**
-     * Inline icon toggles. Status dot is the colored bullet at row start;
-     * agentProvider lets live Claude/Codex/Antigravity sessions replace that dot with
-     * their provider mark; sessionKind covers the isolated-worktree
-     * (GitBranch) and control (Bot) glyphs trailing the title.
-     */
-    icons: {
-      statusDot: boolean;
-      agentProvider: boolean;
-      sessionKind: boolean;
-    };
-    /**
      * When true, hovering a row pops a tooltip with every available
      * field (name, working directory, branch, status) regardless of
      * which ones the row itself shows.
@@ -602,11 +591,6 @@ export const DEFAULT_SETTINGS: AcornSettings = {
       branch: true,
       workingDirectory: false,
       status: true,
-    },
-    icons: {
-      statusDot: true,
-      agentProvider: true,
-      sessionKind: true,
     },
     showDetailsOnHover: true,
   },
@@ -1435,10 +1419,6 @@ function loadSettings(): AcornSettings {
           ...DEFAULT_SETTINGS.sessionDisplay.metadata,
           ...(parsed.sessionDisplay?.metadata ?? {}),
         },
-        icons: {
-          ...DEFAULT_SETTINGS.sessionDisplay.icons,
-          ...(parsed.sessionDisplay?.icons ?? {}),
-        },
         showDetailsOnHover:
           typeof parsed.sessionDisplay?.showDetailsOnHover === "boolean"
             ? parsed.sessionDisplay.showDetailsOnHover
@@ -1522,11 +1502,8 @@ interface SettingsState {
   patchStatusBar: (patch: Partial<AcornSettings["statusBar"]>) => void;
   patchGithub: (patch: Partial<AcornSettings["github"]>) => void;
   patchSessionDisplay: (
-    patch: Partial<
-      Omit<AcornSettings["sessionDisplay"], "metadata" | "icons">
-    > & {
+    patch: Partial<Omit<AcornSettings["sessionDisplay"], "metadata">> & {
       metadata?: Partial<AcornSettings["sessionDisplay"]["metadata"]>;
-      icons?: Partial<AcornSettings["sessionDisplay"]["icons"]>;
     },
   ) => void;
   patchAppearance: (
@@ -1764,17 +1741,13 @@ export const useSettings = create<SettingsState>((set, get) => ({
       const metadata = patch.metadata
         ? { ...s.settings.sessionDisplay.metadata, ...patch.metadata }
         : s.settings.sessionDisplay.metadata;
-      const icons = patch.icons
-        ? { ...s.settings.sessionDisplay.icons, ...patch.icons }
-        : s.settings.sessionDisplay.icons;
-      const { metadata: _m, icons: _i, ...rest } = patch;
+      const { metadata: _m, ...rest } = patch;
       const next: AcornSettings = {
         ...s.settings,
         sessionDisplay: {
           ...s.settings.sessionDisplay,
           ...rest,
           metadata,
-          icons,
         },
       };
       persist(next);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -391,22 +391,6 @@
             "description": "Idle / Running / Needs input / Failed / Completed."
           }
         },
-        "icons": {
-          "label": "Inline icons",
-          "hint": "Glyphs that decorate each session row. Hide to make the list denser.",
-          "statusDot": {
-            "label": "Status dot",
-            "description": "Colored bullet at the row start. Redundant when Status is enabled in metadata."
-          },
-          "agentProvider": {
-            "label": "Agent provider icons",
-            "description": "Use Claude/Codex/Antigravity icons in status positions and Agents History. Turn off to show status dots and text badges."
-          },
-          "sessionKind": {
-            "label": "Session kind icons",
-            "description": "Branch glyph for isolated worktrees and bot glyph for control sessions."
-          }
-        },
         "hover": {
           "label": "Show details on hover",
           "hint": "Pop a tooltip with every field when hovering a session row, regardless of which fields the row itself shows.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -391,22 +391,6 @@
             "description": "Idle / Running / Needs input / Failed / Completed."
           }
         },
-        "icons": {
-          "label": "인라인 아이콘",
-          "hint": "각 세션 행을 꾸미는 글리프입니다. 숨기면 목록이 더 조밀해집니다.",
-          "statusDot": {
-            "label": "상태 점",
-            "description": "행 시작 부분의 색상 점입니다. 메타데이터에서 Status가 켜져 있으면 중복됩니다."
-          },
-          "agentProvider": {
-            "label": "에이전트 제공자 아이콘",
-            "description": "상태 위치와 Agents History에 Claude/Codex/Antigravity 아이콘을 표시합니다. 끄면 상태 점과 텍스트 배지를 표시합니다."
-          },
-          "sessionKind": {
-            "label": "세션 종류 아이콘",
-            "description": "격리된 워크트리에는 브랜치 글리프를, 컨트롤 세션에는 봇 글리프를 표시합니다."
-          }
-        },
         "hover": {
           "label": "호버 시 세부 정보 표시",
           "hint": "세션 행에 마우스를 올리면 행에 표시되는 필드와 관계없이 모든 필드가 포함된 툴팁을 표시합니다.",

--- a/tests/captures/readme.spec.ts
+++ b/tests/captures/readme.spec.ts
@@ -254,7 +254,6 @@ async function bootCapturePage(page: Page, sceneName: SceneName) {
         sessionDisplay: {
           title: "name",
           metadata: { branch: true, workingDirectory: false, status: true },
-          icons: { statusDot: true, agentProvider: true, sessionKind: true },
           showDetailsOnHover: true
         }
       }));

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -3097,28 +3097,42 @@ test.describe("sidebar: project lifecycle", () => {
     expect(localCall?.parentPane).not.toBeNull();
   });
 
-  test("local chat sessions show agent provider icons", async ({
+  test("removed icon preferences cannot hide inline session icons", async ({
     page,
     tauri,
   }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          sessionDisplay: {
+            icons: {
+              statusDot: false,
+              agentProvider: false,
+              sessionKind: false,
+            },
+          },
+        }),
+      );
+    });
     await tauri.handle("list_projects", () => []);
     await tauri.handle("list_sessions", () => [
       {
         id: "local-codex",
         name: "codex",
         repo_path: "/Users/tester",
-        worktree_path: "/Users/tester",
-        branch: "HEAD",
-        isolated: false,
+        worktree_path: "/Users/tester/.acorn/worktrees/codex",
+        branch: "feature/codex",
+        isolated: true,
         project_scoped: false,
         status: "ready",
         created_at: "2026-01-01T00:00:00Z",
         updated_at: "2026-01-01T00:00:00Z",
         last_message: null,
-        kind: "regular",
+        kind: "control",
         owner: { kind: "user" },
         position: null,
-        in_worktree: false,
+        in_worktree: true,
         agent_provider: "codex",
       },
     ]);
@@ -3127,6 +3141,10 @@ test.describe("sidebar: project lifecycle", () => {
 
     const chats = page.getByRole("region", { name: "Local terminal sessions" });
     await expect(chats.getByRole("img", { name: "Codex" })).toBeVisible();
+    await expect(chats.getByLabel("worktree", { exact: true })).toBeVisible();
+    await expect(
+      chats.getByLabel("control session", { exact: true }),
+    ).toBeVisible();
     await expect(
       chats.getByRole("button", { name: /codex/i }),
     ).toBeVisible();

--- a/tests/e2e/statusbar.spec.ts
+++ b/tests/e2e/statusbar.spec.ts
@@ -187,7 +187,7 @@ test.describe("status bar", () => {
     await expect(page.getByText(/^tokens:/)).toHaveCount(0);
   });
 
-  test("uses a generic token icon when agent provider icons are disabled", async ({
+  test("ignores the removed agent provider icon preference", async ({
     page,
     tauri,
   }) => {
@@ -216,6 +216,6 @@ test.describe("status bar", () => {
     await expect(tokenBadge).toContainText("88%");
     await expect(tokenBadge).toContainText("w");
     await expect(tokenBadge).toContainText("66%");
-    await expect(footer.getByRole("img", { name: "Codex" })).toHaveCount(0);
+    await expect(footer.getByRole("img", { name: "Codex" })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
This PR makes inline session icons a fixed part of Acorn's interface instead of an optional appearance preference.

1. **Remove icon preferences** — delete the status-dot, agent-provider, and session-kind toggles from the settings schema, Settings UI, translations, and capture fixtures.
2. **Keep icons visible everywhere** — always render provider/status markers and session-kind glyphs across sidebar rows and previews, pane tabs, kanban/console cards, Agents History, and the status-bar token badge.
3. **Ignore legacy disabled values** — normalize persisted settings without the removed `sessionDisplay.icons` block so existing `false` values no longer hide icons.
4. **Protect the behavior** — cover the removed Settings controls and verify legacy disabled values cannot suppress provider, worktree, control-session, or token-usage icons.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Appearance settings | Three inline-icon toggles | No inline-icon preferences |
| Existing users with icons disabled | Some status/provider/kind icons remain hidden | Icons become visible on next launch |
| Session surfaces | Rendering varies by saved icon preferences | Consistent icon treatment across all surfaces |

## Design notes

- The `sessionDisplay.icons` contract is removed rather than retained with hard-coded defaults. This keeps settings persistence and UI state aligned with the fixed behavior.
- Provider icons continue to occupy the status-marker position for detected agent sessions; ordinary terminal sessions continue to use the colored status dot.
- Existing stored icon fields are harmless unknown JSON after this change and are dropped the next time normalized settings are persisted.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 95 files, 1,029 tests passed
- [x] `pnpm run build:frontend`
- [x] `pnpm run test:e2e tests/e2e/sidebar.spec.ts tests/e2e/statusbar.spec.ts` — 48 tests passed

## Notes

- The frontend build retains the existing Vite dynamic-import and large-chunk warnings; this PR does not introduce new build warnings.
