### PR TITLE
fix(status): surface degraded lifecycle fallback sources

### DIFF
--- a/src-tauri/crates/acorn-session/src/lib.rs
+++ b/src-tauri/crates/acorn-session/src/lib.rs
@@ -15,6 +15,7 @@ pub mod session;
 pub mod status;
 
 pub use session::{
-    Project, ProjectStore, Session, SessionAgentProvider, SessionError, SessionKind, SessionMode,
-    SessionOwner, SessionResult, SessionStatus, SessionStore, SessionTitleSource,
+    AgentStatusSource, Project, ProjectStore, Session, SessionAgentProvider, SessionError,
+    SessionKind, SessionMode, SessionOwner, SessionResult, SessionStatus, SessionStore,
+    SessionTitleSource,
 };

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -895,6 +895,56 @@ mod tests {
     }
 
     #[test]
+    fn hook_ownership_clear_is_revision_safe_and_clears_runtime_evidence() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        let observed_at = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(123_456);
+
+        let first_revision = store.mark_hook_active(&session.id, SessionAgentProvider::Codex);
+        store.begin_hook_turn(&session.id, Some("turn-1"));
+        store.mark_hook_tool_started_at(&session.id, observed_at);
+        store.mark_codex_permission_waiting_at(&session.id, observed_at);
+
+        assert_eq!(
+            store.agent_status_source(&session.id),
+            Some(AgentStatusSource::Hook)
+        );
+        assert!(store
+            .clear_hook_ownership_if_revision(&session.id, first_revision)
+            .expect("session exists"));
+        assert!(!store.is_hook_active(&session.id));
+        assert!(!store.is_hook_confirmed_this_run(&session.id));
+        assert_eq!(store.hook_provider(&session.id), None);
+        assert_eq!(store.agent_status_source(&session.id), None);
+        assert_eq!(store.hook_turn_id(&session.id), None);
+        assert_eq!(store.hook_tool_started_at(&session.id), None);
+        assert_eq!(store.codex_permission_waiting_at(&session.id), None);
+
+        let cleared_revision = store.hook_revision(&session.id);
+        assert!(cleared_revision > first_revision);
+        let replacement_revision =
+            store.mark_hook_active(&session.id, SessionAgentProvider::Claude);
+        store.begin_hook_turn(&session.id, Some("turn-2"));
+
+        assert!(replacement_revision > cleared_revision);
+        assert!(!store
+            .clear_hook_ownership_if_revision(&session.id, first_revision)
+            .expect("session exists"));
+        assert!(store.is_hook_active(&session.id));
+        assert!(store.is_hook_confirmed_this_run(&session.id));
+        assert_eq!(
+            store.hook_provider(&session.id),
+            Some(SessionAgentProvider::Claude)
+        );
+        assert_eq!(
+            store.agent_status_source(&session.id),
+            Some(AgentStatusSource::Hook)
+        );
+        assert_eq!(store.hook_turn_id(&session.id).as_deref(), Some("turn-2"));
+        assert_eq!(store.hook_revision(&session.id), replacement_revision);
+    }
+
+    #[test]
     fn hook_tool_activity_is_scoped_to_a_turn_and_cleared_on_remove() {
         let store = SessionStore::new();
         let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -1,10 +1,10 @@
 pub use acorn_agent::AgentKind as SessionAgentProvider;
 use chrono::{DateTime, Utc};
-use dashmap::{DashMap, DashSet};
+use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::SystemTime;
 use uuid::Uuid;
 
@@ -142,6 +142,18 @@ pub enum SessionStatus {
     WaitingForInput,
     #[serde(rename = "errored", alias = "failed")]
     Errored,
+}
+
+/// Runtime authority that most recently classified a session's lifecycle
+/// status. This is intentionally kept outside the persisted [`Session`] row:
+/// after an app restart, Acorn must re-establish whether native hooks or a
+/// bounded fallback produced the current observation.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentStatusSource {
+    Hook,
+    TranscriptFallback,
+    ProcessFallback,
 }
 
 /// Distinguishes ordinary terminal sessions from "control" sessions, which
@@ -347,6 +359,37 @@ impl Session {
 }
 
 #[derive(Default)]
