### PR TITLE
feat(github): open linked sessions from pull requests

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -38,6 +38,7 @@ import {
   MinusCircle,
   Play,
   Search,
+  SquareTerminal,
   Trash2,
   X,
 } from "lucide-react";
@@ -55,6 +56,8 @@ import {
 } from "../lib/hotkeys";
 import { joinPath } from "../lib/paths";
 import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
+import { findSessionsForPullRequest } from "../lib/sessionContext";
+import { readSessionPullRequestBranchLinks } from "../lib/sessionPullRequestLinks";
 import {
   onPullRequestMutation,
   pullRequestMutationAffectsOpenContext,
@@ -2730,6 +2733,8 @@ function usePrRowActions(
   onMutated?: () => void,
 ) {
   const t = useTranslation();
+  const sessions = useAppStore((s) => s.sessions);
+  const openSessionSurface = useAppStore((s) => s.openSessionSurface);
   const [menu, setMenu] = useState<{
     x: number;
     y: number;
@@ -2895,6 +2900,42 @@ function usePrRowActions(
     setMenu({ x: e.clientX, y: e.clientY, pr });
   }
 
+  const matchingSessions = menu
+    ? findSessionsForPullRequest(
+        sessions,
+        repoPath,
+        menu.pr.head_branch,
+        readSessionPullRequestBranchLinks(),
+      )
+    : [];
+
+  const openSessionMenuItem: ContextMenuItem =
+    matchingSessions.length === 1
+      ? {
+          label: rtf(t, "rightPanel.menu.openSessionWithName", {
+            name: matchingSessions[0].name,
+          }),
+          icon: <SquareTerminal size={12} />,
+          onClick: () => openSessionSurface(matchingSessions[0].id),
+        }
+      : matchingSessions.length > 1
+        ? {
+            type: "submenu",
+            label: rt(t, "rightPanel.menu.openSession"),
+            icon: <SquareTerminal size={12} />,
+            children: matchingSessions.map((session) => ({
+              label: session.name,
+              icon: <SquareTerminal size={12} />,
+              onClick: () => openSessionSurface(session.id),
+            })),
+          }
+        : {
+            label: rt(t, "rightPanel.menu.openSession"),
+            icon: <SquareTerminal size={12} />,
+            disabled: true,
+            onClick: () => undefined,
+          };
+
   const overlays = (
     <>
       <ContextMenu
@@ -2914,6 +2955,7 @@ function usePrRowActions(
                   icon: <ExternalLink size={12} />,
                   onClick: () => void openPrInBrowser(menu.pr),
                 },
+                openSessionMenuItem,
                 { type: "separator" },
                 {
                   label: rt(t, "rightPanel.menu.copyPrNumber"),

--- a/src/lib/sessionContext.test.ts
+++ b/src/lib/sessionContext.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   currentPullRequestSearchQuery,
   findCurrentPullRequestForBranch,
+  findSessionsForPullRequest,
   summarizeAllSessionProcesses,
   summarizeSessionProcesses,
 } from "./sessionContext";
-import type { PullRequestInfo, PullRequestListing } from "./types";
+import type { PullRequestInfo, PullRequestListing, Session } from "./types";
 
 function pr(overrides: Partial<PullRequestInfo>): PullRequestInfo {
   return {
@@ -22,6 +23,27 @@ function pr(overrides: Partial<PullRequestInfo>): PullRequestInfo {
     is_draft: false,
     checks: null,
     labels: [],
+    ...overrides,
+  };
+}
+
+function session(id: string, overrides: Partial<Session> = {}): Session {
+  return {
+    id,
+    name: id,
+    repo_path: "/repo",
+    worktree_path: `/repo/.acorn/worktrees/${id}`,
+    branch: "main",
+    isolated: true,
+    status: "ready",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: null,
+    title_source: "default",
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: true,
     ...overrides,
   };
 }
@@ -62,6 +84,60 @@ describe("session context helpers", () => {
       state: "OPEN",
       is_draft: false,
     });
+  });
+
+  it("finds current and previously linked sessions for a PR branch", () => {
+    const current = session("current", {
+      name: "Current branch",
+      branch: "feature/sidebar-prs",
+      updated_at: "2026-01-02T00:00:00Z",
+    });
+    const previous = session("previous", {
+      name: "Cleaned up branch",
+      branch: "main",
+      updated_at: "2026-01-03T00:00:00Z",
+    });
+    const otherRepo = session("other-repo", {
+      repo_path: "/other",
+      branch: "feature/sidebar-prs",
+    });
+    const local = session("local", {
+      branch: "feature/sidebar-prs",
+      project_scoped: false,
+    });
+
+    expect(
+      findSessionsForPullRequest(
+        [previous, otherRepo, local, current],
+        "/repo/",
+        "feature/sidebar-prs",
+        {
+          previous: {
+            repoPath: "/repo",
+            headBranch: "feature/sidebar-prs",
+          },
+        },
+      ).map((candidate) => candidate.id),
+    ).toEqual(["current", "previous"]);
+  });
+
+  it("orders matching current-branch sessions by recency", () => {
+    const older = session("older", {
+      branch: "feature/sidebar-prs",
+      updated_at: "2026-01-02T00:00:00Z",
+    });
+    const newer = session("newer", {
+      branch: "feature/sidebar-prs",
+      updated_at: "2026-01-03T00:00:00Z",
+    });
+
+    expect(
+      findSessionsForPullRequest(
+        [older, newer],
+        "/repo",
+        "feature/sidebar-prs",
+      ).map((candidate) => candidate.id),
+    ).toEqual(["newer", "older"]);
   });
 
   it("summarizes the visible session process names", () => {

--- a/src/lib/sessionContext.ts
+++ b/src/lib/sessionContext.ts
@@ -1,8 +1,10 @@
 import type {
   PullRequestListing,
+  Session,
   SessionProcessSummary,
   SessionPullRequestSummary,
 } from "./types";
+import type { SessionPullRequestBranchLinks } from "./sessionPullRequestLinks";
 
 const PROCESS_SUMMARY_VISIBLE = 2;
 
@@ -41,6 +43,55 @@ export function findCurrentPullRequestForBranch(
     state: pr.state,
     is_draft: pr.is_draft,
   };
+}
+
+function comparableRepoPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized || "/";
+}
+
+function sessionTimestamp(value: string): number {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+export function findSessionsForPullRequest(
+  sessions: readonly Session[],
+  repoPath: string,
+  headBranch: string,
+  branchLinks: SessionPullRequestBranchLinks = {},
+): Session[] {
+  const targetRepo = comparableRepoPath(repoPath.trim());
+  const targetBranch = headBranch.trim();
+  if (!targetBranch) return [];
+
+  return sessions
+    .filter((session) => {
+      if (session.project_scoped === false) return false;
+      if (comparableRepoPath(session.repo_path.trim()) !== targetRepo) {
+        return false;
+      }
+      if (session.branch.trim() === targetBranch) return true;
+      const link = branchLinks[session.id];
+      return (
+        link?.headBranch.trim() === targetBranch &&
+        comparableRepoPath(link.repoPath.trim()) === targetRepo
+      );
+    })
+    .sort((a, b) => {
+      const aCurrent = a.branch.trim() === targetBranch;
+      const bCurrent = b.branch.trim() === targetBranch;
+      if (aCurrent !== bCurrent) return aCurrent ? -1 : 1;
+      return (
+        sessionTimestamp(b.updated_at) - sessionTimestamp(a.updated_at) ||
+        sessionTimestamp(b.created_at) - sessionTimestamp(a.created_at) ||
+        a.name.localeCompare(b.name, undefined, {
+          sensitivity: "base",
+          numeric: true,
+        }) ||
+        a.id.localeCompare(b.id)
+      );
+    });
 }
 
 export function summarizeSessionProcesses(

--- a/src/lib/sessionPullRequestLinks.ts
+++ b/src/lib/sessionPullRequestLinks.ts
@@ -1,0 +1,59 @@
+const SESSION_PR_BRANCH_LINKS_STORAGE_KEY =
+  "acorn:workspace-kanban:pr-branch-links:v1";
+
+export interface SessionPullRequestBranchLink {
+  repoPath: string;
+  headBranch: string;
+}
+
+export type SessionPullRequestBranchLinks = Record<
+  string,
+  SessionPullRequestBranchLink
+>;
+
+function isSessionPullRequestBranchLink(
+  value: unknown,
+): value is SessionPullRequestBranchLink {
+  if (!value || typeof value !== "object") return false;
+  const link = value as Partial<SessionPullRequestBranchLink>;
+  return (
+    typeof link.repoPath === "string" &&
+    link.repoPath.trim().length > 0 &&
+    typeof link.headBranch === "string" &&
+    link.headBranch.trim().length > 0
+  );
+}
+
+export function readSessionPullRequestBranchLinks(): SessionPullRequestBranchLinks {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(
+      SESSION_PR_BRANCH_LINKS_STORAGE_KEY,
+    );
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, SessionPullRequestBranchLink] =>
+          isSessionPullRequestBranchLink(entry[1]),
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+export function writeSessionPullRequestBranchLinks(
+  links: SessionPullRequestBranchLinks,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      SESSION_PR_BRANCH_LINKS_STORAGE_KEY,
+      JSON.stringify(links),
+    );
+  } catch {
+    // Current-branch PR matching still works when storage is unavailable.
+  }
+}

--- a/src/lib/useKanbanBoardData.test.ts
+++ b/src/lib/useKanbanBoardData.test.ts
@@ -38,11 +38,13 @@ import {
   pickPullRequestForBranch,
   pickPullRequestForBranches,
   pruneKanbanRepoRequestSequences,
-  readKanbanPrBranchLinks,
   summarizeDiffStats,
   useKanbanBoardData,
-  writeKanbanPrBranchLinks,
 } from "./useKanbanBoardData";
+import {
+  readSessionPullRequestBranchLinks,
+  writeSessionPullRequestBranchLinks,
+} from "./sessionPullRequestLinks";
 import type { PullRequestInfo, PullRequestListing, Session } from "./types";
 
 function deferred<T>() {
@@ -140,18 +142,18 @@ describe("kanban PR branch links", () => {
   beforeEach(() => localStorage.clear());
 
   it("persists the PR branch independently from the live checkout", () => {
-    writeKanbanPrBranchLinks({
+    writeSessionPullRequestBranchLinks({
       session: { repoPath: "/repo", headBranch: "feat/x" },
     });
 
-    expect(readKanbanPrBranchLinks()).toEqual({
+    expect(readSessionPullRequestBranchLinks()).toEqual({
       session: { repoPath: "/repo", headBranch: "feat/x" },
     });
   });
 
   it("ignores corrupt persisted links", () => {
     localStorage.setItem("acorn:workspace-kanban:pr-branch-links:v1", "{");
-    expect(readKanbanPrBranchLinks()).toEqual({});
+    expect(readSessionPullRequestBranchLinks()).toEqual({});
   });
 });
 

--- a/src/lib/useKanbanBoardData.ts
+++ b/src/lib/useKanbanBoardData.ts
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api, type FsGitDiffStatsRequest, type FsGitStatusEntry } from "./api";
 import { rightPanelCache } from "./right-panel-cache";
+import {
+  readSessionPullRequestBranchLinks,
+  writeSessionPullRequestBranchLinks,
+  type SessionPullRequestBranchLinks,
+} from "./sessionPullRequestLinks";
 import type { PullRequestInfo, PullRequestListing, Session } from "./types";
 
 /** Per-session board context assembled from PR listings and worktree diffs. */
@@ -27,56 +32,6 @@ const CLEAN_DIFF: DiffSummary = { hasDiff: false, additions: 0, deletions: 0 };
 const PR_POLL_INTERVAL_MS = 60_000;
 const DIFF_POLL_INTERVAL_MS = 20_000;
 const PR_LIST_LIMIT = 50;
-const PR_BRANCH_LINKS_STORAGE_KEY =
-  "acorn:workspace-kanban:pr-branch-links:v1";
-
-export interface KanbanPrBranchLink {
-  repoPath: string;
-  headBranch: string;
-}
-
-export type KanbanPrBranchLinks = Record<string, KanbanPrBranchLink>;
-
-function isKanbanPrBranchLink(value: unknown): value is KanbanPrBranchLink {
-  if (!value || typeof value !== "object") return false;
-  const link = value as Partial<KanbanPrBranchLink>;
-  return (
-    typeof link.repoPath === "string" &&
-    link.repoPath.trim().length > 0 &&
-    typeof link.headBranch === "string" &&
-    link.headBranch.trim().length > 0
-  );
-}
-
-export function readKanbanPrBranchLinks(): KanbanPrBranchLinks {
-  if (typeof window === "undefined") return {};
-  try {
-    const raw = window.localStorage.getItem(PR_BRANCH_LINKS_STORAGE_KEY);
-    if (!raw) return {};
-    const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") return {};
-    return Object.fromEntries(
-      Object.entries(parsed).filter(
-        (entry): entry is [string, KanbanPrBranchLink] =>
-          isKanbanPrBranchLink(entry[1]),
-      ),
-    );
-  } catch {
-    return {};
-  }
-}
-
-export function writeKanbanPrBranchLinks(links: KanbanPrBranchLinks): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(
-      PR_BRANCH_LINKS_STORAGE_KEY,
-      JSON.stringify(links),
-    );
-  } catch {
-    // Current-branch PR matching still works when storage is unavailable.
-  }
-}
 
 /**
  * Pick the PR that best represents a branch when several share a head branch:
@@ -215,8 +170,10 @@ export function useKanbanBoardData(
   const [diffBySession, setDiffBySession] = useState<
     ReadonlyMap<string, DiffSummary>
   >(new Map());
-  const [prBranchLinks, setPrBranchLinks] = useState<KanbanPrBranchLinks>(
-    readKanbanPrBranchLinks,
+  const [prBranchLinks, setPrBranchLinks] = useState<
+    SessionPullRequestBranchLinks
+  >(
+    readSessionPullRequestBranchLinks,
   );
   const prRequestSeqRef = useRef(new Map<string, number>());
   const prInFlightRef = useRef(
@@ -448,7 +405,7 @@ export function useKanbanBoardData(
         changed = true;
       }
       if (!changed) return previous;
-      writeKanbanPrBranchLinks(next);
+      writeSessionPullRequestBranchLinks(next);
       return next;
     });
   }, [prIndexByRepo, sessions]);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1486,6 +1486,8 @@
       "copyAbsolutePath": "Copy absolute path",
       "openDetail": "Open detail",
       "openInBrowser": "Open in browser",
+      "openSession": "Open session",
+      "openSessionWithName": "Open session ({name})",
       "copyPrNumber": "Copy PR number",
       "copyIssueNumber": "Copy issue number",
       "copyUrl": "Copy URL",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1486,6 +1486,8 @@
       "copyAbsolutePath": "절대 경로 복사",
       "openDetail": "상세 열기",
       "openInBrowser": "브라우저에서 열기",
+      "openSession": "세션 열기",
+      "openSessionWithName": "세션 열기({name})",
       "copyPrNumber": "PR 번호 복사",
       "copyIssueNumber": "이슈 번호 복사",
       "copyUrl": "URL 복사",

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -528,6 +528,83 @@ test.describe("right panel: tab switching", () => {
     ).toBeVisible();
   });
 
+  test("right-clicking a pull request opens the session for its head branch", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "main-session",
+        name: "Main work",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        position: 0,
+      },
+      {
+        id: "pr-session",
+        name: "PR work",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.acorn/worktrees/pr-work",
+        branch: "feature/pr-session",
+        isolated: true,
+        status: "ready",
+        created_at: "2026-01-01T00:00:01Z",
+        updated_at: "2026-01-01T00:00:06Z",
+        last_message: null,
+        position: 1,
+      },
+    ]);
+    await tauri.respond("list_pull_requests", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 91,
+          title: "Open the matching session",
+          state: "OPEN",
+          author: "im-ian",
+          head_branch: "feature/pr-session",
+          base_branch: "main",
+          url: "https://github.com/im-ian/acorn/pull/91",
+          updated_at: "2026-05-19T00:00:00Z",
+          is_draft: false,
+          checks: null,
+          labels: [],
+        },
+      ],
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await page.getByRole("button", { name: "PRs" }).click();
+
+    const prRow = page
+      .getByText("Open the matching session")
+      .locator("xpath=ancestor::li[@role='button'][1]");
+    await prRow.click({ button: "right" });
+    await page
+      .getByRole("menuitem", { name: "Open session (PR work)" })
+      .click();
+
+    await expect(
+      page.locator('[data-tab-drag-handle="pr-session"]').locator(".."),
+    ).toHaveClass(/acorn-tab-active-bg/);
+  });
+
   test("posting from the pull request detail modal appends a conversation comment", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

PR rows can now return users directly to the Acorn session that worked on the pull request branch.

1. **Session navigation** — add an Open session action to the PR context menu, opening a single match directly or presenting a submenu when several sessions match.
2. **Branch-aware matching** — scope matches to the active project, prioritize sessions currently on the PR head branch, and retain previously observed PR branch links after branch cleanup.
3. **Shared behavior and coverage** — reuse the same action in the PR search surface, add Korean and English copy, and cover matching and navigation with Vitest and Playwright.

## Expected impact

| Workflow | Before | After |
| --- | --- | --- |
| Return from a PR to its work session | Manually search the sidebar or command palette | Right-click the PR and open the matching session |
| Multiple sessions on one PR branch | No branch-aware navigation | Choose the intended session from a submenu |
| Session checked out back to the base branch | PR association was only visible in Kanban | Previously observed PR branch links remain usable for navigation |

## Design notes

- Matching is limited to project-scoped sessions in the same repository so similarly named branches in other projects cannot steal focus.
- Current branch matches rank ahead of historical links; ties use session recency and stable name/id ordering.
- Navigation uses the existing session-surface action, preserving pane focus and Kanban terminal-popup behavior.
- The persisted branch-link data moved into a shared helper because PR navigation is now its second consumer; the existing storage key and data shape remain unchanged.

## Test plan

- [x] pnpm run typecheck
- [x] pnpm run test — 95 files and 1,034 tests passed
- [x] pnpm run build
- [x] pnpm exec playwright test tests/e2e/right-panel.spec.ts --grep "right-clicking a pull request opens the session" — 1 Chromium test passed