### PR TITLE
fix(security): harden runtime, filesystem, and release boundaries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      frontend-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: weekly
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     name: Frontend
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 9.15.0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: pnpm
@@ -30,6 +36,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Audit dependencies
+        run: pnpm audit --audit-level=moderate
 
       - name: Type check
         run: pnpm run typecheck
@@ -45,20 +54,23 @@ jobs:
   e2e:
     name: E2E (shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         shard: [1, 2]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 9.15.0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: pnpm
@@ -75,7 +87,7 @@ jobs:
         run: echo "version=$(node -p "require('./node_modules/@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
@@ -88,7 +100,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: playwright-report-${{ matrix.shard }}-of-2
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,15 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize every release version. Per-tag groups still allow an older and
+  # newer stable release to race after both inspect the same Latest pointer.
+  group: release
+  cancel-in-progress: false
+
 jobs:
   # Build the Vite frontend once and share `dist/` with every downstream
   # bundler job. The frontend output is identical across macOS targets,
@@ -23,19 +32,40 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 9.15.0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+
+      - name: Validate release version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            tag="$INPUT_TAG"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+          fi
+          node scripts/validate-release-version.mjs "$tag"
+          tag_commit=$(git rev-parse --verify "refs/tags/${tag}^{commit}")
+          head_commit=$(git rev-parse --verify HEAD)
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "checked out $head_commit, but $tag resolves to $tag_commit" >&2
+            exit 1
+          fi
 
       - name: Install JS deps
         run: pnpm install --frozen-lockfile
@@ -44,7 +74,7 @@ jobs:
         run: pnpm run build
 
       - name: Upload frontend artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: frontend-dist
           path: dist/
@@ -56,8 +86,6 @@ jobs:
     runs-on: macos-latest
     needs: frontend
     timeout-minutes: 60
-    permissions:
-      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -66,27 +94,31 @@ jobs:
           - x86_64-apple-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 9.15.0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri
           # Per-target shared key (default key already factors in
@@ -104,7 +136,7 @@ jobs:
       # bumps). Wraps rustc to memoize per-crate compilation outputs.
       - name: Setup sccache
         continue-on-error: true
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       # Probe the GHA cache backend before trusting sccache. When the
       # Azure Edge layer behind `artifactcache.actions.githubusercontent.com`
@@ -140,7 +172,7 @@ jobs:
       # instead of compiling release sidecars and release-ci app binaries
       # back to back.
       - name: Download shared frontend bundle
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: frontend-dist
           path: dist/
@@ -169,7 +201,7 @@ jobs:
         # `frontend` job's artifact one step ago. The sidecar staging
         # script still runs per-target because it cross-compiles for each
         # apple triple.
-        run: pnpm run tauri build --target ${{ matrix.target }} --bundles app dmg --config '{"build":{"beforeBuildCommand":"TAURI_SIDECAR_FORCE_TARGET=1 TAURI_SIDECAR_PROFILE=release-ci pnpm run build:sidecar"}}' -- --profile release-ci
+        run: pnpm run tauri build --target ${{ matrix.target }} --bundles app dmg --config '{"build":{"beforeBuildCommand":"TAURI_SIDECAR_FORCE_TARGET=1 TAURI_SIDECAR_PROFILE=release-ci pnpm run build:sidecar"}}' -- --profile release-ci --locked
 
       - name: Stage release artifacts
         id: stage
@@ -199,32 +231,21 @@ jobs:
             *)         suffix="$target" ;;
           esac
 
-          # DMG (already arch-tagged by tauri — `Acorn_<ver>_<arch>.dmg`)
-          find "${bundle_dir}/dmg" -name "*.dmg" -maxdepth 2 -print0 \
-            | xargs -0 -I{} cp -v {} "$out/"
-
-          # Updater tarball + signature, renamed to add the arch suffix.
-          # The publish job's `latest.json` generator already greps for
-          # `aarch64` / `x86_64` in the filename, so once the names are
-          # tagged here it picks the right pair per platform.
-          while IFS= read -r -d '' f; do
-            base=$(basename "$f" .app.tar.gz)
-            cp -v "$f" "$out/${base}_${suffix}.app.tar.gz"
-          done < <(find "${bundle_dir}/macos" -name "*.app.tar.gz" -maxdepth 2 -print0)
-          while IFS= read -r -d '' f; do
-            base=$(basename "$f" .app.tar.gz.sig)
-            cp -v "$f" "$out/${base}_${suffix}.app.tar.gz.sig"
-          done < <(find "${bundle_dir}/macos" -name "*.app.tar.gz.sig" -maxdepth 2 -print0)
+          # Fail closed unless Tauri produced exactly one DMG and one matching
+          # updater tarball/signature pair, then stage the pair together with
+          # an architecture suffix before matrix artifacts are merged.
+          node scripts/release-artifacts.mjs stage "$bundle_dir" "$out" "$suffix"
 
           ls -la "$out/"
           echo "dir=$out" >> "$GITHUB_OUTPUT"
 
       - name: Upload bundle artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: bundles-${{ matrix.target }}
           path: ${{ steps.stage.outputs.dir }}/**
           if-no-files-found: error
+          retention-days: 1
 
   # Manual-only benchmark of nightly Rust + `-Z share-generics` + parallel
   # rustc against the same shared frontend. Skipped on tag pushes; trigger
@@ -238,13 +259,16 @@ jobs:
     needs: frontend
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 9.15.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: pnpm
@@ -252,18 +276,19 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: frontend-dist
           path: dist/
 
       - name: Setup nightly Rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly
         with:
+          toolchain: nightly
           targets: aarch64-apple-darwin
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: src-tauri
           shared-key: nightly-aarch64
@@ -273,7 +298,7 @@ jobs:
         env:
           RUSTFLAGS: "-Z share-generics=y -Z threads=8"
           CARGO_INCREMENTAL: "0"
-        run: pnpm run tauri build --target aarch64-apple-darwin --bundles app --config '{"build":{"beforeBuildCommand":"TAURI_SIDECAR_FORCE_TARGET=1 TAURI_SIDECAR_PROFILE=release-ci pnpm run build:sidecar"}}' -- --profile release-ci
+        run: pnpm run tauri build --target aarch64-apple-darwin --bundles app --config '{"build":{"beforeBuildCommand":"TAURI_SIDECAR_FORCE_TARGET=1 TAURI_SIDECAR_PROFILE=release-ci pnpm run build:sidecar"}}' -- --profile release-ci --locked
 
   release:
     name: Publish GitHub Release + latest.json
@@ -284,17 +309,19 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
 
       - name: Download all bundles
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           path: bundles
           pattern: bundles-*
@@ -305,16 +332,62 @@ jobs:
 
       - name: Resolve tag + version
         id: meta
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            tag="${{ inputs.tag }}"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            tag="$INPUT_TAG"
           else
             tag="${GITHUB_REF#refs/tags/}"
           fi
-          version="${tag#v}"
+          version=$(node scripts/validate-release-version.mjs "$tag")
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse existing release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          error_file=$(mktemp)
+          if ! release_json=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>"$error_file"); then
+            if grep -q "HTTP 404" "$error_file"; then
+              exit 0
+            fi
+            cat "$error_file" >&2
+            exit 1
+          fi
+          asset_count=$(jq '.assets | length' <<<"$release_json")
+          if [[ "$asset_count" != "0" ]]; then
+            echo "release $TAG already has $asset_count asset(s); refusing a mutable or mixed rerun" >&2
+            exit 1
+          fi
+
+      - name: Enforce latest release order
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$TAG" == *-* ]]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          error_file=$(mktemp)
+          if ! current_tag=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name 2>"$error_file"); then
+            if grep -q "HTTP 404" "$error_file"; then
+              echo "value=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            cat "$error_file" >&2
+            exit 1
+          fi
+          node scripts/validate-release-version.mjs --assert-newer "$TAG" "$current_tag"
+          echo "value=true" >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes
         id: notes
@@ -350,22 +423,11 @@ jobs:
           # tauri.conf.json points at `releases/latest/download/latest.json`
           # which always resolves to the newest tag.
 
-          arm_tar=$(ls bundles/*.app.tar.gz | grep -E 'aarch64' | head -n1 || true)
-          arm_sig=$(ls bundles/*.app.tar.gz.sig | grep -E 'aarch64' | head -n1 || true)
-          x64_tar=$(ls bundles/*.app.tar.gz | grep -E 'x64|x86_64' | head -n1 || true)
-          x64_sig=$(ls bundles/*.app.tar.gz.sig | grep -E 'x64|x86_64' | head -n1 || true)
-
-          # If the bundle filenames don't carry the arch hint (older
-          # tauri builds put both into a single name), fall back to the
-          # only available file for both arches.
-          if [[ -z "$arm_tar" || -z "$x64_tar" ]]; then
-            single_tar=$(ls bundles/*.app.tar.gz | head -n1)
-            single_sig=$(ls bundles/*.app.tar.gz.sig | head -n1)
-            arm_tar="${arm_tar:-$single_tar}"
-            arm_sig="${arm_sig:-$single_sig}"
-            x64_tar="${x64_tar:-$single_tar}"
-            x64_sig="${x64_sig:-$single_sig}"
-          fi
+          node scripts/release-artifacts.mjs inspect bundles > artifact-set.json
+          arm_tar=$(jq -r .armTar artifact-set.json)
+          arm_sig=$(jq -r .armSignature artifact-set.json)
+          x64_tar=$(jq -r .x64Tar artifact-set.json)
+          x64_sig=$(jq -r .x64Signature artifact-set.json)
 
           base="https://github.com/${REPO}/releases/download/${TAG}"
           arm_url="${base}/$(basename "$arm_tar")"
@@ -394,7 +456,7 @@ jobs:
           cat latest.json
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: ${{ steps.meta.outputs.tag }}
@@ -407,10 +469,12 @@ jobs:
             bundles/*.app.tar.gz
             bundles/*.app.tar.gz.sig
             latest.json
+          fail_on_unmatched_files: true
+          overwrite_files: false
           # Stable releases must update GitHub's "Latest" pointer because the
           # app updater resolves latest.json through /releases/latest/download.
           # Keep prerelease tags out of that pointer.
-          make_latest: ${{ contains(steps.meta.outputs.tag, '-') && 'false' || 'true' }}
+          make_latest: ${{ steps.latest.outputs.value }}
           prerelease: ${{ contains(steps.meta.outputs.tag, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (e.g. v0.2.0). Must already exist on the branch you ran this from."
+        description: "Tag to release (e.g. v0.2.0). Must already exist on origin/main."
         required: true
         type: string
 
@@ -30,11 +30,18 @@ jobs:
     name: Build shared frontend bundle
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      release_commit: ${{ steps.release_source.outputs.commit }}
+      release_tag: ${{ steps.release_source.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          # Tag-push events already carry an immutable commit SHA. Manual
+          # runs resolve their requested tag once here; every downstream job
+          # then checks out the validated commit output instead of the tag.
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.sha }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup pnpm
@@ -50,6 +57,7 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Validate release version
+        id: release_source
         env:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
@@ -66,6 +74,12 @@ jobs:
             echo "checked out $head_commit, but $tag resolves to $tag_commit" >&2
             exit 1
           fi
+          if ! git merge-base --is-ancestor "$head_commit" refs/remotes/origin/main; then
+            echo "release commit $head_commit is not reachable from origin/main" >&2
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "commit=$head_commit" >> "$GITHUB_OUTPUT"
 
       - name: Install JS deps
         run: pnpm install --frozen-lockfile
@@ -96,7 +110,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          ref: ${{ needs.frontend.outputs.release_commit }}
           persist-credentials: false
 
       - name: Setup pnpm
@@ -261,7 +275,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          ref: ${{ needs.frontend.outputs.release_commit }}
           persist-credentials: false
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
@@ -302,7 +316,7 @@ jobs:
 
   release:
     name: Publish GitHub Release + latest.json
-    needs: build
+    needs: [frontend, build]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -311,9 +325,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          ref: ${{ needs.frontend.outputs.release_commit }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify pinned release source
+        env:
+          EXPECTED_COMMIT: ${{ needs.frontend.outputs.release_commit }}
+          TAG: ${{ needs.frontend.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          git fetch --force --no-tags origin \
+            "+refs/tags/${TAG}:refs/tags/${TAG}" \
+            "+refs/heads/main:refs/remotes/origin/main"
+          head_commit=$(git rev-parse --verify HEAD)
+          tag_commit=$(git rev-parse --verify "refs/tags/${TAG}^{commit}")
+          if [[ "$head_commit" != "$EXPECTED_COMMIT" || "$tag_commit" != "$EXPECTED_COMMIT" ]]; then
+            echo "release source moved: expected $EXPECTED_COMMIT, HEAD=$head_commit, $TAG=$tag_commit" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$EXPECTED_COMMIT" refs/remotes/origin/main; then
+            echo "release commit $EXPECTED_COMMIT is not reachable from origin/main" >&2
+            exit 1
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -333,16 +367,11 @@ jobs:
       - name: Resolve tag + version
         id: meta
         env:
-          INPUT_TAG: ${{ inputs.tag }}
+          TAG: ${{ needs.frontend.outputs.release_tag }}
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            tag="$INPUT_TAG"
-          else
-            tag="${GITHUB_REF#refs/tags/}"
-          fi
-          version=$(node scripts/validate-release-version.mjs "$tag")
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          version=$(node scripts/validate-release-version.mjs "$TAG")
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Refuse existing release assets
@@ -454,6 +483,19 @@ jobs:
              }' > latest.json
 
           cat latest.json
+
+      - name: Verify release tag did not move
+        env:
+          EXPECTED_COMMIT: ${{ needs.frontend.outputs.release_commit }}
+          TAG: ${{ needs.frontend.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          git fetch --force --no-tags origin "+refs/tags/${TAG}:refs/tags/${TAG}"
+          tag_commit=$(git rev-parse --verify "refs/tags/${TAG}^{commit}")
+          if [[ "$tag_commit" != "$EXPECTED_COMMIT" ]]; then
+            echo "release tag moved: expected $TAG at $EXPECTED_COMMIT, found $tag_commit" >&2
+            exit 1
+          fi
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,59 @@
+name: Security audit
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/security.yml
+      - src-tauri/Cargo.toml
+      - src-tauri/Cargo.lock
+      - src-tauri/crates/**/Cargo.toml
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/security.yml
+      - src-tauri/Cargo.toml
+      - src-tauri/Cargo.lock
+      - src-tauri/crates/**/Cargo.toml
+  schedule:
+    - cron: "23 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust-dependencies:
+    name: Rust dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+
+      - name: Verify locked dependency graph
+        run: cargo metadata --manifest-path src-tauri/Cargo.toml --locked --format-version 1 --no-deps > /dev/null
+
+      - name: Install pinned cargo-audit
+        run: cargo install cargo-audit --version 0.22.2 --locked
+
+      - name: Audit Rust dependencies
+        # quick-xml 0.37.5 is Windows-only through tauri-winrt-notification.
+        # The current official release workflow ships macOS bundles, and
+        # neither vulnerable XML API is reachable in Acorn's Windows-only
+        # notification dependency path. Keep the explicit exceptions visible
+        # until upstream moves to quick-xml >=0.41; every other advisory fails.
+        run: >-
+          cargo audit --file src-tauri/Cargo.lock
+          --ignore RUSTSEC-2026-0194
+          --ignore RUSTSEC-2026-0195

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+# Local environment files may contain API keys or service credentials.
+.env
+.env.*
+!.env.example
+
 node_modules
 dist
 dist-ssr

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "private": true,
   "version": "1.27.0",
   "packageManager": "pnpm@9.15.0",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
+  },
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -34,7 +39,6 @@
     "@tauri-apps/plugin-notification": "^2",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",
-    "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-fit": "^0.11.0",
@@ -46,7 +50,7 @@
     "cmdk": "^1.1.1",
     "lucide-react": "^1.14.0",
     "react": "^19.2.7",
-    "react-diff-viewer-continued": "^4.2.2",
+    "react-diff-viewer-continued": "^4.4.0",
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3",
@@ -60,17 +64,18 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
-    "@storybook/addon-docs": "10.4.3",
-    "@storybook/react-vite": "10.4.3",
+    "@storybook/addon-docs": "10.5.2",
+    "@storybook/react-vite": "10.5.2",
     "@tailwindcss/vite": "^4.3.1",
     "@tauri-apps/cli": "^2.11.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
     "@vitest/ui": "^4.1.9",
+    "esbuild": "^0.28.1",
     "jsdom": "^29.1.1",
     "postcss": "^8.5.15",
-    "storybook": "10.4.3",
+    "storybook": "10.5.2",
     "tailwindcss": "^4.3.1",
     "typescript": "~5.8.3",
     "vite": "^7.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       '@tauri-apps/plugin-process':
         specifier: ^2.3.1
         version: 2.3.1
-      '@tauri-apps/plugin-shell':
-        specifier: ^2.3.5
-        version: 2.3.5
       '@tauri-apps/plugin-updater':
         specifier: ^2.10.1
         version: 2.10.1
@@ -75,8 +72,8 @@ importers:
         specifier: ^19.2.7
         version: 19.2.7
       react-diff-viewer-continued:
-        specifier: ^4.2.2
-        version: 4.2.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^4.4.0
+        version: 4.4.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
@@ -112,11 +109,11 @@ importers:
         specifier: ^1.59.1
         version: 1.60.0
       '@storybook/addon-docs':
-        specifier: 10.4.3
-        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+        specifier: 10.5.2
+        version: 10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.60.4)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
       '@storybook/react-vite':
-        specifier: 10.4.3
-        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.8.3)(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+        specifier: 10.5.2
+        version: 10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.4)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.8.3)(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
@@ -135,6 +132,9 @@ importers:
       '@vitest/ui':
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -142,8 +142,8 @@ importers:
         specifier: ^8.5.15
         version: 8.5.15
       storybook:
-        specifier: 10.4.3
-        version: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 10.5.2
+        version: 10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
@@ -180,40 +180,40 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.29.3':
-    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.28.6':
     resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.28.6':
-    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -226,6 +226,10 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
@@ -234,16 +238,21 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.29.2':
-    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.3':
     resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -267,16 +276,20 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bramus/specificity@2.4.2':
@@ -400,158 +413,158 @@ packages:
   '@emotion/weak-memoize@0.4.0':
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1191,27 +1204,27 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@storybook/addon-docs@10.4.3':
-    resolution: {integrity: sha512-CJGEXSo0zpIy7gvEeeUi09ZbjQUSNDi4YipAeb+lZGGEn8ShZUr2Pk330yd2ZO+ngNWJXD4ZxOb0e3/aIlxb3Q==}
+  '@storybook/addon-docs@10.5.2':
+    resolution: {integrity: sha512-MoBANDsh5qEA14U+JaBoQcYsKbayJDDMopigFN0NdVAsZTdBfVIsL7cnjTFBL6ubB3ifb5M0tCXbScpml1KqiQ==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.4.3
+      storybook: ^10.5.2
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@storybook/builder-vite@10.4.3':
-    resolution: {integrity: sha512-gvXVJvcsqFuSO5PLhS5+BdoYbQDxbkVVrW2cHrf4g089bXVTImZrOSzTO7SEOTs4I9acJqv4nK22WEeJpY+VZw==}
+  '@storybook/builder-vite@10.5.2':
+    resolution: {integrity: sha512-XxY/zpMrEOXqdJaEw8s7fJefDCjO1eRkjvZvb50ojiqDJpTdfguhBrwqlHilpWWt5a12VjbbMrUHza4YPs/bBg==}
     peerDependencies:
-      storybook: ^10.4.3
+      storybook: ^10.5.2
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@storybook/csf-plugin@10.4.3':
-    resolution: {integrity: sha512-D+XF5CVhZmIOI0uhfTKxlQr+gR1z8X9djPy9phiA1USLPAOHagBAucp/PhLwlFVUxrKzEIf8yImrvkCv50IcDg==}
+  '@storybook/csf-plugin@10.5.2':
+    resolution: {integrity: sha512-PK/wXiALFf88mt4HmDtiZJ6NRvhExSXEM9uFIN+OIHxGqg7Xbp6MB0SPdhsTbMY9720ahiu/DJx5iIzkidcA3w==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.4.3
+      storybook: ^10.5.2
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -1233,36 +1246,40 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@storybook/react-dom-shim@10.4.3':
-    resolution: {integrity: sha512-aPZ+Afd+zdoSygISOVCJIYdiqWJM6uRZFw0zhsONwNcn3kU1TNce6iAoBCY8cpEhDAu61M1QjeIHM3LPy/ieog==}
+  '@storybook/react-dom-shim@10.5.2':
+    resolution: {integrity: sha512-TbdYVLuD7gwj1CFsDJhCHUiwfVmzFWzalKEUGy9XgXyNpyOV1CYRsdmRdhaOHgmn2ljQZuTAxSnG7NlElghVaw==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.4.3
+      storybook: ^10.5.2
     peerDependenciesMeta:
       '@types/react':
         optional: true
       '@types/react-dom':
         optional: true
 
-  '@storybook/react-vite@10.4.3':
-    resolution: {integrity: sha512-Pk/hi10JFuwJ5sj/HAapWrgaa9Z83oT4MJPbHqeKzMt3A3jkIru4L9ibnt82bzV3crOaiErprvOlAFDsjxhrrQ==}
+  '@storybook/react-vite@10.5.2':
+    resolution: {integrity: sha512-YZoSLSMwU1dmxW8VkfJy6KzJELkbM2cHpa0mj7dih+p0JyWkWDEjLStrMB+sy9W7jF/fbojyzf0/oHlvVRUc3w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.4.3
+      storybook: ^10.5.2
+      typescript: '>= 4.9.x'
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@storybook/react@10.4.3':
-    resolution: {integrity: sha512-Td+Zoi8ylJTPC1jg5vHw8OK7U2kJgqc5kuAn92UvD4IbAkcpMTBRPHDziK1piv6q7r8yNLVah+ku6IKHpTLeXA==}
+  '@storybook/react@10.5.2':
+    resolution: {integrity: sha512-DQkTEvQ3Tn5ndyZnOyNTnYuJWBZdnUsVFuvImtt1H6QyHsZGhl35/3CqRwERa/P10Sw/6vLP5DS+KhDCz1hWbg==}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.4.3
+      storybook: ^10.5.2
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       '@types/react':
@@ -1460,9 +1477,6 @@ packages:
   '@tauri-apps/plugin-process@2.3.1':
     resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
 
-  '@tauri-apps/plugin-shell@2.3.5':
-    resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
-
   '@tauri-apps/plugin-updater@2.10.1':
     resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
@@ -1522,6 +1536,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -1533,6 +1550,9 @@ packages:
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
+
+  '@types/prismjs@1.26.6':
+    resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1675,8 +1695,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.30:
-    resolution: {integrity: sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==}
+  baseline-browser-mapping@2.10.43:
+    resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1687,8 +1707,8 @@ packages:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.6:
+    resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1700,8 +1720,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001793:
-    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1829,8 +1849,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  electron-to-chromium@1.5.357:
-    resolution: {integrity: sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==}
+  electron-to-chromium@1.5.392:
+    resolution: {integrity: sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==}
 
   empathic@2.0.1:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
@@ -1858,8 +1878,8 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2048,8 +2068,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -2073,6 +2093,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2155,6 +2178,10 @@ packages:
 
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -2337,8 +2364,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  node-releases@2.0.44:
-    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+    engines: {node: '>=18'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -2423,12 +2451,15 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  react-diff-viewer-continued@4.2.2:
-    resolution: {integrity: sha512-8wT0/smXGox70oXJ7SZkTYF1p1Uh7jNGXhN7ykqrqPven0sZ+wM2c62SG3ZqORx5aW75te+WhmUWo0E4NyoSvg==}
+  react-diff-viewer-continued@4.4.0:
+    resolution: {integrity: sha512-ezDte5YNLLLfTuaGaF2mV/8i4FRX7GdxnuA5zt7x1QjwVQHtBY0+NYzHJBwEPboOQNSx9sDU9apH2GfKoDYsyQ==}
     engines: {node: '>= 16'}
     peerDependencies:
       react: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2511,6 +2542,9 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  refractor@5.0.0:
+    resolution: {integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==}
 
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
@@ -2609,13 +2643,13 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
-  storybook@10.4.3:
-    resolution: {integrity: sha512-oTfNXtS/K4PmASbcD+RyW7kxWGt3tknJL3RZodCMh+nnp3X4ng8vYg8yvIhTG/q0dqBxw7Ba8dHsfsEy4631vg==}
+  storybook@10.5.2:
+    resolution: {integrity: sha512-zkYxVZoDMj8njzZc3EH5UyY7885wpi9a1mmWVwFiNHSo+i5r2Go84E2OI1cdOctRymLkNvgs1j5jqAKA0ftBqg==}
     hasBin: true
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       prettier: ^2 || ^3
-      vite-plus: ^0.1.15
+      vite-plus: ^0.1.15 || ^0.2.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2735,8 +2769,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -2989,31 +3023,25 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.3': {}
+  '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.3
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -3023,37 +3051,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.29.1':
+  '@babel/generator@7.29.7':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/helper-compilation-targets@7.28.6':
+  '@babel/helper-compilation-targets@7.29.7':
     dependencies:
-      '@babel/compat-data': 7.29.3
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.2
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.6
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-globals@7.28.0': {}
+  '@babel/helper-globals@7.29.7': {}
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -3061,49 +3096,55 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/helper-validator-option@7.27.1': {}
+  '@babel/helper-validator-option@7.29.7': {}
 
-  '@babel/helpers@7.29.2':
+  '@babel/helpers@7.29.7':
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+  '@babel/parser@7.29.7':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/runtime@7.29.2': {}
 
   '@babel/runtime@7.29.7': {}
 
-  '@babel/template@7.28.6':
+  '@babel/template@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.0':
+  '@babel/traverse@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.3
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -3112,6 +3153,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -3267,82 +3313,82 @@ snapshots:
 
   '@emotion/weak-memoize@0.4.0': {}
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@exodus/bytes@1.15.0': {}
@@ -3813,15 +3859,15 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@storybook/addon-docs@10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.60.4)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@storybook/csf-plugin': 10.4.3(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+      '@storybook/csf-plugin': 10.5.2(esbuild@0.28.1)(rollup@4.60.4)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@storybook/react-dom-shim': 10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook: 10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ts-dedent: 2.3.0
     optionalDependencies:
       '@types/react': 19.2.17
@@ -3832,10 +3878,10 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/builder-vite@10.4.3(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@storybook/builder-vite@10.5.2(esbuild@0.28.1)(rollup@4.60.4)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.3(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
-      storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@storybook/csf-plugin': 10.5.2(esbuild@0.28.1)(rollup@4.60.4)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+      storybook: 10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ts-dedent: 2.3.0
       vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
@@ -3843,12 +3889,12 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.3(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@storybook/csf-plugin@10.5.2(esbuild@0.28.1)(rollup@4.60.4)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
-      storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook: 10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       unplugin: 2.3.11
     optionalDependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       rollup: 4.60.4
       vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
 
@@ -3859,48 +3905,49 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@storybook/react-dom-shim@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@storybook/react-dom-shim@10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook: 10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.8.3)(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@storybook/react-vite@10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.4)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.8.3)(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.8.3)(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
       '@rollup/pluginutils': 5.4.0(rollup@4.60.4)
-      '@storybook/builder-vite': 10.4.3(esbuild@0.27.7)(rollup@4.60.4)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
-      '@storybook/react': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.8.3)
+      '@storybook/builder-vite': 10.5.2(esbuild@0.28.1)(rollup@4.60.4)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+      '@storybook/react': 10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.8.3)
       empathic: 2.0.1
       magic-string: 0.30.21
       react: 19.2.7
       react-docgen: 8.0.3
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
-      storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook: 10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tsconfig-paths: 4.2.0
       vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+    optionalDependencies:
+      typescript: 5.8.3
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
       - esbuild
       - rollup
       - supports-color
-      - typescript
       - webpack
 
-  '@storybook/react@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.8.3)':
+  '@storybook/react@10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.8.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@storybook/react-dom-shim': 10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       react: 19.2.7
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@5.8.3)
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook: 10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -4053,10 +4100,6 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.1
 
-  '@tauri-apps/plugin-shell@2.3.5':
-    dependencies:
-      '@tauri-apps/api': 2.11.1
-
   '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.11.1
@@ -4138,6 +4181,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -4147,6 +4194,8 @@ snapshots:
   '@types/ms@2.1.0': {}
 
   '@types/parse-json@4.0.2': {}
+
+  '@types/prismjs@1.26.6': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -4166,9 +4215,9 @@ snapshots:
 
   '@vitejs/plugin-react@4.7.0(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -4300,7 +4349,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.30: {}
+  baseline-browser-mapping@2.10.43: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -4310,13 +4359,13 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  browserslist@4.28.2:
+  browserslist@4.28.6:
     dependencies:
-      baseline-browser-mapping: 2.10.30
-      caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.357
-      node-releases: 2.0.44
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.10.43
+      caniuse-lite: 1.0.30001806
+      electron-to-chromium: 1.5.392
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.6)
 
   bundle-name@4.1.0:
     dependencies:
@@ -4324,7 +4373,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001793: {}
+  caniuse-lite@1.0.30001806: {}
 
   ccount@2.0.1: {}
 
@@ -4435,7 +4484,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  electron-to-chromium@1.5.357: {}
+  electron-to-chromium@1.5.392: {}
 
   empathic@2.0.1: {}
 
@@ -4456,34 +4505,34 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
-  esbuild@0.27.7:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -4554,7 +4603,7 @@ snapshots:
 
   hast-util-parse-selector@4.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   hast-util-raw@9.1.0:
     dependencies:
@@ -4628,10 +4677,10 @@ snapshots:
 
   hastscript@9.0.1:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       comma-separated-tokens: 2.0.3
       hast-util-parse-selector: 4.0.0
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
   hoist-non-react-statics@3.3.2:
@@ -4692,7 +4741,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -4713,7 +4762,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -4727,6 +4776,8 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -4784,6 +4835,8 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@11.3.6: {}
+
+  lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -5165,7 +5218,7 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  node-releases@2.0.44: {}
+  node-releases@2.0.51: {}
 
   obug@2.1.1: {}
 
@@ -5247,7 +5300,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -5264,7 +5317,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.3.6
+      lru-cache: 11.5.2
       minipass: 7.1.3
 
   path-type@4.0.0: {}
@@ -5299,18 +5352,21 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  property-information@7.2.0: {}
+
   punycode@2.3.1: {}
 
-  react-diff-viewer-continued@4.2.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-diff-viewer-continued@4.4.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@emotion/css': 11.13.5
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
       classnames: 2.5.1
       diff: 9.0.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       memoize-one: 6.0.0
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+      refractor: 5.0.0
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
@@ -5321,9 +5377,9 @@ snapshots:
 
   react-docgen@8.0.3:
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/core': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
       '@types/doctrine': 0.0.9
@@ -5409,6 +5465,13 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  refractor@5.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/prismjs': 1.26.6
+      hastscript: 9.0.1
+      parse-entities: 4.0.2
 
   regex-recursion@6.0.2:
     dependencies:
@@ -5550,16 +5613,18 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  storybook@10.4.3(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/dom': 10.4.1
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
       '@webcontainer/env': 1.1.1
-      esbuild: 0.27.7
+      esbuild: 0.28.1
+      jsonc-parser: 3.3.1
       open: 10.2.0
       oxc-parser: 0.127.0
       oxc-resolver: 11.20.0
@@ -5570,7 +5635,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
     transitivePeerDependencies:
-      - '@testing-library/dom'
       - bufferutil
       - react
       - react-dom
@@ -5660,7 +5724,7 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -5702,9 +5766,9 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.2.3(browserslist@4.28.6):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.6
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -5748,7 +5812,7 @@ snapshots:
 
   vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.15

--- a/scripts/release-artifacts.mjs
+++ b/scripts/release-artifacts.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import {
+  copyFileSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+function filesBelow(root, maxDepth) {
+  const output = [];
+  const visit = (directory, depth) => {
+    if (depth > maxDepth) return;
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) visit(path, depth + 1);
+      else if (entry.isFile()) output.push(path);
+    }
+  };
+  visit(root, 0);
+  return output.sort();
+}
+
+function requireExactlyOne(files, label) {
+  if (files.length !== 1) {
+    throw new Error(`expected exactly one ${label}, found ${files.length}`);
+  }
+  return files[0];
+}
+
+function artifactArchitecture(file) {
+  const name = basename(file);
+  const stem = name.replace(/(?:\.dmg|\.app\.tar\.gz(?:\.sig)?)$/i, "");
+  if (/(?:^|[._-])aarch64$/i.test(stem)) return "aarch64";
+  if (/(?:^|[._-])(?:x64|x86_64)$/i.test(stem)) return "x86_64";
+  throw new Error(
+    `artifact filename must end with exactly one architecture suffix: ${JSON.stringify(name)}`,
+  );
+}
+
+function archFile(files, arch, label) {
+  return requireExactlyOne(
+    files.filter((file) => artifactArchitecture(file) === arch),
+    `${arch} ${label}`,
+  );
+}
+
+export function stageBuildArtifacts(bundleDirectory, outputDirectory, suffix) {
+  if (!/^[A-Za-z0-9_-]+$/.test(suffix)) {
+    throw new Error(`invalid artifact architecture suffix ${JSON.stringify(suffix)}`);
+  }
+
+  const dmgFiles = filesBelow(join(bundleDirectory, "dmg"), 2).filter((file) =>
+    file.endsWith(".dmg"),
+  );
+  const macosFiles = filesBelow(join(bundleDirectory, "macos"), 2);
+  const tarFiles = macosFiles.filter((file) => file.endsWith(".app.tar.gz"));
+  const signatureFiles = macosFiles.filter((file) =>
+    file.endsWith(".app.tar.gz.sig"),
+  );
+  const dmg = requireExactlyOne(dmgFiles, "DMG");
+  const tar = requireExactlyOne(tarFiles, "updater tarball");
+  const signature = requireExactlyOne(signatureFiles, "updater signature");
+  if (signature !== `${tar}.sig`) {
+    throw new Error("updater signature filename does not match its tarball");
+  }
+
+  mkdirSync(outputDirectory, { recursive: true });
+  const base = basename(tar, ".app.tar.gz");
+  const staged = {
+    dmg: join(outputDirectory, basename(dmg)),
+    tar: join(outputDirectory, `${base}_${suffix}.app.tar.gz`),
+    signature: join(outputDirectory, `${base}_${suffix}.app.tar.gz.sig`),
+  };
+  copyFileSync(dmg, staged.dmg);
+  copyFileSync(tar, staged.tar);
+  copyFileSync(signature, staged.signature);
+  return staged;
+}
+
+export function inspectPublishedArtifacts(directory) {
+  const files = readdirSync(directory)
+    .map((name) => join(directory, name))
+    .filter((path) => statSync(path).isFile())
+    .sort();
+  const dmgs = files.filter((file) => file.endsWith(".dmg"));
+  const tarballs = files.filter((file) => file.endsWith(".app.tar.gz"));
+  const signatures = files.filter((file) => file.endsWith(".app.tar.gz.sig"));
+  if (dmgs.length !== 2 || tarballs.length !== 2 || signatures.length !== 2) {
+    throw new Error(
+      `expected two DMGs, tarballs, and signatures; found ${dmgs.length}/${tarballs.length}/${signatures.length}`,
+    );
+  }
+
+  // Classify every file by its terminal Tauri architecture suffix before
+  // selecting it. Earlier tokens may be part of a prerelease version (for
+  // example `2.0.0-x64`) and must not be mistaken for the actual architecture.
+  for (const file of [...dmgs, ...tarballs, ...signatures]) {
+    artifactArchitecture(file);
+  }
+
+  const result = {
+    armDmg: archFile(dmgs, "aarch64", "DMG"),
+    x64Dmg: archFile(dmgs, "x86_64", "DMG"),
+    armTar: archFile(tarballs, "aarch64", "updater tarball"),
+    x64Tar: archFile(tarballs, "x86_64", "updater tarball"),
+  };
+  result.armSignature = `${result.armTar}.sig`;
+  result.x64Signature = `${result.x64Tar}.sig`;
+  const expectedSignatures = [result.armSignature, result.x64Signature].sort();
+  if (JSON.stringify(signatures) !== JSON.stringify(expectedSignatures)) {
+    throw new Error("updater tarball/signature pairs are incomplete or cross-paired");
+  }
+  return result;
+}
+
+function main() {
+  const [mode, ...args] = process.argv.slice(2);
+  if (mode === "stage" && args.length === 3) {
+    const staged = stageBuildArtifacts(args[0], args[1], args[2]);
+    process.stdout.write(`${JSON.stringify(staged, null, 2)}\n`);
+    return;
+  }
+  if (mode === "inspect" && args.length === 1) {
+    process.stdout.write(
+      `${JSON.stringify(inspectPublishedArtifacts(args[0]), null, 2)}\n`,
+    );
+    return;
+  }
+  throw new Error(
+    "usage: release-artifacts.mjs stage <bundle-dir> <output-dir> <arch> | inspect <artifacts-dir>",
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release-artifacts.test.mjs
+++ b/scripts/release-artifacts.test.mjs
@@ -1,0 +1,132 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  inspectPublishedArtifacts,
+  stageBuildArtifacts,
+} from "./release-artifacts.mjs";
+
+const temporaryDirectories = [];
+
+function temporaryDirectory() {
+  const directory = mkdtempSync(join(tmpdir(), "acorn-release-artifacts-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function write(path, contents = "fixture") {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("stageBuildArtifacts", () => {
+  it("stages exactly one matched updater pair with an architecture suffix", () => {
+    const root = temporaryDirectory();
+    const bundle = join(root, "bundle");
+    const output = join(root, "staged");
+    write(join(bundle, "dmg", "Acorn_1.0.0_aarch64.dmg"));
+    write(join(bundle, "macos", "Acorn.app.tar.gz"), "tar");
+    write(join(bundle, "macos", "Acorn.app.tar.gz.sig"), "sig");
+
+    const staged = stageBuildArtifacts(bundle, output, "aarch64");
+
+    expect(basename(staged.tar)).toBe("Acorn_aarch64.app.tar.gz");
+    expect(basename(staged.signature)).toBe("Acorn_aarch64.app.tar.gz.sig");
+  });
+
+  it("rejects missing, duplicate, and mismatched build outputs", () => {
+    const missing = temporaryDirectory();
+    mkdirSync(join(missing, "dmg"), { recursive: true });
+    mkdirSync(join(missing, "macos"), { recursive: true });
+    expect(() => stageBuildArtifacts(missing, join(missing, "out"), "aarch64"))
+      .toThrow(/exactly one DMG/);
+
+    const duplicate = temporaryDirectory();
+    write(join(duplicate, "dmg", "one.dmg"));
+    write(join(duplicate, "dmg", "two.dmg"));
+    write(join(duplicate, "macos", "Acorn.app.tar.gz"));
+    write(join(duplicate, "macos", "Acorn.app.tar.gz.sig"));
+    expect(() => stageBuildArtifacts(duplicate, join(duplicate, "out"), "aarch64"))
+      .toThrow(/exactly one DMG/);
+
+    const mismatched = temporaryDirectory();
+    write(join(mismatched, "dmg", "one.dmg"));
+    write(join(mismatched, "macos", "Acorn.app.tar.gz"));
+    write(join(mismatched, "macos", "Other.app.tar.gz.sig"));
+    expect(() =>
+      stageBuildArtifacts(mismatched, join(mismatched, "out"), "aarch64"),
+    ).toThrow(/does not match/);
+  });
+});
+
+describe("inspectPublishedArtifacts", () => {
+  it("accepts one complete artifact set for each macOS architecture", () => {
+    const directory = temporaryDirectory();
+    for (const arch of ["aarch64", "x86_64"]) {
+      write(join(directory, `Acorn_1.0.0_${arch}.dmg`));
+      write(join(directory, `Acorn_${arch}.app.tar.gz`));
+      write(join(directory, `Acorn_${arch}.app.tar.gz.sig`));
+    }
+
+    const artifacts = inspectPublishedArtifacts(directory);
+
+    expect(basename(artifacts.armTar)).toContain("aarch64");
+    expect(basename(artifacts.x64Tar)).toContain("x86_64");
+  });
+
+  it("rejects a missing architecture or cross-paired signature", () => {
+    const missing = temporaryDirectory();
+    write(join(missing, "Acorn_1.0.0_aarch64.dmg"));
+    write(join(missing, "Acorn_aarch64.app.tar.gz"));
+    write(join(missing, "Acorn_aarch64.app.tar.gz.sig"));
+    expect(() => inspectPublishedArtifacts(missing)).toThrow(/expected two/);
+
+    const mismatched = temporaryDirectory();
+    for (const arch of ["aarch64", "x86_64"]) {
+      write(join(mismatched, `Acorn_1.0.0_${arch}.dmg`));
+      write(join(mismatched, `Acorn_${arch}.app.tar.gz`));
+    }
+    write(join(mismatched, "Acorn_aarch64.app.tar.gz.sig"));
+    write(join(mismatched, "Wrong_x86_64.app.tar.gz.sig"));
+    expect(() => inspectPublishedArtifacts(mismatched)).toThrow(/incomplete or cross-paired/);
+  });
+
+  it("uses the terminal suffix when prerelease versions contain architecture tokens", () => {
+    const directory = temporaryDirectory();
+    write(join(directory, "Acorn_2.0.0-x64_aarch64.dmg"));
+    write(join(directory, "Acorn_2.0.0-aarch64_x86_64.dmg"));
+    for (const arch of ["aarch64", "x86_64"]) {
+      write(join(directory, `Acorn_${arch}.app.tar.gz`));
+      write(join(directory, `Acorn_${arch}.app.tar.gz.sig`));
+    }
+
+    expect(() => inspectPublishedArtifacts(directory)).not.toThrow();
+  });
+
+  it("rejects unclassified architecture filenames", () => {
+    const unclassified = temporaryDirectory();
+    write(join(unclassified, "Acorn_2.0.0_aarch64.dmg"));
+    write(join(unclassified, "Acorn_2.0.0_unknown.dmg"));
+    for (const arch of ["aarch64", "x86_64"]) {
+      write(join(unclassified, `Acorn_${arch}.app.tar.gz`));
+      write(join(unclassified, `Acorn_${arch}.app.tar.gz.sig`));
+    }
+
+    expect(() => inspectPublishedArtifacts(unclassified)).toThrow(
+      /architecture suffix/,
+    );
+  });
+});

--- a/scripts/validate-release-version.mjs
+++ b/scripts/validate-release-version.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const RELEASE_TAG_RE =
+  /^v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?)$/;
+
+export function releaseVersionFromTag(tag) {
+  if (typeof tag !== "string") return null;
+  return RELEASE_TAG_RE.exec(tag)?.[1] ?? null;
+}
+
+export function compareReleaseTags(leftTag, rightTag) {
+  const left = releaseVersionFromTag(leftTag);
+  const right = releaseVersionFromTag(rightTag);
+  if (!left || !right) {
+    throw new Error(
+      `cannot compare invalid release tags ${JSON.stringify(leftTag)} and ${JSON.stringify(rightTag)}`,
+    );
+  }
+
+  const parse = (version) => {
+    const separator = version.indexOf("-");
+    const core = separator === -1 ? version : version.slice(0, separator);
+    const prerelease = separator === -1 ? null : version.slice(separator + 1);
+    return {
+      core: core.split(".").map((part) => BigInt(part)),
+      prerelease: prerelease?.split(".") ?? null,
+    };
+  };
+  const leftVersion = parse(left);
+  const rightVersion = parse(right);
+  for (let index = 0; index < 3; index += 1) {
+    if (leftVersion.core[index] < rightVersion.core[index]) return -1;
+    if (leftVersion.core[index] > rightVersion.core[index]) return 1;
+  }
+  if (!leftVersion.prerelease && !rightVersion.prerelease) return 0;
+  if (!leftVersion.prerelease) return 1;
+  if (!rightVersion.prerelease) return -1;
+
+  const count = Math.max(
+    leftVersion.prerelease.length,
+    rightVersion.prerelease.length,
+  );
+  for (let index = 0; index < count; index += 1) {
+    const leftIdentifier = leftVersion.prerelease[index];
+    const rightIdentifier = rightVersion.prerelease[index];
+    if (leftIdentifier === undefined) return -1;
+    if (rightIdentifier === undefined) return 1;
+    if (leftIdentifier === rightIdentifier) continue;
+    const leftNumeric = /^\d+$/.test(leftIdentifier);
+    const rightNumeric = /^\d+$/.test(rightIdentifier);
+    if (leftNumeric && rightNumeric) {
+      return BigInt(leftIdentifier) < BigInt(rightIdentifier) ? -1 : 1;
+    }
+    if (leftNumeric) return -1;
+    if (rightNumeric) return 1;
+    return leftIdentifier < rightIdentifier ? -1 : 1;
+  }
+  return 0;
+}
+
+export function assertReleaseIsNewer(candidateTag, currentTag) {
+  if (compareReleaseTags(candidateTag, currentTag) <= 0) {
+    throw new Error(
+      `release ${candidateTag} is not newer than current latest ${currentTag}`,
+    );
+  }
+}
+
+export function assertMatchingReleaseVersions(tag, versions) {
+  const releaseVersion = releaseVersionFromTag(tag);
+  if (!releaseVersion) {
+    throw new Error(
+      `invalid release tag ${JSON.stringify(tag)}; expected vMAJOR.MINOR.PATCH with an optional prerelease suffix`,
+    );
+  }
+
+  for (const [source, version] of Object.entries(versions)) {
+    if (version !== releaseVersion) {
+      throw new Error(
+        `release version mismatch: ${source} has ${JSON.stringify(version)}, tag ${tag} requires ${releaseVersion}`,
+      );
+    }
+  }
+  return releaseVersion;
+}
+
+export function readRepositoryVersions(root) {
+  const packageJson = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+  const tauriConfig = JSON.parse(
+    readFileSync(resolve(root, "src-tauri/tauri.conf.json"), "utf8"),
+  );
+  const cargoToml = readFileSync(resolve(root, "src-tauri/Cargo.toml"), "utf8");
+  const packageHeader = /^\[package\]\s*$/m.exec(cargoToml);
+  const packageRemainder = packageHeader
+    ? cargoToml.slice(packageHeader.index + packageHeader[0].length)
+    : "";
+  const nextSection = packageRemainder.search(/^\[/m);
+  const packageSection =
+    nextSection >= 0 ? packageRemainder.slice(0, nextSection) : packageRemainder;
+  const cargoVersion = /^version\s*=\s*"([^"]+)"\s*(?:#.*)?$/m.exec(
+    packageSection ?? "",
+  )?.[1];
+  if (!cargoVersion) {
+    throw new Error("could not read [package].version from src-tauri/Cargo.toml");
+  }
+
+  return {
+    "package.json": packageJson.version,
+    "src-tauri/tauri.conf.json": tauriConfig.version,
+    "src-tauri/Cargo.toml": cargoVersion,
+  };
+}
+
+export function validateRepositoryReleaseVersion(tag, root = process.cwd()) {
+  return assertMatchingReleaseVersions(tag, readRepositoryVersions(root));
+}
+
+function main() {
+  if (process.argv[2] === "--assert-newer" && process.argv.length === 5) {
+    assertReleaseIsNewer(process.argv[3], process.argv[4]);
+    return;
+  }
+  const tag = process.argv[2];
+  const version = validateRepositoryReleaseVersion(tag);
+  process.stdout.write(`${version}\n`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/validate-release-version.test.mjs
+++ b/scripts/validate-release-version.test.mjs
@@ -1,0 +1,106 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  assertReleaseIsNewer,
+  assertMatchingReleaseVersions,
+  compareReleaseTags,
+  readRepositoryVersions,
+  releaseVersionFromTag,
+} from "./validate-release-version.mjs";
+
+const temporaryDirectories = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("releaseVersionFromTag", () => {
+  it("accepts stable and prerelease semantic versions", () => {
+    expect(releaseVersionFromTag("v1.25.0")).toBe("1.25.0");
+    expect(releaseVersionFromTag("v2.0.0-beta.1")).toBe("2.0.0-beta.1");
+    expect(releaseVersionFromTag("v2.0.0-0.01alpha")).toBe(
+      "2.0.0-0.01alpha",
+    );
+  });
+
+  it("rejects malformed, newline-bearing, and zero-padded tags", () => {
+    for (const tag of [
+      "1.25.0",
+      "v1.25",
+      "v01.25.0",
+      "v1.25.0-01",
+      "v1.25.0\nextra",
+    ]) {
+      expect(releaseVersionFromTag(tag)).toBeNull();
+    }
+  });
+});
+
+describe("assertMatchingReleaseVersions", () => {
+  it("requires every shipped manifest to match the tag", () => {
+    expect(
+      assertMatchingReleaseVersions("v1.25.0", {
+        "package.json": "1.25.0",
+        "tauri.conf.json": "1.25.0",
+        "Cargo.toml": "1.25.0",
+      }),
+    ).toBe("1.25.0");
+
+    for (const source of ["package.json", "tauri.conf.json", "Cargo.toml"]) {
+      const versions = {
+        "package.json": "1.25.0",
+        "tauri.conf.json": "1.25.0",
+        "Cargo.toml": "1.25.0",
+        [source]: "1.24.9",
+      };
+      expect(() => assertMatchingReleaseVersions("v1.25.0", versions)).toThrow(
+        source,
+      );
+    }
+  });
+});
+
+describe("release ordering", () => {
+  it("uses semantic-version precedence", () => {
+    expect(compareReleaseTags("v2.0.0", "v1.99.99")).toBe(1);
+    expect(compareReleaseTags("v2.0.0", "v2.0.0")).toBe(0);
+    expect(compareReleaseTags("v2.0.0-beta.2", "v2.0.0-beta.10")).toBe(-1);
+    expect(compareReleaseTags("v2.0.0-alpha-a", "v2.0.0-alpha-b")).toBe(-1);
+    expect(compareReleaseTags("v2.0.0", "v2.0.0-rc.1")).toBe(1);
+  });
+
+  it("rejects stable latest-pointer rollback or replay", () => {
+    expect(() => assertReleaseIsNewer("v1.24.9", "v1.25.0")).toThrow(
+      /not newer/,
+    );
+    expect(() => assertReleaseIsNewer("v1.25.0", "v1.25.0")).toThrow(
+      /not newer/,
+    );
+    expect(() => assertReleaseIsNewer("v1.25.1", "v1.25.0")).not.toThrow();
+  });
+});
+
+describe("readRepositoryVersions", () => {
+  it("reads the package section rather than similarly named TOML sections", () => {
+    const root = mkdtempSync(join(tmpdir(), "acorn-release-version-"));
+    temporaryDirectories.push(root);
+    mkdirSync(join(root, "src-tauri"));
+    writeFileSync(join(root, "package.json"), '{"version":"2.0.0"}');
+    writeFileSync(join(root, "src-tauri/tauri.conf.json"), '{"version":"2.0.0"}');
+    writeFileSync(
+      join(root, "src-tauri/Cargo.toml"),
+      '[workspace.dependencies]\nversion = "999.0.0"\n\n[package]\nname = "acorn"\nversion = "2.0.0"\n\n[lib]\n',
+    );
+
+    expect(readRepositoryVersions(root)).toEqual({
+      "package.json": "2.0.0",
+      "src-tauri/tauri.conf.json": "2.0.0",
+      "src-tauri/Cargo.toml": "2.0.0",
+    });
+  });
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -41,7 +41,6 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
- "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tempfile",
@@ -509,6 +508,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1197,15 +1205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,7 +1255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1985,7 +1984,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2465,9 +2464,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
@@ -3046,16 +3045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,13 +3208,13 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.39.3",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -3404,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.3"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3664,7 +3653,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3720,7 +3709,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3970,11 +3959,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3989,9 +3979,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4062,17 +4052,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared_child"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
-dependencies = [
- "libc",
- "sigchld",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4093,27 +4072,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "sigchld"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
-dependencies = [
- "libc",
- "os_pipe",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
 
 [[package]]
 name = "signal-hook-registry"
@@ -4396,9 +4354,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -4413,9 +4371,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d059f2527558d9dba6f186dec4772610e1aecfd3f94002397613e7e648752b66"
+checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4486,9 +4444,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e4e8230d565106aa19dfbaa01a7ed01abf78047fe0577a83377224bd1bf20e"
+checksum = "08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4513,9 +4471,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8de2cddbbc33dbdf4c84f170121886595efdbcc9cb4b3d76342b79d082cedc"
+checksum = "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4635,27 +4593,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin-shell"
-version = "2.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
-dependencies = [
- "encoding_rs",
- "log",
- "open",
- "os_pipe",
- "regex",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "shared_child",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "tokio",
-]
-
-[[package]]
 name = "tauri-plugin-single-instance"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4705,9 +4642,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.0"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e42bbcb76237351fbaa02f08d808c537dc12eb5a6eabbf3e517b50056334d95"
+checksum = "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8"
 dependencies = [
  "cookie",
  "dpi",
@@ -4730,9 +4667,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cadb13dad0c681e1e0a2c49ae488f0e2906ded3d57e7a0017f4aaf46e387117"
+checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
@@ -4825,7 +4762,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4927,6 +4864,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5729,7 +5681,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -101,7 +101,6 @@ acorn-transcript = { path = "crates/acorn-transcript" }
 tauri = { workspace = true }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
-tauri-plugin-shell = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-single-instance = "2"
@@ -138,9 +137,8 @@ notify = { workspace = true }
 ignore = { workspace = true }
 globset = { workspace = true }
 trash = { workspace = true }
-
-[dev-dependencies]
-# Used by `fs_explorer` unit tests for scratch directories.
+# Secure same-directory atomic replacement for generated control-session
+# markers; tests also use it for scratch directories.
 tempfile = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -4,10 +4,21 @@
   "description": "Capability for the main window",
   "windows": ["main"],
   "permissions": [
-    "core:default",
+    "core:path:default",
+    "core:event:default",
+    "core:window:default",
+    "core:webview:default",
+    "core:app:default",
+    "core:resources:default",
     "core:window:allow-destroy",
-    "opener:allow-open-url",
-    "opener:allow-default-urls",
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [
+        { "url": "http://*" },
+        { "url": "https://*" },
+        { "url": "mailto:*" }
+      ]
+    },
     {
       "identifier": "opener:allow-open-path",
       "allow": [
@@ -16,13 +27,13 @@
         { "path": "$APPLOCALDATA/themes/**/*" }
       ]
     },
-    "dialog:default",
-    "shell:default",
+    "dialog:allow-open",
     "fs:allow-exists",
     "fs:allow-mkdir",
     "fs:allow-read-dir",
     "fs:allow-read-text-file",
     "fs:allow-remove",
+    "fs:allow-stat",
     "fs:allow-write-file",
     "fs:allow-write-text-file",
     {
@@ -39,8 +50,11 @@
         "$APPLOCALDATA/themes/**/*"
       ]
     },
-    "notification:default",
-    "updater:default",
-    "process:default"
+    "notification:allow-is-permission-granted",
+    "notification:allow-request-permission",
+    "notification:allow-notify",
+    "updater:allow-check",
+    "updater:allow-download-and-install",
+    "process:allow-restart"
   ]
 }

--- a/src-tauri/crates/acorn-daemon/src/client.rs
+++ b/src-tauri/crates/acorn-daemon/src/client.rs
@@ -8,7 +8,7 @@
 //! its long-lived session-management traffic does not pay handshake
 //! overhead per request.
 
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self, BufReader, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use interprocess::local_socket::Stream;
@@ -19,6 +19,7 @@ use super::protocol::{
     StatusSnapshot,
 };
 use super::socket;
+use super::wire::read_response_frame_line;
 
 /// Long-lived control-socket connection. Use this when the same caller
 /// will issue more than one request — the connection handshake happens
@@ -47,7 +48,7 @@ impl ControlConn {
         writer.flush()?;
         // Read server hello.
         let mut buf = String::new();
-        reader.read_line(&mut buf)?;
+        read_response_frame_line(&mut reader, &mut buf)?;
         // Currently we do not enforce server hello details — the server
         // already validated ours and will close the connection if its
         // own version is too far ahead. Future versions may inspect
@@ -71,7 +72,7 @@ impl ControlConn {
         )?;
         self.writer.flush()?;
         let mut buf = String::new();
-        if self.reader.read_line(&mut buf)? == 0 {
+        if read_response_frame_line(&mut self.reader, &mut buf)? == 0 {
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
                 "daemon closed",
@@ -97,7 +98,7 @@ pub fn one_shot(payload: ControlPayload) -> io::Result<ControlResponse> {
     )?;
     writer.flush()?;
     let mut buf = String::new();
-    reader.read_line(&mut buf)?;
+    read_response_frame_line(&mut reader, &mut buf)?;
     // Server hello consumed (not currently inspected).
 
     let req = ControlRequest { seq: 1, payload };
@@ -107,8 +108,7 @@ pub fn one_shot(payload: ControlPayload) -> io::Result<ControlResponse> {
         serde_json::to_string(&req).map_err(io::Error::other)?
     )?;
     writer.flush()?;
-    buf.clear();
-    if reader.read_line(&mut buf)? == 0 {
+    if read_response_frame_line(&mut reader, &mut buf)? == 0 {
         return Err(io::Error::new(
             io::ErrorKind::UnexpectedEof,
             "daemon closed",

--- a/src-tauri/crates/acorn-daemon/src/crash.rs
+++ b/src-tauri/crates/acorn-daemon/src/crash.rs
@@ -102,7 +102,7 @@ fn log_tail() -> std::io::Result<Vec<u8>> {
     let mut f = std::fs::File::open(&path)?;
     f.seek(SeekFrom::Start(start))?;
     let mut buf = Vec::with_capacity(LOG_TAIL_BYTES);
-    f.read_to_end(&mut buf)?;
+    f.take(LOG_TAIL_BYTES as u64).read_to_end(&mut buf)?;
     Ok(buf)
 }
 

--- a/src-tauri/crates/acorn-daemon/src/lib.rs
+++ b/src-tauri/crates/acorn-daemon/src/lib.rs
@@ -28,6 +28,7 @@ pub mod ring_buffer;
 pub mod server;
 pub mod session;
 pub mod socket;
+pub mod wire;
 
 #[cfg(test)]
 mod test_env;

--- a/src-tauri/crates/acorn-daemon/src/server.rs
+++ b/src-tauri/crates/acorn-daemon/src/server.rs
@@ -18,7 +18,7 @@
 //!   their next read after the flag is set, or sooner if the client
 //!   closes the connection.
 
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self, BufReader, Write};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -34,6 +34,7 @@ use super::protocol::{
 use super::pty::PtyManager;
 use super::session::SessionRegistry;
 use super::socket::DaemonListeners;
+use super::wire::read_request_frame_line;
 
 /// Wraps all the per-process state a connection handler needs.
 pub struct Daemon {
@@ -174,7 +175,7 @@ impl Daemon {
 
         // Handshake: client `Hello` must arrive first.
         let mut line = String::new();
-        if reader.read_line(&mut line)? == 0 {
+        if read_request_frame_line(&mut reader, &mut line)? == 0 {
             return Ok(()); // immediate close
         }
         let hello: Hello = match serde_json::from_str(line.trim()) {
@@ -204,8 +205,7 @@ impl Daemon {
         )?;
 
         loop {
-            line.clear();
-            let n = reader.read_line(&mut line)?;
+            let n = read_request_frame_line(&mut reader, &mut line)?;
             if n == 0 {
                 return Ok(()); // peer closed
             }
@@ -388,7 +388,7 @@ impl Daemon {
 
         // Hello → StreamAttach → live frames loop.
         let mut line = String::new();
-        if reader.read_line(&mut line)? == 0 {
+        if read_request_frame_line(&mut reader, &mut line)? == 0 {
             return Ok(());
         }
         let hello: Hello = match serde_json::from_str(line.trim()) {
@@ -422,8 +422,7 @@ impl Daemon {
             &serde_json::to_string(&Hello::current(ClientRole::Stream)).unwrap(),
         )?;
 
-        line.clear();
-        if reader.read_line(&mut line)? == 0 {
+        if read_request_frame_line(&mut reader, &mut line)? == 0 {
             return Ok(());
         }
         let attach: StreamAttach = match serde_json::from_str(line.trim()) {
@@ -468,8 +467,7 @@ impl Daemon {
                 let mut r = BufReader::new(input_reader);
                 let mut buf = String::new();
                 loop {
-                    buf.clear();
-                    match r.read_line(&mut buf) {
+                    match read_request_frame_line(&mut r, &mut buf) {
                         Ok(0) => return,
                         Ok(_) => {}
                         Err(_) => return,

--- a/src-tauri/crates/acorn-daemon/src/socket.rs
+++ b/src-tauri/crates/acorn-daemon/src/socket.rs
@@ -14,7 +14,10 @@
 //!   already verified that no other daemon owns the path.
 
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 use interprocess::local_socket::{
     traits::Stream as _StreamConnect, GenericFilePath, ListenerOptions, Name, ToFsName,
@@ -58,10 +61,45 @@ pub fn bind_both() -> io::Result<DaemonListeners> {
 
 /// Bind a single local socket at `path`. Removes any pre-existing file so
 /// a stale socket from a previous crash does not block startup.
-fn bind_one(path: &PathBuf) -> io::Result<interprocess::local_socket::Listener> {
+#[cfg(unix)]
+fn bind_one(path: &Path) -> io::Result<interprocess::local_socket::Listener> {
     if path.exists() {
         let _ = std::fs::remove_file(path);
     }
+    // Keep the default `.sock` staging names shorter than their canonical
+    // names so ordinary data-directory paths retain their prior length bound.
+    let staging_path = path.with_extension("tmp");
+    if staging_path.exists() {
+        let _ = std::fs::remove_file(&staging_path);
+    }
+    let name: Name<'_> = staging_path
+        .as_os_str()
+        .to_fs_name::<GenericFilePath>()
+        .map_err(io::Error::other)?;
+    // The socket is renamed below, so interprocess must not retain its
+    // default drop guard for the staging pathname. Otherwise dropping the
+    // listener could unlink an unrelated file later created at that name.
+    let listener = ListenerOptions::new()
+        .name(name)
+        .reclaim_name(false)
+        .create_sync()?;
+    if let Err(err) =
+        std::fs::set_permissions(&staging_path, std::fs::Permissions::from_mode(0o600))
+    {
+        drop(listener);
+        let _ = std::fs::remove_file(&staging_path);
+        return Err(err);
+    }
+    if let Err(err) = std::fs::rename(&staging_path, path) {
+        drop(listener);
+        let _ = std::fs::remove_file(&staging_path);
+        return Err(err);
+    }
+    Ok(listener)
+}
+
+#[cfg(not(unix))]
+fn bind_one(path: &Path) -> io::Result<interprocess::local_socket::Listener> {
     let name: Name<'_> = path
         .as_os_str()
         .to_fs_name::<GenericFilePath>()
@@ -123,11 +161,56 @@ mod tests {
         let listeners = bind_both().unwrap();
         assert!(listeners.control_path.exists());
         assert!(listeners.stream_path.exists());
+        #[cfg(unix)]
+        {
+            assert_eq!(
+                std::fs::metadata(&listeners.control_path)
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+            assert_eq!(
+                std::fs::metadata(&listeners.stream_path)
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+
+        // The canonical path must be connectable. On Unix this also proves
+        // that renaming the bound socket did not break daemon clients.
+        // Connect to the paths returned by this bind rather than resolving
+        // the process-wide test override again; other path tests mutate that
+        // environment variable in parallel.
+        let control_client =
+            connect_one(&listeners.control_path).expect("control socket should accept connects");
+        let stream_client =
+            connect_one(&listeners.stream_path).expect("stream socket should accept connects");
+        drop((control_client, stream_client));
+
+        #[cfg(unix)]
+        let staging_marker = {
+            // interprocess normally unlinks the path it originally bound when
+            // the listener drops. Since we rename that path, prove its reclaim
+            // guard is disabled and cannot delete a later-created sibling.
+            let marker = listeners.control_path.with_extension("tmp");
+            std::fs::write(&marker, b"keep").unwrap();
+            marker
+        };
 
         // Drop listeners before cleanup so the OS releases the fd.
         let cp = listeners.control_path.clone();
         let sp = listeners.stream_path.clone();
         drop(listeners);
+        #[cfg(unix)]
+        {
+            assert_eq!(std::fs::read(&staging_marker).unwrap(), b"keep");
+            std::fs::remove_file(&staging_marker).unwrap();
+        }
         cleanup_paths(&cp, &sp);
         assert!(!cp.exists());
         assert!(!sp.exists());

--- a/src-tauri/crates/acorn-daemon/src/wire.rs
+++ b/src-tauri/crates/acorn-daemon/src/wire.rs
@@ -1,0 +1,90 @@
+//! Shared newline-delimited JSON framing helpers for daemon sockets.
+//!
+//! `BufRead::read_line` grows its destination until it sees a newline or EOF.
+//! Every daemon socket is reachable by child processes in Acorn sessions, so
+//! accepting an unbounded line would let a misbehaving process exhaust the app
+//! or daemon's memory before JSON parsing gets a chance to reject the frame.
+
+use std::io::{self, BufRead, Read};
+
+/// Maximum encoded client-to-daemon request size, including its newline.
+/// Requests are normally tiny; 1 MiB preserves large paste/spawn payloads
+/// while limiting JSON allocation amplification on an untrusted request.
+pub const MAX_REQUEST_FRAME_BYTES: usize = 1024 * 1024;
+
+/// Maximum encoded daemon-to-client response size, including its newline.
+/// A 4 MiB scrollback snapshot expands to about 5.4 MiB after base64, so 8 MiB
+/// leaves room for its JSON envelope while keeping allocation finite.
+pub const MAX_RESPONSE_FRAME_BYTES: usize = 8 * 1024 * 1024;
+
+/// Read one client-to-daemon frame while bounding destination growth.
+pub fn read_request_frame_line<R: BufRead>(reader: &mut R, line: &mut String) -> io::Result<usize> {
+    read_frame_line_with_limit(reader, line, MAX_REQUEST_FRAME_BYTES)
+}
+
+/// Read one daemon-to-client frame while bounding destination growth.
+pub fn read_response_frame_line<R: BufRead>(
+    reader: &mut R,
+    line: &mut String,
+) -> io::Result<usize> {
+    read_frame_line_with_limit(reader, line, MAX_RESPONSE_FRAME_BYTES)
+}
+
+fn read_frame_line_with_limit<R: BufRead>(
+    reader: &mut R,
+    line: &mut String,
+    max_bytes: usize,
+) -> io::Result<usize> {
+    line.clear();
+    let mut limited = reader.take((max_bytes + 1) as u64);
+    let bytes_read = limited.read_line(line)?;
+    if bytes_read > max_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("daemon protocol frame exceeds {max_bytes}-byte limit"),
+        ));
+    }
+    Ok(bytes_read)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn bounded_reader_accepts_a_frame_at_the_limit() {
+        let mut reader = Cursor::new(b"1234567\nnext\n");
+        let mut line = String::from("stale");
+
+        assert_eq!(
+            read_frame_line_with_limit(&mut reader, &mut line, 8).unwrap(),
+            8
+        );
+        assert_eq!(line, "1234567\n");
+    }
+
+    #[test]
+    fn bounded_reader_rejects_an_oversized_frame() {
+        let mut reader = Cursor::new(b"12345678\n");
+        let mut line = String::new();
+
+        let error = read_frame_line_with_limit(&mut reader, &mut line, 8).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(line.len(), 9);
+    }
+
+    #[test]
+    fn bounded_reader_accepts_a_final_frame_without_a_newline() {
+        let mut reader = Cursor::new(b"final");
+        let mut line = String::new();
+
+        assert_eq!(
+            read_frame_line_with_limit(&mut reader, &mut line, 8).unwrap(),
+            5
+        );
+        assert_eq!(line, "final");
+    }
+}

--- a/src-tauri/crates/acorn-paths/src/lib.rs
+++ b/src-tauri/crates/acorn-paths/src/lib.rs
@@ -4,7 +4,10 @@
 //! state is isolated below that directory with a profile segment.
 
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 use directories::ProjectDirs;
 
@@ -56,17 +59,28 @@ pub fn base_data_dir() -> io::Result<PathBuf> {
     Ok(pd.data_dir().to_path_buf())
 }
 
+fn ensure_private_dir(path: &Path) -> io::Result<()> {
+    std::fs::create_dir_all(path)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    Ok(())
+}
+
 pub fn data_dir() -> io::Result<PathBuf> {
     if let Ok(over) = std::env::var(ENV_DATA_DIR_OVERRIDE) {
         if !over.is_empty() {
             let p = PathBuf::from(over);
-            std::fs::create_dir_all(&p)?;
+            ensure_private_dir(&p)?;
             return Ok(p);
         }
     }
 
-    let dir = base_data_dir()?.join("profiles").join(effective_profile()?);
-    std::fs::create_dir_all(&dir)?;
+    let base = base_data_dir()?;
+    ensure_private_dir(&base)?;
+    let profiles = base.join("profiles");
+    ensure_private_dir(&profiles)?;
+    let dir = profiles.join(effective_profile()?);
+    ensure_private_dir(&dir)?;
     Ok(dir)
 }
 
@@ -106,10 +120,36 @@ mod tests {
 
         assert_eq!(data_dir().unwrap(), tmp);
 
+        #[cfg(unix)]
+        assert_eq!(
+            std::fs::metadata(&tmp).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+
         unsafe {
             std::env::remove_var(ENV_DATA_DIR_OVERRIDE);
             std::env::remove_var(ENV_PROFILE);
         }
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn data_dir_tightens_existing_permissions() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp =
+            PathBuf::from("/tmp").join(format!("acorn-paths-permissions-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755)).unwrap();
+        unsafe { std::env::set_var(ENV_DATA_DIR_OVERRIDE, &tmp) };
+
+        assert_eq!(data_dir().unwrap(), tmp);
+        assert_eq!(
+            std::fs::metadata(&tmp).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+
+        unsafe { std::env::remove_var(ENV_DATA_DIR_OVERRIDE) };
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/src-tauri/crates/acorn-session/src/scrollback.rs
+++ b/src-tauri/crates/acorn-session/src/scrollback.rs
@@ -57,15 +57,23 @@ fn is_safe_session_id(id: &str) -> bool {
 
 pub fn save(data_dir: &Path, session_id: &str, data: &str) -> ScrollbackResult<()> {
     let final_path = session_file(data_dir, session_id)?;
-    let payload = if data.len() > MAX_PAYLOAD_BYTES {
-        // Drop the oldest bytes; xterm-rendered ANSI may break mid-sequence
-        // here, but the frontend re-clears the screen on full restore so a
-        // few corrupted glyphs at the very top are tolerable.
-        &data[data.len() - MAX_PAYLOAD_BYTES..]
-    } else {
-        data
-    };
+    let payload = trailing_utf8_slice(data, MAX_PAYLOAD_BYTES);
     write_atomic(&final_path, payload.as_bytes())
+}
+
+fn trailing_utf8_slice(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+
+    // Drop the oldest bytes, then advance at most three more bytes so slicing
+    // never lands in the middle of a UTF-8 scalar value. ANSI may still start
+    // mid-sequence, but a non-ASCII terminal buffer must not panic the app.
+    let mut start = value.len() - max_bytes;
+    while !value.is_char_boundary(start) {
+        start += 1;
+    }
+    &value[start..]
 }
 
 pub fn load(data_dir: &Path, session_id: &str) -> ScrollbackResult<Option<String>> {
@@ -200,6 +208,12 @@ mod tests {
         assert!(got.contains("hello"));
         // Cleanup
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn payload_truncation_advances_to_a_utf8_boundary() {
+        assert_eq!(trailing_utf8_slice("é1234", 5), "1234");
+        assert_eq!(trailing_utf8_slice("한글", 3), "글");
     }
 
     #[test]

--- a/src-tauri/crates/acorn-transcript/src/lib.rs
+++ b/src-tauri/crates/acorn-transcript/src/lib.rs
@@ -74,9 +74,81 @@ pub const DORMANT_TRANSCRIPT_SECS: u64 = 10;
 // would multiply that cost without changing the answer. A short hold
 // returns the cached result for repeat calls within this window.
 const SCAN_CACHE_TTL_MS: u64 = 300;
+const LIVE_SCAN_SESSION_LIMIT: usize = 2_000;
+const LIVE_AGENT_PROCESS_LIMIT: usize = 2_000;
+
+const PROVIDER_SCAN_LIMITS: ProviderScanLimits = ProviderScanLimits {
+    directory_entries: 10_000,
+    candidates: 2_000,
+    head_opens: 500,
+    head_bytes: 1024 * 1024,
+    line_bytes: 256 * 1024,
+    head_lines: 50,
+};
+
+#[derive(Clone, Copy)]
+struct ProviderScanLimits {
+    directory_entries: usize,
+    candidates: usize,
+    head_opens: usize,
+    head_bytes: usize,
+    line_bytes: usize,
+    head_lines: usize,
+}
+
+struct ProviderScanBudget {
+    limits: ProviderScanLimits,
+    directory_entries: usize,
+    candidates: usize,
+    head_opens: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProviderScanError {
+    LimitExceeded,
+    Incomplete,
+}
+
+type ProviderScanResult<T> = Result<T, ProviderScanError>;
+
+impl ProviderScanBudget {
+    fn new(limits: ProviderScanLimits) -> Self {
+        Self {
+            limits,
+            directory_entries: 0,
+            candidates: 0,
+            head_opens: 0,
+        }
+    }
+
+    fn charge_directory_entry(&mut self) -> ProviderScanResult<()> {
+        charge_limit(&mut self.directory_entries, self.limits.directory_entries)
+    }
+
+    fn charge_candidate(&mut self) -> ProviderScanResult<()> {
+        charge_limit(&mut self.candidates, self.limits.candidates)
+    }
+
+    fn charge_head_open(&mut self) -> ProviderScanResult<()> {
+        charge_limit(&mut self.head_opens, self.limits.head_opens)
+    }
+}
+
+fn charge_limit(used: &mut usize, limit: usize) -> ProviderScanResult<()> {
+    if *used >= limit {
+        return Err(ProviderScanError::LimitExceeded);
+    }
+    *used += 1;
+    Ok(())
+}
+
+fn complete_io<T>(result: std::io::Result<T>) -> ProviderScanResult<T> {
+    result.map_err(|_| ProviderScanError::Incomplete)
+}
 
 struct ScanCache {
     captured_at: Instant,
+    session_key: Vec<(uuid::Uuid, Option<u32>)>,
     mappings: Vec<(uuid::Uuid, AgentKind, String)>,
 }
 
@@ -216,10 +288,16 @@ fn collect_mappings_cached(
     sessions: &[SessionPid],
     scope: MappingScope,
 ) -> Vec<(uuid::Uuid, AgentKind, String)> {
+    if sessions.len() > LIVE_SCAN_SESSION_LIMIT {
+        return Vec::new();
+    }
+    let session_key = scan_cache_session_key(sessions);
     {
         let guard = cache.lock();
         if let Some(cache) = guard.as_ref() {
-            if cache.captured_at.elapsed() < Duration::from_millis(SCAN_CACHE_TTL_MS) {
+            if cache.session_key == session_key
+                && cache.captured_at.elapsed() < Duration::from_millis(SCAN_CACHE_TTL_MS)
+            {
                 return cache.mappings.clone();
             }
         }
@@ -227,9 +305,19 @@ fn collect_mappings_cached(
     let mappings = scan_live_mappings(sessions, scope);
     *cache.lock() = Some(ScanCache {
         captured_at: Instant::now(),
+        session_key,
         mappings: mappings.clone(),
     });
     mappings
+}
+
+fn scan_cache_session_key(sessions: &[SessionPid]) -> Vec<(uuid::Uuid, Option<u32>)> {
+    let mut key = sessions
+        .iter()
+        .map(|session| (session.session_id, session.root_pid))
+        .collect::<Vec<_>>();
+    key.sort_unstable();
+    key
 }
 
 /// Resolve the provider conversation id created by an agent run in `cwd`.
@@ -314,6 +402,9 @@ fn scan_live_mappings(
     sessions: &[SessionPid],
     scope: MappingScope,
 ) -> Vec<(uuid::Uuid, AgentKind, String)> {
+    if sessions.len() > LIVE_SCAN_SESSION_LIMIT {
+        return Vec::new();
+    }
     let mut out = Vec::new();
     let refresh = ProcessRefreshKind::new()
         .with_cwd(UpdateKind::Always)
@@ -396,10 +487,17 @@ fn scan_live_mappings(
             continue;
         };
 
-        let matches =
-            collect_agent_processes_in_tree(&children, Pid::from_u32(root_pid), scope, |pid| {
-                sys.process(pid).and_then(agent_process_node)
-            });
+        let remaining_processes = LIVE_AGENT_PROCESS_LIMIT.saturating_sub(candidates.len());
+        let matches = match collect_agent_processes_in_tree_bounded(
+            &children,
+            Pid::from_u32(root_pid),
+            scope,
+            remaining_processes,
+            |pid| sys.process(pid).and_then(agent_process_node),
+        ) {
+            Ok(matches) => matches,
+            Err(_) => return Vec::new(),
+        };
 
         for process_match in matches {
             if let Some(proc) = sys.process(process_match.pid) {
@@ -453,6 +551,9 @@ fn scan_live_mappings(
             .then_with(|| b.start_time.cmp(&a.start_time))
     });
 
+    let mut claude_budget = ProviderScanBudget::new(PROVIDER_SCAN_LIMITS);
+    let mut codex_budget = ProviderScanBudget::new(PROVIDER_SCAN_LIMITS);
+    let mut antigravity_budget = ProviderScanBudget::new(PROVIDER_SCAN_LIMITS);
     for c in candidates {
         let mut reserved = assigned.clone();
         if c.role == AgentProcessRole::Emit {
@@ -460,103 +561,101 @@ fn scan_live_mappings(
                 reserved.extend(paths.iter().cloned());
             }
         }
-        let candidate = match c.kind {
-            AgentKind::Claude => {
-                let sole_claude_in_cwd = claude_cwd_counts.get(&c.cwd).copied().unwrap_or(0) <= 1;
-                let allow_rotation = sole_claude_in_cwd
-                    && !owner_rotation_quarantined.contains(&owner_rotation_scope(
-                        c.session_id,
-                        c.kind,
-                        &c.cwd,
-                    ));
-                c.explicit_transcript_id
-                    .as_deref()
-                    .and_then(|id| {
-                        find_claude_jsonl_for_uuid(&c.cwd, claude_root.as_deref(), id, &assigned)
-                    })
-                    .or_else(|| {
-                        find_recent_claude_jsonl(
+        let candidate = (|| -> ProviderScanResult<Option<(PathBuf, String)>> {
+            match c.kind {
+                AgentKind::Claude => {
+                    let sole_claude_in_cwd =
+                        claude_cwd_counts.get(&c.cwd).copied().unwrap_or(0) <= 1;
+                    let allow_rotation = sole_claude_in_cwd
+                        && !owner_rotation_quarantined.contains(&owner_rotation_scope(
+                            c.session_id,
+                            c.kind,
+                            &c.cwd,
+                        ));
+                    if let Some(id) = c.explicit_transcript_id.as_deref() {
+                        if let Some(candidate) = find_claude_jsonl_for_uuid_budgeted(
                             &c.cwd,
                             claude_root.as_deref(),
-                            recency_cutoff,
-                            c.start_time,
-                            now,
-                            allow_rotation,
-                            &reserved,
-                        )
-                    })
-            }
-            AgentKind::Codex => {
-                let sole_codex_in_cwd = codex_cwd_counts.get(&c.cwd).copied().unwrap_or(0) <= 1;
-                let allow_rotation = sole_codex_in_cwd
-                    && !owner_rotation_quarantined.contains(&owner_rotation_scope(
-                        c.session_id,
-                        c.kind,
-                        &c.cwd,
-                    ));
-                // `codex resume <uuid>` may attach to an existing JSONL before
-                // Codex appends a new line, so the normal mtime >= process-start
-                // guard would hide the active transcript.
-                c.explicit_transcript_id
-                    .as_deref()
-                    .and_then(|id| find_codex_jsonl_for_uuid(codex_root.as_deref(), id, &assigned))
-                    .or_else(|| {
-                        match codex_rollout_scope_for_mapping(
-                            scope,
-                            c.role,
-                            c.codex_resume_requested,
-                        ) {
-                            CodexRolloutScope::SessionOwner => find_recent_codex_owner_jsonl(
-                                &c.cwd,
-                                codex_root.as_deref(),
-                                recency_cutoff,
-                                c.start_time,
-                                now,
-                                allow_rotation,
-                                &reserved,
-                            ),
-                            CodexRolloutScope::ResumedOwner => find_recent_resumed_codex_jsonl(
-                                &c.cwd,
-                                codex_root.as_deref(),
-                                recency_cutoff,
-                                c.start_time,
-                                now,
-                                allow_rotation,
-                                &reserved,
-                            ),
-                            CodexRolloutScope::AnyTerminal => find_recent_codex_jsonl(
-                                &c.cwd,
-                                codex_root.as_deref(),
-                                recency_cutoff,
-                                c.start_time,
-                                now,
-                                allow_rotation,
-                                &reserved,
-                            ),
+                            id,
+                            &assigned,
+                            &mut claude_budget,
+                        )? {
+                            return Ok(Some(candidate));
                         }
-                    })
-            }
-            AgentKind::Antigravity => {
-                let owner_cursor_id =
-                    antigravity_owner_cursor_id(antigravity_storage_root.as_deref(), &c.cwd);
-                let sole_antigravity_in_cwd =
-                    antigravity_cwd_counts.get(&c.cwd).copied().unwrap_or(0) <= 1;
-                let allow_rotation = sole_antigravity_in_cwd
-                    && !owner_rotation_quarantined.contains(&owner_rotation_scope(
-                        c.session_id,
-                        c.kind,
+                    }
+                    find_recent_claude_jsonl_budgeted(
                         &c.cwd,
-                    ));
-                find_recent_antigravity_jsonl(
-                    &antigravity_roots,
-                    recency_cutoff,
-                    c.start_time,
-                    now,
-                    allow_rotation,
-                    owner_cursor_id.as_deref(),
-                    &reserved,
-                )
+                        claude_root.as_deref(),
+                        recency_cutoff,
+                        c.start_time,
+                        now,
+                        allow_rotation,
+                        &reserved,
+                        &mut claude_budget,
+                    )
+                }
+                AgentKind::Codex => {
+                    let sole_codex_in_cwd = codex_cwd_counts.get(&c.cwd).copied().unwrap_or(0) <= 1;
+                    let allow_rotation = sole_codex_in_cwd
+                        && !owner_rotation_quarantined.contains(&owner_rotation_scope(
+                            c.session_id,
+                            c.kind,
+                            &c.cwd,
+                        ));
+                    // `codex resume <uuid>` may attach to an existing JSONL before
+                    // Codex appends a new line, so the normal mtime >= process-start
+                    // guard would hide the active transcript.
+                    if let Some(id) = c.explicit_transcript_id.as_deref() {
+                        if let Some(candidate) = find_codex_jsonl_for_uuid_budgeted(
+                            codex_root.as_deref(),
+                            id,
+                            &assigned,
+                            &mut codex_budget,
+                        )? {
+                            return Ok(Some(candidate));
+                        }
+                    }
+                    let rollout_scope =
+                        codex_rollout_scope_for_mapping(scope, c.role, c.codex_resume_requested);
+                    find_recent_codex_jsonl_budgeted(
+                        &c.cwd,
+                        codex_root.as_deref(),
+                        recency_cutoff,
+                        c.start_time,
+                        now,
+                        allow_rotation,
+                        &reserved,
+                        rollout_scope,
+                        &mut codex_budget,
+                    )
+                }
+                AgentKind::Antigravity => {
+                    let owner_cursor_id =
+                        antigravity_owner_cursor_id(antigravity_storage_root.as_deref(), &c.cwd);
+                    let sole_antigravity_in_cwd =
+                        antigravity_cwd_counts.get(&c.cwd).copied().unwrap_or(0) <= 1;
+                    let allow_rotation = sole_antigravity_in_cwd
+                        && !owner_rotation_quarantined.contains(&owner_rotation_scope(
+                            c.session_id,
+                            c.kind,
+                            &c.cwd,
+                        ));
+                    find_recent_antigravity_jsonl_budgeted(
+                        &antigravity_roots,
+                        recency_cutoff,
+                        c.start_time,
+                        now,
+                        allow_rotation,
+                        owner_cursor_id.as_deref(),
+                        &reserved,
+                        &mut antigravity_budget,
+                    )
+                }
             }
+        })();
+        let candidate = match candidate {
+            Ok(candidate) => candidate,
+            Err(_) => return Vec::new(),
         };
         if let Some((path, uuid)) = candidate {
             tracing::info!(
@@ -602,12 +701,30 @@ fn scan_live_mappings(
     out
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct LiveAgentProcessLimitExceeded;
+
+#[cfg(test)]
 fn collect_agent_processes_in_tree<F>(
     children: &std::collections::HashMap<Pid, Vec<Pid>>,
     root: Pid,
     scope: MappingScope,
-    mut node_for_pid: F,
+    node_for_pid: F,
 ) -> Vec<AgentProcessMatch>
+where
+    F: FnMut(Pid) -> Option<AgentProcessNode>,
+{
+    collect_agent_processes_in_tree_bounded(children, root, scope, usize::MAX, node_for_pid)
+        .expect("unbounded test traversal cannot exceed its match limit")
+}
+
+fn collect_agent_processes_in_tree_bounded<F>(
+    children: &std::collections::HashMap<Pid, Vec<Pid>>,
+    root: Pid,
+    scope: MappingScope,
+    match_limit: usize,
+    mut node_for_pid: F,
+) -> Result<Vec<AgentProcessMatch>, LiveAgentProcessLimitExceeded>
 where
     F: FnMut(Pid) -> Option<AgentProcessNode>,
 {
@@ -622,6 +739,9 @@ where
             .is_some_and(|(parent, child)| same_logical_agent_invocation(parent, child));
         if let Some(node) = &node {
             if !belongs_to_parent {
+                if out.len() >= match_limit {
+                    return Err(LiveAgentProcessLimitExceeded);
+                }
                 let role = if scope == MappingScope::SessionOwners && below_agent_boundary {
                     AgentProcessRole::Quarantine
                 } else {
@@ -644,7 +764,7 @@ where
             );
         }
     }
-    out
+    Ok(out)
 }
 
 /// Snapshot the by-path owner quarantine, evicting entries that can no
@@ -1194,6 +1314,45 @@ fn codex_sessions_root() -> Option<PathBuf> {
         .map(|p| p.join("sessions"))
 }
 
+fn safe_is_directory(path: &Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .map(|meta| meta.file_type().is_dir())
+        .unwrap_or(false)
+}
+
+fn safe_read_dir(path: &Path) -> ProviderScanResult<Option<std::fs::ReadDir>> {
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(meta) => meta,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err(ProviderScanError::Incomplete),
+    };
+    if !meta.file_type().is_dir() {
+        return Ok(None);
+    }
+    complete_io(std::fs::read_dir(path)).map(Some)
+}
+
+fn safe_directory_entry_path(entry: &std::fs::DirEntry) -> ProviderScanResult<Option<PathBuf>> {
+    Ok(complete_io(entry.file_type())?
+        .is_dir()
+        .then(|| entry.path()))
+}
+
+fn safe_regular_file_metadata(path: &Path) -> Option<std::fs::Metadata> {
+    let meta = std::fs::symlink_metadata(path).ok()?;
+    meta.file_type().is_file().then_some(meta)
+}
+
+fn safe_regular_file_entry_metadata(
+    entry: &std::fs::DirEntry,
+) -> ProviderScanResult<Option<std::fs::Metadata>> {
+    if !complete_io(entry.file_type())?.is_file() {
+        return Ok(None);
+    }
+    let meta = complete_io(std::fs::symlink_metadata(entry.path()))?;
+    Ok(meta.file_type().is_file().then_some(meta))
+}
+
 /// Locate a Codex rollout JSONL by its transcript UUID.
 ///
 /// Codex stores rollouts under `<sessions>/<yyyy>/<mm>/<dd>/`, while the
@@ -1206,71 +1365,136 @@ pub fn locate_codex_transcript(uuid: &str) -> Option<PathBuf> {
 }
 
 fn locate_codex_transcript_in(sessions_root: &Path, uuid: &str) -> Option<PathBuf> {
+    let mut budget = ProviderScanBudget::new(PROVIDER_SCAN_LIMITS);
+    locate_codex_transcript_in_budgeted(sessions_root, uuid, &mut budget)
+        .ok()
+        .flatten()
+}
+
+fn locate_codex_transcript_in_budgeted(
+    sessions_root: &Path,
+    uuid: &str,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<PathBuf>> {
     if !is_uuid_v4_shape(uuid) {
-        return None;
+        return Ok(None);
     }
 
     for day_dir in codex_day_dirs_for_uuid(sessions_root, uuid) {
-        if let Some(path) = find_rollout_for_uuid(&day_dir, uuid) {
-            return Some(path);
+        if let Some(path) = find_rollout_for_uuid_budgeted(&day_dir, uuid, budget)? {
+            return Ok(Some(path));
         }
     }
 
-    for year in iter_subdirs_desc(sessions_root)?.into_iter().take(2) {
-        for month in iter_subdirs_desc(&year)?.into_iter().take(2) {
-            for day in iter_subdirs_desc(&month)?.into_iter().take(7) {
-                if let Some(path) = find_rollout_for_uuid(&day, uuid) {
-                    return Some(path);
+    let Some(years) = iter_subdirs_desc_budgeted(sessions_root, budget)? else {
+        return Ok(None);
+    };
+    for year in years.into_iter().take(2) {
+        let Some(months) = iter_subdirs_desc_budgeted(&year, budget)? else {
+            continue;
+        };
+        for month in months.into_iter().take(2) {
+            let Some(days) = iter_subdirs_desc_budgeted(&month, budget)? else {
+                continue;
+            };
+            for day in days.into_iter().take(7) {
+                if let Some(path) = find_rollout_for_uuid_budgeted(&day, uuid, budget)? {
+                    return Ok(Some(path));
                 }
             }
         }
     }
-    None
+    Ok(None)
 }
 
+#[cfg(test)]
 fn find_codex_jsonl_for_uuid(
     sessions_root: Option<&Path>,
     uuid: &str,
     assigned: &HashSet<PathBuf>,
 ) -> Option<(PathBuf, String)> {
-    let path = locate_codex_transcript_in(sessions_root?, uuid)?;
-    if assigned.contains(&path) {
-        return None;
-    }
-    Some((path, uuid.to_string()))
+    let mut budget = ProviderScanBudget::new(PROVIDER_SCAN_LIMITS);
+    find_codex_jsonl_for_uuid_budgeted(sessions_root, uuid, assigned, &mut budget)
+        .ok()
+        .flatten()
 }
 
-fn find_claude_jsonl_for_uuid(
+fn find_codex_jsonl_for_uuid_budgeted(
+    sessions_root: Option<&Path>,
+    uuid: &str,
+    assigned: &HashSet<PathBuf>,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<(PathBuf, String)>> {
+    let Some(root) = sessions_root else {
+        return Ok(None);
+    };
+    let Some(path) = locate_codex_transcript_in_budgeted(root, uuid, budget)? else {
+        return Ok(None);
+    };
+    if assigned.contains(&path) {
+        return Ok(None);
+    }
+    Ok(Some((path, uuid.to_string())))
+}
+
+fn find_claude_jsonl_for_uuid_budgeted(
     cwd: &Path,
     projects_root: Option<&Path>,
     uuid: &str,
     assigned: &HashSet<PathBuf>,
-) -> Option<(PathBuf, String)> {
-    let root = projects_root?;
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<(PathBuf, String)>> {
+    let Some(root) = projects_root else {
+        return Ok(None);
+    };
+    if !safe_is_directory(root) {
+        return Ok(None);
+    }
     if !is_uuid_v4_shape(uuid) {
-        return None;
+        return Ok(None);
     }
     let filename = format!("{uuid}.jsonl");
-    let slug_path = root.join(slug_for_cwd(cwd)).join(&filename);
-    if claude_uuid_path_matches_cwd(&slug_path, cwd, assigned) {
-        return Some((slug_path, uuid.to_string()));
-    }
-    for project in std::fs::read_dir(root).ok()?.flatten() {
-        let path = project.path().join(&filename);
-        if claude_uuid_path_matches_cwd(&path, cwd, assigned) {
-            return Some((path, uuid.to_string()));
+    let slug_dir = root.join(slug_for_cwd(cwd));
+    if safe_is_directory(&slug_dir) {
+        let slug_path = slug_dir.join(&filename);
+        if claude_uuid_path_matches_cwd_budgeted(&slug_path, cwd, assigned, budget)? {
+            return Ok(Some((slug_path, uuid.to_string())));
         }
     }
-    None
+
+    let Some(projects) = safe_read_dir(root)? else {
+        return Ok(None);
+    };
+    for raw_project in projects {
+        budget.charge_directory_entry()?;
+        let project = complete_io(raw_project)?;
+        let Some(project_dir) = safe_directory_entry_path(&project)? else {
+            continue;
+        };
+        let path = project_dir.join(&filename);
+        if claude_uuid_path_matches_cwd_budgeted(&path, cwd, assigned, budget)? {
+            return Ok(Some((path, uuid.to_string())));
+        }
+    }
+    Ok(None)
 }
 
-fn claude_uuid_path_matches_cwd(path: &Path, cwd: &Path, assigned: &HashSet<PathBuf>) -> bool {
-    if assigned.contains(path) || !path.is_file() {
-        return false;
+fn claude_uuid_path_matches_cwd_budgeted(
+    path: &Path,
+    cwd: &Path,
+    assigned: &HashSet<PathBuf>,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<bool> {
+    if assigned.contains(path) {
+        return Ok(false);
     }
-    read_agent_transcript_cwd(path)
+    budget.charge_candidate()?;
+    if safe_regular_file_metadata(path).is_none() {
+        return Ok(false);
+    }
+    Ok(read_agent_transcript_cwd_budgeted(path, budget)?
         .map(|transcript_cwd| transcript_cwd == cwd)
-        .unwrap_or(true)
+        .unwrap_or(true))
 }
 
 fn codex_day_dirs_for_uuid(sessions_root: &Path, uuid: &str) -> Vec<PathBuf> {
@@ -1317,18 +1541,31 @@ fn uuid_v7_unix_millis(uuid: &str) -> Option<u64> {
     u64::from_str_radix(&compact[..12], 16).ok()
 }
 
-fn find_rollout_for_uuid(day_dir: &Path, uuid: &str) -> Option<PathBuf> {
+fn find_rollout_for_uuid_budgeted(
+    day_dir: &Path,
+    uuid: &str,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<PathBuf>> {
     let suffix = format!("{uuid}.jsonl");
-    for entry in std::fs::read_dir(day_dir).ok()?.flatten() {
+    let Some(entries) = safe_read_dir(day_dir)? else {
+        return Ok(None);
+    };
+    for raw_entry in entries {
+        budget.charge_directory_entry()?;
+        let entry = complete_io(raw_entry)?;
         let path = entry.path();
         let Some(filename) = path.file_name().and_then(|s| s.to_str()) else {
             continue;
         };
-        if filename.starts_with("rollout-") && filename.ends_with(&suffix) {
-            return Some(path);
+        if !filename.starts_with("rollout-") || !filename.ends_with(&suffix) {
+            continue;
+        }
+        budget.charge_candidate()?;
+        if safe_regular_file_entry_metadata(&entry)?.is_some() {
+            return Ok(Some(path));
         }
     }
-    None
+    Ok(None)
 }
 
 fn google_agent_storage_root() -> Option<PathBuf> {
@@ -1345,7 +1582,7 @@ fn antigravity_brain_roots() -> Vec<PathBuf> {
     ["antigravity", "antigravity-ide", "antigravity-cli"]
         .into_iter()
         .map(|profile| root.join(profile).join("brain"))
-        .filter(|path| path.is_dir())
+        .filter(|path| safe_is_directory(path))
         .collect()
 }
 
@@ -1372,30 +1609,87 @@ fn find_recent_claude_jsonl(
     allow_rotation: bool,
     assigned: &HashSet<PathBuf>,
 ) -> Option<(PathBuf, String)> {
-    let root = projects_root?;
+    find_recent_claude_jsonl_with_limits(
+        cwd,
+        projects_root,
+        recency_cutoff,
+        process_start,
+        now,
+        allow_rotation,
+        assigned,
+        PROVIDER_SCAN_LIMITS,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn find_recent_claude_jsonl_with_limits(
+    cwd: &Path,
+    projects_root: Option<&Path>,
+    recency_cutoff: SystemTime,
+    process_start: SystemTime,
+    now: SystemTime,
+    allow_rotation: bool,
+    assigned: &HashSet<PathBuf>,
+    limits: ProviderScanLimits,
+) -> Option<(PathBuf, String)> {
+    let mut budget = ProviderScanBudget::new(limits);
+    find_recent_claude_jsonl_budgeted(
+        cwd,
+        projects_root,
+        recency_cutoff,
+        process_start,
+        now,
+        allow_rotation,
+        assigned,
+        &mut budget,
+    )
+    .ok()
+    .flatten()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn find_recent_claude_jsonl_budgeted(
+    cwd: &Path,
+    projects_root: Option<&Path>,
+    recency_cutoff: SystemTime,
+    process_start: SystemTime,
+    now: SystemTime,
+    allow_rotation: bool,
+    assigned: &HashSet<PathBuf>,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<(PathBuf, String)>> {
+    let Some(root) = projects_root else {
+        return Ok(None);
+    };
+    if !safe_is_directory(root) {
+        return Ok(None);
+    }
     let slug_dir = root.join(slug_for_cwd(cwd));
-    pick_newest_unassigned_jsonl(
+    if let Some(candidate) = pick_newest_unassigned_jsonl_budgeted(
         &slug_dir,
         recency_cutoff,
         process_start,
         now,
         allow_rotation,
         assigned,
+        budget,
+    )? {
+        return Ok(Some(candidate));
+    }
+    find_recent_claude_jsonl_by_cwd_budgeted(
+        cwd,
+        root,
+        recency_cutoff,
+        process_start,
+        now,
+        allow_rotation,
+        assigned,
+        budget,
     )
-    .or_else(|| {
-        find_recent_claude_jsonl_by_cwd(
-            cwd,
-            root,
-            recency_cutoff,
-            process_start,
-            now,
-            allow_rotation,
-            assigned,
-        )
-    })
 }
 
-fn find_recent_claude_jsonl_by_cwd(
+#[allow(clippy::too_many_arguments)]
+fn find_recent_claude_jsonl_by_cwd_budgeted(
     cwd: &Path,
     projects_root: &Path,
     recency_cutoff: SystemTime,
@@ -1403,17 +1697,24 @@ fn find_recent_claude_jsonl_by_cwd(
     now: SystemTime,
     allow_rotation: bool,
     assigned: &HashSet<PathBuf>,
-) -> Option<(PathBuf, String)> {
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<(PathBuf, String)>> {
     let mut candidates: Vec<TranscriptCandidate> = Vec::new();
-    for project in std::fs::read_dir(projects_root).ok()?.flatten() {
-        let dir = project.path();
-        if !dir.is_dir() {
-            continue;
-        }
-        let Ok(entries) = std::fs::read_dir(&dir) else {
+    let Some(projects) = safe_read_dir(projects_root)? else {
+        return Ok(None);
+    };
+    for raw_project in projects {
+        budget.charge_directory_entry()?;
+        let project = complete_io(raw_project)?;
+        let Some(dir) = safe_directory_entry_path(&project)? else {
             continue;
         };
-        for entry in entries.flatten() {
+        let Some(entries) = safe_read_dir(&dir)? else {
+            continue;
+        };
+        for raw_entry in entries {
+            budget.charge_directory_entry()?;
+            let entry = complete_io(raw_entry)?;
             let path = entry.path();
             if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
                 continue;
@@ -1421,12 +1722,15 @@ fn find_recent_claude_jsonl_by_cwd(
             if assigned.contains(&path) {
                 continue;
             }
-            let Ok(meta) = entry.metadata() else { continue };
+            budget.charge_candidate()?;
+            let Some(meta) = safe_regular_file_entry_metadata(&entry)? else {
+                continue;
+            };
             let Ok(mtime) = meta.modified() else { continue };
             if mtime < recency_cutoff || mtime < process_start {
                 continue;
             }
-            let Some(transcript_cwd) = read_agent_transcript_cwd(&path) else {
+            let Some(transcript_cwd) = read_agent_transcript_cwd_budgeted(&path, budget)? else {
                 continue;
             };
             if transcript_cwd != cwd {
@@ -1444,9 +1748,15 @@ fn find_recent_claude_jsonl_by_cwd(
             });
         }
     }
-    pick_anchor_or_rotate(candidates, process_start, now, allow_rotation)
+    Ok(pick_anchor_or_rotate(
+        candidates,
+        process_start,
+        now,
+        allow_rotation,
+    ))
 }
 
+#[cfg(test)]
 fn find_recent_codex_jsonl(
     cwd: &Path,
     sessions_root: Option<&Path>,
@@ -1456,7 +1766,7 @@ fn find_recent_codex_jsonl(
     allow_rotation: bool,
     assigned: &HashSet<PathBuf>,
 ) -> Option<(PathBuf, String)> {
-    find_recent_codex_jsonl_with_scope(
+    find_recent_codex_jsonl_with_limits(
         cwd,
         sessions_root,
         recency_cutoff,
@@ -1464,10 +1774,11 @@ fn find_recent_codex_jsonl(
         now,
         allow_rotation,
         assigned,
-        CodexRolloutScope::AnyTerminal,
+        PROVIDER_SCAN_LIMITS,
     )
 }
 
+#[cfg(test)]
 fn find_recent_codex_owner_jsonl(
     cwd: &Path,
     sessions_root: Option<&Path>,
@@ -1489,6 +1800,7 @@ fn find_recent_codex_owner_jsonl(
     )
 }
 
+#[cfg(test)]
 fn find_recent_resumed_codex_jsonl(
     cwd: &Path,
     sessions_root: Option<&Path>,
@@ -1510,29 +1822,35 @@ fn find_recent_resumed_codex_jsonl(
     )
 }
 
-fn codex_day_dirs_for_scope(root: &Path, scope: CodexRolloutScope) -> Vec<PathBuf> {
-    if scope != CodexRolloutScope::ResumedOwner {
-        return newest_subdir(root)
-            .and_then(|year| newest_subdir(&year))
-            .and_then(|month| newest_subdir(&month))
-            .into_iter()
-            .collect();
-    }
-
-    // A picker, --last, or named resume can reopen a rollout stored under any
-    // historical date. Its file mtime becomes current without changing the
-    // containing directory, so the resume-only path must inspect every date
-    // directory and let the normal mtime/process-start filters discard cold
-    // files. New-session scans stay on the newest day above.
-    let mut days = Vec::new();
-    for year in iter_subdirs_desc(root).unwrap_or_default() {
-        for month in iter_subdirs_desc(&year).unwrap_or_default() {
-            days.extend(iter_subdirs_desc(&month).unwrap_or_default());
-        }
-    }
-    days
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn find_recent_codex_jsonl_with_limits(
+    cwd: &Path,
+    sessions_root: Option<&Path>,
+    recency_cutoff: SystemTime,
+    process_start: SystemTime,
+    now: SystemTime,
+    allow_rotation: bool,
+    assigned: &HashSet<PathBuf>,
+    limits: ProviderScanLimits,
+) -> Option<(PathBuf, String)> {
+    let mut budget = ProviderScanBudget::new(limits);
+    find_recent_codex_jsonl_budgeted(
+        cwd,
+        sessions_root,
+        recency_cutoff,
+        process_start,
+        now,
+        allow_rotation,
+        assigned,
+        CodexRolloutScope::AnyTerminal,
+        &mut budget,
+    )
+    .ok()
+    .flatten()
 }
 
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 fn find_recent_codex_jsonl_with_scope(
     cwd: &Path,
@@ -1544,21 +1862,89 @@ fn find_recent_codex_jsonl_with_scope(
     assigned: &HashSet<PathBuf>,
     scope: CodexRolloutScope,
 ) -> Option<(PathBuf, String)> {
-    // Codex rollouts live under <root>/<year>/<month>/<day>/. The
-    // filename does NOT encode the cwd (unlike claude), so we read each
-    // candidate's first JSONL line and match its `payload.cwd` against
-    // the live process's cwd. New-session scans walk just the newest date
-    // directory; non-UUID resume scans include historical date directories
-    // because reopening a rollout updates the file, not its parent directory.
-    // The cwd check runs while collecting (not after ranking) so the rotation
-    // successor is also guaranteed to belong to this cwd.
-    let root = sessions_root?;
-    let mut candidates: Vec<TranscriptCandidate> = Vec::new();
-    for day_dir in codex_day_dirs_for_scope(root, scope) {
-        let Ok(entries) = std::fs::read_dir(&day_dir) else {
+    let mut budget = ProviderScanBudget::new(PROVIDER_SCAN_LIMITS);
+    find_recent_codex_jsonl_budgeted(
+        cwd,
+        sessions_root,
+        recency_cutoff,
+        process_start,
+        now,
+        allow_rotation,
+        assigned,
+        scope,
+        &mut budget,
+    )
+    .ok()
+    .flatten()
+}
+
+fn codex_day_dirs_for_scope_budgeted(
+    root: &Path,
+    scope: CodexRolloutScope,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Vec<PathBuf>> {
+    if scope != CodexRolloutScope::ResumedOwner {
+        let Some(year) = newest_subdir_budgeted(root, budget)? else {
+            return Ok(Vec::new());
+        };
+        let Some(month) = newest_subdir_budgeted(&year, budget)? else {
+            return Ok(Vec::new());
+        };
+        let Some(day) = newest_subdir_budgeted(&month, budget)? else {
+            return Ok(Vec::new());
+        };
+        return Ok(vec![day]);
+    }
+
+    // A picker, --last, or named resume can reopen a rollout stored under any
+    // historical date. Its file mtime becomes current without changing the
+    // containing directory, so the resume-only path must inspect every date
+    // directory and let the normal mtime/process-start filters discard cold
+    // files. New-session scans stay on the newest day above.
+    let mut days = Vec::new();
+    let Some(years) = iter_subdirs_desc_budgeted(root, budget)? else {
+        return Ok(days);
+    };
+    for year in years {
+        let Some(months) = iter_subdirs_desc_budgeted(&year, budget)? else {
             continue;
         };
-        for entry in entries.flatten() {
+        for month in months {
+            if let Some(month_days) = iter_subdirs_desc_budgeted(&month, budget)? {
+                days.extend(month_days);
+            }
+        }
+    }
+    Ok(days)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn find_recent_codex_jsonl_budgeted(
+    cwd: &Path,
+    sessions_root: Option<&Path>,
+    recency_cutoff: SystemTime,
+    process_start: SystemTime,
+    now: SystemTime,
+    allow_rotation: bool,
+    assigned: &HashSet<PathBuf>,
+    scope: CodexRolloutScope,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<(PathBuf, String)>> {
+    // Codex rollouts live under <root>/<year>/<month>/<day>/. The filename
+    // does not encode the cwd, so inspect each bounded candidate head.
+    // Resume scans include historical dates because reopening a rollout
+    // updates the file rather than its parent directory.
+    let Some(root) = sessions_root else {
+        return Ok(None);
+    };
+    let mut candidates: Vec<TranscriptCandidate> = Vec::new();
+    for day_dir in codex_day_dirs_for_scope_budgeted(root, scope, budget)? {
+        let Some(entries) = safe_read_dir(&day_dir)? else {
+            continue;
+        };
+        for raw_entry in entries {
+            budget.charge_directory_entry()?;
+            let entry = complete_io(raw_entry)?;
             let path = entry.path();
             if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
                 continue;
@@ -1566,20 +1952,20 @@ fn find_recent_codex_jsonl_with_scope(
             if assigned.contains(&path) {
                 continue;
             }
-            let Ok(meta) = entry.metadata() else { continue };
-            let Ok(mtime) = meta.modified() else { continue };
-            if mtime < recency_cutoff {
+            budget.charge_candidate()?;
+            let Some(meta) = safe_regular_file_entry_metadata(&entry)? else {
                 continue;
-            }
-            // Transcript must have been written after this agent process
-            // started — otherwise it belongs to an earlier run.
-            if mtime < process_start {
+            };
+            let Ok(mtime) = meta.modified() else {
+                continue;
+            };
+            if mtime < recency_cutoff || mtime < process_start {
                 continue;
             }
             let Some(uuid) = extract_uuid_from_path(&path) else {
                 continue;
             };
-            let Some(head) = read_codex_rollout_head(&path) else {
+            let Some(head) = read_codex_rollout_head_budgeted(&path, budget)? else {
                 continue;
             };
             if head.cwd != cwd || !head.is_writer_for_scope(scope) {
@@ -1595,9 +1981,14 @@ fn find_recent_codex_jsonl_with_scope(
         }
     }
     if scope == CodexRolloutScope::ResumedOwner {
-        retain_resumed_codex_roots(&mut candidates, root, process_start);
+        retain_resumed_codex_roots(&mut candidates, root, process_start, budget)?;
     }
-    pick_anchor_or_rotate(candidates, process_start, now, allow_rotation)
+    Ok(pick_anchor_or_rotate(
+        candidates,
+        process_start,
+        now,
+        allow_rotation,
+    ))
 }
 
 fn find_completed_codex_jsonl(
@@ -1637,23 +2028,53 @@ fn find_completed_codex_jsonl_with_scope(
     process_start: SystemTime,
     scope: CodexRolloutScope,
 ) -> Option<(PathBuf, String)> {
-    let root = sessions_root?;
+    let mut budget = ProviderScanBudget::new(PROVIDER_SCAN_LIMITS);
+    find_completed_codex_jsonl_budgeted(
+        cwd,
+        sessions_root,
+        recency_cutoff,
+        process_start,
+        scope,
+        &mut budget,
+    )
+    .ok()
+    .flatten()
+}
+
+fn find_completed_codex_jsonl_budgeted(
+    cwd: &Path,
+    sessions_root: Option<&Path>,
+    recency_cutoff: SystemTime,
+    process_start: SystemTime,
+    scope: CodexRolloutScope,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<(PathBuf, String)>> {
+    let Some(root) = sessions_root else {
+        return Ok(None);
+    };
     let mut candidates: Vec<TranscriptCandidate> = Vec::new();
-    for day_dir in codex_day_dirs_for_scope(root, scope) {
-        let Ok(entries) = std::fs::read_dir(&day_dir) else {
+    for day_dir in codex_day_dirs_for_scope_budgeted(root, scope, budget)? {
+        let Some(entries) = safe_read_dir(&day_dir)? else {
             continue;
         };
-        for entry in entries.flatten() {
+        for raw_entry in entries {
+            budget.charge_directory_entry()?;
+            let entry = complete_io(raw_entry)?;
             let path = entry.path();
             if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
                 continue;
             }
-            let Ok(meta) = entry.metadata() else { continue };
-            let Ok(mtime) = meta.modified() else { continue };
+            budget.charge_candidate()?;
+            let Some(meta) = safe_regular_file_entry_metadata(&entry)? else {
+                continue;
+            };
+            let Ok(mtime) = meta.modified() else {
+                continue;
+            };
             if mtime < recency_cutoff || mtime < process_start {
                 continue;
             }
-            let Some(head) = read_codex_rollout_head(&path) else {
+            let Some(head) = read_codex_rollout_head_budgeted(&path, budget)? else {
                 continue;
             };
             if head.cwd != cwd || !head.is_writer_for_scope(scope) {
@@ -1672,17 +2093,20 @@ fn find_completed_codex_jsonl_with_scope(
         }
     }
     if scope == CodexRolloutScope::ResumedOwner {
-        retain_resumed_codex_roots(&mut candidates, root, process_start);
+        retain_resumed_codex_roots(&mut candidates, root, process_start, budget)?;
     }
     candidates.sort_by_key(|candidate| time_distance(candidate.birth, process_start));
     if candidates.len() == 1 {
-        let candidate = candidates.pop()?;
-        Some((candidate.path, candidate.uuid))
+        let Some(candidate) = candidates.pop() else {
+            return Ok(None);
+        };
+        Ok(Some((candidate.path, candidate.uuid)))
     } else {
-        None
+        Ok(None)
     }
 }
 
+#[cfg(test)]
 fn find_recent_antigravity_jsonl(
     brain_roots: &[PathBuf],
     recency_cutoff: SystemTime,
@@ -1692,16 +2116,42 @@ fn find_recent_antigravity_jsonl(
     owner_cursor_id: Option<&str>,
     assigned: &HashSet<PathBuf>,
 ) -> Option<(PathBuf, String)> {
+    let mut budget = ProviderScanBudget::new(PROVIDER_SCAN_LIMITS);
+    find_recent_antigravity_jsonl_budgeted(
+        brain_roots,
+        recency_cutoff,
+        process_start,
+        now,
+        allow_rotation,
+        owner_cursor_id,
+        assigned,
+        &mut budget,
+    )
+    .ok()
+    .flatten()
+}
+
+fn find_recent_antigravity_jsonl_budgeted(
+    brain_roots: &[PathBuf],
+    recency_cutoff: SystemTime,
+    process_start: SystemTime,
+    now: SystemTime,
+    allow_rotation: bool,
+    owner_cursor_id: Option<&str>,
+    assigned: &HashSet<PathBuf>,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<(PathBuf, String)>> {
     let mut candidates: Vec<TranscriptCandidate> = Vec::new();
     for root in brain_roots {
-        let Ok(entries) = std::fs::read_dir(root) else {
+        let Some(entries) = safe_read_dir(root)? else {
             continue;
         };
-        for entry in entries.flatten() {
-            let session_dir = entry.path();
-            if !session_dir.is_dir() {
+        for raw_entry in entries {
+            budget.charge_directory_entry()?;
+            let entry = complete_io(raw_entry)?;
+            let Some(session_dir) = safe_directory_entry_path(&entry)? else {
                 continue;
-            }
+            };
             let Some(uuid) = session_dir.file_name().and_then(|s| s.to_str()) else {
                 continue;
             };
@@ -1712,13 +2162,14 @@ fn find_recent_antigravity_jsonl(
                 .join(".system_generated")
                 .join("logs")
                 .join("transcript.jsonl");
-            if assigned.contains(&path) || !path.is_file() {
+            budget.charge_candidate()?;
+            if assigned.contains(&path) || !safe_antigravity_transcript_path(&session_dir, &path) {
                 continue;
             }
             let Some(id) = antigravity_uuid_from_transcript_path(&path) else {
                 continue;
             };
-            let Ok(meta) = std::fs::metadata(&path) else {
+            let Some(meta) = safe_regular_file_metadata(&path) else {
                 continue;
             };
             let Ok(mtime) = meta.modified() else { continue };
@@ -1734,13 +2185,13 @@ fn find_recent_antigravity_jsonl(
             });
         }
     }
-    pick_anchor_or_rotate_with_target(
+    Ok(pick_anchor_or_rotate_with_target(
         candidates,
         process_start,
         now,
         allow_rotation && owner_cursor_id.is_some(),
         owner_cursor_id,
-    )
+    ))
 }
 
 fn find_completed_antigravity_jsonl(
@@ -1749,34 +2200,55 @@ fn find_completed_antigravity_jsonl(
     recency_cutoff: SystemTime,
     process_start: SystemTime,
 ) -> Option<(PathBuf, String)> {
+    let mut budget = ProviderScanBudget::new(PROVIDER_SCAN_LIMITS);
+    find_completed_antigravity_jsonl_budgeted(
+        cwd,
+        brain_roots,
+        recency_cutoff,
+        process_start,
+        &mut budget,
+    )
+    .ok()
+    .flatten()
+}
+
+fn find_completed_antigravity_jsonl_budgeted(
+    cwd: &Path,
+    brain_roots: &[PathBuf],
+    recency_cutoff: SystemTime,
+    process_start: SystemTime,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<(PathBuf, String)>> {
     let mut candidates: Vec<(PathBuf, SystemTime, String)> = Vec::new();
     for root in brain_roots {
-        let Ok(entries) = std::fs::read_dir(root) else {
+        let Some(entries) = safe_read_dir(root)? else {
             continue;
         };
-        for entry in entries.flatten() {
-            let session_dir = entry.path();
-            if !session_dir.is_dir() {
+        for raw_entry in entries {
+            budget.charge_directory_entry()?;
+            let entry = complete_io(raw_entry)?;
+            let Some(session_dir) = safe_directory_entry_path(&entry)? else {
                 continue;
-            }
+            };
             let path = session_dir
                 .join(".system_generated")
                 .join("logs")
                 .join("transcript.jsonl");
-            if !path.is_file() {
+            budget.charge_candidate()?;
+            if !safe_antigravity_transcript_path(&session_dir, &path) {
                 continue;
             }
             let Some(id) = antigravity_uuid_from_transcript_path(&path) else {
                 continue;
             };
-            let Ok(meta) = std::fs::metadata(&path) else {
+            let Some(meta) = safe_regular_file_metadata(&path) else {
                 continue;
             };
             let Ok(mtime) = meta.modified() else { continue };
             if mtime < recency_cutoff || mtime < process_start {
                 continue;
             }
-            let Some(transcript_cwd) = read_agent_transcript_cwd(&path) else {
+            let Some(transcript_cwd) = read_agent_transcript_cwd_budgeted(&path, budget)? else {
                 continue;
             };
             if transcript_cwd != cwd {
@@ -1788,11 +2260,21 @@ fn find_completed_antigravity_jsonl(
     }
     candidates.sort_by_key(|candidate| time_distance(candidate.1, process_start));
     if candidates.len() == 1 {
-        let (path, _, id) = candidates.pop()?;
-        Some((path, id))
+        let Some((path, _, id)) = candidates.pop() else {
+            return Ok(None);
+        };
+        Ok(Some((path, id)))
     } else {
-        None
+        Ok(None)
     }
+}
+
+fn safe_antigravity_transcript_path(session_dir: &Path, transcript: &Path) -> bool {
+    let generated = session_dir.join(".system_generated");
+    let logs = generated.join("logs");
+    safe_is_directory(&generated)
+        && safe_is_directory(&logs)
+        && safe_regular_file_metadata(transcript).is_some()
 }
 
 /// Read codex rollout's first non-empty JSONL line and pull `payload.cwd`.
@@ -1836,26 +2318,33 @@ impl CodexRolloutHead {
 /// this relationship narrowly; arbitrary backwards transcript moves still
 /// pass the normal dormant-echo guard.
 pub fn codex_rollout_parent_thread_id(path: &Path) -> Option<String> {
-    use std::io::{BufRead, BufReader};
-    let file = std::fs::File::open(path).ok()?;
-    let reader = BufReader::new(file);
-    for line in reader.lines().map_while(Result::ok).take(20) {
-        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
-            continue;
-        };
+    let mut budget = ProviderScanBudget::new(PROVIDER_SCAN_LIMITS);
+    codex_rollout_parent_thread_id_budgeted(path, &mut budget)
+        .ok()
+        .flatten()
+}
+
+fn codex_rollout_parent_thread_id_budgeted(
+    path: &Path,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<String>> {
+    read_bounded_head(path, budget, |line| {
+        let value = serde_json::from_slice::<serde_json::Value>(line).ok()?;
         for scope in [Some(&value), value.get("payload")] {
-            let Some(scope) = scope else { continue };
+            let Some(scope) = scope else {
+                continue;
+            };
             let (is_subagent, parent_thread_id) = codex_subagent_metadata(scope);
             if is_subagent && parent_thread_id.is_some() {
                 return parent_thread_id;
             }
         }
-    }
-    None
+        None
+    })
 }
 
 /// A deliberately resumed sub-agent rollout becomes the root conversation for
-/// this terminal run, but it keeps its original `source.subagent` metadata.
+/// this terminal run, but it keeps its original source.subagent metadata.
 /// Historical ancestors remain candidates so normal birth anchoring selects
 /// the youngest pre-existing rollout. Only descendants born by this process
 /// are removed. Process start times are second-granularity on supported hosts;
@@ -1865,79 +2354,95 @@ fn retain_resumed_codex_roots(
     candidates: &mut Vec<TranscriptCandidate>,
     sessions_root: &Path,
     process_start: SystemTime,
-) {
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<()> {
     let candidate_ids = candidates
         .iter()
         .map(|candidate| candidate.uuid.clone())
         .collect::<HashSet<_>>();
-    candidates.retain(|candidate| {
+    let mut keep = Vec::with_capacity(candidates.len());
+    for candidate in candidates.iter() {
         let born_this_run = candidate.birth.duration_since(process_start).is_ok();
-        !born_this_run
-            || !codex_rollout_has_candidate_ancestor(&candidate.path, &candidate_ids, sessions_root)
-    });
+        let has_candidate_ancestor = if born_this_run {
+            codex_rollout_has_candidate_ancestor_budgeted(
+                &candidate.path,
+                &candidate_ids,
+                sessions_root,
+                budget,
+            )?
+        } else {
+            false
+        };
+        keep.push(!born_this_run || !has_candidate_ancestor);
+    }
+    let mut keep = keep.into_iter();
+    candidates.retain(|_| keep.next().unwrap_or(false));
+    Ok(())
 }
 
-fn codex_rollout_has_candidate_ancestor(
+fn codex_rollout_has_candidate_ancestor_budgeted(
     rollout: &Path,
     candidate_ids: &HashSet<String>,
     sessions_root: &Path,
-) -> bool {
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<bool> {
     const MAX_ANCESTOR_DEPTH: usize = 16;
 
     let mut current = rollout.to_path_buf();
     let mut seen = HashSet::new();
     for _ in 0..MAX_ANCESTOR_DEPTH {
-        let Some(parent_uuid) = codex_rollout_parent_thread_id(&current) else {
-            return false;
+        let Some(parent_uuid) = codex_rollout_parent_thread_id_budgeted(&current, budget)? else {
+            return Ok(false);
         };
         if !seen.insert(parent_uuid.clone()) {
-            return true;
+            return Ok(true);
         }
         if candidate_ids.contains(&parent_uuid) {
-            return true;
+            return Ok(true);
         }
-        let Some((parent_path, _)) =
-            find_codex_jsonl_for_uuid(Some(sessions_root), &parent_uuid, &HashSet::new())
+        let Some((parent_path, _)) = find_codex_jsonl_for_uuid_budgeted(
+            Some(sessions_root),
+            &parent_uuid,
+            &HashSet::new(),
+            budget,
+        )?
         else {
-            return false;
+            return Ok(false);
         };
         current = parent_path;
     }
-    true
+    Ok(true)
 }
 
-/// Read owner metadata from a codex rollout's leading `session_meta` line.
-/// Fields live at the top level in old formats and under `payload` in current
+/// Read owner metadata from a Codex rollout's leading session_meta line.
+/// Fields live at the top level in old formats and under payload in current
 /// ones. Current sub-agent sources encode their parent beneath
-/// `source.subagent`; the payload-level parent id is retained as a fallback
+/// source.subagent; the payload-level parent id is retained as a fallback
 /// for compatible writers.
-fn read_codex_rollout_head(path: &Path) -> Option<CodexRolloutHead> {
-    use std::io::{BufRead, BufReader};
-    let f = std::fs::File::open(path).ok()?;
-    let reader = BufReader::new(f);
-    for line in reader.lines().map_while(Result::ok).take(20) {
-        if line.trim().is_empty() {
-            continue;
-        }
-        let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
-            continue;
-        };
-        for scope in [Some(&v), v.get("payload")] {
-            let Some(scope) = scope else { continue };
-            if let Some(cwd) = scope.get("cwd").and_then(|c| c.as_str()) {
+fn read_codex_rollout_head_budgeted(
+    path: &Path,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<CodexRolloutHead>> {
+    read_bounded_head(path, budget, |line| {
+        let value = serde_json::from_slice::<serde_json::Value>(line).ok()?;
+        for scope in [Some(&value), value.get("payload")] {
+            let Some(scope) = scope else {
+                continue;
+            };
+            if let Some(cwd) = scope.get("cwd").and_then(|cwd| cwd.as_str()) {
                 let (is_subagent, _) = codex_subagent_metadata(scope);
                 return Some(CodexRolloutHead {
                     cwd: PathBuf::from(cwd),
                     originator: scope
                         .get("originator")
-                        .and_then(|o| o.as_str())
+                        .and_then(|originator| originator.as_str())
                         .map(str::to_string),
                     is_subagent,
                 });
             }
         }
-    }
-    None
+        None
+    })
 }
 
 fn codex_subagent_metadata(scope: &serde_json::Value) -> (bool, Option<String>) {
@@ -1967,31 +2472,99 @@ fn find_parent_thread_id(value: &serde_json::Value) -> Option<&str> {
     }
 }
 
-fn read_agent_transcript_cwd(path: &Path) -> Option<PathBuf> {
-    use std::io::{BufRead, BufReader};
-    let f = std::fs::File::open(path).ok()?;
-    let reader = BufReader::new(f);
-    for line in reader.lines().map_while(Result::ok).take(50) {
-        if line.trim().is_empty() {
-            continue;
-        }
-        let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
-            continue;
-        };
+fn read_agent_transcript_cwd_budgeted(
+    path: &Path,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<PathBuf>> {
+    read_bounded_head(path, budget, |line| {
+        let value = serde_json::from_slice::<serde_json::Value>(line).ok()?;
         for key in ["cwd", "project"] {
-            if let Some(path) = v.get(key).and_then(|c| c.as_str()) {
+            if let Some(path) = value.get(key).and_then(|cwd| cwd.as_str()) {
                 return Some(PathBuf::from(path));
             }
-            if let Some(path) = v
+            if let Some(path) = value
                 .get("payload")
-                .and_then(|p| p.get(key))
-                .and_then(|c| c.as_str())
+                .and_then(|payload| payload.get(key))
+                .and_then(|cwd| cwd.as_str())
             {
                 return Some(PathBuf::from(path));
             }
         }
+        None
+    })
+}
+
+fn read_bounded_head<T>(
+    path: &Path,
+    budget: &mut ProviderScanBudget,
+    mut parse_line: impl FnMut(&[u8]) -> Option<T>,
+) -> ProviderScanResult<Option<T>> {
+    use std::io::Read;
+
+    if safe_regular_file_metadata(path).is_none() {
+        return Ok(None);
     }
-    None
+    budget.charge_head_open()?;
+    let mut file = complete_io(std::fs::File::open(path))?;
+    let mut buffer = [0_u8; 8 * 1024];
+    let mut line = Vec::new();
+    let mut bytes_read = 0;
+    let mut lines_read = 0;
+
+    if budget.limits.head_bytes == 0 || budget.limits.head_lines == 0 {
+        return probe_head_boundary(&mut file);
+    }
+
+    while bytes_read < budget.limits.head_bytes {
+        let remaining = budget.limits.head_bytes - bytes_read;
+        let read_len = remaining.min(buffer.len());
+        let read = complete_io(file.read(&mut buffer[..read_len]))?;
+        if read == 0 {
+            if !line.is_empty() {
+                if let Some(value) = parse_line(&line) {
+                    return Ok(Some(value));
+                }
+            }
+            return Ok(None);
+        }
+        bytes_read += read;
+
+        for (index, byte) in buffer[..read].iter().enumerate() {
+            if *byte == b'\n' {
+                lines_read += 1;
+                if let Some(value) = parse_line(&line) {
+                    return Ok(Some(value));
+                }
+                line.clear();
+                if lines_read >= budget.limits.head_lines {
+                    if index + 1 < read {
+                        return Err(ProviderScanError::LimitExceeded);
+                    }
+                    return probe_head_boundary(&mut file);
+                }
+                continue;
+            }
+            if line.len() >= budget.limits.line_bytes {
+                return Err(ProviderScanError::LimitExceeded);
+            }
+            line.push(*byte);
+        }
+    }
+
+    if let Some(value) = parse_line(&line) {
+        return Ok(Some(value));
+    }
+    probe_head_boundary(&mut file)
+}
+
+fn probe_head_boundary<T>(file: &mut std::fs::File) -> ProviderScanResult<Option<T>> {
+    use std::io::Read;
+
+    let mut probe = [0_u8; 1];
+    match complete_io(file.read(&mut probe))? {
+        0 => Ok(None),
+        _ => Err(ProviderScanError::LimitExceeded),
+    }
 }
 
 /// Pick the lexicographically greatest subdirectory of `dir`. Codex
@@ -2000,13 +2573,26 @@ fn read_agent_transcript_cwd(path: &Path) -> Option<PathBuf> {
 /// mtime drift (some filesystems do not bump a directory's mtime when
 /// a child gains a new grandchild, which would mislead a mtime-based
 /// pick).
+#[cfg(test)]
 fn newest_subdir(dir: &Path) -> Option<PathBuf> {
+    let mut budget = ProviderScanBudget::new(PROVIDER_SCAN_LIMITS);
+    newest_subdir_budgeted(dir, &mut budget).ok().flatten()
+}
+
+fn newest_subdir_budgeted(
+    dir: &Path,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<PathBuf>> {
     let mut best: Option<PathBuf> = None;
-    for entry in std::fs::read_dir(dir).ok()?.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
+    let Some(entries) = safe_read_dir(dir)? else {
+        return Ok(None);
+    };
+    for raw_entry in entries {
+        budget.charge_directory_entry()?;
+        let entry = complete_io(raw_entry)?;
+        let Some(path) = safe_directory_entry_path(&entry)? else {
             continue;
-        }
+        };
         match &best {
             None => best = Some(path),
             Some(current) if path.file_name() > current.file_name() => {
@@ -2015,20 +2601,31 @@ fn newest_subdir(dir: &Path) -> Option<PathBuf> {
             _ => {}
         }
     }
-    best
+    Ok(best)
 }
 
-fn iter_subdirs_desc(dir: &Path) -> Option<Vec<PathBuf>> {
-    let mut entries: Vec<PathBuf> = std::fs::read_dir(dir)
-        .ok()?
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| path.is_dir())
-        .collect();
+fn iter_subdirs_desc_budgeted(
+    dir: &Path,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<Vec<PathBuf>>> {
+    let Some(raw_entries) = safe_read_dir(dir)? else {
+        return Ok(None);
+    };
+    let mut entries = Vec::new();
+    for raw_entry in raw_entries {
+        budget.charge_directory_entry()?;
+        let entry = complete_io(raw_entry)?;
+        let Some(path) = safe_directory_entry_path(&entry)? else {
+            continue;
+        };
+        budget.charge_candidate()?;
+        entries.push(path);
+    }
     entries.sort_by(|a, b| b.file_name().cmp(&a.file_name()));
-    Some(entries)
+    Ok(Some(entries))
 }
 
+#[cfg(test)]
 fn pick_newest_unassigned_jsonl(
     dir: &Path,
     recency_cutoff: SystemTime,
@@ -2037,6 +2634,52 @@ fn pick_newest_unassigned_jsonl(
     allow_rotation: bool,
     assigned: &HashSet<PathBuf>,
 ) -> Option<(PathBuf, String)> {
+    pick_newest_unassigned_jsonl_with_limits(
+        dir,
+        recency_cutoff,
+        process_start,
+        now,
+        allow_rotation,
+        assigned,
+        PROVIDER_SCAN_LIMITS,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn pick_newest_unassigned_jsonl_with_limits(
+    dir: &Path,
+    recency_cutoff: SystemTime,
+    process_start: SystemTime,
+    now: SystemTime,
+    allow_rotation: bool,
+    assigned: &HashSet<PathBuf>,
+    limits: ProviderScanLimits,
+) -> Option<(PathBuf, String)> {
+    let mut budget = ProviderScanBudget::new(limits);
+    pick_newest_unassigned_jsonl_budgeted(
+        dir,
+        recency_cutoff,
+        process_start,
+        now,
+        allow_rotation,
+        assigned,
+        &mut budget,
+    )
+    .ok()
+    .flatten()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pick_newest_unassigned_jsonl_budgeted(
+    dir: &Path,
+    recency_cutoff: SystemTime,
+    process_start: SystemTime,
+    now: SystemTime,
+    allow_rotation: bool,
+    assigned: &HashSet<PathBuf>,
+    budget: &mut ProviderScanBudget,
+) -> ProviderScanResult<Option<(PathBuf, String)>> {
     // We track two timestamps per candidate. `created` (file birth
     // time, falling back to mtime when btime is unavailable) is what
     // we rank by: when two `claude` processes run concurrently in the
@@ -2044,7 +2687,12 @@ fn pick_newest_unassigned_jsonl(
     // process's own start time is its transcript. `mtime` is still
     // used as a recency filter so stale years-old files don't surface.
     let mut candidates: Vec<(PathBuf, SystemTime, SystemTime)> = Vec::new();
-    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+    let Some(entries) = safe_read_dir(dir)? else {
+        return Ok(None);
+    };
+    for raw_entry in entries {
+        budget.charge_directory_entry()?;
+        let entry = complete_io(raw_entry)?;
         let path = entry.path();
         if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
             continue;
@@ -2052,7 +2700,10 @@ fn pick_newest_unassigned_jsonl(
         if assigned.contains(&path) {
             continue;
         }
-        let Ok(meta) = entry.metadata() else { continue };
+        budget.charge_candidate()?;
+        let Some(meta) = safe_regular_file_entry_metadata(&entry)? else {
+            continue;
+        };
         let Ok(mtime) = meta.modified() else { continue };
         if mtime < recency_cutoff {
             continue;
@@ -2078,7 +2729,12 @@ fn pick_newest_unassigned_jsonl(
             })
         })
         .collect();
-    pick_anchor_or_rotate(candidates, process_start, now, allow_rotation)
+    Ok(pick_anchor_or_rotate(
+        candidates,
+        process_start,
+        now,
+        allow_rotation,
+    ))
 }
 
 /// A transcript file eligible for pairing with a live agent process.
@@ -2173,10 +2829,7 @@ fn time_distance(a: SystemTime, b: SystemTime) -> u64 {
 fn extract_uuid_from_path(path: &Path) -> Option<String> {
     let filename = path.file_name()?.to_str()?;
     let stem = filename.strip_suffix(".jsonl")?;
-    if stem.len() < 36 {
-        return None;
-    }
-    let candidate = &stem[stem.len() - 36..];
+    let candidate = stem.get(stem.len().checked_sub(36)?..)?;
     is_uuid_v4_shape(candidate).then(|| candidate.to_string())
 }
 
@@ -2256,6 +2909,13 @@ mod tests {
         }
     }
 
+    fn scan_limits_with_entries(directory_entries: usize) -> ProviderScanLimits {
+        ProviderScanLimits {
+            directory_entries,
+            ..PROVIDER_SCAN_LIMITS
+        }
+    }
+
     fn process_roles(matches: Vec<AgentProcessMatch>) -> Vec<(u32, AgentKind, AgentProcessRole)> {
         matches
             .into_iter()
@@ -2305,6 +2965,286 @@ mod tests {
             extract_uuid_from_path(path).as_deref(),
             Some("019e2001-3250-76b0-8410-2e073b38a2c1")
         );
+    }
+
+    #[test]
+    fn rejects_uuid_suffix_at_non_ascii_boundary_without_panicking() {
+        let path = Path::new("가aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee.jsonl");
+
+        assert_eq!(extract_uuid_from_path(path), None);
+    }
+
+    #[test]
+    fn provider_entry_budget_accepts_exact_limit_and_rejects_partial_candidate() {
+        use std::fs::{self, File};
+
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-provider-budget-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let transcript = dir.join("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl");
+        File::create(&transcript).unwrap();
+        File::create(dir.join("decoy.txt")).unwrap();
+        let now = fs::metadata(&transcript).unwrap().modified().unwrap();
+
+        let exact = pick_newest_unassigned_jsonl_with_limits(
+            &dir,
+            SystemTime::UNIX_EPOCH,
+            SystemTime::UNIX_EPOCH,
+            now,
+            false,
+            &HashSet::new(),
+            scan_limits_with_entries(2),
+        );
+        assert_eq!(exact.map(|(_, id)| id).as_deref(), Some(A_UUID));
+
+        let over = pick_newest_unassigned_jsonl_with_limits(
+            &dir,
+            SystemTime::UNIX_EPOCH,
+            SystemTime::UNIX_EPOCH,
+            now,
+            false,
+            &HashSet::new(),
+            scan_limits_with_entries(1),
+        );
+        assert!(
+            over.is_none(),
+            "an over-budget traversal must discard an already collected candidate"
+        );
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn provider_entry_budget_is_shared_across_matcher_lookups() {
+        use std::fs::{self, File};
+
+        let root = std::env::temp_dir().join(format!(
+            "acorn-provider-shared-budget-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let first_dir = root.join("first");
+        let second_dir = root.join("second");
+        fs::create_dir_all(&first_dir).unwrap();
+        fs::create_dir_all(&second_dir).unwrap();
+        let first = first_dir.join(format!("{A_UUID}.jsonl"));
+        let second = second_dir.join(format!("{B_UUID}.jsonl"));
+        File::create(&first).unwrap();
+        File::create(&second).unwrap();
+        let now = fs::metadata(&second).unwrap().modified().unwrap();
+        let mut budget = ProviderScanBudget::new(scan_limits_with_entries(1));
+
+        let first_result = pick_newest_unassigned_jsonl_budgeted(
+            &first_dir,
+            SystemTime::UNIX_EPOCH,
+            SystemTime::UNIX_EPOCH,
+            now,
+            false,
+            &HashSet::new(),
+            &mut budget,
+        );
+        assert!(matches!(first_result, Ok(Some(_))));
+
+        let second_result = pick_newest_unassigned_jsonl_budgeted(
+            &second_dir,
+            SystemTime::UNIX_EPOCH,
+            SystemTime::UNIX_EPOCH,
+            now,
+            false,
+            &HashSet::new(),
+            &mut budget,
+        );
+        assert!(second_result.is_err());
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn transcript_head_rejects_oversized_line_and_snapshot() {
+        use std::fs::{self, File};
+        use std::io::Write;
+
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-provider-head-budget-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let transcript = dir.join(format!("{A_UUID}.jsonl"));
+
+        let mut file = File::create(&transcript).unwrap();
+        writeln!(file, "123456789").unwrap();
+        writeln!(file, "{{\"cwd\":\"/repo\"}}").unwrap();
+        let line_limits = ProviderScanLimits {
+            line_bytes: 8,
+            ..PROVIDER_SCAN_LIMITS
+        };
+        let mut line_budget = ProviderScanBudget::new(line_limits);
+        assert!(read_agent_transcript_cwd_budgeted(&transcript, &mut line_budget).is_err());
+
+        let mut file = File::create(&transcript).unwrap();
+        write!(file, "         {{\"cwd\":\"/repo\"}}\n").unwrap();
+        let snapshot_limits = ProviderScanLimits {
+            head_bytes: 8,
+            line_bytes: 64,
+            ..PROVIDER_SCAN_LIMITS
+        };
+        let mut snapshot_budget = ProviderScanBudget::new(snapshot_limits);
+        assert!(read_agent_transcript_cwd_budgeted(&transcript, &mut snapshot_budget).is_err());
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn transcript_head_accepts_exact_byte_and_line_boundaries() {
+        use std::fs::{self, File};
+        use std::io::Write;
+
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-provider-head-exact-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let transcript = dir.join(format!("{A_UUID}.jsonl"));
+
+        let mut file = File::create(&transcript).unwrap();
+        write!(file, "12345678").unwrap();
+        drop(file);
+        let exact_byte_limits = ProviderScanLimits {
+            head_bytes: 8,
+            line_bytes: 8,
+            ..PROVIDER_SCAN_LIMITS
+        };
+        let mut exact_byte_budget = ProviderScanBudget::new(exact_byte_limits);
+        assert_eq!(
+            read_agent_transcript_cwd_budgeted(&transcript, &mut exact_byte_budget),
+            Ok(None)
+        );
+
+        let mut file = File::create(&transcript).unwrap();
+        write!(file, "{{}}\n{{}}\n").unwrap();
+        drop(file);
+        let exact_line_limits = ProviderScanLimits {
+            head_lines: 2,
+            ..PROVIDER_SCAN_LIMITS
+        };
+        let mut exact_line_budget = ProviderScanBudget::new(exact_line_limits);
+        assert_eq!(
+            read_agent_transcript_cwd_budgeted(&transcript, &mut exact_line_budget),
+            Ok(None)
+        );
+
+        let mut file = File::create(&transcript).unwrap();
+        write!(file, "{{}}\n{{}}\n{{}}\n").unwrap();
+        drop(file);
+        let mut over_line_budget = ProviderScanBudget::new(exact_line_limits);
+        assert_eq!(
+            read_agent_transcript_cwd_budgeted(&transcript, &mut over_line_budget),
+            Err(ProviderScanError::LimitExceeded)
+        );
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn io_errors_mark_provider_scan_incomplete() {
+        let error = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "unreadable");
+
+        assert_eq!(
+            complete_io::<()>(Err(error)),
+            Err(ProviderScanError::Incomplete)
+        );
+    }
+
+    #[test]
+    fn over_limit_sessions_cannot_receive_cached_mappings() {
+        let cached_session = uuid::Uuid::new_v4();
+        let cache = Box::leak(Box::new(Mutex::new(Some(ScanCache {
+            captured_at: Instant::now(),
+            session_key: Vec::new(),
+            mappings: vec![(cached_session, AgentKind::Codex, "cached".to_string())],
+        }))));
+        let sessions = (0..=LIVE_SCAN_SESSION_LIMIT)
+            .map(|_| SessionPid {
+                session_id: uuid::Uuid::new_v4(),
+                root_pid: None,
+            })
+            .collect::<Vec<_>>();
+
+        assert!(collect_mappings_cached(cache, &sessions, MappingScope::SessionOwners).is_empty());
+    }
+
+    #[test]
+    fn changed_under_limit_sessions_cannot_receive_cached_mappings() {
+        let stale_session = SessionPid {
+            session_id: uuid::Uuid::new_v4(),
+            root_pid: Some(41),
+        };
+        let cached_mapping = (
+            stale_session.session_id,
+            AgentKind::Codex,
+            "cached".to_string(),
+        );
+        let cache = Box::leak(Box::new(Mutex::new(Some(ScanCache {
+            captured_at: Instant::now(),
+            session_key: scan_cache_session_key(std::slice::from_ref(&stale_session)),
+            mappings: vec![cached_mapping],
+        }))));
+        let replacement = SessionPid {
+            session_id: stale_session.session_id,
+            root_pid: None,
+        };
+
+        assert!(
+            collect_mappings_cached(cache, &[replacement], MappingScope::SessionOwners,).is_empty()
+        );
+    }
+
+    #[test]
+    fn scan_cache_session_key_is_order_independent() {
+        let first = SessionPid {
+            session_id: uuid::Uuid::new_v4(),
+            root_pid: Some(11),
+        };
+        let second = SessionPid {
+            session_id: uuid::Uuid::new_v4(),
+            root_pid: Some(22),
+        };
+
+        assert_eq!(
+            scan_cache_session_key(&[first.clone(), second.clone()]),
+            scan_cache_session_key(&[second, first]),
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn transcript_picker_rejects_symlinked_file() {
+        use std::fs::{self, File};
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!(
+            "acorn-provider-symlink-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let scan_dir = root.join("scan");
+        fs::create_dir_all(&scan_dir).unwrap();
+        let target = root.join("target.jsonl");
+        File::create(&target).unwrap();
+        let link = scan_dir.join(format!("{A_UUID}.jsonl"));
+        symlink(&target, &link).unwrap();
+
+        let picked = pick_newest_unassigned_jsonl(
+            &scan_dir,
+            SystemTime::UNIX_EPOCH,
+            SystemTime::UNIX_EPOCH,
+            SystemTime::now(),
+            false,
+            &HashSet::new(),
+        );
+        assert!(picked.is_none());
+
+        fs::remove_dir_all(&root).unwrap();
     }
 
     #[test]
@@ -2979,6 +3919,33 @@ mod tests {
 
         assert_eq!(antigravity.get(&cwd), Some(&2));
         assert_eq!(antigravity.get(&other_cwd), Some(&1));
+    }
+
+    #[test]
+    fn process_tree_match_limit_fails_before_collecting_partial_results() {
+        let root = Pid::from_u32(1);
+        let first = Pid::from_u32(2);
+        let second = Pid::from_u32(3);
+        let mut children = std::collections::HashMap::new();
+        children.insert(root, vec![first, second]);
+
+        let exact = collect_agent_processes_in_tree_bounded(
+            &children,
+            root,
+            MappingScope::AllDescendants,
+            2,
+            |pid| (pid != root).then(|| runtime(AgentKind::Codex)),
+        );
+        assert_eq!(exact.unwrap().len(), 2);
+
+        let over = collect_agent_processes_in_tree_bounded(
+            &children,
+            root,
+            MappingScope::AllDescendants,
+            1,
+            |pid| (pid != root).then(|| runtime(AgentKind::Codex)),
+        );
+        assert_eq!(over, Err(LiveAgentProcessLimitExceeded));
     }
 
     #[test]
@@ -4262,7 +5229,8 @@ mod tests {
             },
         ];
 
-        retain_resumed_codex_roots(&mut candidates, &sessions, process_start);
+        let mut budget = ProviderScanBudget::new(PROVIDER_SCAN_LIMITS);
+        retain_resumed_codex_roots(&mut candidates, &sessions, process_start, &mut budget).unwrap();
 
         assert_eq!(
             candidates

--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -116,8 +116,9 @@ pub fn read_tail(path: &Path, max_bytes: u64) -> io::Result<TailRead> {
     let len = file.metadata()?.len();
     let start = len.saturating_sub(max_bytes);
     file.seek(SeekFrom::Start(start))?;
-    let mut buf = Vec::with_capacity(max_bytes.min(len) as usize);
-    file.read_to_end(&mut buf)?;
+    let read_limit = max_bytes.min(len);
+    let mut buf = Vec::with_capacity(read_limit as usize);
+    file.take(read_limit).read_to_end(&mut buf)?;
     Ok(TailRead {
         text: String::from_utf8_lossy(&buf).into_owned(),
         read_full: len <= max_bytes,
@@ -747,6 +748,7 @@ fn nonempty_trimmed(s: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     fn assistant(stop_reason: &str) -> String {
         format!(
@@ -760,6 +762,18 @@ mod tests {
 
     fn classify(kind: AgentKind, tail: &str, read_full: bool) -> Option<TurnState> {
         latest_turn_state(kind, tail, read_full)
+    }
+
+    #[test]
+    fn tail_read_never_returns_more_than_the_byte_budget() {
+        let path = std::env::temp_dir().join(format!("acorn-tail-{}.log", uuid::Uuid::new_v4()));
+        fs::write(&path, b"abcdefgh").unwrap();
+
+        let tail = read_tail(&path, 3).unwrap();
+        let _ = fs::remove_file(path);
+
+        assert_eq!(tail.text, "fgh");
+        assert!(!tail.read_full);
     }
 
     #[test]

--- a/src-tauri/scripts/build-sidecar.sh
+++ b/src-tauri/scripts/build-sidecar.sh
@@ -76,8 +76,8 @@ for entry in "${sidecars[@]}"; do
   fi
 done
 
-echo "build-sidecar: cargo build ${cargo_flags[*]}"
-cargo build "${cargo_flags[@]}"
+echo "build-sidecar: cargo build --locked ${cargo_flags[*]}"
+cargo build --locked "${cargo_flags[@]}"
 
 for entry in "${sidecars[@]}"; do
   bin="${entry%%:*}"

--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -35,6 +35,29 @@ const TITLE_CONTEXT_ENTRY_CHARS: usize = 700;
 const RECENT_SUMMARY_MESSAGES: usize = 6;
 const SUMMARY_MESSAGE_PREVIEW_CHARS: usize = 600;
 const TRANSCRIPT_SUMMARY_CACHE_MAX_ENTRIES: usize = 128;
+const MAX_DISCOVERY_ENTRIES_PER_PROVIDER: usize = 10_000;
+const MAX_TRANSCRIPT_SCAN_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_TRANSCRIPT_SCAN_LINES: usize = 250_000;
+const MAX_TRANSCRIPT_LINE_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Copy)]
+struct TranscriptScanLimits {
+    max_bytes: u64,
+    max_lines: usize,
+    max_line_bytes: usize,
+}
+
+const TRANSCRIPT_SCAN_LIMITS: TranscriptScanLimits = TranscriptScanLimits {
+    max_bytes: MAX_TRANSCRIPT_SCAN_BYTES,
+    max_lines: MAX_TRANSCRIPT_SCAN_LINES,
+    max_line_bytes: MAX_TRANSCRIPT_LINE_BYTES,
+};
+
+struct TranscriptSnapshot {
+    file: fs::File,
+    len: u64,
+    modified: Option<SystemTime>,
+}
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
@@ -366,16 +389,13 @@ fn scan_claude(scope: HistoryScope<'_>, limit: usize) -> Vec<AgentHistoryItem> {
 }
 
 fn scan_antigravity(scope: HistoryScope<'_>, limit: usize) -> Vec<AgentHistoryItem> {
-    let mut files = Vec::new();
-    for root in antigravity_brain_roots() {
-        files.extend(collect_files(
-            &root,
-            ANTIGRAVITY_SCAN_MAX_DIR_DEPTH,
-            is_antigravity_transcript_path,
-        ));
-    }
-    files.sort_by(|a, b| file_updated_at(b).cmp(&file_updated_at(a)));
-    files.truncate(MAX_DISCOVERED_FILES_PER_PROVIDER);
+    let roots = antigravity_brain_root_candidates();
+    let files = collect_files_across_roots_with_entry_limit(
+        &roots,
+        ANTIGRAVITY_SCAN_MAX_DIR_DEPTH,
+        is_antigravity_transcript_path,
+        MAX_DISCOVERY_ENTRIES_PER_PROVIDER,
+    );
     parse_recent_files(files, limit, |path| parse_antigravity_file(path, scope))
 }
 
@@ -428,18 +448,19 @@ fn find_antigravity_history_item_by_path_id(
     scope: HistoryScope<'_>,
     transcript_id: &str,
 ) -> Option<AgentHistoryItem> {
-    if Uuid::parse_str(transcript_id).is_err() {
-        return None;
-    }
-    for root in antigravity_brain_roots() {
-        let path = root
-            .join(transcript_id)
-            .join(".system_generated/logs/transcript.jsonl");
-        if !path.is_file() || !is_antigravity_transcript_path(&path) {
-            continue;
-        }
-        if let Some(item) =
-            parse_antigravity_file(&path, scope).filter(|item| item.id == transcript_id)
+    let storage_root = google_agent_storage_root()?;
+    find_antigravity_history_item_by_path_id_at(scope, transcript_id, &storage_root)
+}
+
+fn find_antigravity_history_item_by_path_id_at(
+    scope: HistoryScope<'_>,
+    transcript_id: &str,
+    storage_root: &Path,
+) -> Option<AgentHistoryItem> {
+    let id = crate::agent_resume::normalize_provider_id(transcript_id).ok()?;
+    for snapshot in crate::agent_resume::open_antigravity_transcript_snapshots_at(storage_root, &id)
+    {
+        if let Some(item) = parse_antigravity_snapshot(snapshot, scope).filter(|item| item.id == id)
         {
             return Some(item);
         }
@@ -477,21 +498,16 @@ fn find_antigravity_history_item_by_parsed_id(
     scope: HistoryScope<'_>,
     transcript_id: &str,
 ) -> Option<AgentHistoryItem> {
-    for root in antigravity_brain_roots() {
-        let files = collect_files(
-            &root,
-            ANTIGRAVITY_SCAN_MAX_DIR_DEPTH,
-            is_antigravity_transcript_path,
-        );
-        if let Some(item) =
-            find_history_item_in_files(parse_budget_files(files), transcript_id, |path| {
-                parse_antigravity_file(path, scope)
-            })
-        {
-            return Some(item);
-        }
-    }
-    None
+    let roots = antigravity_brain_root_candidates();
+    let files = collect_files_across_roots_with_entry_limit(
+        &roots,
+        ANTIGRAVITY_SCAN_MAX_DIR_DEPTH,
+        is_antigravity_transcript_path,
+        MAX_DISCOVERY_ENTRIES_PER_PROVIDER,
+    );
+    find_history_item_in_files(parse_budget_files(files), transcript_id, |path| {
+        parse_antigravity_file(path, scope)
+    })
 }
 
 fn parse_budget_files(files: Vec<PathBuf>) -> impl Iterator<Item = PathBuf> {
@@ -514,20 +530,85 @@ fn collect_files(
     max_dir_depth: usize,
     accept: impl Fn(&Path) -> bool,
 ) -> Vec<PathBuf> {
-    if !root.is_dir() {
-        return Vec::new();
-    }
+    collect_files_with_entry_limit(
+        root,
+        max_dir_depth,
+        accept,
+        MAX_DISCOVERY_ENTRIES_PER_PROVIDER,
+    )
+}
+
+fn collect_files_with_entry_limit(
+    root: &Path,
+    max_dir_depth: usize,
+    accept: impl Fn(&Path) -> bool,
+    max_entries: usize,
+) -> Vec<PathBuf> {
+    collect_files_across_roots_with_entry_limit(
+        &[root.to_path_buf()],
+        max_dir_depth,
+        accept,
+        max_entries,
+    )
+}
+
+fn collect_files_across_roots_with_entry_limit(
+    roots: &[PathBuf],
+    max_dir_depth: usize,
+    accept: impl Fn(&Path) -> bool,
+    max_entries: usize,
+) -> Vec<PathBuf> {
     let mut out = Vec::new();
+    let mut remaining_entries = max_entries;
+    for root in roots {
+        if !collect_files_from_root(
+            root,
+            max_dir_depth,
+            &accept,
+            &mut remaining_entries,
+            &mut out,
+        ) {
+            return Vec::new();
+        }
+    }
+
+    out.sort_by(|a, b| file_updated_at(b).cmp(&file_updated_at(a)));
+    out.truncate(MAX_DISCOVERED_FILES_PER_PROVIDER);
+    out
+}
+
+fn collect_files_from_root(
+    root: &Path,
+    max_dir_depth: usize,
+    accept: &impl Fn(&Path) -> bool,
+    remaining_entries: &mut usize,
+    out: &mut Vec<PathBuf>,
+) -> bool {
+    match fs::symlink_metadata(root) {
+        Ok(metadata) if metadata.file_type().is_dir() => {}
+        Ok(_) => return true,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return true,
+        Err(_) => return false,
+    }
     let mut stack = vec![(root.to_path_buf(), 0_usize)];
 
     while let Some((dir, depth)) = stack.pop() {
         let Ok(entries) = fs::read_dir(&dir) else {
-            continue;
+            return false;
         };
-        for entry in entries.flatten() {
+        for entry in entries {
+            if *remaining_entries == 0 {
+                // An incomplete traversal can select the wrong "newest" files,
+                // so discard it instead of returning a plausible partial list.
+                return false;
+            }
+            *remaining_entries -= 1;
+            let Ok(entry) = entry else {
+                return false;
+            };
             let path = entry.path();
             let Ok(file_type) = entry.file_type() else {
-                continue;
+                return false;
             };
             if file_type.is_dir() {
                 if depth < max_dir_depth {
@@ -538,10 +619,7 @@ fn collect_files(
             }
         }
     }
-
-    out.sort_by(|a, b| file_updated_at(b).cmp(&file_updated_at(a)));
-    out.truncate(MAX_DISCOVERED_FILES_PER_PROVIDER);
-    out
+    true
 }
 
 fn parse_recent_files<T>(
@@ -648,6 +726,29 @@ fn parse_claude_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistor
 
 fn parse_antigravity_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentHistoryItem> {
     let state = parse_agent_state(AgentKind::Antigravity, path)?;
+    build_antigravity_item(path, state, file_updated_at(path), scope)
+}
+
+fn parse_antigravity_snapshot(
+    snapshot: crate::agent_resume::AntigravityTranscriptSnapshot,
+    scope: HistoryScope<'_>,
+) -> Option<AgentHistoryItem> {
+    let crate::agent_resume::AntigravityTranscriptSnapshot {
+        path,
+        file,
+        len,
+        modified,
+    } = snapshot;
+    let state = parse_agent_state_from_opened(AgentKind::Antigravity, &path, file, len)?;
+    build_antigravity_item(&path, state, updated_at_from_modified(modified), scope)
+}
+
+fn build_antigravity_item(
+    path: &Path,
+    state: ParsedAgentFile,
+    updated_at: u64,
+    scope: HistoryScope<'_>,
+) -> Option<AgentHistoryItem> {
     if state.internal_title_generation {
         return None;
     }
@@ -686,7 +787,7 @@ fn parse_antigravity_file(path: &Path, scope: HistoryScope<'_>) -> Option<AgentH
         cwd,
         worktree,
         transcript_path: path.display().to_string(),
-        updated_at: file_updated_at(path),
+        updated_at,
     })
 }
 
@@ -707,23 +808,19 @@ pub fn transcript_title_context(
     path: &Path,
     max_chars: usize,
 ) -> Option<String> {
-    let file = fs::File::open(path).ok()?;
+    let snapshot = open_transcript_snapshot(path, TRANSCRIPT_SCAN_LIMITS)?;
     let mut builder = TitleContextBuilder::new(max_chars);
     let kind = provider.kind();
-    for line in BufReader::new(file).lines().map_while(Result::ok) {
-        let line = line.trim();
-        if !line.starts_with('{') {
-            continue;
-        }
+    scan_transcript_json_lines(snapshot, TRANSCRIPT_SCAN_LIMITS, |line| {
         let Ok(value) = serde_json::from_str::<Value>(line) else {
-            continue;
+            return;
         };
         let parsed = parse_transcript_value(kind, &value);
         let Some(entry) = title_context_entry(&parsed) else {
-            continue;
+            return;
         };
         builder.push(entry);
-    }
+    })?;
     builder.finish()
 }
 
@@ -740,9 +837,9 @@ fn summarize_agent_transcript(
     id: String,
     path: &Path,
 ) -> Option<AgentTranscriptSummary> {
-    let metadata = fs::metadata(path).ok()?;
-    let len = metadata.len();
-    let modified = metadata.modified().ok();
+    let snapshot = open_transcript_snapshot(path, TRANSCRIPT_SCAN_LIMITS)?;
+    let len = snapshot.len;
+    let modified = snapshot.modified;
     let cache_key = TranscriptSummaryCacheKey {
         provider: provider.clone(),
         id: id.clone(),
@@ -752,7 +849,6 @@ fn summarize_agent_transcript(
         return Some(summary);
     }
 
-    let file = fs::File::open(path).ok()?;
     let mut message_count = 0_u64;
     let mut user_messages = 0_u64;
     let mut assistant_messages = 0_u64;
@@ -761,13 +857,9 @@ fn summarize_agent_transcript(
     let mut recent_messages = VecDeque::new();
     let kind = provider.kind();
 
-    for line in BufReader::new(file).lines().map_while(Result::ok) {
-        let line = line.trim();
-        if !line.starts_with('{') {
-            continue;
-        }
+    scan_transcript_json_lines(snapshot, TRANSCRIPT_SCAN_LIMITS, |line| {
         let Ok(value) = serde_json::from_str::<Value>(line) else {
-            continue;
+            return;
         };
         let parsed = parse_transcript_value(kind, &value);
         if let Some(entry) = title_context_entry(&parsed) {
@@ -798,12 +890,12 @@ fn summarize_agent_transcript(
         }
         if let Some(usage) = transcript_usage_from_value(&provider, &value) {
             if is_cumulative_usage_event(&provider, &value) {
-                cumulative_usage = max_token_usage(cumulative_usage, usage);
+                cumulative_usage = max_token_usage(std::mem::take(&mut cumulative_usage), usage);
             } else {
                 add_token_usage(&mut summed_usage, usage);
             }
         }
-    }
+    })?;
 
     let token_usage = if cumulative_usage.total_tokens > summed_usage.total_tokens {
         cumulative_usage
@@ -828,6 +920,56 @@ fn summarize_agent_transcript(
     };
     store_transcript_summary_cache(cache_key, len, modified, summary.clone());
     Some(summary)
+}
+
+fn open_transcript_snapshot(
+    path: &Path,
+    limits: TranscriptScanLimits,
+) -> Option<TranscriptSnapshot> {
+    let path_metadata = fs::symlink_metadata(path).ok()?;
+    if !path_metadata.file_type().is_file() {
+        return None;
+    }
+    let file = fs::File::open(path).ok()?;
+    let metadata = file.metadata().ok()?;
+    if !metadata.is_file() || metadata.len() > limits.max_bytes {
+        return None;
+    }
+    Some(TranscriptSnapshot {
+        file,
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+    })
+}
+
+fn scan_transcript_json_lines(
+    snapshot: TranscriptSnapshot,
+    limits: TranscriptScanLimits,
+    mut visit: impl FnMut(&str),
+) -> Option<()> {
+    let mut reader = BufReader::new(snapshot.file.take(snapshot.len));
+    let mut line = Vec::new();
+    let mut line_count = 0_usize;
+    loop {
+        line.clear();
+        let read_limit = limits.max_line_bytes.checked_add(1)?;
+        let read = reader
+            .by_ref()
+            .take(read_limit as u64)
+            .read_until(b'\n', &mut line)
+            .ok()?;
+        if read == 0 {
+            return Some(());
+        }
+        if line.len() > limits.max_line_bytes || line_count >= limits.max_lines {
+            return None;
+        }
+        line_count += 1;
+        let text = std::str::from_utf8(&line).ok()?.trim();
+        if text.starts_with('{') {
+            visit(text);
+        }
+    }
 }
 
 fn cached_transcript_summary(
@@ -1040,6 +1182,17 @@ fn max_token_usage(
 }
 
 fn parse_agent_state(kind: AgentKind, path: &Path) -> Option<ParsedAgentFile> {
+    let file = fs::File::open(path).ok()?;
+    let len = file.metadata().ok()?.len();
+    parse_agent_state_from_opened(kind, path, file, len)
+}
+
+fn parse_agent_state_from_opened(
+    kind: AgentKind,
+    path: &Path,
+    file: fs::File,
+    len: u64,
+) -> Option<ParsedAgentFile> {
     let mut state = ParsedAgentFile {
         id: if kind == AgentKind::Antigravity {
             antigravity_id_from_path(path)
@@ -1048,7 +1201,7 @@ fn parse_agent_state(kind: AgentKind, path: &Path) -> Option<ParsedAgentFile> {
         },
         ..ParsedAgentFile::default()
     };
-    for line in sample_lines(path).ok()? {
+    for line in sample_lines_from_opened(file, len).ok()? {
         let value = if kind == AgentKind::Claude {
             serde_json::from_str::<Value>(&line).ok()
         } else {
@@ -1091,7 +1244,7 @@ fn parse_agent_state(kind: AgentKind, path: &Path) -> Option<ParsedAgentFile> {
         }
     }
     if kind == AgentKind::Claude && state.conversation_message_count == 0 {
-        state.subagent_transcript_count = count_claude_subagent_transcripts(path);
+        state.subagent_transcript_count = count_claude_subagent_transcripts(path)?;
     }
 
     Some(state)
@@ -1140,20 +1293,42 @@ fn has_recoverable_json_text(value: &Value) -> bool {
     }
 }
 
-fn count_claude_subagent_transcripts(path: &Path) -> u64 {
+fn count_claude_subagent_transcripts(path: &Path) -> Option<u64> {
+    count_claude_subagent_transcripts_with_limit(path, MAX_DISCOVERY_ENTRIES_PER_PROVIDER)
+}
+
+fn count_claude_subagent_transcripts_with_limit(path: &Path, max_entries: usize) -> Option<u64> {
     let Some(dir) = claude_subagent_transcripts_dir(path) else {
-        return 0;
+        return Some(0);
     };
-    let Ok(entries) = fs::read_dir(dir) else {
-        return 0;
+    let metadata = match fs::symlink_metadata(&dir) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Some(0),
+        Err(_) => return None,
     };
-    entries
-        .flatten()
-        .filter(|entry| {
-            entry.file_type().map(|ty| ty.is_file()).unwrap_or(false)
-                && entry.path().extension().and_then(|s| s.to_str()) == Some("jsonl")
-        })
-        .count() as u64
+    if !metadata.file_type().is_dir() {
+        return None;
+    }
+    let entries = fs::read_dir(dir).ok()?;
+    let mut scanned_entries = 0_usize;
+    let mut transcripts = 0_u64;
+    for entry in entries {
+        if scanned_entries >= max_entries {
+            return None;
+        }
+        scanned_entries += 1;
+        let entry = entry.ok()?;
+        if entry.file_type().ok()?.is_file()
+            && entry
+                .path()
+                .extension()
+                .and_then(|extension| extension.to_str())
+                == Some("jsonl")
+        {
+            transcripts = transcripts.checked_add(1)?;
+        }
+    }
+    Some(transcripts)
 }
 
 fn claude_subagent_transcripts_dir(path: &Path) -> Option<PathBuf> {
@@ -1277,8 +1452,12 @@ fn looks_like_acorn_title_generation_prompt(text: &str) -> bool {
 }
 
 fn sample_lines(path: &Path) -> std::io::Result<Vec<String>> {
-    let mut file = fs::File::open(path)?;
+    let file = fs::File::open(path)?;
     let len = file.metadata()?.len();
+    sample_lines_from_opened(file, len)
+}
+
+fn sample_lines_from_opened(mut file: fs::File, len: u64) -> std::io::Result<Vec<String>> {
     let mut bytes = Vec::new();
     let head_max = READ_HEAD_MAX_BYTES.min(len);
     let mut read = 0_u64;
@@ -1299,7 +1478,7 @@ fn sample_lines(path: &Path) -> std::io::Result<Vec<String>> {
         let tail_start = len.saturating_sub(READ_TAIL_BYTES);
         file.seek(SeekFrom::Start(tail_start))?;
         let mut tail = Vec::new();
-        file.read_to_end(&mut tail)?;
+        file.take(READ_TAIL_BYTES).read_to_end(&mut tail)?;
         bytes.push(b'\n');
         bytes.extend(tail);
     }
@@ -1397,10 +1576,7 @@ fn path_has_uuid_stem(path: &Path) -> bool {
 }
 
 fn uuid_suffix(stem: &str) -> Option<String> {
-    if stem.len() < 36 {
-        return None;
-    }
-    let suffix = &stem[stem.len() - 36..];
+    let suffix = stem.get(stem.len().checked_sub(36)?..)?;
     Uuid::parse_str(suffix).ok().map(|_| suffix.to_string())
 }
 
@@ -1575,13 +1751,19 @@ fn google_agent_storage_root() -> Option<PathBuf> {
 }
 
 fn antigravity_brain_roots() -> Vec<PathBuf> {
+    antigravity_brain_root_candidates()
+        .into_iter()
+        .filter(|path| path.is_dir())
+        .collect()
+}
+
+fn antigravity_brain_root_candidates() -> Vec<PathBuf> {
     let Some(root) = google_agent_storage_root() else {
         return Vec::new();
     };
     ["antigravity", "antigravity-ide", "antigravity-cli"]
         .into_iter()
         .map(|profile| root.join(profile).join("brain"))
-        .filter(|path| path.is_dir())
         .collect()
 }
 
@@ -1625,6 +1807,19 @@ struct AgentStateCwd {
     updated_at: u64,
 }
 
+const MAX_AGENT_STATE_ENTRIES: usize = 10_000;
+
+#[derive(Clone, Copy)]
+struct AgentStateLookupLimits {
+    max_entries: usize,
+    max_cwd_bytes: usize,
+}
+
+const AGENT_STATE_LOOKUP_LIMITS: AgentStateLookupLimits = AgentStateLookupLimits {
+    max_entries: MAX_AGENT_STATE_ENTRIES,
+    max_cwd_bytes: crate::agent_resume::AGENT_CWD_MAX_BYTES,
+};
+
 fn antigravity_cwds_from_agent_state(id: &str) -> Vec<String> {
     let Some(data_dir) = acorn_daemon::paths::data_dir().ok() else {
         return Vec::new();
@@ -1636,36 +1831,87 @@ fn antigravity_cwds_from_agent_state(id: &str) -> Vec<String> {
 }
 
 fn antigravity_cwds_from_agent_state_at(data_dir: &Path, id: &str) -> Vec<AgentStateCwd> {
-    let root = data_dir.join("agent-state");
-    let Ok(entries) = fs::read_dir(root) else {
+    antigravity_cwds_from_agent_state_with_limits(data_dir, id, AGENT_STATE_LOOKUP_LIMITS)
+}
+
+fn antigravity_cwds_from_agent_state_with_limits(
+    data_dir: &Path,
+    id: &str,
+    limits: AgentStateLookupLimits,
+) -> Vec<AgentStateCwd> {
+    let Ok(id) = crate::agent_resume::normalize_provider_id(id) else {
         return Vec::new();
     };
-    let mut out = entries
-        .flatten()
-        .filter_map(|entry| {
-            let dir = entry.path();
-            if !dir.is_dir() {
-                return None;
-            }
-            if read_trimmed_state_file(&dir.join("antigravity.id")).as_deref() != Some(id) {
-                return None;
-            }
-            let cwd = read_trimmed_state_file(&dir.join("antigravity.cwd"))?;
-            let updated_at = file_updated_at(&dir.join("antigravity.id"))
-                .max(file_updated_at(&dir.join("antigravity.cwd")));
-            Some(AgentStateCwd { cwd, updated_at })
-        })
-        .collect::<Vec<_>>();
+    let root = data_dir.join("agent-state");
+    let Ok(root_metadata) = fs::symlink_metadata(&root) else {
+        return Vec::new();
+    };
+    if !root_metadata.file_type().is_dir() {
+        return Vec::new();
+    }
+    let Ok(entries) = fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    let mut scanned_entries = 0_usize;
+    for entry in entries {
+        if scanned_entries >= limits.max_entries {
+            // Returning a subset would make a partial scan look authoritative.
+            return Vec::new();
+        }
+        scanned_entries += 1;
+        let Ok(entry) = entry else {
+            return Vec::new();
+        };
+        let Ok(entry_type) = entry.file_type() else {
+            return Vec::new();
+        };
+        if !entry_type.is_dir() {
+            continue;
+        }
+        let dir = entry.path();
+        let Ok(dir_metadata) = fs::symlink_metadata(&dir) else {
+            return Vec::new();
+        };
+        if !dir_metadata.file_type().is_dir() {
+            continue;
+        }
+
+        // These pathname checks reject stable links and special files. A parent
+        // can still be swapped between checks and opens; RES-006 tracks the
+        // dirfd/handle-relative redesign for that remaining TOCTOU window.
+        let marker = match crate::agent_resume::read_provider_marker(&dir.join("antigravity.id")) {
+            Ok(Some(marker)) => marker,
+            Ok(None) => continue,
+            Err(_) => return Vec::new(),
+        };
+        if marker.text != id {
+            continue;
+        }
+        let cwd_snapshot = match crate::agent_resume::read_state_text_with_limit(
+            &dir.join("antigravity.cwd"),
+            limits.max_cwd_bytes,
+        ) {
+            Ok(Some(snapshot)) => snapshot,
+            Ok(None) => continue,
+            Err(_) => return Vec::new(),
+        };
+        let cwd = cwd_snapshot.text.trim().to_string();
+        if cwd.is_empty() {
+            continue;
+        }
+        let updated_at = [marker.modified, cwd_snapshot.modified]
+            .into_iter()
+            .flatten()
+            .filter_map(|time| time.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_secs())
+            .max()
+            .unwrap_or(0);
+        out.push(AgentStateCwd { cwd, updated_at });
+    }
     out.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
     out.dedup_by(|a, b| a.cwd == b.cwd);
     out
-}
-
-fn read_trimmed_state_file(path: &Path) -> Option<String> {
-    fs::read_to_string(path)
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
 }
 
 fn home_dir() -> Option<PathBuf> {
@@ -1712,6 +1958,37 @@ mod tests {
         }
     }
 
+    fn write_antigravity_history_transcript(storage_root: &Path, id: &str, cwd: &Path) -> PathBuf {
+        let transcript = storage_root
+            .join("antigravity/brain")
+            .join(id)
+            .join(".system_generated/logs/transcript.jsonl");
+        fs::create_dir_all(transcript.parent().unwrap()).unwrap();
+        let mut file = fs::File::create(&transcript).unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "type": "USER_INPUT",
+                "status": "DONE",
+                "workspacePaths": [cwd.display().to_string()],
+                "content": "<USER_REQUEST>Secure direct history lookup</USER_REQUEST>",
+            })
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "type": "PLANNER_RESPONSE",
+                "status": "DONE",
+                "content": "Opened snapshot parsed.",
+            })
+        )
+        .unwrap();
+        transcript
+    }
+
     #[test]
     fn codex_transcript_match_accepts_payload_id_when_filename_differs() {
         let dir = tempfile::tempdir().unwrap();
@@ -1738,6 +2015,13 @@ mod tests {
             codex_id_from_filename(path).as_deref(),
             Some("019e4818-7c15-7e60-9b3b-898a1c7803d6")
         );
+    }
+
+    #[test]
+    fn codex_id_from_filename_rejects_non_ascii_boundary_without_panicking() {
+        let path = Path::new("가aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee.jsonl");
+
+        assert_eq!(codex_id_from_filename(path), None);
     }
 
     #[test]
@@ -1811,6 +2095,96 @@ mod tests {
             antigravity_id_from_path(path).as_deref(),
             Some("17f38e8c-3a7e-408b-8c79-aef7432c0fd2")
         );
+    }
+
+    #[test]
+    fn antigravity_direct_history_lookup_parses_secure_opened_snapshot() {
+        let storage = tempfile::tempdir().unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let repo_path = repo.path().canonicalize().unwrap();
+        let id = "17f38e8c-3a7e-408b-8c79-aef7432c0fd2";
+        let transcript = write_antigravity_history_transcript(storage.path(), id, &repo_path);
+
+        let mut snapshots =
+            crate::agent_resume::open_antigravity_transcript_snapshots_at(storage.path(), id);
+        assert_eq!(snapshots.len(), 1, "secure exact locator must open fixture");
+        assert!(
+            parse_antigravity_snapshot(snapshots.pop().unwrap(), HistoryScope::Project(&repo_path))
+                .is_some(),
+            "opened fixture must parse inside project scope"
+        );
+
+        let item = find_antigravity_history_item_by_path_id_at(
+            HistoryScope::Project(&repo_path),
+            "17F38E8C-3A7E-408B-8C79-AEF7432C0FD2",
+            storage.path(),
+        )
+        .unwrap();
+
+        assert_eq!(item.id, id);
+        assert_eq!(
+            item.transcript_path,
+            transcript.canonicalize().unwrap().display().to_string()
+        );
+        assert_eq!(item.title, "Secure direct history lookup");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn antigravity_direct_history_lookup_rejects_symlinked_root_component_and_leaf() {
+        use std::os::unix::fs::symlink;
+
+        let repo = tempfile::tempdir().unwrap();
+        let repo_path = repo.path().canonicalize().unwrap();
+        let id = "17f38e8c-3a7e-408b-8c79-aef7432c0fd2";
+        let outside = tempfile::tempdir().unwrap();
+        let sentinel = write_antigravity_history_transcript(outside.path(), id, &repo_path);
+
+        let linked_root = tempfile::tempdir().unwrap();
+        let profile = linked_root.path().join("antigravity");
+        fs::create_dir(&profile).unwrap();
+        symlink(
+            outside.path().join("antigravity/brain"),
+            profile.join("brain"),
+        )
+        .unwrap();
+        assert!(find_antigravity_history_item_by_path_id_at(
+            HistoryScope::Project(&repo_path),
+            id,
+            linked_root.path(),
+        )
+        .is_none());
+
+        let linked_session = tempfile::tempdir().unwrap();
+        let brain = linked_session.path().join("antigravity/brain");
+        fs::create_dir_all(&brain).unwrap();
+        symlink(
+            outside.path().join("antigravity/brain").join(id),
+            brain.join(id),
+        )
+        .unwrap();
+        assert!(find_antigravity_history_item_by_path_id_at(
+            HistoryScope::Project(&repo_path),
+            id,
+            linked_session.path(),
+        )
+        .is_none());
+
+        let linked_leaf = tempfile::tempdir().unwrap();
+        let leaf = linked_leaf
+            .path()
+            .join("antigravity/brain")
+            .join(id)
+            .join(".system_generated/logs/transcript.jsonl");
+        fs::create_dir_all(leaf.parent().unwrap()).unwrap();
+        symlink(&sentinel, &leaf).unwrap();
+        assert!(find_antigravity_history_item_by_path_id_at(
+            HistoryScope::Project(&repo_path),
+            id,
+            linked_leaf.path(),
+        )
+        .is_none());
+        assert!(sentinel.is_file());
     }
 
     #[test]
@@ -2146,6 +2520,156 @@ mod tests {
     }
 
     #[test]
+    fn antigravity_agent_state_lookup_discards_partial_results_over_raw_entry_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("agent-state");
+        let id = "17f38e8c-3a7e-408b-8c79-aef7432c0fd2";
+        for (session, cwd) in [("session-1", "/tmp/one"), ("session-2", "/tmp/two")] {
+            let state_dir = root.join(session);
+            fs::create_dir_all(&state_dir).unwrap();
+            fs::write(state_dir.join("antigravity.id"), format!("{id}\n")).unwrap();
+            fs::write(state_dir.join("antigravity.cwd"), format!("{cwd}\n")).unwrap();
+        }
+        let limits = AgentStateLookupLimits {
+            max_entries: 2,
+            max_cwd_bytes: crate::agent_resume::AGENT_CWD_MAX_BYTES,
+        };
+        assert_eq!(
+            antigravity_cwds_from_agent_state_with_limits(dir.path(), id, limits).len(),
+            2,
+            "the exact raw-entry budget must remain usable"
+        );
+
+        fs::write(root.join("unrelated"), "raw entry").unwrap();
+        assert!(antigravity_cwds_from_agent_state_with_limits(dir.path(), id, limits).is_empty());
+    }
+
+    #[test]
+    fn antigravity_agent_state_lookup_discards_partial_results_on_state_read_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("agent-state");
+        let id = "17f38e8c-3a7e-408b-8c79-aef7432c0fd2";
+        let valid = root.join("valid");
+        let broken = root.join("broken");
+        fs::create_dir_all(&valid).unwrap();
+        fs::create_dir_all(&broken).unwrap();
+        fs::write(valid.join("antigravity.id"), format!("{id}\n")).unwrap();
+        fs::write(valid.join("antigravity.cwd"), "/tmp/valid\n").unwrap();
+        fs::write(
+            broken.join("antigravity.id"),
+            "x".repeat(crate::agent_resume::PROVIDER_MARKER_MAX_BYTES + 1),
+        )
+        .unwrap();
+        fs::write(broken.join("antigravity.cwd"), "/tmp/broken\n").unwrap();
+        let limits = AgentStateLookupLimits {
+            max_entries: 2,
+            max_cwd_bytes: crate::agent_resume::AGENT_CWD_MAX_BYTES,
+        };
+
+        assert!(
+            antigravity_cwds_from_agent_state_with_limits(dir.path(), id, limits).is_empty(),
+            "a marker read error must discard an already collected cwd"
+        );
+
+        fs::write(broken.join("antigravity.id"), format!("{id}\n")).unwrap();
+        fs::write(
+            broken.join("antigravity.cwd"),
+            "x".repeat(crate::agent_resume::AGENT_CWD_MAX_BYTES + 1),
+        )
+        .unwrap();
+        assert!(
+            antigravity_cwds_from_agent_state_with_limits(dir.path(), id, limits).is_empty(),
+            "a cwd read error must discard an already collected cwd"
+        );
+
+        fs::remove_file(broken.join("antigravity.cwd")).unwrap();
+        let entries = antigravity_cwds_from_agent_state_with_limits(dir.path(), id, limits);
+        assert_eq!(entries.len(), 1, "a missing cwd leaf remains skippable");
+        assert_eq!(entries[0].cwd, "/tmp/valid");
+    }
+
+    #[test]
+    fn antigravity_agent_state_lookup_enforces_injected_cwd_limit_and_valid_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join("agent-state/session-1");
+        let id = "17f38e8c-3a7e-408b-8c79-aef7432c0fd2";
+        let cwd = "/x\n";
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(state_dir.join("antigravity.id"), format!("{id}\n")).unwrap();
+        fs::write(state_dir.join("antigravity.cwd"), cwd).unwrap();
+
+        let exact = AgentStateLookupLimits {
+            max_entries: 1,
+            max_cwd_bytes: cwd.len(),
+        };
+        assert_eq!(
+            antigravity_cwds_from_agent_state_with_limits(dir.path(), id, exact)[0].cwd,
+            "/x"
+        );
+        let over = AgentStateLookupLimits {
+            max_cwd_bytes: cwd.len() - 1,
+            ..exact
+        };
+        assert!(antigravity_cwds_from_agent_state_with_limits(dir.path(), id, over).is_empty());
+
+        for invalid in [
+            "not-a-uuid",
+            "../17f38e8c-3a7e-408b-8c79-aef7432c0fd2",
+            "/tmp/17f38e8c-3a7e-408b-8c79-aef7432c0fd2",
+        ] {
+            assert!(
+                antigravity_cwds_from_agent_state_with_limits(dir.path(), invalid, exact)
+                    .is_empty()
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn antigravity_agent_state_lookup_rejects_symlinked_dirs_and_leaves() {
+        use std::os::unix::fs::symlink;
+
+        let id = "17f38e8c-3a7e-408b-8c79-aef7432c0fd2";
+        let outside = tempfile::tempdir().unwrap();
+        let outside_state = outside.path().join("session");
+        fs::create_dir(&outside_state).unwrap();
+        fs::write(outside_state.join("antigravity.id"), format!("{id}\n")).unwrap();
+        fs::write(outside_state.join("antigravity.cwd"), "/tmp/outside\n").unwrap();
+
+        let linked_root = tempfile::tempdir().unwrap();
+        symlink(outside.path(), linked_root.path().join("agent-state")).unwrap();
+        assert!(antigravity_cwds_from_agent_state_at(linked_root.path(), id).is_empty());
+
+        let linked_session = tempfile::tempdir().unwrap();
+        let root = linked_session.path().join("agent-state");
+        fs::create_dir(&root).unwrap();
+        symlink(&outside_state, root.join("session")).unwrap();
+        assert!(antigravity_cwds_from_agent_state_at(linked_session.path(), id).is_empty());
+
+        let linked_leaf = tempfile::tempdir().unwrap();
+        let state_dir = linked_leaf.path().join("agent-state/session");
+        fs::create_dir_all(&state_dir).unwrap();
+        let id_sentinel = linked_leaf.path().join("id-sentinel");
+        let cwd_sentinel = linked_leaf.path().join("cwd-sentinel");
+        fs::write(&id_sentinel, format!("{id}\n")).unwrap();
+        fs::write(&cwd_sentinel, "/tmp/sentinel\n").unwrap();
+        symlink(&id_sentinel, state_dir.join("antigravity.id")).unwrap();
+        fs::write(state_dir.join("antigravity.cwd"), "/tmp/local\n").unwrap();
+        assert!(antigravity_cwds_from_agent_state_at(linked_leaf.path(), id).is_empty());
+
+        fs::remove_file(state_dir.join("antigravity.id")).unwrap();
+        fs::write(state_dir.join("antigravity.id"), format!("{id}\n")).unwrap();
+        fs::remove_file(state_dir.join("antigravity.cwd")).unwrap();
+        symlink(&cwd_sentinel, state_dir.join("antigravity.cwd")).unwrap();
+        assert!(antigravity_cwds_from_agent_state_at(linked_leaf.path(), id).is_empty());
+        assert_eq!(fs::read_to_string(&id_sentinel).unwrap(), format!("{id}\n"));
+        assert_eq!(
+            fs::read_to_string(&cwd_sentinel).unwrap(),
+            "/tmp/sentinel\n"
+        );
+    }
+
+    #[test]
     fn parse_file_budget_scales_with_requested_limit() {
         assert_eq!(parse_file_budget(0), 0);
         assert_eq!(parse_file_budget(1), MIN_PARSED_FILES_PER_PROVIDER);
@@ -2200,6 +2724,82 @@ mod tests {
         });
 
         assert_eq!(files, vec![parent]);
+    }
+
+    #[test]
+    fn collect_files_discards_traversal_that_exceeds_entry_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("a.jsonl"), "{}\n").unwrap();
+        fs::write(dir.path().join("b.jsonl"), "{}\n").unwrap();
+        let accepts_jsonl = |path: &Path| {
+            path.extension().and_then(|extension| extension.to_str()) == Some("jsonl")
+        };
+
+        assert_eq!(
+            collect_files_with_entry_limit(dir.path(), 0, accepts_jsonl, 2).len(),
+            2,
+            "the exact raw-entry budget must remain usable"
+        );
+        assert!(
+            collect_files_with_entry_limit(dir.path(), 0, accepts_jsonl, 1).is_empty(),
+            "an incomplete traversal must not return a plausible partial history"
+        );
+    }
+
+    #[test]
+    fn collect_files_shares_exact_entry_budget_across_provider_roots() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first");
+        let second = dir.path().join("second");
+        fs::create_dir(&first).unwrap();
+        fs::create_dir(&second).unwrap();
+        fs::write(first.join("a.jsonl"), "{}\n").unwrap();
+        fs::write(second.join("b.jsonl"), "{}\n").unwrap();
+        let roots = vec![first, second.clone()];
+        let accepts_jsonl = |path: &Path| {
+            path.extension().and_then(|extension| extension.to_str()) == Some("jsonl")
+        };
+
+        assert_eq!(
+            collect_files_across_roots_with_entry_limit(&roots, 0, accepts_jsonl, 2).len(),
+            2,
+            "the exact shared budget must remain usable"
+        );
+        fs::write(second.join("c.jsonl"), "{}\n").unwrap();
+        assert!(
+            collect_files_across_roots_with_entry_limit(&roots, 0, accepts_jsonl, 2).is_empty(),
+            "overflow in a later root must discard earlier-root results"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_files_discards_partial_traversal_after_nested_read_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let accepted = dir.path().join("accepted.jsonl");
+        let unreadable = dir.path().join("unreadable");
+        fs::write(&accepted, "{}\n").unwrap();
+        fs::create_dir(&unreadable).unwrap();
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+        if fs::read_dir(&unreadable).is_ok() {
+            fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o700)).unwrap();
+            return;
+        }
+
+        let files = collect_files_with_entry_limit(
+            dir.path(),
+            1,
+            |path| path.extension().and_then(|extension| extension.to_str()) == Some("jsonl"),
+            10,
+        );
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o700)).unwrap();
+
+        assert!(
+            files.is_empty(),
+            "a traversal error must discard already collected history"
+        );
     }
 
     #[test]
@@ -2330,6 +2930,31 @@ mod tests {
         assert_eq!(item.queued_message_count, 1);
         assert_eq!(item.subagent_transcript_count, 1);
         assert_eq!(item.cwd.as_deref(), Some(repo.to_str().unwrap()));
+    }
+
+    #[test]
+    fn claude_subagent_count_discards_directory_over_entry_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = dir
+            .path()
+            .join("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl");
+        fs::write(&transcript, "{}\n").unwrap();
+        let subagents = dir
+            .path()
+            .join("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/subagents");
+        fs::create_dir_all(&subagents).unwrap();
+        fs::write(subagents.join("a.jsonl"), "{}\n").unwrap();
+        fs::write(subagents.join("b.jsonl"), "{}\n").unwrap();
+
+        assert_eq!(
+            count_claude_subagent_transcripts_with_limit(&transcript, 2),
+            Some(2)
+        );
+        assert_eq!(
+            count_claude_subagent_transcripts_with_limit(&transcript, 1),
+            None,
+            "a partial child count must not be surfaced as complete"
+        );
     }
 
     #[test]
@@ -2622,6 +3247,49 @@ mod tests {
         assert!(context.contains("Turn 0"));
         assert!(context.contains("[...]"));
         assert!(context.contains("Turn 19"));
+    }
+
+    #[test]
+    fn transcript_jsonl_scan_enforces_file_line_and_line_count_budgets() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = dir.path().join("transcript.jsonl");
+        let line = b"{\"ok\":true}\n";
+        fs::write(&transcript, line).unwrap();
+
+        let exact = TranscriptScanLimits {
+            max_bytes: line.len() as u64,
+            max_lines: 1,
+            max_line_bytes: line.len(),
+        };
+        let mut visited = 0;
+        let snapshot = open_transcript_snapshot(&transcript, exact).unwrap();
+        assert_eq!(
+            scan_transcript_json_lines(snapshot, exact, |_| visited += 1),
+            Some(())
+        );
+        assert_eq!(visited, 1);
+
+        let file_too_large = TranscriptScanLimits {
+            max_bytes: line.len() as u64 - 1,
+            ..exact
+        };
+        assert!(open_transcript_snapshot(&transcript, file_too_large).is_none());
+
+        let line_too_large = TranscriptScanLimits {
+            max_line_bytes: line.len() - 1,
+            ..exact
+        };
+        let snapshot = open_transcript_snapshot(&transcript, line_too_large).unwrap();
+        assert!(scan_transcript_json_lines(snapshot, line_too_large, |_| {}).is_none());
+
+        fs::write(&transcript, [line.as_slice(), line.as_slice()].concat()).unwrap();
+        let too_many_lines = TranscriptScanLimits {
+            max_bytes: (line.len() * 2) as u64,
+            max_lines: 1,
+            max_line_bytes: line.len(),
+        };
+        let snapshot = open_transcript_snapshot(&transcript, too_many_lines).unwrap();
+        assert!(scan_transcript_json_lines(snapshot, too_many_lines, |_| {}).is_none());
     }
 
     #[test]

--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -20,6 +20,7 @@ const MAX_HEADER_BYTES: usize = 8 * 1024;
 const MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
 const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const READ_TIMEOUT: Duration = Duration::from_secs(2);
+const MAX_CONCURRENT_CONNECTIONS: usize = 32;
 
 type HookEventHandler =
     Arc<dyn Fn(AgentHookEvent) -> AgentHookHandlerOutcome + Send + Sync + 'static>;
@@ -1598,17 +1599,29 @@ fn run_listener(
     handler: HookEventHandler,
     running: Arc<AtomicBool>,
 ) {
+    let active_connections = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     while running.load(Ordering::SeqCst) {
         match listener.accept() {
             Ok((stream, _addr)) => {
+                let Some(permit) = ConnectionPermit::try_acquire(
+                    Arc::clone(&active_connections),
+                    MAX_CONCURRENT_CONNECTIONS,
+                ) else {
+                    // Hook events are best effort and transcript polling is the
+                    // fallback. Drop overload without spawning another thread
+                    // or emitting attacker-amplifiable warning logs.
+                    drop(stream);
+                    continue;
+                };
                 dispatch_connection(
                     stream,
                     token.clone(),
                     handler.clone(),
-                    |stream, token, handler| {
+                    move |stream, token, handler| {
                         std::thread::Builder::new()
                             .name("acorn-agent-hook-conn".to_string())
                             .spawn(move || {
+                                let _permit = permit;
                                 if let Err(err) = handle_connection(stream, &token, &handler) {
                                     tracing::warn!(error = %err, "agent hook connection failed");
                                 }
@@ -1655,6 +1668,27 @@ fn dispatch_connection<F>(
                 );
             }
         }
+    }
+}
+
+struct ConnectionPermit {
+    active: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl ConnectionPermit {
+    fn try_acquire(active: Arc<std::sync::atomic::AtomicUsize>, limit: usize) -> Option<Self> {
+        active
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current < limit).then_some(current + 1)
+            })
+            .ok()?;
+        Some(Self { active })
+    }
+}
+
+impl Drop for ConnectionPermit {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::AcqRel);
     }
 }
 
@@ -2239,13 +2273,14 @@ mod tests {
     use super::{
         apply_agent_hook_event, dispatch_connection, handle_connection, AgentHookApplyOutcome,
         AgentHookEvent, AgentHookEventKind, AgentHookHandlerOutcome, AgentHookOwnership,
-        AgentHookReducer, AgentHookServer, HookEventHandler, MAX_HEADER_BYTES,
+        AgentHookReducer, AgentHookServer, ConnectionPermit, HookEventHandler, MAX_HEADER_BYTES,
     };
     use acorn_session::{
         AgentStatusSource, Session, SessionAgentProvider, SessionKind, SessionStatus,
     };
     use std::io::{self, Read, Write};
     use std::net::{SocketAddr, TcpStream};
+    use std::sync::atomic::Ordering;
     use std::sync::{mpsc, Arc, Mutex};
     use std::time::Duration;
     use uuid::Uuid;
@@ -2448,6 +2483,24 @@ mod tests {
 
         let valid = post(&hooks, hooks.token(), &body);
         assert!(valid.starts_with("HTTP/1.1 204 No Content"));
+    }
+
+    #[test]
+    fn hook_connection_permits_enforce_and_release_the_limit() {
+        let active = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let first = ConnectionPermit::try_acquire(Arc::clone(&active), 2).unwrap();
+        let second = ConnectionPermit::try_acquire(Arc::clone(&active), 2).unwrap();
+
+        assert!(ConnectionPermit::try_acquire(Arc::clone(&active), 2).is_none());
+        assert_eq!(active.load(Ordering::Acquire), 2);
+
+        drop(first);
+        let replacement = ConnectionPermit::try_acquire(Arc::clone(&active), 2).unwrap();
+        assert_eq!(active.load(Ordering::Acquire), 2);
+
+        drop(second);
+        drop(replacement);
+        assert_eq!(active.load(Ordering::Acquire), 0);
     }
 
     #[test]

--- a/src-tauri/src/agent_resume.rs
+++ b/src-tauri/src/agent_resume.rs
@@ -27,8 +27,12 @@
 //! the user starts a new conversation in the same session.
 
 use std::fs;
-use std::io;
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
 use acorn_agent::AgentKind;
 use acorn_transcript::{collapse_preview, parse_transcript_line, read_tail, TranscriptRole};
@@ -42,6 +46,197 @@ const CODEX_ID_ACK_FILE: &str = "codex.id.acknowledged";
 const ANTIGRAVITY_ID_FILE: &str = "antigravity.id";
 const ANTIGRAVITY_ID_ACK_FILE: &str = "antigravity.id.acknowledged";
 
+pub(crate) const PROVIDER_MARKER_MAX_BYTES: usize = 128;
+pub(crate) const AGENT_CWD_MAX_BYTES: usize = 4 * 1024;
+
+pub(crate) struct StateFileSnapshot {
+    pub text: String,
+    pub modified: Option<SystemTime>,
+}
+
+pub(crate) struct AntigravityTranscriptSnapshot {
+    pub path: PathBuf,
+    pub file: fs::File,
+    pub len: u64,
+    pub modified: Option<SystemTime>,
+}
+
+fn invalid_state(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+pub(crate) fn normalize_provider_id(value: &str) -> io::Result<String> {
+    uuid::Uuid::parse_str(value.trim())
+        .map(|id| id.to_string())
+        .map_err(|_| invalid_state("agent provider marker must contain a UUID"))
+}
+
+fn require_plain_directory(path: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_dir() {
+        Ok(())
+    } else {
+        Err(invalid_state(format!(
+            "agent state path is not a regular directory: {}",
+            path.display()
+        )))
+    }
+}
+
+pub(crate) fn validate_state_directory(path: &Path) -> io::Result<()> {
+    require_plain_directory(path)
+}
+
+fn ensure_plain_directory(path: &Path) -> io::Result<()> {
+    match fs::create_dir(path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
+        Err(err) => return Err(err),
+    }
+    require_plain_directory(path)
+}
+
+fn plain_directory_exists(path: &Path) -> io::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(true),
+        Ok(_) => Err(invalid_state(format!(
+            "agent state path is not a regular directory: {}",
+            path.display()
+        ))),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+fn open_regular_state_file(path: &Path) -> io::Result<Option<(fs::File, fs::Metadata)>> {
+    let path_metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    if !path_metadata.file_type().is_file() {
+        return Err(invalid_state(format!(
+            "agent state leaf is not a regular file: {}",
+            path.display()
+        )));
+    }
+
+    let file = fs::File::open(path)?;
+    let opened_metadata = file.metadata()?;
+    if !opened_metadata.file_type().is_file() {
+        return Err(invalid_state(format!(
+            "opened agent state leaf is not a regular file: {}",
+            path.display()
+        )));
+    }
+    #[cfg(unix)]
+    if path_metadata.dev() != opened_metadata.dev() || path_metadata.ino() != opened_metadata.ino()
+    {
+        return Err(invalid_state(format!(
+            "agent state leaf changed while opening: {}",
+            path.display()
+        )));
+    }
+
+    Ok(Some((file, opened_metadata)))
+}
+
+pub(crate) fn read_state_text_with_limit(
+    path: &Path,
+    max_bytes: usize,
+) -> io::Result<Option<StateFileSnapshot>> {
+    let Some((file, metadata)) = open_regular_state_file(path)? else {
+        return Ok(None);
+    };
+    let read_limit = max_bytes
+        .checked_add(1)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "state read limit overflow"))?;
+    let mut bytes = Vec::with_capacity(read_limit.min(4 * 1024 + 1));
+    file.take(read_limit as u64).read_to_end(&mut bytes)?;
+    if bytes.len() > max_bytes {
+        return Err(invalid_state(format!(
+            "agent state leaf exceeds {max_bytes} bytes: {}",
+            path.display()
+        )));
+    }
+    let text = String::from_utf8(bytes)
+        .map_err(|_| invalid_state(format!("agent state leaf is not UTF-8: {}", path.display())))?;
+    Ok(Some(StateFileSnapshot {
+        text,
+        modified: metadata.modified().ok(),
+    }))
+}
+
+pub(crate) fn read_provider_marker(path: &Path) -> io::Result<Option<StateFileSnapshot>> {
+    read_provider_marker_with_limit(path, PROVIDER_MARKER_MAX_BYTES)
+}
+
+fn read_provider_marker_with_limit(
+    path: &Path,
+    max_bytes: usize,
+) -> io::Result<Option<StateFileSnapshot>> {
+    let Some(snapshot) = read_state_text_with_limit(path, max_bytes)? else {
+        return Ok(None);
+    };
+    Ok(Some(StateFileSnapshot {
+        text: normalize_provider_id(&snapshot.text)?,
+        modified: snapshot.modified,
+    }))
+}
+
+fn validate_replace_leaf(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(()),
+        Ok(_) => Err(invalid_state(format!(
+            "agent state leaf is not a regular file: {}",
+            path.display()
+        ))),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+pub(crate) fn replace_state_text_atomically(
+    path: &Path,
+    content: &str,
+    max_bytes: usize,
+) -> io::Result<()> {
+    if content.len() > max_bytes {
+        return Err(invalid_state(format!(
+            "agent state value exceeds {max_bytes} bytes"
+        )));
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| invalid_state("agent state leaf has no parent directory"))?;
+    require_plain_directory(parent)?;
+    validate_replace_leaf(path)?;
+
+    // The leaf is published by same-directory rename, so an existing hard link
+    // is replaced rather than written through. A parent component can still be
+    // swapped between these pathname operations; RES-006 tracks the dirfd/handle
+    // redesign needed to close that remaining TOCTOU window.
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".acorn-agent-state-")
+        .suffix(".tmp")
+        .tempfile_in(parent)?;
+    #[cfg(unix)]
+    temporary
+        .as_file()
+        .set_permissions(fs::Permissions::from_mode(0o600))?;
+    temporary.as_file_mut().write_all(content.as_bytes())?;
+    temporary
+        .persist(path)
+        .map_err(|persist_error| persist_error.error)?;
+    Ok(())
+}
+
+pub(crate) fn replace_provider_marker(path: &Path, value: &str) -> io::Result<String> {
+    let normalized = normalize_provider_id(value)?;
+    replace_state_text_atomically(path, &format!("{normalized}\n"), PROVIDER_MARKER_MAX_BYTES)?;
+    Ok(normalized)
+}
+
 /// Per-Acorn-session scratch directory the resume persister writes
 /// `*.id` into. The directory is also the modal's read source.
 pub fn ensure_session_state_dir(session_id: uuid::Uuid) -> io::Result<PathBuf> {
@@ -49,8 +244,10 @@ pub fn ensure_session_state_dir(session_id: uuid::Uuid) -> io::Result<PathBuf> {
 }
 
 fn ensure_session_state_dir_at(base: &Path, session_id: uuid::Uuid) -> io::Result<PathBuf> {
-    let dir = base.join(AGENT_STATE_DIR_NAME).join(session_id.to_string());
-    fs::create_dir_all(&dir)?;
+    let root = base.join(AGENT_STATE_DIR_NAME);
+    ensure_plain_directory(&root)?;
+    let dir = root.join(session_id.to_string());
+    ensure_plain_directory(&dir)?;
     Ok(dir)
 }
 
@@ -62,8 +259,12 @@ fn session_state_dir_if_exists_at(
     base: &Path,
     session_id: uuid::Uuid,
 ) -> io::Result<Option<PathBuf>> {
-    let dir = base.join(AGENT_STATE_DIR_NAME).join(session_id.to_string());
-    Ok(if dir.is_dir() { Some(dir) } else { None })
+    let root = base.join(AGENT_STATE_DIR_NAME);
+    if !plain_directory_exists(&root)? {
+        return Ok(None);
+    }
+    let dir = root.join(session_id.to_string());
+    Ok(plain_directory_exists(&dir)?.then_some(dir))
 }
 
 /// Shape returned to the frontend modal.
@@ -145,16 +346,14 @@ fn live_transcript_at(base: &Path, session_id: uuid::Uuid) -> Option<LiveTranscr
     ]
     .into_iter()
     .filter_map(|(kind, file)| {
-        let mtime = fs::metadata(dir.join(file))
-            .and_then(|m| m.modified())
-            .ok()?;
-        Some((kind, mtime))
+        let marker = read_provider_marker(&dir.join(file)).ok().flatten()?;
+        Some((kind, marker))
     })
     .collect::<Vec<_>>();
-    markers.sort_by(|a, b| b.1.cmp(&a.1));
-    markers
-        .into_iter()
-        .find_map(|(kind, _)| live_transcript_for_kind_in_dir(&dir, kind))
+    markers.sort_by(|a, b| b.1.modified.cmp(&a.1.modified));
+    markers.into_iter().find_map(|(kind, marker)| {
+        live_transcript_for_id_with_locator(kind, marker.text, &locate_transcript)
+    })
 }
 
 fn live_transcript_for_kind_at(
@@ -182,10 +381,15 @@ fn live_transcript_for_kind_in_dir_with_locator(
         AgentKind::Codex => CODEX_ID_FILE,
         AgentKind::Antigravity => ANTIGRAVITY_ID_FILE,
     };
-    let id = fs::read_to_string(dir.join(file)).ok()?.trim().to_string();
-    if id.is_empty() {
-        return None;
-    }
+    let marker = read_provider_marker(&dir.join(file)).ok().flatten()?;
+    live_transcript_for_id_with_locator(kind, marker.text, locate)
+}
+
+fn live_transcript_for_id_with_locator(
+    kind: AgentKind,
+    id: String,
+    locate: &dyn Fn(AgentKind, &str) -> Option<PathBuf>,
+) -> Option<LiveTranscript> {
     let path = locate(kind, &id)?;
     Some(LiveTranscript { id, path, kind })
 }
@@ -212,32 +416,42 @@ fn candidate_at(
     let Some(state_dir) = session_state_dir_if_exists_at(base, session_id)? else {
         return Ok(None);
     };
-    let uuid = match fs::read_to_string(state_dir.join(id_file)) {
-        Ok(s) => s.trim().to_string(),
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => return Err(err),
+    let uuid = match read_provider_marker(&state_dir.join(id_file))? {
+        Some(marker) => marker.text,
+        None => return Ok(None),
     };
-    if uuid.is_empty() {
-        return Ok(None);
-    }
-    let acked = fs::read_to_string(state_dir.join(ack_file))
-        .map(|s| s.trim().to_string())
-        .unwrap_or_default();
-    if acked == uuid {
+    let acked = read_provider_marker(&state_dir.join(ack_file))?;
+    if acked.as_ref().map(|marker| marker.text.as_str()) == Some(uuid.as_str()) {
         return Ok(None);
     }
 
-    let transcript = locate_transcript(kind, &uuid);
-    let last_activity_unix = transcript
-        .as_ref()
-        .and_then(|p| fs::metadata(p).ok())
-        .and_then(|m| m.modified().ok())
-        .and_then(|mt| mt.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    let conversation_preview = transcript
-        .as_ref()
-        .and_then(|p| extract_conversation_preview(kind, p).ok());
+    let (last_activity_unix, conversation_preview) = if kind == AgentKind::Antigravity {
+        match open_antigravity_transcript_snapshot(&uuid) {
+            Some(snapshot) => {
+                let last_activity = snapshot
+                    .modified
+                    .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|duration| duration.as_secs())
+                    .unwrap_or(0);
+                let preview = extract_conversation_preview_from_snapshot(kind, snapshot).ok();
+                (last_activity, preview)
+            }
+            None => (0, None),
+        }
+    } else {
+        let transcript = locate_transcript(kind, &uuid);
+        let last_activity = transcript
+            .as_ref()
+            .and_then(|path| fs::metadata(path).ok())
+            .and_then(|metadata| metadata.modified().ok())
+            .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0);
+        let preview = transcript
+            .as_ref()
+            .and_then(|path| extract_conversation_preview(kind, path).ok());
+        (last_activity, preview)
+    };
     let last_user_message = conversation_preview
         .as_ref()
         .and_then(|preview| preview.last_user_message.clone());
@@ -272,19 +486,19 @@ fn acknowledge_at(
     let Some(state_dir) = session_state_dir_if_exists_at(base, session_id)? else {
         return Ok(());
     };
-    let id = match fs::read_to_string(state_dir.join(id_file)) {
-        Ok(s) => s,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(err) => return Err(err),
+    let id = match read_provider_marker(&state_dir.join(id_file))? {
+        Some(marker) => marker.text,
+        None => return Ok(()),
     };
-    fs::write(state_dir.join(ack_file), id)
+    replace_provider_marker(&state_dir.join(ack_file), &id).map(drop)
 }
 
 pub(crate) fn locate_transcript(kind: AgentKind, uuid: &str) -> Option<PathBuf> {
+    let uuid = normalize_provider_id(uuid).ok()?;
     match kind {
-        AgentKind::Claude => crate::todos::locate_transcript_for(uuid).ok().flatten(),
-        AgentKind::Codex => locate_codex_transcript(uuid),
-        AgentKind::Antigravity => locate_antigravity_transcript(uuid),
+        AgentKind::Claude => crate::todos::locate_transcript_for(&uuid).ok().flatten(),
+        AgentKind::Codex => locate_codex_transcript(&uuid),
+        AgentKind::Antigravity => locate_antigravity_transcript(&uuid),
     }
 }
 
@@ -295,17 +509,7 @@ fn locate_codex_transcript(uuid: &str) -> Option<PathBuf> {
 }
 
 fn locate_antigravity_transcript(id: &str) -> Option<PathBuf> {
-    for root in antigravity_brain_roots() {
-        let path = root
-            .join(id)
-            .join(".system_generated")
-            .join("logs")
-            .join("transcript.jsonl");
-        if path.is_file() {
-            return Some(path);
-        }
-    }
-    None
+    open_antigravity_transcript_snapshot(id).map(|snapshot| snapshot.path)
 }
 
 fn google_agent_storage_root() -> Option<PathBuf> {
@@ -315,15 +519,108 @@ fn google_agent_storage_root() -> Option<PathBuf> {
         .or_else(|| directories::UserDirs::new().map(|d| d.home_dir().join(".gemini")))
 }
 
-fn antigravity_brain_roots() -> Vec<PathBuf> {
-    let Some(root) = google_agent_storage_root() else {
+fn open_antigravity_transcript_snapshot(id: &str) -> Option<AntigravityTranscriptSnapshot> {
+    let root = google_agent_storage_root()?;
+    open_antigravity_transcript_snapshots_at(&root, id)
+        .into_iter()
+        .next()
+}
+
+pub(crate) fn open_antigravity_transcript_snapshots_at(
+    storage_root: &Path,
+    id: &str,
+) -> Vec<AntigravityTranscriptSnapshot> {
+    let Ok(id) = normalize_provider_id(id) else {
         return Vec::new();
     };
+    let Ok(storage_metadata) = fs::symlink_metadata(storage_root) else {
+        return Vec::new();
+    };
+    if !storage_metadata.file_type().is_dir() {
+        return Vec::new();
+    }
+    let Ok(canonical_storage_root) = storage_root.canonicalize() else {
+        return Vec::new();
+    };
+
+    let mut snapshots = Vec::new();
     ["antigravity", "antigravity-ide", "antigravity-cli"]
         .into_iter()
-        .map(|profile| root.join(profile).join("brain"))
-        .filter(|path| path.is_dir())
-        .collect()
+        .filter_map(|profile| {
+            let profile_dir = storage_root.join(profile);
+            if !plain_directory(&profile_dir) {
+                return None;
+            }
+            let brain_root = profile_dir.join("brain");
+            if !plain_directory(&brain_root) {
+                return None;
+            }
+            open_antigravity_transcript_in_brain_root(&brain_root, &canonical_storage_root, &id)
+        })
+        .for_each(|snapshot| snapshots.push(snapshot));
+    snapshots
+}
+
+fn plain_directory(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_dir())
+        .unwrap_or(false)
+}
+
+fn open_antigravity_transcript_in_brain_root(
+    brain_root: &Path,
+    canonical_storage_root: &Path,
+    id: &str,
+) -> Option<AntigravityTranscriptSnapshot> {
+    let canonical_brain_root = brain_root.canonicalize().ok()?;
+    if !canonical_brain_root.starts_with(canonical_storage_root) {
+        return None;
+    }
+
+    let session_dir = brain_root.join(id);
+    let generated_dir = session_dir.join(".system_generated");
+    let logs_dir = generated_dir.join("logs");
+    if ![
+        session_dir.as_path(),
+        generated_dir.as_path(),
+        logs_dir.as_path(),
+    ]
+    .into_iter()
+    .all(plain_directory)
+    {
+        return None;
+    }
+
+    let path = logs_dir.join("transcript.jsonl");
+    let path_metadata = fs::symlink_metadata(&path).ok()?;
+    if !path_metadata.file_type().is_file() {
+        return None;
+    }
+    let canonical_path = path.canonicalize().ok()?;
+    if !canonical_path.starts_with(&canonical_brain_root) {
+        return None;
+    }
+
+    let file = fs::File::open(&path).ok()?;
+    let opened_metadata = file.metadata().ok()?;
+    if !opened_metadata.file_type().is_file() {
+        return None;
+    }
+    #[cfg(unix)]
+    if path_metadata.dev() != opened_metadata.dev() || path_metadata.ino() != opened_metadata.ino()
+    {
+        return None;
+    }
+
+    // Stable links and special components are rejected before opening, and the
+    // opened leaf is identity-checked. Parent replacement between pathname
+    // operations remains the RES-006 dirfd/handle-relative TOCTOU follow-up.
+    Some(AntigravityTranscriptSnapshot {
+        path: canonical_path,
+        file,
+        len: opened_metadata.len(),
+        modified: opened_metadata.modified().ok(),
+    })
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -354,6 +651,37 @@ pub(crate) fn extract_conversation_preview(
         preview.last_agent_message = preview.last_agent_message.or(recovered.last_agent_message);
     }
     Ok(preview)
+}
+
+fn extract_conversation_preview_from_snapshot(
+    kind: AgentKind,
+    snapshot: AntigravityTranscriptSnapshot,
+) -> io::Result<ConversationPreview> {
+    let AntigravityTranscriptSnapshot { mut file, len, .. } = snapshot;
+    let (tail, read_full) = read_preview_tail(&mut file, len, PREVIEW_TAIL_BYTES)?;
+    let mut preview = scan_conversation_preview(kind, &tail);
+    if preview.last_user_message.is_none() && !read_full {
+        let (wider, _) = read_preview_tail(&mut file, len, PREVIEW_MAX_TAIL_BYTES)?;
+        let recovered = scan_conversation_preview(kind, &wider);
+        preview.last_user_message = recovered.last_user_message;
+        preview.last_agent_message = preview.last_agent_message.or(recovered.last_agent_message);
+    }
+    Ok(preview)
+}
+
+fn read_preview_tail(file: &mut fs::File, len: u64, max_bytes: u64) -> io::Result<(String, bool)> {
+    if max_bytes == 0 {
+        return Ok((String::new(), false));
+    }
+    let start = len.saturating_sub(max_bytes);
+    file.seek(SeekFrom::Start(start))?;
+    let read_limit = max_bytes.min(len);
+    let mut bytes = Vec::with_capacity(read_limit as usize);
+    Read::take(file, read_limit).read_to_end(&mut bytes)?;
+    Ok((
+        String::from_utf8_lossy(&bytes).into_owned(),
+        len <= max_bytes,
+    ))
 }
 
 fn scan_conversation_preview(kind: AgentKind, text: &str) -> ConversationPreview {
@@ -419,6 +747,296 @@ mod tests {
         let dir = base.join(AGENT_STATE_DIR_NAME).join(sid.to_string());
         fs::create_dir_all(&dir).unwrap();
         fs::write(dir.join(file), body).unwrap();
+    }
+
+    fn write_antigravity_transcript(storage_root: &Path, id: &str, body: &str) -> PathBuf {
+        let path = storage_root
+            .join("antigravity/brain")
+            .join(id)
+            .join(".system_generated/logs/transcript.jsonl");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn provider_ids_are_normalized_and_path_shaped_values_are_rejected() {
+        assert_eq!(
+            normalize_provider_id("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE").unwrap(),
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        );
+        assert_eq!(
+            normalize_provider_id("aaaaaaaabbbbccccddddeeeeeeeeeeee").unwrap(),
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        );
+
+        for invalid in [
+            "",
+            "not-a-uuid",
+            "../aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "/tmp/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        ] {
+            assert!(
+                normalize_provider_id(invalid).is_err(),
+                "accepted {invalid:?}"
+            );
+            assert!(locate_transcript(AgentKind::Antigravity, invalid).is_none());
+        }
+    }
+
+    #[test]
+    fn provider_marker_reader_enforces_injected_byte_limit_for_id_and_ack() {
+        let base = ScratchDir::new("marker-limit");
+        let id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        for file in [CLAUDE_ID_FILE, CLAUDE_ID_ACK_FILE] {
+            let path = base.path().join(file);
+            fs::write(&path, id).unwrap();
+            assert_eq!(
+                read_provider_marker_with_limit(&path, id.len())
+                    .unwrap()
+                    .unwrap()
+                    .text,
+                id
+            );
+
+            fs::write(&path, format!("{id}\n")).unwrap();
+            assert!(read_provider_marker_with_limit(&path, id.len()).is_err());
+        }
+    }
+
+    #[test]
+    fn antigravity_snapshot_reads_preview_from_valid_opened_leaf() {
+        let storage = ScratchDir::new("antigravity-secure-preview");
+        let id = "17f38e8c-3a7e-408b-8c79-aef7432c0fd2";
+        let path = write_antigravity_transcript(
+            storage.path(),
+            id,
+            r#"{"type":"USER_INPUT","status":"DONE","content":"<USER_REQUEST>Secure this lookup.</USER_REQUEST>"}
+{"type":"PLANNER_RESPONSE","status":"DONE","content":"The opened snapshot is bounded."}
+"#,
+        );
+
+        let mut snapshots = open_antigravity_transcript_snapshots_at(storage.path(), id);
+        assert_eq!(snapshots.len(), 1);
+        let snapshot = snapshots.pop().unwrap();
+        assert_eq!(snapshot.path, path.canonicalize().unwrap());
+        let preview =
+            extract_conversation_preview_from_snapshot(AgentKind::Antigravity, snapshot).unwrap();
+        assert_eq!(
+            preview.last_user_message.as_deref(),
+            Some("Secure this lookup.")
+        );
+        assert_eq!(
+            preview.last_agent_message.as_deref(),
+            Some("The opened snapshot is bounded.")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn antigravity_snapshot_rejects_symlinked_storage_and_brain_roots() {
+        use std::os::unix::fs::symlink;
+
+        let id = "17f38e8c-3a7e-408b-8c79-aef7432c0fd2";
+        let outside = ScratchDir::new("antigravity-root-sentinel");
+        let sentinel = write_antigravity_transcript(outside.path(), id, "sentinel\n");
+
+        let configured = ScratchDir::new("antigravity-linked-storage");
+        let linked_storage = configured.path().join("storage");
+        symlink(outside.path(), &linked_storage).unwrap();
+        assert!(open_antigravity_transcript_snapshots_at(&linked_storage, id).is_empty());
+
+        let storage = ScratchDir::new("antigravity-linked-brain");
+        let profile = storage.path().join("antigravity");
+        fs::create_dir(&profile).unwrap();
+        symlink(
+            outside.path().join("antigravity/brain"),
+            profile.join("brain"),
+        )
+        .unwrap();
+        assert!(open_antigravity_transcript_snapshots_at(storage.path(), id).is_empty());
+        assert_eq!(fs::read_to_string(sentinel).unwrap(), "sentinel\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn antigravity_snapshot_rejects_symlinked_session_and_internal_components() {
+        use std::os::unix::fs::symlink;
+
+        let id = "17f38e8c-3a7e-408b-8c79-aef7432c0fd2";
+
+        let storage = ScratchDir::new("antigravity-linked-session");
+        let brain = storage.path().join("antigravity/brain");
+        fs::create_dir_all(&brain).unwrap();
+        let outside = ScratchDir::new("antigravity-session-sentinel");
+        let outside_transcript = write_antigravity_transcript(outside.path(), id, "session\n");
+        symlink(
+            outside.path().join("antigravity/brain").join(id),
+            brain.join(id),
+        )
+        .unwrap();
+        assert!(open_antigravity_transcript_snapshots_at(storage.path(), id).is_empty());
+        assert_eq!(fs::read_to_string(outside_transcript).unwrap(), "session\n");
+
+        let storage = ScratchDir::new("antigravity-linked-generated");
+        let session = storage.path().join("antigravity/brain").join(id);
+        fs::create_dir_all(&session).unwrap();
+        let outside = ScratchDir::new("antigravity-generated-sentinel");
+        let generated = outside.path().join(".system_generated");
+        fs::create_dir_all(generated.join("logs")).unwrap();
+        let sentinel = generated.join("logs/transcript.jsonl");
+        fs::write(&sentinel, "generated\n").unwrap();
+        symlink(&generated, session.join(".system_generated")).unwrap();
+        assert!(open_antigravity_transcript_snapshots_at(storage.path(), id).is_empty());
+        assert_eq!(fs::read_to_string(sentinel).unwrap(), "generated\n");
+
+        let storage = ScratchDir::new("antigravity-linked-logs");
+        let generated = storage
+            .path()
+            .join("antigravity/brain")
+            .join(id)
+            .join(".system_generated");
+        fs::create_dir_all(&generated).unwrap();
+        let outside = ScratchDir::new("antigravity-logs-sentinel");
+        let sentinel = outside.path().join("transcript.jsonl");
+        fs::write(&sentinel, "logs\n").unwrap();
+        symlink(outside.path(), generated.join("logs")).unwrap();
+        assert!(open_antigravity_transcript_snapshots_at(storage.path(), id).is_empty());
+        assert_eq!(fs::read_to_string(sentinel).unwrap(), "logs\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn antigravity_snapshot_rejects_symlinked_transcript_leaf() {
+        use std::os::unix::fs::symlink;
+
+        let storage = ScratchDir::new("antigravity-linked-transcript");
+        let id = "17f38e8c-3a7e-408b-8c79-aef7432c0fd2";
+        let leaf = storage
+            .path()
+            .join("antigravity/brain")
+            .join(id)
+            .join(".system_generated/logs/transcript.jsonl");
+        fs::create_dir_all(leaf.parent().unwrap()).unwrap();
+        let sentinel = storage.path().join("transcript-sentinel");
+        fs::write(&sentinel, "leaf\n").unwrap();
+        symlink(&sentinel, &leaf).unwrap();
+
+        assert!(open_antigravity_transcript_snapshots_at(storage.path(), id).is_empty());
+        assert_eq!(fs::read_to_string(sentinel).unwrap(), "leaf\n");
+    }
+
+    #[test]
+    fn candidate_rejects_oversized_or_invalid_provider_markers() {
+        let base = ScratchDir::new("invalid-marker");
+        let sid = uuid::Uuid::new_v4();
+        write_id(
+            base.path(),
+            sid,
+            CLAUDE_ID_FILE,
+            &"x".repeat(PROVIDER_MARKER_MAX_BYTES + 1),
+        );
+        assert!(candidate_at(
+            base.path(),
+            sid,
+            CLAUDE_ID_FILE,
+            CLAUDE_ID_ACK_FILE,
+            AgentKind::Claude,
+        )
+        .is_err());
+
+        write_id(base.path(), sid, CLAUDE_ID_FILE, "../outside");
+        assert!(candidate_at(
+            base.path(),
+            sid,
+            CLAUDE_ID_FILE,
+            CLAUDE_ID_ACK_FILE,
+            AgentKind::Claude,
+        )
+        .is_err());
+
+        write_id(
+            base.path(),
+            sid,
+            CLAUDE_ID_FILE,
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        );
+        write_id(
+            base.path(),
+            sid,
+            CLAUDE_ID_ACK_FILE,
+            &"x".repeat(PROVIDER_MARKER_MAX_BYTES + 1),
+        );
+        assert!(candidate_at(
+            base.path(),
+            sid,
+            CLAUDE_ID_FILE,
+            CLAUDE_ID_ACK_FILE,
+            AgentKind::Claude,
+        )
+        .is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_agent_state_directories_are_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let base = ScratchDir::new("linked-state-root");
+        let outside = ScratchDir::new("linked-state-outside");
+        symlink(outside.path(), base.path().join(AGENT_STATE_DIR_NAME)).unwrap();
+        let sid = uuid::Uuid::new_v4();
+        assert!(ensure_session_state_dir_at(base.path(), sid).is_err());
+        assert!(!outside.path().join(sid.to_string()).exists());
+
+        let base = ScratchDir::new("linked-session-dir");
+        let root = base.path().join(AGENT_STATE_DIR_NAME);
+        fs::create_dir(&root).unwrap();
+        symlink(outside.path(), root.join(sid.to_string())).unwrap();
+        assert!(ensure_session_state_dir_at(base.path(), sid).is_err());
+        assert!(session_state_dir_if_exists_at(base.path(), sid).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_marker_and_ack_leaves_never_touch_their_sentinel() {
+        use std::os::unix::fs::symlink;
+
+        let base = ScratchDir::new("linked-marker");
+        let sid = uuid::Uuid::new_v4();
+        let state_dir = ensure_session_state_dir_at(base.path(), sid).unwrap();
+        let sentinel = base.path().join("sentinel");
+        fs::write(&sentinel, "do not change").unwrap();
+
+        symlink(&sentinel, state_dir.join(CLAUDE_ID_FILE)).unwrap();
+        assert!(candidate_at(
+            base.path(),
+            sid,
+            CLAUDE_ID_FILE,
+            CLAUDE_ID_ACK_FILE,
+            AgentKind::Claude,
+        )
+        .is_err());
+        assert!(acknowledge_at(base.path(), sid, CLAUDE_ID_FILE, CLAUDE_ID_ACK_FILE).is_err());
+        assert_eq!(fs::read_to_string(&sentinel).unwrap(), "do not change");
+
+        fs::remove_file(state_dir.join(CLAUDE_ID_FILE)).unwrap();
+        fs::write(
+            state_dir.join(CLAUDE_ID_FILE),
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\n",
+        )
+        .unwrap();
+        symlink(&sentinel, state_dir.join(CLAUDE_ID_ACK_FILE)).unwrap();
+        assert!(candidate_at(
+            base.path(),
+            sid,
+            CLAUDE_ID_FILE,
+            CLAUDE_ID_ACK_FILE,
+            AgentKind::Claude,
+        )
+        .is_err());
+        assert!(acknowledge_at(base.path(), sid, CLAUDE_ID_FILE, CLAUDE_ID_ACK_FILE).is_err());
+        assert_eq!(fs::read_to_string(&sentinel).unwrap(), "do not change");
     }
 
     #[test]

--- a/src-tauri/src/agent_resume_persister.rs
+++ b/src-tauri/src/agent_resume_persister.rs
@@ -143,9 +143,11 @@ fn tick(state: &AppState) -> io::Result<()> {
         };
         if let Some(cwd_file) = cwd_filename(kind) {
             if let Some(cwd) = session_cwds.get(&session_id) {
-                if let Err(err) =
-                    write_if_changed(&state_dir.join(cwd_file), &format!("{}\n", cwd.display()))
-                {
+                if let Err(err) = write_if_changed(
+                    &state_dir.join(cwd_file),
+                    &format!("{}\n", cwd.display()),
+                    agent_resume::AGENT_CWD_MAX_BYTES,
+                ) {
                     tracing::warn!(
                         %session_id, ?kind, error = %err,
                         "agent_resume_persister: cwd write failed"
@@ -222,12 +224,14 @@ fn bind_marker_in_state_dir_with_policy(
     uuid: &str,
     policy: MarkerBindPolicy,
 ) -> io::Result<()> {
+    let uuid = agent_resume::normalize_provider_id(uuid)?;
+    agent_resume::validate_state_directory(state_dir)?;
     let _guard = marker_bind_lock()
         .lock()
         .unwrap_or_else(PoisonError::into_inner);
     let id_file = state_dir.join(id_filename(kind));
-    let previous = read_trimmed(&id_file);
-    if previous.as_deref() == Some(uuid) {
+    let previous = agent_resume::read_provider_marker(&id_file)?.map(|marker| marker.text);
+    if previous.as_deref() == Some(uuid.as_str()) {
         return Ok(());
     }
     // A backwards move (to an earlier-born transcript) is legitimate
@@ -236,12 +240,12 @@ fn bind_marker_in_state_dir_with_policy(
     // scan can echo the abandoned original once the new transcript
     // goes idle; writing that echo would oscillate the marker. Skip
     // only the dormant-echo case so the marker never flaps.
-    if marker_update_is_blocked(policy, previous.as_deref(), uuid, |prev, next| {
+    if marker_update_is_blocked(policy, previous.as_deref(), &uuid, |prev, next| {
         marker_rollback_is_dormant_echo(kind, prev, next)
     }) {
         return Ok(());
     }
-    write_if_changed(&id_file, &format!("{uuid}\n"))
+    agent_resume::replace_provider_marker(&id_file, &uuid).map(drop)
 }
 
 fn marker_update_is_blocked<F>(
@@ -360,20 +364,35 @@ fn rollback_is_dormant_echo(prev: &Path, next: &Path, now: SystemTime) -> bool {
         .unwrap_or(false)
 }
 
-fn write_if_changed(path: &PathBuf, content: &str) -> io::Result<()> {
-    if fs::read_to_string(path).ok().as_deref() == Some(content) {
+fn write_if_changed(path: &Path, content: &str, max_bytes: usize) -> io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "agent state leaf has no parent directory",
+        )
+    })?;
+    agent_resume::validate_state_directory(parent)?;
+    if agent_resume::read_state_text_with_limit(path, max_bytes)?
+        .as_ref()
+        .map(|snapshot| snapshot.text.as_str())
+        == Some(content)
+    {
         return Ok(());
     }
-    fs::write(path, content)
-}
-
-fn read_trimmed(path: &PathBuf) -> Option<String> {
-    fs::read_to_string(path).ok().map(|s| s.trim().to_string())
+    agent_resume::replace_state_text_atomically(path, content, max_bytes)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+
+    fn read_marker(path: &Path) -> Option<String> {
+        agent_resume::read_provider_marker(path)
+            .ok()
+            .flatten()
+            .map(|marker| marker.text)
+    }
 
     fn session_with_id(id: Uuid) -> Session {
         let mut session = Session::new(
@@ -444,12 +463,12 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            read_trimmed(&marker).as_deref(),
+            read_marker(&marker).as_deref(),
             Some("019e2001-aaaa-76b0-8410-2e073b38a2c1"),
             "first bind must create the marker"
         );
 
-        let mtime_before = fs::metadata(&marker).unwrap().modified().unwrap();
+        let metadata_before = fs::metadata(&marker).unwrap();
         bind_marker_in_state_dir(
             &dir,
             AgentKind::Codex,
@@ -458,9 +477,17 @@ mod tests {
         .unwrap();
         assert_eq!(
             fs::metadata(&marker).unwrap().modified().unwrap(),
-            mtime_before,
+            metadata_before.modified().unwrap(),
             "same-uuid rebind must not rewrite the marker"
         );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+            let metadata_after = fs::metadata(&marker).unwrap();
+            assert_eq!(metadata_after.ino(), metadata_before.ino());
+            assert_eq!(metadata_after.permissions().mode() & 0o777, 0o600);
+        }
 
         bind_marker_in_state_dir(
             &dir,
@@ -469,9 +496,121 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            read_trimmed(&marker).as_deref(),
+            read_marker(&marker).as_deref(),
             Some("019e2001-bbbb-76b0-8410-2e073b38a2c2"),
             "a new uuid must replace the marker"
+        );
+        assert!(fs::read_dir(&dir).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".acorn-agent-state-")
+        }));
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn bind_marker_validates_ids_before_creating_a_leaf() {
+        let dir =
+            std::env::temp_dir().join(format!("acorn-bindbad-{}", uuid::Uuid::new_v4().simple()));
+        fs::create_dir_all(&dir).unwrap();
+
+        for invalid in [
+            "not-a-uuid",
+            "../019e2001-aaaa-76b0-8410-2e073b38a2c1",
+            "/tmp/019e2001-aaaa-76b0-8410-2e073b38a2c1",
+            &"x".repeat(agent_resume::PROVIDER_MARKER_MAX_BYTES + 1),
+        ] {
+            assert!(bind_marker_in_state_dir(&dir, AgentKind::Codex, invalid).is_err());
+            assert!(!dir.join("codex.id").exists());
+        }
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn atomic_state_writer_honors_an_injected_limit_and_is_idempotent() {
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-statewrite-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("antigravity.cwd");
+
+        write_if_changed(&path, "abcd", 4).unwrap();
+        let before = fs::metadata(&path).unwrap();
+        write_if_changed(&path, "abcd", 4).unwrap();
+        let after = fs::metadata(&path).unwrap();
+        assert_eq!(before.modified().unwrap(), after.modified().unwrap());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+            assert_eq!(before.ino(), after.ino());
+            assert_eq!(after.permissions().mode() & 0o777, 0o600);
+        }
+        assert!(write_if_changed(&path, "abcde", 4).is_err());
+        assert_eq!(fs::read_to_string(&path).unwrap(), "abcd");
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn marker_writer_rejects_symlink_and_replaces_hardlink_without_clobbering_sentinel() {
+        use std::os::unix::fs::symlink;
+
+        let dir =
+            std::env::temp_dir().join(format!("acorn-bindlink-{}", uuid::Uuid::new_v4().simple()));
+        fs::create_dir_all(&dir).unwrap();
+        let marker = dir.join("codex.id");
+        let sentinel = dir.join("sentinel");
+        let sentinel_body = "019e2001-bbbb-76b0-8410-2e073b38a2c2\n";
+        fs::write(&sentinel, sentinel_body).unwrap();
+
+        symlink(&sentinel, &marker).unwrap();
+        assert!(bind_marker_in_state_dir(
+            &dir,
+            AgentKind::Codex,
+            "019e2001-aaaa-76b0-8410-2e073b38a2c1",
+        )
+        .is_err());
+        assert_eq!(fs::read_to_string(&sentinel).unwrap(), sentinel_body);
+
+        fs::remove_file(&marker).unwrap();
+        fs::hard_link(&sentinel, &marker).unwrap();
+        bind_marker_in_state_dir(
+            &dir,
+            AgentKind::Codex,
+            "019e2001-aaaa-76b0-8410-2e073b38a2c1",
+        )
+        .unwrap();
+        assert_eq!(fs::read_to_string(&sentinel).unwrap(), sentinel_body);
+        assert_eq!(
+            read_marker(&marker).as_deref(),
+            Some("019e2001-aaaa-76b0-8410-2e073b38a2c1")
+        );
+
+        let outside_state = dir.join("outside-state");
+        let linked_state = dir.join("linked-state");
+        fs::create_dir(&outside_state).unwrap();
+        fs::write(
+            outside_state.join("codex.id"),
+            "019e2001-aaaa-76b0-8410-2e073b38a2c1\n",
+        )
+        .unwrap();
+        symlink(&outside_state, &linked_state).unwrap();
+        assert!(bind_marker_in_state_dir(
+            &linked_state,
+            AgentKind::Codex,
+            "019e2001-aaaa-76b0-8410-2e073b38a2c1",
+        )
+        .is_err());
+        assert_eq!(
+            fs::read_to_string(outside_state.join("codex.id")).unwrap(),
+            "019e2001-aaaa-76b0-8410-2e073b38a2c1\n"
         );
 
         fs::remove_dir_all(&dir).unwrap();
@@ -504,7 +643,7 @@ mod tests {
 
         bind_provider_marker_in_state_dir(&dir, AgentKind::Claude, resumed).unwrap();
 
-        assert_eq!(read_trimmed(&marker).as_deref(), Some(resumed));
+        assert_eq!(read_marker(&marker).as_deref(), Some(resumed));
         fs::remove_dir_all(&dir).unwrap();
     }
 
@@ -535,7 +674,7 @@ mod tests {
             handle.join().unwrap();
         }
 
-        let survivor = read_trimmed(&dir.join("codex.id"));
+        let survivor = read_marker(&dir.join("codex.id"));
         assert!(
             survivor.as_deref() == Some(a) || survivor.as_deref() == Some(b),
             "marker must hold one intact uuid, got {survivor:?}"

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -132,7 +132,7 @@ if [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
   # A read/write FIFO descriptor is held only by this wrapper. The watcher
   # closes its inherited copy and blocks on the read end, so wrapper exit is
   # delivered by kernel EOF without a polling process.
-  if ! _acorn_lifetime_dir=$(umask 077; mktemp -d "${TMPDIR:-/tmp}/acorn-codex-watch.XXXXXX"); then
+  if ! _acorn_lifetime_dir=$(umask 077; mktemp -d "$ACORN_AGENT_WRAPPER_DIR/codex-session.XXXXXX"); then
     _acorn_run_codex "$@"
     exit $?
   fi
@@ -231,6 +231,9 @@ if [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
   exec 9>&-
 
   if [ -n "${ACORN_CODEX_WATCHER_PID-}" ]; then
+    # The watcher owns a `tail | while` pipeline. Stop its direct children
+    # first so they cannot survive the wrapper as orphaned background jobs.
+    pkill -TERM -P "$ACORN_CODEX_WATCHER_PID" >/dev/null 2>&1 || true
     kill "$ACORN_CODEX_WATCHER_PID" >/dev/null 2>&1 || true
     wait "$ACORN_CODEX_WATCHER_PID" 2>/dev/null || true
   fi
@@ -357,7 +360,7 @@ if [ "$raw_contract" = "1" ]; then
   fi
   printf '%s' "$input" | curl -sf --connect-timeout 1 --max-time 1 -X POST \
     -H 'Content-Type: application/json' \
-    -H "X-Acorn-Agent-Hook-Token: $hook_token" \
+    -H @/dev/fd/3 \
     -H 'X-Acorn-Agent-Hook-Provider: codex' \
     -H "X-Acorn-Agent-Hook-Session-Id: $ACORN_AGENT_HOOK_SESSION_ID" \
     -H "X-Acorn-Agent-Hook-Source: $source" \
@@ -365,7 +368,9 @@ if [ "$raw_contract" = "1" ]; then
     -H "X-Acorn-Codex-Version: ${ACORN_CODEX_VERSION-unknown}" \
     -H "X-Acorn-Codex-Native-Hooks-Enabled: ${ACORN_CODEX_NATIVE_HOOKS_ENABLED-0}" \
     --data-binary @- \
-    "$hook_url" >/dev/null 2>&1 || _acorn_spool_event
+    "$hook_url" 3<<EOF >/dev/null 2>&1 || _acorn_spool_event
+X-Acorn-Agent-Hook-Token: $hook_token
+EOF
   exit 0
 fi
 
@@ -389,9 +394,11 @@ if [ -z "$hook_url" ] || [ -z "$hook_token" ]; then
 fi
 printf '%s' "$payload" | curl -sf --connect-timeout 1 --max-time 1 -X POST \
   -H 'Content-Type: application/json' \
-  -H "X-Acorn-Agent-Hook-Token: $hook_token" \
+  -H @/dev/fd/3 \
   --data-binary @- \
-  "$hook_url" >/dev/null 2>&1 || _acorn_spool_event
+  "$hook_url" 3<<EOF >/dev/null 2>&1 || _acorn_spool_event
+X-Acorn-Agent-Hook-Token: $hook_token
+EOF
 "#;
 
 // Claude Code wrapper.
@@ -546,12 +553,14 @@ fi
 
 printf '%s' "$input" | curl -sf --connect-timeout 1 --max-time 1 -X POST \
   -H 'Content-Type: application/json' \
-  -H "X-Acorn-Agent-Hook-Token: $hook_token" \
+  -H @/dev/fd/3 \
   -H 'X-Acorn-Agent-Hook-Provider: claude' \
   -H "X-Acorn-Agent-Hook-Session-Id: $ACORN_AGENT_HOOK_SESSION_ID" \
   -H 'X-Acorn-Agent-Hook-Source: native' \
   --data-binary @- \
-  "$hook_url" >/dev/null 2>&1 || _acorn_spool_event
+  "$hook_url" 3<<EOF >/dev/null 2>&1 || _acorn_spool_event
+X-Acorn-Agent-Hook-Token: $hook_token
+EOF
 "#;
 
 const ANTIGRAVITY_WRAPPER_BODY: &str = r#"#!/bin/sh
@@ -885,11 +894,13 @@ if [ -z "$hook_url" ] || [ -z "$hook_token" ]; then
   _acorn_spool_event
   exit 0
 fi
-curl -sf --connect-timeout 1 --max-time 1 -X POST \
+printf '%s' "$payload" | curl -sf --connect-timeout 1 --max-time 1 -X POST \
   -H 'Content-Type: application/json' \
-  -H "X-Acorn-Agent-Hook-Token: $hook_token" \
-  -d "$payload" \
-  "$hook_url" >/dev/null 2>&1 || _acorn_spool_event
+  -H @/dev/fd/3 \
+  --data-binary @- \
+  "$hook_url" 3<<EOF >/dev/null 2>&1 || _acorn_spool_event
+X-Acorn-Agent-Hook-Token: $hook_token
+EOF
 "#;
 
 pub fn ensure_agent_wrapper_dir() -> io::Result<PathBuf> {
@@ -2308,6 +2319,8 @@ done
         assert!(wrapper.contains(
             "unset CODEX_TUI_RECORD_SESSION CODEX_TUI_SESSION_LOG_PATH ACORN_CODEX_NATIVE_HOOKS_ENABLED"
         ));
+        assert!(wrapper.contains("mktemp -d \"$ACORN_AGENT_WRAPPER_DIR/codex-session.XXXXXX\""));
+        assert!(!wrapper.contains("${TMPDIR:-/tmp}/acorn-codex-session"));
         assert!(wrapper.contains("ACORN_AGENT_HOOK_URL"));
         assert!(wrapper.contains("\"$_acorn_notify\" \"\" jsonl_user"));
         assert!(wrapper.contains("\"$_acorn_notify\" \"\" jsonl_task"));
@@ -2873,6 +2886,63 @@ done
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn codex_wrapper_uses_and_cleans_up_a_private_session_log() {
+        let base = ScratchDir::new("codex-private-log");
+        let wrapper_dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
+        let real_dir = base.path().join("real-bin");
+        let public_tmp = base.path().join("public-tmp");
+        fs::create_dir_all(&real_dir).unwrap();
+        fs::create_dir_all(&public_tmp).unwrap();
+        let capture = base.path().join("capture.txt");
+        write_executable(
+            &real_dir.join("codex"),
+            r#"#!/bin/sh
+printf '%s\n' "$CODEX_TUI_SESSION_LOG_PATH" > "$ACORN_TEST_CAPTURE"
+(stat -f %Lp "$CODEX_TUI_SESSION_LOG_PATH" 2>/dev/null || stat -c %a "$CODEX_TUI_SESSION_LOG_PATH") >> "$ACORN_TEST_CAPTURE"
+(stat -f %Lp "${CODEX_TUI_SESSION_LOG_PATH%/*}" 2>/dev/null || stat -c %a "${CODEX_TUI_SESSION_LOG_PATH%/*}") >> "$ACORN_TEST_CAPTURE"
+printf '{}\n' >> "$CODEX_TUI_SESSION_LOG_PATH"
+"#,
+        )
+        .unwrap();
+
+        let path = format!(
+            "{}:{}:/usr/bin:/bin",
+            wrapper_dir.display(),
+            real_dir.display()
+        );
+        let output = Command::new(wrapper_dir.join("codex"))
+            .env("PATH", path)
+            .env("TMPDIR", &public_tmp)
+            .env("ACORN_AGENT_WRAPPER_DIR", &wrapper_dir)
+            .env("ACORN_AGENT_HOOK_SESSION_ID", "session-1")
+            .env("ACORN_AGENT_HOOK_URL", "http://127.0.0.1:9/agent-hook")
+            .env("ACORN_AGENT_HOOK_TOKEN", "test-token")
+            .env("ACORN_TEST_CAPTURE", &capture)
+            .env_remove("CODEX_TUI_SESSION_LOG_PATH")
+            .output()
+            .expect("run Codex wrapper");
+
+        assert!(
+            output.status.success(),
+            "wrapper failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let captured = fs::read_to_string(&capture).expect("read capture");
+        let mut lines = captured.lines();
+        let log_path = PathBuf::from(lines.next().expect("captured log path"));
+        assert!(log_path.starts_with(&wrapper_dir));
+        assert!(!log_path.starts_with(&public_tmp));
+        assert_eq!(lines.next(), Some("600"));
+        assert_eq!(lines.next(), Some("700"));
+        assert!(!log_path.exists(), "generated log should be removed");
+        assert!(
+            !log_path.parent().expect("log parent").exists(),
+            "generated private directory should be removed"
+        );
+    }
+
     #[test]
     fn wrappers_skip_their_own_dir_when_wrapper_env_is_absent() {
         let base = ScratchDir::new("self-skip");
@@ -3318,6 +3388,92 @@ done
             // Env fallback stays for the no-file case.
             assert!(notify.contains("hook_url=\"${ACORN_AGENT_HOOK_URL-}\""));
             assert!(notify.contains("hook_token=\"${ACORN_AGENT_HOOK_TOKEN-}\""));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn notify_scripts_stream_hook_token_to_curl_header_fd() {
+        use std::io::Write;
+        use std::process::Stdio;
+
+        const HOOK_URL: &str = "http://127.0.0.1:12345/agent-hook";
+        const HOOK_TOKEN: &str = "sentinel-hook-token-never-in-argv";
+
+        let base = ScratchDir::new("notify-token-stdin");
+        let dir = ensure_agent_wrapper_dir_at(base.path()).unwrap();
+        write_agent_hook_endpoint_at(&dir, HOOK_URL, HOOK_TOKEN).unwrap();
+
+        let fake_bin = base.path().join("fake-bin");
+        fs::create_dir_all(&fake_bin).unwrap();
+        write_executable(
+            &fake_bin.join("curl"),
+            r#"#!/bin/sh
+printf '%s\n' "$@" > "$ACORN_TEST_CURL_ARGV"
+cat <&3 > "$ACORN_TEST_CURL_STDIN"
+cat >/dev/null
+"#,
+        )
+        .unwrap();
+
+        let path = format!("{}:/usr/bin:/bin", fake_bin.display());
+        for (name, arg, input) in [
+            ("acorn-codex-notify", Some("start"), ""),
+            (
+                "acorn-claude-notify",
+                None,
+                r#"{"hook_event_name":"SessionStart"}"#,
+            ),
+            ("acorn-antigravity-notify", Some("start"), ""),
+        ] {
+            let argv_capture = base.path().join(format!("{name}.argv"));
+            let stdin_capture = base.path().join(format!("{name}.stdin"));
+            let mut command = Command::new(dir.join(name));
+            command
+                .env("PATH", &path)
+                .env("ACORN_AGENT_WRAPPER_DIR", &dir)
+                .env("ACORN_AGENT_HOOK_SESSION_ID", "session-1")
+                .env("ACORN_TEST_CURL_ARGV", &argv_capture)
+                .env("ACORN_TEST_CURL_STDIN", &stdin_capture)
+                .env_remove("ACORN_AGENT_HOOK_URL")
+                .env_remove("ACORN_AGENT_HOOK_TOKEN")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            if let Some(arg) = arg {
+                command.arg(arg);
+            }
+
+            let mut child = command.spawn().expect("run notify script");
+            child
+                .stdin
+                .take()
+                .expect("notify stdin")
+                .write_all(input.as_bytes())
+                .expect("write notify input");
+            let output = child.wait_with_output().expect("wait for notify script");
+            assert!(
+                output.status.success(),
+                "{name} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+
+            let argv = fs::read_to_string(&argv_capture).expect("read curl argv");
+            let header_stream =
+                fs::read_to_string(&stdin_capture).expect("read curl header stream");
+            assert!(
+                !argv.contains(HOOK_TOKEN),
+                "{name} exposed the hook token in curl argv: {argv}"
+            );
+            assert!(
+                argv.lines().any(|arg| arg == "@/dev/fd/3"),
+                "{name} must ask curl to read the secret header from a descriptor: {argv}"
+            );
+            assert_eq!(
+                header_stream,
+                format!("X-Acorn-Agent-Hook-Token: {HOOK_TOKEN}\n"),
+                "{name} must stream the token header to curl without argv exposure"
+            );
         }
     }
 

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -2899,9 +2899,23 @@ done
         write_executable(
             &real_dir.join("codex"),
             r#"#!/bin/sh
+if [ "${1-}" = "--version" ]; then
+  printf 'codex-cli 0.144.4\n'
+  exit 0
+fi
+for _acorn_arg in "$@"; do
+  [ "$_acorn_arg" = "features" ] && exit 0
+done
+_acorn_mode() {
+  if stat -f '%Lp' "$1" >/dev/null 2>&1; then
+    stat -f '%Lp' "$1"
+  else
+    stat -c '%a' "$1"
+  fi
+}
 printf '%s\n' "$CODEX_TUI_SESSION_LOG_PATH" > "$ACORN_TEST_CAPTURE"
-(stat -f %Lp "$CODEX_TUI_SESSION_LOG_PATH" 2>/dev/null || stat -c %a "$CODEX_TUI_SESSION_LOG_PATH") >> "$ACORN_TEST_CAPTURE"
-(stat -f %Lp "${CODEX_TUI_SESSION_LOG_PATH%/*}" 2>/dev/null || stat -c %a "${CODEX_TUI_SESSION_LOG_PATH%/*}") >> "$ACORN_TEST_CAPTURE"
+_acorn_mode "$CODEX_TUI_SESSION_LOG_PATH" >> "$ACORN_TEST_CAPTURE"
+_acorn_mode "${CODEX_TUI_SESSION_LOG_PATH%/*}" >> "$ACORN_TEST_CAPTURE"
 printf '{}\n' >> "$CODEX_TUI_SESSION_LOG_PATH"
 "#,
         )
@@ -2919,6 +2933,7 @@ printf '{}\n' >> "$CODEX_TUI_SESSION_LOG_PATH"
             .env("ACORN_AGENT_HOOK_SESSION_ID", "session-1")
             .env("ACORN_AGENT_HOOK_URL", "http://127.0.0.1:9/agent-hook")
             .env("ACORN_AGENT_HOOK_TOKEN", "test-token")
+            .env("ACORN_AGENT_INVOCATION_ROOT", "1")
             .env("ACORN_TEST_CAPTURE", &capture)
             .env_remove("CODEX_TUI_SESSION_LOG_PATH")
             .output()
@@ -3433,6 +3448,8 @@ cat >/dev/null
                 .env("PATH", &path)
                 .env("ACORN_AGENT_WRAPPER_DIR", &dir)
                 .env("ACORN_AGENT_HOOK_SESSION_ID", "session-1")
+                .env("ACORN_AGENT_INVOCATION_TOKEN", "owner-invocation")
+                .env("ACORN_AGENT_INVOCATION_DEPTH", "1")
                 .env("ACORN_TEST_CURL_ARGV", &argv_capture)
                 .env("ACORN_TEST_CURL_STDIN", &stdin_capture)
                 .env_remove("ACORN_AGENT_HOOK_URL")

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
-use std::io::{self, BufRead};
+use std::io::{self, Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
@@ -39,6 +39,20 @@ const CHAT_SESSION_STATE_CHANGED_EVENT: &str = "acorn:chat-session-state-changed
 const WORKTREE_IN_USE_BY_OTHER_SESSIONS: &str =
     "Close other sessions using this worktree before removing it.";
 const CODEX_TOOL_PROCESS_START_TOLERANCE: std::time::Duration = std::time::Duration::from_secs(1);
+const MAX_CODEX_REPAIR_TAIL_BYTES: u64 = 8 * 1024 * 1024;
+const MAX_CLAUDE_FORK_PROJECT_ENTRIES: usize = 10_000;
+const MAX_CLAUDE_FORK_TRANSCRIPT_BYTES: u64 = 64 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy)]
+struct ClaudeForkLimits {
+    max_project_entries: usize,
+    max_transcript_bytes: u64,
+}
+
+const DEFAULT_CLAUDE_FORK_LIMITS: ClaudeForkLimits = ClaudeForkLimits {
+    max_project_entries: MAX_CLAUDE_FORK_PROJECT_ENTRIES,
+    max_transcript_bytes: MAX_CLAUDE_FORK_TRANSCRIPT_BYTES,
+};
 
 async fn run_blocking<T, F>(label: &'static str, f: F) -> AppResult<T>
 where
@@ -828,13 +842,11 @@ fn codex_provider_thread_cursor(state: &persistence::ChatSessionState) -> Option
 }
 
 fn latest_codex_agent_message_from_transcript(path: &Path) -> io::Result<Option<String>> {
-    let file = std::fs::File::open(path)?;
-    let reader = io::BufReader::new(file);
-    let lines = reader.lines().collect::<io::Result<Vec<_>>>()?;
+    let tail = acorn_transcript::read_tail(path, MAX_CODEX_REPAIR_TAIL_BYTES)?;
     let mut latest_agent_message = None;
     let mut saw_empty_final = false;
 
-    for line in lines.iter().rev() {
+    for line in tail.text.lines().rev() {
         let line = line.trim();
         if line.is_empty() {
             continue;
@@ -3983,79 +3995,277 @@ fn empty_agent_detection() -> AgentDetection {
 /// and are validated below:
 ///   - `parent_uuid` is checked to be a real UUID before any disk
 ///     lookup, blocking `..`-style filename injection.
-///   - `new_cwd` is slugified and the resulting directory path is
-///     verified to canonicalise under `~/.claude/projects/` before any
-///     `create_dir_all` runs, so a hostile cwd containing path-escape
-///     characters cannot make us materialise directories outside the
-///     claude project root.
+///   - `new_cwd` is slugified and accepted only as one path component;
+///     the destination directory is then verified beneath the canonical
+///     `~/.claude/projects/` root before it is used.
 #[tauri::command]
 pub fn prepare_claude_fork(parent_uuid: String, new_cwd: String) -> AppResult<()> {
+    let home = directories::UserDirs::new()
+        .map(|d| d.home_dir().to_path_buf())
+        .ok_or_else(|| AppError::Other("no home dir".into()))?;
+    prepare_claude_fork_in(
+        &home.join(".claude").join("projects"),
+        &parent_uuid,
+        Path::new(&new_cwd),
+        DEFAULT_CLAUDE_FORK_LIMITS,
+    )
+}
+
+fn prepare_claude_fork_in(
+    projects_root: &Path,
+    parent_uuid: &str,
+    new_cwd: &Path,
+    limits: ClaudeForkLimits,
+) -> AppResult<()> {
     if Uuid::parse_str(&parent_uuid).is_err() {
         return Err(AppError::Other(format!(
             "parent_uuid must be a valid UUID, got: {parent_uuid}"
         )));
     }
 
-    let home = directories::UserDirs::new()
-        .map(|d| d.home_dir().to_path_buf())
-        .ok_or_else(|| AppError::Other("no home dir".into()))?;
-    let projects_root = home.join(".claude").join("projects");
+    let root_metadata = std::fs::symlink_metadata(projects_root)?;
+    validate_claude_fork_directory(projects_root, &root_metadata, "projects root")?;
+    let canonical_root = projects_root.canonicalize()?;
+    let canonical_root_metadata = std::fs::symlink_metadata(&canonical_root)?;
+    validate_claude_fork_directory(
+        &canonical_root,
+        &canonical_root_metadata,
+        "canonical projects root",
+    )?;
+
     let filename = format!("{parent_uuid}.jsonl");
 
     // The parent transcript can live under any number of project
     // slugs depending on where the agent was originally launched, so
-    // walk the projects dir for the first matching filename instead of
-    // recomputing the parent slug from a cwd the caller may not have.
+    // inspect every raw project entry within the budget. Continuing after a
+    // match ensures an oversized directory cannot produce a partial result.
     let mut src: Option<PathBuf> = None;
-    if let Ok(entries) = std::fs::read_dir(&projects_root) {
-        for slug in entries.flatten() {
-            let candidate = slug.path().join(&filename);
-            if candidate.is_file() {
-                src = Some(candidate);
-                break;
-            }
+    for (index, entry) in std::fs::read_dir(&canonical_root)?.enumerate() {
+        if index >= limits.max_project_entries {
+            return Err(AppError::Other(format!(
+                "Claude projects directory exceeds {} entries",
+                limits.max_project_entries
+            )));
+        }
+
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let project_dir = entry.path();
+        let project_metadata = std::fs::symlink_metadata(&project_dir)?;
+        validate_claude_fork_directory(&project_dir, &project_metadata, "project directory")?;
+        let canonical_project = project_dir.canonicalize()?;
+        if canonical_project.parent() != Some(canonical_root.as_path()) {
+            return Err(AppError::InvalidPath(format!(
+                "Claude project directory escapes projects root: {}",
+                project_dir.display()
+            )));
+        }
+
+        let candidate = canonical_project.join(&filename);
+        let candidate_metadata = match std::fs::symlink_metadata(&candidate) {
+            Ok(metadata) => metadata,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+            Err(err) => return Err(err.into()),
+        };
+        validate_claude_fork_regular_file(&candidate, &candidate_metadata, "source transcript")?;
+        let canonical_candidate = candidate.canonicalize()?;
+        if canonical_candidate.parent() != Some(canonical_project.as_path())
+            || !canonical_candidate.starts_with(&canonical_root)
+        {
+            return Err(AppError::InvalidPath(format!(
+                "Claude source transcript escapes projects root: {}",
+                candidate.display()
+            )));
+        }
+        if src.is_none() {
+            src = Some(canonical_candidate);
         }
     }
     let Some(src) = src else {
         return Err(AppError::Other(format!(
             "parent transcript {parent_uuid} not found under {}",
-            projects_root.display()
+            canonical_root.display()
         )));
     };
 
-    let dst_slug = acorn_transcript::slug_for_cwd(std::path::Path::new(&new_cwd));
-    let dst_dir = projects_root.join(&dst_slug);
+    let source_path_metadata = std::fs::symlink_metadata(&src)?;
+    validate_claude_fork_regular_file(&src, &source_path_metadata, "source transcript")?;
+    validate_claude_fork_snapshot_size(&src, &source_path_metadata, limits)?;
+    let mut source = std::fs::File::open(&src)?;
+    let source_open_metadata = source.metadata()?;
+    validate_claude_fork_regular_file(&src, &source_open_metadata, "opened source transcript")?;
+    validate_claude_fork_snapshot_size(&src, &source_open_metadata, limits)?;
+    validate_same_claude_fork_file(&src, &source_path_metadata, &source_open_metadata)?;
+    let source_recheck_metadata = std::fs::symlink_metadata(&src)?;
+    validate_claude_fork_regular_file(&src, &source_recheck_metadata, "source transcript")?;
+    validate_same_claude_fork_file(&src, &source_recheck_metadata, &source_open_metadata)?;
+    let snapshot_len = source_open_metadata.len();
 
-    // Path-traversal guard: resolve both ends and verify the destination
-    // is a real descendant of `projects_root`. We rely on `parent()`
-    // climbing up — `projects_root` exists once `claude` has ever been
-    // run, but `dst_dir` may not, so canonicalize the parent and append
-    // the slug. A weird `new_cwd` (e.g. containing `..` segments that
-    // slugify to bare dashes) shouldn't matter given the per-char filter,
-    // but defense in depth is cheap.
-    if !dst_slug.starts_with('-') || dst_slug.contains('/') || dst_slug.contains("..") {
+    let dst_slug = acorn_transcript::slug_for_cwd(new_cwd);
+    let slug_path = Path::new(&dst_slug);
+    let mut slug_components = slug_path.components();
+    let is_single_normal_component = matches!(slug_components.next(), Some(Component::Normal(_)))
+        && slug_components.next().is_none();
+    if !dst_slug.starts_with('-') || dst_slug.contains("..") || !is_single_normal_component {
         return Err(AppError::Other(format!(
             "refusing to stage transcript under unsafe slug: {dst_slug}"
         )));
     }
-    let canonical_root = projects_root
-        .canonicalize()
-        .unwrap_or(projects_root.clone());
-    let prospective = canonical_root.join(&dst_slug);
-    if !prospective.starts_with(&canonical_root) {
-        return Err(AppError::Other(format!(
-            "destination {} escapes claude projects root {}",
-            prospective.display(),
-            canonical_root.display()
-        )));
+
+    let dst_dir = ensure_claude_fork_destination_directory(&canonical_root, &dst_slug)?;
+    let dst = dst_dir.join(&filename);
+    if claude_fork_destination_exists(&dst)? {
+        return Ok(());
     }
 
-    std::fs::create_dir_all(&dst_dir)?;
-    let dst = dst_dir.join(&filename);
-    if !dst.exists() {
-        std::fs::copy(&src, &dst).map_err(|e| AppError::Other(format!("copy transcript: {e}")))?;
+    // A create-new tempfile in the destination's parent keeps partial copies
+    // unreachable at the final name. Persist uses a same-filesystem atomic
+    // rename, which replaces a concurrently introduced link rather than
+    // following it to another target.
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".acorn-claude-fork-")
+        .suffix(".jsonl.tmp")
+        .tempfile_in(&dst_dir)?;
+    let copied = io::copy(
+        &mut (&mut source).take(snapshot_len),
+        temporary.as_file_mut(),
+    )?;
+    if copied != snapshot_len {
+        return Err(AppError::Other(format!(
+            "source transcript changed while copying: expected {snapshot_len} bytes, copied {copied}"
+        )));
+    }
+    temporary.as_file_mut().flush()?;
+
+    let rechecked_dst_dir = ensure_claude_fork_destination_directory(&canonical_root, &dst_slug)?;
+    if rechecked_dst_dir != dst_dir {
+        return Err(AppError::Other(format!(
+            "Claude destination directory changed while copying: {}",
+            dst_dir.display()
+        )));
+    }
+    if claude_fork_destination_exists(&dst)? {
+        return Ok(());
+    }
+
+    let persisted = temporary
+        .persist(&dst)
+        .map_err(|err| AppError::Other(format!("copy transcript: {}", err.error)))?;
+    let persisted_metadata = persisted.metadata()?;
+    validate_claude_fork_regular_file(&dst, &persisted_metadata, "destination transcript")?;
+    Ok(())
+}
+
+fn validate_claude_fork_directory(
+    path: &Path,
+    metadata: &std::fs::Metadata,
+    label: &str,
+) -> AppResult<()> {
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(AppError::InvalidPath(format!(
+            "Claude {label} must be a real directory: {}",
+            path.display()
+        )));
     }
     Ok(())
+}
+
+fn validate_claude_fork_regular_file(
+    path: &Path,
+    metadata: &std::fs::Metadata,
+    label: &str,
+) -> AppResult<()> {
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(AppError::InvalidPath(format!(
+            "Claude {label} must be a regular file: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_claude_fork_snapshot_size(
+    path: &Path,
+    metadata: &std::fs::Metadata,
+    limits: ClaudeForkLimits,
+) -> AppResult<()> {
+    if metadata.len() > limits.max_transcript_bytes {
+        return Err(AppError::Other(format!(
+            "Claude source transcript exceeds {} bytes: {}",
+            limits.max_transcript_bytes,
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_same_claude_fork_file(
+    path: &Path,
+    before: &std::fs::Metadata,
+    opened: &std::fs::Metadata,
+) -> AppResult<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if before.dev() != opened.dev() || before.ino() != opened.ino() {
+            return Err(AppError::InvalidPath(format!(
+                "Claude source transcript changed while opening: {}",
+                path.display()
+            )));
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (path, before, opened);
+    }
+    Ok(())
+}
+
+fn ensure_claude_fork_destination_directory(
+    canonical_root: &Path,
+    dst_slug: &str,
+) -> AppResult<PathBuf> {
+    let dst_dir = canonical_root.join(dst_slug);
+    loop {
+        match std::fs::symlink_metadata(&dst_dir) {
+            Ok(metadata) => {
+                validate_claude_fork_directory(&dst_dir, &metadata, "destination directory")?;
+                break;
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                match std::fs::create_dir(&dst_dir) {
+                    Ok(()) => {}
+                    Err(create_err) if create_err.kind() == io::ErrorKind::AlreadyExists => {}
+                    Err(create_err) => return Err(create_err.into()),
+                }
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
+
+    let canonical_dst = dst_dir.canonicalize()?;
+    if canonical_dst.parent() != Some(canonical_root) {
+        return Err(AppError::InvalidPath(format!(
+            "Claude destination directory escapes projects root: {}",
+            dst_dir.display()
+        )));
+    }
+    let metadata = std::fs::symlink_metadata(&canonical_dst)?;
+    validate_claude_fork_directory(&canonical_dst, &metadata, "destination directory")?;
+    Ok(canonical_dst)
+}
+
+fn claude_fork_destination_exists(dst: &Path) -> AppResult<bool> {
+    match std::fs::symlink_metadata(dst) {
+        Ok(metadata) => {
+            validate_claude_fork_regular_file(dst, &metadata, "destination transcript")?;
+            Ok(true)
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err.into()),
+    }
 }
 
 /// Live-process snapshot of which agent transcripts (if any) the user is
@@ -4643,13 +4853,29 @@ fn write_control_marker(cwd: &std::path::Path, primer: &str) {
         "<!-- generated by Acorn on every control-session PTY spawn. \
          Safe to commit-ignore. -->\n\n# Control session\n\n{primer}\n",
     );
-    if let Err(err) = std::fs::write(&path, body) {
+    if let Err(err) = replace_control_marker(cwd, &path, body.as_bytes()) {
         tracing::warn!(
             path = %path.display(),
             error = %err,
             "failed to write .acorn-control.md marker",
         );
     }
+}
+
+fn replace_control_marker(cwd: &Path, path: &Path, body: &[u8]) -> io::Result<()> {
+    // The destination is repository-controlled and may already be a symlink or
+    // hard link. Write to an unpredictable create-new file in the same
+    // directory, then atomically replace the directory entry so the marker
+    // write never follows that link to another file.
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".acorn-control.md.")
+        .suffix(".tmp")
+        .tempfile_in(cwd)?;
+    temporary.write_all(body)?;
+    temporary
+        .persist(path)
+        .map_err(|persist_error| persist_error.error)?;
+    Ok(())
 }
 
 #[tauri::command]
@@ -5102,7 +5328,10 @@ pub async fn scrollback_orphan_clear(state: State<'_, AppState>) -> AppResult<us
 #[tauri::command]
 pub async fn read_session_todos(session_id: String, cwd: String) -> AppResult<Vec<TodoItem>> {
     let cwd = PathBuf::from(cwd);
-    todos::read_latest_todos(&session_id, &cwd)
+    run_blocking("read_session_todos", move || {
+        todos::read_latest_todos(&session_id, &cwd)
+    })
+    .await
 }
 
 #[derive(serde::Serialize)]
@@ -7869,6 +8098,35 @@ mod tests {
     }
 
     #[test]
+    fn backfill_empty_codex_assistant_message_does_not_scan_beyond_tail_budget() {
+        use std::io::Write as _;
+
+        let mut state = chat_state_for_runtime(vec![
+            chat_message("u1", crate::persistence::ChatRole::User, "다시 봐줘"),
+            chat_message("a1", crate::persistence::ChatRole::Assistant, ""),
+        ]);
+        let tmp = tempfile::tempdir().unwrap();
+        let transcript = tmp.path().join("rollout.jsonl");
+        let mut file = std::fs::File::create(&transcript).unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"event_msg","payload":{{"type":"task_complete","last_agent_message":"too old"}}}}"#
+        )
+        .unwrap();
+        file.set_len(super::MAX_CODEX_REPAIR_TAIL_BYTES + 1024)
+            .unwrap();
+        drop(file);
+
+        assert!(
+            !super::backfill_latest_empty_codex_assistant_message_from_path(
+                &mut state,
+                &transcript
+            )
+        );
+        assert_eq!(state.messages.last().unwrap().content, "");
+    }
+
+    #[test]
     fn chat_stream_parser_records_codex_token_count_metadata() {
         let mut parser = super::ChatCliOutputParser::new(super::ChatCliOutputMode::CodexJson);
         let mut chunks = Vec::new();
@@ -9398,6 +9656,325 @@ mod tests {
             super::chat_worktree_base_name_for_repo(repo, "123456789abc"),
             "momentry-worktree-123456789abc"
         );
+    }
+
+    const CLAUDE_FORK_TEST_UUID: &str = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+    fn claude_fork_test_limits(
+        max_project_entries: usize,
+        max_transcript_bytes: u64,
+    ) -> super::ClaudeForkLimits {
+        super::ClaudeForkLimits {
+            max_project_entries,
+            max_transcript_bytes,
+        }
+    }
+
+    fn write_claude_fork_source(root: &Path, contents: &[u8]) -> PathBuf {
+        let project = root.join("-source-project");
+        std::fs::create_dir(&project).expect("create source project");
+        let source = project.join(format!("{CLAUDE_FORK_TEST_UUID}.jsonl"));
+        std::fs::write(&source, contents).expect("write source transcript");
+        source
+    }
+
+    #[test]
+    fn prepare_claude_fork_atomically_copies_snapshot_and_keeps_regular_destination() {
+        let root = tempfile::tempdir().expect("temporary Claude projects root");
+        let source = write_claude_fork_source(root.path(), b"parent snapshot\n");
+        let new_cwd = Path::new("/tmp/acorn-fork-target");
+        let destination_dir = root.path().join(acorn_transcript::slug_for_cwd(new_cwd));
+        let destination = destination_dir.join(format!("{CLAUDE_FORK_TEST_UUID}.jsonl"));
+        let limits = claude_fork_test_limits(8, 1024);
+
+        super::prepare_claude_fork_in(root.path(), CLAUDE_FORK_TEST_UUID, new_cwd, limits)
+            .expect("stage transcript");
+        assert_eq!(
+            std::fs::read(&destination).expect("read staged transcript"),
+            b"parent snapshot\n"
+        );
+        assert!(std::fs::read_dir(&destination_dir)
+            .expect("list destination directory")
+            .flatten()
+            .all(|entry| !entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".acorn-claude-fork-")));
+
+        std::fs::write(&source, b"new source contents\n").expect("replace source contents");
+        std::fs::write(&destination, b"existing destination\n")
+            .expect("replace destination contents");
+        super::prepare_claude_fork_in(root.path(), CLAUDE_FORK_TEST_UUID, new_cwd, limits)
+            .expect("existing regular destination is idempotent");
+        assert_eq!(
+            std::fs::read(&destination).expect("read existing destination"),
+            b"existing destination\n"
+        );
+    }
+
+    #[test]
+    fn prepare_claude_fork_fails_closed_over_raw_project_entry_budget() {
+        let root = tempfile::tempdir().expect("temporary Claude projects root");
+        write_claude_fork_source(root.path(), b"parent snapshot\n");
+        std::fs::create_dir(root.path().join("-extra-project")).expect("create extra project");
+        let new_cwd = Path::new("/tmp/acorn-fork-over-budget");
+
+        let error = super::prepare_claude_fork_in(
+            root.path(),
+            CLAUDE_FORK_TEST_UUID,
+            new_cwd,
+            claude_fork_test_limits(1, 1024),
+        )
+        .expect_err("raw entry overflow must discard a partial match");
+
+        assert!(error.to_string().contains("exceeds 1 entries"));
+        assert!(!root
+            .path()
+            .join(acorn_transcript::slug_for_cwd(new_cwd))
+            .exists());
+    }
+
+    #[test]
+    fn prepare_claude_fork_rejects_oversized_source_snapshot() {
+        let root = tempfile::tempdir().expect("temporary Claude projects root");
+        write_claude_fork_source(root.path(), b"12345");
+        let new_cwd = Path::new("/tmp/acorn-fork-oversized");
+
+        let error = super::prepare_claude_fork_in(
+            root.path(),
+            CLAUDE_FORK_TEST_UUID,
+            new_cwd,
+            claude_fork_test_limits(4, 4),
+        )
+        .expect_err("oversized source must be rejected");
+
+        assert!(error.to_string().contains("exceeds 4 bytes"));
+        assert!(!root
+            .path()
+            .join(acorn_transcript::slug_for_cwd(new_cwd))
+            .exists());
+    }
+
+    #[test]
+    fn prepare_claude_fork_rejects_non_regular_source_and_destination() {
+        let root = tempfile::tempdir().expect("temporary Claude projects root");
+        let source_project = root.path().join("-source-project");
+        std::fs::create_dir(&source_project).expect("create source project");
+        std::fs::create_dir(source_project.join(format!("{CLAUDE_FORK_TEST_UUID}.jsonl")))
+            .expect("create directory at source leaf");
+
+        let source_error = super::prepare_claude_fork_in(
+            root.path(),
+            CLAUDE_FORK_TEST_UUID,
+            Path::new("/tmp/acorn-fork-special-source"),
+            claude_fork_test_limits(4, 1024),
+        )
+        .expect_err("directory source must be rejected");
+        assert!(source_error.to_string().contains("must be a regular file"));
+
+        std::fs::remove_dir(source_project.join(format!("{CLAUDE_FORK_TEST_UUID}.jsonl")))
+            .expect("remove directory source");
+        std::fs::write(
+            source_project.join(format!("{CLAUDE_FORK_TEST_UUID}.jsonl")),
+            b"parent snapshot\n",
+        )
+        .expect("write regular source");
+        let new_cwd = Path::new("/tmp/acorn-fork-special-destination");
+        let destination_dir = root.path().join(acorn_transcript::slug_for_cwd(new_cwd));
+        std::fs::create_dir(&destination_dir).expect("create destination directory");
+        std::fs::create_dir(destination_dir.join(format!("{CLAUDE_FORK_TEST_UUID}.jsonl")))
+            .expect("create directory at destination leaf");
+
+        let destination_error = super::prepare_claude_fork_in(
+            root.path(),
+            CLAUDE_FORK_TEST_UUID,
+            new_cwd,
+            claude_fork_test_limits(4, 1024),
+        )
+        .expect_err("directory destination must be rejected");
+        assert!(destination_error
+            .to_string()
+            .contains("must be a regular file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_claude_fork_rejects_linked_root_project_source_and_destination() {
+        use std::os::unix::fs::symlink;
+
+        let limits = claude_fork_test_limits(8, 1024);
+
+        let actual_root = tempfile::tempdir().expect("actual Claude projects root");
+        write_claude_fork_source(actual_root.path(), b"parent snapshot\n");
+        let root_parent = tempfile::tempdir().expect("configured root parent");
+        let linked_root = root_parent.path().join("projects");
+        symlink(actual_root.path(), &linked_root).expect("link projects root");
+        assert!(super::prepare_claude_fork_in(
+            &linked_root,
+            CLAUDE_FORK_TEST_UUID,
+            Path::new("/tmp/acorn-fork-linked-root"),
+            limits,
+        )
+        .is_err());
+
+        let linked_project_root = tempfile::tempdir().expect("linked project root");
+        let outside_project = tempfile::tempdir().expect("outside source project");
+        std::fs::write(
+            outside_project
+                .path()
+                .join(format!("{CLAUDE_FORK_TEST_UUID}.jsonl")),
+            b"outside source\n",
+        )
+        .expect("write outside source");
+        symlink(
+            outside_project.path(),
+            linked_project_root.path().join("-linked-project"),
+        )
+        .expect("link source project");
+        assert!(super::prepare_claude_fork_in(
+            linked_project_root.path(),
+            CLAUDE_FORK_TEST_UUID,
+            Path::new("/tmp/acorn-fork-linked-project"),
+            limits,
+        )
+        .is_err());
+
+        let linked_source_root = tempfile::tempdir().expect("linked source root");
+        let source_project = linked_source_root.path().join("-source-project");
+        std::fs::create_dir(&source_project).expect("create source project");
+        let outside_source = tempfile::NamedTempFile::new().expect("outside source");
+        std::fs::write(outside_source.path(), b"outside source\n").expect("write outside source");
+        symlink(
+            outside_source.path(),
+            source_project.join(format!("{CLAUDE_FORK_TEST_UUID}.jsonl")),
+        )
+        .expect("link source transcript");
+        assert!(super::prepare_claude_fork_in(
+            linked_source_root.path(),
+            CLAUDE_FORK_TEST_UUID,
+            Path::new("/tmp/acorn-fork-linked-source"),
+            limits,
+        )
+        .is_err());
+
+        let linked_destination_root = tempfile::tempdir().expect("linked destination root");
+        write_claude_fork_source(linked_destination_root.path(), b"parent snapshot\n");
+        let new_cwd = Path::new("/tmp/acorn-fork-linked-destination");
+        let destination_dir = linked_destination_root
+            .path()
+            .join(acorn_transcript::slug_for_cwd(new_cwd));
+        std::fs::create_dir(&destination_dir).expect("create destination directory");
+        let outside_destination = tempfile::NamedTempFile::new().expect("outside destination");
+        std::fs::write(outside_destination.path(), b"outside sentinel\n")
+            .expect("write destination sentinel");
+        symlink(
+            outside_destination.path(),
+            destination_dir.join(format!("{CLAUDE_FORK_TEST_UUID}.jsonl")),
+        )
+        .expect("link destination transcript");
+
+        assert!(super::prepare_claude_fork_in(
+            linked_destination_root.path(),
+            CLAUDE_FORK_TEST_UUID,
+            new_cwd,
+            limits,
+        )
+        .is_err());
+        assert_eq!(
+            std::fs::read(outside_destination.path()).expect("read destination sentinel"),
+            b"outside sentinel\n"
+        );
+
+        let linked_destination_dir_root =
+            tempfile::tempdir().expect("linked destination directory root");
+        write_claude_fork_source(linked_destination_dir_root.path(), b"parent snapshot\n");
+        let new_cwd = Path::new("/tmp/acorn-fork-linked-destination-directory");
+        let outside_destination_dir = tempfile::tempdir().expect("outside destination directory");
+        symlink(
+            outside_destination_dir.path(),
+            linked_destination_dir_root
+                .path()
+                .join(acorn_transcript::slug_for_cwd(new_cwd)),
+        )
+        .expect("link destination directory");
+
+        assert!(super::prepare_claude_fork_in(
+            linked_destination_dir_root.path(),
+            CLAUDE_FORK_TEST_UUID,
+            new_cwd,
+            limits,
+        )
+        .is_err());
+        assert!(!outside_destination_dir
+            .path()
+            .join(format!("{CLAUDE_FORK_TEST_UUID}.jsonl"))
+            .exists());
+    }
+
+    #[test]
+    fn control_marker_is_atomically_created_and_replaced() {
+        let directory = tempfile::tempdir().expect("temporary control cwd");
+        let marker = directory.path().join(".acorn-control.md");
+
+        super::write_control_marker(directory.path(), "first primer");
+        assert!(std::fs::read_to_string(&marker)
+            .expect("read first marker")
+            .contains("first primer"));
+
+        super::write_control_marker(directory.path(), "second primer");
+        let body = std::fs::read_to_string(&marker).expect("read replaced marker");
+        assert!(body.contains("second primer"));
+        assert!(!body.contains("first primer"));
+        assert!(std::fs::read_dir(directory.path())
+            .expect("list control cwd")
+            .flatten()
+            .all(|entry| !entry.file_name().to_string_lossy().ends_with(".tmp")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn control_marker_replacement_does_not_follow_a_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().expect("temporary control cwd");
+        let outside = tempfile::NamedTempFile::new().expect("outside sentinel");
+        std::fs::write(outside.path(), "outside sentinel").expect("write sentinel");
+        let marker = directory.path().join(".acorn-control.md");
+        symlink(outside.path(), &marker).expect("symlink marker");
+
+        super::write_control_marker(directory.path(), "trusted primer");
+
+        assert_eq!(
+            std::fs::read_to_string(outside.path()).expect("read sentinel"),
+            "outside sentinel"
+        );
+        assert!(std::fs::symlink_metadata(&marker)
+            .expect("marker metadata")
+            .file_type()
+            .is_file());
+        assert!(std::fs::read_to_string(&marker)
+            .expect("read marker")
+            .contains("trusted primer"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn control_marker_replacement_does_not_modify_a_hard_link_peer() {
+        let directory = tempfile::tempdir().expect("temporary control cwd");
+        let outside = tempfile::NamedTempFile::new().expect("outside sentinel");
+        std::fs::write(outside.path(), "outside sentinel").expect("write sentinel");
+        let marker = directory.path().join(".acorn-control.md");
+        std::fs::hard_link(outside.path(), &marker).expect("hard-link marker");
+
+        super::write_control_marker(directory.path(), "trusted primer");
+
+        assert_eq!(
+            std::fs::read_to_string(outside.path()).expect("read sentinel"),
+            "outside sentinel"
+        );
+        assert!(std::fs::read_to_string(&marker)
+            .expect("read marker")
+            .contains("trusted primer"));
     }
 
     #[test]

--- a/src-tauri/src/daemon_bridge.rs
+++ b/src-tauri/src/daemon_bridge.rs
@@ -101,7 +101,6 @@ pub type BridgeResult<T> = Result<T, BridgeError>;
 /// `ControlResult::SessionSpawned` so callers can wire the pid into
 /// status polling without re-listing sessions.
 pub struct SpawnOutcome {
-    pub session_id: Uuid,
     pub pid: Option<u32>,
 }
 
@@ -342,9 +341,7 @@ impl DaemonBridge {
             agent_resume_token,
         };
         match Self::unpack_error(self.call(ControlPayload::SpawnSession { spec })?)? {
-            ControlResult::SessionSpawned { session_id, pid } => {
-                Ok(SpawnOutcome { session_id, pid })
-            }
+            ControlResult::SessionSpawned { pid, .. } => Ok(SpawnOutcome { pid }),
             other => Err(unexpected(other)),
         }
     }

--- a/src-tauri/src/daemon_commands.rs
+++ b/src-tauri/src/daemon_commands.rs
@@ -8,9 +8,6 @@
 //! to the daemon when the user has the killswitch on. Frontend call
 //! sites do not have to know which side served them.
 
-use std::collections::HashMap;
-use std::path::PathBuf;
-
 use serde::Serialize;
 use tauri::State;
 use uuid::Uuid;
@@ -164,80 +161,6 @@ pub fn daemon_list_sessions(
         .collect())
 }
 
-/// Frontend → daemon spawn proxy. Invoked by the legacy `pty_spawn`
-/// command once daemon-routed spawning lands, and directly by tests
-/// that exercise the daemon path. Returns the session UUID the daemon
-/// assigned (always equal to `session_id` when supplied).
-#[allow(clippy::too_many_arguments)]
-#[tauri::command]
-pub fn daemon_spawn_session(
-    session_id: String,
-    name: String,
-    cwd: String,
-    command: String,
-    args: Vec<String>,
-    env: HashMap<String, String>,
-    cols: u16,
-    rows: u16,
-    kind: String,
-    repo_path: Option<String>,
-    branch: Option<String>,
-    agent_kind: Option<String>,
-    agent_resume_token: Option<String>,
-    state: State<'_, AppState>,
-) -> Result<String, String> {
-    let id = Uuid::parse_str(&session_id).map_err(|e| format!("invalid session id: {e}"))?;
-    let session_kind = parse_kind(&kind)?;
-    let agent = agent_kind.as_deref().and_then(parse_agent_kind);
-    let outcome = state
-        .daemon_bridge
-        .spawn(
-            id,
-            name,
-            PathBuf::from(cwd),
-            command,
-            args,
-            env,
-            cols,
-            rows,
-            session_kind,
-            repo_path.map(PathBuf::from),
-            branch,
-            agent,
-            agent_resume_token,
-        )
-        .map_err(|e| e.to_string())?;
-    Ok(outcome.session_id.to_string())
-}
-
-#[tauri::command]
-pub fn daemon_send_input(
-    target_session_id: String,
-    data_b64: String,
-    state: State<'_, AppState>,
-) -> Result<(), String> {
-    let id = Uuid::parse_str(&target_session_id).map_err(|e| format!("invalid session id: {e}"))?;
-    let bytes = base64_decode(&data_b64)?;
-    state
-        .daemon_bridge
-        .send_input(id, &bytes)
-        .map_err(|e| e.to_string())
-}
-
-#[tauri::command]
-pub fn daemon_resize(
-    target_session_id: String,
-    cols: u16,
-    rows: u16,
-    state: State<'_, AppState>,
-) -> Result<(), String> {
-    let id = Uuid::parse_str(&target_session_id).map_err(|e| format!("invalid session id: {e}"))?;
-    state
-        .daemon_bridge
-        .resize(id, cols, rows)
-        .map_err(|e| e.to_string())
-}
-
 #[tauri::command]
 pub fn daemon_kill_session(
     target_session_id: String,
@@ -369,27 +292,6 @@ pub fn daemon_adopt_session(
     Ok(())
 }
 
-fn parse_kind(kind: &str) -> Result<SessionKind, String> {
-    match kind {
-        "regular" => Ok(SessionKind::Regular),
-        "control" => Ok(SessionKind::Control),
-        other => Err(format!("unknown session kind: {other}")),
-    }
-}
-
-fn parse_agent_kind(s: &str) -> Option<AgentKind> {
-    match s {
-        "claude-code" => Some(AgentKind::ClaudeCode),
-        "aider" => Some(AgentKind::Aider),
-        "llm" => Some(AgentKind::Llm),
-        "open-interpreter" => Some(AgentKind::OpenInterpreter),
-        "codex" => Some(AgentKind::Codex),
-        "antigravity" => Some(AgentKind::Antigravity),
-        "unknown" => Some(AgentKind::Unknown),
-        _ => None,
-    }
-}
-
 fn agent_kind_to_str(k: AgentKind) -> String {
     match k {
         AgentKind::ClaudeCode => "claude-code".into(),
@@ -399,71 +301,5 @@ fn agent_kind_to_str(k: AgentKind) -> String {
         AgentKind::Codex => "codex".into(),
         AgentKind::Antigravity => "antigravity".into(),
         AgentKind::Unknown => "unknown".into(),
-    }
-}
-
-/// Same RFC 4648 decoder pattern as the daemon's own — duplicated to
-/// keep the frontend command layer dep-light.
-fn base64_decode(input: &str) -> Result<Vec<u8>, String> {
-    fn val(c: u8) -> Result<u8, String> {
-        match c {
-            b'A'..=b'Z' => Ok(c - b'A'),
-            b'a'..=b'z' => Ok(26 + c - b'a'),
-            b'0'..=b'9' => Ok(52 + c - b'0'),
-            b'+' => Ok(62),
-            b'/' => Ok(63),
-            _ => Err(format!("non-base64 byte 0x{c:02x}")),
-        }
-    }
-    let bytes: Vec<u8> = input.bytes().filter(|b| !b.is_ascii_whitespace()).collect();
-    if bytes.is_empty() {
-        return Ok(Vec::new());
-    }
-    let mut out = Vec::with_capacity(bytes.len() / 4 * 3);
-    let mut chunks = bytes.chunks(4);
-    while let Some(chunk) = chunks.next() {
-        if chunk.len() != 4 {
-            return Err("bad base64 length".into());
-        }
-        let pad = chunk.iter().rev().take_while(|&&c| c == b'=').count();
-        let v0 = val(chunk[0])?;
-        let v1 = val(chunk[1])?;
-        let v2 = if pad >= 2 { 0 } else { val(chunk[2])? };
-        let v3 = if pad >= 1 { 0 } else { val(chunk[3])? };
-        let n =
-            (u32::from(v0) << 18) | (u32::from(v1) << 12) | (u32::from(v2) << 6) | u32::from(v3);
-        out.push((n >> 16) as u8);
-        if pad < 2 {
-            out.push((n >> 8) as u8);
-        }
-        if pad < 1 {
-            out.push(n as u8);
-        }
-    }
-    Ok(out)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_kind_known_values() {
-        assert!(matches!(parse_kind("regular"), Ok(SessionKind::Regular)));
-        assert!(matches!(parse_kind("control"), Ok(SessionKind::Control)));
-        assert!(parse_kind("frobnicate").is_err());
-    }
-
-    #[test]
-    fn parse_agent_kind_known_values() {
-        assert!(matches!(
-            parse_agent_kind("claude-code"),
-            Some(AgentKind::ClaudeCode)
-        ));
-        assert!(matches!(
-            parse_agent_kind("antigravity"),
-            Some(AgentKind::Antigravity)
-        ));
-        assert!(parse_agent_kind("nope").is_none());
     }
 }

--- a/src-tauri/src/daemon_stream.rs
+++ b/src-tauri/src/daemon_stream.rs
@@ -13,7 +13,7 @@
 //! which is a single short RPC round-trip per event and avoids managing two
 //! per-session sockets on the app side.
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufReader, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -28,6 +28,7 @@ use uuid::Uuid;
 use crate::pty_output::{self, PtyOutputRouter};
 use acorn_daemon::protocol::{ClientRole, Hello, StreamAttach, StreamFrame};
 use acorn_daemon::socket;
+use acorn_daemon::wire::read_response_frame_line;
 use acorn_pty::{transition_shell_hint, ShellHint};
 
 /// Per-session attachment handle. Dropping the handle does not stop the
@@ -174,7 +175,7 @@ pub fn attach<R: Runtime>(
     // check already succeeded, the rest is telemetry.
     let mut reader = BufReader::new(conn);
     let mut buf = String::new();
-    reader.read_line(&mut buf)?;
+    read_response_frame_line(&mut reader, &mut buf)?;
 
     let attach = StreamAttach {
         session_id,
@@ -234,8 +235,7 @@ fn pump_loop<R: Runtime>(
         if stop.load(Ordering::SeqCst) {
             break;
         }
-        line.clear();
-        match reader.read_line(&mut line) {
+        match read_response_frame_line(&mut reader, &mut line) {
             Ok(0) => {
                 // Daemon closed the connection without an Exit frame —
                 // could be a daemon shutdown or a crash. Emit an Exit
@@ -265,8 +265,9 @@ fn pump_loop<R: Runtime>(
         let frame: StreamFrame = match serde_json::from_str(line.trim()) {
             Ok(f) => f,
             Err(err) => {
-                tracing::warn!(%session_id, error = %err, raw = %line.trim(), "bad daemon stream frame");
-                continue;
+                log_bad_daemon_stream_frame(session_id, line.len(), &err);
+                let _ = app.emit(&exit_event, ExitPayload { code: None });
+                break;
             }
         };
         match frame {
@@ -297,9 +298,39 @@ fn pump_loop<R: Runtime>(
     registry.drop_attachment_if_current(&session_id, &handle);
 }
 
+fn log_bad_daemon_stream_frame(session_id: Uuid, frame_bytes: usize, error: &serde_json::Error) {
+    // Protocol frames can contain terminal output and other sensitive data.
+    // Keep malformed payload bytes out of logs and fail the attachment closed
+    // after the caller records this bounded diagnostic.
+    tracing::warn!(%session_id, %frame_bytes, error = %error, "bad daemon stream frame");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    #[derive(Clone, Default)]
+    struct SharedLogWriter(Arc<StdMutex<Vec<u8>>>);
+
+    impl std::io::Write for SharedLogWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedLogWriter {
+        type Writer = SharedLogWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
 
     fn test_attachment() -> Arc<StreamAttachment> {
         Arc::new(StreamAttachment {
@@ -350,5 +381,28 @@ mod tests {
         assert!(registry.attachment_matches_output_token(&id, Some(7)));
         assert!(!registry.attachment_matches_output_token(&id, Some(8)));
         assert!(registry.attachment_matches_output_token(&id, None));
+    }
+
+    #[test]
+    fn malformed_frame_log_omits_payload_contents() {
+        let raw = "{\"secret\":\"sentinel-escape-\u{1b}[31m";
+        let error = serde_json::from_str::<StreamFrame>(raw).unwrap_err();
+        let writer = SharedLogWriter::default();
+        let captured = Arc::clone(&writer.0);
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_writer(writer)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            log_bad_daemon_stream_frame(Uuid::nil(), raw.len(), &error);
+        });
+
+        let output = String::from_utf8(captured.lock().unwrap().clone()).unwrap();
+        assert!(output.contains("bad daemon stream frame"));
+        assert!(output.contains(&format!("frame_bytes={}", raw.len())));
+        assert!(!output.contains("sentinel-escape"));
+        assert!(!output.contains("[31m"));
     }
 }

--- a/src-tauri/src/fs_explorer.rs
+++ b/src-tauri/src/fs_explorer.rs
@@ -1,7 +1,11 @@
+use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
 use std::path::{Component, Path, PathBuf};
-use std::sync::mpsc::{self, Receiver};
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -21,6 +25,16 @@ const EVENT_FS_CHANGED: &str = "acorn:fs-changed";
 const WATCH_BATCH_WINDOW: Duration = Duration::from_millis(75);
 const WATCH_EVENT_CAP: usize = 256;
 const WATCH_THROTTLE_GAP: Duration = Duration::from_millis(200);
+const WATCH_QUEUE_CAPACITY: usize = 1024;
+const MAX_GITIGNORE_BYTES: u64 = 1024 * 1024;
+const MAX_DIRECTORY_ENTRIES: usize = 10_000;
+const MAX_GITIGNORE_LINES: usize = 10_000;
+// Diff stats are informational. Treat unusually large repository inputs as
+// unknown instead of reading entire files or blobs into memory just to count.
+const MAX_DIFF_STAT_FILE_BYTES: u64 = 8 * 1024 * 1024;
+const MAX_DIFF_STAT_LINES: u32 = 200_000;
+const MAX_DIFF_STAT_PATHS: usize = 5_000;
+const MAX_DIFF_STAT_CALLBACK_LINES: u32 = 500_000;
 
 const SUPERVISOR_INITIAL_BACKOFF: Duration = Duration::from_millis(800);
 const SUPERVISOR_MAX_BACKOFF: Duration = Duration::from_millis(12_800);
@@ -439,14 +453,65 @@ fn find_repo_root(start: &Path) -> Option<PathBuf> {
 fn build_gitignore(repo_root: &Path) -> Gitignore {
     let mut b = GitignoreBuilder::new(repo_root);
     let root_ignore = repo_root.join(".gitignore");
-    if root_ignore.exists() {
-        let _ = b.add(root_ignore);
-    }
+    add_bounded_gitignore_file(&mut b, &root_ignore);
     let exclude = repo_root.join(".git").join("info").join("exclude");
-    if exclude.exists() {
-        let _ = b.add(exclude);
-    }
+    add_bounded_gitignore_file(&mut b, &exclude);
     b.build().unwrap_or_else(|_| Gitignore::empty())
+}
+
+fn add_bounded_gitignore_file(builder: &mut GitignoreBuilder, path: &Path) {
+    // Repositories are untrusted input. Never let a linked special file (for
+    // example `/dev/zero`) or an oversized ignore file block the explorer.
+    let Ok(link_meta) = std::fs::symlink_metadata(path) else {
+        return;
+    };
+    if link_meta.file_type().is_symlink()
+        || !link_meta.is_file()
+        || link_meta.len() > MAX_GITIGNORE_BYTES
+    {
+        return;
+    }
+
+    let Ok(file) = File::open(path) else {
+        return;
+    };
+    let Ok(open_meta) = file.metadata() else {
+        return;
+    };
+    if !open_meta.is_file() || open_meta.len() > MAX_GITIGNORE_BYTES {
+        return;
+    }
+
+    // Re-check the byte limit while reading because the file can grow after
+    // metadata is inspected. Parsing happens only after all limits pass, so a
+    // rejected file cannot leave a partially populated matcher behind.
+    let mut bytes = Vec::with_capacity(open_meta.len() as usize);
+    if file
+        .take(MAX_GITIGNORE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .is_err()
+        || bytes.len() as u64 > MAX_GITIGNORE_BYTES
+    {
+        return;
+    }
+    let Ok(contents) = String::from_utf8(bytes) else {
+        return;
+    };
+    let lines: Vec<&str> = contents.lines().collect();
+    if lines.len() > MAX_GITIGNORE_LINES {
+        return;
+    }
+
+    for (index, line) in lines.into_iter().enumerate() {
+        // Match the ignore crate's file parser, including its first-line BOM
+        // handling, while retaining the source path in parse diagnostics.
+        let line = if index == 0 {
+            line.trim_start_matches('\u{feff}')
+        } else {
+            line
+        };
+        let _ = builder.add_line(Some(path.to_path_buf()), line);
+    }
 }
 
 fn is_hidden(name: &str) -> bool {
@@ -476,6 +541,22 @@ fn fs_list_dir_scoped(
     show_hidden: bool,
     respect_gitignore: bool,
 ) -> AppResult<ListResult> {
+    fs_list_dir_scoped_with_limit(
+        scope,
+        path,
+        show_hidden,
+        respect_gitignore,
+        MAX_DIRECTORY_ENTRIES,
+    )
+}
+
+fn fs_list_dir_scoped_with_limit(
+    scope: &FsScope,
+    path: String,
+    show_hidden: bool,
+    respect_gitignore: bool,
+    max_entries: usize,
+) -> AppResult<ListResult> {
     let dir = scope.authorize_existing(Path::new(&path))?.resolved;
     if !dir.is_dir() {
         return Err(AppError::InvalidPath(format!("not a directory: {path}")));
@@ -484,7 +565,12 @@ fn fs_list_dir_scoped(
     let gi = repo_root.as_deref().map(build_gitignore);
 
     let mut entries: Vec<FileEntry> = Vec::new();
-    for item in std::fs::read_dir(&dir)? {
+    for (index, item) in std::fs::read_dir(&dir)?.enumerate() {
+        if index >= max_entries {
+            return Err(AppError::Other(format!(
+                "directory contains more than {max_entries} entries"
+            )));
+        }
         let item = item?;
         let p = item.path();
         let name = match p.file_name().and_then(|n| n.to_str()) {
@@ -676,28 +762,8 @@ fn fs_open_default_scoped(scope: &FsScope, path: String) -> AppResult<()> {
     if !p.exists() {
         return Err(AppError::InvalidPath(format!("missing: {path}")));
     }
-    #[cfg(target_os = "macos")]
-    {
-        std::process::Command::new("open")
-            .arg(&scoped.requested)
-            .spawn()
-            .map_err(|e| AppError::Other(format!("open failed: {e}")))?;
-    }
-    #[cfg(target_os = "linux")]
-    {
-        std::process::Command::new("xdg-open")
-            .arg(&scoped.requested)
-            .spawn()
-            .map_err(|e| AppError::Other(format!("xdg-open failed: {e}")))?;
-    }
-    #[cfg(target_os = "windows")]
-    {
-        std::process::Command::new("cmd")
-            .args(["/c", "start", ""])
-            .arg(&scoped.requested)
-            .spawn()
-            .map_err(|e| AppError::Other(format!("start failed: {e}")))?;
-    }
+    tauri_plugin_opener::open_path(&scoped.resolved, None::<&str>)
+        .map_err(|e| AppError::Other(format!("open failed: {e}")))?;
     Ok(())
 }
 
@@ -835,6 +901,11 @@ fn fs_git_diff_stats_scoped(
     repo_root: String,
     entries: Vec<GitDiffStatsRequest>,
 ) -> AppResult<HashMap<String, GitDiffStatsEntry>> {
+    if entries.len() > MAX_DIFF_STAT_PATHS {
+        return Err(AppError::Other(format!(
+            "diff stat path limit exceeded (maximum {MAX_DIFF_STAT_PATHS})"
+        )));
+    }
     let root = scope.authorize_existing(Path::new(&repo_root))?.resolved;
     if !root.exists() {
         return Err(AppError::InvalidPath(format!("missing: {repo_root}")));
@@ -883,7 +954,12 @@ fn fs_git_diff_stats_scoped(
 
     // Untracked / freshly-added: line count of the working-tree file.
     for (abs, path) in added {
-        let additions = std::fs::read(&path).map(|b| count_lines(&b)).unwrap_or(0);
+        let additions = count_file_lines_bounded(&path).ok_or_else(|| {
+            AppError::Other(format!(
+                "diff stats unavailable for oversized or unreadable file: {}",
+                path.display()
+            ))
+        })?;
         out.insert(
             abs,
             GitDiffStatsEntry {
@@ -899,9 +975,12 @@ fn fs_git_diff_stats_scoped(
         let deletions = head_tree
             .as_ref()
             .and_then(|t| t.get_path(Path::new(&rel)).ok())
-            .and_then(|e| e.to_object(&repo).ok())
-            .and_then(|o| o.as_blob().map(|b| count_lines(b.content())))
-            .unwrap_or(0);
+            .and_then(|e| count_blob_lines_bounded(&repo, e.id()))
+            .ok_or_else(|| {
+                AppError::Other(format!(
+                    "diff stats unavailable for oversized or unreadable blob: {rel}"
+                ))
+            })?;
         out.insert(
             abs,
             GitDiffStatsEntry {
@@ -915,43 +994,73 @@ fn fs_git_diff_stats_scoped(
     // pathspec, fan out via `foreach` line callbacks per delta path.
     if !diffable.is_empty() {
         let mut opts = git2::DiffOptions::new();
-        opts.include_untracked(true).recurse_untracked_dirs(false);
+        opts.include_untracked(true)
+            .recurse_untracked_dirs(false)
+            .disable_pathspec_match(true)
+            .max_size(MAX_DIFF_STAT_FILE_BYTES as i64);
         for (_, rel) in &diffable {
             opts.pathspec(rel);
         }
         match repo.diff_tree_to_workdir_with_index(head_tree.as_ref(), Some(&mut opts)) {
             Ok(diff) => {
-                let mut per_path: HashMap<String, (u32, u32)> = HashMap::new();
+                let per_path: RefCell<HashMap<String, (u32, u32)>> = RefCell::new(HashMap::new());
+                let current_path: RefCell<Option<String>> = RefCell::new(None);
+                let mut callback_lines = 0u32;
+                let mut limit_hit = false;
                 let foreach_result = diff.foreach(
-                    &mut |_delta, _progress| true,
-                    None,
-                    None,
-                    Some(&mut |delta, _hunk, line| {
+                    &mut |delta, _progress| {
                         let rel = delta
                             .new_file()
                             .path()
                             .or_else(|| delta.old_file().path())
-                            .and_then(|p| p.to_str())
-                            .unwrap_or("")
-                            .to_string();
-                        if rel.is_empty() {
-                            return true;
+                            .and_then(|path| path.to_str())
+                            .filter(|path| !path.is_empty())
+                            .map(str::to_owned);
+                        if let Some(rel) = &rel {
+                            per_path.borrow_mut().entry(rel.clone()).or_default();
                         }
-                        let entry = per_path.entry(rel).or_default();
-                        match line.origin() {
-                            '+' => entry.0 = entry.0.saturating_add(1),
-                            '-' => entry.1 = entry.1.saturating_add(1),
-                            _ => {}
+                        *current_path.borrow_mut() = rel;
+                        true
+                    },
+                    None,
+                    None,
+                    Some(&mut |_delta, _hunk, line| {
+                        callback_lines = callback_lines.saturating_add(1);
+                        if callback_lines > MAX_DIFF_STAT_CALLBACK_LINES {
+                            limit_hit = true;
+                            return false;
+                        }
+                        let current_path = current_path.borrow();
+                        let Some(rel) = current_path.as_deref() else {
+                            return true;
+                        };
+                        let mut counts = per_path.borrow_mut();
+                        let Some(entry) = counts.get_mut(rel) else {
+                            return true;
+                        };
+                        let changed_line = matches!(line.origin(), '+' | '-');
+                        if changed_line && entry.0.saturating_add(entry.1) >= MAX_DIFF_STAT_LINES {
+                            limit_hit = true;
+                            return false;
+                        } else {
+                            match line.origin() {
+                                '+' => entry.0 = entry.0.saturating_add(1),
+                                '-' => entry.1 = entry.1.saturating_add(1),
+                                _ => {}
+                            }
                         }
                         true
                     }),
                 );
-                if let Err(err) = foreach_result {
-                    // Partial walk: per_path holds whatever landed before the
-                    // error. Surface so callers can see zero counts are not
-                    // "no changes" but "we lost track halfway".
-                    tracing::warn!(error = %err, "diff foreach interrupted; stats may be partial");
+                if limit_hit {
+                    return Err(AppError::Other(format!(
+                        "diff stat line limit exceeded (maximum {MAX_DIFF_STAT_LINES} per file, {MAX_DIFF_STAT_CALLBACK_LINES} total callbacks)"
+                    )));
                 }
+                if let Err(err) = foreach_result {
+                    return Err(err.into());
+                }
+                let per_path = per_path.into_inner();
                 for (abs, rel) in diffable {
                     let (a, d) = per_path.get(&rel).copied().unwrap_or((0, 0));
                     out.insert(
@@ -964,16 +1073,7 @@ fn fs_git_diff_stats_scoped(
                 }
             }
             Err(err) => {
-                tracing::warn!(error = %err, "diff_tree_to_workdir_with_index failed; diff stats zeroed");
-                for (abs, _rel) in diffable {
-                    out.insert(
-                        abs,
-                        GitDiffStatsEntry {
-                            additions: 0,
-                            deletions: 0,
-                        },
-                    );
-                }
+                return Err(err.into());
             }
         }
     }
@@ -981,15 +1081,90 @@ fn fs_git_diff_stats_scoped(
     Ok(out)
 }
 
-fn count_lines(bytes: &[u8]) -> u32 {
-    if bytes.is_empty() {
-        return 0;
+fn count_file_lines_bounded(path: &Path) -> Option<u32> {
+    let link_meta = std::fs::symlink_metadata(path).ok()?;
+    if link_meta.file_type().is_symlink()
+        || !link_meta.is_file()
+        || link_meta.len() > MAX_DIFF_STAT_FILE_BYTES
+    {
+        return None;
     }
-    let mut n = bytes.iter().filter(|&&b| b == b'\n').count() as u32;
-    if bytes.last() != Some(&b'\n') {
-        n += 1;
+
+    let file = File::open(path).ok()?;
+    let open_meta = file.metadata().ok()?;
+    if !open_meta.is_file() || open_meta.len() > MAX_DIFF_STAT_FILE_BYTES {
+        return None;
     }
-    n
+    count_lines_bounded(file, MAX_DIFF_STAT_FILE_BYTES, MAX_DIFF_STAT_LINES)
+        .ok()
+        .flatten()
+}
+
+fn count_blob_lines_bounded(repo: &Repository, oid: git2::Oid) -> Option<u32> {
+    // Inspect the object header before `find_blob` asks libgit2 to materialize
+    // the blob contents.
+    let odb = repo.odb().ok()?;
+    let (size, kind) = odb.read_header(oid).ok()?;
+    if kind != git2::ObjectType::Blob || u64::try_from(size).ok()? > MAX_DIFF_STAT_FILE_BYTES {
+        return None;
+    }
+    let blob = repo.find_blob(oid).ok()?;
+    if u64::try_from(blob.content().len()).ok()? > MAX_DIFF_STAT_FILE_BYTES {
+        return None;
+    }
+    count_lines_bounded(
+        blob.content(),
+        MAX_DIFF_STAT_FILE_BYTES,
+        MAX_DIFF_STAT_LINES,
+    )
+    .ok()
+    .flatten()
+}
+
+fn count_lines_bounded<R: Read>(
+    reader: R,
+    max_bytes: u64,
+    max_lines: u32,
+) -> std::io::Result<Option<u32>> {
+    let mut reader = reader.take(max_bytes.saturating_add(1));
+    let mut buffer = [0u8; 64 * 1024];
+    let mut bytes_read = 0u64;
+    let mut line_count = 0u32;
+    let mut saw_bytes = false;
+    let mut last_was_newline = false;
+
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        bytes_read = bytes_read.saturating_add(read as u64);
+        if bytes_read > max_bytes {
+            return Ok(None);
+        }
+        saw_bytes = true;
+        last_was_newline = buffer[read - 1] == b'\n';
+        let newlines = buffer[..read].iter().filter(|&&byte| byte == b'\n').count() as u32;
+        let Some(next_count) = line_count.checked_add(newlines) else {
+            return Ok(None);
+        };
+        if next_count > max_lines {
+            return Ok(None);
+        }
+        line_count = next_count;
+    }
+
+    if saw_bytes && !last_was_newline {
+        let Some(next_count) = line_count.checked_add(1) else {
+            return Ok(None);
+        };
+        if next_count > max_lines {
+            return Ok(None);
+        }
+        line_count = next_count;
+    }
+
+    Ok(Some(line_count))
 }
 
 fn classify_status(s: Status) -> &'static str {
@@ -1088,11 +1263,34 @@ fn fs_prepare_asset_scoped<R: Runtime>(
     if !scoped.resolved.is_file() {
         return Err(AppError::InvalidPath(format!("not a file: {path}")));
     }
+    validate_embeddable_asset(&scoped.requested, &scoped.resolved)?;
     let meta = std::fs::metadata(&scoped.resolved)?;
     app.asset_protocol_scope()
         .allow_file(&scoped.resolved)
         .map_err(|e| AppError::Other(format!("asset scope failed: {e}")))?;
     Ok(PrepareAssetResult { size: meta.len() })
+}
+
+fn validate_embeddable_asset(requested_path: &Path, resolved_path: &Path) -> AppResult<()> {
+    // The frontend chooses its renderer from the requested filename, so a
+    // symlink must not change whether the backend enforces PDF validation.
+    let is_pdf = requested_path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("pdf"));
+    if !is_pdf {
+        return Ok(());
+    }
+
+    use std::io::Read;
+    let mut header = [0u8; 5];
+    let bytes_read = std::fs::File::open(resolved_path)?.read(&mut header)?;
+    if bytes_read != header.len() || header != *b"%PDF-" {
+        return Err(AppError::InvalidPath(
+            "refusing to embed a file with an invalid PDF header".into(),
+        ));
+    }
+    Ok(())
 }
 
 fn fs_read_file_scoped(scope: &FsScope, path: String) -> AppResult<ReadFileResult> {
@@ -1152,12 +1350,20 @@ fn fs_git_diff_lines_scoped(scope: &FsScope, path: String) -> AppResult<Vec<Line
     let target = PathBuf::from(&path);
     let scoped = scope.authorize_existing(&target)?;
     let target = scoped.resolved;
-    if !target.is_file() {
+    let target_metadata = std::fs::metadata(&target)?;
+    if !target_metadata.is_file() {
         return Ok(Vec::new());
+    }
+    if target_metadata.len() > MAX_DIFF_STAT_FILE_BYTES {
+        return Err(AppError::Other(format!(
+            "diff line byte limit exceeded for {} (maximum {MAX_DIFF_STAT_FILE_BYTES} bytes)",
+            target.display()
+        )));
     }
     let repo = match Repository::discover(&target) {
         Ok(r) => r,
-        Err(_) => return Ok(Vec::new()),
+        Err(err) if err.code() == git2::ErrorCode::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err.into()),
     };
     let workdir = match repo.workdir() {
         Some(p) => p.to_path_buf(),
@@ -1169,18 +1375,55 @@ fn fs_git_diff_lines_scoped(scope: &FsScope, path: String) -> AppResult<Vec<Line
     };
 
     let mut opts = git2::DiffOptions::new();
-    opts.pathspec(&rel).context_lines(0).include_untracked(true);
-    let tree = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
-    let diff = match repo.diff_tree_to_workdir_with_index(tree.as_ref(), Some(&mut opts)) {
-        Ok(d) => d,
-        Err(_) => return Ok(Vec::new()),
+    opts.pathspec(&rel)
+        .disable_pathspec_match(true)
+        .context_lines(0)
+        .include_untracked(true)
+        .recurse_untracked_dirs(false)
+        .max_size(MAX_DIFF_STAT_FILE_BYTES as i64);
+    let tree = match repo.head() {
+        Ok(head) => Some(head.peel_to_tree()?),
+        Err(err)
+            if matches!(
+                err.code(),
+                git2::ErrorCode::NotFound | git2::ErrorCode::UnbornBranch
+            ) =>
+        {
+            None
+        }
+        Err(err) => return Err(err.into()),
     };
+    let diff = repo.diff_tree_to_workdir_with_index(tree.as_ref(), Some(&mut opts))?;
+    if diff.deltas().any(|delta| {
+        delta.old_file().size() > MAX_DIFF_STAT_FILE_BYTES
+            || delta.new_file().size() > MAX_DIFF_STAT_FILE_BYTES
+    }) {
+        return Err(AppError::Other(format!(
+            "diff line byte limit exceeded for {} (maximum {MAX_DIFF_STAT_FILE_BYTES} bytes)",
+            target.display()
+        )));
+    }
 
-    let mut out: Vec<LineDiffEntry> = Vec::new();
     let mut adds: Vec<u32> = Vec::new();
-    let mut dels: Vec<u32> = Vec::new();
-    let mut current_marker: Option<u32> = None;
-    diff.print(git2::DiffFormat::Patch, |_delta, _hunk, line| {
+    let mut dels = std::collections::HashSet::new();
+    let mut callback_lines = 0u32;
+    let mut changed_lines = 0u32;
+    let mut limit_hit = false;
+    let print_result = diff.print(git2::DiffFormat::Patch, |_delta, _hunk, line| {
+        callback_lines = callback_lines.saturating_add(1);
+        if callback_lines > MAX_DIFF_STAT_CALLBACK_LINES {
+            limit_hit = true;
+            return false;
+        }
+
+        if matches!(line.origin(), '+' | '-') {
+            if changed_lines >= MAX_DIFF_STAT_LINES {
+                limit_hit = true;
+                return false;
+            }
+            changed_lines = changed_lines.saturating_add(1);
+        }
+
         match line.origin() {
             '+' => {
                 if let Some(n) = line.new_lineno() {
@@ -1189,33 +1432,31 @@ fn fs_git_diff_lines_scoped(scope: &FsScope, path: String) -> AppResult<Vec<Line
             }
             '-' => {
                 if let Some(n) = line.old_lineno() {
-                    dels.push(n);
-                }
-                // Track the new-side anchor for "modified" classification.
-                if current_marker.is_none() {
-                    current_marker = line.new_lineno();
+                    dels.insert(n);
                 }
             }
-            _ => {
-                current_marker = None;
-            }
+            _ => {}
         }
         true
-    })
-    .ok();
+    });
+    if limit_hit {
+        return Err(AppError::Other(format!(
+            "diff line limit exceeded (maximum {MAX_DIFF_STAT_LINES} changed lines, {MAX_DIFF_STAT_CALLBACK_LINES} total callbacks)"
+        )));
+    }
+    print_result?;
 
     // Classify: a deleted-only hunk shows as a "deleted" anchor on the
     // line immediately AFTER the deletion; an added line that follows
     // a deletion in the same hunk shows as "modified"; pure additions
     // show as "added".
-    let del_set: std::collections::HashSet<u32> = dels.iter().copied().collect();
-    let add_set: std::collections::HashSet<u32> = adds.iter().copied().collect();
+    let mut out = Vec::with_capacity(adds.len().saturating_add(1));
     for n in adds.iter().copied() {
         // Heuristic: if the prior new-line was a deletion anchor or a
         // contiguous addition started at n, mark as modified vs added.
         // We classify all adds as `added` here; the frontend collapses
         // the visual to a single bar so the distinction is cosmetic.
-        let kind = if del_set.contains(&n) {
+        let kind = if dels.contains(&n) {
             "modified"
         } else {
             "added"
@@ -1234,7 +1475,6 @@ fn fs_git_diff_lines_scoped(scope: &FsScope, path: String) -> AppResult<Vec<Line
             kind: "deleted".into(),
         });
     }
-    let _ = add_set; // silence: kept for future "modified vs added" refinement
     Ok(out)
 }
 
@@ -1294,12 +1534,15 @@ pub fn fs_watch_set_root<R: Runtime>(
                 return Ok(());
             }
         }
-        let (tx, rx) = mpsc::channel();
-        let batcher = spawn_watch_batcher(app.clone(), root.clone(), rx);
+        let (tx, rx) = mpsc::sync_channel(WATCH_QUEUE_CAPACITY);
+        let queue_overflowed = Arc::new(AtomicBool::new(false));
+        let batcher =
+            spawn_watch_batcher(app.clone(), root.clone(), rx, Arc::clone(&queue_overflowed));
         let tx_for_cb = tx.clone();
+        let overflow_for_cb = Arc::clone(&queue_overflowed);
         drop(tx);
         let mut watcher: RecommendedWatcher = notify::recommended_watcher(move |res| {
-            let _ = tx_for_cb.send(res);
+            try_enqueue_watch_result(&tx_for_cb, &overflow_for_cb, res);
         })
         .map_err(|e| AppError::Other(format!("notify init failed: {e}")))?;
         watcher
@@ -1328,15 +1571,31 @@ fn spawn_watch_batcher<R: Runtime>(
     app: AppHandle<R>,
     root: PathBuf,
     rx: Receiver<notify::Result<Event>>,
+    queue_overflowed: Arc<AtomicBool>,
 ) -> WatchBatcher {
-    let thread = std::thread::spawn(move || run_watch_batcher(app, root, rx));
+    let thread = std::thread::spawn(move || run_watch_batcher(app, root, rx, queue_overflowed));
     WatchBatcher { _thread: thread }
+}
+
+fn try_enqueue_watch_result(
+    tx: &SyncSender<notify::Result<Event>>,
+    queue_overflowed: &AtomicBool,
+    result: notify::Result<Event>,
+) {
+    match tx.try_send(result) {
+        Ok(()) => {}
+        Err(TrySendError::Full(_)) => {
+            queue_overflowed.store(true, AtomicOrdering::Release);
+        }
+        Err(TrySendError::Disconnected(_)) => {}
+    }
 }
 
 fn run_watch_batcher<R: Runtime>(
     app: AppHandle<R>,
     root: PathBuf,
     rx: Receiver<notify::Result<Event>>,
+    queue_overflowed: Arc<AtomicBool>,
 ) {
     let mut last_emit: Option<Instant> = None;
     let mut supervisor = SupervisorState::default();
@@ -1360,6 +1619,7 @@ fn run_watch_batcher<R: Runtime>(
                 Err(mpsc::RecvTimeoutError::Disconnected) => break,
             }
         }
+        apply_watch_queue_overflow(&mut batch, &queue_overflowed);
 
         let Some(payload) = batch.finish() else {
             continue;
@@ -1378,6 +1638,14 @@ fn run_watch_batcher<R: Runtime>(
             tracing::warn!(error = %e, "fs-changed emit failed");
         }
     }
+}
+
+fn apply_watch_queue_overflow(batch: &mut WatchBatch, queue_overflowed: &AtomicBool) -> bool {
+    if !queue_overflowed.swap(false, AtomicOrdering::AcqRel) {
+        return false;
+    }
+    batch.request_root_refresh();
+    true
 }
 
 fn throttle_delay(last_emit: Option<Instant>, now: Instant) -> Duration {
@@ -1478,8 +1746,7 @@ impl WatchBatch {
 
     fn add_event(&mut self, event: Event) {
         if event.need_rescan() {
-            self.add_path(self.root.clone(), BatchedKind::Updated);
-            self.overflow = true;
+            self.request_root_refresh();
             return;
         }
 
@@ -1507,6 +1774,13 @@ impl WatchBatch {
             }
             self.add_path(path, kind);
         }
+    }
+
+    fn request_root_refresh(&mut self) {
+        self.seen.clear();
+        self.seen.insert(self.root.clone(), BatchedKind::Updated);
+        self.common_ancestor = Some(self.root.clone());
+        self.overflow = true;
     }
 
     fn add_path(&mut self, path: PathBuf, kind: BatchedKind) {
@@ -1722,6 +1996,19 @@ mod tests {
         repo
     }
 
+    fn commit_paths(repo: &git2::Repository, paths: &[&str]) {
+        let sig = git2::Signature::now("acorn-test", "test@acorn").unwrap();
+        let mut index = repo.index().unwrap();
+        for path in paths {
+            index.add_path(Path::new(path)).unwrap();
+        }
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "commit", &tree, &[])
+            .unwrap();
+    }
+
     #[test]
     fn scope_from_state_ignores_local_session_roots() {
         let state = AppState::new();
@@ -1830,6 +2117,26 @@ mod tests {
     }
 
     #[test]
+    fn rejects_directories_over_the_entry_budget() {
+        let d = tmpdir();
+        fs::write(d.path().join("one.txt"), b"").unwrap();
+        fs::write(d.path().join("two.txt"), b"").unwrap();
+        fs::write(d.path().join("three.txt"), b"").unwrap();
+
+        let scope = scope_for(d.path());
+        let err = fs_list_dir_scoped_with_limit(
+            &scope,
+            d.path().to_string_lossy().into_owned(),
+            false,
+            false,
+            2,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("more than 2 entries"));
+    }
+
+    #[test]
     fn hides_dotfiles_by_default() {
         let d = tmpdir();
         fs::write(d.path().join(".env"), b"").unwrap();
@@ -1874,6 +2181,48 @@ mod tests {
         .unwrap();
         let off_names: Vec<_> = off.entries.iter().map(|e| e.name.clone()).collect();
         assert_eq!(off_names, vec!["build", "keep.txt", "secret.txt"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skips_symlinked_gitignore_files() {
+        use std::os::unix::fs::symlink;
+
+        let d = tmpdir();
+        fs::create_dir(d.path().join(".git")).unwrap();
+        let outside = tmpdir();
+        let outside_ignore = outside.path().join("ignore");
+        fs::write(&outside_ignore, b"secret.txt\n").unwrap();
+        symlink(&outside_ignore, d.path().join(".gitignore")).unwrap();
+        fs::write(d.path().join("secret.txt"), b"").unwrap();
+
+        let scope = scope_for(d.path());
+        let result =
+            fs_list_dir_scoped(&scope, d.path().to_string_lossy().into_owned(), false, true)
+                .unwrap();
+        assert!(result
+            .entries
+            .iter()
+            .any(|entry| entry.name == "secret.txt"));
+    }
+
+    #[test]
+    fn skips_oversized_gitignore_files() {
+        let d = tmpdir();
+        fs::create_dir(d.path().join(".git")).unwrap();
+        let mut oversized = b"secret.txt\n".to_vec();
+        oversized.resize(MAX_GITIGNORE_BYTES as usize + 1, b'#');
+        fs::write(d.path().join(".gitignore"), oversized).unwrap();
+        fs::write(d.path().join("secret.txt"), b"").unwrap();
+
+        let scope = scope_for(d.path());
+        let result =
+            fs_list_dir_scoped(&scope, d.path().to_string_lossy().into_owned(), false, true)
+                .unwrap();
+        assert!(result
+            .entries
+            .iter()
+            .any(|entry| entry.name == "secret.txt"));
     }
 
     #[test]
@@ -1946,6 +2295,47 @@ mod tests {
         batch.add_event(Event::new(EventKind::Any).set_flag(notify::event::Flag::Rescan));
 
         let payload = batch.finish().unwrap();
+        assert_eq!(payload.paths, vec![root.to_string_lossy().into_owned()]);
+        assert!(payload.overflow);
+        assert_eq!(
+            payload.refresh,
+            Some(FsRefreshHint {
+                kind: FsRefreshKind::Root,
+                path: root.to_string_lossy().into_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn watch_callback_queue_is_bounded_and_coalesces_overflow_to_one_root_refresh() {
+        let d = tmpdir();
+        let root = d.path().canonicalize().unwrap();
+        let (tx, rx) = mpsc::sync_channel(1);
+        let queue_overflowed = AtomicBool::new(false);
+
+        try_enqueue_watch_result(
+            &tx,
+            &queue_overflowed,
+            Ok(create_event(vec![root.join("first.rs")])),
+        );
+        try_enqueue_watch_result(
+            &tx,
+            &queue_overflowed,
+            Ok(create_event(vec![root.join("dropped.rs")])),
+        );
+
+        let queued = rx.try_recv().expect("the first event remains queued");
+        assert_eq!(
+            queued.expect("queued notify event").paths,
+            vec![root.join("first.rs")]
+        );
+        assert!(matches!(rx.try_recv(), Err(mpsc::TryRecvError::Empty)));
+        assert!(queue_overflowed.load(AtomicOrdering::Acquire));
+
+        let mut batch = new_batch(&root);
+        assert!(apply_watch_queue_overflow(&mut batch, &queue_overflowed));
+        assert!(!apply_watch_queue_overflow(&mut batch, &queue_overflowed));
+        let payload = batch.finish().expect("overflow refresh payload");
         assert_eq!(payload.paths, vec![root.to_string_lossy().into_owned()]);
         assert!(payload.overflow);
         assert_eq!(
@@ -2062,6 +2452,41 @@ mod tests {
         let res = fs_read_file_scoped(&scope, outside_file.to_string_lossy().into_owned()).unwrap();
 
         assert_eq!(res.content, "hello");
+    }
+
+    #[test]
+    fn embedded_pdf_requires_pdf_magic_bytes() {
+        let d = tmpdir();
+        let valid = d.path().join("valid.pdf");
+        let disguised_html = d.path().join("disguised.pdf");
+        fs::write(&valid, b"%PDF-1.7\n").unwrap();
+        fs::write(&disguised_html, b"<html><script></script></html>").unwrap();
+
+        assert!(validate_embeddable_asset(&valid, &valid).is_ok());
+        assert!(validate_embeddable_asset(&disguised_html, &disguised_html).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn embedded_pdf_symlink_validates_requested_extension() {
+        use std::os::unix::fs::symlink;
+
+        let d = tmpdir();
+        let html = d.path().join("payload.html");
+        let pdf_link = d.path().join("preview.pdf");
+        fs::write(&html, b"<html><script></script></html>").unwrap();
+        symlink(&html, &pdf_link).unwrap();
+
+        assert!(validate_embeddable_asset(&pdf_link, &html).is_err());
+    }
+
+    #[test]
+    fn embedded_non_pdf_asset_is_unchanged() {
+        let d = tmpdir();
+        let image = d.path().join("image.png");
+        fs::write(&image, b"not checked here").unwrap();
+
+        assert!(validate_embeddable_asset(&image, &image).is_ok());
     }
 
     #[test]
@@ -2464,6 +2889,90 @@ mod tests {
     }
 
     #[test]
+    fn bounded_line_counter_enforces_byte_and_line_limits() {
+        assert_eq!(
+            count_lines_bounded(std::io::Cursor::new(b"alpha\nbeta"), 10, 2).unwrap(),
+            Some(2)
+        );
+        assert_eq!(
+            count_lines_bounded(std::io::Cursor::new(Vec::<u8>::new()), 0, 0).unwrap(),
+            Some(0)
+        );
+        assert_eq!(
+            count_lines_bounded(std::io::Cursor::new(b"12345"), 4, 10).unwrap(),
+            None
+        );
+        assert_eq!(
+            count_lines_bounded(std::io::Cursor::new(b"a\nb\nc\n"), 16, 2).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn diff_stats_rejects_oversized_added_files_instead_of_reporting_zero() {
+        let d = tmpdir();
+        let repo_path = d.path().canonicalize().unwrap();
+        Repository::init(&repo_path).unwrap();
+        let oversized = repo_path.join("oversized.txt");
+        File::create(&oversized)
+            .unwrap()
+            .set_len(MAX_DIFF_STAT_FILE_BYTES + 1)
+            .unwrap();
+
+        let scope = scope_for(&repo_path);
+        let error = fs_git_diff_stats_scoped(
+            &scope,
+            repo_path.to_string_lossy().into_owned(),
+            vec![GitDiffStatsRequest {
+                path: oversized.to_string_lossy().into_owned(),
+                kind: "added".to_string(),
+            }],
+        )
+        .expect_err("oversized file should not look like a zero-line file");
+
+        assert!(error.to_string().contains("diff stats unavailable"));
+    }
+
+    #[test]
+    fn diff_stats_aborts_when_changed_line_limit_is_exceeded() {
+        use git2::Signature;
+
+        let d = tmpdir();
+        let repo_path = d.path().canonicalize().unwrap();
+        let repo = Repository::init(&repo_path).unwrap();
+        let changed = repo_path.join("many-lines.txt");
+        fs::write(&changed, "base\n").unwrap();
+
+        let sig = Signature::now("t", "t@t").unwrap();
+        {
+            let mut index = repo.index().unwrap();
+            index.add_path(Path::new("many-lines.txt")).unwrap();
+            index.write().unwrap();
+            let tree_id = index.write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+                .unwrap();
+        }
+
+        let mut contents = String::from("base\n");
+        contents.push_str(&"added\n".repeat(MAX_DIFF_STAT_LINES as usize + 1));
+        fs::write(&changed, contents).unwrap();
+
+        let scope = scope_for(&repo_path);
+        let error = fs_git_diff_stats_scoped(
+            &scope,
+            repo_path.to_string_lossy().into_owned(),
+            vec![GitDiffStatsRequest {
+                path: changed.to_string_lossy().into_owned(),
+                kind: "modified".to_string(),
+            }],
+        )
+        .expect_err("line-heavy diff should stop at the callback budget");
+
+        assert!(error.to_string().contains("diff stat line limit exceeded"));
+    }
+
+    #[test]
     fn diff_stats_handles_multiple_modified_paths_in_one_call() {
         use git2::{Repository, Signature};
 
@@ -2507,5 +3016,89 @@ mod tests {
         assert_eq!(stats[&x_key].deletions, 0);
         assert_eq!(stats[&y_key].additions, 0);
         assert_eq!(stats[&y_key].deletions, 1);
+    }
+
+    #[test]
+    fn diff_lines_returns_markers_for_requested_file() {
+        let d = tmpdir();
+        let repo_path = d.path().canonicalize().unwrap();
+        let repo = Repository::init(&repo_path).unwrap();
+        let changed = repo_path.join("normal.txt");
+        fs::write(&changed, "one\ntwo\nthree\n").unwrap();
+        commit_paths(&repo, &["normal.txt"]);
+        fs::write(&changed, "one\ntwo\nadded\nthree\n").unwrap();
+
+        let scope = scope_for(&repo_path);
+        let lines =
+            fs_git_diff_lines_scoped(&scope, changed.to_string_lossy().into_owned()).unwrap();
+        let markers: Vec<_> = lines
+            .iter()
+            .map(|entry| (entry.line, entry.kind.as_str()))
+            .collect();
+
+        assert_eq!(markers, vec![(3, "added")]);
+    }
+
+    #[test]
+    fn diff_lines_treats_glob_metacharacters_as_literal_filename() {
+        let d = tmpdir();
+        let repo_path = d.path().canonicalize().unwrap();
+        let repo = Repository::init(&repo_path).unwrap();
+        let target = repo_path.join("literal[ab].txt");
+        let glob_match = repo_path.join("literala.txt");
+        fs::write(&target, "one\ntwo\n").unwrap();
+        fs::write(&glob_match, "one\ntwo\n").unwrap();
+        commit_paths(&repo, &["literal[ab].txt", "literala.txt"]);
+
+        fs::write(&target, "one\nchanged\n").unwrap();
+        fs::write(&glob_match, "one\ntwo\nunrelated\nlines\n").unwrap();
+
+        let scope = scope_for(&repo_path);
+        let lines =
+            fs_git_diff_lines_scoped(&scope, target.to_string_lossy().into_owned()).unwrap();
+        let markers: Vec<_> = lines
+            .iter()
+            .map(|entry| (entry.line, entry.kind.as_str()))
+            .collect();
+
+        assert_eq!(markers, vec![(2, "modified")]);
+    }
+
+    #[test]
+    fn diff_lines_aborts_when_changed_line_limit_is_exceeded() {
+        let d = tmpdir();
+        let repo_path = d.path().canonicalize().unwrap();
+        let repo = Repository::init(&repo_path).unwrap();
+        let changed = repo_path.join("many-lines.txt");
+        fs::write(&changed, "base\n").unwrap();
+        commit_paths(&repo, &["many-lines.txt"]);
+
+        let mut contents = String::from("base\n");
+        contents.push_str(&"x\n".repeat(MAX_DIFF_STAT_LINES as usize + 1));
+        fs::write(&changed, contents).unwrap();
+
+        let scope = scope_for(&repo_path);
+        let error = fs_git_diff_lines_scoped(&scope, changed.to_string_lossy().into_owned())
+            .expect_err("line-heavy diff should stop at the changed-line budget");
+
+        assert!(error.to_string().contains("diff line limit exceeded"));
+    }
+
+    #[test]
+    fn diff_lines_rejects_oversized_worktree_file() {
+        let d = tmpdir();
+        let repo_path = d.path().canonicalize().unwrap();
+        Repository::init(&repo_path).unwrap();
+        let oversized = repo_path.join("oversized.txt");
+        File::create(&oversized)
+            .unwrap()
+            .set_len(MAX_DIFF_STAT_FILE_BYTES + 1)
+            .unwrap();
+
+        let scope = scope_for(&repo_path);
+        let error = fs_git_diff_lines_scoped(&scope, oversized.to_string_lossy().into_owned())
+            .expect_err("oversized file should stop before diff generation");
+
+        assert!(error.to_string().contains("diff line byte limit exceeded"));
     }
 }

--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -1,11 +1,78 @@
 use git2::{DiffOptions, Repository};
 use serde::Serialize;
-use std::collections::{HashMap, VecDeque};
+use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fs::File;
+use std::io::Read;
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 
 use crate::error::{AppError, AppResult};
 use crate::worktree::ensure_repo;
+
+// Repositories are untrusted input. These limits bound the local diff payload
+// before it is serialized across the Tauri boundary; ordinary source diffs
+// remain far below them, while oversized images use the existing no-preview UI.
+const MAX_DIFF_TEXT_FILE_BYTES: i64 = 8 * 1024 * 1024;
+const MAX_DIFF_FILES: usize = 5_000;
+const MAX_DIFF_PATCH_BYTES: usize = 16 * 1024 * 1024;
+const MAX_DIFF_IMAGE_BYTES: usize = 8 * 1024 * 1024;
+const MAX_DIFF_TOTAL_IMAGE_BYTES: usize = 24 * 1024 * 1024;
+
+// Commit repositories are untrusted too. Pagination and object budgets bound
+// the response page, while graph budgets keep pushed classification finite.
+const MAX_COMMIT_PAGE_SIZE: usize = 500;
+const MAX_COMMIT_OFFSET: usize = 100_000;
+const MAX_COMMIT_PAGE_OBJECT_BYTES: usize = 1024 * 1024;
+const MAX_COMMIT_PAGE_TOTAL_OBJECT_BYTES: usize = 16 * 1024 * 1024;
+const MAX_REMOTE_TRACKING_REFS: usize = 2_048;
+const MAX_PUSHED_HISTORY_COMMITS: usize = 250_000;
+const MAX_PUSHED_HISTORY_PARENT_EDGES: usize = 1_000_000;
+const MAX_PUSHED_HISTORY_COMMIT_OBJECT_BYTES: usize = 1024 * 1024;
+const MAX_PUSHED_HISTORY_TOTAL_OBJECT_BYTES: usize = 128 * 1024 * 1024;
+
+#[derive(Clone, Copy)]
+struct DiffLimits {
+    max_files: usize,
+    max_patch_bytes: usize,
+    max_image_bytes: usize,
+    max_total_image_bytes: usize,
+}
+
+const LOCAL_DIFF_LIMITS: DiffLimits = DiffLimits {
+    max_files: MAX_DIFF_FILES,
+    max_patch_bytes: MAX_DIFF_PATCH_BYTES,
+    max_image_bytes: MAX_DIFF_IMAGE_BYTES,
+    max_total_image_bytes: MAX_DIFF_TOTAL_IMAGE_BYTES,
+};
+
+#[derive(Clone, Copy)]
+struct PushedHistoryLimits {
+    max_remote_refs: usize,
+    max_commits: usize,
+    max_parent_edges: usize,
+    max_commit_object_bytes: usize,
+    max_total_object_bytes: usize,
+}
+
+const LOCAL_PUSHED_HISTORY_LIMITS: PushedHistoryLimits = PushedHistoryLimits {
+    max_remote_refs: MAX_REMOTE_TRACKING_REFS,
+    max_commits: MAX_PUSHED_HISTORY_COMMITS,
+    max_parent_edges: MAX_PUSHED_HISTORY_PARENT_EDGES,
+    max_commit_object_bytes: MAX_PUSHED_HISTORY_COMMIT_OBJECT_BYTES,
+    max_total_object_bytes: MAX_PUSHED_HISTORY_TOTAL_OBJECT_BYTES,
+};
+
+#[derive(Clone, Copy)]
+struct CommitPageObjectLimits {
+    max_object_bytes: usize,
+    max_total_object_bytes: usize,
+}
+
+const LOCAL_COMMIT_PAGE_OBJECT_LIMITS: CommitPageObjectLimits = CommitPageObjectLimits {
+    max_object_bytes: MAX_COMMIT_PAGE_OBJECT_BYTES,
+    max_total_object_bytes: MAX_COMMIT_PAGE_TOTAL_OBJECT_BYTES,
+};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CommitInfo {
@@ -249,16 +316,28 @@ fn resolve_ssh_hostname(alias: &str) -> Option<String> {
 }
 
 pub fn list_commits(repo_path: &Path, offset: usize, limit: usize) -> AppResult<Vec<CommitInfo>> {
+    validate_commit_page(offset, limit)?;
     let repo = ensure_repo(repo_path)?;
-    let pushed_set = pushed_oid_set(&repo);
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
 
     let mut walk = repo.revwalk()?;
     walk.push_head()?;
     walk.set_sorting(git2::Sort::TIME)?;
 
-    let mut out = Vec::with_capacity(limit);
+    let mut page_oids = Vec::with_capacity(limit);
     for oid in walk.skip(offset).take(limit) {
-        let oid = oid?;
+        page_oids.push(oid?);
+    }
+    if page_oids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    validate_commit_page_objects(&repo, &page_oids, LOCAL_COMMIT_PAGE_OBJECT_LIMITS)?;
+    let pushed_set = pushed_page_oids(&repo, &page_oids, LOCAL_PUSHED_HISTORY_LIMITS)?;
+    let mut out = Vec::with_capacity(page_oids.len());
+    for oid in page_oids {
         let commit = repo.find_commit(oid)?;
         let author = commit.author();
         out.push(CommitInfo {
@@ -275,38 +354,210 @@ pub fn list_commits(repo_path: &Path, offset: usize, limit: usize) -> AppResult<
     Ok(out)
 }
 
-/// Build the set of commit OIDs reachable from any remote-tracking branch.
-/// A commit is "pushed" if its OID is in this set. Computed in a single
-/// revwalk to avoid quadratic per-commit ancestry checks.
-fn pushed_oid_set(repo: &Repository) -> std::collections::HashSet<git2::Oid> {
-    let mut set = std::collections::HashSet::new();
-    let Ok(mut walk) = repo.revwalk() else {
-        return set;
-    };
-    let _ = walk.set_sorting(git2::Sort::TOPOLOGICAL);
+fn validate_commit_page(offset: usize, limit: usize) -> AppResult<()> {
+    if limit > MAX_COMMIT_PAGE_SIZE {
+        return Err(AppError::Other(format!(
+            "commit page limit exceeded (maximum {MAX_COMMIT_PAGE_SIZE})"
+        )));
+    }
+    if offset > MAX_COMMIT_OFFSET {
+        return Err(AppError::Other(format!(
+            "commit offset limit exceeded (maximum {MAX_COMMIT_OFFSET})"
+        )));
+    }
+    Ok(())
+}
 
-    let Ok(branches) = repo.branches(Some(git2::BranchType::Remote)) else {
-        return set;
-    };
-    let mut pushed_any = false;
-    for entry in branches.flatten() {
-        let (branch, _) = entry;
+fn validate_commit_page_objects(
+    repo: &Repository,
+    page_oids: &[git2::Oid],
+    limits: CommitPageObjectLimits,
+) -> AppResult<()> {
+    let odb = repo.odb()?;
+    let mut total_object_bytes = 0usize;
+    for oid in page_oids {
+        let (object_bytes, object_type) = odb.read_header(*oid)?;
+        if object_type != git2::ObjectType::Commit {
+            return Err(AppError::Other(format!(
+                "commit page contains non-commit object {oid}"
+            )));
+        }
+        if object_bytes > limits.max_object_bytes {
+            return Err(AppError::Other(format!(
+                "commit page object byte limit exceeded (maximum {})",
+                limits.max_object_bytes
+            )));
+        }
+        total_object_bytes = total_object_bytes
+            .checked_add(object_bytes)
+            .ok_or_else(|| AppError::Other("commit page object byte count overflow".to_string()))?;
+        if total_object_bytes > limits.max_total_object_bytes {
+            return Err(AppError::Other(format!(
+                "commit page total object byte limit exceeded (maximum {})",
+                limits.max_total_object_bytes
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Return only requested OIDs that are reachable from a remote-tracking ref.
+/// A bounded explicit walk avoids retaining the repository's entire remote
+/// history and errors instead of presenting an unproven negative result.
+fn pushed_page_oids(
+    repo: &Repository,
+    candidates: &[git2::Oid],
+    limits: PushedHistoryLimits,
+) -> AppResult<HashSet<git2::Oid>> {
+    let mut candidate_set = HashSet::new();
+    candidate_set
+        .try_reserve(candidates.len())
+        .map_err(|_| AppError::Other("failed to reserve pushed commit candidates".to_string()))?;
+    candidate_set.extend(candidates.iter().copied());
+    if candidate_set.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let branches = repo.branches(Some(git2::BranchType::Remote))?;
+    let mut remote_ref_count = 0usize;
+    let mut remote_tip_set = HashSet::new();
+    let mut remote_tips = Vec::new();
+    for entry in branches {
+        remote_ref_count = remote_ref_count
+            .checked_add(1)
+            .ok_or_else(|| AppError::Other("remote tracking ref count overflow".to_string()))?;
+        if remote_ref_count > limits.max_remote_refs {
+            return Err(AppError::Other(format!(
+                "remote tracking ref limit exceeded (maximum {})",
+                limits.max_remote_refs
+            )));
+        }
+
+        let (branch, _) = entry?;
         if branch.get().symbolic_target().is_some() {
             continue;
         }
-        if let Some(oid) = branch.get().target() {
-            if walk.push(oid).is_ok() {
-                pushed_any = true;
-            }
+        let oid = branch.get().target().ok_or_else(|| {
+            AppError::Other("remote tracking ref has no direct target".to_string())
+        })?;
+        if remote_tip_set.contains(&oid) {
+            continue;
+        }
+        remote_tip_set
+            .try_reserve(1)
+            .map_err(|_| AppError::Other("failed to reserve remote commit tips".to_string()))?;
+        remote_tips
+            .try_reserve(1)
+            .map_err(|_| AppError::Other("failed to reserve remote commit tips".to_string()))?;
+        remote_tip_set.insert(oid);
+        remote_tips.push(oid);
+    }
+    if remote_tips.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let mut pushed = HashSet::new();
+    pushed
+        .try_reserve(candidate_set.len())
+        .map_err(|_| AppError::Other("failed to reserve pushed commit results".to_string()))?;
+    for oid in &remote_tips {
+        if candidate_set.contains(oid) {
+            pushed.insert(*oid);
         }
     }
-    if !pushed_any {
-        return set;
+    if pushed.len() == candidate_set.len() {
+        return Ok(pushed);
     }
-    for oid in walk.flatten() {
-        set.insert(oid);
+
+    let mut seen = HashSet::new();
+    let mut pending = Vec::new();
+    for oid in remote_tips {
+        enqueue_pushed_history_commit(&mut seen, &mut pending, oid, limits.max_commits)?;
     }
-    set
+
+    let odb = repo.odb()?;
+    let mut parent_edges = 0usize;
+    let mut total_object_bytes = 0usize;
+
+    while let Some(oid) = pending.pop() {
+        if candidate_set.contains(&oid) {
+            pushed.insert(oid);
+            if pushed.len() == candidate_set.len() {
+                return Ok(pushed);
+            }
+        }
+
+        let (object_bytes, object_type) = odb.read_header(oid)?;
+        if object_type != git2::ObjectType::Commit {
+            return Err(AppError::Other(format!(
+                "remote tracking ref history contains non-commit object {oid}"
+            )));
+        }
+        if object_bytes > limits.max_commit_object_bytes {
+            return Err(AppError::Other(format!(
+                "remote commit object byte limit exceeded (maximum {})",
+                limits.max_commit_object_bytes
+            )));
+        }
+        total_object_bytes = total_object_bytes
+            .checked_add(object_bytes)
+            .ok_or_else(|| {
+                AppError::Other("remote commit object byte count overflow".to_string())
+            })?;
+        if total_object_bytes > limits.max_total_object_bytes {
+            return Err(AppError::Other(format!(
+                "remote commit history byte limit exceeded (maximum {})",
+                limits.max_total_object_bytes
+            )));
+        }
+
+        let commit = repo.find_commit(oid)?;
+        parent_edges = parent_edges
+            .checked_add(commit.parent_count())
+            .ok_or_else(|| {
+                AppError::Other("remote commit parent edge count overflow".to_string())
+            })?;
+        if parent_edges > limits.max_parent_edges {
+            return Err(AppError::Other(format!(
+                "remote commit parent edge limit exceeded (maximum {})",
+                limits.max_parent_edges
+            )));
+        }
+        for index in 0..commit.parent_count() {
+            enqueue_pushed_history_commit(
+                &mut seen,
+                &mut pending,
+                commit.parent_id(index)?,
+                limits.max_commits,
+            )?;
+        }
+    }
+
+    Ok(pushed)
+}
+
+fn enqueue_pushed_history_commit(
+    seen: &mut HashSet<git2::Oid>,
+    pending: &mut Vec<git2::Oid>,
+    oid: git2::Oid,
+    max_commits: usize,
+) -> AppResult<()> {
+    if seen.contains(&oid) {
+        return Ok(());
+    }
+    if seen.len() >= max_commits {
+        return Err(AppError::Other(format!(
+            "remote commit history limit exceeded (maximum {max_commits})"
+        )));
+    }
+    seen.try_reserve(1)
+        .map_err(|_| AppError::Other("failed to reserve remote commit history".to_string()))?;
+    pending
+        .try_reserve(1)
+        .map_err(|_| AppError::Other("failed to reserve remote commit history".to_string()))?;
+    seen.insert(oid);
+    pending.push(oid);
+    Ok(())
 }
 
 pub fn list_staged(repo_path: &Path) -> AppResult<Vec<StagedFile>> {
@@ -379,6 +630,7 @@ pub fn diff_for_commit(repo_path: &Path, sha: &str) -> AppResult<DiffPayload> {
     let parent_tree = parent.as_ref().map(|p| p.tree()).transpose()?;
     let commit_tree = commit.tree()?;
     let mut opts = DiffOptions::new();
+    opts.max_size(MAX_DIFF_TEXT_FILE_BYTES);
     let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), Some(&mut opts))?;
     collect_diff(&repo, &diff)
 }
@@ -398,8 +650,13 @@ fn diff_staged_with_pathspec(repo_path: &Path, pathspec: Option<&str>) -> AppRes
     let mut opts = DiffOptions::new();
     opts.include_untracked(true)
         .recurse_untracked_dirs(true)
-        .show_untracked_content(true);
+        .show_untracked_content(true)
+        .max_size(MAX_DIFF_TEXT_FILE_BYTES);
     if let Some(path) = pathspec {
+        // A repository may legitimately contain glob metacharacters in a
+        // filename. File-scoped requests must never expand those characters
+        // into additional diff paths.
+        opts.disable_pathspec_match(true);
         opts.pathspec(path);
     }
     let diff = repo.diff_tree_to_workdir_with_index(head_tree.as_ref(), Some(&mut opts))?;
@@ -432,11 +689,29 @@ fn validate_relative_git_path(path: &str) -> AppResult<()> {
 }
 
 fn collect_diff(repo: &Repository, diff: &git2::Diff) -> AppResult<DiffPayload> {
-    use std::cell::RefCell;
-    let acc: RefCell<Vec<DiffFile>> = RefCell::new(Vec::new());
-    let current: RefCell<Option<DiffFile>> = RefCell::new(None);
+    collect_diff_with_limits(repo, diff, LOCAL_DIFF_LIMITS)
+}
 
-    diff.foreach(
+fn collect_diff_with_limits(
+    repo: &Repository,
+    diff: &git2::Diff,
+    limits: DiffLimits,
+) -> AppResult<DiffPayload> {
+    let delta_count = diff.deltas().len();
+    if delta_count > limits.max_files {
+        return Err(AppError::Other(format!(
+            "diff file limit exceeded (maximum {})",
+            limits.max_files
+        )));
+    }
+
+    let acc: RefCell<Vec<DiffFile>> = RefCell::new(Vec::with_capacity(delta_count));
+    let current: RefCell<Option<DiffFile>> = RefCell::new(None);
+    let patch_bytes = Cell::new(0usize);
+    let patch_limit_hit = Cell::new(false);
+    let mut image_bytes_remaining = limits.max_total_image_bytes;
+
+    let foreach_result = diff.foreach(
         &mut |delta, _| {
             if let Some(prev) = current.borrow_mut().take() {
                 acc.borrow_mut().push(prev);
@@ -447,8 +722,20 @@ fn collect_diff(repo: &Repository, diff: &git2::Diff) -> AppResult<DiffPayload> 
             let is_image = is_image_path(path_for_type);
             let (old_image, new_image) = if is_image {
                 (
-                    image_data_uri(repo, delta.old_file().id(), old_path.as_deref()),
-                    image_data_uri_workdir(repo, delta.new_file().id(), new_path.as_deref()),
+                    image_data_uri_bounded(
+                        repo,
+                        delta.old_file().id(),
+                        old_path.as_deref(),
+                        limits.max_image_bytes,
+                        &mut image_bytes_remaining,
+                    ),
+                    image_data_uri_workdir_bounded(
+                        repo,
+                        delta.new_file().id(),
+                        new_path.as_deref(),
+                        limits.max_image_bytes,
+                        &mut image_bytes_remaining,
+                    ),
                 )
             } else {
                 (None, None)
@@ -468,8 +755,13 @@ fn collect_diff(repo: &Repository, diff: &git2::Diff) -> AppResult<DiffPayload> 
             // Without this callback the patch stream contains only +/-/space
             // body lines, so the renderer has no per-line numbering anchor.
             // libgit2's `header()` already includes the trailing newline.
+            let raw_header = hunk.header();
+            if !reserve_patch_bytes(&patch_bytes, raw_header.len(), limits.max_patch_bytes) {
+                patch_limit_hit.set(true);
+                return false;
+            }
             if let Some(f) = current.borrow_mut().as_mut() {
-                let header = std::str::from_utf8(hunk.header()).unwrap_or("");
+                let header = std::str::from_utf8(raw_header).unwrap_or("");
                 f.patch.push_str(header);
             }
             true
@@ -477,23 +769,49 @@ fn collect_diff(repo: &Repository, diff: &git2::Diff) -> AppResult<DiffPayload> 
         Some(&mut |_delta, _hunk, line| {
             if let Some(f) = current.borrow_mut().as_mut() {
                 let origin = line.origin();
-                let prefix = match origin {
-                    '+' | '-' | ' ' => format!("{origin}"),
-                    _ => String::new(),
+                let prefix = matches!(origin, '+' | '-' | ' ').then_some(origin);
+                let prefix_bytes = usize::from(prefix.is_some());
+                let Some(additional_bytes) = line.content().len().checked_add(prefix_bytes) else {
+                    patch_limit_hit.set(true);
+                    return false;
                 };
+                if !reserve_patch_bytes(&patch_bytes, additional_bytes, limits.max_patch_bytes) {
+                    patch_limit_hit.set(true);
+                    return false;
+                }
                 let content = std::str::from_utf8(line.content()).unwrap_or("");
-                f.patch.push_str(&prefix);
+                if let Some(prefix) = prefix {
+                    f.patch.push(prefix);
+                }
                 f.patch.push_str(content);
             }
             true
         }),
-    )?;
+    );
+    if patch_limit_hit.get() {
+        return Err(AppError::Other(format!(
+            "diff patch byte limit exceeded (maximum {})",
+            limits.max_patch_bytes
+        )));
+    }
+    foreach_result?;
     if let Some(prev) = current.borrow_mut().take() {
         acc.borrow_mut().push(prev);
     }
     Ok(DiffPayload {
         files: acc.into_inner(),
     })
+}
+
+fn reserve_patch_bytes(used: &Cell<usize>, additional: usize, limit: usize) -> bool {
+    let Some(total) = used.get().checked_add(additional) else {
+        return false;
+    };
+    if total > limit {
+        return false;
+    }
+    used.set(total);
+    true
 }
 
 fn is_image_path(path: &str) -> bool {
@@ -536,29 +854,89 @@ pub(crate) fn encode_data_uri(bytes: &[u8], path: &str) -> String {
     )
 }
 
-fn image_data_uri(repo: &Repository, oid: git2::Oid, path: Option<&str>) -> Option<String> {
+fn image_data_uri_bounded(
+    repo: &Repository,
+    oid: git2::Oid,
+    path: Option<&str>,
+    max_image_bytes: usize,
+    image_bytes_remaining: &mut usize,
+) -> Option<String> {
     let path = path?;
     if oid.is_zero() {
         return None;
     }
+    let allowed_bytes = max_image_bytes.min(*image_bytes_remaining);
+    let odb = repo.odb().ok()?;
+    let (size, kind) = odb.read_header(oid).ok()?;
+    if kind != git2::ObjectType::Blob || size > allowed_bytes {
+        return None;
+    }
     let blob = repo.find_blob(oid).ok()?;
-    Some(encode_data_uri(blob.content(), path))
+    if blob.content().len() > allowed_bytes {
+        return None;
+    }
+    let preview = encode_data_uri(blob.content(), path);
+    *image_bytes_remaining -= blob.content().len();
+    Some(preview)
 }
 
 /// Resolve image bytes for the "new" side of a diff.
 /// Falls back to reading the workdir file when the diff has no oid (untracked
 /// or staged-but-unwritten cases).
-fn image_data_uri_workdir(repo: &Repository, oid: git2::Oid, path: Option<&str>) -> Option<String> {
+fn image_data_uri_workdir_bounded(
+    repo: &Repository,
+    oid: git2::Oid,
+    path: Option<&str>,
+    max_image_bytes: usize,
+    image_bytes_remaining: &mut usize,
+) -> Option<String> {
     let path = path?;
     if !oid.is_zero() {
-        if let Ok(blob) = repo.find_blob(oid) {
-            return Some(encode_data_uri(blob.content(), path));
-        }
+        return image_data_uri_bounded(
+            repo,
+            oid,
+            Some(path),
+            max_image_bytes,
+            image_bytes_remaining,
+        );
     }
-    let workdir = repo.workdir()?;
-    let abs = workdir.join(path);
-    let bytes = std::fs::read(abs).ok()?;
-    Some(encode_data_uri(&bytes, path))
+    let allowed_bytes = max_image_bytes.min(*image_bytes_remaining);
+    let bytes = read_workdir_image(repo, path, allowed_bytes)?;
+    let preview = encode_data_uri(&bytes, path);
+    *image_bytes_remaining -= bytes.len();
+    Some(preview)
+}
+
+fn read_workdir_image(repo: &Repository, path: &str, max_bytes: usize) -> Option<Vec<u8>> {
+    validate_relative_git_path(path).ok()?;
+    let workdir = repo.workdir()?.canonicalize().ok()?;
+    let candidate = workdir.join(path);
+    let metadata = std::fs::symlink_metadata(&candidate).ok()?;
+    let max_bytes_u64 = u64::try_from(max_bytes).unwrap_or(u64::MAX);
+    if metadata.file_type().is_symlink() || !metadata.is_file() || metadata.len() > max_bytes_u64 {
+        return None;
+    }
+    let resolved = candidate.canonicalize().ok()?;
+    if !resolved.starts_with(&workdir) {
+        return None;
+    }
+    let file = File::open(resolved).ok()?;
+    let open_meta = file.metadata().ok()?;
+    if !open_meta.is_file() || open_meta.len() > max_bytes_u64 {
+        return None;
+    }
+
+    // Re-check while reading because a regular file may grow after metadata
+    // inspection. `take` also bounds unusual virtual files reporting size 0.
+    let capacity = usize::try_from(open_meta.len()).ok()?;
+    let mut bytes = Vec::with_capacity(capacity);
+    file.take(max_bytes_u64.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .ok()?;
+    if bytes.len() > max_bytes {
+        return None;
+    }
+    Some(bytes)
 }
 
 #[cfg(test)]
@@ -603,6 +981,40 @@ mod tests {
             .expect("commit")
     }
 
+    fn linear_history(repo: &git2::Repository) -> [git2::Oid; 4] {
+        let first_oid = commit_file(repo, "history.txt", "a\n", "first", &[]);
+        let first = repo.find_commit(first_oid).expect("first commit");
+        let second_oid = commit_file(repo, "history.txt", "b\n", "second", &[&first]);
+        drop(first);
+        let second = repo.find_commit(second_oid).expect("second commit");
+        let third_oid = commit_file(repo, "history.txt", "c\n", "third", &[&second]);
+        drop(second);
+        let third = repo.find_commit(third_oid).expect("third commit");
+        let fourth_oid = commit_file(repo, "history.txt", "d\n", "fourth", &[&third]);
+        drop(third);
+        [first_oid, second_oid, third_oid, fourth_oid]
+    }
+
+    fn set_remote_ref(repo: &git2::Repository, name: &str, oid: git2::Oid) {
+        repo.reference(
+            &format!("refs/remotes/origin/{name}"),
+            oid,
+            true,
+            "test remote ref",
+        )
+        .expect("create remote ref");
+    }
+
+    fn test_pushed_history_limits() -> PushedHistoryLimits {
+        PushedHistoryLimits {
+            max_remote_refs: 16,
+            max_commits: 32,
+            max_parent_edges: 64,
+            max_commit_object_bytes: 1024 * 1024,
+            max_total_object_bytes: 8 * 1024 * 1024,
+        }
+    }
+
     #[test]
     fn ssh_hostname_cache_bounds_successes_and_failures() {
         let mut cache = SshHostnameCache::with_capacity(2);
@@ -621,6 +1033,307 @@ mod tests {
     fn ssh_hostname_validation_rejects_oversized_cache_keys() {
         assert!(is_plain_hostname(&"a".repeat(255)));
         assert!(!is_plain_hostname(&"a".repeat(256)));
+    }
+
+    #[test]
+    fn commit_pagination_rejects_pathological_renderer_values() {
+        assert!(validate_commit_page(0, MAX_COMMIT_PAGE_SIZE).is_ok());
+        assert!(validate_commit_page(MAX_COMMIT_OFFSET, 50).is_ok());
+
+        let page_error = validate_commit_page(0, usize::MAX).unwrap_err();
+        assert!(page_error.to_string().contains("page limit exceeded"));
+
+        let offset_error = validate_commit_page(usize::MAX, 50).unwrap_err();
+        assert!(offset_error.to_string().contains("offset limit exceeded"));
+    }
+
+    #[test]
+    fn commit_page_object_budgets_enforce_individual_and_total_boundaries() {
+        let root = unique_temp_dir("commit-page-object-budgets");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        let [first, second, _third, _fourth] = linear_history(&repo);
+        let odb = repo.odb().expect("object database");
+        let first_bytes = odb.read_header(first).expect("first header").0;
+        let second_bytes = odb.read_header(second).expect("second header").0;
+        let total_bytes = first_bytes
+            .checked_add(second_bytes)
+            .expect("small test object sizes");
+        let (largest_oid, largest_bytes) = if first_bytes >= second_bytes {
+            (first, first_bytes)
+        } else {
+            (second, second_bytes)
+        };
+
+        let exact = CommitPageObjectLimits {
+            max_object_bytes: largest_bytes,
+            max_total_object_bytes: total_bytes,
+        };
+        validate_commit_page_objects(&repo, &[first, second], exact)
+            .expect("objects exactly at page budgets");
+
+        let individual_limited = CommitPageObjectLimits {
+            max_object_bytes: largest_bytes - 1,
+            max_total_object_bytes: total_bytes,
+        };
+        let individual_error =
+            validate_commit_page_objects(&repo, &[largest_oid], individual_limited)
+                .expect_err("commit exceeds individual page object budget");
+        assert!(individual_error
+            .to_string()
+            .contains("commit page object byte limit"));
+
+        let total_limited = CommitPageObjectLimits {
+            max_object_bytes: largest_bytes,
+            max_total_object_bytes: total_bytes - 1,
+        };
+        let total_error = validate_commit_page_objects(&repo, &[first, second], total_limited)
+            .expect_err("commits exceed total page object budget");
+        assert!(total_error
+            .to_string()
+            .contains("commit page total object byte limit"));
+
+        drop(odb);
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn commit_page_object_validation_rejects_non_commit_oids() {
+        let root = unique_temp_dir("commit-page-non-commit");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        let blob = repo.blob(b"not a commit").expect("create blob");
+
+        let error = validate_commit_page_objects(
+            &repo,
+            &[blob],
+            CommitPageObjectLimits {
+                max_object_bytes: 1024,
+                max_total_object_bytes: 1024,
+            },
+        )
+        .expect_err("page oid must be a commit");
+        assert!(error.to_string().contains("non-commit object"));
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn zero_sized_commit_page_skips_history_traversal() {
+        let root = unique_temp_dir("zero-commit-page");
+        git2::Repository::init(&root).expect("init repo");
+
+        assert!(list_commits(&root, 0, 0).unwrap().is_empty());
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn pushed_history_marks_only_remote_reachable_page_commits() {
+        let root = unique_temp_dir("pushed-history-exact");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        let [first, second, third, _fourth] = linear_history(&repo);
+        set_remote_ref(&repo, "main", second);
+
+        let pushed = pushed_page_oids(&repo, &[third, second, first], test_pushed_history_limits())
+            .expect("classify page commits");
+        assert!(!pushed.contains(&third));
+        assert!(pushed.contains(&second));
+        assert!(pushed.contains(&first));
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn pushed_history_without_remotes_returns_exact_negatives() {
+        let root = unique_temp_dir("pushed-history-no-remotes");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        let commit = commit_file(&repo, "a.txt", "a\n", "only", &[]);
+        let limits = PushedHistoryLimits {
+            max_remote_refs: 0,
+            max_commits: 0,
+            max_parent_edges: 0,
+            max_commit_object_bytes: 0,
+            max_total_object_bytes: 0,
+        };
+
+        assert!(pushed_page_oids(&repo, &[commit], limits)
+            .expect("no remotes")
+            .is_empty());
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn pushed_history_counts_symbolic_remote_refs_against_the_budget() {
+        let root = unique_temp_dir("pushed-history-ref-budget");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        let commit = commit_file(&repo, "a.txt", "a\n", "only", &[]);
+        set_remote_ref(&repo, "main", commit);
+        set_remote_ref(&repo, "backup", commit);
+        repo.reference_symbolic(
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/main",
+            true,
+            "test symbolic remote ref",
+        )
+        .expect("create symbolic remote ref");
+
+        let too_small = PushedHistoryLimits {
+            max_remote_refs: 2,
+            ..test_pushed_history_limits()
+        };
+        let error = pushed_page_oids(&repo, &[commit], too_small)
+            .expect_err("all remote iterator entries must count");
+        assert!(error.to_string().contains("remote tracking ref limit"));
+
+        let exact = PushedHistoryLimits {
+            max_remote_refs: 3,
+            ..test_pushed_history_limits()
+        };
+        assert!(pushed_page_oids(&repo, &[commit], exact)
+            .expect("exact remote ref budget")
+            .contains(&commit));
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn pushed_history_enforces_unique_commit_and_parent_edge_budgets() {
+        let root = unique_temp_dir("pushed-history-graph-budgets");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        let [_first, _second, third, fourth] = linear_history(&repo);
+        set_remote_ref(&repo, "main", third);
+
+        let commit_limited = PushedHistoryLimits {
+            max_commits: 2,
+            ..test_pushed_history_limits()
+        };
+        let commit_error = pushed_page_oids(&repo, &[fourth], commit_limited)
+            .expect_err("remote graph exceeds unique commit budget");
+        assert!(commit_error
+            .to_string()
+            .contains("remote commit history limit"));
+
+        let edge_limited = PushedHistoryLimits {
+            max_parent_edges: 1,
+            ..test_pushed_history_limits()
+        };
+        let edge_error = pushed_page_oids(&repo, &[fourth], edge_limited)
+            .expect_err("remote graph exceeds parent edge budget");
+        assert!(edge_error
+            .to_string()
+            .contains("remote commit parent edge limit"));
+
+        let exact = PushedHistoryLimits {
+            max_commits: 3,
+            max_parent_edges: 2,
+            ..test_pushed_history_limits()
+        };
+        assert!(pushed_page_oids(&repo, &[fourth], exact)
+            .expect("exact graph budgets")
+            .is_empty());
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn pushed_history_enforces_commit_object_budgets() {
+        let root = unique_temp_dir("pushed-history-object-budgets");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        let [first, second, third, fourth] = linear_history(&repo);
+        set_remote_ref(&repo, "main", third);
+        let odb = repo.odb().expect("object database");
+        let first_bytes = odb.read_header(first).expect("first header").0;
+        let second_bytes = odb.read_header(second).expect("second header").0;
+        let third_bytes = odb.read_header(third).expect("third header").0;
+
+        let per_object_limited = PushedHistoryLimits {
+            max_commit_object_bytes: third_bytes - 1,
+            ..test_pushed_history_limits()
+        };
+        let object_error = pushed_page_oids(&repo, &[fourth], per_object_limited)
+            .expect_err("remote commit exceeds per-object budget");
+        assert!(object_error
+            .to_string()
+            .contains("remote commit object byte limit"));
+
+        let total_bytes = first_bytes
+            .checked_add(second_bytes)
+            .and_then(|bytes| bytes.checked_add(third_bytes))
+            .expect("small test object sizes");
+        let cumulative_limited = PushedHistoryLimits {
+            max_commit_object_bytes: first_bytes.max(second_bytes).max(third_bytes),
+            max_total_object_bytes: total_bytes - 1,
+            ..test_pushed_history_limits()
+        };
+        let total_error = pushed_page_oids(&repo, &[fourth], cumulative_limited)
+            .expect_err("remote history exceeds cumulative object budget");
+        assert!(total_error
+            .to_string()
+            .contains("remote commit history byte limit"));
+
+        drop(odb);
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn pushed_history_returns_early_after_all_candidates_are_found() {
+        let root = unique_temp_dir("pushed-history-early-success");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        let [_first, second, third, _fourth] = linear_history(&repo);
+        set_remote_ref(&repo, "main", third);
+        set_remote_ref(&repo, "backup", second);
+        let limits = PushedHistoryLimits {
+            max_remote_refs: 2,
+            max_commits: 0,
+            max_parent_edges: 0,
+            max_commit_object_bytes: 0,
+            max_total_object_bytes: 0,
+        };
+
+        assert!(pushed_page_oids(&repo, &[third], limits)
+            .expect("tip candidate needs no ancestor traversal")
+            .contains(&third));
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn pushed_history_rejects_non_commit_remote_targets() {
+        let root = unique_temp_dir("pushed-history-non-commit");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        let commit = commit_file(&repo, "a.txt", "a\n", "only", &[]);
+        let blob = repo.blob(b"not a commit").expect("create blob");
+        set_remote_ref(&repo, "invalid", blob);
+
+        let error = pushed_page_oids(&repo, &[commit], test_pushed_history_limits())
+            .expect_err("non-commit remote target must fail closed");
+        assert!(error.to_string().contains("non-commit object"));
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn empty_commit_page_skips_invalid_remote_history() {
+        let root = unique_temp_dir("empty-page-skips-remote-history");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&repo, "a.txt", "a\n", "only", &[]);
+        let blob = repo.blob(b"not a commit").expect("create blob");
+        set_remote_ref(&repo, "invalid", blob);
+        drop(repo);
+
+        assert!(list_commits(&root, 1, 1)
+            .expect("empty page does not need pushed classification")
+            .is_empty());
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]
@@ -674,6 +1387,27 @@ mod tests {
     }
 
     #[test]
+    fn diff_staged_file_treats_glob_metacharacters_literally() {
+        let root = unique_temp_dir("staged-file-literal-pathspec");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        let first_oid = commit_file(&repo, "*.rs", "literal\n", "init literal", &[]);
+        let first = repo.find_commit(first_oid).expect("first commit");
+        let second_oid = commit_file(&repo, "other.rs", "other\n", "init other", &[&first]);
+        let _second = repo.find_commit(second_oid).expect("second commit");
+        fs::write(root.join("*.rs"), "literal\nchanged\n").expect("write literal glob file");
+        fs::write(root.join("other.rs"), "other\nchanged\n").expect("write other file");
+        drop(_second);
+        drop(first);
+        drop(repo);
+
+        let payload = diff_staged_file(&root, "*.rs").expect("diff for literal glob path");
+        assert_eq!(payload.files.len(), 1);
+        assert_eq!(payload.files[0].new_path.as_deref(), Some("*.rs"));
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
     fn diff_staged_file_rejects_paths_outside_repo() {
         let root = unique_temp_dir("staged-file-path-validation");
         git2::Repository::init(&root).expect("init repo");
@@ -683,5 +1417,125 @@ mod tests {
         assert!(diff_staged_file(&root, "").is_err());
 
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn workdir_image_read_stays_inside_repo() {
+        let parent = unique_temp_dir("image-containment");
+        let root = parent.join("repo");
+        fs::create_dir_all(&root).expect("create repo dir");
+        fs::write(parent.join("outside.png"), b"outside").expect("write outside image");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        fs::write(root.join("inside.png"), b"inside").expect("write image");
+
+        assert_eq!(
+            read_workdir_image(&repo, "inside.png", MAX_DIFF_IMAGE_BYTES),
+            Some(b"inside".to_vec())
+        );
+        assert_eq!(
+            read_workdir_image(&repo, "../outside.png", MAX_DIFF_IMAGE_BYTES),
+            None
+        );
+
+        drop(repo);
+        std::fs::remove_dir_all(&parent).ok();
+    }
+
+    #[test]
+    fn workdir_image_read_rejects_files_over_the_byte_limit() {
+        let root = unique_temp_dir("image-byte-limit");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        fs::write(root.join("large.png"), b"12345").expect("write image");
+
+        assert_eq!(read_workdir_image(&repo, "large.png", 4), None);
+        assert_eq!(
+            read_workdir_image(&repo, "large.png", 5),
+            Some(b"12345".to_vec())
+        );
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn repository_image_preview_respects_per_image_and_aggregate_budgets() {
+        let root = unique_temp_dir("image-blob-budget");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        let oid = repo.blob(b"image-bytes").expect("write blob");
+
+        let mut too_small = 10;
+        assert_eq!(
+            image_data_uri_bounded(&repo, oid, Some("asset.png"), 64, &mut too_small),
+            None
+        );
+        assert_eq!(too_small, 10);
+
+        let mut exact = 11;
+        let preview = image_data_uri_bounded(&repo, oid, Some("asset.png"), 64, &mut exact)
+            .expect("preview within budget");
+        assert!(preview.starts_with("data:image/png;base64,"));
+        assert_eq!(exact, 0);
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn collect_diff_enforces_file_and_patch_budgets() {
+        let root = unique_temp_dir("patch-byte-limit");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&repo, "a.txt", "alpha\n", "init", &[]);
+        fs::write(root.join("a.txt"), "alpha\nbravo\n").expect("modify file");
+        let head_tree = repo
+            .head()
+            .expect("head")
+            .peel_to_tree()
+            .expect("head tree");
+        let diff = repo
+            .diff_tree_to_workdir_with_index(Some(&head_tree), None)
+            .expect("workdir diff");
+
+        let file_limits = DiffLimits {
+            max_files: 0,
+            ..LOCAL_DIFF_LIMITS
+        };
+        let file_error = collect_diff_with_limits(&repo, &diff, file_limits)
+            .expect_err("diff with too many files should be rejected");
+        assert!(file_error.to_string().contains("file limit"));
+
+        let limits = DiffLimits {
+            max_patch_bytes: 4,
+            ..LOCAL_DIFF_LIMITS
+        };
+        let error = collect_diff_with_limits(&repo, &diff, limits)
+            .expect_err("oversized patch should be rejected");
+        assert!(error.to_string().contains("patch byte limit"));
+
+        drop(diff);
+        drop(head_tree);
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn workdir_image_read_rejects_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_temp_dir("image-symlink");
+        let outside = unique_temp_dir("image-symlink-outside");
+        let outside_image = outside.join("secret.png");
+        fs::write(&outside_image, b"secret").expect("write outside image");
+        symlink(&outside_image, root.join("linked.png")).expect("create symlink");
+        let repo = git2::Repository::init(&root).expect("init repo");
+
+        assert_eq!(
+            read_workdir_image(&repo, "linked.png", MAX_DIFF_IMAGE_BYTES),
+            None
+        );
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&outside).ok();
     }
 }

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -152,14 +152,14 @@ pub fn start<R: Runtime>(app: AppHandle<R>, state: AppState) -> Option<IpcServer
     if let Err(err) =
         std::fs::set_permissions(&staging_path, std::fs::Permissions::from_mode(0o600))
     {
-        // Tighten on best-effort. If chmod fails we keep going — it just
-        // means the socket is more permissive than ideal, not that the
-        // server is unsafe (the unix peer is still local).
         tracing::warn!(
             error = %err,
             path = %staging_path.display(),
-            "ipc: chmod 0600 failed",
+            "ipc: chmod 0600 failed; server disabled",
         );
+        drop(listener);
+        let _ = std::fs::remove_file(&staging_path);
+        return None;
     }
     if let Err(err) = std::fs::rename(&staging_path, &path) {
         tracing::warn!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -242,7 +242,6 @@ pub fn run() {
     builder = builder
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -797,9 +796,6 @@ pub fn run() {
             daemon_commands::daemon_restart,
             daemon_commands::daemon_shutdown,
             daemon_commands::daemon_list_sessions,
-            daemon_commands::daemon_spawn_session,
-            daemon_commands::daemon_send_input,
-            daemon_commands::daemon_resize,
             daemon_commands::daemon_kill_session,
             daemon_commands::daemon_forget_session,
             daemon_commands::daemon_forget_inactive_sessions,

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -2542,7 +2542,11 @@ fn build_commit_message_prompt(
     // afterwards if details are missing.
     const MAX_DIFF_BYTES: usize = 12_000;
     let trimmed_diff = if diff.len() > MAX_DIFF_BYTES {
-        format!("{}\n…(diff truncated)…", &diff[..MAX_DIFF_BYTES])
+        let mut end = MAX_DIFF_BYTES;
+        while !diff.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}\n…(diff truncated)…", &diff[..end])
     } else {
         diff.to_string()
     };
@@ -3087,6 +3091,16 @@ mod tests {
         );
 
         assert!(prompt.contains("Write a merge commit message."));
+    }
+
+    #[test]
+    fn commit_message_prompt_truncates_diff_on_a_utf8_boundary() {
+        let diff = format!("{}é", "a".repeat(11_999));
+
+        let prompt = build_commit_message_prompt(MergeMethod::Squash, "", &fake_view(), &diff);
+
+        assert!(prompt.contains("\n…(diff truncated)…"));
+        assert!(!prompt.contains('é'));
     }
 
     #[test]

--- a/src-tauri/src/shell_init.rs
+++ b/src-tauri/src/shell_init.rs
@@ -20,7 +20,7 @@
 //! the macOS default and the only shell that needs file-side help.
 
 use std::fs;
-use std::io;
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
 const SHELL_INIT_DIR_NAME: &str = "shell-init";
@@ -28,6 +28,7 @@ const ZSHENV_NAME: &str = ".zshenv";
 const ZPROFILE_NAME: &str = ".zprofile";
 const ZSHRC_NAME: &str = ".zshrc";
 const ZLOGIN_NAME: &str = ".zlogin";
+const MAX_STAGED_INIT_BYTES: u64 = 64 * 1024;
 
 const ZSHENV_BODY: &str = include_str!("../shell-init/zshenv");
 const ZPROFILE_BODY: &str = include_str!("../shell-init/zprofile");
@@ -66,12 +67,41 @@ pub(crate) fn is_shell_init_dir(path: &Path) -> bool {
     let zshrc = path.join(ZSHRC_NAME);
     path.file_name()
         .is_some_and(|name| name == SHELL_INIT_DIR_NAME)
-        && fs::read_to_string(zshenv)
-            .map(|body| body.contains("Acorn zsh env init."))
-            .unwrap_or(false)
-        && fs::read_to_string(zshrc)
-            .map(|body| body.contains("Acorn zsh interactive init."))
-            .unwrap_or(false)
+        && bounded_regular_file_contains(&zshenv, "Acorn zsh env init.")
+        && bounded_regular_file_contains(&zshrc, "Acorn zsh interactive init.")
+}
+
+fn bounded_regular_file_contains(path: &Path, marker: &str) -> bool {
+    let Ok(link_metadata) = fs::symlink_metadata(path) else {
+        return false;
+    };
+    if link_metadata.file_type().is_symlink()
+        || !link_metadata.is_file()
+        || link_metadata.len() > MAX_STAGED_INIT_BYTES
+    {
+        return false;
+    }
+
+    let Ok(file) = fs::File::open(path) else {
+        return false;
+    };
+    let Ok(open_metadata) = file.metadata() else {
+        return false;
+    };
+    if !open_metadata.is_file() || open_metadata.len() > MAX_STAGED_INIT_BYTES {
+        return false;
+    }
+
+    let mut bytes = Vec::with_capacity(open_metadata.len() as usize);
+    if file
+        .take(MAX_STAGED_INIT_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .is_err()
+        || bytes.len() as u64 > MAX_STAGED_INIT_BYTES
+    {
+        return false;
+    }
+    std::str::from_utf8(&bytes).is_ok_and(|body| body.contains(marker))
 }
 
 #[cfg(all(test, unix))]
@@ -175,6 +205,34 @@ mod tests {
         let dir = ensure_shell_init_dir_at(base.path()).unwrap();
         assert!(is_shell_init_dir(&dir));
         assert!(!is_shell_init_dir(base.path()));
+    }
+
+    #[test]
+    fn shell_init_detection_rejects_oversized_marker_file() {
+        let base = ScratchDir::new("detect-oversized");
+        let dir = ensure_shell_init_dir_at(base.path()).unwrap();
+        let zshenv = dir.join(ZSHENV_NAME);
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&zshenv)
+            .unwrap()
+            .set_len(MAX_STAGED_INIT_BYTES + 1)
+            .unwrap();
+
+        assert!(!is_shell_init_dir(&dir));
+    }
+
+    #[test]
+    fn shell_init_detection_rejects_special_marker_file() {
+        use std::os::unix::fs::symlink;
+
+        let base = ScratchDir::new("detect-special");
+        let dir = ensure_shell_init_dir_at(base.path()).unwrap();
+        let zshenv = dir.join(ZSHENV_NAME);
+        fs::remove_file(&zshenv).unwrap();
+        symlink("/dev/zero", &zshenv).unwrap();
+
+        assert!(!is_shell_init_dir(&dir));
     }
 
     #[test]

--- a/src-tauri/src/todos.rs
+++ b/src-tauri/src/todos.rs
@@ -19,11 +19,53 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
-use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::fs::{File, Metadata};
+use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
+use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
+
+const MAX_PROJECT_DIR_ENTRIES: usize = 10_000;
+const MAX_TRANSCRIPT_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_JSONL_LINE_BYTES: usize = 1024 * 1024;
+const MAX_TRANSCRIPT_LINES: usize = 250_000;
+const MAX_REPLAY_ITEMS: usize = 50_000;
+const MAX_TASKS: usize = 2_000;
+const MAX_PENDING_CREATES: usize = 2_000;
+const MAX_TODO_TEXT_BYTES: usize = 16 * 1024;
+const MAX_STATUS_BYTES: usize = 128;
+const MAX_TOOL_USE_ID_BYTES: usize = 256;
+const MAX_RETAINED_TEXT_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Clone, Copy)]
+struct ReplayLimits {
+    max_project_dir_entries: usize,
+    max_transcript_bytes: u64,
+    max_jsonl_line_bytes: usize,
+    max_transcript_lines: usize,
+    max_replay_items: usize,
+    max_tasks: usize,
+    max_pending_creates: usize,
+    max_todo_text_bytes: usize,
+    max_status_bytes: usize,
+    max_tool_use_id_bytes: usize,
+    max_retained_text_bytes: usize,
+}
+
+const DEFAULT_LIMITS: ReplayLimits = ReplayLimits {
+    max_project_dir_entries: MAX_PROJECT_DIR_ENTRIES,
+    max_transcript_bytes: MAX_TRANSCRIPT_BYTES,
+    max_jsonl_line_bytes: MAX_JSONL_LINE_BYTES,
+    max_transcript_lines: MAX_TRANSCRIPT_LINES,
+    max_replay_items: MAX_REPLAY_ITEMS,
+    max_tasks: MAX_TASKS,
+    max_pending_creates: MAX_PENDING_CREATES,
+    max_todo_text_bytes: MAX_TODO_TEXT_BYTES,
+    max_status_bytes: MAX_STATUS_BYTES,
+    max_tool_use_id_bytes: MAX_TOOL_USE_ID_BYTES,
+    max_retained_text_bytes: MAX_RETAINED_TEXT_BYTES,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TodoItem {
@@ -49,21 +91,63 @@ pub fn locate_transcript_for(session_id: &str) -> AppResult<Option<PathBuf>> {
 
 fn locate_transcript(session_id: &str) -> AppResult<Option<PathBuf>> {
     let root = projects_root()?;
+    locate_transcript_in(&root, session_id, DEFAULT_LIMITS)
+}
+
+fn locate_transcript_in(
+    root: &Path,
+    session_id: &str,
+    limits: ReplayLimits,
+) -> AppResult<Option<PathBuf>> {
     if !root.exists() {
         return Ok(None);
     }
-    let target = format!("{session_id}.jsonl");
-    let entries = match std::fs::read_dir(&root) {
+    let target = transcript_file_name(session_id)?;
+    // The configured root itself may intentionally be a symlink (for example,
+    // to another volume). Resolve it once, then reject links below that root.
+    let canonical_root = match root.canonicalize() {
+        Ok(root) => root,
+        Err(_) => return Ok(None),
+    };
+    let entries = match std::fs::read_dir(&canonical_root) {
         Ok(e) => e,
         Err(_) => return Ok(None),
     };
-    for entry in entries.flatten() {
+    for (index, entry) in entries.enumerate() {
+        if index >= limits.max_project_dir_entries {
+            return Err(limit_error(
+                "Claude project directory entries",
+                limits.max_project_dir_entries,
+            ));
+        }
+        let Ok(entry) = entry else { continue };
+        let Ok(entry_type) = entry.file_type() else {
+            continue;
+        };
+        if !entry_type.is_dir() {
+            continue;
+        }
         let candidate = entry.path().join(&target);
-        if candidate.is_file() {
-            return Ok(Some(candidate));
+        let Ok(candidate_meta) = std::fs::symlink_metadata(&candidate) else {
+            continue;
+        };
+        if candidate_meta.file_type().is_symlink() || !candidate_meta.is_file() {
+            continue;
+        }
+        let Ok(resolved) = candidate.canonicalize() else {
+            continue;
+        };
+        if resolved.starts_with(&canonical_root) {
+            return Ok(Some(resolved));
         }
     }
     Ok(None)
+}
+
+fn transcript_file_name(session_id: &str) -> AppResult<String> {
+    let session_id = Uuid::parse_str(session_id)
+        .map_err(|_| AppError::InvalidPath("transcript session id must be a UUID".into()))?;
+    Ok(format!("{session_id}.jsonl"))
 }
 
 /// Parsed pending TaskCreate awaiting its tool_result to learn the task ID.
@@ -73,23 +157,286 @@ struct PendingCreate {
 }
 
 pub fn read_latest_todos(session_id: &str, _cwd: &Path) -> AppResult<Vec<TodoItem>> {
-    let path = match locate_transcript(session_id)? {
+    let root = projects_root()?;
+    read_latest_todos_in(&root, session_id, DEFAULT_LIMITS)
+}
+
+fn read_latest_todos_in(
+    root: &Path,
+    session_id: &str,
+    limits: ReplayLimits,
+) -> AppResult<Vec<TodoItem>> {
+    let path = match locate_transcript_in(root, session_id, limits)? {
         Some(p) => p,
         None => return Ok(Vec::new()),
     };
-    let f = File::open(&path)?;
-    let reader = BufReader::new(f);
+    read_todos_from_path(&path, limits)
+}
 
-    let mut todo_write_snapshot: Option<Vec<TodoItem>> = None;
-    let mut pending: HashMap<String, PendingCreate> = HashMap::new();
-    let mut tasks: BTreeMap<u32, TodoItem> = BTreeMap::new();
-    let mut creation_order: Vec<u32> = Vec::new();
+fn read_todos_from_path(path: &Path, limits: ReplayLimits) -> AppResult<Vec<TodoItem>> {
+    read_todos_from_path_with(path, limits, |path| File::open(path))
+}
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
+fn read_todos_from_path_with<F>(
+    path: &Path,
+    limits: ReplayLimits,
+    open: F,
+) -> AppResult<Vec<TodoItem>>
+where
+    F: FnOnce(&Path) -> std::io::Result<File>,
+{
+    let path_meta = std::fs::symlink_metadata(path)?;
+    validate_transcript_metadata(path, &path_meta)?;
+    let file = open(path)?;
+    let metadata = file.metadata()?;
+    validate_transcript_metadata(path, &metadata)?;
+    validate_same_transcript_file(path, &path_meta, &metadata)?;
+    let snapshot_len = metadata.len();
+    if snapshot_len > limits.max_transcript_bytes {
+        return Err(limit_error(
+            "bytes",
+            usize::try_from(limits.max_transcript_bytes).unwrap_or(usize::MAX),
+        ));
+    }
+
+    // Replay the size observed on the opened descriptor. Appends after this
+    // point are intentionally deferred to the next refresh instead of growing
+    // the current request without bound.
+    let reader = BufReader::new(file.take(snapshot_len));
+    replay_todos(reader, limits)
+}
+
+fn validate_transcript_metadata(path: &Path, metadata: &Metadata) -> AppResult<()> {
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(AppError::InvalidPath(format!(
+            "todo transcript must be a regular file: {}",
+            path.display()
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if metadata.nlink() > 1 {
+            return Err(AppError::InvalidPath(format!(
+                "todo transcript must not be hard-linked: {}",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_same_transcript_file(
+    path: &Path,
+    before: &Metadata,
+    opened: &Metadata,
+) -> AppResult<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    if before.dev() != opened.dev() || before.ino() != opened.ino() {
+        return Err(AppError::InvalidPath(format!(
+            "todo transcript changed while opening: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn validate_same_transcript_file(
+    _path: &Path,
+    _before: &Metadata,
+    _opened: &Metadata,
+) -> AppResult<()> {
+    Ok(())
+}
+
+#[derive(Default)]
+struct ReplayState {
+    todo_write_snapshot: Option<Vec<TodoItem>>,
+    pending: HashMap<String, PendingCreate>,
+    tasks: BTreeMap<u32, TodoItem>,
+    creation_order: Vec<u32>,
+    retained_text_bytes: usize,
+}
+
+impl ReplayState {
+    fn finish(self, limits: ReplayLimits) -> AppResult<Vec<TodoItem>> {
+        if let Some(todos) = self.todo_write_snapshot {
+            return Ok(todos);
+        }
+
+        let mut ordered = Vec::with_capacity(self.creation_order.len());
+        let mut output_text_bytes = 0usize;
+        for id in self.creation_order {
+            let Some(task) = self.tasks.get(&id) else {
+                continue;
+            };
+            output_text_bytes = add_with_limit(
+                output_text_bytes,
+                todo_item_bytes(task),
+                "retained todo text bytes",
+                limits.max_retained_text_bytes,
+            )?;
+            ordered.push(task.clone());
+        }
+        Ok(ordered)
+    }
+
+    fn set_snapshot(&mut self, todos: Vec<TodoItem>, limits: ReplayLimits) -> AppResult<()> {
+        if todos.len() > limits.max_tasks {
+            return Err(limit_error("tasks", limits.max_tasks));
+        }
+        let mut retained = 0usize;
+        for todo in &todos {
+            validate_todo_item(todo, limits)?;
+            retained = add_with_limit(
+                retained,
+                todo_item_bytes(todo),
+                "retained todo text bytes",
+                limits.max_retained_text_bytes,
+            )?;
+        }
+
+        self.pending.clear();
+        self.tasks.clear();
+        self.creation_order.clear();
+        self.todo_write_snapshot = Some(todos);
+        self.retained_text_bytes = retained;
+        Ok(())
+    }
+
+    fn insert_pending(
+        &mut self,
+        tool_use_id: &str,
+        subject: &str,
+        active_form: Option<&str>,
+        limits: ReplayLimits,
+    ) -> AppResult<()> {
+        validate_bytes(
+            tool_use_id,
+            "tool use id bytes",
+            limits.max_tool_use_id_bytes,
+        )?;
+        validate_bytes(subject, "todo content bytes", limits.max_todo_text_bytes)?;
+        if let Some(active_form) = active_form {
+            validate_bytes(
+                active_form,
+                "todo active form bytes",
+                limits.max_todo_text_bytes,
+            )?;
+        }
+        if !self.pending.contains_key(tool_use_id)
+            && self.pending.len() >= limits.max_pending_creates
+        {
+            return Err(limit_error(
+                "pending task creates",
+                limits.max_pending_creates,
+            ));
+        }
+
+        let old_bytes = self
+            .pending
+            .get(tool_use_id)
+            .map(|old| pending_bytes(tool_use_id, old))
+            .unwrap_or(0);
+        let new_entry = PendingCreate {
+            subject: subject.to_string(),
+            active_form: active_form.map(str::to_string),
         };
+        let new_bytes = pending_bytes(tool_use_id, &new_entry);
+        self.retained_text_bytes = replace_with_limit(
+            self.retained_text_bytes,
+            old_bytes,
+            new_bytes,
+            "retained todo text bytes",
+            limits.max_retained_text_bytes,
+        )?;
+        self.pending.insert(tool_use_id.to_string(), new_entry);
+        Ok(())
+    }
+
+    fn update_task_status(&mut self, id: u32, status: &str, limits: ReplayLimits) -> AppResult<()> {
+        let Some(task) = self.tasks.get(&id) else {
+            return Ok(());
+        };
+        validate_bytes(status, "todo status bytes", limits.max_status_bytes)?;
+        self.retained_text_bytes = replace_with_limit(
+            self.retained_text_bytes,
+            task.status.len(),
+            status.len(),
+            "retained todo text bytes",
+            limits.max_retained_text_bytes,
+        )?;
+        self.tasks.get_mut(&id).expect("task checked above").status = status.to_string();
+        Ok(())
+    }
+
+    fn resolve_pending(
+        &mut self,
+        tool_use_id: &str,
+        task_id: Option<u32>,
+        limits: ReplayLimits,
+    ) -> AppResult<()> {
+        validate_bytes(
+            tool_use_id,
+            "tool use id bytes",
+            limits.max_tool_use_id_bytes,
+        )?;
+        let Some(pending_entry) = self.pending.remove(tool_use_id) else {
+            return Ok(());
+        };
+        self.retained_text_bytes = self
+            .retained_text_bytes
+            .checked_sub(pending_bytes(tool_use_id, &pending_entry))
+            .ok_or_else(|| AppError::Other("todo replay byte accounting underflow".into()))?;
+        let Some(task_id) = task_id else {
+            return Ok(());
+        };
+        if self.creation_order.len() >= limits.max_tasks {
+            return Err(limit_error("tasks", limits.max_tasks));
+        }
+        if !self.tasks.contains_key(&task_id) && self.tasks.len() >= limits.max_tasks {
+            return Err(limit_error("tasks", limits.max_tasks));
+        }
+
+        let task = TodoItem {
+            content: pending_entry.subject,
+            status: "pending".to_string(),
+            active_form: pending_entry.active_form,
+        };
+        validate_todo_item(&task, limits)?;
+        let old_bytes = self.tasks.get(&task_id).map(todo_item_bytes).unwrap_or(0);
+        self.retained_text_bytes = replace_with_limit(
+            self.retained_text_bytes,
+            old_bytes,
+            todo_item_bytes(&task),
+            "retained todo text bytes",
+            limits.max_retained_text_bytes,
+        )?;
+        self.tasks.insert(task_id, task);
+        self.creation_order.push(task_id);
+        Ok(())
+    }
+}
+
+fn replay_todos<R: BufRead>(mut reader: R, limits: ReplayLimits) -> AppResult<Vec<TodoItem>> {
+    let mut state = ReplayState::default();
+    let mut line = Vec::new();
+    let mut line_count = 0usize;
+    let mut replay_items = 0usize;
+
+    loop {
+        let read = read_bounded_line(&mut reader, &mut line, limits.max_jsonl_line_bytes)?;
+        if read == 0 {
+            break;
+        }
+        line_count = add_with_limit(line_count, 1, "lines", limits.max_transcript_lines)?;
+        let Ok(line) = std::str::from_utf8(&line) else {
+            continue;
+        };
+
         // Cheap pre-filter: every shape we care about mentions one of these tool
         // names verbatim. Skip JSON parsing for unrelated lines.
         if !line.contains("\"TodoWrite\"")
@@ -112,33 +459,24 @@ pub fn read_latest_todos(session_id: &str, _cwd: &Path) -> AppResult<Vec<TodoIte
             None => continue,
         };
         for item in content {
-            handle_item(
-                item,
-                &mut todo_write_snapshot,
-                &mut pending,
-                &mut tasks,
-                &mut creation_order,
-            );
+            replay_items = add_with_limit(
+                replay_items,
+                1,
+                "replay content items",
+                limits.max_replay_items,
+            )?;
+            handle_item(item, &mut state, limits)?;
         }
     }
 
-    if let Some(todos) = todo_write_snapshot {
-        return Ok(todos);
-    }
-    let ordered: Vec<TodoItem> = creation_order
-        .into_iter()
-        .filter_map(|id| tasks.get(&id).cloned())
-        .collect();
-    Ok(ordered)
+    state.finish(limits)
 }
 
 fn handle_item(
     item: &serde_json::Value,
-    todo_write_snapshot: &mut Option<Vec<TodoItem>>,
-    pending: &mut HashMap<String, PendingCreate>,
-    tasks: &mut BTreeMap<u32, TodoItem>,
-    creation_order: &mut Vec<u32>,
-) {
+    state: &mut ReplayState,
+    limits: ReplayLimits,
+) -> AppResult<()> {
     let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
     if item_type == "tool_use" {
         let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("");
@@ -146,106 +484,157 @@ fn handle_item(
             "TodoWrite" => {
                 if let Some(todos_val) = item.get("input").and_then(|i| i.get("todos")) {
                     if let Ok(parsed) = serde_json::from_value::<Vec<TodoItem>>(todos_val.clone()) {
-                        *todo_write_snapshot = Some(parsed);
+                        state.set_snapshot(parsed, limits)?;
                     }
                 }
             }
             "TaskCreate" => {
-                let tool_use_id = item
-                    .get("id")
-                    .and_then(|i| i.as_str())
-                    .unwrap_or("")
-                    .to_string();
+                if state.todo_write_snapshot.is_some() {
+                    return Ok(());
+                }
+                let tool_use_id = item.get("id").and_then(|i| i.as_str()).unwrap_or("");
                 let input = item.get("input");
                 let subject = input
                     .and_then(|i| i.get("subject"))
                     .and_then(|s| s.as_str())
-                    .unwrap_or("")
-                    .to_string();
+                    .unwrap_or("");
                 let active_form = input
                     .and_then(|i| i.get("activeForm"))
-                    .and_then(|s| s.as_str())
-                    .map(|s| s.to_string());
+                    .and_then(|s| s.as_str());
                 if !tool_use_id.is_empty() {
-                    pending.insert(
-                        tool_use_id,
-                        PendingCreate {
-                            subject,
-                            active_form,
-                        },
-                    );
+                    state.insert_pending(tool_use_id, subject, active_form, limits)?;
                 }
             }
             "TaskUpdate" => {
+                if state.todo_write_snapshot.is_some() {
+                    return Ok(());
+                }
                 let input = item.get("input");
                 let task_id = input.and_then(|i| i.get("taskId")).and_then(|t| {
                     t.as_str()
                         .and_then(|s| s.parse::<u32>().ok())
-                        .or_else(|| t.as_u64().map(|n| n as u32))
+                        .or_else(|| t.as_u64().and_then(|n| u32::try_from(n).ok()))
                 });
                 let status = input
                     .and_then(|i| i.get("status"))
                     .and_then(|s| s.as_str())
                     .unwrap_or("");
                 if let Some(id) = task_id {
-                    if let Some(task) = tasks.get_mut(&id) {
-                        task.status = status.to_string();
-                    }
+                    state.update_task_status(id, status, limits)?;
                 }
             }
             _ => {}
         }
-        return;
+        return Ok(());
     }
     if item_type == "tool_result" {
+        if state.todo_write_snapshot.is_some() {
+            return Ok(());
+        }
         let tool_use_id = item
             .get("tool_use_id")
             .and_then(|i| i.as_str())
             .unwrap_or("");
         if tool_use_id.is_empty() {
-            return;
+            return Ok(());
         }
-        let pending_entry = match pending.remove(tool_use_id) {
-            Some(p) => p,
-            None => return,
-        };
-        // tool_result.content can be a string or array of {type:"text", text:...}
-        let text = extract_tool_result_text(item);
-        if let Some(id) = parse_task_id(&text) {
-            tasks.insert(
-                id,
-                TodoItem {
-                    content: pending_entry.subject,
-                    status: "pending".to_string(),
-                    active_form: pending_entry.active_form,
-                },
-            );
-            creation_order.push(id);
-        }
+        state.resolve_pending(tool_use_id, task_id_from_tool_result(item), limits)?;
     }
+    Ok(())
 }
 
-fn extract_tool_result_text(item: &serde_json::Value) -> String {
-    let c = match item.get("content") {
-        Some(c) => c,
-        None => return String::new(),
-    };
+fn task_id_from_tool_result(item: &serde_json::Value) -> Option<u32> {
+    let c = item.get("content")?;
     if let Some(s) = c.as_str() {
-        return s.to_string();
+        return parse_task_id(s);
     }
     if let Some(arr) = c.as_array() {
-        let mut out = String::new();
-        for sub in arr {
-            if let Some(t) = sub.get("text").and_then(|t| t.as_str()) {
-                if !out.is_empty() {
-                    out.push('\n');
-                }
-                out.push_str(t);
-            }
-        }
-        return out;
+        return arr
+            .iter()
+            .filter_map(|sub| sub.get("text").and_then(|text| text.as_str()))
+            .find_map(parse_task_id);
     }
-    String::new()
+    None
+}
+
+fn read_bounded_line<R: BufRead>(
+    reader: &mut R,
+    line: &mut Vec<u8>,
+    max_bytes: usize,
+) -> AppResult<usize> {
+    line.clear();
+    let read_limit = max_bytes
+        .checked_add(1)
+        .ok_or_else(|| AppError::Other("todo JSONL line limit overflow".into()))?;
+    let mut limited = reader.take(read_limit as u64);
+    let read = limited.read_until(b'\n', line)?;
+    if line.len() > max_bytes {
+        return Err(limit_error("JSONL line bytes", max_bytes));
+    }
+    Ok(read)
+}
+
+fn validate_todo_item(item: &TodoItem, limits: ReplayLimits) -> AppResult<()> {
+    validate_bytes(
+        &item.content,
+        "todo content bytes",
+        limits.max_todo_text_bytes,
+    )?;
+    validate_bytes(&item.status, "todo status bytes", limits.max_status_bytes)?;
+    if let Some(active_form) = &item.active_form {
+        validate_bytes(
+            active_form,
+            "todo active form bytes",
+            limits.max_todo_text_bytes,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_bytes(value: &str, label: &str, max: usize) -> AppResult<()> {
+    if value.len() > max {
+        return Err(limit_error(label, max));
+    }
+    Ok(())
+}
+
+fn todo_item_bytes(item: &TodoItem) -> usize {
+    item.content.len() + item.status.len() + item.active_form.as_ref().map(String::len).unwrap_or(0)
+}
+
+fn pending_bytes(tool_use_id: &str, pending: &PendingCreate) -> usize {
+    tool_use_id.len()
+        + pending.subject.len()
+        + pending.active_form.as_ref().map(String::len).unwrap_or(0)
+}
+
+fn add_with_limit(current: usize, additional: usize, label: &str, max: usize) -> AppResult<usize> {
+    let next = current
+        .checked_add(additional)
+        .ok_or_else(|| limit_error(label, max))?;
+    if next > max {
+        return Err(limit_error(label, max));
+    }
+    Ok(next)
+}
+
+fn replace_with_limit(
+    current: usize,
+    removed: usize,
+    added: usize,
+    label: &str,
+    max: usize,
+) -> AppResult<usize> {
+    let remaining = current
+        .checked_sub(removed)
+        .ok_or_else(|| AppError::Other("todo replay byte accounting underflow".into()))?;
+    add_with_limit(remaining, added, label, max)
+}
+
+fn limit_error(label: &str, max: usize) -> AppError {
+    AppError::Other(format!(
+        "todo transcript {label} limit exceeded (maximum {max})"
+    ))
 }
 
 /// Parse `"Task #42 created successfully: ..."` → 42.
@@ -257,4 +646,416 @@ fn parse_task_id(text: &str) -> Option<u32> {
         .find(|c: char| !c.is_ascii_digit())
         .unwrap_or(rest.len());
     rest[..end].parse::<u32>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+    use std::io::{Cursor, Write};
+
+    const SESSION_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+
+    fn small_limits() -> ReplayLimits {
+        ReplayLimits {
+            max_project_dir_entries: 8,
+            max_transcript_bytes: 16 * 1024,
+            max_jsonl_line_bytes: 8 * 1024,
+            max_transcript_lines: 32,
+            max_replay_items: 32,
+            max_tasks: 8,
+            max_pending_creates: 8,
+            max_todo_text_bytes: 256,
+            max_status_bytes: 32,
+            max_tool_use_id_bytes: 64,
+            max_retained_text_bytes: 1024,
+        }
+    }
+
+    fn transcript_line(items: Vec<Value>) -> Vec<u8> {
+        let mut line = serde_json::to_vec(&json!({
+            "message": { "content": items }
+        }))
+        .unwrap();
+        line.push(b'\n');
+        line
+    }
+
+    fn task_create(tool_use_id: &str, subject: &str) -> Value {
+        json!({
+            "type": "tool_use",
+            "name": "TaskCreate",
+            "id": tool_use_id,
+            "input": { "subject": subject, "activeForm": format!("Doing {subject}") }
+        })
+    }
+
+    fn task_result(tool_use_id: &str, task_id: u32) -> Value {
+        json!({
+            "type": "tool_result",
+            "tool_use_id": tool_use_id,
+            "content": format!("Task #{task_id} created successfully")
+        })
+    }
+
+    fn task_update(task_id: Value, status: &str) -> Value {
+        json!({
+            "type": "tool_use",
+            "name": "TaskUpdate",
+            "input": { "taskId": task_id, "status": status }
+        })
+    }
+
+    fn todo_write(content: &str, status: &str) -> Value {
+        json!({
+            "type": "tool_use",
+            "name": "TodoWrite",
+            "input": {
+                "todos": [{
+                    "content": content,
+                    "status": status,
+                    "activeForm": format!("Doing {content}")
+                }]
+            }
+        })
+    }
+
+    fn replay(bytes: &[u8], limits: ReplayLimits) -> AppResult<Vec<TodoItem>> {
+        replay_todos(BufReader::new(Cursor::new(bytes)), limits)
+    }
+
+    fn write_transcript(root: &Path, bytes: &[u8]) -> PathBuf {
+        let project = root.join("-tmp-acorn");
+        std::fs::create_dir_all(&project).unwrap();
+        let path = project.join(format!("{SESSION_ID}.jsonl"));
+        std::fs::write(&path, bytes).unwrap();
+        path
+    }
+
+    #[test]
+    fn transcript_file_name_normalizes_uuid() {
+        let file = transcript_file_name("550E8400-E29B-41D4-A716-446655440000").unwrap();
+        assert_eq!(file, "550e8400-e29b-41d4-a716-446655440000.jsonl");
+    }
+
+    #[test]
+    fn transcript_file_name_rejects_path_components() {
+        assert!(transcript_file_name("../outside").is_err());
+        assert!(transcript_file_name("/tmp/outside").is_err());
+    }
+
+    #[test]
+    fn replays_task_create_result_and_update_in_creation_order() {
+        let bytes = transcript_line(vec![
+            task_create("tool-1", "First"),
+            task_result("tool-1", 1),
+            task_create("tool-2", "Second"),
+            task_result("tool-2", 2),
+            task_update(json!(1), "completed"),
+        ]);
+
+        let todos = replay(&bytes, small_limits()).unwrap();
+
+        assert_eq!(todos.len(), 2);
+        assert_eq!(todos[0].content, "First");
+        assert_eq!(todos[0].status, "completed");
+        assert_eq!(todos[1].content, "Second");
+        assert_eq!(todos[1].status, "pending");
+    }
+
+    #[test]
+    fn last_valid_todo_write_snapshot_still_wins() {
+        let bytes = transcript_line(vec![
+            task_create("tool-1", "Task API item"),
+            task_result("tool-1", 1),
+            todo_write("Old snapshot", "pending"),
+            task_update(json!(1), "completed"),
+            todo_write("Latest snapshot", "in_progress"),
+        ]);
+
+        let todos = replay(&bytes, small_limits()).unwrap();
+
+        assert_eq!(todos.len(), 1);
+        assert_eq!(todos[0].content, "Latest snapshot");
+        assert_eq!(todos[0].status, "in_progress");
+    }
+
+    #[test]
+    fn locates_only_regular_transcripts_below_the_project_root() {
+        let root = tempfile::tempdir().unwrap();
+        let path = write_transcript(root.path(), b"\n");
+
+        let located = locate_transcript_in(root.path(), SESSION_ID, small_limits())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(located, path.canonicalize().unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn allows_configured_root_symlink_but_rejects_nested_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let actual = tempfile::tempdir().unwrap();
+        let regular = actual.path().join("regular-projects");
+        std::fs::create_dir(&regular).unwrap();
+        let expected = write_transcript(&regular, b"\n");
+        let configured_parent = tempfile::tempdir().unwrap();
+        let configured = configured_parent.path().join("projects");
+        symlink(&regular, &configured).unwrap();
+        assert_eq!(
+            locate_transcript_in(&configured, SESSION_ID, small_limits())
+                .unwrap()
+                .unwrap(),
+            expected.canonicalize().unwrap()
+        );
+
+        let nested_root = tempfile::tempdir().unwrap();
+        let outside_project = tempfile::tempdir().unwrap();
+        std::fs::write(
+            outside_project.path().join(format!("{SESSION_ID}.jsonl")),
+            b"\n",
+        )
+        .unwrap();
+        symlink(
+            outside_project.path(),
+            nested_root.path().join("linked-project"),
+        )
+        .unwrap();
+        assert!(
+            locate_transcript_in(nested_root.path(), SESSION_ID, small_limits())
+                .unwrap()
+                .is_none()
+        );
+
+        let leaf_root = tempfile::tempdir().unwrap();
+        let leaf_project = leaf_root.path().join("project");
+        std::fs::create_dir(&leaf_project).unwrap();
+        let outside_file = tempfile::NamedTempFile::new().unwrap();
+        symlink(
+            outside_file.path(),
+            leaf_project.join(format!("{SESSION_ID}.jsonl")),
+        )
+        .unwrap();
+        assert!(
+            locate_transcript_in(leaf_root.path(), SESSION_ID, small_limits())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_leaf_replaced_with_symlink_between_validation_and_open() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("transcript.jsonl");
+        let moved = directory.path().join("validated-transcript.jsonl");
+        std::fs::write(
+            &path,
+            transcript_line(vec![todo_write("validated", "pending")]),
+        )
+        .unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            outside.path(),
+            transcript_line(vec![todo_write("outside", "completed")]),
+        )
+        .unwrap();
+
+        let error = read_todos_from_path_with(&path, small_limits(), |requested| {
+            std::fs::rename(requested, &moved)?;
+            symlink(outside.path(), requested)?;
+            File::open(requested)
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("changed while opening"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_hard_linked_transcript() {
+        let directory = tempfile::tempdir().unwrap();
+        let outside = directory.path().join("outside.jsonl");
+        let linked = directory.path().join("transcript.jsonl");
+        std::fs::write(
+            &outside,
+            transcript_line(vec![todo_write("outside", "completed")]),
+        )
+        .unwrap();
+        std::fs::hard_link(&outside, &linked).unwrap();
+
+        let error = read_todos_from_path(&linked, small_limits()).unwrap_err();
+
+        assert!(error.to_string().contains("must not be hard-linked"));
+    }
+
+    #[test]
+    fn rejects_project_directory_scans_over_budget() {
+        let root = tempfile::tempdir().unwrap();
+        write_transcript(root.path(), b"\n");
+        let limits = ReplayLimits {
+            max_project_dir_entries: 0,
+            ..small_limits()
+        };
+
+        let error = locate_transcript_in(root.path(), SESSION_ID, limits).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("directory entries limit exceeded"));
+    }
+
+    #[test]
+    fn enforces_snapshot_file_and_jsonl_line_byte_budgets() {
+        let root = tempfile::tempdir().unwrap();
+        let bytes = transcript_line(vec![todo_write("bounded", "pending")]);
+        let path = write_transcript(root.path(), &bytes);
+
+        let exact_file = ReplayLimits {
+            max_transcript_bytes: bytes.len() as u64,
+            max_jsonl_line_bytes: bytes.len(),
+            ..small_limits()
+        };
+        assert_eq!(read_todos_from_path(&path, exact_file).unwrap().len(), 1);
+
+        let short_file = ReplayLimits {
+            max_transcript_bytes: bytes.len() as u64 - 1,
+            ..exact_file
+        };
+        assert!(read_todos_from_path(&path, short_file).is_err());
+
+        let short_line = ReplayLimits {
+            max_jsonl_line_bytes: bytes.len() - 1,
+            ..exact_file
+        };
+        assert!(replay(&bytes, short_line).is_err());
+    }
+
+    #[test]
+    fn enforces_line_replay_item_pending_and_task_budgets() {
+        let two_lines = b"{}\n{}\n";
+        let line_limited = ReplayLimits {
+            max_transcript_lines: 1,
+            ..small_limits()
+        };
+        assert!(replay(two_lines, line_limited).is_err());
+
+        let two_items = transcript_line(vec![
+            task_update(json!(1), "pending"),
+            task_update(json!(2), "pending"),
+        ]);
+        let item_limited = ReplayLimits {
+            max_replay_items: 1,
+            ..small_limits()
+        };
+        assert!(replay(&two_items, item_limited).is_err());
+
+        let pending = transcript_line(vec![
+            task_create("tool-1", "First"),
+            task_create("tool-2", "Second"),
+        ]);
+        let pending_limited = ReplayLimits {
+            max_pending_creates: 1,
+            ..small_limits()
+        };
+        assert!(replay(&pending, pending_limited).is_err());
+
+        let tasks = transcript_line(vec![
+            task_create("tool-1", "First"),
+            task_result("tool-1", 1),
+            task_create("tool-2", "Second"),
+            task_result("tool-2", 2),
+        ]);
+        let task_limited = ReplayLimits {
+            max_tasks: 1,
+            ..small_limits()
+        };
+        assert!(replay(&tasks, task_limited).is_err());
+    }
+
+    #[test]
+    fn enforces_field_and_aggregate_retained_text_budgets() {
+        let create = transcript_line(vec![task_create("tool-id", "subject")]);
+        let id_limited = ReplayLimits {
+            max_tool_use_id_bytes: 3,
+            ..small_limits()
+        };
+        assert!(replay(&create, id_limited).is_err());
+
+        let content_limited = ReplayLimits {
+            max_todo_text_bytes: 3,
+            ..small_limits()
+        };
+        assert!(replay(&create, content_limited).is_err());
+
+        let status = transcript_line(vec![
+            task_create("a", "x"),
+            task_result("a", 1),
+            task_update(json!(1), "completed"),
+        ]);
+        let status_limited = ReplayLimits {
+            max_status_bytes: 3,
+            ..small_limits()
+        };
+        assert!(replay(&status, status_limited).is_err());
+
+        let aggregate = transcript_line(vec![task_create("a", "1234"), task_create("b", "5678")]);
+        let aggregate_limited = ReplayLimits {
+            max_retained_text_bytes: 20,
+            ..small_limits()
+        };
+        assert!(replay(&aggregate, aggregate_limited).is_err());
+    }
+
+    #[test]
+    fn oversized_numeric_task_id_does_not_wrap_to_an_existing_task() {
+        let bytes = transcript_line(vec![
+            task_create("tool-0", "Zero"),
+            task_result("tool-0", 0),
+            task_update(json!(u64::from(u32::MAX) + 1), "completed"),
+        ]);
+
+        let todos = replay(&bytes, small_limits()).unwrap();
+
+        assert_eq!(todos.len(), 1);
+        assert_eq!(todos[0].status, "pending");
+    }
+
+    #[test]
+    fn malformed_and_invalid_utf8_records_remain_skippable() {
+        let mut bytes = b"{\"TaskCreate\":\xff}\n".to_vec();
+        bytes.extend(transcript_line(vec![todo_write("valid", "pending")]));
+
+        let todos = replay(&bytes, small_limits()).unwrap();
+
+        assert_eq!(todos.len(), 1);
+        assert_eq!(todos[0].content, "valid");
+    }
+
+    #[test]
+    fn opened_file_snapshot_excludes_later_appends() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("transcript.jsonl");
+        let initial = transcript_line(vec![todo_write("initial", "pending")]);
+        std::fs::write(&path, &initial).unwrap();
+        let file = File::open(&path).unwrap();
+        let snapshot_len = file.metadata().unwrap().len();
+
+        let appended = transcript_line(vec![todo_write("appended", "completed")]);
+        let mut writer = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        writer.write_all(&appended).unwrap();
+        writer.flush().unwrap();
+
+        let todos = replay_todos(BufReader::new(file.take(snapshot_len)), small_limits()).unwrap();
+
+        assert_eq!(todos.len(), 1);
+        assert_eq!(todos[0].content, "initial");
+    }
 }

--- a/src-tauri/src/token_usage.rs
+++ b/src-tauri/src/token_usage.rs
@@ -1,15 +1,25 @@
-use std::fs;
+use std::fs::{self, File};
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use acorn_transcript::read_tail;
 use directories::UserDirs;
 use serde::Serialize;
 use serde_json::Value;
 
+use crate::error::{AppError, AppResult};
+
 const CODEX_SESSION_SCAN_LIMIT: usize = 20;
+const CODEX_SESSION_MAX_ENTRIES: usize = 10_000;
+const CODEX_SESSION_MAX_DEPTH: usize = 4;
 const CODEX_SESSION_TAIL_BYTES: u64 = 256 * 1024;
+const CLAUDE_RATE_LIMIT_MAX_BYTES: u64 = 64 * 1024;
+const CODEX_SQLITE_STDOUT_MAX_BYTES: usize = 256 * 1024;
+const CODEX_SQLITE_TIMEOUT: Duration = Duration::from_secs(2);
+const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -52,8 +62,10 @@ struct RateLimitWindow {
 }
 
 #[tauri::command]
-pub fn get_agent_token_usage() -> AgentTokenUsageSnapshot {
-    read_agent_token_usage()
+pub async fn get_agent_token_usage() -> AppResult<AgentTokenUsageSnapshot> {
+    tauri::async_runtime::spawn_blocking(read_agent_token_usage)
+        .await
+        .map_err(|err| AppError::Other(format!("token usage task failed: {err}")))
 }
 
 fn read_agent_token_usage() -> AgentTokenUsageSnapshot {
@@ -147,9 +159,12 @@ fn read_codex_rate_limits() -> ProviderRateLimits {
 fn read_codex_rate_limits_from_latest_sessions() -> Option<ProviderRateLimits> {
     let home = home_dir()?;
     let sessions = home.join(".codex").join("sessions");
-    let files = latest_jsonl_files(&sessions, CODEX_SESSION_SCAN_LIMIT);
+    let scan = latest_jsonl_files(&sessions, CODEX_SESSION_SCAN_LIMIT);
+    if scan.truncated {
+        return None;
+    }
 
-    for file in files {
+    for file in scan.files {
         if let Some(parsed) = read_codex_rate_limits_from_session_file(&file) {
             return Some(parsed);
         }
@@ -159,6 +174,9 @@ fn read_codex_rate_limits_from_latest_sessions() -> Option<ProviderRateLimits> {
 }
 
 fn read_codex_rate_limits_from_session_file(file: &Path) -> Option<ProviderRateLimits> {
+    if !is_plain_regular_file(file) {
+        return None;
+    }
     let text = read_tail(file, CODEX_SESSION_TAIL_BYTES).ok()?.text;
     for line in text.lines().rev() {
         if !line.contains("\"rate_limits\"") {
@@ -186,27 +204,27 @@ fn read_codex_rate_limits_from_sqlite() -> ProviderRateLimits {
         return ProviderRateLimits::default();
     };
     let db = home.join(".codex").join("logs_2.sqlite");
-    if !db.exists() {
+    if !is_plain_regular_file(&db) {
         return ProviderRateLimits::default();
     }
 
     let query = r#"
         select feedback_log_body from logs
         where feedback_log_body like '%"type":"codex.rate_limits"%'
+          and length(feedback_log_body) <= 262144
         order by ts desc, ts_nanos desc, id desc
         limit 1;
     "#;
-    let Ok(output) = Command::new("/usr/bin/sqlite3")
-        .arg(&db)
-        .arg(query)
-        .output()
-    else {
+    let mut command = Command::new("/usr/bin/sqlite3");
+    command.arg(&db).arg(query);
+    let Ok(stdout) = command_stdout_bounded(
+        &mut command,
+        CODEX_SQLITE_STDOUT_MAX_BYTES,
+        CODEX_SQLITE_TIMEOUT,
+    ) else {
         return ProviderRateLimits::default();
     };
-    if !output.status.success() {
-        return ProviderRateLimits::default();
-    }
-    let text = String::from_utf8_lossy(&output.stdout);
+    let text = String::from_utf8_lossy(&stdout);
     let Some(json_text) = extract_codex_event_json(&text) else {
         return ProviderRateLimits::default();
     };
@@ -239,10 +257,10 @@ fn parse_codex_rate_limits(value: &Value, source: &str) -> ProviderRateLimits {
 
 fn read_claude_rate_limits() -> ProviderRateLimits {
     for path in claude_rate_limit_paths() {
-        let Ok(data) = fs::read_to_string(&path) else {
+        let Ok(data) = read_bounded_regular_file(&path, CLAUDE_RATE_LIMIT_MAX_BYTES) else {
             continue;
         };
-        let Ok(value) = serde_json::from_str::<Value>(&data) else {
+        let Ok(value) = serde_json::from_slice::<Value>(&data) else {
             continue;
         };
         let Some(rate_limits) = value.get("rate_limits") else {
@@ -318,35 +336,258 @@ fn extract_codex_event_json(text: &str) -> Option<String> {
     Some(trimmed[start..].to_string())
 }
 
-fn latest_jsonl_files(root: &Path, limit: usize) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    collect_jsonl_files(root, &mut files);
-    files.sort_by(|a, b| b.1.cmp(&a.1));
-    files
-        .into_iter()
-        .take(limit)
-        .map(|(path, _)| path)
-        .collect()
+#[derive(Debug, Default, PartialEq, Eq)]
+struct SessionScanResult {
+    files: Vec<PathBuf>,
+    visited_entries: usize,
+    truncated: bool,
 }
 
-fn collect_jsonl_files(root: &Path, files: &mut Vec<(PathBuf, SystemTime)>) {
-    let Ok(entries) = fs::read_dir(root) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let Ok(metadata) = entry.metadata() else {
-            continue;
-        };
-        if metadata.is_dir() {
-            collect_jsonl_files(&path, files);
-            continue;
-        }
-        if !metadata.is_file() || path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
-            continue;
-        }
-        files.push((path, metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH)));
+fn latest_jsonl_files(root: &Path, limit: usize) -> SessionScanResult {
+    latest_jsonl_files_with_budget(
+        root,
+        limit,
+        CODEX_SESSION_MAX_ENTRIES,
+        CODEX_SESSION_MAX_DEPTH,
+    )
+}
+
+fn latest_jsonl_files_with_budget(
+    root: &Path,
+    file_limit: usize,
+    entry_limit: usize,
+    max_depth: usize,
+) -> SessionScanResult {
+    let mut scan = SessionScanResult::default();
+    if file_limit == 0 || !is_plain_directory(root) {
+        return scan;
     }
+
+    let mut candidates = Vec::with_capacity(file_limit.saturating_add(1));
+    collect_jsonl_files(
+        root,
+        0,
+        file_limit,
+        entry_limit,
+        max_depth,
+        &mut candidates,
+        &mut scan,
+    );
+    if scan.truncated {
+        // A partial traversal can make an old file look newest. Discard it so
+        // the caller uses the separately bounded SQLite fallback instead.
+        return scan;
+    }
+    scan.files = candidates.into_iter().map(|(path, _)| path).collect();
+    scan
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_jsonl_files(
+    root: &Path,
+    depth: usize,
+    file_limit: usize,
+    entry_limit: usize,
+    max_depth: usize,
+    files: &mut Vec<(PathBuf, SystemTime)>,
+    scan: &mut SessionScanResult,
+) {
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(_) => {
+            scan.truncated = true;
+            return;
+        }
+    };
+
+    for entry in entries {
+        if scan.visited_entries >= entry_limit {
+            scan.truncated = true;
+            return;
+        }
+        scan.visited_entries += 1;
+
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => {
+                scan.truncated = true;
+                return;
+            }
+        };
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(_) => {
+                scan.truncated = true;
+                return;
+            }
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            if depth >= max_depth {
+                scan.truncated = true;
+                return;
+            }
+            collect_jsonl_files(
+                &path,
+                depth + 1,
+                file_limit,
+                entry_limit,
+                max_depth,
+                files,
+                scan,
+            );
+            if scan.truncated {
+                return;
+            }
+            continue;
+        }
+        if !file_type.is_file() || path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let metadata = match entry.metadata() {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                scan.truncated = true;
+                return;
+            }
+        };
+        retain_latest_file(
+            files,
+            path,
+            metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+            file_limit,
+        );
+    }
+}
+
+fn retain_latest_file(
+    files: &mut Vec<(PathBuf, SystemTime)>,
+    path: PathBuf,
+    modified: SystemTime,
+    limit: usize,
+) {
+    files.push((path, modified));
+    files.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| b.0.cmp(&a.0)));
+    files.truncate(limit);
+}
+
+fn is_plain_directory(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_dir())
+        .unwrap_or(false)
+}
+
+fn is_plain_regular_file(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_file())
+        .unwrap_or(false)
+}
+
+fn read_bounded_regular_file(path: &Path, max_bytes: u64) -> io::Result<Vec<u8>> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "expected a regular file without symlinks",
+        ));
+    }
+    if metadata.len() > max_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "file exceeds byte budget",
+        ));
+    }
+
+    let file = File::open(path)?;
+    let capacity = metadata.len().min(max_bytes).min(usize::MAX as u64) as usize;
+    let mut data = Vec::with_capacity(capacity);
+    file.take(max_bytes.saturating_add(1))
+        .read_to_end(&mut data)?;
+    if data.len() as u64 > max_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "file grew beyond byte budget while reading",
+        ));
+    }
+    Ok(data)
+}
+
+fn command_stdout_bounded(
+    command: &mut Command,
+    max_stdout: usize,
+    timeout: Duration,
+) -> io::Result<Vec<u8>> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    let mut child = command.spawn()?;
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            terminate_child(&mut child);
+            return Err(io::Error::other("child stdout pipe missing"));
+        }
+    };
+    let reader = match thread::Builder::new()
+        .name("token-usage-stdout".to_string())
+        .spawn(move || {
+            let mut bytes = Vec::with_capacity(max_stdout.min(8 * 1024));
+            stdout
+                .take((max_stdout as u64).saturating_add(1))
+                .read_to_end(&mut bytes)?;
+            Ok::<_, io::Error>(bytes)
+        }) {
+        Ok(reader) => reader,
+        Err(err) => {
+            terminate_child(&mut child);
+            return Err(err);
+        }
+    };
+
+    let started = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if started.elapsed() >= timeout => {
+                terminate_child(&mut child);
+                let _ = reader.join();
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "child process exceeded time budget",
+                ));
+            }
+            Ok(None) => thread::sleep(CHILD_POLL_INTERVAL),
+            Err(err) => {
+                terminate_child(&mut child);
+                let _ = reader.join();
+                return Err(err);
+            }
+        }
+    };
+    let bytes = reader
+        .join()
+        .map_err(|_| io::Error::other("child stdout reader panicked"))??;
+    if bytes.len() > max_stdout {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "child stdout exceeds byte budget",
+        ));
+    }
+    if !status.success() {
+        return Err(io::Error::other(format!(
+            "child process exited with {status}"
+        )));
+    }
+    Ok(bytes)
+}
+
+fn terminate_child(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 fn render_source_path(path: &Path) -> String {
@@ -379,6 +620,7 @@ mod tests {
     use super::*;
     use std::fs::File;
     use std::io::Write;
+    use tempfile::tempdir;
 
     #[test]
     fn parses_codex_primary_and_secondary_windows() {
@@ -445,6 +687,155 @@ mod tests {
 
         assert_eq!(window.used_percent, 10.5);
         assert_eq!(window.reset_at, Some(1779860400.0));
+    }
+
+    #[test]
+    fn retains_only_the_newest_file_candidates() {
+        let mut files = Vec::new();
+        retain_latest_file(
+            &mut files,
+            PathBuf::from("old.jsonl"),
+            UNIX_EPOCH + Duration::from_secs(1),
+            2,
+        );
+        retain_latest_file(
+            &mut files,
+            PathBuf::from("new.jsonl"),
+            UNIX_EPOCH + Duration::from_secs(3),
+            2,
+        );
+        retain_latest_file(
+            &mut files,
+            PathBuf::from("middle.jsonl"),
+            UNIX_EPOCH + Duration::from_secs(2),
+            2,
+        );
+
+        assert_eq!(
+            files.into_iter().map(|(path, _)| path).collect::<Vec<_>>(),
+            vec![PathBuf::from("new.jsonl"), PathBuf::from("middle.jsonl")]
+        );
+    }
+
+    #[test]
+    fn session_scan_discards_results_when_entry_budget_is_exhausted() {
+        let root = tempdir().expect("temp dir");
+        for name in ["a.jsonl", "b.jsonl", "c.jsonl"] {
+            fs::write(root.path().join(name), b"{}\n").expect("write session");
+        }
+
+        let scan = latest_jsonl_files_with_budget(root.path(), 20, 2, 4);
+
+        assert!(scan.truncated);
+        assert_eq!(scan.visited_entries, 2);
+        assert!(scan.files.is_empty());
+    }
+
+    #[test]
+    fn session_scan_discards_results_beyond_depth_budget() {
+        let root = tempdir().expect("temp dir");
+        let nested = root.path().join("year").join("month");
+        fs::create_dir_all(&nested).expect("create nested dirs");
+        fs::write(nested.join("session.jsonl"), b"{}\n").expect("write session");
+
+        let scan = latest_jsonl_files_with_budget(root.path(), 20, 100, 0);
+
+        assert!(scan.truncated);
+        assert!(scan.files.is_empty());
+    }
+
+    #[test]
+    fn bounded_regular_file_accepts_exact_limit_and_rejects_oversize() {
+        let root = tempdir().expect("temp dir");
+        let path = root.path().join("limits.json");
+        fs::write(&path, b"1234").expect("write exact file");
+        assert_eq!(read_bounded_regular_file(&path, 4).unwrap(), b"1234");
+
+        fs::write(&path, b"12345").expect("write oversized file");
+        let err = read_bounded_regular_file(&path, 4).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn session_scan_and_readers_reject_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempdir().expect("session root");
+        let outside = tempdir().expect("outside root");
+        let outside_file = outside.path().join("outside.jsonl");
+        fs::write(
+            &outside_file,
+            br#"{"payload":{"rate_limits":{"primary":{"used_percent":42}}}}"#,
+        )
+        .expect("write outside session");
+        fs::write(root.path().join("regular.jsonl"), b"{}\n").expect("write regular session");
+        symlink(outside.path(), root.path().join("linked-dir")).expect("link directory");
+        let linked_file = root.path().join("linked.jsonl");
+        symlink(&outside_file, &linked_file).expect("link file");
+
+        let scan = latest_jsonl_files_with_budget(root.path(), 20, 100, 4);
+
+        assert!(!scan.truncated);
+        assert_eq!(scan.files, vec![root.path().join("regular.jsonl")]);
+        assert!(read_codex_rate_limits_from_session_file(&linked_file).is_none());
+        assert_eq!(
+            read_bounded_regular_file(&linked_file, 1024)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn bounded_command_rejects_oversized_stdout() {
+        let mut command = command_fixture("command_fixture_writes_large_stdout");
+
+        let err = command_stdout_bounded(&mut command, 64, Duration::from_secs(2)).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn bounded_command_terminates_after_timeout() {
+        let mut command = command_fixture("command_fixture_sleeps");
+
+        let err =
+            command_stdout_bounded(&mut command, 1024, Duration::from_millis(40)).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    }
+
+    fn command_fixture(name: &str) -> Command {
+        let mut command = Command::new(std::env::current_exe().expect("current test executable"));
+        command
+            .arg("--exact")
+            .arg(format!("token_usage::tests::{name}"))
+            .arg("--nocapture")
+            .env("ACORN_TOKEN_USAGE_TEST_FIXTURE", name);
+        command
+    }
+
+    #[test]
+    fn command_fixture_writes_large_stdout() {
+        if std::env::var("ACORN_TOKEN_USAGE_TEST_FIXTURE").as_deref()
+            != Ok("command_fixture_writes_large_stdout")
+        {
+            return;
+        }
+        std::io::stdout()
+            .write_all(&vec![b'x'; 4 * 1024])
+            .expect("write fixture stdout");
+    }
+
+    #[test]
+    fn command_fixture_sleeps() {
+        if std::env::var("ACORN_TOKEN_USAGE_TEST_FIXTURE").as_deref()
+            != Ok("command_fixture_sleeps")
+        {
+            return;
+        }
+        thread::sleep(Duration::from_secs(2));
     }
 
     fn temp_file_path(label: &str) -> PathBuf {

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -1,6 +1,7 @@
 use git2::{BranchType, Repository, WorktreeAddOptions, WorktreePruneOptions};
 use serde::Serialize;
-use std::io::Write;
+use std::fs::{File, Metadata, OpenOptions};
+use std::io::{ErrorKind, Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
@@ -9,6 +10,7 @@ use crate::error::{AppError, AppResult};
 
 const ACORN_DIR: &str = ".acorn";
 const EXCLUDE_ENTRY: &str = ".acorn/";
+const MAX_GIT_EXCLUDE_BYTES: u64 = 1024 * 1024;
 const DELETED_WORKTREES_DIR: &str = ".acorn-deleted-worktrees";
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -78,33 +80,141 @@ pub fn worktree_root(repo_path: &Path) -> PathBuf {
     repo_path.join(ACORN_DIR).join("worktrees")
 }
 
-fn ensure_git_excluded(repo_path: &Path) -> AppResult<()> {
-    let info_dir = repo_path.join(".git").join("info");
-    if !info_dir.exists() {
-        std::fs::create_dir_all(&info_dir)?;
-    }
+fn ensure_git_excluded(repo: &Repository) -> AppResult<()> {
+    // A linked worktree's `Repository::path()` is its per-worktree admin
+    // directory. Ignore rules live in the shared Git common directory, so use
+    // `commondir()` for both main and linked worktree repositories.
+    let common_dir = repo.commondir().canonicalize()?;
+    let info_dir = common_dir.join("info");
+    ensure_real_directory(&info_dir)?;
     let exclude_path = info_dir.join("exclude");
 
-    let already = std::fs::read_to_string(&exclude_path)
-        .map(|s| s.lines().any(|l| l.trim() == EXCLUDE_ENTRY))
-        .unwrap_or(false);
+    let mut file = open_git_exclude(&exclude_path)?;
+    let mut contents = Vec::with_capacity(
+        usize::try_from(file.metadata()?.len().min(MAX_GIT_EXCLUDE_BYTES)).unwrap_or(0),
+    );
+    (&mut file)
+        .take(MAX_GIT_EXCLUDE_BYTES + 1)
+        .read_to_end(&mut contents)?;
+    if contents.len() as u64 > MAX_GIT_EXCLUDE_BYTES {
+        return Err(AppError::InvalidPath(format!(
+            "Git exclude file exceeds {MAX_GIT_EXCLUDE_BYTES} bytes: {}",
+            exclude_path.display()
+        )));
+    }
+
+    let already = String::from_utf8_lossy(&contents)
+        .lines()
+        .any(|line| line.trim() == EXCLUDE_ENTRY);
     if already {
         return Ok(());
     }
 
-    let mut f = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&exclude_path)?;
-    writeln!(f, "{EXCLUDE_ENTRY}")?;
+    writeln!(file, "{EXCLUDE_ENTRY}")?;
+    Ok(())
+}
+
+fn ensure_real_directory(path: &Path) -> AppResult<()> {
+    loop {
+        match std::fs::symlink_metadata(path) {
+            Ok(metadata) => {
+                if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                    return Err(AppError::InvalidPath(format!(
+                        "Git metadata path must be a real directory: {}",
+                        path.display()
+                    )));
+                }
+                return Ok(());
+            }
+            Err(err) if err.kind() == ErrorKind::NotFound => match std::fs::create_dir(path) {
+                Ok(()) => {}
+                Err(create_err) if create_err.kind() == ErrorKind::AlreadyExists => {}
+                Err(create_err) => return Err(create_err.into()),
+            },
+            Err(err) => return Err(err.into()),
+        }
+    }
+}
+
+fn open_git_exclude(path: &Path) -> AppResult<File> {
+    loop {
+        match std::fs::symlink_metadata(path) {
+            Ok(path_metadata) => {
+                validate_git_exclude_metadata(path, &path_metadata)?;
+                let file = OpenOptions::new().read(true).append(true).open(path)?;
+                let opened_metadata = file.metadata()?;
+                validate_git_exclude_metadata(path, &opened_metadata)?;
+                validate_same_file(path, &path_metadata, &opened_metadata)?;
+                return Ok(file);
+            }
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                match OpenOptions::new()
+                    .read(true)
+                    .append(true)
+                    .create_new(true)
+                    .open(path)
+                {
+                    Ok(file) => {
+                        validate_git_exclude_metadata(path, &file.metadata()?)?;
+                        return Ok(file);
+                    }
+                    Err(create_err) if create_err.kind() == ErrorKind::AlreadyExists => {}
+                    Err(create_err) => return Err(create_err.into()),
+                }
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
+}
+
+fn validate_git_exclude_metadata(path: &Path, metadata: &Metadata) -> AppResult<()> {
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(AppError::InvalidPath(format!(
+            "Git exclude path must be a regular file: {}",
+            path.display()
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if metadata.nlink() > 1 {
+            return Err(AppError::InvalidPath(format!(
+                "Git exclude path must not be hard-linked: {}",
+                path.display()
+            )));
+        }
+    }
+    if metadata.len() > MAX_GIT_EXCLUDE_BYTES {
+        return Err(AppError::InvalidPath(format!(
+            "Git exclude file exceeds {MAX_GIT_EXCLUDE_BYTES} bytes: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_same_file(path: &Path, before: &Metadata, opened: &Metadata) -> AppResult<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    if before.dev() != opened.dev() || before.ino() != opened.ino() {
+        return Err(AppError::InvalidPath(format!(
+            "Git exclude file changed while opening: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn validate_same_file(_path: &Path, _before: &Metadata, _opened: &Metadata) -> AppResult<()> {
     Ok(())
 }
 
 pub fn create_worktree(repo_path: &Path, name: &str) -> AppResult<PathBuf> {
     let repo = ensure_repo(repo_path)?;
-    ensure_git_excluded(repo_path).ok();
-    let root = worktree_root(repo_path);
-    std::fs::create_dir_all(&root)?;
+    ensure_git_excluded(&repo).ok();
+    let root = checked_worktree_root(repo_path, true)?;
     let target = root.join(name);
 
     if target.exists() {
@@ -242,7 +352,7 @@ pub fn stage_remove_worktree_at_path(
         }
     }
 
-    if is_acorn_managed_worktree_path(repo_path, worktree_path) {
+    if is_acorn_managed_worktree_path(repo_path, worktree_path)? {
         if worktree_path.exists() && is_linked_worktree_root(worktree_path) {
             std::fs::remove_dir_all(worktree_path)?;
             return Ok(None);
@@ -396,15 +506,74 @@ pub(crate) fn same_path(left: &Path, right: &Path) -> bool {
     }
 }
 
-fn is_acorn_managed_worktree_path(repo_path: &Path, worktree_path: &Path) -> bool {
+fn is_acorn_managed_worktree_path(repo_path: &Path, worktree_path: &Path) -> AppResult<bool> {
     if worktree_path
         .components()
         .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
     {
-        return false;
+        return Ok(false);
     }
+    let root = checked_worktree_root(repo_path, false)?;
+    Ok(worktree_path.parent() == Some(root.as_path()) && worktree_path.file_name().is_some())
+}
+
+/// Validate Acorn's managed-worktree storage without following repository-
+/// controlled symlinks. A cloned repository can contain `.acorn` (or a
+/// `worktrees` entry beneath it) as a symlink; blindly creating or deleting
+/// through that path would escape the repository boundary.
+fn checked_worktree_root(repo_path: &Path, create: bool) -> AppResult<PathBuf> {
+    let canonical_repo = repo_path.canonicalize()?;
+    if !canonical_repo.is_dir() {
+        return Err(AppError::InvalidPath(format!(
+            "repository path is not a directory: {}",
+            repo_path.display()
+        )));
+    }
+
+    let acorn_dir = repo_path.join(ACORN_DIR);
     let root = worktree_root(repo_path);
-    worktree_path.parent() == Some(root.as_path()) && worktree_path.file_name().is_some()
+    if !checked_directory_component(&acorn_dir, create)? {
+        return Ok(root);
+    }
+    if !checked_directory_component(&root, create)? {
+        return Ok(root);
+    }
+
+    let canonical_root = root.canonicalize()?;
+    if !canonical_root.starts_with(&canonical_repo) {
+        return Err(AppError::InvalidPath(format!(
+            "managed worktree root escapes repository: {}",
+            root.display()
+        )));
+    }
+    Ok(root)
+}
+
+fn checked_directory_component(path: &Path, create: bool) -> AppResult<bool> {
+    loop {
+        match std::fs::symlink_metadata(path) {
+            Ok(metadata) => {
+                if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                    return Err(AppError::InvalidPath(format!(
+                        "managed worktree path component must be a real directory: {}",
+                        path.display()
+                    )));
+                }
+                return Ok(true);
+            }
+            Err(err) if err.kind() == ErrorKind::NotFound && create => {
+                match std::fs::create_dir(path) {
+                    Ok(()) => {}
+                    Err(create_err) if create_err.kind() == ErrorKind::AlreadyExists => {}
+                    Err(create_err) => return Err(create_err.into()),
+                }
+                // Re-read with symlink_metadata after creation so a component
+                // that appeared concurrently is validated before use.
+            }
+            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(false),
+            Err(err) => return Err(err.into()),
+        }
+    }
 }
 
 /// Returns `true` when `path` is the root of a *linked* git worktree.
@@ -476,6 +645,151 @@ mod tests {
             .unwrap_or_else(|_| panic!("set HEAD to {refname}"));
     }
 
+    fn git_exclude_path(repo: &Repository) -> PathBuf {
+        repo.commondir().join("info").join("exclude")
+    }
+
+    #[test]
+    fn ensure_git_excluded_creates_missing_file_and_keeps_existing_rules() {
+        let root = unique_temp_dir("git-exclude-normal");
+        let repo = Repository::init(&root).expect("init repo");
+        let exclude = git_exclude_path(&repo);
+        std::fs::remove_file(&exclude).ok();
+
+        ensure_git_excluded(&repo).expect("create missing exclude");
+        assert_eq!(
+            std::fs::read_to_string(&exclude).expect("read created exclude"),
+            format!("{EXCLUDE_ENTRY}\n")
+        );
+
+        std::fs::write(&exclude, "custom-rule\n").expect("write existing exclude");
+        ensure_git_excluded(&repo).expect("append Acorn rule");
+        ensure_git_excluded(&repo).expect("keep Acorn rule idempotent");
+        let contents = std::fs::read_to_string(&exclude).expect("read updated exclude");
+        assert!(contents.starts_with("custom-rule\n"));
+        assert_eq!(
+            contents
+                .lines()
+                .filter(|line| line.trim() == EXCLUDE_ENTRY)
+                .count(),
+            1
+        );
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn ensure_git_excluded_uses_common_dir_for_linked_worktree() {
+        let root = unique_temp_dir("git-exclude-linked");
+        let repo = init_repo_with_tracked_file(&root);
+        drop(repo);
+        let worktree_path = create_worktree(&root, "linked").expect("create linked worktree");
+        let linked_repo = Repository::open(&worktree_path).expect("open linked worktree");
+        let exclude = git_exclude_path(&linked_repo);
+        std::fs::write(&exclude, "shared-rule\n").expect("reset shared exclude");
+
+        ensure_git_excluded(&linked_repo).expect("update common exclude");
+
+        let contents = std::fs::read_to_string(root.join(".git/info/exclude"))
+            .expect("read main repository exclude");
+        assert!(contents.contains("shared-rule"));
+        assert!(contents.lines().any(|line| line.trim() == EXCLUDE_ENTRY));
+
+        drop(linked_repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_git_excluded_rejects_external_symlink_without_modifying_target() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_temp_dir("git-exclude-symlink");
+        let external = unique_temp_dir("git-exclude-symlink-external");
+        let sentinel = external.join("sentinel.txt");
+        std::fs::write(&sentinel, "do not modify\n").expect("write sentinel");
+        let repo = Repository::init(&root).expect("init repo");
+        let exclude = git_exclude_path(&repo);
+        std::fs::remove_file(&exclude).ok();
+        symlink(&sentinel, &exclude).expect("link exclude to sentinel");
+
+        let error = ensure_git_excluded(&repo).expect_err("symlink must be rejected");
+
+        assert!(matches!(error, AppError::InvalidPath(_)));
+        assert_eq!(
+            std::fs::read_to_string(&sentinel).expect("read sentinel"),
+            "do not modify\n"
+        );
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&external).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_git_excluded_rejects_external_hardlink_without_modifying_target() {
+        let root = unique_temp_dir("git-exclude-hardlink");
+        let external = unique_temp_dir("git-exclude-hardlink-external");
+        let sentinel = external.join("sentinel.txt");
+        std::fs::write(&sentinel, "do not modify\n").expect("write sentinel");
+        let repo = Repository::init(&root).expect("init repo");
+        let exclude = git_exclude_path(&repo);
+        std::fs::remove_file(&exclude).ok();
+        std::fs::hard_link(&sentinel, &exclude).expect("hard-link exclude to sentinel");
+
+        let error = ensure_git_excluded(&repo).expect_err("hardlink must be rejected");
+
+        assert!(matches!(error, AppError::InvalidPath(_)));
+        assert_eq!(
+            std::fs::read_to_string(&sentinel).expect("read sentinel"),
+            "do not modify\n"
+        );
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&external).ok();
+    }
+
+    #[test]
+    fn ensure_git_excluded_rejects_oversized_file() {
+        let root = unique_temp_dir("git-exclude-oversized");
+        let repo = Repository::init(&root).expect("init repo");
+        let exclude = git_exclude_path(&repo);
+        File::create(&exclude)
+            .expect("create exclude")
+            .set_len(MAX_GIT_EXCLUDE_BYTES + 1)
+            .expect("make exclude oversized");
+
+        let error = ensure_git_excluded(&repo).expect_err("oversized exclude must be rejected");
+
+        assert!(matches!(error, AppError::InvalidPath(_)));
+        assert_eq!(
+            std::fs::metadata(&exclude).expect("exclude metadata").len(),
+            MAX_GIT_EXCLUDE_BYTES + 1
+        );
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn ensure_git_excluded_rejects_non_regular_file() {
+        let root = unique_temp_dir("git-exclude-non-regular");
+        let repo = Repository::init(&root).expect("init repo");
+        let exclude = git_exclude_path(&repo);
+        std::fs::remove_file(&exclude).ok();
+        std::fs::create_dir(&exclude).expect("replace exclude with directory");
+
+        let error = ensure_git_excluded(&repo).expect_err("directory must be rejected");
+
+        assert!(matches!(error, AppError::InvalidPath(_)));
+
+        drop(repo);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
     #[test]
     fn create_worktree_starts_new_branch_from_main_when_head_is_elsewhere() {
         let root = unique_temp_dir("base-main");
@@ -523,6 +837,53 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_worktree_rejects_symlinked_acorn_directory() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_temp_dir("symlinked-acorn");
+        let external = unique_temp_dir("symlinked-acorn-external");
+        let repo = init_repo_with_tracked_file(&root);
+        drop(repo);
+        symlink(&external, root.join(ACORN_DIR)).expect("symlink .acorn");
+
+        let error = create_worktree(&root, "worker").expect_err("symlink must be rejected");
+
+        assert!(matches!(error, AppError::InvalidPath(_)));
+        assert!(!external.join("worktrees").join("worker").exists());
+        let repo = Repository::open(&root).expect("reopen repo");
+        assert!(repo.find_branch("worker", BranchType::Local).is_err());
+
+        std::fs::remove_file(root.join(ACORN_DIR)).ok();
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&external).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_worktree_rejects_symlinked_worktrees_directory() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_temp_dir("symlinked-worktrees");
+        let external = unique_temp_dir("symlinked-worktrees-external");
+        let repo = init_repo_with_tracked_file(&root);
+        drop(repo);
+        std::fs::create_dir(root.join(ACORN_DIR)).expect("create .acorn");
+        symlink(&external, root.join(ACORN_DIR).join("worktrees")).expect("symlink worktrees");
+
+        let error = create_worktree(&root, "worker").expect_err("symlink must be rejected");
+
+        assert!(matches!(error, AppError::InvalidPath(_)));
+        assert!(!external.join("worker").exists());
+        let repo = Repository::open(&root).expect("reopen repo");
+        assert!(repo.find_branch("worker", BranchType::Local).is_err());
+
+        std::fs::remove_file(root.join(ACORN_DIR).join("worktrees")).ok();
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&external).ok();
     }
 
     #[test]
@@ -862,5 +1223,31 @@ mod tests {
             "stale fallback must not delete paths outside managed worktrees"
         );
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_worktree_rejects_symlinked_managed_root() {
+        use std::os::unix::fs::symlink;
+
+        let root = unique_temp_dir("remove-symlinked-root");
+        let external = unique_temp_dir("remove-symlinked-root-external");
+        Repository::init(&root).expect("init repo");
+        let rogue = external.join("worktrees").join("rogue");
+        std::fs::create_dir_all(&rogue).expect("create outside worktree shape");
+        std::fs::write(rogue.join(".git"), "gitdir: /outside\n").expect("write linked marker");
+        symlink(&external, root.join(ACORN_DIR)).expect("symlink .acorn");
+        let requested = root.join(ACORN_DIR).join("worktrees").join("rogue");
+
+        let error = stage_remove_worktree_at_path(&root, &requested)
+            .expect_err("symlinked managed root must be rejected");
+
+        assert!(matches!(error, AppError::InvalidPath(_)));
+        assert!(rogue.exists());
+        assert!(rogue.join(".git").exists());
+
+        std::fs::remove_file(root.join(ACORN_DIR)).ok();
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&external).ok();
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,9 +47,6 @@
     ]
   },
   "plugins": {
-    "opener": {
-      "requireLiteralLeadingDot": false
-    },
     "updater": {
       "active": true,
       "endpoints": [

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -89,6 +89,7 @@ export function ImageLightbox({ image, onClose }: ImageLightboxProps) {
       <img
         src={image.src}
         alt={image.alt ?? ""}
+        referrerPolicy="no-referrer"
         onClick={(e) => e.stopPropagation()}
         className="max-h-[90vh] max-w-[90vw] cursor-default rounded border border-white/10 object-contain shadow-2xl"
       />

--- a/src/components/MediaViewer.tsx
+++ b/src/components/MediaViewer.tsx
@@ -258,6 +258,7 @@ function renderMedia(
       key={src}
       src={src}
       title={title}
+      referrerPolicy="no-referrer"
       className="h-full w-full border-0 bg-white"
     />
   );

--- a/src/components/chat/ChatMessageBody.test.tsx
+++ b/src/components/chat/ChatMessageBody.test.tsx
@@ -133,4 +133,29 @@ describe("ChatMessageBody", () => {
     expect(container.textContent).toContain("const partial");
     expect(container.querySelector("[data-chat-code-block]")).toBeTruthy();
   });
+
+  it("waits for approval before loading a remote Markdown image", () => {
+    act(() => {
+      root.render(
+        <ChatMessageBody
+          content={"![Remote build](https://tracker.example/build.png)"}
+        />,
+      );
+    });
+
+    expect(container.querySelector("img")).toBeNull();
+    const load = container.querySelector<HTMLButtonElement>(
+      "[data-remote-image-placeholder]",
+    );
+    expect(load).not.toBeNull();
+
+    act(() => load!.click());
+
+    const image = container.querySelector("img");
+    expect(image?.getAttribute("src")).toBe(
+      "https://tracker.example/build.png",
+    );
+    expect(image?.getAttribute("referrerpolicy")).toBe("no-referrer");
+  });
+
 });

--- a/src/components/chat/ChatMessageBody.tsx
+++ b/src/components/chat/ChatMessageBody.tsx
@@ -3,6 +3,10 @@ import ReactMarkdown, { type Components } from "react-markdown";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import remarkGfm from "remark-gfm";
 import { cn } from "../../lib/cn";
+import {
+  markdownImageUrlTransform,
+  RemoteImage,
+} from "../ui/RemoteImage";
 import { ChatCodeBlock } from "./ChatCodeBlock";
 
 interface ChatMessageBodyProps {
@@ -77,6 +81,19 @@ export function ChatMessageBody({
         <blockquote className="my-2 border-l-2 border-border pl-3 text-fg-muted">
           {children}
         </blockquote>
+      );
+    },
+    img({ src, alt, title, width, height }) {
+      return (
+        <RemoteImage
+          src={src}
+          alt={alt ?? ""}
+          title={title}
+          width={width}
+          height={height}
+          loading="lazy"
+          className="my-2 max-w-full rounded border border-border"
+        />
       );
     },
     code({ className, children, ...rest }) {
@@ -154,7 +171,11 @@ export function ChatMessageBody({
       )}
       data-chat-message-body
     >
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        urlTransform={markdownImageUrlTransform}
+        components={components}
+      >
         {renderableStreamingContent(content, isStreaming)}
       </ReactMarkdown>
     </div>

--- a/src/components/ui/Markdown.test.tsx
+++ b/src/components/ui/Markdown.test.tsx
@@ -58,6 +58,32 @@ describe("Markdown — interactive task list", () => {
     expect(handler).toHaveBeenCalledWith(1, true);
   });
 
+  it("does not let a raw HTML checkbox shift or invoke a GFM task index", () => {
+    const handler = vi.fn();
+    act(() => {
+      root.render(
+        <Markdown
+          content={
+            '<input type="checkbox" acornTaskIndex="0" data-task-index="0">\n\n- [ ] real task'
+          }
+          onTaskToggle={handler}
+        />,
+      );
+    });
+    const boxes = container.querySelectorAll<HTMLInputElement>(
+      'input[type="checkbox"]',
+    );
+    expect(boxes).toHaveLength(2);
+    expect(boxes[0]?.disabled).toBe(true);
+    expect(boxes[1]?.disabled).toBe(false);
+
+    act(() => boxes[0]!.click());
+    expect(handler).not.toHaveBeenCalled();
+
+    act(() => boxes[1]!.click());
+    expect(handler).toHaveBeenCalledWith(0, true);
+  });
+
   it("keeps checkboxes read-only when no handler is given", () => {
     act(() => {
       root.render(<Markdown content={"- [ ] one"} />);
@@ -80,5 +106,34 @@ describe("Markdown — interactive task list", () => {
       root.render(<Markdown content={"안녕\n하세요"} />);
     });
     expect(container.querySelectorAll("br")).toHaveLength(0);
+  });
+
+  it("removes raw picture sources and gates the fallback remote image", () => {
+    act(() => {
+      root.render(
+        <Markdown
+          content={
+            '<picture><source srcset="https://tracker.example/large.png 2x"><img src="https://tracker.example/fallback.png" srcset="https://tracker.example/fallback@2x.png 2x" alt="Remote preview"></picture>'
+          }
+        />,
+      );
+    });
+
+    expect(container.querySelector("picture")).toBeNull();
+    expect(container.querySelector("source")).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
+
+    const load = container.querySelector<HTMLButtonElement>(
+      "[data-remote-image-placeholder]",
+    );
+    expect(load).not.toBeNull();
+    act(() => load!.click());
+
+    const image = container.querySelector("img");
+    expect(image?.getAttribute("src")).toBe(
+      "https://tracker.example/fallback.png",
+    );
+    expect(image?.getAttribute("srcset")).toBeNull();
+    expect(image?.getAttribute("referrerpolicy")).toBe("no-referrer");
   });
 });

--- a/src/components/ui/Markdown.tsx
+++ b/src/components/ui/Markdown.tsx
@@ -7,6 +7,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { cn } from "../../lib/cn";
 import { ImageLightbox } from "../ImageLightbox";
 import { Tooltip } from "../Tooltip";
+import { markdownImageUrlTransform, RemoteImage } from "./RemoteImage";
 
 // Sanitize schema for PR/comment markdown bodies — they routinely embed raw
 // HTML (image uploads, GitHub's `<img width="…">` snippets, details/summary).
@@ -24,6 +25,7 @@ const sanitizeSchema = {
       "height",
       "loading",
     ],
+    source: [],
     a: [
       ...(defaultSchema.attributes?.a ?? []),
       "href",
@@ -33,13 +35,24 @@ const sanitizeSchema = {
     ],
     input: [
       ...(defaultSchema.attributes?.input ?? []),
-      // Stamped by `rehypeTaskIndex` below so the React input component can
-      // map a click back to its source-order checkbox.
-      "dataTaskIndex",
+      // Stamped only on parser-generated GFM tasks by `rehypeTaskIndex` below,
+      // so raw HTML checkboxes cannot impersonate an editable task.
+      "acornTaskIndex",
+    ],
+  },
+  protocols: {
+    ...defaultSchema.protocols,
+    src: [
+      ...(defaultSchema.protocols?.src ?? []),
+      "data",
+      "blob",
+      "asset",
     ],
   },
   tagNames: [
-    ...(defaultSchema.tagNames ?? []),
+    ...(defaultSchema.tagNames ?? []).filter(
+      (tagName) => tagName !== "picture" && tagName !== "source",
+    ),
     "details",
     "summary",
   ],
@@ -47,9 +60,10 @@ const sanitizeSchema = {
 
 // Walks the HAST tree once (outside React's render cycle, so immune to
 // StrictMode double-invocation) and stamps each task-list checkbox input
-// with a `data-task-index` attribute reflecting its source-order position.
-// Runs after `rehypeRaw` (whose tree-rebuild strips positions) and before
-// `rehypeSanitize`, which is configured above to allow the data attr.
+// with an internal task index reflecting its parsed source order.
+// Runs before `rehypeRaw`: parser-generated GFM inputs already exist as HAST
+// elements, while attacker-authored HTML is still an opaque `raw` node. The
+// stamp survives raw-tree rebuilding and is allowlisted by `rehypeSanitize`.
 function rehypeTaskIndex() {
   return (tree: { children?: unknown[]; [k: string]: unknown }) => {
     let i = 0;
@@ -66,7 +80,7 @@ function rehypeTaskIndex() {
         n.tagName === "input" &&
         n.properties?.type === "checkbox"
       ) {
-        n.properties = { ...n.properties, dataTaskIndex: i++ };
+        n.properties = { ...n.properties, acornTaskIndex: i++ };
       }
       n.children?.forEach(walk);
     };
@@ -287,7 +301,7 @@ function MarkdownImpl({
       img({ src, alt, title, width, height }) {
         const url = typeof src === "string" ? src : undefined;
         const image = (
-          <img
+          <RemoteImage
             src={url}
             alt={alt ?? ""}
             width={width}
@@ -322,27 +336,35 @@ function MarkdownImpl({
             />
           );
         }
-        // `rehypeTaskIndex` stamps this on each checkbox input during the
-        // HAST tree walk — a single-pass numbering that survives StrictMode's
-        // double-invocation of the React renderer.
-        const indexRaw = (props as { "data-task-index"?: unknown })[
-          "data-task-index"
-        ];
+        // `rehypeTaskIndex` stamps only parser-generated GFM checkboxes during
+        // the pre-raw HAST walk. Raw HTML checkboxes have no valid index and
+        // remain disabled.
+        const indexRaw = (props as { acornTaskIndex?: unknown })
+          .acornTaskIndex;
+        // rehype-sanitize may stringify the generated number. The camelCase
+        // HAST-only property is still trustworthy: HTML parsing lowercases an
+        // attacker-authored attribute before the sanitizer allowlist runs.
         const index =
           typeof indexRaw === "number"
             ? indexRaw
             : typeof indexRaw === "string"
               ? Number(indexRaw)
               : -1;
+        const isEditableTask = Number.isInteger(index) && index >= 0;
         return (
           <input
             type="checkbox"
             checked={!!checked}
+            disabled={!isEditableTask}
+            readOnly={!isEditableTask}
             onChange={(e) => {
-              if (!Number.isFinite(index) || index < 0) return;
+              if (!isEditableTask) return;
               onTaskToggle(index, e.currentTarget.checked);
             }}
-            className="mr-1 cursor-pointer align-middle acorn-check"
+            className={cn(
+              "mr-1 align-middle acorn-check",
+              isEditableTask && "cursor-pointer",
+            )}
           />
         );
       },
@@ -361,10 +383,11 @@ function MarkdownImpl({
         <ReactMarkdown
           remarkPlugins={remarkPlugins}
           rehypePlugins={[
-            rehypeRaw,
             rehypeTaskIndex,
+            rehypeRaw,
             [rehypeSanitize, sanitizeSchema],
           ]}
+          urlTransform={markdownImageUrlTransform}
           components={components}
         >
           {content}

--- a/src/components/ui/RemoteImage.test.tsx
+++ b/src/components/ui/RemoteImage.test.tsx
@@ -1,0 +1,171 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  imageSourceKind,
+  MAX_DATA_IMAGE_SOURCE_BYTES,
+  RemoteImage,
+} from "./RemoteImage";
+
+describe("RemoteImage", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("waits for approval before assigning a remote source", () => {
+    act(() => {
+      root.render(
+        <RemoteImage
+          src="https://tracker.example/pixel.png"
+          srcSet="https://tracker.example/pixel@2x.png 2x"
+          alt="Build result"
+        />,
+      );
+    });
+
+    expect(container.querySelector("img")).toBeNull();
+    const load = container.querySelector<HTMLButtonElement>(
+      "[data-remote-image-placeholder]",
+    );
+    expect(load).not.toBeNull();
+    expect(load?.textContent).toContain("tracker.example");
+
+    act(() => load!.click());
+
+    const image = container.querySelector("img");
+    expect(image?.getAttribute("src")).toBe(
+      "https://tracker.example/pixel.png",
+    );
+    expect(image?.getAttribute("srcset")).toBeNull();
+    expect(image?.getAttribute("referrerpolicy")).toBe("no-referrer");
+  });
+
+  it("requires fresh approval when the remote source changes", () => {
+    act(() => {
+      root.render(<RemoteImage src="https://one.example/image.png" />);
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>("[data-remote-image-placeholder]")!
+        .click();
+    });
+    expect(container.querySelector("img")).not.toBeNull();
+
+    act(() => {
+      root.render(<RemoteImage src="https://two.example/image.png" />);
+    });
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(
+      container.querySelector("[data-remote-image-placeholder]"),
+    ).not.toBeNull();
+  });
+
+  it.each([
+    "/images/local.png",
+    "data:image/png;base64,iVBORw0KGgo=",
+    "blob:https://example.com/8a3e3c30-7ad9-4bf6-ae6f-26f48d71ec29",
+    "asset://localhost/background.png",
+    "http://asset.localhost/background.png",
+  ])("renders the safe local source %s immediately", (src) => {
+    act(() => {
+      root.render(<RemoteImage src={src} alt="Local image" />);
+    });
+
+    expect(
+      container.querySelector("[data-remote-image-placeholder]"),
+    ).toBeNull();
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(src);
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "file:///etc/passwd",
+  ])("does not render the unsafe source %s", (src) => {
+    act(() => {
+      root.render(<RemoteImage src={src} alt="Unsafe image" />);
+    });
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(
+      container.querySelector("[data-remote-image-placeholder]"),
+    ).toBeNull();
+    expect(container.textContent).toBe("Unsafe image");
+  });
+
+  it("does not render an oversized raster data source", () => {
+    const prefix = "data:image/png;base64,";
+    const src =
+      prefix + "A".repeat(MAX_DATA_IMAGE_SOURCE_BYTES - prefix.length + 1);
+    act(() => {
+      root.render(<RemoteImage src={src} alt="Oversized image" />);
+    });
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(
+      container.querySelector("[data-remote-image-placeholder]"),
+    ).toBeNull();
+    expect(container.textContent).toBe("Oversized image");
+  });
+
+  it("measures raster data sources in bytes rather than UTF-16 units", () => {
+    const prefix = "data:image/png,";
+    const unicodePayload = "가".repeat(
+      Math.floor(MAX_DATA_IMAGE_SOURCE_BYTES / 3) + 1,
+    );
+
+    expect((prefix + unicodePayload).length).toBeLessThan(
+      MAX_DATA_IMAGE_SOURCE_BYTES,
+    );
+    expect(imageSourceKind(prefix + unicodePayload)).toBe("unsafe");
+  });
+
+  it("keeps relative and same-document Tauri image URLs local", () => {
+    const base = document.createElement("base");
+    base.href = "tauri://localhost/";
+    document.head.appendChild(base);
+
+    try {
+      expect(imageSourceKind("docs/screenshot.png")).toBe("local");
+      expect(imageSourceKind("/docs/screenshot.png")).toBe("local");
+      expect(imageSourceKind("tauri://localhost/docs/screenshot.png")).toBe(
+        "local",
+      );
+      expect(imageSourceKind("tauri://other/docs/screenshot.png")).toBe(
+        "unsafe",
+      );
+    } finally {
+      base.remove();
+    }
+  });
+
+  it("does not treat authority URLs or alternate asset ports as local", () => {
+    expect(imageSourceKind("//tracker.example/pixel.png")).toBe("remote");
+    expect(imageSourceKind(String.raw`\\tracker.example\pixel.png`)).toBe(
+      "remote",
+    );
+    expect(imageSourceKind("http://asset.localhost:8080/pixel.png")).toBe(
+      "remote",
+    );
+  });
+
+  it.each([
+    "h\nttps://tracker.example/pixel.png",
+    "ht\ttps://tracker.example/pixel.png",
+    "http\r://tracker.example/pixel.png",
+    "d\nata:image/png;base64,iVBORw0KGgo=",
+  ])("rejects a URL containing parser-stripped controls: %j", (src) => {
+    expect(imageSourceKind(src)).toBe("unsafe");
+  });
+});

--- a/src/components/ui/RemoteImage.tsx
+++ b/src/components/ui/RemoteImage.tsx
@@ -1,0 +1,136 @@
+import { useState, type ComponentPropsWithoutRef } from "react";
+import { defaultUrlTransform } from "react-markdown";
+import { useTranslation } from "../../lib/useTranslation";
+
+export type ImageSourceKind = "local" | "remote" | "unsafe";
+
+export const MAX_DATA_IMAGE_SOURCE_BYTES = 2 * 1024 * 1024;
+
+const SAFE_DATA_IMAGE_RE =
+  /^data:image\/(?:avif|bmp|gif|jpeg|png|webp|x-icon|vnd\.microsoft\.icon)(?:[;,]|$)/i;
+
+function parseImageUrl(value: string): URL | null {
+  try {
+    const base =
+      typeof document === "undefined" ? "http://localhost/" : document.baseURI;
+    return new URL(value, base);
+  } catch {
+    return null;
+  }
+}
+
+export function imageSourceKind(value: string): ImageSourceKind {
+  const source = value.trim();
+  if (!source) return "unsafe";
+  // WHATWG URL parsing removes ASCII tab/newline characters even when they
+  // split a scheme. Reject internal controls before classification so an
+  // obfuscated remote or data URL cannot be mistaken for a relative path.
+  if (/[\u0000-\u001f\u007f]/.test(source)) return "unsafe";
+
+  if (/^data:/i.test(source)) {
+    return source.length <= MAX_DATA_IMAGE_SOURCE_BYTES &&
+      SAFE_DATA_IMAGE_RE.test(source) &&
+      new TextEncoder().encode(source).byteLength <= MAX_DATA_IMAGE_SOURCE_BYTES
+      ? "local"
+      : "unsafe";
+  }
+
+  const url = parseImageUrl(source);
+  if (!url) return "unsafe";
+
+  if (url.protocol === "blob:" || url.protocol === "asset:") {
+    return "local";
+  }
+
+  if (typeof document !== "undefined") {
+    try {
+      const documentUrl = new URL(document.baseURI);
+      if (
+        url.protocol === documentUrl.protocol &&
+        url.host === documentUrl.host
+      ) {
+        return "local";
+      }
+    } catch {
+      // Continue to the explicit protocol allowlist below.
+    }
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return "unsafe";
+  }
+
+  if (url.protocol === "http:" && url.host === "asset.localhost") {
+    return "local";
+  }
+  if (typeof window !== "undefined" && url.origin === window.location.origin) {
+    return "local";
+  }
+
+  return "remote";
+}
+
+export function markdownImageUrlTransform(
+  value: string,
+  key: string,
+  node: { tagName?: string },
+): string | undefined {
+  if (key === "src" && node.tagName === "img") {
+    return imageSourceKind(value) === "unsafe" ? "" : value;
+  }
+  return defaultUrlTransform(value);
+}
+
+type RemoteImageProps = ComponentPropsWithoutRef<"img">;
+
+export function RemoteImage({
+  src,
+  // Each responsive candidate would need independent approval.
+  srcSet: _srcSet,
+  sizes: _sizes,
+  alt = "",
+  referrerPolicy,
+  ...props
+}: RemoteImageProps) {
+  const t = useTranslation();
+  const source = src?.trim() ?? "";
+  const kind = imageSourceKind(source);
+  const remoteHost = kind === "remote" ? parseImageUrl(source)?.host : null;
+  // Approval is URL-specific so content updates cannot reuse it for a new URL.
+  const [approvedRemoteSource, setApprovedRemoteSource] = useState<
+    string | null
+  >(null);
+
+  if (kind === "unsafe") {
+    return alt ? <span>{alt}</span> : null;
+  }
+
+  if (kind === "remote" && approvedRemoteSource !== source) {
+    const loadLabel = t("remoteImage.load");
+    const approvalLabel = `${loadLabel}: ${remoteHost ?? source}${alt ? ` — ${alt}` : ""}`;
+    return (
+      <button
+        type="button"
+        aria-label={approvalLabel}
+        data-remote-image-placeholder
+        onClick={() => setApprovedRemoteSource(source)}
+        className="my-2 max-w-full rounded border border-border bg-bg-elevated px-3 py-2 text-left text-[11px] text-fg-muted transition hover:border-fg-subtle hover:text-fg"
+      >
+        {loadLabel}
+        {remoteHost ? (
+          <span className="ml-1 font-mono text-[10px]">({remoteHost})</span>
+        ) : null}
+        {alt ? <span className="mt-1 block truncate text-fg">{alt}</span> : null}
+      </button>
+    );
+  }
+
+  return (
+    <img
+      {...props}
+      src={source}
+      alt={alt}
+      referrerPolicy={kind === "remote" ? "no-referrer" : referrerPolicy}
+    />
+  );
+}

--- a/src/lib/themes.catalog.test.ts
+++ b/src/lib/themes.catalog.test.ts
@@ -7,6 +7,7 @@ const tauriFsMock = vi.hoisted(() => ({
   readDir: vi.fn(),
   readTextFile: vi.fn(),
   remove: vi.fn(),
+  stat: vi.fn(),
   writeTextFile: vi.fn(),
 }));
 
@@ -21,6 +22,7 @@ vi.mock("@tauri-apps/plugin-opener", () => ({ openPath: vi.fn() }));
 
 import {
   THEME_CSS_VARS,
+  fetchThemeCatalog,
   installCatalogTheme,
   loadUserThemes,
   parseThemeCatalog,
@@ -53,6 +55,7 @@ beforeEach(() => {
   tauriFsMock.readDir.mockResolvedValue([]);
   tauriFsMock.readTextFile.mockResolvedValue("");
   tauriFsMock.remove.mockResolvedValue(undefined);
+  tauriFsMock.stat.mockResolvedValue({ isFile: true, size: VALID_CSS.length });
   tauriFsMock.writeTextFile.mockResolvedValue(undefined);
 });
 
@@ -89,6 +92,22 @@ describe("parseThemeCatalog", () => {
       }),
     ).toThrow(/invalid file path/);
   });
+
+  it("bounds the remote catalog before JSON parsing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("x", {
+          status: 200,
+          headers: { "Content-Length": "300000" },
+        }),
+      ),
+    );
+
+    await expect(fetchThemeCatalog()).rejects.toThrow(
+      /Theme catalog is too large/,
+    );
+  });
 });
 
 describe("theme filesystem capability", () => {
@@ -96,6 +115,7 @@ describe("theme filesystem capability", () => {
     expect(defaultCapability.permissions).toContain(
       "fs:allow-write-text-file",
     );
+    expect(defaultCapability.permissions).toContain("fs:allow-stat");
   });
 });
 
@@ -157,6 +177,51 @@ describe("catalog theme persistence", () => {
     expect(tauriFsMock.writeTextFile).not.toHaveBeenCalled();
   });
 
+  it("rejects network-capable CSS including escaped spellings", async () => {
+    const unsafeCss = [
+      `${VALID_CSS}\n:root { background: url(https://example.invalid/pixel); }`,
+      `${VALID_CSS}\n@import "https://example.invalid/theme.css";`,
+      String.raw`${VALID_CSS}
+:root { cursor: u\72 l(https://example.invalid/cursor); }`,
+      String.raw`${VALID_CSS}
+@\69 mport "https://example.invalid/theme.css";`,
+      `${VALID_CSS}\n:root { background: u/**/rl(https://example.invalid/pixel); }`,
+      `${VALID_CSS}\n@im/**/port "https://example.invalid/theme.css";`,
+      `${VALID_CSS}\n:root { background: image-set("https://example.invalid/pixel" 1x); }`,
+      `${VALID_CSS}\n@font-face { src: src("https://example.invalid/font"); }`,
+      `${VALID_CSS}\n:root { --open: "/*"; background: url("https://example.invalid/pixel"); --close: "*/"; }`,
+      `${VALID_CSS}\n:root { background: u\\72\r\nl("https://example.invalid/pixel"); }`,
+      `${VALID_CSS}\n@\\69\r\nmport "https://example.invalid/theme.css";`,
+    ];
+
+    for (const css of unsafeCss) {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(new Response(css, { status: 200 })),
+      );
+
+      await expect(installCatalogTheme(THEME)).rejects.toThrow(
+        /cannot load external CSS resources/,
+      );
+    }
+
+    expect(tauriFsMock.writeTextFile).not.toHaveBeenCalled();
+  });
+
+  it("bounds downloaded CSS while reading the response body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("x".repeat(1_000_001), { status: 200 }),
+      ),
+    );
+
+    await expect(installCatalogTheme(THEME)).rejects.toThrow(
+      /Theme note is too large/,
+    );
+    expect(tauriFsMock.writeTextFile).not.toHaveBeenCalled();
+  });
+
   it("loads catalog metadata separately from custom CSS files", async () => {
     tauriFsMock.readDir.mockResolvedValue([
       { isFile: true, name: "note.css" },
@@ -200,6 +265,106 @@ describe("catalog theme persistence", () => {
         source: "user",
       }),
     ]);
+  });
+
+  it("revalidates persisted catalog CSS without restricting user themes", async () => {
+    tauriFsMock.readDir.mockResolvedValue([
+      { isFile: true, name: "note.css" },
+      { isFile: true, name: "personal.css" },
+    ]);
+    tauriFsMock.readTextFile.mockImplementation((path: string) => {
+      if (path.endsWith("catalog.json")) {
+        return Promise.resolve(
+          JSON.stringify({
+            schemaVersion: 1,
+            installed: {
+              note: {
+                label: "Note",
+                mode: "light",
+                version: 2,
+                file: "note.css",
+              },
+            },
+          }),
+        );
+      }
+      const base = path.endsWith("note.css")
+        ? VALID_CSS
+        : VALID_CSS.split("note").join("personal");
+      return Promise.resolve(
+        `${base}\n:root { background: url(https://example.invalid/pixel); }`,
+      );
+    });
+
+    const themes = await loadUserThemes();
+
+    expect(themes).toEqual([
+      expect.objectContaining({
+        id: "personal",
+        source: "user",
+      }),
+    ]);
+  });
+
+  it("skips oversized persisted catalog CSS before reading it", async () => {
+    tauriFsMock.readDir.mockResolvedValue([
+      { isFile: true, name: "note.css" },
+    ]);
+    tauriFsMock.readTextFile.mockImplementation((path: string) => {
+      if (path.endsWith("catalog.json")) {
+        return Promise.resolve(
+          JSON.stringify({
+            schemaVersion: 1,
+            installed: {
+              note: {
+                label: "Note",
+                mode: "light",
+                version: 2,
+                file: "note.css",
+              },
+            },
+          }),
+        );
+      }
+      return Promise.reject(new Error("oversized CSS must not be read"));
+    });
+    tauriFsMock.stat.mockImplementation((path: string) =>
+      Promise.resolve({
+        isFile: true,
+        size: path.endsWith("note.css") ? 1_000_001 : VALID_CSS.length,
+      }),
+    );
+
+    await expect(loadUserThemes()).resolves.toEqual([]);
+    expect(tauriFsMock.readTextFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed before reading oversized installed metadata", async () => {
+    tauriFsMock.readDir.mockResolvedValue([
+      { isFile: true, name: "personal.css" },
+    ]);
+    tauriFsMock.stat.mockResolvedValue({ isFile: true, size: 300_000 });
+    tauriFsMock.readTextFile.mockRejectedValue(
+      new Error("oversized metadata must not be read"),
+    );
+
+    await expect(loadUserThemes()).resolves.toEqual([]);
+    expect(tauriFsMock.readTextFile).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when installed metadata provenance is corrupt", async () => {
+    tauriFsMock.readDir.mockResolvedValue([
+      { isFile: true, name: "note.css" },
+    ]);
+    tauriFsMock.readTextFile.mockImplementation((path: string) => {
+      if (path.endsWith("catalog.json")) {
+        return Promise.resolve('{"schemaVersion":1,"installed":"invalid"}');
+      }
+      return Promise.reject(new Error("unclassified CSS must not be read"));
+    });
+
+    await expect(loadUserThemes()).resolves.toEqual([]);
+    expect(tauriFsMock.readTextFile).toHaveBeenCalledTimes(1);
   });
 
   it("removes only files recorded as catalog-managed", async () => {

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -5,6 +5,7 @@ import {
   readDir,
   readTextFile,
   remove,
+  stat,
   writeTextFile,
 } from "@tauri-apps/plugin-fs";
 import { openPath, openUrl } from "@tauri-apps/plugin-opener";
@@ -117,8 +118,153 @@ export function validateThemeCss(css: string): ValidateResult {
 const STYLE_ELEMENT_ID = "acorn-theme";
 const USER_THEMES_DIR = "themes";
 const INSTALLED_METADATA_FILE = "catalog.json";
+const MAX_THEME_CATALOG_BYTES = 256 * 1024;
+const MAX_INSTALLED_THEME_METADATA_BYTES = 256 * 1024;
 const MAX_THEME_CSS_BYTES = 1_000_000;
 const THEME_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function normalizeCssSecurityTokens(css: string): string {
+  // Match CSS Syntax preprocessing before scanning. In particular, CRLF is
+  // one newline, which can be consumed as the optional terminator of a hex
+  // escape (for example `u\\72\r\nl` becomes `url`).
+  const input = css
+    .replace(/\r\n?|\f/g, "\n")
+    .replace(/\0/g, "\ufffd");
+  let normalized = "";
+  let index = 0;
+
+  const consumeEscape = (): string => {
+    index += 1; // Backslash.
+    if (index >= input.length) return "";
+
+    if (index < input.length && /[0-9a-f]/i.test(input[index])) {
+      const start = index;
+      while (index < input.length && index - start < 6) {
+        if (!/[0-9a-f]/i.test(input[index])) break;
+        index += 1;
+      }
+      const codePoint = Number.parseInt(input.slice(start, index), 16);
+      if (/[\t\n ]/.test(input[index] ?? "")) index += 1;
+      return codePoint === 0 ||
+        codePoint > 0x10ffff ||
+        (codePoint >= 0xd800 && codePoint <= 0xdfff)
+        ? "\ufffd"
+        : String.fromCodePoint(codePoint);
+    }
+
+    const escaped = input[index];
+    index += 1;
+    // A newline is not a valid escape outside a string. Separating adjacent
+    // identifiers is conservative and avoids manufacturing a false token.
+    return escaped === "\n" ? " " : escaped;
+  };
+
+  const consumeString = (quote: string): void => {
+    index += 1;
+    while (index < input.length) {
+      const current = input[index];
+      if (current === quote) {
+        index += 1;
+        return;
+      }
+      // An unescaped newline ends a CSS string as a bad-string token. Leave it
+      // for the outer scanner so following declarations are still inspected.
+      if (current === "\n") return;
+      if (current === "\\") {
+        if (input[index + 1] === "\n") {
+          index += 2;
+        } else {
+          consumeEscape();
+        }
+        continue;
+      }
+      index += 1;
+    }
+  };
+
+  while (index < input.length) {
+    const current = input[index];
+    if (current === '"' || current === "'") {
+      // String contents cannot create a request by themselves. Keep a token
+      // boundary, while still detecting an enclosing @import outside it.
+      normalized += " ";
+      consumeString(current);
+      continue;
+    }
+    if (current === "/" && input[index + 1] === "*") {
+      index += 2;
+      const end = input.indexOf("*/", index);
+      if (end < 0) break;
+      index = end + 2;
+      continue;
+    }
+    if (current === "\\") {
+      normalized += consumeEscape();
+      continue;
+    }
+    normalized += current;
+    index += 1;
+  }
+
+  return normalized;
+}
+
+function containsCatalogNetworkPrimitive(css: string): boolean {
+  const normalized = normalizeCssSecurityTokens(css);
+  return (
+    /(?:^|[^\w-])(?:url|src|image|(?:-webkit-)?image-set)\s*\(/i.test(
+      normalized,
+    ) || /@\s*import\b/i.test(normalized)
+  );
+}
+
+async function readBoundedResponseText(
+  response: Response,
+  maxBytes: number,
+  label: string,
+): Promise<string> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength && /^\d+$/.test(contentLength)) {
+    const declaredBytes = Number(contentLength);
+    if (Number.isSafeInteger(declaredBytes) && declaredBytes > maxBytes) {
+      throw new Error(`${label} is too large`);
+    }
+  }
+
+  if (!response.body) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new Error(`${label} is too large`);
+    }
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error(`${label} is too large`);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+}
 
 export function applyTheme(id: string, css: string): void {
   let styleEl = document.getElementById(STYLE_ELEMENT_ID) as
@@ -207,7 +353,12 @@ export async function fetchThemeCatalog(): Promise<ThemeCatalogEntry[]> {
   if (!response.ok) {
     throw new Error(`Theme catalog request failed: ${response.status}`);
   }
-  return parseThemeCatalog(await response.json());
+  const body = await readBoundedResponseText(
+    response,
+    MAX_THEME_CATALOG_BYTES,
+    "Theme catalog",
+  );
+  return parseThemeCatalog(JSON.parse(body));
 }
 
 async function ensureThemesDir(): Promise<string> {
@@ -231,23 +382,25 @@ function installedMetadataFromUnknown(value: unknown): InstalledThemeMetadata {
     value.schemaVersion !== 1 ||
     !isRecord(value.installed)
   ) {
-    return emptyInstalledMetadata();
+    throw new Error("Invalid installed theme metadata");
   }
 
   const installed: Record<string, InstalledCatalogTheme> = {};
   for (const [id, entry] of Object.entries(value.installed)) {
-    if (!THEME_ID_PATTERN.test(id) || !isRecord(entry)) continue;
     if (
+      !THEME_ID_PATTERN.test(id) ||
+      !isRecord(entry) ||
       typeof entry.label !== "string" ||
+      entry.label.trim().length === 0 ||
       !isThemeMode(entry.mode) ||
       !Number.isSafeInteger(entry.version) ||
       (entry.version as number) < 1 ||
       entry.file !== `${id}.css`
     ) {
-      continue;
+      throw new Error(`Invalid installed theme metadata for ${id}`);
     }
     installed[id] = {
-      label: entry.label,
+      label: entry.label.trim(),
       mode: entry.mode,
       version: entry.version as number,
       file: entry.file,
@@ -259,14 +412,21 @@ function installedMetadataFromUnknown(value: unknown): InstalledThemeMetadata {
 async function readInstalledMetadata(
   dir: string,
 ): Promise<InstalledThemeMetadata> {
-  try {
-    const path = await join(dir, INSTALLED_METADATA_FILE);
-    if (!(await exists(path))) return emptyInstalledMetadata();
-    return installedMetadataFromUnknown(JSON.parse(await readTextFile(path)));
-  } catch (error) {
-    console.warn("[acorn] failed to read installed theme metadata", error);
-    return emptyInstalledMetadata();
+  const path = await join(dir, INSTALLED_METADATA_FILE);
+  if (!(await exists(path))) return emptyInstalledMetadata();
+
+  const info = await stat(path);
+  if (!info.isFile || info.size > MAX_INSTALLED_THEME_METADATA_BYTES) {
+    throw new Error("Installed theme metadata is too large or not regular");
   }
+  const contents = await readTextFile(path);
+  if (
+    new TextEncoder().encode(contents).byteLength >
+    MAX_INSTALLED_THEME_METADATA_BYTES
+  ) {
+    throw new Error("Installed theme metadata is too large");
+  }
+  return installedMetadataFromUnknown(JSON.parse(contents));
 }
 
 async function writeInstalledMetadata(
@@ -274,7 +434,14 @@ async function writeInstalledMetadata(
   metadata: InstalledThemeMetadata,
 ): Promise<void> {
   const path = await join(dir, INSTALLED_METADATA_FILE);
-  await writeTextFile(path, `${JSON.stringify(metadata, null, 2)}\n`);
+  const contents = `${JSON.stringify(metadata, null, 2)}\n`;
+  if (
+    new TextEncoder().encode(contents).byteLength >
+    MAX_INSTALLED_THEME_METADATA_BYTES
+  ) {
+    throw new Error("Installed theme metadata is too large");
+  }
+  await writeTextFile(path, contents);
 }
 
 export async function loadUserThemes(): Promise<AcornTheme[]> {
@@ -293,7 +460,32 @@ export async function loadUserThemes(): Promise<AcornTheme[]> {
 
       const id = entry.name.replace(/\.css$/, "");
       const path = await join(dir, entry.name);
+      const installed = metadata.installed[id];
+
+      if (installed?.file === entry.name) {
+        const info = await stat(path);
+        if (!info.isFile || info.size > MAX_THEME_CSS_BYTES) {
+          console.warn(
+            `[acorn] skipping catalog theme ${entry.name}: file is too large or not regular`,
+          );
+          continue;
+        }
+      }
+
       const css = await readTextFile(path);
+
+      if (installed?.file === entry.name) {
+        try {
+          assertCatalogThemeCss(id, css);
+        } catch (error) {
+          console.warn(
+            `[acorn] skipping catalog theme ${entry.name}:`,
+            error,
+          );
+          continue;
+        }
+      }
+
       const result = validateThemeCss(css);
 
       if (!result.ok) {
@@ -305,7 +497,6 @@ export async function loadUserThemes(): Promise<AcornTheme[]> {
         continue;
       }
 
-      const installed = metadata.installed[id];
       themes.push({
         id,
         label: installed?.label ?? humanize(id),
@@ -329,6 +520,9 @@ export async function loadUserThemes(): Promise<AcornTheme[]> {
 function assertCatalogThemeCss(id: string, css: string): void {
   if (new TextEncoder().encode(css).byteLength > MAX_THEME_CSS_BYTES) {
     throw new Error(`Theme ${id} is too large`);
+  }
+  if (containsCatalogNetworkPrimitive(css)) {
+    throw new Error(`Theme ${id} cannot load external CSS resources`);
   }
   const validation = validateThemeCss(css);
   if (!validation.ok) {
@@ -357,7 +551,11 @@ export async function installCatalogTheme(
     throw new Error(`Theme download failed: ${response.status}`);
   }
 
-  const css = await response.text();
+  const css = await readBoundedResponseText(
+    response,
+    MAX_THEME_CSS_BYTES,
+    `Theme ${catalogTheme.id}`,
+  );
   assertCatalogThemeCss(catalogTheme.id, css);
 
   const dir = await ensureThemesDir();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1103,6 +1103,9 @@
     "openInBrowser": "Open in browser",
     "close": "Close"
   },
+  "remoteImage": {
+    "load": "Load remote image"
+  },
   "mediaViewer": {
     "zoomControls": "Image zoom controls",
     "zoomIn": "Zoom in",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1103,6 +1103,9 @@
     "openInBrowser": "브라우저에서 열기",
     "close": "닫기"
   },
+  "remoteImage": {
+    "load": "원격 이미지 불러오기"
+  },
   "mediaViewer": {
     "zoomControls": "이미지 확대/축소 컨트롤",
     "zoomIn": "확대",

--- a/tests/e2e/file-explorer.spec.ts
+++ b/tests/e2e/file-explorer.spec.ts
@@ -849,6 +849,10 @@ test.describe("file explorer", () => {
       "src",
       /%2Ftmp%2Fdemo%2Fspec\.pdf/,
     );
+    await expect(page.locator('iframe[title="spec.pdf"]')).toHaveAttribute(
+      "referrerpolicy",
+      "no-referrer",
+    );
   });
 
   test("finds matches inside a code viewer tab", async ({ page, tauri }) => {

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -69,6 +69,28 @@ export const tauriMockSource = `
     if (cmd === 'plugin:fs|mkdir') return Promise.resolve(undefined);
     if (cmd === 'plugin:fs|read_dir') return Promise.resolve([]);
     if (cmd === 'plugin:fs|read_text_file') return Promise.resolve('');
+    if (cmd === 'plugin:fs|stat') {
+      return Promise.resolve({
+        isFile: true,
+        isDirectory: false,
+        isSymlink: false,
+        size: 0,
+        mtime: null,
+        atime: null,
+        birthtime: null,
+        readonly: false,
+        fileAttributes: null,
+        dev: null,
+        ino: null,
+        mode: null,
+        nlink: null,
+        uid: null,
+        gid: null,
+        rdev: null,
+        blksize: null,
+        blocks: null,
+      });
+    }
     return undefined;
   }
 
@@ -291,11 +313,6 @@ export const tauriMockSource = `
     if (cmd === 'daemon_restart') return Promise.resolve(undefined);
     if (cmd === 'daemon_shutdown') return Promise.resolve(undefined);
     if (cmd === 'daemon_list_sessions') return Promise.resolve([]);
-    if (cmd === 'daemon_spawn_session') {
-      return Promise.reject(new Error('daemon disabled in E2E'));
-    }
-    if (cmd === 'daemon_send_input') return Promise.resolve(undefined);
-    if (cmd === 'daemon_resize') return Promise.resolve(undefined);
     if (cmd === 'daemon_kill_session') return Promise.resolve(undefined);
     if (cmd === 'daemon_forget_session') return Promise.resolve(undefined);
     if (cmd === 'daemon_forget_inactive_sessions') return Promise.resolve(0);

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -184,6 +184,15 @@ test.describe("right panel: tab switching", () => {
     page,
     tauri,
   }) => {
+    let remoteImageRequests = 0;
+    await page.route("https://example.com/issue.png", async (route) => {
+      remoteImageRequests += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "image/svg+xml",
+        body: '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>',
+      });
+    });
     await seedActiveSession(tauri);
     await tauri.respond("list_issues", {
       kind: "ok",
@@ -257,9 +266,29 @@ test.describe("right panel: tab switching", () => {
     await expect(comments.nth(0)).toContainText("Older in-app issue comment.");
     await expect(comments.nth(1)).toContainText("Newer in-app issue comment.");
 
-    await dialog.getByRole("img", { name: "Issue screenshot" }).click();
+    await expect(
+      dialog.getByRole("img", { name: "Issue screenshot" }),
+    ).toHaveCount(0);
+    expect(remoteImageRequests).toBe(0);
+    await dialog
+      .getByRole("button", {
+        name: "Load remote image: example.com — Issue screenshot",
+      })
+      .click();
+    const issueScreenshot = dialog.getByRole("img", {
+      name: "Issue screenshot",
+    });
+    await expect(issueScreenshot).toHaveAttribute(
+      "referrerpolicy",
+      "no-referrer",
+    );
+    await expect.poll(() => remoteImageRequests).toBeGreaterThan(0);
+    await issueScreenshot.click();
     const imagePreview = page.getByRole("dialog", { name: "Image preview" });
     await expect(imagePreview).toBeVisible();
+    await expect(
+      imagePreview.getByRole("img", { name: "Issue screenshot" }),
+    ).toHaveAttribute("referrerpolicy", "no-referrer");
     await imagePreview
       .getByRole("button", { name: "Open in browser" })
       .hover();


### PR DESCRIPTION
## Summary

This PR hardens Acorn's local trust boundaries and release pipeline across the renderer, Rust backend, agent integrations, filesystem, Git, and CI surfaces.

1. **Runtime and IPC boundaries.** Tighten local data, socket, marker, spool, and session-log permissions; bound daemon NDJSON and hook request processing; remove unused daemon renderer commands; and keep hook bearer tokens out of process arguments.
2. **Filesystem and Git boundaries.** Add project-scoped containment checks, opened-file snapshots, symlink/special-file/hard-link rejection, bounded directory and Git traversal, atomic owner-only writes, and PDF magic-byte validation.
3. **Transcript and resource budgets.** Bound agent history, resume discovery, transcript pairing, todo replay, token-usage probes, Git history/diffs/images, and filesystem watcher queues so hostile or corrupted local data fails closed.
4. **Renderer privacy and authority.** Require approval before loading remote Markdown images, send approved image requests without referrers, constrain raw-HTML task identity, reject network-capable or oversized theme CSS, and remove unused Tauri shell/plugin capabilities.
5. **Supply chain and release integrity.** Refresh vulnerable dependencies, pin GitHub Actions and cross-job release inputs to validated commits, reduce workflow permissions, add Dependabot and Rust audit coverage, and enforce release tag/version/artifact/latest-manifest consistency.

## Expected impact

| Area | Before | After | Expected impact |
|---|---|---|---|
| Markdown privacy | Remote images could load during rendering | Explicit per-image approval plus no-referrer requests | Prevents passive IP/referrer disclosure from untrusted Markdown |
| Theme safety | Remote CSS could be large or request external resources | Download/parse limits and network-capable primitive rejection | Reduces CSS resource abuse and unbounded processing |
| Renderer authority | Broader default plugin and daemon command surface | Unused shell, process, FS, and daemon invokes removed | Narrows renderer-accessible capabilities |
| Local runtime | Several reads, scans, frames, and queues were link-following or unbounded | Owner-only state, opened snapshots, atomic writes, and explicit budgets | Limits local data disclosure, clobbering, memory growth, and traversal DoS |
| CI and release | Mutable action tags and permissive artifact/version handling | SHA-pinned actions, immutable cross-job source handoff, least privilege, exact version checks, and strict artifact pairing | Improves reproducibility and reduces supply-chain/release mix-up risk |

## Design notes

- Hook transport keeps the latest lifecycle reducer and replay model while enforcing an 8 KiB header limit, an 8 MiB body limit, a two-second read timeout, and 32 concurrent connections. The 8 MiB body ceiling preserves documented Codex payload compatibility.
- Hook tokens are streamed to curl through file descriptor 3 while event payloads remain on stdin; failed deliveries retain the existing bounded, owner-only spool behavior.
- Filesystem checks validate regular opened snapshots and reject links or partial over-budget scans. Operations fail closed rather than returning a trusted-looking partial result.
- The release workflow resolves and validates the tag once, pins every downstream job to that commit, rechecks `origin/main` ancestry and tag identity before publication, stages one exact artifact set per architecture, checks update-manifest pairing, and refuses stale or rollback-prone latest metadata.
- This reduces renderer and local-input attack surface; it does not claim that the renderer is a complete sandbox while interactive PTY execution remains an intentional product capability.

## Follow-up (not in this PR)

1. Add authenticated, capability-scoped daemon connections and bind hook credentials to individual sessions.
2. Consolidate bounded/serialized persistence and use handle-relative filesystem operations for stronger TOCTOU resistance.
3. Isolate AI generation for untrusted pull-request content and keep remaining provider prompts out of process arguments.
4. Add separated build provenance, Developer ID signing/notarization, and signed updater-metadata freshness enforcement.
5. Move remote themes to a signed catalog with a parser-level allowlist.
6. Make Rust/Tauri compilation and security regression tests required pull-request checks.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 99 files, 1,122 tests passed
- [x] `pnpm run build:frontend`
- [x] `pnpm run build:storybook`
- [x] `pnpm exec playwright test` — 247 tests passed
- [x] `pnpm exec vitest run scripts/release-artifacts.test.mjs scripts/validate-release-version.test.mjs` — 12 tests passed
- [x] `pnpm audit --audit-level=moderate` — no known vulnerabilities
- [x] `cargo metadata --manifest-path src-tauri/Cargo.toml --locked --format-version 1 --no-deps`
- [x] `cargo check --workspace --locked`
- [x] `cargo test --workspace --locked -- --test-threads=1` — 831 passed, 1 existing ignored
- [x] Changed Rust files: `rustfmt --edition 2021 --config skip_children=true --check`
- [x] `cargo audit --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195` — 623 dependencies scanned; no unignored vulnerability failure
- [x] `git diff --check origin/main...HEAD`

## Notes

- The two explicit `quick-xml 0.37.5` audit exceptions are Windows-only through `tauri-winrt-notification`; Acorn's current release workflow ships macOS bundles. Non-failing unmaintained/unsound dependency warnings remain visible for follow-up.
- A full `cargo fmt --all -- --check` still reports pre-existing formatting differences in three untouched files: `acorn-daemon/src/protocol.rs`, `acorn-ipc/src/bin/acorn-ipc.rs`, and `src/pty_env.rs`. Every changed Rust file passes an isolated format check.
- On this macOS host, two existing Codex `tail -F` integration tests can miss their startup event under default parallel scheduling. Both pass individually, the 51 wrapper tests pass serially, and the full 831-test workspace passes serially.
- Signing, notarization, and secret-backed release publication were not exercised locally.
- The detailed local audit worksheet remains untracked because it includes unresolved attack-surface specifics; the reviewable follow-up themes are summarized above.

