### PR TITLE
chore(release): v1.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.27.0",
+  "version": "1.28.0",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.27.0"
+version = "1.28.0"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.27.0"
+version = "1.28.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Cuts Acorn v1.28.0 from the final green `main` after merging every open pull request.

1. **Version synchronization:** updates `package.json`, Tauri config, Cargo manifest, and Cargo lock metadata from `1.27.0` to `1.28.0`.
2. **Release scope:** includes the canvas/session features, project-location memory, lifecycle and file refresh fixes, GitHub label readability, diff/terminal/bundle performance work, security hardening, and dependency/toolchain refreshes merged since v1.27.0.
3. **Publication path:** prepares the exact commit that will be tagged `v1.28.0` for the macOS universal and Apple Silicon release workflow.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Application version | All runtime and packaging metadata report `1.28.0`. |
| User-visible changes | New canvas/session workflows plus accumulated fixes and performance improvements become available in the stable channel. |
| Updater | The release workflow will publish bilingual notes and signed artifacts for both supported macOS architectures. |

## Design notes

- This is a minor release because the range includes user-visible features in #679, #693, and #694.
- The release commit contains version metadata only; implementation changes were reviewed and merged independently before this bump.
- The generated notes group changes into Features, Fixes, Performance, Security, and Build & CI with Korean and English summaries.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 1,142 tests passed
- [x] `pnpm run build`
- [x] `pnpm audit --audit-level=moderate` — no known vulnerabilities
- [x] `cargo metadata --locked --no-deps --format-version 1 --manifest-path src-tauri/Cargo.toml`
- [x] `node scripts/validate-release-version.mjs v1.28.0`
- [x] Release-note generation and validation tests — 9 tests passed

## Notes

- `v1.28.0` does not yet exist as a local tag, remote tag, or GitHub release.
- The release PR uses `skip-changelog` so the metadata-only bump is not listed as a product change.
