### PR TITLE
fix(canvas): center sessions opened from notifications

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -222,7 +222,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   function handleOpenActivity(notificationId: string, sessionId: string) {
     const state = useAppStore.getState();
     state.markSessionNotificationRead(notificationId);
-    state.openSessionSurface(sessionId);
+    state.openSessionSurface(sessionId, { centerInCanvas: true });
     close();
   }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3920,7 +3920,7 @@ function SidebarActivityRow({
 
   const openSession = () => {
     markRead(notification.id);
-    openSessionSurface(notification.sessionId);
+    openSessionSurface(notification.sessionId, { centerInCanvas: true });
   };
 
   return (

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -998,7 +998,7 @@ function NotificationRow({
 
   const openSession = () => {
     markRead(notification.id);
-    openSessionSurface(notification.sessionId);
+    openSessionSurface(notification.sessionId, { centerInCanvas: true });
     onClose();
   };
 

--- a/src/components/WorkspaceCanvas.tsx
+++ b/src/components/WorkspaceCanvas.tsx
@@ -45,6 +45,7 @@ import { useTranslation } from "../lib/useTranslation";
 import {
   WORKSPACE_CANVAS_MAX_ZOOM,
   WORKSPACE_CANVAS_MIN_ZOOM,
+  centerWorkspaceCanvasNode,
   clampWorkspaceCanvasNode,
   fitWorkspaceCanvasViewport,
   reconcileWorkspaceCanvasState,
@@ -58,7 +59,7 @@ import {
   type WorkspaceCanvasState,
   type WorkspaceCanvasViewport,
 } from "../lib/workspaceCanvas";
-import { useAppStore } from "../store";
+import { useAppStore, type FocusSessionEventDetail } from "../store";
 import { Button, IconButton, StatusDot, type StatusTone } from "./ui";
 import { ChatPane } from "./ChatPane";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
@@ -316,6 +317,27 @@ export function WorkspaceCanvas({
     [updateCanvas],
   );
 
+  const centerSession = useCallback(
+    (sessionId: string) => {
+      const current = canvasRef.current;
+      const node = current.nodes[sessionId];
+      if (!node) return;
+      const root = rootRef.current;
+      const container = root
+        ? { width: root.clientWidth, height: root.clientHeight }
+        : containerSizeRef.current;
+      containerSizeRef.current = container;
+      const viewport = centerWorkspaceCanvasNode(
+        current.viewport,
+        node,
+        container,
+      );
+      if (sameViewport(current.viewport, viewport)) return;
+      updateCanvas((state) => ({ ...state, viewport }), "soon");
+    },
+    [updateCanvas],
+  );
+
   useEffect(() => {
     const current = canvasRef.current;
     const next = reconcileWorkspaceCanvasState(current, reconciliationIds);
@@ -355,13 +377,18 @@ export function WorkspaceCanvas({
 
   useEffect(() => {
     const onFocusSession = (event: Event) => {
-      const detail = (event as CustomEvent<{ sessionId?: string }>).detail;
-      if (detail?.sessionId) revealSession(detail.sessionId);
+      const detail = (event as CustomEvent<FocusSessionEventDetail>).detail;
+      if (!detail?.sessionId) return;
+      if (detail.canvasTarget === "center") {
+        centerSession(detail.sessionId);
+        return;
+      }
+      revealSession(detail.sessionId);
     };
     window.addEventListener("acorn:focus-session", onFocusSession);
     return () =>
       window.removeEventListener("acorn:focus-session", onFocusSession);
-  }, [revealSession]);
+  }, [centerSession, revealSession]);
 
   useEffect(() => {
     return () => {

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -136,7 +136,9 @@ describe("notifications", () => {
 
     handleAction({ extra: { sessionId: "session-1" } });
 
-    expect(openSessionSurface).toHaveBeenCalledWith("session-1");
+    expect(openSessionSurface).toHaveBeenCalledWith("session-1", {
+      centerInCanvas: true,
+    });
     expect(mocks.show).toHaveBeenCalled();
     expect(mocks.unminimize).toHaveBeenCalled();
     expect(mocks.setFocus).toHaveBeenCalled();

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -292,7 +292,9 @@ export async function startNotificationClickHandler(): Promise<() => void> {
     void win.show();
     void win.unminimize();
     void win.setFocus();
-    useAppStore.getState().openSessionSurface(sessionId);
+    useAppStore
+      .getState()
+      .openSessionSurface(sessionId, { centerInCanvas: true });
     markSessionNotificationsRead(sessionId);
   });
   return () => {

--- a/src/lib/workspaceCanvas.test.ts
+++ b/src/lib/workspaceCanvas.test.ts
@@ -4,6 +4,7 @@ import {
   WORKSPACE_CANVAS_MIN_NODE_HEIGHT,
   WORKSPACE_CANVAS_MIN_NODE_WIDTH,
   WORKSPACE_CANVAS_MIN_ZOOM,
+  centerWorkspaceCanvasNode,
   findWorkspaceCanvasMinimapNodeAtPoint,
   fitWorkspaceCanvasViewport,
   centerWorkspaceCanvasViewportFromMinimapPoint,
@@ -113,6 +114,16 @@ describe("workspaceCanvas", () => {
         { width: 1_000, height: 700 },
       ),
     ).toEqual({ offset: { x: -348, y: 0 }, zoom: 1 });
+  });
+
+  it("centers a selected node without changing the zoom", () => {
+    expect(
+      centerWorkspaceCanvasNode(
+        { offset: { x: -40, y: 20 }, zoom: 0.8 },
+        { x: 900, y: 100, width: 400, height: 300, zIndex: 1 },
+        { width: 1_000, height: 700 },
+      ),
+    ).toEqual({ offset: { x: -380, y: 150 }, zoom: 0.8 });
   });
 
   it("maps nodes and the viewport into a minimap and recenters from it", () => {

--- a/src/lib/workspaceCanvas.ts
+++ b/src/lib/workspaceCanvas.ts
@@ -385,6 +385,22 @@ export function revealWorkspaceCanvasNode(
   return { zoom, offset: { x, y } };
 }
 
+export function centerWorkspaceCanvasNode(
+  viewport: WorkspaceCanvasViewport,
+  node: WorkspaceCanvasNode,
+  container: WorkspaceCanvasSize,
+): WorkspaceCanvasViewport {
+  if (container.width <= 0 || container.height <= 0) return viewport;
+  const zoom = clampWorkspaceCanvasZoom(viewport.zoom);
+  return {
+    zoom,
+    offset: {
+      x: container.width / 2 - (node.x + node.width / 2) * zoom,
+      y: container.height / 2 - (node.y + node.height / 2) * zoom,
+    },
+  };
+}
+
 function rectFromNode(node: WorkspaceCanvasNode): WorkspaceCanvasRect {
   return {
     x: node.x,

--- a/src/store.ts
+++ b/src/store.ts
@@ -343,6 +343,16 @@ export interface ProjectWorkspace {
 }
 
 export type WorkspaceViewMode = "panes" | "kanban" | "canvas";
+
+export interface OpenSessionSurfaceOptions {
+  centerInCanvas?: boolean;
+}
+
+export interface FocusSessionEventDetail {
+  sessionId: string;
+  canvasTarget?: "reveal" | "center";
+}
+
 type WorkspaceViewScope = "project" | "local";
 
 export interface MoveTabArgs {
@@ -449,7 +459,10 @@ interface AppStateModel {
   pollSessionStatuses: (ids?: string[]) => Promise<void>;
   selectTab: (id: string | null) => void;
   selectSession: (id: string | null) => void;
-  openSessionSurface: (id: string) => boolean;
+  openSessionSurface: (
+    id: string,
+    options?: OpenSessionSurfaceOptions,
+  ) => boolean;
   focusLocalSessions: () => void;
   setActiveProject: (repoPath: string) => void;
   setActiveProjectFolder: (folderId: string) => void;
@@ -2194,7 +2207,7 @@ export const useAppStore = create<AppStateModel>()(
     }
   },
 
-  openSessionSurface(id) {
+  openSessionSurface(id, options) {
     if (!get().sessions.some((session) => session.id === id)) return false;
 
     get().selectSession(id);
@@ -2205,6 +2218,15 @@ export const useAppStore = create<AppStateModel>()(
       state.openTerminalPopup(id);
     } else {
       state.closeTerminalPopup();
+    }
+    if (options?.centerInCanvas && typeof window !== "undefined") {
+      requestAnimationFrame(() => {
+        window.dispatchEvent(
+          new CustomEvent<FocusSessionEventDetail>("acorn:focus-session", {
+            detail: { sessionId: id, canvasTarget: "center" },
+          }),
+        );
+      });
     }
     return true;
   },

--- a/tests/e2e/session-notifications.spec.ts
+++ b/tests/e2e/session-notifications.spec.ts
@@ -193,6 +193,105 @@ test.describe("session notification center", () => {
     await expect(activity.getByText("Ready", { exact: true })).toHaveCount(0);
   });
 
+  test("centers the destination session when opened from a notification in canvas mode", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "session-1",
+        name: "foreground",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "working",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+      {
+        id: "session-2",
+        name: "agent run",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "working",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 1,
+        in_worktree: false,
+      },
+    ]);
+    await tauri.respond("detect_session_statuses", [
+      {
+        id: "session-2",
+        status: "waiting_for_input",
+        branch: null,
+        agent_provider: null,
+      },
+    ]);
+
+    await page.goto("/");
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Canvas" }).click();
+
+    const canvas = page.getByTestId("workspace-canvas");
+    const world = page.getByTestId("workspace-canvas-world");
+    const target = canvas.locator('[data-canvas-session-id="session-2"]');
+    const initialOffset = Number(
+      await world.getAttribute("data-canvas-offset-x"),
+    );
+    await canvas.dispatchEvent("wheel", { deltaX: 1_800, deltaY: 900 });
+    await expect
+      .poll(async () =>
+        Number(await world.getAttribute("data-canvas-offset-x")),
+      )
+      .toBeLessThan(initialOffset - 1_000);
+
+    await expect(page.getByRole("button", { name: "Session notifications" }))
+      .toContainText("1");
+    await page.getByRole("button", { name: "Session notifications" }).click();
+    await page.getByRole("menuitem", { name: /Waiting for input/ }).click();
+
+    await expect
+      .poll(async () => {
+        const [canvasBox, targetBox] = await Promise.all([
+          canvas.boundingBox(),
+          target.boundingBox(),
+        ]);
+        if (!canvasBox || !targetBox) return Number.POSITIVE_INFINITY;
+        const horizontalDelta = Math.abs(
+          canvasBox.x + canvasBox.width / 2 -
+            (targetBox.x + targetBox.width / 2),
+        );
+        const verticalDelta = Math.abs(
+          canvasBox.y + canvasBox.height / 2 -
+            (targetBox.y + targetBox.height / 2),
+        );
+        return Math.max(horizontalDelta, verticalDelta);
+      })
+      .toBeLessThan(3);
+  });
+
   test("opens the kanban terminal popover from sidebar activity rows", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

Canvas notifications now bring their destination session to the center of the viewport while preserving the current zoom level.

1. **Notification routing** — mark notification-driven session opens from the status bar, sidebar activity, command palette, and system notifications as canvas-centering requests.
2. **Canvas navigation** — extend the existing `acorn:focus-session` contract with an opt-in center target and calculate the viewport offset from the live canvas dimensions.
3. **Regression coverage** — cover the centering math and the full notification-click interaction without changing normal session or minimap reveal behavior.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Notification click in canvas mode | Target session is only moved enough to become visible | Target session is placed at the canvas center |
| Canvas zoom | Preserved | Preserved |
| Normal session and minimap navigation | Reveal target without forced centering | Unchanged |

## Design notes

- `openSessionSurface` accepts an optional notification-specific centering intent so ordinary session selection keeps its existing behavior.
- The typed focus event carries `canvasTarget: "center"`; non-canvas consumers continue to use the existing session id and canvas falls back to reveal semantics when the target is absent.
- Centering reads the live canvas dimensions at action time to avoid stale resize measurements during workspace layout changes.
- The centering path composes with the latest canvas alignment and zoom-reveal behavior from `main`.

## Test plan

- [x] `pnpm test` — 100 test files, 1,140 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec vitest run src/lib/workspaceCanvas.test.ts src/lib/notifications.test.ts` — 2 test files, 34 tests passed
- [x] `pnpm exec playwright test tests/e2e/session-notifications.spec.ts tests/e2e/canvas.spec.ts` — 20 tests passed
- [x] `git diff --cached --check` — passed