+struct HookRuntimeState {
+    confirmed: bool,
+    revision: u64,
+    lifecycle_revision: u64,
+    status_source: Option<AgentStatusSource>,
+    tool_started_at: Option<SystemTime>,
+    turn_id: Option<String>,
+    permission_waiting_at: Option<SystemTime>,
+}
+
+impl HookRuntimeState {
+    fn advance_revision(&mut self) -> u64 {
+        self.revision = self.revision.saturating_add(1);
+        self.revision
+    }
+
+    fn advance_lifecycle_revision(&mut self) -> u64 {
+        self.lifecycle_revision = self.lifecycle_revision.saturating_add(1);
+        self.lifecycle_revision
+    }
+
+    fn clear_ownership_evidence(&mut self) {
+        self.confirmed = false;
+        self.status_source = None;
+        self.tool_started_at = None;
+        self.turn_id = None;
+        self.permission_waiting_at = None;
+    }
+}
+
+#[derive(Default)]
 pub struct SessionStore {
     inner: DashMap<Uuid, Session>,
     /// Sessions that reported at least one agent lifecycle hook event
@@ -360,33 +403,26 @@ pub struct SessionStore {
     /// process-liveness edge after no agent remains.
     ///
     /// Hook activity itself also persists across restarts via the session's
-    /// `hook_active` field; this set distinguishes "confirmed live this run"
+    /// `hook_active` field; this ledger distinguishes "confirmed live this run"
     /// (an event actually arrived at this app instance's hook server) from
     /// "was hook-owned before the restart", which the poll's boot
-    /// reconciliation needs — a turn that ended while the app was closed
-    /// lost its turn-end event forever and must be recovered from the
-    /// transcript exactly once.
-    hook_confirmed: DashSet<Uuid>,
-    /// Per-session lifecycle generation for this app run. Every hook event
-    /// advances the revision before touching the session row so conditional
-    /// status writes can reject observations made before a newer event.
-    hook_revisions: DashMap<Uuid, u64>,
-    /// Start of the first Codex exec tool observed in the current turn.
-    /// Runtime-only: after an app restart, process-tree arbitration stays
-    /// conservative until a fresh tagged tool event arrives.
-    hook_tool_started_at: DashMap<Uuid, SystemTime>,
-    /// Codex turn currently owned by each Acorn session. Runtime-only and
-    /// deliberately cleared as soon as a new user turn starts, before Codex
-    /// assigns that turn an id. This lets delayed completion notifications
-    /// fail closed instead of overwriting the new turn's Working status.
-    hook_turn_ids: DashMap<Uuid, String>,
-    /// Start of the current Codex approval wait. Runtime-only: process-tree
-    /// reconciliation may promote Waiting back to Working only for a tool
-    /// descendant that appeared after this boundary.
-    codex_permission_waiting_at: DashMap<Uuid, SystemTime>,
+    /// reconciliation needs when durable delivery has no retained event for
+    /// the boundary. In that case the transcript is consulted once as a
+    /// bounded compatibility signal.
+    /// Runtime lifecycle state is kept behind one lock so revision checks,
+    /// source transitions, and ownership evidence can be changed atomically.
+    /// Methods that also touch `inner` always acquire this ledger first and a
+    /// session row second.
+    hook_runtime: Mutex<HashMap<Uuid, HookRuntimeState>>,
 }
 
 impl SessionStore {
+    fn lock_hook_runtime(&self) -> MutexGuard<'_, HashMap<Uuid, HookRuntimeState>> {
+        self.hook_runtime
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     pub fn new() -> Arc<Self> {
         Arc::new(Self::default())
     }
@@ -430,19 +466,25 @@ impl SessionStore {
     }
 
     pub fn update_status(&self, id: &Uuid, status: SessionStatus) -> SessionResult<Session> {
+        let mut runtime = self.lock_hook_runtime();
         let mut entry = self
             .inner
             .get_mut(id)
             .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
         entry.status = status;
         entry.updated_at = Utc::now();
+        let state = runtime.entry(*id).or_default();
+        state.status_source = None;
+        state.advance_lifecycle_revision();
         Ok(entry.clone())
     }
 
-    /// Update status without bumping `updated_at`. No-op if the status is
-    /// unchanged. Used by the periodic liveness probe so polling doesn't
-    /// reshuffle the sidebar's most-recent-first ordering.
+    /// Apply an unattributed status without bumping `updated_at`. Explicit
+    /// writes clear runtime provenance and always advance the lifecycle fence,
+    /// even when the visible status is unchanged, so a stale poll cannot
+    /// overwrite them or report an authority that did not produce the value.
     pub fn refresh_status(&self, id: &Uuid, status: SessionStatus) -> SessionResult<Session> {
+        let mut runtime = self.lock_hook_runtime();
         let mut entry = self
             .inner
             .get_mut(id)
@@ -450,14 +492,78 @@ impl SessionStore {
         if entry.status != status {
             entry.status = status;
         }
+        let state = runtime.entry(*id).or_default();
+        state.status_source = None;
+        state.advance_lifecycle_revision();
         Ok(entry.clone())
     }
 
     pub fn hook_revision(&self, id: &Uuid) -> u64 {
-        self.hook_revisions
+        self.lock_hook_runtime()
             .get(id)
-            .map(|revision| *revision)
+            .map(|state| state.revision)
             .unwrap_or(0)
+    }
+
+    pub fn agent_status_source(&self, id: &Uuid) -> Option<AgentStatusSource> {
+        self.lock_hook_runtime()
+            .get(id)
+            .and_then(|state| state.status_source)
+    }
+
+    /// Read the lifecycle state that poll arbitration compares as one
+    /// snapshot. Holding the runtime ledger while cloning the session row
+    /// prevents a reducer from pairing a newer source with an older status.
+    pub fn lifecycle_snapshot(
+        &self,
+        id: &Uuid,
+    ) -> SessionResult<(SessionStatus, Option<AgentStatusSource>, u64, u64)> {
+        let runtime = self.lock_hook_runtime();
+        let entry = self
+            .inner
+            .get(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        let state = runtime.get(id);
+        Ok((
+            entry.status,
+            state.and_then(|state| state.status_source),
+            state.map(|state| state.revision).unwrap_or(0),
+            state.map(|state| state.lifecycle_revision).unwrap_or(0),
+        ))
+    }
+
+    /// Record or clear lifecycle authority without changing the session
+    /// status. Reducers should prefer [`Self::refresh_status_with_source`] so
+    /// their paired status/source transition is observed under one critical
+    /// section.
+    pub fn mark_agent_status_source(&self, id: &Uuid, source: Option<AgentStatusSource>) {
+        let mut runtime = self.lock_hook_runtime();
+        if !self.inner.contains_key(id) {
+            return;
+        }
+        let state = runtime.entry(*id).or_default();
+        state.status_source = source;
+        state.advance_lifecycle_revision();
+    }
+
+    /// Refresh status and its runtime authority together without bumping
+    /// `updated_at`.
+    pub fn refresh_status_with_source(
+        &self,
+        id: &Uuid,
+        status: SessionStatus,
+        source: Option<AgentStatusSource>,
+    ) -> SessionResult<Session> {
+        let mut runtime = self.lock_hook_runtime();
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        entry.status = status;
+        let state = runtime.entry(*id).or_default();
+        state.status_source = source;
+        state.advance_lifecycle_revision();
+        Ok(entry.clone())
     }
 
     /// Refresh status only when both the stored state and hook generation
@@ -471,40 +577,161 @@ impl SessionStore {
         expected_hook_revision: u64,
         status: SessionStatus,
     ) -> SessionResult<bool> {
+        let mut runtime = self.lock_hook_runtime();
         let mut entry = self
             .inner
             .get_mut(id)
             .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
-        if entry.status != expected_status || self.hook_revision(id) != expected_hook_revision {
+        let state = runtime.entry(*id).or_default();
+        if entry.status != expected_status || state.revision != expected_hook_revision {
             return Ok(false);
         }
         entry.status = status;
+        state.advance_lifecycle_revision();
         Ok(true)
+    }
+
+    /// Refresh status and lifecycle authority only if the complete state
+    /// observed by a poll is still current. Comparing both source and hook
+    /// generation rejects stale polls after a fallback transition, because
+    /// fallback events deliberately do not advance the native hook revision.
+    pub fn refresh_status_and_source_if_hook_revision(
+        &self,
+        id: &Uuid,
+        expected_status: SessionStatus,
+        expected_source: Option<AgentStatusSource>,
+        expected_hook_revision: u64,
+        status: SessionStatus,
+        source: Option<AgentStatusSource>,
+    ) -> SessionResult<bool> {
+        let mut runtime = self.lock_hook_runtime();
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        let state = runtime.entry(*id).or_default();
+        if entry.status != expected_status
+            || state.status_source != expected_source
+            || state.revision != expected_hook_revision
+        {
+            return Ok(false);
+        }
+        entry.status = status;
+        state.status_source = source;
+        state.advance_lifecycle_revision();
+        Ok(true)
+    }
+
+    /// Apply a poll-derived status/source pair only while no lifecycle writer
+    /// has run since the poll captured its snapshot. The monotonic lifecycle
+    /// revision closes ABA races where fallback events return to the same
+    /// visible status and source before a slow poll completes.
+    pub fn refresh_status_and_source_if_lifecycle_revision(
+        &self,
+        id: &Uuid,
+        expected_status: SessionStatus,
+        expected_source: Option<AgentStatusSource>,
+        expected_lifecycle_revision: u64,
+        status: SessionStatus,
+        source: Option<AgentStatusSource>,
+    ) -> SessionResult<Option<u64>> {
+        let mut runtime = self.lock_hook_runtime();
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        let state = runtime.entry(*id).or_default();
+        if entry.status != expected_status
+            || state.status_source != expected_source
+            || state.lifecycle_revision != expected_lifecycle_revision
+        {
+            return Ok(None);
+        }
+        entry.status = status;
+        state.status_source = source;
+        Ok(Some(state.advance_lifecycle_revision()))
     }
 
     /// Record that `id` reported an agent lifecycle hook event, marking its
     /// hook channel live so the status poll defers turn-boundary
-    /// classification to hooks (see the `hook_confirmed` field). Also stamps
+    /// classification to hooks (see [`Self::is_hook_confirmed_this_run`]). Also stamps
     /// the session's persisted `hook_active` flag so hook ownership survives
     /// an app restart. The persisted flag is idempotent; the runtime revision
     /// advances for every event.
     pub fn mark_hook_active(&self, id: &Uuid, provider: SessionAgentProvider) -> u64 {
-        let revision = {
-            let mut revision = self.hook_revisions.entry(*id).or_default();
-            *revision = revision.saturating_add(1);
-            *revision
+        let mut runtime = self.lock_hook_runtime();
+        let Some(mut entry) = self.inner.get_mut(id) else {
+            return runtime.get(id).map(|state| state.revision).unwrap_or(0);
         };
-        self.hook_confirmed.insert(*id);
-        if let Some(mut entry) = self.inner.get_mut(id) {
-            if !entry.hook_active {
-                // Deliberately no `updated_at` bump — hook telemetry must
-                // not reshuffle the sidebar's most-recent-first ordering.
-                entry.hook_active = true;
-            }
-            entry.hook_provider = Some(provider);
-            entry.agent_provider = Some(provider);
+        let state = runtime.entry(*id).or_default();
+        let revision = state.advance_revision();
+        state.advance_lifecycle_revision();
+        state.confirmed = true;
+        state.status_source = Some(AgentStatusSource::Hook);
+        if !entry.hook_active {
+            // Deliberately no `updated_at` bump — hook telemetry must
+            // not reshuffle the sidebar's most-recent-first ordering.
+            entry.hook_active = true;
         }
+        entry.hook_provider = Some(provider);
+        entry.agent_provider = Some(provider);
         revision
+    }
+
+    /// Apply a native lifecycle transition and claim hook ownership as one
+    /// transaction. Reducers use this instead of publishing hook provenance
+    /// before the corresponding status is visible.
+    pub fn apply_native_status(
+        &self,
+        id: &Uuid,
+        provider: SessionAgentProvider,
+        status: SessionStatus,
+    ) -> SessionResult<u64> {
+        let mut runtime = self.lock_hook_runtime();
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        let state = runtime.entry(*id).or_default();
+        let revision = state.advance_revision();
+        state.advance_lifecycle_revision();
+        state.confirmed = true;
+        state.status_source = Some(AgentStatusSource::Hook);
+        entry.status = status;
+        entry.hook_active = true;
+        entry.hook_provider = Some(provider);
+        entry.agent_provider = Some(provider);
+        Ok(revision)
+    }
+
+    /// Clear persisted and runtime hook ownership only when the caller's
+    /// lifecycle generation is still current. The revision advances before
+    /// releasing the ledger so any observation made before this clear cannot
+    /// later re-apply stale status or provider metadata.
+    pub fn clear_hook_ownership_if_revision(
+        &self,
+        id: &Uuid,
+        expected_hook_revision: u64,
+        expected_lifecycle_revision: u64,
+    ) -> SessionResult<bool> {
+        let mut runtime = self.lock_hook_runtime();
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        let state = runtime.entry(*id).or_default();
+        if state.revision != expected_hook_revision
+            || state.lifecycle_revision != expected_lifecycle_revision
+        {
+            return Ok(false);
+        }
+
+        state.advance_revision();
+        state.advance_lifecycle_revision();
+        state.clear_ownership_evidence();
+        entry.hook_active = false;
+        entry.hook_provider = None;
+        Ok(true)
     }
 
     /// Reset per-turn tool evidence and bind the Codex turn id when Codex
@@ -513,63 +740,78 @@ impl SessionStore {
     /// any completion for the previous id is stale. Keeping that boundary in
     /// the map also distinguishes it from runtime state lost on app restart.
     pub fn begin_hook_turn(&self, id: &Uuid, turn_id: Option<&str>) {
-        self.hook_tool_started_at.remove(id);
-        self.codex_permission_waiting_at.remove(id);
-        match turn_id.map(str::trim).filter(|turn_id| !turn_id.is_empty()) {
-            Some(turn_id) => {
-                self.hook_turn_ids.insert(*id, turn_id.to_string());
-            }
-            None => {
-                self.hook_turn_ids.insert(*id, String::new());
-            }
-        }
+        let mut runtime = self.lock_hook_runtime();
+        let state = runtime.entry(*id).or_default();
+        state.tool_started_at = None;
+        state.permission_waiting_at = None;
+        state.turn_id = Some(
+            turn_id
+                .map(str::trim)
+                .filter(|turn_id| !turn_id.is_empty())
+                .unwrap_or_default()
+                .to_string(),
+        );
     }
 
     pub fn hook_turn_id(&self, id: &Uuid) -> Option<String> {
-        self.hook_turn_ids
+        self.lock_hook_runtime()
             .get(id)
-            .map(|turn_id| turn_id.value().clone())
+            .and_then(|state| state.turn_id.clone())
             .filter(|turn_id| !turn_id.is_empty())
     }
 
     /// Whether this app run has observed a Codex turn boundary, including a
     /// user submission for which Codex has not assigned a turn id yet.
     pub fn has_hook_turn_boundary(&self, id: &Uuid) -> bool {
-        self.hook_turn_ids.contains_key(id)
+        self.lock_hook_runtime()
+            .get(id)
+            .and_then(|state| state.turn_id.as_ref())
+            .is_some()
     }
 
     /// Record the first exec tool observed in the current Codex turn. Keeping
     /// the earliest timestamp ensures a background process launched by an
     /// earlier tool still counts after later tools run in the same turn.
     pub fn mark_hook_tool_started_at(&self, id: &Uuid, started_at: SystemTime) {
-        self.hook_tool_started_at.entry(*id).or_insert(started_at);
+        let mut runtime = self.lock_hook_runtime();
+        runtime
+            .entry(*id)
+            .or_default()
+            .tool_started_at
+            .get_or_insert(started_at);
     }
 
     pub fn hook_tool_started_at(&self, id: &Uuid) -> Option<SystemTime> {
-        self.hook_tool_started_at
+        self.lock_hook_runtime()
             .get(id)
-            .map(|started_at| *started_at)
+            .and_then(|state| state.tool_started_at)
     }
 
     pub fn mark_codex_permission_waiting_at(&self, id: &Uuid, requested_at: SystemTime) {
-        self.codex_permission_waiting_at.insert(*id, requested_at);
+        self.lock_hook_runtime()
+            .entry(*id)
+            .or_default()
+            .permission_waiting_at = Some(requested_at);
     }
 
     pub fn codex_permission_waiting_at(&self, id: &Uuid) -> Option<SystemTime> {
-        self.codex_permission_waiting_at
+        self.lock_hook_runtime()
             .get(id)
-            .map(|requested_at| *requested_at)
+            .and_then(|state| state.permission_waiting_at)
     }
 
     pub fn clear_codex_permission_waiting(&self, id: &Uuid) {
-        self.codex_permission_waiting_at.remove(id);
+        if let Some(state) = self.lock_hook_runtime().get_mut(id) {
+            state.permission_waiting_at = None;
+        }
     }
 
     /// Whether `id` has ever reported an agent lifecycle hook event — either
     /// this run or (via the persisted `hook_active` session flag) in a
     /// previous one.
     pub fn is_hook_active(&self, id: &Uuid) -> bool {
-        self.hook_confirmed.contains(id)
+        let runtime = self.lock_hook_runtime();
+        runtime.get(id).is_some_and(|state| state.confirmed)
             || self
                 .inner
                 .get(id)
@@ -587,7 +829,9 @@ impl SessionStore {
     /// is set; the status poll uses that gap to reconcile a turn boundary
     /// that was crossed while the app was closed.
     pub fn is_hook_confirmed_this_run(&self, id: &Uuid) -> bool {
-        self.hook_confirmed.contains(id)
+        self.lock_hook_runtime()
+            .get(id)
+            .is_some_and(|state| state.confirmed)
     }
 
     /// Refresh derived live-agent metadata without bumping `updated_at`.
@@ -608,6 +852,58 @@ impl SessionStore {
         Ok(entry.clone())
     }
 
+    /// Refresh process-derived provider metadata only while both the native
+    /// hook generation and lifecycle authority still match the poll's
+    /// observation. This prevents a stale process scan from overwriting a
+    /// provider claimed by a newer hook or fallback event.
+    pub fn refresh_agent_state_if_hook_revision(
+        &self,
+        id: &Uuid,
+        expected_hook_revision: u64,
+        expected_source: Option<AgentStatusSource>,
+        provider: Option<SessionAgentProvider>,
+        transcript_id: Option<String>,
+    ) -> SessionResult<bool> {
+        let runtime = self.lock_hook_runtime();
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        let state = runtime.get(id);
+        let revision = state.map(|state| state.revision).unwrap_or(0);
+        let source = state.and_then(|state| state.status_source);
+        if revision != expected_hook_revision || source != expected_source {
+            return Ok(false);
+        }
+        entry.agent_provider = provider;
+        entry.agent_transcript_id = transcript_id;
+        Ok(true)
+    }
+
+    pub fn refresh_agent_state_if_lifecycle_revision(
+        &self,
+        id: &Uuid,
+        expected_lifecycle_revision: u64,
+        expected_source: Option<AgentStatusSource>,
+        provider: Option<SessionAgentProvider>,
+        transcript_id: Option<String>,
+    ) -> SessionResult<bool> {
+        let runtime = self.lock_hook_runtime();
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        let state = runtime.get(id);
+        let lifecycle_revision = state.map(|state| state.lifecycle_revision).unwrap_or(0);
+        let source = state.and_then(|state| state.status_source);
+        if lifecycle_revision != expected_lifecycle_revision || source != expected_source {
+            return Ok(false);
+        }
+        entry.agent_provider = provider;
+        entry.agent_transcript_id = transcript_id;
+        Ok(true)
+    }
+
     /// Record provider identity from a non-authoritative owner observation
     /// before its native hook arrives. A provider-specific transcript can
     /// prove which agent owns the PTY without proving lifecycle status, so a
@@ -618,26 +914,29 @@ impl SessionStore {
         id: &Uuid,
         provider: SessionAgentProvider,
     ) -> SessionResult<Session> {
+        let mut runtime = self.lock_hook_runtime();
         let mut entry = self
             .inner
             .get_mut(id)
             .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        let switches_provider = entry
+            .agent_provider
+            .is_some_and(|current| current != provider)
+            || entry
+                .hook_provider
+                .is_some_and(|current| current != provider);
         entry.agent_provider = Some(provider);
-        let clears_previous_hook = entry.hook_provider != Some(provider);
-        if clears_previous_hook {
+        if switches_provider {
             entry.hook_provider = None;
             entry.hook_active = false;
+            let state = runtime.entry(*id).or_default();
+            if state.confirmed {
+                state.advance_revision();
+            }
+            state.advance_lifecycle_revision();
+            state.clear_ownership_evidence();
         }
-        let updated = entry.clone();
-        drop(entry);
-
-        if clears_previous_hook {
-            self.hook_confirmed.remove(id);
-            self.hook_tool_started_at.remove(id);
-            self.hook_turn_ids.remove(id);
-            self.codex_permission_waiting_at.remove(id);
-        }
-        Ok(updated)
+        Ok(entry.clone())
     }
 
     /// Flip the explicit auto-title opt-in. Used by the status poll to
@@ -770,15 +1069,14 @@ impl SessionStore {
     }
 
     pub fn remove(&self, id: &Uuid) -> SessionResult<Session> {
-        self.hook_confirmed.remove(id);
-        self.hook_revisions.remove(id);
-        self.hook_tool_started_at.remove(id);
-        self.hook_turn_ids.remove(id);
-        self.codex_permission_waiting_at.remove(id);
-        self.inner
+        let mut runtime = self.lock_hook_runtime();
+        let removed = self
+            .inner
             .remove(id)
             .map(|(_, v)| v)
-            .ok_or_else(|| SessionError::NotFound(id.to_string()))
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        runtime.remove(id);
+        Ok(removed)
     }
 
     /// Assign explicit positions (0..N) to the sessions listed in `order`,
@@ -904,14 +1202,24 @@ mod tests {
         store.begin_hook_turn(&session.id, Some("turn-1"));
         store.mark_hook_tool_started_at(&session.id, observed_at);
         store.mark_codex_permission_waiting_at(&session.id, observed_at);
+        let first_lifecycle_revision = store
+            .lifecycle_snapshot(&session.id)
+            .expect("session exists")
+            .3;
 
         assert_eq!(
             store.agent_status_source(&session.id),
             Some(AgentStatusSource::Hook)
         );
-        assert!(store
-            .clear_hook_ownership_if_revision(&session.id, first_revision)
-            .expect("session exists"));
+        assert!(
+            store
+                .clear_hook_ownership_if_revision(
+                    &session.id,
+                    first_revision,
+                    first_lifecycle_revision,
+                )
+                .expect("session exists")
+        );
         assert!(!store.is_hook_active(&session.id));
         assert!(!store.is_hook_confirmed_this_run(&session.id));
         assert_eq!(store.hook_provider(&session.id), None);
@@ -927,9 +1235,15 @@ mod tests {
         store.begin_hook_turn(&session.id, Some("turn-2"));
 
         assert!(replacement_revision > cleared_revision);
-        assert!(!store
-            .clear_hook_ownership_if_revision(&session.id, first_revision)
-            .expect("session exists"));
+        assert!(
+            !store
+                .clear_hook_ownership_if_revision(
+                    &session.id,
+                    first_revision,
+                    first_lifecycle_revision,
+                )
+                .expect("session exists")
+        );
         assert!(store.is_hook_active(&session.id));
         assert!(store.is_hook_confirmed_this_run(&session.id));
         assert_eq!(
@@ -1049,6 +1363,239 @@ mod tests {
     }
 
     #[test]
+    fn status_and_source_refresh_requires_the_complete_observed_state() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        store
+            .refresh_status_with_source(
+                &session.id,
+                SessionStatus::Working,
+                Some(AgentStatusSource::ProcessFallback),
+            )
+            .expect("session exists");
+        let revision = store.hook_revision(&session.id);
+
+        assert!(!store
+            .refresh_status_and_source_if_hook_revision(
+                &session.id,
+                SessionStatus::Working,
+                Some(AgentStatusSource::Hook),
+                revision,
+                SessionStatus::WaitingForInput,
+                Some(AgentStatusSource::TranscriptFallback),
+            )
+            .expect("session exists"));
+        assert_eq!(
+            store.agent_status_source(&session.id),
+            Some(AgentStatusSource::ProcessFallback)
+        );
+
+        assert!(store
+            .refresh_status_and_source_if_hook_revision(
+                &session.id,
+                SessionStatus::Working,
+                Some(AgentStatusSource::ProcessFallback),
+                revision,
+                SessionStatus::WaitingForInput,
+                Some(AgentStatusSource::TranscriptFallback),
+            )
+            .expect("session exists"));
+        assert_eq!(
+            store.get(&session.id).expect("session exists").status,
+            SessionStatus::WaitingForInput
+        );
+        assert_eq!(
+            store.agent_status_source(&session.id),
+            Some(AgentStatusSource::TranscriptFallback)
+        );
+
+        store.mark_hook_active(&session.id, SessionAgentProvider::Codex);
+        assert!(!store
+            .refresh_status_and_source_if_hook_revision(
+                &session.id,
+                SessionStatus::WaitingForInput,
+                Some(AgentStatusSource::TranscriptFallback),
+                revision,
+                SessionStatus::Ready,
+                None,
+            )
+            .expect("session exists"));
+        assert_eq!(
+            store.agent_status_source(&session.id),
+            Some(AgentStatusSource::Hook)
+        );
+    }
+
+    #[test]
+    fn lifecycle_revision_rejects_an_aba_fallback_write() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        store
+            .refresh_status_with_source(
+                &session.id,
+                SessionStatus::Working,
+                Some(AgentStatusSource::TranscriptFallback),
+            )
+            .expect("session exists");
+        let (_, source, _, lifecycle_revision) = store
+            .lifecycle_snapshot(&session.id)
+            .expect("session exists");
+
+        store
+            .refresh_status_with_source(
+                &session.id,
+                SessionStatus::WaitingForInput,
+                Some(AgentStatusSource::TranscriptFallback),
+            )
+            .expect("session exists");
+        store
+            .refresh_status_with_source(
+                &session.id,
+                SessionStatus::Working,
+                Some(AgentStatusSource::TranscriptFallback),
+            )
+            .expect("session exists");
+
+        assert_eq!(
+            store
+                .refresh_status_and_source_if_lifecycle_revision(
+                    &session.id,
+                    SessionStatus::Working,
+                    source,
+                    lifecycle_revision,
+                    SessionStatus::Ready,
+                    None,
+                )
+                .expect("session exists"),
+            None
+        );
+        assert_eq!(
+            store.get(&session.id).expect("session exists").status,
+            SessionStatus::Working
+        );
+    }
+
+    #[test]
+    fn explicit_status_writes_clear_source_and_fence_stale_polls() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        store
+            .apply_native_status(
+                &session.id,
+                SessionAgentProvider::Codex,
+                SessionStatus::Working,
+            )
+            .expect("session exists");
+        let (status, source, _, lifecycle_revision) = store
+            .lifecycle_snapshot(&session.id)
+            .expect("session exists");
+
+        store
+            .update_status(&session.id, SessionStatus::Ready)
+            .expect("session exists");
+        let (_, updated_source, _, updated_lifecycle_revision) = store
+            .lifecycle_snapshot(&session.id)
+            .expect("session exists");
+        assert_eq!(updated_source, None);
+        assert!(updated_lifecycle_revision > lifecycle_revision);
+        assert_eq!(
+            store
+                .refresh_status_and_source_if_lifecycle_revision(
+                    &session.id,
+                    status,
+                    source,
+                    lifecycle_revision,
+                    SessionStatus::WaitingForInput,
+                    Some(AgentStatusSource::TranscriptFallback),
+                )
+                .expect("session exists"),
+            None
+        );
+
+        store
+            .refresh_status_with_source(
+                &session.id,
+                SessionStatus::WaitingForInput,
+                Some(AgentStatusSource::TranscriptFallback),
+            )
+            .expect("session exists");
+        let (_, _, _, fallback_lifecycle_revision) = store
+            .lifecycle_snapshot(&session.id)
+            .expect("session exists");
+        store
+            .refresh_status(&session.id, SessionStatus::Working)
+            .expect("session exists");
+        let (_, refreshed_source, _, refreshed_lifecycle_revision) = store
+            .lifecycle_snapshot(&session.id)
+            .expect("session exists");
+        assert_eq!(refreshed_source, None);
+        assert!(refreshed_lifecycle_revision > fallback_lifecycle_revision);
+    }
+
+    #[test]
+    fn conditional_agent_state_refresh_checks_revision_and_source() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        store.mark_agent_status_source(&session.id, Some(AgentStatusSource::ProcessFallback));
+        let revision = store.hook_revision(&session.id);
+
+        assert!(!store
+            .refresh_agent_state_if_hook_revision(
+                &session.id,
+                revision,
+                Some(AgentStatusSource::Hook),
+                Some(SessionAgentProvider::Codex),
+                Some("codex-stale".to_string()),
+            )
+            .expect("session exists"));
+        assert_eq!(
+            store
+                .get(&session.id)
+                .expect("session exists")
+                .agent_provider,
+            None
+        );
+
+        assert!(store
+            .refresh_agent_state_if_hook_revision(
+                &session.id,
+                revision,
+                Some(AgentStatusSource::ProcessFallback),
+                Some(SessionAgentProvider::Codex),
+                Some("codex-current".to_string()),
+            )
+            .expect("session exists"));
+        store.mark_hook_active(&session.id, SessionAgentProvider::Claude);
+
+        assert!(!store
+            .refresh_agent_state_if_hook_revision(
+                &session.id,
+                revision,
+                Some(AgentStatusSource::ProcessFallback),
+                None,
+                None,
+            )
+            .expect("session exists"));
+        let stored = store.get(&session.id).expect("session exists");
+        assert_eq!(stored.agent_provider, Some(SessionAgentProvider::Claude));
+        assert_eq!(stored.agent_transcript_id.as_deref(), Some("codex-current"));
+    }
+
+    #[test]
+    fn agent_status_source_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&AgentStatusSource::TranscriptFallback)
+                .expect("source serializes"),
+            "\"transcript_fallback\""
+        );
+        assert_eq!(
+            serde_json::from_str::<AgentStatusSource>("\"process_fallback\"")
+                .expect("source deserializes"),
+            AgentStatusSource::ProcessFallback
+        );
+    }
+
+    #[test]
     fn hook_activity_persists_on_session_and_survives_reload() {
         let store = SessionStore::new();
         let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
@@ -1115,6 +1662,7 @@ mod tests {
         store.begin_hook_turn(&session.id, Some("turn-1"));
         store.mark_hook_tool_started_at(&session.id, SystemTime::now());
         store.mark_codex_permission_waiting_at(&session.id, SystemTime::now());
+        let hook_revision = store.hook_revision(&session.id);
 
         let switched = store
             .prepare_agent_provider_switch(&session.id, SessionAgentProvider::Antigravity)
@@ -1127,6 +1675,8 @@ mod tests {
         assert_eq!(switched.hook_provider, None);
         assert!(!switched.hook_active);
         assert!(!store.is_hook_confirmed_this_run(&session.id));
+        assert_eq!(store.agent_status_source(&session.id), None);
+        assert!(store.hook_revision(&session.id) > hook_revision);
         assert_eq!(store.hook_turn_id(&session.id), None);
         assert_eq!(store.hook_tool_started_at(&session.id), None);
         assert_eq!(store.codex_permission_waiting_at(&session.id), None);

--- a/src-tauri/crates/acorn-session/src/status.rs
+++ b/src-tauri/crates/acorn-session/src/status.rs
@@ -55,15 +55,30 @@ pub enum StatusReason {
     ShellPrompt,
 }
 
+/// Evidence that actually produced this detection. A resolved transcript path
+/// is not itself transcript evidence: read failures and meta-only tails retain
+/// the previous observation instead of claiming JSONL fallback authority.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum StatusEvidence {
+    Transcript,
+    Process,
+    Previous,
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct StatusDetection {
     pub status: SessionStatus,
     pub reason: Option<StatusReason>,
+    pub evidence: StatusEvidence,
 }
 
 impl StatusDetection {
-    fn new(status: SessionStatus, reason: Option<StatusReason>) -> Self {
-        Self { status, reason }
+    fn new(status: SessionStatus, reason: Option<StatusReason>, evidence: StatusEvidence) -> Self {
+        Self {
+            status,
+            reason,
+            evidence,
+        }
     }
 }
 
@@ -106,7 +121,7 @@ pub fn detect_with_reason(
     shell_hint: Option<ShellHint>,
 ) -> StatusDetection {
     if matches!(shell_hint, Some(ShellHint::Idle) | None) {
-        return StatusDetection::new(SessionStatus::Ready, None);
+        return StatusDetection::new(SessionStatus::Ready, None, StatusEvidence::Process);
     }
 
     let (path, kind) = match transcript {
@@ -119,15 +134,19 @@ pub fn detect_with_reason(
         .and_then(|tail| latest_turn_state(kind, &tail.text, tail.read_full));
 
     match classified {
-        Some(TurnState::Ready) => {
-            StatusDetection::new(SessionStatus::Ready, Some(StatusReason::TurnComplete))
+        Some(TurnState::Ready) => StatusDetection::new(
+            SessionStatus::Ready,
+            Some(StatusReason::TurnComplete),
+            StatusEvidence::Transcript,
+        ),
+        Some(TurnState::Working) => {
+            StatusDetection::new(SessionStatus::Working, None, StatusEvidence::Transcript)
         }
-        Some(TurnState::Working) => StatusDetection::new(SessionStatus::Working, None),
         // Transcript exists but the tail held no turn lines; keep
         // whatever the caller previously observed instead of regressing
         // to Ready. The next poll that lands on a real turn line corrects
         // it.
-        None => StatusDetection::new(previous, None),
+        None => StatusDetection::new(previous, None, StatusEvidence::Previous),
     }
 }
 
@@ -138,11 +157,17 @@ fn map_shell_hint(hint: Option<ShellHint>) -> SessionStatus {
 
 fn detect_shell_hint(hint: Option<ShellHint>) -> StatusDetection {
     match hint {
-        Some(ShellHint::Running) => StatusDetection::new(SessionStatus::Working, None),
-        Some(ShellHint::NeedsInput) => {
-            StatusDetection::new(SessionStatus::Ready, Some(StatusReason::ShellPrompt))
+        Some(ShellHint::Running) => {
+            StatusDetection::new(SessionStatus::Working, None, StatusEvidence::Process)
         }
-        Some(ShellHint::Idle) | None => StatusDetection::new(SessionStatus::Ready, None),
+        Some(ShellHint::NeedsInput) => StatusDetection::new(
+            SessionStatus::Ready,
+            Some(StatusReason::ShellPrompt),
+            StatusEvidence::Process,
+        ),
+        Some(ShellHint::Idle) | None => {
+            StatusDetection::new(SessionStatus::Ready, None, StatusEvidence::Process)
+        }
     }
 }
 
@@ -409,10 +434,10 @@ mod tests {
 
     #[test]
     fn detect_uses_shell_hint_when_no_transcript() {
-        assert_eq!(
-            detect(None, SessionStatus::Ready, Some(ShellHint::Running)),
-            SessionStatus::Working
-        );
+        let detection = detect_with_reason(None, SessionStatus::Ready, Some(ShellHint::Running));
+
+        assert_eq!(detection.status, SessionStatus::Working);
+        assert_eq!(detection.evidence, StatusEvidence::Process);
     }
 
     #[test]
@@ -459,21 +484,41 @@ mod tests {
             r#"{"timestamp":"t","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","last_agent_message":"done","completed_at":1,"duration_ms":1,"time_to_first_token_ms":1}}"#,
         );
 
-        assert_eq!(
-            detect_with_reason(
-                Some((path, AgentKind::Codex)),
-                SessionStatus::Working,
-                Some(ShellHint::Running),
-            ),
-            StatusDetection::new(SessionStatus::Ready, Some(StatusReason::TurnComplete)),
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Codex)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
         );
+
+        assert_eq!(detection.status, SessionStatus::Ready);
+        assert_eq!(detection.reason, Some(StatusReason::TurnComplete));
+        assert_eq!(detection.evidence, StatusEvidence::Transcript);
+    }
+
+    #[test]
+    fn detect_preserves_previous_evidence_when_transcript_has_no_turn() {
+        let path = write_status_transcript(&meta_lines().join("\n"));
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Claude)),
+            SessionStatus::WaitingForInput,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::WaitingForInput);
+        assert_eq!(detection.reason, None);
+        assert_eq!(detection.evidence, StatusEvidence::Previous);
     }
 
     #[test]
     fn detect_reports_ready_with_shell_prompt_reason() {
         assert_eq!(
             detect_with_reason(None, SessionStatus::Working, Some(ShellHint::NeedsInput)),
-            StatusDetection::new(SessionStatus::Ready, Some(StatusReason::ShellPrompt)),
+            StatusDetection::new(
+                SessionStatus::Ready,
+                Some(StatusReason::ShellPrompt),
+                StatusEvidence::Process,
+            ),
         );
     }
 

--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use acorn_session::{SessionAgentProvider, SessionStatus, SessionStore};
+use acorn_session::{AgentStatusSource, SessionAgentProvider, SessionStatus, SessionStore};
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use serde::Deserialize;
@@ -161,6 +161,12 @@ impl AgentHookReducer {
             }
         };
         if event.provider != SessionAgentProvider::Codex {
+            if transcript_fallback_duplicates_native_status(&self.sessions, &session, &event) {
+                return Ok(AgentHookApplyOutcome::Ignored {
+                    status: session.status,
+                    reason: "transcript fallback duplicates native status",
+                });
+            }
             validate_agent_hook_session(&session, &event, false)?;
             let transcript_provider_switch = event.source.as_deref() == Some("transcript")
                 && event_can_switch_provider(&event)
@@ -1217,6 +1223,39 @@ fn push_scoped_session_bounded(
     values.push_back(value);
 }
 
+fn transcript_fallback_duplicates_native_status(
+    sessions: &SessionStore,
+    session: &acorn_session::Session,
+    event: &AgentHookEvent,
+) -> bool {
+    if event.provider != SessionAgentProvider::Antigravity
+        || event.source.as_deref() != Some("transcript")
+        || session.hook_provider != Some(event.provider)
+        || !sessions.is_hook_confirmed_this_run(&event.session_id)
+    {
+        return false;
+    }
+
+    sessions.agent_status_source(&event.session_id) == Some(AgentStatusSource::Hook)
+        && session.status == event.event.session_status()
+}
+
+fn is_fallback_observation(event: &AgentHookEvent) -> bool {
+    event.source.as_deref() == Some("transcript")
+        || (event.provider == SessionAgentProvider::Codex
+            && matches!(
+                event.source.as_deref(),
+                Some(
+                    "legacy"
+                        | "jsonl_user"
+                        | "jsonl_task"
+                        | "jsonl_tool"
+                        | "jsonl_approval"
+                        | "legacy_completion"
+                )
+            ))
+}
+
 pub fn apply_agent_hook_event(
     sessions: &SessionStore,
     event: AgentHookEvent,
@@ -1256,6 +1295,12 @@ pub fn apply_agent_hook_event(
     // behind native UserPromptSubmit or Stop. PTY writes and native hooks own
     // the real transition, so a delayed preview must never overwrite them.
     if event.provider == SessionAgentProvider::Codex && event.source.as_deref() == Some("preview") {
+        return Ok(session.status);
+    }
+
+    if event.provider != SessionAgentProvider::Codex
+        && transcript_fallback_duplicates_native_status(sessions, &session, &event)
+    {
         return Ok(session.status);
     }
 
@@ -1336,17 +1381,7 @@ pub fn apply_agent_hook_event(
         }
     }
 
-    // Mark native hook channels live so the transcript-tail status poll
-    // defers turn-boundary classification to them instead of clobbering a
-    // just-set resting status (Ready/WaitingForInput) back to Working on its
-    // next tick. Transcript-derived wrapper observations are only a low-latency
-    // preview of the same data the poll reads. Treating those as an
-    // authoritative hook would make a missed line, owner rotation, or watcher
-    // restart permanently hide the fresher transcript classification.
-    // See `poll_defers_to_hook` in `commands`.
-    let is_authoritative_hook = event.source.as_deref() != Some("transcript");
-    let hook_revision =
-        is_authoritative_hook.then(|| sessions.mark_hook_active(&event.session_id, event.provider));
+    let is_authoritative_hook = !is_fallback_observation(&event);
 
     // The Codex JSONL watcher tags task and exec starts separately. This
     // runtime-only turn evidence lets the process poll distinguish a real
@@ -1361,25 +1396,25 @@ pub fn apply_agent_hook_event(
     }
 
     let status = event.event.session_status();
-    if let (Some(turn_id), Some(revision)) = (scoped_codex_completion, hook_revision) {
+    if let Some(turn_id) = scoped_codex_completion {
         if sessions.hook_turn_id(&event.session_id).as_deref() != Some(turn_id) {
             return Err(format!(
                 "stale Codex turn completion for {}: owner changed before apply",
                 event.session_id
             ));
         }
-        let applied = sessions
-            .refresh_status_if_hook_revision(&event.session_id, session.status, revision, status)
+    }
+    if is_authoritative_hook {
+        sessions
+            .apply_native_status(&event.session_id, event.provider, status)
             .map_err(|err| err.to_string())?;
-        if !applied {
-            return Err(format!(
-                "stale Codex turn completion for {}: superseded before apply",
-                event.session_id
-            ));
-        }
     } else {
         sessions
-            .refresh_status(&event.session_id, status)
+            .refresh_status_with_source(
+                &event.session_id,
+                status,
+                Some(AgentStatusSource::TranscriptFallback),
+            )
             .map_err(|err| err.to_string())?;
     }
     Ok(status)
@@ -1436,20 +1471,7 @@ fn apply_validated_agent_hook_event(
     event: AgentHookEvent,
     effects: CodexStoreEffects,
 ) -> Result<SessionStatus, AgentHookApplyError> {
-    let is_codex_fallback = event.provider == SessionAgentProvider::Codex
-        && matches!(
-            event.source.as_deref(),
-            Some(
-                "jsonl_user" | "jsonl_task" | "jsonl_tool" | "jsonl_approval" | "legacy_completion"
-            )
-        );
-    let is_transcript_observation = event.source.as_deref() == Some("transcript");
-    if !is_codex_fallback && !is_transcript_observation {
-        // Advance the hook generation before touching turn evidence or status.
-        // Pollers use this revision to reject a write based on an older
-        // snapshot while a native hook event is being applied.
-        sessions.mark_hook_active(&event.session_id, event.provider);
-    }
+    let is_authoritative_hook = !is_fallback_observation(&event);
 
     if event.provider == SessionAgentProvider::Codex {
         if effects.begin_turn {
@@ -1469,9 +1491,19 @@ fn apply_validated_agent_hook_event(
     let status = effects
         .status_override
         .unwrap_or_else(|| event.event.session_status());
-    sessions
-        .refresh_status(&event.session_id, status)
-        .map_err(|err| AgentHookApplyError::Conflict(err.to_string()))?;
+    if is_authoritative_hook {
+        sessions
+            .apply_native_status(&event.session_id, event.provider, status)
+            .map_err(|err| AgentHookApplyError::Conflict(err.to_string()))?;
+    } else {
+        sessions
+            .refresh_status_with_source(
+                &event.session_id,
+                status,
+                Some(AgentStatusSource::TranscriptFallback),
+            )
+            .map_err(|err| AgentHookApplyError::Conflict(err.to_string()))?;
+    }
     Ok(status)
 }
 
@@ -3900,6 +3932,51 @@ mod tests {
     }
 
     #[test]
+    fn legacy_codex_completion_is_a_transcript_fallback_not_a_native_hook() {
+        let sessions = acorn_session::SessionStore::new();
+        let mut session = Session::new(
+            "Codex".to_string(),
+            "/tmp/repo".into(),
+            "/tmp/repo".into(),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        session.agent_provider = Some(SessionAgentProvider::Codex);
+        session.status = SessionStatus::Working;
+        let session_id = session.id;
+        sessions.insert(session);
+        let reducer = AgentHookReducer::new(sessions.clone());
+
+        assert!(matches!(
+            reducer
+                .apply(AgentHookEvent {
+                    session_id,
+                    provider: SessionAgentProvider::Codex,
+                    event: AgentHookEventKind::NeedsInput,
+                    message: None,
+                    source: Some("legacy".to_string()),
+                    lifecycle_id: None,
+                    provider_session_id: None,
+                    provider_turn_id: None,
+                    provider_tool_id: None,
+                    provider_version: None,
+                    native_hooks_enabled: None,
+                    ownership: AgentHookOwnership::Owner,
+                })
+                .expect("legacy completion applies"),
+            AgentHookApplyOutcome::Applied(SessionStatus::WaitingForInput)
+        ));
+        assert_eq!(sessions.hook_revision(&session_id), 0);
+        assert!(!sessions.is_hook_confirmed_this_run(&session_id));
+        assert_eq!(sessions.hook_provider(&session_id), None);
+        assert_eq!(
+            sessions.agent_status_source(&session_id),
+            Some(AgentStatusSource::TranscriptFallback)
+        );
+    }
+
+    #[test]
     fn reducer_tracks_the_applied_status_source_across_native_and_fallback_events() {
         let (sessions, session_id, reducer) = codex_reducer_fixture();
 
@@ -4053,7 +4130,7 @@ mod tests {
     }
 
     #[test]
-    fn antigravity_transcript_fallback_yields_to_confirmed_native_events() {
+    fn antigravity_transcript_fallback_ignores_native_duplicates_but_recovers_gaps() {
         let sessions = acorn_session::SessionStore::new();
         let mut session = Session::new(
             "Antigravity".to_string(),
@@ -4097,8 +4174,8 @@ mod tests {
 
         assert!(matches!(
             reducer
-                .apply(event(AgentHookEventKind::Start, "transcript"))
-                .expect("delayed transcript event is classified"),
+                .apply(event(AgentHookEventKind::NeedsInput, "transcript"))
+                .expect("matching transcript duplicate is classified"),
             AgentHookApplyOutcome::Ignored { .. }
         ));
         assert_eq!(
@@ -4108,6 +4185,17 @@ mod tests {
         assert_eq!(
             sessions.agent_status_source(&session_id),
             Some(AgentStatusSource::Hook)
+        );
+
+        assert!(matches!(
+            reducer
+                .apply(event(AgentHookEventKind::Start, "transcript"))
+                .expect("missing native transition falls back"),
+            AgentHookApplyOutcome::Applied(SessionStatus::Working)
+        ));
+        assert_eq!(
+            sessions.agent_status_source(&session_id),
+            Some(AgentStatusSource::TranscriptFallback)
         );
 
         let boot_sessions = acorn_session::SessionStore::new();

--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -2209,7 +2209,9 @@ mod tests {
         AgentHookEvent, AgentHookEventKind, AgentHookHandlerOutcome, AgentHookOwnership,
         AgentHookReducer, AgentHookServer, HookEventHandler, MAX_HEADER_BYTES,
     };
-    use acorn_session::{Session, SessionAgentProvider, SessionKind, SessionStatus};
+    use acorn_session::{
+        AgentStatusSource, Session, SessionAgentProvider, SessionKind, SessionStatus,
+    };
     use std::io::{self, Read, Write};
     use std::net::{SocketAddr, TcpStream};
     use std::sync::{mpsc, Arc, Mutex};
@@ -3898,6 +3900,38 @@ mod tests {
     }
 
     #[test]
+    fn reducer_tracks_the_applied_status_source_across_native_and_fallback_events() {
+        let (sessions, session_id, reducer) = codex_reducer_fixture();
+
+        assert!(matches!(
+            apply_codex(&reducer, session_id, "native_prompt", Some("turn-1")),
+            AgentHookApplyOutcome::Applied(SessionStatus::Working)
+        ));
+        assert_eq!(
+            sessions.agent_status_source(&session_id),
+            Some(AgentStatusSource::Hook)
+        );
+
+        assert!(matches!(
+            apply_codex(&reducer, session_id, "jsonl_approval", Some("turn-1")),
+            AgentHookApplyOutcome::Applied(SessionStatus::WaitingForInput)
+        ));
+        assert_eq!(
+            sessions.agent_status_source(&session_id),
+            Some(AgentStatusSource::TranscriptFallback)
+        );
+
+        assert!(matches!(
+            apply_codex(&reducer, session_id, "native_tool_start", Some("turn-1")),
+            AgentHookApplyOutcome::Applied(SessionStatus::Working)
+        ));
+        assert_eq!(
+            sessions.agent_status_source(&session_id),
+            Some(AgentStatusSource::Hook)
+        );
+    }
+
+    #[test]
     fn reducer_native_tool_ignores_late_matching_fallback_approval() {
         let (sessions, session_id, reducer) = codex_reducer_fixture();
         apply_codex(&reducer, session_id, "native_prompt", Some("turn-1"));
@@ -4016,6 +4050,109 @@ mod tests {
         assert_eq!(sessions.hook_revision(&session_id), 0);
         assert!(!sessions.is_hook_confirmed_this_run(&session_id));
         assert_eq!(sessions.hook_provider(&session_id), None);
+    }
+
+    #[test]
+    fn antigravity_transcript_fallback_yields_to_confirmed_native_events() {
+        let sessions = acorn_session::SessionStore::new();
+        let mut session = Session::new(
+            "Antigravity".to_string(),
+            "/tmp/repo".into(),
+            "/tmp/repo".into(),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        session.agent_provider = Some(SessionAgentProvider::Antigravity);
+        let session_id = session.id;
+        sessions.insert(session);
+        let reducer = AgentHookReducer::new(sessions.clone());
+
+        let event = |event, source: &str| AgentHookEvent {
+            session_id,
+            provider: SessionAgentProvider::Antigravity,
+            event,
+            message: None,
+            source: Some(source.to_string()),
+            lifecycle_id: None,
+            provider_session_id: None,
+            provider_turn_id: None,
+            provider_tool_id: None,
+            provider_version: None,
+            native_hooks_enabled: None,
+            ownership: AgentHookOwnership::Owner,
+        };
+
+        assert!(matches!(
+            reducer
+                .apply(event(AgentHookEventKind::NeedsInput, "hook"))
+                .expect("native event applies"),
+            AgentHookApplyOutcome::Applied(SessionStatus::WaitingForInput)
+        ));
+        assert!(sessions.is_hook_confirmed_this_run(&session_id));
+        assert_eq!(
+            sessions.agent_status_source(&session_id),
+            Some(AgentStatusSource::Hook)
+        );
+
+        assert!(matches!(
+            reducer
+                .apply(event(AgentHookEventKind::Start, "transcript"))
+                .expect("delayed transcript event is classified"),
+            AgentHookApplyOutcome::Ignored { .. }
+        ));
+        assert_eq!(
+            sessions.get(&session_id).expect("session").status,
+            SessionStatus::WaitingForInput
+        );
+        assert_eq!(
+            sessions.agent_status_source(&session_id),
+            Some(AgentStatusSource::Hook)
+        );
+
+        let boot_sessions = acorn_session::SessionStore::new();
+        let mut persisted = Session::new(
+            "Antigravity".to_string(),
+            "/tmp/repo".into(),
+            "/tmp/repo".into(),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        persisted.status = SessionStatus::WaitingForInput;
+        persisted.agent_provider = Some(SessionAgentProvider::Antigravity);
+        persisted.hook_active = true;
+        persisted.hook_provider = Some(SessionAgentProvider::Antigravity);
+        let boot_session_id = persisted.id;
+        boot_sessions.insert(persisted);
+        let boot_reducer = AgentHookReducer::new(boot_sessions.clone());
+        let boot_fallback = AgentHookEvent {
+            session_id: boot_session_id,
+            provider: SessionAgentProvider::Antigravity,
+            event: AgentHookEventKind::Start,
+            message: None,
+            source: Some("transcript".to_string()),
+            lifecycle_id: None,
+            provider_session_id: None,
+            provider_turn_id: None,
+            provider_tool_id: None,
+            provider_version: None,
+            native_hooks_enabled: None,
+            ownership: AgentHookOwnership::Owner,
+        };
+
+        assert!(!boot_sessions.is_hook_confirmed_this_run(&boot_session_id));
+        assert!(matches!(
+            boot_reducer
+                .apply(boot_fallback)
+                .expect("unconfirmed boot fallback applies"),
+            AgentHookApplyOutcome::Applied(SessionStatus::Working)
+        ));
+        assert!(!boot_sessions.is_hook_confirmed_this_run(&boot_session_id));
+        assert_eq!(
+            boot_sessions.agent_status_source(&boot_session_id),
+            Some(AgentStatusSource::TranscriptFallback)
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -27,7 +27,8 @@ use acorn_session::scrollback;
 use acorn_session::status as session_status;
 use acorn_session::status::StatusReason as SessionStatusReason;
 use acorn_session::{
-    Project, Session, SessionAgentProvider, SessionKind, SessionMode, SessionOwner, SessionStatus,
+    AgentStatusSource, Project, Session, SessionAgentProvider, SessionKind, SessionMode,
+    SessionOwner, SessionStatus,
 };
 use acorn_transcript::{assistant_message_text, collapse_preview};
 
@@ -2514,11 +2515,15 @@ fn is_style_suffix_base(word: &str) -> bool {
 }
 
 fn persist(state: &AppState) {
-    if let Err(e) = persistence::save_sessions(&state.sessions.list()) {
-        tracing::warn!("failed to persist sessions: {e}");
-    }
+    persist_sessions(state);
     if let Err(e) = persistence::save_projects(&state.projects.list()) {
         tracing::warn!("failed to persist projects: {e}");
+    }
+}
+
+fn persist_sessions(state: &AppState) {
+    if let Err(e) = persistence::save_sessions(&state.sessions) {
+        tracing::warn!("failed to persist sessions: {e}");
     }
 }
 
@@ -5105,6 +5110,7 @@ pub struct SessionStatusEntry {
     pub id: String,
     pub status: SessionStatus,
     pub status_reason: Option<SessionStatusReason>,
+    pub agent_status_source: Option<AgentStatusSource>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -5252,18 +5258,28 @@ fn poll_defers_to_hook(
     hook_provider.map_or(true, |provider| provider == live_agent_kind)
 }
 
+fn fallback_agent_status_source(
+    live_agent_kind: Option<AgentKind>,
+    evidence: session_status::StatusEvidence,
+    previous_source: Option<AgentStatusSource>,
+) -> Option<AgentStatusSource> {
+    live_agent_kind?;
+    match evidence {
+        session_status::StatusEvidence::Transcript => Some(AgentStatusSource::TranscriptFallback),
+        session_status::StatusEvidence::Process => Some(AgentStatusSource::ProcessFallback),
+        session_status::StatusEvidence::Previous => previous_source,
+    }
+}
+
 /// Recover a turn boundary that was crossed while the app was closed.
 ///
 /// `hook_active` persists across restarts, so right after boot the poll
-/// already defers to the persisted hook-set status. But a hooked agent whose
-/// turn *ended* while no app instance was listening lost that turn-end event
-/// forever — the store still says Working and, since a resting agent emits no
-/// further events, nothing would ever correct it. Until the first hook event
-/// of this run confirms the channel, allow exactly the one transition hooks
-/// can no longer report: Working -> WaitingForInput backed by a real
-/// turn-complete marker in the transcript (a finished turn leaves the agent
-/// awaiting the user's next instruction, which is what the lost turn-end
-/// hook would have reported).
+/// already defers to the persisted hook-set status. Durable hook delivery
+/// normally replays events received while the app is unavailable, but the
+/// transcript remains the bounded compatibility signal for records that
+/// predate durable delivery or could not be retained. Until the first hook
+/// event of this run confirms the channel, allow exactly one recovery:
+/// Working -> WaitingForInput backed by a real turn-complete marker.
 ///
 /// One-directional on purpose: while the app is closed nobody can submit a
 /// prompt to the session, so a resting status cannot regress to Working
@@ -5288,6 +5304,24 @@ fn detect_session_statuses_blocking(
     state: AppState,
     ids: Vec<String>,
 ) -> AppResult<Vec<SessionStatusEntry>> {
+    // Fence every poll write against lifecycle events that arrive while the
+    // process table and transcripts are being inspected. The clear-on-exit
+    // path advances this generation before a later invocation can claim the
+    // same provider again.
+    let lifecycle_snapshots_before_refresh: HashMap<
+        Uuid,
+        (SessionStatus, Option<AgentStatusSource>, u64, u64),
+    > = ids
+        .iter()
+        .filter_map(|id| Uuid::parse_str(id).ok())
+        .filter_map(|id| {
+            state
+                .sessions
+                .lifecycle_snapshot(&id)
+                .ok()
+                .map(|snapshot| (id, snapshot))
+        })
+        .collect();
     // One process-table snapshot covers every session in this poll. cwd is
     // refreshed because the live PTY descendant cwd drives branch detection
     // — a non-isolated session whose terminal `cd`'d into a git worktree
@@ -5323,6 +5357,7 @@ fn detect_session_statuses_blocking(
 
     let mut promoted_auto_title = false;
     let mut reconciled_hook_status = false;
+    let mut cleared_hook_ownership = false;
     let entries: Vec<SessionStatusEntry> = ids
         .into_iter()
         .map(|id| {
@@ -5332,10 +5367,19 @@ fn detect_session_statuses_blocking(
             // `session_status::detect` for the full rationale).
             let parsed_id = Uuid::parse_str(&id).ok();
             let session = parsed_id.and_then(|uuid| state.sessions.get(&uuid).ok());
-            let previous = session
-                .as_ref()
-                .map(|s| s.status)
+            let initial_lifecycle =
+                parsed_id.and_then(|uuid| lifecycle_snapshots_before_refresh.get(&uuid).copied());
+            let previous = initial_lifecycle
+                .map(|(status, _, _, _)| status)
+                .or_else(|| session.as_ref().map(|session| session.status))
                 .unwrap_or(SessionStatus::Ready);
+            let previous_source = initial_lifecycle.and_then(|(_, source, _, _)| source);
+            let observed_hook_revision = initial_lifecycle
+                .map(|(_, _, revision, _)| revision)
+                .unwrap_or(0);
+            let observed_lifecycle_revision = initial_lifecycle
+                .map(|(_, _, _, revision)| revision)
+                .unwrap_or(0);
             if matches!(session.as_ref().map(|s| s.mode), Some(SessionMode::Chat)) {
                 let git_context = session
                     .as_ref()
@@ -5352,6 +5396,7 @@ fn detect_session_statuses_blocking(
                     id,
                     status: previous,
                     status_reason: None,
+                    agent_status_source: None,
                     last_message: conversation_preview
                         .as_ref()
                         .and_then(|p| p.last_agent_message.clone()),
@@ -5413,6 +5458,37 @@ fn detect_session_statuses_blocking(
             let live_agent = root_pid_value
                 .and_then(|pid| live_agent_in_descendants(&sys, &children, Pid::from_u32(pid)));
             let live_agent_kind = live_agent.map(|(kind, _)| kind);
+            let hook_active_before_clear = parsed_id
+                .map(|uuid| state.sessions.is_hook_active(&uuid))
+                .unwrap_or(false);
+            let hook_provider_before_clear =
+                parsed_id.and_then(|uuid| state.sessions.hook_provider(&uuid));
+            let hook_ownership_cleared = hook_active_before_clear
+                && !poll_defers_to_hook(
+                    hook_active_before_clear,
+                    hook_provider_before_clear,
+                    live_agent_kind,
+                )
+                && parsed_id.is_some_and(|uuid| {
+                    state
+                        .sessions
+                        .clear_hook_ownership_if_revision(
+                            &uuid,
+                            observed_hook_revision,
+                            observed_lifecycle_revision,
+                        )
+                        .unwrap_or(false)
+                });
+            cleared_hook_ownership |= hook_ownership_cleared;
+            let (expected_poll_source, expected_poll_lifecycle_revision) = if hook_ownership_cleared
+            {
+                parsed_id
+                    .and_then(|uuid| state.sessions.lifecycle_snapshot(&uuid).ok())
+                    .map(|(_, source, _, lifecycle_revision)| (source, lifecycle_revision))
+                    .unwrap_or((None, observed_lifecycle_revision))
+            } else {
+                (previous_source, observed_lifecycle_revision)
+            };
             let codex_tool_started_at =
                 parsed_id.and_then(|uuid| state.sessions.hook_tool_started_at(&uuid));
             let codex_permission_waiting_at =
@@ -5506,62 +5582,121 @@ fn detect_session_statuses_blocking(
                 hook_provider,
                 live_agent_kind,
             );
+            let mut metadata_write_allowed = true;
+            let metadata_expected_lifecycle_revision;
+            let metadata_expected_source;
             // When a live hooked agent owns the status, keep the hook-set value
             // instead of the stale transcript reading. Re-read it fresh: a hook
             // may have written during this poll's process-table / transcript
             // I/O, and reusing the `previous` captured before that I/O would
             // clobber the newer hook status back to an old value.
-            let status = if defer_to_hook {
-                let stored = parsed_id
-                    .and_then(|uuid| state.sessions.get(&uuid).ok())
-                    .map(|s| s.status)
-                    .unwrap_or(previous);
-                // A turn that ended while the app was closed lost its
-                // turn-end hook event; recover it from the transcript until
-                // the first event of this run re-confirms the channel (see
-                // `hook_boot_reconciled_status`). The this-run flag is read
-                // here — after the poll's I/O — so an event landing during
-                // that window disables the recovery before it can clobber
-                // the fresher hook write.
-                let hook_revision = parsed_id
-                    .map(|uuid| state.sessions.hook_revision(&uuid))
-                    .unwrap_or(0);
+            let (status, agent_status_source, status_reason) = if defer_to_hook {
+                let (stored, stored_source, hook_revision, lifecycle_revision) = parsed_id
+                    .and_then(|uuid| state.sessions.lifecycle_snapshot(&uuid).ok())
+                    .unwrap_or((
+                        previous,
+                        previous_source,
+                        observed_hook_revision,
+                        observed_lifecycle_revision,
+                    ));
+                // Reconcile only while this app instance has not received a
+                // native event. The revision/source checks make the status
+                // and diagnostic provenance one conditional write.
+                let reconciliation_requested =
+                    hook_boot_reconciled_status(stored, hook_revision > 0, detection);
                 let reconciled = parsed_id.and_then(|uuid| {
-                    hook_boot_reconciled_status(stored, hook_revision > 0, detection).and_then(
-                        |reconciled| {
-                            state
-                                .sessions
-                                .refresh_status_if_hook_revision(
-                                    &uuid,
-                                    stored,
-                                    hook_revision,
-                                    reconciled,
-                                )
-                                .ok()
-                                .filter(|applied| *applied)
-                                .map(|_| reconciled)
-                        },
-                    )
+                    reconciliation_requested.and_then(|reconciled| {
+                        state
+                            .sessions
+                            .refresh_status_and_source_if_lifecycle_revision(
+                                &uuid,
+                                stored,
+                                stored_source,
+                                lifecycle_revision,
+                                reconciled,
+                                Some(AgentStatusSource::TranscriptFallback),
+                            )
+                            .ok()
+                            .flatten()
+                            .map(|_| reconciled)
+                    })
                 });
+                if reconciliation_requested.is_some() && reconciled.is_none() {
+                    metadata_write_allowed = false;
+                }
                 reconciled_hook_status |= reconciled.is_some();
-                let hook_status = parsed_id
-                    .and_then(|uuid| state.sessions.get(&uuid).ok())
-                    .map(|session| session.status)
-                    .or(reconciled)
-                    .unwrap_or(stored);
+                let (hook_status, current_source, _, current_lifecycle_revision) = parsed_id
+                    .and_then(|uuid| state.sessions.lifecycle_snapshot(&uuid).ok())
+                    .unwrap_or((
+                        reconciled.unwrap_or(stored),
+                        reconciled
+                            .map(|_| AgentStatusSource::TranscriptFallback)
+                            .or(stored_source),
+                        hook_revision,
+                        lifecycle_revision,
+                    ));
                 // Codex can finish its main turn while a background command
                 // remains alive. Its persistent helpers are filtered below.
                 // Keep the permission boundary until a lifecycle event
                 // changes the store; this poll result is intentionally not
                 // written over a hook-owned Waiting status.
-                hook_status_with_live_tool_activity(
+                let visible_status = hook_status_with_live_tool_activity(
                     hook_status,
                     live_agent_kind,
                     live_codex_tool_child,
                     codex_permission_waiting_at.is_some(),
-                )
+                );
+                metadata_expected_lifecycle_revision = current_lifecycle_revision;
+                metadata_expected_source = current_source;
+                let visible_source = if visible_status != hook_status {
+                    Some(AgentStatusSource::ProcessFallback)
+                } else {
+                    // Runtime provenance is intentionally not persisted. Right
+                    // after restart a persisted hook owner therefore remains
+                    // unknown until replay, reconciliation, or a fresh native
+                    // event establishes the source; do not guess `Hook` here.
+                    current_source
+                };
+                (visible_status, visible_source, None)
             } else {
-                detection.status
+                let candidate_source = fallback_agent_status_source(
+                    live_agent_kind,
+                    detection.evidence,
+                    expected_poll_source,
+                );
+                let applied_lifecycle_revision = match parsed_id {
+                    Some(uuid) => state
+                        .sessions
+                        .refresh_status_and_source_if_lifecycle_revision(
+                            &uuid,
+                            previous,
+                            expected_poll_source,
+                            expected_poll_lifecycle_revision,
+                            detection.status,
+                            candidate_source,
+                        )
+                        .ok()
+                        .flatten(),
+                    None => Some(expected_poll_lifecycle_revision),
+                };
+                if let Some(applied_lifecycle_revision) = applied_lifecycle_revision {
+                    metadata_expected_lifecycle_revision = applied_lifecycle_revision;
+                    metadata_expected_source = candidate_source;
+                    (detection.status, candidate_source, detection.reason)
+                } else {
+                    metadata_write_allowed = false;
+                    let (latest_status, latest_source, _, latest_lifecycle_revision) = parsed_id
+                        .and_then(|uuid| state.sessions.lifecycle_snapshot(&uuid).ok())
+                        .unwrap_or((
+                            detection.status,
+                            candidate_source,
+                            observed_hook_revision,
+                            expected_poll_lifecycle_revision,
+                        ));
+                    metadata_expected_lifecycle_revision = latest_lifecycle_revision;
+                    metadata_expected_source = latest_source;
+                    (latest_status, latest_source, None)
+                }
             };
             // Branch source priority:
             //  1. deepest PTY descendant cwd — reflects `cd` + `git checkout`
@@ -5577,29 +5712,25 @@ fn detect_session_statuses_blocking(
             let git_context = live_git_context.or(fallback_git_context);
             let branch = git_context.as_ref().map(|(branch, _)| branch.clone());
             let git_context_path = git_context.map(|(_, path)| path);
-            // Mirror the detected status into the in-memory store so persisted
-            // sessions reflect liveness on next save. Best-effort: ignore errors
-            // (e.g. UUID parse failure for a stale id from the frontend).
+            // Keep live-agent metadata on the same lifecycle fence as the
+            // status/source write. A native or fallback event that landed
+            // during this poll must retain its newer provider claim.
             if let Some(uuid) = parsed_id {
-                // Deferring means a hook owns the status; leave the store value
-                // untouched so a hook write racing this poll's I/O survives.
-                if !defer_to_hook {
-                    let _ = state.sessions.refresh_status(&uuid, status);
+                if metadata_write_allowed {
+                    let _ = state.sessions.refresh_agent_state_if_lifecycle_revision(
+                        &uuid,
+                        metadata_expected_lifecycle_revision,
+                        metadata_expected_source,
+                        agent_provider,
+                        agent_transcript_id.clone(),
+                    );
                 }
-                let _ = state.sessions.refresh_agent_state(
-                    &uuid,
-                    agent_provider,
-                    agent_transcript_id.clone(),
-                );
             }
             SessionStatusEntry {
                 id,
                 status,
-                status_reason: if defer_to_hook {
-                    None
-                } else {
-                    detection.reason
-                },
+                status_reason,
+                agent_status_source,
                 last_message: transcript_preview,
                 last_user_message: conversation_preview
                     .as_ref()
@@ -5624,14 +5755,22 @@ fn detect_session_statuses_blocking(
         .collect();
     // Promotion must survive an app restart — without the save a session
     // would silently fall back to ineligible until the agent runs again.
-    if status_poll_needs_persist(promoted_auto_title, reconciled_hook_status) {
-        persist(&state);
+    if status_poll_needs_persist(
+        promoted_auto_title,
+        reconciled_hook_status,
+        cleared_hook_ownership,
+    ) {
+        persist_sessions(&state);
     }
     Ok(entries)
 }
 
-fn status_poll_needs_persist(promoted_auto_title: bool, reconciled_hook_status: bool) -> bool {
-    promoted_auto_title || reconciled_hook_status
+fn status_poll_needs_persist(
+    promoted_auto_title: bool,
+    reconciled_hook_status: bool,
+    cleared_hook_ownership: bool,
+) -> bool {
+    promoted_auto_title || reconciled_hook_status || cleared_hook_ownership
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -7087,47 +7226,48 @@ mod tests {
     }
 
     #[test]
-    fn agent_status_source_distinguishes_hook_and_degraded_fallbacks() {
+    fn fallback_agent_status_source_tracks_the_evidence_that_was_used() {
+        use super::session_status::StatusEvidence;
         use super::AgentStatusSource;
 
         assert_eq!(
-            super::agent_status_source(
+            super::fallback_agent_status_source(
                 Some(super::AgentKind::Codex),
-                true,
-                false,
-                true,
-            ),
-            Some(AgentStatusSource::Hook)
-        );
-        assert_eq!(
-            super::agent_status_source(
-                Some(super::AgentKind::Codex),
-                true,
-                true,
-                true,
+                StatusEvidence::Transcript,
+                Some(AgentStatusSource::ProcessFallback),
             ),
             Some(AgentStatusSource::TranscriptFallback)
         );
         assert_eq!(
-            super::agent_status_source(
+            super::fallback_agent_status_source(
                 Some(super::AgentKind::Claude),
-                false,
-                false,
-                true,
-            ),
-            Some(AgentStatusSource::TranscriptFallback)
-        );
-        assert_eq!(
-            super::agent_status_source(
-                Some(super::AgentKind::Antigravity),
-                false,
-                false,
-                false,
+                StatusEvidence::Process,
+                Some(AgentStatusSource::TranscriptFallback),
             ),
             Some(AgentStatusSource::ProcessFallback)
         );
         assert_eq!(
-            super::agent_status_source(None, false, false, true),
+            super::fallback_agent_status_source(
+                Some(super::AgentKind::Antigravity),
+                StatusEvidence::Previous,
+                Some(AgentStatusSource::TranscriptFallback),
+            ),
+            Some(AgentStatusSource::TranscriptFallback)
+        );
+        assert_eq!(
+            super::fallback_agent_status_source(
+                Some(super::AgentKind::Antigravity),
+                StatusEvidence::Previous,
+                None,
+            ),
+            None
+        );
+        assert_eq!(
+            super::fallback_agent_status_source(
+                None,
+                StatusEvidence::Transcript,
+                Some(AgentStatusSource::Hook),
+            ),
             None
         );
     }
@@ -7218,6 +7358,7 @@ mod tests {
         let detection = super::session_status::StatusDetection {
             status: acorn_session::SessionStatus::Ready,
             reason: Some(super::SessionStatusReason::TurnComplete),
+            evidence: super::session_status::StatusEvidence::Transcript,
         };
         assert_eq!(
             super::hook_boot_reconciled_status(
@@ -7236,6 +7377,7 @@ mod tests {
         let detection = super::session_status::StatusDetection {
             status: acorn_session::SessionStatus::Ready,
             reason: Some(super::SessionStatusReason::TurnComplete),
+            evidence: super::session_status::StatusEvidence::Transcript,
         };
         assert_eq!(
             super::hook_boot_reconciled_status(
@@ -7249,9 +7391,10 @@ mod tests {
 
     #[test]
     fn status_poll_persists_successful_boot_reconciliation() {
-        assert!(!super::status_poll_needs_persist(false, false));
-        assert!(super::status_poll_needs_persist(true, false));
-        assert!(super::status_poll_needs_persist(false, true));
+        assert!(!super::status_poll_needs_persist(false, false, false));
+        assert!(super::status_poll_needs_persist(true, false, false));
+        assert!(super::status_poll_needs_persist(false, true, false));
+        assert!(super::status_poll_needs_persist(false, false, true));
     }
 
     #[test]
@@ -7259,6 +7402,7 @@ mod tests {
         let detection = super::session_status::StatusDetection {
             status: acorn_session::SessionStatus::Working,
             reason: None,
+            evidence: super::session_status::StatusEvidence::Previous,
         };
         assert_eq!(
             super::hook_boot_reconciled_status(
@@ -7275,6 +7419,7 @@ mod tests {
         let detection = super::session_status::StatusDetection {
             status: acorn_session::SessionStatus::Ready,
             reason: Some(super::SessionStatusReason::TurnComplete),
+            evidence: super::session_status::StatusEvidence::Transcript,
         };
         assert_eq!(
             super::hook_boot_reconciled_status(
@@ -7294,6 +7439,7 @@ mod tests {
         let detection = super::session_status::StatusDetection {
             status: acorn_session::SessionStatus::Ready,
             reason: Some(super::SessionStatusReason::TurnComplete),
+            evidence: super::session_status::StatusEvidence::Transcript,
         };
         assert_eq!(
             super::hook_boot_reconciled_status(
@@ -7312,6 +7458,7 @@ mod tests {
         let detection = super::session_status::StatusDetection {
             status: acorn_session::SessionStatus::Working,
             reason: None,
+            evidence: super::session_status::StatusEvidence::Previous,
         };
         assert_eq!(
             super::hook_boot_reconciled_status(
@@ -7330,6 +7477,7 @@ mod tests {
         let detection = super::session_status::StatusDetection {
             status: acorn_session::SessionStatus::Ready,
             reason: Some(super::SessionStatusReason::ShellPrompt),
+            evidence: super::session_status::StatusEvidence::Process,
         };
         assert_eq!(
             super::hook_boot_reconciled_status(

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7087,6 +7087,52 @@ mod tests {
     }
 
     #[test]
+    fn agent_status_source_distinguishes_hook_and_degraded_fallbacks() {
+        use super::AgentStatusSource;
+
+        assert_eq!(
+            super::agent_status_source(
+                Some(super::AgentKind::Codex),
+                true,
+                false,
+                true,
+            ),
+            Some(AgentStatusSource::Hook)
+        );
+        assert_eq!(
+            super::agent_status_source(
+                Some(super::AgentKind::Codex),
+                true,
+                true,
+                true,
+            ),
+            Some(AgentStatusSource::TranscriptFallback)
+        );
+        assert_eq!(
+            super::agent_status_source(
+                Some(super::AgentKind::Claude),
+                false,
+                false,
+                true,
+            ),
+            Some(AgentStatusSource::TranscriptFallback)
+        );
+        assert_eq!(
+            super::agent_status_source(
+                Some(super::AgentKind::Antigravity),
+                false,
+                false,
+                false,
+            ),
+            Some(AgentStatusSource::ProcessFallback)
+        );
+        assert_eq!(
+            super::agent_status_source(None, false, false, true),
+            None
+        );
+    }
+
+    #[test]
     fn live_tool_activity_only_resumes_a_codex_permission_wait() {
         assert_eq!(
             super::hook_status_with_live_tool_activity(

--- a/src-tauri/src/daemon_commands.rs
+++ b/src-tauri/src/daemon_commands.rs
@@ -360,7 +360,7 @@ pub fn daemon_adopt_session(
     };
     state.sessions.insert(session);
 
-    if let Err(e) = crate::persistence::save_sessions(&state.sessions.list()) {
+    if let Err(e) = crate::persistence::save_sessions(&state.sessions) {
         tracing::warn!("failed to persist sessions after adopt: {e}");
     }
     if let Err(e) = crate::persistence::save_projects(&state.projects.list()) {

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -397,7 +397,7 @@ fn handle_promote_self<R: Runtime>(
         Err(err) => return err,
     };
     if !already_control {
-        if let Err(err) = persistence::save_sessions(&state.sessions.list()) {
+        if let Err(err) = persistence::save_sessions(&state.sessions) {
             tracing::warn!(error = %err, "ipc: persist after promote-self failed");
         }
         if let Err(err) = app.emit(
@@ -769,7 +769,7 @@ fn handle_new_session<R: Runtime>(
         .unwrap_or("project")
         .to_string();
     state.projects.ensure(repo, basename);
-    if let Err(err) = persistence::save_sessions(&state.sessions.list()) {
+    if let Err(err) = persistence::save_sessions(&state.sessions) {
         tracing::warn!(error = %err, "ipc: persist sessions after new-session failed");
     }
     // Nudge the frontend so the new session appears in the sidebar
@@ -846,7 +846,7 @@ fn handle_kill_session<R: Runtime>(
             };
         }
     }
-    if let Err(err) = persistence::save_sessions(&state.sessions.list()) {
+    if let Err(err) = persistence::save_sessions(&state.sessions) {
         tracing::warn!(error = %err, "ipc: persist after kill-session failed");
     }
     for session in &sessions_to_remove {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -416,7 +416,7 @@ pub fn run() {
                 projects_dirty = true;
             }
             if sessions_dirty {
-                if let Err(err) = persistence::save_sessions(&state.sessions.list()) {
+                if let Err(err) = persistence::save_sessions(&state.sessions) {
                     tracing::warn!("failed to persist sessions after project path cleanup: {err}");
                 }
             }
@@ -523,7 +523,7 @@ pub fn run() {
                         }
                     }
                 }
-                if let Err(err) = persistence::save_sessions(&hook_sessions.list()) {
+                if let Err(err) = persistence::save_sessions(&hook_sessions) {
                     tracing::warn!(error = %err, "agent hook persist status failed");
                 }
                 if let Err(err) = hook_app

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -1,9 +1,10 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::{AppError, AppResult};
-use acorn_session::{Project, Session};
+use acorn_session::{Project, Session, SessionStore};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -15,6 +16,13 @@ const PROJECTS_FILE: &str = "projects.json";
 const PROJECTS_TMP_FILE: &str = "projects.json.tmp";
 const CHAT_SESSIONS_DIR: &str = "chat-sessions";
 pub const CHAT_SESSION_SCHEMA_VERSION: u32 = 1;
+static SESSION_SAVE_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_session_save() -> MutexGuard<'static, ()> {
+    SESSION_SAVE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 fn utc_now() -> DateTime<Utc> {
     Utc::now()
@@ -379,16 +387,29 @@ pub fn load_sessions_with_status() -> AppResult<(Vec<Session>, bool)> {
     }
 }
 
-/// Persist sessions atomically: write to a temp file, then rename into place.
-pub fn save_sessions(sessions: &[Session]) -> AppResult<()> {
+/// Persist the latest session-store snapshot atomically. The process-wide gate
+/// is acquired before taking the snapshot and held through rename, so delayed
+/// save requests re-read current state instead of overwriting a newer lifecycle
+/// claim with a stale caller-owned vector. It also protects the shared temp
+/// path from concurrent in-process writers.
+pub fn save_sessions(sessions: &SessionStore) -> AppResult<()> {
     let final_path = sessions_path()?;
     let tmp_path = sessions_tmp_path()?;
+    save_session_store_to_paths(sessions, &final_path, &tmp_path)
+}
 
-    let payload = serde_json::to_vec_pretty(sessions)
+fn save_session_store_to_paths(
+    sessions: &SessionStore,
+    final_path: &Path,
+    tmp_path: &Path,
+) -> AppResult<()> {
+    let _save_guard = lock_session_save();
+    let sessions = sessions.list();
+    let payload = serde_json::to_vec_pretty(&sessions)
         .map_err(|err| AppError::Other(format!("failed to serialize sessions: {err}")))?;
 
-    fs::write(&tmp_path, &payload)?;
-    fs::rename(&tmp_path, &final_path)?;
+    fs::write(tmp_path, &payload)?;
+    fs::rename(tmp_path, final_path)?;
     tracing::info!(
         count = sessions.len(),
         path = %final_path.display(),
@@ -725,9 +746,131 @@ fn update_chat_message_in_dir(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use std::sync::{mpsc, Arc, Barrier, Mutex};
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn persistence_test_session(name: &str) -> Session {
+        Session::new(
+            name.to_string(),
+            "/tmp/acorn-persistence-test".into(),
+            "/tmp/acorn-persistence-test".into(),
+            "main".to_string(),
+            false,
+            acorn_session::SessionKind::Regular,
+        )
+    }
+
+    #[test]
+    fn concurrent_session_store_saves_leave_a_complete_parseable_snapshot() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let final_path = Arc::new(dir.path().join(SESSIONS_FILE));
+        let tmp_path = Arc::new(dir.path().join(SESSIONS_TMP_FILE));
+        let store = acorn_session::SessionStore::new();
+        let barrier = Arc::new(Barrier::new(8));
+        let mut workers = Vec::new();
+
+        for index in 0..8 {
+            let final_path = final_path.clone();
+            let tmp_path = tmp_path.clone();
+            let store = store.clone();
+            let barrier = barrier.clone();
+            workers.push(std::thread::spawn(move || {
+                barrier.wait();
+                store.insert(persistence_test_session(&format!("session-{index}")));
+                save_session_store_to_paths(&store, &final_path, &tmp_path)
+            }));
+        }
+
+        for worker in workers {
+            worker
+                .join()
+                .expect("save worker did not panic")
+                .expect("concurrent save succeeds");
+        }
+
+        let saved: Vec<Session> = serde_json::from_slice(
+            &fs::read(final_path.as_ref()).expect("saved sessions file exists"),
+        )
+        .expect("saved sessions parse");
+        assert_eq!(saved.len(), 8);
+        assert!(!tmp_path.exists());
+    }
+
+    #[test]
+    fn delayed_session_save_resnapshots_a_newer_native_claim() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let final_path = dir.path().join(SESSIONS_FILE);
+        let tmp_path = dir.path().join(SESSIONS_TMP_FILE);
+        let store = acorn_session::SessionStore::new();
+        let session = store.insert(persistence_test_session("native-claim"));
+        let save_gate = lock_session_save();
+        let (started_tx, started_rx) = mpsc::channel();
+        let save_store = store.clone();
+        let save_final_path = final_path.clone();
+        let save_tmp_path = tmp_path.clone();
+        let delayed_save = std::thread::spawn(move || {
+            started_tx.send(()).expect("signal delayed save");
+            save_session_store_to_paths(&save_store, &save_final_path, &save_tmp_path)
+        });
+        started_rx.recv().expect("delayed save started");
+
+        store
+            .apply_native_status(
+                &session.id,
+                acorn_session::SessionAgentProvider::Codex,
+                acorn_session::SessionStatus::Working,
+            )
+            .expect("native claim applies");
+        drop(save_gate);
+        delayed_save
+            .join()
+            .expect("delayed save did not panic")
+            .expect("delayed save succeeds");
+
+        let saved: Vec<Session> =
+            serde_json::from_slice(&fs::read(final_path).expect("saved sessions file exists"))
+                .expect("saved sessions parse");
+        assert_eq!(saved.len(), 1);
+        assert_eq!(saved[0].status, acorn_session::SessionStatus::Working);
+        assert!(saved[0].hook_active);
+        assert_eq!(
+            saved[0].hook_provider,
+            Some(acorn_session::SessionAgentProvider::Codex)
+        );
+    }
+
+    #[test]
+    fn cleared_hook_ownership_survives_save_and_reload() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let final_path = dir.path().join(SESSIONS_FILE);
+        let tmp_path = dir.path().join(SESSIONS_TMP_FILE);
+        let store = acorn_session::SessionStore::new();
+        let session = store.insert(persistence_test_session("cleared-owner"));
+        store
+            .apply_native_status(
+                &session.id,
+                acorn_session::SessionAgentProvider::Claude,
+                acorn_session::SessionStatus::WaitingForInput,
+            )
+            .expect("native claim applies");
+        let (_, _, hook_revision, lifecycle_revision) = store
+            .lifecycle_snapshot(&session.id)
+            .expect("session exists");
+        assert!(store
+            .clear_hook_ownership_if_revision(&session.id, hook_revision, lifecycle_revision,)
+            .expect("ownership clear applies"));
+
+        save_session_store_to_paths(&store, &final_path, &tmp_path)
+            .expect("cleared ownership saves");
+        let saved: Vec<Session> =
+            serde_json::from_slice(&fs::read(final_path).expect("saved sessions file exists"))
+                .expect("saved sessions parse");
+
+        assert_eq!(saved.len(), 1);
+        assert!(!saved[0].hook_active);
+        assert_eq!(saved[0].hook_provider, None);
+    }
 
     #[test]
     fn data_dir_is_resolvable() {

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -35,6 +35,7 @@ import type { TranslationKey, Translator } from "../lib/i18n";
 import { useSettings } from "../lib/settings";
 import { useToasts } from "../lib/toasts";
 import type {
+  AgentStatusSource,
   MemoryProcess,
   SessionNotification,
   SessionNotificationKind,
@@ -77,14 +78,37 @@ function sessionStatusReasonLabel(
   }
 }
 
+function agentStatusSourceLabel(
+  t: Translator,
+  source: AgentStatusSource | null | undefined,
+): string | null {
+  switch (source) {
+    case "hook":
+      return statusBarText(t, "statusBar.agentStatusSource.hook");
+    case "transcript_fallback":
+      return statusBarText(
+        t,
+        "statusBar.agentStatusSource.transcript_fallback",
+      );
+    case "process_fallback":
+      return statusBarText(t, "statusBar.agentStatusSource.process_fallback");
+    default:
+      return null;
+  }
+}
+
 function sessionStatusDetailLabel(
   t: Translator,
   status: SessionStatus,
   reason: SessionStatusReason | null | undefined,
+  source: AgentStatusSource | null | undefined,
 ): string {
   const label = statusBarText(t, SESSION_STATUS_KEYS[status]);
-  const reasonLabel = sessionStatusReasonLabel(t, reason);
-  return reasonLabel ? `${label} · ${reasonLabel}` : label;
+  const details = [
+    sessionStatusReasonLabel(t, reason),
+    agentStatusSourceLabel(t, source),
+  ].filter((detail): detail is string => detail !== null);
+  return [label, ...details].join(" · ");
 }
 
 function statusBarText(t: Translator, key: StatusBarTranslationKey): string {
@@ -351,6 +375,7 @@ export function StatusBar() {
                 t,
                 active.status,
                 active.status_reason,
+                active.agent_status_source,
               )}
             >
               {statusBarFormat(t, "statusBar.status", {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
   AcornIpcStatus,
+  AgentStatusSource,
   AgentTokenUsageSnapshot,
   AgentHistoryItem,
   AgentTranscriptSummary,
@@ -640,6 +641,7 @@ export const api = {
       id: string;
       status: SessionStatus;
       status_reason?: SessionStatusReason | null;
+      agent_status_source?: AgentStatusSource | null;
       status_started_at?: string | null;
       last_message?: string | null;
       last_user_message?: string | null;
@@ -661,6 +663,7 @@ export const api = {
         id: string;
         status: SessionStatus;
         status_reason?: SessionStatusReason | null;
+        agent_status_source?: AgentStatusSource | null;
         status_started_at?: string | null;
         last_message?: string | null;
         last_user_message?: string | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,11 @@ export type SessionStatus =
 
 export type SessionStatusReason = "turn_complete" | "shell_prompt";
 
+export type AgentStatusSource =
+  | "hook"
+  | "transcript_fallback"
+  | "process_fallback";
+
 export type SessionNotificationKind = "waiting_for_input" | "errored";
 
 export interface SessionNotification {
@@ -122,6 +127,8 @@ export interface Session {
   status: SessionStatus;
   /** Ephemeral status-poll detail. Not persisted in backend sessions. */
   status_reason?: SessionStatusReason | null;
+  /** Ephemeral status control path reported by status polling. */
+  agent_status_source?: AgentStatusSource | null;
   /** Ephemeral time when the current status started. */
   status_started_at?: string | null;
   created_at: string;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -906,6 +906,11 @@
       "waitingForInput": "waiting for input",
       "errored": "error"
     },
+    "agentStatusSource": {
+      "hook": "Native hook",
+      "transcript_fallback": "Transcript fallback (degraded)",
+      "process_fallback": "Process fallback (degraded)"
+    },
     "sessionStatusReason": {
       "turn_complete": "agent turn complete",
       "shell_prompt": "shell prompt detected"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -906,6 +906,11 @@
       "waitingForInput": "입력 대기",
       "errored": "오류"
     },
+    "agentStatusSource": {
+      "hook": "네이티브 훅",
+      "transcript_fallback": "트랜스크립트 폴백(기능 저하)",
+      "process_fallback": "프로세스 폴백(기능 저하)"
+    },
     "sessionStatusReason": {
       "turn_complete": "에이전트 응답 완료",
       "shell_prompt": "셸 프롬프트 감지"

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2351,6 +2351,25 @@ describe("reconcile via refreshSessions", () => {
     );
   });
 
+  it("clears an omitted agent status source when list_sessions changes status", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          status: "working",
+          agent_status_source: "hook",
+        }),
+      ],
+    );
+    mockApi.listSessions.mockResolvedValueOnce([
+      session("a1", REPO_A, { status: "ready" }),
+    ]);
+
+    await useAppStore.getState().refreshSessions();
+
+    expect(useAppStore.getState().sessions[0]?.agent_status_source).toBeUndefined();
+  });
+
   it("drops removed sessions from the pane that held them", async () => {
     // Single-pane variant — this exercises filter-out without depending on
     // the cross-pane collapse path, which has a runtime-specific divergence
@@ -2545,6 +2564,25 @@ describe("pollSessionStatuses", () => {
         agent_status_source: null,
         branch: null,
       },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.agent_status_source).toBeNull();
+  });
+
+  it("clears an omitted agent status source when a legacy poll changes status", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          status: "working",
+          agent_status_source: "hook",
+        }),
+      ],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      { id: "a1", status: "ready", branch: null },
     ]);
 
     await useAppStore.getState().pollSessionStatuses(["a1"]);

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2490,6 +2490,27 @@ describe("pollSessionStatuses", () => {
     expect(sessions.find((s) => s.id === "a2")?.status).toBe("working");
   });
 
+  it("merges the agent status source reported by status polling", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A, { agent_status_source: "hook" })],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "working",
+        agent_status_source: "transcript_fallback",
+        branch: null,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.agent_status_source).toBe(
+      "transcript_fallback",
+    );
+  });
+
   it("polls only the requested existing session ids", async () => {
     await seed(
       [project(REPO_A, 0)],

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2333,6 +2333,24 @@ describe("cycleProject", () => {
 });
 
 describe("reconcile via refreshSessions", () => {
+  it("preserves an ephemeral agent status source when list_sessions omits it", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          agent_status_source: "transcript_fallback",
+        }),
+      ],
+    );
+    mockApi.listSessions.mockResolvedValueOnce([session("a1", REPO_A)]);
+
+    await useAppStore.getState().refreshSessions();
+
+    expect(useAppStore.getState().sessions[0]?.agent_status_source).toBe(
+      "transcript_fallback",
+    );
+  });
+
   it("drops removed sessions from the pane that held them", async () => {
     // Single-pane variant — this exercises filter-out without depending on
     // the cross-pane collapse path, which has a runtime-specific divergence
@@ -2509,6 +2527,29 @@ describe("pollSessionStatuses", () => {
     expect(useAppStore.getState().sessions[0]?.agent_status_source).toBe(
       "transcript_fallback",
     );
+  });
+
+  it("clears a stale agent status source when status polling reports null", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [
+        session("a1", REPO_A, {
+          agent_status_source: "transcript_fallback",
+        }),
+      ],
+    );
+    mockApi.detectSessionStatuses.mockResolvedValueOnce([
+      {
+        id: "a1",
+        status: "ready",
+        agent_status_source: null,
+        branch: null,
+      },
+    ]);
+
+    await useAppStore.getState().pollSessionStatuses(["a1"]);
+
+    expect(useAppStore.getState().sessions[0]?.agent_status_source).toBeNull();
   });
 
   it("polls only the requested existing session ids", async () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -138,6 +138,7 @@ function mergeRefreshedSessionRuntimeState(
     if (current.status === refreshed.status) {
       preserve("status_reason");
       preserve("status_started_at");
+      preserve("agent_status_source");
     }
     if (refreshed.last_message === null && current.last_message !== null) {
       merged.last_message = current.last_message;
@@ -1906,6 +1907,15 @@ export const useAppStore = create<AppStateModel>()(
                 )
                   ? (update.status_reason ?? null)
                   : (sess.status_reason ?? null);
+                const nextAgentStatusSource =
+                  Object.prototype.hasOwnProperty.call(
+                    update,
+                    "agent_status_source",
+                  )
+                    ? (update.agent_status_source ?? null)
+                    : nextStatus === sess.status
+                      ? (sess.agent_status_source ?? null)
+                      : null;
                 const nextStatusStartedAt = Object.prototype.hasOwnProperty.call(
                   update,
                   "status_started_at",
@@ -1993,6 +2003,8 @@ export const useAppStore = create<AppStateModel>()(
                 if (
                   nextStatus !== sess.status ||
                   nextStatusReason !== (sess.status_reason ?? null) ||
+                  nextAgentStatusSource !==
+                    (sess.agent_status_source ?? null) ||
                   nextStatusStartedAt !== (sess.status_started_at ?? null) ||
                   nextBranch !== sess.branch ||
                   nextLastMessage !== sess.last_message ||
@@ -2019,6 +2031,7 @@ export const useAppStore = create<AppStateModel>()(
                     ...sess,
                     status: nextStatus,
                     status_reason: nextStatusReason,
+                    agent_status_source: nextAgentStatusSource,
                     status_started_at: nextStatusStartedAt,
                     branch: nextBranch,
                     last_message: nextLastMessage,

--- a/tests/e2e/statusbar.spec.ts
+++ b/tests/e2e/statusbar.spec.ts
@@ -113,27 +113,41 @@ test.describe("status bar", () => {
     await expect(tooltip.locator("svg")).toHaveCount(3);
   });
 
-  test("identifies degraded transcript lifecycle fallback in the status tooltip", async ({
-    page,
-    tauri,
-  }) => {
-    await tauri.respond("list_projects", [PROJECT]);
-    await tauri.respond("list_sessions", [
-      {
-        ...BASE_SESSION,
-        status: "working",
-        agent_provider: "codex",
-        agent_status_source: "transcript_fallback",
-      },
-    ]);
+  for (const { source, label } of [
+    { source: "hook", label: "Native hook" },
+    {
+      source: "transcript_fallback",
+      label: "Transcript fallback (degraded)",
+    },
+    { source: "process_fallback", label: "Process fallback (degraded)" },
+  ]) {
+    test(`identifies ${source} lifecycle diagnostics from status polling`, async ({
+      page,
+      tauri,
+    }) => {
+      await tauri.respond("list_projects", [PROJECT]);
+      await tauri.respond("list_sessions", [
+        { ...BASE_SESSION, agent_provider: "codex" },
+      ]);
+      await tauri.respond("detect_session_statuses", [
+        {
+          id: BASE_SESSION.id,
+          status: "working",
+          status_reason: null,
+          agent_status_source: source,
+          branch: null,
+        },
+      ]);
 
-    await page.goto("/");
+      await page.goto("/");
 
-    await expect(page.locator('footer span[title*="Transcript fallback"]')).toHaveAttribute(
-      "title",
-      "working · Transcript fallback (degraded)",
-    );
-  });
+      const detail = `working · ${label}`;
+      await expect(page.locator(`footer span[title="${detail}"]`)).toHaveAttribute(
+        "title",
+        detail,
+      );
+    });
+  }
 
   test("shows only Codex token usage for an active Codex tab", async ({
     page,

--- a/tests/e2e/statusbar.spec.ts
+++ b/tests/e2e/statusbar.spec.ts
@@ -113,6 +113,28 @@ test.describe("status bar", () => {
     await expect(tooltip.locator("svg")).toHaveCount(3);
   });
 
+  test("identifies degraded transcript lifecycle fallback in the status tooltip", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      {
+        ...BASE_SESSION,
+        status: "working",
+        agent_provider: "codex",
+        agent_status_source: "transcript_fallback",
+      },
+    ]);
+
+    await page.goto("/");
+
+    await expect(page.locator('footer span[title*="Transcript fallback"]')).toHaveAttribute(
+      "title",
+      "working · Transcript fallback (degraded)",
+    );
+  });
+
   test("shows only Codex token usage for an active Codex tab", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

This closes the remaining Phase 1 gap in #666 by making native lifecycle hooks authoritative while exposing bounded fallback paths as degraded diagnostics.

1. **Lifecycle provenance:** Track whether each applied status came from a native hook, transcript fallback, or process fallback without guessing the source after restart.
2. **Race-safe precedence:** Apply native status, ownership, and provenance atomically; fence poll writes with lifecycle revisions so stale or ABA-shaped observations cannot overwrite newer hook state.
3. **Bounded recovery:** Keep Codex/Antigravity transcript and process recovery for missed events, classify legacy JSONL observations as fallback, and prevent duplicate fallback observations from claiming native ownership.
4. **Durable cleanup and UI diagnostics:** Clear stale hook evidence on process exit/provider changes, serialize session persistence before snapshotting, and surface localized source tooltips in the status bar.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Status diagnostics | Native and fallback updates were indistinguishable | Native hook, transcript fallback, and process fallback are explicit |
| Native precedence | A stale poll could race with lifecycle updates | Lifecycle-revision CAS protects newer native state |
| Restart behavior | Persisted ownership could imply an unverified source | Source remains unknown until replay, reconciliation, or a new event establishes it |
| Persistence | Concurrent snapshots could overwrite newer ownership metadata | Writers serialize before taking the store snapshot |

## Design notes

- Fallback is intentionally retained as a bounded recovery path; this PR makes degraded operation visible instead of silently treating fallback as native.
- Lifecycle runtime state uses one ledger and a consistent ledger-to-session lock order. Status polls write through revision-checked APIs rather than mutating session rows directly.
- Transcript-path availability alone is not provenance. A transcript source is recorded only when transcript content actually classifies the status; process evidence is recorded separately.
- Persisted hook ownership is not converted into a synthetic native source on startup.

## Follow-up (not in this PR)

- Antigravity does not expose a stable turn/sequence identifier. Exact duplicate native/transcript observations are suppressed, while contradictory transcript transitions remain available as explicitly degraded recovery. A future turn-scoped fence can tighten this if the provider exposes suitable identity.

## Test plan

- [x] `env -u ACORN_DATA_DIR -u ACORN_IPC_SOCKET cargo test --manifest-path src-tauri/Cargo.toml --workspace --all-targets --no-fail-fast -- --test-threads=1` — all targets passed (one ignored test)
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` — passed
- [x] Changed Rust files: `rustfmt --edition 2021 --check --config skip_children=true ...` — passed
- [x] `pnpm typecheck` — passed
- [x] `pnpm test` — 96 files / 1,082 tests passed
- [x] `pnpm build` — production frontend build passed
- [x] `pnpm test:e2e` — 247 tests passed

## Notes

- Running the workspace tests with Acorn's injected `ACORN_DATA_DIR` makes the pre-existing `acorn-ipc::socket_path::falls_back_to_data_dir` test observe the forced prod path. The isolated test and the full workspace pass when that override is unset; this is not caused by this PR.
- `cargo fmt --all --check` under the local Rust 1.95 formatter reports pre-existing formatting differences in unchanged files. All Rust files changed by this PR pass the targeted formatter check.

Closes #666
