### PR TITLE
fix(highlight): keep line comments tokenizing in WKWebView

### DIFF
--- a/src/lib/highlight.test.ts
+++ b/src/lib/highlight.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { parseDiff } from "./diff";
-import { highlightDiff, highlightThemeForMode } from "./highlight";
+import {
+  compileGrammarRegex,
+  highlightDiff,
+  highlightThemeForMode,
+} from "./highlight";
+
+// The TextMate line-comment rule shared by the JS/TS grammars.
+const COMMENT_PATTERN = "(^[\\t ]+)?((//)(?:\\s*((@)internal)(?=\\s|$))?)";
 
 describe("highlightThemeForMode", () => {
   it("uses a high-contrast light syntax theme for light app themes", () => {
@@ -9,6 +16,24 @@ describe("highlightThemeForMode", () => {
 
   it("keeps the dark syntax theme for dark app themes", () => {
     expect(highlightThemeForMode("dark")).toBe("github-dark");
+  });
+});
+
+describe("compileGrammarRegex", () => {
+  // JavaScriptCore start-anchors any pattern containing a bare `^`, even inside
+  // an optional group, so it never finds a trailing `//`. Vitest runs on V8 and
+  // cannot observe that, so assert the shape that keeps WKWebView correct.
+  it("compiles a leading optional `^` group without a bare start anchor", () => {
+    const compiled = compileGrammarRegex(COMMENT_PATTERN);
+
+    expect(compiled.source).not.toMatch(/^\(\^/);
+    expect(compiled.source).toContain("(?<=");
+  });
+
+  it("still matches a comment that does not start the line", () => {
+    const compiled = compileGrammarRegex(COMMENT_PATTERN);
+
+    expect(compiled.exec("const a = []; // hi")?.index).toBe(14);
   });
 });
 

--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -1,6 +1,7 @@
 import {
   createHighlighter,
   createJavaScriptRegexEngine,
+  defaultJavaScriptRegexConstructor,
   type BundledLanguage,
   type BundledTheme,
   type Highlighter,
@@ -75,7 +76,37 @@ const FILENAME_LANG: Record<string, BundledLanguage> = {
 // engine: the hardened renderer CSP (script-src 'self', no wasm-unsafe-eval)
 // blocks WebAssembly instantiation in the WKWebView, which would otherwise
 // make createHighlighter reject and silently drop all highlighting.
-const jsEngine = createJavaScriptRegexEngine({ forgiving: true });
+//
+// `singleline: false` is a JavaScriptCore workaround, not a semantic choice.
+// Shiki's default (`singleline: true`) compiles TextMate `^` to a bare `^`
+// anchor, and JSC then treats the whole pattern as start-anchored even when the
+// `^` sits inside an optional group — so `(^[\t ]+)?(//)` never matches a
+// trailing `//` and comments stop tokenizing, which lets a backtick inside a
+// comment open a template literal that swallows the rest of the file. Turning
+// the rule off emits a `(?<=^|\n)` lookbehind instead, which JSC scans
+// correctly. Shiki tokenizes one newline-free line at a time, so line-anchored
+// and string-anchored `^`/`$` are equivalent here.
+//
+// JSC's optimizeBOL bug is open and unassigned to a release:
+// https://bugs.webkit.org/show_bug.cgi?id=216671 (filed 2020)
+// https://bugs.webkit.org/show_bug.cgi?id=317274
+export function compileGrammarRegex(pattern: string): RegExp {
+  return defaultJavaScriptRegexConstructor(pattern, {
+    target: "auto",
+    rules: {
+      allowOrphanBackrefs: true,
+      asciiWordBoundaries: true,
+      captureGroup: true,
+      recursionLimit: 5,
+      singleline: false,
+    },
+  });
+}
+
+const jsEngine = createJavaScriptRegexEngine({
+  forgiving: true,
+  regexConstructor: compileGrammarRegex,
+});
 
 let highlighterPromise: Promise<Highlighter> | null = null;
 const loadedLangs = new Set<BundledLanguage>();


### PR DESCRIPTION
## Summary

Syntax highlighting broke for the rest of a file once the tokenizer passed a backtick — in the code viewer, in diffs, and in chat code blocks. The trigger is a backtick inside a `//` comment, which is common in this codebase and in the files it displays.

The file, the grammar and shiki were all fine. The bug is in JavaScriptCore, so it only reproduces in the WKWebView (and in Safari), never in Node or Chromium — which is why it survived the unit tests.

## Root cause

JSC's YARR `optimizeBOL` pass start-anchors a pattern that merely *contains* a `^`, even when that `^` sits inside an optional group. It then refuses to scan forward, so the match fails outright:

```js
/(?:^x)?(\/\/)/g.exec("  const x = []; // hi")
// Chromium → index 16
// WebKit   → null
```

Acorn compiles TextMate grammars with shiki's pure-JS regex engine (the hardened renderer CSP blocks the oniguruma WASM engine — see #373). That engine's default `singleline: true` rule compiles TextMate `^` to a bare `^` anchor, which walks straight into the JSC bug. The shared JS/TS line-comment rule is `(^[\t ]+)?((//)(?:\s*((@)internal)(?=\s|$))?)`, so **no `//` comment past column 0 ever matched**. Comments stopped tokenizing, a backtick inside a comment opened a real template literal, and everything after it was painted as a string until the next stray backtick.

The JSC bug is open upstream and has been since 2020:

- https://bugs.webkit.org/show_bug.cgi?id=216671 (ASSIGNED, filed 2020-09-17)
- https://bugs.webkit.org/show_bug.cgi?id=317274 (NEW, filed 2026-06-16)

## Fix

Compile grammar patterns with `singleline: false`. `oniguruma-to-es` then emits a `(?<=^|\n)` lookbehind instead of a bare `^`, which JSC scans correctly.

This is a workaround, not a semantic change: shiki tokenizes one newline-free line at a time (`splitLines(code)` with `preserveEnding = false`), so line-anchored and string-anchored `^`/`$` are equivalent on the inputs the engine actually sees. Chromium output is byte-identical before and after.

## Test plan

- [x] `vitest run src/lib src/components` — 898 tests pass (94 files)
- [x] `pnpm typecheck`
- [x] New unit tests in `src/lib/highlight.test.ts`. Vitest runs on V8 and cannot observe the JSC bug, so they pin the *shape* that keeps WKWebView correct: the compiled regex must not start with a bare `^` anchor, and must still match a `//` that is not at column 0. Reverting the `rules` override fails the first assertion.
- [x] Verified end to end in Playwright WebKit 26.4 (`AppleWebKit/605.1.15`, same JSC as the WKWebView), driving the real `highlightCode()` from `src/lib/highlight.ts` over the file from the report: all 220 lines now match the Chromium baseline exactly (48 lines differed before the fix).

### What the WebKit run showed

Rendering the same file through the pre-fix engine config and through this branch's `highlightCode()`, side by side in WebKit:

- **Before** — line 30 `const templateStack = []; // ` + backtick: `//` is painted as an operator (`#F97583`), then the backtick opens a template literal and the comment tail plus the following lines are painted as string (`#9ECBFF`). This matches the pixel colours in the reported screenshot.
- **After** — every `//` comment is painted as a comment (`#6A737D`) and backticks inside comments are inert.
