### PR TITLE
feat(canvas): add quick session actions and terminal overlays

### DIFF
--- a/src/components/WorkspaceCanvas.tsx
+++ b/src/components/WorkspaceCanvas.tsx
@@ -1,6 +1,10 @@
 import {
+  Bot,
+  ChevronDown,
+  CircleHelp,
   CirclePlus,
   GitBranch,
+  Maximize2,
   Minus,
   PanelsTopLeft,
   Plus,
@@ -18,14 +22,21 @@ import {
   useState,
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import {
   AgentProviderIcon,
   resolveSessionAgentProvider,
 } from "../lib/agentProvider";
+import { formatHotkey } from "../lib/hotkeys";
 import { basename } from "../lib/pathUtils";
 import type { TranslationKey, Translator } from "../lib/i18n";
+import {
+  PROJECT_SESSION_CREATE_ACTIONS,
+  type ProjectSessionCreateAction,
+} from "../lib/projectSessionCreateActions";
+import { useSettings } from "../lib/settings";
 import type { Session, SessionStatus } from "../lib/types";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
@@ -47,6 +58,7 @@ import {
 } from "../lib/workspaceCanvas";
 import { useAppStore } from "../store";
 import { Button, IconButton, StatusDot, type StatusTone } from "./ui";
+import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { Tooltip } from "./Tooltip";
 import { WorkspaceCanvasMinimap } from "./WorkspaceCanvasMinimap";
 
@@ -61,6 +73,17 @@ const STATUS_TONE: Record<SessionStatus, StatusTone> = {
   waiting_for_input: "warning",
   errored: "danger",
 };
+
+const STATUS_ICON_CLASS: Record<SessionStatus, string> = {
+  ready: "text-fg-muted",
+  working: "text-accent",
+  waiting_for_input: "text-warning",
+  errored: "text-danger",
+};
+
+const CANVAS_SESSION_CREATE_ACTIONS = PROJECT_SESSION_CREATE_ACTIONS.filter(
+  (action) => action.mode === "terminal",
+);
 
 const VIEWPORT_SAVE_DEBOUNCE_MS = 220;
 const WHEEL_ZOOM_SENSITIVITY = 0.0015;
@@ -94,6 +117,31 @@ function canvasElementScale(element: HTMLElement): number {
   if (element.offsetWidth <= 0 || rect.width <= 0) return 1;
   const scale = rect.width / element.offsetWidth;
   return Number.isFinite(scale) && scale > 0 ? scale : 1;
+}
+
+function canvasSessionCreateIcon(id: ProjectSessionCreateAction["id"]) {
+  switch (id) {
+    case "terminal":
+      return <CirclePlus size={12} />;
+    case "isolated":
+      return <GitBranch size={12} />;
+    case "control":
+      return <Bot size={12} />;
+    case "chat":
+      return null;
+  }
+}
+
+function dispatchCanvasSessionCreate(action: ProjectSessionCreateAction) {
+  const eventName =
+    action.id === "terminal"
+      ? "acorn:new-session"
+      : action.id === "isolated"
+        ? "acorn:new-isolated-session"
+        : action.id === "control"
+          ? "acorn:new-control-session"
+          : null;
+  if (eventName) window.dispatchEvent(new CustomEvent(eventName));
 }
 
 type AppStateSnapshot = ReturnType<typeof useAppStore.getState>;
@@ -134,6 +182,7 @@ export function WorkspaceCanvas({
 }: WorkspaceCanvasProps) {
   const t = useTranslation();
   const showToast = useToasts((state) => state.show);
+  const shortcuts = useSettings((state) => state.settings.shortcuts);
   const rootRef = useRef<HTMLElement | null>(null);
   const saveTimerRef = useRef<number | null>(null);
   const cancelPanRef = useRef<(() => void) | null>(null);
@@ -168,6 +217,15 @@ export function WorkspaceCanvas({
   const canvasRef = useRef(canvas);
   const resetUndoRef = useRef<WorkspaceCanvasState | null>(null);
   const [canUndoReset, setCanUndoReset] = useState(false);
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    sessionId: string | null;
+  } | null>(null);
+  const [createMenu, setCreateMenu] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
   const [containerSize, setContainerSize] = useState<WorkspaceCanvasSize>({
     width: 0,
     height: 0,
@@ -492,6 +550,21 @@ export function WorkspaceCanvas({
     store.setWorkspaceViewMode("panes");
   }, []);
 
+  const openExpanded = useCallback(
+    (sessionId: string) => {
+      activateNode(sessionId);
+      useAppStore.getState().openTerminalPopup(sessionId);
+      requestAnimationFrame(() => {
+        window.dispatchEvent(
+          new CustomEvent("acorn:focus-session", {
+            detail: { sessionId },
+          }),
+        );
+      });
+    },
+    [activateNode],
+  );
+
   const resetLayout = useCallback(() => {
     const previous = canvasRef.current;
     const next = resetWorkspaceCanvasState(reconciliationIds);
@@ -516,6 +589,105 @@ export function WorkspaceCanvas({
     persistCanvas(restored);
   }, [applyCanvas, persistCanvas, reconciliationIds]);
 
+  const contextSession = contextMenu?.sessionId
+    ? terminalSessions.find((session) => session.id === contextMenu.sessionId) ??
+      null
+    : null;
+  const sessionCreateMenuItems = useMemo<ContextMenuItem[]>(
+    () => [
+      {
+        type: "group-title",
+        label: canvasText(t, "workspace.canvas.contextCreateSession"),
+      },
+      ...CANVAS_SESSION_CREATE_ACTIONS.map((action) => ({
+        label: t(action.labelKey),
+        icon: canvasSessionCreateIcon(action.id),
+        shortcut: action.hotkeyId
+          ? formatHotkey(shortcuts[action.hotkeyId])
+          : undefined,
+        onClick: () => dispatchCanvasSessionCreate(action),
+      })),
+    ],
+    [shortcuts, t],
+  );
+  const contextMenuItems = useMemo<ContextMenuItem[]>(() => {
+    const items: ContextMenuItem[] = [];
+    if (contextSession) {
+      items.push(
+        {
+          type: "group-title",
+          label: canvasText(t, "workspace.canvas.contextSession"),
+        },
+        {
+          label: canvasText(t, "workspace.canvas.expandSession", {
+            name: contextSession.name,
+          }),
+          icon: <Maximize2 size={12} />,
+          onClick: () => openExpanded(contextSession.id),
+        },
+        {
+          label: canvasText(t, "workspace.canvas.openInPanes", {
+            name: contextSession.name,
+          }),
+          icon: <PanelsTopLeft size={12} />,
+          onClick: () => openInPanes(contextSession.id),
+        },
+      );
+    }
+    items.push(...sessionCreateMenuItems);
+    items.push(
+      {
+        type: "group-title",
+        label: canvasText(t, "workspace.canvas.contextLayout"),
+      },
+      {
+        label: canvasText(t, "workspace.canvas.fit"),
+        icon: <Scan size={12} />,
+        disabled: terminalSessions.length === 0,
+        onClick: () => fitAll(),
+      },
+      {
+        label: canvasText(t, "workspace.canvas.reset"),
+        icon: <RotateCcw size={12} />,
+        disabled: terminalSessions.length === 0,
+        onClick: resetLayout,
+      },
+    );
+    return items;
+  }, [
+    contextSession,
+    fitAll,
+    openExpanded,
+    openInPanes,
+    resetLayout,
+    sessionCreateMenuItems,
+    t,
+    terminalSessions.length,
+  ]);
+
+  const openCanvasContextMenu = useCallback(
+    (event: ReactMouseEvent<HTMLElement>) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (
+        target.closest("[data-workspace-canvas-toolbar]") ||
+        target.closest("[data-canvas-terminal-body]")
+      ) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      setCreateMenu(null);
+      const node = target.closest<HTMLElement>("[data-canvas-session-id]");
+      setContextMenu({
+        x: event.clientX,
+        y: event.clientY,
+        sessionId: node?.dataset.canvasSessionId ?? null,
+      });
+    },
+    [],
+  );
+
   const worldStyle: CSSProperties = {
     transform: `translate3d(${canvas.viewport.offset.x}px, ${canvas.viewport.offset.y}px, 0) scale(${canvas.viewport.zoom})`,
     transformOrigin: "0 0",
@@ -538,6 +710,7 @@ export function WorkspaceCanvas({
       data-testid="workspace-canvas"
       data-workspace-canvas
       onPointerDown={startPan}
+      onContextMenu={openCanvasContextMenu}
     >
       <div className="pointer-events-none absolute inset-0" style={gridStyle} />
       <div
@@ -563,7 +736,7 @@ export function WorkspaceCanvas({
               onCommit={(purpose, snap) =>
                 commitNode(session.id, purpose, snap)
               }
-              onOpenInPanes={() => openInPanes(session.id)}
+              onExpand={() => openExpanded(session.id)}
               t={t}
             />
           );
@@ -609,20 +782,25 @@ export function WorkspaceCanvas({
             )}
           </span>
         </span>
-        <Tooltip
-          label={canvasText(t, "workspace.canvas.newSession")}
-          side="bottom"
+        <Button
+          size="xs"
+          aria-label={canvasText(t, "workspace.canvas.contextCreateSession")}
+          aria-haspopup="menu"
+          aria-expanded={createMenu !== null}
+          onClick={(event) => {
+            const rect = event.currentTarget.getBoundingClientRect();
+            setContextMenu(null);
+            setCreateMenu((current) =>
+              current === null
+                ? { x: rect.left, y: rect.bottom + 4 }
+                : null,
+            );
+          }}
         >
-          <IconButton
-            aria-label={canvasText(t, "workspace.canvas.newSession")}
-            size="xs"
-            onClick={() =>
-              window.dispatchEvent(new CustomEvent("acorn:new-session"))
-            }
-          >
-            <CirclePlus size={12} />
-          </IconButton>
-        </Tooltip>
+          <CirclePlus size={12} />
+          {canvasText(t, "workspace.canvas.contextCreateSession")}
+          <ChevronDown size={12} aria-hidden="true" />
+        </Button>
         <span className="mx-0.5 h-4 w-px bg-border" aria-hidden="true" />
         <Tooltip
           label={canvasText(t, "workspace.canvas.zoomOut")}
@@ -680,6 +858,19 @@ export function WorkspaceCanvas({
             <RotateCcw size={12} />
           </IconButton>
         </Tooltip>
+        <Tooltip
+          label={canvasText(t, "workspace.canvas.hint")}
+          side="bottom"
+          delay={250}
+          multiline
+        >
+          <IconButton
+            aria-label={canvasText(t, "workspace.canvas.showHelp")}
+            size="xs"
+          >
+            <CircleHelp size={12} />
+          </IconButton>
+        </Tooltip>
         {canUndoReset ? (
           <Button
             aria-label={canvasText(t, "workspace.canvas.undoReset")}
@@ -716,11 +907,20 @@ export function WorkspaceCanvas({
         />
       ) : null}
 
-      {containerSize.width >= 600 && containerSize.height >= 360 ? (
-        <div className="pointer-events-none absolute bottom-3 left-3 z-20 rounded-full border border-border/80 bg-bg/75 px-3 py-1 font-mono text-[10px] text-fg-muted shadow-lg backdrop-blur">
-          {canvasText(t, "workspace.canvas.hint")}
-        </div>
-      ) : null}
+      <ContextMenu
+        open={createMenu !== null}
+        x={createMenu?.x ?? 0}
+        y={createMenu?.y ?? 0}
+        items={sessionCreateMenuItems}
+        onClose={() => setCreateMenu(null)}
+      />
+      <ContextMenu
+        open={contextMenu !== null}
+        x={contextMenu?.x ?? 0}
+        y={contextMenu?.y ?? 0}
+        items={contextMenuItems}
+        onClose={() => setContextMenu(null)}
+      />
     </section>
   );
 }
@@ -735,7 +935,7 @@ interface WorkspaceCanvasTerminalNodeProps {
     updater: (node: WorkspaceCanvasNode) => WorkspaceCanvasNode,
   ) => void;
   onCommit: (purpose: "move" | "resize", snap: boolean) => void;
-  onOpenInPanes: () => void;
+  onExpand: () => void;
   t: Translator;
 }
 
@@ -748,7 +948,7 @@ const WorkspaceCanvasTerminalNode = memo(
     onActivate,
     onUpdate,
     onCommit,
-    onOpenInPanes,
+    onExpand,
     t,
   }: WorkspaceCanvasTerminalNodeProps) {
     const bodyRef = useRef<HTMLDivElement | null>(null);
@@ -939,18 +1139,20 @@ const WorkspaceCanvasTerminalNode = memo(
             onFocus={onActivate}
             aria-pressed={active}
           >
-            <StatusDot
-              tone={STATUS_TONE[session.status]}
-              size="sm"
-              pulse={session.status === "working"}
-            />
             {provider ? (
               <AgentProviderIcon
                 provider={provider}
-                className="size-3 text-fg-muted"
+                className={`size-3 animate-pulse ${STATUS_ICON_CLASS[session.status]}`}
               />
             ) : (
-              <TerminalIcon size={12} className="shrink-0 text-fg-muted" />
+              <>
+                <StatusDot
+                  tone={STATUS_TONE[session.status]}
+                  size="sm"
+                  pulse={session.status === "working"}
+                />
+                <TerminalIcon size={12} className="shrink-0 text-fg-muted" />
+              </>
             )}
             <span className="min-w-0 flex-1 truncate text-xs font-medium text-fg">
               {session.name}
@@ -963,19 +1165,20 @@ const WorkspaceCanvasTerminalNode = memo(
             ) : null}
           </button>
           <Tooltip
-            label={canvasText(t, "workspace.canvas.openInPanes", {
+            label={canvasText(t, "workspace.canvas.expandSession", {
               name: session.name,
             })}
             side="bottom"
           >
             <IconButton
-              aria-label={canvasText(t, "workspace.canvas.openInPanes", {
+              aria-label={canvasText(t, "workspace.canvas.expandSession", {
                 name: session.name,
               })}
               size="xs"
-              onClick={onOpenInPanes}
+              data-testid="workspace-canvas-node-expand"
+              onClick={onExpand}
             >
-              <PanelsTopLeft size={12} />
+              <Maximize2 size={12} />
             </IconButton>
           </Tooltip>
         </header>

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -253,8 +253,8 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
   });
 
   useEffect(() => {
-    if (!isKanban) closeTerminalPopup();
-  }, [closeTerminalPopup, isKanban]);
+    if (!isKanban && !isCanvas) closeTerminalPopup();
+  }, [closeTerminalPopup, isCanvas, isKanban]);
 
   return (
     <div className="h-full min-w-0 overflow-hidden" data-workspace-main>
@@ -280,6 +280,7 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
             workspaceSessionIds={workspaceSessionIds}
             sessions={sessions}
           />
+          <CanvasTerminalPopoverOverlay sessions={sessions} />
           <WorkspaceTabPreviewOverlay />
         </div>
       ) : null}
@@ -297,6 +298,56 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
       </div>
     </div>
   );
+}
+
+function CanvasTerminalPopoverOverlay({
+  sessions,
+}: {
+  sessions: readonly Session[];
+}) {
+  const terminalPopupSessionId = useAppStore((s) => s.terminalPopupSessionId);
+  const closeTerminalPopup = useAppStore((s) => s.closeTerminalPopup);
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  const session = terminalPopupSessionId
+    ? sessions.find((candidate) => candidate.id === terminalPopupSessionId) ??
+      null
+    : null;
+
+  useLayoutEffect(() => {
+    if (!terminalPopupSessionId) {
+      setAnchor((current) => (current ? null : current));
+      return;
+    }
+    if (!session) {
+      closeTerminalPopup();
+      return;
+    }
+    const nextAnchor = document.querySelector<HTMLElement>(
+      `[data-canvas-session-id="${cssAttributeEscape(terminalPopupSessionId)}"]`,
+    );
+    if (!nextAnchor) {
+      closeTerminalPopup();
+      return;
+    }
+    setAnchor((current) => (current === nextAnchor ? current : nextAnchor));
+  }, [closeTerminalPopup, session, terminalPopupSessionId]);
+
+  const close = useCallback(() => {
+    const returnFocus = anchor?.querySelector<HTMLElement>(
+      '[data-testid="workspace-canvas-node-expand"]',
+    );
+    closeTerminalPopup();
+    setAnchor(null);
+    if (returnFocus) requestAnimationFrame(() => returnFocus.focus());
+  }, [anchor, closeTerminalPopup]);
+
+  return session && anchor ? (
+    <KanbanTerminalPopover
+      session={session}
+      anchor={anchor}
+      onClose={close}
+    />
+  ) : null;
 }
 
 function WorkspaceTabPreviewOverlay() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -952,7 +952,8 @@
       "regionLabel": "Workspace canvas",
       "toolbarLabel": "Canvas controls",
       "empty": "No terminal sessions on this canvas. Chat sessions stay available in Panes.",
-      "hint": "Drag empty space or middle-drag to pan · Pinch or modifier-scroll to zoom · Alt skips snapping",
+      "hint": "Right-click for session actions · Drag empty space or middle-drag to pan · Pinch or modifier-scroll to zoom · Alt skips snapping",
+      "showHelp": "Show canvas controls help",
       "terminalCountOne": "1 terminal",
       "terminalCountOther": "{count} terminals",
       "zoomOut": "Zoom out",
@@ -968,8 +969,12 @@
       "overviewCollapse": "Collapse canvas overview",
       "overviewExpand": "Expand canvas overview",
       "newSession": "New session",
+      "contextSession": "Session",
+      "contextCreateSession": "Create session",
+      "contextLayout": "Layout",
       "moveSession": "Move {name}",
       "resizeSession": "Resize {name}",
+      "expandSession": "Expand {name}",
       "openInPanes": "Open {name} in panes"
     },
     "kanban": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -952,7 +952,8 @@
       "regionLabel": "작업공간 캔버스",
       "toolbarLabel": "캔버스 도구",
       "empty": "이 캔버스에 터미널 세션이 없습니다. 채팅 세션은 패널에서 계속 사용할 수 있습니다.",
-      "hint": "빈 공간 또는 가운데 버튼 드래그: 이동 · 핀치/보조키+스크롤: 확대·축소 · Alt: 스냅 해제",
+      "hint": "우클릭: 세션 메뉴 · 빈 공간 또는 가운데 버튼 드래그: 이동 · 핀치/보조키+스크롤: 확대·축소 · Alt: 스냅 해제",
+      "showHelp": "캔버스 조작 도움말 보기",
       "terminalCountOne": "터미널 1개",
       "terminalCountOther": "터미널 {count}개",
       "zoomOut": "축소",
@@ -968,8 +969,12 @@
       "overviewCollapse": "캔버스 미니맵 접기",
       "overviewExpand": "캔버스 미니맵 펼치기",
       "newSession": "새 세션",
+      "contextSession": "세션",
+      "contextCreateSession": "세션 만들기",
+      "contextLayout": "레이아웃",
       "moveSession": "{name} 이동",
       "resizeSession": "{name} 크기 조절",
+      "expandSession": "{name} 크게 보기",
       "openInPanes": "패널에서 {name} 열기"
     },
     "kanban": {

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -35,6 +35,164 @@ function session(id: string, repoPath = PROJECT.repo_path) {
 }
 
 test.describe("workspace canvas mode", () => {
+  test("uses a pulsing live-agent icon instead of the status dot", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      {
+        ...session("alpha"),
+        status: "waiting_for_input",
+        agent_provider: "codex",
+      },
+      session("beta"),
+    ]);
+
+    await page.goto("/");
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Canvas" }).click();
+
+    const alpha = page.locator('[data-canvas-session-id="alpha"]');
+    const liveAgent = alpha.getByRole("img", { name: "Codex" });
+    await expect(liveAgent).toBeVisible();
+    await expect(liveAgent).toHaveClass(/animate-pulse/);
+    await expect(alpha.locator("header .rounded-full")).toHaveCount(0);
+
+    const beta = page.locator('[data-canvas-session-id="beta"]');
+    await expect(beta.locator("header .rounded-full")).toHaveCount(1);
+    await expect(beta.getByRole("img")).toHaveCount(0);
+  });
+
+  test("creates sessions from canvas menus and expands a terminal without leaving canvas", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __canvasSessions?: Array<Record<string, unknown>>;
+      };
+      w.__canvasSessions = w.__canvasSessions ?? [];
+      return w.__canvasSessions;
+    });
+    await tauri.handle("create_session", (args) => {
+      const input = args as Record<string, unknown>;
+      const w = window as unknown as {
+        __canvasCreateCalls?: Array<Record<string, unknown>>;
+        __canvasSessions?: Array<Record<string, unknown>>;
+      };
+      w.__canvasCreateCalls = [...(w.__canvasCreateCalls ?? []), input];
+      const repoPath =
+        typeof input.repoPath === "string" ? input.repoPath : "/tmp/demo";
+      const created = {
+        id: "canvas-created",
+        name: "canvas-created",
+        repo_path: repoPath,
+        worktree_path: repoPath,
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        mode: "terminal",
+        owner: { kind: "user" },
+        position: null,
+        in_worktree: false,
+      };
+      w.__canvasSessions = [...(w.__canvasSessions ?? []), created];
+      return created;
+    });
+
+    await page.goto("/");
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Canvas" }).click();
+
+    const canvas = page.getByTestId("workspace-canvas");
+    const canvasBox = await canvas.boundingBox();
+    if (!canvasBox) throw new Error("Canvas is not visible");
+    await canvas.click({
+      button: "right",
+      position: { x: canvasBox.width / 2, y: canvasBox.height / 2 },
+    });
+    await expect(
+      page.getByRole("menuitem", { name: "New session", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", {
+        name: "New worktree session",
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", {
+        name: "New control session",
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "New chat session", exact: true }),
+    ).toHaveCount(0);
+    await page.keyboard.press("Escape");
+
+    const createButton = canvas.getByRole("button", {
+      name: "Create session",
+    });
+    await createButton.click();
+    await page
+      .getByRole("menuitem", { name: "New session", exact: true })
+      .click();
+
+    const node = canvas.locator(
+      '[data-canvas-session-id="canvas-created"]',
+    );
+    await expect(node).toBeVisible();
+    const calls = await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __canvasCreateCalls?: Array<Record<string, unknown>>;
+          }
+        ).__canvasCreateCalls ?? [],
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      repoPath: "/tmp/demo",
+      isolated: false,
+      kind: "regular",
+    });
+
+    await node.getByRole("button", { name: "Expand canvas-created" }).click();
+    const popover = page.getByTestId("kanban-terminal-popover");
+    await expect(popover).toBeVisible();
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Canvas",
+    );
+    await expect(
+      popover.locator('[data-acorn-terminal-slot="canvas-created"]'),
+    ).toBeAttached();
+
+    await popover.getByRole("button", { name: "Close" }).click();
+    await expect(popover).toHaveCount(0);
+    await expect(
+      node.locator('[data-acorn-terminal-slot="canvas-created"]'),
+    ).toBeAttached();
+
+    await node
+      .getByTestId("workspace-canvas-node-drag-handle")
+      .click({ button: "right" });
+    await page
+      .getByRole("menuitem", { name: "Open canvas-created in panes" })
+      .click();
+    await expect(page.getByTestId("workspace-view-status")).toContainText(
+      "Panes",
+    );
+  });
+
   test("moves, resizes, zooms, and restores live terminal nodes", async ({
     page,
     tauri,
@@ -50,6 +208,17 @@ test.describe("workspace canvas mode", () => {
     const nodes = canvas.getByTestId("workspace-canvas-node");
     const alpha = canvas.locator('[data-canvas-session-id="alpha"]');
     await expect(canvas).toBeVisible();
+    await expect(
+      canvas.getByText("Right-click for session actions", { exact: false }),
+    ).toHaveCount(0);
+    await canvas
+      .getByRole("button", { name: "Show canvas controls help" })
+      .hover();
+    await expect(page.getByRole("tooltip")).toContainText(
+      "Right-click for session actions",
+    );
+    await canvas.getByRole("button", { name: "Move alpha" }).hover();
+    await expect(page.getByRole("tooltip")).toHaveCount(0);
     await expect(nodes).toHaveCount(2);
     await expect(
       alpha.locator(


### PR DESCRIPTION
## Summary

Canvas mode now keeps session creation, terminal expansion, and interaction guidance inside the canvas workflow.

1. **Faster session creation** — replace the fixed create button with a Kanban-style dropdown and add blank-canvas or node context menus for session actions.
2. **In-place terminal expansion** — replace the pane-switch title action with the shared terminal overlay while retaining an explicit Open in panes context action.
3. **Clearer session state** — show one pulsing provider icon whenever an agent is attached instead of duplicating it beside the status dot.
4. **Less visual noise** — move persistent canvas instructions behind a help tooltip with hover and keyboard-focus access.

## Expected impact

| Flow | Before | After |
| --- | --- | --- |
| Session creation | One fixed top-bar action | Regular, worktree, and control sessions from a dropdown or context menu |
| Terminal focus | Title action leaves Canvas for panes | Terminal expands in an overlay without leaving Canvas |
| Agent status | Status dot and provider icon appear together | One pulsing provider icon communicates the live agent state |
| Canvas guidance | Instruction pill is always visible | Guidance appears on demand from the help icon |

## Design notes

- Session creation continues through the existing global creation events, preserving established repository and session-kind behavior.
- Chat sessions remain excluded because Canvas mode only renders terminal-backed sessions.
- The overlay reuses the existing terminal popup state, shared terminal host portal, and Kanban terminal popover so the live terminal is moved rather than remounted.
- Right-clicks inside terminal bodies are left untouched so native terminal context behavior remains available.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 96 files and 1,058 tests passed
- [x] `pnpm exec playwright test tests/e2e/canvas.spec.ts` — 7 tests passed
- [x] `pnpm run build`
- [x] `git diff --check`

## Notes

- The production build passes with the existing Vite mixed static/dynamic import and chunk-size warnings; these warnings are not introduced by this PR.