### PR TITLE
fix(status): move Claude hook classification into Rust and bind transcript markers from hooks

### DIFF
--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -1739,11 +1739,98 @@ fn validate_request(request: &[u8], token: &str, handler: &HookEventHandler) -> 
 fn parse_agent_hook_request(head: &str, body: &[u8]) -> Result<Option<AgentHookEvent>, String> {
     match header_value(head, "x-acorn-agent-hook-provider") {
         Some("codex") => parse_raw_codex_hook_request(head, body),
+        Some("claude") => parse_raw_claude_hook_request(head, body),
         Some(provider) => Err(format!("unsupported raw hook provider: {provider}")),
         None => serde_json::from_slice::<AgentHookEvent>(body)
             .map(Some)
             .map_err(|err| err.to_string()),
     }
+}
+
+/// Normalize a raw Claude Code hook payload forwarded verbatim by
+/// `acorn-claude-notify`. The shell script used to classify events with
+/// field-boundary regexes; real JSON parsing here is immune to escaped
+/// decoy text and keeps the drop rules reviewable next to the reducer.
+fn parse_raw_claude_hook_request(
+    head: &str,
+    body: &[u8],
+) -> Result<Option<AgentHookEvent>, String> {
+    let session_id = header_value(head, "x-acorn-agent-hook-session-id")
+        .ok_or_else(|| "missing Acorn session id".to_string())?
+        .parse::<Uuid>()
+        .map_err(|_| "invalid Acorn session id".to_string())?;
+    let raw_source = header_value(head, "x-acorn-agent-hook-source")
+        .ok_or_else(|| "missing Claude hook source".to_string())?;
+    if raw_source != "native" {
+        return Err(format!("unsupported Claude hook source: {raw_source}"));
+    }
+    let payload = serde_json::from_slice::<Value>(body).map_err(|err| err.to_string())?;
+
+    // Claude includes a non-empty agent_id only when this configured hook
+    // fires inside a subagent. Child prompts, attention requests, and Stop
+    // events do not own the parent Acorn terminal and must not transition
+    // its aggregate status. A top-level `claude --agent` still carries
+    // agent_type without agent_id and stays an owner.
+    if payload
+        .get("agent_id")
+        .and_then(Value::as_str)
+        .is_some_and(|id| !id.trim().is_empty())
+    {
+        return Ok(None);
+    }
+
+    let hook_event_name = payload
+        .get("hook_event_name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "Claude hook payload has no hook_event_name".to_string())?;
+    let event = match hook_event_name {
+        "SessionStart" | "UserPromptSubmit" => AgentHookEventKind::Start,
+        // Claude can emit Stop while background tasks or session crons are
+        // still able to wake the parent turn. Those sessions stay Working;
+        // only a Stop with no pending background work is actually awaiting
+        // the user's next prompt.
+        "Stop" if claude_stop_has_pending_background_work(&payload) => return Ok(None),
+        "Stop" => AgentHookEventKind::NeedsInput,
+        "Notification" | "PermissionRequest" => AgentHookEventKind::NeedsInput,
+        "Error" => AgentHookEventKind::Error,
+        // The settings file registers exactly the events above; anything
+        // else is a future Claude addition we have no mapping for yet.
+        _ => return Ok(None),
+    };
+
+    // Claude's own conversation UUID. Downstream this binds the session's
+    // durable transcript marker, replacing cwd+mtime inference as the
+    // primary pairing signal.
+    let provider_session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .and_then(|value| normalized_id(Some(value)))
+        .filter(|value| value.len() <= 512)
+        .map(str::to_string);
+
+    Ok(Some(AgentHookEvent {
+        session_id,
+        provider: SessionAgentProvider::Claude,
+        event,
+        message: None,
+        source: Some("native".to_string()),
+        lifecycle_id: None,
+        provider_session_id,
+        provider_turn_id: None,
+        provider_tool_id: None,
+        provider_version: None,
+        native_hooks_enabled: None,
+        ownership: AgentHookOwnership::Owner,
+    }))
+}
+
+fn claude_stop_has_pending_background_work(payload: &Value) -> bool {
+    ["background_tasks", "session_crons"].iter().any(|key| {
+        payload
+            .get(*key)
+            .and_then(Value::as_array)
+            .is_some_and(|items| !items.is_empty())
+    })
 }
 
 fn parse_raw_codex_hook_request(head: &str, body: &[u8]) -> Result<Option<AgentHookEvent>, String> {
@@ -2337,6 +2424,213 @@ mod tests {
                 .as_deref(),
             Some("not-a-turn-id")
         );
+    }
+
+    #[test]
+    fn raw_claude_native_payloads_are_normalized_in_rust() {
+        let (tx, rx) = mpsc::channel();
+        let hooks = AgentHookServer::start_with_handler(move |event| {
+            tx.send(event).expect("send event");
+        })
+        .expect("hook server starts");
+        let session_id = Uuid::new_v4();
+        let claude_uuid = "019e4818-7c15-4e60-9b3b-898a1c7803d6";
+
+        for (hook_event_name, expected_event) in [
+            ("SessionStart", AgentHookEventKind::Start),
+            ("UserPromptSubmit", AgentHookEventKind::Start),
+            ("Notification", AgentHookEventKind::NeedsInput),
+            ("PermissionRequest", AgentHookEventKind::NeedsInput),
+            ("Error", AgentHookEventKind::Error),
+        ] {
+            let body = serde_json::json!({
+                "session_id": claude_uuid,
+                "transcript_path": format!("/home/user/.claude/projects/repo/{claude_uuid}.jsonl"),
+                "hook_event_name": hook_event_name,
+            })
+            .to_string();
+            let response = post_raw_claude_hook(&hooks, session_id, &body);
+            assert!(
+                response.starts_with("HTTP/1.1 204 No Content"),
+                "unexpected {hook_event_name} response: {response:?}"
+            );
+            let event = rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("native event delivered");
+            assert_eq!(event.session_id, session_id);
+            assert_eq!(event.provider, SessionAgentProvider::Claude);
+            assert_eq!(event.event, expected_event, "{hook_event_name}");
+            assert_eq!(event.source.as_deref(), Some("native"));
+            assert_eq!(event.provider_session_id.as_deref(), Some(claude_uuid));
+            assert_eq!(event.ownership, super::AgentHookOwnership::Owner);
+        }
+
+        let stop = serde_json::json!({
+            "session_id": claude_uuid,
+            "hook_event_name": "Stop",
+            "background_tasks": [],
+            "session_crons": [],
+        })
+        .to_string();
+        let response = post_raw_claude_hook(&hooks, session_id, &stop);
+        assert!(response.starts_with("HTTP/1.1 204 No Content"));
+        let event = rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("Stop delivered");
+        assert_eq!(event.event, AgentHookEventKind::NeedsInput);
+    }
+
+    #[test]
+    fn raw_claude_stop_with_background_work_emits_no_transition() {
+        let (tx, rx) = mpsc::channel();
+        let hooks = AgentHookServer::start_with_handler(move |event| {
+            tx.send(event).expect("send event");
+        })
+        .expect("hook server starts");
+        let session_id = Uuid::new_v4();
+
+        for payload in [
+            serde_json::json!({
+                "hook_event_name": "Stop",
+                "background_tasks": [{"id": "agent-1", "type": "agent", "status": "running"}],
+                "session_crons": [],
+            }),
+            serde_json::json!({
+                "hook_event_name": "Stop",
+                "background_tasks": [],
+                "session_crons": [{"id": "cron-1", "schedule": "in 1m", "recurring": false}],
+            }),
+        ] {
+            let response = post_raw_claude_hook(&hooks, session_id, &payload.to_string());
+            assert!(
+                response.starts_with("HTTP/1.1 202 Accepted"),
+                "a Stop with pending background work is a pause, got {response:?}"
+            );
+            assert!(
+                rx.try_recv().is_err(),
+                "a background pause must not reach the reducer"
+            );
+        }
+
+        // Decoy text inside a string field must not suppress the real wait.
+        let decoy = serde_json::json!({
+            "hook_event_name": "Stop",
+            "background_tasks": [],
+            "session_crons": [],
+            "last_assistant_message": "decoy: \"background_tasks\":[{\"status\":\"running\"}]",
+        });
+        let response = post_raw_claude_hook(&hooks, session_id, &decoy.to_string());
+        assert!(response.starts_with("HTTP/1.1 204 No Content"));
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(1))
+                .expect("clean Stop delivered")
+                .event,
+            AgentHookEventKind::NeedsInput
+        );
+    }
+
+    #[test]
+    fn raw_claude_subagent_events_cannot_transition_the_parent_session() {
+        let (tx, rx) = mpsc::channel();
+        let hooks = AgentHookServer::start_with_handler(move |event| {
+            tx.send(event).expect("send event");
+        })
+        .expect("hook server starts");
+        let session_id = Uuid::new_v4();
+
+        for hook_event_name in [
+            "UserPromptSubmit",
+            "Notification",
+            "PermissionRequest",
+            "Stop",
+        ] {
+            let payload = serde_json::json!({
+                "hook_event_name": hook_event_name,
+                "agent_id": "019f6338-6250-7303-88a6-a7add31dba1d",
+                "agent_type": "Explore",
+                "background_tasks": [],
+                "session_crons": [],
+            });
+            let response = post_raw_claude_hook(&hooks, session_id, &payload.to_string());
+            assert!(
+                response.starts_with("HTTP/1.1 202 Accepted"),
+                "a child {hook_event_name} must not transition its parent session"
+            );
+            assert!(rx.try_recv().is_err());
+        }
+
+        // A top-level `claude --agent` carries agent_type without agent_id.
+        let top_level_agent = serde_json::json!({
+            "hook_event_name": "PermissionRequest",
+            "agent_type": "reviewer",
+        });
+        let response = post_raw_claude_hook(&hooks, session_id, &top_level_agent.to_string());
+        assert!(response.starts_with("HTTP/1.1 204 No Content"));
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(1))
+                .expect("owner event delivered")
+                .event,
+            AgentHookEventKind::NeedsInput
+        );
+
+        // Empty and null agent_id are owner shapes, not children.
+        for agent_id in [serde_json::json!(""), serde_json::Value::Null] {
+            let payload = serde_json::json!({
+                "hook_event_name": "UserPromptSubmit",
+                "agent_id": agent_id,
+            });
+            let response = post_raw_claude_hook(&hooks, session_id, &payload.to_string());
+            assert!(response.starts_with("HTTP/1.1 204 No Content"));
+            assert_eq!(
+                rx.recv_timeout(Duration::from_secs(1))
+                    .expect("owner event delivered")
+                    .event,
+                AgentHookEventKind::Start
+            );
+        }
+
+        // Escaped decoy text must not read as a child id.
+        let decoy = serde_json::json!({
+            "hook_event_name": "PermissionRequest",
+            "message": "literal decoys: {\"agent_id\":\"not-a-real-field\",\"hook_event_name\":\"Stop\"}",
+        });
+        let response = post_raw_claude_hook(&hooks, session_id, &decoy.to_string());
+        assert!(response.starts_with("HTTP/1.1 204 No Content"));
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(1))
+                .expect("decoy-carrying owner event delivered")
+                .event,
+            AgentHookEventKind::NeedsInput
+        );
+    }
+
+    #[test]
+    fn raw_claude_unknown_or_malformed_events_fail_safe() {
+        let (tx, rx) = mpsc::channel();
+        let hooks = AgentHookServer::start_with_handler(move |event| {
+            tx.send(event).expect("send event");
+        })
+        .expect("hook server starts");
+        let session_id = Uuid::new_v4();
+
+        // Events without a mapping (future Claude additions) are dropped,
+        // not errors — the registered settings only name the known five.
+        for hook_event_name in ["SubagentStop", "PostToolUse", "SessionEnd"] {
+            let payload = serde_json::json!({"hook_event_name": hook_event_name});
+            let response = post_raw_claude_hook(&hooks, session_id, &payload.to_string());
+            assert!(
+                response.starts_with("HTTP/1.1 202 Accepted"),
+                "unmapped {hook_event_name} must be dropped, got {response:?}"
+            );
+            assert!(rx.try_recv().is_err());
+        }
+
+        let missing_name = serde_json::json!({"session_id": "x"});
+        let response = post_raw_claude_hook(&hooks, session_id, &missing_name.to_string());
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request"));
+
+        let response = post_raw_claude_hook(&hooks, session_id, "not-json");
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request"));
     }
 
     #[test]
