### PR TITLE
fix(workspace): keep work summaries in kanban + canvas overlays

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -612,7 +612,7 @@ export function Pane({ paneId }: PaneProps) {
             isActive={isFocused}
           />
         ) : null}
-        {active?.kind === "work-summary" ? (
+        {active?.kind === "work-summary" && workspaceViewMode === "panes" ? (
           <WorkSummaryView
             tab={active}
             session={

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -130,6 +130,7 @@ import { PullRequestDetailModal } from "./PullRequestDetailModal";
 import { ResizeHandle } from "./ResizeHandle";
 import { Tooltip } from "./Tooltip";
 import { WorkspaceCanvas } from "./WorkspaceCanvas";
+import { WorkSummaryView } from "./WorkSummaryView";
 
 const STATUS_TONE: Record<SessionStatus, StatusTone> = {
   ready: "neutral",
@@ -268,7 +269,7 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
               }
             />
           </div>
-          <KanbanFilePreviewOverlay />
+          <WorkspaceTabPreviewOverlay />
         </div>
       ) : null}
       {isCanvas ? (
@@ -279,7 +280,7 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
             workspaceSessionIds={workspaceSessionIds}
             sessions={sessions}
           />
-          <KanbanFilePreviewOverlay />
+          <WorkspaceTabPreviewOverlay />
         </div>
       ) : null}
       {/*
@@ -298,30 +299,36 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
   );
 }
 
-function KanbanFilePreviewOverlay() {
+function WorkspaceTabPreviewOverlay() {
   const t = useTranslation();
   const closeShortcut = useSettings((s) =>
     formatHotkey(s.settings.shortcuts.closeTab),
   );
   const activeTabId = useAppStore((s) => s.activeTabId);
   const workspaceTabs = useAppStore((s) => s.workspaceTabs);
+  const sessionsById = useAppStore(selectSessionsById);
   const closeWorkspaceTab = useAppStore((s) => s.closeWorkspaceTab);
   const closeTerminalPopup = useAppStore((s) => s.closeTerminalPopup);
+  const openCodeViewerTab = useAppStore((s) => s.openCodeViewerTab);
   const updateCodeViewerTabViewState = useAppStore(
     (s) => s.updateCodeViewerTabViewState,
   );
   const tab = activeTabId ? workspaceTabs[activeTabId] : undefined;
 
   useEffect(() => {
-    if (tab?.kind === "code") closeTerminalPopup();
+    if (tab) closeTerminalPopup();
   }, [closeTerminalPopup, tab?.id, tab?.kind]);
 
-  if (!tab || tab.kind !== "code") return null;
+  if (!tab) return null;
 
   return (
     <div
       className="absolute inset-0 z-40 flex items-center justify-center bg-bg/45 p-4 backdrop-blur-[1px]"
-      data-testid="kanban-file-preview-overlay"
+      data-testid={
+        tab.kind === "code"
+          ? "kanban-file-preview-overlay"
+          : "workspace-work-summary-overlay"
+      }
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) closeWorkspaceTab(tab.id);
       }}
@@ -350,16 +357,28 @@ function KanbanFilePreviewOverlay() {
           </Tooltip>
         </header>
         <div className="min-h-0 flex-1">
-          <FileViewer
-            key={tab.id}
-            path={tab.path}
-            target={tab.target}
-            viewState={tab.viewState}
-            onViewStateChange={(patch) =>
-              updateCodeViewerTabViewState(tab.id, patch)
-            }
-            isActive
-          />
+          {tab.kind === "code" ? (
+            <FileViewer
+              key={tab.id}
+              path={tab.path}
+              target={tab.target}
+              viewState={tab.viewState}
+              onViewStateChange={(patch) =>
+                updateCodeViewerTabViewState(tab.id, patch)
+              }
+              isActive
+            />
+          ) : (
+            <WorkSummaryView
+              key={tab.id}
+              tab={tab}
+              session={
+                tab.sessionId ? sessionsById.get(tab.sessionId) ?? null : null
+              }
+              isActive
+              onOpenFile={(path) => openCodeViewerTab(path, tab.repoPath)}
+            />
+          )}
         </div>
       </section>
     </div>
@@ -1200,7 +1219,6 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
   const renameSession = useAppStore((s) => s.renameSession);
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
   const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
-  const setWorkspaceViewMode = useAppStore((s) => s.setWorkspaceViewMode);
   const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
   const sessionSilenced = useAppStore((s) =>
     Boolean(s.silencedSessionIds[session.id]),
@@ -1341,11 +1359,7 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
         icon: <BarChart3 size={12} />,
         onClick: () => {
           selectSession(session.id);
-          void openWorkSummaryTab({ sessionId: session.id })
-            .then(() => setWorkspaceViewMode("panes"))
-            .catch((err: unknown) => {
-              console.error("[WorkspaceMain] open work summary failed", err);
-            });
+          void openWorkSummaryTab({ sessionId: session.id });
         },
       },
       {
@@ -1435,7 +1449,6 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
       session.worktree_path,
       showToast,
       setSessionSilenced,
-      setWorkspaceViewMode,
       t,
       transcriptPath,
       worktreeName,
@@ -1815,7 +1828,6 @@ function KanbanTerminalPopover({
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
   const selectSession = useAppStore((s) => s.selectSession);
   const openWorkSummaryTab = useAppStore((s) => s.openWorkSummaryTab);
-  const setWorkspaceViewMode = useAppStore((s) => s.setWorkspaceViewMode);
   const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
   const sessionSilenced = useAppStore((s) =>
     Boolean(s.silencedSessionIds[session.id]),
@@ -1970,11 +1982,7 @@ function KanbanTerminalPopover({
         icon: <BarChart3 size={12} />,
         onClick: () => {
           selectSession(session.id);
-          void openWorkSummaryTab({ sessionId: session.id })
-            .then(() => setWorkspaceViewMode("panes"))
-            .catch((err: unknown) => {
-              console.error("[WorkspaceMain] open work summary failed", err);
-            });
+          void openWorkSummaryTab({ sessionId: session.id });
         },
       },
       {
@@ -2070,7 +2078,6 @@ function KanbanTerminalPopover({
       session.worktree_path,
       showToast,
       setSessionSilenced,
-      setWorkspaceViewMode,
       t,
       transcriptPath,
       worktreeName,

--- a/tests/e2e/work-summary.spec.ts
+++ b/tests/e2e/work-summary.spec.ts
@@ -98,6 +98,90 @@ const CHAT_STATE = {
 };
 
 test.describe("work summary", () => {
+  test("opens as an overlay without leaving alternate workspace modes", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [SESSION]);
+    await tauri.respond("load_chat_session_state", CHAT_STATE);
+    await tauri.respond("fs_git_status", {
+      statuses: {},
+      huge: false,
+      limit: 500,
+    });
+
+    await page.goto("/");
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    const board = page.getByTestId("workspace-kanban");
+    const card = board.getByRole("button", { name: "Open summary-session" });
+    await expect(card).toBeVisible();
+
+    await card.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Open Work Summary" }).click();
+
+    const overlay = page.getByTestId("workspace-work-summary-overlay");
+    await expect(overlay).toBeVisible();
+    await expect(
+      overlay.getByRole("heading", { name: "Work Summary" }),
+    ).toBeVisible();
+    await expect(board).toBeVisible();
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Kanban",
+    );
+
+    await overlay.getByRole("button", { name: "Close" }).click();
+    await expect(overlay).toHaveCount(0);
+
+    await card.click();
+    const terminalPopover = page.getByTestId("kanban-terminal-popover");
+    await expect(terminalPopover).toBeVisible();
+    await page
+      .getByTestId("kanban-terminal-popover-drag-handle")
+      .click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Open Work Summary" }).click();
+
+    await expect(overlay).toBeVisible();
+    await expect(terminalPopover).toHaveCount(0);
+    await expect(board).toBeVisible();
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Kanban",
+    );
+
+    await overlay.getByRole("button", { name: "Close" }).click();
+
+    const sidebarSession = page
+      .locator("aside [role='button']")
+      .filter({ hasText: "summary-session" })
+      .first();
+    await expect(sidebarSession).toBeVisible();
+    await sidebarSession.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Open Work Summary" }).click();
+
+    await expect(overlay).toBeVisible();
+    await expect(board).toBeVisible();
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Kanban",
+    );
+
+    await overlay.getByRole("button", { name: "Close" }).click();
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Canvas" }).click();
+    const canvas = page.getByTestId("workspace-canvas");
+    await expect(canvas).toBeVisible();
+
+    await sidebarSession.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Open Work Summary" }).click();
+
+    await expect(overlay).toBeVisible();
+    await expect(canvas).toBeVisible();
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Canvas",
+    );
+  });
+
   test("opens a changed file from the summary tab", async ({ page, tauri }) => {
     await tauri.respond("list_projects", [PROJECT]);
     await tauri.respond("list_sessions", [SESSION]);


### PR DESCRIPTION
## Summary
Work Summary now behaves like other frontend-owned preview tabs in alternate workspace modes.

1. **Overlay rendering** — extend the existing workspace preview overlay to render Work Summary in both kanban and canvas modes.
2. **Mode preservation** — remove the forced pane transition from kanban card and terminal-popover actions, and avoid mounting the hidden pane copy of Work Summary outside pane mode.
3. **Regression coverage** — exercise card, terminal-popover, and sidebar entry points across kanban and canvas while retaining the existing file-preview behavior.

## Expected impact
| Surface | Before | After |
| --- | --- | --- |
| Kanban card / terminal menu | Opening Work Summary switched to panes | Work Summary opens over the board |
| Kanban sidebar action | The hidden pane tab changed without a visible summary | Work Summary opens over the board |
| Canvas sidebar action | The hidden pane tab changed without a visible summary | Work Summary opens over the canvas |
| File preview | Opened as an overlay | Unchanged |

## Design notes
- The active frontend-owned workspace tab remains the source of truth for the overlay, so close and activation-history behavior stays aligned with pane tabs.
- The hidden pane layout remains mounted for terminal DOM stability, while Work Summary itself renders only in pane mode to prevent duplicate polling and listeners.
- Opening a changed file from Work Summary continues through `openCodeViewerTab`, replacing the overlay content with the file preview.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run src/components/Pane.test.tsx src/components/WorkspaceMain.test.tsx src/components/WorkspaceCanvas.test.tsx` — 34 passed
- [x] `pnpm exec playwright test tests/e2e/work-summary.spec.ts tests/e2e/canvas.spec.ts` — 3 passed
- [x] `pnpm exec playwright test tests/e2e/file-explorer.spec.ts --grep "right-panel file in an overlay while staying in kanban"` — 1 passed
- [x] `pnpm run test` — 96 files, 1,049 tests passed
- [x] `pnpm run build` — production frontend build passed