### PR TITLE
feat(canvas): add close actions to session cards

### DIFF
--- a/src/components/WorkspaceCanvas.tsx
+++ b/src/components/WorkspaceCanvas.tsx
@@ -13,6 +13,7 @@ import {
   Scan,
   Terminal as TerminalIcon,
   Undo2,
+  X,
 } from "lucide-react";
 import {
   memo,
@@ -192,6 +193,9 @@ export function WorkspaceCanvas({
   const activeSessionId = useAppStore((state) => state.activeSessionId);
   const setWorkspaceCanvasState = useAppStore(
     (state) => state.setWorkspaceCanvasState,
+  );
+  const requestRemoveSession = useAppStore(
+    (state) => state.requestRemoveSession,
   );
   const canvasSessions = sessions;
   const sessionIds = useMemo(
@@ -630,6 +634,11 @@ export function WorkspaceCanvas({
         icon: <PanelsTopLeft size={12} />,
         onClick: () => openInPanes(contextSession.id),
       });
+      items.push({
+        label: canvasText(t, "workspace.canvas.closeSession"),
+        icon: <X size={12} />,
+        onClick: () => requestRemoveSession(contextSession.id),
+      });
     }
     items.push(...sessionCreateMenuItems);
     items.push(
@@ -656,6 +665,7 @@ export function WorkspaceCanvas({
     fitAll,
     openExpanded,
     openInPanes,
+    requestRemoveSession,
     resetLayout,
     sessionCreateMenuItems,
     t,
@@ -734,6 +744,7 @@ export function WorkspaceCanvas({
                 commitNode(session.id, purpose, snap)
               }
               onExpand={() => openExpanded(session.id)}
+              onClose={() => requestRemoveSession(session.id)}
               t={t}
             />
           );
@@ -933,6 +944,7 @@ interface WorkspaceCanvasSessionNodeProps {
   ) => void;
   onCommit: (purpose: "move" | "resize", snap: boolean) => void;
   onExpand: () => void;
+  onClose: () => void;
   t: Translator;
 }
 
@@ -946,6 +958,7 @@ const WorkspaceCanvasSessionNode = memo(
     onUpdate,
     onCommit,
     onExpand,
+    onClose,
     t,
   }: WorkspaceCanvasSessionNodeProps) {
     const bodyRef = useRef<HTMLDivElement | null>(null);
@@ -1190,6 +1203,25 @@ const WorkspaceCanvasSessionNode = memo(
               </IconButton>
             </Tooltip>
           )}
+          <Tooltip
+            label={canvasText(t, "workspace.canvas.closeSessionButton", {
+              name: session.name,
+            })}
+            side="bottom"
+          >
+            <IconButton
+              aria-label={canvasText(
+                t,
+                "workspace.canvas.closeSessionButton",
+                { name: session.name },
+              )}
+              size="xs"
+              data-testid="workspace-canvas-node-close"
+              onClick={onClose}
+            >
+              <X size={12} />
+            </IconButton>
+          </Tooltip>
         </header>
         {session.mode === "chat" ? (
           <div

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -997,7 +997,9 @@
       "moveSession": "Move {name}",
       "resizeSession": "Resize {name}",
       "expandSession": "Expand {name}",
-      "openInPanes": "Open {name} in panes"
+      "openInPanes": "Open {name} in panes",
+      "closeSession": "Close session",
+      "closeSessionButton": "Close {name}"
     },
     "kanban": {
       "title": "Workspace kanban",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -997,7 +997,9 @@
       "moveSession": "{name} 이동",
       "resizeSession": "{name} 크기 조절",
       "expandSession": "{name} 크게 보기",
-      "openInPanes": "패널에서 {name} 열기"
+      "openInPanes": "패널에서 {name} 열기",
+      "closeSession": "세션 닫기",
+      "closeSessionButton": "{name} 닫기"
     },
     "kanban": {
       "title": "작업공간 칸반",

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -242,6 +242,92 @@ test.describe("workspace canvas mode", () => {
     );
   });
 
+  test("closes sessions from the canvas context menu and title button", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __canvasRemovedIds?: string[] };
+      const removedIds = w.__canvasRemovedIds ?? [];
+      return ["alpha", "beta"]
+        .filter((id) => !removedIds.includes(id))
+        .map((id) => ({
+          id,
+          name: id,
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:05Z",
+          last_message: null,
+          title_source: "default",
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+        }));
+    });
+    await tauri.handle("remove_session", (args) => {
+      const w = window as unknown as {
+        __canvasRemoveCalls?: unknown[];
+        __canvasRemovedIds?: string[];
+      };
+      const id = (args as { id: string }).id;
+      w.__canvasRemoveCalls = [...(w.__canvasRemoveCalls ?? []), args];
+      w.__canvasRemovedIds = [...(w.__canvasRemovedIds ?? []), id];
+      return null;
+    });
+
+    await page.goto("/");
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Canvas" }).click();
+
+    const node = page.locator('[data-canvas-session-id="alpha"]');
+    await node
+      .getByTestId("workspace-canvas-node-drag-handle")
+      .click({ button: "right" });
+    await page
+      .getByRole("menuitem", { name: "Close session", exact: true })
+      .click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(
+      dialog.getByRole("heading", { name: "Remove session" }),
+    ).toBeVisible();
+    await dialog.getByRole("button", { name: "Remove", exact: true }).click();
+
+    await expect(node).toHaveCount(0);
+    const beta = page.locator('[data-canvas-session-id="beta"]');
+    await beta.getByRole("button", { name: "Close beta" }).click();
+    await expect(
+      dialog.getByRole("heading", { name: "Remove session" }),
+    ).toBeVisible();
+    await dialog.getByRole("button", { name: "Remove", exact: true }).click();
+
+    await expect(beta).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __canvasRemoveCalls?: Array<{
+                  id: string;
+                  removeWorktree: boolean;
+                }>;
+              }
+            ).__canvasRemoveCalls ?? [],
+        ),
+      )
+      .toEqual([
+        { id: "alpha", removeWorktree: false },
+        { id: "beta", removeWorktree: false },
+      ]);
+  });
+
   test("moves, resizes, zooms, and restores live terminal nodes", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Canvas sessions can now be closed without switching back to panes or the sidebar.

1. **Context-menu close** — adds a localized `Close session` item to each canvas session menu.
2. **Header close button** — adds an accessible `X` action to terminal and chat session cards.
3. **Existing safety flow** — routes both entry points through `requestRemoveSession`, preserving running-session warnings, confirmation settings, and worktree cleanup choices.
4. **Regression coverage** — verifies both canvas close entry points and their backend removal arguments in Playwright.

## Expected impact

| Surface | Before | After |
| --- | --- | --- |
| Canvas session header | Expand action only | Direct close action with a session-specific accessible label |
| Canvas session context menu | Expand/open actions only | Localized `Close session` action |
| Close safeguards | Available from other workspace surfaces | Same confirmation, running-session warning, and worktree handling from canvas |

## Design notes

- The canvas does not remove sessions directly. Both actions set the existing pending-removal state so `App` remains the single owner of close warnings and removal dialogs.
- English and Korean labels are defined under the canvas translation namespace; locale shape validation is covered by TypeScript.
- The E2E handler keeps browser-side session state so the test confirms both the context-menu and title-button paths independently.

## Test plan

- [x] `pnpm run typecheck` — passes on the rebased branch
- [x] `pnpm run test` — 96 files, 1,077 tests passed
- [x] `pnpm run build` — production frontend build passed
- [x] `pnpm run test:e2e` — 244 Playwright tests passed
- [x] `pnpm exec playwright test tests/e2e/canvas.spec.ts` — 8 canvas tests passed after rebase