### PR TITLE
feat(settings): add searchable theme library

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -961,6 +961,31 @@ describe("SettingsModal font controls", () => {
     expect(document.body.textContent).toContain("Downloaded");
     expect(document.body.textContent).toContain("Available to download");
 
+    const catalogSearch = document.querySelector<HTMLInputElement>(
+      'input[aria-label="Search theme library"]',
+    );
+    expect(catalogSearch).not.toBeNull();
+    setInputValue(catalogSearch as HTMLInputElement, "github-light");
+
+    const catalogList = document.querySelector(
+      '[role="list"][aria-label="Theme library"]',
+    );
+    expect(
+      Array.from(catalogList?.querySelectorAll('[role="listitem"]') ?? []).map(
+        (element) => element.textContent,
+      ),
+    ).toEqual([expect.stringContaining("GitHub Light")]);
+
+    setInputValue(catalogSearch as HTMLInputElement, "missing-theme");
+    expect(
+      document.querySelector('[role="list"][aria-label="Theme library"]'),
+    ).toBeNull();
+    expect(document.body.textContent).toContain(
+      "No themes match your search.",
+    );
+
+    setInputValue(catalogSearch as HTMLInputElement, "");
+
     const previewButton = Array.from(document.querySelectorAll("button")).find(
       (element) => element.textContent?.trim() === "Preview themes",
     );

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -9,6 +9,7 @@ import {
   Loader2,
   RefreshCcw,
   Save,
+  Search,
   Settings as SettingsIcon,
   Sparkles,
   Trash2,
@@ -111,6 +112,7 @@ import {
   CodeValue,
   CommandHint,
   Field,
+  IconInput,
   Modal,
   ModalFooter,
   ModalHeader,
@@ -1817,6 +1819,16 @@ function ThemeCatalogSection({
   const uninstall = useThemes((state) => state.uninstall);
   const showToast = useToasts((state) => state.show);
   const t = useTranslation();
+  const [catalogQuery, setCatalogQuery] = useState("");
+
+  const normalizedCatalogQuery = catalogQuery.trim().toLowerCase();
+  const filteredCatalog = normalizedCatalogQuery
+    ? catalog.filter((theme) =>
+        `${theme.label} ${theme.id}`
+          .toLowerCase()
+          .includes(normalizedCatalogQuery),
+      )
+    : catalog;
 
   useEffect(() => {
     if (catalogStatus === "idle") {
@@ -1868,28 +1880,45 @@ function ThemeCatalogSection({
       title={st(t, "settings.appearance.theme.library.title")}
       description={st(t, "settings.appearance.theme.library.description")}
     >
-      <div className="flex justify-end gap-2">
-        <Button
-          variant="outline"
-          size="xs"
-          onClick={() => void openThemePreview()}
-        >
-          <ExternalLink size={11} />
-          {st(t, "settings.appearance.theme.library.preview")}
-        </Button>
-        <Button
-          variant="outline"
-          size="xs"
-          disabled={catalogStatus === "loading"}
-          onClick={() => void loadCatalog()}
-        >
-          {catalogStatus === "loading" ? (
-            <Loader2 size={11} className="animate-spin" />
-          ) : (
-            <RefreshCcw size={11} />
+      <div className="flex flex-wrap items-center gap-2">
+        <IconInput
+          type="search"
+          value={catalogQuery}
+          onChange={(event) => setCatalogQuery(event.currentTarget.value)}
+          leading={<Search size={12} aria-hidden="true" />}
+          placeholder={st(
+            t,
+            "settings.appearance.theme.library.searchPlaceholder",
           )}
-          {st(t, "settings.appearance.theme.library.refresh")}
-        </Button>
+          aria-label={st(
+            t,
+            "settings.appearance.theme.library.searchPlaceholder",
+          )}
+          className="min-w-48 flex-1 sm:max-w-64"
+        />
+        <div className="ml-auto flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="xs"
+            onClick={() => void openThemePreview()}
+          >
+            <ExternalLink size={11} />
+            {st(t, "settings.appearance.theme.library.preview")}
+          </Button>
+          <Button
+            variant="outline"
+            size="xs"
+            disabled={catalogStatus === "loading"}
+            onClick={() => void loadCatalog()}
+          >
+            {catalogStatus === "loading" ? (
+              <Loader2 size={11} className="animate-spin" />
+            ) : (
+              <RefreshCcw size={11} />
+            )}
+            {st(t, "settings.appearance.theme.library.refresh")}
+          </Button>
+        </div>
       </div>
 
       {catalogStatus === "loading" && catalog.length === 0 ? (
@@ -1905,13 +1934,13 @@ function ThemeCatalogSection({
         </Notice>
       ) : null}
 
-      {catalog.length > 0 ? (
+      {filteredCatalog.length > 0 ? (
         <div
           className="overflow-hidden rounded-lg border border-border"
           role="list"
           aria-label={st(t, "settings.appearance.theme.library.title")}
         >
-          {catalog.map((entry) => (
+          {filteredCatalog.map((entry) => (
             <ThemeCatalogRow
               key={entry.id}
               entry={entry}
@@ -1921,6 +1950,10 @@ function ThemeCatalogSection({
               onUninstall={() => void handleUninstall(entry)}
             />
           ))}
+        </div>
+      ) : catalog.length > 0 ? (
+        <div className="py-4 text-center text-xs text-fg-muted">
+          {st(t, "settings.appearance.theme.library.noMatches")}
         </div>
       ) : null}
     </SettingsGroup>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -300,6 +300,8 @@
           "description": "Download and update themes from the acorn-themes repository. Removing a downloaded theme does not affect custom CSS files.",
           "preview": "Preview themes",
           "refresh": "Refresh library",
+          "searchPlaceholder": "Search theme library",
+          "noMatches": "No themes match your search.",
           "loading": "Loading the theme library…",
           "loadFailed": "Couldn't load the theme library.",
           "download": "Download",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -300,6 +300,8 @@
           "description": "acorn-themes 저장소에서 테마를 다운로드하고 업데이트합니다. 다운로드한 테마를 삭제해도 직접 추가한 CSS 파일에는 영향을 주지 않습니다.",
           "preview": "테마 미리보기",
           "refresh": "라이브러리 새로고침",
+          "searchPlaceholder": "테마 라이브러리 검색",
+          "noMatches": "검색과 일치하는 테마가 없습니다.",
           "loading": "테마 라이브러리를 불러오는 중…",
           "loadFailed": "테마 라이브러리를 불러오지 못했습니다.",
           "download": "다운로드",

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -68,6 +68,13 @@ test.describe("settings modal", () => {
                 version: 1,
                 file: "themes/note.css",
               },
+              {
+                id: "one-dark-pro",
+                label: "One Dark Pro",
+                mode: "dark",
+                version: 1,
+                file: "themes/one-dark-pro.css",
+              },
             ],
           }),
         }),
@@ -159,6 +166,28 @@ test.describe("settings modal", () => {
       .getByRole("option", { name: "Acorn Dark Green", exact: true })
       .click();
 
+    const themeLibrary = modal.getByRole("list", {
+      name: /^(Theme library|테마 라이브러리)$/,
+    });
+    const librarySearch = modal.getByRole("searchbox", {
+      name: /^(Search theme library|테마 라이브러리 검색)$/,
+    });
+    await expect(themeLibrary.getByRole("listitem")).toHaveCount(2);
+
+    await librarySearch.fill("note");
+    await expect(themeLibrary.getByRole("listitem")).toHaveCount(1);
+    await expect(themeLibrary).toContainText("Note");
+    await expect(themeLibrary).not.toContainText("One Dark Pro");
+
+    await librarySearch.fill("missing-theme");
+    await expect(themeLibrary).toHaveCount(0);
+    await expect(
+      modal.getByText(
+        /^(No themes match your search\.|검색과 일치하는 테마가 없습니다\.)$/,
+      ),
+    ).toBeVisible();
+
+    await librarySearch.fill("");
     const noteRow = modal.getByRole("listitem").filter({ hasText: "Note" });
     await expect(noteRow).toContainText(/Available to download|다운로드 가능/);
     await noteRow.getByRole("button", { name: /^(Download|다운로드)$/ }).click();


### PR DESCRIPTION
## Summary
Makes the downloadable theme catalog easier to navigate as the library grows.

1. **Searchable catalog** — adds an accessible search field that filters downloadable themes by display name or theme ID.
2. **Localized feedback** — adds English and Korean search placeholders and no-match states.
3. **Regression coverage** — verifies filtering, empty results, and the existing download/select/remove flow at component and browser levels.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Theme discovery | Users scan the full downloadable catalog | Users narrow the catalog immediately by name or ID |
| No-match feedback | No catalog-specific search state | A localized empty state explains that no theme matched |
| Installed theme selection | Searchable selector | Unchanged |

## Design notes
- The search state stays local to the theme catalog section and does not alter catalog data or installation state.
- Filtering includes both `label` and `id`, so human-readable names and CSS theme identifiers are discoverable.
- The shared `IconInput` component preserves existing settings styling and accessible searchbox semantics.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 95 test files and 1,032 tests pass
- [x] `pnpm exec playwright test tests/e2e/settings.spec.ts --grep "downloads, selects, and removes a catalog theme"` — 1 Chromium test passes
- [x] `pnpm run build` — production build passes