### PR TITLE
feat(projects): remember the last new-project location

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9993,4 +9993,41 @@ mod tests {
         );
         assert_eq!(infer_acornd_root_from_session_pids(&by_pid, &[999]), None);
     }
+
+    #[test]
+    fn remembered_project_parent_folder_is_regranted_when_it_exists() {
+        let app_data = tempfile::tempdir().unwrap();
+        let parent_root = tempfile::tempdir().unwrap();
+        let parent = parent_root.path().join("projects");
+        std::fs::create_dir(&parent).unwrap();
+        crate::persistence::save_last_project_parent_folder_to_dir(app_data.path(), &parent)
+            .unwrap();
+        let state = crate::state::AppState::default();
+
+        let restored = super::get_last_project_parent_folder_from_dir(&state, app_data.path())
+            .unwrap();
+
+        let canonical = parent.canonicalize().unwrap();
+        assert_eq!(restored, Some(canonical.to_string_lossy().into_owned()));
+        assert_eq!(state.folder_grants.lock().as_slice(), &[canonical]);
+    }
+
+    #[test]
+    fn missing_remembered_project_parent_folder_is_cleared() {
+        let app_data = tempfile::tempdir().unwrap();
+        let missing = app_data.path().join("removed-projects");
+        crate::persistence::save_last_project_parent_folder_to_dir(app_data.path(), &missing)
+            .unwrap();
+        let state = crate::state::AppState::default();
+
+        let restored = super::get_last_project_parent_folder_from_dir(&state, app_data.path())
+            .unwrap();
+
+        assert_eq!(restored, None);
+        assert_eq!(
+            crate::persistence::load_last_project_parent_folder_from_dir(app_data.path()).unwrap(),
+            None
+        );
+        assert!(state.folder_grants.lock().is_empty());
+    }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3336,7 +3336,73 @@ pub async fn select_project_parent_folder<R: Runtime>(
         return Ok(None);
     };
     let path = remember_folder_grant(state.inner(), &path)?;
+    if let Err(err) = persistence::save_last_project_parent_folder(&path) {
+        tracing::warn!(
+            error = %err,
+            path = %path.display(),
+            "failed to remember project parent folder"
+        );
+    }
     Ok(Some(path.to_string_lossy().into_owned()))
+}
+
+#[tauri::command]
+pub fn get_last_project_parent_folder(state: State<'_, AppState>) -> AppResult<Option<String>> {
+    let data_dir = persistence::data_dir()?;
+    get_last_project_parent_folder_from_dir(state.inner(), &data_dir)
+}
+
+fn get_last_project_parent_folder_from_dir(
+    state: &AppState,
+    data_dir: &Path,
+) -> AppResult<Option<String>> {
+    let remembered = match persistence::load_last_project_parent_folder_from_dir(data_dir) {
+        Ok(value) => value,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to load remembered project parent folder");
+            if let Err(clear_err) = persistence::clear_last_project_parent_folder_from_dir(data_dir)
+            {
+                tracing::warn!(
+                    error = %clear_err,
+                    "failed to clear invalid remembered project parent folder"
+                );
+            }
+            return Ok(None);
+        }
+    };
+    let Some(path) = remembered else {
+        return Ok(None);
+    };
+
+    if !path.is_dir() {
+        if let Err(err) = persistence::clear_last_project_parent_folder_from_dir(data_dir) {
+            tracing::warn!(
+                error = %err,
+                path = %path.display(),
+                "failed to clear missing remembered project parent folder"
+            );
+        }
+        return Ok(None);
+    }
+
+    match remember_folder_grant(state, &path) {
+        Ok(path) => Ok(Some(path.to_string_lossy().into_owned())),
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                path = %path.display(),
+                "remembered project parent folder is no longer accessible"
+            );
+            if let Err(clear_err) = persistence::clear_last_project_parent_folder_from_dir(data_dir)
+            {
+                tracing::warn!(
+                    error = %clear_err,
+                    "failed to clear inaccessible remembered project parent folder"
+                );
+            }
+            Ok(None)
+        }
+    }
 }
 
 #[tauri::command]
