### PR TITLE
feat(workspace): add persistent infinite canvas terminal mode

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -17,6 +17,7 @@ import {
   MessageSquareText,
   Plus,
   RefreshCw,
+  Scan,
   Sparkles,
   Terminal,
   Trash2,
@@ -51,9 +52,15 @@ function cpt(t: Translator, key: CommandPaletteTranslationKey): string {
 }
 
 function workspaceModeLabel(t: Translator, mode: WorkspaceViewMode): string {
-  return mode === "kanban"
-    ? t("workspace.mode.kanban")
-    : t("workspace.mode.panes");
+  if (mode === "kanban") return t("workspace.mode.kanban");
+  if (mode === "canvas") return t("workspace.mode.canvas");
+  return t("workspace.mode.panes");
+}
+
+function nextWorkspaceMode(mode: WorkspaceViewMode): WorkspaceViewMode {
+  if (mode === "panes") return "kanban";
+  if (mode === "kanban") return "canvas";
+  return "panes";
 }
 
 const ACTIVITY_KIND_KEYS: Record<
@@ -84,9 +91,13 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const workspaceViewMode = useAppStore((s) => s.workspaceViewMode);
   const t = useTranslation();
   const nextWorkspaceViewMode: WorkspaceViewMode =
-    workspaceViewMode === "kanban" ? "panes" : "kanban";
+    nextWorkspaceMode(workspaceViewMode);
   const NextWorkspaceViewIcon =
-    nextWorkspaceViewMode === "kanban" ? Kanban : Columns3;
+    nextWorkspaceViewMode === "kanban"
+      ? Kanban
+      : nextWorkspaceViewMode === "canvas"
+        ? Scan
+        : Columns3;
 
   // Derived once per render — sessions array identity is stable from zustand
   // until the underlying list actually changes.
@@ -441,7 +452,15 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           <Command.Item
             value="toggle-workspace-view"
             onSelect={handleToggleWorkspaceView}
-            keywords={["workspace", "view", "panes", "pane", "kanban", "board"]}
+            keywords={[
+              "workspace",
+              "view",
+              "panes",
+              "pane",
+              "kanban",
+              "board",
+              "canvas",
+            ]}
           >
             <NextWorkspaceViewIcon size={14} className="text-fg-muted" />
             <span>{cpt(t, "commandPalette.commands.toggleWorkspaceView")}</span>

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -481,10 +481,10 @@ describe("SettingsModal font controls", () => {
     openInterfaceTab();
 
     clickElement(getComboboxByLabel("Default workspace mode"));
-    clickOption("Kanban");
+    clickOption("Canvas");
 
     expect(patchInterface).toHaveBeenCalledWith({
-      defaultWorkspaceViewMode: "kanban",
+      defaultWorkspaceViewMode: "canvas",
     });
   });
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -9,6 +9,7 @@ import {
   Loader2,
   RefreshCcw,
   Save,
+  Scan,
   Settings as SettingsIcon,
   Sparkles,
   Trash2,
@@ -1400,7 +1401,7 @@ function ProjectTabPrioritySection({
 function isDefaultWorkspaceViewMode(
   value: string,
 ): value is DefaultWorkspaceViewMode {
-  return value === "panes" || value === "kanban";
+  return value === "panes" || value === "kanban" || value === "canvas";
 }
 
 function DefaultWorkspaceViewModeSection({
@@ -1423,6 +1424,11 @@ function DefaultWorkspaceViewModeSection({
       value: "kanban",
       label: t("workspace.mode.kanban"),
       icon: <Kanban size={13} />,
+    },
+    {
+      value: "canvas",
+      label: t("workspace.mode.canvas"),
+      icon: <Scan size={13} />,
     },
   ];
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -18,6 +18,7 @@ import {
   Gauge,
   Kanban,
   Loader2,
+  Scan,
   Settings,
   Trash2,
   X,
@@ -103,13 +104,13 @@ function statusBarFormat(
 }
 
 function workspaceViewLabel(t: Translator, mode: WorkspaceViewMode): string {
-  return mode === "kanban"
-    ? t("workspace.mode.kanban")
-    : t("workspace.mode.panes");
+  if (mode === "kanban") return t("workspace.mode.kanban");
+  if (mode === "canvas") return t("workspace.mode.canvas");
+  return t("workspace.mode.panes");
 }
 
 function isWorkspaceViewMode(value: string): value is WorkspaceViewMode {
-  return value === "panes" || value === "kanban";
+  return value === "panes" || value === "kanban" || value === "canvas";
 }
 
 function useHomeDir(): string | null {
@@ -309,6 +310,11 @@ export function StatusBar() {
       label: workspaceViewLabel(t, "kanban"),
       icon: <Kanban size={12} />,
     },
+    {
+      value: "canvas",
+      label: workspaceViewLabel(t, "canvas"),
+      icon: <Scan size={12} />,
+    },
   ];
 
   return (
@@ -382,7 +388,7 @@ export function StatusBar() {
               if (isWorkspaceViewMode(value)) setWorkspaceViewMode(value);
             }}
             className={cn(
-              "w-[5.75rem] shrink-0",
+              "w-[6.25rem] shrink-0",
               "[&>button]:h-5 [&>button]:rounded [&>button]:border-transparent [&>button]:bg-transparent",
               "[&>button]:font-mono [&>button]:text-xs [&>button]:text-fg-muted",
               "[&>button]:hover:bg-bg-elevated [&>button]:hover:text-fg",

--- a/src/components/TerminalHost.test.tsx
+++ b/src/components/TerminalHost.test.tsx
@@ -357,6 +357,52 @@ describe("TerminalHost", () => {
     popoverBody.remove();
   });
 
+  it("mounts every workspace terminal in its canvas node and reuses it in panes", async () => {
+    installWorkspaceSessions(["first", "second"]);
+    const firstCanvasBody = document.createElement("div");
+    firstCanvasBody.dataset.canvasTerminalBody = "first";
+    const secondCanvasBody = document.createElement("div");
+    secondCanvasBody.dataset.canvasTerminalBody = "second";
+    const paneBody = document.createElement("div");
+    paneBody.dataset.paneBody = "root";
+    document.body.append(firstCanvasBody, secondCanvasBody, paneBody);
+    useAppStore.setState({ workspaceViewMode: "canvas" });
+
+    render();
+    await flushEffects();
+
+    const firstTerminal = firstCanvasBody.querySelector<HTMLElement>(
+      '[data-acorn-terminal-slot="first"] [data-testid="terminal"]',
+    );
+    expect(firstTerminal).not.toBeNull();
+    expect(
+      secondCanvasBody.querySelector(
+        '[data-acorn-terminal-slot="second"] [data-testid="terminal"]',
+      ),
+    ).not.toBeNull();
+    expect(terminalRows()).toEqual([
+      { id: "first", active: true },
+      { id: "second", active: true },
+    ]);
+
+    await act(async () => {
+      useAppStore.setState({ workspaceViewMode: "panes" });
+      await Promise.resolve();
+    });
+    await flushEffects();
+
+    expect(
+      paneBody.querySelector(
+        '[data-acorn-terminal-slot="first"] [data-testid="terminal"]',
+      ),
+    ).toBe(firstTerminal);
+    expect(secondCanvasBody.childElementCount).toBe(0);
+
+    firstCanvasBody.remove();
+    secondCanvasBody.remove();
+    paneBody.remove();
+  });
+
   it("uses the configured resident terminal limit when evicting idle daemon terminals", async () => {
     const ids = ["s1", "s2", "s3", "s4"];
     useSettings.setState({

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -181,7 +181,11 @@ function visibleTerminalSessionIdKey(state: AppStateSnapshot): string {
     if (ws) {
       ids.push(
         ...Object.values(ws.panes)
-          .map((pane) => pane.activeTabId)
+          .flatMap((pane) =>
+            state.workspaceViewMode === "canvas"
+              ? pane.tabIds
+              : [pane.activeTabId],
+          )
           .filter((id): id is string => Boolean(id)),
       );
     }
@@ -201,6 +205,12 @@ function visibleTerminalTargetKey(
   if (!workspaceId) return null;
   const ws = state.workspaces[workspaceId];
   if (!ws) return null;
+  if (
+    state.workspaceViewMode === "canvas" &&
+    Object.values(ws.panes).some((pane) => pane.tabIds.includes(sessionId))
+  ) {
+    return `canvas:${sessionId}`;
+  }
   for (const pane of Object.values(ws.panes)) {
     if (pane.activeTabId === sessionId) return `pane:${pane.id}`;
   }
@@ -217,6 +227,12 @@ function terminalDestinationForTargetKey(
       `[data-terminal-popover-body="${cssEscape(sessionId)}"]`,
     ) as HTMLElement | null;
   }
+  if (targetKey.startsWith("canvas:")) {
+    const sessionId = targetKey.slice("canvas:".length);
+    return document.querySelector(
+      `[data-canvas-terminal-body="${cssEscape(sessionId)}"]`,
+    ) as HTMLElement | null;
+  }
   if (targetKey.startsWith("pane:")) {
     const paneId = targetKey.slice("pane:".length);
     return document.querySelector(
@@ -228,6 +244,14 @@ function terminalDestinationForTargetKey(
 
 function terminalTargetIsPopover(targetKey: string | null): boolean {
   return Boolean(targetKey?.startsWith("popover:"));
+}
+
+function terminalTargetIsCanvas(targetKey: string | null): boolean {
+  return Boolean(targetKey?.startsWith("canvas:"));
+}
+
+function terminalTargetNeedsDomRetry(targetKey: string | null): boolean {
+  return terminalTargetIsPopover(targetKey) || terminalTargetIsCanvas(targetKey);
 }
 
 function parseSessionIdKey(key: string): Set<string> {
@@ -263,6 +287,8 @@ function PortaledTerminal({ session }: { session: Session }) {
   const isFocusedPane = useAppStore((state) =>
     terminalTargetIsPopover(visibleTargetKey)
       ? true
+      : terminalTargetIsCanvas(visibleTargetKey)
+        ? state.activeSessionId === session.id
       : isSessionInFocusedPane(session.id, state.panes, state.focusedPaneId),
   );
   const workspaceKey = useAppStore((state) =>
@@ -297,7 +323,7 @@ function PortaledTerminal({ session }: { session: Session }) {
       if (target.parentElement !== nextParent) nextParent.appendChild(target);
       if (
         dest === null &&
-        terminalTargetIsPopover(visibleTargetKey) &&
+        terminalTargetNeedsDomRetry(visibleTargetKey) &&
         attempts < 30
       ) {
         attempts += 1;

--- a/src/components/WorkspaceCanvas.tsx
+++ b/src/components/WorkspaceCanvas.tsx
@@ -1,0 +1,936 @@
+import {
+  CirclePlus,
+  GitBranch,
+  Minus,
+  PanelsTopLeft,
+  Plus,
+  RotateCcw,
+  Scan,
+  Terminal as TerminalIcon,
+} from "lucide-react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import {
+  AgentProviderIcon,
+  resolveSessionAgentProvider,
+} from "../lib/agentProvider";
+import { basename } from "../lib/pathUtils";
+import type { TranslationKey, Translator } from "../lib/i18n";
+import type { Session, SessionStatus } from "../lib/types";
+import { useTranslation } from "../lib/useTranslation";
+import {
+  WORKSPACE_CANVAS_MAX_ZOOM,
+  WORKSPACE_CANVAS_MIN_ZOOM,
+  clampWorkspaceCanvasNode,
+  fitWorkspaceCanvasViewport,
+  reconcileWorkspaceCanvasState,
+  resetWorkspaceCanvasState,
+  revealWorkspaceCanvasNode,
+  snapWorkspaceCanvasValue,
+  workspaceCanvasStatesEqual,
+  zoomWorkspaceCanvasAtPoint,
+  type WorkspaceCanvasNode,
+  type WorkspaceCanvasSize,
+  type WorkspaceCanvasState,
+  type WorkspaceCanvasViewport,
+} from "../lib/workspaceCanvas";
+import { useAppStore } from "../store";
+import { Button, IconButton, StatusDot, type StatusTone } from "./ui";
+import { Tooltip } from "./Tooltip";
+
+type WorkspaceCanvasTranslationKey = Extract<
+  TranslationKey,
+  `workspace.canvas.${string}`
+>;
+
+const STATUS_TONE: Record<SessionStatus, StatusTone> = {
+  ready: "neutral",
+  working: "accent",
+  waiting_for_input: "warning",
+  errored: "danger",
+};
+
+const VIEWPORT_SAVE_DEBOUNCE_MS = 220;
+const WHEEL_ZOOM_SENSITIVITY = 0.0015;
+const TOOLBAR_ZOOM_STEP = 0.15;
+
+function canvasText(
+  t: Translator,
+  key: WorkspaceCanvasTranslationKey,
+  values: Record<string, string | number> = {},
+): string {
+  return t(key).replace(/\{(\w+)\}/g, (match, name) =>
+    Object.prototype.hasOwnProperty.call(values, name)
+      ? String(values[name])
+      : match,
+  );
+}
+
+function sameViewport(
+  first: WorkspaceCanvasViewport,
+  second: WorkspaceCanvasViewport,
+): boolean {
+  return (
+    first.zoom === second.zoom &&
+    first.offset.x === second.offset.x &&
+    first.offset.y === second.offset.y
+  );
+}
+
+function canvasElementScale(element: HTMLElement): number {
+  const rect = element.getBoundingClientRect();
+  if (element.offsetWidth <= 0 || rect.width <= 0) return 1;
+  const scale = rect.width / element.offsetWidth;
+  return Number.isFinite(scale) && scale > 0 ? scale : 1;
+}
+
+type AppStateSnapshot = ReturnType<typeof useAppStore.getState>;
+
+function activeWorkspaceLabel(
+  state: AppStateSnapshot,
+  workspaceId: string | null,
+): string | null {
+  if (!workspaceId) return null;
+  for (const folders of Object.values(state.projectFolders)) {
+    const folder = folders.find((candidate) => candidate.id === workspaceId);
+    if (folder) {
+      const project = state.projects.find(
+        (candidate) => candidate.repo_path === folder.repoPath,
+      );
+      if (folder.cwdPath !== folder.repoPath) {
+        return `${project?.name ?? basename(folder.repoPath)} / ${folder.name}`;
+      }
+      return project?.name ?? basename(folder.repoPath);
+    }
+  }
+  return (
+    state.projects.find((project) => project.repo_path === workspaceId)?.name ??
+    basename(workspaceId)
+  );
+}
+
+interface WorkspaceCanvasProps {
+  workspaceId: string | null;
+  workspaceSessionIds: readonly string[];
+  sessions: readonly Session[];
+}
+
+export function WorkspaceCanvas({
+  workspaceId,
+  workspaceSessionIds,
+  sessions,
+}: WorkspaceCanvasProps) {
+  const t = useTranslation();
+  const rootRef = useRef<HTMLElement | null>(null);
+  const saveTimerRef = useRef<number | null>(null);
+  const cancelPanRef = useRef<(() => void) | null>(null);
+  const persisted = useAppStore((state) =>
+    workspaceId ? state.workspaces[workspaceId]?.canvas : undefined,
+  );
+  const activeSessionId = useAppStore((state) => state.activeSessionId);
+  const setWorkspaceCanvasState = useAppStore(
+    (state) => state.setWorkspaceCanvasState,
+  );
+  const terminalSessions = useMemo(
+    () => sessions.filter((session) => session.mode !== "chat"),
+    [sessions],
+  );
+  const sessionIds = useMemo(
+    () => terminalSessions.map((session) => session.id),
+    [terminalSessions],
+  );
+  const reconciliationIds =
+    sessions.length === 0 ? workspaceSessionIds : sessionIds;
+  const reconciliationIdsKey = reconciliationIds.join("\0");
+  const [canvas, setCanvas] = useState<WorkspaceCanvasState>(() => {
+    return reconcileWorkspaceCanvasState(persisted, reconciliationIds);
+  });
+  const canvasRef = useRef(canvas);
+  const containerSizeRef = useRef<WorkspaceCanvasSize>({
+    width: 0,
+    height: 0,
+  });
+  const workspaceLabel =
+    useAppStore((state) => activeWorkspaceLabel(state, workspaceId)) ??
+    t("workspace.mode.canvas");
+
+  const applyCanvas = useCallback((next: WorkspaceCanvasState) => {
+    canvasRef.current = next;
+    setCanvas(next);
+  }, []);
+
+  const persistCanvas = useCallback(
+    (next: WorkspaceCanvasState) => {
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+      }
+      if (!workspaceId) return;
+      setWorkspaceCanvasState(workspaceId, next);
+    },
+    [setWorkspaceCanvasState, workspaceId],
+  );
+
+  const schedulePersist = useCallback(
+    (next: WorkspaceCanvasState) => {
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current);
+      }
+      saveTimerRef.current = window.setTimeout(() => {
+        saveTimerRef.current = null;
+        persistCanvas(next);
+      }, VIEWPORT_SAVE_DEBOUNCE_MS);
+    },
+    [persistCanvas],
+  );
+
+  const updateCanvas = useCallback(
+    (
+      updater: (current: WorkspaceCanvasState) => WorkspaceCanvasState,
+      persist: "now" | "soon" | "later" = "later",
+    ) => {
+      const current = canvasRef.current;
+      const next = updater(current);
+      if (workspaceCanvasStatesEqual(current, next)) return current;
+      applyCanvas(next);
+      if (persist === "now") persistCanvas(next);
+      if (persist === "soon") schedulePersist(next);
+      return next;
+    },
+    [applyCanvas, persistCanvas, schedulePersist],
+  );
+
+  const fitAll = useCallback(
+    (state = canvasRef.current, persist: "now" | "soon" = "now") => {
+      const viewport = fitWorkspaceCanvasViewport(
+        state.nodes,
+        containerSizeRef.current,
+      );
+      return updateCanvas((current) => ({ ...current, viewport }), persist);
+    },
+    [updateCanvas],
+  );
+
+  const revealSession = useCallback(
+    (sessionId: string) => {
+      const current = canvasRef.current;
+      const node = current.nodes[sessionId];
+      if (!node) return;
+      const viewport = revealWorkspaceCanvasNode(
+        current.viewport,
+        node,
+        containerSizeRef.current,
+      );
+      if (sameViewport(current.viewport, viewport)) return;
+      updateCanvas((state) => ({ ...state, viewport }), "soon");
+    },
+    [updateCanvas],
+  );
+
+  useEffect(() => {
+    const current = canvasRef.current;
+    const next = reconcileWorkspaceCanvasState(current, reconciliationIds);
+    if (workspaceCanvasStatesEqual(current, next)) return;
+    applyCanvas(next);
+    persistCanvas(next);
+  }, [applyCanvas, persistCanvas, reconciliationIds, reconciliationIdsKey]);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const updateSize = (size: WorkspaceCanvasSize) => {
+      containerSizeRef.current = size;
+    };
+    updateSize({ width: root.clientWidth, height: root.clientHeight });
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(([entry]) => {
+      if (!entry) return;
+      updateSize({
+        width: entry.contentRect.width,
+        height: entry.contentRect.height,
+      });
+    });
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (activeSessionId) revealSession(activeSessionId);
+  }, [activeSessionId, revealSession]);
+
+  useEffect(() => {
+    const onFocusSession = (event: Event) => {
+      const detail = (event as CustomEvent<{ sessionId?: string }>).detail;
+      if (detail?.sessionId) revealSession(detail.sessionId);
+    };
+    window.addEventListener("acorn:focus-session", onFocusSession);
+    return () =>
+      window.removeEventListener("acorn:focus-session", onFocusSession);
+  }, [revealSession]);
+
+  useEffect(() => {
+    return () => {
+      cancelPanRef.current?.();
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current);
+      }
+      persistCanvas(canvasRef.current);
+    };
+  }, [persistCanvas]);
+
+  const setViewport = useCallback(
+    (viewport: WorkspaceCanvasViewport, persist: "now" | "soon" = "soon") =>
+      updateCanvas((current) => ({ ...current, viewport }), persist),
+    [updateCanvas],
+  );
+
+  const zoomAround = useCallback(
+    (nextZoom: number, point: { x: number; y: number }) => {
+      setViewport(
+        zoomWorkspaceCanvasAtPoint(canvasRef.current.viewport, nextZoom, point),
+      );
+    },
+    [setViewport],
+  );
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const onWheel = (event: WheelEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (target.closest("[data-workspace-canvas-toolbar]")) return;
+      const explicitZoom = event.ctrlKey || event.metaKey;
+      if (target.closest("[data-canvas-terminal-body]") && !explicitZoom) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      const scale = canvasElementScale(root);
+      if (explicitZoom) {
+        const rect = root.getBoundingClientRect();
+        const point = {
+          x: (event.clientX - rect.left) / scale,
+          y: (event.clientY - rect.top) / scale,
+        };
+        const currentZoom = canvasRef.current.viewport.zoom;
+        const multiplier = Math.exp(-event.deltaY * WHEEL_ZOOM_SENSITIVITY);
+        zoomAround(currentZoom * multiplier, point);
+        return;
+      }
+      const current = canvasRef.current.viewport;
+      setViewport({
+        ...current,
+        offset: {
+          x: current.offset.x - event.deltaX / scale,
+          y: current.offset.y - event.deltaY / scale,
+        },
+      });
+    };
+    root.addEventListener("wheel", onWheel, { capture: true, passive: false });
+    return () => root.removeEventListener("wheel", onWheel, { capture: true });
+  }, [setViewport, zoomAround]);
+
+  const startPan = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (event.button !== 0 && event.button !== 1) return;
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        (target.closest("[data-workspace-canvas-toolbar]") ||
+          (event.button === 0 &&
+            target.closest("[data-workspace-canvas-node]")))
+      ) {
+        return;
+      }
+      const root = rootRef.current;
+      if (!root) return;
+      event.preventDefault();
+      cancelPanRef.current?.();
+      const start = { x: event.clientX, y: event.clientY };
+      const startOffset = { ...canvasRef.current.viewport.offset };
+      const scale = canvasElementScale(root);
+      const previousCursor = document.body.style.cursor;
+      const previousUserSelect = document.body.style.userSelect;
+      document.body.style.cursor = "grabbing";
+      document.body.style.userSelect = "none";
+
+      const onMove = (moveEvent: PointerEvent) => {
+        const current = canvasRef.current.viewport;
+        setViewport(
+          {
+            ...current,
+            offset: {
+              x: startOffset.x + (moveEvent.clientX - start.x) / scale,
+              y: startOffset.y + (moveEvent.clientY - start.y) / scale,
+            },
+          },
+          "soon",
+        );
+      };
+      let finished = false;
+      const cleanup = () => {
+        if (finished) return;
+        finished = true;
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousUserSelect;
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", finish);
+        window.removeEventListener("pointercancel", finish);
+        window.removeEventListener("blur", finish);
+        if (cancelPanRef.current === cleanup) cancelPanRef.current = null;
+      };
+      const finish = () => {
+        cleanup();
+        persistCanvas(canvasRef.current);
+      };
+      cancelPanRef.current = cleanup;
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", finish);
+      window.addEventListener("pointercancel", finish);
+      window.addEventListener("blur", finish);
+    },
+    [persistCanvas, setViewport],
+  );
+
+  const updateNode = useCallback(
+    (
+      sessionId: string,
+      updater: (node: WorkspaceCanvasNode) => WorkspaceCanvasNode,
+      persist: "now" | "soon" | "later" = "later",
+    ) =>
+      updateCanvas((current) => {
+        const node = current.nodes[sessionId];
+        if (!node) return current;
+        const nextNode = clampWorkspaceCanvasNode(updater(node));
+        return {
+          ...current,
+          nodes: { ...current.nodes, [sessionId]: nextNode },
+        };
+      }, persist),
+    [updateCanvas],
+  );
+
+  const activateNode = useCallback(
+    (sessionId: string) => {
+      useAppStore.getState().selectTab(sessionId);
+      const values = Object.values(canvasRef.current.nodes);
+      const topZ = values.reduce((max, node) => Math.max(max, node.zIndex), 0);
+      const current = canvasRef.current.nodes[sessionId];
+      if (current && current.zIndex !== topZ) {
+        updateNode(sessionId, (node) => ({ ...node, zIndex: topZ + 1 }), "now");
+      }
+      revealSession(sessionId);
+    },
+    [revealSession, updateNode],
+  );
+
+  const commitNode = useCallback(
+    (sessionId: string, purpose: "move" | "resize", snap: boolean) => {
+      const next = updateNode(
+        sessionId,
+        (node) =>
+          snap
+            ? purpose === "move"
+              ? {
+                  ...node,
+                  x: snapWorkspaceCanvasValue(node.x),
+                  y: snapWorkspaceCanvasValue(node.y),
+                }
+              : {
+                  ...node,
+                  width: snapWorkspaceCanvasValue(node.width),
+                  height: snapWorkspaceCanvasValue(node.height),
+                }
+            : node,
+        "later",
+      );
+      persistCanvas(next);
+    },
+    [persistCanvas, updateNode],
+  );
+
+  const openInPanes = useCallback((sessionId: string) => {
+    const store = useAppStore.getState();
+    store.selectSession(sessionId);
+    store.setWorkspaceViewMode("panes");
+  }, []);
+
+  const resetLayout = useCallback(() => {
+    const next = resetWorkspaceCanvasState(sessionIds);
+    applyCanvas(next);
+    persistCanvas(next);
+  }, [applyCanvas, persistCanvas, sessionIds]);
+
+  const worldStyle: CSSProperties = {
+    transform: `translate3d(${canvas.viewport.offset.x}px, ${canvas.viewport.offset.y}px, 0) scale(${canvas.viewport.zoom})`,
+    transformOrigin: "0 0",
+  };
+  const gridStep = 20 * canvas.viewport.zoom;
+  const gridStyle: CSSProperties = {
+    backgroundImage:
+      "radial-gradient(circle, color-mix(in oklab, var(--color-fg-muted) 32%, transparent) 1px, transparent 1px)",
+    backgroundPosition: `${canvas.viewport.offset.x}px ${canvas.viewport.offset.y}px`,
+    backgroundSize: `${gridStep}px ${gridStep}px`,
+  };
+  const zoomPercent = Math.round(canvas.viewport.zoom * 100);
+
+  return (
+    <section
+      ref={rootRef}
+      role="region"
+      aria-label={canvasText(t, "workspace.canvas.regionLabel")}
+      className="relative h-full min-w-0 cursor-grab overflow-hidden rounded-[var(--acorn-pane-radius)] border border-border bg-bg-sidebar/55"
+      data-testid="workspace-canvas"
+      data-workspace-canvas
+      onPointerDown={startPan}
+    >
+      <div className="pointer-events-none absolute inset-0" style={gridStyle} />
+      <div
+        className="absolute left-0 top-0 size-px"
+        style={worldStyle}
+        data-testid="workspace-canvas-world"
+        data-canvas-zoom={canvas.viewport.zoom}
+        data-canvas-offset-x={canvas.viewport.offset.x}
+        data-canvas-offset-y={canvas.viewport.offset.y}
+      >
+        {terminalSessions.map((session) => {
+          const node = canvas.nodes[session.id];
+          if (!node) return null;
+          return (
+            <WorkspaceCanvasTerminalNode
+              key={session.id}
+              session={session}
+              node={node}
+              zoom={canvas.viewport.zoom}
+              active={activeSessionId === session.id}
+              onActivate={() => activateNode(session.id)}
+              onUpdate={(updater) => updateNode(session.id, updater)}
+              onCommit={(purpose, snap) =>
+                commitNode(session.id, purpose, snap)
+              }
+              onOpenInPanes={() => openInPanes(session.id)}
+              t={t}
+            />
+          );
+        })}
+      </div>
+
+      {terminalSessions.length === 0 ? (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="pointer-events-auto flex flex-col items-center gap-2 rounded-xl border border-border bg-bg/85 px-4 py-3 text-xs text-fg-muted shadow-lg backdrop-blur">
+            <span>{canvasText(t, "workspace.canvas.empty")}</span>
+            <Button
+              size="xs"
+              variant="accentSoft"
+              onClick={() =>
+                window.dispatchEvent(new CustomEvent("acorn:new-session"))
+              }
+            >
+              <CirclePlus size={12} />
+              {canvasText(t, "workspace.canvas.newSession")}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      <div
+        role="toolbar"
+        aria-label={canvasText(t, "workspace.canvas.toolbarLabel")}
+        className="acorn-no-scrollbar absolute left-3 top-3 z-30 flex max-w-[calc(100%-1.5rem)] items-center gap-2 overflow-x-auto rounded-lg border border-border bg-bg/88 px-2 py-1.5 text-xs shadow-xl backdrop-blur-md"
+        data-workspace-canvas-toolbar
+      >
+        <span className="flex min-w-0 items-center gap-1.5 border-r border-border pr-2 text-fg">
+          <TerminalIcon size={13} className="shrink-0 text-accent" />
+          <span className="truncate font-medium">{workspaceLabel}</span>
+          <span className="shrink-0 text-[10px] text-fg-muted">
+            {canvasText(
+              t,
+              terminalSessions.length === 1
+                ? "workspace.canvas.terminalCountOne"
+                : "workspace.canvas.terminalCountOther",
+              {
+                count: terminalSessions.length,
+              },
+            )}
+          </span>
+        </span>
+        <Tooltip
+          label={canvasText(t, "workspace.canvas.newSession")}
+          side="bottom"
+        >
+          <IconButton
+            aria-label={canvasText(t, "workspace.canvas.newSession")}
+            size="xs"
+            onClick={() =>
+              window.dispatchEvent(new CustomEvent("acorn:new-session"))
+            }
+          >
+            <CirclePlus size={12} />
+          </IconButton>
+        </Tooltip>
+        <span className="mx-0.5 h-4 w-px bg-border" aria-hidden="true" />
+        <Tooltip
+          label={canvasText(t, "workspace.canvas.zoomOut")}
+          side="bottom"
+        >
+          <IconButton
+            aria-label={canvasText(t, "workspace.canvas.zoomOut")}
+            size="xs"
+            disabled={canvas.viewport.zoom <= WORKSPACE_CANVAS_MIN_ZOOM}
+            onClick={() => {
+              const size = containerSizeRef.current;
+              zoomAround(canvasRef.current.viewport.zoom - TOOLBAR_ZOOM_STEP, {
+                x: size.width / 2,
+                y: size.height / 2,
+              });
+            }}
+          >
+            <Minus size={12} />
+          </IconButton>
+        </Tooltip>
+        <span className="w-9 text-center font-mono text-[10px] tabular-nums text-fg-muted">
+          {zoomPercent}%
+        </span>
+        <Tooltip label={canvasText(t, "workspace.canvas.zoomIn")} side="bottom">
+          <IconButton
+            aria-label={canvasText(t, "workspace.canvas.zoomIn")}
+            size="xs"
+            disabled={canvas.viewport.zoom >= WORKSPACE_CANVAS_MAX_ZOOM}
+            onClick={() => {
+              const size = containerSizeRef.current;
+              zoomAround(canvasRef.current.viewport.zoom + TOOLBAR_ZOOM_STEP, {
+                x: size.width / 2,
+                y: size.height / 2,
+              });
+            }}
+          >
+            <Plus size={12} />
+          </IconButton>
+        </Tooltip>
+        <Tooltip label={canvasText(t, "workspace.canvas.fit")} side="bottom">
+          <IconButton
+            aria-label={canvasText(t, "workspace.canvas.fit")}
+            size="xs"
+            onClick={() => fitAll()}
+          >
+            <Scan size={12} />
+          </IconButton>
+        </Tooltip>
+        <Tooltip label={canvasText(t, "workspace.canvas.reset")} side="bottom">
+          <IconButton
+            aria-label={canvasText(t, "workspace.canvas.reset")}
+            size="xs"
+            onClick={resetLayout}
+          >
+            <RotateCcw size={12} />
+          </IconButton>
+        </Tooltip>
+      </div>
+
+      <div className="pointer-events-none absolute bottom-3 left-1/2 z-20 -translate-x-1/2 rounded-full border border-border/80 bg-bg/75 px-3 py-1 font-mono text-[10px] text-fg-muted shadow-lg backdrop-blur">
+        {canvasText(t, "workspace.canvas.hint")}
+      </div>
+    </section>
+  );
+}
+
+interface WorkspaceCanvasTerminalNodeProps {
+  session: Session;
+  node: WorkspaceCanvasNode;
+  zoom: number;
+  active: boolean;
+  onActivate: () => void;
+  onUpdate: (
+    updater: (node: WorkspaceCanvasNode) => WorkspaceCanvasNode,
+  ) => void;
+  onCommit: (purpose: "move" | "resize", snap: boolean) => void;
+  onOpenInPanes: () => void;
+  t: Translator;
+}
+
+const WorkspaceCanvasTerminalNode = memo(
+  function WorkspaceCanvasTerminalNode({
+    session,
+    node,
+    zoom,
+    active,
+    onActivate,
+    onUpdate,
+    onCommit,
+    onOpenInPanes,
+    t,
+  }: WorkspaceCanvasTerminalNodeProps) {
+    const bodyRef = useRef<HTMLDivElement | null>(null);
+    const cancelGestureRef = useRef<(() => void) | null>(null);
+    const provider = resolveSessionAgentProvider(session);
+
+    useEffect(() => {
+      const body = bodyRef.current;
+      if (!body) return;
+      const activate = () => onActivate();
+      body.addEventListener("mousedown", activate, true);
+      body.addEventListener("focusin", activate, true);
+      return () => {
+        body.removeEventListener("mousedown", activate, true);
+        body.removeEventListener("focusin", activate, true);
+      };
+    }, [onActivate]);
+
+    useEffect(
+      () => () => {
+        cancelGestureRef.current?.();
+      },
+      [],
+    );
+
+    const startPointerGesture = (
+      cursor: string,
+      purpose: "move" | "resize",
+      start: { x: number; y: number },
+      onMove: (event: PointerEvent) => void,
+    ) => {
+      cancelGestureRef.current?.();
+      const previousCursor = document.body.style.cursor;
+      const previousUserSelect = document.body.style.userSelect;
+      document.body.style.cursor = cursor;
+      document.body.style.userSelect = "none";
+      let finished = false;
+      let moved = false;
+
+      const handleMove = (event: PointerEvent) => {
+        if (event.clientX !== start.x || event.clientY !== start.y)
+          moved = true;
+        onMove(event);
+      };
+
+      const cleanup = () => {
+        if (finished) return;
+        finished = true;
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousUserSelect;
+        window.removeEventListener("pointermove", handleMove);
+        window.removeEventListener("pointerup", finish);
+        window.removeEventListener("pointercancel", finish);
+        window.removeEventListener("blur", finish);
+        if (cancelGestureRef.current === cleanup) {
+          cancelGestureRef.current = null;
+        }
+      };
+      const finish = (event: Event) => {
+        cleanup();
+        if (moved) {
+          onCommit(purpose, !("altKey" in event) || !event.altKey);
+        }
+      };
+
+      cancelGestureRef.current = cleanup;
+      window.addEventListener("pointermove", handleMove);
+      window.addEventListener("pointerup", finish);
+      window.addEventListener("pointercancel", finish);
+      window.addEventListener("blur", finish);
+    };
+
+    const startDrag = (event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onActivate();
+      const start = { x: event.clientX, y: event.clientY };
+      const startNode = { ...node };
+      const root = document.querySelector<HTMLElement>(
+        "[data-workspace-canvas]",
+      );
+      const appScale = root ? canvasElementScale(root) : 1;
+      const onMove = (moveEvent: PointerEvent) => {
+        onUpdate((current) => ({
+          ...current,
+          x: startNode.x + (moveEvent.clientX - start.x) / (appScale * zoom),
+          y: startNode.y + (moveEvent.clientY - start.y) / (appScale * zoom),
+        }));
+      };
+      startPointerGesture("grabbing", "move", start, onMove);
+    };
+
+    const startResize = (event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onActivate();
+      const start = { x: event.clientX, y: event.clientY };
+      const startNode = { ...node };
+      const root = document.querySelector<HTMLElement>(
+        "[data-workspace-canvas]",
+      );
+      const appScale = root ? canvasElementScale(root) : 1;
+      const onMove = (moveEvent: PointerEvent) => {
+        onUpdate((current) => ({
+          ...current,
+          width:
+            startNode.width + (moveEvent.clientX - start.x) / (appScale * zoom),
+          height:
+            startNode.height +
+            (moveEvent.clientY - start.y) / (appScale * zoom),
+        }));
+      };
+      startPointerGesture("nwse-resize", "resize", start, onMove);
+    };
+
+    const nudgeNode = (
+      event: ReactKeyboardEvent<HTMLButtonElement>,
+      purpose: "move" | "resize",
+    ) => {
+      const direction =
+        event.key === "ArrowLeft"
+          ? { x: -1, y: 0 }
+          : event.key === "ArrowRight"
+            ? { x: 1, y: 0 }
+            : event.key === "ArrowUp"
+              ? { x: 0, y: -1 }
+              : event.key === "ArrowDown"
+                ? { x: 0, y: 1 }
+                : null;
+      if (!direction) return;
+      event.preventDefault();
+      onActivate();
+      const step = event.shiftKey ? 40 : 20;
+      onUpdate((current) =>
+        purpose === "move"
+          ? {
+              ...current,
+              x: current.x + direction.x * step,
+              y: current.y + direction.y * step,
+            }
+          : {
+              ...current,
+              width: current.width + direction.x * step,
+              height: current.height + direction.y * step,
+            },
+      );
+      onCommit(purpose, false);
+    };
+
+    return (
+      <article
+        className={`absolute flex cursor-default flex-col overflow-hidden rounded-xl border bg-bg shadow-2xl transition-[border-color,box-shadow] ${
+          active
+            ? "border-accent/70 ring-1 ring-accent/30"
+            : "border-border hover:border-fg-muted/45"
+        }`}
+        aria-label={
+          session.branch ? `${session.name}, ${session.branch}` : session.name
+        }
+        style={{
+          left: node.x,
+          top: node.y,
+          width: node.width,
+          height: node.height,
+          zIndex: node.zIndex,
+        }}
+        data-workspace-canvas-node
+        data-canvas-session-id={session.id}
+        data-canvas-node-x={node.x}
+        data-canvas-node-y={node.y}
+        data-canvas-node-width={node.width}
+        data-canvas-node-height={node.height}
+        data-testid="workspace-canvas-node"
+      >
+        <header className="flex h-9 shrink-0 items-center gap-1.5 border-b border-border bg-bg-sidebar/90 px-1.5">
+          <button
+            type="button"
+            aria-label={canvasText(t, "workspace.canvas.moveSession", {
+              name: session.name,
+            })}
+            className="flex h-7 min-w-0 flex-1 touch-none cursor-grab items-center gap-2 rounded-md px-1.5 text-left hover:bg-fill focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/45 active:cursor-grabbing"
+            data-testid="workspace-canvas-node-drag-handle"
+            onPointerDown={startDrag}
+            onKeyDown={(event) => nudgeNode(event, "move")}
+            onClick={onActivate}
+            onFocus={onActivate}
+            aria-pressed={active}
+          >
+            <StatusDot
+              tone={STATUS_TONE[session.status]}
+              size="sm"
+              pulse={session.status === "working"}
+            />
+            {provider ? (
+              <AgentProviderIcon
+                provider={provider}
+                className="size-3 text-fg-muted"
+              />
+            ) : (
+              <TerminalIcon size={12} className="shrink-0 text-fg-muted" />
+            )}
+            <span className="min-w-0 flex-1 truncate text-xs font-medium text-fg">
+              {session.name}
+            </span>
+            {session.branch ? (
+              <span className="flex max-w-[35%] shrink-0 items-center gap-1 truncate font-mono text-[10px] text-fg-muted">
+                <GitBranch size={10} className="shrink-0" />
+                <span className="truncate">{session.branch}</span>
+              </span>
+            ) : null}
+          </button>
+          <Tooltip
+            label={canvasText(t, "workspace.canvas.openInPanes", {
+              name: session.name,
+            })}
+            side="bottom"
+          >
+            <IconButton
+              aria-label={canvasText(t, "workspace.canvas.openInPanes", {
+                name: session.name,
+              })}
+              size="xs"
+              onClick={onOpenInPanes}
+            >
+              <PanelsTopLeft size={12} />
+            </IconButton>
+          </Tooltip>
+        </header>
+        <div
+          ref={bodyRef}
+          className="relative min-h-0 flex-1 cursor-text overflow-hidden bg-bg"
+          data-canvas-terminal-body={session.id}
+          data-testid="workspace-canvas-terminal-body"
+        />
+        <button
+          type="button"
+          aria-label={canvasText(t, "workspace.canvas.resizeSession", {
+            name: session.name,
+          })}
+          className="absolute bottom-0 right-0 z-10 flex size-5 touch-none cursor-nwse-resize items-end justify-end rounded-tl-md text-fg-muted/70 hover:bg-bg-elevated hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/45"
+          data-testid="workspace-canvas-node-resize-handle"
+          onPointerDown={startResize}
+          onKeyDown={(event) => nudgeNode(event, "resize")}
+          onFocus={onActivate}
+        >
+          <span
+            aria-hidden="true"
+            className="mb-1 mr-1 block size-2.5 border-b border-r border-current"
+          />
+        </button>
+      </article>
+    );
+  },
+  (previous, next) =>
+    previous.session === next.session &&
+    previous.node.x === next.node.x &&
+    previous.node.y === next.node.y &&
+    previous.node.width === next.node.width &&
+    previous.node.height === next.node.height &&
+    previous.node.zIndex === next.node.zIndex &&
+    previous.zoom === next.zoom &&
+    previous.active === next.active &&
+    previous.t === next.t,
+);

--- a/src/components/WorkspaceMain.test.tsx
+++ b/src/components/WorkspaceMain.test.tsx
@@ -2,6 +2,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LayoutNode } from "../lib/layout";
+import type { Session } from "../lib/types";
 
 vi.mock("./LayoutRenderer", async () => {
   const React = await vi.importActual<typeof import("react")>("react");
@@ -12,7 +13,7 @@ vi.mock("./LayoutRenderer", async () => {
 });
 
 import { WorkspaceMain } from "./WorkspaceMain";
-import { useAppStore } from "../store";
+import { useAppStore, type WorkspaceViewMode } from "../store";
 import { DEFAULT_SETTINGS, useSettings } from "../lib/settings";
 
 const REPO = "/Users/me/repo";
@@ -31,6 +32,7 @@ function resetStore(): void {
         },
       },
       activeProject: REPO,
+      activeProjectFolderId: REPO,
       layout: LAYOUT,
       panes: { root: pane },
       focusedPaneId: "root",
@@ -49,6 +51,50 @@ function queryLayout(): HTMLElement | null {
 
 function queryKanban(): HTMLElement | null {
   return document.querySelector<HTMLElement>("[data-testid='workspace-kanban']");
+}
+
+function queryCanvas(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(
+    "[data-testid='workspace-canvas']",
+  );
+}
+
+function installCanvasSessions(ids: string[]): void {
+  const sessions: Session[] = ids.map((id) => ({
+    id,
+    name: id,
+    repo_path: REPO,
+    worktree_path: `${REPO}/.worktrees/${id}`,
+    branch: `feat/${id}`,
+    isolated: false,
+    status: "ready",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: null,
+    title_source: "default",
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: false,
+  }));
+  const pane = {
+    id: "root",
+    tabIds: ids,
+    activeTabId: ids[0] ?? null,
+  };
+  useAppStore.setState((state) => ({
+    sessions,
+    panes: { root: pane },
+    activeTabId: pane.activeTabId,
+    activeSessionId: pane.activeTabId,
+    workspaces: {
+      ...state.workspaces,
+      [REPO]: {
+        ...state.workspaces[REPO],
+        panes: { root: pane },
+      },
+    },
+  }));
 }
 
 function queryColumnResizeHandle(): HTMLElement | null {
@@ -98,7 +144,7 @@ describe("WorkspaceMain", () => {
     vi.clearAllMocks();
   });
 
-  function render(viewMode: "panes" | "kanban"): void {
+  function render(viewMode: WorkspaceViewMode): void {
     act(() => {
       root.render(<WorkspaceMain layout={LAYOUT} viewMode={viewMode} />);
     });
@@ -128,6 +174,158 @@ describe("WorkspaceMain", () => {
 
     render("kanban");
     expect(queryLayout()?.parentElement?.className).toContain("hidden");
+  });
+
+  it("keeps the pane layout mounted while the canvas is shown", () => {
+    render("panes");
+    const initial = queryLayout();
+
+    render("canvas");
+    expect(queryCanvas()).not.toBeNull();
+    expect(queryLayout()).toBe(initial);
+    expect(queryLayout()?.parentElement?.className).toContain("hidden");
+
+    render("panes");
+    expect(queryCanvas()).toBeNull();
+    expect(queryLayout()).toBe(initial);
+  });
+
+  it("moves and resizes canvas terminals and persists their geometry", () => {
+    installCanvasSessions(["alpha", "beta"]);
+    render("canvas");
+
+    const nodes = document.querySelectorAll<HTMLElement>(
+      "[data-testid='workspace-canvas-node']",
+    );
+    expect(nodes).toHaveLength(2);
+    const alpha = document.querySelector<HTMLElement>(
+      '[data-canvas-session-id="alpha"]',
+    );
+    expect(alpha).not.toBeNull();
+
+    const dragHandle = alpha!.querySelector<HTMLElement>(
+      "[data-testid='workspace-canvas-node-drag-handle']",
+    );
+    firePointer(dragHandle!, "pointerdown", { clientX: 100, clientY: 100 });
+    firePointer(window, "pointerup", { clientX: 100, clientY: 100 });
+    expect(alpha!.dataset.canvasNodeX).toBe("48");
+    expect(alpha!.dataset.canvasNodeY).toBe("48");
+
+    firePointer(dragHandle!, "pointerdown", { clientX: 100, clientY: 100 });
+    firePointer(window, "pointermove", { clientX: 152, clientY: 132 });
+    firePointer(window, "pointerup", { clientX: 152, clientY: 132 });
+
+    expect(alpha!.dataset.canvasNodeX).toBe("100");
+    expect(alpha!.dataset.canvasNodeY).toBe("80");
+    expect(
+      useAppStore.getState().workspaces[REPO].canvas?.nodes.alpha,
+    ).toMatchObject({ x: 100, y: 80 });
+
+    const resizeHandle = alpha!.querySelector<HTMLElement>(
+      "[data-testid='workspace-canvas-node-resize-handle']",
+    );
+    firePointer(resizeHandle!, "pointerdown", {
+      clientX: 100,
+      clientY: 100,
+    });
+    firePointer(window, "pointermove", { clientX: 180, clientY: 160 });
+    firePointer(window, "pointerup", { clientX: 180, clientY: 160 });
+
+    expect(alpha!.dataset.canvasNodeWidth).toBe("700");
+    expect(alpha!.dataset.canvasNodeHeight).toBe("460");
+    expect(alpha!.dataset.canvasNodeX).toBe("100");
+    expect(alpha!.dataset.canvasNodeY).toBe("80");
+    expect(
+      useAppStore.getState().workspaces[REPO].canvas?.nodes.alpha,
+    ).toMatchObject({ width: 700, height: 460 });
+  });
+
+  it("preserves saved nodes while sessions are transiently empty at startup", () => {
+    const pane = {
+      id: "root",
+      tabIds: ["alpha"],
+      activeTabId: "alpha",
+    };
+    useAppStore.setState((state) => ({
+      panes: { root: pane },
+      activeTabId: "alpha",
+      activeSessionId: "alpha",
+      workspaces: {
+        ...state.workspaces,
+        [REPO]: {
+          ...state.workspaces[REPO],
+          panes: { root: pane },
+          canvas: {
+            viewport: { offset: { x: -40, y: 20 }, zoom: 0.8 },
+            nodes: {
+              alpha: {
+                x: 320,
+                y: 180,
+                width: 680,
+                height: 440,
+                zIndex: 1,
+              },
+            },
+          },
+        },
+      },
+    }));
+    render("canvas");
+    expect(useAppStore.getState().workspaces[REPO].canvas?.nodes.alpha.x).toBe(
+      320,
+    );
+
+    act(() => installCanvasSessions(["alpha"]));
+
+    expect(
+      document.querySelector<HTMLElement>('[data-canvas-session-id="alpha"]')
+        ?.dataset.canvasNodeX,
+    ).toBe("320");
+    expect(useAppStore.getState().workspaces[REPO].canvas?.nodes.alpha.x).toBe(
+      320,
+    );
+  });
+
+  it("prunes saved nodes after the final pane tab is removed", () => {
+    installCanvasSessions(["alpha"]);
+    render("canvas");
+    expect(
+      document.querySelector('[data-canvas-session-id="alpha"]'),
+    ).not.toBeNull();
+
+    const emptyPane = { id: "root", tabIds: [], activeTabId: null };
+    act(() => {
+      useAppStore.setState((state) => ({
+        sessions: [],
+        panes: { root: emptyPane },
+        activeTabId: null,
+        activeSessionId: null,
+        workspaces: {
+          ...state.workspaces,
+          [REPO]: {
+            ...state.workspaces[REPO],
+            panes: { root: emptyPane },
+          },
+        },
+      }));
+    });
+
+    expect(useAppStore.getState().workspaces[REPO].canvas?.nodes).toEqual({});
+  });
+
+  it("activates a canvas terminal when focus enters its portaled body", () => {
+    installCanvasSessions(["alpha", "beta"]);
+    render("canvas");
+    const betaBody = document.querySelector<HTMLElement>(
+      '[data-canvas-terminal-body="beta"]',
+    );
+    const input = document.createElement("textarea");
+    betaBody!.appendChild(input);
+
+    act(() => input.focus());
+
+    expect(useAppStore.getState().activeSessionId).toBe("beta");
+    expect(useAppStore.getState().panes.root.activeTabId).toBe("beta");
   });
 
   it("resizes the column during a drag and restores body styles on pointerup", () => {

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -87,6 +87,7 @@ import {
 } from "../lib/settings";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
+import { isWorkspaceTabId } from "../lib/workspaceTabs";
 import {
   KANBAN_COLUMN_DEFAULT_WIDTH,
   clampKanbanColumnWidth,
@@ -128,6 +129,7 @@ import { LayoutRenderer } from "./LayoutRenderer";
 import { PullRequestDetailModal } from "./PullRequestDetailModal";
 import { ResizeHandle } from "./ResizeHandle";
 import { Tooltip } from "./Tooltip";
+import { WorkspaceCanvas } from "./WorkspaceCanvas";
 
 const STATUS_TONE: Record<SessionStatus, StatusTone> = {
   ready: "neutral",
@@ -217,23 +219,33 @@ interface WorkspaceMainProps {
 
 export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
   const isKanban = viewMode === "kanban";
+  const isCanvas = viewMode === "canvas";
   const panes = useAppStore((s) => s.panes);
   const sessionsById = useAppStore(selectSessionsById);
+  const workspaceId = useAppStore(
+    (s) => s.activeProjectFolderId ?? s.activeProject,
+  );
   const closeTerminalPopup = useAppStore((s) => s.closeTerminalPopup);
-  const sessions = useMemo(() => {
-    const ordered: Session[] = [];
+  const workspaceSessionIds = useMemo(() => {
+    const ordered: string[] = [];
     const seen = new Set<string>();
     for (const pane of Object.values(panes)) {
       for (const id of pane.tabIds) {
-        if (seen.has(id)) continue;
-        const session = sessionsById.get(id);
-        if (!session) continue;
+        if (seen.has(id) || isWorkspaceTabId(id)) continue;
         seen.add(id);
-        ordered.push(session);
+        ordered.push(id);
       }
     }
     return ordered;
-  }, [panes, sessionsById]);
+  }, [panes]);
+  const sessions = useMemo(() => {
+    const ordered: Session[] = [];
+    for (const id of workspaceSessionIds) {
+      const session = sessionsById.get(id);
+      if (session) ordered.push(session);
+    }
+    return ordered;
+  }, [sessionsById, workspaceSessionIds]);
   const [prRefreshKey, setPrRefreshKey] = useState(0);
   const boardData = useKanbanBoardData(sessions, prRefreshKey, {
     pollDiffs: isKanban,
@@ -259,14 +271,27 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
           <KanbanFilePreviewOverlay />
         </div>
       ) : null}
+      {isCanvas ? (
+        <div className="relative h-full min-w-0 overflow-hidden">
+          <WorkspaceCanvas
+            key={workspaceId ?? "__local__"}
+            workspaceId={workspaceId}
+            workspaceSessionIds={workspaceSessionIds}
+            sessions={sessions}
+          />
+          <KanbanFilePreviewOverlay />
+        </div>
+      ) : null}
       {/*
-        Keep the pane layout mounted (hidden) in kanban mode instead of
+        Keep the pane layout mounted (hidden) in alternate views instead of
         unmounting it. TerminalHost appendChild's each live terminal's target
         div into a pane body; unmounting the layout orphans those divs, so
         returning to panes shows blank terminals until an unrelated reattach.
         Hiding preserves the pane-body DOM identity so the terminals stay put.
       */}
-      <div className={cn("h-full min-w-0", isKanban && "hidden")}>
+      <div
+        className={cn("h-full min-w-0", viewMode !== "panes" && "hidden")}
+      >
         <LayoutRenderer node={layout} />
       </div>
     </div>
@@ -295,7 +320,7 @@ function KanbanFilePreviewOverlay() {
 
   return (
     <div
-      className="absolute inset-0 z-20 flex items-center justify-center bg-bg/45 p-4 backdrop-blur-[1px]"
+      className="absolute inset-0 z-40 flex items-center justify-center bg-bg/45 p-4 backdrop-blur-[1px]"
       data-testid="kanban-file-preview-overlay"
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) closeWorkspaceTab(tab.id);

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -120,7 +120,7 @@ describe("interface settings", () => {
       STORAGE_KEY,
       JSON.stringify({
         interface: {
-          defaultWorkspaceViewMode: "kanban",
+          defaultWorkspaceViewMode: "canvas",
           prioritizeNeedsInputTabs: true,
           kanbanTerminalPopoverPlacement: "center",
           kanbanTerminalPopoverDefaultSize: "fullscreen",
@@ -134,7 +134,7 @@ describe("interface settings", () => {
 
     expect(
       useSettings.getState().settings.interface.defaultWorkspaceViewMode,
-    ).toBe("kanban");
+    ).toBe("canvas");
     expect(
       useSettings.getState().settings.interface.prioritizeNeedsInputTabs,
     ).toBe(true);

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -130,7 +130,7 @@ export const TERMINAL_LINE_HEIGHT_MAX = 2.0;
 export const TERMINAL_LINE_HEIGHT_STEP = 0.05;
 
 export type ToastPosition = "top" | "bottom";
-export type DefaultWorkspaceViewMode = "panes" | "kanban";
+export type DefaultWorkspaceViewMode = "panes" | "kanban" | "canvas";
 export type KanbanTerminalPopoverPlacement = "card" | "center";
 export type KanbanTerminalPopoverDefaultSize = "custom" | "fullscreen";
 
@@ -688,6 +688,7 @@ const VALID_TOAST_POSITIONS = new Set<ToastPosition>(["top", "bottom"]);
 const VALID_WORKSPACE_VIEW_MODES = new Set<DefaultWorkspaceViewMode>([
   "panes",
   "kanban",
+  "canvas",
 ]);
 const VALID_KANBAN_TERMINAL_POPOVER_PLACEMENTS =
   new Set<KanbanTerminalPopoverPlacement>(["card", "center"]);

--- a/src/lib/workspaceCanvas.test.ts
+++ b/src/lib/workspaceCanvas.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  WORKSPACE_CANVAS_MAX_ZOOM,
+  WORKSPACE_CANVAS_MIN_NODE_HEIGHT,
+  WORKSPACE_CANVAS_MIN_NODE_WIDTH,
+  WORKSPACE_CANVAS_MIN_ZOOM,
+  fitWorkspaceCanvasViewport,
+  normalizeWorkspaceCanvasState,
+  reconcileWorkspaceCanvasState,
+  revealWorkspaceCanvasNode,
+  resetWorkspaceCanvasState,
+  snapWorkspaceCanvasValue,
+  workspaceCanvasStatesEqual,
+  zoomWorkspaceCanvasAtPoint,
+} from "./workspaceCanvas";
+
+describe("workspaceCanvas", () => {
+  it("repairs persisted bounds and discards malformed nodes", () => {
+    expect(
+      normalizeWorkspaceCanvasState({
+        viewport: { offset: { x: 10, y: 20 }, zoom: 99 },
+        nodes: {
+          good: { x: 1, y: 2, width: 10, height: 20, zIndex: 3.8 },
+          broken: { x: "nope", y: 2, width: 600, height: 400, zIndex: 2 },
+        },
+      }),
+    ).toEqual({
+      viewport: {
+        offset: { x: 10, y: 20 },
+        zoom: WORKSPACE_CANVAS_MAX_ZOOM,
+      },
+      nodes: {
+        good: {
+          x: 1,
+          y: 2,
+          width: WORKSPACE_CANVAS_MIN_NODE_WIDTH,
+          height: WORKSPACE_CANVAS_MIN_NODE_HEIGHT,
+          zIndex: 3,
+        },
+      },
+    });
+  });
+
+  it("preserves known nodes, removes stale ones, and places new sessions", () => {
+    const result = reconcileWorkspaceCanvasState(
+      {
+        viewport: { offset: { x: -10, y: 25 }, zoom: 0.8 },
+        nodes: {
+          first: { x: 100, y: 120, width: 500, height: 320, zIndex: 4 },
+          stale: { x: 0, y: 0, width: 500, height: 320, zIndex: 2 },
+        },
+      },
+      ["first", "second", "second"],
+    );
+
+    expect(result.viewport).toEqual({
+      offset: { x: -10, y: 25 },
+      zoom: 0.8,
+    });
+    expect(Object.keys(result.nodes)).toEqual(["first", "second"]);
+    expect(result.nodes.first).toMatchObject({ x: 100, y: 120, zIndex: 4 });
+    expect(result.nodes.second.zIndex).toBe(5);
+    expect(result.nodes.second).not.toMatchObject({ x: 100, y: 120 });
+  });
+
+  it("resets sessions into a deterministic two-column layout", () => {
+    const result = resetWorkspaceCanvasState(["a", "b", "c"]);
+    expect(result.nodes.a.x).toBe(result.nodes.c.x);
+    expect(result.nodes.a.y).toBeLessThan(result.nodes.c.y);
+    expect(result.nodes.b.x).toBeGreaterThan(result.nodes.a.x);
+  });
+
+  it("keeps the world point under the cursor fixed while zooming", () => {
+    const viewport = zoomWorkspaceCanvasAtPoint(
+      { offset: { x: 50, y: 20 }, zoom: 1 },
+      1.5,
+      { x: 250, y: 120 },
+    );
+    expect(viewport).toEqual({
+      offset: { x: -50, y: -30 },
+      zoom: 1.5,
+    });
+  });
+
+  it("fits all nodes into the viewport and respects the minimum zoom", () => {
+    const viewport = fitWorkspaceCanvasViewport(
+      {
+        first: { x: 0, y: 0, width: 620, height: 400, zIndex: 1 },
+        second: { x: 0, y: 8_000, width: 620, height: 400, zIndex: 2 },
+      },
+      { width: 1_000, height: 700 },
+    );
+    expect(viewport.zoom).toBe(WORKSPACE_CANVAS_MIN_ZOOM);
+  });
+
+  it("compares persisted layouts by value and snaps committed geometry", () => {
+    const state = resetWorkspaceCanvasState(["a"]);
+    expect(workspaceCanvasStatesEqual(structuredClone(state), state)).toBe(
+      true,
+    );
+    expect(snapWorkspaceCanvasValue(31)).toBe(40);
+    expect(snapWorkspaceCanvasValue(-9)).toBe(0);
+  });
+
+  it("pans only enough to reveal a selected node", () => {
+    expect(
+      revealWorkspaceCanvasNode(
+        { offset: { x: 0, y: 0 }, zoom: 1 },
+        { x: 900, y: 100, width: 400, height: 300, zIndex: 1 },
+        { width: 1_000, height: 700 },
+      ),
+    ).toEqual({ offset: { x: -348, y: 0 }, zoom: 1 });
+  });
+});

--- a/src/lib/workspaceCanvas.ts
+++ b/src/lib/workspaceCanvas.ts
@@ -1,0 +1,374 @@
+export interface WorkspaceCanvasPoint {
+  x: number;
+  y: number;
+}
+
+export interface WorkspaceCanvasSize {
+  width: number;
+  height: number;
+}
+
+export interface WorkspaceCanvasViewport {
+  offset: WorkspaceCanvasPoint;
+  zoom: number;
+}
+
+export interface WorkspaceCanvasNode {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  zIndex: number;
+}
+
+export interface WorkspaceCanvasState {
+  viewport: WorkspaceCanvasViewport;
+  nodes: Record<string, WorkspaceCanvasNode>;
+}
+
+export const WORKSPACE_CANVAS_MIN_ZOOM = 0.35;
+export const WORKSPACE_CANVAS_MAX_ZOOM = 2;
+export const WORKSPACE_CANVAS_MIN_NODE_WIDTH = 360;
+export const WORKSPACE_CANVAS_MIN_NODE_HEIGHT = 240;
+export const WORKSPACE_CANVAS_DEFAULT_NODE_WIDTH = 620;
+export const WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT = 400;
+export const WORKSPACE_CANVAS_GRID_SIZE = 20;
+
+const WORKSPACE_CANVAS_MAX_NODE_WIDTH = 2_400;
+const WORKSPACE_CANVAS_MAX_NODE_HEIGHT = 1_600;
+const WORKSPACE_CANVAS_COORDINATE_LIMIT = 100_000;
+const WORKSPACE_CANVAS_NODE_GAP = 40;
+const WORKSPACE_CANVAS_NODE_ORIGIN = 48;
+const WORKSPACE_CANVAS_DEFAULT_COLUMNS = 2;
+
+export function defaultWorkspaceCanvasViewport(): WorkspaceCanvasViewport {
+  return { offset: { x: 48, y: 48 }, zoom: 1 };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function normalizePoint(value: unknown): WorkspaceCanvasPoint | null {
+  if (!value || typeof value !== "object") return null;
+  const point = value as Partial<WorkspaceCanvasPoint>;
+  const x = finiteNumber(point.x);
+  const y = finiteNumber(point.y);
+  if (x === null || y === null) return null;
+  return {
+    x: clamp(
+      x,
+      -WORKSPACE_CANVAS_COORDINATE_LIMIT,
+      WORKSPACE_CANVAS_COORDINATE_LIMIT,
+    ),
+    y: clamp(
+      y,
+      -WORKSPACE_CANVAS_COORDINATE_LIMIT,
+      WORKSPACE_CANVAS_COORDINATE_LIMIT,
+    ),
+  };
+}
+
+export function clampWorkspaceCanvasZoom(zoom: number): number {
+  if (!Number.isFinite(zoom)) return 1;
+  return clamp(zoom, WORKSPACE_CANVAS_MIN_ZOOM, WORKSPACE_CANVAS_MAX_ZOOM);
+}
+
+export function clampWorkspaceCanvasNode(
+  node: WorkspaceCanvasNode,
+): WorkspaceCanvasNode {
+  return {
+    x: clamp(
+      Number.isFinite(node.x) ? node.x : 0,
+      -WORKSPACE_CANVAS_COORDINATE_LIMIT,
+      WORKSPACE_CANVAS_COORDINATE_LIMIT,
+    ),
+    y: clamp(
+      Number.isFinite(node.y) ? node.y : 0,
+      -WORKSPACE_CANVAS_COORDINATE_LIMIT,
+      WORKSPACE_CANVAS_COORDINATE_LIMIT,
+    ),
+    width: clamp(
+      Number.isFinite(node.width)
+        ? node.width
+        : WORKSPACE_CANVAS_DEFAULT_NODE_WIDTH,
+      WORKSPACE_CANVAS_MIN_NODE_WIDTH,
+      WORKSPACE_CANVAS_MAX_NODE_WIDTH,
+    ),
+    height: clamp(
+      Number.isFinite(node.height)
+        ? node.height
+        : WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT,
+      WORKSPACE_CANVAS_MIN_NODE_HEIGHT,
+      WORKSPACE_CANVAS_MAX_NODE_HEIGHT,
+    ),
+    zIndex: clamp(
+      Number.isFinite(node.zIndex) ? Math.trunc(node.zIndex) : 1,
+      1,
+      Number.MAX_SAFE_INTEGER,
+    ),
+  };
+}
+
+function normalizeNode(value: unknown): WorkspaceCanvasNode | null {
+  if (!value || typeof value !== "object") return null;
+  const node = value as Partial<WorkspaceCanvasNode>;
+  const x = finiteNumber(node.x);
+  const y = finiteNumber(node.y);
+  const width = finiteNumber(node.width);
+  const height = finiteNumber(node.height);
+  const zIndex = finiteNumber(node.zIndex);
+  if (
+    x === null ||
+    y === null ||
+    width === null ||
+    height === null ||
+    zIndex === null
+  ) {
+    return null;
+  }
+  return clampWorkspaceCanvasNode({ x, y, width, height, zIndex });
+}
+
+export function normalizeWorkspaceCanvasState(
+  value: unknown,
+): WorkspaceCanvasState | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const state = value as Partial<WorkspaceCanvasState>;
+  if (!state.viewport || typeof state.viewport !== "object") return undefined;
+  const viewport = state.viewport as Partial<WorkspaceCanvasViewport>;
+  const offset = normalizePoint(viewport.offset);
+  const zoom = finiteNumber(viewport.zoom);
+  if (!offset || zoom === null) return undefined;
+
+  const nodes: Record<string, WorkspaceCanvasNode> = {};
+  if (state.nodes && typeof state.nodes === "object") {
+    for (const [sessionId, rawNode] of Object.entries(state.nodes)) {
+      if (!sessionId.trim()) continue;
+      const node = normalizeNode(rawNode);
+      if (node) nodes[sessionId] = node;
+    }
+  }
+
+  return {
+    viewport: { offset, zoom: clampWorkspaceCanvasZoom(zoom) },
+    nodes,
+  };
+}
+
+function defaultNodeAt(index: number, zIndex: number): WorkspaceCanvasNode {
+  const column = index % WORKSPACE_CANVAS_DEFAULT_COLUMNS;
+  const row = Math.floor(index / WORKSPACE_CANVAS_DEFAULT_COLUMNS);
+  return {
+    x:
+      WORKSPACE_CANVAS_NODE_ORIGIN +
+      column *
+        (WORKSPACE_CANVAS_DEFAULT_NODE_WIDTH + WORKSPACE_CANVAS_NODE_GAP),
+    y:
+      WORKSPACE_CANVAS_NODE_ORIGIN +
+      row * (WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT + WORKSPACE_CANVAS_NODE_GAP),
+    width: WORKSPACE_CANVAS_DEFAULT_NODE_WIDTH,
+    height: WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT,
+    zIndex,
+  };
+}
+
+function nodesOverlap(
+  first: WorkspaceCanvasNode,
+  second: WorkspaceCanvasNode,
+): boolean {
+  const gap = WORKSPACE_CANVAS_NODE_GAP / 2;
+  return !(
+    first.x + first.width + gap <= second.x ||
+    second.x + second.width + gap <= first.x ||
+    first.y + first.height + gap <= second.y ||
+    second.y + second.height + gap <= first.y
+  );
+}
+
+function nextOpenNode(
+  existing: readonly WorkspaceCanvasNode[],
+  zIndex: number,
+): WorkspaceCanvasNode {
+  for (let index = 0; index < 10_000; index += 1) {
+    const candidate = defaultNodeAt(index, zIndex);
+    if (!existing.some((node) => nodesOverlap(candidate, node))) {
+      return candidate;
+    }
+  }
+  return defaultNodeAt(existing.length, zIndex);
+}
+
+export function reconcileWorkspaceCanvasState(
+  value: unknown,
+  sessionIds: readonly string[],
+): WorkspaceCanvasState {
+  const normalized = normalizeWorkspaceCanvasState(value) ?? {
+    viewport: defaultWorkspaceCanvasViewport(),
+    nodes: {},
+  };
+  const ids = [...new Set(sessionIds.filter((id) => id.trim().length > 0))];
+  const nodes: Record<string, WorkspaceCanvasNode> = {};
+  let maxZ = 0;
+
+  for (const id of ids) {
+    const existing = normalized.nodes[id];
+    if (!existing) continue;
+    nodes[id] = existing;
+    maxZ = Math.max(maxZ, existing.zIndex);
+  }
+
+  for (const id of ids) {
+    if (nodes[id]) continue;
+    maxZ += 1;
+    nodes[id] = nextOpenNode(Object.values(nodes), maxZ);
+  }
+
+  return { viewport: normalized.viewport, nodes };
+}
+
+export function resetWorkspaceCanvasState(
+  sessionIds: readonly string[],
+): WorkspaceCanvasState {
+  const ids = [...new Set(sessionIds.filter((id) => id.trim().length > 0))];
+  return {
+    viewport: defaultWorkspaceCanvasViewport(),
+    nodes: Object.fromEntries(
+      ids.map((id, index) => [id, defaultNodeAt(index, index + 1)]),
+    ),
+  };
+}
+
+export function workspaceCanvasStatesEqual(
+  first: WorkspaceCanvasState | undefined,
+  second: WorkspaceCanvasState,
+): boolean {
+  if (!first) return false;
+  if (
+    first.viewport.zoom !== second.viewport.zoom ||
+    first.viewport.offset.x !== second.viewport.offset.x ||
+    first.viewport.offset.y !== second.viewport.offset.y
+  ) {
+    return false;
+  }
+  const firstIds = Object.keys(first.nodes);
+  const secondIds = Object.keys(second.nodes);
+  if (firstIds.length !== secondIds.length) return false;
+  return secondIds.every((id) => {
+    const a = first.nodes[id];
+    const b = second.nodes[id];
+    return Boolean(
+      a &&
+        b &&
+        a.x === b.x &&
+        a.y === b.y &&
+        a.width === b.width &&
+        a.height === b.height &&
+        a.zIndex === b.zIndex,
+    );
+  });
+}
+
+export function zoomWorkspaceCanvasAtPoint(
+  viewport: WorkspaceCanvasViewport,
+  nextZoom: number,
+  point: WorkspaceCanvasPoint,
+): WorkspaceCanvasViewport {
+  const zoom = clampWorkspaceCanvasZoom(nextZoom);
+  const currentZoom = clampWorkspaceCanvasZoom(viewport.zoom);
+  const worldPoint = {
+    x: (point.x - viewport.offset.x) / currentZoom,
+    y: (point.y - viewport.offset.y) / currentZoom,
+  };
+  return {
+    zoom,
+    offset: {
+      x: point.x - worldPoint.x * zoom,
+      y: point.y - worldPoint.y * zoom,
+    },
+  };
+}
+
+export function fitWorkspaceCanvasViewport(
+  nodes: Readonly<Record<string, WorkspaceCanvasNode>>,
+  container: WorkspaceCanvasSize,
+  padding = 56,
+): WorkspaceCanvasViewport {
+  const values = Object.values(nodes);
+  if (
+    values.length === 0 ||
+    !Number.isFinite(container.width) ||
+    !Number.isFinite(container.height) ||
+    container.width <= 0 ||
+    container.height <= 0
+  ) {
+    return defaultWorkspaceCanvasViewport();
+  }
+
+  const minX = Math.min(...values.map((node) => node.x));
+  const minY = Math.min(...values.map((node) => node.y));
+  const maxX = Math.max(...values.map((node) => node.x + node.width));
+  const maxY = Math.max(...values.map((node) => node.y + node.height));
+  const contentWidth = Math.max(maxX - minX, 1);
+  const contentHeight = Math.max(maxY - minY, 1);
+  const availableWidth = Math.max(container.width - padding * 2, 1);
+  const availableHeight = Math.max(container.height - padding * 2, 1);
+  const zoom = clampWorkspaceCanvasZoom(
+    Math.min(availableWidth / contentWidth, availableHeight / contentHeight, 1),
+  );
+
+  return {
+    zoom,
+    offset: {
+      x: (container.width - contentWidth * zoom) / 2 - minX * zoom,
+      y: (container.height - contentHeight * zoom) / 2 - minY * zoom,
+    },
+  };
+}
+
+export function revealWorkspaceCanvasNode(
+  viewport: WorkspaceCanvasViewport,
+  node: WorkspaceCanvasNode,
+  container: WorkspaceCanvasSize,
+  padding = 48,
+): WorkspaceCanvasViewport {
+  if (container.width <= 0 || container.height <= 0) return viewport;
+  const zoom = clampWorkspaceCanvasZoom(viewport.zoom);
+  const left = node.x * zoom + viewport.offset.x;
+  const top = node.y * zoom + viewport.offset.y;
+  const right = left + node.width * zoom;
+  const bottom = top + node.height * zoom;
+  const availableWidth = Math.max(container.width - padding * 2, 1);
+  const availableHeight = Math.max(container.height - padding * 2, 1);
+  let x = viewport.offset.x;
+  let y = viewport.offset.y;
+
+  if (node.width * zoom > availableWidth) {
+    x += container.width / 2 - (left + right) / 2;
+  } else if (left < padding) {
+    x += padding - left;
+  } else if (right > container.width - padding) {
+    x -= right - (container.width - padding);
+  }
+
+  if (node.height * zoom > availableHeight) {
+    y += container.height / 2 - (top + bottom) / 2;
+  } else if (top < padding) {
+    y += padding - top;
+  } else if (bottom > container.height - padding) {
+    y -= bottom - (container.height - padding);
+  }
+
+  return { zoom, offset: { x, y } };
+}
+
+export function snapWorkspaceCanvasValue(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  const snapped =
+    Math.round(value / WORKSPACE_CANVAS_GRID_SIZE) * WORKSPACE_CANVAS_GRID_SIZE;
+  return Object.is(snapped, -0) ? 0 : snapped;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -943,7 +943,24 @@
     "mode": {
       "ariaLabel": "Workspace view mode",
       "panes": "Panes",
-      "kanban": "Kanban"
+      "kanban": "Kanban",
+      "canvas": "Canvas"
+    },
+    "canvas": {
+      "regionLabel": "Workspace canvas",
+      "toolbarLabel": "Canvas controls",
+      "empty": "No terminal sessions on this canvas. Chat sessions stay available in Panes.",
+      "hint": "Drag empty space or middle-drag to pan · Pinch or modifier-scroll to zoom · Alt skips snapping",
+      "terminalCountOne": "1 terminal",
+      "terminalCountOther": "{count} terminals",
+      "zoomOut": "Zoom out",
+      "zoomIn": "Zoom in",
+      "fit": "Fit all terminals",
+      "reset": "Reset terminal layout",
+      "newSession": "New session",
+      "moveSession": "Move {name}",
+      "resizeSession": "Resize {name}",
+      "openInPanes": "Open {name} in panes"
     },
     "kanban": {
       "title": "Workspace kanban",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -943,7 +943,24 @@
     "mode": {
       "ariaLabel": "작업공간 보기 모드",
       "panes": "패널",
-      "kanban": "칸반"
+      "kanban": "칸반",
+      "canvas": "캔버스"
+    },
+    "canvas": {
+      "regionLabel": "작업공간 캔버스",
+      "toolbarLabel": "캔버스 도구",
+      "empty": "이 캔버스에 터미널 세션이 없습니다. 채팅 세션은 패널에서 계속 사용할 수 있습니다.",
+      "hint": "빈 공간 또는 가운데 버튼 드래그: 이동 · 핀치/보조키+스크롤: 확대·축소 · Alt: 스냅 해제",
+      "terminalCountOne": "터미널 1개",
+      "terminalCountOther": "터미널 {count}개",
+      "zoomOut": "축소",
+      "zoomIn": "확대",
+      "fit": "모든 터미널 맞추기",
+      "reset": "터미널 배치 초기화",
+      "newSession": "새 세션",
+      "moveSession": "{name} 이동",
+      "resizeSession": "{name} 크기 조절",
+      "openInPanes": "패널에서 {name} 열기"
     },
     "kanban": {
       "title": "작업공간 칸반",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -694,6 +694,22 @@ describe("openSessionSurface", () => {
     expect(state.terminalPopupSessionId).toBeNull();
   });
 
+  it("keeps canvas mode visible when opening one of its sessions", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A), session("a2", REPO_A)],
+    );
+
+    useAppStore.getState().setWorkspaceViewMode("canvas");
+
+    expect(useAppStore.getState().openSessionSurface("a2")).toBe(true);
+
+    const state = useAppStore.getState();
+    expect(state.activeSessionId).toBe("a2");
+    expect(state.workspaceViewMode).toBe("canvas");
+    expect(state.terminalPopupSessionId).toBeNull();
+  });
+
   it("does not open a surface for an unknown session", async () => {
     await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
 
@@ -1886,6 +1902,35 @@ describe("splitFocusedPane", () => {
     useAppStore.getState().setWorkspaceViewMode("panes");
 
     expect(useAppStore.getState().workspaces[REPO_A].viewMode).toBe("panes");
+  });
+
+  it("stores canvas geometry independently for each workspace", async () => {
+    await seed(
+      [project(REPO_A, 0), project(REPO_B, 1)],
+      [session("a1", REPO_A), session("b1", REPO_B)],
+    );
+
+    useAppStore.getState().setWorkspaceCanvasState(REPO_A, {
+      viewport: { offset: { x: -120, y: 45 }, zoom: 0.8 },
+      nodes: {
+        a1: { x: 80, y: 120, width: 640, height: 420, zIndex: 2 },
+      },
+    });
+
+    expect(useAppStore.getState().workspaces[REPO_A].canvas).toEqual({
+      viewport: { offset: { x: -120, y: 45 }, zoom: 0.8 },
+      nodes: {
+        a1: { x: 80, y: 120, width: 640, height: 420, zIndex: 2 },
+      },
+    });
+    expect(useAppStore.getState().workspaces[REPO_B].canvas).toBeUndefined();
+
+    useAppStore.getState().setActiveProject(REPO_B);
+    useAppStore.getState().setWorkspaceViewMode("canvas");
+    expect(useAppStore.getState().workspaceViewMode).toBe("canvas");
+    expect(useAppStore.getState().workspaces[REPO_A].canvas?.nodes.a1.x).toBe(
+      80,
+    );
   });
 
   it("stores the workspace view mode per project", async () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -80,6 +80,11 @@ import {
   summarizeTokenUsage,
   type WorkSummaryTokenBaseline,
 } from "./lib/workSummary";
+import {
+  normalizeWorkspaceCanvasState,
+  workspaceCanvasStatesEqual,
+  type WorkspaceCanvasState,
+} from "./lib/workspaceCanvas";
 
 export type { RightGroup, RightTab };
 
@@ -331,11 +336,12 @@ export interface ProjectWorkspace {
   focusedPaneId: PaneId;
   viewMode?: WorkspaceViewMode;
   localViewMode?: WorkspaceViewMode;
+  canvas?: WorkspaceCanvasState;
   rightTab?: RightTab;
   rightTabByGroup?: Record<RightGroup, RightTab>;
 }
 
-export type WorkspaceViewMode = "panes" | "kanban";
+export type WorkspaceViewMode = "panes" | "kanban" | "canvas";
 type WorkspaceViewScope = "project" | "local";
 
 export interface MoveTabArgs {
@@ -459,6 +465,10 @@ interface AppStateModel {
   ) => void;
   setFocusedPane: (paneId: PaneId) => void;
   setWorkspaceViewMode: (mode: WorkspaceViewMode) => void;
+  setWorkspaceCanvasState: (
+    workspaceId: string,
+    canvas: WorkspaceCanvasState,
+  ) => void;
   openTerminalPopup: (sessionId: string) => void;
   closeTerminalPopup: () => void;
   focusAdjacentPane: (direction: PaneFocusDirection) => void;
@@ -685,6 +695,7 @@ function emptyWorkspace(
 
 type PersistedWorkspaceState = Partial<ProjectWorkspace> & {
   localViewMode?: unknown;
+  canvas?: unknown;
   rightTab?: unknown;
   rightTabByGroup?: Partial<Record<RightGroup, unknown>>;
 };
@@ -712,7 +723,9 @@ function defaultWorkspaceViewMode(): WorkspaceViewMode {
 }
 
 function readWorkspaceViewMode(value: unknown): WorkspaceViewMode | null {
-  return value === "kanban" || value === "panes" ? value : null;
+  return value === "kanban" || value === "panes" || value === "canvas"
+    ? value
+    : null;
 }
 
 function normalizeWorkspaceViewMode(
@@ -2541,6 +2554,26 @@ export const useAppStore = create<AppStateModel>()(
     });
   },
 
+  setWorkspaceCanvasState(workspaceId, canvas) {
+    const normalized = normalizeWorkspaceCanvasState(canvas);
+    if (!normalized) return;
+    set((s) => {
+      const workspace = s.workspaces[workspaceId];
+      if (
+        !workspace ||
+        workspaceCanvasStatesEqual(workspace.canvas, normalized)
+      ) {
+        return s;
+      }
+      return {
+        workspaces: {
+          ...s.workspaces,
+          [workspaceId]: { ...workspace, canvas: normalized },
+        },
+      };
+    });
+  },
+
   openTerminalPopup(sessionId) {
     set({ terminalPopupSessionId: sessionId });
   },
@@ -2633,7 +2666,9 @@ export const useAppStore = create<AppStateModel>()(
     const sessionId = latestNeedsInputSessionId(get());
     if (!sessionId) return false;
     get().selectSession(sessionId);
-    get().setWorkspaceViewMode("panes");
+    if (get().workspaceViewMode === "kanban") {
+      get().setWorkspaceViewMode("panes");
+    }
     return get().activeSessionId === sessionId;
   },
 
@@ -4063,6 +4098,9 @@ export const useAppStore = create<AppStateModel>()(
           const explicitLocalViewMode = readWorkspaceViewMode(
             (ws as PersistedWorkspaceState).localViewMode,
           );
+          const canvas = normalizeWorkspaceCanvasState(
+            (ws as PersistedWorkspaceState).canvas,
+          );
           const newPanes: Record<PaneId, PaneState> = {};
           for (const [pid, pane] of Object.entries(ws.panes ?? {})) {
             const normalized = normalizePaneState(
@@ -4103,6 +4141,11 @@ export const useAppStore = create<AppStateModel>()(
             normalizedWorkspace.localViewMode = explicitLocalViewMode;
           } else {
             delete normalizedWorkspace.localViewMode;
+          }
+          if (canvas) {
+            normalizedWorkspace.canvas = canvas;
+          } else {
+            delete normalizedWorkspace.canvas;
           }
           sanitized[key] = normalizedWorkspace;
         }

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -1,0 +1,193 @@
+import { expect, test } from "./support";
+
+const PROJECT = {
+  repo_path: "/tmp/demo",
+  name: "demo",
+  created_at: "2026-01-01T00:00:00Z",
+  position: 0,
+};
+
+function session(id: string) {
+  return {
+    id,
+    name: id,
+    repo_path: "/tmp/demo",
+    worktree_path: `/tmp/demo/.worktrees/${id}`,
+    branch: `feat/${id}`,
+    isolated: false,
+    status: "ready",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:05Z",
+    last_message: null,
+    title_source: "default",
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: false,
+  };
+}
+
+test.describe("workspace canvas mode", () => {
+  test("moves, resizes, zooms, and restores live terminal nodes", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [session("alpha"), session("beta")]);
+
+    await page.goto("/");
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Canvas" }).click();
+
+    const canvas = page.getByTestId("workspace-canvas");
+    const nodes = canvas.getByTestId("workspace-canvas-node");
+    const alpha = canvas.locator('[data-canvas-session-id="alpha"]');
+    await expect(canvas).toBeVisible();
+    await expect(nodes).toHaveCount(2);
+    await expect(
+      alpha.locator(
+        '[data-canvas-terminal-body="alpha"] [data-acorn-terminal-slot="alpha"] .acorn-terminal-shell',
+      ),
+    ).toBeVisible();
+    await expect(
+      canvas.locator(
+        '[data-canvas-terminal-body="beta"] [data-acorn-terminal-slot="beta"] .acorn-terminal-shell',
+      ),
+    ).toBeAttached();
+
+    const initialX = Number(await alpha.getAttribute("data-canvas-node-x"));
+    const initialY = Number(await alpha.getAttribute("data-canvas-node-y"));
+    const dragHandle = alpha.getByTestId("workspace-canvas-node-drag-handle");
+    const dragBox = await dragHandle.boundingBox();
+    if (!dragBox) throw new Error("Canvas drag handle is not visible");
+    await page.mouse.move(
+      dragBox.x + dragBox.width / 2,
+      dragBox.y + dragBox.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      dragBox.x + dragBox.width / 2 + 80,
+      dragBox.y + dragBox.height / 2 + 40,
+    );
+    await page.mouse.up();
+
+    await expect
+      .poll(async () => Number(await alpha.getAttribute("data-canvas-node-x")))
+      .toBeGreaterThan(initialX);
+    await expect
+      .poll(async () => Number(await alpha.getAttribute("data-canvas-node-y")))
+      .toBeGreaterThan(initialY);
+
+    const initialWidth = Number(
+      await alpha.getAttribute("data-canvas-node-width"),
+    );
+    const initialHeight = Number(
+      await alpha.getAttribute("data-canvas-node-height"),
+    );
+    const resizeHandle = alpha.getByTestId(
+      "workspace-canvas-node-resize-handle",
+    );
+    const resizeBox = await resizeHandle.boundingBox();
+    if (!resizeBox) throw new Error("Canvas resize handle is not visible");
+    await page.mouse.move(
+      resizeBox.x + resizeBox.width / 2,
+      resizeBox.y + resizeBox.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      resizeBox.x + resizeBox.width / 2 + 100,
+      resizeBox.y + resizeBox.height / 2 + 80,
+    );
+    await page.mouse.up();
+
+    await expect
+      .poll(async () =>
+        Number(await alpha.getAttribute("data-canvas-node-width")),
+      )
+      .toBeGreaterThan(initialWidth);
+    await expect
+      .poll(async () =>
+        Number(await alpha.getAttribute("data-canvas-node-height")),
+      )
+      .toBeGreaterThan(initialHeight);
+
+    const world = page.getByTestId("workspace-canvas-world");
+    const initialZoom = Number(await world.getAttribute("data-canvas-zoom"));
+    await page.getByRole("button", { name: "Zoom in" }).click();
+    await expect
+      .poll(async () => Number(await world.getAttribute("data-canvas-zoom")))
+      .toBeGreaterThan(initialZoom);
+    const changedZoom = Number(await world.getAttribute("data-canvas-zoom"));
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = localStorage.getItem("acorn-workspaces");
+          if (!raw) return null;
+          const state = JSON.parse(raw).state;
+          const workspace = state.workspaces?.["/tmp/demo"];
+          if (!workspace?.canvas?.nodes?.alpha) return null;
+          return {
+            mode: workspace.viewMode,
+            node: workspace.canvas.nodes.alpha,
+            zoom: workspace.canvas.viewport.zoom,
+          };
+        }),
+      )
+      .not.toBeNull();
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = localStorage.getItem("acorn-workspaces");
+          return raw
+            ? (JSON.parse(raw).state.workspaces?.["/tmp/demo"]?.canvas?.viewport
+                ?.zoom ?? null)
+            : null;
+        }),
+      )
+      .toBe(changedZoom);
+
+    const saved = await page.evaluate(() => {
+      const raw = localStorage.getItem("acorn-workspaces");
+      const workspace = JSON.parse(raw!).state.workspaces["/tmp/demo"];
+      return {
+        mode: workspace.viewMode as string,
+        node: workspace.canvas.nodes.alpha as {
+          x: number;
+          y: number;
+          width: number;
+          height: number;
+        },
+        zoom: workspace.canvas.viewport.zoom as number,
+      };
+    });
+    expect(saved.mode).toBe("canvas");
+
+    await page.reload();
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Canvas",
+    );
+    await expect(page.getByTestId("workspace-canvas")).toBeVisible();
+    const restored = page.locator('[data-canvas-session-id="alpha"]');
+    await expect(restored).toHaveAttribute(
+      "data-canvas-node-x",
+      String(saved.node.x),
+    );
+    await expect(restored).toHaveAttribute(
+      "data-canvas-node-y",
+      String(saved.node.y),
+    );
+    await expect(restored).toHaveAttribute(
+      "data-canvas-node-width",
+      String(saved.node.width),
+    );
+    await expect(restored).toHaveAttribute(
+      "data-canvas-node-height",
+      String(saved.node.height),
+    );
+    await expect(page.getByTestId("workspace-canvas-world")).toHaveAttribute(
+      "data-canvas-zoom",
+      String(saved.zoom),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a third workspace view for arranging live terminal sessions on a persistent infinite canvas.

1. **Canvas workspace surface** - add movable, resizable terminal cards with free panning, cursor-anchored zoom, fit/reset controls, grid snapping, and keyboard movement/resizing.
2. **Live terminal continuity** - extend `TerminalHost` portal routing so every Canvas card reuses the existing xterm DOM and PTY instead of remounting the terminal when switching views.
3. **Project-scoped persistence** - store normalized node geometry, z-order, and viewport state per workspace; reconcile newly created and removed sessions without losing the remaining layout.
4. **Product integration** - expose Canvas in the status bar, command palette cycle, default workspace setting, empty state, and Korean/English translations.
5. **Regression coverage** - cover geometry helpers, store hydration, session-surface routing, terminal portal reuse, component interactions, and full browser persistence.

## Expected impact

| Workflow | Before | After |
| --- | --- | --- |
| Organize several live terminals | Pane splits or Kanban terminal overlays | Freely position and resize terminals on a shared project canvas |
| Switch workspace views | Only Panes and Kanban available | Panes, Kanban, and Canvas retain their project-scoped mode |
| Return to a terminal layout | Rebuild the arrangement manually | Restore saved positions, sizes, z-order, pan, and zoom |
| Focus a session from sidebar/notifications | Route to its Panes or Kanban surface | Keep Canvas visible and reveal/activate the target terminal |

## Design notes

- The canvas uses regular DOM nodes plus a CSS transform rather than a new canvas dependency. This keeps Acorn's existing component and accessibility primitives available.
- `TerminalHost` remains the single owner of live xterm instances. Canvas provides stable portal destinations, so switching modes moves existing terminal DOM without restarting the PTY.
- Persisted canvas data is clamped and normalized during store hydration. Workspace pane tab IDs are the reconciliation source so startup session-loading gaps do not erase saved layouts.
- Initial entry stays at 100% zoom for terminal readability; Fit is an explicit overview action.
- Canvas state is scoped to the active project workspace. This PR renders terminal sessions only; chat sessions remain available in Panes.

## Follow-up (not in this PR)

- Support chat-session cards.
- Add minimap/overview affordances, multi-select, and undo for layout reset and batch edits.
- Add a semantic large-board overview for layouts that need zoom below the interactive terminal minimum.

## Test plan

- [x] `pnpm typecheck` - passes
- [x] `pnpm test` - 96 files, 1,047 tests pass
- [x] `pnpm build` - production frontend build passes
- [x] `PLAYWRIGHT_PORT=1435 pnpm exec playwright test tests/e2e/canvas.spec.ts --project=chromium` - 1 Canvas E2E passes
- [x] Self-review - no blocking findings; `git diff --check` passes

## Notes

- The build retains the existing Vite dynamic/static import and chunk-size warnings; it completes successfully.
