### PR TITLE
fix(status): trust Claude hook transcript markers when resuming

### DIFF
--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -1762,10 +1762,9 @@ fn parse_agent_hook_request(head: &str, body: &[u8]) -> Result<Option<AgentHookE
     }
 }
 
-/// Normalize a raw Claude Code hook payload forwarded verbatim by
-/// `acorn-claude-notify`. The shell script used to classify events with
-/// field-boundary regexes; real JSON parsing here is immune to escaped
-/// decoy text and keeps the drop rules reviewable next to the reducer.
+/// Normalize a raw Claude Code hook payload forwarded by
+/// `acorn-claude-notify`. Structured top-level field parsing prevents
+/// escaped content from impersonating ownership or lifecycle fields.
 fn parse_raw_claude_hook_request(
     head: &str,
     body: &[u8],
@@ -1813,9 +1812,8 @@ fn parse_raw_claude_hook_request(
         _ => return Ok(None),
     };
 
-    // Claude's own conversation UUID. Downstream this binds the session's
-    // durable transcript marker, replacing cwd+mtime inference as the
-    // primary pairing signal.
+    // Claude's conversation UUID binds the session's durable transcript
+    // marker without cwd and mtime ambiguity.
     let provider_session_id = payload
         .get("session_id")
         .and_then(Value::as_str)

--- a/src-tauri/src/agent_resume_persister.rs
+++ b/src-tauri/src/agent_resume_persister.rs
@@ -429,6 +429,24 @@ mod tests {
         fs::remove_dir_all(&dir).unwrap();
     }
 
+    #[test]
+    fn provider_declared_bind_replaces_the_existing_marker() {
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-provider-bind-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let marker = dir.join("claude.id");
+        let previous = "019f2001-bbbb-76b0-8410-2e073b38a2c2";
+        let resumed = "019e2001-aaaa-76b0-8410-2e073b38a2c1";
+        fs::write(&marker, format!("{previous}\n")).unwrap();
+
+        bind_provider_marker_in_state_dir(&dir, AgentKind::Claude, resumed).unwrap();
+
+        assert_eq!(read_trimmed(&marker).as_deref(), Some(resumed));
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
     /// Two writers race the same marker (background tick vs status-poll
     /// fallback). The bind lock must serialize them: every call succeeds
     /// and the surviving value is one of the written uuids, never a torn

--- a/src-tauri/src/agent_resume_persister.rs
+++ b/src-tauri/src/agent_resume_persister.rs
@@ -177,6 +177,18 @@ pub fn bind_session_marker(session_id: uuid::Uuid, kind: AgentKind, uuid: &str) 
     bind_marker_in_state_dir(&state_dir, kind, uuid)
 }
 
+/// Bind a provider-owned conversation identifier as the session's durable
+/// marker. Provider hooks identify the active conversation directly, so
+/// transcript activity heuristics must not reject this update.
+pub fn bind_provider_session_marker(
+    session_id: uuid::Uuid,
+    kind: AgentKind,
+    uuid: &str,
+) -> io::Result<()> {
+    let state_dir = agent_resume::ensure_session_state_dir(session_id)?;
+    bind_provider_marker_in_state_dir(&state_dir, kind, uuid)
+}
+
 /// Serializes marker writes across the background tick and the status
 /// poll's fallback. The read-check-write below is not atomic on its own;
 /// two threads interleaving could skip the dormant-echo arbitration and
@@ -187,6 +199,29 @@ fn marker_bind_lock() -> &'static Mutex<()> {
 }
 
 fn bind_marker_in_state_dir(state_dir: &Path, kind: AgentKind, uuid: &str) -> io::Result<()> {
+    bind_marker_in_state_dir_with_policy(state_dir, kind, uuid, MarkerBindPolicy::Inferred)
+}
+
+fn bind_provider_marker_in_state_dir(
+    state_dir: &Path,
+    kind: AgentKind,
+    uuid: &str,
+) -> io::Result<()> {
+    bind_marker_in_state_dir_with_policy(state_dir, kind, uuid, MarkerBindPolicy::ProviderDeclared)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MarkerBindPolicy {
+    Inferred,
+    ProviderDeclared,
+}
+
+fn bind_marker_in_state_dir_with_policy(
+    state_dir: &Path,
+    kind: AgentKind,
+    uuid: &str,
+    policy: MarkerBindPolicy,
+) -> io::Result<()> {
     let _guard = marker_bind_lock()
         .lock()
         .unwrap_or_else(PoisonError::into_inner);
@@ -201,10 +236,12 @@ fn bind_marker_in_state_dir(state_dir: &Path, kind: AgentKind, uuid: &str) -> io
     // scan can echo the abandoned original once the new transcript
     // goes idle; writing that echo would oscillate the marker. Skip
     // only the dormant-echo case so the marker never flaps.
-    if let Some(prev) = previous.as_deref() {
-        if marker_rollback_is_dormant_echo(kind, prev, uuid) {
-            return Ok(());
-        }
+    if policy == MarkerBindPolicy::Inferred
+        && previous
+            .as_deref()
+            .is_some_and(|prev| marker_rollback_is_dormant_echo(kind, prev, uuid))
+    {
+        return Ok(());
     }
     write_if_changed(&id_file, &format!("{uuid}\n"))
 }

--- a/src-tauri/src/agent_resume_persister.rs
+++ b/src-tauri/src/agent_resume_persister.rs
@@ -236,14 +236,25 @@ fn bind_marker_in_state_dir_with_policy(
     // scan can echo the abandoned original once the new transcript
     // goes idle; writing that echo would oscillate the marker. Skip
     // only the dormant-echo case so the marker never flaps.
-    if policy == MarkerBindPolicy::Inferred
-        && previous
-            .as_deref()
-            .is_some_and(|prev| marker_rollback_is_dormant_echo(kind, prev, uuid))
-    {
+    if marker_update_is_blocked(policy, previous.as_deref(), uuid, |prev, next| {
+        marker_rollback_is_dormant_echo(kind, prev, next)
+    }) {
         return Ok(());
     }
     write_if_changed(&id_file, &format!("{uuid}\n"))
+}
+
+fn marker_update_is_blocked<F>(
+    policy: MarkerBindPolicy,
+    previous: Option<&str>,
+    next: &str,
+    dormant_echo: F,
+) -> bool
+where
+    F: FnOnce(&str, &str) -> bool,
+{
+    policy == MarkerBindPolicy::Inferred
+        && previous.is_some_and(|previous| dormant_echo(previous, next))
 }
 
 fn id_filename(kind: AgentKind) -> &'static str {
@@ -477,6 +488,19 @@ mod tests {
         let previous = "019f2001-bbbb-76b0-8410-2e073b38a2c2";
         let resumed = "019e2001-aaaa-76b0-8410-2e073b38a2c1";
         fs::write(&marker, format!("{previous}\n")).unwrap();
+
+        assert!(marker_update_is_blocked(
+            MarkerBindPolicy::Inferred,
+            Some(previous),
+            resumed,
+            |_, _| true,
+        ));
+        assert!(!marker_update_is_blocked(
+            MarkerBindPolicy::ProviderDeclared,
+            Some(previous),
+            resumed,
+            |_, _| true,
+        ));
 
         bind_provider_marker_in_state_dir(&dir, AgentKind::Claude, resumed).unwrap();
 

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -462,10 +462,8 @@ else
   [ "$legacy_owner_session_id" = "$legacy_session_id" ] || exit 0
 fi
 
-# Forward the raw hook payload; Rust owns classification. Subagent
-# filtering, Stop-with-background-work suppression, and the event mapping
-# live in `parse_raw_claude_hook_request`, where real JSON parsing replaces
-# the field-boundary regexes this script used to carry.
+# Forward the raw hook payload with transport attribution. Rust owns
+# structured classification, including subagent filtering and Stop handling.
 
 # Resolve the hook endpoint at send time. Each app launch rewrites the
 # endpoint file with that run's server URL + token (the hook server binds a
@@ -2879,8 +2877,8 @@ done
         assert!(notify.contains("X-Acorn-Agent-Hook-Source: native"));
         assert!(notify.contains("X-Acorn-Agent-Hook-Token"));
         assert!(notify.contains("--data-binary @-"));
-        // Classification (subagent filter, Stop suppression, event mapping)
-        // moved to Rust — the script must not re-grow shell-side event logic.
+        // The notify helper is transport-only; classification belongs to the
+        // structured Rust adapter.
         assert!(!notify.contains("hook_event_name"));
         assert!(!notify.contains("agent_id"));
         assert!(!notify.contains("background_tasks"));
@@ -2964,9 +2962,8 @@ done
     #[cfg(unix)]
     #[test]
     fn claude_notify_forwards_raw_payload_for_owner_invocations() {
-        // Classification (subagent filter, Stop suppression, event mapping)
-        // lives in `parse_raw_claude_hook_request`; the script's only job is
-        // to deliver the payload byte-for-byte with transport attribution.
+        // Owner payloads reach the Rust adapter unchanged apart from
+        // insignificant trailing JSON whitespace.
         let payload = serde_json::json!({
             "hook_event_name": "Stop",
             "session_id": "019e4818-7c15-4e60-9b3b-898a1c7803d6",
@@ -3025,9 +3022,8 @@ done
         );
     }
 
-    // The Stop/background, subagent-filter, decoy, and attention-ordering
-    // scenarios that used to run against this script live in
-    // `agent_hooks::tests` now — classification moved to Rust wholesale.
+    // Classifier behavior lives in `agent_hooks::tests`; wrapper tests cover
+    // transport and invocation attribution only.
 
     #[test]
     fn writes_hook_endpoint_file_atomically_with_owner_only_perms() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -496,17 +496,16 @@ pub fn run() {
                         return agent_hooks::AgentHookHandlerOutcome::Conflict;
                     }
                 };
-                // A Claude hook payload names its own conversation UUID —
-                // ground truth from the provider. Binding it here makes the
-                // durable marker authoritative from the first turn event,
-                // instead of waiting for the persister's cwd+mtime inference
-                // (which stays on as fallback and multi-process arbiter).
+                // Claude names the active conversation directly. Bind that
+                // provider-owned identifier without applying transcript mtime
+                // heuristics; the PTY-tree scan remains the fallback and
+                // multi-process arbiter when hooks are unavailable.
                 if provider == acorn_session::SessionAgentProvider::Claude {
                     if let Some(claude_uuid) = provider_session_id
                         .as_deref()
                         .filter(|id| uuid::Uuid::parse_str(id).is_ok())
                     {
-                        if let Err(err) = agent_resume_persister::bind_session_marker(
+                        if let Err(err) = agent_resume_persister::bind_provider_session_marker(
                             session_id,
                             acorn_agent::AgentKind::Claude,
                             claude_uuid,


### PR DESCRIPTION
## Summary

This follow-up hardens the Claude resume-marker binding introduced in #669.

1. **Trust provider-declared markers** — route a validated Claude hook `session_id` through an authoritative bind policy so resuming an older conversation cannot be rejected as a dormant transcript echo.
2. **Preserve fallback arbitration** — keep the existing dormant rollback guard for PTY-tree and status-poll inference paths.
3. **Strengthen coverage and comments** — exercise the policy boundary directly and keep affected comments focused on current behavior.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Resume an older dormant Claude conversation | The hook-provided UUID could be silently rejected by the inferred-marker rollback guard | The validated provider UUID becomes the durable marker immediately |
| Background transcript inference sees a stale dormant conversation | Rollback is blocked | Unchanged; rollback remains blocked |
| Hook delivery is unavailable | PTY-tree scanning remains the fallback | Unchanged |

## Design notes

- `MarkerBindPolicy` selects whether the shared marker write path applies transcript activity heuristics.
- Provider and inferred writes still share the same process-wide lock and idempotent file write.
- The hook handler validates the Claude UUID before using the provider-declared path.
- Codex and Antigravity inference behavior is unchanged.

## Test plan

- [x] `cargo test -p acorn --lib agent_resume_persister::tests::provider_declared_bind_replaces_the_existing_marker -- --exact --nocapture`
- [x] `cargo test --workspace --all-targets --no-fail-fast` — all workspace targets passed; the main Acorn library reported 474 passed, 1 ignored
- [x] Changed Rust files pass targeted `rustfmt --check`
- [x] `git diff origin/main...HEAD --check`

## Notes

- Full `cargo fmt --all -- --check` still reports pre-existing formatting drift in `crates/acorn-daemon/src/protocol.rs`, `crates/acorn-ipc/src/bin/acorn-ipc.rs`, and `src/pty_env.rs`. These files are outside this PR and were not modified.