@@ -10004,8 +10070,8 @@ mod tests {
             .unwrap();
         let state = crate::state::AppState::default();
 
-        let restored = super::get_last_project_parent_folder_from_dir(&state, app_data.path())
-            .unwrap();
+        let restored =
+            super::get_last_project_parent_folder_from_dir(&state, app_data.path()).unwrap();
 
         let canonical = parent.canonicalize().unwrap();
         assert_eq!(restored, Some(canonical.to_string_lossy().into_owned()));
@@ -10020,8 +10086,8 @@ mod tests {
             .unwrap();
         let state = crate::state::AppState::default();
 
-        let restored = super::get_last_project_parent_folder_from_dir(&state, app_data.path())
-            .unwrap();
+        let restored =
+            super::get_last_project_parent_folder_from_dir(&state, app_data.path()).unwrap();
 
         assert_eq!(restored, None);
         assert_eq!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -709,6 +709,7 @@ pub fn run() {
             commands::list_projects,
             commands::add_project,
             commands::select_project_parent_folder,
+            commands::get_last_project_parent_folder,
             commands::create_new_project,
             commands::remove_project,
             commands::get_project_settings,

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -14,6 +14,8 @@ const SESSIONS_FILE: &str = "sessions.json";
 const SESSIONS_TMP_FILE: &str = "sessions.json.tmp";
 const PROJECTS_FILE: &str = "projects.json";
 const PROJECTS_TMP_FILE: &str = "projects.json.tmp";
+const LAST_PROJECT_PARENT_FOLDER_FILE: &str = "last-project-parent-folder.json";
+const LAST_PROJECT_PARENT_FOLDER_TMP_FILE: &str = "last-project-parent-folder.json.tmp";
 const CHAT_SESSIONS_DIR: &str = "chat-sessions";
 pub const CHAT_SESSION_SCHEMA_VERSION: u32 = 1;
 static SESSION_SAVE_LOCK: Mutex<()> = Mutex::new(());
@@ -469,6 +471,68 @@ pub fn save_projects(projects: &[Project]) -> AppResult<()> {
         path = %final_path.display(),
         "saved projects to disk"
     );
+    Ok(())
+}
+
+fn last_project_parent_folder_path(base_dir: &Path) -> PathBuf {
+    base_dir.join(LAST_PROJECT_PARENT_FOLDER_FILE)
+}
+
+fn last_project_parent_folder_tmp_path(base_dir: &Path) -> PathBuf {
+    base_dir.join(LAST_PROJECT_PARENT_FOLDER_TMP_FILE)
+}
+
+pub(crate) fn load_last_project_parent_folder_from_dir(
+    base_dir: &Path,
+) -> AppResult<Option<PathBuf>> {
+    let path = last_project_parent_folder_path(base_dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(path)?;
+    let value = serde_json::from_slice::<String>(&bytes).map_err(|err| {
+        AppError::Other(format!(
+            "failed to parse remembered project parent folder: {err}"
+        ))
+    })?;
+    if value.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(PathBuf::from(value)))
+}
+
+pub(crate) fn save_last_project_parent_folder_to_dir(
+    base_dir: &Path,
+    parent: &Path,
+) -> AppResult<()> {
+    fs::create_dir_all(base_dir)?;
+    let final_path = last_project_parent_folder_path(base_dir);
+    let tmp_path = last_project_parent_folder_tmp_path(base_dir);
+    let payload = serde_json::to_vec(&parent.to_string_lossy().into_owned()).map_err(|err| {
+        AppError::Other(format!(
+            "failed to serialize remembered project parent folder: {err}"
+        ))
+    })?;
+    fs::write(&tmp_path, payload)?;
+    fs::rename(tmp_path, final_path)?;
+    Ok(())
+}
+
+pub fn save_last_project_parent_folder(parent: &Path) -> AppResult<()> {
+    save_last_project_parent_folder_to_dir(&data_dir()?, parent)
+}
+
+pub(crate) fn clear_last_project_parent_folder_from_dir(base_dir: &Path) -> AppResult<()> {
+    for path in [
+        last_project_parent_folder_path(base_dir),
+        last_project_parent_folder_tmp_path(base_dir),
+    ] {
+        match fs::remove_file(path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(AppError::Io(err)),
+        }
+    }
     Ok(())
 }
 

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -958,6 +958,24 @@ mod tests {
     }
 
     #[test]
+    fn remembered_project_parent_folder_round_trips_and_clears() {
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = tmp.path().join("projects");
+
+        save_last_project_parent_folder_to_dir(tmp.path(), &parent).unwrap();
+        assert_eq!(
+            load_last_project_parent_folder_from_dir(tmp.path()).unwrap(),
+            Some(parent)
+        );
+
+        clear_last_project_parent_folder_from_dir(tmp.path()).unwrap();
+        assert_eq!(
+            load_last_project_parent_folder_from_dir(tmp.path()).unwrap(),
+            None
+        );
+    }
+
+    #[test]
     fn missing_chat_state_returns_empty_state() {
         let tmp = tempfile::tempdir().unwrap();
         let session_id = uuid::Uuid::new_v4().to_string();

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -1,5 +1,5 @@
 import { FolderPlus } from "lucide-react";
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { api } from "../lib/api";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
@@ -43,14 +43,32 @@ export function NewProjectDialog({
   const [error, setError] = useState<string | null>(null);
   const [ignoreSafeName, setIgnoreSafeName] = useState(false);
   const [pending, setPending] = useState(false);
+  const locationPickedRef = useRef(false);
 
   useEffect(() => {
     if (!isOpen) return;
+    let cancelled = false;
+    locationPickedRef.current = false;
     setName("");
     setParentPath("");
     setError(null);
     setIgnoreSafeName(false);
     setPending(false);
+    void api
+      .getLastProjectParentFolder()
+      .then((path) => {
+        if (!cancelled && !locationPickedRef.current) {
+          setParentPath(path ?? "");
+        }
+      })
+      .catch(() => {
+        if (!cancelled && !locationPickedRef.current) {
+          setParentPath("");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [isOpen]);
 
   useDialogShortcuts(isOpen, {
@@ -84,6 +102,7 @@ export function NewProjectDialog({
       dt(t, "dialogs.newProject.selectParentFolder"),
     );
     if (!picked) return;
+    locationPickedRef.current = true;
     setParentPath(picked);
     setError(null);
   }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -279,6 +279,9 @@ export const api = {
   selectProjectParentFolder(title?: string): Promise<string | null> {
     return invoke<string | null>("select_project_parent_folder", { title });
   },
+  getLastProjectParentFolder(): Promise<string | null> {
+    return invoke<string | null>("get_last_project_parent_folder");
+  },
   createNewProject(
     parentPath: string,
     name: string,

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -111,6 +111,9 @@ export const tauriMockSource = `
     if (cmd === 'select_project_parent_folder') {
       return Promise.resolve('/tmp');
     }
+    if (cmd === 'get_last_project_parent_folder') {
+      return Promise.resolve(null);
+    }
     if (cmd === 'create_session_from_dialog') {
       return Promise.resolve(null);
     }

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -3756,6 +3756,59 @@ test.describe("sidebar: project lifecycle", () => {
     });
   });
 
+  test("New project remembers the most recently selected parent folder", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("get_last_project_parent_folder", () => {
+      const w = window as unknown as { __lastProjectParent?: string };
+      return w.__lastProjectParent ?? null;
+    });
+    await tauri.handle("select_project_parent_folder", () => {
+      const w = window as unknown as { __lastProjectParent?: string };
+      w.__lastProjectParent = "/tmp/remembered-parent";
+      return w.__lastProjectParent;
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "New project" }).click();
+    await expect(page.getByLabel("Project location")).toHaveValue("");
+
+    await page.getByRole("button", { name: "Choose" }).click();
+    await expect(page.getByLabel("Project location")).toHaveValue(
+      "/tmp/remembered-parent",
+    );
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await page.getByRole("button", { name: "New project" }).click();
+
+    await expect(page.getByLabel("Project location")).toHaveValue(
+      "/tmp/remembered-parent",
+    );
+  });
+
+  test("New project falls back to an empty location when the remembered folder is missing", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("get_last_project_parent_folder", () => {
+      const w = window as unknown as { __lastParentReads?: number };
+      w.__lastParentReads = (w.__lastParentReads ?? 0) + 1;
+      return w.__lastParentReads === 1 ? "/tmp/removed-parent" : null;
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "New project" }).click();
+    await expect(page.getByLabel("Project location")).toHaveValue(
+      "/tmp/removed-parent",
+    );
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await page.getByRole("button", { name: "New project" }).click();
+
+    await expect(page.getByLabel("Project location")).toHaveValue("");
+  });
+
   test("New project can override long-name safe warnings", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

New Project now reopens at the last selected parent folder without weakening Acorn's native folder-grant boundary.

1. **Remember the parent folder** — persist the canonical parent path after the native folder picker grants it.
2. **Restore safely** — validate the saved directory on reopen, re-register its backend grant, and clear missing, malformed, or inaccessible paths.
3. **Keep modal updates race-safe** — cancel stale async restores and preserve a newer picker result.
4. **Cover the full flow** — add Rust persistence/grant tests and Playwright regressions for restore and empty fallback behavior.

## Expected impact

| Flow | Before | After |
| --- | --- | --- |
| Reopen New Project | Location is always empty | Last valid parent folder is restored |
| Restart Acorn | Previous selection is unavailable | Backend validates and re-grants the saved folder |
| Remembered folder was removed | No remembered state | Location falls back to empty and the stale record is cleared |

## Design notes

- The remembered path is backend-owned instead of localStorage-owned. This prevents renderer-controlled state from bypassing the existing rule that new project roots must originate from Acorn's native folder picker.
- The path is written atomically under Acorn's profile data directory. Restore errors are non-blocking so the modal remains usable with an empty Location.
- The frontend restore effect follows the existing StrictMode cancellation pattern and cannot overwrite a folder selected while restoration is pending.

## Test plan

- [x] pnpm run test — 100 files, 1,125 tests passed
- [x] cargo test --manifest-path src-tauri/Cargo.toml — 594 passed, 1 pre-existing ignored
- [x] pnpm exec playwright test tests/e2e/sidebar.spec.ts --grep remembered/new-project cases — 3 passed
- [x] pnpm run build — production bundle completed

## Notes

- The production build reports the existing dynamic-import and chunk-size warnings. These are not caused by this PR.
- Rust reports the existing unused cache len-method warnings. These are not caused by this PR.
