### PR TITLE
fix(canvas): start at origin and place new sessions near active nodes

### DIFF
--- a/src/components/WorkspaceCanvas.tsx
+++ b/src/components/WorkspaceCanvas.tsx
@@ -255,6 +255,10 @@ export function WorkspaceCanvas({
     return reconcileWorkspaceCanvasState(persisted, reconciliationIds);
   });
   const canvasRef = useRef(canvas);
+  // Session creation can activate the new id before its canvas node exists.
+  const placementAnchorSessionIdRef = useRef<string | null>(
+    activeSessionId && canvas.nodes[activeSessionId] ? activeSessionId : null,
+  );
   const resetUndoRef = useRef<WorkspaceCanvasState | null>(null);
   const [canUndoReset, setCanUndoReset] = useState(false);
   const [contextMenu, setContextMenu] = useState<{
@@ -380,13 +384,36 @@ export function WorkspaceCanvas({
 
   useEffect(() => {
     const current = canvasRef.current;
-    const next = reconcileWorkspaceCanvasState(current, reconciliationIds);
+    const placementAnchorSessionId =
+      activeSessionId && current.nodes[activeSessionId]
+        ? activeSessionId
+        : placementAnchorSessionIdRef.current;
+    const next = reconcileWorkspaceCanvasState(
+      current,
+      reconciliationIds,
+      placementAnchorSessionId,
+    );
     setInteractionHints(null);
     if (workspaceCanvasStatesEqual(current, next)) return;
     clearResetUndo();
     applyCanvas(next);
     persistCanvas(next);
-  }, [applyCanvas, clearResetUndo, persistCanvas, reconciliationIds]);
+  }, [
+    activeSessionId,
+    applyCanvas,
+    clearResetUndo,
+    persistCanvas,
+    reconciliationIds,
+  ]);
+
+  useEffect(() => {
+    if (!activeSessionId) {
+      placementAnchorSessionIdRef.current = null;
+      return;
+    }
+    if (!canvasRef.current.nodes[activeSessionId]) return;
+    placementAnchorSessionIdRef.current = activeSessionId;
+  }, [activeSessionId, reconciliationIds]);
 
   useEffect(() => {
     const root = rootRef.current;

--- a/src/components/WorkspaceMain.test.tsx
+++ b/src/components/WorkspaceMain.test.tsx
@@ -240,18 +240,18 @@ describe("WorkspaceMain", () => {
     );
     firePointer(dragHandle!, "pointerdown", { clientX: 100, clientY: 100 });
     firePointer(window, "pointerup", { clientX: 100, clientY: 100 });
-    expect(alpha!.dataset.canvasNodeX).toBe("40");
-    expect(alpha!.dataset.canvasNodeY).toBe("40");
+    expect(alpha!.dataset.canvasNodeX).toBe("0");
+    expect(alpha!.dataset.canvasNodeY).toBe("0");
 
     firePointer(dragHandle!, "pointerdown", { clientX: 100, clientY: 100 });
     firePointer(window, "pointermove", { clientX: 152, clientY: 132 });
     firePointer(window, "pointerup", { clientX: 152, clientY: 132 });
 
-    expect(alpha!.dataset.canvasNodeX).toBe("100");
-    expect(alpha!.dataset.canvasNodeY).toBe("80");
+    expect(alpha!.dataset.canvasNodeX).toBe("60");
+    expect(alpha!.dataset.canvasNodeY).toBe("40");
     expect(
       useAppStore.getState().workspaces[REPO].canvas?.nodes.alpha,
-    ).toMatchObject({ x: 100, y: 80 });
+    ).toMatchObject({ x: 60, y: 40 });
 
     const resizeHandle = alpha!.querySelector<HTMLElement>(
       "[data-testid='workspace-canvas-node-resize-handle']",
@@ -265,8 +265,8 @@ describe("WorkspaceMain", () => {
 
     expect(alpha!.dataset.canvasNodeWidth).toBe("700");
     expect(alpha!.dataset.canvasNodeHeight).toBe("460");
-    expect(alpha!.dataset.canvasNodeX).toBe("100");
-    expect(alpha!.dataset.canvasNodeY).toBe("80");
+    expect(alpha!.dataset.canvasNodeX).toBe("60");
+    expect(alpha!.dataset.canvasNodeY).toBe("40");
     expect(
       useAppStore.getState().workspaces[REPO].canvas?.nodes.alpha,
     ).toMatchObject({ width: 700, height: 460 });

--- a/src/lib/workspaceCanvas.test.ts
+++ b/src/lib/workspaceCanvas.test.ts
@@ -83,8 +83,8 @@ describe("workspaceCanvas", () => {
     const result = resetWorkspaceCanvasState(["a", "b", "c"]);
 
     expect(result.nodes.a).toMatchObject({
-      x: 40,
-      y: 40,
+      x: 0,
+      y: 0,
       width: 620,
       height: 400,
     });
@@ -117,11 +117,56 @@ describe("workspaceCanvas", () => {
       zIndex: 1,
     });
     expect(result.nodes.new).toEqual({
-      x: 720,
-      y: 40,
+      x: 680,
+      y: 0,
       width: 620,
       height: 400,
       zIndex: 2,
+    });
+  });
+
+  it("places a new session beside the active canvas session", () => {
+    const result = reconcileWorkspaceCanvasState(
+      {
+        viewport: { offset: { x: -120, y: 40 }, zoom: 1 },
+        nodes: {
+          active: { x: 100, y: 200, width: 700, height: 460, zIndex: 4 },
+          other: { x: 0, y: 0, width: 620, height: 400, zIndex: 2 },
+        },
+      },
+      ["active", "other", "new"],
+      "active",
+    );
+
+    expect(result.nodes.active).toMatchObject({ x: 100, y: 200, zIndex: 4 });
+    expect(result.nodes.new).toEqual({
+      x: 860,
+      y: 200,
+      width: 620,
+      height: 400,
+      zIndex: 5,
+    });
+  });
+
+  it("uses another nearby side when the active session's right side is occupied", () => {
+    const result = reconcileWorkspaceCanvasState(
+      {
+        viewport: { offset: { x: 48, y: 48 }, zoom: 1 },
+        nodes: {
+          active: { x: 0, y: 0, width: 620, height: 400, zIndex: 1 },
+          right: { x: 680, y: 0, width: 620, height: 400, zIndex: 2 },
+        },
+      },
+      ["active", "right", "new"],
+      "active",
+    );
+
+    expect(result.nodes.new).toEqual({
+      x: 0,
+      y: 460,
+      width: 620,
+      height: 400,
+      zIndex: 3,
     });
   });
 

--- a/src/lib/workspaceCanvas.ts
+++ b/src/lib/workspaceCanvas.ts
@@ -78,7 +78,7 @@ const WORKSPACE_CANVAS_MAX_NODE_WIDTH = 2_400;
 const WORKSPACE_CANVAS_MAX_NODE_HEIGHT = 1_600;
 const WORKSPACE_CANVAS_COORDINATE_LIMIT = 100_000;
 const WORKSPACE_CANVAS_NODE_GAP = WORKSPACE_CANVAS_GRID_SIZE * 3;
-const WORKSPACE_CANVAS_NODE_ORIGIN = WORKSPACE_CANVAS_GRID_SIZE * 2;
+const WORKSPACE_CANVAS_NODE_ORIGIN = 0;
 const WORKSPACE_CANVAS_DEFAULT_COLUMNS = 2;
 
 export function defaultWorkspaceCanvasViewport(): WorkspaceCanvasViewport {
@@ -225,12 +225,11 @@ function nodesOverlap(
   first: WorkspaceCanvasNode,
   second: WorkspaceCanvasNode,
 ): boolean {
-  const gap = WORKSPACE_CANVAS_NODE_GAP / 2;
   return !(
-    first.x + first.width + gap <= second.x ||
-    second.x + second.width + gap <= first.x ||
-    first.y + first.height + gap <= second.y ||
-    second.y + second.height + gap <= first.y
+    first.x + first.width <= second.x ||
+    second.x + second.width <= first.x ||
+    first.y + first.height <= second.y ||
+    second.y + second.height <= first.y
   );
 }
 
@@ -247,9 +246,69 @@ function nextOpenNode(
   return defaultNodeAt(existing.length, zIndex);
 }
 
+function snapWorkspaceCanvasUp(value: number): number {
+  return normalizeZero(
+    Math.ceil(value / WORKSPACE_CANVAS_GRID_SIZE) * WORKSPACE_CANVAS_GRID_SIZE,
+  );
+}
+
+function snapWorkspaceCanvasDown(value: number): number {
+  return normalizeZero(
+    Math.floor(value / WORKSPACE_CANVAS_GRID_SIZE) * WORKSPACE_CANVAS_GRID_SIZE,
+  );
+}
+
+function nextOpenNodeNear(
+  existing: readonly WorkspaceCanvasNode[],
+  anchor: WorkspaceCanvasNode,
+  zIndex: number,
+): WorkspaceCanvasNode {
+  const alignedX = snapWorkspaceCanvasValue(anchor.x);
+  const alignedY = snapWorkspaceCanvasValue(anchor.y);
+  const rightX = snapWorkspaceCanvasUp(
+    anchor.x + anchor.width + WORKSPACE_CANVAS_NODE_GAP,
+  );
+  const belowY = snapWorkspaceCanvasUp(
+    anchor.y + anchor.height + WORKSPACE_CANVAS_NODE_GAP,
+  );
+  const leftX = snapWorkspaceCanvasDown(
+    anchor.x - WORKSPACE_CANVAS_NODE_GAP - WORKSPACE_CANVAS_DEFAULT_NODE_WIDTH,
+  );
+  const aboveY = snapWorkspaceCanvasDown(
+    anchor.y -
+      WORKSPACE_CANVAS_NODE_GAP -
+      WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT,
+  );
+  const positions: readonly WorkspaceCanvasPoint[] = [
+    { x: rightX, y: alignedY },
+    { x: alignedX, y: belowY },
+    { x: leftX, y: alignedY },
+    { x: alignedX, y: aboveY },
+    { x: rightX, y: belowY },
+    { x: leftX, y: belowY },
+    { x: rightX, y: aboveY },
+    { x: leftX, y: aboveY },
+  ];
+
+  for (const position of positions) {
+    const candidate = clampWorkspaceCanvasNode({
+      ...position,
+      width: WORKSPACE_CANVAS_DEFAULT_NODE_WIDTH,
+      height: WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT,
+      zIndex,
+    });
+    if (!existing.some((node) => nodesOverlap(candidate, node))) {
+      return candidate;
+    }
+  }
+
+  return nextOpenNode(existing, zIndex);
+}
+
 export function reconcileWorkspaceCanvasState(
   value: unknown,
   sessionIds: readonly string[],
+  placementAnchorSessionId: string | null = null,
 ): WorkspaceCanvasState {
   const normalized = normalizeWorkspaceCanvasState(value) ?? {
     viewport: defaultWorkspaceCanvasViewport(),
@@ -269,7 +328,13 @@ export function reconcileWorkspaceCanvasState(
   for (const id of ids) {
     if (nodes[id]) continue;
     maxZ += 1;
-    nodes[id] = nextOpenNode(Object.values(nodes), maxZ);
+    const existing = Object.values(nodes);
+    const anchor = placementAnchorSessionId
+      ? nodes[placementAnchorSessionId]
+      : undefined;
+    nodes[id] = anchor
+      ? nextOpenNodeNear(existing, anchor, maxZ)
+      : nextOpenNode(existing, maxZ);
   }
 
   return { viewport: normalized.viewport, nodes };

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -153,6 +153,8 @@ test.describe("workspace canvas mode", () => {
       '[data-canvas-session-id="canvas-created"]',
     );
     await expect(node).toBeVisible();
+    await expect(node).toHaveAttribute("data-canvas-node-x", "0");
+    await expect(node).toHaveAttribute("data-canvas-node-y", "0");
     const calls = await page.evaluate(
       () =>
         (
@@ -191,6 +193,8 @@ test.describe("workspace canvas mode", () => {
 
     const chatNode = canvas.locator('[data-canvas-session-id="canvas-chat"]');
     await expect(chatNode).toBeVisible();
+    await expect(chatNode).toHaveAttribute("data-canvas-node-x", "680");
+    await expect(chatNode).toHaveAttribute("data-canvas-node-y", "0");
     await expect(
       chatNode.getByRole("textbox", { name: "Chat message" }),
     ).toBeVisible();
@@ -762,7 +766,7 @@ test.describe("workspace canvas mode", () => {
       dragBox.y + dragBox.height / 2 + 60,
     );
 
-    await expect(alpha).toHaveAttribute("data-canvas-node-x", "720");
+    await expect(alpha).toHaveAttribute("data-canvas-node-x", "680");
     await expect(
       canvas.locator('[data-canvas-alignment-axis="x"]'),
     ).toBeVisible();
@@ -771,7 +775,7 @@ test.describe("workspace canvas mode", () => {
     await expect(
       canvas.locator('[data-canvas-alignment-axis="x"]'),
     ).toHaveCount(0);
-    await expect(alpha).toHaveAttribute("data-canvas-node-x", "720");
+    await expect(alpha).toHaveAttribute("data-canvas-node-x", "680");
   });
 
   test("keeps Alt gestures on whole pixels when the canvas loses focus", async ({
@@ -937,8 +941,8 @@ test.describe("workspace canvas mode", () => {
     await page.mouse.move(start.x, start.y);
     await page.mouse.down();
     await page.mouse.move(start.x + 100, start.y + 6);
-    await expect(alpha).toHaveAttribute("data-canvas-node-x", "140");
-    await expect(alpha).toHaveAttribute("data-canvas-node-y", "40");
+    await expect(alpha).toHaveAttribute("data-canvas-node-x", "100");
+    await expect(alpha).toHaveAttribute("data-canvas-node-y", "0");
     await expect(
       canvas.locator('[data-canvas-alignment-axis="y"]'),
     ).toBeVisible();
@@ -948,8 +952,8 @@ test.describe("workspace canvas mode", () => {
         new PointerEvent("pointercancel", { clientX: 0, clientY: 0 }),
       ),
     );
-    await expect(alpha).toHaveAttribute("data-canvas-node-x", "140");
-    await expect(alpha).toHaveAttribute("data-canvas-node-y", "40");
+    await expect(alpha).toHaveAttribute("data-canvas-node-x", "100");
+    await expect(alpha).toHaveAttribute("data-canvas-node-y", "0");
     await expect(canvas.getByTestId("workspace-canvas-alignment-guide"))
       .toHaveCount(0);
     await page.mouse.up();
@@ -1282,7 +1286,7 @@ test.describe("workspace canvas mode", () => {
       y: await alpha.getAttribute("data-canvas-node-y"),
       zoom: await world.getAttribute("data-canvas-zoom"),
     };
-    expect(beforeReset.x).not.toBe("40");
+    expect(beforeReset.x).not.toBe("0");
     expect(beforeReset.zoom).not.toBe("1");
 
     const terminalSlot = alpha.locator(
@@ -1294,8 +1298,8 @@ test.describe("workspace canvas mode", () => {
     );
     await page.getByRole("button", { name: "Reset session layout" }).click();
 
-    await expect(alpha).toHaveAttribute("data-canvas-node-x", "40");
-    await expect(alpha).toHaveAttribute("data-canvas-node-y", "40");
+    await expect(alpha).toHaveAttribute("data-canvas-node-x", "0");
+    await expect(alpha).toHaveAttribute("data-canvas-node-y", "0");
     await expect(world).toHaveAttribute("data-canvas-zoom", "1");
 
     await expect(


### PR DESCRIPTION
## Summary

Canvas session creation now starts from a predictable world origin and keeps new windows close to the current context.

1. **Zero-origin defaults** — place the first session and reset layouts at `(0, 0)` while retaining viewport padding so the canvas toolbar stays clear.
2. **Active-session placement** — retain the last active canvas session through asynchronous creation, then search adjacent grid positions right-first before falling back to the global layout.
3. **Compatibility and coverage** — preserve stored node coordinates, avoid actual node overlap, and cover both terminal and chat creation paths.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| First session on an empty canvas | Starts at `(40, 40)` | Starts at `(0, 0)` |
| New session with an active canvas node | Uses the next global two-column slot | Uses the nearest available adjacent slot, right-first |
| Existing saved canvas layout | Existing coordinates are preserved | Existing coordinates remain preserved; only new nodes are placed |

## Design notes

- `reconcileWorkspaceCanvasState` accepts an optional placement anchor and evaluates grid-aligned positions around that node in right, below, left, above, then diagonal order.
- `WorkspaceCanvas` retains the last active canvas session because session creation can activate the new id before its canvas node exists.
- Candidate placement checks actual rectangle overlap. The normal 60px grid gap remains part of generated positions, while older off-origin layouts can still use the closest non-overlapping slot.
- The viewport keeps its 48px visual offset; `(0, 0)` is the canvas world coordinate.

## Test plan

- [x] `pnpm test` — 100 files, 1,142 tests passed
- [x] `PLAYWRIGHT_PORT=1421 pnpm exec playwright test tests/e2e/canvas.spec.ts` — 16 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — production build passed
- [x] `git diff --check` — passed

## Notes

- Vite continues to report the existing mixed static/dynamic import and large-chunk warnings during `pnpm run build`; the build succeeds and these warnings are not caused by this PR.