### PR TITLE
perf(terminal): move agent detection off the output hot path

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -972,36 +972,8 @@ export function Terminal({
     const unlistenFns: UnlistenFn[] = [];
     let observedLinkedWorktreePath: string | null = null;
     let liveCwdProbeTimer: number | null = null;
-    let agentProbeTimer: number | null = null;
     let daemonSessionAliveAtMount = false;
     let replayScrollbackOnSpawn = true;
-    let agentImagePasteFallbackActive = providerSupportsImagePasteFallback(
-      pasteAgentProviderRef.current,
-    );
-
-    const refreshAgentDetection = () => {
-      void api
-        .detectSessionAgent(sessionId)
-        .then((agent) => {
-          if (disposed) return;
-          agentImagePasteFallbackActive =
-            providerSupportsImagePasteFallback(pasteAgentProviderRef.current) ||
-            detectionHasImagePasteFallbackProvider(agent);
-        })
-        .catch((err: unknown) => {
-          console.debug("[Terminal] agent detection failed", err);
-        });
-    };
-
-    const scheduleAgentDetection = () => {
-      if (disposed || agentProbeTimer !== null) return;
-      agentProbeTimer = window.setTimeout(() => {
-        agentProbeTimer = null;
-        if (disposed) return;
-        refreshAgentDetection();
-      }, 500);
-    };
-    refreshAgentDetection();
 
     const rememberLinkedWorktreeCwd = (path: string, source: string) => {
       void api
@@ -1238,18 +1210,13 @@ export function Terminal({
     let imagePasteFallbackSerial = 0;
     const IMAGE_PASTE_FALLBACK_DELAY_MS = 500;
     const agentImagePasteFallbackIsActive = async (): Promise<boolean> => {
-      if (
-        agentImagePasteFallbackActive ||
-        providerSupportsImagePasteFallback(pasteAgentProviderRef.current)
-      ) {
+      if (providerSupportsImagePasteFallback(pasteAgentProviderRef.current)) {
         return true;
       }
       try {
         const agent = await api.detectSessionAgent(sessionId);
         if (disposed) return false;
-        agentImagePasteFallbackActive =
-          detectionHasImagePasteFallbackProvider(agent);
-        return agentImagePasteFallbackActive;
+        return detectionHasImagePasteFallbackProvider(agent);
       } catch (err: unknown) {
         console.debug("[Terminal] agent detection failed", err);
         return false;
@@ -2498,7 +2465,6 @@ export function Terminal({
       // triggering our shell's OSC 7 prompt hook. Probe the live descendant
       // cwd on output bursts so exit adoption stays tied to this session.
       scheduleLiveCwdProbe();
-      scheduleAgentDetection();
     };
     let outputSubscriptionToken: number | null = null;
 
@@ -2915,9 +2881,6 @@ export function Terminal({
       resizeDisposable.dispose();
       if (liveCwdProbeTimer !== null) {
         window.clearTimeout(liveCwdProbeTimer);
-      }
-      if (agentProbeTimer !== null) {
-        window.clearTimeout(agentProbeTimer);
       }
       if (imagePasteFallbackTimer !== null) {
         window.clearTimeout(imagePasteFallbackTimer);

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -2528,7 +2528,6 @@ export function Terminal({
           if (disposed) return;
           ptyReady = false;
           lastPtyResize = null;
-          agentImagePasteFallbackActive = false;
           // Adopt only when Acorn queued an explicit worktree command, or
           // when this terminal itself was observed running inside a fresh
           // linked worktree. Plain user `exit` must not adopt unrelated

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -787,6 +787,16 @@ test.describe("terminal: spawn", () => {
         antigravity: null,
       };
     });
+    await tauri.handle("clipboard_snapshot", () => ({
+      supported: true,
+      changeCount: 1,
+      types: ["public.png"],
+      text: null,
+      hasImage: true,
+      mimeType: "image/png",
+      extension: "png",
+      dataB64: "AQID",
+    }));
 
     await page.goto("/");
     await page
@@ -832,27 +842,11 @@ test.describe("terminal: spawn", () => {
         }
       ).__imagePasteAgentActive = true;
       (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
-
-      const textarea = document.querySelector<HTMLTextAreaElement>(
-        ".xterm-helper-textarea",
+      window.dispatchEvent(
+        new CustomEvent("acorn:terminal-paste", {
+          detail: { sessionId: "s-term" },
+        }),
       );
-      if (!textarea) throw new Error("xterm helper textarea missing");
-      const image = new File([new Uint8Array([1, 2, 3])], "shot.png", {
-        type: "image/png",
-      });
-      const event = new ClipboardEvent("paste", {
-        bubbles: true,
-        cancelable: true,
-      });
-      Object.defineProperty(event, "clipboardData", {
-        value: {
-          getData: () => "",
-          files: { 0: image, length: 1 },
-          items: { length: 0 },
-          types: ["Files", "image/png"],
-        },
-      });
-      textarea.dispatchEvent(event);
     });
 
     await expect

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -762,6 +762,117 @@ test.describe("terminal: spawn", () => {
       .toEqual(["pnpm run dev"]);
   });
 
+  test("detects image-paste agents on demand instead of polling on output", async ({
+    page,
+    tauri,
+  }) => {
+    await seedWritableTerminal(tauri);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __agentProbeOutputChannelId?: number;
+      };
+      w.__agentProbeOutputChannelId = channel.id;
+      return 1;
+    });
+    await tauri.handle("detect_session_agent", () => {
+      const w = window as unknown as {
+        __agentProbeCalls?: number;
+        __imagePasteAgentActive?: boolean;
+      };
+      w.__agentProbeCalls = (w.__agentProbeCalls ?? 0) + 1;
+      return {
+        claude: w.__imagePasteAgentActive ? "claude-session" : null,
+        codex: null,
+        antigravity: null,
+      };
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __agentProbeOutputChannelId?: number })
+              .__agentProbeOutputChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    await emitSubscribedPtyOutput(
+      page,
+      "__agentProbeOutputChannelId",
+      "streaming one\r\n",
+    );
+    await emitSubscribedPtyOutput(
+      page,
+      "__agentProbeOutputChannelId",
+      "streaming two\r\n",
+      1,
+    );
+    await page.waitForTimeout(650);
+
+    expect(
+      await page.evaluate(
+        () =>
+          (window as unknown as { __agentProbeCalls?: number })
+            .__agentProbeCalls ?? 0,
+      ),
+    ).toBe(0);
+
+    await page.evaluate(() => {
+      (
+        window as unknown as {
+          __imagePasteAgentActive?: boolean;
+          __ptyWrites?: string[];
+        }
+      ).__imagePasteAgentActive = true;
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+
+      const textarea = document.querySelector<HTMLTextAreaElement>(
+        ".xterm-helper-textarea",
+      );
+      if (!textarea) throw new Error("xterm helper textarea missing");
+      const image = new File([new Uint8Array([1, 2, 3])], "shot.png", {
+        type: "image/png",
+      });
+      const event = new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+      });
+      Object.defineProperty(event, "clipboardData", {
+        value: {
+          getData: () => "",
+          files: { 0: image, length: 1 },
+          items: { length: 0 },
+          types: ["Files", "image/png"],
+        },
+      });
+      textarea.dispatchEvent(event);
+    });
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __agentProbeCalls?: number })
+              .__agentProbeCalls ?? 0,
+        ),
+      )
+      .toBe(1);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as unknown as { __ptyWrites?: string[] }).__ptyWrites,
+        ),
+      )
+      .toEqual(["\x16"]);
+  });
+
   test("does not write selected terminal text on right-click by default", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Move live agent detection out of the terminal output hot path while preserving image-paste compatibility.

1. **Remove output polling** — stop mounting a full agent scan and stop scheduling another scan for every 500 ms PTY output burst.
2. **Keep the compatibility path precise** — use the session's known provider as the fast path and run one fresh detection only when an image paste arrives without a provider hint.
3. **Lock the invoke contract down** — add a Playwright regression that proves streaming output performs zero detections while an unknown-provider image paste performs exactly one and still sends the agent Ctrl+V fallback.

## Expected impact

| Path | Before | After |
| --- | --- | --- |
| Busy terminal agent scans | Mount scan plus up to ~120 full scans/minute/pane during sustained output | 0 scans from mount or PTY output |
| Known-provider image paste | Background scans still run | 0 detection calls; provider hint is used directly |
| Unknown-provider image paste | Detection refreshed speculatively from output | 1 fresh detection at paste time |

## Design notes

- `detect_session_agent` deliberately refreshes the host process table and resolves live transcript mappings on every call, so it is appropriate for an explicit user action but too expensive for the PTY output path.
- Detection results are not cached across pastes. This avoids keeping a stale positive after an agent exits while the regular session-status path continues to provide the cheap known-provider hint.
- Context-menu agent detection remains unchanged; only the Terminal image-paste consumer moves to on-demand detection.

## Test plan

- [x] `PLAYWRIGHT_PORT=1420 node_modules/.bin/playwright test tests/e2e/terminal.spec.ts -g "detects image-paste agents on demand"` — 1 passed
- [x] `PLAYWRIGHT_PORT=1420 node_modules/.bin/playwright test tests/e2e/terminal.spec.ts` — 33 passed
- [x] `node node_modules/vitest/vitest.mjs run src/lib/terminalPaste.test.ts src/lib/agentProvider.test.ts` — 22 passed
- [x] `node node_modules/typescript/bin/tsc --noEmit` — passed
- [x] GitHub Actions required checks — Frontend and both E2E shards passed.

## Notes

- The regression test observed 3 `detect_session_agent` calls on the old path after mount plus two output chunks; the optimized path records 0 before the image paste and exactly 1 afterward.
