### PR TITLE
feat(status): spool and replay hook events lost while the app is closed

### DIFF
--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -1773,11 +1773,13 @@ struct SpooledTransportMeta {
 
 /// Drain the notify scripts' spool directory: events POSTed while no app
 /// instance was listening land there instead of being dropped. Files are
-/// named `<unix-ts>-<pid>.json`, so a lexicographic sort approximates
-/// arrival order (sub-second ordering between two writers is unknowable —
-/// the reducer's stale-event rejection absorbs that). Every file is
-/// consumed regardless of outcome so a malformed or permanently rejected
-/// event can never wedge the replay.
+/// named `<unix-ts>-<pid>.json` and replay in numeric (timestamp, pid)
+/// order. Ordering within one second is best-effort — pid order is not
+/// arrival order — so a mis-ordered same-second pair can leave a stale
+/// status until the session's next live event corrects it; the pre-spool
+/// behavior was losing both events outright. Every file is consumed
+/// regardless of outcome so a malformed or permanently rejected event can
+/// never wedge the replay.
 pub fn replay_spooled_hook_events<F>(spool_dir: &std::path::Path, handler: F) -> usize
 where
     F: Fn(AgentHookEvent) -> AgentHookHandlerOutcome,
@@ -1790,7 +1792,7 @@ where
         .map(|entry| entry.path())
         .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
         .collect();
-    files.sort();
+    files.sort_by_key(|path| spool_replay_order_key(path));
     let mut replayed = 0;
     for path in files {
         match parse_spooled_hook_event(&path) {
@@ -1810,6 +1812,22 @@ where
         let _ = std::fs::remove_file(&path);
     }
     replayed
+}
+
+/// Numeric sort key for `<unix-ts>-<pid>.json` spool names: a string sort
+/// would order `"21000"` before `"3000"` on a same-second tie. Unparseable
+/// names sort last, tie-broken by the full path for determinism.
+fn spool_replay_order_key(path: &std::path::Path) -> (u64, u64, std::path::PathBuf) {
+    let stem = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("");
+    let (ts, pid) = stem.split_once('-').unwrap_or((stem, ""));
+    (
+        ts.parse::<u64>().unwrap_or(u64::MAX),
+        pid.parse::<u64>().unwrap_or(u64::MAX),
+        path.to_path_buf(),
+    )
 }
 
 fn parse_spooled_hook_event(path: &std::path::Path) -> Result<Option<AgentHookEvent>, String> {
@@ -2907,6 +2925,53 @@ mod tests {
         assert!(
             leftover.is_empty(),
             "all spooled events must be consumed: {leftover:?}"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn replay_spool_order_is_numeric_not_lexicographic() {
+        let dir =
+            std::env::temp_dir().join(format!("acorn-spool-order-{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let session_id = Uuid::new_v4();
+        let claude_uuid = "019e4818-7c15-4e60-9b3b-898a1c7803d6";
+        let meta =
+            format!(r#"{{"provider":"claude","session_id":"{session_id}","source":"native"}}"#);
+        let start_body = serde_json::json!({
+            "session_id": claude_uuid,
+            "hook_event_name": "UserPromptSubmit",
+        });
+        let stop_body = serde_json::json!({
+            "session_id": claude_uuid,
+            "hook_event_name": "Stop",
+            "background_tasks": [],
+            "session_crons": [],
+        });
+        // Same second; pid 9 wrote first, pid 100 second. A string sort
+        // would replay "…-100.json" before "…-9.json" and end on Start.
+        std::fs::write(
+            dir.join("1700000001-9.json"),
+            format!("{meta}\n{start_body}"),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("1700000001-100.json"),
+            format!("{meta}\n{stop_body}"),
+        )
+        .unwrap();
+
+        let seen = Mutex::new(Vec::new());
+        let replayed = super::replay_spooled_hook_events(&dir, |event| {
+            seen.lock().unwrap().push(event.event);
+            AgentHookHandlerOutcome::Applied
+        });
+
+        assert_eq!(replayed, 2);
+        assert_eq!(
+            seen.into_inner().unwrap(),
+            vec![AgentHookEventKind::Start, AgentHookEventKind::NeedsInput],
+            "same-second ties must break on numeric pid order",
         );
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -1751,6 +1751,111 @@ fn validate_request(request: &[u8], token: &str, handler: &HookEventHandler) -> 
     }
 }
 
+/// Transport metadata line at the head of a spooled hook event file — the
+/// headers the original POST carried. An empty object means the body is a
+/// self-describing normalized envelope (Antigravity, legacy Codex shape)
+/// that parses through the generic header-less branch.
+#[derive(Debug, Default, Deserialize)]
+struct SpooledTransportMeta {
+    #[serde(default)]
+    provider: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default)]
+    lifecycle_id: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    native_hooks_enabled: Option<String>,
+}
+
+/// Drain the notify scripts' spool directory: events POSTed while no app
+/// instance was listening land there instead of being dropped. Files are
+/// named `<unix-ts>-<pid>.json`, so a lexicographic sort approximates
+/// arrival order (sub-second ordering between two writers is unknowable —
+/// the reducer's stale-event rejection absorbs that). Every file is
+/// consumed regardless of outcome so a malformed or permanently rejected
+/// event can never wedge the replay.
+pub fn replay_spooled_hook_events<F>(spool_dir: &std::path::Path, handler: F) -> usize
+where
+    F: Fn(AgentHookEvent) -> AgentHookHandlerOutcome,
+{
+    let Ok(entries) = std::fs::read_dir(spool_dir) else {
+        return 0;
+    };
+    let mut files: Vec<std::path::PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    files.sort();
+    let mut replayed = 0;
+    for path in files {
+        match parse_spooled_hook_event(&path) {
+            Ok(Some(event)) => {
+                handler(event);
+                replayed += 1;
+            }
+            Ok(None) => {}
+            Err(err) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %err,
+                    "spooled agent hook event rejected",
+                );
+            }
+        }
+        let _ = std::fs::remove_file(&path);
+    }
+    replayed
+}
+
+fn parse_spooled_hook_event(path: &std::path::Path) -> Result<Option<AgentHookEvent>, String> {
+    let metadata = std::fs::metadata(path).map_err(|err| err.to_string())?;
+    if metadata.len() > MAX_BODY_BYTES as u64 {
+        return Err("spooled event exceeds size limit".to_string());
+    }
+    let raw = std::fs::read(path).map_err(|err| err.to_string())?;
+    let meta_end = raw
+        .iter()
+        .position(|byte| *byte == b'\n')
+        .ok_or_else(|| "missing transport metadata line".to_string())?;
+    let meta: SpooledTransportMeta =
+        serde_json::from_slice(&raw[..meta_end]).map_err(|err| err.to_string())?;
+    let head = synthetic_request_head(&meta)?;
+    parse_agent_hook_request(&head, &raw[meta_end + 1..])
+}
+
+/// Rebuild the HTTP request head the spooled POST would have carried so a
+/// replayed event travels the exact same parse path as a live one.
+fn synthetic_request_head(meta: &SpooledTransportMeta) -> Result<String, String> {
+    let mut head = String::from("POST /agent-hook HTTP/1.1");
+    for (name, value) in [
+        ("x-acorn-agent-hook-provider", &meta.provider),
+        ("x-acorn-agent-hook-session-id", &meta.session_id),
+        ("x-acorn-agent-hook-source", &meta.source),
+        ("x-acorn-codex-lifecycle-id", &meta.lifecycle_id),
+        ("x-acorn-codex-version", &meta.version),
+        (
+            "x-acorn-codex-native-hooks-enabled",
+            &meta.native_hooks_enabled,
+        ),
+    ] {
+        if let Some(value) = value {
+            if value.chars().any(char::is_control) {
+                return Err(format!("control characters in spooled {name}"));
+            }
+            head.push_str("\r\n");
+            head.push_str(name);
+            head.push_str(": ");
+            head.push_str(value);
+        }
+    }
+    Ok(head)
+}
+
 fn parse_agent_hook_request(head: &str, body: &[u8]) -> Result<Option<AgentHookEvent>, String> {
     match header_value(head, "x-acorn-agent-hook-provider") {
         Some("codex") => parse_raw_codex_hook_request(head, body),
@@ -2712,6 +2817,135 @@ mod tests {
         ));
         assert!(!reducer.lanes.contains_key(&removed_id));
         assert_eq!(reducer.lanes.len(), 1);
+    }
+
+    #[test]
+    fn replay_spooled_hook_events_drains_in_order_and_consumes_files() {
+        let dir = std::env::temp_dir().join(format!("acorn-spool-{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let session_id = Uuid::new_v4();
+        let claude_uuid = "019e4818-7c15-4e60-9b3b-898a1c7803d6";
+
+        let meta =
+            format!(r#"{{"provider":"claude","session_id":"{session_id}","source":"native"}}"#);
+        let start_body = serde_json::json!({
+            "session_id": claude_uuid,
+            "hook_event_name": "UserPromptSubmit",
+        });
+        let stop_body = serde_json::json!({
+            "session_id": claude_uuid,
+            "hook_event_name": "Stop",
+            "background_tasks": [],
+            "session_crons": [],
+        });
+        std::fs::write(
+            dir.join("1700000001-100.json"),
+            format!("{meta}\n{start_body}"),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("1700000002-101.json"),
+            format!("{meta}\n{stop_body}"),
+        )
+        .unwrap();
+        // A subagent event is classified away, not replayed — but consumed.
+        let child_body = serde_json::json!({
+            "session_id": claude_uuid,
+            "hook_event_name": "Stop",
+            "agent_id": "019f6338-6250-7303-88a6-a7add31dba1d",
+        });
+        std::fs::write(
+            dir.join("1700000003-102.json"),
+            format!("{meta}\n{child_body}"),
+        )
+        .unwrap();
+        // Malformed metadata is rejected and consumed.
+        std::fs::write(dir.join("1700000004-103.json"), "not-json\n{}").unwrap();
+        // Header-injection through metadata values fails closed and is consumed.
+        std::fs::write(
+            dir.join("1700000005-104.json"),
+            format!(
+                "{}\n{}",
+                r#"{"provider":"claude","session_id":"x\r\nx-acorn-agent-hook-provider: codex","source":"native"}"#,
+                start_body
+            ),
+        )
+        .unwrap();
+        // A header-less envelope parses through the generic branch.
+        let envelope = serde_json::json!({
+            "session_id": session_id,
+            "provider": "antigravity",
+            "event": "needs_input",
+            "source": "transcript",
+        });
+        std::fs::write(dir.join("1700000006-105.json"), format!("{{}}\n{envelope}")).unwrap();
+        // In-flight tmp files are not picked up.
+        std::fs::write(dir.join(".tmp-106"), "partial").unwrap();
+
+        let seen = Mutex::new(Vec::new());
+        let replayed = super::replay_spooled_hook_events(&dir, |event| {
+            seen.lock().unwrap().push(event);
+            AgentHookHandlerOutcome::Applied
+        });
+
+        assert_eq!(replayed, 3);
+        let seen = seen.into_inner().unwrap();
+        assert_eq!(seen[0].event, AgentHookEventKind::Start);
+        assert_eq!(seen[0].provider, SessionAgentProvider::Claude);
+        assert_eq!(seen[0].session_id, session_id);
+        assert_eq!(seen[0].provider_session_id.as_deref(), Some(claude_uuid));
+        assert_eq!(seen[0].source.as_deref(), Some("native"));
+        assert_eq!(seen[1].event, AgentHookEventKind::NeedsInput);
+        assert_eq!(seen[2].provider, SessionAgentProvider::Antigravity);
+        assert_eq!(seen[2].source.as_deref(), Some("transcript"));
+        let leftover: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.ends_with(".json"))
+            .collect();
+        assert!(
+            leftover.is_empty(),
+            "all spooled events must be consumed: {leftover:?}"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn replay_spooled_codex_meta_reconstructs_transport_headers() {
+        let dir =
+            std::env::temp_dir().join(format!("acorn-spool-codex-{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let session_id = Uuid::new_v4();
+        let meta = format!(
+            r#"{{"provider":"codex","session_id":"{session_id}","source":"native","lifecycle_id":"123_456","version":"0.144.4","native_hooks_enabled":"1"}}"#
+        );
+        let body = serde_json::json!({
+            "session_id": "019f6338-6021-77d0-9120-54428d3e2a42",
+            "turn_id": "019f6338-6250-7303-88a6-a7add31dba1d",
+            "hook_event_name": "UserPromptSubmit",
+        });
+        std::fs::write(dir.join("1700000001-100.json"), format!("{meta}\n{body}")).unwrap();
+
+        let seen = Mutex::new(Vec::new());
+        let replayed = super::replay_spooled_hook_events(&dir, |event| {
+            seen.lock().unwrap().push(event);
+            AgentHookHandlerOutcome::Applied
+        });
+
+        assert_eq!(replayed, 1);
+        let seen = seen.into_inner().unwrap();
+        assert_eq!(seen[0].session_id, session_id);
+        assert_eq!(seen[0].provider, SessionAgentProvider::Codex);
+        assert_eq!(seen[0].event, AgentHookEventKind::Start);
+        assert_eq!(seen[0].source.as_deref(), Some("native_prompt"));
+        assert_eq!(seen[0].lifecycle_id.as_deref(), Some("123_456"));
+        assert_eq!(
+            seen[0].provider_turn_id.as_deref(),
+            Some("019f6338-6250-7303-88a6-a7add31dba1d")
+        );
+        assert_eq!(seen[0].native_hooks_enabled, Some(true));
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     #[test]

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -14,6 +14,7 @@ const CLAUDE_SETTINGS_NAME: &str = "acorn-claude-settings.json";
 const ANTIGRAVITY_WRAPPER_NAME: &str = "agy";
 const ANTIGRAVITY_NOTIFY_NAME: &str = "acorn-antigravity-notify";
 const HOOK_ENDPOINT_NAME: &str = "agent-hook-endpoint";
+const HOOK_SPOOL_DIR_NAME: &str = "agent-hook-spool";
 
 const CODEX_WRAPPER_BODY: &str = r#"#!/bin/sh
 _acorn_wrapper_dir="${ACORN_AGENT_WRAPPER_DIR-}"
@@ -310,6 +311,28 @@ if [ "$source" = "legacy_completion" ]; then
   fi
 fi
 
+# Spool this event when the POST fails: a wrapper-owned PTY outlives the
+# app, and a dropped POST here is a lost lifecycle transition. Line 1 is
+# the transport metadata the POST carried; the rest is the raw body. The
+# app drains and replays this directory on its next boot.
+_acorn_spool_event() {
+  [ -n "${ACORN_AGENT_WRAPPER_DIR-}" ] || return 0
+  _acorn_spool_dir="$ACORN_AGENT_WRAPPER_DIR/agent-hook-spool"
+  (umask 077; mkdir -p "$_acorn_spool_dir") 2>/dev/null || return 0
+  set -- "$_acorn_spool_dir"/*.json
+  if [ "$#" -ge 512 ] && [ -e "$1" ]; then
+    return 0
+  fi
+  _acorn_spool_tmp="$_acorn_spool_dir/.tmp-$$"
+  {
+    printf '%s\n' "$_acorn_spool_meta"
+    printf '%s' "$_acorn_spool_body"
+  } > "$_acorn_spool_tmp" 2>/dev/null || { rm -f "$_acorn_spool_tmp" 2>/dev/null; return 0; }
+  chmod 600 "$_acorn_spool_tmp" 2>/dev/null || true
+  mv "$_acorn_spool_tmp" "$_acorn_spool_dir/$(date +%s 2>/dev/null || echo 0)-$$.json" 2>/dev/null ||
+    rm -f "$_acorn_spool_tmp" 2>/dev/null
+}
+
 # Resolve the current app instance at send time so daemon-owned terminals
 # survive app restarts without retaining a stale port or token.
 hook_url=""
@@ -322,11 +345,16 @@ if [ -z "$hook_url" ] || [ -z "$hook_token" ]; then
   hook_url="${ACORN_AGENT_HOOK_URL-}"
   hook_token="${ACORN_AGENT_HOOK_TOKEN-}"
 fi
-[ -n "$hook_url" ] || exit 0
-[ -n "$hook_token" ] || exit 0
 [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] || exit 0
 
 if [ "$raw_contract" = "1" ]; then
+  _acorn_spool_meta=$(printf '{"provider":"codex","session_id":"%s","source":"%s","lifecycle_id":"%s","version":"%s","native_hooks_enabled":"%s"}' \
+    "$ACORN_AGENT_HOOK_SESSION_ID" "$source" "${ACORN_CODEX_LIFECYCLE_ID-}" "${ACORN_CODEX_VERSION-unknown}" "${ACORN_CODEX_NATIVE_HOOKS_ENABLED-0}")
+  _acorn_spool_body="$input"
+  if [ -z "$hook_url" ] || [ -z "$hook_token" ]; then
+    _acorn_spool_event
+    exit 0
+  fi
   printf '%s' "$input" | curl -sf --connect-timeout 1 --max-time 1 -X POST \
     -H 'Content-Type: application/json' \
     -H "X-Acorn-Agent-Hook-Token: $hook_token" \
@@ -337,7 +365,7 @@ if [ "$raw_contract" = "1" ]; then
     -H "X-Acorn-Codex-Version: ${ACORN_CODEX_VERSION-unknown}" \
     -H "X-Acorn-Codex-Native-Hooks-Enabled: ${ACORN_CODEX_NATIVE_HOOKS_ENABLED-0}" \
     --data-binary @- \
-    "$hook_url" >/dev/null 2>&1 || true
+    "$hook_url" >/dev/null 2>&1 || _acorn_spool_event
   exit 0
 fi
 
@@ -353,11 +381,17 @@ case "${source:-hook}" in
   *) source="hook" ;;
 esac
 payload=$(printf '{"session_id":"%s","provider":"codex","event":"%s","source":"%s"}' "$ACORN_AGENT_HOOK_SESSION_ID" "$event" "${source:-hook}")
+_acorn_spool_meta='{}'
+_acorn_spool_body="$payload"
+if [ -z "$hook_url" ] || [ -z "$hook_token" ]; then
+  _acorn_spool_event
+  exit 0
+fi
 printf '%s' "$payload" | curl -sf --connect-timeout 1 --max-time 1 -X POST \
   -H 'Content-Type: application/json' \
   -H "X-Acorn-Agent-Hook-Token: $hook_token" \
   --data-binary @- \
-  "$hook_url" >/dev/null 2>&1 || true
+  "$hook_url" >/dev/null 2>&1 || _acorn_spool_event
 "#;
 
 // Claude Code wrapper.
@@ -467,6 +501,28 @@ fi
 # live in `parse_raw_claude_hook_request`, where real JSON parsing replaces
 # the field-boundary regexes this script used to carry.
 
+# Spool this event when the POST fails: a wrapper-owned PTY outlives the
+# app, and a dropped POST here is a lost lifecycle transition. Line 1 is
+# the transport metadata the POST carried; the rest is the raw body. The
+# app drains and replays this directory on its next boot.
+_acorn_spool_event() {
+  [ -n "${ACORN_AGENT_WRAPPER_DIR-}" ] || return 0
+  _acorn_spool_dir="$ACORN_AGENT_WRAPPER_DIR/agent-hook-spool"
+  (umask 077; mkdir -p "$_acorn_spool_dir") 2>/dev/null || return 0
+  set -- "$_acorn_spool_dir"/*.json
+  if [ "$#" -ge 512 ] && [ -e "$1" ]; then
+    return 0
+  fi
+  _acorn_spool_tmp="$_acorn_spool_dir/.tmp-$$"
+  {
+    printf '%s\n' "$_acorn_spool_meta"
+    printf '%s' "$_acorn_spool_body"
+  } > "$_acorn_spool_tmp" 2>/dev/null || { rm -f "$_acorn_spool_tmp" 2>/dev/null; return 0; }
+  chmod 600 "$_acorn_spool_tmp" 2>/dev/null || true
+  mv "$_acorn_spool_tmp" "$_acorn_spool_dir/$(date +%s 2>/dev/null || echo 0)-$$.json" 2>/dev/null ||
+    rm -f "$_acorn_spool_tmp" 2>/dev/null
+}
+
 # Resolve the hook endpoint at send time. Each app launch rewrites the
 # endpoint file with that run's server URL + token (the hook server binds a
 # fresh port and token per run), so an agent session that outlives an app
@@ -482,9 +538,13 @@ if [ -z "$hook_url" ] || [ -z "$hook_token" ]; then
   hook_url="${ACORN_AGENT_HOOK_URL-}"
   hook_token="${ACORN_AGENT_HOOK_TOKEN-}"
 fi
-[ -n "$hook_url" ] || exit 0
-[ -n "$hook_token" ] || exit 0
 [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] || exit 0
+_acorn_spool_meta=$(printf '{"provider":"claude","session_id":"%s","source":"native"}' "$ACORN_AGENT_HOOK_SESSION_ID")
+_acorn_spool_body="$input"
+if [ -z "$hook_url" ] || [ -z "$hook_token" ]; then
+  _acorn_spool_event
+  exit 0
+fi
 
 printf '%s' "$input" | curl -sf --connect-timeout 1 --max-time 1 -X POST \
   -H 'Content-Type: application/json' \
@@ -493,7 +553,7 @@ printf '%s' "$input" | curl -sf --connect-timeout 1 --max-time 1 -X POST \
   -H "X-Acorn-Agent-Hook-Session-Id: $ACORN_AGENT_HOOK_SESSION_ID" \
   -H 'X-Acorn-Agent-Hook-Source: native' \
   --data-binary @- \
-  "$hook_url" >/dev/null 2>&1 || true
+  "$hook_url" >/dev/null 2>&1 || _acorn_spool_event
 "#;
 
 const ANTIGRAVITY_WRAPPER_BODY: &str = r#"#!/bin/sh
@@ -781,6 +841,28 @@ case "$event" in
     ;;
 esac
 
+# Spool this event when the POST fails: a wrapper-owned PTY outlives the
+# app, and a dropped POST here is a lost lifecycle transition. Line 1 is
+# the transport metadata the POST carried; the rest is the raw body. The
+# app drains and replays this directory on its next boot.
+_acorn_spool_event() {
+  [ -n "${ACORN_AGENT_WRAPPER_DIR-}" ] || return 0
+  _acorn_spool_dir="$ACORN_AGENT_WRAPPER_DIR/agent-hook-spool"
+  (umask 077; mkdir -p "$_acorn_spool_dir") 2>/dev/null || return 0
+  set -- "$_acorn_spool_dir"/*.json
+  if [ "$#" -ge 512 ] && [ -e "$1" ]; then
+    return 0
+  fi
+  _acorn_spool_tmp="$_acorn_spool_dir/.tmp-$$"
+  {
+    printf '%s\n' "$_acorn_spool_meta"
+    printf '%s' "$_acorn_spool_body"
+  } > "$_acorn_spool_tmp" 2>/dev/null || { rm -f "$_acorn_spool_tmp" 2>/dev/null; return 0; }
+  chmod 600 "$_acorn_spool_tmp" 2>/dev/null || true
+  mv "$_acorn_spool_tmp" "$_acorn_spool_dir/$(date +%s 2>/dev/null || echo 0)-$$.json" 2>/dev/null ||
+    rm -f "$_acorn_spool_tmp" 2>/dev/null
+}
+
 # Resolve the hook endpoint at send time. Each app launch rewrites the
 # endpoint file with that run's server URL + token (the hook server binds a
 # fresh port and token per run), so an agent session that outlives an app
@@ -796,16 +878,20 @@ if [ -z "$hook_url" ] || [ -z "$hook_token" ]; then
   hook_url="${ACORN_AGENT_HOOK_URL-}"
   hook_token="${ACORN_AGENT_HOOK_TOKEN-}"
 fi
-[ -n "$hook_url" ] || exit 0
-[ -n "$hook_token" ] || exit 0
 [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] || exit 0
 
 payload=$(printf '{"session_id":"%s","provider":"antigravity","event":"%s","source":"%s"}' "$ACORN_AGENT_HOOK_SESSION_ID" "$event" "$source")
-curl -sf -X POST \
+_acorn_spool_meta='{}'
+_acorn_spool_body="$payload"
+if [ -z "$hook_url" ] || [ -z "$hook_token" ]; then
+  _acorn_spool_event
+  exit 0
+fi
+curl -sf --connect-timeout 1 --max-time 1 -X POST \
   -H 'Content-Type: application/json' \
   -H "X-Acorn-Agent-Hook-Token: $hook_token" \
   -d "$payload" \
-  "$hook_url" >/dev/null 2>&1 || true
+  "$hook_url" >/dev/null 2>&1 || _acorn_spool_event
 "#;
 
 pub fn ensure_agent_wrapper_dir() -> io::Result<PathBuf> {
@@ -838,6 +924,13 @@ fn write_agent_hook_endpoint_at(dir: &Path, url: &str, token: &str) -> io::Resul
     // previous endpoint or the new one, never a torn file.
     fs::rename(&tmp, &path)?;
     Ok(path)
+}
+
+/// Directory where the notify scripts spool hook events they could not
+/// deliver (no app instance listening). Drained through
+/// `agent_hooks::replay_spooled_hook_events` on the next app boot.
+pub fn agent_hook_spool_dir() -> io::Result<PathBuf> {
+    Ok(ensure_agent_wrapper_dir()?.join(HOOK_SPOOL_DIR_NAME))
 }
 
 /// Best-effort removal of a stale endpoint file. Called when this run has no
@@ -3028,6 +3121,149 @@ done
     // The Stop/background, subagent-filter, decoy, and attention-ordering
     // scenarios that used to run against this script live in
     // `agent_hooks::tests` now — classification moved to Rust wholesale.
+
+    #[test]
+    fn notify_scripts_spool_undeliverable_events() {
+        let base = ScratchDir::new("spool-content");
+        let dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
+        for name in [
+            "acorn-claude-notify",
+            "acorn-codex-notify",
+            "acorn-antigravity-notify",
+        ] {
+            let notify = fs::read_to_string(dir.join(name)).unwrap();
+            assert!(
+                notify.contains("agent-hook-spool"),
+                "{name} must spool undeliverable events"
+            );
+            assert!(
+                notify.contains("|| _acorn_spool_event"),
+                "{name} must spool on POST failure"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    fn run_claude_notify_with_curl(curl_body: &str, payload: &str) -> (ScratchDir, PathBuf) {
+        use std::io::Write as _;
+
+        let base = ScratchDir::new("spool-run");
+        let wrapper_dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
+        let fake_bin = base.path().join("fake-bin");
+        fs::create_dir_all(&fake_bin).unwrap();
+        write_executable(&fake_bin.join("curl"), curl_body).unwrap();
+
+        let mut child = Command::new(wrapper_dir.join(CLAUDE_NOTIFY_NAME))
+            .env("PATH", format!("{}:/usr/bin:/bin", fake_bin.display()))
+            .env("ACORN_AGENT_WRAPPER_DIR", &wrapper_dir)
+            .env(
+                "ACORN_AGENT_HOOK_SESSION_ID",
+                "11111111-2222-4333-8444-555555555555",
+            )
+            .env("ACORN_AGENT_HOOK_URL", "http://127.0.0.1:1/agent-hook")
+            .env("ACORN_AGENT_HOOK_TOKEN", "token-1")
+            .env("ACORN_AGENT_INVOCATION_TOKEN", "owner-invocation")
+            .env("ACORN_AGENT_INVOCATION_DEPTH", "1")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(payload.as_bytes())
+            .unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert!(
+            output.status.success(),
+            "notify failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let spool_dir = wrapper_dir.join("agent-hook-spool");
+        (base, spool_dir)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn claude_notify_spools_event_when_post_fails() {
+        let payload =
+            r#"{"hook_event_name":"Stop","session_id":"019e4818-7c15-4e60-9b3b-898a1c7803d6"}"#;
+        let (_scratch, spool_dir) = run_claude_notify_with_curl("#!/bin/sh\nexit 7\n", payload);
+
+        let files: Vec<PathBuf> = fs::read_dir(&spool_dir)
+            .expect("spool dir must exist after a failed POST")
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+            .collect();
+        assert_eq!(files.len(), 1, "exactly one event must be spooled");
+        let content = fs::read_to_string(&files[0]).unwrap();
+        let (meta, body) = content.split_once('\n').expect("meta line + body");
+        let meta: serde_json::Value = serde_json::from_str(meta).expect("meta must be JSON");
+        assert_eq!(meta["provider"], "claude");
+        assert_eq!(meta["session_id"], "11111111-2222-4333-8444-555555555555");
+        assert_eq!(meta["source"], "native");
+        assert_eq!(body, payload, "the raw payload must be preserved verbatim");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn claude_notify_does_not_spool_on_successful_post() {
+        let payload = r#"{"hook_event_name":"Stop"}"#;
+        let (_scratch, spool_dir) =
+            run_claude_notify_with_curl("#!/bin/sh\ncat >/dev/null\nexit 0\n", payload);
+
+        let spooled = fs::read_dir(&spool_dir)
+            .map(|entries| entries.flatten().count())
+            .unwrap_or(0);
+        assert_eq!(spooled, 0, "a delivered event must not be spooled");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn claude_notify_spool_respects_file_cap() {
+        let payload = r#"{"hook_event_name":"Stop"}"#;
+        let base = ScratchDir::new("spool-cap");
+        let wrapper_dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
+        let spool_dir = wrapper_dir.join("agent-hook-spool");
+        fs::create_dir_all(&spool_dir).unwrap();
+        for index in 0..512 {
+            fs::write(spool_dir.join(format!("1700000000-{index}.json")), "{}\n{}").unwrap();
+        }
+        let fake_bin = base.path().join("fake-bin");
+        fs::create_dir_all(&fake_bin).unwrap();
+        write_executable(&fake_bin.join("curl"), "#!/bin/sh\nexit 7\n").unwrap();
+
+        use std::io::Write as _;
+        let mut child = Command::new(wrapper_dir.join(CLAUDE_NOTIFY_NAME))
+            .env("PATH", format!("{}:/usr/bin:/bin", fake_bin.display()))
+            .env("ACORN_AGENT_WRAPPER_DIR", &wrapper_dir)
+            .env(
+                "ACORN_AGENT_HOOK_SESSION_ID",
+                "11111111-2222-4333-8444-555555555555",
+            )
+            .env("ACORN_AGENT_HOOK_URL", "http://127.0.0.1:1/agent-hook")
+            .env("ACORN_AGENT_HOOK_TOKEN", "token-1")
+            .env("ACORN_AGENT_INVOCATION_TOKEN", "owner-invocation")
+            .env("ACORN_AGENT_INVOCATION_DEPTH", "1")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(payload.as_bytes())
+            .unwrap();
+        assert!(child.wait_with_output().unwrap().status.success());
+
+        let count = fs::read_dir(&spool_dir).unwrap().flatten().count();
+        assert_eq!(count, 512, "a full spool must drop the event, not grow");
+    }
 
     #[test]
     fn writes_hook_endpoint_file_atomically_with_owner_only_perms() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -430,7 +430,11 @@ pub fn run() {
             let hook_reducer = std::sync::Arc::new(agent_hooks::AgentHookReducer::new(
                 hook_sessions.clone(),
             ));
-            match agent_hooks::AgentHookServer::start_with_outcome_handler(move |event| {
+            let hook_handler: std::sync::Arc<
+                dyn Fn(agent_hooks::AgentHookEvent) -> agent_hooks::AgentHookHandlerOutcome
+                    + Send
+                    + Sync,
+            > = std::sync::Arc::new(move |event: agent_hooks::AgentHookEvent| {
                 let session_id = event.session_id;
                 let provider = event.provider;
                 let source = event.source.clone();
@@ -547,6 +551,29 @@ pub fn run() {
                     "agent hook status applied",
                 );
                 agent_hooks::AgentHookHandlerOutcome::Applied
+            });
+            // Drain events the notify scripts spooled while no app instance
+            // was listening. Runs before the hook server starts, so no live
+            // POST can interleave with the replay; anything spooled after
+            // this scan is picked up on the next boot.
+            match agent_wrappers::agent_hook_spool_dir() {
+                Ok(spool_dir) => {
+                    let replay_handler = hook_handler.clone();
+                    let replayed = agent_hooks::replay_spooled_hook_events(
+                        &spool_dir,
+                        move |event| replay_handler(event),
+                    );
+                    if replayed > 0 {
+                        tracing::info!(replayed, "replayed spooled agent hook events");
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(error = %err, "agent hook spool dir unavailable");
+                }
+            }
+            let server_handler = hook_handler.clone();
+            match agent_hooks::AgentHookServer::start_with_outcome_handler(move |event| {
+                server_handler(event)
             }) {
                 Ok(server) => {
                     // Publish only after normalized sessions and backfilled


### PR DESCRIPTION
## Summary

This delivers the #666 Phase 2 goals — hook events fired while no app instance is listening are no longer lost — through a spool-and-replay journal instead of moving the receiver into `acornd`.

1. **Spool on failed delivery.** All three notify scripts write the event to `$ACORN_AGENT_WRAPPER_DIR/agent-hook-spool/<unix-ts>-<pid>.json` when the POST fails or no endpoint is resolvable: line 1 is the transport metadata the POST would have carried (an empty object for the normalized-envelope shapes), the rest is the raw body. Files are written via tmp + rename with owner-only permissions, capped at 512 entries, and the Antigravity POST gains the same bounded curl timeouts the other scripts already had.
2. **Replay through the live parse path.** `replay_spooled_hook_events` drains the directory in filename order, rebuilds the HTTP request head from the metadata (rejecting control characters so metadata cannot inject headers), and feeds `parse_agent_hook_request` — a replayed event travels byte-for-byte the same classification, validation, and reducer path as a live one. Every file is consumed regardless of outcome.
3. **Boot ordering.** The replay runs after the reducer exists but before the hook server starts and the endpoint file is published, so no live POST can interleave with it. Events spooled between the scan and the publish are picked up on the next boot — a bounded residue where each of these events was previously dropped outright.

## Why not move the receiver into acornd (the Phase 2 sketch in #666)

- **The daemon is optional.** `DaemonBridge` has a killswitch and every spawn failure falls back to an in-process PTY, so a daemon-only receiver would need a permanent app-side twin anyway. The spool covers daemon-managed and in-process sessions identically.
- **The daemon outlives app upgrades.** There is no version-forced daemon restart (the `Hello` handshake gates on protocol major only), so lifecycle logic living in `acornd` would freeze at the installed daemon's version while the reducer is still evolving — it changed in three consecutive PRs this month.
- **The journal is the part that pays.** The daemon move's remaining benefits (no dead endpoint, daemon-lifetime consistency) reduce to "events are not lost", which the spool achieves without a new push channel on the control socket, daemon-side persistence, or a `SessionStore` mirror. If a daemon-owned receiver becomes necessary later, the spool format already is the wire format.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Claude/Codex finishes a turn while the app is closed | Stop event dropped; status recovered only by one-shot transcript boot reconciliation (Working → Waiting only, tail-window dependent) | Event spooled and replayed through the reducer on next boot |
| Agent errors or requests permission during app downtime | Transition lost entirely (no reconciliation branch) | Replayed on next boot |
| App closed for many turns | Only the final state was approximated | Full event sequence replays in order; reducer stale-rejection absorbs sub-second ordering ambiguity |
| Hook server fails to start for a run | Events dropped for the whole run | Events spool and replay on the next healthy boot |
| Spool directory fills (512 files) | n/a | New events drop (previous behavior), spool never grows unbounded |

## Design notes

- Transcript-based boot reconciliation (`hook_boot_reconciled_status`) stays in place this release as a belt for pre-upgrade sessions and for spool residue; retiring it is a follow-up once the spool has soaked.
- Replay sorts on numeric (timestamp, pid). Sub-second ordering between two concurrent writers is best-effort — pid order is not arrival order — so a mis-ordered same-second pair can leave a stale status until the session's next live event corrects it; the pre-spool behavior was losing both events outright.
- A replayed event for a removed session is rejected by the reducer and its file is consumed — replay can never wedge on a permanently rejected event.
- Spool files live inside the Acorn data directory with `0600`/`0700` permissions; payloads (which can contain prompt text) are readable only by the owner, matching the endpoint token file's threat model.

## Follow-up (not in this PR)

- Retire `hook_boot_reconciled_status` and the transcript-tail recovery paths after a compatibility period.
- Wrapper-bypass diagnostics (live agent with hooks inactive), carried over from #669.

## Test plan

- [x] `env -u ACORN_* … cargo test --workspace --all-targets --no-fail-fast` — all workspace targets passed.
- [x] `cargo test --lib agent_hooks::tests` — replay ordering/consumption, Codex metadata reconstruction, header-injection rejection, envelope parsing, subagent drop.
- [x] `cargo test --lib agent_wrappers::tests` — 49 passed: spool-on-failure content, no-spool-on-success, 512-file cap, spool presence in all three scripts.
- [x] `cargo fmt` — applied; drift in untouched files reverted.

## Notes

- Rust-only change plus embedded shell scripts; frontend untouched.
- Pre-existing dead-code warnings remain; all tests pass.

Refs #666
