### PR TITLE
fix(github): keep dark labels readable across themes

### DIFF
--- a/src/components/GitHubLabelChip.tsx
+++ b/src/components/GitHubLabelChip.tsx
@@ -17,8 +17,8 @@ export function GitHubLabelChip({
   const color = `#${hex}`;
   const labelStyle: CSSProperties = {
     backgroundColor: `${color}1f`,
-    borderColor: `${color}40`,
-    color,
+    borderColor: `color-mix(in srgb, ${color} 65%, var(--color-fg))`,
+    color: "var(--color-fg)",
     ...style,
   };
 

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -98,6 +98,47 @@ test.describe("right panel: tab switching", () => {
     await expect(page.getByText(/Select a commit to see diff/i)).toBeVisible();
   });
 
+  test("keeps black GitHub labels readable in the dark theme", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    await tauri.respond("list_pull_requests", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 91,
+          title: "Keep dark labels readable",
+          state: "OPEN",
+          author: "im-ian",
+          head_branch: "fix/label-contrast",
+          base_branch: "main",
+          url: "https://github.com/im-ian/acorn/pull/91",
+          updated_at: "2026-07-20T00:00:00Z",
+          is_draft: false,
+          checks: null,
+          labels: [{ name: "github_actions", color: "000000" }],
+        },
+      ],
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await page.getByRole("button", { name: "PRs" }).click();
+
+    const label = page.getByText("github_actions", { exact: true }).locator("..");
+    await expect(label).toBeVisible();
+    const colors = await label.evaluate((element) => ({
+      label: getComputedStyle(element).color,
+      foreground: getComputedStyle(document.body).color,
+      border: getComputedStyle(element).borderColor,
+    }));
+
+    expect(colors.label).toBe(colors.foreground);
+    expect(colors.border).not.toBe("rgb(0, 0, 0)");
+  });
+
   test("double-clicking a commit opens the diff modal before the diff finishes loading", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
GitHub label chips now remain legible when repositories use black or near-black label colors on Acorn's dark themes.

1. **Theme-aware text** — render label names with the active theme foreground while preserving the GitHub label color in the chip background.
2. **Visible outlines** — blend label borders toward the theme foreground so very dark colors retain a visible chip boundary.
3. **Regression coverage** — exercise a black `github_actions` label in the real PR-list UI and verify its computed text and border colors.

## Expected impact
| Scenario | Before | After |
| --- | --- | --- |
| Black or near-black label on a dark theme | Text and outline can disappear into the panel surface | Label name uses the readable theme foreground and the outline remains visible |
| Colored GitHub labels | Original color drives all chip paint | Original color remains in the background and border treatment while text contrast follows the theme |
| PR/issue lists and detail modals | Contrast varies by label color | Shared label component applies the same behavior across every surface |

## Design notes
- The fix lives in the shared `GitHubLabelChip`, which is used by PR rows, issue rows, and both detail modals.
- Theme CSS variables adapt immediately to built-in and custom themes without adding a theme-mode branch or one-off handling for black.
- Caller-provided inline styles still override the component defaults.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` — 100 files, 1,140 tests pass
- [x] `pnpm run build` passes
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts --grep "keeps black GitHub labels readable"` — 1 test passes
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts` — 29 tests pass
