### PR TITLE
perf(bundle): ship only Acorn's supported Shiki grammars

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@shikijs/core": "^4.0.2",
+    "@shikijs/engine-javascript": "^4.0.2",
+    "@shikijs/langs": "^4.0.2",
+    "@shikijs/themes": "^4.0.2",
     "@tanstack/react-virtual": "^3.13.24",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
@@ -57,7 +61,6 @@
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
-    "shiki": "^4.0.2",
     "tailwind-merge": "^3.5.0",
     "tinykeys": "^3.0.0",
     "zustand": "^5.0.14"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,18 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.7)
+      '@shikijs/core':
+        specifier: ^4.0.2
+        version: 4.0.2
+      '@shikijs/engine-javascript':
+        specifier: ^4.0.2
+        version: 4.0.2
+      '@shikijs/langs':
+        specifier: ^4.0.2
+        version: 4.0.2
+      '@shikijs/themes':
+        specifier: ^4.0.2
+        version: 4.0.2
       '@tanstack/react-virtual':
         specifier: ^3.13.24
         version: 3.13.24(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -92,9 +104,6 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
-      shiki:
-        specifier: ^4.0.2
-        version: 4.0.2
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.6.0
@@ -1176,10 +1185,6 @@ packages:
 
   '@shikijs/engine-javascript@4.0.2':
     resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
-    engines: {node: '>=20'}
-
-  '@shikijs/engine-oniguruma@4.0.2':
-    resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
     engines: {node: '>=20'}
 
   '@shikijs/langs@4.0.2':
@@ -2611,10 +2616,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  shiki@4.0.2:
-    resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
-    engines: {node: '>=20'}
-
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -3830,11 +3831,6 @@ snapshots:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
-
-  '@shikijs/engine-oniguruma@4.0.2':
-    dependencies:
-      '@shikijs/types': 4.0.2
-      '@shikijs/vscode-textmate': 10.0.2
 
   '@shikijs/langs@4.0.2':
     dependencies:
@@ -5581,17 +5577,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.4: {}
-
-  shiki@4.0.2:
-    dependencies:
-      '@shikijs/core': 4.0.2
-      '@shikijs/engine-javascript': 4.0.2
-      '@shikijs/engine-oniguruma': 4.0.2
-      '@shikijs/langs': 4.0.2
-      '@shikijs/themes': 4.0.2
-      '@shikijs/types': 4.0.2
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
 
   siginfo@2.0.0: {}
 

--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -1,19 +1,25 @@
 import {
-  createHighlighter,
+  createBundledHighlighter,
+  type HighlighterGeneric,
+} from "@shikijs/core";
+import {
   createJavaScriptRegexEngine,
   defaultJavaScriptRegexConstructor,
-  type BundledLanguage,
-  type BundledTheme,
-  type Highlighter,
-} from "shiki";
+} from "@shikijs/engine-javascript";
 import type { ParsedLine } from "./diff";
+import {
+  HIGHLIGHT_LANGUAGE_LOADERS,
+  HIGHLIGHT_THEME_LOADERS,
+  type HighlightLanguage,
+  type HighlightTheme,
+} from "./highlightRegistry";
 import type { ThemeMode } from "./themes";
 
-const DARK_THEME: BundledTheme = "github-dark";
-const LIGHT_THEME: BundledTheme = "github-light-high-contrast";
-const THEMES: BundledTheme[] = [DARK_THEME, LIGHT_THEME];
+const DARK_THEME: HighlightTheme = "github-dark";
+const LIGHT_THEME: HighlightTheme = "github-light-high-contrast";
+const THEMES: HighlightTheme[] = [DARK_THEME, LIGHT_THEME];
 