@@ -4282,6 +4576,20 @@ mod tests {
 
     fn post_raw_codex_hook(hooks: &AgentHookServer, session_id: Uuid, body: &str) -> String {
         post_raw_codex_source(hooks, session_id, "native", body)
+    }
+
+    fn post_raw_claude_hook(hooks: &AgentHookServer, session_id: Uuid, body: &str) -> String {
+        let mut stream = TcpStream::connect(addr_from_url(hooks.hook_url())).expect("connect hook");
+        write!(
+            stream,
+            "POST /agent-hook HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nX-Acorn-Agent-Hook-Token: {}\r\nX-Acorn-Agent-Hook-Provider: claude\r\nX-Acorn-Agent-Hook-Session-Id: {session_id}\r\nX-Acorn-Agent-Hook-Source: native\r\nContent-Length: {}\r\n\r\n{body}",
+            hooks.token(),
+            body.len()
+        )
+        .expect("write raw Claude request");
+        let mut response = String::new();
+        stream.read_to_string(&mut response).expect("read response");
+        response
     }
 
     fn post_raw_codex_source(

--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -136,15 +136,30 @@ impl AgentHookReducer {
         &self,
         event: AgentHookEvent,
     ) -> Result<AgentHookApplyOutcome, AgentHookApplyError> {
+        // Lane creation is the only growth point of this map, so prune dead
+        // entries here: a session removed mid-run stops receiving events and
+        // would otherwise leave its lane resident for the app lifetime
+        // (`SessionStore::remove` cannot reach this map).
+        if !self.lanes.contains_key(&event.session_id) {
+            self.lanes.retain(|id, _| self.sessions.get(id).is_ok());
+        }
         let lane = self
             .lanes
             .entry(event.session_id)
             .or_insert_with(|| Arc::new(Mutex::new(HookLane::default())))
             .clone();
         let mut lane = lane.lock();
-        let session = self.sessions.get(&event.session_id).map_err(|_| {
-            AgentHookApplyError::Unavailable(format!("session not found: {}", event.session_id))
-        })?;
+        let session = match self.sessions.get(&event.session_id) {
+            Ok(session) => session,
+            Err(_) => {
+                // An event for a removed session must not re-grow the map.
+                self.lanes.remove(&event.session_id);
+                return Err(AgentHookApplyError::Unavailable(format!(
+                    "session not found: {}",
+                    event.session_id
+                )));
+            }
+        };
         if event.provider != SessionAgentProvider::Codex {
             validate_agent_hook_session(&session, &event, false)?;
             let transcript_provider_switch = event.source.as_deref() == Some("transcript")
@@ -2631,6 +2646,72 @@ mod tests {
 
         let response = post_raw_claude_hook(&hooks, session_id, "not-json");
         assert!(response.starts_with("HTTP/1.1 400 Bad Request"));
+    }
+
+    #[test]
+    fn reducer_prunes_lanes_for_removed_sessions() {
+        fn claude_start(session_id: Uuid) -> AgentHookEvent {
+            AgentHookEvent {
+                session_id,
+                provider: SessionAgentProvider::Claude,
+                event: AgentHookEventKind::Start,
+                message: None,
+                source: Some("native".to_string()),
+                lifecycle_id: None,
+                provider_session_id: None,
+                provider_turn_id: None,
+                provider_tool_id: None,
+                provider_version: None,
+                native_hooks_enabled: None,
+                ownership: AgentHookOwnership::Owner,
+            }
+        }
+        fn new_session(name: &str) -> Session {
+            Session::new(
+                name.to_string(),
+                "/tmp/repo".into(),
+                "/tmp/repo".into(),
+                "main".to_string(),
+                false,
+                SessionKind::Regular,
+            )
+        }
+
+        let sessions = acorn_session::SessionStore::new();
+        let removed = new_session("removed");
+        let removed_id = removed.id;
+        sessions.insert(removed);
+        let reducer = AgentHookReducer::new(sessions.clone());
+
+        reducer
+            .apply(claude_start(removed_id))
+            .expect("first event creates the lane");
+        assert_eq!(reducer.lanes.len(), 1);
+
+        sessions.remove(&removed_id).expect("session removed");
+
+        // A new session's first event prunes lanes left by removed sessions.
+        let kept = new_session("kept");
+        let kept_id = kept.id;
+        sessions.insert(kept);
+        reducer
+            .apply(claude_start(kept_id))
+            .expect("event for the live session applies");
+        assert_eq!(
+            reducer.lanes.len(),
+            1,
+            "the dead lane must be pruned when a new lane is created"
+        );
+        assert!(reducer.lanes.contains_key(&kept_id));
+
+        // A late event for the removed session is rejected without
+        // re-growing the map.
+        assert!(matches!(
+            reducer.apply(claude_start(removed_id)),
+            Err(super::AgentHookApplyError::Unavailable(_))
+        ));
+        assert!(!reducer.lanes.contains_key(&removed_id));
+        assert_eq!(reducer.lanes.len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -446,6 +446,7 @@ exec "$REAL_BIN" "$@"
 
 const CLAUDE_NOTIFY_BODY: &str = r#"#!/bin/sh
 input=$(cat 2>/dev/null || true)
+[ -n "$input" ] || exit 0
 compact_input=$(printf '%s\n' "$input" | tr '\r\n' '  ')
 
 if [ -n "${ACORN_AGENT_INVOCATION_TOKEN-}" ]; then
@@ -461,36 +462,10 @@ else
   [ "$legacy_owner_session_id" = "$legacy_session_id" ] || exit 0
 fi
 
-# Claude includes a non-empty agent_id only when this configured hook fires
-# inside a subagent. Child prompts, attention requests, and Stop events do not
-# own the parent Acorn terminal and must not transition its aggregate status.
-# A top-level `claude --agent` may still carry agent_type without agent_id.
-if printf '%s\n' "$compact_input" | grep -qE '(^|[,{])[[:space:]]*"agent_id"[[:space:]]*:[[:space:]]*"[^"]+"'; then
-  exit 0
-fi
-
-hook_event_name=$(printf '%s\n' "$input" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
-
-event=""
-# Claude can emit Stop while background tasks or session crons are still able
-# to wake the parent turn. Keep those sessions Working; only a Stop with no
-# pending background work is actually awaiting the user's next prompt. The
-# field-boundary regex cannot match JSON-escaped decoy text inside strings.
-case "$hook_event_name" in
-  SessionStart|UserPromptSubmit) event="start" ;;
-  Stop)
-    if printf '%s\n' "$compact_input" | grep -qE '(^|[,{])[[:space:]]*"(background_tasks|session_crons)"[[:space:]]*:[[:space:]]*\[[[:space:]]*\{'; then
-      # This is a pause, not a new start. Sending nothing preserves both the
-      # existing Working state and any concurrent attention request.
-      event=""
-    else
-      event="needs_input"
-    fi
-    ;;
-  Notification|PermissionRequest) event="needs_input" ;;
-  Error) event="error" ;;
-esac
-[ -n "$event" ] || exit 0
+# Forward the raw hook payload; Rust owns classification. Subagent
+# filtering, Stop-with-background-work suppression, and the event mapping
+# live in `parse_raw_claude_hook_request`, where real JSON parsing replaces
+# the field-boundary regexes this script used to carry.
 
 # Resolve the hook endpoint at send time. Each app launch rewrites the
 # endpoint file with that run's server URL + token (the hook server binds a
@@ -511,11 +486,13 @@ fi
 [ -n "$hook_token" ] || exit 0
 [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] || exit 0
 
-payload=$(printf '{"session_id":"%s","provider":"claude","event":"%s","source":"hook"}' "$ACORN_AGENT_HOOK_SESSION_ID" "$event")
-curl -sf -X POST \
+printf '%s' "$input" | curl -sf --connect-timeout 1 --max-time 1 -X POST \
   -H 'Content-Type: application/json' \
   -H "X-Acorn-Agent-Hook-Token: $hook_token" \
-  -d "$payload" \
+  -H 'X-Acorn-Agent-Hook-Provider: claude' \
+  -H "X-Acorn-Agent-Hook-Session-Id: $ACORN_AGENT_HOOK_SESSION_ID" \
+  -H 'X-Acorn-Agent-Hook-Source: native' \
+  --data-binary @- \
   "$hook_url" >/dev/null 2>&1 || true
 "#;
 
@@ -2897,12 +2874,16 @@ done
         assert!(wrapper.contains("exec \"$REAL_BIN\" \"$@\""));
 
         let notify = fs::read_to_string(dir.join("acorn-claude-notify")).unwrap();
-        assert!(notify.contains("\"provider\":\"claude\""));
-        assert!(notify.contains("SessionStart|UserPromptSubmit) event=\"start\""));
-        assert!(!notify.contains("SubagentStop"));
-        assert!(notify.contains("Notification|PermissionRequest) event=\"needs_input\""));
+        assert!(notify.contains("X-Acorn-Agent-Hook-Provider: claude"));
+        assert!(notify.contains("X-Acorn-Agent-Hook-Session-Id: $ACORN_AGENT_HOOK_SESSION_ID"));
+        assert!(notify.contains("X-Acorn-Agent-Hook-Source: native"));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
-        assert!(notify.contains("ACORN_AGENT_HOOK_SESSION_ID"));
+        assert!(notify.contains("--data-binary @-"));
+        // Classification (subagent filter, Stop suppression, event mapping)
+        // moved to Rust — the script must not re-grow shell-side event logic.
+        assert!(!notify.contains("hook_event_name"));
+        assert!(!notify.contains("agent_id"));
+        assert!(!notify.contains("background_tasks"));
 
         let settings = fs::read_to_string(dir.join("acorn-claude-settings.json")).unwrap();
         let notify_path = dir.join("acorn-claude-notify").display().to_string();
@@ -2980,91 +2961,35 @@ done
         }
     }
 
+    #[cfg(unix)]
     #[test]
-    fn claude_notify_maps_runtime_hook_events() {
-        let base = ScratchDir::new("events");
-        let dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
-        let notify = fs::read_to_string(dir.join("acorn-claude-notify")).unwrap();
-        assert!(notify.contains("SessionStart|UserPromptSubmit) event=\"start\""));
-        assert!(!notify.contains("SubagentStop"));
-        assert!(notify.contains("Notification|PermissionRequest) event=\"needs_input\""));
-        assert!(notify.contains("Error) event=\"error\""));
+    fn claude_notify_forwards_raw_payload_for_owner_invocations() {
+        // Classification (subagent filter, Stop suppression, event mapping)
+        // lives in `parse_raw_claude_hook_request`; the script's only job is
+        // to deliver the payload byte-for-byte with transport attribution.
+        let payload = serde_json::json!({
+            "hook_event_name": "Stop",
+            "session_id": "019e4818-7c15-4e60-9b3b-898a1c7803d6",
+            "agent_id": "019f6338-6250-7303-88a6-a7add31dba1d",
+            "background_tasks": [{"id": "agent-1", "status": "running"}],
+        });
+        let posted = notify_payload_for_input(CLAUDE_NOTIFY_NAME, &[], &payload.to_string(), None)
+            .expect("an owner invocation must forward the payload");
+        assert_eq!(posted, payload);
     }
 
     #[cfg(unix)]
     #[test]
-    fn claude_stop_with_background_work_emits_no_transition() {
-        let payloads = [
-            serde_json::json!({
-                "hook_event_name": "Stop",
-                "background_tasks": [{"id": "agent-1", "type": "agent", "status": "running"}],
-                "session_crons": [],
-            }),
-            serde_json::json!({
-                "hook_event_name": "Stop",
-                "background_tasks": [{"id": "shell-1", "type": "shell", "status": "pending"}],
-                "session_crons": [],
-            }),
-            serde_json::json!({
-                "hook_event_name": "Stop",
-                "background_tasks": [],
-                "session_crons": [{"id": "cron-1", "schedule": "in 1m", "recurring": false}],
-            }),
-            serde_json::json!({
-                "hook_event_name": "Stop",
-                "background_tasks": [],
-                "session_crons": [{"id": "cron-2", "schedule": "*/5 * * * *", "recurring": true}],
-            }),
-        ];
+    fn claude_notify_gates_nested_and_legacy_invocations() {
+        let stop =
+            r#"{"hook_event_name":"Stop","session_id":"019e4818-7c15-4e60-9b3b-898a1c7803d6"}"#;
 
-        for payload in payloads {
-            let pretty = serde_json::to_string_pretty(&payload).unwrap();
-            assert_eq!(
-                notify_event_for_stdin(CLAUDE_NOTIFY_NAME, &pretty),
-                None,
-                "{pretty}",
-            );
-        }
-    }
+        // A top-level hook posts without waiting for the asynchronous
+        // claude.id marker.
+        assert!(notify_payload_for_input(CLAUDE_NOTIFY_NAME, &[], stop, None).is_some());
 
-    #[cfg(unix)]
-    #[test]
-    fn claude_stop_waits_only_when_no_background_work_remains() {
-        let payloads = [
-            serde_json::json!({
-                "hook_event_name": "Stop",
-                "session_id": "019e4818-7c15-4e60-9b3b-898a1c7803d6",
-                "background_tasks": [],
-                "session_crons": [],
-            }),
-            serde_json::json!({
-                "hook_event_name": "Stop",
-                "background_tasks": [],
-                "session_crons": [],
-                "last_assistant_message": "decoy: \"background_tasks\":[{\"status\":\"running\"}]",
-            }),
-        ];
-
-        for payload in payloads {
-            let body = serde_json::to_string(&payload).unwrap();
-            assert_eq!(
-                notify_event_for_stdin(CLAUDE_NOTIFY_NAME, &body).as_deref(),
-                Some("needs_input"),
-                "{body}",
-            );
-        }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn claude_native_stop_uses_synchronous_wrapper_ownership() {
-        let stop = r#"{"hook_event_name":"Stop","background_tasks":[],"session_crons":[]}"#;
-
-        assert_eq!(
-            notify_event_for_stdin(CLAUDE_NOTIFY_NAME, stop).as_deref(),
-            Some("needs_input"),
-            "a top-level hook must not wait for the asynchronous claude.id marker",
-        );
+        // A nested wrapper stays silent even with a matching conversation
+        // marker — depth gating happens before any payload inspection.
         assert_eq!(
             notify_payload_for_input_with_invocation(
                 CLAUDE_NOTIFY_NAME,
@@ -3076,116 +3001,33 @@ done
             None,
             "a matching conversation marker cannot authorize a nested wrapper",
         );
-    }
 
-    #[cfg(unix)]
-    #[test]
-    fn claude_subagent_hooks_cannot_transition_the_parent_session() {
-        for hook_event_name in [
-            "UserPromptSubmit",
-            "Notification",
-            "PermissionRequest",
-            "Stop",
-        ] {
-            let payload = serde_json::json!({
-                "hook_event_name": hook_event_name,
-                "agent_id": "019f6338-6250-7303-88a6-a7add31dba1d",
-                "agent_type": "Explore",
-                "background_tasks": [],
-                "session_crons": [],
-            });
-            assert_eq!(
-                notify_payload_for_input(CLAUDE_NOTIFY_NAME, &[], &payload.to_string(), None,),
+        // A tokenless legacy owner (provider that survived an app update)
+        // posts only when the payload conversation matches its marker.
+        assert!(notify_payload_for_input_with_invocation(
+            CLAUDE_NOTIFY_NAME,
+            &[],
+            stop,
+            Some(("claude.id", "019e4818-7c15-4e60-9b3b-898a1c7803d6")),
+            None,
+        )
+        .is_some());
+        assert_eq!(
+            notify_payload_for_input_with_invocation(
+                CLAUDE_NOTIFY_NAME,
+                &[],
+                stop,
+                Some(("claude.id", "11111111-2222-4333-8444-555555555555")),
                 None,
-                "a child {hook_event_name} must not transition its parent session",
-            );
-        }
-
-        let top_level_agent = serde_json::json!({
-            "hook_event_name": "PermissionRequest",
-            "agent_type": "reviewer",
-        });
-        assert_eq!(
-            notify_event_for_stdin(CLAUDE_NOTIFY_NAME, &top_level_agent.to_string()).as_deref(),
-            Some("needs_input"),
-            "top-level --agent sessions have agent_type without a child agent_id",
-        );
-
-        let decoy = serde_json::json!({
-            "hook_event_name": "PermissionRequest",
-            "message": "literal decoys: {\"agent_id\":\"not-a-real-field\",\"hook_event_name\":\"Stop\"}",
-        });
-        assert_eq!(
-            notify_event_for_stdin(CLAUDE_NOTIFY_NAME, &decoy.to_string()).as_deref(),
-            Some("needs_input"),
-            "escaped message text must not look like a top-level child id",
+            ),
+            None,
+            "a mismatched legacy owner marker must fail closed",
         );
     }
 
-    #[cfg(unix)]
-    #[test]
-    fn claude_explicit_attention_events_do_not_require_owner_binding() {
-        for payload in [
-            serde_json::json!({"hook_event_name": "PermissionRequest"}),
-            serde_json::json!({
-                "hook_event_name": "Notification",
-                "notification_type": "agent_needs_input",
-            }),
-        ] {
-            assert_eq!(
-                notify_event_for_stdin(CLAUDE_NOTIFY_NAME, &payload.to_string()).as_deref(),
-                Some("needs_input"),
-            );
-        }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn claude_background_hooks_cannot_erase_pending_attention() {
-        let background_stop = serde_json::json!({
-            "hook_event_name": "Stop",
-            "background_tasks": [{"id": "agent-1", "status": "running"}],
-            "session_crons": [],
-        });
-        let subagent_stop = serde_json::json!({
-            "hook_event_name": "SubagentStop",
-            "background_tasks": [],
-            "session_crons": [],
-        });
-        let permission = serde_json::json!({"hook_event_name": "PermissionRequest"});
-        let notification = serde_json::json!({
-            "hook_event_name": "Notification",
-            "notification_type": "agent_needs_input",
-        });
-        let final_stop = serde_json::json!({
-            "hook_event_name": "Stop",
-            "background_tasks": [],
-            "session_crons": [],
-        });
-
-        let events = [
-            permission,
-            background_stop.clone(),
-            subagent_stop,
-            notification,
-            background_stop,
-            final_stop,
-        ]
-        .into_iter()
-        .map(|payload| notify_event_for_stdin(CLAUDE_NOTIFY_NAME, &payload.to_string()))
-        .collect::<Vec<_>>();
-        assert_eq!(
-            events,
-            [
-                Some("needs_input".into()),
-                None,
-                None,
-                Some("needs_input".into()),
-                None,
-                Some("needs_input".into()),
-            ]
-        );
-    }
+    // The Stop/background, subagent-filter, decoy, and attention-ordering
+    // scenarios that used to run against this script live in
+    // `agent_hooks::tests` now — classification moved to Rust wholesale.
 
     #[test]
     fn writes_hook_endpoint_file_atomically_with_owner_only_perms() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -496,6 +496,30 @@ pub fn run() {
                         return agent_hooks::AgentHookHandlerOutcome::Conflict;
                     }
                 };
+                // A Claude hook payload names its own conversation UUID —
+                // ground truth from the provider. Binding it here makes the
+                // durable marker authoritative from the first turn event,
+                // instead of waiting for the persister's cwd+mtime inference
+                // (which stays on as fallback and multi-process arbiter).
+                if provider == acorn_session::SessionAgentProvider::Claude {
+                    if let Some(claude_uuid) = provider_session_id
+                        .as_deref()
+                        .filter(|id| uuid::Uuid::parse_str(id).is_ok())
+                    {
+                        if let Err(err) = agent_resume_persister::bind_session_marker(
+                            session_id,
+                            acorn_agent::AgentKind::Claude,
+                            claude_uuid,
+                        ) {
+                            tracing::warn!(
+                                %session_id,
+                                claude_uuid,
+                                error = %err,
+                                "claude hook transcript bind failed",
+                            );
+                        }
+                    }
+                }
                 if let Err(err) = persistence::save_sessions(&hook_sessions.list()) {
                     tracing::warn!(error = %err, "agent hook persist status failed");
                 }


### PR DESCRIPTION
## Summary

This extends the #666 direction to Claude: lifecycle classification moves out of the `acorn-claude-notify` shell script into Rust, and the hook payload's own conversation UUID becomes the primary transcript-binding signal.

1. **Raw payload forwarding.** `acorn-claude-notify` now forwards the raw Claude hook payload with `X-Acorn-Agent-Hook-Provider: claude` transport headers (mirroring the Codex raw contract) and bounded curl timeouts, instead of classifying events with field-boundary regexes on compacted JSON. Depth gating and the tokenless legacy-owner marker check stay in the script as transport-level attribution.
2. **Rust-side classification.** `parse_raw_claude_hook_request` performs the subagent `agent_id` filter, the Stop-with-background-work suppression, and the event mapping with real JSON parsing — immune to escaped decoy text and reviewable next to the reducer. A top-level `claude --agent` (agent_type without agent_id) remains an owner.
3. **Hook-driven transcript binding.** Every applied Claude event carries Claude's own `session_id`; the production hook handler binds it into the durable `claude.id` marker through the existing `bind_session_marker` write policy. The resume persister's cwd+mtime inference stays on as fallback and multi-process arbiter.
4. **Reducer lane cleanup.** `AgentHookReducer.lanes` no longer grows monotonically: lane creation prunes entries whose session was removed, and a late event for a removed session drops its lane instead of re-growing the map.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Hook payload contains decoy text resembling `agent_id` or `background_tasks` inside a string field | Field-boundary regexes could misclassify in edge shapes | JSON parsing reads only the real top-level fields |
| Claude `/clear` rotation | Marker followed the abandoned transcript until the persister's dormant-echo guard caught up | The first hook event of the new conversation binds the new UUID directly |
| Two Claude processes in the same cwd | Transcript rotation disabled, session could stay unbound | Hook payload names the owning conversation exactly |
| Hook command hangs on a dead endpoint | `curl` without timeouts could block Claude's hook execution | 1s connect/total timeouts bound the stall |
| Session removed mid-run after Codex hook events | Its `HookLane` stayed resident for the app lifetime | Lane is pruned on the next lane creation or late event |

## Design notes

- The Codex reducer (`CodexLane` turn/lifecycle scoping) is intentionally not extended to Claude: Claude events keep the existing non-Codex reducer path (`mark_hook_active` + status refresh) with unchanged semantics, so this PR changes where classification happens, not what it decides.
- The event source label for raw-forwarded Claude events is `native`; nothing downstream matches on the previous `hook` literal for non-Codex providers.
- Marker binding reuses the persister's guarded writer (same lock, same dormant-echo rollback gate), so hook-driven and scan-driven writes cannot flap the marker.
- The old POST shape (pre-classified JSON without a provider header) still parses through the generic branch, covering any in-flight notify invocation during an app update.

## Follow-up (not in this PR)

- Bypass diagnostics: surfacing when a live Claude process runs without hooks (wrapper bypassed via absolute path or renamed binary), where status degrades to transcript-tail inference that cannot express WaitingForInput.
- Phase 2 of #666: moving the hook receiver and lifecycle state into `acornd`.

## Test plan

- [x] `env -u ACORN_* … cargo test --workspace --all-targets --no-fail-fast` — all workspace targets passed.
- [x] `cargo test --lib agent_hooks::tests` — 63 passed (5 new: Claude payload normalization, background-Stop suppression, subagent filter + decoy resistance, unknown-event fail-safe, lane pruning).
- [x] `cargo test --lib agent_wrappers::tests` — 45 passed (shell classification tests replaced by transport tests; scenarios ported to `agent_hooks::tests`).
- [x] `cargo fmt` — applied; formatting drift in untouched files reverted.

## Notes

- Rust-only change; the frontend bundle is untouched.
- Pre-existing dead-code warnings in cache/test helpers remain; all tests pass.

Refs #666
