### PR TITLE
fix(sidebar): make priority-sorted session drag-and-drop stick

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -825,7 +825,7 @@ export function Sidebar() {
     });
     // While `prioritizeNeedsInputTabs` is on, rows are displayed grouped by
     // priority and the sort re-applies on every render, so a slot in the other
-    // group is one the drop could never keep.
+    // group of the same reorder container is one the drop could never keep.
     if (!prioritizeNeedsInputTabs) return collisions;
     return refuseCrossPriorityGroupDrop(dragPriorityIndex, activeId, collisions);
   };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -116,8 +116,8 @@ import {
 } from "../lib/projectFolders";
 import {
   buildProjectTopLevelItems,
-  orderProjectTopLevelItems,
   orderSessionsByPriority,
+  planProjectTopLevelDrag,
   type ProjectTopLevelFolderItem,
   type ProjectTopLevelSessionItem,
 } from "../lib/sidebarProjectItems";
@@ -822,16 +822,15 @@ export function Sidebar() {
     activeItemId: string,
     overItemId: string,
   ): boolean {
-    const items = buildProjectTopLevelItems(
+    const plan = planProjectTopLevelDrag(
       project,
       projectItemOrders[project.repoPath] ?? [],
+      prioritizeNeedsInputTabs,
+      activeItemId,
+      overItemId,
     );
-    const ids = items.map((item) => item.id);
-    const fromIdx = ids.indexOf(activeItemId);
-    const toIdx = ids.indexOf(overItemId);
-    if (fromIdx < 0 || toIdx < 0 || fromIdx === toIdx) return false;
-    const nextIds = arrayMove(ids, fromIdx, toIdx);
-    const nextItems = orderProjectTopLevelItems(items, nextIds);
+    if (!plan) return false;
+    const { nextOrder: nextIds, nextItems } = plan;
     setProjectItemOrders((prev) =>
       stringArraysEqual(prev[project.repoPath] ?? [], nextIds)
         ? prev
@@ -866,6 +865,7 @@ export function Sidebar() {
     const items = buildProjectTopLevelItems(
       project,
       projectItemOrders[project.repoPath] ?? [],
+      prioritizeNeedsInputTabs,
     ).filter((item) => item.id !== activeId);
     const overIdx = items.findIndex(
       (item) => item.id === overId && item.type === "session",

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -117,9 +117,9 @@ import {
 import {
   buildDragPriorityIndex,
   buildProjectTopLevelItems,
-  isSameDragPriorityGroup,
   orderSessionsByPriority,
   planProjectTopLevelDrag,
+  refuseCrossPriorityGroupDrop,
   type ProjectTopLevelFolderItem,
   type ProjectTopLevelSessionItem,
 } from "../lib/sidebarProjectItems";
@@ -825,20 +825,9 @@ export function Sidebar() {
     });
     // While `prioritizeNeedsInputTabs` is on, rows are displayed grouped by
     // priority and the sort re-applies on every render, so a slot in the other
-    // group is one the drop could never keep. Refuse the row the drag actually
-    // landed on rather than dropping it from the candidates: a withheld
-    // candidate does not leave a hole, it hands the slot to whatever ranked
-    // next — usually a neighbouring workspace's drop zone, which would file the
-    // session away into a folder the user never aimed at.
-    const target = collisions[0];
-    if (
-      prioritizeNeedsInputTabs &&
-      target &&
-      !isSameDragPriorityGroup(dragPriorityIndex, activeId, String(target.id))
-    ) {
-      return [];
-    }
-    return collisions;
+    // group is one the drop could never keep.
+    if (!prioritizeNeedsInputTabs) return collisions;
+    return refuseCrossPriorityGroupDrop(dragPriorityIndex, activeId, collisions);
   };
 
   function onDragStart(event: DragStartEvent) {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -842,7 +842,6 @@ export function Sidebar() {
     const plan = planProjectTopLevelDrag(
       project,
       projectItemOrders[project.repoPath] ?? [],
-      prioritizeNeedsInputTabs,
       activeItemId,
       overItemId,
     );
@@ -882,7 +881,6 @@ export function Sidebar() {
     const items = buildProjectTopLevelItems(
       project,
       projectItemOrders[project.repoPath] ?? [],
-      prioritizeNeedsInputTabs,
     ).filter((item) => item.id !== activeId);
     const overIdx = items.findIndex(
       (item) => item.id === overId && item.type === "session",

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -115,7 +115,9 @@ import {
   type ProjectFolderProjectGroup,
 } from "../lib/projectFolders";
 import {
+  buildDragPriorityIndex,
   buildProjectTopLevelItems,
+  isSameDragPriorityGroup,
   orderSessionsByPriority,
   planProjectTopLevelDrag,
   type ProjectTopLevelFolderItem,
@@ -794,16 +796,31 @@ export function Sidebar() {
     () => projectGroups.map((p) => projectDragId(p.repoPath)),
     [projectGroups],
   );
+  const dragPriorityIndex = useMemo(
+    () => buildDragPriorityIndex(allWorkspaceGroups),
+    [allWorkspaceGroups],
+  );
   // Scoped collision detection: only consider droppables sharing the active
   // item's namespace. Without this, dragging a project over an expanded
   // project's child session row makes `over.id` resolve to the session,
   // which gets dropped on the floor by onDragEnd.
+  //
+  // While `prioritizeNeedsInputTabs` is on, rows are also displayed grouped by
+  // priority, and the sort re-applies on every render — so a slot in the other
+  // group is one the drop could never keep. Withhold those slots rather than
+  // open them and snap the row back on release.
   const scopedCollision: CollisionDetection = (args) => {
     const activeId = String(args.active.id);
     const filtered = args.droppableContainers.filter((c) => {
       const id = String(c.id);
       if (activeId.startsWith(PROJECT_DRAG_PREFIX)) {
         return id.startsWith(PROJECT_DRAG_PREFIX);
+      }
+      if (
+        prioritizeNeedsInputTabs &&
+        !isSameDragPriorityGroup(dragPriorityIndex, activeId, id)
+      ) {
+        return false;
       }
       if (activeId.startsWith(FOLDER_DRAG_PREFIX)) {
         return id.startsWith(FOLDER_DRAG_PREFIX) || isSessionRowDragId(id);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -796,9 +796,12 @@ export function Sidebar() {
     () => projectGroups.map((p) => projectDragId(p.repoPath)),
     [projectGroups],
   );
+  // Project rows only: local terminal rows are displayed in their saved order,
+  // so confining their drags to a priority group would cost slots and buy
+  // nothing.
   const dragPriorityIndex = useMemo(
-    () => buildDragPriorityIndex(allWorkspaceGroups),
-    [allWorkspaceGroups],
+    () => buildDragPriorityIndex(projectGroups),
+    [projectGroups],
   );
   // Scoped collision detection: only consider droppables sharing the active
   // item's namespace. Without this, dragging a project over an expanded

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -807,11 +807,6 @@ export function Sidebar() {
   // item's namespace. Without this, dragging a project over an expanded
   // project's child session row makes `over.id` resolve to the session,
   // which gets dropped on the floor by onDragEnd.
-  //
-  // While `prioritizeNeedsInputTabs` is on, rows are also displayed grouped by
-  // priority, and the sort re-applies on every render — so a slot in the other
-  // group is one the drop could never keep. Withhold those slots rather than
-  // open them and snap the row back on release.
   const scopedCollision: CollisionDetection = (args) => {
     const activeId = String(args.active.id);
     const filtered = args.droppableContainers.filter((c) => {
@@ -819,18 +814,31 @@ export function Sidebar() {
       if (activeId.startsWith(PROJECT_DRAG_PREFIX)) {
         return id.startsWith(PROJECT_DRAG_PREFIX);
       }
-      if (
-        prioritizeNeedsInputTabs &&
-        !isSameDragPriorityGroup(dragPriorityIndex, activeId, id)
-      ) {
-        return false;
-      }
       if (activeId.startsWith(FOLDER_DRAG_PREFIX)) {
         return id.startsWith(FOLDER_DRAG_PREFIX) || isSessionRowDragId(id);
       }
       return id.startsWith(SESSION_DRAG_PREFIX);
     });
-    return closestCenter({ ...args, droppableContainers: filtered });
+    const collisions = closestCenter({
+      ...args,
+      droppableContainers: filtered,
+    });
+    // While `prioritizeNeedsInputTabs` is on, rows are displayed grouped by
+    // priority and the sort re-applies on every render, so a slot in the other
+    // group is one the drop could never keep. Refuse the row the drag actually
+    // landed on rather than dropping it from the candidates: a withheld
+    // candidate does not leave a hole, it hands the slot to whatever ranked
+    // next — usually a neighbouring workspace's drop zone, which would file the
+    // session away into a folder the user never aimed at.
+    const target = collisions[0];
+    if (
+      prioritizeNeedsInputTabs &&
+      target &&
+      !isSameDragPriorityGroup(dragPriorityIndex, activeId, String(target.id))
+    ) {
+      return [];
+    }
+    return collisions;
   };
 
   function onDragStart(event: DragStartEvent) {

--- a/src/lib/sidebarProjectItems.test.ts
+++ b/src/lib/sidebarProjectItems.test.ts
@@ -6,6 +6,7 @@ import {
   orderSessionsByPriority,
   orderProjectTopLevelItems,
   planProjectTopLevelDrag,
+  refuseCrossPriorityGroupDrop,
 } from "./sidebarProjectItems";
 import {
   makeDefaultProjectFolder,
@@ -283,6 +284,66 @@ describe("sidebar project items", () => {
     expect(
       isSameDragPriorityGroup(index, "session:idle-root", "session:folder:needs-folder"),
     ).toBe(true);
+  });
+
+  describe("refuseCrossPriorityGroupDrop", () => {
+    const index = buildDragPriorityIndex([project()]);
+    const collisionsFor = (...ids: string[]) => ids.map((id) => ({ id }));
+
+    it("refuses the drop when the winning row is in the other group", () => {
+      const collisions = collisionsFor(
+        "session:needs-root",
+        "session:running-root",
+      );
+
+      expect(
+        refuseCrossPriorityGroupDrop(index, "session:idle-root", collisions),
+      ).toEqual([]);
+    });
+
+    it("keeps every candidate when the winning row shares the group", () => {
+      const collisions = collisionsFor(
+        "session:running-root",
+        "session:needs-root",
+      );
+
+      expect(
+        refuseCrossPriorityGroupDrop(index, "session:idle-root", collisions),
+      ).toBe(collisions);
+    });
+
+    // Refusing must not rewrite the ranking: dropping the winner would promote
+    // whatever ranked next — typically a folder drop zone — and file the
+    // session into a folder the user never aimed at.
+    it("refuses rather than promoting the runner-up", () => {
+      const collisions = collisionsFor(
+        "session:needs-root",
+        "session:folder:idle-folder",
+      );
+
+      expect(
+        refuseCrossPriorityGroupDrop(index, "session:idle-root", collisions),
+      ).toEqual([]);
+    });
+
+    it("leaves drop zones and unindexed rows alone", () => {
+      const dropZone = collisionsFor("session:folder:needs-folder");
+      expect(
+        refuseCrossPriorityGroupDrop(index, "session:idle-root", dropZone),
+      ).toBe(dropZone);
+
+      // Local terminal rows are absent from the index and must stay draggable.
+      const localRow = collisionsFor("session:local-1");
+      expect(
+        refuseCrossPriorityGroupDrop(index, "session:local-2", localRow),
+      ).toBe(localRow);
+    });
+
+    it("has nothing to refuse when nothing collided", () => {
+      expect(
+        refuseCrossPriorityGroupDrop(index, "session:idle-root", []),
+      ).toEqual([]);
+    });
   });
 
   it("can move waiting and error sessions above ready work", () => {

--- a/src/lib/sidebarProjectItems.test.ts
+++ b/src/lib/sidebarProjectItems.test.ts
@@ -312,6 +312,14 @@ describe("sidebar project items", () => {
       ).toBe(collisions);
     });
 
+    it("allows a cross-group row drop when it moves between containers", () => {
+      const collisions = collisionsFor("session:idle-root");
+
+      expect(
+        refuseCrossPriorityGroupDrop(index, "session:nested-needs", collisions),
+      ).toBe(collisions);
+    });
+
     // Refusing must not rewrite the ranking: dropping the winner would promote
     // whatever ranked next — typically a folder drop zone — and file the
     // session into a folder the user never aimed at.

--- a/src/lib/sidebarProjectItems.test.ts
+++ b/src/lib/sidebarProjectItems.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildDragPriorityIndex,
   buildProjectTopLevelItems,
+  isSameDragPriorityGroup,
   orderSessionsByPriority,
   orderProjectTopLevelItems,
   planProjectTopLevelDrag,
@@ -224,6 +226,43 @@ describe("sidebar project items", () => {
         "session:not-a-real-item",
       ),
     ).toBeNull();
+  });
+
+  it("indexes drag ids by the priority group they are displayed in", () => {
+    const index = buildDragPriorityIndex([project()]);
+
+    expect(index.get("session:needs-root")).toBe(true);
+    expect(index.get("session:failed-root")).toBe(true);
+    expect(index.get("session:idle-root")).toBe(false);
+    expect(index.get("session:running-root")).toBe(false);
+    // A folder joins the priority group as soon as one session inside it needs
+    // attention, matching how the folder row is displayed.
+    expect(index.get("folder:needs-folder")).toBe(true);
+    expect(index.get("folder:idle-folder")).toBe(false);
+    expect(index.get("session:nested-needs")).toBe(true);
+    expect(index.get("session:nested-idle")).toBe(false);
+  });
+
+  it("only pairs drag ids that share a priority group", () => {
+    const index = buildDragPriorityIndex([project()]);
+
+    expect(
+      isSameDragPriorityGroup(index, "session:idle-root", "session:running-root"),
+    ).toBe(true);
+    expect(
+      isSameDragPriorityGroup(index, "session:needs-root", "session:failed-root"),
+    ).toBe(true);
+    expect(
+      isSameDragPriorityGroup(index, "session:idle-root", "session:needs-root"),
+    ).toBe(false);
+    expect(
+      isSameDragPriorityGroup(index, "session:running-root", "folder:needs-folder"),
+    ).toBe(false);
+    // Drop zones (folder / project targets) carry no priority group, so they
+    // stay available as move targets.
+    expect(
+      isSameDragPriorityGroup(index, "session:idle-root", "session:folder:needs-folder"),
+    ).toBe(true);
   });
 
   it("can move waiting and error sessions above ready work", () => {

--- a/src/lib/sidebarProjectItems.test.ts
+++ b/src/lib/sidebarProjectItems.test.ts
@@ -161,16 +161,42 @@ describe("sidebar project items", () => {
     ]);
   });
 
-  it("plans a drag against the order the user sees, not the saved order", () => {
-    const manualOrder = [
+  const MANUAL_ORDER = [
+    "session:idle-root",
+    "session:failed-root",
+    "session:needs-root",
+    "session:running-root",
+    "folder:idle-folder",
+    "folder:needs-folder",
+  ];
+
+  it("plans a drag without floating priority items into the saved order", () => {
+    // running-root and idle-root are both ready work, so the collision filter
+    // allows this drag. Only those two may move; the waiting and errored rows
+    // keep their saved slots rather than being rewritten to where the priority
+    // sort happens to show them today.
+    const planned = planProjectTopLevelDrag(
+      project(),
+      MANUAL_ORDER,
+      "session:running-root",
+      "session:idle-root",
+    );
+
+    expect(planned?.nextOrder).toEqual([
+      "session:running-root",
       "session:idle-root",
       "session:failed-root",
       "session:needs-root",
-      "session:running-root",
       "folder:idle-folder",
       "folder:needs-folder",
-    ];
-    const displayed = buildProjectTopLevelItems(project(), manualOrder, true);
+    ]);
+  });
+
+  it("lands a same-group drag exactly where the user dropped it", () => {
+    // The plan is scored against the saved order while the user drags in the
+    // sorted one. For a drag inside a single priority group the two must agree,
+    // otherwise the sort yanks the row back on the next render.
+    const displayed = buildProjectTopLevelItems(project(), MANUAL_ORDER, true);
     expect(displayed.map((item) => item.id)).toEqual([
       "session:failed-root",
       "session:needs-root",
@@ -180,23 +206,19 @@ describe("sidebar project items", () => {
       "folder:idle-folder",
     ]);
 
-    // Drag running-root from the bottom of the ready group up onto needs-root.
-    // The priority sort pins needs-root above it, but running-root must still
-    // land ahead of idle-root once the list re-renders.
     const planned = planProjectTopLevelDrag(
       project(),
-      manualOrder,
-      true,
+      MANUAL_ORDER,
       "session:running-root",
-      "session:needs-root",
+      "session:idle-root",
     );
-
-    expect(planned).not.toBeNull();
     const redisplayed = buildProjectTopLevelItems(
       project(),
       planned!.nextOrder,
       true,
     ).map((item) => item.id);
+
+    // What the user saw: running-root picked up and dropped onto idle-root.
     expect(redisplayed).toEqual([
       "session:failed-root",
       "session:needs-root",
@@ -211,8 +233,7 @@ describe("sidebar project items", () => {
     expect(
       planProjectTopLevelDrag(
         project(),
-        ["session:idle-root", "session:running-root"],
-        false,
+        MANUAL_ORDER,
         "session:idle-root",
         "session:idle-root",
       ),
@@ -220,8 +241,7 @@ describe("sidebar project items", () => {
     expect(
       planProjectTopLevelDrag(
         project(),
-        ["session:idle-root", "session:running-root"],
-        false,
+        MANUAL_ORDER,
         "session:idle-root",
         "session:not-a-real-item",
       ),

--- a/src/lib/sidebarProjectItems.test.ts
+++ b/src/lib/sidebarProjectItems.test.ts
@@ -249,7 +249,7 @@ describe("sidebar project items", () => {
     ).toBeNull();
   });
 
-  it("indexes drag ids by the priority group they are displayed in", () => {
+  it("indexes drag ids by priority group and reorder container", () => {
     const index = buildDragPriorityIndex([project()]);
 
     expect(index.get("session:needs-root")).toEqual({

--- a/src/lib/sidebarProjectItems.test.ts
+++ b/src/lib/sidebarProjectItems.test.ts
@@ -3,6 +3,7 @@ import {
   buildProjectTopLevelItems,
   orderSessionsByPriority,
   orderProjectTopLevelItems,
+  planProjectTopLevelDrag,
 } from "./sidebarProjectItems";
 import {
   makeDefaultProjectFolder,
@@ -156,6 +157,73 @@ describe("sidebar project items", () => {
       "folder:idle-folder",
       "folder:needs-folder",
     ]);
+  });
+
+  it("plans a drag against the order the user sees, not the saved order", () => {
+    const manualOrder = [
+      "session:idle-root",
+      "session:failed-root",
+      "session:needs-root",
+      "session:running-root",
+      "folder:idle-folder",
+      "folder:needs-folder",
+    ];
+    const displayed = buildProjectTopLevelItems(project(), manualOrder, true);
+    expect(displayed.map((item) => item.id)).toEqual([
+      "session:failed-root",
+      "session:needs-root",
+      "folder:needs-folder",
+      "session:idle-root",
+      "session:running-root",
+      "folder:idle-folder",
+    ]);
+
+    // Drag running-root from the bottom of the ready group up onto needs-root.
+    // The priority sort pins needs-root above it, but running-root must still
+    // land ahead of idle-root once the list re-renders.
+    const planned = planProjectTopLevelDrag(
+      project(),
+      manualOrder,
+      true,
+      "session:running-root",
+      "session:needs-root",
+    );
+
+    expect(planned).not.toBeNull();
+    const redisplayed = buildProjectTopLevelItems(
+      project(),
+      planned!.nextOrder,
+      true,
+    ).map((item) => item.id);
+    expect(redisplayed).toEqual([
+      "session:failed-root",
+      "session:needs-root",
+      "folder:needs-folder",
+      "session:running-root",
+      "session:idle-root",
+      "folder:idle-folder",
+    ]);
+  });
+
+  it("reports no drag plan when the item does not move", () => {
+    expect(
+      planProjectTopLevelDrag(
+        project(),
+        ["session:idle-root", "session:running-root"],
+        false,
+        "session:idle-root",
+        "session:idle-root",
+      ),
+    ).toBeNull();
+    expect(
+      planProjectTopLevelDrag(
+        project(),
+        ["session:idle-root", "session:running-root"],
+        false,
+        "session:idle-root",
+        "session:not-a-real-item",
+      ),
+    ).toBeNull();
   });
 
   it("can move waiting and error sessions above ready work", () => {

--- a/src/lib/sidebarProjectItems.test.ts
+++ b/src/lib/sidebarProjectItems.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildDragPriorityIndex,
   buildProjectTopLevelItems,
-  isSameDragPriorityGroup,
+  isPriorityDropAllowed,
   orderSessionsByPriority,
   orderProjectTopLevelItems,
   planProjectTopLevelDrag,
@@ -252,37 +252,53 @@ describe("sidebar project items", () => {
   it("indexes drag ids by the priority group they are displayed in", () => {
     const index = buildDragPriorityIndex([project()]);
 
-    expect(index.get("session:needs-root")).toBe(true);
-    expect(index.get("session:failed-root")).toBe(true);
-    expect(index.get("session:idle-root")).toBe(false);
-    expect(index.get("session:running-root")).toBe(false);
+    expect(index.get("session:needs-root")).toEqual({
+      containerId: "project:/repo/app",
+      isPrioritized: true,
+    });
+    expect(index.get("session:failed-root")?.isPrioritized).toBe(true);
+    expect(index.get("session:idle-root")?.isPrioritized).toBe(false);
+    expect(index.get("session:running-root")?.isPrioritized).toBe(false);
     // A folder joins the priority group as soon as one session inside it needs
     // attention, matching how the folder row is displayed.
-    expect(index.get("folder:needs-folder")).toBe(true);
-    expect(index.get("folder:idle-folder")).toBe(false);
-    expect(index.get("session:nested-needs")).toBe(true);
-    expect(index.get("session:nested-idle")).toBe(false);
+    expect(index.get("folder:needs-folder")).toEqual({
+      containerId: "project:/repo/app",
+      isPrioritized: true,
+    });
+    expect(index.get("folder:idle-folder")?.isPrioritized).toBe(false);
+    expect(index.get("session:nested-needs")).toEqual({
+      containerId: "folder:needs-folder",
+      isPrioritized: true,
+    });
+    expect(index.get("session:nested-idle")?.isPrioritized).toBe(false);
   });
 
-  it("only pairs drag ids that share a priority group", () => {
+  it("only rejects cross-group rows inside the same container", () => {
     const index = buildDragPriorityIndex([project()]);
 
     expect(
-      isSameDragPriorityGroup(index, "session:idle-root", "session:running-root"),
+      isPriorityDropAllowed(index, "session:idle-root", "session:running-root"),
     ).toBe(true);
     expect(
-      isSameDragPriorityGroup(index, "session:needs-root", "session:failed-root"),
+      isPriorityDropAllowed(index, "session:needs-root", "session:failed-root"),
     ).toBe(true);
     expect(
-      isSameDragPriorityGroup(index, "session:idle-root", "session:needs-root"),
+      isPriorityDropAllowed(index, "session:idle-root", "session:needs-root"),
     ).toBe(false);
     expect(
-      isSameDragPriorityGroup(index, "session:running-root", "folder:needs-folder"),
+      isPriorityDropAllowed(index, "session:running-root", "folder:needs-folder"),
     ).toBe(false);
+    expect(
+      isPriorityDropAllowed(index, "session:nested-needs", "session:idle-root"),
+    ).toBe(true);
     // Drop zones (folder / project targets) carry no priority group, so they
     // stay available as move targets.
     expect(
-      isSameDragPriorityGroup(index, "session:idle-root", "session:folder:needs-folder"),
+      isPriorityDropAllowed(
+        index,
+        "session:idle-root",
+        "session:folder:needs-folder",
+      ),
     ).toBe(true);
   });
 

--- a/src/lib/sidebarProjectItems.ts
+++ b/src/lib/sidebarProjectItems.ts
@@ -83,11 +83,16 @@ export interface ProjectTopLevelDragPlan {
 /**
  * Resolve a sidebar drag into the manual order to persist.
  *
- * `prioritizeNeedsInputTabs` only changes how the list is displayed — the saved
- * order stays manual. So the drag has to be resolved against the displayed
- * list: the drop indices the user aimed at are positions in that list, and
- * scoring them against the unsorted order records the move in the wrong slot,
- * which the next render then sorts straight back to where it started.
+ * The move is scored against the saved order, never the order on screen: with
+ * `prioritizeNeedsInputTabs` on those differ, and rewriting the saved order to
+ * match the screen would bake a snapshot of today's waiting tabs into the
+ * manual order the setting promises to keep intact.
+ *
+ * Scoring against the saved order is safe because drags are confined to a
+ * single priority group (see [[isSameDragPriorityGroup]]): the priority sort is
+ * a stable partition, so moving a row among its own kind changes only that
+ * group's internal order — which lands identically whether the move is scored
+ * on screen or in the saved order.
  *
  * Returns null when the drag is a no-op or references an item that is not on
  * the project's top level.
@@ -95,15 +100,10 @@ export interface ProjectTopLevelDragPlan {
 export function planProjectTopLevelDrag(
   project: ProjectFolderProjectGroup,
   order: readonly string[],
-  prioritizeNeedsInputTabs: boolean,
   activeItemId: string,
   overItemId: string,
 ): ProjectTopLevelDragPlan | null {
-  const items = buildProjectTopLevelItems(
-    project,
-    order,
-    prioritizeNeedsInputTabs,
-  );
+  const items = buildProjectTopLevelItems(project, order);
   const fromIdx = items.findIndex((item) => item.id === activeItemId);
   const toIdx = items.findIndex((item) => item.id === overItemId);
   if (fromIdx < 0 || toIdx < 0 || fromIdx === toIdx) return null;

--- a/src/lib/sidebarProjectItems.ts
+++ b/src/lib/sidebarProjectItems.ts
@@ -75,6 +75,44 @@ export function orderProjectTopLevelItems(
   return prioritizeNeedsInputTabs ? orderItemsByPriority(ordered) : ordered;
 }
 
+export interface ProjectTopLevelDragPlan {
+  nextOrder: string[];
+  nextItems: ProjectTopLevelItem[];
+}
+
+/**
+ * Resolve a sidebar drag into the manual order to persist.
+ *
+ * `prioritizeNeedsInputTabs` only changes how the list is displayed — the saved
+ * order stays manual. So the drag has to be resolved against the displayed
+ * list: the drop indices the user aimed at are positions in that list, and
+ * scoring them against the unsorted order records the move in the wrong slot,
+ * which the next render then sorts straight back to where it started.
+ *
+ * Returns null when the drag is a no-op or references an item that is not on
+ * the project's top level.
+ */
+export function planProjectTopLevelDrag(
+  project: ProjectFolderProjectGroup,
+  order: readonly string[],
+  prioritizeNeedsInputTabs: boolean,
+  activeItemId: string,
+  overItemId: string,
+): ProjectTopLevelDragPlan | null {
+  const items = buildProjectTopLevelItems(
+    project,
+    order,
+    prioritizeNeedsInputTabs,
+  );
+  const fromIdx = items.findIndex((item) => item.id === activeItemId);
+  const toIdx = items.findIndex((item) => item.id === overItemId);
+  if (fromIdx < 0 || toIdx < 0 || fromIdx === toIdx) return null;
+  const nextItems = [...items];
+  const [moved] = nextItems.splice(fromIdx, 1);
+  nextItems.splice(toIdx, 0, moved);
+  return { nextOrder: nextItems.map((item) => item.id), nextItems };
+}
+
 export function orderSessionsByPriority(
   sessions: readonly Session[],
   prioritizeNeedsInputTabs: boolean,

--- a/src/lib/sidebarProjectItems.ts
+++ b/src/lib/sidebarProjectItems.ts
@@ -131,10 +131,14 @@ export function buildDragPriorityIndex(
   const index = new Map<string, boolean>();
   for (const group of groups) {
     for (const folderGroup of group.folders) {
-      index.set(
-        sidebarFolderItemId(folderGroup.folder.id),
-        folderGroup.sessions.some(hasPriorityStatus),
-      );
+      // The default folder is flattened into top-level session rows and never
+      // drawn as a folder row, so it has no drag id to index.
+      if (!isDefaultProjectFolder(folderGroup.folder)) {
+        index.set(
+          sidebarFolderItemId(folderGroup.folder.id),
+          folderGroupHasPriorityStatus(folderGroup),
+        );
+      }
       for (const session of folderGroup.sessions) {
         index.set(sidebarSessionItemId(session.id), hasPriorityStatus(session));
       }
@@ -163,6 +167,30 @@ export function isSameDragPriorityGroup(
   return active === over;
 }
 
+/**
+ * Drop a drag that landed on a row in the other priority group.
+ *
+ * Takes ranked collisions and returns them untouched, or nothing at all. It
+ * deliberately does not withhold the offending row from the ranking: a withheld
+ * candidate leaves no hole, it hands the slot to whatever ranked next — for a
+ * session row typically a neighbouring folder's drop zone, which would file the
+ * session away into a folder the user never pointed at.
+ *
+ * Call only while the priority sort is on; with the sort off every row keeps
+ * the slot it is dropped in and there is nothing to refuse.
+ */
+export function refuseCrossPriorityGroupDrop<T extends { id: string | number }>(
+  index: ReadonlyMap<string, boolean>,
+  activeId: string,
+  collisions: T[],
+): T[] {
+  const target = collisions[0];
+  if (!target) return collisions;
+  return isSameDragPriorityGroup(index, activeId, String(target.id))
+    ? collisions
+    : [];
+}
+
 export function orderSessionsByPriority(
   sessions: readonly Session[],
   prioritizeNeedsInputTabs: boolean,
@@ -179,7 +207,12 @@ function orderItemsByPriority(
 
 function itemHasPriorityStatus(item: ProjectTopLevelItem): boolean {
   if (item.type === "session") return hasPriorityStatus(item.session);
-  return item.folderGroup.sessions.some(hasPriorityStatus);
+  return folderGroupHasPriorityStatus(item.folderGroup);
+}
+
+/** A folder joins the priority group as soon as one session inside it does. */
+function folderGroupHasPriorityStatus(folderGroup: ProjectFolderGroup): boolean {
+  return folderGroup.sessions.some(hasPriorityStatus);
 }
 
 function hasPriorityStatus(session: Session): boolean {

--- a/src/lib/sidebarProjectItems.ts
+++ b/src/lib/sidebarProjectItems.ts
@@ -117,8 +117,13 @@ export function planProjectTopLevelDrag(
  * Map every draggable sidebar row id to the priority group it is displayed in:
  * true for rows the priority sort floats to the top, false for the rest.
  *
- * Ids that are not rows — the folder and project drop zones — are absent, so
- * callers can tell "different group" apart from "not a row at all".
+ * Pass only groups whose rows are actually displayed with the priority sort
+ * applied. An unindexed id is read as "unconstrained" rather than "other
+ * group", so rows that are displayed in their saved order keep every drop slot.
+ *
+ * Ids that are not rows — the folder and project drop zones — are absent for
+ * the same reason: dropping onto them moves a session between workspaces
+ * instead of reordering it, which the priority sort has no say over.
  */
 export function buildDragPriorityIndex(
   groups: readonly ProjectFolderProjectGroup[],

--- a/src/lib/sidebarProjectItems.ts
+++ b/src/lib/sidebarProjectItems.ts
@@ -186,7 +186,8 @@ export function isPriorityDropAllowed(
 }
 
 /**
- * Drop a drag that landed on a row in the other priority group.
+ * Drop a drag that landed on a row in the other priority group of the same
+ * reorder container.
  *
  * Takes ranked collisions and returns them untouched, or nothing at all. It
  * deliberately does not withhold the offending row from the ranking: a withheld

--- a/src/lib/sidebarProjectItems.ts
+++ b/src/lib/sidebarProjectItems.ts
@@ -113,6 +113,51 @@ export function planProjectTopLevelDrag(
   return { nextOrder: nextItems.map((item) => item.id), nextItems };
 }
 
+/**
+ * Map every draggable sidebar row id to the priority group it is displayed in:
+ * true for rows the priority sort floats to the top, false for the rest.
+ *
+ * Ids that are not rows — the folder and project drop zones — are absent, so
+ * callers can tell "different group" apart from "not a row at all".
+ */
+export function buildDragPriorityIndex(
+  groups: readonly ProjectFolderProjectGroup[],
+): Map<string, boolean> {
+  const index = new Map<string, boolean>();
+  for (const group of groups) {
+    for (const folderGroup of group.folders) {
+      index.set(
+        sidebarFolderItemId(folderGroup.folder.id),
+        folderGroup.sessions.some(hasPriorityStatus),
+      );
+      for (const session of folderGroup.sessions) {
+        index.set(sidebarSessionItemId(session.id), hasPriorityStatus(session));
+      }
+    }
+  }
+  return index;
+}
+
+/**
+ * Whether a row may be dropped onto another while the priority sort is on.
+ *
+ * The sort re-floats waiting and errored rows on every render, so a drop that
+ * crosses the group boundary can never hold its slot — it snaps back the
+ * instant it lands. Refusing the drop keeps the boundary honest instead.
+ *
+ * Ids missing from the index are drop zones rather than rows, and stay open.
+ */
+export function isSameDragPriorityGroup(
+  index: ReadonlyMap<string, boolean>,
+  activeId: string,
+  overId: string,
+): boolean {
+  const active = index.get(activeId);
+  const over = index.get(overId);
+  if (active === undefined || over === undefined) return true;
+  return active === over;
+}
+
 export function orderSessionsByPriority(
   sessions: readonly Session[],
   prioritizeNeedsInputTabs: boolean,

--- a/src/lib/sidebarProjectItems.ts
+++ b/src/lib/sidebarProjectItems.ts
@@ -89,7 +89,7 @@ export interface ProjectTopLevelDragPlan {
  * manual order the setting promises to keep intact.
  *
  * Scoring against the saved order is safe because drags are confined to a
- * single priority group (see [[isSameDragPriorityGroup]]): the priority sort is
+ * single priority group (see [[isPriorityDropAllowed]]): the priority sort is
  * a stable partition, so moving a row among its own kind changes only that
  * group's internal order — which lands identically whether the move is scored
  * on screen or in the saved order.
@@ -114,8 +114,9 @@ export function planProjectTopLevelDrag(
 }
 
 /**
- * Map every draggable sidebar row id to the priority group it is displayed in:
- * true for rows the priority sort floats to the top, false for the rest.
+ * Map every draggable sidebar row id to its priority group and reorder
+ * container. The container distinguishes reordering inside one sorted list
+ * from moving a session between workspaces.
  *
  * Pass only groups whose rows are actually displayed with the priority sort
  * applied. An unindexed id is read as "unconstrained" rather than "other
@@ -125,22 +126,35 @@ export function planProjectTopLevelDrag(
  * the same reason: dropping onto them moves a session between workspaces
  * instead of reordering it, which the priority sort has no say over.
  */
+export interface DragPriorityPlacement {
+  containerId: string;
+  isPrioritized: boolean;
+}
+
 export function buildDragPriorityIndex(
   groups: readonly ProjectFolderProjectGroup[],
-): Map<string, boolean> {
-  const index = new Map<string, boolean>();
+): Map<string, DragPriorityPlacement> {
+  const index = new Map<string, DragPriorityPlacement>();
   for (const group of groups) {
+    const topLevelContainerId = `project:${group.repoPath}`;
     for (const folderGroup of group.folders) {
+      const isDefaultFolder = isDefaultProjectFolder(folderGroup.folder);
       // The default folder is flattened into top-level session rows and never
       // drawn as a folder row, so it has no drag id to index.
-      if (!isDefaultProjectFolder(folderGroup.folder)) {
-        index.set(
-          sidebarFolderItemId(folderGroup.folder.id),
-          folderGroupHasPriorityStatus(folderGroup),
-        );
+      if (!isDefaultFolder) {
+        index.set(sidebarFolderItemId(folderGroup.folder.id), {
+          containerId: topLevelContainerId,
+          isPrioritized: folderGroupHasPriorityStatus(folderGroup),
+        });
       }
+      const sessionContainerId = isDefaultFolder
+        ? topLevelContainerId
+        : `folder:${folderGroup.folder.id}`;
       for (const session of folderGroup.sessions) {
-        index.set(sidebarSessionItemId(session.id), hasPriorityStatus(session));
+        index.set(sidebarSessionItemId(session.id), {
+          containerId: sessionContainerId,
+          isPrioritized: hasPriorityStatus(session),
+        });
       }
     }
   }
@@ -151,20 +165,24 @@ export function buildDragPriorityIndex(
  * Whether a row may be dropped onto another while the priority sort is on.
  *
  * The sort re-floats waiting and errored rows on every render, so a drop that
- * crosses the group boundary can never hold its slot — it snaps back the
- * instant it lands. Refusing the drop keeps the boundary honest instead.
+ * crosses the group boundary inside one container can never hold its slot — it
+ * snaps back the instant it lands. Across containers, the workspace move still
+ * has meaning and the destination sort decides the row's final position.
  *
  * Ids missing from the index are drop zones rather than rows, and stay open.
  */
-export function isSameDragPriorityGroup(
-  index: ReadonlyMap<string, boolean>,
+export function isPriorityDropAllowed(
+  index: ReadonlyMap<string, DragPriorityPlacement>,
   activeId: string,
   overId: string,
 ): boolean {
   const active = index.get(activeId);
   const over = index.get(overId);
   if (active === undefined || over === undefined) return true;
-  return active === over;
+  return (
+    active.containerId !== over.containerId ||
+    active.isPrioritized === over.isPrioritized
+  );
 }
 
 /**
@@ -180,13 +198,13 @@ export function isSameDragPriorityGroup(
  * the slot it is dropped in and there is nothing to refuse.
  */
 export function refuseCrossPriorityGroupDrop<T extends { id: string | number }>(
-  index: ReadonlyMap<string, boolean>,
+  index: ReadonlyMap<string, DragPriorityPlacement>,
   activeId: string,
   collisions: T[],
 ): T[] {
   const target = collisions[0];
   if (!target) return collisions;
-  return isSameDragPriorityGroup(index, activeId, String(target.id))
+  return isPriorityDropAllowed(index, activeId, String(target.id))
     ? collisions
     : [];
 }

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -2183,10 +2183,18 @@ test.describe("sidebar: project lifecycle", () => {
     });
   });
 
-  test("project workspace sessions can move out next to root sessions by drag and drop", async ({
+  test("project workspace sessions can move across priority groups into the project root", async ({
     page,
     tauri,
   }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          interface: { prioritizeNeedsInputTabs: true },
+        }),
+      );
+    });
     await tauri.handle("list_projects", () => [
       {
         repo_path: "/tmp/demo",
@@ -2224,7 +2232,7 @@ test.describe("sidebar: project lifecycle", () => {
           branch: "main",
           isolated: false,
           project_scoped: true,
-          status: "ready",
+          status: "waiting_for_input",
           created_at: "2026-01-01T00:00:01Z",
           updated_at: "2026-01-01T00:00:01Z",
           last_message: null,
@@ -2271,7 +2279,7 @@ test.describe("sidebar: project lifecycle", () => {
       .getByRole("button", { name: /^root main · Ready/ })
       .first();
     const child = sidebar
-      .getByRole("button", { name: /^child main · Ready/ })
+      .getByRole("button", { name: /^child main · Waiting for input/ })
       .first();
 
     await dragBetween(page, child, frontend);

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -3979,7 +3979,7 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(projects.last()).toHaveAccessibleName("Project beta");
   });
 
-  test("settings can move waiting and error project tabs to the top", async ({
+  test("priority sorting preserves drag order within each status group", async ({
     page,
     tauri,
   }) => {
@@ -4152,6 +4152,20 @@ test.describe("sidebar: project lifecycle", () => {
       })
       .toBe("priority-order");
 
+    await dragBetween(page, needs, errored);
+
+    await expect
+      .poll(async () => {
+        const readyBox = await ready.boundingBox();
+        const erroredBox = await errored.boundingBox();
+        const needsBox = await needs.boundingBox();
+        if (!readyBox || !erroredBox || !needsBox) return "missing";
+        return needsBox.y < erroredBox.y && erroredBox.y < readyBox.y
+          ? "reordered-priority-group"
+          : "different";
+      })
+      .toBe("reordered-priority-group");
+
     await pressHotkey(page, { mod: true, key: "," });
     await settings
       .getByRole("checkbox", {
@@ -4166,7 +4180,7 @@ test.describe("sidebar: project lifecycle", () => {
         const erroredBox = await errored.boundingBox();
         const needsBox = await needs.boundingBox();
         if (!readyBox || !erroredBox || !needsBox) return "missing";
-        return readyBox.y < erroredBox.y && erroredBox.y < needsBox.y
+        return readyBox.y < needsBox.y && needsBox.y < erroredBox.y
           ? "manual-order"
           : "different";
       })


### PR DESCRIPTION
## Summary

Priority-sorted sidebar rows now preserve the user's drag intent without corrupting the saved manual order or blocking moves between workspaces.

1. **Stable same-group reordering** — score top-level drags against the saved order and persist only the moved priority group's relative order.
2. **Container-aware drop guard** — refuse cross-priority row drops only inside the same sorted container; allow row-to-row moves between the project root and named workspaces.
3. **Regression coverage** — add pure helper tests plus Playwright coverage for same-group reordering, setting toggles, and cross-container moves.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Reorder two ready or two attention-needed rows with priority sorting on | Row could snap back after drop | Displayed order matches the drop and persists |
| Drop across priority groups inside one list | Sort immediately undid the requested slot | Invalid slot is not offered |
| Move a session between workspaces via a row in the other priority group | Drop was incorrectly discarded | Workspace move succeeds; destination sort chooses final placement |
| Turn priority sorting off after reordering | Saved order could reflect a transient status snapshot | Manual order remains intact |

## Design notes

- The saved project-item order remains the source of truth; the priority sort stays a display-only stable partition.
- Each indexed row carries both its priority group and reorder-container id. Cross-group drops are unstable only when both rows belong to the same container.
- Project-root sessions and workspace folder rows share the project top-level container. Sessions inside each named workspace use that workspace as their container.
- Local terminal rows and explicit folder/project drop zones remain unindexed and unconstrained.

## Test plan

- [x] `pnpm run test` — 96 test files, 1,069 tests passed.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run build:frontend` — production bundle built successfully.
- [x] `pnpm run test:e2e tests/e2e/sidebar.spec.ts` — 43 Playwright tests passed.
- [x] Regression reproducer failed before the container-aware fix and passed after it.
- [x] GitHub Actions CI passes on the final pushed head.

## Notes

- The frontend build reports the existing dynamic-import and large-chunk warnings; this PR does not add new build warnings.