-const EXT_LANG: Record<string, BundledLanguage> = {
+const EXT_LANG: Record<string, HighlightLanguage> = {
   ts: "typescript",
   tsx: "tsx",
   mts: "typescript",
@@ -66,7 +72,7 @@ const EXT_LANG: Record<string, BundledLanguage> = {
   xml: "xml",
 };
 
-const FILENAME_LANG: Record<string, BundledLanguage> = {
+const FILENAME_LANG: Record<string, HighlightLanguage> = {
   Dockerfile: "docker",
   Makefile: "make",
   "CMakeLists.txt": "cmake",
@@ -108,26 +114,36 @@ const jsEngine = createJavaScriptRegexEngine({
   regexConstructor: compileGrammarRegex,
 });
 
-let highlighterPromise: Promise<Highlighter> | null = null;
-const loadedLangs = new Set<BundledLanguage>();
-const loadingLang = new Map<BundledLanguage, Promise<void>>();
+const createHighlighter = createBundledHighlighter({
+  langs: HIGHLIGHT_LANGUAGE_LOADERS,
+  themes: HIGHLIGHT_THEME_LOADERS,
+  engine: () => jsEngine,
+});
 
-function getHighlighter(): Promise<Highlighter> {
+type AcornHighlighter = HighlighterGeneric<HighlightLanguage, HighlightTheme>;
+
+let highlighterPromise: Promise<AcornHighlighter> | null = null;
+const loadedLangs = new Set<HighlightLanguage>();
+const loadingLang = new Map<HighlightLanguage, Promise<void>>();
+
+function getHighlighter(): Promise<AcornHighlighter> {
   if (!highlighterPromise) {
     highlighterPromise = createHighlighter({
       themes: THEMES,
       langs: [],
-      engine: jsEngine,
     });
   }
   return highlighterPromise;
 }
 
-export function highlightThemeForMode(mode: ThemeMode): BundledTheme {
+export function highlightThemeForMode(mode: ThemeMode): HighlightTheme {
   return mode === "light" ? LIGHT_THEME : DARK_THEME;
 }
 
-async function ensureLang(h: Highlighter, lang: BundledLanguage): Promise<boolean> {
+async function ensureLang(
+  h: AcornHighlighter,
+  lang: HighlightLanguage,
+): Promise<boolean> {
   if (loadedLangs.has(lang)) return true;
   let pending = loadingLang.get(lang);
   if (!pending) {
@@ -148,7 +164,9 @@ async function ensureLang(h: Highlighter, lang: BundledLanguage): Promise<boolea
   return loadedLangs.has(lang);
 }
 
-export function langFromPath(path: string | null | undefined): BundledLanguage | null {
+export function langFromPath(
+  path: string | null | undefined,
+): HighlightLanguage | null {
   if (!path) return null;
   const display = path.includes(" → ") ? path.split(" → ").pop() ?? path : path;
   const base = display.split("/").filter(Boolean).pop() ?? display;
@@ -168,7 +186,7 @@ function escapeHtml(s: string): string {
 
 async function renderLines(
   src: string[],
-  lang: BundledLanguage,
+  lang: HighlightLanguage,
   mode: ThemeMode,
 ): Promise<string[]> {
   if (src.length === 0) return [];
@@ -197,7 +215,7 @@ async function renderLines(
  */
 export async function highlightCode(
   content: string,
-  lang: BundledLanguage | null,
+  lang: HighlightLanguage | null,
   mode: ThemeMode = "dark",
 ): Promise<(string | null)[]> {
   const lines = content.split("\n");
@@ -213,7 +231,7 @@ export async function highlightCode(
  */
 export async function highlightDiff(
   lines: ParsedLine[],
-  lang: BundledLanguage,
+  lang: HighlightLanguage,
   mode: ThemeMode = "dark",
 ): Promise<(string | null)[]> {
   const html: (string | null)[] = new Array(lines.length).fill(null);

--- a/src/lib/highlightRegistry.test.ts
+++ b/src/lib/highlightRegistry.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  HIGHLIGHT_LANGUAGE_LOADERS,
+  HIGHLIGHT_THEME_LOADERS,
+} from "./highlightRegistry";
+
+const SUPPORTED_LANGUAGES = [
+  "bash",
+  "c",
+  "cmake",
+  "cpp",
+  "csharp",
+  "css",
+  "dart",
+  "docker",
+  "fish",
+  "go",
+  "graphql",
+  "html",
+  "java",
+  "javascript",
+  "json",
+  "jsonc",
+  "jsx",
+  "kotlin",
+  "less",
+  "lua",
+  "make",
+  "markdown",
+  "mdx",
+  "php",
+  "proto",
+  "python",
+  "ruby",
+  "rust",
+  "scala",
+  "scss",
+  "sql",
+  "svelte",
+  "swift",
+  "toml",
+  "tsx",
+  "typescript",
+  "vue",
+  "xml",
+  "yaml",
+] as const;
+
+describe("highlight registry", () => {
+  it("bundles loaders only for languages Acorn can select", () => {
+    expect(Object.keys(HIGHLIGHT_LANGUAGE_LOADERS).sort()).toEqual(
+      [...SUPPORTED_LANGUAGES].sort(),
+    );
+  });
+
+  it("bundles only the two themes exposed by the app", () => {
+    expect(Object.keys(HIGHLIGHT_THEME_LOADERS).sort()).toEqual([
+      "github-dark",
+      "github-light-high-contrast",
+    ]);
+  });
+
+  it("resolves representative language and theme registrations", async () => {
+    const [typescript, darkTheme] = await Promise.all([
+      HIGHLIGHT_LANGUAGE_LOADERS.typescript(),
+      HIGHLIGHT_THEME_LOADERS["github-dark"](),
+    ]);
+
+    expect(typescript.default.some((language) => language.name === "typescript")).toBe(
+      true,
+    );
+    expect(darkTheme.default.name).toBe("github-dark");
+  });
+});

--- a/src/lib/highlightRegistry.ts
+++ b/src/lib/highlightRegistry.ts
@@ -1,0 +1,50 @@
+export const HIGHLIGHT_LANGUAGE_LOADERS = {
+  bash: () => import("@shikijs/langs/bash"),
+  c: () => import("@shikijs/langs/c"),
+  cmake: () => import("@shikijs/langs/cmake"),
+  cpp: () => import("@shikijs/langs/cpp"),
+  csharp: () => import("@shikijs/langs/csharp"),
+  css: () => import("@shikijs/langs/css"),
+  dart: () => import("@shikijs/langs/dart"),
+  docker: () => import("@shikijs/langs/docker"),
+  fish: () => import("@shikijs/langs/fish"),
+  go: () => import("@shikijs/langs/go"),
+  graphql: () => import("@shikijs/langs/graphql"),
+  html: () => import("@shikijs/langs/html"),
+  java: () => import("@shikijs/langs/java"),
+  javascript: () => import("@shikijs/langs/javascript"),
+  json: () => import("@shikijs/langs/json"),
+  jsonc: () => import("@shikijs/langs/jsonc"),
+  jsx: () => import("@shikijs/langs/jsx"),
+  kotlin: () => import("@shikijs/langs/kotlin"),
+  less: () => import("@shikijs/langs/less"),
+  lua: () => import("@shikijs/langs/lua"),
+  make: () => import("@shikijs/langs/make"),
+  markdown: () => import("@shikijs/langs/markdown"),
+  mdx: () => import("@shikijs/langs/mdx"),
+  php: () => import("@shikijs/langs/php"),
+  proto: () => import("@shikijs/langs/proto"),
+  python: () => import("@shikijs/langs/python"),
+  ruby: () => import("@shikijs/langs/ruby"),
+  rust: () => import("@shikijs/langs/rust"),
+  scala: () => import("@shikijs/langs/scala"),
+  scss: () => import("@shikijs/langs/scss"),
+  sql: () => import("@shikijs/langs/sql"),
+  svelte: () => import("@shikijs/langs/svelte"),
+  swift: () => import("@shikijs/langs/swift"),
+  toml: () => import("@shikijs/langs/toml"),
+  tsx: () => import("@shikijs/langs/tsx"),
+  typescript: () => import("@shikijs/langs/typescript"),
+  vue: () => import("@shikijs/langs/vue"),
+  xml: () => import("@shikijs/langs/xml"),
+  yaml: () => import("@shikijs/langs/yaml"),
+} as const;
+
+export const HIGHLIGHT_THEME_LOADERS = {
+  "github-dark": () => import("@shikijs/themes/github-dark"),
+  "github-light-high-contrast": () =>
+    import("@shikijs/themes/github-light-high-contrast"),
+} as const;
+
+export type HighlightLanguage = keyof typeof HIGHLIGHT_LANGUAGE_LOADERS;
+export type HighlightTheme = keyof typeof HIGHLIGHT_THEME_LOADERS;


### PR DESCRIPTION
## Summary

Replace Shiki's full language/theme bundle with a typed, Acorn-specific registry so production builds contain only syntax assets the app can select.

1. **Use fine-grained Shiki packages** — replace the root `shiki` dependency with `@shikijs/core`, the existing JavaScript regex engine, and explicit language/theme packages.
2. **Bound the lazy registry** — keep the existing 39 language mappings and two app themes, but give Vite one dynamic import per supported registration instead of exposing Shiki's complete catalog.
3. **Guard the bundle contract** — add tests that lock the supported registry and verify representative language/theme registrations resolve.

## Expected impact

| Production frontend metric | `main` | This PR | Change |
| --- | ---: | ---: | ---: |
| Total `dist` bytes | 12,464,859 B | 5,679,870 B | **-6,784,989 B (-54.43%)** |
| Aggregate gzip bytes | 3,032,036 B | 1,590,899 B | **-1,441,137 B (-47.53%)** |
| Emitted files | 307 | 47 | **-260 (-84.69%)** |
| Entry JS bytes | 2,416,609 B | 2,374,935 B | **-41,674 B (-1.72%)** |
| Entry JS gzip bytes | 696,984 B | 681,108 B | **-15,876 B (-2.28%)** |

Measurements use clean production builds from the same checkout and aggregate every emitted file; gzip figures use `gzip -9` for a consistent before/after comparison.

## Design notes

- `langFromPath` keeps the same extension, filename, and fence-language behavior; its return type is now derived from the registry, so a mapping cannot reference a grammar that is not bundled.
- Languages and themes remain lazy chunks. The change narrows the available loader table rather than eagerly loading all 39 grammars.
- The pure-JavaScript regex engine and the JavaScriptCore anchor workaround are unchanged, preserving the hardened WKWebView CSP behavior.
- Unknown file types still fall back to plain text before Shiki is invoked.

## Follow-up (not in this PR)

- Lazy-mounting Settings and Command Palette can reduce the initial entry chunk further, but does not reduce total shipped bytes and should remain a separate startup-focused change.
- The Acorn illustration can be resized to its rendered resolution for another asset reduction after cross-platform visual QA.

## Test plan

- [x] `pnpm install --frozen-lockfile --offline` — lockfile accepted with the fine-grained dependencies.
- [x] `pnpm exec vitest run src/lib/highlightRegistry.test.ts src/lib/highlight.test.ts` — 8 tests passed.
- [x] `pnpm test` — 100 files / 1,125 tests passed.
- [x] `pnpm typecheck` — passed.
- [x] `pnpm build` — TypeScript and Vite production build passed; output measured at 5,679,870 B across 47 files.
- [x] GitHub Actions CI — Frontend and both E2E shards passed.

## Notes

- Dependabot PR #683 also touches `package.json` and `pnpm-lock.yaml`; whichever PR lands second may need to regenerate its lockfile.
- Vite still reports the pre-existing mixed static/dynamic import notices and the large entry/CPP chunk warning. Those warnings are not introduced by this PR; the measured entry and total output are both smaller.
