### PR TITLE
fix(files): refresh untracked files after agent branch switches

### DIFF
--- a/src/components/FileExplorer.listener.test.tsx
+++ b/src/components/FileExplorer.listener.test.tsx
@@ -273,4 +273,99 @@ describe("FileExplorer filesystem listener", () => {
 
     expect(vi.getTimerCount()).toBe(0);
   });
+
+  it("refetches every loaded directory when gitignore rules change", async () => {
+    const rootPath = "/tmp/acorn-gitignore";
+    const generatedPath = `${rootPath}/generated`;
+    let fsListener:
+      | ((event: {
+          payload: {
+            paths: string[];
+            root: string;
+            cap: number;
+            dotgit_changed: boolean;
+          };
+        }) => void)
+      | null = null;
+    eventMocks.listen.mockImplementation((_event, handler) => {
+      fsListener = handler;
+      return Promise.resolve(() => {});
+    });
+    apiMocks.fsListDir.mockImplementation(async (path: string) => ({
+      entries:
+        path === rootPath
+          ? [
+              {
+                name: "generated",
+                path: generatedPath,
+                is_dir: true,
+                is_symlink: false,
+                size: 0,
+                modified_ms: 1,
+                gitignored: false,
+              },
+            ]
+          : [],
+      repo_root: rootPath,
+    }));
+
+    await act(async () => {
+      root?.render(<FileExplorer rootPath={rootPath} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const generatedButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("generated"),
+    );
+    expect(generatedButton).toBeInstanceOf(HTMLButtonElement);
+
+    await act(async () => {
+      generatedButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(apiMocks.fsListDir).toHaveBeenCalledWith(generatedPath, false, true);
+    apiMocks.fsListDir.mockClear();
+
+    await act(async () => {
+      fsListener?.({
+        payload: {
+          paths: [`${rootPath}/.gitignore`],
+          root: rootPath,
+          cap: 256,
+          dotgit_changed: false,
+        },
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(apiMocks.fsListDir).toHaveBeenCalledWith(rootPath, false, true);
+    expect(apiMocks.fsListDir).toHaveBeenCalledWith(generatedPath, false, true);
+  });
+
+  it("refreshes loaded directories and git status when the branch revision changes", async () => {
+    const rootPath = "/tmp/acorn-branch";
+
+    await act(async () => {
+      root?.render(
+        <FileExplorer rootPath={rootPath} gitRevision="feature/one" />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    apiMocks.fsListDir.mockClear();
+    apiMocks.fsGitStatus.mockClear();
+
+    await act(async () => {
+      root?.render(
+        <FileExplorer rootPath={rootPath} gitRevision="feature/two" />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(apiMocks.fsListDir).toHaveBeenCalledWith(rootPath, false, true);
+    expect(apiMocks.fsGitStatus).toHaveBeenCalledWith(rootPath);
+  });
 });

--- a/src/components/FileExplorer.listener.test.tsx
+++ b/src/components/FileExplorer.listener.test.tsx
@@ -346,6 +346,7 @@ describe("FileExplorer filesystem listener", () => {
 
   it("refreshes loaded directories and git status when the branch revision changes", async () => {
     const rootPath = "/tmp/acorn-branch";
+    const hasFocus = vi.spyOn(document, "hasFocus").mockReturnValue(true);
 
     await act(async () => {
       root?.render(
@@ -367,5 +368,6 @@ describe("FileExplorer filesystem listener", () => {
 
     expect(apiMocks.fsListDir).toHaveBeenCalledWith(rootPath, false, true);
     expect(apiMocks.fsGitStatus).toHaveBeenCalledWith(rootPath);
+    hasFocus.mockRestore();
   });
 });

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -38,7 +38,10 @@ import {
 import { cn } from "../lib/cn";
 import { retainRecentGitStatPaths } from "../lib/fileExplorerGitStats";
 import { matchesHotkeyEvent } from "../lib/hotkeys";
-import { planGitRefresh } from "../lib/git-refresh-scheduler";
+import {
+  planGitRefresh,
+  type GitRefreshTrigger,
+} from "../lib/git-refresh-scheduler";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { rightPanelCache } from "../lib/right-panel-cache";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
@@ -77,6 +80,7 @@ function fileExplorerText(
 
 interface FileExplorerProps {
   rootPath: string;
+  gitRevision?: string | null;
 }
 
 interface DirState {
@@ -114,6 +118,10 @@ function pathInsideRoot(path: string, rootPath: string): boolean {
   const target = trimTrailingSlash(path);
   if (root === "/") return target.startsWith("/");
   return target === root || target.startsWith(root + "/");
+}
+
+function isGitignorePath(path: string): boolean {
+  return /(^|[\\/])\.gitignore$/.test(path);
 }
 
 function nearestCachedRefreshDir(
@@ -307,7 +315,10 @@ function setLocalBool(key: string, value: boolean) {
   }
 }
 
-export function FileExplorer({ rootPath }: FileExplorerProps) {
+export function FileExplorer({
+  rootPath,
+  gitRevision = null,
+}: FileExplorerProps) {
   const t = useTranslation();
   const findShortcut = useSettings((s) => s.settings.shortcuts.findInView);
   const renameShortcut = useSettings((s) => s.settings.shortcuts.renameItem);
@@ -364,7 +375,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
   const visiblePathsRef = useRef<Set<string>>(new Set());
   const changedPathsRef = useRef<Set<string>>(new Set());
   const statusInFlightRef = useRef<Promise<void> | null>(null);
-  const statusRefreshPendingRef = useRef(false);
+  const statusRefreshPendingRef = useRef<GitRefreshTrigger | null>(null);
   const lastStatusSuccessRef = useRef<number | null>(null);
   const refreshDeferTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingDotgitRef = useRef(false);
@@ -408,7 +419,9 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
 
   const refreshGitStatus = useCallback(async () => {
     if (statusInFlightRef.current) {
-      statusRefreshPendingRef.current = true;
+      if (statusRefreshPendingRef.current !== "user") {
+        statusRefreshPendingRef.current = "fs-event";
+      }
       return statusInFlightRef.current;
     }
 
@@ -445,11 +458,13 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
 
     const promise = run().finally(() => {
       statusInFlightRef.current = null;
-      if (statusRefreshPendingRef.current) {
-        statusRefreshPendingRef.current = false;
+      const pendingTrigger = statusRefreshPendingRef.current;
+      if (pendingTrigger) {
+        statusRefreshPendingRef.current = null;
+        if (pendingTrigger === "user") lastStatusSuccessRef.current = null;
         // Route through the scheduler so huge / focus / quiet-window guards
         // still apply to the re-fire instead of bypassing them.
-        scheduleRefreshRef.current?.("fs-event");
+        scheduleRefreshRef.current?.(pendingTrigger);
       }
     });
     statusInFlightRef.current = promise;
@@ -497,7 +512,12 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
           // The in-flight refreshGitStatus will re-enter the scheduler via
           // scheduleRefreshRef once it settles; flag the pending so the
           // .finally arm fires the retry.
-          statusRefreshPendingRef.current = true;
+          if (
+            trigger === "user" ||
+            statusRefreshPendingRef.current === null
+          ) {
+            statusRefreshPendingRef.current = trigger;
+          }
           break;
         case "defer-until-focus":
         case "skip-huge":
@@ -745,6 +765,33 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
     cacheRef.current = cache;
   }, [cache]);
 
+  const gitContextRef = useRef({ rootPath, gitRevision });
+  useEffect(() => {
+    const previous = gitContextRef.current;
+    gitContextRef.current = { rootPath, gitRevision };
+    if (
+      previous.rootPath !== rootPath ||
+      previous.gitRevision === gitRevision
+    ) {
+      return;
+    }
+
+    for (const path of new Set([rootPath, ...Object.keys(cacheRef.current)])) {
+      void fetchDir(path);
+    }
+    gitHugeRef.current = false;
+    lastStatusSuccessRef.current = null;
+    pendingDotgitRef.current = true;
+    scheduleGitStatusRefresh("user");
+    scheduleGitDiffStats();
+  }, [
+    fetchDir,
+    gitRevision,
+    rootPath,
+    scheduleGitDiffStats,
+    scheduleGitStatusRefresh,
+  ]);
+
   // Listen for backend fs-changed batches and refresh only loaded
   // directories. Overflow batches carry a subtree/root refresh hint so
   // large generated-file bursts do not fan out into per-file work.
@@ -766,6 +813,7 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
       const current = cacheRef.current;
       const toFetch = new Set<string>();
       const changedPaths = payload.paths.filter((p) => pathInsideRoot(p, rootPath));
+      const gitignoreChanged = changedPaths.some(isGitignorePath);
 
       retainRecentGitStatPaths(
         changedPathsRef.current,
@@ -773,7 +821,10 @@ export function FileExplorer({ rootPath }: FileExplorerProps) {
         payload.cap,
       );
 
-      if (payload.overflow && payload.refresh) {
+      if (gitignoreChanged) {
+        toFetch.add(rootPath);
+        for (const path of Object.keys(current)) toFetch.add(path);
+      } else if (payload.overflow && payload.refresh) {
         const refreshPath =
           payload.refresh.kind === "root" ? rootPath : payload.refresh.path;
         toFetch.add(nearestCachedRefreshDir(refreshPath, current, rootPath));

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -552,6 +552,7 @@ export function RightPanel() {
             <FileExplorer
               key={codePanelRepoPath}
               rootPath={codePanelRepoPath}
+              gitRevision={active?.branch ?? null}
             />
           ) : (
             <Empty msg={rt(t, "rightPanel.empty.noProject")} />

--- a/src/components/WorkSummaryView.test.tsx
+++ b/src/components/WorkSummaryView.test.tsx
@@ -391,6 +391,69 @@ describe("WorkSummaryView", () => {
     expect(mocks.fsGitStatus).toHaveBeenCalledOnce();
   });
 
+  it("starts a fresh git summary request when the branch changes in the same cwd", async () => {
+    const first = deferred<Awaited<ReturnType<typeof mocks.fsGitStatus>>>();
+    const second = deferred<Awaited<ReturnType<typeof mocks.fsGitStatus>>>();
+    mocks.fsGitStatus
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const tab = makeWorkSummaryWorkspaceTab({
+      repoPath: REPO,
+      cwdPath: `${REPO}/.worktrees/s1`,
+      sessionId: "s1",
+      title: "Feature runner Summary",
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkSummaryView
+          tab={tab}
+          session={session({ branch: "feature/one", mode: "chat" })}
+          isActive
+        />,
+      );
+      await Promise.resolve();
+    });
+    expect(mocks.fsGitStatus).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      root.render(
+        <WorkSummaryView
+          tab={tab}
+          session={session({ branch: "feature/two", mode: "chat" })}
+          isActive
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(mocks.fsGitStatus).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      second.resolve({
+        statuses: {
+          [`${REPO}/.worktrees/s1/feature-two.ts`]: {
+            kind: "added",
+            additions: 0,
+            deletions: 0,
+          },
+        },
+        huge: false,
+        limit: 500,
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("feature-two.ts");
+
+    await act(async () => {
+      first.resolve({ statuses: {}, huge: false, limit: 500 });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("feature-two.ts");
+  });
+
   it("does not let an old git summary completion clear a newer cwd request", async () => {
     vi.useFakeTimers();
     const first = deferred<Awaited<ReturnType<typeof mocks.fsGitStatus>>>();

--- a/src/components/WorkSummaryView.tsx
+++ b/src/components/WorkSummaryView.tsx
@@ -154,6 +154,7 @@ export function WorkSummaryView({
     session?.agent_transcript_id ?? "",
     session?.agent_transcript_path ?? "",
   ].join("\u0000");
+  const summaryIdentity = [tab.cwdPath, session?.branch ?? ""].join("\u0000");
 
   const fetchSummary = useCallback(async (): Promise<WorkSummarySnapshot> => {
     const status = await api.fsGitStatus(tab.cwdPath, GIT_STATUS_FILE_LIMIT);
@@ -168,16 +169,16 @@ export function WorkSummaryView({
 
   const fetchSummaryCoalesced = useCallback(() => {
     const existing = summaryInFlightRef.current;
-    if (existing?.identity === tab.cwdPath) return existing.promise;
+    if (existing?.identity === summaryIdentity) return existing.promise;
 
     const promise = fetchSummary().finally(() => {
       if (summaryInFlightRef.current?.promise === promise) {
         summaryInFlightRef.current = null;
       }
     });
-    summaryInFlightRef.current = { identity: tab.cwdPath, promise };
+    summaryInFlightRef.current = { identity: summaryIdentity, promise };
     return promise;
-  }, [fetchSummary, tab.cwdPath]);
+  }, [fetchSummary, summaryIdentity]);
 
   const fetchConversation = useCallback(async (): Promise<WorkSummaryConversationSnapshot> => {
     if (!session) {

--- a/tests/e2e/file-explorer.spec.ts
+++ b/tests/e2e/file-explorer.spec.ts
@@ -1057,9 +1057,13 @@ test.describe("file explorer", () => {
     await tauri.handle("pty_repo_root", () => repo);
     await tauri.handle("fs_list_dir", (args) => {
       const { path } = args as { path: string };
-      const switched = (
-        window as unknown as { __fileExplorerBranchSwitched?: boolean }
-      ).__fileExplorerBranchSwitched;
+      const state = window as unknown as {
+        __fileExplorerBranchSwitched?: boolean;
+        __fileExplorerListCalls?: Array<{ path: string; switched: boolean }>;
+      };
+      const switched = Boolean(state.__fileExplorerBranchSwitched);
+      state.__fileExplorerListCalls = state.__fileExplorerListCalls ?? [];
+      state.__fileExplorerListCalls.push({ path, switched });
       if (path === "/tmp/branch-refresh") {
         return {
           repo_root: "/tmp/branch-refresh",
@@ -1120,9 +1124,8 @@ test.describe("file explorer", () => {
     await page.getByRole("button", { name: "Code" }).click();
     await page.getByRole("button", { name: "Files", exact: true }).click();
     await page.getByRole("button", { name: "generated", exact: true }).click();
-    await expect(
-      page.getByRole("button", { name: "result.json", exact: true }),
-    ).toHaveCount(0);
+    const resultRow = page.getByRole("button", { name: /^result\.json/ });
+    await expect(resultRow).toHaveCount(0);
 
     await page.evaluate(() => {
       (
@@ -1133,9 +1136,22 @@ test.describe("file explorer", () => {
     await expect(
       page.getByRole("button", { name: /^branch agent feature\/visible · Working$/ }),
     ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "result.json", exact: true }),
-    ).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __fileExplorerListCalls?: Array<{
+                  path: string;
+                  switched: boolean;
+                }>;
+              }
+            ).__fileExplorerListCalls ?? [],
+        ),
+      )
+      .toContainEqual({ path: "/tmp/branch-refresh/generated", switched: true });
+    await expect(resultRow).toBeVisible();
     await expect(page.getByLabel("Git status added")).toBeVisible();
   });
 });

--- a/tests/e2e/file-explorer.spec.ts
+++ b/tests/e2e/file-explorer.spec.ts
@@ -1012,4 +1012,130 @@ test.describe("file explorer", () => {
 
     await expect(page.getByRole("button", { name: "Preview" })).toBeVisible();
   });
+
+  test("shows newly unignored files after the active agent changes branches", async ({
+    page,
+    tauri,
+  }) => {
+    const repo = "/tmp/branch-refresh";
+
+    await tauri.respond("list_projects", [
+      {
+        repo_path: repo,
+        name: "branch-refresh",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "branch-session",
+        name: "branch agent",
+        repo_path: repo,
+        worktree_path: repo,
+        branch: "feature/ignored",
+        isolated: false,
+        status: "working",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("detect_session_statuses", (args) => {
+      const ids = Array.isArray((args as { ids?: unknown }).ids)
+        ? ((args as { ids: string[] }).ids)
+        : [];
+      const switched = (
+        window as unknown as { __fileExplorerBranchSwitched?: boolean }
+      ).__fileExplorerBranchSwitched;
+      return ids.map((id) => ({
+        id,
+        status: "working",
+        branch: switched ? "feature/visible" : "feature/ignored",
+      }));
+    });
+    await tauri.handle("pty_repo_root", () => repo);
+    await tauri.handle("fs_list_dir", (args) => {
+      const { path } = args as { path: string };
+      const switched = (
+        window as unknown as { __fileExplorerBranchSwitched?: boolean }
+      ).__fileExplorerBranchSwitched;
+      if (path === "/tmp/branch-refresh") {
+        return {
+          repo_root: "/tmp/branch-refresh",
+          entries: [
+            {
+              name: "generated",
+              path: "/tmp/branch-refresh/generated",
+              is_dir: true,
+              is_symlink: false,
+              size: 0,
+              modified_ms: 0,
+              gitignored: false,
+            },
+          ],
+        };
+      }
+      if (path === "/tmp/branch-refresh/generated" && switched) {
+        return {
+          repo_root: "/tmp/branch-refresh",
+          entries: [
+            {
+              name: "result.json",
+              path: "/tmp/branch-refresh/generated/result.json",
+              is_dir: false,
+              is_symlink: false,
+              size: 12,
+              modified_ms: 0,
+              gitignored: false,
+            },
+          ],
+        };
+      }
+      return { repo_root: "/tmp/branch-refresh", entries: [] };
+    });
+    await tauri.handle("fs_git_status", () => {
+      const switched = (
+        window as unknown as { __fileExplorerBranchSwitched?: boolean }
+      ).__fileExplorerBranchSwitched;
+      return {
+        statuses: switched
+          ? {
+              "/tmp/branch-refresh/generated/result.json": {
+                kind: "added",
+                additions: 0,
+                deletions: 0,
+              },
+            }
+          : {},
+        huge: false,
+        limit: 10_000,
+      };
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^branch agent feature\/ignored · Working$/ })
+      .click();
+    await page.getByRole("button", { name: "Code" }).click();
+    await page.getByRole("button", { name: "Files", exact: true }).click();
+    await page.getByRole("button", { name: "generated", exact: true }).click();
+    await expect(
+      page.getByRole("button", { name: "result.json", exact: true }),
+    ).toHaveCount(0);
+
+    await page.evaluate(() => {
+      (
+        window as unknown as { __fileExplorerBranchSwitched?: boolean }
+      ).__fileExplorerBranchSwitched = true;
+    });
+
+    await expect(
+      page.getByRole("button", { name: /^branch agent feature\/visible · Working$/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "result.json", exact: true }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Git status added")).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
Keep File Explorer and Work Summary aligned with the active agent branch when a linked worktree switches branches without emitting an in-tree Git metadata event.

1. **Branch-aware file refresh** — pass the active session branch into File Explorer and refetch the root plus every loaded directory when it changes.
2. **Reliable Git decorations** — schedule an explicit user-priority Git status and diff-stat refresh, including when another status request is already in flight.
3. **Gitignore cache invalidation** — refresh every loaded directory after a `.gitignore` change so newly unignored files become visible.
4. **Branch-aware work summaries** — key coalesced summary requests by cwd and branch so a prior branch request cannot suppress or overwrite the new summary.
5. **Regression coverage** — cover loaded-directory invalidation, in-flight summary ordering, and the full agent branch-switch flow in Playwright.

## Expected impact
| Scenario | Before | After |
| --- | --- | --- |
| Agent switches branches in the same linked worktree | Untracked or newly unignored files and Git decorations could remain stale | Loaded directories, Git status, and diff stats refresh from the new branch |
| A nested directory is already expanded when `.gitignore` changes | Its cached listing could omit files until manually reloaded | All loaded directory caches are invalidated |
| Work Summary request overlaps a branch switch | The cwd-only coalescing key could reuse the old request | A branch-specific request starts and stale completion is ignored |

## Design notes
- Linked worktree Git metadata can live outside the watched repository root, so the already-polled active session branch is used as the explicit revision signal.
- The refresh stays within the existing Git refresh scheduler and promotes branch changes to the existing `user` trigger instead of bypassing focus, large-repository, or debounce policy.
- Directory invalidation is limited to the root and currently loaded cache entries; unopened subtrees remain lazy.
- No backend API or data contract changes are required.

## Test plan
- [x] `pnpm exec vitest run src/components/FileExplorer.listener.test.tsx src/components/WorkSummaryView.test.tsx` — 19 tests pass
- [x] `pnpm run test` — 96 files, 1,080 tests pass
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run build` — production build passes
- [x] `pnpm exec playwright test tests/e2e/file-explorer.spec.ts` — 9 tests pass
- [x] `pnpm exec playwright test tests/e2e/work-summary.spec.ts` — 2 tests pass

## Notes
- The production build reports the repository's existing Vite dynamic/static import and chunk-size warnings; the build completes successfully.