### PR TITLE
fix(sessions): sync Acorn tab titles to Codex and Claude

### DIFF
--- a/src-tauri/src/agent_session_names.rs
+++ b/src-tauri/src/agent_session_names.rs
@@ -1,0 +1,527 @@
+//! Best-effort propagation of Acorn tab titles into provider-native sessions.
+//!
+//! Acorn remains the source of truth for its own tab title. Provider updates
+//! run on one background worker so a slow or unavailable CLI never blocks a
+//! rename, and successive renames are applied in the same order Acorn stored
+//! them.
+
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::{mpsc, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+use acorn_agent::AgentKind;
+use acorn_session::{Session, SessionKind, SessionMode, SessionOwner, SessionTitleSource};
+use serde_json::{json, Value};
+
+use crate::agent_resume::LiveTranscript;
+
+const CODEX_RPC_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_PROVIDER_TITLE_BYTES: usize = 1_024;
+
+struct TitleSyncRequest {
+    target: LiveTranscript,
+    title: String,
+}
+
+enum ReaderEvent {
+    Line(String),
+    Error(String),
+    Eof,
+}
+
+/// Queue a provider-native title update without delaying or failing the Acorn
+/// operation that produced it. Antigravity has no verified naming interface,
+/// so it is intentionally left unchanged.
+pub fn enqueue(target: LiveTranscript, title: impl Into<String>) {
+    if target.kind == AgentKind::Antigravity {
+        return;
+    }
+
+    let title = title.into().trim().to_string();
+    if title.is_empty() {
+        return;
+    }
+    if title.len() > MAX_PROVIDER_TITLE_BYTES {
+        tracing::warn!(
+            provider = target.kind.as_str(),
+            transcript_id = %target.id,
+            title_bytes = title.len(),
+            "skipping provider session name sync because the title is too large"
+        );
+        return;
+    }
+
+    let Some(sender) = worker_sender() else {
+        return;
+    };
+    if let Err(err) = sender.send(TitleSyncRequest { target, title }) {
+        tracing::warn!(error = %err, "provider session name worker is unavailable");
+    }
+}
+
+/// Propagate a title that already existed before Acorn discovered the native
+/// session id. Manual names apply to the newly-bound conversation; generated
+/// names apply only when they were generated from that exact transcript, so a
+/// `/new` conversation never inherits the previous conversation's title.
+pub fn enqueue_existing_title(session: &Session, target: LiveTranscript) {
+    if should_sync_existing_title(session, &target.id) {
+        enqueue(target, session.name.clone());
+    }
+}
+
+fn should_sync_existing_title(session: &Session, transcript_id: &str) -> bool {
+    if session.kind != SessionKind::Regular
+        || session.mode != SessionMode::Terminal
+        || !matches!(session.owner, SessionOwner::User)
+    {
+        return false;
+    }
+    match session.title_source {
+        SessionTitleSource::Default => false,
+        SessionTitleSource::Manual => true,
+        SessionTitleSource::Generated => {
+            session.generated_title_transcript_id.as_deref() == Some(transcript_id)
+        }
+    }
+}
+
+fn worker_sender() -> Option<&'static mpsc::Sender<TitleSyncRequest>> {
+    static WORKER: OnceLock<Option<mpsc::Sender<TitleSyncRequest>>> = OnceLock::new();
+    WORKER
+        .get_or_init(|| {
+            let (sender, receiver) = mpsc::channel();
+            match thread::Builder::new()
+                .name("agent-session-name-sync".to_string())
+                .spawn(move || worker(receiver))
+            {
+                Ok(_) => Some(sender),
+                Err(err) => {
+                    tracing::warn!(error = %err, "failed to start provider session name worker");
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+
+fn worker(receiver: mpsc::Receiver<TitleSyncRequest>) {
+    while let Ok(request) = receiver.recv() {
+        if let Err(error) = sync_title(&request.target, &request.title) {
+            tracing::warn!(
+                provider = request.target.kind.as_str(),
+                transcript_id = %request.target.id,
+                error = %error,
+                "failed to sync Acorn title to provider session"
+            );
+        }
+    }
+}
+
+fn sync_title(target: &LiveTranscript, title: &str) -> Result<(), String> {
+    let session_id = uuid::Uuid::parse_str(&target.id)
+        .map(|id| id.to_string())
+        .map_err(|_| "provider session id is not a UUID".to_string())?;
+
+    match target.kind {
+        AgentKind::Codex => sync_codex_title(&session_id, title),
+        AgentKind::Claude => append_claude_title(&target.path, &session_id, title),
+        AgentKind::Antigravity => Ok(()),
+    }
+}
+
+/// Codex exposes thread naming through its app-server JSONL protocol. A fresh
+/// short-lived server is used for each queued update; it writes the shared
+/// Codex thread metadata read by the desktop app and then exits.
+fn sync_codex_title(thread_id: &str, title: &str) -> Result<(), String> {
+    let child = spawn_codex_app_server()?;
+    run_codex_name_protocol(child, thread_id, title)
+}
+
+fn spawn_codex_app_server() -> Result<Child, String> {
+    for attempt in 0..2 {
+        let path = crate::cli_resolver::resolve("codex").map_err(|err| err.to_string())?;
+        let mut command = Command::new(path);
+        command
+            .args(["app-server", "--stdio"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        crate::shell_env::apply_to_command(&mut command);
+
+        match command.spawn() {
+            Ok(child) => return Ok(child),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound && attempt == 0 => {
+                crate::cli_resolver::invalidate("codex");
+            }
+            Err(err) => return Err(crate::cli_resolver::spawn_error("codex", err).to_string()),
+        }
+    }
+    Err("failed to start Codex app server".to_string())
+}
+
+fn run_codex_name_protocol(mut child: Child, thread_id: &str, title: &str) -> Result<(), String> {
+    let result = (|| {
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "Codex app server stdout was not captured".to_string())?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "Codex app server stdin was not captured".to_string())?;
+        let (event_tx, event_rx) = mpsc::channel();
+        thread::Builder::new()
+            .name("codex-name-rpc-reader".to_string())
+            .spawn(move || {
+                let reader = BufReader::new(stdout);
+                for line in reader.lines() {
+                    match line {
+                        Ok(line) => {
+                            if event_tx.send(ReaderEvent::Line(line)).is_err() {
+                                return;
+                            }
+                        }
+                        Err(err) => {
+                            let _ = event_tx.send(ReaderEvent::Error(err.to_string()));
+                            return;
+                        }
+                    }
+                }
+                let _ = event_tx.send(ReaderEvent::Eof);
+            })
+            .map_err(|err| format!("failed to start Codex response reader: {err}"))?;
+
+        write_rpc_line(&mut stdin, &initialize_request())?;
+        wait_for_rpc_response(&event_rx, 1, CODEX_RPC_TIMEOUT)?;
+
+        write_rpc_line(&mut stdin, &json!({"method": "initialized", "params": {}}))?;
+        write_rpc_line(&mut stdin, &set_name_request(thread_id, title))?;
+        wait_for_rpc_response(&event_rx, 2, CODEX_RPC_TIMEOUT)
+    })();
+
+    // The protocol scope has closed stdin. Bound the lifetime of app-server
+    // versions that keep running after the client disconnects.
+    let _ = child.kill();
+    let _ = child.wait();
+    result
+}
+
+fn initialize_request() -> Value {
+    json!({
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "clientInfo": {
+                "name": "acorn",
+                "title": "Acorn",
+                "version": env!("CARGO_PKG_VERSION")
+            },
+            "capabilities": null
+        }
+    })
+}
+
+fn set_name_request(thread_id: &str, title: &str) -> Value {
+    json!({
+        "id": 2,
+        "method": "thread/name/set",
+        "params": {
+            "threadId": thread_id,
+            "name": title
+        }
+    })
+}
+
+fn write_rpc_line(stdin: &mut ChildStdin, value: &Value) -> Result<(), String> {
+    let mut line = serde_json::to_vec(value)
+        .map_err(|err| format!("failed to encode Codex request: {err}"))?;
+    line.push(b'\n');
+    stdin
+        .write_all(&line)
+        .and_then(|_| stdin.flush())
+        .map_err(|err| format!("failed to write Codex request: {err}"))
+}
+
+fn wait_for_rpc_response(
+    receiver: &mpsc::Receiver<ReaderEvent>,
+    request_id: u64,
+    timeout: Duration,
+) -> Result<(), String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(format!(
+                "Codex app server timed out waiting for response {request_id}"
+            ));
+        }
+        match receiver.recv_timeout(deadline.saturating_duration_since(now)) {
+            Ok(ReaderEvent::Line(line)) => {
+                if let Some(response) = parse_rpc_response(&line, request_id) {
+                    return response;
+                }
+            }
+            Ok(ReaderEvent::Error(error)) => {
+                return Err(format!("failed to read Codex response: {error}"));
+            }
+            Ok(ReaderEvent::Eof) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(format!(
+                    "Codex app server exited before response {request_id}"
+                ));
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                return Err(format!(
+                    "Codex app server timed out waiting for response {request_id}"
+                ));
+            }
+        }
+    }
+}
+
+fn parse_rpc_response(line: &str, request_id: u64) -> Option<Result<(), String>> {
+    let response: Value = serde_json::from_str(line).ok()?;
+    if response.get("id").and_then(Value::as_u64) != Some(request_id) {
+        return None;
+    }
+    if let Some(error) = response.get("error") {
+        let message = error
+            .get("message")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| error.to_string());
+        return Some(Err(format!(
+            "Codex app server rejected the request: {message}"
+        )));
+    }
+    Some(Ok(()))
+}
+
+/// Claude Code has no external rename command for an already-running session.
+/// Its documented `/rename` feature is persisted as an append-only
+/// `custom-title` transcript record, so Acorn writes the same record to the
+/// already-resolved transcript. Existing conversation entries are never
+/// rewritten.
+fn append_claude_title(path: &Path, session_id: &str, title: &str) -> Result<(), String> {
+    let expected_name = format!("{session_id}.jsonl");
+    if path.file_name().and_then(|name| name.to_str()) != Some(expected_name.as_str()) {
+        return Err("Claude transcript filename does not match its session id".to_string());
+    }
+
+    let path_metadata = fs::symlink_metadata(path)
+        .map_err(|err| format!("failed to inspect Claude transcript: {err}"))?;
+    if !path_metadata.file_type().is_file() {
+        return Err("Claude transcript path is not a regular file".to_string());
+    }
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .append(true)
+        .open(path)
+        .map_err(|err| format!("failed to open Claude transcript: {err}"))?;
+    let opened_metadata = file
+        .metadata()
+        .map_err(|err| format!("failed to inspect opened Claude transcript: {err}"))?;
+    if !opened_metadata.is_file() {
+        return Err("opened Claude transcript is not a regular file".to_string());
+    }
+    #[cfg(unix)]
+    if path_metadata.dev() != opened_metadata.dev() || path_metadata.ino() != opened_metadata.ino()
+    {
+        return Err("Claude transcript changed while it was being opened".to_string());
+    }
+
+    let needs_separator = if opened_metadata.len() == 0 {
+        false
+    } else {
+        file.seek(SeekFrom::End(-1))
+            .and_then(|_| {
+                let mut byte = [0_u8; 1];
+                file.read_exact(&mut byte).map(|_| byte[0] != b'\n')
+            })
+            .map_err(|err| format!("failed to inspect Claude transcript ending: {err}"))?
+    };
+
+    let mut record = Vec::new();
+    if needs_separator {
+        record.push(b'\n');
+    }
+    record.extend(
+        serde_json::to_vec(&json!({
+            "type": "custom-title",
+            "customTitle": title,
+            "sessionId": session_id
+        }))
+        .map_err(|err| format!("failed to encode Claude title record: {err}"))?,
+    );
+    record.push(b'\n');
+    file.write_all(&record)
+        .map_err(|err| format!("failed to append Claude title record: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn claude_target(path: &Path, id: &str) -> LiveTranscript {
+        LiveTranscript {
+            id: id.to_string(),
+            path: path.to_path_buf(),
+            kind: AgentKind::Claude,
+        }
+    }
+
+    fn titled_session(source: SessionTitleSource) -> Session {
+        let mut session = Session::new(
+            "release fix".to_string(),
+            PathBuf::from("/tmp/acorn"),
+            PathBuf::from("/tmp/acorn"),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        session.title_source = source;
+        session
+    }
+
+    #[test]
+    fn existing_manual_title_syncs_when_provider_binding_appears() {
+        let session = titled_session(SessionTitleSource::Manual);
+
+        assert!(should_sync_existing_title(
+            &session,
+            "019c1464-9f4e-7302-bc0f-81a1449fc365"
+        ));
+    }
+
+    #[test]
+    fn existing_generated_title_only_syncs_to_its_source_transcript() {
+        let mut session = titled_session(SessionTitleSource::Generated);
+        session.generated_title_transcript_id =
+            Some("019c1464-9f4e-7302-bc0f-81a1449fc365".to_string());
+
+        assert!(should_sync_existing_title(
+            &session,
+            "019c1464-9f4e-7302-bc0f-81a1449fc365"
+        ));
+        assert!(!should_sync_existing_title(
+            &session,
+            "019c1464-9f4e-7302-bc0f-81a1449fc366"
+        ));
+    }
+
+    #[test]
+    fn default_and_chat_titles_do_not_sync_on_provider_binding() {
+        let default_session = titled_session(SessionTitleSource::Default);
+        let mut chat_session = titled_session(SessionTitleSource::Manual);
+        chat_session.mode = SessionMode::Chat;
+
+        assert!(!should_sync_existing_title(
+            &default_session,
+            "019c1464-9f4e-7302-bc0f-81a1449fc365"
+        ));
+        assert!(!should_sync_existing_title(
+            &chat_session,
+            "019c1464-9f4e-7302-bc0f-81a1449fc365"
+        ));
+    }
+
+    #[test]
+    fn codex_set_name_request_uses_thread_name_rpc() {
+        let request = set_name_request("019c1464-9f4e-7302-bc0f-81a1449fc365", "release fix");
+
+        assert_eq!(request["method"], "thread/name/set");
+        assert_eq!(
+            request["params"]["threadId"],
+            "019c1464-9f4e-7302-bc0f-81a1449fc365"
+        );
+        assert_eq!(request["params"]["name"], "release fix");
+    }
+
+    #[test]
+    fn rpc_response_parser_ignores_notifications_and_reports_errors() {
+        assert!(parse_rpc_response(r#"{"method":"thread/started","params":{}}"#, 2).is_none());
+        assert!(parse_rpc_response(r#"{"id":2,"result":{}}"#, 2)
+            .expect("matching response")
+            .is_ok());
+        let error = parse_rpc_response(
+            r#"{"id":2,"error":{"code":-32600,"message":"no rollout found"}}"#,
+            2,
+        )
+        .expect("matching response")
+        .expect_err("server error");
+        assert!(error.contains("no rollout found"));
+    }
+
+    #[test]
+    fn claude_title_is_appended_without_rewriting_transcript() {
+        let dir = tempfile::tempdir().unwrap();
+        let id = "019c1464-9f4e-7302-bc0f-81a1449fc365";
+        let path = dir.path().join(format!("{id}.jsonl"));
+        fs::write(&path, b"{\"type\":\"user\",\"message\":\"keep me\"}\n").unwrap();
+
+        sync_title(&claude_target(&path, id), "fix \"quoted\" title").unwrap();
+
+        let lines = fs::read_to_string(&path).unwrap();
+        let mut lines = lines.lines();
+        assert_eq!(lines.next(), Some(r#"{"type":"user","message":"keep me"}"#));
+        let title: Value = serde_json::from_str(lines.next().expect("title record")).unwrap();
+        assert_eq!(title["type"], "custom-title");
+        assert_eq!(title["customTitle"], "fix \"quoted\" title");
+        assert_eq!(title["sessionId"], id);
+        assert!(lines.next().is_none());
+    }
+
+    #[test]
+    fn claude_title_rejects_a_mismatched_transcript_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let id = "019c1464-9f4e-7302-bc0f-81a1449fc365";
+        let path = dir.path().join("different.jsonl");
+        fs::write(&path, b"{}\n").unwrap();
+
+        let error = sync_title(&claude_target(&path, id), "title").unwrap_err();
+
+        assert!(error.contains("filename"));
+        assert_eq!(fs::read_to_string(path).unwrap(), "{}\n");
+    }
+
+    #[test]
+    fn claude_title_separates_a_transcript_missing_its_final_newline() {
+        let dir = tempfile::tempdir().unwrap();
+        let id = "019c1464-9f4e-7302-bc0f-81a1449fc365";
+        let path = dir.path().join(format!("{id}.jsonl"));
+        fs::write(&path, b"{\"type\":\"user\"}").unwrap();
+
+        sync_title(&claude_target(&path, id), "title").unwrap();
+
+        let lines = fs::read_to_string(path).unwrap();
+        assert_eq!(lines.lines().count(), 2);
+        assert!(lines.starts_with("{\"type\":\"user\"}\n"));
+        assert!(lines.ends_with('\n'));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn claude_title_rejects_symlink_transcripts() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let id = "019c1464-9f4e-7302-bc0f-81a1449fc365";
+        let target = dir.path().join("target.jsonl");
+        let path = dir.path().join(format!("{id}.jsonl"));
+        fs::write(&target, b"{}\n").unwrap();
+        symlink(&target, &path).unwrap();
+
+        let error = sync_title(&claude_target(&path, id), "title").unwrap_err();
+
+        assert!(error.contains("regular file"));
+        assert_eq!(fs::read_to_string(target).unwrap(), "{}\n");
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3922,8 +3922,15 @@ pub fn rename_session(state: State<'_, AppState>, id: String, name: String) -> A
             "control-session owned tabs cannot be renamed".to_string(),
         ));
     }
+    let native_session = (current.kind == SessionKind::Regular
+        && current.mode == SessionMode::Terminal)
+        .then(|| crate::session_titles::resolve_native_session(id))
+        .flatten();
     let updated = state.sessions.rename(&id, trimmed)?;
     persist(&state);
+    if let Some(native_session) = native_session {
+        crate::agent_session_names::enqueue(native_session, updated.name.clone());
+    }
     Ok(enrich_session(updated))
 }
 
@@ -4056,6 +4063,7 @@ fn generate_session_title_inner(
             session: enrich_session(session),
         });
     };
+    let native_session = title_input.native_session.clone();
     let generated = crate::session_titles::generate_title_in_dir(
         &ai,
         prompt.as_deref(),
@@ -4079,6 +4087,9 @@ fn generate_session_title_inner(
         .sessions
         .set_generated_title(&id, generated, Some(transcript_id))?;
     persist(&state);
+    if let Some(native_session) = native_session {
+        crate::agent_session_names::enqueue(native_session, updated.name.clone());
+    }
     Ok(GenerateSessionTitleResult {
         status: GenerateSessionTitleStatus::Generated,
         session: enrich_session(updated),
@@ -6019,6 +6030,13 @@ fn detect_session_statuses_blocking(
             // titles and resume for the whole session. Bind the live
             // codex process straight to its rollout instead.
             let live = live.or_else(|| codex_live_transcript_fallback(&sys, parsed_id, live_agent));
+            let agent_binding_changed =
+                session
+                    .as_ref()
+                    .zip(live.as_ref())
+                    .is_some_and(|(session, transcript)| {
+                        session.agent_transcript_id.as_deref() != Some(transcript.id.as_str())
+                    });
             let agent_transcript_id = live.as_ref().map(|t| t.id.clone());
             let transcript = match live.as_ref() {
                 Some(t) => Some((t.path.clone(), t.kind)),
@@ -6209,15 +6227,27 @@ fn detect_session_statuses_blocking(
             // Keep live-agent metadata on the same lifecycle fence as the
             // status/source write. A native or fallback event that landed
             // during this poll must retain its newer provider claim.
-            if let Some(uuid) = parsed_id {
+            let agent_metadata_applied = if let Some(uuid) = parsed_id {
                 if metadata_write_allowed {
-                    let _ = state.sessions.refresh_agent_state_if_lifecycle_revision(
-                        &uuid,
-                        metadata_expected_lifecycle_revision,
-                        metadata_expected_source,
-                        agent_provider,
-                        agent_transcript_id.clone(),
-                    );
+                    state
+                        .sessions
+                        .refresh_agent_state_if_lifecycle_revision(
+                            &uuid,
+                            metadata_expected_lifecycle_revision,
+                            metadata_expected_source,
+                            agent_provider,
+                            agent_transcript_id.clone(),
+                        )
+                        .unwrap_or(false)
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+            if agent_metadata_applied && agent_binding_changed {
+                if let (Some(session), Some(transcript)) = (session.as_ref(), live.clone()) {
+                    crate::agent_session_names::enqueue_existing_title(session, transcript);
                 }
             }
             SessionStatusEntry {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod agent_history;
 mod agent_hooks;
 mod agent_resume;
 mod agent_resume_persister;
+mod agent_session_names;
 mod agent_wrappers;
 mod ai;
 mod chat_runs;

--- a/src-tauri/src/session_titles.rs
+++ b/src-tauri/src/session_titles.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
+
+#[cfg(test)]
+use std::path::PathBuf;
 
 use acorn_session::{Session, SessionKind, SessionMode, SessionOwner, SessionTitleSource};
 
@@ -30,6 +33,7 @@ Rules:
 pub struct ResolvedTitleInput {
     pub transcript_id: String,
     pub title_context: String,
+    pub native_session: Option<agent_resume::LiveTranscript>,
 }
 
 pub fn can_generate_title(session: &Session, transcript_id: Option<&str>) -> bool {
@@ -88,12 +92,17 @@ fn effective_prompt(prompt: Option<&str>) -> String {
 }
 
 pub fn resolve_title_input(session_id: uuid::Uuid) -> Option<ResolvedTitleInput> {
-    let (path, provider, transcript_id) = resolve_transcript(session_id)?;
-    let title_context =
-        agent_history::transcript_title_context(provider, &path, TITLE_CONTEXT_CHARS)?;
+    let native_session = resolve_native_session(session_id)?;
+    let provider: AgentHistoryProvider = native_session.kind.into();
+    let title_context = agent_history::transcript_title_context(
+        provider,
+        &native_session.path,
+        TITLE_CONTEXT_CHARS,
+    )?;
     Some(ResolvedTitleInput {
-        transcript_id,
+        transcript_id: native_session.id.clone(),
         title_context,
+        native_session: Some(native_session),
     })
 }
 
@@ -128,6 +137,7 @@ pub fn chat_title_input_from_state(
     Some(ResolvedTitleInput {
         transcript_id: format!("chat:{}", first_user_message.id),
         title_context: title_context.chars().take(TITLE_CONTEXT_CHARS).collect(),
+        native_session: None,
     })
 }
 
@@ -220,15 +230,19 @@ fn title_generation_command(mut resolved: ResolvedAiCommand) -> ResolvedAiComman
     resolved
 }
 
-fn resolve_transcript(session_id: uuid::Uuid) -> Option<(PathBuf, AgentHistoryProvider, String)> {
+pub fn resolve_native_session(session_id: uuid::Uuid) -> Option<agent_resume::LiveTranscript> {
     if let Some(live) = agent_resume::live_transcript(session_id) {
-        return Some((live.path, live.kind.into(), live.id));
+        return Some(live);
     }
 
     todos::locate_transcript_for(&session_id.to_string())
         .ok()
         .flatten()
-        .map(|path| (path, AgentHistoryProvider::Claude, session_id.to_string()))
+        .map(|path| agent_resume::LiveTranscript {
+            path,
+            kind: acorn_agent::AgentKind::Claude,
+            id: session_id.to_string(),
+        })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Acorn의 수동/자동 터미널 탭 제목을 provider-native conversation에도 동기화해 Codex 앱의 `New task` 같은 기본 이름을 남기지 않습니다.

1. **Provider-native naming** — Codex app-server의 `thread/name/set` RPC를 호출하고, Claude에는 `/rename`과 같은 `custom-title` 메타데이터를 기록합니다.
2. **Title lifecycle wiring** — 수동 rename, 자동 생성 제목, native transcript가 뒤늦게 바인딩된 세션까지 동일한 제목 수명주기에 연결합니다.
3. **Safety and isolation** — 순서가 보장된 백그라운드 worker, 제한된 Codex RPC timeout, Claude UUID/path/inode 검증, transcript 일치 검사를 추가했습니다.
4. **Regression coverage** — provider별 payload, 동기화 조건, Claude JSONL append 안전성을 검증하는 단위 테스트를 추가했습니다.

## Expected impact

| Behavior | Before | After |
| --- | --- | --- |
| CLI에서 만든 Codex session의 Codex 앱 이름 | `New task` 등 기본 이름 | Acorn 탭 제목 |
| Claude `/resume` 목록 이름 | Acorn 제목과 독립적 | Acorn 탭 제목 |
| Acorn rename 응답성 | 로컬 rename만 수행 | provider 동기화를 best-effort background로 수행해 동일 |
| `/new` 이후 자동 제목 | 이전 transcript 제목이 이어질 수 있음 | 현재 transcript와 일치할 때만 동기화 |

## Design notes

- Acorn 제목을 source of truth로 사용합니다. provider 쪽에서만 따로 rename한 제목을 보존하는 기능은 이번 범위에 포함하지 않습니다.
- 수동 제목과 생성 제목만 동기화하며 기본 제목, chat/control terminal, Antigravity는 기존 동작을 유지합니다.
- Codex는 app-server RPC를 사용합니다. Claude는 실행 중인 기존 세션을 외부에서 rename하는 API가 없어 native append-only `custom-title` record를 기록합니다.
- provider 동기화 실패나 timeout은 Acorn의 제목 저장을 막지 않습니다.

## Follow-up (not in this PR)

- 안정적인 naming API가 제공되면 Antigravity를 같은 경로에 추가합니다.
- Claude가 외부 live-title 갱신 API를 제공하면 실행 중 prompt bar의 즉시 repaint도 연결할 수 있습니다.

## Test plan

- [x] `cargo test agent_session_names --lib --quiet` — 9 passed
- [x] `cargo test --workspace --quiet -- --test-threads=1` — 846 passed, 1 ignored
- [x] `pnpm audit --audit-level=moderate`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 1,142 passed
- [x] `pnpm run build:frontend`
- [x] changed-file `rustfmt --check`
- [x] `git diff --check`
