### PR TITLE
fix(kanban): organize card context menu + remove redundant Open

### DIFF
--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -1293,20 +1293,24 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
         disabled: !canRegenerateTitle,
       },
       {
-        label: openLabel,
-        icon:
-          session.mode === "chat" ? (
-            <MessageSquareText size={12} />
-          ) : (
-            <TerminalIcon size={12} />
-          ),
-        onClick: () => {
-          const anchor = document.querySelector<HTMLElement>(
-            `[data-kanban-session-id="${cssAttributeEscape(session.id)}"]`,
-          );
-          if (anchor) onOpen(session.id, anchor);
-        },
+        label: manualDone
+          ? t("workspace.kanban.actions.restoreFromDone")
+          : t("workspace.kanban.actions.markAsDone"),
+        icon: <CheckCircle2 size={12} />,
+        onClick: () => onToggleManualDone(session.id),
       },
+      {
+        label: sidebarText(
+          t,
+          sessionSilenced
+            ? "sidebar.actions.resumeNotifications"
+            : "sidebar.actions.silenceNotifications",
+        ),
+        icon: sessionSilenced ? <Bell size={12} /> : <BellOff size={12} />,
+        onClick: () => setSessionSilenced(session.id, !sessionSilenced),
+      },
+      { type: "separator" },
+      workspaceContextMenuGroupTitle(t, "open"),
       {
         label: sidebarText(t, "sidebar.actions.openWorkSummary"),
         icon: <BarChart3 size={12} />,
@@ -1319,24 +1323,6 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
             });
         },
       },
-      {
-        label: sidebarText(
-          t,
-          sessionSilenced
-            ? "sidebar.actions.resumeNotifications"
-            : "sidebar.actions.silenceNotifications",
-        ),
-        icon: sessionSilenced ? <Bell size={12} /> : <BellOff size={12} />,
-        onClick: () => setSessionSilenced(session.id, !sessionSilenced),
-      },
-      {
-        label: manualDone
-          ? t("workspace.kanban.actions.restoreFromDone")
-          : t("workspace.kanban.actions.markAsDone"),
-        icon: <CheckCircle2 size={12} />,
-        onClick: () => onToggleManualDone(session.id),
-      },
-      workspaceContextMenuGroupTitle(t, "open"),
       {
         label: sidebarText(t, "sidebar.actions.openWorktreeInEditor"),
         icon: <PencilLine size={12} />,
@@ -1358,6 +1344,7 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
           });
         },
       },
+      { type: "separator" },
       workspaceContextMenuGroupTitle(t, "copy"),
       {
         type: "submenu",
@@ -1396,6 +1383,7 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
           },
         ],
       },
+      { type: "separator" },
       workspaceContextMenuGroupTitle(t, "danger"),
       {
         label: sidebarText(t, "sidebar.actions.removeSessionMenu"),
@@ -1410,9 +1398,7 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
       generateSessionTitle,
       isGeneratingTitle,
       manualDone,
-      onOpen,
       onToggleManualDone,
-      openLabel,
       openWorkSummaryTab,
       renameSession,
       requestRemoveSession,
@@ -1420,7 +1406,6 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
       sessionSilenced,
       session.branch,
       session.id,
-      session.mode,
       session.name,
       session.worktree_path,
       showToast,

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -1041,27 +1041,22 @@ test.describe("workspace kanban mode", () => {
       clientX: shellMenuTargetBox.x + shellMenuTargetBox.width / 2,
       clientY: shellMenuTargetBox.y + shellMenuTargetBox.height / 2,
     });
+    const cardMenu = page.getByRole("menu");
+    await expect(cardMenu.getByRole("menuitem")).toHaveText([
+      "Rename",
+      "Regenerate Name",
+      "Mark as done",
+      "Silence Notifications",
+      "Open Work Summary",
+      "Open Worktree in Editor",
+      "Reveal in Finder",
+      "Copy",
+      "Remove Session",
+    ]);
+    await expect(cardMenu.getByRole("separator")).toHaveCount(3);
     await expect(
-      page.getByRole("menuitem", { name: "Open shell" }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("menuitem", { name: "Rename" }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("menuitem", { name: "Regenerate Name" }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("menuitem", { name: "Open Work Summary" }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("menuitem", { name: "Silence Notifications" }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("menuitem", { name: "Reveal in Finder" }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("menuitem", { name: "Remove Session" }),
-    ).toBeVisible();
+      cardMenu.getByRole("menuitem", { name: "Open shell", exact: true }),
+    ).toHaveCount(0);
     await page.keyboard.press("Escape");
 
     await board.getByRole("button", { name: "Open shell" }).click();


### PR DESCRIPTION
## Summary

This tidies the Kanban card context menu so session actions are easier to scan and do not repeat the card primary open behavior.

1. **Action order** — keep session editing and state actions together, then place work summary and external targets under Open.
2. **Visual separation** — add dividers between the Session, Open, Copy, and Danger groups.
3. **Redundant action removal** — remove `Open <session>` from the right-click menu while preserving normal card click and keyboard opening.
4. **Regression coverage** — assert the exact visible item order, divider count, and absence of the redundant Open action.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Kanban card context menu | Actions were mixed across categories and repeated the card Open behavior | Actions follow Session → Open → Copy → Danger with visible dividers |
| Session opening | Card click and context-menu Open both opened the same session | Card click and keyboard activation remain the single direct-open paths |

## Design notes

- Reuses the existing `ContextMenuItem` group-title and separator variants; no shared menu contract changes are required.
- `Open Work Summary` now sits with the other Open actions, while Kanban lifecycle and notification actions remain in the Session group.
- The scope is the Kanban card right-click menu; the terminal popover header menu keeps its existing behavior.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 95 files, 1,034 tests pass
- [x] `pnpm exec playwright test tests/e2e/kanban.spec.ts --grep "groups active workspace sessions by lifecycle and opens a card terminal popover"` — 1 test passes
- [x] Captured and visually inspected the rendered Kanban context menu with its group dividers